### PR TITLE
Fix the API passing an int where we demand an array

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -882,7 +882,7 @@ class UserController extends DashboardController {
             $DefaultRoles = C('Garden.Registration.DefaultRoles', array());
             $User['RoleID'] = $DefaultRoles;
          }
-         elseif (is_int($User['RoleID'])) {
+         elseif (is_numeric($User['RoleID'])) {
             // UserModel->Save() demands an array for RoleID.
             $User['RoleID'] = array($User['RoleID']);
          }


### PR DESCRIPTION
If an int is passed for `RoleID` when creating a new user, convert it to an array before passing it along. 

Fixes support request 5338.
