### PR TITLE
Remove the /e modifier from Gdn_Format::HtmlFilter().

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -876,11 +876,12 @@ class Gdn_Format {
             }
 
             // Allow the code tag to keep all enclosed HTML encoded.
-            $Mixed = preg_replace(
-               array('/<code([^>]*)>(.+?)<\/code>/sei'),
-               array('\'<code\'.RemoveQuoteSlashes(\'\1\').\'>\'.htmlspecialchars(RemoveQuoteSlashes(\'\2\')).\'</code>\''),
-               $Mixed
-            );
+            $Mixed = preg_replace_callback('`<code([^>]*)>(.+?)<\/code>`si', function($Matches) {
+               $Result = "<code{$Matches[1]}>".
+                  htmlspecialchars($Matches[2]).
+                  '</code>';
+               return $Result;
+            }, $Mixed);
 
             // Do HTML filtering before our special changes.
             $Result = $Formatter->Format($Mixed);


### PR DESCRIPTION
The /e modifier is deprecated and will end up being removed before we know it. This change accomplishes what the /e modifier accomplished with `preg_replace_callback()`.