### PR TITLE
tab-enter should submit, not cancel, a form

### DIFF
--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -27,6 +27,7 @@ $Editing = isset($this->Comment);
    echo $this->Form->Errors();
    
    $CommentOptions = array('MultiLine' => TRUE);
+   $CommentOptions['tabindex'] = 1;
    /*
     Caused non-root users to not be able to add comments. Must take categories
     into account. Look at CheckPermission for more information.
@@ -34,7 +35,7 @@ $Editing = isset($this->Comment);
       $CommentOptions['Disabled'] = 'disabled';
       $CommentOptions['Value'] = T('You do not have permission to write new comments.');
    }
-   */
+    */
    $this->FireEvent('BeforeBodyField');
    echo Wrap($this->Form->TextBox('Body', $CommentOptions), 'div', array('class' => 'TextBoxWrapper'));
    $this->FireEvent('AfterBodyField');
@@ -52,6 +53,7 @@ $Editing = isset($this->Comment);
    )).' ';
    
    $ButtonOptions = array('class' => 'Button CommentButton');
+   $ButtonOptions['tabindex'] = 2;
    /*
     Caused non-root users to not be able to add comments. Must take categories
     into account. Look at CheckPermission for more information.


### PR DESCRIPTION
It's dangerous that when you press tab-enter, something people are used to on most web forms with a text box followed by a submit button, that some browsers would select the "Back to Discussions" link and follow it, discarding changes in the text box.

The "tabindex" property can be set in order to give the browser hints about where the keyboard tabbing should go. More information is available at the following links:

http://www.w3.org/TR/html4/interact/forms.html#adef-tabindex
http://www.w3.org/TR/html5/editing.html#sequential-focus-navigation-and-the-tabindex-attribute
