### PR TITLE
Include FieldName in ValidationResults

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -2327,7 +2327,7 @@ PASSWORDMETER;
       if ($Valid === TRUE)
          return TRUE;
       else {
-         $this->AddError('@'.$Valid);
+         $this->AddError('@'.$Valid, $FieldName);
          return FALSE;
       }
 


### PR DESCRIPTION
Form method ValidateRule fails to add the field name when creating an error, making the use of inline errors impossible.
