### PR TITLE
RemoveMobileUnfriendlyPlugins: unregister all MobileUnfriendly plugins

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -465,8 +465,9 @@ class Gdn_PluginManager extends Gdn_Pluggable {
          $PluginInfo = $this->GetPluginInfo($PluginName);
 
          // Remove plugin hooks from plugins that dont explicitly claim to be friendly with mobile themes
-         if (!GetValue('MobileFriendly', $PluginInfo))
-            $this->UnRegisterPlugin($PluginName.'Plugin');
+         if (!val('MobileFriendly', $PluginInfo)) {
+            $this->UnRegisterPlugin(val('ClassName', $PluginInfo));
+         }
       }
    }
 


### PR DESCRIPTION
see: http://vanillaforums.org/discussion/comment/216131/#Comment_216131

PluginManager->UnRegisterPlugin() unregisters by classname, but the
classname isn't always PluginName + 'Plugin'

This causes plugins not to be removed on mobile, regardless of what the
PluginInfo says about mobile-friendlyness.

This PR fixes that.
