### PR TITLE
Bugfix for permission names in "add category"

### DIFF
--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -250,12 +250,11 @@ class PermissionModel extends Gdn_Model {
          foreach($JuncData as $JuncRow) {
             $JuncRow['JunctionTable'] = $JunctionTable;
             $JuncRow['JunctionColumn'] = $JunctionColumn;
-            if(!is_null($JunctionID)) {
+            
+            if (!is_null($JunctionID))
                $JuncRow['JunctionID'] = $JunctionID;
-            }
-            if ($JuncRow['JunctionID'] <= 0) {
+            else
                $JuncRow['Name'] = sprintf(T('Default %s Permissions'), T('Permission.'.$JunctionTable, $JunctionTable));
-            }
             
             if(array_key_exists('CanSession', $JuncRow)) {
                if(!$JuncRow['CanSession']) {


### PR DESCRIPTION
Hi, I noticed this bug when testing Vanilla Forum for the first time. I just had to take a peak, and think I found a solution.

When adding a category, checking "This category has custom permissions." all permissions get the name "Default Category Permissions", making it very difficult (if not impossible) to know where you set permissions.

I found out that the root category have -1 as ID, making one of your if-statements fail because it checks if the value is lower of equal as 0. 

Added some comments on the commit as well.
