### PR TITLE
Fix CSS font asset paths for HTTPS

### DIFF
--- a/applications/dashboard/controllers/class.dashboardcontroller.php
+++ b/applications/dashboard/controllers/class.dashboardcontroller.php
@@ -45,7 +45,7 @@ class DashboardController extends Gdn_Controller {
          $this->AddCssFile('vanillicon.css', 'static');
       } else {
          if (!C('Garden.Cdns.Disable', FALSE))
-            $this->AddCssFile('http://fonts.googleapis.com/css?family=Rokkitt');
+            $this->AddCssFile('//fonts.googleapis.com/css?family=Rokkitt');
          $this->AddCssFile('admin.css');
          $this->AddCssFile('magnific-popup.css');
       }

--- a/themes/bittersweet/design/custom.css
+++ b/themes/bittersweet/design/custom.css
@@ -2,7 +2,7 @@
   font-family: 'Bitter';
   font-style: normal;
   font-weight: 400;
-  src: local('Bitter-Regular'), url('http://themes.googleusercontent.com/static/fonts/bitter/v3/2PcBT6-VmYhQCus-O11S5-vvDin1pK8aKteLpeZ5c0A.woff') format('woff');
+  src: local('Bitter-Regular'), url('//themes.googleusercontent.com/static/fonts/bitter/v3/2PcBT6-VmYhQCus-O11S5-vvDin1pK8aKteLpeZ5c0A.woff') format('woff');
 }
 body,
 .SiteTitle,


### PR DESCRIPTION
Allow browser to determine the appropriate protocol to request font assets. This eliminates insecure content warnings when serving over HTTPS.
