### PR TITLE
Fix for offset in pagination

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -112,8 +112,6 @@ class DiscussionController extends VanillaController {
             // (((67 comments / 10 perpage) = 6.7) rounded down = 6) * 10 perpage = offset 60;
             $this->Offset = floor($CountCommentWatch / $Limit) * $Limit;
          }
-         if ($ActualResponses <= $Limit)
-            $this->Offset = 0;
 
          if ($this->Offset == $ActualResponses)
             $this->Offset -= $Limit;


### PR DESCRIPTION
For example, when asking for page=5 when ActualResponses=15 and Limit=20 - it will zero the offset.
But, if asking for page=15 when ActualResponses=21 and Limit=20 - it won't zero the offset and will return the last 6 comments. This is not a consistent behavior