### PR TITLE
Check permissions in NotifyNewDiscussion

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1589,6 +1589,10 @@ class DiscussionModel extends VanillaModel {
             continue;
          
          $UserID = $Row['UserID'];
+         // Check user can still see the discussion.
+         if (!Gdn::UserModel()->GetCategoryViewPermission($UserID, $Category['CategoryID']))
+            continue;
+            
          $Name = $Row['Name'];
          if (strpos($Name, '.Email.') !== FALSE) {
             $NotifyUsers[$UserID]['Emailed'] = ActivityModel::SENT_PENDING;


### PR DESCRIPTION
Check for permissions when notifying of new discussions
Partly fixing https://github.com/vanillaforums/Garden/issues/1518
