### PR TITLE
Bugfix: ClearTag() does not work when all 3 parameters are specified.

### DIFF
--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -185,7 +185,7 @@ if (!class_exists('HeadModule', FALSE)) {
          if (is_array($Property))
             $Query = array_change_key_case($Property);
          elseif ($Property)
-            $Query = array(strtolower($Property), $Value);
+            $Query = array(strtolower($Property) => $Value);
          else
             $Query = FALSE;
    


### PR DESCRIPTION
A fix for the following use case that wasn't working: **ClearTag('link', 'rel', 'stylesheet')**.
