### PR TITLE
Autodetect Internet on install for using CDNs

### DIFF
--- a/applications/dashboard/controllers/class.setupcontroller.php
+++ b/applications/dashboard/controllers/class.setupcontroller.php
@@ -224,10 +224,14 @@ class SetupController extends DashboardController {
             
             // Detect rewrite abilities
             $CanRewrite = (bool)$this->Form->GetFormValue('RewriteUrls');
-      
+
+            // Detect Internet connection for CDNs
+            $Disconnected = !(bool)@fsockopen('ajax.googleapis.com',80);
+
             SaveToConfig(array(
                'Garden.Version' => ArrayValue('Version', GetValue('Dashboard', $ApplicationInfo, array()), 'Undefined'),
                'Garden.RewriteUrls' => $CanRewrite,
+               'Garden.Cdns.Disable' => $Disconnected,
                'Garden.CanProcessImages' => function_exists('gd_info'),
                'EnabledPlugins.GettingStarted' => 'GettingStarted', // Make sure the getting started plugin is enabled
                'EnabledPlugins.HtmLawed' => 'HtmLawed' // Make sure html purifier is enabled so html has a default way of being safely parsed.


### PR DESCRIPTION
Installing Vanilla on localhost without a network connection shouldn't auto-break your install.
