### PR TITLE
Relax the permission requirements for viewing the dashboard.

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -446,6 +446,7 @@ class SettingsController extends DashboardController {
       $this->AddJsFile('settings.js');
       $this->Title(T('Dashboard'));
 
+      $this->RequiredAdminPermissions[] = 'Garden.Settings.View';
       $this->RequiredAdminPermissions[] = 'Garden.Settings.Manage';
       $this->RequiredAdminPermissions[] = 'Garden.Users.Add';
       $this->RequiredAdminPermissions[] = 'Garden.Users.Edit';

--- a/plugins/VanillaStats/class.vanillastats.plugin.php
+++ b/plugins/VanillaStats/class.vanillastats.plugin.php
@@ -93,6 +93,7 @@ class VanillaStatsPlugin extends Gdn_Plugin {
       // Load javascript & css, check permissions, and load side menu for this page.
       $Sender->AddJsFile('settings.js');
       $Sender->Title(T('Dashboard'));
+      $Sender->RequiredAdminPermissions[] = 'Garden.Settings.View';
       $Sender->RequiredAdminPermissions[] = 'Garden.Settings.Manage';
       $Sender->RequiredAdminPermissions[] = 'Garden.Users.Add';
       $Sender->RequiredAdminPermissions[] = 'Garden.Users.Edit';


### PR DESCRIPTION
Since most dashboard links use the Garden.Settings.View permission check then that permission should also be allowed to view the basic dashboard index.
