### PR TITLE
Make password strength strings easier to translate.

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -51,7 +51,14 @@ class UserModel extends Gdn_Model {
       $Controller->AddDefinition('MinPassLength', C('Garden.Registration.MinPasswordLength'));
       $Controller->AddDefinition(
          'PasswordTranslations',
-         implode(',', array(T('Too Short'), T('Password '), T('Password Contains Username'), T('Password Very Weak'), T('Password Weak'), T('Password Ok'), T('Password Good'), T('Password Strong')))
+         implode(',', array(
+            T('Password Too Short', 'Too Short'),
+            T('Password Contains Username', 'Contains Username'),
+            T('Password Very Weak', 'Very Weak'),
+            T('Password Weak', 'Weak'),
+            T('Password Ok', 'OK'),
+            T('Password Good', 'Good'),
+            T('Password Strong', 'Strong')))
       );
    }
 


### PR DESCRIPTION
We originally had the password strength strings as one csv string. This turned out to be a complete disaster when we sent off that string to be translated.
