### PR TITLE
Ensure right-floated counts appear before label.

### DIFF
--- a/applications/vanilla/views/modules/categories.php
+++ b/applications/vanilla/views/modules/categories.php
@@ -12,7 +12,7 @@ if ($this->Data !== FALSE) {
    <ul class="PanelInfo PanelCategories">
    <?php
    echo '<li'.($OnCategories ? ' class="Active"' : '').'>'.
-      Anchor('<span class="Aside"><span class="Count">'.BigPlural($CountDiscussions, '%s discussion').'</span></span>'.T('All Categories'), '/categories', 'ItemLink')
+      Anchor('<span class="Aside"><span class="Count">'.BigPlural($CountDiscussions, '%s discussion').'</span></span> '.T('All Categories'), '/categories', 'ItemLink')
       .'</li>';
 
    $MaxDepth = C('Vanilla.Categories.MaxDisplayDepth');
@@ -32,9 +32,9 @@ if ($this->Data !== FALSE) {
       $CountText = '<span class="Aside"><span class="Count">'.BigPlural($Category->CountAllDiscussions, '%s discussion').'</span></span>';
 
       if ($DoHeadings && $Category->Depth == 1) {
-         echo $CountText.htmlspecialchars($Category->Name);
+         echo $CountText.' '.htmlspecialchars($Category->Name);
       } else {
-         echo Anchor($CountText.htmlspecialchars($Category->Name), CategoryUrl($Category), 'ItemLink');
+         echo Anchor($CountText.' '.htmlspecialchars($Category->Name), CategoryUrl($Category), 'ItemLink');
       }
       echo "</li>\n";
    }


### PR DESCRIPTION
This will allow for proper document flow where the category label can be truncated using `text-overflow` if need be.

![image](https://cloud.githubusercontent.com/assets/1174718/3067828/54e8ada2-e287-11e3-8684-e606e2c15e96.png)

![image](https://cloud.githubusercontent.com/assets/1174718/3067836/7039ae9e-e287-11e3-8a62-de3ec5ed1a20.png)
