### PR TITLE
#2456 min/max comment length to advanced

### DIFF
--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -56,7 +56,9 @@ class SettingsController extends Gdn_Controller {
          'Garden.EditContentTimeout',
          'Vanilla.AdminCheckboxes.Use',
          'Vanilla.Discussions.SortField' => 'd.DateLastComment',
-         'Vanilla.Discussions.UserSortField'
+         'Vanilla.Discussions.UserSortField',
+         'Vanilla.Comment.MaxLength',
+         'Vanilla.Comment.MinLength'
       ));
 
       // Set the model on the form.
@@ -75,6 +77,8 @@ class SettingsController extends Gdn_Controller {
          $ConfigurationModel->Validation->ApplyRule('Vanilla.Comments.PerPage', 'Integer');
          $ConfigurationModel->Validation->ApplyRule('Vanilla.Archive.Date', 'Date');
          $ConfigurationModel->Validation->ApplyRule('Garden.EditContentTimeout', 'Integer');
+         $ConfigurationModel->Validation->ApplyRule('Vanilla.Comment.MaxLength', 'Required');
+         $ConfigurationModel->Validation->ApplyRule('Vanilla.Comment.MaxLength', 'Integer');
 
          // Grab old config values to check for an update.
          $ArchiveDateBak = Gdn::Config('Vanilla.Archive.Date');
@@ -190,9 +194,7 @@ class SettingsController extends Gdn_Controller {
          'Vanilla.Discussion.SpamLock',
          'Vanilla.Comment.SpamCount',
          'Vanilla.Comment.SpamTime',
-         'Vanilla.Comment.SpamLock',
-         'Vanilla.Comment.MaxLength',
-         'Vanilla.Comment.MinLength'
+         'Vanilla.Comment.SpamLock'
       );
       if ($IsConversationsEnabled) {
          $ConfigurationFields = array_merge(
@@ -234,8 +236,7 @@ class SettingsController extends Gdn_Controller {
          $ConfigurationModel->Validation->ApplyRule('Vanilla.Comment.SpamTime', 'Integer');
          $ConfigurationModel->Validation->ApplyRule('Vanilla.Comment.SpamLock', 'Required');
          $ConfigurationModel->Validation->ApplyRule('Vanilla.Comment.SpamLock', 'Integer');
-         $ConfigurationModel->Validation->ApplyRule('Vanilla.Comment.MaxLength', 'Required');
-         $ConfigurationModel->Validation->ApplyRule('Vanilla.Comment.MaxLength', 'Integer');
+
 
          if ($IsConversationsEnabled) {
 

--- a/applications/vanilla/views/settings/advanced.php
+++ b/applications/vanilla/views/settings/advanced.php
@@ -106,4 +106,20 @@ echo $this->Form->Errors();
       ?>
    </li>
 </ul>
+<ul>
+   <li>
+      <div class="Info"><?php echo T("It is a good idea to keep the maximum number of characters allowed in a comment down to a reasonable size."); ?></div>
+      <?php
+         echo $this->Form->Label('Max Comment Length', 'Vanilla.Comment.MaxLength');
+         echo $this->Form->TextBox('Vanilla.Comment.MaxLength', array('class' => 'InputBox SmallInput'));
+      ?>
+   </li>
+   <li>
+      <div class="Info"><?php echo T("You can specify a minimum comment length to discourage short comments."); ?></div>
+      <?php
+         echo $this->Form->Label('Min Comment Length', 'Vanilla.Comment.MinLength');
+         echo $this->Form->TextBox('Vanilla.Comment.MinLength', array('class' => 'InputBox SmallInput'));
+      ?>
+   </li>
+</ul>
 <?php echo $this->Form->Close('Save');

--- a/applications/vanilla/views/settings/floodcontrol.php
+++ b/applications/vanilla/views/settings/floodcontrol.php
@@ -86,20 +86,5 @@ echo $this->Form->Errors();
 
    </tbody>
 </table>
-<ul>
-   <li>
-      <div class="Info"><?php echo T("It is a good idea to keep the maximum number of characters allowed in a comment down to a reasonable size."); ?></div>
-      <?php
-         echo $this->Form->Label('Max Comment Length', 'Vanilla.Comment.MaxLength');
-         echo $this->Form->TextBox('Vanilla.Comment.MaxLength', array('class' => 'InputBox SmallInput'));
-      ?>
-   </li>
-   <li>
-      <div class="Info"><?php echo T("You can specify a minimum comment length to discourage short comments."); ?></div>
-      <?php
-         echo $this->Form->Label('Min Comment Length', 'Vanilla.Comment.MinLength');
-         echo $this->Form->TextBox('Vanilla.Comment.MinLength', array('class' => 'InputBox SmallInput'));
-      ?>
-   </li>
-</ul>
-<?php echo $this->Form->Close('Save');
+
+<p><?php echo $this->Form->Close('Save'); ?> </p>


### PR DESCRIPTION
Moved min/max comment length to advanced section, instead of flood
control.