### PR TITLE
Improve error reporting and fix PHP strict errors.

### DIFF
--- a/library/core/class.autoloader.php
+++ b/library/core/class.autoloader.php
@@ -251,7 +251,7 @@ class Gdn_Autoloader {
       if (!preg_match("/^[a-zA-Z0-9_\x7f-\xff]*$/", $ClassName))
          return;
 
-      $MapType = GetValue('MapType', $Options, self::GetMapType($ClassName));
+      $MapType = val('MapType', $Options, self::GetMapType($ClassName));
 
       $DefaultOptions = array(
          'Quiet'              => FALSE,
@@ -302,7 +302,7 @@ class Gdn_Autoloader {
          $Extension
       ));
 
-      $MapGroupHashes = GetValue($MapGroupIdentifier, self::$MapGroups, array());
+      $MapGroupHashes = val($MapGroupIdentifier, self::$MapGroups, array());
       $PriorityHashes = array();
       $PriorityHashes = array();
       foreach ($MapGroupHashes as $MapHash => $Trash) {
@@ -353,11 +353,11 @@ class Gdn_Autoloader {
          $ResponseHashes = array();
          foreach ($ResultMapHashes as $MapHash => $PriorityInfo) {
 
-            if (GetValue('duration', $PriorityInfo) == self::PRIORITY_ONCE)
+            if (val('duration', $PriorityInfo) == self::PRIORITY_ONCE)
                unset(self::$Priorities[$ContextType][$PriorityType][$MapHash]);
 
             // If this request is being specific about the required maptype, reject anything that doesnt match
-            if (!is_null($MapType) && GetValue('maptype', $PriorityInfo) != $MapType)
+            if (!is_null($MapType) && val('maptype', $PriorityInfo) != $MapType)
                continue;
 
             $ResponseHashes[$MapHash] = $PriorityInfo;
@@ -381,11 +381,11 @@ class Gdn_Autoloader {
          'SaveToDisk'            => TRUE
       );
       if (array_key_exists($ContextType, self::$Prefixes))
-         $DefaultOptions['ContextPrefix'] = GetValue($ContextType, self::$Prefixes);
+         $DefaultOptions['ContextPrefix'] = val($ContextType, self::$Prefixes);
 
       $Options = array_merge($DefaultOptions, $Options);
 
-      $Extension = GetValue('Extension', $Options, NULL);
+      $Extension = val('Extension', $Options, NULL);
 
       // Determine cache root on-disk location
       $Hits = 0; str_replace(PATH_ROOT, '', $SearchPath, $Hits);
@@ -402,7 +402,7 @@ class Gdn_Autoloader {
       $MapHash = md5($MapIdentifier);
 
       // Allow intrinsic ordering / layering of contexts by prefixing them with a context number
-      $MapHash = 'context:'.GetValue($ContextType, array_flip(self::$ContextOrder)).'_'.$Extension.'_'.$MapHash;
+      $MapHash = 'context:'.val($ContextType, array_flip(self::$ContextOrder)).'_'.$Extension.'_'.$MapHash;
       $MapHash = self::MakeMapHash($MapType, $ContextType, $Extension, $MapRootLocation);
 
       if (!is_array(self::$Maps))
@@ -450,7 +450,7 @@ class Gdn_Autoloader {
       $MapHash = md5($MapIdentifier);
 
       // Allow intrinsic ordering / layering of contexts by prefixing them with a context number
-      $MapHash = 'context:'.GetValue($ContextType, array_flip(self::$ContextOrder)).'_'.$Extension.'_'.$MapHash;
+      $MapHash = 'context:'.val($ContextType, array_flip(self::$ContextOrder)).'_'.$Extension.'_'.$MapHash;
 
       return $MapHash;
    }
@@ -572,12 +572,12 @@ class Gdn_Autoloader_Map {
       $this->Paths = array();
       $this->BuildOptions = $Options;
 
-      $ExtensionName = GetValue('Extension', $Options, NULL);
-      $Recursive = GetValue('SearchSubfolders', $Options, TRUE);
-      $ContextPrefix = GetValue('ContextPrefix', $Options, NULL);
-      $MapIdentifier = GetValue('MapIdentifier', $Options, NULL);
-      $SaveToDisk = GetValue('SaveToDisk', $Options, TRUE);
-      $FileStructure = GetValue('Structure', $Options, self::STRUCTURE_FLAT);
+      $ExtensionName = val('Extension', $Options, NULL);
+      $Recursive = val('SearchSubfolders', $Options, TRUE);
+      $ContextPrefix = val('ContextPrefix', $Options, NULL);
+      $MapIdentifier = val('MapIdentifier', $Options, NULL);
+      $SaveToDisk = val('SaveToDisk', $Options, TRUE);
+      $FileStructure = val('Structure', $Options, self::STRUCTURE_FLAT);
 
       $MapName = $MapType;
       if (!is_null($ExtensionName))
@@ -609,13 +609,13 @@ class Gdn_Autoloader_Map {
    public function AddPath($SearchPath, $Options) {
       $PathOptions = array(
          'path'         => $SearchPath,
-         'recursive'    => (bool)GetValue('SearchSubfolders', $Options),
-         'filter'       => GetValue('ClassFilter', $Options),
+         'recursive'    => (bool)val('SearchSubfolders', $Options),
+         'filter'       => val('ClassFilter', $Options),
          'topic'        => self::TOPIC_DEFAULT
       );
 
       if ($this->MapInfo['structure'] == self::STRUCTURE_SPLIT) {
-         $SplitTopic = GetValue('SplitTopic', $Options, NULL);
+         $SplitTopic = val('SplitTopic', $Options, NULL);
          if (is_null($SplitTopic))
             throw new Exception("Trying to use 'split' structure but no SplitTopic provided. Path: {$SearchPath}");
          $PathOptions['topic'] = $SplitTopic;
@@ -625,11 +625,11 @@ class Gdn_Autoloader_Map {
    }
 
    public function ContextType() {
-      return $this->MapInfo['contexttype']; //GetValue('contexttype', $this->MapInfo);
+      return $this->MapInfo['contexttype']; //val('contexttype', $this->MapInfo);
    }
 
    public function Extension() {
-      return $this->MapInfo['extension']; //GetValue('extension', $this->MapInfo);
+      return $this->MapInfo['extension']; //val('extension', $this->MapInfo);
    }
 
    protected function FindFile($Path, $SearchFiles, $Recursive) {
@@ -710,16 +710,16 @@ class Gdn_Autoloader_Map {
    }
 
    public function Lookup($ClassName, $MapOnly = TRUE) {
-      $MapName = $this->MapInfo['name']; //GetValue('name', $this->MapInfo);
+      $MapName = $this->MapInfo['name'];
 
       // Lazyload cache data
       if (is_null($this->Map)) {
          $this->Map = array();
-         $OnDiskMapFile = $this->MapInfo['ondisk']; //GetValue('ondisk', $this->MapInfo);
+         $OnDiskMapFile = $this->MapInfo['ondisk'];
 
          // Loading cache data from disk
          if (file_exists($OnDiskMapFile)) {
-            $Structure = $this->MapInfo['structure']; //GetValue('structure', $this->MapInfo);
+            $Structure = $this->MapInfo['structure'];
             $MapContents = parse_ini_file($OnDiskMapFile, TRUE);
 
             try {
@@ -746,9 +746,9 @@ class Gdn_Autoloader_Map {
          case 'split':
             // This file stored split, so look for this class in each virtual sub-path, by topic
             foreach ($this->Paths as $Path => $PathOptions) {
-               $LookupSplitTopic = GetValue('topic', $PathOptions);
+               $LookupSplitTopic = val('topic', $PathOptions);
                if (array_key_exists($LookupSplitTopic, $this->Map) && array_key_exists($ClassName, $this->Map[$LookupSplitTopic])) {
-                  return GetValue($ClassName, $this->Map[$LookupSplitTopic]);
+                  return val($ClassName, $this->Map[$LookupSplitTopic]);
                }
             }
             break;
@@ -758,7 +758,7 @@ class Gdn_Autoloader_Map {
             // This file is stored flat, so just look in the DEFAULT_TOPIC
             $LookupSplitTopic = self::TOPIC_DEFAULT;
             if (array_key_exists($LookupSplitTopic, $this->Map) && array_key_exists($ClassName, $this->Map[$LookupSplitTopic])) {
-               return GetValue($ClassName, $this->Map[$LookupSplitTopic]);
+               return val($ClassName, $this->Map[$LookupSplitTopic]);
             }
             break;
       }
@@ -776,14 +776,14 @@ class Gdn_Autoloader_Map {
          );
 
          foreach ($this->Paths as $Path => $PathOptions) {
-            $ClassFilter = GetValue('filter', $PathOptions);
+            $ClassFilter = val('filter', $PathOptions);
             if (!fnmatch($ClassFilter, $ClassName)) continue;
 
-            $Recursive = GetValue('recursive', $PathOptions);
+            $Recursive = val('recursive', $PathOptions);
             $File = $this->FindFile($Path, $Files, $Recursive);
 
             if ($File !== FALSE) {
-               $SplitTopic = GetValue('topic', $PathOptions, self::TOPIC_DEFAULT);
+               $SplitTopic = val('topic', $PathOptions, self::TOPIC_DEFAULT);
                $this->Map[$SplitTopic][$ClassName] = $File;
                $this->MapInfo['dirty'] = TRUE;
 
@@ -811,24 +811,24 @@ class Gdn_Autoloader_Map {
       if (!is_null($ExtraPaths)) {
          $ExtraPathsRemove = array();
          foreach ($ExtraPaths as $PathOpts) {
-            $ExtraPath = GetValue('path', $PathOpts);
+            $ExtraPath = val('path', $PathOpts);
             if (array_key_exists($ExtraPath, $this->Paths)) continue;
 
             $ExtraPathsRemove[] = $ExtraPath;
             $ExtraOptions = $this->BuildOptions;
-            $ExtraOptions['SplitTopic'] = GetValue('topic', $PathOpts);
+            $ExtraOptions['SplitTopic'] = val('topic', $PathOpts);
             $this->AddPath($ExtraPath, $ExtraOptions);
          }
       }
 
       foreach ($this->Paths as $Path => $PathOptions) {
 
-         $Recursive = GetValue('recursive', $PathOptions);
+         $Recursive = val('recursive', $PathOptions);
          $Files = $this->FindFiles($Path, $FileMasks, $Recursive);
          if ($Files === FALSE) continue;
 
          foreach ($Files as $File) {
-            $SplitTopic = GetValue('topic', $PathOptions, self::TOPIC_DEFAULT);
+            $SplitTopic = val('topic', $PathOptions, self::TOPIC_DEFAULT);
 
             $ProvidedClass = $this->GetClassNameFromFile($File);
             if ($ProvidedClass) {
@@ -896,19 +896,19 @@ class Gdn_Autoloader_Map {
    }
 
    public function MapType() {
-      return $this->MapInfo['maptype']; //GetValue('maptype', $this->MapInfo);
+      return $this->MapInfo['maptype'];
    }
 
    public function Shutdown() {
 
-      if (!GetValue('dirty', $this->MapInfo)) return FALSE;
-      if (!GetValue('save', $this->MapInfo)) return FALSE;
+      if (!val('dirty', $this->MapInfo)) return FALSE;
+      if (!val('save', $this->MapInfo)) return FALSE;
 
       if (!sizeof($this->Map))
          return FALSE;
 
-      $MapName = GetValue('name', $this->MapInfo);
-      $FileName = GetValue('ondisk', $this->MapInfo);
+      $MapName = val('name', $this->MapInfo);
+      $FileName = val('ondisk', $this->MapInfo);
 
       $MapContents = '';
       foreach ($this->Map as $SplitTopic => $TopicFiles) {

--- a/library/core/class.configuration.php
+++ b/library/core/class.configuration.php
@@ -460,7 +460,8 @@ class Gdn_Configuration extends Gdn_Pluggable {
       if (!$UseSplitting) {
          $this->MassImport($ConfigurationSource->Export());
       } else {
-         self::MergeConfig($this->Data, $ConfigurationSource->Export());
+         $Loaded = $ConfigurationSource->Export();
+         self::MergeConfig($this->Data, $Loaded);
       }
    }
 
@@ -618,8 +619,10 @@ class Gdn_Configuration extends Gdn_Pluggable {
     * This method does that
     */
    public function OverlayDynamic() {
-      if ($this->Dynamic instanceof Gdn_ConfigurationSource)
-         self::MergeConfig($this->Data, $this->Dynamic->Export());
+      if ($this->Dynamic instanceof Gdn_ConfigurationSource) {
+         $Loaded = $this->Dynamic->Export();
+         self::MergeConfig($this->Data, $Loaded);
+      }
    }
 
    /**

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -415,7 +415,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
          $MethodName = strtolower($Method);
          // Loop through their individual methods looking for event handlers and method overrides.
          if (isset($MethodName[9])) {
-            $Suffix = array_pop(explode('_',$MethodName));
+            $Suffix = trim(strrchr($MethodName, '_'), '_');
             switch ($Suffix) {
                case 'handler':
                case 'before':

--- a/library/core/class.thememanager.php
+++ b/library/core/class.thememanager.php
@@ -57,7 +57,7 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
       // If there is a hooks file in the theme folder, include it.
       $ThemeName = $this->CurrentTheme();
       $ThemeInfo = $this->GetThemeInfo($ThemeName);
-      $ThemeHooks = GetValue('RealHooksFile', $ThemeInfo, NULL);
+      $ThemeHooks = val('RealHooksFile', $ThemeInfo, NULL);
       if (file_exists($ThemeHooks))
          include_once($ThemeHooks);
    }
@@ -103,7 +103,7 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
             sort($PathListing);
 
             $PathIntegrityHash = md5(serialize($PathListing));
-            if (GetValue('CacheIntegrityHash',$SearchPathCache) != $PathIntegrityHash) {
+            if (val('CacheIntegrityHash',$SearchPathCache) != $PathIntegrityHash) {
                // Trace('Need to re-index theme cache');
                // Need to re-index this folder
                $PathIntegrityHash = $this->IndexSearchPath($SearchPath, $CacheThemeInfo, $PathListing);
@@ -141,30 +141,30 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
          $ThemePath = CombinePaths(array($SearchPath,$ThemeFolderName));
          $ThemeFiles = $this->FindThemeFiles($ThemePath);
 
-         if (GetValue('about', $ThemeFiles) === FALSE)
+         if (val('about', $ThemeFiles) === FALSE)
             continue;
 
-         $ThemeAboutFile = GetValue('about', $ThemeFiles);
+         $ThemeAboutFile = val('about', $ThemeFiles);
          $SearchThemeInfo = $this->ScanThemeFile($ThemeAboutFile);
 
          // Don't index archived themes.
-//         if (GetValue('Archived', $SearchThemeInfo, FALSE))
+//         if (val('Archived', $SearchThemeInfo, FALSE))
 //            continue;
 
          // Add the screenshot.
          if (array_key_exists('screenshot', $ThemeFiles)) {
-            $RelativeScreenshot = ltrim(str_replace(PATH_ROOT, '', GetValue('screenshot', $ThemeFiles)),'/');
+            $RelativeScreenshot = ltrim(str_replace(PATH_ROOT, '', val('screenshot', $ThemeFiles)),'/');
             $SearchThemeInfo['ScreenshotUrl'] = Asset($RelativeScreenshot, TRUE);
          }
 
          // Add the mobile screenshot.
          if (array_key_exists('mobilescreenshot', $ThemeFiles)) {
-            $RelativeScreenshot = ltrim(str_replace(PATH_ROOT, '', GetValue('mobilescreenshot', $ThemeFiles)),'/');
+            $RelativeScreenshot = ltrim(str_replace(PATH_ROOT, '', val('mobilescreenshot', $ThemeFiles)),'/');
             $SearchThemeInfo['MobileScreenshotUrl'] = Asset($RelativeScreenshot, TRUE);
          }
 
          if (array_key_exists('hooks', $ThemeFiles)) {
-            $SearchThemeInfo['HooksFile'] = GetValue('hooks', $ThemeFiles, FALSE);
+            $SearchThemeInfo['HooksFile'] = val('hooks', $ThemeFiles, FALSE);
             $SearchThemeInfo['RealHooksFile'] = realpath($SearchThemeInfo['HooksFile']);
          }
 
@@ -332,7 +332,7 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
    }
 
    public function GetThemeInfo($ThemeName) {
-      return GetValue($ThemeName, $this->AvailableThemes(), FALSE);
+      return val($ThemeName, $this->AvailableThemes(), FALSE);
    }
 
    public function CurrentTheme() {
@@ -414,24 +414,24 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
 
       // Set the theme.
       $ThemeInfo = $this->GetThemeInfo($ThemeName);
-      $ThemeFolder = GetValue('Folder', $ThemeInfo, '');
+      $ThemeFolder = val('Folder', $ThemeInfo, '');
 
       $oldTheme = $IsMobile ? C('Garden.MobileTheme', 'mobile') : C('Garden.Theme', 'default');
 
       if ($ThemeFolder == '') {
          throw new Exception(T('The theme folder was not properly defined.'));
       } else {
-         $Options = GetValueR("{$ThemeName}.Options", $this->AvailableThemes());
+         $Options = valr("{$ThemeName}.Options", $this->AvailableThemes());
          if ($Options) {
             if ($IsMobile) {
                SaveToConfig(array(
                   'Garden.MobileTheme' => $ThemeName,
-                  'Garden.MobileThemeOptions.Name' => GetValueR("{$ThemeName}.Name", $this->AvailableThemes(), $ThemeFolder)
+                  'Garden.MobileThemeOptions.Name' => valr("{$ThemeName}.Name", $this->AvailableThemes(), $ThemeFolder)
                ));
             } else {
                SaveToConfig(array(
                   'Garden.Theme' => $ThemeName,
-                  'Garden.ThemeOptions.Name' => GetValueR("{$ThemeName}.Name", $this->AvailableThemes(), $ThemeFolder)
+                  'Garden.ThemeOptions.Name' => valr("{$ThemeName}.Name", $this->AvailableThemes(), $ThemeFolder)
                ));
             }
          } else {
@@ -464,7 +464,7 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
    public function TestTheme($ThemeName) {
       // Get some info about the currently enabled theme.
       $EnabledTheme = $this->EnabledThemeInfo();
-      $EnabledThemeFolder = GetValue('Folder', $EnabledTheme, '');
+      $EnabledThemeFolder = val('Folder', $EnabledTheme, '');
       $OldClassName = $EnabledThemeFolder . 'ThemeHooks';
 
       // Make sure that the theme's requirements are met
@@ -472,14 +472,14 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
       $EnabledApplications = $ApplicationManager->EnabledApplications();
 
       $NewThemeInfo = $this->GetThemeInfo($ThemeName);
-      $ThemeName = GetValue('Index', $NewThemeInfo, $ThemeName);
+      $ThemeName = val('Index', $NewThemeInfo, $ThemeName);
       $RequiredApplications = ArrayValue('RequiredApplications', $NewThemeInfo, FALSE);
       $ThemeFolder = ArrayValue('Folder', $NewThemeInfo, '');
       CheckRequirements($ThemeName, $RequiredApplications, $EnabledApplications, 'application'); // Applications
 
       // If there is a hooks file, include it and run the setup method.
       $ClassName = "{$ThemeFolder}ThemeHooks";
-      $HooksFile = GetValue("HooksFile", $NewThemeInfo, NULL);
+      $HooksFile = val("HooksFile", $NewThemeInfo, NULL);
       if (!is_null($HooksFile) && file_exists($HooksFile)) {
          include_once($HooksFile);
          if (class_exists($ClassName)) {

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -36,19 +36,7 @@ function Gdn_ErrorHandler($ErrorNumber, $Message, $File, $Line, $Arguments) {
 
    if (($ErrorReporting & $ErrorNumber) !== $ErrorNumber) {
       if (function_exists('Trace')) {
-         $Backtrace = debug_backtrace();
-         $Tr = '';
-         $i = 0;
-         foreach ($Backtrace as $Info) {
-            if (!isset($Info['file']))
-               continue;
-
-            $Tr .= "\n{$Info['file']} line {$Info['line']}.";
-            if ($i > 2)
-               break;
-            $i++;
-         }
-         Trace("$ErrorNumber: $Message{$Tr}", TRACE_NOTICE);
+         Trace("$Message in $File line $Line", TRACE_NOTICE);
       }
 
       // Ignore errors that are below the current error reporting level.

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -454,8 +454,9 @@ if (!function_exists('CleanErrorArguments')) {
    }
 }
 
-// Set up Garden to handle php errors
-set_error_handler('Gdn_ErrorHandler', E_ALL);
+// Set up Garden to handle php errors.
+// Remove the "& ~E_STRICT" from time to time to clean up some easy strict errors.
+set_error_handler('Gdn_ErrorHandler', E_ALL & ~E_STRICT);
 set_exception_handler('Gdn_ExceptionHandler');
 
 

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -778,11 +778,8 @@ if (!function_exists('Debug')) {
       $Changed = $Debug != $Value;
       $Debug = $Value;
       if ($Debug) {
-         error_reporting(E_ALL & ~(E_STRICT | E_DEPRECATED | E_USER_DEPRECATED | E_NOTICE | E_USER_NOTICE));
          Logger::logLevel(Logger::DEBUG);
       } else {
-         error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);
-
          if ($Changed) {
             Logger::logLevel(C('Garden.LogLevel', Logger::INFO));
          }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -778,14 +778,13 @@ if (!function_exists('Debug')) {
       $Changed = $Debug != $Value;
       $Debug = $Value;
       if ($Debug) {
-         error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED);
-         ini_set('display_errors', 1);
-         Logger::logLevel(LogLevel::DEBUG);
+         error_reporting(E_ALL & ~(E_STRICT | E_DEPRECATED | E_USER_DEPRECATED | E_NOTICE | E_USER_NOTICE));
+         Logger::logLevel(Logger::DEBUG);
       } else {
          error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);
 
          if ($Changed) {
-            Logger::logLevel(C('Garden.LogLevel', LogLevel::INFO));
+            Logger::logLevel(C('Garden.LogLevel', Logger::INFO));
          }
       }
    }


### PR DESCRIPTION
I was working on an experimental change to our error reporting and noticed a tonne of strict errors in our app which gives me OCD twitches.

EDIT: This PR also includes some changes to the way we error report so it may need a bit more of a go-through although I think the risk is fairly low(ish). Since the changes are fairly significant I'll try and explain them here.

- Don't use a separate error reporting level for debug mode. Debug mode will trace errors that are beneath the error reporting level and display the detailed error page on more severe errors.
-  `display_errors` is never turned on anymore. It's not needed and is a security vulnerability.
- Don't do anything with `E_STRICT` errors.
- Don't trace @ suppressed errors.
- Remove the backtrace from errors that are below the error reporting level as they aren't needed. This is a small optimization too.