### PR TITLE
check for existence of OAuthException

### DIFF
--- a/library/vendors/oauth/OAuth.php
+++ b/library/vendors/oauth/OAuth.php
@@ -3,7 +3,7 @@
 
 /* Generic exception class
  */
-if(!class_exists('OAuthException')) {
+if (!class_exists('OAuthException')) {
   class OAuthException extends Exception {
     // pass
   }


### PR DESCRIPTION
Some hosts may have the php OAuth extension installed, which already
defines  OAuthException
