### PR TITLE
Emoji api enhancements.

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1467,10 +1467,11 @@ jQuery(document).ready(function($) {
 
       // Emoji, set in definition list in foot, by Emoji class. Make sure
       // that class is getting instantiated, otherwise emoji will be empty.
-      var emoji_array = gdn.definition('emoji', []);
-      var emoji = (emoji_array.length)
-         ? $.parseJSON(emoji_array)
-         : [];
+      var emoji = gdn.definition('emoji', []);
+
+      if ((typeof emoji) === 'string') {
+         emoji = emoji.length ? $.parseJSON(emoji) : [];
+      }
 
       // Handle iframe situation
       var iframe_window = (iframe)

--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -431,10 +431,22 @@ class Emoji {
     *
     * @param string $emoji_path The full path to Emoji file.
     * @param string $emoji_name The name given to Emoji.
-    * @return string The html that represents the emiji.
+    * @return string The html that represents the emoji.
     */
    public function img($emoji_path, $emoji_name) {
-      return sprintf($this->format, Url($emoji_path), $emoji_name);
+      $dir = Asset(dirname($emoji_path));
+      $filename = basename($emoji_name);
+      $ext = '.'.pathinfo($filename, PATHINFO_EXTENSION);
+      $basename = basename($filename, $ext);
+      $src = Asset($emoji_path);
+
+      $img = str_replace(
+         array('%1$s', '%2$s', '{src}', '{name}', '{dir}', '{filename}', '{basename}', '{ext}'),
+         array($src, $emoji_name, $src, $emoji_name, $dir, $filename, $basename, $ext),
+         $this->format
+         );
+
+      return $img;
    }
 
    /**

--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -250,7 +250,7 @@ class Emoji {
             );
          }
 
-         $c->AddDefinition('emoji', json_encode($emoji));
+         $c->AddDefinition('emoji', $emoji);
       }
    }
 

--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -213,12 +213,13 @@ class Emoji {
          ':('          => 'disappointed',
          ';)'          => 'wink',
          ':\\'         => 'confused',
+         ':/'          => 'confused',
          ':o'          => 'open_mouth',
          ':s'          => 'confounded',
          ':p'          => 'stuck_out_tongue',
          ":'("         => 'cry',
          ':|'          => 'neutral_face',
-       //'D:'          => 'anguished',
+         'D:'          => 'anguished',
          'B)'          => 'sunglasses',
          ':#'          => 'grin',
          'o:)'         => 'innocent',
@@ -226,6 +227,25 @@ class Emoji {
          '(*)'         => 'star',
          '>:)'         => 'smiling_imp'
        );
+
+      $this->editorList = array(
+         ':)'          => 'smile',
+         ':D'          => 'smiley',
+         ':('          => 'disappointed',
+         ';)'          => 'wink',
+         ':\\'         => 'confused',
+         ':o'          => 'open_mouth',
+         ':s'          => 'confounded',
+         ':p'          => 'stuck_out_tongue',
+         ":'("         => 'cry',
+         ':|'          => 'neutral_face',
+         'B)'          => 'sunglasses',
+         ':#'          => 'grin',
+         'o:)'         => 'innocent',
+         '<3'          => 'heart',
+         '(*)'         => 'star',
+         '>:)'         => 'smiling_imp'
+      );
 
       Gdn::PluginManager()->CallEventHandlers($this, 'Emoji', 'Init', 'Handler');
 


### PR DESCRIPTION
Add enhancements to the emoji api so that emoji packs can do more.

- Add more options to the image format string for emoji so that packs can pass @2x retina images or sprite sheets.
- Add a seperate editor list for the default emoji so that more aliases can be added.
- Pass the emoji auto-complete data as a raw array since the new definition list format supports that.