### PR TITLE
Don't linkify @mentions and #hashtags in CODE blocks

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1339,6 +1339,12 @@ EOT;
             return $Formatter->FormatMentions($Mixed);
          }
 
+         $protectCodeBlocks = C('Garden.Format.Mentions') || C('Garden.Format.Hashtags');
+         if($protectCodeBlocks)
+            $Mixed = preg_replace_callback('/<code>.*?[@#].*?<\/code>/si',
+               function ($match) { return preg_replace('/[@#]/', '\0\0', $match[0]);
+            }, $Mixed);
+
          // Handle @mentions.
          if(C('Garden.Format.Mentions')) {
             $urlFormat = str_replace('{name}', '$2', self::$MentionsUrlFormat);
@@ -1358,6 +1364,11 @@ EOT;
 					$Mixed
 				);
 			}
+
+         if($protectCodeBlocks)
+            $Mixed = preg_replace_callback('/<code>.*?[@#]{2}.*?<\/code>/si',
+               function ($match) { return preg_replace('/([@#]){2}/', '\1', $match[0]);
+            }, $Mixed);
 
 			// Handle "/me does x" action statements
          if(C('Garden.Format.MeActions')) {


### PR DESCRIPTION
A straightforward/dumb implementation.
Arguably it should be generalized to protect code blocks from all kinds of content modification (see #2467), implemented via preg_replace_callback processing the inter-code spans (in one step, unlike the two-step replacement here), if the idea itself will be accepted.