### PR TITLE
Update for vBulletin 5.1 password hashing

### DIFF
--- a/library/core/class.passwordhash.php
+++ b/library/core/class.passwordhash.php
@@ -143,6 +143,10 @@ class Gdn_PasswordHash extends PasswordHash {
             $VbHash = md5(md5($Password).$Salt);
             $Result = $VbHash == $VbStoredHash;
             break;
+         case 'vbulletin5': // Since 5.1
+            // md5 sum the raw password before crypt. Nice work as usual vb.
+            $Result = $StoredHash === crypt(md5($Password), $StoredHash);
+            break;
          case 'xenforo':
             $Data = @unserialize($StoredHash);
             if (!is_array($Data))


### PR DESCRIPTION
New 'vbulletin5' HashMethod to compliment Porter 2.0.4.

"Feature" but it should go in master and be backported to 2.1.
