### PR TITLE
Fix PagerUrl to allow hooking & setting

### DIFF
--- a/applications/dashboard/modules/class.pagermodule.php
+++ b/applications/dashboard/modules/class.pagermodule.php
@@ -435,6 +435,8 @@ class PagerModule extends Gdn_Module {
          $Url = GetValue('Url', $Options, $Pager->Controller()->SelfUrl.'?Page={Page}&'.http_build_query($Get));
 
          $Pager->Configure($Offset, $Limit, $TotalRecords, $Url);
+      } elseif ($Url = val('Url', $Options)) {
+         $Pager->Url = $Url;
       }
 
       echo $Pager->ToString($WriteCount > 0 ? 'more' : 'less');

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -170,17 +170,19 @@ class DiscussionsController extends VanillaController {
       $PagerFactory = new Gdn_PagerFactory();
 		$this->EventArguments['PagerType'] = 'Pager';
 		$this->FireEvent('BeforeBuildPager');
+      if (!$this->Data('_PagerUrl')) {
+         $this->SetData('_PagerUrl', 'discussions/{Page}');
+      }
       $this->Pager = $PagerFactory->GetPager($this->EventArguments['PagerType'], $this);
       $this->Pager->ClientID = 'Pager';
       $this->Pager->Configure(
          $Offset,
          $Limit,
          $CountDiscussions,
-         'discussions/%1$s'
+         $this->Data('_PagerUrl')
       );
       PagerModule::Current($this->Pager);
-      if (!$this->Data('_PagerUrl'))
-         $this->SetData('_PagerUrl', 'discussions/{Page}');
+
       $this->SetData('_Page', $Page);
       $this->SetData('_Limit', $Limit);
 		$this->FireEvent('AfterBuildPager');


### PR DESCRIPTION
* Setting `_PagerUrl` had no effect on `DiscussionsController->Index()`
* The Pager's `Url` option was ignored after page 1.