### PR TITLE
Correct typo in function call "EventArgs" instead of "EventArguments"

### DIFF
--- a/applications/dashboard/views/user/users.php
+++ b/applications/dashboard/views/user/users.php
@@ -34,7 +34,7 @@ foreach ($this->UserData->Result() as $User) {
       <td><?php echo Gdn_Format::Date($User->DateLastActive, 'html'); ?></td>
       <td><?php echo htmlspecialchars($User->LastIPAddress); ?></td>
       <?php
-         $this->EventArgs['User'] = $User;
+         $this->EventArguments['User'] = $User;
          $this->FireEvent('UserCell');
       ?>
       <?php if ($EditUser || $DeleteUser) { ?>


### PR DESCRIPTION
Event UserCell was misbehaving because the current user has never been passed as the EventArgument
Backport to 2.1