### PR TITLE
Optimize vBulletin import

### DIFF
--- a/applications/dashboard/models/class.vbulletinimportmodel.php
+++ b/applications/dashboard/models/class.vbulletinimportmodel.php
@@ -32,7 +32,7 @@ class vBulletinImportModel extends Gdn_Model {
     */
    public function ProcessAvatars() {
       $UploadImage = new Gdn_UploadImage();
-      $UserData = $this->SQL->Select('u.*')->From('User u')->Get();
+      $UserData = $this->SQL->Select('u.*')->From('User u')->Where('u.Photo is not null')->Get();
       foreach ($UserData->Result() as $User) {
          try {
             $Image = PATH_ROOT . DS . 'uploads' . DS . $User->Photo;


### PR DESCRIPTION
This query is executed when importing a vBulletin forum.
It becomes very slow when you have lots of users (several hundred thousands in my case).
Since it is only used to import avatars, we can filter to only fetch users who actually have a picture set.
