### PR TITLE
Add HTTP proxy support

### DIFF
--- a/applications/dashboard/controllers/class.utilitycontroller.php
+++ b/applications/dashboard/controllers/class.utilitycontroller.php
@@ -469,7 +469,7 @@ class UtilityController extends DashboardController {
       $this->Render('Blank');
    }
 	
-	/**
+   /**
     * Grab a feed from the mothership.
     *
     * @since 2.0.?
@@ -478,12 +478,15 @@ class UtilityController extends DashboardController {
     * @param int $Length Number of items to get.
     * @param string $FeedFormat How we want it (valid formats are 'normal' or 'sexy'. OK, not really).
     */
-	public function GetFeed($Type = 'news', $Length = 5, $FeedFormat = 'normal') {
-		echo file_get_contents('http://vanillaforums.org/vforg/home/getfeed/'.$Type.'/'.$Length.'/'.$FeedFormat.'/?DeliveryType=VIEW');
-		$this->DeliveryType(DELIVERY_TYPE_NONE);
+   public function GetFeed($Type = 'news', $Length = 5, $FeedFormat = 'normal') {
+      // Set proxy if needed
+      $context = GetStreamContextForHttpProxy();
+	  
+      echo file_get_contents('http://vanillaforums.org/vforg/home/getfeed/'.$Type.'/'.$Length.'/'.$FeedFormat.'/?DeliveryType=VIEW', false, $context);
+      $this->DeliveryType(DELIVERY_TYPE_NONE);
       $this->Render();
-	}
-   
+   }
+
    /** 
     * Return some meta information about any page on the internet in JSON format.
     */

--- a/applications/dashboard/views/settings/helper_functions.php
+++ b/applications/dashboard/views/settings/helper_functions.php
@@ -69,6 +69,9 @@ function GetTutorials($TutorialCode = '') {
       $Tutorials[$i]['LargeThumbnail'] = $LargeThumbnail;
    }
    
