### PR TITLE
Remove initial check for invitation on form load

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1482,14 +1482,10 @@ EOT;
          ->GetWhere(array('Code' => $this->Form->GetValue('InvitationCode')))
          ->FirstRow(DATASET_TYPE_ARRAY);
 
-      if (!$Invitation) {
-         $this->Form->AddError('Invitation not found.', 'Code');
-      } else {
-         if ($Expires = GetValue('DateExpires', $Invitation)) {
-            $Expires = Gdn_Format::ToTimestamp($Expires);
-            if ($Expires <= time()) {
+      if ($Expires = GetValue('DateExpires', $Invitation)) {
+         $Expires = Gdn_Format::ToTimestamp($Expires);
+         if ($Expires <= time()) {
 
-            }
          }
       }
 


### PR DESCRIPTION
This fixes an annoyance (at least for me) when users load or visit the register page without an invitation code. This may not be how you'd like it, but I thought I'd submit it anyways. The check is still there for the actual invitation code on submit, so if they don't enter a code, then it will error like normal. This seems a bit more friendly to me instead of throwing the error in their face right away.
