### PR TITLE
Use the .Hidden class on the preview button instead of jQuery’s hide/show methods.

### DIFF
--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -18,7 +18,7 @@ jQuery(document).ready(function($) {
 
          // Reveal the "Preview" button and hide this one
          $(this).parents('.CommentForm').find('.PreviewButton').show();
-         $(this).hide();
+         $(this).addClass('Hidden');
       }
 
       resetCommentForm(this);
@@ -157,7 +157,7 @@ jQuery(document).ready(function($) {
             } else if (preview) {
                // Reveal the "Edit" button and hide this one
                $(btn).hide();
-               $(parent).find('.WriteButton').show();
+               $(parent).find('.WriteButton').removeClass('Hidden');
 
                $(frm).trigger('PreviewLoaded', [frm]);
                $(frm).find('.TextBoxWrapper').hide().after(json.Data);


### PR DESCRIPTION
This is so that the write button can be styled with display: inline-block. Otherwise it gets set to display: inline when shown.
