### PR TITLE
Fix Emoji to allow array data & use editor lists correctly

### DIFF
--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -398,14 +398,12 @@ class Emoji {
    public function setEmojiEditorList($value) {
       // Convert the editor list to the proper format.
       $list = array();
-      $aliases2 = array_flip($this->aliases);
       foreach ($value as $emoji) {
-         if (isset($this->aliases[$emoji])) {
+         if (isset($this->emoji[$emoji])) {
+            $list[$this->ldelim.$emoji.$this->rdelim] = $emoji;
+         }
+         elseif (isset($this->aliases[$emoji])) {
             $list[$emoji] = $this->aliases[$emoji];
-         } elseif (isset($aliases2[$emoji])) {
-            $list[$aliases2[$emoji]] = $emoji;
-         } elseif (isset($this->emoji[$emoji])) {
-            $list[$emoji] = ":$emoji:";
          }
       }
       $this->editorList = $list;


### PR DESCRIPTION
The docs say you can define the $emoji data like this:

```
 array (
      'emoji_name' => array('filename.png', 'misc info'...)
 )
```

But when you do that in a custom Emoji set, you'll get array-to-string conversion errors because it isn't accounting for this possibility later.

Also, setEmojiEditorList currently: 
1. Only allows aliased emoji
2. Doesn't allow multiple aliases
3. Doesn't respect the ldelim & rdelim properties. 

This is a case of "I have no idea how this ever worked".
