### PR TITLE
Improvement for auto-linked text in comments.

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -844,8 +844,15 @@ EOT;
             $Punc = $Matches[2];
          }
 
+         // Get human-readable text from url.
+         $Text = $Url;
+         if (strpos($Text ,'%') !== FALSE) {
+            $Text = rawurldecode($Text);
+            $Text = htmlspecialchars($Text, ENT_QUOTES, C('Garden.Charset', ''));
+         }
+
          $Result = <<<EOT
-<a href="$Url" target="_blank"$nofollow>$Url</a>$Punc
+<a href="$Url" target="_blank"$nofollow>$Text</a>$Punc
 EOT;
       }
       return $Result;


### PR DESCRIPTION
Get human-readable text from url for LinksCallback() function in library/core/class.format.php.
See http://twitpic.com/5un7nw for example.
