### PR TITLE
Add dba/counts handler to the core tagging plugin

### DIFF
--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -610,6 +610,18 @@ class TaggingPlugin extends Gdn_Plugin {
    }
 
    /**
+    * Add update routines to the DBA controller
+    *
+    * @param DbaController $Sender
+    */
+   public function DbaController_CountJobs_Handler($Sender) {
+      $Name = 'Recalculate Tag.CountDiscussions';
+      $Url = "/dba/counts.json?" . http_build_query(array('table' => 'Tag', 'column' => 'CountDiscussions'));
+
+      $Sender->Data['Jobs'][$Name] = $Url;
+   }
+  
+   /**
     * Setup is called when the plugin is enabled.
     */
    public function Setup() {

--- a/plugins/Tagging/class.tagmodel.php
+++ b/plugins/Tagging/class.tagmodel.php
@@ -70,6 +70,27 @@ class TagModel extends Gdn_Model {
          }
       }
    }
+   
+   public function Counts($Column, $UserID = NULL) {
+      $Px = $this->Database->DatabasePrefix;
+      // Delete all the orphaned tagdiscussion records
+      $Sql = 'delete td.* ' .
+             "from {$Px}TagDiscussion as td " .
+             "left join {$Px}Discussion as d ON td.DiscussionID = d.DiscussionID " .
+             'where d.DiscussionID is null';
+
+      $this->Database->Query($Sql);
+
+      $Result = array('Complete' => TRUE);
+      switch($Column) {
+      case 'CountDiscussions':
+         Gdn::Database()->Query(DBAModel::GetCountSQL('count', 'Tag', 'TagDiscussion', 'CountDiscussions', 'DiscussionID', 'TagID', 'TagID'));
+         break;
+      default:
+         throw new Gdn_UserException("Unknown column $Column");
+      }
+      return $Result;
+   }
 
    public static function ValidateTag($Tag) {
       // Tags can't contain commas.


### PR DESCRIPTION
Closes #1896.

When deleting spammers, I found my tag counts would be messed up if they
used any tags. This fixes that.
