### PR TITLE
Update themes/EmbedFriendly/design/custom.css

### DIFF
--- a/themes/EmbedFriendly/design/custom.css
+++ b/themes/EmbedFriendly/design/custom.css
@@ -113,7 +113,6 @@
       overflow: visible;
       visibility: hidden;
       position: absolute;
-      left: 0;
       right: 2px; /* Don't know why this is adding some extra padding */
       width: auto;
       display: block;


### PR DESCRIPTION
left and right positioning on #Panel (>800px) is a CSS conflict. Removed left because I think that's how it is supposed to be - and fixes the problem ;)
