### PR TITLE
Fix the server side exploit to converstion recipient restriction.

### DIFF
--- a/applications/conversations/js/conversations.js
+++ b/applications/conversations/js/conversations.js
@@ -146,10 +146,10 @@ jQuery(document).ready(function($) {
          url: $(frm).attr('action'),
          data: $(frm).serialize() + '&DeliveryType=VIEW&DeliveryMethod=JSON',
          dataType: 'json',
-         error: function(XMLHttpRequest, textStatus, errorThrown) {
-            $('span.Progress').remove();
+         error: function(xhr, textStatus, errorThrown) {
+            $('span.TinyProgress').remove();
             $(btn).show();
-            $.popup({}, XMLHttpRequest.responseText);
+            gdn.informError(xhr);
          },
          success: function(json) {
             gdn.inform(json);

--- a/applications/conversations/models/class.conversationmessagemodel.php
+++ b/applications/conversations/models/class.conversationmessagemodel.php
@@ -338,4 +338,26 @@ class ConversationMessageModel extends ConversationsModel {
       }
       return $MessageID;
    }
+
+   /**
+    * @param array $FormPostValues
+    * @param bool $Insert
+    * @return bool
+    */
+   public function Validate($FormPostValues, $Insert = FALSE) {
+      $valid = parent::Validate($FormPostValues, $Insert);
+
+      if (!CheckPermission('Garden.Moderation.Manage') && C('Conversations.MaxRecipients')) {
+         $max = C('Conversations.MaxRecipients');
+         if (isset($FormPostValues['RecipientUserID']) && count($FormPostValues['RecipientUserID']) > $max) {
+            $this->Validation->AddValidationResult(
+               'To',
+               Plural($max, "You are limited to %s recipient.", "You are limited to %s recipients.")
+            );
+            $valid = false;
+         }
+      }
+
+      return $valid;
+   }
 }


### PR DESCRIPTION
Check Conversations.MaxRecipients on the server side and not just the client side. Fix the error handling when adding a receipient.
