### PR TITLE
Don't use anonymous function in MessageModel

### DIFF
--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -124,8 +124,8 @@ class MessageModel extends Gdn_Model {
          }
          return $Result;
       }
-      
-      $Result = $this->SQL
+
+      $Messages = $this->SQL
          ->Select()
          ->From('Message')
          ->Where('Enabled', '1')
@@ -140,11 +140,15 @@ class MessageModel extends Gdn_Model {
          ->WhereNotIn('MessageID', $Prefs)
          ->OrderBy('Sort', 'asc')
          ->Get()->ResultArray();
-      
-      $Result = array_filter($Result, function($Message) use ($CategoryID) {
-         return $this->InCategory($CategoryID, GetValue('CategoryID', $Message), GetValue('IncludeSubcategories', $Message));
-      });
-      
+
+      $Result = array();
+
+      foreach ($Messages as $Message) {
+         if ($this->InCategory($CategoryID, GetValue('CategoryID', $Message), GetValue('IncludeSubcategories', $Message))) {
+            $Result[] = $Message;
+         }
+      }
+
       return $Result;
    }
    


### PR DESCRIPTION
The $this variable wasn't allowed in anonymous functions until 5.4;
Mitigate this by using a $context variable and passing it into the scope.

I looked and it seemed like this was the only occurence of the problem throughout the codebase.

Fixes #2143 from what I can see.

@myevit can you verify this fixes your issue?

Edit: Removed the anonymous function from MessageModel altogether to get 5.2 compatibility
