### PR TITLE
Fix comment notifications to respect Discussions.View permissions

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -933,14 +933,13 @@ class CommentModel extends VanillaModel {
             $ActivityModel->Queue($Activity, 'BookmarkComment', array('CheckRecord' => TRUE));
          }
 
-         // Record user-comment activity.
-         if ($Discussion != FALSE) {
+         // Check user can still see the discussion.
+         if (($Discussion != FALSE) && ($UserModel->GetCategoryViewPermission(GetValue('InsertUserID', $Discussion), $Discussion->CategoryID))) {
+            // Record user-comment activity.
             $Activity['NotifyUserID'] = GetValue('InsertUserID', $Discussion);
             $ActivityModel->Queue($Activity, 'DiscussionComment');
-			}
-         
-         // Record advanced notifications.
-         if ($Discussion !== FALSE) {
+            
+	    // Record advanced notifications 
             $this->RecordAdvancedNotications($ActivityModel, $Activity, $Discussion);
          }
          


### PR DESCRIPTION
Check for permissions before notifying users of new comments (e.g. if they've started a discussion in a category they're no longer allowed to see)
Related to https://github.com/vanillaforums/Garden/issues/1518

Also combined "Record user-comment activity" and "Record advanced notifications" in one if clause.
