### PR TITLE
Move Vanilla Image Resizing to a plugin

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -870,34 +870,3 @@ jQuery(document).ready(function($) {
 			stash('CommentForDiscussionID_' + gdn.definition('DiscussionID'), comment);
 	});
 });
-
-// Shrink large images to fit into message space, and pop into new window when clicked.
-// This needs to happen in onload because otherwise the image sizes are not yet known.
-jQuery(window).load(function() {
-   
-   var toggler = function(t_img, t_width) {
-      if (t_img.css('width') == 'auto')
-         t_img.css('width',t_width);
-      else
-         t_img.css('width','auto');
-      return false;
-   }
-   
-   jQuery('div.Message img').each(function(i,img) {
-      var img = jQuery(img);
-      var container = img.parents('div.Message');
-      if (img.width() > container.width()) {
-         var smwidth = container.width();
-         
-         img.css('width', smwidth).css('cursor', 'pointer');
-         img.after('<div class="ImageResized">' + gdn.definition('ImageResized', 'This image has been resized to fit in the page. Click to enlarge.') + '</div>');
-         
-         img.next().click(function() {
-            return toggler(img, smwidth);
-         });
-         img.click(function() {
-            return toggler(img, smwidth);
-         })
-      }
-   });
-});

--- a/plugins/VanillaImageResize/default.php
+++ b/plugins/VanillaImageResize/default.php
@@ -1,0 +1,23 @@
+<?php if (!defined('APPLICATION')) die();
+
+$PluginInfo['VanillaImageResize'] = array(
+    'Description' => 'Resize large images to fit browser widths.',
+    'Version' => '1.0',
+    'Author' => 'Vanilla',
+    'AuthorEmail' => 'vanilla@vanillaforums.org',
+    'AuthorUrl' => 'http://vanillaforums.org'
+);
+
+class vanillaImageResizePlugin extends Gdn_Plugin
+{
+  public function Base_Render_Before(&$Sender)
+  {
+    $Sender->AddJsFile($this->GetResource('js/VanillaImageResize.js', FALSE, FALSE));
+  }
+
+  public function Setup()
+  {
+    // Intentionally left blank
+  }
+}
+

--- a/plugins/VanillaImageResize/js/VanillaImageResize.js
+++ b/plugins/VanillaImageResize/js/VanillaImageResize.js
@@ -1,0 +1,30 @@
+// Shrink large images to fit into message space, and pop into new window when clicked.
+// This needs to happen in onload because otherwise the image sizes are not yet known.
+jQuery(window).load(function() {
+
+   var toggler = function(t_img, t_width) {
+      if (t_img.css('width') == 'auto')
+         t_img.css('width',t_width);
+      else
+         t_img.css('width','auto');
+      return false;
+   }
+
+   jQuery('div.Message img').each(function(i,img) {
+      var img = jQuery(img);
+      var container = img.parents('div.Message');
+      if (img.width() > container.width()) {
+         var smwidth = container.width();
+
+         img.css('width', smwidth).css('cursor', 'pointer');
+         img.after('<div class="ImageResized">' + gdn.definition('ImageResized', 'This image has been resized to fit in the page. Click to enlarge.') + '</div>');
+
+         img.next().click(function() {
+            return toggler(img, smwidth);
+         });
+         img.click(function() {
+            return toggler(img, smwidth);
+         })
+      }
+   });
+});


### PR DESCRIPTION
Just as stated, since I prefer using my ImageResizer plugin with its different interface and more functionality I got tired of having to remove the vanillas resize code that was added long after my plugin was released every upgrade.
This moves vanillas built in code from global.js into a plugin of its own which is easily disabled.
