### PR TITLE
Pass in Category Row by Reference to EventArguments

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -159,7 +159,7 @@ function WriteListItem($Row, $Depth = 1) {
             echo CategoryPhoto($Row);
             echo Anchor(htmlspecialchars($Row['Name']), $Row['Url'], 'Title');
          
-            Gdn::Controller()->EventArguments['Category'] = $Row;
+            Gdn::Controller()->EventArguments['Category'] = &$Row;
             Gdn::Controller()->FireEvent('AfterCategoryTitle'); 
             echo '</'.$H.'>';
          ?>
@@ -248,7 +248,7 @@ function WriteTableRow($Row, $Depth = 1) {
 
                echo "<{$H}>";
             echo Anchor(htmlspecialchars($Row['Name']), $Row['Url']);
-               Gdn::Controller()->EventArguments['Category'] = $Row;
+               Gdn::Controller()->EventArguments['Category'] = &$Row;
                Gdn::Controller()->FireEvent('AfterCategoryTitle'); 
                echo "</{$H}>";
             ?>


### PR DESCRIPTION
Pass in category row by reference to EventArguments so that it can be accessed by plugins hooking into the event.
