### PR TITLE
Take the changed username when connecting through SSO.

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -504,6 +504,10 @@ EOT;
          $EmailUnique = C('Garden.Registration.EmailUnique', TRUE);
          $AutoConnect = C('Garden.Registration.AutoConnect');
 
+         if ($IsPostBack && $this->Form->GetFormValue('ConnectName')) {
+            $this->Form->SetFormValue('Name', $this->Form->GetFormValue('ConnectName'));
+         }
+
          // Get the existing users that match the name or email of the connection.
          $Search = FALSE;
          if ($this->Form->GetFormValue('Name') && $NameUnique) {


### PR DESCRIPTION
The entry/connect page has several use-cases where a user is presented with a username option. Before their choice was never honoured. This change fixes that.

I'm hoping that this pull request can get merged into stage and tested against a few known SSO configurations for customers. I've already tested that this isn't a way of hijacking a username as the code requires a password if you choose an existing username.
