### PR TITLE
HeadModule->GetTags() doesn't work with a filter.

### DIFF
--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -220,7 +220,7 @@ if (!class_exists('HeadModule', FALSE)) {
          // Loop through each tag.
          $Tags = array();
          foreach ($this->_Tags as $Index => $Attributes) {
-            $Tag = $Attributes[self::TAG_KEY];
+            $TagType = $Attributes[self::TAG_KEY];
             if ($TagType == $RequestedType)
                $Tags[] = $Attributes;
          }


### PR DESCRIPTION
Because of a typo in the implementation no tags are returned when the function is called with a parameter.
