### PR TITLE
Eliminate unneeded specifity for .ContentColumn

### DIFF
--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -69,7 +69,7 @@ textarea, input[type=text] {
    margin: auto;
    width: 960px;
 }
-#Body .ContentColumn {
+.ContentColumn {
    margin: 0 0 0 230px
 }
 


### PR DESCRIPTION
There is no need to precede class .ContentColumn with #Body. That class is only used once `<div class="Column ContentColumn" id="Content">`.
