### PR TITLE
Add a display as option of “Heading” to categories.

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -218,11 +218,7 @@ class CategoriesController extends VanillaController {
          }
 
          // Load the subtree.
-         if (C('Vanilla.ExpandCategories'))
-            $Categories = CategoryModel::GetSubtree($CategoryIdentifier);
-         else
-            $Categories = array($Category);
-
+         $Categories = CategoryModel::GetSubtree($CategoryIdentifier, false);
          $this->SetData('Categories', $Categories);
 
          // Setup head
@@ -245,7 +241,10 @@ class CategoriesController extends VanillaController {
 
          // Get a DiscussionModel
          $DiscussionModel = new DiscussionModel();
-         $CategoryIDs = ConsolidateArrayValuesByKey($this->Data('Categories'), 'CategoryID');
+         $CategoryIDs = array($CategoryID);
+         if (C('Vanilla.ExpandCategories')) {
+            $CategoryIDs = array_merge($CategoryIDs, array_column($this->Data('Categories'), 'CategoryID'));
+         }
          $Wheres = array('d.CategoryID' => $CategoryIDs);
          $this->SetData('_ShowCategoryLink', count($CategoryIDs) > 1);
 
@@ -347,7 +346,7 @@ class CategoriesController extends VanillaController {
       $this->CategoryModel->Watching = !Gdn::Session()->GetPreference('ShowAllCategories');
 
       if ($Category) {
-         $Subtree = CategoryModel::GetSubtree($Category);
+         $Subtree = CategoryModel::GetSubtree($Category, false);
          $CategoryIDs = ConsolidateArrayValuesByKey($Subtree, 'CategoryID');
          $Categories = $this->CategoryModel->GetFull($CategoryIDs)->ResultArray();
       } else {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -187,10 +187,13 @@ class CategoryModel extends Gdn_Model {
             $Category['PhotoUrl'] = '';
 
          if ($Category['DisplayAs'] == 'Default') {
-            if ($Category['Depth'] <= C('Vanilla.Categories.NavDepth', 0))
+            if ($Category['Depth'] == 1 && C('Vanilla.Categories.DoHeadings')) {
+               $Category['DisplayAs'] = 'Heading';
+            } elseif ($Category['Depth'] <= C('Vanilla.Categories.NavDepth', 0)) {
                $Category['DisplayAs'] = 'Categories';
-            else
+            } else {
                $Category['DisplayAs'] = 'Discussions';
+            }
          }
 
          if (!GetValue('CssClass', $Category))

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1188,7 +1188,7 @@ class CategoryModel extends Gdn_Model {
       if ($Root) {
          $Root = (array)$Root;
          // Make the tree out of this category as a subtree.
-         $DepthAdjust = C('Vanilla.Categories.DoHeadings') ? -$Root['Depth'] : 0;
+         $DepthAdjust = -$Root['Depth'];
          $Result = self::_MakeTreeChildren($Root, $Categories, $DepthAdjust);
       } else {
          // Make a tree out of all categories.
@@ -1204,8 +1204,10 @@ class CategoryModel extends Gdn_Model {
    }
 
    protected static function _MakeTreeChildren($Category, $Categories, $DepthAdj = null) {
-      if (is_null($DepthAdj))
-         $DepthAdjust = C('Vanilla.Categories.DoHeadings') ? -1 : 0;
+      if (is_null($DepthAdj)) {
+         $DepthAdj = -val('Depth', $Category);
+      }
+
       $Result = array();
       foreach ($Category['ChildIDs'] as $ID) {
          if (!isset($Categories[$ID]))

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -868,20 +868,21 @@ class CategoryModel extends Gdn_Model {
    /**
     * Get all of the ancestor categories above this one.
     * @param int|string $Category The category ID or url code.
-    * @param bool $CheckPermissions Whether or not to only return the categories with view permission.
+    * @param bool $checkPermissions Whether or not to only return the categories with view permission.
+    * @param bool $includeHeadings Whether or not to include heading categories.
     * @return array
     */
-   public static function GetAncestors($CategoryID, $CheckPermissions = TRUE) {
+   public static function GetAncestors($categoryID, $checkPermissions = true, $includeHeadings = false) {
       $Categories = self::Categories();
       $Result = array();
 
       // Grab the category by ID or url code.
-      if (is_numeric($CategoryID)) {
-         if (isset($Categories[$CategoryID]))
-            $Category = $Categories[$CategoryID];
+      if (is_numeric($categoryID)) {
+         if (isset($Categories[$categoryID]))
+            $Category = $Categories[$categoryID];
       } else {
          foreach ($Categories as $ID => $Value) {
-            if ($Value['UrlCode'] == $CategoryID) {
+            if ($Value['UrlCode'] == $categoryID) {
                $Category = $Categories[$ID];
                break;
             }
@@ -900,7 +901,7 @@ class CategoryModel extends Gdn_Model {
             break;
          $Max--;
 
-         if ($CheckPermissions && !$Category['PermsDiscussionsView']) {
+         if ($checkPermissions && !$Category['PermsDiscussionsView']) {
             $Category = $Categories[$Category['ParentCategoryID']];
             continue;
          }
@@ -909,16 +910,18 @@ class CategoryModel extends Gdn_Model {
             break;
 
          // Return by ID or code.
-         if (is_numeric($CategoryID))
+         if (is_numeric($categoryID))
             $ID = $Category['CategoryID'];
          else
             $ID = $Category['UrlCode'];
 
-         $Result[$ID] = $Category;
+         if ($includeHeadings || $Category['DisplayAs'] !== 'Heading') {
+            $Result[$ID] = $Category;
+         }
 
          $Category = $Categories[$Category['ParentCategoryID']];
       }
-      $Result = array_reverse($Result, TRUE); // order for breadcrumbs
+      $Result = array_reverse($Result, true); // order for breadcrumbs
       return $Result;
    }
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -947,22 +947,23 @@ class CategoryModel extends Gdn_Model {
    }
 
    /**
+    * Get the subtree starting at a given parent.
     *
-    *
-    * @since 2.0.18
-    * @acces public
-    * @param int $ID
-    * @return array
+    * @param string $ParentCategory The ID or url code of the parent category.
+    * @param bool $IncludeParent Whether or not to include the parent in the result.
+    * @return array An array of categories.
     */
-   public static function GetSubtree($ID) {
+   public static function GetSubtree($ParentCategory, $IncludeParent = true) {
       $Result = array();
-      $Category = self::Categories($ID);
+      $Category = self::Categories($ParentCategory);
       if ($Category) {
-         $Result[$Category['CategoryID']] = $Category;
+         if ($IncludeParent) {
+            $Result[$Category['CategoryID']] = $Category;
+         }
          $ChildIDs = GetValue('ChildIDs', $Category);
 
          foreach ($ChildIDs as $ChildID) {
-            $Result = array_merge($Result, self::GetSubtree($ChildID));
+            $Result = array_replace($Result, self::GetSubtree($ChildID, true));
          }
       }
       return $Result;

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -42,7 +42,7 @@ $Construct->PrimaryKey('CategoryID')
    ->Column('PermissionCategoryID', 'int', '-1') // default to root.
    ->Column('PointsCategoryID', 'int', '0') // default to global.
    ->Column('HideAllDiscussions', 'tinyint(1)', '0')
-   ->Column('DisplayAs', array('Categories', 'Discussions', 'Default'), 'Default')
+   ->Column('DisplayAs', array('Categories', 'Discussions', 'Heading', 'Default'), 'Default')
    ->Column('InsertUserID', 'int', FALSE, 'key')
    ->Column('UpdateUserID', 'int', TRUE)
    ->Column('DateInserted', 'datetime')

--- a/applications/vanilla/views/modules/categories.php
+++ b/applications/vanilla/views/modules/categories.php
@@ -16,13 +16,12 @@ if ($this->Data !== FALSE) {
       .'</li>';
 
    $MaxDepth = C('Vanilla.Categories.MaxDisplayDepth');
-   $DoHeadings = C('Vanilla.Categories.DoHeadings');
 
    foreach ($this->Data->Result() as $Category) {
       if ($Category->CategoryID < 0 || $MaxDepth > 0 && $Category->Depth > $MaxDepth)
          continue;
 
-      if ($DoHeadings && $Category->Depth == 1)
+      if ($Category->DisplayAs === 'Heading')
          $CssClass = 'Heading '.$Category->CssClass;
       else
          $CssClass = 'Depth'.$Category->Depth.($CategoryID == $Category->CategoryID ? ' Active' : '').' '.$Category->CssClass;
@@ -31,7 +30,7 @@ if ($this->Data !== FALSE) {
 
       $CountText = '<span class="Aside"><span class="Count">'.BigPlural($Category->CountAllDiscussions, '%s discussion').'</span></span>';
 
-      if ($DoHeadings && $Category->Depth == 1) {
+      if ($Category->DisplayAs === 'Heading') {
          echo $CountText.' '.htmlspecialchars($Category->Name);
       } else {
          echo Anchor($CountText.' '.htmlspecialchars($Category->Name), CategoryUrl($Category), 'ItemLink');

--- a/applications/vanilla/views/settings/addcategory.php
+++ b/applications/vanilla/views/settings/addcategory.php
@@ -62,7 +62,7 @@ echo $this->Form->Errors();
    <li>
       <?php
          echo $this->Form->Label('Display As', 'DisplayAs');
-         echo $this->Form->DropDown('DisplayAs', array('Default' => 'Default', 'Categories' => 'Categories', 'Discussions' => 'Discussions'));
+         echo $this->Form->DropDown('DisplayAs', array('Default' => 'Default', 'Categories' => 'Categories', 'Discussions' => 'Discussions', 'Heading' => 'Heading'));
       ?>
    </li>
    <li>
@@ -80,9 +80,9 @@ echo $this->Form->Errors();
    <li id="Permissions">
       <?php
          echo $this->Form->CheckBox('CustomPermissions', 'This category has custom permissions.');
-         
+
          echo '<div class="CategoryPermissions">';
-         
+
          if (count($this->Data('DiscussionTypes')) > 1) {
             echo '<div class="P DiscussionTypes">';
             echo $this->Form->Label('Discussion Types');
@@ -91,7 +91,7 @@ echo $this->Form->Errors();
             }
             echo '</div>';
          }
-         
+
          echo $this->Form->Simple(
             $this->Data('_PermissionFields', array()),
          array('Wrap' => array('', '')));

--- a/applications/vanilla/views/settings/editcategory.php
+++ b/applications/vanilla/views/settings/editcategory.php
@@ -41,8 +41,8 @@ echo $this->Form->Errors();
          echo $this->Form->Label('Photo', 'PhotoUpload');
          if ($Photo = $this->Form->GetValue('Photo')) {
             echo Img(Gdn_Upload::Url($Photo));
-            echo '<br />'.Anchor(T('Delete Photo'), 
-               CombinePaths(array('vanilla/settings/deletecategoryphoto', $this->Category->CategoryID, Gdn::Session()->TransientKey())), 
+            echo '<br />'.Anchor(T('Delete Photo'),
+               CombinePaths(array('vanilla/settings/deletecategoryphoto', $this->Category->CategoryID, Gdn::Session()->TransientKey())),
                'SmallButton Danger PopConfirm');
          }
          echo $this->Form->Input('PhotoUpload', 'file');
@@ -56,7 +56,7 @@ echo $this->Form->Errors();
    <li>
       <?php
          echo $this->Form->Label('Display As', 'DisplayAs');
-         echo $this->Form->DropDown('DisplayAs', array('Default' => 'Default', 'Categories' => 'Categories', 'Discussions' => 'Discussions'));
+         echo $this->Form->DropDown('DisplayAs', array('Default' => 'Default', 'Categories' => 'Categories', 'Discussions' => 'Discussions', 'Heading' => 'Heading'));
       ?>
    </li>
    <li>
@@ -81,9 +81,9 @@ echo $this->Form->Errors();
       <?php
 		if(count($this->PermissionData) > 0) {
          echo $this->Form->CheckBox('CustomPermissions', 'This category has custom permissions.');
-         
+
          echo '<div class="CategoryPermissions">';
-         
+
          if (count($this->Data('DiscussionTypes')) > 1) {
             echo '<div class="P DiscussionTypes">';
             echo $this->Form->Label('Discussion Types');
@@ -92,7 +92,7 @@ echo $this->Form->Errors();
             }
             echo '</div>';
          }
-         
+
          echo $this->Form->Simple(
             $this->Data('_PermissionFields', array()),
          array('Wrap' => array('', ''), 'ItemWrap' => array('<div class="P">', '</div>')));

--- a/library/core/class.theme.php
+++ b/library/core/class.theme.php
@@ -42,8 +42,9 @@ class Gdn_Theme {
 
       if ($HomeLink) {
          $HomeUrl = GetValue('HomeUrl', $Options);
-         if (!$HomeUrl)
+         if (!$HomeUrl) {
             $HomeUrl = Url('/', TRUE);
+         }
 
          $Row = array('Name' => $HomeLink, 'Url' => $HomeUrl, 'CssClass' => 'CrumbLabel HomeCrumb');
          if (!is_string($HomeLink))
@@ -73,7 +74,7 @@ class Gdn_Theme {
             $Result .= '<span itemprop="child" itemscope itemtype="http://data-vocabulary.org/Breadcrumb">';
          }
 
-         $Row['Url'] = Url($Row['Url']);
+         $Row['Url'] = $Row['Url'] ? Url($Row['Url']) : '#';
          $CssClass = 'CrumbLabel '.GetValue('CssClass', $Row);
          if ($DataCount == count($Data))
             $CssClass .= ' Last';


### PR DESCRIPTION
The Vanilla.Categories.DoHeadings has the effect of rendering all categories of depth 1 to be headings. This change paves the way to have sub-categories also display as non-clickable headings.

Note that this pull request doesn’t update any views at this time so additional view work will have to be done in a future pull request.