### PR TITLE
Changed YouTube embed to use modern iframe format

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -81,12 +81,9 @@ jQuery(document).ready(function($) {
       var width = $preview.width(), height = $preview.height(), videoid = Container.attr('id').replace('youtube-', '');
 
       $preview.hide();
-      $player.html('<object width="'+width+'" height="'+height+'">'
-         + '<param name="movie" value="http://www.youtube.com/v/'+videoid+'&amp;hl=en_US&amp;fs=1&amp;autoplay=1"></param>'
-         + '<param name="allowFullScreen" value="true"></param>'
-         + '<param name="allowscriptaccess" value="always"></param>'
-         + '<embed src="http://www.youtube.com/v/'+videoid+'&amp;hl=en_US&amp;fs=1&amp;autoplay=1" type="application/x-shockwave-flash" allowscriptaccess="always" allowfullscreen="true" width="'+width+'" height="'+height+'"></embed>'
-         + '</object>');
+      $player.html('<iframe width="'+width+'" height="'+height+'" '
+         + 'src="https://www.youtube-nocookie.com/embed/'+videoid+'" '
+         + 'frameborder="0" allowfullscreen></iframe>');
       $player.show();
       
       return false;


### PR DESCRIPTION
The Vanilla forum is still using the old style of YouTube embedding that uses a Flash object. The new style uses an iframe. The new style is superior as it allows for use of HTML5 video. It also works on mobile devices where flash is not present.
