### PR TITLE
[2.1.1] Fix for "u.Photo isn't in GROUP BY" Fatal Error

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -280,7 +280,7 @@ class ConversationModel extends Gdn_Model {
          ->Join('ConversationMessage cm', 'uc.ConversationID = cm.ConversationID and uc.UserID = cm.InsertUserID', 'left')
          ->Where('uc.ConversationID', $ConversationID)
          // ->Where('uc.UserID <>', $IgnoreUserID)
-         ->GroupBy('uc.UserID, u.Name, u.Email, uc.Deleted')
+         ->GroupBy('uc.UserID, u.Name, u.Email, uc.Deleted, u.Photo')
          ->Get();
    }
    


### PR DESCRIPTION
Fatal error with the message "u.Photo isn't in GROUP BY" occurs when viewing a conversation. This might be due to MySQL strict mode.
