### PR TITLE
[WIP] Login rate limit: no-cache implementation

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3454,75 +3454,94 @@ class UserModel extends Gdn_Model {
     * @param array $User
     * @param boolean $PasswordOK
     */
-   public static function RateLimit($User, $PasswordOK) {
-      if (!Gdn::Cache()->ActiveEnabled()) return FALSE;
-//      $CoolingDown = FALSE;
-//
-//      // 1. Check if we're in userid cooldown
-//      $UserCooldownKey = FormatString(self::LOGIN_COOLDOWN_KEY, array('Source' => $User['UserID']));
-//      if (!$CoolingDown) {
-//         $InUserCooldown = Gdn::Cache()->Get($UserCooldownKey);
-//         if ($InUserCooldown) {
-//            $CoolingDown = $InUserCooldown;
-//            $CooldownError = T('LoginUserCooldown', "Your account is temporarily locked due to failed login attempts. Try again in %s.");
-//         }
-//      }
-//
-//      // 2. Check if we're in source IP cooldown
-//      $SourceCooldownKey = FormatString(self::LOGIN_COOLDOWN_KEY, array('Source' => Gdn::Request()->IpAddress()));
-//      if (!$CoolingDown) {
-//         $InSourceCooldown = Gdn::Cache()->Get($SourceCooldownKey);
-//         if ($InSourceCooldown) {
-//            $CoolingDown = $InUserCooldown;
-//            $CooldownError = T('LoginSourceCooldown', "Your IP is temporarily blocked due to failed login attempts. Try again in %s.");
-//         }
-//      }
-//
-//      // Block cooled down people
-//      if ($CoolingDown) {
-//         $Timespan = $InUserCooldown;
-//         $Timespan -= 3600 * ($Hours = (int) floor($Timespan / 3600));
-//         $Timespan -= 60 * ($Minutes = (int) floor($Timespan / 60));
-//         $Seconds = $Timespan;
-//
-//         $TimeFormat = array();
-//         if ($Hours) $TimeFormat[] = "{$Hours} ".Plural($Hours, 'hour', 'hours');
-//         if ($Minutes) $TimeFormat[] = "{$Minutes} ".Plural($Minutes, 'minute', 'minutes');
-//         if ($Seconds) $TimeFormat[] = "{$Seconds} ".Plural($Seconds, 'second', 'seconds');
-//         $TimeFormat = implode(', ', $TimeFormat);
-//         throw new Exception(sprintf($CooldownError, $TimeFormat));
-//      }
-//
-//      // Logged in OK
-//      if ($PasswordOK) {
-//         Gdn::Cache()->Remove($UserCooldownKey);
-//         Gdn::Cache()->Remove($SourceCooldownKey);
-//      }
+    public static function RateLimit($User, $PasswordOK) {
+        if (!Gdn::Cache()->ActiveEnabled()) {
+            $Now = time();
+            $UserModel = Gdn::UserModel();
+            $LastLoginAttempt = $UserModel->GetAttribute($User->UserID, 'LastLoginAttempt', 0);
+            $UserRate = $UserModel->GetAttribute($User->UserID, 'LoginRate', 0);
 
-      // Rate limiting
-      $UserRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => $User->UserID));
-      $UserRate = (int)Gdn::Cache()->Get($UserRateKey);
-      $UserRate += 1;
-      Gdn::Cache()->Store($UserRateKey, 1, array(
-         Gdn_Cache::FEATURE_EXPIRY => self::LOGIN_RATE
-      ));
+            if ($LastLoginAttempt + self::LOGIN_RATE <= $Now) {
+                $UserRate = 0;
+            }
 
-      $SourceRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => Gdn::Request()->IpAddress()));
-      $SourceRate = (int)Gdn::Cache()->Get($SourceRateKey);
-      $SourceRate += 1;
-      Gdn::Cache()->Store($SourceRateKey, 1, array(
-         Gdn_Cache::FEATURE_EXPIRY => self::LOGIN_RATE
-      ));
+            $UserModel->SaveAttribute($User->UserID, 'LastLoginAttempt', $Now);
+            $UserModel->SaveAttribute($User->UserID, 'LoginRate', $UserRate + 1);
 
-      // Put user into cooldown mode
-      if ($UserRate > 1)
-         throw new Gdn_UserException(T('LoginUserCooldown', "You are trying to log in too often. Slow down!."));
+            // TODO
+            $SourceRate = 0;
 
