### PR TITLE
Strip out unnecessary call to htmlspecialchars

### DIFF
--- a/library/core/class.theme.php
+++ b/library/core/class.theme.php
@@ -236,7 +236,7 @@ class Gdn_Theme {
             if (!$Text && $Session->IsValid()) {
                $IsFullPath = strtolower(substr($Session->User->Photo, 0, 7)) == 'http://' || strtolower(substr($Session->User->Photo, 0, 8)) == 'https://';
                $PhotoUrl = ($IsFullPath) ? $Session->User->Photo : Gdn_Upload::Url(ChangeBasename($Session->User->Photo, 'n%s'));
-               $Text = Img($PhotoUrl, array('alt' => htmlspecialchars($Session->User->Name)));
+               $Text = Img($PhotoUrl, array('alt' => $Session->User->Name));
             }
 
             break;

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -858,7 +858,7 @@ if (!function_exists('UserPhoto')) {
          }
          $Href = Url(UserUrl($User));
          return '<a title="'.$Title.'" href="'.$Href.'"'.$LinkClass.'>'
-            .Img($PhotoUrl, array('alt' => htmlspecialchars($Name), 'class' => $ImgClass))
+            .Img($PhotoUrl, array('alt' => $Name, 'class' => $ImgClass))
             .'</a>';
       } else {
          return '';


### PR DESCRIPTION
Function `Img()` uses function [`Attribute()`](https://github.com/vanilla/vanilla/blob/master/library/core/functions.render.php#L560) 
to transform the attributes array to html and [that function uses htmlspecialchars](https://github.com/vanilla/vanilla/blob/master/library/core/functions.general.php#L445)  for each value. So it is not needed to use htmlspecialchars already in the function call.