### PR TITLE
Pass $Database into Structure when creating it inside a Database object

### DIFF
--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -438,8 +438,7 @@ class Gdn_Database {
    public function Structure() {
       if(is_null($this->_Structure)) {
          $Name = $this->Engine . 'Structure';
-         $this->_Structure = Gdn::Factory($Name);
-         $this->_Structure->Database = $this;
+         $this->_Structure = Gdn::Factory($Name, $this);
       }
 
       return $this->_Structure;


### PR DESCRIPTION
As it was, the Structure doesn't initialize with the correct database
and even sets the wrong prefix incorrectly.  This meant that the
standard database may have been initialized unnecessarily as well.

This patch passes the database object as an argument to the constructor.