### PR TITLE
Core: modified Flyout logic to regard href values that begin with a fragment identifier synonymous with an empty href.

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -651,7 +651,9 @@ jQuery(document).ready(function($) {
       var href = $elem.attr('href');
       var progressClass = $elem.hasClass('Bookmark') ? 'Bookmarking' : 'InProgress';
 
-      if (!href)
+      // If empty, or starts with a fragment identifier, do not send
+      // an async request.
+      if (!href || href.trim().indexOf('#') === 0)
          return;
       gdn.disable(this, progressClass);
       e.stopPropagation();


### PR DESCRIPTION
This is a fix in response to https://github.com/vanilla/internal/pull/35#commitcomment-6639084.
