### PR TITLE
Rate limit logins on installs without a cache

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3489,81 +3489,75 @@ class UserModel extends Gdn_Model {
       return $this->GetID($UserID);
    }
 
-   /**
+    /**
     * Check and apply login rate limiting
     *
     * @param array $User
     * @param boolean $PasswordOK
     */
-   public static function RateLimit($User, $PasswordOK) {
-      if (!Gdn::Cache()->ActiveEnabled()) return FALSE;
-//      $CoolingDown = FALSE;
-//
-//      // 1. Check if we're in userid cooldown
-//      $UserCooldownKey = FormatString(self::LOGIN_COOLDOWN_KEY, array('Source' => $User['UserID']));
-//      if (!$CoolingDown) {
-//         $InUserCooldown = Gdn::Cache()->Get($UserCooldownKey);
-//         if ($InUserCooldown) {
-//            $CoolingDown = $InUserCooldown;
-//            $CooldownError = T('LoginUserCooldown', "Your account is temporarily locked due to failed login attempts. Try again in %s.");
-//         }
-//      }
-//
-//      // 2. Check if we're in source IP cooldown
-//      $SourceCooldownKey = FormatString(self::LOGIN_COOLDOWN_KEY, array('Source' => Gdn::Request()->IpAddress()));
-//      if (!$CoolingDown) {
-//         $InSourceCooldown = Gdn::Cache()->Get($SourceCooldownKey);
-//         if ($InSourceCooldown) {
-//            $CoolingDown = $InUserCooldown;
-//            $CooldownError = T('LoginSourceCooldown', "Your IP is temporarily blocked due to failed login attempts. Try again in %s.");
-//         }
-//      }
-//
-//      // Block cooled down people
-//      if ($CoolingDown) {
-//         $Timespan = $InUserCooldown;
-//         $Timespan -= 3600 * ($Hours = (int) floor($Timespan / 3600));
-//         $Timespan -= 60 * ($Minutes = (int) floor($Timespan / 60));
-//         $Seconds = $Timespan;
-//
-//         $TimeFormat = array();
-//         if ($Hours) $TimeFormat[] = "{$Hours} ".Plural($Hours, 'hour', 'hours');
-//         if ($Minutes) $TimeFormat[] = "{$Minutes} ".Plural($Minutes, 'minute', 'minutes');
-//         if ($Seconds) $TimeFormat[] = "{$Seconds} ".Plural($Seconds, 'second', 'seconds');
-//         $TimeFormat = implode(', ', $TimeFormat);
-//         throw new Exception(sprintf($CooldownError, $TimeFormat));
-//      }
-//
-//      // Logged in OK
-//      if ($PasswordOK) {
-//         Gdn::Cache()->Remove($UserCooldownKey);
-//         Gdn::Cache()->Remove($SourceCooldownKey);
-//      }
+    public static function RateLimit($User, $PasswordOK) {
+        if (Gdn::Cache()->ActiveEnabled()) {
 
-      // Rate limiting
-      $UserRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => $User->UserID));
-      $UserRate = (int)Gdn::Cache()->Get($UserRateKey);
-      $UserRate += 1;
-      Gdn::Cache()->Store($UserRateKey, 1, array(
-         Gdn_Cache::FEATURE_EXPIRY => self::LOGIN_RATE
-      ));
+            // Rate limit using Gdn_Cache.
+            $UserRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => $User->UserID));
+            $UserRate = (int)Gdn::Cache()->Get($UserRateKey);
+            $UserRate += 1;
+            Gdn::Cache()->Store($UserRateKey, 1, array(
+                Gdn_Cache::FEATURE_EXPIRY => self::LOGIN_RATE
+            ));
 
-      $SourceRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => Gdn::Request()->IpAddress()));
-      $SourceRate = (int)Gdn::Cache()->Get($SourceRateKey);
-      $SourceRate += 1;
-      Gdn::Cache()->Store($SourceRateKey, 1, array(
-         Gdn_Cache::FEATURE_EXPIRY => self::LOGIN_RATE
-      ));
+            $SourceRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => Gdn::Request()->IpAddress()));
+            $SourceRate = (int)Gdn::Cache()->Get($SourceRateKey);
+            $SourceRate += 1;
+            Gdn::Cache()->Store($SourceRateKey, 1, array(
+                Gdn_Cache::FEATURE_EXPIRY => self::LOGIN_RATE
+            ));
 
-      // Put user into cooldown mode
-      if ($UserRate > 1)
-         throw new Gdn_UserException(T('LoginUserCooldown', "You are trying to log in too often. Slow down!."));
+        } elseif (C('Garden.Apc', false) && function_exists('apc_store')) {
 
-      if ($SourceRate > 1)
-         throw new Gdn_UserException(T('LoginSourceCooldown', "Your IP is trying to log in too often. Slow down!"));
+            // Rate limit using the APC data store.
+            $UserRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => $User->UserID));
+            $UserRate = (int)apc_fetch($UserRateKey);
+            $UserRate += 1;
+            apc_store($UserRateKey, 1, self::LOGIN_RATE);
 
-      return TRUE;
-   }
+            $SourceRateKey = FormatString(self::LOGIN_RATE_KEY, array('Source' => Gdn::Request()->IpAddress()));
+            $SourceRate = (int)apc_fetch($SourceRateKey);
+            $SourceRate += 1;
+            apc_store($SourceRateKey, 1, self::LOGIN_RATE);
+
+        } else {
+
+            // Rate limit using user attributes.
+            $Now = time();
+            $UserModel = Gdn::UserModel();
+            $LastLoginAttempt = $UserModel->GetAttribute($User->UserID, 'LastLoginAttempt', 0);
+            $UserRate = $UserModel->GetAttribute($User->UserID, 'LoginRate', 0);
+            $UserRate += 1;
+
+            if ($LastLoginAttempt + self::LOGIN_RATE < $Now) {
+                $UserRate = 0;
+            }
+
+            $UserModel->SaveToSerializedColumn('Attributes', $User->UserID,
+                array('LastLoginAttempt' => $Now, 'LoginRate' => 1)
+            );
+
+            // IP rate limiting is not available without an active cache.
+            $SourceRate = 0;
+
+        }
+
+        // Put user into cooldown mode.
+        if ($UserRate > 1) {
+            throw new Gdn_UserException(T('LoginUserCooldown', 'You are trying to log in too often. Slow down!.'));
+        }
+        if ($SourceRate > 1) {
+            throw new Gdn_UserException(T('LoginSourceCooldown', 'Your IP is trying to log in too often. Slow down!'));
+        }
+
+        return true;
+    }
 
 	public function SetField($RowID, $Property, $Value = FALSE) {
       if (!is_array($Property))


### PR DESCRIPTION
This chooses the best available store for rate limiting:
Gdn_Cache > APC store > Database (User attributes)

I have tested the APC and UserModel store variant. The Gdn_Cache implementation hasn't changed.

New pull for #2346 with a cleaner changeset