### PR TITLE
2.0 branch - notifications bug fix

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -782,7 +782,7 @@ class CommentModel extends VanillaModel {
     */
    public function RecordAdvancedNotications($ActivityModel, $Discussion, $Comment, &$NotifiedUsers) {
       // Grab all of the users that need to be notified.
-      $Data = $this->SQL->GetWhere('UserMeta', array('Name' => 'Preferences.Email.NewDiscussion'))->ResultArray();
+      $Data = $this->SQL->GetWhere('UserMeta', array('Name' => 'Preferences.Email.NewComment'))->ResultArray();
       
       // Grab all of their follow/unfollow preferences.
       $UserIDs = ConsolidateArrayValuesByKey($Data, 'UserID');


### PR DESCRIPTION
With just the "Email me when someone starts a new discussion" preference checked, users were getting notified of every comment which was created. This change puts in place the correct behaviour. This has been fixed differently in the 2.1 branch, but since some new preferences were added, the code is a little complicated to back-port. 
