### PR TITLE
Profile editing: fallback to Preferences to match MeModule behavior

### DIFF
--- a/applications/dashboard/modules/class.profileoptionsmodule.php
+++ b/applications/dashboard/modules/class.profileoptionsmodule.php
@@ -33,6 +33,8 @@ class ProfileOptionsModule extends Gdn_Module {
          // Profile Editing
          if (hasEditProfile($Controller->User->UserID)) {
             $ProfileOptions[] = array('Text' => Sprite('SpEditProfile').' '.T('Edit Profile'), 'Url' => UserUrl($Controller->User, '', 'edit'));
+         } else {
+            $ProfileOptions[] = array('Text' => Sprite('SpEditProfile').' '.T('Preferences'), 'Url' => UserUrl($Controller->User, '', 'preferences'));
          }
 
          // Ban/Unban


### PR DESCRIPTION
If a user doesn't have profile editing permission, the MeModule falls back to a "Preferences" link. The profile should do the same.