### PR TITLE
Twitter Fix for conflict with @mention

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -129,7 +129,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
 
          switch ($Label) {
             case 'Twitter':
-               $Fields['Twitter'] = Anchor('@'.$Value, 'http://twitter.com/'.$Value);
+               $Fields['Twitter'] = '@'.Anchor($Value, 'http://twitter.com/'.$Value);
                break;
             case 'Facebook':
                $Fields['Facebook'] = Anchor($Value, 'http://facebook.com/'.$Value);


### PR DESCRIPTION
This fixes removes conflict when a user enters Twitter username, because it defaults to @mention profile url.
