### PR TITLE
Set RSS DelveryType when we detect a feed format

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -518,9 +518,11 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
       switch ($Request->OutputFormat()) {
          case 'rss':
             $this->_SyndicationMethod = SYNDICATION_RSS;
+            $this->_DeliveryMethod = DELIVERY_METHOD_RSS;
             break;
          case 'atom':
             $this->_SyndicationMethod = SYNDICATION_ATOM;
+            $this->_DeliveryMethod = DELIVERY_METHOD_RSS;
             break;
          case 'default':
          default:


### PR DESCRIPTION
Pockets are currently triggered when looking at a Category RSS feed because it hits the `GdnDispatcherControllerFoundException` in the Dispatcher with a `DeliveryType` of `false`, which then overrides the `DeliveryType` to `XHTML`. When we detect the `OutputFormat()` earlier and find a syndication type result, also set the correct DeliveryType so that doesn't happen.

xdebug ![](http://icrontic.com/images/linc/dance.gif)