### PR TITLE
CLEditor: Background color fix

### DIFF
--- a/plugins/cleditor/design/cleditor.css
+++ b/plugins/cleditor/design/cleditor.css
@@ -19,3 +19,7 @@ blockquote.Quote, blockQuote.UserQuote {
 .Spoiler {
    background: #ff0;
 }
+
+.cleditorGroup {
+   background: #ffffff;
+}


### PR DESCRIPTION
Changed background default to white so it doesn't clash with dark backgrounds
