### PR TITLE
Changed T('Requires') to T('Requires: ') for consistency

### DIFF
--- a/applications/dashboard/views/settings/themes.php
+++ b/applications/dashboard/views/settings/themes.php
@@ -165,7 +165,7 @@ if ($AddonUrl != '')
                   $RequiredApplications = GetValue('RequiredApplications', $ThemeInfo, FALSE);
                   if (is_array($RequiredApplications)) {
                      echo '<dl>
-                        <dt>'.T('Requires').'</dt>
+                        <dt>'.T('Requires: ').'</dt>
                         <dd>';
 
                      $i = 0;


### PR DESCRIPTION
Simply to make wording more consistent on screen and it will slightly reduce need for language definitions ('Requires: ' is used 4 times, while 'Require' is only used here)
