### PR TITLE
Harmonize charset (where used) in htmlspecialchars

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -640,7 +640,7 @@ class Gdn_Format {
       if (!is_string($Mixed))
          return self::To($Mixed, 'Display');
       else {
-         $Mixed = htmlspecialchars($Mixed, ENT_QUOTES, C('Garden.Charset', ''));
+         $Mixed = htmlspecialchars($Mixed, ENT_QUOTES, C('Garden.Charset', 'UTF-8'));
          $Mixed = str_replace(array("&quot;","&amp;"), array('"','&'), $Mixed);
          $Mixed = self::Mentions($Mixed);
          $Mixed = self::Links($Mixed);
@@ -687,9 +687,9 @@ class Gdn_Format {
          return self::To($Mixed, 'Form');
       else {
          if(C('Garden.Format.ReplaceNewlines', TRUE))
-            return nl2br(htmlspecialchars($Mixed, ENT_QUOTES, C('Garden.Charset', '')));
+            return nl2br(htmlspecialchars($Mixed, ENT_QUOTES, C('Garden.Charset', 'UTF-8')));
          else
-            return htmlspecialchars($Mixed, ENT_QUOTES, C('Garden.Charset', ''));
+            return htmlspecialchars($Mixed, ENT_QUOTES, C('Garden.Charset', 'UTF-8'));
       }
    }
 
@@ -851,7 +851,7 @@ class Gdn_Format {
          } else {
             // The text does not contain html and does not have to be purified.
             // This is an optimization because purifying is very slow and memory intense.
-            $Result = htmlspecialchars($Mixed, ENT_NOQUOTES, 'UTF-8');
+            $Result = htmlspecialchars($Mixed, ENT_NOQUOTES, C('Garden.Charset', 'UTF-8'));
             $Result = Gdn_Format::Mentions($Result);
             $Result = Gdn_Format::Links($Result);
 	    $Result = Emoji::instance()->translateToHtml($Result);
@@ -1188,7 +1188,7 @@ EOT;
          $Text = $Url;
          if (strpos($Text ,'%') !== FALSE) {
             $Text = rawurldecode($Text);
-            $Text = htmlspecialchars($Text, ENT_QUOTES, C('Garden.Charset', ''));
+            $Text = htmlspecialchars($Text, ENT_QUOTES, C('Garden.Charset', 'UTF-8'));
          }
 
          $nofollow = (self::$DisplayNoFollow) ? ' rel="nofollow"' : '';

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -221,7 +221,7 @@ function Gdn_ExceptionHandler($Exception) {
          // This is an ajax request, so dump an error that is more eye-friendly in the debugger
          echo '<h1>FATAL ERROR IN: ',$SenderObject,'.',$SenderMethod,"();</h1>\n<pre class=\"AjaxError\">\"".$SenderMessage."\"\n";
          if ($SenderCode != '')
-            echo htmlspecialchars($SenderCode, ENT_COMPAT, 'UTF-8')."\n";
+            echo htmlspecialchars($SenderCode, ENT_COMPAT, C('Garden.Charset', 'UTF-8'))."\n";
 
          if (is_array($ErrorLines) && $Line > -1)
             echo "\nLOCATION: ",$File,"\n";

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -442,7 +442,7 @@ if (!function_exists('Attribute')) {
             continue;
 
          if ($Val != '' && $Attribute != 'Standard') {
-            $Return .= ' '.$Attribute.'="'.htmlspecialchars($Val, ENT_COMPAT, 'UTF-8').'"';
+            $Return .= ' '.$Attribute.'="'.htmlspecialchars($Val, ENT_COMPAT, C('Garden.Charset', 'UTF-8')).'"';
          }
       }
       return $Return;

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -396,7 +396,7 @@ if (!function_exists('Anchor')) {
       if (!in_array($Prefix, array('https:/', 'http://', 'mailto:')) && ($Destination != '' || $ForceAnchor === FALSE))
          $Destination = Gdn::Request()->Url($Destination, $WithDomain, $SSL);
 
-      return '<a href="'.htmlspecialchars($Destination, ENT_COMPAT, 'UTF-8').'"'.Attribute($CssClass).Attribute($Attributes).'>'.$Text.'</a>';
+      return '<a href="'.htmlspecialchars($Destination, ENT_COMPAT, C('Garden.Charset', 'UTF-8')).'"'.Attribute($CssClass).Attribute($Attributes).'>'.$Text.'</a>';
    }
 }
 

--- a/plugins/Debugger/views/debug.php
+++ b/plugins/Debugger/views/debug.php
@@ -4,7 +4,7 @@
 <?php
 // Add the canonical Url.
 if (method_exists($Sender, 'CanonicalUrl')) {
-   $CanonicalUrl = htmlspecialchars($Sender->CanonicalUrl(), ENT_COMPAT, 'UTF-8');
+   $CanonicalUrl = htmlspecialchars($Sender->CanonicalUrl(), ENT_COMPAT, C('Garden.Charset', 'UTF-8'));
 
    echo '<div class="CanonicalUrl"><b>'.T('Canonical Url')."</b>: <a href=\"$CanonicalUrl\" accesskey=\"r\">$CanonicalUrl</a></div>";
 }


### PR DESCRIPTION
htmlspecialchars uses a mixture of `C('Garden.Charset', '')`, `C('Garden.Charset', 'UTF-8')`, `UTF-8` and no charset info at all. I've harmonized all that uses any charset parameter to respect config setting and default to UTF-8 (`C('Garden.Charset', 'UTF-8')`)