### PR TITLE
Emotify: Surpress Emoji rendering and autocomplete

### DIFF
--- a/plugins/Emotify/class.emotify.plugin.php
+++ b/plugins/Emotify/class.emotify.plugin.php
@@ -28,6 +28,14 @@ class EmotifyPlugin implements Gdn_IPlugin {
    public function AssetModel_StyleCss_Handler($Sender) {
       $Sender->AddCssFile('emotify.css', 'plugins/Emotify');
    }
+   
+	/**
+	 * Surpress Emoji rendering and autocomplete.
+	 */
+   	public function Gdn_Dispatcher_AfterAnalyzeRequest_Handler($Sender) {
+		SaveToConfig('Garden.EmojiSet', 'none', false);
+		Emoji::instance()->setFromManifest(['emoji' => []]);
+	}
 	
 	/**
 	 * Replace emoticons in comments.


### PR DESCRIPTION
Since Emoji are rendered through vanilla before Emotify comes in, a
number of smilies are broken.

This removes  the EmojiSet and the Emoji autocomplete list for the time
Emotify is enabled.