### PR TITLE
Fix bc for Tag table structure looking for CategoryID on utility-update

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -590,8 +590,12 @@ if ($PhotoIDExists) {
    $Construct->Table('User')->DropColumn('PhotoID');
 }
 
+$Construct->Table('Tag');
+$FullNameColumnExists = $Construct->ColumnExists('FullName');
+$TagCategoryColumnExists = $Construct->ColumnExists('CategoryID');
+
 // This is a fix for erroneous unique constraint.
-if ($Construct->TableExists('Tag')) {
+if ($Construct->TableExists('Tag') && $TagCategoryColumnExists) {
    $Db = Gdn::Database();
    $Px = Gdn::Database()->DatabasePrefix;
 
@@ -623,9 +627,6 @@ if ($Construct->TableExists('Tag')) {
       }
    }
 }
-
-$Construct->Table('Tag');
-$FullNameColumnExists = $Construct->ColumnExists('FullName');
 
 $Construct->Table('Tag')
 	->PrimaryKey('TagID')


### PR DESCRIPTION
Running utility-update on a forum where GDN_Tag lacks CategoryID will fatal error when it attempts to run code under "fix for erroneous unique constraint". This bumps the Tag column checks up and adds one for CategoryID. A table without CategoryID presumably does not need that fix anyway.
