### PR TITLE
Bugfix: Allow proper paths when VanillaForums run on a port != 80

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -96,9 +96,6 @@ class Gdn_Request {
                $Value = !is_null($Value) ? trim($Value, '/') : $Value;
                break;
             case 'HOST':
-               $HostParts = explode(':', $Value);
-               $Value = array_shift($HostParts);
-               break;
             case 'SCHEME':
             case 'METHOD':
             case 'FOLDER':


### PR DESCRIPTION
Exploding HOST (localhost:9090 => [localhost, 9090]) and then cutting out the port results in incorrect paths when running Vanilla Forums locally on any post other than 80.

This can be seen in some (but not all) of the requests, such as logout (goes to localhost) and when using the Facebook plugin (redirect URI becomes localhost which results in Facebook rejecting it for security reasons).

Git blame says that tburry added the lines specifically exploding HOST and discarding the port number, so it'd be best to get his feedback before merging in case this was done for a specific reason and may result in unintended results.

This issue has been discussed at http://vanillaforums.org/discussion/20149/troubles-installing-the-master-branch-of-the-vanillaforums previously.
