### PR TITLE
Allow non-magic HTML parsing & fix it in Profile Extender fields

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -809,43 +809,6 @@ class Gdn_Format {
 
    /**
     * Takes a mixed variable, filters unsafe HTML and returns it.
-    * Use this instead of Gdn_Format::Html() when you do not want magic formatting.
-    *
-    * @param mixed $Mixed An object, array, or string to be formatted.
-    * @return string
-    */
-   public static function HtmlFilter($Mixed) {
-      if (!is_string($Mixed)) {
-         return self::To($Mixed, 'HtmlFilter');
-      } else {
-         if (IsHtml($Mixed)) {
-            // Purify HTML with our formatter.
-            $Formatter = Gdn::Factory('HtmlFormatter');
-            if (is_null($Formatter)) {
-               // If there is no HtmlFormatter then make sure that script injections won't work.
-               return self::Display($Mixed);
-            }
-
-            // Allow the code tag to keep all enclosed HTML encoded.
-            $Mixed = preg_replace(
-               array('/<code([^>]*)>(.+?)<\/code>/sei'),
-               array('\'<code\'.RemoveQuoteSlashes(\'\1\').\'>\'.htmlspecialchars(RemoveQuoteSlashes(\'\2\')).\'</code>\''),
-               $Mixed
-            );
-
-            // Do HTML filtering before our special changes.
-            $Result = $Formatter->Format($Mixed);
-         }
-         else {
-            $Result = htmlspecialchars($Mixed, ENT_NOQUOTES, 'UTF-8');
-         }
-
-         return $Result;
-      }
-   }
-
-   /**
-    * Takes a mixed variable, filters unsafe HTML and returns it.
     * Does "magic" formatting of links, mentions, link embeds, emoji, & linebreaks.
     *
     * @param mixed $Mixed An object, array, or string to be formatted.
@@ -886,6 +849,43 @@ class Gdn_Format {
                $Result = preg_replace("/(\015\012)|(\015)|(\012)/", "<br />", $Result);
                $Result = FixNl2Br($Result);
             }
+         }
+
+         return $Result;
+      }
+   }
+
+   /**
+    * Takes a mixed variable, filters unsafe HTML and returns it.
+    * Use this instead of Gdn_Format::Html() when you do not want magic formatting.
+    *
+    * @param mixed $Mixed An object, array, or string to be formatted.
+    * @return string
+    */
+   public static function HtmlFilter($Mixed) {
+      if (!is_string($Mixed)) {
+         return self::To($Mixed, 'HtmlFilter');
+      } else {
+         if (IsHtml($Mixed)) {
+            // Purify HTML with our formatter.
+            $Formatter = Gdn::Factory('HtmlFormatter');
+            if (is_null($Formatter)) {
+               // If there is no HtmlFormatter then make sure that script injections won't work.
+               return self::Display($Mixed);
+            }
+
+            // Allow the code tag to keep all enclosed HTML encoded.
+            $Mixed = preg_replace(
+               array('/<code([^>]*)>(.+?)<\/code>/sei'),
+               array('\'<code\'.RemoveQuoteSlashes(\'\1\').\'>\'.htmlspecialchars(RemoveQuoteSlashes(\'\2\')).\'</code>\''),
+               $Mixed
+            );
+
+            // Do HTML filtering before our special changes.
+            $Result = $Formatter->Format($Mixed);
+         }
+         else {
+            $Result = htmlspecialchars($Mixed, ENT_NOQUOTES, 'UTF-8');
          }
 
          return $Result;

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -818,7 +818,7 @@ class Gdn_Format {
       if (!is_string($Mixed)) {
          return self::To($Mixed, 'Html');
       } else {
-         if (IsHtml($Mixed)) {
+         if (self::IsHtml($Mixed)) {
             // Purify HTML
             $Mixed = Gdn_Format::HtmlFilter($Mixed);
             // Links
@@ -866,7 +866,7 @@ class Gdn_Format {
       if (!is_string($Mixed)) {
          return self::To($Mixed, 'HtmlFilter');
       } else {
-         if (IsHtml($Mixed)) {
+         if (self::IsHtml($Mixed)) {
             // Purify HTML with our formatter.
             $Formatter = Gdn::Factory('HtmlFormatter');
             if (is_null($Formatter)) {
@@ -911,6 +911,16 @@ class Gdn_Format {
          .'</div>'
          .'<div class="Caption">'.$Caption.'</div>'
       .'</div>';
+   }
+
+   /**
+    * Detect HTML for the purposes of doing advanced filtering.
+    *
+    * @param $Text
+    * @return bool
+    */
+   protected static function IsHtml($Text) {
+      return strpos($Text, '<') !== FALSE || (bool)preg_match('/&#?[a-z0-9]{1,10};/i', $Text);
    }
 
    /**

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -811,7 +811,7 @@ class Gdn_Format {
     * Takes a mixed variable, filters unsafe HTML and returns it.
     * Use this instead of Gdn_Format::Html() when you do not want magic formatting.
     *
-    * @param string $Mixed to be formatted.
+    * @param mixed $Mixed An object, array, or string to be formatted.
     * @return string
     */
    public static function HtmlFilter($Mixed) {

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -883,8 +883,7 @@ class Gdn_Format {
 
             // Do HTML filtering before our special changes.
             $Result = $Formatter->Format($Mixed);
-         }
-         else {
+         } else {
             $Result = htmlspecialchars($Mixed, ENT_NOQUOTES, 'UTF-8');
          }
 

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1766,6 +1766,18 @@ if (!function_exists('InSubArray')) {
    }
 }
 
+if (!function_exists('IsHtml')) {
+   /**
+    * Determine whether text contains HTML.
+    *
+    * @param string $Text
+    * @return bool Whether HTML was detected.
+    */
+   function IsHtml($Text) {
+      return strpos($Text, '<') !== FALSE || (bool)preg_match('/&#?[a-z0-9]{1,10};/i', $Text);
+   }
+}
+
 if (!function_exists('IsMobile')) {
    /**
     * Returns whether or not the site is in mobile mode.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1766,18 +1766,6 @@ if (!function_exists('InSubArray')) {
    }
 }
 
-if (!function_exists('IsHtml')) {
-   /**
-    * Determine whether text contains HTML.
-    *
-    * @param string $Text
-    * @return bool Whether HTML was detected.
-    */
-   function IsHtml($Text) {
-      return strpos($Text, '<') !== FALSE || (bool)preg_match('/&#?[a-z0-9]{1,10};/i', $Text);
-   }
-}
-
 if (!function_exists('IsMobile')) {
    /**
     * Returns whether or not the site is in mobile mode.

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -7,7 +7,7 @@
 $PluginInfo['ProfileExtender'] = array(
    'Name' => 'Profile Extender',
    'Description' => 'Add fields (like status, location, or gamer tags) to profiles and registration.',
-   'Version' => '3.0.1',
+   'Version' => '3.0.2',
    'RequiredApplications' => array('Vanilla' => '2.1'),
    'MobileFriendly' => TRUE,
    //'RegisterPermissions' => array('Plugins.ProfileExtender.Add'),
@@ -378,8 +378,9 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
          
          // Get all field data, error check
          $AllFields = $this->GetProfileFields();
-         if (!is_array($AllFields) || !is_array($ProfileFields))
+         if (!is_array($AllFields) || !is_array($ProfileFields)) {
             return;
+         }
 
          // DateOfBirth is special case that core won't handle
          // Hack it in here instead
@@ -392,17 +393,18 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
          // Display all non-hidden fields
          $ProfileFields = array_reverse($ProfileFields);
          foreach ($ProfileFields as $Name => $Value) {
-            if (!$Value)
+            // Skip empty and hidden fields.
+            if (!$Value || !GetValue('OnProfile', $AllFields[$Name])) {
                continue;
-            if (!GetValue('OnProfile', $AllFields[$Name]))
-               continue;
+            }
 
             // Non-magic fields must be plain text, but we'll auto-link
-            if (!in_array($Name, $this->MagicLabels))
+            if (!in_array($Name, $this->MagicLabels)) {
                $Value = Gdn_Format::Links(Gdn_Format::Text($Value));
+            }
 
             echo ' <dt class="ProfileExtend Profile'.Gdn_Format::AlphaNumeric($Name).'">'.Gdn_Format::Text($AllFields[$Name]['Label']).'</dt> ';
-            echo ' <dd class="ProfileExtend Profile'.Gdn_Format::AlphaNumeric($Name).'">'.Gdn_Format::Html($Value).'</dd> ';
+            echo ' <dd class="ProfileExtend Profile'.Gdn_Format::AlphaNumeric($Name).'">'.Gdn_Format::HtmlFilter($Value).'</dd> ';
          }
       } catch (Exception $ex) {
          // No errors


### PR DESCRIPTION
Replaces #2377

* Adds `Gdn_Format::HtmlFilter()` as non-magic HTML parsing.
* Add `IsHtml()` convenience function.
* Fixes Profile Extender automatically magic-parsing its field values, which is bad on profiles.