### PR TITLE
Mobile: Always use modern layout for discussions

### DIFF
--- a/themes/mobile/class.mobilethemehooks.php
+++ b/themes/mobile/class.mobilethemehooks.php
@@ -22,6 +22,9 @@ class MobileThemeHooks implements Gdn_IPlugin {
          Gdn::PluginManager()->RemoveMobileUnfriendlyPlugins();
       }
       SaveToConfig('Garden.Format.EmbedSize', '240x135', FALSE);
+
+      // The table discussions layout takes up too much space on small screens.
+      SaveToConfig('Vanilla.Discussions.Layout', 'modern', FALSE);
    }
    
    /** Add mobile meta info. Add script to hide iPhone browser bar on pageload. */


### PR DESCRIPTION
Temporarily set the default (modern) view for discussions in the themehooks.

#2371 re-opened against stage