### PR TITLE
Fix category discussion counter on move

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -154,22 +154,22 @@ class DiscussionModel extends VanillaModel {
 
       }
 
-		// Add any additional fields that were requested
-		if(is_array($AdditionalFields)) {
-			foreach($AdditionalFields as $Alias => $Field) {
-				// See if a new table needs to be joined to the query.
-				$TableAlias = explode('.', $Field);
-				$TableAlias = $TableAlias[0];
-				if(array_key_exists($TableAlias, $Tables)) {
-					$Join = $Tables[$TableAlias];
-					$this->SQL->Join($Join[0], $Join[1]);
-					unset($Tables[$TableAlias]);
-				}
+      // Add any additional fields that were requested
+      if(is_array($AdditionalFields)) {
+         foreach($AdditionalFields as $Alias => $Field) {
+            // See if a new table needs to be joined to the query.
+            $TableAlias = explode('.', $Field);
+            $TableAlias = $TableAlias[0];
+            if(array_key_exists($TableAlias, $Tables)) {
+               $Join = $Tables[$TableAlias];
+               $this->SQL->Join($Join[0], $Join[1]);
+               unset($Tables[$TableAlias]);
+            }
 
-				// Select the field.
-				$this->SQL->Select($Field, '', is_numeric($Alias) ? '' : $Alias);
-			}
-		}
+            // Select the field.
+            $this->SQL->Select($Field, '', is_numeric($Alias) ? '' : $Alias);
+         }
+      }
 
       $this->FireEvent('AfterDiscussionSummaryQuery');
    }
@@ -225,16 +225,16 @@ class DiscussionModel extends VanillaModel {
             ->Select('w.CountComments', '', 'CountCommentWatch')
             ->Join('UserDiscussion w', 'd.DiscussionID = w.DiscussionID and w.UserID = '.$UserID, 'left');
       } else {
-			$this->SQL
-				->Select('0', '', 'WatchUserID')
-				->Select('now()', '', 'DateLastViewed')
-				->Select('0', '', 'Dismissed')
-				->Select('0', '', 'Bookmarked')
-				->Select('0', '', 'CountCommentWatch')
-				->Select('d.Announce','','IsAnnounce');
+         $this->SQL
+            ->Select('0', '', 'WatchUserID')
+            ->Select('now()', '', 'DateLastViewed')
+            ->Select('0', '', 'Dismissed')
+            ->Select('0', '', 'Bookmarked')
+            ->Select('0', '', 'CountCommentWatch')
+            ->Select('d.Announce','','IsAnnounce');
       }
 
-		$this->AddArchiveWhere($this->SQL);
+      $this->AddArchiveWhere($this->SQL);
 
       if ($Offset !== FALSE && $Limit !== FALSE)
          $this->SQL->Limit($Limit, $Offset);
