### PR TITLE
Give better feedback if ini files are busted

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -45,7 +45,8 @@ Gdn_Autoloader::Start();
 // Guard against broken cache files
 if (!class_exists('Gdn')) {
    // Throwing an exception here would result in a white screen for the user.
-   exit("Class GDN not found. This often indicates the .ini files in the folder 'cache' are out of date and should be deleted.");
+   // This error usually indicates the .ini files in /cache are out of date and should be deleted.
+   exit("Class Gdn not found.");
 }
 
 // Cache Layer

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -42,6 +42,12 @@ require_once(PATH_LIBRARY_CORE.'/functions.compatibility.php');
 require_once(PATH_LIBRARY_CORE.'/class.autoloader.php');
 Gdn_Autoloader::Start();
 
+// Guard against broken cache files
+if (!class_exists('Gdn')) {
+   // Throwing an exception here would result in a white screen for the user.
+   exit("Class GDN not found. This often indicates the .ini files in the folder 'cache' are out of date and should be deleted.");
+}
+
 // Cache Layer
 Gdn::FactoryInstall(Gdn::AliasCache, 'Gdn_Cache', NULL, Gdn::FactoryRealSingleton, 'Initialize');
 


### PR DESCRIPTION
The goal here is to protect against a common problem: the .ini files in the `cache` folder get messed up for whatever reason during an upgrade and it completely baffles the user with an error like "Fatal error: Class 'Gdn' not found".

Examples: http://vanillaforums.org/search?adv=&search=%22Fatal+error%3A+Class+%27Gdn%27+not+found%22&title=&author=&cat=all&tags=&discussion_d=1&discussion_question=1&comment_c=1&comment_answer=1&page_p=1&within=1+day&date=

This is the most straightforward way I could see of making this an easy issue to sidestep for our open source users, but I'm not sure it's the best solution. Suggestions welcome.