### PR TITLE
Use "Select a category" in new discussion forms CategoryDropDown

### DIFF
--- a/applications/vanilla/views/post/discussion.php
+++ b/applications/vanilla/views/post/discussion.php
@@ -23,7 +23,7 @@ if (!$CancelUrl) {
 			echo '<div class="P">';
 				echo '<div class="Category">';
 				echo $this->Form->Label('Category', 'CategoryID'), ' ';
-				echo $this->Form->CategoryDropDown('CategoryID', array('Value' => GetValue('CategoryID', $this->Category)));
+				echo $this->Form->CategoryDropDown('CategoryID', array('Value' => val('CategoryID', $this->Category), 'IncludeNull' => TRUE));
 				echo '</div>';
 			echo '</div>';
       }


### PR DESCRIPTION
See that question http://vanillaforums.org/discussion/29331/new-discussion-blank-category-available-as-option-but-isnt-selected-by-default 
I think it is just a matter of taste if you would like to see a blank line when user hasn't chosen any category yet or you see the "Select a category" text.

But the blank line cannot be chosen/has to be changed (post would be done to root category) and this is not obvious to users. So I'd say it's a better UX if user is informed that he has a todo here.

Btw: I've also replaced `GetValue` with `val` but I don't think that's of big interest. And I was tempted to replace it with $this->Category->CategoryID, but I didn't want to change to much...