### PR TITLE
New Smarty plugin: {categories_link}

### DIFF
--- a/library/vendors/SmartyPlugins/function.categories_link.php
+++ b/library/vendors/SmartyPlugins/function.categories_link.php
@@ -1,0 +1,19 @@
+<?php if (!defined('APPLICATION')) exit();
+/*
+Copyright 2008, 2009 Vanilla Forums Inc.
+This file is part of Garden.
+Garden is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+Garden is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+You should have received a copy of the GNU General Public License along with Garden.  If not, see <http://www.gnu.org/licenses/>.
+Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
+*/
+
+
+/**
+ */
+function smarty_function_categories_link($Params, &$Smarty) {
+   $Wrap = GetValue('wrap', $Params, 'li');
+   return Gdn_Theme::Link('categories',
+      GetValue('text', $Params, T('Categories')),
+      GetValue('format', $Params, Wrap('<a href="%url" class="%class">%text</a>', $Wrap)));
+}


### PR DESCRIPTION
{category_link} is already present but links to the currently active category and not the category index.
