### PR TITLE
Exploding HOST (localhost:9090 => [localhost, 9090] and cutting out the ...

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -96,9 +96,6 @@ class Gdn_Request {
                $Value = !is_null($Value) ? trim($Value, '/') : $Value;
                break;
             case 'HOST':
-               $HostParts = explode(':', $Value);
-               $Value = array_shift($HostParts);
-               break;
             case 'SCHEME':
             case 'METHOD':
             case 'FOLDER':


### PR DESCRIPTION
...port results in incorrect paths when running Vanilla Forums locally on any post other than 80