### PR TITLE
Don't restyle radios and checkboxes in TextBoxWrapper

### DIFF
--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -386,7 +386,7 @@ textarea.TextBox {
 	width: auto;
 }
 .TextBoxWrapper textarea,
-.TextBoxWrapper input {
+.TextBoxWrapper input:not([type=radio]):not([type=checkbox]) {
    width: 100%;
    display: block;
 }


### PR DESCRIPTION
style.css has this:
```css
.TextBoxWrapper textarea,
.TextBoxWrapper input {
   width: 100%;
   display: block;
}
```
I have a plugin that adds a post format chooser to the activity form and this CSS makes my radio buttons show up weird. I can always re-override, but hey, let's have sensible defaults. This PR makes that block not apply to radios or checkboxes. Tested with 2.1.6.