### PR TITLE
Add support for default category for new discussions (Vanilla.Categories.Default)

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -106,6 +106,10 @@ class PostController extends VanillaController {
       
       Gdn_Theme::Section('PostDiscussion');
       
+      if ($CategoryUrlCode == '' && C('Vanilla.Categories.Default')) {
+         $CategoryUrlCode = C('Vanilla.Categories.Default');
+      }
+      
       // Set discussion, draft, and category data
       $DiscussionID = isset($this->Discussion) ? $this->Discussion->DiscussionID : '';
       $DraftID = isset($this->Draft) ? $this->Draft->DraftID : 0;


### PR DESCRIPTION
This provides the facility to specify a default category for new discussions, via the Vanilla.Categories.Default option (which is a category URL code). We want this for our own forum in order to avoid fragmentation by users who don't care what category their new discussion goes into.