-      if ($SourceRate > 1)
-         throw new Gdn_UserException(T('LoginSourceCooldown', "Your IP is trying to log in too often. Slow down!"));
+        } else {
+//          $CoolingDown = FALSE;
+//
+//          //   1. Check if we're in userid cooldown
+//          $UserCooldownKey = FormatString(self::LOGIN_COOLDOWN_KEY, array('Source' => $User['UserID']));
+//          if (!$CoolingDown) {
+//              $InUserCooldown = Gdn::Cache()->Get($UserCooldownKey);
+//              if ($InUserCooldown) {
+//                  $CoolingDown = $InUserCooldown;
+//                  $CooldownError = T('LoginUserCooldown', "Your account is temporarily locked due to failed login attempts. Try again in %s.");
+//              }
+//          }
+//
+//          //   2. Check if we're in source IP cooldown
+//          $SourceCooldownKey = FormatString(self::LOGIN_COOLDOWN_KEY, array('Source' => Gdn::Request()->IpAddress()));
+//          if (!$CoolingDown) {
+//              $InSourceCooldown = Gdn::Cache()->Get($SourceCooldownKey);
+//              if ($InSourceCooldown) {
+//                  $CoolingDown = $InUserCooldown;
+//                  $CooldownError = T('LoginSourceCooldown', "Your IP is temporarily blocked due to failed login attempts. Try again in %s.");
+//              }
+//          }
+//
+//          //   Block cooled down people
+//          if ($CoolingDown) {
+//              $Timespan = $InUserCooldown;
+//              $Timespan -= 3600 * ($Hours = (int) floor($Timespan / 3600));
+//              $Timespan -= 60 * ($Minutes = (int) floor($Timespan / 60));
+//              $Seconds = $Timespan;
+//
+//              $TimeFormat = array();
+//              if ($Hours) $TimeFormat[] = "{$Hours} ".Plural($Hours, 'hour', 'hours');
+//              if ($Minutes) $TimeFormat[] = "{$Minutes} ".Plural($Minutes, 'minute', 'minutes');
+//              if ($Seconds) $TimeFormat[] = "{$Seconds} ".Plural($Seconds, 'second', 'seconds');
+//              $TimeFormat = implode(', ', $TimeFormat);
+//              throw new Exception(sprintf($CooldownError, $TimeFormat));
+//          }
+//
+//          //   Logged in OK
+//          if ($PasswordOK) {
+//              Gdn::Cache()->Remove($UserCooldownKey);
+//              Gdn::Cache()->Remove($SourceCooldownKey);
+//          }
 
-      return TRUE;
-   }
+            // Rate limiting
+            $UserRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => $User->UserID));
+            $UserRate = (int)Gdn::Cache()->Get($UserRateKey);
+            $UserRate += 1;
+            Gdn::Cache()->Store($UserRateKey, 1, array(
+                Gdn_Cache::FEATURE_EXPIRY => self::LOGIN_RATE
+            ));
+
+            $SourceRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => Gdn::Request()->IpAddress()));
+            $SourceRate = (int)Gdn::Cache()->Get($SourceRateKey);
+            $SourceRate += 1;
+            Gdn::Cache()->Store($SourceRateKey, 1, array(
+                Gdn_Cache::FEATURE_EXPIRY => self::LOGIN_RATE
+            ));
+        }
+
+        // Put user into cooldown mode
+        if ($UserRate > 1) {
+            throw new Gdn_UserException(T('LoginUserCooldown', "You are trying to log in too often. Slow down!."));
+        }
+
+        if ($SourceRate > 1) {
+            throw new Gdn_UserException(T('LoginSourceCooldown', "Your IP is trying to log in too often. Slow down!"));
+        }
+
+        return TRUE;
+    }
 
 	public function SetField($RowID, $Property, $Value = FALSE) {
       if (!is_array($Property))


### PR DESCRIPTION
Currently login rate limiting is limited to installs with caching. This
tries to fix that.

WIP because I need feedback on how to implement IP rate limiting without
being too DB-expensive.

The actual fix is this part:
https://github.com/bleistivt/vanilla/blob/a2d656b136cd86b5a59a48f3249dc2896e5da7c1/applications/dashboard/models/class.usermodel.php#L3458-L3474