### PR TITLE
 Hash root user pass upon installation.

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -984,6 +984,11 @@ class UserModel extends Gdn_Model {
          $Fields = $this->Validation->SchemaValidationFields(); // Only fields that are present in the schema
          $Fields['UserID'] = 1;
          
+         // Encrypt the password for saving only if it won't be hashed in _Insert()
+         $PasswordHash = new Gdn_PasswordHash();
+         $Fields['Password'] = $PasswordHash->HashPassword($Fields['Password']);
+         $Fields['HashMethod'] = 'Vanilla';
+         
          if ($this->GetID($UserID) !== FALSE) {
             $this->SQL->Put($this->Name, $Fields);
          } else {


### PR DESCRIPTION
There's an oversight with Vanilla's installer where upon initial user creation, the password is stored in plaintext in the DB. This can only be corrected via changing the password. This changeset corrects this oversight as it can be easily overlooked.

Special thanks to Phillip Stephens (https://wiiking2.com/) for noting this behavior.
- Jon "gm112" Basniak
