### PR TITLE
Page not found error when Deleting Discussion from within a discussion thread.

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -410,12 +410,12 @@ class DiscussionController extends VanillaController {
       
       // Redirect
       if ($this->_DeliveryType === DELIVERY_TYPE_ALL)
-         Redirect(GetIncomingValue('Target', '/discussions'));
+         Redirect(GetIncomingValue('Target', '/vanilla/discussions'));
          
       if ($this->Form->ErrorCount() > 0)
          $this->SetJson('ErrorMessage', $this->Form->Errors());
          
-      $this->RedirectUrl = GetIncomingValue('Target', Url('discussions'));
+      $this->RedirectUrl = GetIncomingValue('Target', '/vanilla/discussions');
       $this->Render();         
    }
 


### PR DESCRIPTION
Hi,

This fixes an issue whereby if you try to delete a Discussion from within the discussion itself by clicking on the "Delete Discussion" link in the first post, you receive a "Page not found error".

Best regards
Nick
