### PR TITLE
There is an issue with parse_ini_file which for some reason change the t...

### DIFF
--- a/library/core/class.autoloader.php
+++ b/library/core/class.autoloader.php
@@ -893,6 +893,18 @@ class Gdn_Autoloader_Map {
    public function MapType() {
       return $this->MapInfo['maptype']; //GetValue('maptype', $this->MapInfo);
    }
+   
+    /**
+    * Try to fix path that has backslash in Windows OS
+    *
+    * @path string 
+    * @return string
+    *
+    * Check to see if the path is not empty and if it is not in a form of drive: then replace any "\" with "/" to avoid 
+    * the parse_fn_file bug and it also further check to see if it has only one "/" and the OS is "WIN" then it will prepend "/" 
+    * in front of the path so it has the correct file path.
+    *  
+    */
     function fixBackSlash($path) {
         if (!empty($path) and !preg_match('/[A-Za-z]\:/',$path)) {
             $path = str_replace("\\", "/", $path);  // convert to / to avoid parse_in_file create array with missing \
@@ -901,7 +913,8 @@ class Gdn_Autoloader_Map {
             }
         }
         return $path;
-    }    
+    } 
+    
    public function Shutdown() {
       
       if (!GetValue('dirty', $this->MapInfo)) return FALSE;

--- a/library/core/class.autoloader.php
+++ b/library/core/class.autoloader.php
@@ -893,7 +893,15 @@ class Gdn_Autoloader_Map {
    public function MapType() {
       return $this->MapInfo['maptype']; //GetValue('maptype', $this->MapInfo);
    }
-   
+    function fixBackSlash($path) {
+        if (!empty($path) and !preg_match('/[A-Za-z]\:/',$path)) {
+            $path = str_replace("\\", "/", $path);  // convert to / to avoid parse_in_file create array with missing \
+            if (preg_match('/^\/{1}\w/',$path)==TRUE and (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN')) { // for some reason there is only 1 / then add / to have a valid network path
+                $path = "/" . $path;
+            }
+        }
+        return $path;
+    }    
    public function Shutdown() {
       
       if (!GetValue('dirty', $this->MapInfo)) return FALSE;
@@ -909,6 +917,7 @@ class Gdn_Autoloader_Map {
       foreach ($this->Map as $SplitTopic => $TopicFiles) {
          $MapContents .= "[{$SplitTopic}]\n";
          foreach ($TopicFiles as $ClassName => $Location)
+          $Location = $this->fixBackSlash($Location);               
             $MapContents .= "{$ClassName} = \"{$Location}\"\n";
       }
       

--- a/library/core/class.librarymap.php
+++ b/library/core/class.librarymap.php
@@ -252,6 +252,7 @@ class Gdn_LibraryMap {
             }
          }
          try {
+            $CacheContents = str_replace("\\", "/", $CacheContents);  // fix \\ to / to get around parse_ini_file issue that drop off \ when load network file    
             Gdn_FileSystem::SaveFile(PATH_CACHE.DS.$FileName, $CacheContents, LOCK_EX);
          }
          catch (Exception $e) {}


### PR DESCRIPTION
There is an issue with parse_ini_file which for some reason change the two \ into one \ in the cache ini file when Vanilla is running from a Windows network share.

For example: (two backslashes)
gdn = "\\networkshare\folder\Garden/library/core/class.gdn.php"

Will become: (one backslash)
gdn = "\networkshare\folder\Garden/library/core/class.gdn.php"

This fix will produce (forward slash)
gdn = "//networkshare/folder/Garden/library/core/class.gdn.php"

This fix will enable Vanilla to run on a Windows network share where without it, Vanilla will hit a "bonk" screen.
