### PR TITLE
Fix the category add/edit community manager permissions.

### DIFF
--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -271,7 +271,7 @@ class SettingsController extends Gdn_Controller {
     */
    public function AddCategory() {
       // Check permission
-      $this->Permission('Garden.Settings.Manage');
+      $this->Permission('Garden.Community.Manage');
 
       // Set up head
       $this->AddJsFile('jquery.alphanumeric.js');
@@ -470,7 +470,7 @@ class SettingsController extends Gdn_Controller {
     */
    public function EditCategory($CategoryID = '') {
       // Check permission
-      $this->Permission('Garden.Settings.Manage');
+      $this->Permission('Garden.Community.Manage');
 
       // Set up models
       $RoleModel = new RoleModel();

--- a/applications/vanilla/views/settings/managecategories.php
+++ b/applications/vanilla/views/settings/managecategories.php
@@ -73,6 +73,7 @@ if (C('Vanilla.Categories.Use')) {
    $LastRight = 0;
    $OpenCount = 0;
    $Loop = 0;
+   $CanDelete = CheckPermission('Garden.Settings.Manage');
    foreach ($this->CategoryData->Result() as $Category) {
       if ($Category->CategoryID > 0) {
          // Only check stack if there is one
@@ -123,7 +124,7 @@ if (C('Vanilla.Categories.Use')) {
                   </td>
                   <td class="Buttons">'
                      .Anchor(T('Edit'), 'vanilla/settings/editcategory/'.$Category->CategoryID, 'SmallButton')
-                     .Anchor(T('Delete'), 'vanilla/settings/deletecategory/'.$Category->CategoryID, 'SmallButton')
+                     .($CanDelete ? Anchor(T('Delete'), 'vanilla/settings/deletecategory/'.$Category->CategoryID, 'SmallButton') : '')
                   .'</td>
                </tr>
             </table>'


### PR DESCRIPTION
Adding/editing categories should check the Garden.Community.Manage permission. Deleting categories should check the Garden.Settings.Manage permission so the delete button should be conditionally rendered in the UI.
