### PR TITLE
Embedvanilla onhashchange workaround for buggy Internet Explorer IE7 document mode

### DIFF
--- a/plugins/embedvanilla/remote.js
+++ b/plugins/embedvanilla/remote.js
@@ -90,7 +90,7 @@ window.vanilla.embed = function(host) {
 
    if (!window.gadgets) {
       if (!disablePath) {
-         if ("onhashchange" in window) {
+         if ("onhashchange" in window && !(document.documentMode < 8)) {
             if (window.addEventListener)
                window.addEventListener("hashchange", checkHash, false);
             else


### PR DESCRIPTION
When Vanilla is embedded in a site where IE8 runs in IE7 compatibility mode, IE8 incorrectly reports that onhashchange is available when in fact the event is never fired.
