### PR TITLE
Add "token-input-focused" class to Tagging plugin

### DIFF
--- a/plugins/Tagging/js/jquery.tokeninput.vanilla.js
+++ b/plugins/Tagging/js/jquery.tokeninput.vanilla.js
@@ -64,6 +64,7 @@ var DEFAULT_CLASSES = {
     dropdownItem: "token-input-dropdown-item",
     dropdownItem2: "token-input-dropdown-item2",
     selectedDropdownItem: "token-input-selected-dropdown-item",
+    focused: "token-input-focused",
     inputToken: "token-input-input-token"
 };
 
@@ -203,10 +204,12 @@ $.TokenList = function (input, url_or_data, settings) {
             if (settings.tokenLimit === null || settings.tokenLimit !== token_count) {
                 show_dropdown_hint();
             }
+            token_list.addClass(settings.classes.focused);
         })
         .blur(function () {
             hide_dropdown();
             $(this).val("");
+            token_list.removeClass(settings.classes.focused);
         })
         .bind("keyup keydown blur update", resize_input)
         .keydown(function (event) {


### PR DESCRIPTION
Hi,

It seems that the Tagging plugin is missing at least one commit from the original `jquery-tokeninput` repository - a commit that adds the `token-input-focused` class to simulate the CSS focus property. Personally, I use this class in the VanillaBootstrap as it utilizes `jquery-tokeninput-bootstrap-theme` by @leonkenneth, who also came up with the idea for the `token-input-focused` class (https://github.com/loopj/jquery-tokeninput/pull/308).

//Kasper
