### PR TITLE
Remove tab shortcut

### DIFF
--- a/plugins/editor/js/buttonbarplus.js
+++ b/plugins/editor/js/buttonbarplus.js
@@ -336,7 +336,7 @@
             ButtonBar.BindShortcut(TextArea, 'url', 'ctrl+L');
             ButtonBar.BindShortcut(TextArea, 'code', 'ctrl+O');
             ButtonBar.BindShortcut(TextArea, 'blockquote', 'ctrl+Q');
-            ButtonBar.BindShortcut(TextArea, 'post', 'tab');
+            //ButtonBar.BindShortcut(TextArea, 'post', 'tab');
          },
 
          BindShortcut: function(TextArea, Operation, Shortcut, ShortcutMode, OpFunction) {


### PR DESCRIPTION
The tab shortcut interferes with the mentions autocomplete.

This also jumps the selection to the post button when the mention
autocomplete is active, see #2201

Commented out the line, because pressing tab already jumps to the post
button in my tests, making it redundant.