### PR TITLE
Clear deleted roles from table UserRole

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -372,6 +372,8 @@ class RoleModel extends Gdn_Model {
             ->Set('UserRole.RoleID', $ReplacementRoleID)
             ->Where(array('UserRole.RoleID' => $RoleID))
             ->Put();
+      } else {
+         $this->SQL->Delete('UserRole', array('RoleID' => $RoleID));
       }
       
       // Remove permissions for this role.


### PR DESCRIPTION
See https://github.com/vanilla/vanilla/issues/2385  
If a role should be deleted and not replaced, all entries in UserRole for that role should also be deleted so that it couldn't happen that users will be assigned to a newly created role just because of relicts in table UserRole