### PR TITLE
fix helper inclusion

### DIFF
--- a/applications/vanilla/views/categories/all.php
+++ b/applications/vanilla/views/categories/all.php
@@ -1,5 +1,5 @@
 <?php if (!defined('APPLICATION')) exit();
-include dirname(__FILE__).'/helper_functions.php';
+include($this->FetchViewLocation('helper_functions', 'categories'));
 
 $CatList = '';
 $DoHeadings = C('Vanilla.Categories.DoHeadings');


### PR DESCRIPTION
Use FetchViewLocation() to include helper_functions.php.

Fix a fatal error you get when you copy this view in a theme folder to customize it.
