### PR TITLE
Allows user to add message on registration page

### DIFF
--- a/applications/dashboard/controllers/class.messagecontroller.php
+++ b/applications/dashboard/controllers/class.messagecontroller.php
@@ -187,7 +187,7 @@ class MessageController extends DashboardController {
       $ControllerData['Vanilla/Discussion/Index'] = T('Comments Page');
       $ControllerData['Vanilla/Post/Discussion'] = T('New Discussion Form');
       $ControllerData['Dashboard/Entry/SignIn'] = T('Sign In');
-        $ControllerData['Dashboard/Entry/Register'] = T('Registration');
+      $ControllerData['Dashboard/Entry/Register'] = T('Registration');
       // 2011-09-09 - mosullivan - No longer allowing messages in dashboard
       // $ControllerData['Dashboard/Settings/Index'] = 'Dashboard Home';
       $this->EventArguments['ControllerData'] = &$ControllerData;


### PR DESCRIPTION
This will allow users who have approval set as registration method to easily add a message to new users.
