### PR TITLE
Update class.activitymodel.php

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1343,10 +1343,13 @@ class ActivityModel extends Gdn_Model {
       $Activity = array(
          'ActivityType' => 'WallPost',
          'ActivityUserID' => $WallPost['RegardingUserID'],
+         'Format' => $WallPost['Format'],
          'NotifyUserID' => $WallPost['ActivityUserID'],
          'RecordType' => 'Activity',
          'RecordID' => $WallPost['ActivityID'],
+         'RegardingUserID' => $WallPost['ActivityUserID'],
          'Route' => UserUrl($NotifyUser, ''),
+         'Story' => $WallPost['Story'],
          'HeadlineFormat' => T('HeadlineFormat.NotifyWallPost', '{ActivityUserID,User} posted on your <a href="{Url,url}">wall</a>.')
       );
       


### PR DESCRIPTION
Fixed NotifyWallPost which does not store Format, RegardingUserID and Story into table Activity when inserting second line for wallpost-activity. Result was a buggy notification list (/profile/notifications) where wrong avatar was shown and text was missing.
