### PR TITLE
Avoid using the RoleModel cache because it doesn't yet exist on this bra...

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -843,12 +843,13 @@ class UserModel extends Gdn_Model {
             if (isset($Fields['Email']) && $UserID == Gdn::Session()->UserID && $Fields['Email'] != Gdn::Session()->User->Email && !Gdn::Session()->CheckPermission('Garden.Users.Edit')) {
                $User = Gdn::Session()->User;
                $Attributes = Gdn::Session()->User->Attributes;
-               
+
+               $RoleModel = new RoleModel();
                $ConfirmEmailRoleID = C('Garden.Registration.ConfirmEmailRole');
-               if (RoleModel::Roles($ConfirmEmailRoleID)) {
+               if ($RoleModel->GetByRoleID($ConfirmEmailRoleID)) {
                   // The confirm email role is set and it exists so go ahead with the email confirmation.
                   $EmailKey = TouchValue('EmailKey', $Attributes, RandomString(8));
-                  
+
                   if ($RoleIDs)
                      $ConfirmedEmailRoles = $RoleIDs;
                   else


### PR DESCRIPTION
...nch. This fixes a problem in which Garden 2.0 installations will hang indefinitely due to a PHP error when trying to change one's own email address on an account.

Note I am naive when it comes to Vanilla's source code but this seems to do the trick and seems to be the quickest fix for sustaining 2.0 functionality until I can update to 2.1.
