### PR TITLE
Allow device types to overridden in the config.

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1785,6 +1785,9 @@ if (!function_exists('IsMobile')) {
       }
 
       $type = userAgentType();
+      // Check the config for an override. (ex. Consider tablets mobile)
+      $type = C('Garden.Devices.'.ucfirst($type), $type);
+
       switch ($type) {
          case 'app':
          case 'mobile':


### PR DESCRIPTION
This feature currently only works well with our infrastructure’s varnish device detection.

Currently, tablets will display the desktop theme and apps will display the mobile theme. This feature allows you to specify a config setting to change that. So for example specifying `Garden.Devices.Tablet = ‘mobile’` will make tablets look like mobile devices on the server.
