### PR TITLE
Twitter registration user email updated

### DIFF
--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -270,7 +270,7 @@ class TwitterPlugin extends Gdn_Plugin {
       $Form->SetFormValue('ProviderName', 'Twitter');
       $Form->SetFormValue('Name', GetValue('screen_name', $Profile));
       $Form->SetFormValue('FullName', GetValue('name', $Profile));
-      $Form->SetFormValue('Email', GetValue('screen_name', $Profile).'@foo.com');
+      $Form->SetFormValue('Email', GetValue('screen_name', $Profile).'@via.twitter.com');
       $Form->SetFormValue('Photo', GetValue('profile_image_url', $Profile));
       $Sender->SetData('Verified', TRUE);
    }


### PR DESCRIPTION
It's a bit strange having the default email be "username@foo.com", as it feels a bit spammy when looking at newly registered users.

I've edited the main Twitter plugin class to have new Twitter users' email appear as "username@via.twitter.com".

It just provides a bit more information to me, the Admin, in the user panel.
