### PR TITLE
Add port (if required) to WebRoot

### DIFF
--- a/library/core/class.url.php
+++ b/library/core/class.url.php
@@ -25,7 +25,16 @@ class Gdn_Url {
       $WebRoot = Gdn::Request()->WebRoot();
 
       if ($WithDomain)
-         $Result = Gdn::Request()->Domain().'/'.$WebRoot;
+      {
+        if (!in_array(Gdn::Request()->Port(), array(80, 443)))
+        {
+            $Result = Gdn::Request()->Domain().':'.Gdn::Request()->Port() . '/'.$WebRoot;            
+        }
+        else
+        {
+            $Result = Gdn::Request()->Domain().'/'.$WebRoot;
+        }
+      }
       else
          $Result = $WebRoot;
 


### PR DESCRIPTION
When site is running on a non-standard port (e.g. 4000), upload files
(such as logo in banner) do not display because port is not included in
their URL - added logic to WebRoot call to ensure this is included when
needed.
