### PR TITLE
Remove user's comments in moderation queue on DeleteContent

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2560,7 +2560,10 @@ class UserModel extends Gdn_Model {
       
       // Remove activity comments.
       $this->GetDelete('ActivityComment', array('InsertUserID' => $UserID), $Content);
-      
+
+      // Remove comments in moderation queue
+      $this->GetDelete('Log', array('RecordUserID' => $UserID, 'Operation' => 'Pending'), $Content);
+
       // Clear out information on the user.
       $this->SetField($UserID, array(
           'About' => NULL,


### PR DESCRIPTION
Remove comments in moderation queue when deleting users. Should fix this issue: https://github.com/vanillaforums/Garden/issues/1681
