### PR TITLE
Proposal: Allow simple javascript anchors

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -392,12 +392,11 @@ if (!function_exists('Anchor')) {
 			unset($Attributes['WithDomain']);
       }
 
-      // Don't convert Javascript to URL
-      $IsJS = preg_match('/(^javascript:)/', $Destination);
 
-      $Prefix = substr($Destination, 0, 7);
-      if (!in_array($Prefix, array('https:/', 'http://', 'mailto:')) && ($Destination != '' || $ForceAnchor === FALSE) && IsJS == 0)
-         $Destination = Gdn::Request()->Url($Destination, $WithDomain, $SSL);
+      // Figure out URL Structure
+      $Parse = parse_url($Destination);
+      if (!isset($Parse['scheme']) && ($Destination != '' || $ForceAnchor === FALSE) )
+          $Destination = Gdn::Request()->Url($Destination, $WithDomain, $SSL);
 
       return '<a href="'.htmlspecialchars($Destination, ENT_COMPAT, 'UTF-8').'"'.Attribute($CssClass).Attribute($Attributes).'>'.$Text.'</a>';
    }


### PR DESCRIPTION
This change would allow Anchors to be simple javascript links, often useful when using an anchor simply to trigger a javascript event.

Currently attempting to create an anchor such as:
`<a href="javascript:;">I can't exist</a>`
Results in Garden prepending the forum path to the link, e.g. 
`<a href="/vanilla-forums/javascript:;">I can't exist</a>`

This may just be a personal preference of mine, but it seemed like useful functionality to have without any sacrifice in particular. Figured it was at least worth the suggestion.
