### PR TITLE
Add missing ButtonBar* classes

### DIFF
--- a/plugins/ButtonBar/views/buttonbar.php
+++ b/plugins/ButtonBar/views/buttonbar.php
@@ -1,13 +1,13 @@
 <div class="ButtonBar">
    <div class="BarWrap"><?php
-      echo '<span class="ButtonWrap"><span>bold</span></span>';
-      echo '<span class="ButtonWrap"><span>italic</span></span>';
-      echo '<span class="ButtonWrap"><span>underline</span></span>';
-      echo '<span class="ButtonWrap"><span>strike</span></span>';
-      echo '<span class="ButtonWrap"><span>code</span></span>';
-      echo '<span class="ButtonWrap"><span>image</span></span>';
-      echo '<span class="ButtonWrap"><span>url</span></span>';
-      echo '<span class="ButtonWrap"><span>quote</span></span>';
-      echo '<span class="ButtonWrap"><span>spoiler</span></span>';
+      echo '<span class="ButtonWrap ButtonBarBold"><span>bold</span></span>';
+      echo '<span class="ButtonWrap ButtonBarItalic"><span>italic</span></span>';
+      echo '<span class="ButtonWrap ButtonBarUnderline"><span>underline</span></span>';
+      echo '<span class="ButtonWrap ButtonBarStrike"><span>strike</span></span>';
+      echo '<span class="ButtonWrap ButtonBarCode"><span>code</span></span>';
+      echo '<span class="ButtonWrap ButtonBarImage"><span>image</span></span>';
+      echo '<span class="ButtonWrap ButtonBarUrl"><span>url</span></span>';
+      echo '<span class="ButtonWrap ButtonBarQuote"><span>quote</span></span>';
+      echo '<span class="ButtonWrap ButtonBarSpoiler"><span>spoiler</span></span>';
    ?></div>
 </div>


### PR DESCRIPTION
This addresses a long standing issue where the icons in the editor would all show up as the bold sprite icon instead of the appropriate bold, italic, underline, etc. icon.
