### PR TITLE
Unified the tabs' count-box rendering on Discussions and Profile pages.

### DIFF
--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -98,21 +98,16 @@ function WriteFilterTabs($Sender) {
    $CountBookmarks = 0;
    $CountDiscussions = 0;
    $CountDrafts = 0;
+   
    if ($Session->IsValid()) {
       $CountBookmarks = $Session->User->CountBookmarks;
       $CountDiscussions = $Session->User->CountDiscussions;
       $CountDrafts = $Session->User->CountDrafts;
    }
-   if ($CountBookmarks === NULL) {
-      $Bookmarked .= '<span class="Popin" rel="'.Url('/discussions/UserBookmarkCount').'">-</span>';
-   } elseif (is_numeric($CountBookmarks) && $CountBookmarks > 0)
-      $Bookmarked .= '<span>'.$CountBookmarks.'</span>';
-
-   if (is_numeric($CountDiscussions) && $CountDiscussions > 0)
-      $MyDiscussions .= '<span>'.$CountDiscussions.'</span>';
-
-   if (is_numeric($CountDrafts) && $CountDrafts > 0)
-      $MyDrafts .= '<span>'.$CountDrafts.'</span>';
+   
+   $Bookmarked .= CountString($CountBookmarks, Url('/discussions/UserBookmarkCount'));
+   $MyDiscussions .= CountString($CountDiscussions);
+   $MyDrafts .= CountString($CountDrafts);
       
    ?>
 <div class="Tabs DiscussionsTabs">


### PR DESCRIPTION
Updated the tab rendering of **/discussions/index** to use the same function for count-string rendering as the one used on the user's profile page (Discussions and Comments tabs rendered by _/vanilla/settings/class.hooks.php_). This will allow to a plugin to make the tab count visibility optional by defining a custom **CountString** function (the current one is defined in _/library/core/functions.render.php_). Currently there's no way to disable the visibility of the tabs' count boxes on the **/discussions/index** page.
