### PR TITLE
use schemeless URL for CDN jQuery so it can be loaded even with HTTPS

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1735,9 +1735,9 @@ class Gdn_Controller extends Gdn_Pluggable {
 
             // And now search for/add all JS files.
             $Cdns = array();
-            if (Gdn::Request()->Scheme() != 'https' && !C('Garden.Cdns.Disable', FALSE)) {
+            if (!C('Garden.Cdns.Disable', FALSE)) {
                $Cdns = array(
-                  'jquery.js' => 'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js'
+                  'jquery.js' => '//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js'
                   );
             }
 


### PR DESCRIPTION
This modifies the jQuery CDNJS URL so it uses [schemeless](http://tools.ietf.org/html/rfc1808#section-4) URLs.

This way it will inherit the scheme (http or https) of the base URL.
