### PR TITLE
Fix typo in ProxyHead().

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2417,7 +2417,7 @@ if (!function_exists('ProxyHead')) {
 
          $Request = "HEAD $Path?$Query HTTP/1.1\r\n";
 
-         $HostHeader = $Host.($Post != 80) ? ":{$Port}" : '';
+         $HostHeader = $Host.($Port != 80) ? ":{$Port}" : '';
          $Header = array(
             'Host'            => $HostHeader,
             'User-Agent'      => ArrayValue('HTTP_USER_AGENT', $_SERVER, 'Vanilla/2.0'),


### PR DESCRIPTION
It looks like there is just a typo in a variable name in the ProxyHead() function.

PhpStorm has some excellent features that other IDEs do not have that allows errors like these to be found. Other IDEs do not have said features and thus do not find said errors.
