### PR TITLE
Prevent the autoloader from looking into some common non-php directories.

### DIFF
--- a/library/core/class.autoloader.php
+++ b/library/core/class.autoloader.php
@@ -23,81 +23,81 @@ class Gdn_Autoloader {
     * @var array
     */
    protected static $Maps;
-      
+
    /**
     * Array of pathname prefixes used to namespace similar libraries
     *
     * @var array
     */
    protected static $Prefixes;
-   
+
    /**
     * Array of contexts used to establish search order
     *
     * @var array
     */
    protected static $ContextOrder;
-   
+
    /**
     * Array of maps that pertain to the same CONTEXT+Extension
     *
     * @var array
     */
    protected static $MapGroups;
-   
+
    /**
-    * List of priority/preferred CONTEXT+Extension[+MapType] groups for the next lookup 
+    * List of priority/preferred CONTEXT+Extension[+MapType] groups for the next lookup
     *
     * @var array
     */
    protected static $Priorities;
-   
+
    const CONTEXT_CORE            = 'core';
    const CONTEXT_APPLICATION     = 'application';
    const CONTEXT_PLUGIN          = 'plugin';
    const CONTEXT_LOCALE          = 'locale';
    const CONTEXT_THEME           = 'theme';
-   
+
    const MAP_LIBRARY             = 'library';
    const MAP_CONTROLLER          = 'controller';
    const MAP_PLUGIN              = 'plugin';
    const MAP_VENDORS             = 'vendors';
-   
+
    const PRIORITY_TYPE_PREFER    = 'prefer';
    const PRIORITY_TYPE_RESTRICT  = 'restrict';
-   
+
    const PRIORITY_ONCE           = 'once';
    const PRIORITY_PERSIST        = 'persist';
-   
+
    /**
     * Attach mappings for vanilla extension folders
     *
     * @param string $ExtensionType type of extension to map. one of: CONTEXT_THEME, CONTEXT_PLUGIN, CONTEXT_APPLICATION
     */
    public static function Attach($ExtensionType) {
-   
+
       switch ($ExtensionType) {
          case self::CONTEXT_APPLICATION:
-         
+
             if (Gdn::ApplicationManager() instanceof Gdn_ApplicationManager) {
                $EnabledApplications = Gdn::ApplicationManager()->EnabledApplicationFolders();
-               
+
                foreach ($EnabledApplications as $EnabledApplication) {
                   self::AttachApplication($EnabledApplication);
                }
             }
-            
+
          break;
-         
+
          case self::CONTEXT_PLUGIN:
 
             if (Gdn::PluginManager() instanceof Gdn_PluginManager) {
-            
+
                foreach (Gdn::PluginManager()->SearchPaths() as $SearchPath => $SearchPathName) {
-               
+
                   if ($SearchPathName === TRUE || $SearchPathName == 1)
                      $SearchPathName = md5($SearchPath);
-               
+
                   // If we have already loaded the plugin manager, use its internal folder list
                   if (Gdn::PluginManager()->Started()) {
                      $Folders = Gdn::PluginManager()->EnabledPluginFolders($SearchPath);
@@ -111,7 +111,7 @@ class Gdn_Autoloader {
                            'PreWarm'               => TRUE
                         ));
                      }
-                     
+
                      $PluginMap = self::GetMap(self::MAP_LIBRARY, self::CONTEXT_PLUGIN);
                      if ($PluginMap && !$PluginMap->MapIsOnDisk())
                         Gdn::PluginManager()->ForceAutoloaderIndex();
@@ -120,14 +120,14 @@ class Gdn_Autoloader {
             }
 
          break;
-         
+
          case self::CONTEXT_THEME:
-         
+
          break;
       }
-   
+
    }
-   
+
    public static function AttachApplication($Application) {
       $ApplicationPath = CombinePaths(array(PATH_APPLICATIONS."/{$Application}"));
 
@@ -158,133 +158,133 @@ class Gdn_Autoloader {
          'ClassFilter'           => '*'
       ));
    }
-   
+
    protected static function DoLookup($ClassName, $MapType) {
       // We loop over the caches twice. First, hit only their cached data.
       // If all cache hits miss, search filesystem.
-      
+
       if (!is_array(self::$Maps))
          return FALSE;
-      
+
       $Priorities = array();
-      
+
       // Binary flip - cacheonly or cache+fs
       foreach (array(TRUE, FALSE) as $MapOnly) {
-      
+
          $SkipMaps = array(); $ContextType = NULL;
          $SkipTillNextContext = FALSE;
-         
+
          // Drill to the caches associated with this map type
          foreach (self::$Maps as $MapHash => &$Map) {
             if ($MapType !== NULL && $Map->MapType() != $MapType) {
                continue;
             }
-            
+
             $MapContext = self::GetContextType($MapHash);
             if ($MapContext != $ContextType) {
                // Hit new context
                $SkipMaps = array();
                $ContextType = $MapContext;
-               
+
                if (!array_key_exists($ContextType, $Priorities))
                   $Priorities[$ContextType] = self::Priorities($ContextType, $MapType);
-               
+
                if (array_key_exists($ContextType, $Priorities) && is_array($Priorities[$ContextType])) {
                   foreach ($Priorities[$ContextType] as $PriorityMapHash => $PriorityInfo) {
-                  
+
                      // If we're in a RESTRICT priority and we come to the end, wait till we hit the next context before looking further
                      if ($PriorityMapHash == 'FAIL_CONTEXT_IF_NOT_FOUND') {
                         $SkipTillNextContext = TRUE;
                         break;
                      }
                      $PriorityMap = self::Map($PriorityMapHash);
-                     
+
                      $File = $PriorityMap->Lookup($ClassName, $MapOnly);
                      if ($File !== FALSE) return $File;
-                     
+
                      // Don't check this map again
                      array_push($SkipMaps, $PriorityMapHash);
                   }
                }
             }
-            
+
             // If this map was already checked by a priority, or if we've exhausted a RESTRICT priority, skip maps until the next
             // context level is reached.
             if (in_array($MapHash, $SkipMaps) || $SkipTillNextContext === TRUE) continue;
-            
+
             // Finally, search this map.
             $File = $Map->Lookup($ClassName, $MapOnly);
             if ($File !== FALSE) return $File;
          }
       }
-      
+
       return FALSE;
    }
-   
+
    public static function GetContextType($MapHash) {
       $Matched = preg_match('/^context:(\d+)_.*/', $MapHash, $Matches);
       if ($Matched && isset($Matches[1]))
          $ContextIdentifier = $Matches[1];
       else
          return FALSE;
-      
+
       if (isset($ContextIdentifier, self::$ContextOrder))
          return self::$ContextOrder[$ContextIdentifier];
       return FALSE;
    }
-   
+
    public static function GetMapType($ClassName) {
       // Strip leading 'Gdn_'
       if (substr($ClassName, 0, 4) == 'Gdn_')
          $ClassName = substr($ClassName, 4);
-      
+
       $ClassName = strtolower($ClassName);
       $Length = strlen($ClassName);
-      
+
       if (substr($ClassName, -10) == 'controller' && $Length > 10)
          return self::MAP_CONTROLLER;
-      
+
       return self::MAP_LIBRARY;
    }
-   
+
    public static function Lookup($ClassName, $Options = array()) {
       if (!preg_match("/^[a-zA-Z0-9_\x7f-\xff]*$/", $ClassName))
          return;
-      
+
       $MapType = GetValue('MapType', $Options, self::GetMapType($ClassName));
-      
+
       $DefaultOptions = array(
          'Quiet'              => FALSE,
          'RespectPriorities'  => TRUE
       );
       $Options = array_merge($DefaultOptions, $Options);
-      
+
       $File = self::DoLookup($ClassName, $MapType);
-      
+
       if ($File !== FALSE) {
          if (!isset($Options['Quiet']) || !$Options['Quiet'])
             include_once($File);
       }
       return $File;
    }
-   
+
    /**
     * Get an Autoloader Map by hash
-    * 
+    *
     * @param type $MapHash
     * @return Gdn_Autoloader_Map
     */
    public static function Map($MapHash) {
       if (array_key_exists($MapHash, self::$Maps))
          return self::$Maps[$MapHash];
-      
+
       if (is_null($MapHash)) return self::$Maps;
       return FALSE;
    }
-   
+
    /**
     * Lookup and return an Autoloader Map
-    * 
+    *
     * @param type $MapType
     * @param type $ContextType
     * @param type $Extension
@@ -295,13 +295,13 @@ class Gdn_Autoloader {
       $MapHash = self::MakeMapHash($MapType, $ContextType, $Extension, $MapRootLocation);
       return self::Map($MapHash);
    }
-   
+
    public static function Priority($ContextType, $Extension, $MapType = NULL, $PriorityType = self::PRIORITY_TYPE_PREFER, $PriorityDuration = self::PRIORITY_ONCE) {
       $MapGroupIdentifier = implode('|',array(
          $ContextType,
          $Extension
       ));
-      
+
       $MapGroupHashes = GetValue($MapGroupIdentifier, self::$MapGroups, array());
       $PriorityHashes = array();
       $PriorityHashes = array();
@@ -309,37 +309,37 @@ class Gdn_Autoloader {
          $ThisMapType = self::Map($MapHash)->MapType();
          // We're restricting this priority to a certain maptype, so exclude non matchers
          if (!is_null($MapType) && $ThisMapType != $MapType) continue;
-         
+
          $PriorityHashes[$MapHash] = array(
             'maptype'      => $ThisMapType,
             'duration'     => $PriorityDuration,
             'prioritytype' => $PriorityType
          );
       }
-      
+
       if (!sizeof($PriorityHashes)) return FALSE;
-      
-      if (!is_array(self::$Priorities)) 
+
+      if (!is_array(self::$Priorities))
          self::$Priorities = array();
-      
+
       if (!array_key_exists($ContextType,self::$Priorities))
          self::$Priorities[$ContextType] = array(
             self::PRIORITY_TYPE_RESTRICT  => array(),
             self::PRIORITY_TYPE_PREFER    => array()
          );
-      
+
       // Add new priorities to list
       self::$Priorities[$ContextType][$PriorityType] = array_merge(self::$Priorities[$ContextType][$PriorityType], $PriorityHashes);
-      
+
       return TRUE;
    }
-   
+
    public static function Priorities($ContextType, $MapType = NULL) {
-      if (!is_array(self::$Priorities) || !array_key_exists($ContextType,self::$Priorities)) 
+      if (!is_array(self::$Priorities) || !array_key_exists($ContextType,self::$Priorities))
          return FALSE;
-      
+
       /**
-       * First, gather the RESTRICT requirements. If these exist, they are the only hashes that will be sent, and a 'FAIL_IF_NOT_FOUND' 
+       * First, gather the RESTRICT requirements. If these exist, they are the only hashes that will be sent, and a 'FAIL_IF_NOT_FOUND'
        * flag will be appended to the list to halt lookups.
        *
        * If there are no RESTRICT priorities, check for PREFER priorities and send those.
@@ -348,30 +348,30 @@ class Gdn_Autoloader {
        */
       foreach (array(self::PRIORITY_TYPE_RESTRICT, self::PRIORITY_TYPE_PREFER) as $PriorityType) {
          if (!sizeof(self::$Priorities[$ContextType][$PriorityType])) continue;
-         
+
          $ResultMapHashes = self::$Priorities[$ContextType][$PriorityType];
          $ResponseHashes = array();
          foreach ($ResultMapHashes as $MapHash => $PriorityInfo) {
-         
+
             if (GetValue('duration', $PriorityInfo) == self::PRIORITY_ONCE)
                unset(self::$Priorities[$ContextType][$PriorityType][$MapHash]);
-         
+
             // If this request is being specific about the required maptype, reject anything that doesnt match
             if (!is_null($MapType) && GetValue('maptype', $PriorityInfo) != $MapType)
                continue;
-            
+
             $ResponseHashes[$MapHash] = $PriorityInfo;
          }
-         
+
          if ($PriorityType == self::PRIORITY_TYPE_RESTRICT)
             $ResponseHashes['FAIL_CONTEXT_IF_NOT_FOUND'] = TRUE;
-         
+
          return $ResponseHashes;
       }
-      
+
       return FALSE;
    }
