### PR TITLE
Send notifications on wall comments and other goodies.

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -934,11 +934,12 @@ class ActivityModel extends Gdn_Model {
                   $this->SQL->Put('Activity', array('DateUpdated' => $Comment['DateInserted']), array('ActivityID' => $_ActivityID));
                }
             }
+
+            // Send a notification to the original person.
+            if (val('ActivityType', $Activity) === 'WallPost') {
+               $this->NotifyWallComment($Comment, $Activity);
+            }
          }
-
-         // Send a notification to the original person.
-         $this->NotifyWallComment($Comment, $Activity);
-
 
          return $ID;
       }

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -936,6 +936,10 @@ class ActivityModel extends Gdn_Model {
             }
          }
 
+         // Send a notification to the original person.
+         $this->NotifyWallComment($Comment, $Activity);
+
+
          return $ID;
       }
       return FALSE;
@@ -1366,6 +1370,30 @@ class ActivityModel extends Gdn_Model {
 //      decho($NewActivity, 'MergedActivity');
 //      die();
       return $NewActivity;
+   }
+
+   /**
+    * Notify the user of wall comments.
+    *
+    * @param $WallPost
+    */
+   protected function NotifyWallComment($Comment, $WallPost) {
+      $NotifyUser = Gdn::UserModel()->GetID($WallPost['ActivityUserID']);
+
+      $Activity = array(
+         'ActivityType' => 'WallComment',
+         'ActivityUserID' => $Comment['InsertUserID'],
+         'Format' => $Comment['Format'],
+         'NotifyUserID' => $WallPost['ActivityUserID'],
+         'RecordType' => 'ActivityComment',
+         'RecordID' => $Comment['ActivityCommentID'],
+         'RegardingUserID' => $WallPost['ActivityUserID'],
+         'Route' => UserUrl($NotifyUser, ''),
+         'Story' => $Comment['Body'],
+         'HeadlineFormat' => T('HeadlineFormat.NotifyWallComment', '{ActivityUserID,User} commented on your <a href="{Url,url}">wall</a>.')
+      );
+
+      $this->Save($Activity, 'WallComment');
    }
 
    protected function NotifyWallPost($WallPost) {

--- a/applications/dashboard/views/activity/helper_functions.php
+++ b/applications/dashboard/views/activity/helper_functions.php
@@ -7,26 +7,26 @@ function WriteActivity($Activity, &$Sender, &$Session) {
    $ActivityType = $ActivityType[0];
    $Author = UserBuilder($Activity, 'Activity');
    $PhotoAnchor = '';
-   
+
    if ($Activity->Photo) {
       $PhotoAnchor = Anchor(
          Img($Activity->Photo, array('class' => 'ProfilePhoto ProfilePhotoMedium')),
          $Activity->PhotoUrl, 'PhotoWrap');
    }
-   
+
    $CssClass = 'Item Activity Activity-'.$ActivityType;
    if ($PhotoAnchor != '')
       $CssClass .= ' HasPhoto';
-   
+
    $Format = GetValue('Format', $Activity);
-      
+
    $Title = '';
    $Excerpt = $Activity->Story;
    if ($Format) {
       $Excerpt = Gdn_Format::To($Excerpt, $Format);
    }
-   
-   if (!in_array($ActivityType, array('WallComment', 'WallPost', 'AboutUpdate'))) {
+
+   if ($Activity->NotifyUserID > 0 || !in_array($ActivityType, array('WallComment', 'WallPost', 'AboutUpdate'))) {
       $Title = '<div class="Title">'.GetValue('Headline', $Activity).'</div>';
    } else if ($ActivityType == 'WallPost') {
       $RegardingUser = UserBuilder($Activity, 'Regarding');
@@ -36,7 +36,7 @@ function WriteActivity($Activity, &$Sender, &$Session) {
          .' <span>&rarr;</span> '
          .UserAnchor($Author, 'Name')
          .'</div>';
-      
+
       if (!$Format)
          $Excerpt = Gdn_Format::Display($Excerpt);
    } else {
@@ -64,7 +64,7 @@ function WriteActivity($Activity, &$Sender, &$Session) {
    <div class="ItemContent Activity">
       <?php echo $Title; ?>
       <?php echo WrapIf($Excerpt, 'div', array('class' => 'Excerpt')); ?>
-      <?php 
+      <?php
       $Sender->EventArguments['Activity'] = $Activity;
       $Sender->FireAs('ActivityController')->FireEvent('AfterActivityBody');
 
@@ -79,24 +79,24 @@ function WriteActivity($Activity, &$Sender, &$Session) {
          $ID = GetValue('SharedNotifyUserID', $Activity->Data);
          if (!$ID)
             $ID = GetValue('CommentNotifyUserID', $Activity->Data);
-         
+
          if ($ID)
-            $SharedString = FormatString(T('Comments are between {UserID,you}.'), array('UserID' => array($Activity->NotifyUserID, $ID))); 
-         
+            $SharedString = FormatString(T('Comments are between {UserID,you}.'), array('UserID' => array($Activity->NotifyUserID, $ID)));
+
          $AllowComments = $Activity->NotifyUserID < 0 || $SharedString;
-         
-         
-         
+
+
+
          if ($AllowComments && $Session->CheckPermission('Garden.Profiles.Edit'))
             echo '<span class="MItem AddComment">'
                .Anchor(T('Activity.Comment', 'Comment'), '#CommentForm_'.$Activity->ActivityID, 'CommentOption');
-         
+
             if ($SharedString) {
                echo ' <span class="MItem"><i>'.$SharedString.'</i></span>';
             }
-         
+
             echo '</span>';
-         
+
          $Sender->FireEvent('AfterMeta');
          ?>
       </div>
@@ -111,7 +111,7 @@ function WriteActivity($Activity, &$Sender, &$Session) {
    } else {
       echo '<ul class="DataList ActivityComments Hidden">';
    }
-   
+
    if ($Session->CheckPermission('Garden.Profiles.Edit')):
       ?>
       <li class="CommentForm">
@@ -123,16 +123,16 @@ function WriteActivity($Activity, &$Sender, &$Session) {
          $CommentForm->AddHidden('Return', Gdn_Url::Request());
          echo $CommentForm->Open(array('action' => Url('/dashboard/activity/comment'), 'class' => 'Hidden'));
          echo '<div class="TextBoxWrapper">'.$CommentForm->TextBox('Body', array('MultiLine' => TRUE, 'value' => '')).'</div>';
-         
+
          echo '<div class="Buttons">';
          echo $CommentForm->Button('Comment', array('class' => 'Button Primary'));
          echo '</div>';
-         
+
          echo $CommentForm->Close();
       ?></li>
-   <?php 
+   <?php
    endif;
-   
+
    echo '</ul>';
 ?>
 </li>
@@ -147,7 +147,7 @@ function WriteActivityComment($Comment, &$Sender, &$Session) {
    $CssClass = 'Item ActivityComment ActivityComment';
    if ($PhotoAnchor != '')
       $CssClass .= ' HasPhoto';
-   
+
 ?>
 <li id="ActivityComment_<?php echo $Comment['ActivityCommentID']; ?>" class="<?php echo $CssClass; ?>">
    <?php if ($PhotoAnchor != '') { ?>
@@ -174,7 +174,7 @@ function WriteActivityTabs() {
    $Sender = Gdn::Controller();
    $ModPermission = Gdn::Session()->CheckPermission('Garden.Moderation.Manage');
    $AdminPermission = Gdn::Session()->CheckPermission('Garden.Settings.Manage');
-   
+
    if (!$ModPermission && !$AdminPermission)
       return;
 ?>
@@ -186,7 +186,7 @@ function WriteActivityTabs() {
             ?>
          </li>
          <?php
-         if ($ModPermission): 
+         if ($ModPermission):
          ?>
          <li <?php if ($Sender->Data('Filter') == 'mods') echo 'class="Active"'; ?>>
             <?php
@@ -195,7 +195,7 @@ function WriteActivityTabs() {
          </li>
          <?php
          endif;
-         
+
          if ($AdminPermission):
          ?>
          <li <?php if ($Sender->Data('Filter') == 'admins') echo 'class="Active"'; ?>>


### PR DESCRIPTION
- Send a wall comment notification when someone comments on a wall post.
- Wall posts and status updates now bump when comments are added.
- Fix the notifications view for wall comment and post notifications.

This PR will resolve #1663.