### PR TITLE
Flush Zend OPcache after config file is saved

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3013,6 +3013,10 @@ if (!function_exists('SaveToConfig')) {
     */
    function SaveToConfig($Name, $Value = '', $Options = array()) {
       Gdn::Config()->SaveToConfig($Name, $Value, $Options);
+
+      // Flush Zend OPcache after config file is saved.
+      if (function_exists('opcache_reset'))
+         opcache_reset();
    }
 }
 


### PR DESCRIPTION
**Issue to be addressed:** Currently, any changes to the config file via the admin dashboard or any code that calls `SaveToConfig()` does get saved to the `/conf/config.php` file successfully, but it won't be loaded into memory until the re-validate frequency has passed, so new config settings won't take place until the PHP service is restarted or the cache has been reset.

**Proposed change:** Add a line to clear the cache after saving the config file. For production websites that have Zend OPcache enabled and configured with the `opcache.revalidate_freq` PHP ini setting set to an integer, for seconds, greater than zero, flushing the cache would allow new configuration values to be loaded into memory immediately.

**To sum up:** Zend OPcache "improves PHP performance by storing precompiled script bytecode in shared memory, thereby removing the need for PHP to load and parse scripts on each request." The advantage of this change is to allow websites powered by Vanilla to take advantage of the performance gain from Zend OPcache with a reasonable `opcache.revalidate_freq` setting without having to restart the PHP service or wait for the cache to be re-validated for new config settings take place.

**Notes:**

- With Zend OPcache enabled and configured like above, any form in Vanilla that uses a model to save changes to the database takes affect immediately after saving the form; any changes to the database show up immediately and are not affected by having Zend OPcache enabled, so flushing the cache is only necessary for changes to the config file to take affect.
- Calling `opcache_compile_file` or `opcache_invalidate` on the `/conf/config.php` file directly doesn't work as the config values are already stored in memory.
- To point it out, `Gdn::Config()->SaveToConfig()` returns `int(0)` in any case, but the PHPDoc above the function definition states that it should return a "bool: Whether or not the save was successful. NULL if no changes were necessary."