### PR TITLE
Let BeforeBodyBox change the BodyBox again

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -161,13 +161,12 @@ class Gdn_Form extends Gdn_Pluggable {
       $this->EventArguments['Column'] = $Column;
       $this->EventArguments['Attributes'] = $Attributes;
 
-      $Result = '<div class="bodybox-wrap">';
+      $Result = $this->TextBox($Column, $Attributes).$this->Hidden('Format');
+
       $this->EventArguments['BodyBox'] =& $Result;
       $this->FireEvent('BeforeBodyBox');
-      $Result .= $this->TextBox($Column, $Attributes).$this->Hidden('Format').
-         '</div>';
 
-      return $Result;
+      return '<div class="bodybox-wrap">'.$Result.'</div>';
    }
 
    /**

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -160,13 +160,10 @@ class Gdn_Form extends Gdn_Pluggable {
       $this->EventArguments['Table'] = GetValue('Table', $Attributes);
       $this->EventArguments['Column'] = $Column;
       $this->EventArguments['Attributes'] = $Attributes;
-
-      $Result = $this->TextBox($Column, $Attributes).$this->Hidden('Format');
-
-      $this->EventArguments['BodyBox'] =& $Result;
+      $this->EventArguments['BodyBox'] = $this->TextBox($Column, $Attributes).$this->Hidden('Format');
       $this->FireEvent('BeforeBodyBox');
 
-      return '<div class="bodybox-wrap">'.$Result.'</div>';
+      return '<div class="bodybox-wrap">'.$this->EventArguments['BodyBox'].'</div>';
    }
 
    /**

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -157,13 +157,15 @@ class Gdn_Form extends Gdn_Pluggable {
       $Attributes['format'] = htmlspecialchars($Attributes['format']);
       $this->SetValue('Format', $Attributes['format']);
 
+      $Result = $this->TextBox($Column, $Attributes).$this->Hidden('Format');
+
       $this->EventArguments['Table'] = GetValue('Table', $Attributes);
       $this->EventArguments['Column'] = $Column;
       $this->EventArguments['Attributes'] = $Attributes;
-      $this->EventArguments['BodyBox'] = $this->TextBox($Column, $Attributes).$this->Hidden('Format');
+      $this->EventArguments['BodyBox'] =& $Result;
       $this->FireEvent('BeforeBodyBox');
 
-      return '<div class="bodybox-wrap">'.$this->EventArguments['BodyBox'].'</div>';
+      return '<div class="bodybox-wrap">'.$Result.'</div>';
    }
 
    /**


### PR DESCRIPTION
I'm creating a plugin that allows the user to choose the format (HTML or Markdown) of each of their individual posts.

Prior to [this commit](https://github.com/vanilla/vanilla/commit/e2b1f69393d0fe54ff7790b9957fe8402329e9bb#diff-bcdcd95ad070ab8428b1b3eb3e2353cbL150), `BeforeBodyBox`'s `BodyBox` parameter contained HTML for the textbox and the hidden `Format` input. My plugin would rewrite this string to remove the hidden input.

After that commit, `BeforeBodyBox` does not receive the hidden input in the `BodyBox` parameter - it's always `<div class="bodybox-wrap">`, which is pretty pointless.

This PR restores the old behaviour (the current behaviour in 2.1.x). It additionally makes it easier than in 2.1 for `BeforeBodyBox` to change `BodyBox`: it no longer needs to modify the passed string object; it can set a new one if it wants.