### PR TITLE
Reset tag cloud list style and padding

### DIFF
--- a/plugins/Tagging/design/tag.css
+++ b/plugins/Tagging/design/tag.css
@@ -11,6 +11,10 @@
 .MessageList .Meta.InlineTags {
    min-height: 0;
 }
+.TagCloud {
+   padding: 0;
+   list-style: none;
+}
 .TagCloud li {
    display: inline-block;
    background: #F7F7F7;


### PR DESCRIPTION
Future themes should not (and mine already don't) pollute the global scope with `<ul>` and `<ol>` resets. Both for semantic reasons, but also because we need to reconsider our use of lists.
