### PR TITLE
Terminate Declaration Statement in categories.js

### DIFF
--- a/applications/vanilla/js/categories.js
+++ b/applications/vanilla/js/categories.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function($) {
    $("#Form_Name").keyup(function(event) {
       if ($('#Form_CodeIsDefined').val() == '0') {
          $('#UrlCode').show();
-         var val = $(this).val().replace(/[ \/\\&.?;,<>'"]+/g, '-')
+         var val = $(this).val().replace(/[ \/\\&.?;,<>'"]+/g, '-');
          val = val.replace(/\-+/g, '-').toLowerCase();
          $("#Form_UrlCode").val(val);
          $("#UrlCode span").text(val);


### PR DESCRIPTION
Added missing delimiter in `/vanilla/applications/vanilla/js/categories.js`. Also applies to Vanilla 2.1.
