### PR TITLE
Add dba/fixtree for categories after import/manipulation

### DIFF
--- a/applications/dashboard/controllers/class.dbacontroller.php
+++ b/applications/dashboard/controllers/class.dbacontroller.php
@@ -12,51 +12,51 @@
 
 class DbaController extends DashboardController {
    /// Properties ///
-   
+
    /**
-    * @var Gdn_Form 
+    * @var Gdn_Form
     */
    public $Form = NULL;
-   
+
    /**
-    * @var DBAModel 
+    * @var DBAModel
     */
    public $Model = NULL;
-   
-   
+
+
    /// Methods ///
-   
+
    public function __construct() {
       parent::__construct();
    }
-   
+
    public function Initialize() {
       parent::Initialize();
       Gdn_Theme::Section('Dashboard');
       $this->Model = new DBAModel();
       $this->Form = new Gdn_Form();
       $this->Form->InputPrefix = '';
-      
+
       $this->AddJsFile('dba.js');
    }
-   
+
    public function Counts($Table = FALSE, $Column = FALSE, $From = FALSE, $To = FALSE, $Max = FALSE) {
       set_time_limit(300);
       $this->Permission('Garden.Settings.Manage');
-      
+
       if ($Table && $Column && strcasecmp($this->Request->RequestMethod(), Gdn_Request::INPUT_POST) == 0) {
          if (!ValidateRequired($Table))
             throw new Gdn_UserException("Table is required.");
          if (!ValidateRequired($Column))
             throw new Gdn_UserException("Column is required.");
-         
+
          $Result = $this->Model->Counts($Table, $Column, $From, $To);
          $this->SetData('Result', $Result);
       } else {
          $this->SetData('Jobs', array());
          $this->FireEvent('CountJobs');
       }
-      
+
       $this->SetData('Title', T('Recalculate Counts'));
       $this->AddSideMenu();
       $this->Render('Job');
@@ -81,36 +81,54 @@ class DbaController extends DashboardController {
       $this->AddSideMenu();
       $this->Render('Job');
    }
-   
+
+   /**
+    * Fix the category tree after an import that only gives a sort & parent.
+    */
+   public function FixTree() {
+      $this->Permission('Garden.Settings.Manage');
+
+      if ($this->Request->IsAuthenticatedPostBack()) {
+         $CategoryModel = new CategoryModel();
+         $CategoryModel->RebuildTree();
+         $this->SetData('Result', array('Complete' => TRUE));
+      }
+
+      $this->SetData('Title', "Fix category tree from an import.");
+      $this->_SetJob($this->Data('Title'));
+      $this->AddSideMenu();
+      $this->Render('Job');
+   }
+
    public function FixUrlCodes($Table, $Column) {
       $this->Permission('Garden.Settings.Manage');
-      
+
       if ($this->Request->IsAuthenticatedPostBack()) {
          $Result = $this->Model->FixUrlCodes($Table, $Column);
          $this->SetData('Result', $Result);
       }
-      
+
       $this->SetData('Title', "Fix url codes for $Table.$Column");
       $this->_SetJob($this->Data('Title'));
       $this->AddSideMenu();
       $this->Render('Job');
    }
-   
+
    public function HtmlEntityDecode($Table, $Column) {
       $this->Permission('Garden.Settings.Manage');
-      
+
 //      die($this->Request->RequestMethod());
       if (strcasecmp($this->Request->RequestMethod(), Gdn_Request::INPUT_POST) == 0) {
          $Result = $this->Model->HtmlEntityDecode($Table, $Column);
          $this->SetData('Result', $Result);
       }
-      
+
       $this->SetData('Title', "Decode Html Entities for $Table.$Column");
       $this->_SetJob($this->Data('Title'));
       $this->AddSideMenu();
       $this->Render('Job');
    }
-   
+
    protected function _SetJob($Name) {
       $Args = array_change_key_case($this->ReflectArgs);
       $Url = "/dba/{$this->RequestMethod}.json?".http_build_query($Args);

--- a/applications/dashboard/controllers/class.dbacontroller.php
+++ b/applications/dashboard/controllers/class.dbacontroller.php
@@ -85,7 +85,7 @@ class DbaController extends DashboardController {
    /**
     * Fix the category tree after an import that only gives a sort & parent.
     */
-   public function FixTree() {
+   public function RebuildCategoryTree() {
       $this->Permission('Garden.Settings.Manage');
 
       if ($this->Request->IsAuthenticatedPostBack()) {


### PR DESCRIPTION
We do imports that only set `Sort` & `ParentCategoryID`, and/or sometimes need to do manual manipulations of the category table. This lets us rebuild the tree on the fly.