### PR TITLE
Emotify fix.

### DIFF
--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -297,7 +297,7 @@ class TaggingPlugin extends Gdn_Plugin {
       } else {
          // Make sure the tag is valid
          $Tag = $Sender->Form->GetFormValue('Name');
-         if (!ValidateRegex($Tag, '/^([\d\w\+-_.#]+)$/si'))
+         if (!ValidateRegex($Tag, '/^([\pL\pN\s\d\w\+-_.#]+)$/usi'))
             $Sender->Form->AddError('Tags can only contain the following characters: a-z 0-9 + # _ .');         
          
          // Make sure that the tag name is not already in use.


### PR DESCRIPTION
Emotify does not convert smileys at the end of the paragraphs or any closing tag (this mostly happens when visual editors are used). This patch fixes this problem.
