### PR TITLE
Escalate the permissions required for mass banning.

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -272,7 +272,7 @@ class SettingsController extends DashboardController {
     * @param int $ID Ban ID we're editing or deleting.
     */
    public function Bans($Action = '', $Search = '', $Page = '', $ID = '') {
-      $this->Permission('Garden.Moderation.Manage');
+      $this->Permission('Garden.Settings.Manage');
 
       // Page setup
       $this->AddSideMenu();
@@ -290,11 +290,13 @@ class SettingsController extends DashboardController {
             $this->Form->SetModel($BanModel);
 
             if ($this->Form->AuthenticatedPostBack()) {
-               if ($ID)
+               if ($ID) {
                   $this->Form->SetFormValue('BanID', $ID);
+               }
+
                try {
                   // Save the ban.
-                  $this->Form->Save();
+                  $NewID = $this->Form->Save();
                } catch (Exception $Ex) {
                   $this->Form->AddError($Ex);
                }

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -160,7 +160,7 @@ class DashboardHooks implements Gdn_IPlugin {
       if (Gdn::Session()->CheckPermission(array('Garden.Moderation.Manage', 'Moderation.ModerationQueue.Manage'), FALSE))
          $Menu->AddLink('Moderation', T('Moderation Queue').' <span class="Popin" rel="/dashboard/log/count/moderate"></span>', 'dashboard/log/moderation');
       $Menu->AddLink('Moderation', T('Change Log'), 'dashboard/log/edits', 'Garden.Moderation.Manage');
-      $Menu->AddLink('Moderation', T('Banning'), 'dashboard/settings/bans', 'Garden.Moderation.Manage');
+      $Menu->AddLink('Moderation', T('Banning'), 'dashboard/settings/bans', 'Garden.Settings.Manage');
 
 		$Menu->AddItem('Forum', T('Forum Settings'), FALSE, array('class' => 'Forum'));
       $Menu->AddLink('Forum', T('Social'), 'dashboard/social', 'Garden.Settings.Manage');

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -696,6 +696,10 @@ $Construct->Table('Ban')
    ->Column('CountBlockedRegistrations', 'uint', 0)
    ->Column('InsertUserID', 'int')
    ->Column('DateInserted', 'datetime')
+   ->Column('InsertIPAddress', 'varchar(15)', TRUE)
+   ->Column('UpdateUserID', 'int', TRUE)
+   ->Column('DateUpdated', 'datetime', TRUE)
+   ->Column('UpdateIPAddress', 'varchar(15)', TRUE)
    ->Engine('InnoDB')
    ->Set($Explicit, $Drop);
 


### PR DESCRIPTION
Make mass banning an admin permission and add some additional tracking information to the ban table. Note that the additional information on the ban table will take effect after a structure update, but will still work without it.