### PR TITLE
Correct typo: "DateLastVisit" should be "DateLastActive"

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -740,7 +740,7 @@ class UserController extends DashboardController {
          if (strpos($Field, '.') !== FALSE)
             $Field = array_pop(explode('.', $Field));
 
-         if (!in_array($Field, array('Name', 'Email', 'LastIPAddress', 'InsertIPAddress', 'RankID', 'DateFirstVisit', 'DateLastVisit')))
+         if (!in_array($Field, array('Name', 'Email', 'LastIPAddress', 'InsertIPAddress', 'RankID', 'DateFirstVisit', 'DateLastActive')))
             return FALSE;
 
          return array("$Field $Op" => $FilterValue);


### PR DESCRIPTION
UserControllers function _GetFilter() uses the field name "DateLastVisit" which doesn't exist. The field is called "DateLastActive".
Using `/dashboard/user?Keywords=&Go=Go&Filter=DateLastActive = 2015-01-23 11:46:40` wouldn't work because the filter field "DateLastActive" doesn't exist and therefore the filter is ignored. `/dashboard/user?Keywords=&Go=Go&Filter=DateLastVisit = 2015-01-23 11:46:40` breaks the request because you get a `WHERE user.DateLastVisit..." sql and that column doesn't exist.

But to be honest: I have no clue what this means in practice. You have to use it like that `/dashboard/user?Keywords=&Go=Go&Filter=DateLastActive = 2015-01-23 11:46:40` in order to get results and who wants to filter any date field by such an exact time (hours, minutes and seconds are needed)?

Furthermore I haven't seen any possibility to add a filter to the user list (besides the keywords input box). You have to add `&Filter=Field = Value` manually to the url which is really awkward.
And "=" is the only valid operator so those have all the same results:
`&Filter=Field = Value`
`&Filter=Field < Value`
`&Filter=Field > Value`
`&Filter=Field != Value`
