### PR TITLE
Updated class.request.php to support non-standard ports

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -857,7 +857,7 @@ class Gdn_Request {
 
       $Port = $this->Port();
       $Host = $this->Host();
-      if (!in_array($Port, array(80, 443)))
+      if (!in_array($Port, array(80, 443)) && (strpos($Host, ':'.$Port) === FALSE))
          $Host .= ':'.$Port;
 
       if ($WithDomain === '//') {


### PR DESCRIPTION
Depending on the source used to fill it the 'Host' environment variable, it may already contain the port. This change makes sure the port is added only if not already present, since otherwise Gdn_Request::Url could return Host:port:port in those scenarios.

I've spent two hours trying to figure out why my local installation on port 86 was failing with a blank screen; eventually I figured out it wasn't my nginx configuration what was failing but vanilla itself, as it tried to redirect to host:86:86/index.php?p=/dashboard/setup upon accessing index.php.