+   // Set proxy if needed
+   $context = GetStreamContextForHttpProxy();
+
    if ($TutorialCode != '') {
       $Keys = ConsolidateArrayValuesByKey($Tutorials, 'Code');
       $Index = array_search($TutorialCode, $Keys);
@@ -79,7 +82,7 @@ function GetTutorials($TutorialCode = '') {
       $Tutorial = GetValue($Index, $Tutorials);
       $VideoID = GetValue('VideoID', $Tutorial);
       try {
-         $Vimeo = unserialize(file_get_contents("http://vimeo.com/api/v2/video/".$Tutorial['VideoID'].".php"));
+         $Vimeo = unserialize(file_get_contents("http://vimeo.com/api/v2/video/".$Tutorial['VideoID'].".php", false, $context));
          $Tutorial['Thumbnail'] = GetValue('thumbnail_medium', GetValue('0', $Vimeo));
          $Tutorial['LargeThumbnail'] = GetValue('thumbnail_large', GetValue('0', $Vimeo));
       } catch (Exception $Ex) {
@@ -90,7 +93,7 @@ function GetTutorials($TutorialCode = '') {
       // Loop through each tutorial populating the thumbnail image location
       try {
          foreach ($Tutorials as $Key => $Tutorial) {
-            $Vimeo = unserialize(file_get_contents("http://vimeo.com/api/v2/video/".$Tutorial['VideoID'].".php"));
+            $Vimeo = unserialize(file_get_contents("http://vimeo.com/api/v2/video/".$Tutorial['VideoID'].".php", false, $context));
             $Tutorials[$Key]['Thumbnail'] = GetValue('thumbnail_medium', GetValue('0', $Vimeo));
             $Tutorials[$Key]['LargeThumbnail'] = GetValue('thumbnail_large', GetValue('0', $Vimeo));
          }

--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -147,3 +147,9 @@ $Configuration['Routes']['DefaultForumRoot'] = 'discussions';
 $Configuration['Routes']['Default404'] = array('dashboard/home/filenotfound', 'NotFound');
 $Configuration['Routes']['DefaultPermission'] = array('dashboard/home/permission', 'NotAuthorized');
 $Configuration['Routes']['UpdateMode'] = 'dashboard/home/updatemode';
+
+// Optional HTTP proxy
+$Configuration['Proxy']['Hostname'] = null;
+$configuration['Proxy']['Port'] = '3128';
+$Configuration['Proxy']['Login'] = NULL;
+$Configuration['Proxy']['Password'] = NULL;

--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -38,7 +38,7 @@ class ProxyRequest {
    public $ActionLog;
    
    protected $Options;
-   
+
    /**
     * Set up ProxyRequest
     * 
@@ -362,7 +362,7 @@ class ProxyRequest {
       // We need cURL
       if (!function_exists('curl_init'))
          throw new Exception('Encountered an error while making a request to the remote server: Your PHP configuration does not allow cURL requests.');
-      
+
       $Handler = curl_init();
       curl_setopt($Handler, CURLOPT_HEADER, FALSE);
       curl_setopt($Handler, CURLINFO_HEADER_OUT, TRUE);
@@ -467,6 +467,9 @@ class ProxyRequest {
       curl_setopt($Handler, CURLOPT_URL, $Url);
       curl_setopt($Handler, CURLOPT_PORT, $Port);
       
+      // Set proxy if any
+      SetCurlOptionsForHttpProxy($Handler);
+
       $this->CurlReceive($Handler);
 
       if ($Simulate) return NULL;

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -81,6 +81,9 @@ class FacebookPlugin extends Gdn_Plugin {
          Trace("  GET  $Url");
       }
 
+      // Set proxy if needed
+      SetCurlOptionsForHttpProxy($ch);
+
       $Response = curl_exec($ch);
 
       $HttpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -505,6 +508,8 @@ class FacebookPlugin extends Gdn_Plugin {
       curl_setopt($C, CURLOPT_RETURNTRANSFER, TRUE);
       curl_setopt($C, CURLOPT_SSL_VERIFYPEER, FALSE);
       curl_setopt($C, CURLOPT_URL, $Url);
+      // Set proxy if needed
+      SetCurlOptionsForHttpProxy($C);
       $Contents = curl_exec($C);
 
       $Info = curl_getinfo($C);
@@ -520,7 +525,7 @@ class FacebookPlugin extends Gdn_Plugin {
 
       $AccessToken = GetValue('access_token', $Tokens);
 //      $Expires = GetValue('expires', $Tokens, NULL);
-      
+
       return $AccessToken;
    }
 
@@ -530,9 +535,10 @@ class FacebookPlugin extends Gdn_Plugin {
 //      curl_setopt($C, CURLOPT_RETURNTRANSFER, TRUE);
 //      curl_setopt($C, CURLOPT_SSL_VERIFYPEER, FALSE);
 //      curl_setopt($C, CURLOPT_URL, $Url);
+//      SetCurlOptionsForHttpProxy($C);
 //      $Contents = curl_exec($C);
 //      $Contents = ProxyRequest($Url);
-      $Contents = file_get_contents($Url);
+      $Contents = file_get_contents($Url, false, GetStreamContextForHttpProxy());
       $Profile = json_decode($Contents, TRUE);
       return $Profile;
    }

--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -706,6 +706,8 @@ class TwitterPlugin extends Gdn_Plugin {
          default:
             curl_setopt($C, CURLOPT_URL, $Request->to_url());
       }
+      // Set proxy if needed
+      SetCurlOptionsForHttpProxy($C);
       return $C;
    }
 


### PR DESCRIPTION
Hi,
Several features of Vanilla do not work if the server is behind an HTTP proxy server. Could you please review this patch which adds the support of an HTTP proxy (with or without cURL). It mainly adds functions in library/core/functions.general.php (is it the right place?) and the following configuration variables:

  $Configuration['Proxy']['Hostname'] = NULL;
  $configuration['Proxy']['Port'] = '3128';
  $Configuration['Proxy']['Login'] = NULL;
  $Configuration['Proxy']['Password'] = NULL;

Other third party plugins not contained in Vanilla core could then use these methods (eg: SocialLogin).

I have made the following tests using Squid. 

Facebook Social Connect = login with facebook whereas a local account exists with the same email
Twitter Social Connect = login with twitter whereas a local account exists with the same email
Google Sign = login with google whereas a local account exists with the same email
OpenID plugin = login with google url whereas a local account exists with the same email

Without proxy and with php-curl extension: 
- Statistics in dashboard: ok
- News feeds in dashboard: ok
- Recaptcha: ok
- Facebook Social Connect: ok
- Twitter Social Connect: ok
- Google Sign In plugin: ok
- OpenID plugin: ok

Without proxy and without php-curl extension:
- Statistics in dashboard: ko (curl is required in library/core/class.proxyrequest.php)
- News feeds in dashboard: ok
- Recaptcha: ok
- Facebook Social Connect: ko (curl is required in plugins/Facebook/class.facebook.plugin.php)
- Twitter Social Connect: ko (curl is required in plugins/Twitter/class.twitter.plugin.php)
- Google Sign In plugin: ok
- OpenID plugin: ok

With proxy and with php-curl extension:
- Statistics in dashboard: ok
- News feeds in dashboard: ok
- Recaptcha: ok
- Facebook Social Connect: ok
- Twitter Social Connect: ok
- Google Sign In plugin: ok
- OpenID plugin: ok

With proxy and without php-curl extension:
- Statistics in dashboard: ko (curl is required in library/core/class.proxyrequest.php)
- News feeds in dashboard: ok
- Recaptcha: ok
- Facebook Social Connect: ko (curl is required in plugins/Facebook/class.facebook.plugin.php)
- Twitter Social Connect: ko (curl is required in plugins/Twitter/class.twitter.plugin.php)
- Google Sign In plugin: ok
- OpenID plugin: ok

With proxy which requires authentication and with php-curl extension:
- Statistics in dashboard: ok
- News feeds in dashboard: ok
- Recaptcha: ok
- Facebook Social Connect: ok
- Twitter Social Connect: ok
- Google Sign In plugin: ok
- OpenID plugin: ok

With proxy which requires authentication and without php-curl extension:
- Statistics in dashboard: ko (curl is required in library/core/class.proxyrequest.php)
- News feeds in dashboard: ok
- Recaptcha: ok
- Facebook Social Connect: ko (curl is required in plugins/Facebook/class.facebook.plugin.php)
- Twitter Social Connect: ko (curl is required in plugins/Twitter/class.twitter.plugin.php)
- Google Sign In plugin: ok
- OpenID plugin: ok

Thanks,
Mathieu