### PR TITLE
Support new array syntax in $PluginInfo

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -857,7 +857,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
       ${$VariableName} = array();
 
       foreach ($Lines as $Line) {
-         if ($InfoBuffer && substr(trim($Line), -2) == ');') {
+         if ($InfoBuffer && substr(trim($Line), -1) == ';') {
             $PluginInfoString .= $Line;
             $ClassBuffer = TRUE;
             $InfoBuffer = FALSE;


### PR DESCRIPTION
This patch makes the PluginManager recognize plugins, that use the [ ] array syntax in the $PluginInfo array

Tested with the standard plugins + addons repository (all working with new and old syntax).

Tried different things, but matching <code>;</code> is just as robust as matching <code>);</code>, they both fail in the same unlikely cases: 
- array contains a string with a break after a semicolon
- second instruction on the same line
