### PR TITLE
Fixes double-parsing of special Profile Extender fields

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -805,7 +805,7 @@ class Gdn_Format {
     * @param mixed $Mixed An object, array, or string to be formatted.
     * @return string
     */
-   public static function Html($Mixed) {
+   public static function Html($Mixed, $Options = array()) {
       if (!is_string($Mixed)) {
          return self::To($Mixed, 'Html');
       } else {
@@ -832,10 +832,19 @@ class Gdn_Format {
             $Mixed = $Formatter->Format($Mixed);
 
             // Links
-            $Mixed = Gdn_Format::Links($Mixed);
+            if (val('Links', $Options, true)) {
+               $Mixed = Gdn_Format::Links($Mixed);
+            }
+
             // Mentions & Hashes
-            $Mixed = Gdn_Format::Mentions($Mixed);
-            $Mixed = Emoji::instance()->translateToHtml($Mixed);
+            if (val('Mentions', $Options, true)) {
+               $Mixed = Gdn_Format::Mentions($Mixed);
+            }
+
+            // Emoji
+            if (val('Emoji', $Options, true)) {
+               $Mixed = Emoji::instance()->translateToHtml($Mixed);
+            }
 
             // nl2br
             if(C('Garden.Format.ReplaceNewlines', TRUE)) {

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -378,8 +378,9 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
          
          // Get all field data, error check
          $AllFields = $this->GetProfileFields();
-         if (!is_array($AllFields) || !is_array($ProfileFields))
+         if (!is_array($AllFields) || !is_array($ProfileFields)) {
             return;
+         }
 
          // DateOfBirth is special case that core won't handle
          // Hack it in here instead
@@ -391,18 +392,19 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
 
          // Display all non-hidden fields
          $ProfileFields = array_reverse($ProfileFields);
+         $FormatOptions = array('Links' => FALSE, 'Mentions' => FALSE, 'Emoji' => FALSE);
          foreach ($ProfileFields as $Name => $Value) {
-            if (!$Value)
+            if (!$Value || !GetValue('OnProfile', $AllFields[$Name])) {
                continue;
-            if (!GetValue('OnProfile', $AllFields[$Name]))
-               continue;
+            }
 
             // Non-magic fields must be plain text, but we'll auto-link
-            if (!in_array($Name, $this->MagicLabels))
+            if (!in_array($Name, $this->MagicLabels)) {
                $Value = Gdn_Format::Links(Gdn_Format::Text($Value));
+            }
 
             echo ' <dt class="ProfileExtend Profile'.Gdn_Format::AlphaNumeric($Name).'">'.Gdn_Format::Text($AllFields[$Name]['Label']).'</dt> ';
-            echo ' <dd class="ProfileExtend Profile'.Gdn_Format::AlphaNumeric($Name).'">'.Gdn_Format::Html($Value).'</dd> ';
+            echo ' <dd class="ProfileExtend Profile'.Gdn_Format::AlphaNumeric($Name).'">'.Gdn_Format::Html($Value, $FormatOptions).'</dd> ';
          }
       } catch (Exception $ex) {
          // No errors


### PR DESCRIPTION
* Adds ability to use `Gdn_Format::Html()` without magic parsing
* Fixes Profile Extender's special Twitter field from linking to profile (mention) instead of Twitter profile
* Generally fix inadvertent magic parsing of profile fields and potentially getting weird stuff like embedded YouTube there