### PR TITLE
Use the key as a property rather than and index

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -571,15 +571,15 @@ if (!function_exists('ConsolidateArrayValuesByKey')) {
       $Return = array();
       foreach ($Array as $Index => $AssociativeArray) {
 
-			if (is_object($AssociativeArray)) {
-				if($ValueKey === '') {
-					$Return[] = $AssociativeArray->$Key;
-				} elseif(property_exists($AssociativeArray, $ValueKey)) {
-					$Return[$AssociativeArray[$Key]] = $AssociativeArray->$ValueKey;
-				} else {
-					$Return[$AssociativeArray->$Key] = $DefaultValue;
-				}
-			} elseif (is_array($AssociativeArray) && array_key_exists($Key, $AssociativeArray)) {
+		if (is_object($AssociativeArray)) {
+			if($ValueKey === '') {
+				$Return[] = $AssociativeArray->$Key;
+			} elseif(property_exists($AssociativeArray, $ValueKey)) {
+				$Return[$AssociativeArray->$Key] = $AssociativeArray->$ValueKey;
+			} else {
+				$Return[$AssociativeArray->$Key] = $DefaultValue;
+			}
+		} elseif (is_array($AssociativeArray) && array_key_exists($Key, $AssociativeArray)) {
             if($ValueKey === '') {
                $Return[] = $AssociativeArray[$Key];
             } elseif (array_key_exists($ValueKey, $AssociativeArray)) {


### PR DESCRIPTION
ConsolidateArrayValuesByKey() currently checks the object for a $ValueKey property then tries to access the $Key as an index on the object. This fails.

Use the $Key property of the object as an index instead for intended behavior.

I searched the code base for uses of this function with at least 3 parameters and found 6 occurrences. Everyone of those occurrences passes an array rather than an object, so this may be a currently unused code path.

The type of data I was trying to consolidate was in the form:

```
Array
(
    [0] => stdClass Object
        (
            [ActionID] => 5
            [Name] => Promote
            [Description] => This post deserves to be featured on the best of page!
            [Tooltip] => Click me if this content should be featured.
            [CssClass] => ReactPointUp
            [AwardValue] => 5
            [Permission] => Garden.Curation.Manage
            [Sort] => 0
        )
    [1] => stdClass Object
        (
            [ActionID] => 1
            [Name] => Awesome
            [Description] => I approve!
            [Tooltip] => This indicates casual approval
            [CssClass] => ReactHeart
            [AwardValue] => 1
            [Permission] => Yaga.Reactions.Add
            [Sort] => 1
        )
    [2] => stdClass Object
        (
            [ActionID] => 6
            [Name] => WTF
            [Description] => What just happened?
            [Tooltip] => Click me if you don't know what is going on.
            [CssClass] => ReactShocked2
            [AwardValue] => 1
            [Permission] => Yaga.Reactions.Add
            [Sort] => 2
        )
    [3] => stdClass Object
        (
            [ActionID] => 4
            [Name] => Insightful
            [Description] => This is insightful!
            [Tooltip] => Click me if this post made you think in a new way
            [CssClass] => ReactEye2
            [AwardValue] => 1
            [Permission] => Yaga.Reactions.Add
            [Sort] => 3
        )
    [4] => stdClass Object
        (
            [ActionID] => 3
            [Name] => HEH
            [Description] => This indicates you are funny.
            [Tooltip] => That is funny!
            [CssClass] => ReactWink
            [AwardValue] => 1
            [Permission] => Yaga.Reactions.Add
            [Sort] => 4
        )
    [5] => stdClass Object
        (
            [ActionID] => 2
            [Name] => Meh
            [Description] => I disapprove!
            [Tooltip] => This indicates casual disapproval
            [CssClass] => ReactNeutral
            [AwardValue] => 0
            [Permission] => Yaga.Reactions.Add
            [Sort] => 5
        )
)
```

With my call being `ConsolidateArrayValuesByKey($Actions, 'ActionID', 'Name');`. This threw the following error before the proposed patch:

`Fatal error: Cannot use object of type stdClass as array in /www/vanilla21/library/core/functions.general.php`
