### PR TITLE
Fixed UserModel::SetMeta() from deleting other user's meta entries

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1972,7 +1972,7 @@ class UserModel extends Gdn_Model {
             Gdn::Database()->Query($Sql, array(':UserID' => $UserID, ':Name' => $Name, ':Value' => $Value, ':Value1' => $Value));
       }
       if (count($Deletes))
-         Gdn::SQL()->WhereIn('Name', $Deletes)->Delete('UserMeta');
+         Gdn::SQL()->WhereIn('Name', $Deletes)->Where('UserID',$UserID)->Delete('UserMeta');
    }
 
    public function SetTransientKey($UserID, $ExplicitKey = '') {


### PR DESCRIPTION
Right now if SetMeta() is called it accepts an array of meta entries and if any of their values are blank it marks them for deletion, then later calls a SQL statement that deletes all entries in the GDN_UserMeta table with the same name without checking UserID, which means if multiple users have a meta preference set and one user unsets it it will be unset for all users. Adding another where clause to check UserID seems to fix the problem.
