### PR TITLE
Discussion category tab fix

### DIFF
--- a/applications/vanilla/views/discussion/index.php
+++ b/applications/vanilla/views/discussion/index.php
@@ -16,7 +16,7 @@ if ($Session->IsValid()) {
 <div class="Tabs HeadingTabs DiscussionTabs">
    <ul>
       <li><?php
-         if (Gdn::Config('Vanilla.Categories.Use') === TRUE) {
+         if (Gdn::Config('Vanilla.Categories.Use') == TRUE) {
             echo Anchor($this->Discussion->Category, 'categories/'.$this->Discussion->CategoryUrlCode);
          } else {
             echo Anchor(T('All Discussions'), 'discussions');


### PR DESCRIPTION
Discussion header category tab was showing All Discussions instead of the current category even if Vanilla.Categories.Use is true. Fixed by removing strict comparison (=== to ==).
