### PR TITLE
Edit function decho

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -600,7 +600,7 @@ if (!function_exists('decho')) {
    function decho($Mixed, $Prefix = 'DEBUG', $Permission = FALSE) {
       $Prefix = StringEndsWith($Prefix, ': ', TRUE, TRUE).': ';
       
-      if (!$Permission || Gdn::Session()->CheckPermission('Garden.Debug.Allow')) {
+      if ($Permission || Gdn::Session()->CheckPermission('Garden.Debug.Allow')) {
          echo '<pre style="text-align: left; padding: 0 4px;">'.$Prefix;
          if (is_string($Mixed))
             echo $Mixed;


### PR DESCRIPTION
In 2.1 $Permission was added to decho but the way it was implemented made it default to always show $Mixed, unless $Permission = TRUE was given as an argument. Changed that so that output of decho is now not visible by default again.
