### PR TITLE
Hotfix/sqldriver groups concat type

### DIFF
--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -131,6 +131,7 @@ class MessageModel extends Gdn_Model {
          ->Where('Enabled', '1')
          ->BeginWhereGroup()
          ->WhereIn('Controller', $Exceptions)
+         ->OrOp()
          ->BeginWhereGroup()
          ->OrWhere('Application', $Application)
          ->Where('Controller', $Controller)

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1984,6 +1984,7 @@ class UserModel extends Gdn_Model {
          $this->SQL->Join('UserRole ur2', "u.UserID = ur2.UserID and ur2.RoleID = $RoleID");
       } elseif (isset($IPAddress)) {
          $this->SQL
+            ->OrOp()
             ->BeginWhereGroup()
             ->OrWhere('u.InsertIPAddress', $IPAddress)
             ->OrWhere('u.LastIPAddress', $IPAddress)
@@ -1996,6 +1997,7 @@ class UserModel extends Gdn_Model {
 
          if (is_array($Like)) {
             $this->SQL
+               ->OrOp()
                ->BeginWhereGroup()
                ->OrLike($Like, '', 'right')
                ->EndWhereGroup();
@@ -2066,6 +2068,7 @@ class UserModel extends Gdn_Model {
 
          if (is_array($Like)) {
             $this->SQL
+               ->OrOp()
                ->BeginWhereGroup()
                ->OrLike($Like, '', 'right')
                ->EndWhereGroup();

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -691,6 +691,7 @@ class CommentModel extends VanillaModel {
          if (!isset($PrevWhere)) {
             $this->SQL->Where($Expr, $Value);
          } else {
+            $this->SQL->OrOp();
             $this->SQL->BeginWhereGroup();
             $this->SQL->OrWhere($PrevWhere[0], $PrevWhere[1]);
             $this->SQL->Where($Expr, $Value);

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -185,6 +185,20 @@ abstract class Gdn_SQLDriver {
    protected $_WhereConcatDefault;
 
    /**
+    * The logical operator used to concatenate where group clauses.
+    *
+    * @var string
+    */
+   protected $_WhereGroupConcat;
+
+   /**
+    * The default $_WhereGroupConcat that will be reverted back to after every where or where group clause is appended.
+    *
+    * @var string
+    */
+   protected $_WhereGroupConcatDefault;
+
+   /**
     * The number of where groups to open.
     *
     * @var int
@@ -234,6 +248,7 @@ abstract class Gdn_SQLDriver {
       $this->_WhereConcat = 'and';
       if($SetDefault) {
          $this->_WhereConcatDefault = 'and';
+         $this->_WhereGroupConcatDefault = 'and';
       }
 
       return $this;
@@ -256,11 +271,21 @@ abstract class Gdn_SQLDriver {
    }
 
    /**
+    * A convenience method that calls Gdn_DatabaseDriver::BeginWhereGroup with concatenated with an 'or.'
+    * @See Gdn_DatabaseDriver::BeginWhereGroup()
+    * @return Gdn_SQLDriver $this
+    */
+   public function OrBeginWhereGroup() {
+      return $this->OrOp()->BeginWhereGroup();
+   }
+
+   /**
     * Begin bracketed group in the where clause to group logical expressions together.
     *
     * @return Gdn_SQLDriver $this
     */
    public function BeginWhereGroup() {
+      $this->_WhereGroupConcat = $this->_WhereConcat;
       $this->_WhereGroupCount++;
       $this->_OpenWhereGroupCount++;
       return $this;
@@ -1486,6 +1511,7 @@ abstract class Gdn_SQLDriver {
       $this->_WhereConcat = 'or';
       if($SetDefault) {
          $this->_WhereConcatDefault = 'or';
+         $this->_WhereGroupConcatDefault = 'or';
       }
 
       return $this;
@@ -1703,6 +1729,8 @@ abstract class Gdn_SQLDriver {
       $this->_Wheres          = array();
       $this->_WhereConcat     = 'and';
       $this->_WhereConcatDefault = 'and';
+      $this->_WhereGroupConcat = 'and';
+      $this->_WhereGroupConcatDefault = 'and';
       $this->_WhereGroupCount = 0;
       $this->_OpenWhereGroupCount = 0;
       $this->_GroupBys        = array();
@@ -1941,6 +1969,10 @@ abstract class Gdn_SQLDriver {
       // Figure out the concatenation operator.
       $Concat = '';
 
+      if ($this->_OpenWhereGroupCount > 0) {
+         $this->_WhereConcat = $this->_WhereGroupConcat;
+      }
+
       if(count($this->_Wheres) > 0) {
          $Concat = str_repeat(' ', $this->_WhereGroupCount + 1) . $this->_WhereConcat . ' ';
       }
@@ -1953,6 +1985,7 @@ abstract class Gdn_SQLDriver {
 
       // Revert the concat back to 'and'.
       $this->_WhereConcat = $this->_WhereConcatDefault;
+      $this->_WhereGroupConcat = $this->_WhereGroupConcatDefault;
 
       $this->_Wheres[] = $Concat . $Sql;
 


### PR DESCRIPTION
this makes it possible to set an or/and explicitly in a beginwheregroup so that doing an `OrOp()` after starting a `BeginWhereGroup()` doesn't make the entire group an OR.  If this is all intentional then perhaps the documentation should be made clearer - and I'd be fine with updating the comments in a pull request, just not sure of what is exactly the correct outcome.

This is so that this code:
```php
Gdn::SQL()
    ->Select('*')
    ->From('Test t')
    ->Where('ID', 5)
    ->BeginWhereGroup()
    ->OrWhere('InsertIPAddress', 123456)
    ->EndWhereGroup();
```
would not generate:
```sql
select t.*
from Test t
where t.Id = :ID
  or (t.InsertIpAddress = :tInsertIpAddress)
```
instead of the correct output of:
```sql
select t.*
from Test t
where t.Id = :ID
  and (t.InsertIpAddress = :tInsertIpAddress)
```

This also adds `OrBeginWhereGroup`.

The scary thing is that while I've looked through the code for the few situations where this exists, and this is the "correct" behavior.. this could cause backwards compatibility issues - not just with the internals but with plugins as well.