### PR TITLE
Fix pager bug in search page

### DIFF
--- a/applications/dashboard/views/search/results.php
+++ b/applications/dashboard/views/search/results.php
@@ -81,6 +81,6 @@ $RecordCount = $this->Data('RecordCount');
 if ($RecordCount)
    echo '<span class="Gloss">'.Plural($RecordCount, '%s result', '%s results').'</span>';
 
-PagerModule::Write(array('Wrapper' => '<div %1$s>%2$s</div>'));
+echo $this->Pager->ToString();
 
 echo '</div>';


### PR DESCRIPTION
`PagerModule::Write` without any custom arguments has been erroneously used. Replaced it with `$this->Pager` (which gets initialized in the SearchController) and its method `ToString`. A hint have been that the wrong pager expressed "Next" while the controller sets `$this->Pager->MoreCode = 'More Results';`     
    
Tested successfully with search words that yield       
0 result,   
1 result,   
2 results and    
more than C('Garden.Search.PerPage') results    