### PR TITLE
Refactor the validation object.

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1539,11 +1539,10 @@ class DiscussionModel extends VanillaModel {
             $Fields = $this->Validation->SchemaValidationFields();
 
             // Get DiscussionID if one was sent
-            $DiscussionID = intval(ArrayValue('DiscussionID', $Fields, 0));
+            $DiscussionID = intval(val('DiscussionID', $Fields, 0));
 
-            // Remove the primary key from the fields for saving
-            $Fields = RemoveKeyFromArray($Fields, 'DiscussionID');
-
+            // Remove the primary key from the fields for saving.
+            unset($Fields['DiscussionID']);
             $StoredCategoryID = FALSE;
 
             if ($DiscussionID > 0) {

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -12,7 +12,7 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
  *
  * @package Vanilla
  */
- 
+
 /**
  * Manages unpublished drafts of comments and discussions.
  *
@@ -22,17 +22,17 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 class DraftModel extends VanillaModel {
    /**
     * Class constructor. Defines the related database table name.
-    * 
+    *
     * @since 2.0.0
     * @access public
     */
    public function __construct() {
       parent::__construct('Draft');
    }
-   
+
    /**
     * Build base SQL query used by get methods.
-    * 
+    *
     * @since 2.0.0
     * @access public
     */
@@ -41,13 +41,13 @@ class DraftModel extends VanillaModel {
          ->Select('d.*')
          ->From('Draft d');
    }
-   
+
 	/**
 	 * Gets drafts matching the given criteria.
-	 * 
+	 *
     * @since 2.0.0
     * @access public
-	 * 
+	 *
 	 * @param int $UserID Unique ID of user that wrote the drafts.
 	 * @param int $Offset Number of results to skip.
 	 * @param int $Limit Max number of drafts to return.
@@ -60,7 +60,7 @@ class DraftModel extends VanillaModel {
 
       if (!is_numeric($Limit) || $Limit < 1)
          $Limit = 100;
-         
+
       $this->DraftQuery();
       $this->SQL
          ->Select('d.Name, di.Name', 'coalesce', 'Name')
@@ -68,19 +68,19 @@ class DraftModel extends VanillaModel {
          ->Where('d.InsertUserID', $UserID)
          ->OrderBy('d.DateInserted', 'desc')
          ->Limit($Limit, $Offset);
-         
+
       if (is_numeric($DiscussionID) && $DiscussionID > 0)
          $this->SQL->Where('d.DiscussionID', $DiscussionID);
-      
+
       return $this->SQL->Get();
    }
-   
+
    /**
 	 * Gets data for a single draft.
-	 * 
+	 *
     * @since 2.0.0
     * @access public
-	 * 
+	 *
 	 * @param int $DraftID Unique ID of draft to get data for.
 	 * @return object SQL results.
 	 */
@@ -91,13 +91,13 @@ class DraftModel extends VanillaModel {
          ->Get()
          ->FirstRow();
    }
-   
+
    /**
 	 * Gets number of drafts a user has.
-	 * 
+	 *
     * @since 2.0.0
     * @access public
-	 * 
+	 *
 	 * @param int $UserID Unique ID of user to count drafts for.
 	 * @return int Total drafts.
 	 */
@@ -110,48 +110,52 @@ class DraftModel extends VanillaModel {
          ->FirstRow()
          ->CountDrafts;
    }
-   
+
    /**
 	 * Insert or update a draft from form values.
-	 * 
+	 *
     * @since 2.0.0
     * @access public
-	 * 
+	 *
 	 * @param array $FormPostValues Form values sent from form model.
 	 * @return int Unique ID of draft.
 	 */
    public function Save($FormPostValues) {
       $Session = Gdn::Session();
-      
+
       // Define the primary key in this model's table.
       $this->DefineSchema();
-      
-      // Add & apply any extra validation rules:      
+
+      // Add & apply any extra validation rules:
       $this->Validation->ApplyRule('Body', 'Required');
       $MaxCommentLength = Gdn::Config('Vanilla.Comment.MaxLength');
       if (is_numeric($MaxCommentLength) && $MaxCommentLength > 0) {
          $this->Validation->SetSchemaProperty('Body', 'Length', $MaxCommentLength);
          $this->Validation->ApplyRule('Body', 'Length');
       }
-      
+
       // Get the DraftID from the form so we know if we are inserting or updating.
       $DraftID = ArrayValue('DraftID', $FormPostValues, '');
       $Insert = $DraftID == '' ? TRUE : FALSE;
-      
+
+      if (!$DraftID) {
+         unset($FormPostValues['DraftID']);
+      }
+
       // Remove the discussionid from the form value collection if it's empty
       if (array_key_exists('DiscussionID', $FormPostValues) && $FormPostValues['DiscussionID'] == '')
          unset($FormPostValues['DiscussionID']);
-      
+
       if ($Insert) {
          // If no categoryid is defined, grab the first available.
          if (ArrayValue('CategoryID', $FormPostValues) === FALSE)
             $FormPostValues['CategoryID'] = $this->SQL->Get('Category', '', '', 1)->FirstRow()->CategoryID;
-            
+
       }
       // Add the update fields because this table's default sort is by DateUpdated (see $this->Get()).
       $this->AddInsertFields($FormPostValues);
       $this->AddUpdateFields($FormPostValues);
-      
+
       // Remove checkboxes from the fields if they were unchecked
       if (ArrayValue('Announce', $FormPostValues, '') === FALSE)
          unset($FormPostValues['Announce']);
@@ -161,12 +165,12 @@ class DraftModel extends VanillaModel {
 
       if (ArrayValue('Sink', $FormPostValues, '') === FALSE)
          unset($FormPostValues['Sink']);
-         
+
       // Validate the form posted values
       if ($this->Validate($FormPostValues, $Insert)) {
          $Fields = $this->Validation->SchemaValidationFields(); // All fields on the form that relate to the schema
          $DraftID = intval(ArrayValue('DraftID', $Fields, 0));
-         
+
          // If the post is new and it validates, make sure the user isn't spamming
          if ($DraftID > 0) {
             // Update the draft
@@ -179,18 +183,18 @@ class DraftModel extends VanillaModel {
             $this->UpdateUser($Session->UserID);
          }
       }
-      
+
       return $DraftID;
    }
 
    /**
 	 * Deletes a specified draft.
-	 * 
+	 *
 	 * This is a hard delete that completely removes it.
-	 * 
+	 *
     * @since 2.0.0
     * @access public
-	 * 
+	 *
 	 * @param int $DraftID Unique ID of the draft to be deleted.
 	 * @return bool Always returns TRUE.
 	 */
@@ -202,26 +206,26 @@ class DraftModel extends VanillaModel {
          ->Where('DraftID', $DraftID)
          ->Get()
          ->FirstRow();
-         
+
       $this->SQL->Delete('Draft', array('DraftID' => $DraftID));
       if (is_object($DraftUser))
          $this->UpdateUser($DraftUser->InsertUserID);
 
       return TRUE;
    }
-   
+
    /**
 	 * Updates a user's draft count.
-	 * 
+	 *
     * @since 2.0.0
     * @access public
-	 * 
+	 *
 	 * @param int $UserID Unique ID of the user to be updated.
 	 */
    public function UpdateUser($UserID) {
       // Retrieve a draft count
       $CountDrafts = $this->GetCount($UserID);
-      
+
       // Update CountDrafts column of user table fot this user
       Gdn::UserModel()->SetField($UserID, 'CountDrafts', $CountDrafts);
    }

--- a/library/core/class.configurationmodel.php
+++ b/library/core/class.configurationmodel.php
@@ -2,7 +2,7 @@
 
 /**
  * Represents and manages configuration data
- * 
+ *
  * This generic model can be instantiated (with the configuration array
  * name it is intended to represent) and used directly, or it can be extended
  * and overridden for more complicated procedures related to different
@@ -56,10 +56,10 @@ class Gdn_ConfigurationModel {
     * @param string $ConfigurationArrayName The name of the configuration array that is being manipulated.
     * @param object $Validation
     */
-   public function __construct(&$Validation) {
+   public function __construct($Validation) {
       $this->Name = 'Configuration';
       $this->Data = array();
-      $this->Validation = &$Validation;
+      $this->Validation = $Validation;
    }
 
    /**
@@ -137,20 +137,20 @@ class Gdn_ConfigurationModel {
       // Fudge your way through the schema application. This will allow me to
       // force the validation object to expect the fieldnames contained in
       // $this->Data.
-      $this->Validation->ApplySchema($this->Data);
+      $this->Validation->SetSchema($this->Data);
       // Validate the form posted values
       if ($this->Validation->Validate($FormPostValues)) {
          // Merge the validation fields and the forced settings into a single array
          $Settings = $this->Validation->ValidationFields();
          if (is_array($this->_ForceSettings))
             $Settings = MergeArrays($Settings, $this->_ForceSettings);
-            
+
          $SaveResults = SaveToConfig($Settings);
-         
+
          // If the Live flag is true, set these in memory too
          if ($SaveResults && $Live)
             Gdn::Config()->Set($Settings, TRUE);
-         
+
          return $SaveResults;
       } else {
          return FALSE;
@@ -166,7 +166,7 @@ class Gdn_ConfigurationModel {
     * @todo $FormPostValues needs a description and correct variable type.
     */
    public function Validate($FormPostValues) {
-      $this->Validation->ApplySchema($this->Data);
+      $this->Validation->SetSchema($this->Data);
       // Validate the form posted values
       return $this->Validation->Validate($FormPostValues);
    }

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -2,7 +2,7 @@
 
 /**
  * Model base class
- * 
+ *
  * This generic model can be instantiated (with the table name it is intended to
  * represent) and used directly, or it can be extended and overridden for more
  * complicated procedures related to different tables.
@@ -89,7 +89,7 @@ class Gdn_Model extends Gdn_Pluggable {
     * @var Gdn_Schema
     */
    public $Schema;
-   
+
    /**
     * Contains the sql driver for the object.
     *
@@ -145,17 +145,17 @@ class Gdn_Model extends Gdn_Pluggable {
 
    /**
     * Take all of the values that aren't in the schema and put them into the attributes column.
-    * 
+    *
     * @param array $Data
     * @param string $Name
     * @return array
     */
    protected function CollapseAttributes($Data, $Name = 'Attributes') {
       $this->DefineSchema();
-      
+
       $Row = array_intersect_key($Data, $this->Schema->Fields());
       $Attributes = array_diff_key($Data, $Row);
-      
+
       TouchValue($Name, $Row, array());
       if (isset($Row[$Name]) && is_array($Row[$Name]))
          $Row[$Name] = array_merge($Row[$Name], $Attributes);
@@ -163,10 +163,10 @@ class Gdn_Model extends Gdn_Pluggable {
          $Row[$Name] = $Attributes;
       return $Row;
    }
-   
+
    /**
     * Expand all of the values in the attributes column so they become part of the row.
-    * 
+    *
     * @param array $Row
     * @param string $Name
     * @return array
@@ -176,10 +176,10 @@ class Gdn_Model extends Gdn_Pluggable {
       if (isset($Row[$Name])) {
          $Attributes = $Row[$Name];
          unset($Row[$Name]);
-         
+
          if (is_string($Attributes))
             $Attributes = @unserialize($Attributes);
-         
+
          if (is_array($Attributes))
             $Row = array_merge($Row, $Attributes);
       }
@@ -201,7 +201,7 @@ class Gdn_Model extends Gdn_Pluggable {
             $this->PrimaryKey = $this->PrimaryKey[0];
          }
 
-         $this->Validation->ApplyRulesBySchema($this->Schema);
+         $this->Validation->SetSchema($this->Schema);
       }
       return $this->Schema;
    }
@@ -244,30 +244,30 @@ class Gdn_Model extends Gdn_Pluggable {
       }
       return $PrimaryKeyVal;
    }
-   
+
    /**
     * Update a row in the database.
-    * 
+    *
     * @since 2.1
     * @param int $RowID
     * @param array|string $Property
-    * @param atom $Value 
+    * @param atom $Value
     */
    public function SetField($RowID, $Property, $Value = FALSE) {
       if (!is_array($Property))
          $Property = array($Property => $Value);
-      
-      $this->DefineSchema();      
+
+      $this->DefineSchema();
       $Set = array_intersect_key($Property, $this->Schema->Fields());
       self::SerializeRow($Set);
       $this->SQL->Put($this->Name, $Set, array($this->PrimaryKey => $RowID));
    }
-   
+
    /**
     * Serialize Attributes and Data columns in a row.
-    * 
+    *
     * @param array $Row
-    * @since 2.1 
+    * @since 2.1
     */
    public static function SerializeRow(&$Row) {
       foreach ($Row as $Name => &$Value) {
@@ -290,13 +290,13 @@ class Gdn_Model extends Gdn_Pluggable {
          // This is done after validation to allow custom validations to work.
          $SchemaFields = $this->Schema->Fields();
          $Fields = array_intersect_key($Fields, $SchemaFields);
-         
+
          // Quote all of the fields.
          $QuotedFields = array();
          foreach ($Fields as $Name => $Value) {
             if (is_array($Value) && in_array($Name, array('Attributes', 'Data')))
                $Value = empty($Value) ? NULL : serialize($Value);
-            
+
             $QuotedFields[$this->SQL->QuoteIdentifier(trim($Name, '`'))] = $Value;
          }
 
@@ -318,8 +318,8 @@ class Gdn_Model extends Gdn_Pluggable {
       // primary key (always included in $Where when updating) might be "required"
       $AllFields = $Fields;
       if (is_array($Where))
-         $AllFields = array_merge($Fields, $Where); 
-         
+         $AllFields = array_merge($Fields, $Where);
+
       if ($this->Validate($AllFields)) {
          $this->AddUpdateFields($Fields);
 
@@ -333,7 +333,7 @@ class Gdn_Model extends Gdn_Pluggable {
          foreach ($Fields as $Name => $Value) {
             if (is_array($Value) && in_array($Name, array('Attributes', 'Data')))
                $Value = empty($Value) ? NULL : serialize($Value);
-            
+
             $QuotedFields[$this->SQL->QuoteIdentifier(trim($Name, '`'))] = $Value;
          }
 
@@ -360,10 +360,10 @@ class Gdn_Model extends Gdn_Pluggable {
       }
       return $Result;
    }
-   
+
    /**
     * Filter out any potentially insecure fields before they go to the database.
-    * @param array $Data 
+    * @param array $Data
     */
    public function FilterForm($Data) {
       $Data = array_diff_key($Data, array('Attributes' => 0, 'DateInserted' => 0, 'InsertUserID' => 0, 'InsertIPAddress' => 0, 'CheckBoxes' => 0,
@@ -398,14 +398,14 @@ class Gdn_Model extends Gdn_Pluggable {
 
       return $this->SQL->Get($this->Name, $OrderFields, $OrderDirection, $Limit, $PageNumber);
    }
-   
+
    /**
     * Returns a count of the # of records in the table
     * @param array $Wheres
     */
    public function GetCount($Wheres = '') {
       $this->_BeforeGet();
-      
+
       $this->SQL
          ->Select('*', 'count', 'Count')
          ->From($this->Name);
@@ -427,24 +427,24 @@ class Gdn_Model extends Gdn_Pluggable {
     * @param string $DatasetType The format of the result dataset.
     * @param array $Options options to pass to the database.
     * @return array|object
-    * 
+    *
     * @since 2.3 Added the $Options parameter.
     */
    public function GetID($ID, $DatasetType = FALSE, $Options = array()) {
       $this->Options($Options);
       $Result = $this->GetWhere(array($this->PrimaryKey => $ID))->FirstRow($DatasetType);
-      
+
       $Fields = array('Attributes', 'Data');
-      
+
       foreach ($Fields as $Field) {
          if (is_array($Result)) {
             if (isset($Result[$Field]) && is_string($Result[$Field])) {
                $Val = unserialize($Result[$Field]);
                if ($Val)
-                  $Result[$Field] = $Val; 
+                  $Result[$Field] = $Val;
                else
                   $Result[$Field] = $Val;
-            }               
+            }
          } elseif (is_object($Result)) {
             if (isset($Result->$Field) && is_string($Result->$Field)) {
                $Val = unserialize($Result->$Field);
@@ -455,7 +455,7 @@ class Gdn_Model extends Gdn_Pluggable {
             }
          }
       }
-      
+
       return $Result;
    }
 
@@ -471,7 +471,7 @@ class Gdn_Model extends Gdn_Pluggable {
     */
    public function GetWhere($Where = FALSE, $OrderFields = '', $OrderDirection = 'asc', $Limit = FALSE, $Offset = FALSE) {
       $this->_BeforeGet();
-      
+
       return $this->SQL->GetWhere($this->Name, $Where, $OrderFields, $OrderDirection, $Limit, $Offset);
    }
 
@@ -544,7 +544,7 @@ class Gdn_Model extends Gdn_Pluggable {
          $Fields['UpdateIPAddress'] = Gdn::Request()->IpAddress();
       }
    }
-   
+
    /**
     * Gets/sets an option on the object.
     *
@@ -565,11 +565,11 @@ class Gdn_Model extends Gdn_Pluggable {
    }
 
 	public function SaveToSerializedColumn($Column, $RowID, $Name, $Value = '') {
-		
+
 		if (!isset($this->Schema)) $this->DefineSchema();
 		// TODO: need to be sure that $this->PrimaryKey is only one primary key
 		$FieldName = $this->PrimaryKey;
-		
+
 		// Load the existing values
 		$Row = $this->SQL
 			->Select($Column)
@@ -577,18 +577,18 @@ class Gdn_Model extends Gdn_Pluggable {
 			->Where($FieldName, $RowID)
 			->Get()
 			->FirstRow();
-		
+
 		if(!$Row) throw new Exception(T('ErrorRecordNotFound'));
 		$Values = Gdn_Format::Unserialize($Row->$Column);
-		
+
 		if (is_string($Values) && $Values != '')
 			throw new Exception(T('Serialized column failed to be unserialized.'));
-		
+
 		if (!is_array($Values)) $Values = array();
 		if (!is_array($Name)) $Name = array($Name => $Value); // Assign the new value(s)
 
 		$Values = Gdn_Format::Serialize(array_merge($Values, $Name));
-		
+
 		// Save the values back to the db
 		return $this->SQL
 			->From($this->Name)
@@ -596,12 +596,12 @@ class Gdn_Model extends Gdn_Pluggable {
 			->Set($Column, $Values)
 			->Put();
 	}
-   
-    
+
+
 	public function SetProperty($RowID, $Property, $ForceValue = FALSE) {
 		if (!isset($this->Schema)) $this->DefineSchema();
 		$PrimaryKey = $this->PrimaryKey;
-        
+
 		if ($ForceValue !== FALSE) {
             $Value = $ForceValue;
 		} else {
@@ -615,12 +615,12 @@ class Gdn_Model extends Gdn_Pluggable {
             ->Put();
 		return $Value;
    }
-   
+
    /**
     * Get something from $Record['Attributes'] by dot-formatted key
-    * 
+    *
     * Pass record byref
-    * 
+    *
     * @param array $Record
     * @param string $Attribute
     * @param mixed $Default Optional.
@@ -630,23 +630,23 @@ class Gdn_Model extends Gdn_Pluggable {
       $RV = "Attributes.{$Attribute}";
       return GetValueR($RV, $Record, $Default);
    }
-   
+
    /**
     * Set something on $Record['Attributes'] by dot-formatted key
-    * 
+    *
     * Pass record byref
-    * 
+    *
     * @param array $Record
     * @param string $Attribute
     * @param mixed $Value
-    * @return mixed 
+    * @return mixed
     */
    public static function SetRecordAttribute(&$Record, $Attribute, $Value) {
       if (!array_key_exists('Attributes', $Record))
          $Record['Attributes'] = array();
-      
+
       if (!is_array($Record['Attributes'])) return NULL;
-      
+
       $Work = &$Record['Attributes'];
       $Parts = explode('.', $Attribute);
       while ($Part = array_shift($Parts)) {
@@ -654,9 +654,9 @@ class Gdn_Model extends Gdn_Pluggable {
          $Work[$Part] = $SetValue;
          $Work = &$Work[$Part];
       }
-      
+
       return $Value;
    }
-   
+
 }
 

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -325,9 +325,19 @@ class Gdn_Validation {
 
       // Add all of the fields from the schema.
       foreach ($this->GetSchemaRules() as $Field => $Rules) {
-         if (!array_key_exists($Field, $PostedFields) && (!$Insert || !in_array('Required', $Rules))) {
-            // Don't enforce missing fields that aren't required or required fields during an update.
-            continue;
+         $FieldInfo = $this->_Schema[$Field];
+
+         if (!array_key_exists($Field, $PostedFields)) {
+            $Required = in_array('Required', $Rules);
+
+            // Don't enforce fields that aren't required or required fields during a sparse update.
+            if (!$Required || !$Insert) {
+               continue;
+            }
+            // Fields with a non-null default can be left out.
+            if (val('Default', $FieldInfo, NULL) !== NULL) {
+               continue;
+            }
          }
          $Result[$Field] = val($Field, $PostedFields, NULL);
       }
@@ -347,9 +357,19 @@ class Gdn_Validation {
 
       // Add all of the fields from the schema.
       foreach ($this->GetSchemaRules() as $Field => $Rules) {
-         if (!$Insert && !array_key_exists($Field, $PostedFields) && !in_array('Required', $Rules)) {
-            // Don't enforce required fields on an update.
-            continue;
+         $FieldInfo = $this->_Schema[$Field];
+         
+         if (!array_key_exists($Field, $PostedFields)) {
+            $Required = in_array('Required', $Rules);
+
+            // Don't enforce fields that aren't required or required fields during a sparse update.
+            if (!$Required || !$Insert) {
+               continue;
+            }
+            // Fields with a non-null default can be left out.
+            if (val('Default', $FieldInfo, NULL) !== NULL) {
+               continue;
+            }
          }
          if (isset($Result[$Field])) {
             $Result[$Field] = array_unique(array_merge($Result[$Field], $Rules));

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -135,7 +135,7 @@ class Gdn_Validation {
    protected function ApplyRulesBySchema() {
       $this->_SchemaRules = array();
 
-      foreach($this->_Schema as $Field => $Properties) {
+      foreach ($this->_Schema as $Field => $Properties) {
          if (is_scalar($Properties)) {
             // Some code passes a record as a schema so account for that here.
             $Properties = array(
@@ -150,85 +150,81 @@ class Gdn_Validation {
          // Create an array to hold rules for this field
          $RuleNames = array();
 
-         if ($Properties->AutoIncrement === TRUE) {
-            // Skip all rules for auto-incrementing integer columns - they will
-         // not be inserted or updated.
-         } else {
-            // Force non-null fields without defaults to be required.
-            if ($Properties->AllowNull === FALSE && $Properties->Default == '') {
-               $RuleNames[] = 'Required';
-            }
-
-            // Force other constraints based on field type.
-            switch($Properties->Type) {
-               case 'bit':
-               case 'bool':
-               case 'boolean':
-                  $RuleNames[] = 'Boolean';
-                  break;
-
-               case 'tinyint':
-               case 'smallint':
-               case 'mediumint':
-               case 'int':
-               case 'integer':
-               case 'bigint':
-                  $RuleNames[] = 'Integer';
-                  break;
-
-               case 'double':
-               case 'float':
-               case 'real':
-               case 'decimal':
-               case 'dec':
-               case 'numeric':
-               case 'fixed':
-                  $RuleNames[] = 'Decimal';
-                  break;
-
-               case 'date':
-               case 'datetime':
-                  $RuleNames[] = 'Date';
-                  break;
-               case 'time':
-                  $RuleNames[] = 'Time';
-                  break;
-               case 'year':
-                  $RuleNames[] = 'Year';
-                  break;
-               case 'timestamp':
-                  $RuleNames[] = 'Timestamp';
-                  break;
-
-               case 'char':
-               case 'varchar':
-               case 'tinyblob':
-               case 'blob':
-               case 'mediumblob':
-               case 'longblob':
-               case 'tinytext':
-               case 'mediumtext':
-               case 'text':
-               case 'longtext':
-               case 'binary':
-               case 'varbinary':
-                  if (!in_array($Field, array('Attributes', 'Data', 'Preferences', 'Permissions'))) {
-                     $RuleNames[] = 'String';
-                  }
-                  if ($Properties->Length != '')
-                     $RuleNames[] = 'Length';
-                  break;
-
-               case 'enum':
-               case 'set':
-                  $RuleNames[] = 'Enum';
-                  break;
-            }
-
-            if ($Field == 'Format') {
-               $RuleNames[] = 'Format';
-            }
+         // Force non-null fields without defaults to be required.
+         if ($Properties->AllowNull === FALSE && $Properties->Default == '') {
+            $RuleNames[] = 'Required';
          }
+
+         // Force other constraints based on field type.
+         switch ($Properties->Type) {
+            case 'bit':
+            case 'bool':
+            case 'boolean':
+               $RuleNames[] = 'Boolean';
+               break;
+
+            case 'tinyint':
+            case 'smallint':
+            case 'mediumint':
+            case 'int':
+            case 'integer':
+            case 'bigint':
+               $RuleNames[] = 'Integer';
+               break;
+
+            case 'double':
+            case 'float':
+            case 'real':
+            case 'decimal':
+            case 'dec':
+            case 'numeric':
+            case 'fixed':
+               $RuleNames[] = 'Decimal';
+               break;
+
+            case 'date':
+            case 'datetime':
+               $RuleNames[] = 'Date';
+               break;
+            case 'time':
+               $RuleNames[] = 'Time';
+               break;
+            case 'year':
+               $RuleNames[] = 'Year';
+               break;
+            case 'timestamp':
+               $RuleNames[] = 'Timestamp';
+               break;
+
+            case 'char':
+            case 'varchar':
+            case 'tinyblob':
+            case 'blob':
+            case 'mediumblob':
+            case 'longblob':
+            case 'tinytext':
+            case 'mediumtext':
+            case 'text':
+            case 'longtext':
+            case 'binary':
+            case 'varbinary':
+               if (!in_array($Field, array('Attributes', 'Data', 'Preferences', 'Permissions'))) {
+                  $RuleNames[] = 'String';
+               }
+               if ($Properties->Length != '')
+                  $RuleNames[] = 'Length';
+               break;
+
+            case 'enum':
+            case 'set':
+               $RuleNames[] = 'Enum';
+               break;
+         }
+
+         if ($Field == 'Format') {
+            $RuleNames[] = 'Format';
+         }
+         
          // Assign the rules to the field.
          // echo '<div>Field: '.$Field.'</div>';
          // print_r($RuleNames);
@@ -326,7 +322,7 @@ class Gdn_Validation {
                continue;
             }
             // Fields with a non-null default can be left out.
-            if (val('Default', $FieldInfo, NULL) !== NULL) {
+            if (val('Default', $FieldInfo, NULL) !== NULL || val('AutoIncrement', $FieldInfo)) {
                continue;
             }
          }
@@ -358,7 +354,7 @@ class Gdn_Validation {
                continue;
             }
             // Fields with a non-null default can be left out.
-            if (val('Default', $FieldInfo, NULL) !== NULL) {
+            if (val('Default', $FieldInfo, NULL) !== NULL || val('AutoIncrement', $FieldInfo)) {
                continue;
             }
          }

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -128,6 +128,16 @@ class Gdn_Validation {
       $this->_SchemaRules = array();
 
       foreach($this->_Schema as $Field => $Properties) {
+         if (is_scalar($Properties)) {
+            $Properties = array(
+               'AutoIncrement' => FALSE,
+               'AllowNull' => TRUE,
+               'Type' => 'text',
+               'Length' => ''
+            );
+            $Properties = (object)$Properties;
+         }
+
          // Create an array to hold rules for this field
          $RuleNames = array();
 
@@ -358,7 +368,7 @@ class Gdn_Validation {
       // Add all of the fields from the schema.
       foreach ($this->GetSchemaRules() as $Field => $Rules) {
          $FieldInfo = $this->_Schema[$Field];
-         
+
          if (!array_key_exists($Field, $PostedFields)) {
             $Required = in_array('Required', $Rules);
 

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -35,18 +35,6 @@ class Gdn_Validation {
     */
    protected $_ValidationFields;
 
-
-   /**
-    * An associative array of fieldname => value pairs that are in
-    * $this->_ValidationFields AND $this->_Schema. This array is populated by
-    * $this->AddValidationField(); You can access it from outside this class
-    * with $this->SchemaValidationFields();
-    *
-    * @var array
-    */
-   protected $_SchemaValidationFields = array();
-
-
    /**
     * An array of FieldName => Reason arrays that describe which fields failed
     * validation and which functions/regex caused them to fail.
@@ -57,8 +45,8 @@ class Gdn_Validation {
 
 
    /**
-    * An associative array of $FieldName => array($RuleName1, $RuleNameN)
-    * rules to be applied to fields.
+    * An associative array of $FieldName => array($RuleName1, $RuleNameN) rules to be applied to fields.
+    * These are rules that have been explicitly called with {@link Gdn_Validation::ApplyRule()}.
     *
     * @var array
     */
@@ -66,19 +54,19 @@ class Gdn_Validation {
 
 
    /**
+    * An associative array of $FieldName => array($RuleName1, $RuleNameN) rules to be applied to fields.
+    * These are rules that come from the current schema that have been applied by {@link Gdn_Validation::ApplyRulesBySchema()}.
+    * @var array
+    */
+   protected $_SchemaRules = array();
+
+
+   /**
     * The schema being used to generate validation rules.
     *
     * @var array
     */
-   protected $_Schema = NULL;
-
-
-   /**
-    * An array of fields from $this->_Schema that are required for validation.
-    *
-    * @var array
-    */
-   private $_RequiredSchemaFields = array();
+   protected $_Schema = array();
 
 
    /**
@@ -93,11 +81,12 @@ class Gdn_Validation {
     * Class constructor. Optionally takes a schema definition to generate
     * validation rules for.
     *
-    * @param object $Schema A schema object to generate validation rules for.
+    * @param Gdn_Schema $Schema A schema object to generate validation rules for.
     */
    public function __construct($Schema = FALSE) {
-      if ($Schema !== FALSE)
-         $this->ApplyRulesBySchema($Schema);
+      if (is_object($Schema) || is_array($Schema)) {
+         $this->SetSchema($Schema);
+      }
 
       // Define the default validation functions
       $this->_Rules = array();
@@ -134,10 +123,10 @@ class Gdn_Validation {
     * Examines the provided schema and fills $this->_Rules with rules based
     * on the properties of each field in the table schema.
     *
-    * @param object $Schema A schema object to generate validation rules for.
     */
-   public function ApplyRulesBySchema($Schema) {
-      $this->_Schema = $Schema->Fetch();
+   protected function ApplyRulesBySchema() {
+      $this->_SchemaRules = array();
+
       foreach($this->_Schema as $Field => $Properties) {
          // Create an array to hold rules for this field
          $RuleNames = array();
@@ -149,7 +138,6 @@ class Gdn_Validation {
             // Force non-null fields without defaults to be required.
             if ($Properties->AllowNull === FALSE && $Properties->Default == '') {
                $RuleNames[] = 'Required';
-               $this->_RequiredSchemaFields[] = $Field;
             }
 
             // Force other constraints based on field type.
@@ -225,7 +213,7 @@ class Gdn_Validation {
          // Assign the rules to the field.
          // echo '<div>Field: '.$Field.'</div>';
          // print_r($RuleNames);
-         $this->_ApplyRule($Field, $RuleNames);
+         $this->ApplyRuleTo($this->_SchemaRules, $Field, $RuleNames);
       }
    }
 
@@ -253,30 +241,41 @@ class Gdn_Validation {
     * Apply an array of validation rules all at once.
     * @param array $Fields
     */
-   public function ApplyRules($Fields) {
-      foreach ($Fields as $Index => $Row) {
-         $Validation = GetValue('Validation', $Row);
-         if (!$Validation)
-            continue;
-
-         $FieldName = GetValue('Name', $Row, $Index);
-         if (is_string($Validation)) {
-            $this->ApplyRule($FieldName, $Validation);
-         } elseif (is_array($Validation)) {
-            foreach ($Validation as $Rule) {
-               if (is_array($Rule)) {
-                  $this->ApplyRule($FieldName, $Rule[0], $Rule[1]);
-               } else {
-                  $this->ApplyRule($FieldName, $Rule);
-               }
-            }
-         }
-      }
-   }
+//   public function ApplyRules($Fields) {
+//      foreach ($Fields as $Index => $Row) {
+//         $Validation = GetValue('Validation', $Row);
+//         if (!$Validation)
+//            continue;
+//
+//         $FieldName = GetValue('Name', $Row, $Index);
+//         if (is_string($Validation)) {
+//            $this->ApplyRule($FieldName, $Validation);
+//         } elseif (is_array($Validation)) {
+//            foreach ($Validation as $Rule) {
+//               if (is_array($Rule)) {
+//                  $this->ApplyRule($FieldName, $Rule[0], $Rule[1]);
+//               } else {
+//                  $this->ApplyRule($FieldName, $Rule);
+//               }
+//            }
+//         }
+//      }
+//   }
 
    protected function _ApplyRule($FieldName, $RuleName, $CustomError = '') {
-      if (!is_array($this->_FieldRules))
-         $this->_FieldRules = array();
+      $this->ApplyRuleTo($this->_FieldRules, $FieldName, $RuleName, $CustomError);
+   }
+
+   /**
+    * Apply a rule to the given rules array.
+    *
+    * @param array $Array The rules array to apply the rule to.
+    * @param string $FieldName The name of the field that the rule applies to.
+    * @param string $RuleName The name of the rule.
+    * @param string $CustomError A custom error string when the rule is broken.
+    */
+   protected function ApplyRuleTo(&$Array, $FieldName, $RuleName, $CustomError = '') {
+      $Array = (array)$Array;
 
       if (!is_array($RuleName)) {
          if ($CustomError != '')
@@ -286,11 +285,11 @@ class Gdn_Validation {
       }
 
       if (count($RuleName) > 0) {
-         $ExistingRules = ArrayValue($FieldName, $this->_FieldRules, array());
+         $ExistingRules = val($FieldName, $Array, array());
 
          // Merge the new rules with the existing ones (array_merge) and make
          // sure there is only one of each rule applied (array_unique).
-         $this->_FieldRules[$FieldName] = array_unique(array_merge($ExistingRules, $RuleName));
+         $Array[$FieldName] = array_unique(array_merge($ExistingRules, $RuleName));
       }
    }
 
@@ -301,7 +300,9 @@ class Gdn_Validation {
     * @param array $Schema
     */
    public function ApplySchema($Schema) {
+      Deprecated('ApplySchema', 'SetSchema');
       $this->_Schema = $Schema;
+      $this->_SchemaRules = NULL;
    }
 
 
@@ -310,40 +311,86 @@ class Gdn_Validation {
     * $PostedFields collection.
     *
     * @param array $PostedFields The associative array collection of field names to add.
-    * @param array $Schema A schema to examine for field names. If not provided, it will look for
-    *  fields that are in $this->_FieldRules and $PostedFields.
     * @param boolean $Insert A boolean value indicating if the posted fields are to be inserted or
-    * updated. If being inserted, the schema's required field rules will be
-    * enforced.
+    * updated. If being inserted, the schema's required field rules will be enforced.
+    * @return array Returns the subset of {@link $PostedFields} that will be validated.
     */
-   public function DefineValidationFields($PostedFields, $Schema = NULL, $Insert = FALSE) {
-      $this->ValidationFields();
+   protected function DefineValidationFields($PostedFields, $Insert = FALSE) {
+      $Result = array();
 
-      if ($Schema != NULL)
-         $this->_Schema = $Schema;
-
-      // What fields should be validated?
-
-      // 1. Any field that was already explicitly added to the validationfields collection
-      foreach($this->_ValidationFields as $Field => $Val) {
-         $this->AddValidationField($Field, $PostedFields);
+      // Start with the fields that have been explicitly defined by `ApplyRule`.
+      foreach ($this->_FieldRules as $Field => $Rules) {
+         $Result[$Field] = val($Field, $PostedFields, NULL);
       }
 
-      if ($Schema != NULL) {
-         // 2. Any field that is required by the schema
-         foreach($Schema as $Field => $Properties) {
-            if (array_key_exists($Field, $PostedFields) || ($Insert && in_array($Field, $this->_RequiredSchemaFields)))
-               $this->AddValidationField($Field, $PostedFields);
+      // Add all of the fields from the schema.
+      foreach ($this->GetSchemaRules() as $Field => $Rules) {
+         if (!array_key_exists($Field, $PostedFields) && (!$Insert || !in_array('Required', $Rules))) {
+            // Don't enforce missing fields that aren't required or required fields during an update.
+            continue;
          }
-      } else {
-         // 3. Any of the form-posted field
-         foreach($this->_FieldRules as $Field => $Rules) {
-            if (array_key_exists($Field, $PostedFields))
-               $this->AddValidationField($Field, $PostedFields);
-         }
+         $Result[$Field] = val($Field, $PostedFields, NULL);
       }
+
+      return $Result;
    }
 
+   /**
+    * Get all of the validation rules that apply to a given set of data.
+    *
+    * @param array $PostedFields The data that will be validated.
+    * @param bool $Insert Whether or not this is an insert.
+    * @return array Returns an array of `[$Field => [$Rules, ...]`.
+    */
+   protected function DefineValidationRules($PostedFields, $Insert = FALSE) {
+      $Result = (array)$this->_FieldRules;
+
+      // Add all of the fields from the schema.
+      foreach ($this->GetSchemaRules() as $Field => $Rules) {
+         if (!$Insert && !array_key_exists($Field, $PostedFields) && !in_array('Required', $Rules)) {
+            // Don't enforce required fields on an update.
+            continue;
+         }
+         if (isset($Result[$Field])) {
+            $Result[$Field] = array_unique(array_merge($Result[$Field], $Rules));
+         } else {
+            $Result[$Field] = $Rules;
+         }
+      }
+
+      return $Result;
+   }
+
+   /**
+    * Set the schema for this validation.
+    *
+    * @param Gdn_Schema|array $Schema The new schema to set.
+    * @return Gdn_Validation Returns `$this` for fluent calls.
+    */
+   public function SetSchema($Schema) {
+      if ($Schema instanceof Gdn_Schema) {
+         $this->_Schema = $Schema->Fields();
+      } elseif (is_array($Schema)) {
+         $this->_Schema = $Schema;
+      } else {
+         throw new \Exception('Invalid schema of type '.gettype($Schema).'.', 500);
+      }
+      $this->_SchemaRules = null;
+
+      return $this;
+   }
+
+   /**
+    * Get all of the rules as defined by the schema.
+    *
+    * @return array Returns an array in the form `[$FieldName => [$Rules, ...]`.
+    */
+   public function GetSchemaRules() {
+      if (!$this->_SchemaRules) {
+         $this->ApplyRulesBySchema($this->_Schema);
+      }
+      return $this->_SchemaRules;
+   }
 
    /**
     * Returns the an array of fieldnames that are being validated.
@@ -351,8 +398,9 @@ class Gdn_Validation {
     * @return array
     */
    public function ValidationFields() {
-      if (!is_array($this->_ValidationFields))
+      if (!is_array($this->_ValidationFields)) {
          $this->_ValidationFields = array();
+      }
 
       return $this->_ValidationFields;
    }
@@ -406,16 +454,13 @@ class Gdn_Validation {
     * @param array $PostedFields The associative array collection of field names to examine for the value
     *  of $FieldName.
     */
-   public function AddValidationField($FieldName, $PostedFields) {
-      $this->ValidationFields();
+   protected function AddValidationField($FieldName, $PostedFields) {
+      if (!is_array($this->_ValidationFields)) {
+         $this->_ValidationFields = array();
+      }
 
-//      if (in_array($FieldName, $this->_ValidationFields) === FALSE) {
-         $Value = ArrayValue($FieldName, $PostedFields, NULL);
-         $this->_ValidationFields[$FieldName] = $Value;
-         // Also add to the array of field names that are being validated *and* are present in the schema
-         if (is_array($this->_Schema) && array_key_exists($FieldName, $this->_Schema))
-            $this->_SchemaValidationFields[$FieldName] = $Value;
-//      }
+      $Value = ArrayValue($FieldName, $PostedFields, NULL);
+      $this->_ValidationFields[$FieldName] = $Value;
    }
 
 
@@ -426,7 +471,8 @@ class Gdn_Validation {
     * @return array
     */
    public function SchemaValidationFields() {
-      return $this->_SchemaValidationFields;
+      $Result = array_intersect_key($this->_ValidationFields, $this->_Schema);
+      return $Result;
    }
 
 
@@ -525,28 +571,36 @@ class Gdn_Validation {
     * @return boolean Whether or not the validation was successful.
     */
    public function Validate($PostedFields, $Insert = FALSE) {
-      $this->DefineValidationFields($PostedFields, $this->_Schema, $Insert);
-
       // Create an array to hold validation result messages
-      if (!is_array($this->_ValidationResults))
+      if (!is_array($this->_ValidationResults)) {
          $this->_ValidationResults = array();
+      }
 
       // Check for a honeypot (anti-spam input)
-      $HoneypotName = Gdn::Config('Garden.Forms.HoneypotName', '');
+      $HoneypotName = C('Garden.Forms.HoneypotName', '');
       $HoneypotContents = GetPostValue($HoneypotName, '');
-      if ($HoneypotContents != '')
+      if ($HoneypotContents != '') {
          $this->AddValidationResult($HoneypotName, "You've filled our honeypot! We use honeypots to help prevent spam. If you're not a spammer or a bot, you should contact the application administrator for help.");
+      }
 
+      $FieldRules = $this->DefineValidationRules($PostedFields, $Insert);
+      $Fields = $this->DefineValidationFields($PostedFields, $Insert);
 
       // Loop through the fields that should be validated
-      foreach($this->_ValidationFields as $FieldName => $FieldValue) {
+      foreach($Fields as $FieldName => $FieldValue) {
          // If this field has rules to be enforced...
-         if (array_key_exists($FieldName, $this->_FieldRules) && is_array($this->_FieldRules[$FieldName])) {
-            // Enforce them...
-            $this->_FieldRules[$FieldName] = array_values($this->_FieldRules[$FieldName]);
-            $RuleCount = count($this->_FieldRules[$FieldName]);
-            for($i = 0; $i < $RuleCount; ++$i) {
-               $RuleName = $this->_FieldRules[$FieldName][$i];
+         if (array_key_exists($FieldName, $FieldRules) && is_array($FieldRules[$FieldName])) {
+            // Enforce them.
+            $Rules = $FieldRules[$FieldName];
+
+            // Get the field info for the field.
+            $FieldInfo = array('Name' => $FieldName);
+            if (is_array($this->_Schema) && array_key_exists($FieldName, $this->_Schema)) {
+               $FieldInfo = array_merge($FieldInfo, (array)$this->_Schema[$FieldName]);
+            }
+            $FieldInfo = (object)$FieldInfo;
+
+            foreach($Rules as $RuleName) {
                if (array_key_exists($RuleName, $this->_Rules)) {
                   $Rule = $this->_Rules[$RuleName];
                   // echo '<div>FieldName: '.$FieldName.'; Rule: '.$Rule.'</div>';
@@ -554,13 +608,6 @@ class Gdn_Validation {
                      $Function = substr($Rule, 9);
                      if (!function_exists($Function))
                         trigger_error(ErrorMessage('Specified validation function could not be found.', 'Validation', 'Validate', $Function), E_USER_ERROR);
-
-                     // Call the function. Core-defined validation functions can
-                     // be found in ./functions.validation.php
-                     $FieldInfo = array('Name' => $FieldName);
-                     if (is_array($this->_Schema) && array_key_exists($FieldName, $this->_Schema))
-                        $FieldInfo = array_merge($FieldInfo, (array)$this->_Schema[$FieldName]);
-                     $FieldInfo = (object)$FieldInfo;
 
                      $ValidationResult = $Function($FieldValue, $FieldInfo, $PostedFields);
                      if ($ValidationResult !== TRUE) {
@@ -571,7 +618,6 @@ class Gdn_Validation {
                         // Add the result
                         $this->AddValidationResult($FieldName, $ErrorCode);
                         // Only add one error per field
-                        $i = $RuleCount;
                      }
                   } else if (substr($Rule, 0, 6) == 'regex:') {
                      $Regex = substr($Rule, 6);
@@ -587,7 +633,8 @@ class Gdn_Validation {
             }
          }
       }
-      return count($this->_ValidationResults) == 0 ? TRUE : FALSE;
+      $this->_ValidationFields = $Fields;
+      return count($this->_ValidationResults) === 0;
    }
 
    /**

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -70,6 +70,12 @@ class Gdn_Validation {
 
 
    /**
+    * @var bool Whether or not to reset the validation results on validate.
+    */
+   protected $_ResetOnValidate = FALSE;
+
+
+   /**
     * An array of FieldName.RuleName => "Custom Error Message"s. See $this->ApplyRule.
     *
     * @var array
@@ -81,12 +87,14 @@ class Gdn_Validation {
     * Class constructor. Optionally takes a schema definition to generate
     * validation rules for.
     *
-    * @param Gdn_Schema $Schema A schema object to generate validation rules for.
+    * @param Gdn_Schema|array $Schema A schema object to generate validation rules for.
+    * @param bool Whether or not to reset the validation results on {@link Validate()}.
     */
-   public function __construct($Schema = FALSE) {
+   public function __construct($Schema = FALSE, $ResetOnValidate = FALSE) {
       if (is_object($Schema) || is_array($Schema)) {
          $this->SetSchema($Schema);
       }
+      $this->setResetOnValidate($ResetOnValidate);
 
       // Define the default validation functions
       $this->_Rules = array();
@@ -450,6 +458,26 @@ class Gdn_Validation {
       $this->_Rules[$RuleName] = $Rule;
    }
 
+   /**
+    * Whether or not the validation results etc should reset whenever {@link Validate()} is called.
+    *
+    * @return boolean Returns true if we reset or false otherwise.
+    */
+   public function resetOnValidate() {
+      return $this->_ResetOnValidate;
+   }
+
+   /**
+    * Set whether or not the validation results etc should reset whenever {@link Validate()} is called.
+    *
+    * @param boolean $ResetOnValidate True to reset or false otherwise.
+    * @return Gdn_Validation Returns `$this` for fluent calls.
+    */
+   public function setResetOnValidate($ResetOnValidate) {
+      $this->_ResetOnValidate = $ResetOnValidate;
+      return $this;
+   }
+
 
    /**
     * Adds a fieldname to the $this->_ValidationFields collection.
@@ -581,7 +609,7 @@ class Gdn_Validation {
     */
    public function Validate($PostedFields, $Insert = FALSE) {
       // Create an array to hold validation result messages
-      if (!is_array($this->_ValidationResults)) {
+      if (!is_array($this->_ValidationResults) || $this->resetOnValidate()) {
          $this->_ValidationResults = array();
       }
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -40,14 +40,22 @@ if (!function_exists('ValidateRegex')) {
 
 if (!function_exists('ValidateRequired')) {
    function ValidateRequired($Value, $Field = '') {
-      if (is_array($Value) === TRUE)
-         return count($Value) > 0 ? TRUE : FALSE;
+      if (is_array($Value) === TRUE) {
+         return count($Value) > 0;
+      }
 
-      if (is_string($Value))
+      if (is_string($Value)) {
+         // Empty strings should pass if the default value of the field is an empty string.
+         if ($Value === '' && val('Default', $Field, NULL) === '') {
+            return TRUE;
+         }
+
          return trim($Value) == '' ? FALSE : TRUE;
+      }
 
-      if (is_numeric($Value))
+      if (is_numeric($Value)) {
          return TRUE;
+      }
 
       return FALSE;
    }

--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -25,7 +25,7 @@
 $PluginInfo['Tagging'] = array(
    'Name' => 'Tagging',
    'Description' => 'Users may add tags to each discussion they create. Existing tags are shown in the sidebar for navigation by tag.',
-   'Version' => '1.8.10',
+   'Version' => '1.8.11',
    'SettingsUrl' => '/dashboard/settings/tagging',
    'SettingsPermission' => 'Garden.Settings.Manage',
    'Author' => "Mark O'Sullivan",
@@ -624,6 +624,7 @@ class TaggingPlugin extends Gdn_Plugin {
       $CanAddTags = (!empty($TagTypes[$Type]['addtag']) && $TagTypes[$Type]['addtag'])
          ? 1
          : 0;
+      $CanAddTags &= CheckPermission('Plugins.Tagging.Add');
 
       $Sender->SetData('_CanAddTags', $CanAddTags);
 
@@ -776,7 +777,7 @@ class TaggingPlugin extends Gdn_Plugin {
       $Sender->SetData('Title', T('Delete Tag'));
       $Sender->Render('delete', '', 'plugins/Tagging');
    }
-   
+
    /**
     * Add update routines to the DBA controller
     *

--- a/plugins/Tagging/class.tagmodel.php
+++ b/plugins/Tagging/class.tagmodel.php
@@ -480,39 +480,12 @@ class TagModel extends Gdn_Model {
       return $result;
    }
 
-   /**
-    * @param array $FormPostValues
-    * @param bool $Insert
-    * @return bool
-    */
-   public function Validate($FormPostValues, $Insert = FALSE) {
-      $this->DefineSchema();
-
-      $Type = GetValue('Type', $FormPostValues, '');
-      $SetType = FALSE;
-
-      // The model doesn't play well with empty string defaults so spoof an empty string default.
-      if ($Insert && !$Type) {
-         $FormPostValues['Type'] = 'Default';
-         $SetType = TRUE;
-      }
-
-      $Result = $this->Validation->Validate($FormPostValues, $Insert);
-
-      if ($SetType) {
-         $FormPostValues['Type'] = $Type;
-         $this->Validation->AddValidationField('Type', $FormPostValues);
-      }
-
-      return $Result;
-   }
-   
    public function Counts($Column, $UserID = NULL) {
       // Delete all the orphaned tagdiscussion records
       $Px = $this->Database->DatabasePrefix;
       $Sql = "delete td.* from {$Px}TagDiscussion as td left join {$Px}Discussion as d ON td.DiscussionID = d.DiscussionID where d.DiscussionID is null";
       $this->Database->Query($Sql);
-      
+
       $Result = array('Complete' => TRUE);
       switch($Column) {
          case 'CountDiscussions':


### PR DESCRIPTION
The GDN_Validation object has some severe edge cases and this aims to deal with them.

- Remove a bunch of properties that can be calculated from other properties.
- Make `Gdn_Validation->Validate()` a bit more idempotent.
- Separate rules applied manually from those applied from the schema so that the schema does not pollute the validation object during `Validate()`.
- Protect methods that really shouldn’t be called externally.
- Remove some dangerous methods.
- Allow columns with default values to be left out during inserts.
- Add a ResetOnValidate property to Gdn_Validation to allow the validation results to reset whenever `Validate()` is called.
- Change the way auto-increment fields are validated.
- Allow empty strings to validate as required if the default field value is an empty string.