### PR TITLE
Original URL request parameters are lost when going through log in screen

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1159,7 +1159,7 @@ class Gdn_Controller extends Gdn_Pluggable {
          );
 
          if (!$Session->IsValid() && $this->DeliveryType() == DELIVERY_TYPE_ALL) {
-            Redirect('/entry/signin?Target='.urlencode($this->SelfUrl));
+            Redirect('/entry/signin?Target='.urlencode($this->Request->PathAndQuery()));
          } else {
             Gdn::Dispatcher()->Dispatch('DefaultPermission');
             exit();


### PR DESCRIPTION
I don't know what happened in #1985, but this didn't get applied to master or stage.
