### PR TITLE
Added BeforeDeleteComment event to Delete function in CommentModel

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1021,6 +1021,12 @@ class CommentModel extends VanillaModel {
          ->Get()->FirstRow(DATASET_TYPE_ARRAY);
          
       if ($Data) {
+      	 // Allow event to bypass updating the comment count
+      	 $this->EventArguments['UpdateCount'] = TRUE;
+	 $this->EventArguments['DiscussionID'] = $Data['DiscussionID'];
+	 $this->FireEvent('BeforeDeleteComment');
+	 if ($this->EventArguments['UpdateCount'])
+	 {
 			// If this is the last comment, get the one before and update the LastCommentID field
 			if ($Data['LastCommentID'] == $CommentID) {
 				$OldData = $this->SQL
@@ -1061,8 +1067,9 @@ class CommentModel extends VanillaModel {
 				->Set('CountComments', 'CountComments - 1', FALSE)
 				->Where('DiscussionID', $Data['DiscussionID'])
 				->Put();
-			
-			$this->FireEvent('DeleteComment');
+	 }		
+	
+	 $this->FireEvent('DeleteComment');
 
          // Log the deletion.
          unset($Data['LastCommentID'], $Data['DiscussionDateInserted']);


### PR DESCRIPTION
There's also an IF statement that wraps all of the comment count and last comment link updating code.

I need to be able to stop the function from updating the discussion comment counts, and I'm pretty sure this is the only way to do it. Now a plugin can handle the event, set the event argument to false, and it will skip all of the update code. By default the event argument is true and nothing changes.
