### PR TITLE
Change the translation of "Locale".

### DIFF
--- a/applications/dashboard/locale/en-CA/definitions.php
+++ b/applications/dashboard/locale/en-CA/definitions.php
@@ -19,9 +19,6 @@ if (!function_exists('FormatPossessive')) {
    }
 }
 
-$Definition['Locale'] = 'en-CA';
-$Definition['_Locale'] = 'Locale';
-
 $Definition['Apply for Membership'] = 'Register';
 
 // THESE ARE RELATED TO VALIDATION FUNCTIONS IN /garden/library/core/validation.functions.php
@@ -143,7 +140,7 @@ $Definition['Date.DefaultDateTimeFormat'] = '%B %e, %Y %l:%M%p';
 $Definition['Saved'] = 'Your changes have been saved.';
 $Definition['%s new plural'] = '%s new';
 $Definition['TermsOfService'] = 'Terms of Service';
-$Definition['TermsOfServiceText'] = 
+$Definition['TermsOfServiceText'] =
 "You agree, through your use of this service, that you will not use this
 community to post any material which is knowingly false and/or defamatory,
 inaccurate, abusive, vulgar, hateful, harassing, obscene, profane, sexually

--- a/applications/dashboard/views/settings/locales.php
+++ b/applications/dashboard/views/settings/locales.php
@@ -53,7 +53,7 @@ foreach ($this->Data('AvailableLocales') as $Key => $Info) {
    // Hide skeleton locale pack
    if ($Key == 'skeleton')
       continue;
-      
+
    $ToggleText = $this->Data("EnabledLocales.$Key") ? 'Disable' : 'Enable';
    $RowClass = $this->Data("EnabledLocales.$Key") ? 'Enabled' : 'Disabled';
    if ($Alt) $RowClass .= ' Alt';
@@ -74,7 +74,7 @@ foreach ($this->Data('AvailableLocales') as $Key => $Info) {
          $RequiredApplications = GetValue('RequiredApplications', $Info, FALSE);
          $RequiredPlugins = GetValue('RequiredPlugins', $Info, FALSE);
 
-         $InfoItems = ArrayTranslate($Info, array('Locale' => T('_Locale'), 'Version' => T('Version')));
+         $InfoItems = ArrayTranslate($Info, array('Locale' => T('Locale'), 'Version' => T('Version')));
          $InfoString = ImplodeAssoc(': ', '<span>|</span>', $InfoItems);
 
 //            if (is_array($RequiredApplications) || is_array($RequiredPlugins)) {


### PR DESCRIPTION
The "Locale" translation code always translated to the current locale you are on such as "en-CA". This flummoxes translators and they never translate it correctly (and I don't blame them).
With a more localizable product it's time we let the word "locale" be used inside the app as proud first class citizen of the application.
