### PR TITLE
Fix url checks for profile photos.

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1332,7 +1332,7 @@ class UserModel extends Gdn_Model {
       // Set corrected PhotoUrls.
       $Result =& $Data->Result();
       foreach ($Result as &$Row) {
-         if ($Row->Photo && !IsUrl($Row->Photo) === FALSE) {
+         if ($Row->Photo && !IsUrl($Row->Photo)) {
             $Row->Photo = Gdn_Upload::Url($Row->Photo);
          }
       }
@@ -2015,7 +2015,7 @@ class UserModel extends Gdn_Model {
       $Result =& $Data->Result();
 
       foreach ($Result as &$Row) {
-         if ($Row->Photo && !IsUrl($Row->Photo) === FALSE) {
+         if ($Row->Photo && !IsUrl($Row->Photo)) {
             $Row->Photo = Gdn_Upload::Url($Row->Photo);
          }
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1332,7 +1332,7 @@ class UserModel extends Gdn_Model {
       // Set corrected PhotoUrls.
       $Result =& $Data->Result();
       foreach ($Result as &$Row) {
-         if ($Row->Photo && strpos($Row->Photo, '//') === FALSE) {
+         if ($Row->Photo && !IsUrl($Row->Photo) === FALSE) {
             $Row->Photo = Gdn_Upload::Url($Row->Photo);
          }
       }
@@ -1700,10 +1700,11 @@ class UserModel extends Gdn_Model {
                   }
 
                   if (isset($OldPhoto) && $OldPhoto != $Photo) {
-                     if (strpos($Photo, '//'))
+                     if (IsUrl($Photo)) {
                         $PhotoUrl = $Photo;
-                     else
+                     } else {
                         $PhotoUrl = Gdn_Upload::Url(ChangeBasename($Photo, 'n%s'));
+                     }
 
                      $ActivityModel = new ActivityModel();
                      if ($UserID == Gdn::Session()->UserID) {
@@ -2014,7 +2015,7 @@ class UserModel extends Gdn_Model {
       $Result =& $Data->Result();
 
       foreach ($Result as &$Row) {
-         if ($Row->Photo && strpos($Row->Photo, '//') === FALSE) {
+         if ($Row->Photo && !IsUrl($Row->Photo) === FALSE) {
             $Row->Photo = Gdn_Upload::Url($Row->Photo);
          }
 


### PR DESCRIPTION
There are checks in some of the `ProfileController` methods for whether or not a user’s photo is a url or not. These needed to be updated to the now standardized `IsUrl()`. Without this the activity feed renders incorrect photo change activities and some user API calls will have incorrect photo urls.