### PR TITLE
Bugfix: GetTags() is not working when a parameter is specified.

### DIFF
--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -220,7 +220,7 @@ if (!class_exists('HeadModule', FALSE)) {
          // Loop through each tag.
          $Tags = array();
          foreach ($this->_Tags as $Index => $Attributes) {
-            $Tag = $Attributes[self::TAG_KEY];
+            $TagType = $Attributes[self::TAG_KEY];
             if ($TagType == $RequestedType)
                $Tags[] = $Attributes;
          }


### PR DESCRIPTION
A fix for the following use case that wasn't working: **GetTags('script')**.
