### PR TITLE
Use as many recently used IP addresses in AllIPAddresses that will fit

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2452,11 +2452,11 @@ class UserModel extends Gdn_Model {
       if (!is_array($AllIPs))
          $AllIPs = array();
       if ($IP = GetValue('InsertIPAddress', $User))
-         $AllIPs[] = ForceIPv4($IP);
+         array_unshift($AllIPs, ForceIPv4($IP));
       if ($IP = GetValue('LastIPAddress', $User))
-         $AllIPs[] = $IP;
-      // This will be a unique list of IPs, most recently used last. array_unique keeps the first key found.
-      $AllIPs = array_reverse(array_unique(array_reverse($AllIPs)));
+         array_unshift($AllIPs, $IP);
+      // This will be a unique list of IPs, most recently used first. array_unique keeps the first key found.
+      $AllIPs = array_unique($AllIPs);
       $Fields['AllIPAddresses'] = $AllIPs;
 
       // Set the hour offset based on the client's clock.
@@ -3588,7 +3588,7 @@ class UserModel extends Gdn_Model {
             $Property['AllIPAddresses'] = implode(',', $IPs);
             // Ensure this isn't too big for our column
             while (strlen($Property['AllIPAddresses']) > $Fields['AllIPAddresses']->Length) {
-              array_shift($IPs);
+              array_pop($IPs);
               $Property['AllIPAddresses'] = implode(',', $IPs);
             }
          }


### PR DESCRIPTION
Fixes #2005.

- `AllIPAddresses` is now a list of the most recently used IP addresses rather than being "all".
- This list is now sorted from least recently used to most recently used rather than sorted alphanumerically.
- If a new IP address brings the list over the size of the column (currently 100 characters), least recently used IP address(es) will be dropped until it's back within the limit.

Note that 100 characters is enough room for between 6 and 14 IP addresses.

**Test 1 - a new IP address brings you over the limit**
- Update your user to have a nearly full IP address list: `update GDN_User SET AllIPAddresses = '123.123.123.109,123.123.123.107,123.123.123.105,123.123.123.103,123.123.123.101,123.123.123.100' where UserId = YOURUSERID;`
- Log out
- Log in

Expected result: no error, login works fine. `AllIPAddresses` is set to 
~~123.123.123.109,~~123.123.123.107,123.123.123.105,123.123.123.103,123.123.123.101,123.123.123.100**,127.0.0.1**
Oldest IP is removed, new IP is added.

**Test 2 - a new IP address was used in the past**
- Update your user to have a lot of IP addresses, including the IP address you're currently using: `update GDN_User SET AllIPAddresses = '127.0.0.1,123.123.123.107,123.123.123.105,123.123.123.103,123.123.123.101,123.123.123.100' where UserId = YOURUSERID;`
- Log out
- Log in

Expected result: no error, login works fine. `AllIPAddresses` is set to 
~~127.0.0.1,~~123.123.123.107,123.123.123.105,123.123.123.103,123.123.123.101,123.123.123.100**,127.0.0.1**. 
Previously used IP address is moved to the end of the list.