### PR TITLE
Include Prefix in RenameColumn Method

### DIFF
--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -106,7 +106,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
       // Rename the column
       // The syntax for renaming a column is:
       // ALTER TABLE tablename CHANGE COLUMN oldname newname originaldefinition;
-      if (!$this->Query('alter table `'.$this->_TableName.'` change column `'.$OldName.'` `'.$NewName.'` '.$this->_DefineColumn($OldColumn)))
+      if (!$this->Query('alter table `'.$OldPrefix.$this->_TableName.'` change column `'.$OldName.'` `'.$NewName.'` '.$this->_DefineColumn($OldColumn)))
          throw new Exception(sprintf(T('Failed to rename table `%1$s` to `%2$s`.'), $OldName, $NewName));
 
       return TRUE;


### PR DESCRIPTION
Fixes the error: `table does not exist` due to the prefix being missing from the SQL command.

The call to reproduce this error is: `RenameColumn('OldColumnName', 'NewColumnName');`
