### PR TITLE
Update library/core/functions.general.php

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -616,7 +616,7 @@ if (!function_exists('Debug')) {
       
       $Debug = $Value;
       if ($Debug)
-         error_reporting(E_ALL);
+         error_reporting(E_ALL ^E_STRICT);
       else
          error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);
    }


### PR DESCRIPTION
E_ALL includes E_STRICT starting from PHP 5.4 (http://php.net/manual/en/function.error-reporting.php).
Current behaviour prevents Vanilla from running on 5.4, and causes confusion due to error_reporting settings being over-written.
