### PR TITLE
OpenID Plugin: Make signing in with OpenID optional.

### DIFF
--- a/plugins/OpenID/class.openid.plugin.php
+++ b/plugins/OpenID/class.openid.plugin.php
@@ -198,7 +198,7 @@ class OpenIDPlugin extends Gdn_Plugin {
    public function EntryController_SignIn_Handler($Sender, $Args) {
 //      if (!$this->IsEnabled()) return;
 
-      if (isset($Sender->Data['Methods']) && !C('Plugins.OpenID.DisableSignIn')) {
+      if (isset($Sender->Data['Methods']) && $this->SignInAllowed()) {
          $Url = $this->_AuthorizeHref();
 
          // Add the OpenID method to the controller.


### PR DESCRIPTION
Since the OpenID plugin is requisite for other plugins,
make the ability for users to be able to sign in with OpenID
optional.

Fix bug where full name field is " " by default.
