### PR TITLE
Allow users without admin access to assign roles and edit permissions.

### DIFF
--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -247,9 +247,24 @@ class RoleController extends DashboardController {
       $this->AddJsFile('jquery-ui.js');
       $this->Title(T('Roles & Permissions'));
 
-      if (!$RoleID)
-         $RoleData = $this->RoleModel->Get()->ResultArray();
-      else {
+      if (!$RoleID) {
+         $RoleData = $this->RoleModel->GetWithRankPermissions()->ResultArray();
+
+         // Check to see which roles can be modified.
+         foreach ($RoleData as &$Row) {
+            $CanModify = TRUE;
+
+            if (!Gdn::Session()->CheckPermission('Garden.Settings.Manage')) {
+               foreach (Gdn::PermissionModel()->RankPermissions as $Permission) {
+                  if ($Row[$Permission] && !Gdn::Session()->CheckPermission($Permission)) {
+                     $CanModify = FALSE;
+                     break;
+                  }
+               }
+            }
+            $Row['CanModify'] = $CanModify;
+         }
+      } else {
          $Role = $this->RoleModel->GetID($RoleID);
          $RoleData = array($Role);
       }

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -16,7 +16,7 @@ class RoleController extends DashboardController {
    /**
     * @var RoleModel
     */
-   protected $RoleModel;
+   public $RoleModel;
 
    /**
     * Set menu path. Automatically run on every use.

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -204,7 +204,7 @@ class RoleController extends DashboardController {
          $Permissions = $PermissionModel->GetPermissionsEdit($RoleID ? $RoleID : 0, $LimitToSuffix);
          // Remove permissions the user doesn't have access to.
          if (!Gdn::Session()->CheckPermission('Garden.Settings.Manage')) {
-            foreach (Gdn::PermissionModel()->RankPermissions as $Permission) {
+            foreach ($this->RoleModel->RankPermissions as $Permission) {
                if (Gdn::Session()->CheckPermission($Permission)) {
                   continue;
                }
@@ -255,7 +255,7 @@ class RoleController extends DashboardController {
             $CanModify = TRUE;
 
             if (!Gdn::Session()->CheckPermission('Garden.Settings.Manage')) {
-               foreach (Gdn::PermissionModel()->RankPermissions as $Permission) {
+               foreach ($this->RoleModel->RankPermissions as $Permission) {
                   if ($Row[$Permission] && !Gdn::Session()->CheckPermission($Permission)) {
                      $CanModify = FALSE;
                      break;
@@ -299,7 +299,7 @@ class RoleController extends DashboardController {
 
       // Remove ranking permissions.
       $Permissions = $this->Form->GetFormValue('Permission');
-      foreach (Gdn::PermissionModel()->RankPermissions as $Permission) {
+      foreach ($this->RoleModel->RankPermissions as $Permission) {
          if (!Gdn::Session()->CheckPermission($Permission) && in_array($Permission, $Permissions)) {
             $Index = array_search($Permission, $Permissions);
             unset($Permissions[$Index]);

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -2,7 +2,7 @@
 
 /**
  * RBAC (Role Based Access Control) system.
- * 
+ *
  * @copyright 2003 Vanilla Forums, Inc
  * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
  * @package Garden
@@ -12,7 +12,12 @@
 class RoleController extends DashboardController {
    /** @var array Models to automatically instantiate. */
    public $Uses = array('Database', 'Form', 'RoleModel');
-   
+
+   /**
+    * @var RoleModel
+    */
+   protected $RoleModel;
+
    /**
     * Set menu path. Automatically run on every use.
     *
@@ -25,7 +30,7 @@ class RoleController extends DashboardController {
       if ($this->Menu)
          $this->Menu->HighlightRoute('/dashboard/settings');
    }
-   
+
    /**
     * Create new role.
     *
@@ -42,7 +47,7 @@ class RoleController extends DashboardController {
       $this->View = 'Edit';
       $this->Edit();
    }
-   
+
    /**
     * Remove a role.
     *
@@ -50,28 +55,28 @@ class RoleController extends DashboardController {
     * @access public
     */
    public function Delete($RoleID = FALSE) {
-		if(!$this->_Permission())
+		if(!$this->_Permission($RoleID))
 			return;
 
 		$this->Title(T('Delete Role'));
       $this->AddSideMenu('dashboard/role');
-      
+
       $Role = $this->RoleModel->GetByRoleID($RoleID);
       if ($Role->Deletable == '0')
          $this->Form->AddError('You cannot delete this role.');
-      
+
       // Make sure the form knows which item we are deleting.
       $this->Form->AddHidden('RoleID', $RoleID);
-      
+
       // Figure out how many users will be affected by this deletion
       $this->AffectedUsers = $this->RoleModel->GetUserCount($RoleID);
-      
+
       // Figure out how many users will be orphaned by this deletion
       $this->OrphanedUsers = $this->RoleModel->GetUserCount($RoleID, TRUE);
 
       // Get a list of roles other than this one that can act as a replacement
       $this->ReplacementRoles = $this->RoleModel->GetByNotRoleID($RoleID);
-      
+
       if ($this->Form->AuthenticatedPostBack()) {
          // Make sure that a replacement role has been selected if there were going to be orphaned users
          if ($this->OrphanedUsers > 0) {
@@ -89,7 +94,7 @@ class RoleController extends DashboardController {
       }
       $this->Render();
    }
-   
+
    /**
     * Manage default role assignments.
     *
@@ -135,7 +140,7 @@ class RoleController extends DashboardController {
 
       $this->Render();
    }
-   
+
    /**
     * Show a warning if default roles are not setup yet.
     *
@@ -164,7 +169,7 @@ class RoleController extends DashboardController {
             '</div>';
       }
    }
-   
+
    /**
     * Edit a role.
     *
@@ -172,31 +177,32 @@ class RoleController extends DashboardController {
     * @access public
     */
    public function Edit($RoleID = FALSE) {
-		if(!$this->_Permission())
-			return;
+		if(!$this->_Permission($RoleID)) {
+         return;
+      }
 
       if ($this->Head && $this->Head->Title() == '')
          $this->Head->Title(T('Edit Role'));
-         
+
       $this->AddSideMenu('dashboard/role');
       $PermissionModel = Gdn::PermissionModel();
       $this->Role = $this->RoleModel->GetByRoleID($RoleID);
       // $this->EditablePermissions = is_object($this->Role) ? $this->Role->EditablePermissions : '1';
       $this->AddJsFile('jquery.gardencheckboxgrid.js');
-      
+
       // Set the model on the form.
       $this->Form->SetModel($this->RoleModel);
-      
+
       // Make sure the form knows which item we are editing.
       $this->Form->AddHidden('RoleID', $RoleID);
-      
+
       $LimitToSuffix = !$this->Role || $this->Role->CanSession == '1' ? '' : 'View';
-      
+
       // If seeing the form for the first time...
       if ($this->Form->AuthenticatedPostBack() === FALSE) {
          // Get the role data for the requested $RoleID and put it into the form.
          $this->SetData('PermissionData', $PermissionModel->GetPermissionsEdit($RoleID ? $RoleID : 0, $LimitToSuffix), true);
-            
+
          $this->Form->SetData($this->Role);
       } else {
          // If the form has been posted back...
@@ -208,10 +214,10 @@ class RoleController extends DashboardController {
             $this->SetData('PermissionData', $PermissionModel->GetPermissionsEdit($RoleID, $LimitToSuffix), true);
          }
       }
-      
+
       $this->Render();
    }
-   
+
    /**
     * Show list of roles.
     *
@@ -219,20 +225,20 @@ class RoleController extends DashboardController {
     * @access public
     */
    public function Index($RoleID = NULL) {
-		$this->Permission('Garden.Settings.Manage');
+		$this->_Permission();
 
       $this->AddSideMenu('dashboard/role');
       $this->AddJsFile('jquery.tablednd.js');
       $this->AddJsFile('jquery-ui.js');
       $this->Title(T('Roles & Permissions'));
-      
+
       if (!$RoleID)
          $RoleData = $this->RoleModel->Get()->ResultArray();
       else {
          $Role = $this->RoleModel->GetID($RoleID);
          $RoleData = array($Role);
       }
-      
+
       $this->SetData('Roles', $RoleData);
       $this->Render();
    }
@@ -243,8 +249,16 @@ class RoleController extends DashboardController {
     * @since 2.0.0
     * @access protected
     */
-	protected function _Permission() {
-      $this->Permission('Garden.Settings.Manage');
+	protected function _Permission($RoleID = NULL) {
+      $this->Permission(array('Garden.Settings.Manage', 'Garden.Roles.Manage'), FALSE);
+
+      if ($RoleID && !CheckPermission('Garden.Settings.Manage')) {
+         // Make sure the user can assign this role.
+         $Assignable = $this->RoleModel->GetAssignable();
+         if (!isset($Assignable[$RoleID])) {
+            throw PermissionException('@'.T("You don't have permission to modify this role."));
+         }
+      }
 		return TRUE;
 	}
 }

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -205,6 +205,8 @@ class RoleController extends DashboardController {
 
          $this->Form->SetData($this->Role);
       } else {
+         $this->RemoveRankPermissions();
+
          // If the form has been posted back...
          // 2. Save the data (validation occurs within):
          if ($RoleID = $this->Form->Save()) {
@@ -261,4 +263,16 @@ class RoleController extends DashboardController {
       }
 		return TRUE;
 	}
+
+   protected function RemoveRankPermissions() {
+      // Remove ranking permissions.
+      $Permissions = $this->Form->GetFormValue('Permission');
+      foreach (Gdn::PermissionModel()->RankPermissions as $Permission) {
+         if (!Gdn::Session()->CheckPermission($Permission) && in_array($Permission, $Permissions)) {
+            $Index = array_search($Permission, $Permissions);
+            unset($Permissions[$Index]);
+         }
+      }
+      $this->Form->SetFormValue('Permission', $Permissions);
+   }
 }

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -1,8 +1,8 @@
 <?php if (!defined('APPLICATION')) exit();
- 
+
 /**
  * Manage users.
- * 
+ *
  * @copyright 2003 Vanilla Forums, Inc
  * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
  * @package Garden
@@ -123,14 +123,8 @@ class UserController extends DashboardController {
       $this->AddSideMenu('dashboard/user');
 
       $RoleModel = new RoleModel();
-      $RoleData = $AllRoles = $RoleModel->GetArray();
-
-      // If not administrator, restrict to default registration roles.
-      if (!CheckPermission('Garden.Settings.Manage')) {
-         $DefaultRoleIDs = C('Garden.Registration.DefaultRoles', array(8));
-         $DefaultRoles = array_combine($DefaultRoleIDs, $DefaultRoleIDs);
-         $RoleData = array_intersect_key($AllRoles, $DefaultRoles);
-      }
+      $AllRoles = $RoleModel->GetArray();
+      $RoleData = $RoleModel->GetAssignable();
 
       // By default, people with access here can freely assign all roles
       $this->RoleData = $RoleData;
@@ -154,7 +148,9 @@ class UserController extends DashboardController {
             // user, adjusted for his ability to affect those roles
             $RequestedRoles = $this->Form->GetFormValue('RoleID');
 
-            if (!is_array($RequestedRoles)) $RequestedRoles = array();
+            if (!is_array($RequestedRoles)) {
+               $RequestedRoles = array();
+            }
             $RequestedRoles = array_flip($RequestedRoles);
             $UserNewRoles = array_intersect_key($this->RoleData, $RequestedRoles);
 
@@ -559,7 +555,7 @@ class UserController extends DashboardController {
       // Only admins can reassign roles
       $RoleModel = new RoleModel();
       $AllRoles = $RoleModel->GetArray();
-      $RoleData = (CheckPermission('Garden.Settings.Manage')) ? $AllRoles : array();
+      $RoleData = $RoleModel->GetAssignable();
 
       $UserModel = new UserModel();
       $User = $UserModel->GetID($UserID, DATASET_TYPE_ARRAY);
@@ -661,8 +657,9 @@ class UserController extends DashboardController {
             $UserImmutableRoles = array_intersect_key($ImmutableRoles, $UserRoleData);
 
             // Apply immutable roles
-            foreach ($UserImmutableRoles as $IMRoleID => $IMRoleName)
+            foreach ($UserImmutableRoles as $IMRoleID => $IMRoleName) {
                $UserNewRoles[$IMRoleID] = $IMRoleName;
+            }
 
             // Put the data back into the forum object as if the user had submitted
             // this themselves

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -11,6 +11,16 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 class PermissionModel extends Gdn_Model {
 
    /**
+    * @var array A list of permissions that define an increasing ranking of permissions.
+    */
+   public $RankPermissions = array(
+      'Garden.Moderation.Manage',
+      'Garden.Community.Manage',
+      'Garden.Users.Add',
+      'Garden.Settings.Manage'
+   );
+
+   /**
     * Class constructor. Defines the related database table name.
     */
    public function __construct() {

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -9,17 +9,6 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 */
 
 class PermissionModel extends Gdn_Model {
-
-   /**
-    * @var array A list of permissions that define an increasing ranking of permissions.
-    */
-   public $RankPermissions = array(
-      'Garden.Moderation.Manage',
-      'Garden.Community.Manage',
-      'Garden.Users.Add',
-      'Garden.Settings.Manage'
-   );
-
    /**
     * Class constructor. Defines the related database table name.
     */

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -12,10 +12,22 @@ class RoleModel extends Gdn_Model {
    public static $Roles = NULL;
 
    /**
+    * @var array A list of permissions that define an increasing ranking of permissions.
+    */
+   public $RankPermissions = array(
+      'Garden.Moderation.Manage',
+      'Garden.Community.Manage',
+      'Garden.Users.Add',
+      'Garden.Settings.Manage',
+      'Conversations.Moderation.Manage'
+   );
+
+   /**
     * Class constructor. Defines the related database table name.
     */
    public function __construct() {
       parent::__construct('Role');
+      $this->FireEvent('Init');
    }
 
    public function ClearCache() {
@@ -86,7 +98,7 @@ class RoleModel extends Gdn_Model {
          ->LeftJoin('Permission p', 'p.RoleID = r.RoleID and p.JunctionID is null')
          ->OrderBy('Sort', 'asc');
 
-      foreach (Gdn::PermissionModel()->RankPermissions as $Permission) {
+      foreach ($this->RankPermissions as $Permission) {
          $this->SQL->Select("`$Permission`", '', $Permission);
       }
 
@@ -128,7 +140,7 @@ class RoleModel extends Gdn_Model {
          ->LeftJoin('Permission p', 'p.RoleID = r.RoleID and p.JunctionID is null'); // join to global permissions
 
       // Don't select roles that I don't have a ranking permission for.
-      foreach (Gdn::PermissionModel()->RankPermissions as $Permission) {
+      foreach ($this->RankPermissions as $Permission) {
          if (!Gdn::Session()->CheckPermission($Permission)) {
             $Sql->Where("coalesce(`$Permission`, 0)", '0', FALSE, FALSE);
          }

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -75,6 +75,26 @@ class RoleModel extends Gdn_Model {
    }
 
    /**
+    * Get all of the roles including their ranking permissions.
+    *
+    * @return Gdn_DataSet Returns all of the roles with the ranking permissions.
+    */
+   public function GetWithRankPermissions() {
+      $this->SQL
+         ->Select('r.*')
+         ->From('Role r')
+         ->LeftJoin('Permission p', 'p.RoleID = r.RoleID and p.JunctionID is null')
+         ->OrderBy('Sort', 'asc');
+
+      foreach (Gdn::PermissionModel()->RankPermissions as $Permission) {
+         $this->SQL->Select("`$Permission`", '', $Permission);
+      }
+
+      $Result = $this->SQL->Get();
+      return $Result;
+   }
+
+   /**
     * Returns an array of RoleID => RoleName pairs.
     *
     * @return array

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -139,9 +139,11 @@ class RoleModel extends Gdn_Model {
          ->From('Role r')
          ->LeftJoin('Permission p', 'p.RoleID = r.RoleID and p.JunctionID is null'); // join to global permissions
 
-      // Don't select roles that I don't have a ranking permission for.
+      // Community managers can assign permissions they have,
+      // but other users can't assign any ranking permissions.
+      $CM = Gdn::Session()->CheckPermission('Garden.Community.Manage');
       foreach ($this->RankPermissions as $Permission) {
-         if (!Gdn::Session()->CheckPermission($Permission)) {
+         if (!$CM || !Gdn::Session()->CheckPermission($Permission)) {
             $Sql->Where("coalesce(`$Permission`, 0)", '0', FALSE, FALSE);
          }
       }

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -105,12 +105,12 @@ class RoleModel extends Gdn_Model {
 
       $Sql->Select('r.RoleID, r.Name')
          ->From('Role r')
-         ->Join('Permission p', 'p.RoleID = r.RoleID and p.JunctionID is null'); // join to global permissions
+         ->LeftJoin('Permission p', 'p.RoleID = r.RoleID and p.JunctionID is null'); // join to global permissions
 
       // Don't select roles that I don't have a ranking permission for.
       foreach (Gdn::PermissionModel()->RankPermissions as $Permission) {
          if (!Gdn::Session()->CheckPermission($Permission)) {
-            $Sql->Where("`$Permission`", 0);
+            $Sql->Where("coalesce(`$Permission`, 0)", '0', FALSE, FALSE);
          }
       }
 

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -10,35 +10,35 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 
 class RoleModel extends Gdn_Model {
    public static $Roles = NULL;
-   
+
    /**
     * Class constructor. Defines the related database table name.
     */
    public function __construct() {
       parent::__construct('Role');
    }
-   
+
    public function ClearCache() {
       $Key = 'Roles';
       Gdn::Cache()->Remove($Key);
    }
-   
+
    public function Define($Values) {
       if(array_key_exists('RoleID', $Values)) {
          $RoleID = $Values['RoleID'];
          unset($Values['RoleID']);
-         
+
          $this->SQL->Replace('Role', $Values, array('RoleID' => $RoleID), TRUE);
       } else {
          // Check to see if there is a role with the same name.
          $RoleID = $this->SQL->GetWhere('Role', array('Name' => $Values['Name']))->Value('RoleID', NULL);
-         
+
          if(is_null($RoleID)) {
             // Figure out the next role ID.
             $MaxRoleID = $this->SQL->Select('r.RoleID', 'MAX')->From('Role r')->Get()->Value('RoleID', 0);
             $RoleID = $MaxRoleID + 1;
             $Values['RoleID'] = $RoleID;
-            
+
             // Insert the role.
             $this->SQL->Insert('Role', $Values);
          } else {
@@ -73,18 +73,17 @@ class RoleModel extends Gdn_Model {
          ->OrderBy('Sort', 'asc')
          ->Get();
    }
-   
+
    /**
     * Returns an array of RoleID => RoleName pairs.
     *
     * @return array
     */
    public function GetArray() {
-      // $RoleData = $this->GetEditablePermissions();
-      $RoleData = $this->Get();
-      $RoleIDs = ConsolidateArrayValuesByKey($RoleData->ResultArray(), 'RoleID');
-      $RoleNames = ConsolidateArrayValuesByKey($RoleData->ResultArray(), 'Name');
-      return ArrayCombine($RoleIDs, $RoleNames);
+      $RoleData = $this->Get()->ResultArray();
+      $Result = array_column($RoleData, 'Name', 'RoleID');
+
+      return $Result;
    }
 
    /**
@@ -108,7 +107,7 @@ class RoleModel extends Gdn_Model {
    public function GetByRoleID($RoleID) {
       return $this->GetWhere(array('RoleID' => $RoleID))->FirstRow();
    }
-   
+
    /**
     * Returns a resultset of role data related to the specified UserID.
     *
@@ -131,17 +130,17 @@ class RoleModel extends Gdn_Model {
    public function GetByNotRoleID($RoleID) {
       return $this->GetWhere(array('RoleID <>' => $RoleID));
    }
-   
+
    public function GetPermissions($RoleID) {
       $PermissionModel = Gdn::PermissionModel();
       $Role = self::Roles($RoleID);
-      
+
       $LimitToSuffix = GetValue('CanSession', $Role, TRUE) ? '' : 'View';
-      
+
       $Result = $PermissionModel->GetPermissions($RoleID, $LimitToSuffix);
-      return $Result;      
+      return $Result;
    }
-   
+
    /**
     * Returns the number of users assigned to the provided RoleID. If
     * $UsersOnlyWithThisRole is TRUE, it will return the number of users who
@@ -160,19 +159,19 @@ class RoleModel extends Gdn_Model {
             ->Where('ur.RoleID', $RoleID)
             ->Get()
             ->FirstRow();
-            
+
          return $Data ? $Data->UserCount : 0;
       } else {
          return $this->SQL->GetCount('UserRole', array('RoleID' => $RoleID));
       }
    }
-   
+
    public function GetApplicantCount($Force = FALSE) {
       $CacheKey = 'Moderation.ApplicantCount';
-      
+
       if ($Force)
          Gdn::Cache()->Remove($CacheKey);
-      
+
       $Count = Gdn::Cache()->Get($CacheKey);
       if ($Count === Gdn_Cache::CACHEOP_FAILURE) {
          $Count = Gdn::SQL()
@@ -181,15 +180,15 @@ class RoleModel extends Gdn_Model {
             ->Join('UserRole ur', 'u.UserID = ur.UserID')
             ->Where('ur.RoleID',  C('Garden.Registration.ApplicantRoleID', 0))
             ->Where('u.Deleted', '0')
-            ->Get()->Value('UserCount', 0);    
-         
+            ->Get()->Value('UserCount', 0);
+
          Gdn::Cache()->Store($CacheKey, $Count, array(
             Gdn_Cache::FEATURE_EXPIRY  => 300 // 5 minutes
          ));
       }
       return $Count;
    }
-   
+
    /**
     * Retrieves all roles with the specified permission(s).
     *
@@ -198,12 +197,12 @@ class RoleModel extends Gdn_Model {
    public function GetByPermission($Permission) {
       if (!is_array($Permission))
          $Permission = array($Permission);
-         
+
       $this->SQL->Select('r.*')
          ->From('Role r')
          ->Join('Permission per', "per.RoleID = r.RoleID")
          ->Where('per.JunctionTable is null');
-         
+
       $this->SQL->BeginWhereGroup();
       $PermissionCount = count($Permission);
       for ($i = 0; $i < $PermissionCount; ++$i) {
@@ -212,38 +211,38 @@ class RoleModel extends Gdn_Model {
       $this->SQL->EndWhereGroup();
       return $this->SQL->Get();
    }
-   
+
    /**
     *
-    * @param array|string $Names 
+    * @param array|string $Names
     */
    public static function GetByName($Names, &$Missing = NULL) {
       if (is_string($Names)) {
          $Names = explode(',', $Names);
          $Names = array_map('trim', $Names);
       }
-      
+
       // Make a lookup array of the names.
       $Names = array_unique($Names);
       $Names = array_combine($Names, $Names);
       $Names = array_change_key_case($Names);
-      
+
       $Roles = RoleModel::Roles();
       $Result = array();
       foreach ($Roles as $RoleID => $Role) {
          $Name = strtolower($Role['Name']);
-         
+
          if (isset($Names[$Name])) {
             $Result[$RoleID] = $Role;
             unset($Names[$Name]);
          }
       }
-      
+
       $Missing = array_values($Names);
-      
+
       return $Result;
    }
-   
+
    public static function Roles($RoleID = NULL, $Force = FALSE) {
       if (self::$Roles == NULL) {
          $Key = 'Roles';
@@ -256,7 +255,7 @@ class RoleModel extends Gdn_Model {
       } else {
          $Roles = self::$Roles;
       }
-      
+
       if ($RoleID === NULL)
          return $Roles;
       elseif (array_key_exists($RoleID, $Roles))
@@ -266,7 +265,7 @@ class RoleModel extends Gdn_Model {
       else
          return NULL;
    }
-   
+
    public function Save($FormPostValues) {
       // Define the primary key in this model's table.
       $this->DefineSchema();
@@ -277,13 +276,13 @@ class RoleModel extends Gdn_Model {
          // Figure out the next role ID.
          $MaxRoleID = $this->SQL->Select('r.RoleID', 'MAX')->From('Role r')->Get()->Value('RoleID', 0);
          $RoleID = $MaxRoleID + 1;
-         
+
          $this->AddInsertFields($FormPostValues);
          $FormPostValues['RoleID'] = strval($RoleID); // string for validation
       } else {
          $this->AddUpdateFields($FormPostValues);
       }
-      
+
       // Validate the form posted values
       if ($this->Validate($FormPostValues, $Insert)) {
          $this->Validation->AddValidationField('Permission', $FormPostValues);
@@ -298,11 +297,11 @@ class RoleModel extends Gdn_Model {
          }
          // Now update the role permissions
          $Role = $this->GetByRoleID($RoleID);
-         
+
          $PermissionModel = Gdn::PermissionModel();
          $Permissions = $PermissionModel->PivotPermissions($Permissions, array('RoleID' => $RoleID));
          $PermissionModel->SaveAll($Permissions, array('RoleID' => $RoleID));
-         
+
          if (Gdn::Cache()->ActiveEnabled()) {
             // Don't update the user table if we are just using cached permissions.
             $this->ClearCache();
@@ -323,7 +322,7 @@ class RoleModel extends Gdn_Model {
 
    public static function SetUserRoles(&$Users, $UserIDColumn = 'UserID', $RolesColumn = 'Roles') {
       $UserIDs = array_unique(ConsolidateArrayValuesByKey($Users, $UserIDColumn));
-      
+
       // Try and get all of the mappings from the cache.
       $Keys = array();
       foreach ($UserIDs as $UserID) {
@@ -332,7 +331,7 @@ class RoleModel extends Gdn_Model {
       $UserRoles = Gdn::Cache()->Get($Keys);
       if (!is_array($UserRoles))
          $UserRoles = array();
-      
+
       // Grab all of the data that doesn't exist from the DB.
       $MissingIDs = array();
       foreach($Keys as $UserID => $Key) {
@@ -346,9 +345,9 @@ class RoleModel extends Gdn_Model {
          ->From('UserRole ur')
          ->WhereIn('ur.UserID', array_keys($MissingIDs))
          ->Get()->ResultArray();
-         
+
          $DbUserRoles = Gdn_DataSet::Index($DbUserRoles, 'UserID', array('Unique' => FALSE));
-         
+
          // Store the user role mappings.
          foreach ($DbUserRoles as $UserID => $Rows) {
             $RoleIDs = ConsolidateArrayValuesByKey($Rows, 'RoleID');
@@ -357,19 +356,19 @@ class RoleModel extends Gdn_Model {
             $UserRoles[$Key] = $RoleIDs;
          }
       }
-      
+
       $AllRoles = self::Roles(); // roles indexed by role id.
 
       // Skip personal info roles
       if (!CheckPermission('Garden.PersonalInfo.View')) {
          $AllRoles = array_filter($AllRoles, 'self::FilterPersonalInfo');
       }
-      
+
       // Join the users.
       foreach ($Users as &$User) {
          $UserID = GetValue($UserIDColumn, $User);
          $Key = $Keys[$UserID];
-         
+
          $RoleIDs = GetValue($Key, $UserRoles, array());
          $Roles = array();
          foreach ($RoleIDs as $RoleID) {
@@ -380,7 +379,7 @@ class RoleModel extends Gdn_Model {
          SetValue($RolesColumn, $User, $Roles);
       }
    }
-   
+
    public function Delete($RoleID, $ReplacementRoleID) {
       // First update users that will be orphaned
       if (is_numeric($ReplacementRoleID) && $ReplacementRoleID > 0) {
@@ -396,11 +395,11 @@ class RoleModel extends Gdn_Model {
       } else {
          $this->SQL->Delete('UserRole', array('RoleID' => $RoleID));
       }
-      
+
       // Remove permissions for this role.
       $PermissionModel = Gdn::PermissionModel();
       $PermissionModel->Delete($RoleID);
-      
+
       // Remove the role
       $this->SQL->Delete('Role', array('RoleID' => $RoleID));
    }

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -146,7 +146,10 @@ class DashboardHooks implements Gdn_IPlugin {
 
       $Menu->AddItem('Users', T('Users'), FALSE, array('class' => 'Users'));
       $Menu->AddLink('Users', T('Users'), '/dashboard/user', array('Garden.Users.Add', 'Garden.Users.Edit', 'Garden.Users.Delete'), array('class' => 'nav-users'));
-      $Menu->AddLink('Users', T('Roles & Permissions'), 'dashboard/role', 'Garden.Settings.Manage', array('class' => 'nav-roles'));
+
+      if (Gdn::Session()->CheckPermission(array('Garden.Settings.Manage', 'Garden.Roles.Manage'), FALSE)) {
+         $Menu->AddLink('Users', T('Roles & Permissions'), 'dashboard/role', FALSE, array('class' => 'nav-roles'));
+      }
 
       $Menu->AddLink('Users', T('Registration'), 'dashboard/settings/registration', 'Garden.Settings.Manage', array('class' => 'nav-registration'));
       $Menu->AddLink('Users', T('Authentication'), 'dashboard/authentication', 'Garden.Settings.Manage', array('class' => 'nav-authentication'));

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -274,7 +274,6 @@ $PermissionModel->Undefine(array(
    'Garden.Email.Manage',
    'Garden.Plugins.Manage',
    'Garden.Registration.Manage',
-   'Garden.Roles.Manage',
    'Garden.Routes.Manage',
    'Garden.Themes.Manage',
    'Garden.Messages.Manage'

--- a/applications/dashboard/views/role/index.php
+++ b/applications/dashboard/views/role/index.php
@@ -37,7 +37,7 @@ foreach ($this->Data('Roles') as $Role) {
    <tr id="<?php echo $Role['RoleID']; ?>"<?php echo $Alt ? ' class="Alt"' : ''; ?>>
       <td class="Info">
          <strong><?php echo $Role['Name']; ?></strong>
-         <?php if ($Advanced) { ?>
+         <?php if ($Advanced && $Role['CanModify']) { ?>
          <div>
             <?php
             echo Anchor(T('Edit'), "/role/edit/{$Role['RoleID']}", 'SmallButton');

--- a/applications/dashboard/views/user/index.php
+++ b/applications/dashboard/views/user/index.php
@@ -24,7 +24,7 @@ $ViewPersonalInfo = $Session->CheckPermission('Garden.PersonalInfo.View');
       echo ' ', $this->Form->Button(T('Go'));
       echo ' ', sprintf(T('%s user(s) found.'), $this->Data('RecordCount'));
       echo '</div>';
-      
+
    ?>
 </div>
 <div class="Wrap">
@@ -35,8 +35,12 @@ $ViewPersonalInfo = $Session->CheckPermission('Garden.PersonalInfo.View');
          echo Anchor(T('Delete'), '#', 'Popup SmallButton');
       ?>
    </span>-->
-   
-   <?php echo Anchor(T('Add User'), 'dashboard/user/add', 'Popup SmallButton'); ?>
+
+   <?php
+   if (CheckPermission('Garden.Users.Add')) {
+      echo Anchor(T('Add User'), 'dashboard/user/add', 'Popup SmallButton');
+   }
+   ?>
 </div>
 <table id="Users" class="AltColumns">
    <thead>


### PR DESCRIPTION
- Define a set of ranking permissions. This means that users can only assign roles/permissions if they
have those ranking permissions.
- Administrators can assign any role.
- Community managers with the edit users permission can assign roles that they have ranking permission of.
- Other users with the edit users permission can assign roles without any ranking permission.
- Add a hidden Garden.Roles.Manage permission that can be defined in plugins that will allow non admins to add and edit roles.