### PR TITLE
PermissionsModel -> SaveAll breaking other permissions

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -420,7 +420,7 @@ class CategoryModel extends Gdn_Model {
          if ($AllowDiscussions) {
             $PermissionModel = Gdn::PermissionModel();
             $Permissions = $PermissionModel->PivotPermissions(GetValue('Permission', $FormPostValues, array()), array('JunctionID' => $CategoryID));
-            $PermissionModel->SaveAll($Permissions, array('JunctionID' => $CategoryID));
+            $PermissionModel->SaveAll($Permissions, array('JunctionID' => $CategoryID, 'JunctionTable' => 'Category'));
          }
          
          // Force the user permissions to refresh.


### PR DESCRIPTION
The SaveAll without JunctionTable specified brakes other permissions using junctiontable
