### PR TITLE
Bugfix for CommentCount watch

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -429,13 +429,16 @@ class CommentModel extends VanillaModel {
       if ($Session->UserID > 0) {
 
          // Max comments we could have seen
-         $CountWatch = $Limit * ($Offset + 1);
+         $CountWatch = $Limit + $Offset;
          if ($CountWatch > $TotalComments)
             $CountWatch = $TotalComments;
 
          // This dicussion looks familiar...
          if (is_numeric($Discussion->CountCommentWatch)) {
 
+            if ($CountWatch < $Discussion->CountCommentWatch)
+               $CountWatch = $Discussion->CountCommentWatch;
+               
             if (isset($Discussion->DateLastViewed))
                $NewComments |= Gdn_Format::ToTimestamp($Discussion->DateLastComment) > Gdn_Format::ToTimestamp($Discussion->DateLastViewed);
 


### PR DESCRIPTION
The watched comment calculation was wrong as Offset is not a page number but an actual offset.
