### PR TITLE
fix IpAddress()

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -344,6 +344,7 @@ class Gdn_Request {
       $this->RequestHost(     isset($_SERVER['HTTP_X_FORWARDED_HOST']) ? GetValue('HTTP_X_FORWARDED_HOST',$_SERVER) : (isset($_SERVER['HTTP_HOST']) ? GetValue('HTTP_HOST',$_SERVER) : GetValue('SERVER_NAME',$_SERVER)));
       $this->RequestMethod(   isset($_SERVER['REQUEST_METHOD']) ? GetValue('REQUEST_METHOD',$_SERVER) : 'CONSOLE');
       
+      $this->WithArgs(Gdn_Request::INPUT_SERVER);
       // Request IP
       
       // Loadbalancers


### PR DESCRIPTION
https://github.com/vanillaforums/Garden/blob/master/library/core/class.request.php#L350-L357
you call `GetValueFrom` function to get some server variable, and `GetValueFrom` lookup values form `$this->_RequestArguments`, but `$this->_RequestArguments` is initialized by `$this->WithArgs(Gdn_Request::INPUT_SERVER)` or `FromEnvironment()` . So you has to call `$this->WithArgs(Gdn_Request::INPUT_SERVER)` before here. Or the IpAddress() may return '0.0.0.1' ;
