### PR TITLE
Do not force embed for popups.

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -94,7 +94,9 @@ class DashboardHooks implements Gdn_IPlugin {
             $Sender->AddDefinition('RemoteUrl', $RemoteUrl);
 
          // Force embedding?
-         if (!IsSearchEngine() && !IsMobile() && strtolower($Sender->ControllerName) != 'entry') {
+         $IsAPopup = (isset($_GET['display']) && $_GET['display'] == 'popup');
+
+         if (!IsSearchEngine() && !IsMobile() && strtolower($Sender->ControllerName) != 'entry' && !$IsAPopup) {
             $Sender->AddDefinition('ForceEmbedForum', C('Garden.Embed.ForceForum') ? '1' : '0');
             $Sender->AddDefinition('ForceEmbedDashboard', C('Garden.Embed.ForceDashboard') ? '1' : '0');
          }


### PR DESCRIPTION
Allow to display popup pages without causing a redirect to the form where they need to be embedded.

This will avoid loading headers/footers from the embedded site.

We noticed this with the OpenID login popup.
