### PR TITLE
Put the enable/disable category use on a proper authenticated post back endpoint.

### DIFF
--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -581,21 +581,6 @@ class SettingsController extends Gdn_Controller {
       // Get category data
       $this->SetData('CategoryData', $this->CategoryModel->GetAll('TreeLeft'), TRUE);
 
-      // Enable/Disable Categories
-      if (Gdn::Session()->ValidateTransientKey(GetValue(1, $this->RequestArgs))) {
-         if (!Gdn::Session()->CheckPermission('Garden.Settings.Manage')) {
-            throw PermissionException('Garden.Settings.Manage');
-         }
-
-         $Toggle = GetValue(0, $this->RequestArgs, '');
-         if ($Toggle == 'enable') {
-            SaveToConfig('Vanilla.Categories.Use', TRUE);
-         } else if ($Toggle == 'disable') {
-            SaveToConfig('Vanilla.Categories.Use', FALSE);
-         }
-         Redirect('vanilla/settings/managecategories');
-      }
-
       // Setup & save forms
       $Validation = new Gdn_Validation();
       $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
@@ -627,6 +612,31 @@ class SettingsController extends Gdn_Controller {
 
       // Render default view
       $this->Render();
+   }
+
+
+   /**
+    * Enable or disable the use of categories in Vanilla.
+    *
+    * @param bool $enabled Whether or not to enable/disable categories.
+    * @throws Exception Throws an exception if accessed through an invalid post back.
+    */
+   public function EnableCategories($enabled) {
+      $this->Permission('Garden.Settings.Manage');
+
+      if ($this->Form->AuthenticatedPostBack()) {
+         $enabled = (bool)$enabled;
+         SaveToConfig('Vanilla.Categories.Use', $enabled);
+         $this->SetData('Enabled', $enabled);
+
+         if ($this->DeliveryType() !== DELIVERY_TYPE_DATA) {
+            $this->RedirectUrl = Url('/vanilla/settings/managecategories');
+         }
+      } else {
+         throw ForbiddenException('GET');
+      }
+
+      return $this->Render('Blank', 'Utility', 'Dashboard');
    }
 
    /**

--- a/applications/vanilla/views/settings/managecategories.php
+++ b/applications/vanilla/views/settings/managecategories.php
@@ -26,10 +26,10 @@ $Session = Gdn::Session();
    if (C('Vanilla.Categories.Use')) {
       echo Anchor(T('Add Category'), 'vanilla/settings/addcategory', 'SmallButton');
       if (CheckPermission('Garden.Settings.Manage')) {
-         echo Wrap(Anchor(T("Don't use Categories"), 'vanilla/settings/managecategories/disable/' . Gdn::Session()->TransientKey(), 'SmallButton'));
+         echo Wrap(Anchor(T("Don't use Categories"), 'vanilla/settings/enablecategories?enabled=0', 'SmallButton Hijack'));
       }
    } elseif (CheckPermission('Garden.Settings.Manage')) {
-      echo Anchor(T('Use Categories'), 'vanilla/settings/managecategories/enable/'.Gdn::Session()->TransientKey(), 'SmallButton');
+      echo Anchor(T('Use Categories'), 'vanilla/settings/enablecategories?enabled=1'.Gdn::Session()->TransientKey(), 'SmallButton Hijack');
    }
 ?></div>
 <?php


### PR DESCRIPTION
This change happened because hitting the manage categories page always throws a csrf error. Rather than just patching it I decided to make the toggle a proper postback which is better and also fixes the csrf error.