### PR TITLE
Only Use Garden.HomepageTitle if Controller is DefaultController

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -97,7 +97,8 @@ class DiscussionsController extends VanillaController {
       // Setup head.
       if (!$this->Data('Title')) {
          $Title = C('Garden.HomepageTitle');
-         if ($Title)
+         $DefaultControllerRoute = Gdn::Router()->GetRoute('DefaultController')['Destination'];
+         if ($Title && ($DefaultControllerRoute == 'discussions'))
             $this->Title($Title, '');
          else
             $this->Title(T('Recent Discussions'));


### PR DESCRIPTION
Something like can be implemented, so that other applications that have one of their own controllers set as DefaultController (or DefaultForumRoot) will have the homepage title. Discussions should only use the homepage title if it is the DefaultController.
