### PR TITLE
Removed unneeded call to T() function

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -2270,7 +2270,7 @@ PASSWORDMETER;
                break;
             case 'checkbox':
                $Result .= $Description
-                       . $this->CheckBox($Row['Name'], T($LabelCode));
+                       . $this->CheckBox($Row['Name'], $LabelCode);
                break;
             case 'dropdown':
                $Result .= $this->Label($LabelCode, $Row['Name'])


### PR DESCRIPTION
Class Forms function Checkbox() already translates the parameter Label: https://github.com/vanilla/vanilla/blob/master/library/core/class.form.php#L394-407   
So it doesn't have to be used when passing a label.