### PR TITLE
Change RSS Link from feed URL to application URL

### DIFF
--- a/applications/dashboard/views/rss.master
+++ b/applications/dashboard/views/rss.master
@@ -6,7 +6,7 @@
 	xmlns:atom="http://www.w3.org/2005/Atom">
 	<channel>
       <title><?php echo $this->Head->Title(); ?></title>
-      <link><?php echo htmlspecialchars(Url('', TRUE, TRUE)); ?></link>
+      <link><?php echo htmlspecialchars(Url('/', TRUE, TRUE)); ?></link>
       <pubDate><?php echo date('r'); ?></pubDate>
       <?php
          $this->RenderAsset('RssHead');


### PR DESCRIPTION
Following the link within an RSS Reader (Ex. Google Reader) leads straight back to the RSS feed. It'd be more useful to link to the application URL instead.

Tested with app at domain root, and when in a sub-directory, and works in both situations.
