### PR TITLE
Don't show react button if social reactions are turned off

### DIFF
--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -184,6 +184,9 @@ class GooglePlusPlugin extends Gdn_Plugin {
     * Add 'Google+' option to the row.
     */
    public function Base_AfterReactions_Handler($Sender, $Args) {
+      if (!$this->SocialReactions()) {
+         return;
+      }
       echo Gdn_Theme::BulletItem('Share');
 //      if ($this->AccessToken()) {
 //         $Url = Url("post/twitter/{$Args['RecordType']}?id={$Args['RecordID']}", TRUE);


### PR DESCRIPTION
The config option ``Plugins.GooglePlus.SocialReactions`` wasn't respected by the plugin