### PR TITLE
Extend Facebook plugin to store access token & allow different scopes

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -233,7 +233,8 @@ class FacebookPlugin extends Gdn_Plugin {
       
       // Save some original data in the attributes of the connection for later API calls.
       $Attributes = array(
-          'Facebook.Profile' => $Profile
+          'Facebook.Profile' => $Profile,
+          'Facebook.Token' => $AccessToken
       );
       $Form->SetFormValue('Attributes', $Attributes);
       
@@ -255,13 +256,15 @@ class FacebookPlugin extends Gdn_Plugin {
 
    public function AuthorizeUri($Query = FALSE) {
       $AppID = C('Plugins.Facebook.ApplicationID');
+      $FBScope = C('Plugins.Facebook.Scope', Array('email','publish_stream'));
 
       $RedirectUri = $this->RedirectUri();
       if ($Query)
          $RedirectUri .= '&'.$Query;
       $RedirectUri = urlencode($RedirectUri);
 
-      $SigninHref = "https://graph.facebook.com/oauth/authorize?client_id=$AppID&redirect_uri=$RedirectUri&scope=email,publish_stream";
+      $Scopes = implode(',', $FBScope);
+      $SigninHref = "https://graph.facebook.com/oauth/authorize?client_id=$AppID&redirect_uri=$RedirectUri&scope=$Scopes";
       if ($Query)
          $SigninHref .= '&'.$Query;
       return $SigninHref;


### PR DESCRIPTION
This patch extends the Facebook plugin to:
- Store the Facebook token as a user attribute (useful for if the user logs in via user/pass or if a plugin wants to access the Facebook API whilst the user is offline)
- Allow configuration of the Facebook scopes requested via config.php

All these changes are backwards compatible, have been tested and will allow for improved Facebook interaction for both Vanilla Forums and Vanilla Forum plugins. Both these changes are necessary if any new Vanilla Forum plugins want to take advantage of Facebook fully.
