### PR TITLE
Check permissions in RecordAdvancedNotications

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1018,6 +1018,10 @@ class CommentModel extends VanillaModel {
             continue;
          
          $UserID = $Row['UserID'];
+         // Check user can still see the discussion.
+         if (!Gdn::UserModel()->GetCategoryViewPermission($UserID, $Category['CategoryID']))
+            continue;
+
          $Name = $Row['Name'];
          if (strpos($Name, '.Email.') !== FALSE) {
             $NotifyUsers[$UserID]['Emailed'] = ActivityModel::SENT_PENDING;


### PR DESCRIPTION
Check permissions when using advanced notifications
Partly fixing https://github.com/vanillaforums/Garden/issues/1518
