### PR TITLE
Conversations: Fix hash in activities and popin

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -556,7 +556,7 @@ class ConversationModel extends ConversationsModel {
             'RecordID' => $ConversationID,
             'Story' => GetValue('Body', $FormPostValues),
             'Format' => GetValue('Format', $FormPostValues, C('Garden.InputFormatter')),
-            'Route' => "/messages/$ConversationID#$MessageID"
+            'Route' => "/messages/$ConversationID#Message_$MessageID"
          );
 
          $Subject = GetValue('Subject', $Fields);

--- a/applications/conversations/views/messages/popin.php
+++ b/applications/conversations/views/messages/popin.php
@@ -21,10 +21,10 @@ if (count($this->Data('Conversations'))):
    }
    $PhotoUser = UserBuilder($Row, 'LastInsert');
    ?>
-   <li class="Item" rel="<?php echo Url("/messages/{$Row['ConversationID']}#latest"); ?>">
+   <li class="Item" rel="<?php echo Url("/messages/{$Row['ConversationID']}#Message_{$Row['LastMessageID']}"); ?>">
       <div class="Author Photo"><?php echo UserPhoto($PhotoUser); ?></div>
       <div class="ItemContent">
-         <b class="Subject"><?php echo Anchor($Subject, "/messages/{$Row['ConversationID']}#latest"); ?></b>
+         <b class="Subject"><?php echo Anchor($Subject, "/messages/{$Row['ConversationID']}#Message_{$Row['LastMessageID']}"); ?></b>
          <?php
          $Excerpt = SliceString(Gdn_Format::PlainText($Row['LastBody'], $Row['LastFormat']), 80);
          echo Wrap(nl2br(htmlspecialchars($Excerpt)), 'div', array('class' => 'Excerpt'));


### PR DESCRIPTION
Both #latest (popin) and #1234 (activities) don't take you to the latest message, the actual
ID is #Message_1234
