### PR TITLE
Added BeforeUpdateCommentCountQuery event to UpdateCommentCount function.

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -909,6 +909,8 @@ class CommentModel extends VanillaModel {
       // Get the discussion.
       $Discussion = $this->SQL->GetWhere('Discussion', array('DiscussionID' => $DiscussionID))->FirstRow(DATASET_TYPE_ARRAY);
 
+      $this->FireEvent('BeforeUpdateCommentCountQuery');
+      
       $Data = $this->SQL
          ->Select('c.CommentID', 'max', 'LastCommentID')
          ->Select('c.DateInserted', 'max', 'DateLastComment')


### PR DESCRIPTION
I'd like to be able to add SQL statements to the get query inside UpdateCommentCount, but the BeforeUpdateCommentCount event that's already there fires after SQL->Get() has been called, so as far as I know there's no way to do that. IF there is, let me know and you can ignore this pull request!
