### PR TITLE
Change to SSL requirement for 2.1 users

### DIFF
--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -33,7 +33,7 @@ require_once PATH_LIBRARY.'/vendors/oauth/OAuth.php';
 
 class TwitterPlugin extends Gdn_Plugin {
    const ProviderKey = 'Twitter';
-   public static $BaseApiUrl = 'http://api.twitter.com/1.1/';
+   public static $BaseApiUrl = 'https://api.twitter.com/1.1/';
 
    protected $_AccessToken = NULL;
    
@@ -267,7 +267,7 @@ class TwitterPlugin extends Gdn_Plugin {
             $this->SetOAuthToken($Data['oauth_token'], $Data['oauth_token_secret'], 'request');
 
             // Redirect to twitter's authorization page.
-            $Url = "http://api.twitter.com/oauth/authenticate?oauth_token={$Data['oauth_token']}";
+            $Url = "https://api.twitter.com/oauth/authenticate?oauth_token={$Data['oauth_token']}";
             Redirect($Url);
          }
       }


### PR DESCRIPTION
Users of 2.1 face "SSL required" errors with Twitter plugin.
