### PR TITLE
Fix for GetUnread to include unread discussions without comments

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -383,6 +383,7 @@ class DiscussionModel extends VanillaModel {
       $this->DiscussionSummaryQuery($AdditionalFields, FALSE);
          
       if ($UserID > 0) {
+         $Perms = self::CategoryPermissions();
          $this->SQL
             ->Select('w.UserID', '', 'WatchUserID')
             ->Select('w.DateLastViewed, w.Dismissed, w.Bookmarked')
@@ -393,7 +394,14 @@ class DiscussionModel extends VanillaModel {
             //->OrWhere('d.DateLastComment >', 'w.DateLastViewed')
             //->EndWhereGroup()
             ->Where('d.CountComments >', 'COALESCE(w.CountComments, 0)', TRUE, FALSE)
-            ->OrWhere('w.DateLastViewed', NULL);
+            ->OrOp()     
+            ->BeginWhereGroup()     
+            ->Where('w.DateLastViewed', NULL);
+         if($Perms !== TRUE) {
+            $this->SQL->WhereIn('d.CategoryID', $Perms);
+         }
+         $this->SQL
+            ->EndWhereGroup();
       } else {
 			$this->SQL
 				->Select('0', '', 'WatchUserID')


### PR DESCRIPTION
GetUnread didn't show unread discussions without comments. [First fix](https://github.com/vanillaforums/vanilla/commit/1ab28953605778e1479ba9e518b10e367319d648) didn't respect permissions - thanks @peregrine-web for raising that [issue](https://github.com/vanillaforums/vanilla/issues/1871)   
   
This fix includes unread discussions without comments and adds a permission check to the function