### PR TITLE
Fix the wording of unverified user tooltip.

### DIFF
--- a/applications/dashboard/views/profile/helper_functions.php
+++ b/applications/dashboard/views/profile/helper_functions.php
@@ -4,21 +4,21 @@ if (!function_exists('UserVerified')):
 /**
  * Return the verified status of a user with a link to change it.
  * @param array|object $User
- * @return string 
+ * @return string
  */
 function UserVerified($User) {
    $UserID = GetValue('UserID', $User);
-   
+
    if (GetValue('Verified', $User)) {
       $Label = T('Verified');
       $Title = T('Verified Description', 'Verified users bypass spam and pre-moderation filters.');
       $Url = "/user/verify.json?userid=$UserID&verified=0";
    } else {
       $Label = T('Not Verified');
-      $Title = T('Not Verified Description', 'Unverified users are passed thru any enabled spam and pre-moderation filters.');
+      $Title = T('Not Verified Description', 'Unverified users are passed through spam and pre-moderation filters.');
       $Url = "/user/verify.json?userid=$UserID&verified=1";
    }
-   
+
    if (Gdn::Session()->CheckPermission('Garden.Moderation.Manage')) {
       return Anchor($Label, $Url, array('title' => $Title, 'class' => 'User-Verified Hijack'));
    } else {


### PR DESCRIPTION
- Change thru to through. http://grammarist.com/spelling/through-thru/
- Don’t talk about site config to users that potentially aren’t
  concerned with administration.