### PR TITLE
Fix bug where too many stub discussions are created.

### DIFF
--- a/applications/vanilla/settings/stub.php
+++ b/applications/vanilla/settings/stub.php
@@ -6,12 +6,14 @@
  * @package Vanilla
  */
 
-// Only do this once, ever.
-$DiscussionModel = new DiscussionModel();
-if ($DiscussionModel->GetCount())
-   return;
-
 $SQL = Gdn::Database()->SQL();
+
+// Only do this once, ever.
+$Row = $SQL->Get('Discussion', '', 'asc', 1)->FirstRow(DATASET_TYPE_ARRAY);
+if ($Row) {
+   return;
+}
+
 $DiscussionModel = new DiscussionModel();
 
 // Prep default content


### PR DESCRIPTION
If you have a community where guests can view any discussions then a utility/update will continuously add the initial stub discussion.