### PR TITLE
Promoted Content module fixes and improvements

### DIFF
--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -334,10 +334,11 @@ class PromotedContentModule extends Gdn_Module {
          if ($this->ShowDiscussions()) {
             $Discussions = Gdn::SQL()->Select('d.*')
                ->From('Discussion d')
-               ->Where('Score >', $MinScore)
-               ->OrderBy('Score', 'DESC')
+               ->OrderBy('DateInserted', 'DESC')
                ->Limit($this->Limit);
-            if ($MinScore !== FALSE) $Discussions->Where('Score >', $MinScore);
+            if ($MinScore !== FALSE) {
+               $Discussions->Where('Score >', $MinScore);
+            }
             $Discussions = $Discussions->Get()->Result(DATASET_TYPE_ARRAY);
          }
 
@@ -346,9 +347,11 @@ class PromotedContentModule extends Gdn_Module {
          if ($this->ShowComments()) {
             $Comments = Gdn::SQL()->Select('c.*')
                ->From('Comment c')
-               ->OrderBy('Score', 'DESC')
+               ->OrderBy('DateInserted', 'DESC')
                ->Limit($this->Limit);
-            if ($MinScore !== FALSE) $Comments->Where('Score >', $MinScore);
+            if ($MinScore !== FALSE) {
+               $Comments->Where('Score >', $MinScore);
+            }
             $Comments = $Comments->Get()->Result(DATASET_TYPE_ARRAY);
 
             $this->JoinCategory($Comments);

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -377,6 +377,40 @@ class PromotedContentModule extends Gdn_Module {
    }
 
    /**
+    * Selected content that passed the Promoted threshold.
+    *
+    * This uses the Reactions caching system & options.
+    *
+    * @param array $Parameters Not used.
+    * @return array $Content
+    */
+   protected function SelectByPromoted($Parameters) {
+      if (!class_exists('ReactionModel')) {
+         return;
+      }
+
+      $RecordTypes = array();
+      if ($this->ShowDiscussions()) {
+         $RecordTypes[] = 'Discussion';
+      }
+      if ($this->ShowComments()) {
+         $RecordTypes[] = 'Comments';
+      }
+
+      $ReactionModel = new ReactionModel();
+      $PromotedTagID = $ReactionModel->DefineTag('Promoted', 'BestOf');
+      $Content = $ReactionModel->GetRecordsWhere(
+          array('TagID' => $PromotedTagID, 'RecordType' => $RecordTypes),
+          'DateInserted',
+          'desc',
+          $this->Limit);
+
+      $this->Prepare($Content);
+
+      return $Content;
+   }
+
+   /**
     * Attach CategoryID to Comments
     *
     * @param array $Comments

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -394,7 +394,7 @@ class PromotedContentModule extends Gdn_Module {
          $RecordTypes[] = 'Discussion';
       }
       if ($this->ShowComments()) {
-         $RecordTypes[] = 'Comments';
+         $RecordTypes[] = 'Comment';
       }
 
       $ReactionModel = new ReactionModel();
@@ -482,7 +482,7 @@ class PromotedContentModule extends Gdn_Module {
                $Fields = array_merge($Fields, array('CommentID'));
 
                // Comment specific
-               $Replacement['Name'] = GetValueR('Discussion.Name', $ContentItem);
+               $Replacement['Name'] = GetValueR('Discussion.Name', $ContentItem, $ContentItem['Name']);
                break;
 
             case 'discussion':

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -420,7 +420,7 @@ class PromotedContentModule extends Gdn_Module {
 
          foreach ($Section as $Item) {
             $ItemField = GetValue($Field, $Item);
-            $Interleaved[$ItemField] = array_merge($Item, array('ItemType' => $SectionType));
+            $Interleaved[$ItemField] = array_merge($Item, array('RecordType' => $SectionType));
 
             ksort($Interleaved);
          }
@@ -438,10 +438,10 @@ class PromotedContentModule extends Gdn_Module {
    protected function Prepare(&$Content) {
 
       foreach ($Content as &$ContentItem) {
-         $ContentType = GetValue('ItemType', $ContentItem);
+         $ContentType = val('RecordType', $ContentItem);
 
          $Replacement = array();
-         $Fields = array('DiscussionID', 'CategoryID', 'DateInserted', 'DateUpdated', 'InsertUserID', 'Body', 'Format', 'ItemType');
+         $Fields = array('DiscussionID', 'CategoryID', 'DateInserted', 'DateUpdated', 'InsertUserID', 'Body', 'Format', 'RecordType');
 
          switch (strtolower($ContentType)) {
             case 'comment':

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -75,6 +75,7 @@ class PromotedContentModule extends Gdn_Module {
 
    public function __construct() {
       parent::__construct();
+      $this->_ApplicationFolder = 'vanilla';
    }
 
    public function GetData() {

--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -50,8 +50,8 @@ function WritePromotedContent($Content, $Sender) {
          $ContentURL = DiscussionUrl($Content);
          break;
    }
-   $Sender->EventArguments['Content'] = $Content;
-   $Sender->EventArguments['ContentUrl'] = $ContentURL;
+   $Sender->EventArguments['Content'] = &$Content;
+   $Sender->EventArguments['ContentUrl'] = &$ContentURL;
 ?>
    <div id="<?php echo "Promoted_{$ContentType}_{$ContentID}"; ?>" class="<?php echo CssClass($Content); ?>">
       <div class="AuthorWrap">

--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -50,8 +50,8 @@ function WritePromotedContent($Content, $Sender) {
          $ContentURL = DiscussionUrl($Content);
          break;
    }
-   $Sender->EventArgs['Content'] = $Content;
-   $Sender->EventArgs['ContentUrl'] = $ContentURL;
+   $Sender->EventArguments['Content'] = $Content;
+   $Sender->EventArguments['ContentUrl'] = $ContentURL;
 ?>
    <div id="<?php echo "Promoted_{$ContentType}_{$ContentID}"; ?>" class="<?php echo CssClass($Content); ?>">
       <div class="AuthorWrap">

--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -38,9 +38,9 @@ function WritePromotedContent($Content, $Sender) {
    if ($UserPhotoFirst === NULL)
       $UserPhotoFirst = C('Vanilla.Comment.UserPhotoFirst', TRUE);
 
-   $ContentType = GetValue('ItemType', $Content);
-   $ContentID = GetValue("{$ContentType}ID", $Content);
-   $Author = GetValue('Author', $Content);
+   $ContentType = val('RecordType', $Content);
+   $ContentID = val("{$ContentType}ID", $Content);
+   $Author = val('Author', $Content);
 
    switch (strtolower($ContentType)) {
       case 'comment':
@@ -69,8 +69,8 @@ function WritePromotedContent($Content, $Sender) {
          </span>
          <span class="AuthorInfo">
             <?php
-            echo ' '.WrapIf(htmlspecialchars(GetValue('Title', $Author)), 'span', array('class' => 'MItem AuthorTitle'));
-            echo ' '.WrapIf(htmlspecialchars(GetValue('Location', $Author)), 'span', array('class' => 'MItem AuthorLocation'));
+            echo ' '.WrapIf(htmlspecialchars(val('Title', $Author)), 'span', array('class' => 'MItem AuthorTitle'));
+            echo ' '.WrapIf(htmlspecialchars(val('Location', $Author)), 'span', array('class' => 'MItem AuthorLocation'));
             $Sender->FireEvent('AuthorInfo');
             ?>
          </span>


### PR DESCRIPTION
**Fix `SelectByScore`:** As currently coded, the top-scoring posts will get stuck in the PromotedContent module forever by all-time top scoring. We really just want the freshest content that passed our threshold. Also, the `where` clause was getting double-added.

**Add `SelectByPromoted`:** Add integration with Reactions since it is coming to core anyway.

**Fix conventions & errors**: There were several naming & syntax contention errors preventing the above from working correctly.