### PR TITLE
be explicit over nullable fields in GDN_MySQLStructure

### DIFF
--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -561,10 +561,11 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
       if (is_array($Column->Enum))
          $Return .= "('".implode("','", $Column->Enum)."')";
 
-      if (!$Column->AllowNull)
+      if (!$Column->AllowNull) {
          $Return .= ' not null';
-      else
+      } else {
          $Return .= ' null';
+      }
 
       if (!(is_null($Column->Default)) && strcasecmp($Column->Type, 'timestamp') != 0)
          $Return .= " default ".self::_QuoteValue($Column->Default);

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -563,6 +563,8 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
 
       if (!$Column->AllowNull)
          $Return .= ' not null';
+      else
+         $Return .= ' null';
 
       if (!(is_null($Column->Default)) && strcasecmp($Column->Type, 'timestamp') != 0)
          $Return .= " default ".self::_QuoteValue($Column->Default);


### PR DESCRIPTION
Mark columns as explicitly null when they are marked as such in the structure

Per the MySQL column definition this is perfectly fine:

```
column_definition:
    data_type [NOT NULL | NULL] [DEFAULT default_value]
      [AUTO_INCREMENT] [UNIQUE [KEY] | [PRIMARY] KEY]
      [COMMENT 'string']
      [COLUMN_FORMAT {FIXED|DYNAMIC|DEFAULT}]
      [STORAGE {DISK|MEMORY|DEFAULT}]
      [reference_definition]
```