### PR TITLE
Auto-detect import models; Regenerate SystemUserID on import

### DIFF
--- a/applications/dashboard/models/class.importmodel.php
+++ b/applications/dashboard/models/class.importmodel.php
@@ -632,6 +632,10 @@ class ImportModel extends Gdn_Model {
             $SQLPath = 'import/import_'.date('Y-m-d_His').'.sql';
             $this->Data('SQLPath', $SQLPath);
          }
+      } else {
+         // Importing will overwrite our System user record.
+         // Our CustomFinalization step (e.g. vbulletinimportmodel) needs this to be regenerated.
+         RemoveFromConfig('Garden.SystemUserID');
       }
 
       return TRUE;


### PR DESCRIPTION
This will make symlinking in a custom importmodel much less painful and remove a gotcha for new core ones.

Dropping SystemUserID from the config on import is really a bugfix, IMO.
