### PR TITLE
Fix Resized Images Not Popping Up in New Window When Clicked

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1228,7 +1228,7 @@ jQuery(window).load(function() {
       var container = img.closest('div.Message');
       if (img.naturalWidth() > container.width() && container.width() > 0) {
          img.after('<div class="ImageResized">' + gdn.definition('ImageResized', 'This image has been resized to fit in the page. Click to enlarge.') + '</div>');
-         img.wrap('<a href="'+$(img).attr('src')+'"></a>');
+         img.wrap('<a href="'+$(img).attr('src')+'" target="_blank"></a>');
       }
    });
    


### PR DESCRIPTION
Added `target="_blank"` to the img.wrap argument to make resized images pop up in a new window when clicked as the comment before onload says so.
