### PR TITLE
Fix for GetUnread to include unread discussions without comments

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -437,7 +437,10 @@ class DiscussionModel extends VanillaModel {
             //->Where('w.DateLastViewed', NULL)
             //->OrWhere('d.DateLastComment >', 'w.DateLastViewed')
             //->EndWhereGroup()
-            ->Where('d.CountComments >', 'COALESCE(w.CountComments, 0)', TRUE, FALSE);
+            ->BeginWhereGroup()
+            ->Where('d.CountComments >', 'COALESCE(w.CountComments, 0)', TRUE, FALSE)
+            ->OrWhere('w.DateLastViewed', NULL)
+            ->EndWhereGroup();
       } else {
          $this->SQL
             ->Select('0', '', 'WatchUserID')


### PR DESCRIPTION
GetUnread only showed discussions with unread comments.This fix includes unread discussions without any comments.

Keep current branch up with changes in 2.1. See: https://github.com/vanilla/vanilla/pull/2367