### PR TITLE
Allow 'bit' field in MySQL structure

### DIFF
--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -569,7 +569,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
          'bit',
       );
 
-      if (!is_array($Column->Type) && !in_array($Column->Type, $ValidColumnTypes))
+      if (!is_array($Column->Type) && !in_array(strtolower($Column->Type), $ValidColumnTypes))
          throw new Exception(sprintf(T('The specified data type (%1$s) is not accepted for the MySQL database.'), $Column->Type));
 
       $Return = '`'.$Column->Name.'` '.$Column->Type;


### PR DESCRIPTION
This change will allow you to create a `bit` field using the `Gdn_DatabaseStructure` class.

This change also does a `strtolower` on the column type before making the check so that you can specify field types regardless of case - perhaps this is by design, though.  If that's the case, I can remove that change from the pull request.
