### PR TITLE
Fix pager inconsistencies between discussions and categories

### DIFF
--- a/applications/dashboard/modules/class.pagermodule.php
+++ b/applications/dashboard/modules/class.pagermodule.php
@@ -267,7 +267,7 @@ class PagerModule extends Gdn_Module {
       $this->EventArguments['PageCount'] = &$PageCount;
       $this->FireEvent('BeforePagerSetsCount');
       $this->_PageCount = $PageCount;
-      $CurrentPage = ceil($this->Offset / $this->Limit) + 1;
+      $CurrentPage = PageNumber($this->Offset, $this->Limit);
 
       // Show $Range pages on either side of current
       $Range = C('Garden.Modules.PagerRange', 3);

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -261,6 +261,12 @@ class CategoriesController extends VanillaController {
 
          $Page = PageNumber($Offset, $Limit);
 
+         // Allow page manipulation
+         $this->EventArguments['Page'] = &$Page;
+         $this->EventArguments['Offset'] = &$Offset;
+         $this->EventArguments['Limit'] = &$Limit;
+         $this->FireEvent('AfterPageCalculation');
+
          // We want to limit the number of pages on large databases because requesting a super-high page can kill the db.
          $MaxPages = C('Vanilla.Categories.MaxPages');
          if ($MaxPages && $Page > $MaxPages) {
@@ -285,7 +291,9 @@ class CategoriesController extends VanillaController {
 
          // Build a pager
          $PagerFactory = new Gdn_PagerFactory();
-         $this->Pager = $PagerFactory->GetPager('Pager', $this);
+         $this->EventArguments['PagerType'] = 'Pager';
+         $this->FireEvent('BeforeBuildPager');
+         $this->Pager = $PagerFactory->GetPager($this->EventArguments['PagerType'], $this);
          $this->Pager->ClientID = 'Pager';
          $this->Pager->Configure(
             $Offset,
@@ -296,6 +304,8 @@ class CategoriesController extends VanillaController {
          $this->Pager->Record = $Category;
          PagerModule::Current($this->Pager);
          $this->SetData('_Page', $Page);
+         $this->SetData('_Limit', $Limit);
+         $this->FireEvent('AfterBuildPager');
 
          // Set the canonical Url.
          $this->CanonicalUrl(CategoryUrl($Category, PageNumber($Offset, $Limit)));

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -158,6 +158,7 @@ class DiscussionsController extends VanillaController {
          $CountDiscussions,
          'discussions/%1$s'
       );
+      PagerModule::Current($this->Pager);
       if (!$this->Data('_PagerUrl'))
          $this->SetData('_PagerUrl', 'discussions/{Page}');
       $this->SetData('_Page', $Page);


### PR DESCRIPTION
- PagerModule: Fix old use of ceil instead of PageNumber()
- CategoriesController: Sync events/args to DiscussionsController
- DiscussionsController: Use the new PagerModule::Current() call to be consistent with CategoriesController

I'm doing a little custom pagination experiment and the lack of synchronicity here was tripping me up really badly.