-   
+
    public static function RegisterMap($MapType, $ContextType, $SearchPath, $Options = array()) {
       $DefaultOptions = array(
          'SearchSubfolders'      => TRUE,
@@ -382,15 +382,15 @@ class Gdn_Autoloader {
       );
       if (array_key_exists($ContextType, self::$Prefixes))
          $DefaultOptions['ContextPrefix'] = GetValue($ContextType, self::$Prefixes);
-      
+
       $Options = array_merge($DefaultOptions, $Options);
-      
+
       $Extension = GetValue('Extension', $Options, NULL);
-      
+
       // Determine cache root on-disk location
       $Hits = 0; str_replace(PATH_ROOT, '', $SearchPath, $Hits);
       $MapRootLocation = PATH_CACHE;
-      
+
       // Build a unique identifier that refers to this map (same map type, context, extension, and cachefile location)
       $MapIdentifier = implode('|',array(
          $MapType,
@@ -400,23 +400,23 @@ class Gdn_Autoloader {
       ));
       $Options['MapIdentifier'] = $MapIdentifier;
       $MapHash = md5($MapIdentifier);
-      
+
       // Allow intrinsic ordering / layering of contexts by prefixing them with a context number
       $MapHash = 'context:'.GetValue($ContextType, array_flip(self::$ContextOrder)).'_'.$Extension.'_'.$MapHash;
       $MapHash = self::MakeMapHash($MapType, $ContextType, $Extension, $MapRootLocation);
-      
+
       if (!is_array(self::$Maps))
          self::$Maps = array();
-         
+
       if (!array_key_exists($MapHash, self::$Maps)) {
          $Map = Gdn_Autoloader_Map::Load($MapType, $ContextType, $MapRootLocation, $Options);
          self::$Maps[$MapHash] = $Map;
       }
-      
+
       ksort(self::$Maps, SORT_REGULAR);
-      
+
       $AddPathResult = self::$Maps[$MapHash]->AddPath($SearchPath, $Options);
-         
+
       /*
        * Build a unique identifier that refers to this cached list (context and extension)
        *
@@ -427,15 +427,15 @@ class Gdn_Autoloader {
          $ContextType,
          $Extension
       ));
-      
+
       if (!is_array(self::$MapGroups))
          self::$MapGroups = array();
-      
+
       if (!array_key_exists($MapGroupIdentifier,self::$MapGroups))
          self::$MapGroups[$MapGroupIdentifier] = array();
 
       self::$MapGroups[$MapGroupIdentifier][$MapHash] = TRUE;
-      
+
       return $AddPathResult;
    }
 
@@ -454,7 +454,7 @@ class Gdn_Autoloader {
 
       return $MapHash;
    }
-   
+
    public static function ForceIndex($MapType, $ContextType, $Extension = self::CONTEXT_CORE) {
       $Map = self::GetMap($MapType, $ContextType, $Extension);
       $Map->Index();
@@ -478,9 +478,9 @@ class Gdn_Autoloader {
          if ($Extension == 'ini' && $File != 'locale_map.ini')
             @unlink(CombinePaths(array(PATH_CACHE, $File)));
       }
-      
+
    }
-   
+
    /**
     * Register core mappings
     *
@@ -490,7 +490,7 @@ class Gdn_Autoloader {
     * @param void
     */
    public static function Start() {
-      
+
       self::$Prefixes = array(
          self::CONTEXT_CORE            => 'c',
          self::CONTEXT_APPLICATION     => 'a',
@@ -504,22 +504,22 @@ class Gdn_Autoloader {
          self::CONTEXT_APPLICATION,
          self::CONTEXT_CORE
       );
-      
+
       self::$Maps = array();
       self::$MapGroups = array();
-   
+
       // Register autoloader with the SPL
       spl_autoload_register(array('Gdn_Autoloader', 'Lookup'));
-      
+
       // Configure library/core and library/database
       self::RegisterMap(self::MAP_LIBRARY, self::CONTEXT_CORE, PATH_LIBRARY.'/core');
       self::RegisterMap(self::MAP_LIBRARY, self::CONTEXT_CORE, PATH_LIBRARY.'/database');
       self::RegisterMap(self::MAP_LIBRARY, self::CONTEXT_CORE, PATH_LIBRARY.'/vendors');
-      
+
       // Register shutdown function to auto save changed cache files
       register_shutdown_function(array('Gdn_Autoloader', 'Shutdown'));
    }
-   
+
    /**
     * Save current caches
     *
@@ -532,62 +532,62 @@ class Gdn_Autoloader {
       foreach (self::$Maps as $MapHash => &$Map)
          $Map->Shutdown();
    }
-   
+
 }
 
 class Gdn_Autoloader_Map {
-   
+
    /**
     * Sprintf format string that describes the on-disk name of the mapping caches
-    * 
+    *
     * @const string
     */
    const DISK_MAP_NAME_FORMAT = '%s/%s_map.ini';
-   
+
    const LOOKUP_CLASS_MASK = 'class.%s.php';
    const LOOKUP_INTERFACE_MASK = 'interface.%s.php';
-   
+
    /**
     * Map file structure type
-    * 
+    *
     *  flat - file contains one topic, 'cache', with all classname -> file entries in a single list
     *  split - file contains a topic for each path, with only that path's files in the list
-    * 
+    *
     * @const string
     */
    const STRUCTURE_FLAT = 'flat';
    const STRUCTURE_SPLIT = 'split';
-   
+
    const TOPIC_DEFAULT = 'cache';
-   
+
    protected $BuildOptions;
    protected $MapInfo;
    protected $Map;
    protected $Ignore;
    protected $Paths;
-   
+
    private function __construct($MapType, $ContextType, $MapRootLocation, $Options) {
       $this->Map = NULL;
       $this->Ignore = array('.','..');
       $this->Paths = array();
       $this->BuildOptions = $Options;
-      
+
       $ExtensionName = GetValue('Extension', $Options, NULL);
       $Recursive = GetValue('SearchSubfolders', $Options, TRUE);
       $ContextPrefix = GetValue('ContextPrefix', $Options, NULL);
       $MapIdentifier = GetValue('MapIdentifier', $Options, NULL);
       $SaveToDisk = GetValue('SaveToDisk', $Options, TRUE);
       $FileStructure = GetValue('Structure', $Options, self::STRUCTURE_FLAT);
-      
+
       $MapName = $MapType;
       if (!is_null($ExtensionName))
          $MapName = $ExtensionName.'_'.$MapName;
-         
+
       if (!is_null($ContextPrefix))
          $MapName = $ContextPrefix.'_'.$MapName;
-      
+
       $OnDiskMapFile = sprintf(self::DISK_MAP_NAME_FORMAT, $MapRootLocation, strtolower($MapName));
-      
+
       $this->MapInfo = array(
          'ondisk'       => $OnDiskMapFile,
          'identifier'   => $MapIdentifier,
@@ -601,11 +601,11 @@ class Gdn_Autoloader_Map {
          'structure'    => $FileStructure
       );
    }
-   
+
    public function MapIsOnDisk() {
       return file_exists($this->MapInfo['ondisk']);
    }
-   
+
    public function AddPath($SearchPath, $Options) {
       $PathOptions = array(
          'path'         => $SearchPath,
@@ -613,36 +613,39 @@ class Gdn_Autoloader_Map {
          'filter'       => GetValue('ClassFilter', $Options),
          'topic'        => self::TOPIC_DEFAULT
       );
-      
+
       if ($this->MapInfo['structure'] == self::STRUCTURE_SPLIT) {
          $SplitTopic = GetValue('SplitTopic', $Options, NULL);
          if (is_null($SplitTopic))
             throw new Exception("Trying to use 'split' structure but no SplitTopic provided. Path: {$SearchPath}");
          $PathOptions['topic'] = $SplitTopic;
       }
-      
+
       $this->Paths[$SearchPath] = $PathOptions;
    }
-   
+
    public function ContextType() {
       return $this->MapInfo['contexttype']; //GetValue('contexttype', $this->MapInfo);
    }
-   
+
    public function Extension() {
       return $this->MapInfo['extension']; //GetValue('extension', $this->MapInfo);
    }
-   
+
    protected function FindFile($Path, $SearchFiles, $Recursive) {
       if (!is_array($SearchFiles))
          $SearchFiles = array($SearchFiles);
-      
-      if (!is_dir($Path)) return FALSE;
+
+      $Folder = basename($Path);
+      if (!is_dir($Path) || substr($Folder, 0, 1) === '.' || $Folder === 'node_modules') {
+         return false;
+      }
 
       $Files = scandir($Path);
       foreach ($Files as $FileName) {
          if (in_array($FileName, $this->Ignore)) continue;
          $FullPath = CombinePaths(array($Path, $FileName));
-         
+
          // If this is a folder...
          if (is_dir($FullPath)) {
             if ($Recursive) {
@@ -654,16 +657,16 @@ class Gdn_Autoloader_Map {
                continue;
             }
          }
-         
+
          if (in_array($FileName, $SearchFiles)) return $FullPath;
       }
       return FALSE;
    }
-   
+
    protected function FindFiles($Path, $FileMasks, $Recursive) {
       if (!is_array($FileMasks))
          $FileMasks = array($FileMasks);
-      
+
       if (!is_dir($Path)) return FALSE;
 
       $FoundFiles = array();
@@ -671,12 +674,12 @@ class Gdn_Autoloader_Map {
       foreach ($Files as $FileName) {
          if (in_array($FileName, $this->Ignore)) continue;
          $FullPath = CombinePaths(array($Path, $FileName));
-         
+
          // If this is a folder, maybe recurse it eh?
          if (is_dir($FullPath)) {
             if ($Recursive) {
                $Recurse = $this->FindFiles($FullPath, $FileMasks, $Recursive);
-               if ($Recurse !== FALSE) 
+               if ($Recurse !== FALSE)
                   $FoundFiles = array_merge($FoundFiles, $Recurse);
                continue;
             }
@@ -693,10 +696,10 @@ class Gdn_Autoloader_Map {
             }
          }
       }
-      
+
       return $FoundFiles;
    }
-   
+
    /**
     * Autoloader cache static constructor
     *
@@ -705,29 +708,29 @@ class Gdn_Autoloader_Map {
    public static function Load($MapType, $ContextType, $MapRootLocation, $Options) {
       return new Gdn_Autoloader_Map($MapType, $ContextType, $MapRootLocation, $Options);
    }
-   
+
    public function Lookup($ClassName, $MapOnly = TRUE) {
       $MapName = $this->MapInfo['name']; //GetValue('name', $this->MapInfo);
-      
+
       // Lazyload cache data
       if (is_null($this->Map)) {
          $this->Map = array();
          $OnDiskMapFile = $this->MapInfo['ondisk']; //GetValue('ondisk', $this->MapInfo);
-         
+
          // Loading cache data from disk
          if (file_exists($OnDiskMapFile)) {
             $Structure = $this->MapInfo['structure']; //GetValue('structure', $this->MapInfo);
             $MapContents = parse_ini_file($OnDiskMapFile, TRUE);
-            
+
             try {
                // Detect legacy flat files which are now stored split
                if ($Structure == self::STRUCTURE_SPLIT && array_key_exists(self::TOPIC_DEFAULT, $MapContents))
                   throw new Exception();
-               
+
                // Bad file?
                if ($MapContents == FALSE || !is_array($MapContents))
                   throw new Exception();
-               
+
                // All's well that ends well. Load the cache.
                $this->Map = $MapContents;
             } catch (Exception $Ex) {
@@ -735,10 +738,10 @@ class Gdn_Autoloader_Map {
             }
          }
       }
-   
+
       // Always look by lowercase classname
       $ClassName = strtolower($ClassName);
-      
+
       switch ($this->MapInfo['structure']) {
          case 'split':
             // This file stored split, so look for this class in each virtual sub-path, by topic
@@ -749,7 +752,7 @@ class Gdn_Autoloader_Map {
                }
             }
             break;
-         
+
          default:
          case 'flat':
             // This file is stored flat, so just look in the DEFAULT_TOPIC
@@ -759,83 +762,83 @@ class Gdn_Autoloader_Map {
             }
             break;
       }
-      
+
       // Look at the filesystem, too
       if (!$MapOnly) {
          if (substr($ClassName, 0, 4) == 'gdn_')
             $FSClassName = substr($ClassName, 4);
          else
             $FSClassName = $ClassName;
-         
+
          $Files = array(
             sprintf(self::LOOKUP_CLASS_MASK, $FSClassName),
             sprintf(self::LOOKUP_INTERFACE_MASK, $FSClassName)
          );
-                  
+
          foreach ($this->Paths as $Path => $PathOptions) {
             $ClassFilter = GetValue('filter', $PathOptions);
             if (!fnmatch($ClassFilter, $ClassName)) continue;
-            
+
             $Recursive = GetValue('recursive', $PathOptions);
             $File = $this->FindFile($Path, $Files, $Recursive);
-            
+
             if ($File !== FALSE) {
                $SplitTopic = GetValue('topic', $PathOptions, self::TOPIC_DEFAULT);
                $this->Map[$SplitTopic][$ClassName] = $File;
                $this->MapInfo['dirty'] = TRUE;
-               
+
                return $File;
             }
          }
       }
-      
+
       return FALSE;
    }
-   
+
    /**
     * Try to index the entire map
-    * 
+    *
     * @return void
     */
    public function Index($ExtraPaths = NULL) {
-      
+
       $FileMasks = array(
          sprintf(self::LOOKUP_CLASS_MASK, '*'),
          sprintf(self::LOOKUP_INTERFACE_MASK, '*')
       );
-      
+
       $ExtraPathsRemove = NULL;
       if (!is_null($ExtraPaths)) {
          $ExtraPathsRemove = array();
          foreach ($ExtraPaths as $PathOpts) {
             $ExtraPath = GetValue('path', $PathOpts);
             if (array_key_exists($ExtraPath, $this->Paths)) continue;
-            
+
             $ExtraPathsRemove[] = $ExtraPath;
             $ExtraOptions = $this->BuildOptions;
             $ExtraOptions['SplitTopic'] = GetValue('topic', $PathOpts);
             $this->AddPath($ExtraPath, $ExtraOptions);
          }
       }
-      
+
       foreach ($this->Paths as $Path => $PathOptions) {
 
          $Recursive = GetValue('recursive', $PathOptions);
          $Files = $this->FindFiles($Path, $FileMasks, $Recursive);
          if ($Files === FALSE) continue;
-         
+
          foreach ($Files as $File) {
             $SplitTopic = GetValue('topic', $PathOptions, self::TOPIC_DEFAULT);
-            
+
             $ProvidedClass = $this->GetClassNameFromFile($File);
             if ($ProvidedClass) {
                $this->Map[$SplitTopic][$ProvidedClass] = $File;
                $this->MapInfo['dirty'] = TRUE;
             }
-               
+
 //            $ProvidesClasses = $this->Investigate($File);
 //            if ($ProvidesClasses === FALSE) continue;
-//            
+//
 //            foreach ($ProvidesClasses as $ProvidedClass) {
 //               $ProvidedClass = strtolower($ProvidedClass);
 //               $this->Map[$SplitTopic][$ProvidedClass] = $File;
@@ -843,15 +846,15 @@ class Gdn_Autoloader_Map {
 //            }
          }
       }
-      
+
       // Save
       $this->Shutdown();
-      
+
       if (!is_null($ExtraPathsRemove))
          foreach ($ExtraPathsRemove as $RemPath)
             unset($this->Paths[$RemPath]);
    }
-   
+
    protected function Investigate($File) {
       if (!file_exists($File)) return;
       $Lines = file($File);
@@ -862,7 +865,7 @@ class Gdn_Autoloader_Map {
             $ClassesFound[] = $Matches[1];
             continue;
          }
-         
+
          if (preg_match('/^interface[\s]+([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)[\s]+(?:.*)?{/',$Line,$Matches)) {
             $ClassesFound[] = $Matches[1];
             continue;
@@ -870,10 +873,10 @@ class Gdn_Autoloader_Map {
       }
       return $ClassesFound;
    }
-   
+
    protected function GetClassNameFromFile($File) {
       if (StringEndsWith($File, '.plugin.php')) return FALSE;
-      
+
       $FileName = basename($File);
       $Modes = array(
          'class'     => self::LOOKUP_CLASS_MASK,
@@ -891,36 +894,36 @@ class Gdn_Autoloader_Map {
       }
       return FALSE;
    }
-   
+
    public function MapType() {
       return $this->MapInfo['maptype']; //GetValue('maptype', $this->MapInfo);
    }
-   
+
    public function Shutdown() {
-      
+
       if (!GetValue('dirty', $this->MapInfo)) return FALSE;
       if (!GetValue('save', $this->MapInfo)) return FALSE;
-      
+
       if (!sizeof($this->Map))
          return FALSE;
-         
+
       $MapName = GetValue('name', $this->MapInfo);
       $FileName = GetValue('ondisk', $this->MapInfo);
-      
+
       $MapContents = '';
       foreach ($this->Map as $SplitTopic => $TopicFiles) {
          $MapContents .= "[{$SplitTopic}]\n";
          foreach ($TopicFiles as $ClassName => $Location)
             $MapContents .= "{$ClassName} = \"{$Location}\"\n";
       }
-      
+
       try {
          Gdn_FileSystem::SaveFile($FileName, $MapContents, LOCK_EX);
          $this->MapInfo['dirty'] = FALSE;
       }
       catch (Exception $e) { return FALSE; }
-      
+
       return TRUE;
    }
-   
+
 }


### PR DESCRIPTION
We’ve been working a lot more with gulp and sass lately and these libraries can create many, many nested folders causing the autoloader to take very long to find classes, even timing out the request in the process.
