### PR TITLE
Fixes missing data when retrieving multiple users, as in users/multi API endpoint

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1114,15 +1114,17 @@ class UserModel extends Gdn_Model {
          $Keys = array();
          // Make keys for cache query
          foreach ($IDs as $UserID) {
-            if (!$UserID) continue;
-
+            if (!$UserID) {
+               continue;
+            }
             $Keys[] = FormatString(self::USERID_KEY, array('UserID' => $UserID));
          }
 
          // Query cache layer
          $CacheData = Gdn::Cache()->Get($Keys);
-         if (!is_array($CacheData))
+         if (!is_array($CacheData)) {
             $CacheData = array();
+         }
 
          foreach ($CacheData as $RealKey => $User) {
             if ($User === NULL) {
@@ -1130,6 +1132,7 @@ class UserModel extends Gdn_Model {
             } else {
                $ResultUserID = GetValue('UserID', $User);
             }
+            $this->SetCalculatedFields($User);
             $Data[$ResultUserID] = $User;
          }
 


### PR DESCRIPTION
Adds missing SetCalculatedFields for cached users in GetIDs().

To test this, on a server using memcached, enable Simple API and access this endpoint:

/api/v1/users/multi.json?Users.ID=1,2,3,4,5 (or multiple UserIDs of your choice)

Where multiple listed users have the Photo field set (not null). Without the fix, the second+ queries should be missing PhotoUrl for cached users. With the fix, all PhotoUrls should return successfully every time.
