### PR TITLE
Wrap inline CODE tags in FireFox

### DIFF
--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -1998,18 +1998,22 @@ code, pre {
    -webkit-border-radius: 2px;
    background: #ff9;
    padding: 4px 8px;
-   white-space: pre;
    font-family: monospace;
    overflow: auto;
-	border: 1px solid #eec;
+   border: 1px solid #eec;
+}
+code {
+   white-space: pre-wrap;
 }
 pre {
    display: block;
    margin: 1em 0;
+   white-space: pre;
 }
 pre code {
    border: none;
    padding: 0;
+   white-space: pre;
 }
 mark {
     padding: 0 2px;


### PR DESCRIPTION
Unlike Chrome, FireFox doesn't force wrapping of long lines inside code blocks with white-space:pre so such lines break the site layout.