### PR TITLE
Added new events to allow 3rd parties to interact with Activity logging

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -194,6 +194,8 @@ class ActivityModel extends Gdn_Model {
          ->From('Activity a')
          ->Join('Activity a2', 'a.ActivityID = a2.ActivityID') // self-join for index speed.
          ->Join('ActivityType t', 'a2.ActivityTypeID = t.ActivityTypeID');
+         
+      $this->FireEvent('AfterActivityQuery');         
 
       // Add prefixes to the where.
       foreach ($Where as $Key => $Value) {
@@ -1129,6 +1131,11 @@ class ActivityModel extends Gdn_Model {
 
          return; // don't notify users of something they did.
       }
+      
+      // Fire event before sending an email, so that a Plugin can do something before that happens
+      $this->EventArguments['Activity'] = &$Activity;
+      $this->FireEvent('BeforeProcessingActivityNotifications');
+      
 
       // Check the user's preference.
       if ($Preference) {


### PR DESCRIPTION
Events will simplify interaction with the recording of Activities.
- Added firing of event BeforeProcessingActivityNotifications in ActivityModel::Save(). This was necessary for a post scheduling feature to be implemented, to prevent emails from being sent until the post is actually published.
- Added firing of event AfterActivityQuery in ActivityModel::GetWhere(). This allows to filter activities that should not be displayed, based on any criteria.
