### PR TITLE
Adds click-to-complete mentions

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1678,7 +1678,6 @@ jQuery(document).ready(function($) {
                   }
                }
             },
-            display_timeout: 0,
             cWindow: iframe_window
          })
          .atwho({

--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -455,7 +455,6 @@
             break;
           case KEY_CODE.DOWN:
           case KEY_CODE.UP:
-          case KEY_CODE.TAB:
             $.noop();
             break;
           default:
@@ -479,10 +478,10 @@
             view.prev();
             break;
           case KEY_CODE.DOWN:
-          case KEY_CODE.TAB:
             e.preventDefault();
             view.next();
             break;
+          case KEY_CODE.TAB:
           case KEY_CODE.ENTER:
             if (!view.visible()) {
               return;

--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -455,6 +455,7 @@
             break;
           case KEY_CODE.DOWN:
           case KEY_CODE.UP:
+          case KEY_CODE.TAB:
             $.noop();
             break;
           default:
@@ -478,10 +479,10 @@
             view.prev();
             break;
           case KEY_CODE.DOWN:
+          case KEY_CODE.TAB:
             e.preventDefault();
             view.next();
             break;
-          case KEY_CODE.TAB:
           case KEY_CODE.ENTER:
             if (!view.visible()) {
               return;


### PR DESCRIPTION
- Options in the <code>@mention</code> flyout can now be selected with a mouseclick.
This was already the librarys default, but "overridden" by the
display_timeout setting of 0 in global.js.
(The inputs blur event is triggered before the click event, closing the flyout before anything
can be selected. This is the reason for the timeout being there.)

- The tab key no longer closes the flyout, but moves to the next item.
This required 2 minimal changes in the library.

Fixes https://github.com/vanilla/vanilla/issues/2201