### PR TITLE
Prevent manipulation of field Form when posting discussion/comments

### DIFF
--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -336,7 +336,7 @@ class Gdn_Model extends Gdn_Pluggable {
     */
    public function FilterForm($Data) {
       $Data = array_diff_key($Data, array('Attributes' => 0, 'DateInserted' => 0, 'InsertUserID' => 0, 'InsertIPAddress' => 0,
-            'DateUpdated' => 0, 'UpdateUserID' => 0, 'UpdateIPAddress' => 0));
+            'DateUpdated' => 0, 'UpdateUserID' => 0, 'UpdateIPAddress' => 0, 'Format' => 0));
       return $Data;
    }
 


### PR DESCRIPTION
Add 'Format' to the fields that are filtered out from POST data.   

By now it is possible to spoof the post data to set Format to whatever you like. So malicious users can override Garden.InputFormatter settings on individual basis. Although I think that this is no big issues, users shouldn't be able to add arbitrary text to columns where they shouldn't be able to insert _anything_ on their own