@@ -244,8 +244,8 @@ class DiscussionModel extends VanillaModel {
 
       $this->EventArguments['SortField'] = &$SortField;
       $this->EventArguments['SortDirection'] = C('Vanilla.Discussions.SortDirection', 'desc');
-		$this->EventArguments['Wheres'] = &$Wheres;
-		$this->FireEvent('BeforeGet'); // @see 'BeforeGetCount' for consistency in results vs. counts
+      $this->EventArguments['Wheres'] = &$Wheres;
+      $this->FireEvent('BeforeGet'); // @see 'BeforeGetCount' for consistency in results vs. counts
 
       $IncludeAnnouncements = FALSE;
       if (strtolower(GetValue('Announce', $Wheres)) == 'all') {
@@ -256,16 +256,16 @@ class DiscussionModel extends VanillaModel {
       if (is_array($Wheres))
          $this->SQL->Where($Wheres);
 
-		// Whitelist sorting options
-		if (!in_array($SortField, array('d.DiscussionID', 'd.DateLastComment', 'd.DateInserted'))) {
-			trigger_error("You are sorting discussions by a possibly sub-optimal column.", E_USER_NOTICE);
+      // Whitelist sorting options
+      if (!in_array($SortField, array('d.DiscussionID', 'd.DateLastComment', 'd.DateInserted'))) {
+         trigger_error("You are sorting discussions by a possibly sub-optimal column.", E_USER_NOTICE);
       }
 
-		$SortDirection = $this->EventArguments['SortDirection'];
-		if ($SortDirection != 'asc')
-			$SortDirection = 'desc';
+      $SortDirection = $this->EventArguments['SortDirection'];
+      if ($SortDirection != 'asc')
+         $SortDirection = 'desc';
 
-		$this->SQL->OrderBy($SortField, $SortDirection);
+      $this->SQL->OrderBy($SortField, $SortDirection);
 
       // Set range and fetch
       $Data = $this->SQL->Get();
@@ -281,16 +281,16 @@ class DiscussionModel extends VanillaModel {
       CategoryModel::JoinCategories($Data);
 
       // Change discussions returned based on additional criteria
-		$this->AddDiscussionColumns($Data);
+      $this->AddDiscussionColumns($Data);
 
       if (C('Vanilla.Views.Denormalize', FALSE))
          $this->AddDenormalizedViews($Data);
 
-		// Prep and fire event
-		$this->EventArguments['Data'] = $Data;
-		$this->FireEvent('AfterAddColumns');
+      // Prep and fire event
+      $this->EventArguments['Data'] = $Data;
+      $this->FireEvent('AfterAddColumns');
 
-		return $Data;
+      return $Data;
    }
 
    public function GetWhere($Where = array(), $Offset = 0, $Limit = FALSE) {
@@ -377,7 +377,7 @@ class DiscussionModel extends VanillaModel {
       $Result =& $Data->Result();
 
       // Change discussions returned based on additional criteria
-		$this->AddDiscussionColumns($Data);
+      $this->AddDiscussionColumns($Data);
 
       // If not looking at discussions filtered by bookmarks or user, filter announcements out.
       if ($RemoveAnnouncements && !isset($Where['w.Bookmarked']) && !isset($Wheres['d.InsertUserID']))
@@ -391,8 +391,8 @@ class DiscussionModel extends VanillaModel {
          $this->AddDenormalizedViews($Data);
 
       // Prep and fire event
-		$this->EventArguments['Data'] = $Data;
-		$this->FireEvent('AfterAddColumns');
+      $this->EventArguments['Data'] = $Data;
+      $this->FireEvent('AfterAddColumns');
 
       return $Data;
    }
@@ -435,24 +435,24 @@ class DiscussionModel extends VanillaModel {
             //->EndWhereGroup()
             ->Where('d.CountComments >', 'COALESCE(w.CountComments, 0)', TRUE, FALSE);
       } else {
-			$this->SQL
-				->Select('0', '', 'WatchUserID')
-				->Select('now()', '', 'DateLastViewed')
-				->Select('0', '', 'Dismissed')
-				->Select('0', '', 'Bookmarked')
-				->Select('0', '', 'CountCommentWatch')
-				->Select('d.Announce','','IsAnnounce');
+         $this->SQL
+            ->Select('0', '', 'WatchUserID')
+            ->Select('now()', '', 'DateLastViewed')
+            ->Select('0', '', 'Dismissed')
+            ->Select('0', '', 'Bookmarked')
+            ->Select('0', '', 'CountCommentWatch')
+            ->Select('d.Announce','','IsAnnounce');
       }
 
-		$this->AddArchiveWhere($this->SQL);
+      $this->AddArchiveWhere($this->SQL);
 
 
       $this->SQL->Limit($Limit, $Offset);
 
       $this->EventArguments['SortField'] = C('Vanilla.Discussions.SortField', 'd.DateLastComment');
       $this->EventArguments['SortDirection'] = C('Vanilla.Discussions.SortDirection', 'desc');
-		$this->EventArguments['Wheres'] = &$Wheres;
-		$this->FireEvent('BeforeGetUnread'); // @see 'BeforeGetCount' for consistency in results vs. counts
+      $this->EventArguments['Wheres'] = &$Wheres;
+      $this->FireEvent('BeforeGetUnread'); // @see 'BeforeGetCount' for consistency in results vs. counts
 
       $IncludeAnnouncements = FALSE;
       if (strtolower(GetValue('Announce', $Wheres)) == 'all') {
@@ -463,17 +463,17 @@ class DiscussionModel extends VanillaModel {
       if (is_array($Wheres))
          $this->SQL->Where($Wheres);
 
-		// Get sorting options from config
-		$SortField = $this->EventArguments['SortField'];
-		if (!in_array($SortField, array('d.DiscussionID', 'd.DateLastComment', 'd.DateInserted'))) {
-			trigger_error("You are sorting discussions by a possibly sub-optimal column.", E_USER_NOTICE);
+      // Get sorting options from config
+      $SortField = $this->EventArguments['SortField'];
+      if (!in_array($SortField, array('d.DiscussionID', 'd.DateLastComment', 'd.DateInserted'))) {
+         trigger_error("You are sorting discussions by a possibly sub-optimal column.", E_USER_NOTICE);
       }
 
-		$SortDirection = $this->EventArguments['SortDirection'];
-		if ($SortDirection != 'asc')
-			$SortDirection = 'desc';
+      $SortDirection = $this->EventArguments['SortDirection'];
+      if ($SortDirection != 'asc')
+         $SortDirection = 'desc';
 
-		$this->SQL->OrderBy($SortField, $SortDirection);
+      $this->SQL->OrderBy($SortField, $SortDirection);
 
       // Set range and fetch
       $Data = $this->SQL->Get();
@@ -484,8 +484,8 @@ class DiscussionModel extends VanillaModel {
             $this->RemoveAnnouncements($Data);
       }
 
-		// Change discussions returned based on additional criteria
-		$this->AddDiscussionColumns($Data);
+      // Change discussions returned based on additional criteria
+      $this->AddDiscussionColumns($Data);
 
       // Join in the users.
       Gdn::UserModel()->JoinUsers($Data, array('FirstUserID', 'LastUserID'));
@@ -494,11 +494,11 @@ class DiscussionModel extends VanillaModel {
       if (C('Vanilla.Views.Denormalize', FALSE))
          $this->AddDenormalizedViews($Data);
 
-		// Prep and fire event
-		$this->EventArguments['Data'] = $Data;
-		$this->FireEvent('AfterAddColumns');
+      // Prep and fire event
+      $this->EventArguments['Data'] = $Data;
+      $this->FireEvent('AfterAddColumns');
 
-		return $Data;
+      return $Data;
    }
 
    /**
@@ -560,7 +560,7 @@ class DiscussionModel extends VanillaModel {
       }
    }
 
-	/**
+   /**
     * Modifies discussion data before it is returned.
     *
     * Takes archiving into account and fixes inaccurate comment counts.
@@ -570,13 +570,13 @@ class DiscussionModel extends VanillaModel {
     *
     * @param object $Data SQL result.
     */
-	public function AddDiscussionColumns($Data) {
-		// Change discussions based on archiving.
-		$Result = &$Data->Result();
-		foreach($Result as &$Discussion) {
+   public function AddDiscussionColumns($Data) {
+      // Change discussions based on archiving.
+      $Result = &$Data->Result();
+      foreach($Result as &$Discussion) {
          $this->Calculate($Discussion);
-		}
-	}
+      }
+   }
 
    public function Calculate(&$Discussion) {
       $ArchiveTimestamp = Gdn_Format::ToTimestamp(Gdn::Config('Vanilla.Archive.Date', 0));
@@ -664,26 +664,26 @@ class DiscussionModel extends VanillaModel {
       $this->FireEvent('SetCalculatedFields');
    }
 
-	/**
+   /**
     * Add SQL Where to account for archive date.
     *
     * @since 2.0.0
     * @access public
     *
-	 * @param object $Sql Gdn_SQLDriver
-	 */
-	public function AddArchiveWhere($Sql = NULL) {
-		if(is_null($Sql))
-			$Sql = $this->SQL;
+    * @param object $Sql Gdn_SQLDriver
+    */
+   public function AddArchiveWhere($Sql = NULL) {
+      if(is_null($Sql))
+         $Sql = $this->SQL;
 
-		$Exclude = Gdn::Config('Vanilla.Archive.Exclude');
-		if($Exclude) {
-			$ArchiveDate = Gdn::Config('Vanilla.Archive.Date');
-			if($ArchiveDate) {
-				$Sql->Where('d.DateLastComment >', $ArchiveDate);
-			}
-		}
-	}
+      $Exclude = Gdn::Config('Vanilla.Archive.Exclude');
+      if($Exclude) {
+         $ArchiveDate = Gdn::Config('Vanilla.Archive.Date');
+         if($ArchiveDate) {
+            $Sql->Where('d.DateLastComment >', $ArchiveDate);
+         }
+      }
+   }
 
 
 
@@ -693,9 +693,9 @@ class DiscussionModel extends VanillaModel {
     * @since 2.0.0
     * @access public
     *
-	 * @param array $Wheres SQL conditions.
-	 * @return object SQL result.
-	 */
+    * @param array $Wheres SQL conditions.
+    * @return object SQL result.
+    */
    public function GetAnnouncements($Wheres = '') {
       $Session = Gdn::Session();
       $Limit = Gdn::Config('Vanilla.Discussions.PerPage', 50);
@@ -767,7 +767,7 @@ class DiscussionModel extends VanillaModel {
       }
       $this->_AnnouncementIDs = $AnnouncementIDs;
 
-		$this->AddDiscussionColumns($Data);
+      $this->AddDiscussionColumns($Data);
 
       if (C('Vanilla.Views.Denormalize', FALSE))
          $this->AddDenormalizedViews($Data);
@@ -775,11 +775,11 @@ class DiscussionModel extends VanillaModel {
       Gdn::UserModel()->JoinUsers($Data, array('FirstUserID', 'LastUserID'));
       CategoryModel::JoinCategories($Data);
 
-		// Prep and fire event
-		$this->EventArguments['Data'] = $Data;
-		$this->FireEvent('AfterAddColumns');
+      // Prep and fire event
+      $this->EventArguments['Data'] = $Data;
+      $this->FireEvent('AfterAddColumns');
 
-		return $Data;
+      return $Data;
    }
 
    /**
@@ -788,9 +788,9 @@ class DiscussionModel extends VanillaModel {
     * @since 2.0.0
     * @access public
     *
-	 * @param int $DiscussionID Unique ID to find bookmarks for.
-	 * @return object SQL result.
-	 */
+    * @param int $DiscussionID Unique ID to find bookmarks for.
+    * @return object SQL result.
+    */
    public function GetBookmarkUsers($DiscussionID) {
       return $this->SQL
          ->Select('UserID')
@@ -841,13 +841,13 @@ class DiscussionModel extends VanillaModel {
             ->Select('w.CountComments', '', 'CountCommentWatch')
             ->Join('UserDiscussion w', 'd2.DiscussionID = w.DiscussionID and w.UserID = '.$UserID, 'left');
       } else {
-			$this->SQL
-				->Select('0', '', 'WatchUserID')
-				->Select('now()', '', 'DateLastViewed')
-				->Select('0', '', 'Dismissed')
-				->Select('0', '', 'Bookmarked')
-				->Select('0', '', 'CountCommentWatch')
-				->Select('d.Announce','','IsAnnounce');
+         $this->SQL
+            ->Select('0', '', 'WatchUserID')
+            ->Select('now()', '', 'DateLastViewed')
+            ->Select('0', '', 'Dismissed')
+            ->Select('0', '', 'Bookmarked')
+            ->Select('0', '', 'CountCommentWatch')
+            ->Select('d.Announce','','IsAnnounce');
       }
 
       if ($LastDiscussionID) {
@@ -888,14 +888,15 @@ class DiscussionModel extends VanillaModel {
       }
 
       // Change discussions returned based on additional criteria
-		$this->AddDiscussionColumns($Data);
+      $this->AddDiscussionColumns($Data);
 
       // Join in the users.
       Gdn::UserModel()->JoinUsers($Data, array('FirstUserID', 'LastUserID'));
       CategoryModel::JoinCategories($Data);
 
-      if (C('Vanilla.Views.Denormalize', FALSE))
+      if (C('Vanilla.Views.Denormalize', FALSE)) {
          $this->AddDenormalizedViews($Data);
+      }
 
       return $Data;
    }
@@ -920,20 +921,20 @@ class DiscussionModel extends VanillaModel {
     * @since 2.0.0
     * @access public
     *
-	 * @param bool $Escape Prepends category IDs with @
-	 * @return array Protected local _CategoryPermissions
-	 */
+    * @param bool $Escape Prepends category IDs with @
+    * @return array Protected local _CategoryPermissions
+    */
    public static function CategoryPermissions($Escape = FALSE) {
       if(is_null(self::$_CategoryPermissions)) {
          $Session = Gdn::Session();
 
          if((is_object($Session->User) && $Session->User->Admin)) {
             self::$_CategoryPermissions = TRUE;
-			} elseif(C('Garden.Permissions.Disabled.Category')) {
-				if($Session->CheckPermission('Vanilla.Discussions.View'))
-					self::$_CategoryPermissions = TRUE;
-				else
-					self::$_CategoryPermissions = array(); // no permission
+         } elseif(C('Garden.Permissions.Disabled.Category')) {
+            if($Session->CheckPermission('Vanilla.Discussions.View'))
+               self::$_CategoryPermissions = TRUE;
+            else
+               self::$_CategoryPermissions = array(); // no permission
          } else {
             $SQL = Gdn::SQL();
 
@@ -1009,10 +1010,10 @@ class DiscussionModel extends VanillaModel {
     * @since 2.0.0
     * @access public
     *
-	 * @param array $Wheres SQL conditions.
-	 * @param bool $ForceNoAnnouncements Not used.
-	 * @return int Number of discussions.
-	 */
+    * @param array $Wheres SQL conditions.
+    * @param bool $ForceNoAnnouncements Not used.
+    * @return int Number of discussions.
+    */
    public function GetCount($Wheres = '', $ForceNoAnnouncements = FALSE) {
       if (is_array($Wheres) && count($Wheres) == 0)
          $Wheres = '';
@@ -1055,7 +1056,7 @@ class DiscussionModel extends VanillaModel {
       }
 
       $this->EventArguments['Wheres'] = &$Wheres;
-		$this->FireEvent('BeforeGetCount'); // @see 'BeforeGet' for consistency in count vs. results
+      $this->FireEvent('BeforeGetCount'); // @see 'BeforeGet' for consistency in count vs. results
 
       $this->SQL
          ->Select('d.DiscussionID', 'count', 'CountDiscussions')
@@ -1078,10 +1079,10 @@ class DiscussionModel extends VanillaModel {
     * @since 2.0.0
     * @access public
     *
-	 * @param array $Wheres SQL conditions.
-	 * @param bool $ForceNoAnnouncements Not used.
-	 * @return int Number of discussions.
-	 */
+    * @param array $Wheres SQL conditions.
+    * @param bool $ForceNoAnnouncements Not used.
+    * @return int Number of discussions.
+    */
    public function GetUnreadCount($Wheres = '', $ForceNoAnnouncements = FALSE) {
       if (is_array($Wheres) && count($Wheres) == 0)
          $Wheres = '';
@@ -1124,7 +1125,7 @@ class DiscussionModel extends VanillaModel {
       }
 
       $this->EventArguments['Wheres'] = &$Wheres;
-		$this->FireEvent('BeforeGetUnreadCount'); // @see 'BeforeGet' for consistency in count vs. results
+      $this->FireEvent('BeforeGetUnreadCount'); // @see 'BeforeGet' for consistency in count vs. results
 
       $this->SQL
          ->Select('d.DiscussionID', 'count', 'CountDiscussions')
@@ -1152,9 +1153,9 @@ class DiscussionModel extends VanillaModel {
     * @since 2.0.18
     * @access public
     *
-	 * @param int $ForeignID Foreign ID of discussion to get.
-	 * @return object SQL result.
-	 */
+    * @param int $ForeignID Foreign ID of discussion to get.
+    * @return object SQL result.
+    */
    public function GetForeignID($ForeignID, $Type = '') {
       $Hash = ForeignIDHash($ForeignID);
       $Session = Gdn::Session();
@@ -1169,20 +1170,20 @@ class DiscussionModel extends VanillaModel {
          ->Select('d.DateLastComment', '', 'LastDate')
          ->Select('d.LastCommentUserID', '', 'LastUserID')
          ->Select('lcu.Name', '', 'LastName')
-			->Select('iu.Name', '', 'InsertName')
-			->Select('iu.Photo', '', 'InsertPhoto')
+         ->Select('iu.Name', '', 'InsertName')
+         ->Select('iu.Photo', '', 'InsertPhoto')
          ->From('Discussion d')
          ->Join('Category ca', 'd.CategoryID = ca.CategoryID', 'left')
          ->Join('UserDiscussion w', 'd.DiscussionID = w.DiscussionID and w.UserID = '.$Session->UserID, 'left')
-			->Join('User iu', 'd.InsertUserID = iu.UserID', 'left') // Insert user
-			->Join('Comment lc', 'd.LastCommentID = lc.CommentID', 'left') // Last comment
+         ->Join('User iu', 'd.InsertUserID = iu.UserID', 'left') // Insert user
+         ->Join('Comment lc', 'd.LastCommentID = lc.CommentID', 'left') // Last comment
          ->Join('User lcu', 'lc.InsertUserID = lcu.UserID', 'left') // Last comment user
          ->Where('d.ForeignID', $Hash);
 
-		if ($Type != '')
-			$this->SQL->Where('d.Type', $Type);
+      if ($Type != '')
+         $this->SQL->Where('d.Type', $Type);
 
-		$Discussion = $this->SQL
+      $Discussion = $this->SQL
          ->Get()
          ->FirstRow();
 
@@ -1198,9 +1199,9 @@ class DiscussionModel extends VanillaModel {
     * @since 2.0.0
     * @access public
     *
-	 * @param int $DiscussionID Unique ID of discussion to get.
-	 * @return object SQL result.
-	 */
+    * @param int $DiscussionID Unique ID of discussion to get.
+    * @return object SQL result.
+    */
    public function GetID($DiscussionID, $DataSetType = DATASET_TYPE_OBJECT, $Options = array()) {
       $Session = Gdn::Session();
       $this->FireEvent('BeforeGetID');
@@ -1232,7 +1233,7 @@ class DiscussionModel extends VanillaModel {
       if (C('Vanilla.Views.Denormalize', FALSE))
          $this->AddDenormalizedViews($Discussion);
 
-		return $Discussion;
+      return $Discussion;
    }
 
    /**
@@ -1241,9 +1242,9 @@ class DiscussionModel extends VanillaModel {
     * @since 2.0.18
     * @access public
     *
-	 * @param array $DiscussionIDs Array of DiscussionIDs to get.
-	 * @return object SQL result.
-	 */
+    * @param array $DiscussionIDs Array of DiscussionIDs to get.
+    * @return object SQL result.
+    */
    public function GetIn($DiscussionIDs) {
       $Session = Gdn::Session();
       $this->FireEvent('BeforeGetIn');
@@ -1257,13 +1258,13 @@ class DiscussionModel extends VanillaModel {
          ->Select('d.DateLastComment', '', 'LastDate')
          ->Select('d.LastCommentUserID', '', 'LastUserID')
          ->Select('lcu.Name', '', 'LastName')
-			->Select('iu.Name', '', 'InsertName')
-			->Select('iu.Photo', '', 'InsertPhoto')
+         ->Select('iu.Name', '', 'InsertName')
+         ->Select('iu.Photo', '', 'InsertPhoto')
          ->From('Discussion d')
          ->Join('Category ca', 'd.CategoryID = ca.CategoryID', 'left')
          ->Join('UserDiscussion w', 'd.DiscussionID = w.DiscussionID and w.UserID = '.$Session->UserID, 'left')
-			->Join('User iu', 'd.InsertUserID = iu.UserID', 'left') // Insert user
-			->Join('Comment lc', 'd.LastCommentID = lc.CommentID', 'left') // Last comment
+         ->Join('User iu', 'd.InsertUserID = iu.UserID', 'left') // Insert user
+         ->Join('Comment lc', 'd.LastCommentID = lc.CommentID', 'left') // Last comment
          ->Join('User lcu', 'lc.InsertUserID = lcu.UserID', 'left') // Last comment user
          ->WhereIn('d.DiscussionID', $DiscussionIDs)
          ->Get();
@@ -1404,7 +1405,7 @@ class DiscussionModel extends VanillaModel {
       }
 
       $Insert = $DiscussionID == '' ? TRUE : FALSE;
-		$this->EventArguments['Insert'] = $Insert;
+      $this->EventArguments['Insert'] = $Insert;
 
       if ($Insert) {
          unset($FormPostValues['DiscussionID']);
@@ -1437,10 +1438,10 @@ class DiscussionModel extends VanillaModel {
       if (ArrayValue('Sink', $FormPostValues, '') === FALSE)
          $FormPostValues['Sink'] = 0;
 
-		//	Prep and fire event
-		$this->EventArguments['FormPostValues'] = &$FormPostValues;
-		$this->EventArguments['DiscussionID'] = $DiscussionID;
-		$this->FireEvent('BeforeSaveDiscussion');
+      //	Prep and fire event
+      $this->EventArguments['FormPostValues'] = &$FormPostValues;
+      $this->EventArguments['DiscussionID'] = $DiscussionID;
+      $this->FireEvent('BeforeSaveDiscussion');
 
       // Validate the form posted values
       $this->Validate($FormPostValues, $Insert);
@@ -1495,14 +1496,15 @@ class DiscussionModel extends VanillaModel {
 
                // Check for spam.
                $Spam = SpamModel::IsSpam('Discussion', $Fields);
-            	if ($Spam)
+               if ($Spam) {
                   return SPAM;
+               }
 
                // Check for approval
-					$ApprovalRequired = CheckRestriction('Vanilla.Approval.Require');
-					if ($ApprovalRequired && !GetValue('Verified', Gdn::Session()->User)) {
-               	LogModel::Insert('Pending', 'Discussion', $Fields);
-               	return UNAPPROVED;
+               $ApprovalRequired = CheckRestriction('Vanilla.Approval.Require');
+               if ($ApprovalRequired && !GetValue('Verified', Gdn::Session()->User)) {
+                  LogModel::Insert('Pending', 'Discussion', $Fields);
+                  return UNAPPROVED;
                }
 
                // Create discussion
@@ -1541,7 +1543,7 @@ class DiscussionModel extends VanillaModel {
                $FormPostValues['DiscussionID'] = $DiscussionID;
 
                // Do data prep.
-					$DiscussionName = ArrayValue('Name', $Fields, '');
+               $DiscussionName = ArrayValue('Name', $Fields, '');
                $Story = ArrayValue('Body', $Fields, '');
                $NotifiedUsers = array();
 
@@ -1622,17 +1624,19 @@ class DiscussionModel extends VanillaModel {
             $CategoryID = GetValue('CategoryID', $Discussion, FALSE);
 
             // Update discussion counter for affected categories.
-            if ($Insert)
+            if ($Insert || $StoredCategoryID) {
                $this->IncrementNewDiscussion($Discussion);
+            }
 
-            if ($StoredCategoryID)
+            if ($StoredCategoryID) {
                $this->UpdateDiscussionCount($StoredCategoryID);
+            }
 
-				// Fire an event that the discussion was saved.
-				$this->EventArguments['FormPostValues'] = $FormPostValues;
-				$this->EventArguments['Fields'] = $Fields;
-				$this->EventArguments['DiscussionID'] = $DiscussionID;
-				$this->FireEvent('AfterSaveDiscussion');
+            // Fire an event that the discussion was saved.
+            $this->EventArguments['FormPostValues'] = $FormPostValues;
+            $this->EventArguments['Fields'] = $Fields;
+            $this->EventArguments['DiscussionID'] = $DiscussionID;
+            $this->FireEvent('AfterSaveDiscussion');
          }
       }
 
@@ -1716,19 +1720,19 @@ class DiscussionModel extends VanillaModel {
     */
    public function UpdateDiscussionCount($CategoryID, $Discussion = FALSE) {
       $DiscussionID = GetValue('DiscussionID', $Discussion, FALSE);
-		if (strcasecmp($CategoryID, 'All') == 0) {
-			$Exclude = (bool)Gdn::Config('Vanilla.Archive.Exclude');
-			$ArchiveDate = Gdn::Config('Vanilla.Archive.Date');
-			$Params = array();
-			$Where = '';
+      if (strcasecmp($CategoryID, 'All') == 0) {
+         $Exclude = (bool)Gdn::Config('Vanilla.Archive.Exclude');
+         $ArchiveDate = Gdn::Config('Vanilla.Archive.Date');
+         $Params = array();
+         $Where = '';
 
-			if($Exclude && $ArchiveDate) {
-				$Where = 'where d.DateLastComment > :ArchiveDate';
-				$Params[':ArchiveDate'] = $ArchiveDate;
-			}
+         if($Exclude && $ArchiveDate) {
+            $Where = 'where d.DateLastComment > :ArchiveDate';
+            $Params[':ArchiveDate'] = $ArchiveDate;
+         }
 
-			// Update all categories.
-			$Sql = "update :_Category c
+         // Update all categories.
+         $Sql = "update :_Category c
             left join (
               select
                 d.CategoryID,
@@ -1742,19 +1746,19 @@ class DiscussionModel extends VanillaModel {
             set
                c.CountDiscussions = coalesce(d.CountDiscussions, 0),
                c.CountComments = coalesce(d.CountComments, 0)";
-			$Sql = str_replace(':_', $this->Database->DatabasePrefix, $Sql);
-			$this->Database->Query($Sql, $Params, 'DiscussionModel_UpdateDiscussionCount');
+         $Sql = str_replace(':_', $this->Database->DatabasePrefix, $Sql);
+         $this->Database->Query($Sql, $Params, 'DiscussionModel_UpdateDiscussionCount');
 
-		} elseif (is_numeric($CategoryID)) {
+      } elseif (is_numeric($CategoryID)) {
          $this->SQL
             ->Select('d.DiscussionID', 'count', 'CountDiscussions')
             ->Select('d.CountComments', 'sum', 'CountComments')
             ->From('Discussion d')
             ->Where('d.CategoryID', $CategoryID);
 
-			$this->AddArchiveWhere();
+         $this->AddArchiveWhere();
 
-			$Data = $this->SQL->Get()->FirstRow();
+         $Data = $this->SQL->Get()->FirstRow();
          $CountDiscussions = (int)GetValue('CountDiscussions', $Data, 0);
          $CountComments = (int)GetValue('CountComments', $Data, 0);
 
@@ -1832,21 +1836,21 @@ class DiscussionModel extends VanillaModel {
       Gdn::UserModel()->SetField($UserID, 'CountDiscussions', $CountDiscussions);
    }
 
-	/**
-	 * Update and get bookmark count for the specified user.
-	 *
+   /**
+    * Update and get bookmark count for the specified user.
+    *
     * @since 2.0.0
     * @access public
     *
     * @param int $UserID Unique ID of user to update.
     * @return int Total number of bookmarks user has.
     */
-	public function SetUserBookmarkCount($UserID) {
-		$Count = $this->UserBookmarkCount($UserID);
+   public function SetUserBookmarkCount($UserID) {
+      $Count = $this->UserBookmarkCount($UserID);
       Gdn::UserModel()->SetField($UserID, 'CountBookmarks', $Count);
 
-		return $Count;
-	}
+      return $Count;
+   }
 
    /**
     * Updates a discussion field.
@@ -1877,9 +1881,9 @@ class DiscussionModel extends VanillaModel {
       return $Value;
    }
 
-	/**
-	 * Sets the discussion score for specified user.
-	 *
+   /**
+    * Sets the discussion score for specified user.
+    *
     * @since 2.0.0
     * @access public
     *
@@ -1888,34 +1892,34 @@ class DiscussionModel extends VanillaModel {
     * @param int $Score New score for discussion.
     * @return int Total score.
     */
-	public function SetUserScore($DiscussionID, $UserID, $Score) {
-		// Insert or update the UserDiscussion row
-		$this->SQL->Replace(
-			'UserDiscussion',
-			array('Score' => $Score),
-			array('DiscussionID' => $DiscussionID, 'UserID' => $UserID)
-		);
+   public function SetUserScore($DiscussionID, $UserID, $Score) {
+      // Insert or update the UserDiscussion row
+      $this->SQL->Replace(
+         'UserDiscussion',
+         array('Score' => $Score),
+         array('DiscussionID' => $DiscussionID, 'UserID' => $UserID)
+      );
 
-		// Get the total new score
-		$TotalScore = $this->SQL->Select('Score', 'sum', 'TotalScore')
-			->From('UserDiscussion')
-			->Where('DiscussionID', $DiscussionID)
-			->Get()
-			->FirstRow()
-			->TotalScore;
+      // Get the total new score
+      $TotalScore = $this->SQL->Select('Score', 'sum', 'TotalScore')
+         ->From('UserDiscussion')
+         ->Where('DiscussionID', $DiscussionID)
+         ->Get()
+         ->FirstRow()
+         ->TotalScore;
 
-		// Update the Discussion's cached version
-		$this->SQL->Update('Discussion')
-			->Set('Score', $TotalScore)
-			->Where('DiscussionID', $DiscussionID)
-			->Put();
+      // Update the Discussion's cached version
+      $this->SQL->Update('Discussion')
+         ->Set('Score', $TotalScore)
+         ->Where('DiscussionID', $DiscussionID)
+         ->Put();
 
-		return $TotalScore;
-	}
+      return $TotalScore;
+   }
 
-	/**
-	 * Gets the discussion score for specified user.
-	 *
+   /**
+    * Gets the discussion score for specified user.
+    *
     * @since 2.0.0
     * @access public
     *
@@ -1923,26 +1927,26 @@ class DiscussionModel extends VanillaModel {
     * @param int $UserID Unique ID of user whose score we're getting.
     * @return int Total score.
     */
-	public function GetUserScore($DiscussionID, $UserID) {
-		$Data = $this->SQL->Select('Score')
-			->From('UserDiscussion')
-			->Where('DiscussionID', $DiscussionID)
-			->Where('UserID', $UserID)
-			->Get()
-			->FirstRow();
+   public function GetUserScore($DiscussionID, $UserID) {
+      $Data = $this->SQL->Select('Score')
+         ->From('UserDiscussion')
+         ->Where('DiscussionID', $DiscussionID)
+         ->Where('UserID', $UserID)
+         ->Get()
+         ->FirstRow();
 
-		return $Data ? $Data->Score : 0;
-	}
+      return $Data ? $Data->Score : 0;
+   }
 
-	/**
-	 * Increments view count for the specified discussion.
-	 *
+   /**
+    * Increments view count for the specified discussion.
+    *
     * @since 2.0.0
     * @access public
     *
     * @param int $DiscussionID Unique ID of discussion to get +1 view.
     */
-	public function AddView($DiscussionID) {
+   public function AddView($DiscussionID) {
       $IncrementBy = 0;
       if (
          C('Vanilla.Views.Denormalize', FALSE) &&
@@ -1954,8 +1958,9 @@ class DiscussionModel extends VanillaModel {
 
          // Increment. If not success, create key.
          $Views = Gdn::Cache()->Increment($CacheKey);
-         if ($Views === Gdn_Cache::CACHEOP_FAILURE)
+         if ($Views === Gdn_Cache::CACHEOP_FAILURE) {
             Gdn::Cache()->Store($CacheKey, 1);
+         }
 
          // Every X views, writeback to Discussions
          if (($Views % $WritebackLimit) == 0) {
@@ -1974,7 +1979,7 @@ class DiscussionModel extends VanillaModel {
             ->Put();
       }
 
-	}
+   }
 
    /**
     * Bookmarks (or unbookmarks) a discussion for the specified user.
@@ -1990,16 +1995,18 @@ class DiscussionModel extends VanillaModel {
          array('DiscussionID' => $DiscussionID, 'UserID' => $UserID))->FirstRow(DATASET_TYPE_ARRAY);
 
       if ($UserDiscussion) {
-         if ($Bookmarked === NULL)
+         if ($Bookmarked === NULL) {
             $Bookmarked = !$UserDiscussion['Bookmarked'];
+         }
 
          // Update the bookmarked value.
          $this->SQL->Put('UserDiscussion',
             array('Bookmarked' => (int)$Bookmarked),
             array('DiscussionID' => $DiscussionID, 'UserID' => $UserID));
       } else {
-         if ($Bookmarked === NULL)
+         if ($Bookmarked === NULL) {
             $Bookmarked = TRUE;
+         }
 
          // Insert the new bookmarked value.
          $this->SQL->Options('Ignore', TRUE)
@@ -2044,12 +2051,12 @@ class DiscussionModel extends VanillaModel {
          ->Select('lcu.Name', '', 'LastName')
          ->From('Discussion d')
          ->Join('UserDiscussion w', "d.DiscussionID = w.DiscussionID and w.UserID = $UserID", 'left')
-			->Join('User lcu', 'd.LastCommentUserID = lcu.UserID', 'left') // Last comment user
+         ->Join('User lcu', 'd.LastCommentUserID = lcu.UserID', 'left') // Last comment user
          ->Where('d.DiscussionID', $DiscussionID)
          ->Get();
 
-		$this->AddDiscussionColumns($DiscussionData);
-		$Discussion = $DiscussionData->FirstRow();
+      $this->AddDiscussionColumns($DiscussionData);
+      $Discussion = $DiscussionData->FirstRow();
 
       if ($Discussion->WatchUserID == '') {
          $this->SQL->Options('Ignore', TRUE);
@@ -2071,16 +2078,16 @@ class DiscussionModel extends VanillaModel {
          $Discussion->Bookmarked = $State;
       }
 
-		// Update the cached bookmark count on the discussion
-		$BookmarkCount = $this->BookmarkCount($DiscussionID);
-		$this->SQL->Update('Discussion')
-			->Set('CountBookmarks', $BookmarkCount)
-			->Where('DiscussionID', $DiscussionID)
-			->Put();
+      // Update the cached bookmark count on the discussion
+      $BookmarkCount = $this->BookmarkCount($DiscussionID);
+      $this->SQL->Update('Discussion')
+         ->Set('CountBookmarks', $BookmarkCount)
+         ->Where('DiscussionID', $DiscussionID)
+         ->Put();
       $this->CountDiscussionBookmarks = $BookmarkCount;
 
 
-		// Prep and fire event
+      // Prep and fire event
       $this->EventArguments['Discussion'] = $Discussion;
       $this->EventArguments['State'] = $State;
       $this->FireEvent('AfterBookmarkDiscussion');
@@ -2131,11 +2138,11 @@ class DiscussionModel extends VanillaModel {
       return $Data !== FALSE ? $Data->Count : 0;
    }
 
-	/**
-	 * Delete a discussion. Update and/or delete all related data.
-	 *
-	 * Events: DeleteDiscussion.
-	 *
+   /**
+    * Delete a discussion. Update and/or delete all related data.
+    *
+    * Events: DeleteDiscussion.
+    *
     * @since 2.0.0
     * @access public
     *
@@ -2143,8 +2150,8 @@ class DiscussionModel extends VanillaModel {
     * @return bool Always returns TRUE.
     */
    public function Delete($DiscussionID, $Options = array()) {
-		// Retrieve the users who have bookmarked this discussion.
-		$BookmarkData = $this->GetBookmarkUsers($DiscussionID);
+      // Retrieve the users who have bookmarked this discussion.
+      $BookmarkData = $this->GetBookmarkUsers($DiscussionID);
 
       $Data = $this->SQL
          ->Select('*')
@@ -2169,8 +2176,9 @@ class DiscussionModel extends VanillaModel {
 
       $Log = GetValue('Log', $Options, TRUE);
       $LogOptions = GetValue('LogOptions', $Options, array());
-      if ($Log === TRUE)
+      if ($Log === TRUE) {
          $Log = 'Delete';
+      }
 
       LogModel::BeginTransaction();
 
@@ -2193,23 +2201,23 @@ class DiscussionModel extends VanillaModel {
       $this->SQL->Delete('Comment', array('DiscussionID' => $DiscussionID));
       $this->SQL->Delete('Discussion', array('DiscussionID' => $DiscussionID));
 
-		$this->SQL->Delete('UserDiscussion', array('DiscussionID' => $DiscussionID));
+      $this->SQL->Delete('UserDiscussion', array('DiscussionID' => $DiscussionID));
       $this->UpdateDiscussionCount($CategoryID);
 
       // Get the user's discussion count.
       $this->UpdateUserDiscussionCount($UserID);
 
-		// Update bookmark counts for users who had bookmarked this discussion
-		foreach ($BookmarkData->Result() as $User) {
-			$this->SetUserBookmarkCount($User->UserID);
-		}
+      // Update bookmark counts for users who had bookmarked this discussion
+      foreach ($BookmarkData->Result() as $User) {
+         $this->SetUserBookmarkCount($User->UserID);
+      }
 
       return TRUE;
    }
 
    /**
-	 * Convert tags from stored format to user-presentable format.
-	 *
+    * Convert tags from stored format to user-presentable format.
+    *
     * @since 2.1
     * @access protected
     *
@@ -2218,15 +2226,17 @@ class DiscussionModel extends VanillaModel {
     */
    protected function FormatTags($Tags) {
       // Don't bother if there aren't any tags
-      if (!$Tags)
+      if (!$Tags) {
          return '';
+      }
 
       // Get the array
       $TagsArray = Gdn_Format::Unserialize($Tags);
 
       // Compensate for deprecated space-separated format
-      if (is_string($TagsArray) && $TagsArray == $Tags)
+      if (is_string($TagsArray) && $TagsArray == $Tags) {
          $TagsArray = explode(' ', $Tags);
+      }
 
       // Safe format
       $TagsArray = Gdn_Format::Text($TagsArray);


### PR DESCRIPTION
Ensure that discussion counter increments when a discussion is moved to a new category. Convert tabs to spaces and add braces to all control statements.
