### PR TITLE
Prevent view counts from being increased by API calls

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -85,7 +85,7 @@ class DiscussionController extends VanillaController {
 
       // If $Offset isn't defined, assume that the user has not clicked to
       // view a next or previous page, and this is a "view" to be counted.
-      if ($Offset == '')
+      if ($Offset == '' && !in_array($this->_DeliveryMethod, array(DELIVERY_METHOD_JSON, DELIVERY_METHOD_XML))
          $this->DiscussionModel->AddView($DiscussionID);
 
       $this->Offset = $Offset;


### PR DESCRIPTION
When I make a API call from an external application to /Discussion.(json|xml)?DiscussionID=x to show comment counts, view count of that discussion increases.

It is an unwanted behavior considering our case. This patch prevents it.
