### PR TITLE
Render HTML date in conversations

### DIFF
--- a/applications/conversations/views/messages/messages.php
+++ b/applications/conversations/views/messages/messages.php
@@ -35,7 +35,7 @@ foreach ($Messages as $Message) {
             echo UserAnchor($Author, 'Name');
             ?>
          </span>
-         <span class="MItem DateCreated"><?php echo Gdn_Format::Date($Message->DateInserted); ?></span>
+         <span class="MItem DateCreated"><?php echo Gdn_Format::Date($Message->DateInserted, 'html'); ?></span>
          <?php
          $this->FireEvent('AfterConversationMessageDate');
          ?>


### PR DESCRIPTION
Dates in conversations were missing the <code>< time ></code> element.