### PR TITLE
TermsOfService: Fix markdown error.

### DIFF
--- a/applications/dashboard/controllers/class.homecontroller.php
+++ b/applications/dashboard/controllers/class.homecontroller.php
@@ -118,8 +118,6 @@ class HomeController extends Gdn_Controller {
     * @access public
     */
    public function TermsOfService() {
-      require_once PATH_LIBRARY.'/vendors/markdown/markdown.php';
-
       $this->Render();
    }
 

--- a/applications/dashboard/views/home/termsofservice.php
+++ b/applications/dashboard/views/home/termsofservice.php
@@ -2,5 +2,5 @@
 
 <h1><?php echo T('TermsOfService');?></h1>
 <div class="Legal">
-   <?php echo Markdown(T('TermsOfServiceText'));?>
+   <?php echo Gdn_Format::Markdown(T('TermsOfServiceText'));?>
 </div>


### PR DESCRIPTION
Markdown has been relocated.  This was causing TOS page to 500.
