### PR TITLE
Clear notifications immediately

### DIFF
--- a/applications/dashboard/views/home/updatemode.php
+++ b/applications/dashboard/views/home/updatemode.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 
 <div class="SplashInfo">
-   <h1><?php echo T('wMaintenance Mode'); ?></h1>
+   <h1><?php echo T('Maintenance Mode'); ?></h1>
    <p><?php echo T('The site is currently undergoing maintenance.'); ?></p>
 </div>
 <!-- Domain: <?php echo Gdn::Config('Garden.Domain', ''); ?> -->

--- a/applications/dashboard/views/home/updatemode.php
+++ b/applications/dashboard/views/home/updatemode.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 
 <div class="SplashInfo">
-   <h1><?php echo T('Maintenance Mode'); ?></h1>
+   <h1><?php echo T('wMaintenance Mode'); ?></h1>
    <p><?php echo T('The site is currently undergoing maintenance.'); ?></p>
 </div>
 <!-- Domain: <?php echo Gdn::Config('Garden.Domain', ''); ?> -->

--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -31,10 +31,10 @@ if ($Session->IsValid()):
       echo '<div class="MeMenu">';
          // Notifications
          $CountNotifications = $User->CountNotifications;
-         $CNotifications = is_numeric($CountNotifications) && $CountNotifications > 0 ? '<span class="Alert">'.$CountNotifications.'</span>' : '';
+         $CNotifications = is_numeric($CountNotifications) && $CountNotifications > 0 ? '<span class="Alert NotificationsAlert">'.$CountNotifications.'</span>' : '';
 
          echo '<span class="ToggleFlyout" rel="/profile/notificationspopin">';
-         echo Anchor(Sprite('SpNotifications', 'Sprite Sprite16').Wrap(T('Notifications'), 'em').$CNotifications, UserUrl($User), 'MeButton FlyoutButton', array('title' => T('Notifications')));
+         echo Anchor(Sprite('SpNotifications', 'Sprite Sprite16').Wrap(T('Notifications'), 'em').$CNotifications, UserUrl($User), 'MeButton FlyoutButton NotificationsClear', array('title' => T('Notifications')));
          echo Sprite('SpFlyoutHandle', 'Arrow');
          echo '<div class="Flyout FlyoutMenu"></div></span>';
 

--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -34,7 +34,7 @@ if ($Session->IsValid()):
          $CNotifications = is_numeric($CountNotifications) && $CountNotifications > 0 ? '<span class="Alert NotificationsAlert">'.$CountNotifications.'</span>' : '';
 
          echo '<span class="ToggleFlyout" rel="/profile/notificationspopin">';
-         echo Anchor(Sprite('SpNotifications', 'Sprite Sprite16').Wrap(T('Notifications'), 'em').$CNotifications, UserUrl($User), 'MeButton FlyoutButton NotificationsClear', array('title' => T('Notifications')));
+         echo Anchor(Sprite('SpNotifications', 'Sprite Sprite16').Wrap(T('Notifications'), 'em').$CNotifications, UserUrl($User), 'MeButton FlyoutButton js-clear-notifications', array('title' => T('Notifications')));
          echo Sprite('SpFlyoutHandle', 'Arrow');
          echo '<div class="Flyout FlyoutMenu"></div></span>';
 

--- a/js/global.js
+++ b/js/global.js
@@ -1087,7 +1087,7 @@ jQuery(document).ready(function($) {
    }
 
    // Clear notifications alerts when they are accessed anywhere.
-   $(document).delegate('.NotificationsClear', 'click', function() {
+   $(document).on('click', '.NotificationsClear', function() {
       $('.NotificationsAlert').remove();
    });
 

--- a/js/global.js
+++ b/js/global.js
@@ -1087,7 +1087,7 @@ jQuery(document).ready(function($) {
    }
 
    // Clear notifications alerts when they are accessed anywhere.
-   $(document).on('click', '.NotificationsClear', function() {
+   $(document).on('click', '.js-clear-notifications', function() {
       $('.NotificationsAlert').remove();
    });
 

--- a/js/global.js
+++ b/js/global.js
@@ -1086,6 +1086,11 @@ jQuery(document).ready(function($) {
       setInterval(pingForNotifications, 60000);
    }
 
+   // Clear notifications alerts when they are accessed anywhere.
+   $(document).delegate('.NotificationsClear', 'click', function() {
+      $('.NotificationsAlert').remove();
+   });
+
 	// Stash something in the user's session (or unstash the value if it was not provided)
 	stash = function(name, value, callback) {
 		$.ajax({


### PR DESCRIPTION
When notifications are clicked in the MeModule, the `Alert` sticks around even tho they have been cleared on the backend. This adds an instant-clearing mechanism in the UI using generic class names we can use elsewhere to accomplish the same effect anywhere we access notifications or display its count.