### PR TITLE
Add permission check to /utility/sort

### DIFF
--- a/applications/dashboard/controllers/class.utilitycontroller.php
+++ b/applications/dashboard/controllers/class.utilitycontroller.php
@@ -180,6 +180,7 @@ class UtilityController extends DashboardController {
     * @access public
     */
    public function Sort() {
+      $this->Permission('Garden.Settings.Manage');
       $Session = Gdn::Session();
       $TransientKey = GetPostValue('TransientKey', '');
       $Target = GetPostValue('Target', '');


### PR DESCRIPTION
/utility/sort has no permission check. So any registered user can write directly to column Sort in any table that contains such a column (Category, RoleID, Message)
