### PR TITLE
Fix HTML special char bug

### DIFF
--- a/applications/dashboard/views/search/results.php
+++ b/applications/dashboard/views/search/results.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 
 <?php if (!count($this->Data('SearchResults')) && $this->Data('SearchTerm'))
-   echo '<p class="NoResults">', sprintf(T('No results for %s.', 'No results for <b>%s</b>.'), htmlspecialchars($this->Data('SearchTerm'))), '</p>';
+   echo '<p class="NoResults">', sprintf(T('No results for %s.', 'No results for <b>%s</b>.'), $this->Data('SearchTerm')), '</p>';
 ?>
 <ol id="search-results" class="DataList DataList-Search" start="<?php echo $this->Data('From'); ?>">
    <?php foreach ($this->Data('SearchResults') as $Row): ?>


### PR DESCRIPTION
`$this->Data('SearchTerm')` is already sanitized in controller with `$this->SetData('SearchTerm', Gdn_Format::Text($Search), TRUE);` so `htmlspecialchars()` mustn't be called in the output (again)