### PR TITLE
Add BeforeAddonDisabled FireEvent

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -1032,6 +1032,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
          }
       }
 
+      $this->FireEvent('BeforeAddonDisabled');
       // 2. Perform necessary hook action
       $this->_PluginHook($PluginName, self::ACTION_DISABLE, TRUE);
 


### PR DESCRIPTION
Permits plugin authors to hook plugin disable process. e.g. in order to get feedback from admin if created data should be purged or kept.  
Could be useful for plugins that collect lot of custom data while usage
