### PR TITLE
theme-support for plugin-files

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1245,29 +1245,23 @@ class Gdn_Controller extends Gdn_Pluggable {
             foreach ($this->_CssFiles as $CssInfo) {
                $CssFile = $CssInfo['FileName'];
                
+               $CssPaths = array(); 
                if(strpos($CssFile, '/') !== FALSE) {
-                  // A direct path to the file was given.
-                  $CssPaths = array(CombinePaths(array(PATH_ROOT, str_replace('/', DS, $CssFile))));
+                   if( $this->Theme) {
+                     $CssPaths = $this->getCssThemePath( $CssFile); 
+                   } 
+                   // A direct path to the file was given.
+                   $CssPaths[] = CombinePaths(array(PATH_ROOT, str_replace('/', DS, $CssFile)));
                } else {
-                  $CssGlob = preg_replace('/(.*)(\.css)/', '\1*\2', $CssFile);
-                  $AppFolder = $CssInfo['AppFolder'];
-                  if ($AppFolder == '')
+                   $CssGlob = preg_replace('/(.*)(\.css)/', '\1*\2', $CssFile);
+                   $AppFolder = $CssInfo['AppFolder'];
+                   if ($AppFolder == '')
                      $AppFolder = $this->ApplicationFolder;
    
                   // CSS comes from one of four places:
                   $CssPaths = array();
                   if ($this->Theme) {
-                     // 1. Application-specific css. eg. root/themes/theme_name/app_name/design/
-                     // $CssPaths[] = PATH_THEMES . DS . $this->Theme . DS . $AppFolder . DS . 'design' . DS . $CssGlob;
-                     // 2. Theme-wide theme view. eg. root/themes/theme_name/design/
-                     // a) Check to see if a customized version of the css is there.
-                     if ($this->ThemeOptions) {
-                        $Filenames = GetValueR('Styles.Value', $this->ThemeOptions);
-                        if (is_string($Filenames) && $Filenames != '%s')
-                           $CssPaths[] = PATH_THEMES.DS.$this->Theme.DS.'design'.DS.ChangeBasename($CssFile, $Filenames);
-                     }
-                     // b) Use the default filename.
-                     $CssPaths[] = PATH_THEMES . DS . $this->Theme . DS . 'design' . DS . $CssFile;
+                     $CssPaths = $this->getCssThemePath( $CssFile); 
                   }
 
 
@@ -1538,5 +1532,23 @@ class Gdn_Controller extends Gdn_Pluggable {
    public function Title($Title) {
       $this->SetData('Title', $Title);
    }
+
+  /**
+   * 1. Application-specific css. eg. root/themes/theme_name/app_name/design/
+   * $CssPaths[] = PATH_THEMES . DS . $this->Theme . DS . $AppFolder . DS . 'design' . DS . $CssGlob;
+   * 2. Theme-wide theme view. eg. root/themes/theme_name/design/
+   * a) Check to see if a customized version of the css is there.
+   */
+    public function getCssThemePath($CssFile) {
+        $CssPath = array(); 
+        if ($this->ThemeOptions) {
+          $Filenames = GetValueR('Styles.Value', $this->ThemeOptions);
+          if (is_string($Filenames) && $Filenames != '%s')
+             $CssPaths[] = PATH_THEMES.DS.$this->Theme.DS.'design'.DS.ChangeBasename($CssFile, $Filenames);
+        }
+        // b) Use the default filename.
+        $CssPaths[] = PATH_THEMES . DS . $this->Theme . DS . 'design' . DS . $CssFile;
+        return $CssPaths; 
+    }
    
 }


### PR DESCRIPTION
most plugins call AddCssFile by direct-path, and so this css-files are not themeable. There is no bug-report, but Issue #385 is related. 

This fix allows the modification of files called by direct-path in a template.

changes: 
- add template-paths to direct-path (no slash at beginning) in $_CssFiles Iteration
- copy existing template-code to new method getCssThemePath() to avoid duplicate code

as a result the following css-path is added to glob-arr: templates/$tmpl_name/design/plugins/FileUpload/css/fileupload.css

parent is vanilla master
