### PR TITLE
Add events for TrollManagement fixes

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -1426,11 +1426,13 @@ class ProfileController extends Gdn_Controller {
     * @return bool Always true.
     */
    public function GetUserInfo($UserReference = '', $Username = '', $UserID = '', $CheckPermissions = FALSE) {
-      if ($this->_UserInfoRetrieved)
+      if ($this->_UserInfoRetrieved) {
          return;
+      }
 
-      if (!C('Garden.Profile.Public') && !Gdn::Session()->IsValid())
+      if (!C('Garden.Profile.Public') && !Gdn::Session()->IsValid()) {
          throw PermissionException();
+      }
 
       // If a UserID was provided as a querystring parameter, use it over anything else:
       if ($UserID) {
@@ -1442,13 +1444,16 @@ class ProfileController extends Gdn_Controller {
       if ($UserReference == '') {
          if ($Username) {
             $this->User = $this->UserModel->GetByUsername($Username);
-         } else
+         } else {
             $this->User = $this->UserModel->GetID(Gdn::Session()->UserID);
+         }
       } elseif (is_numeric($UserReference) && $Username != '') {
          $this->User = $this->UserModel->GetID($UserReference);
       } else {
          $this->User = $this->UserModel->GetByUsername($UserReference);
       }
+
+      $this->FireEvent('UserLoaded');
 
       if ($this->User === FALSE) {
          throw NotFoundException('User');
@@ -1475,8 +1480,9 @@ class ProfileController extends Gdn_Controller {
          }
       }
 
-      if ($CheckPermissions && Gdn::Session()->UserID != $this->User->UserID)
+      if ($CheckPermissions && Gdn::Session()->UserID != $this->User->UserID) {
          $this->Permission(array('Garden.Users.Edit', 'Moderation.Profiles.Edit'), FALSE);
+      }
 
       $this->AddSideMenu();
       $this->_UserInfoRetrieved = TRUE;

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -294,6 +294,9 @@ class CommentModel extends VanillaModel {
 
       Gdn::UserModel()->JoinUsers($Data, array('InsertUserID', 'UpdateUserID'));
 
+      $this->EventArguments['Comments'] =& $Data;
+      $this->FireEvent('AfterGet');
+
       return $Data;
    }
 
@@ -446,7 +449,7 @@ class CommentModel extends VanillaModel {
 
             if ($CountWatch < $Discussion->CountCommentWatch)
                $CountWatch = $Discussion->CountCommentWatch;
-               
+
             if (isset($Discussion->DateLastViewed))
                $NewComments |= Gdn_Format::ToTimestamp($Discussion->DateLastComment) > Gdn_Format::ToTimestamp($Discussion->DateLastViewed);
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -942,6 +942,9 @@ class DiscussionModel extends VanillaModel {
          $this->AddDenormalizedViews($Data);
       }
 
+      $this->EventArguments['Data'] =& $Data;
+      $this->FireEvent('AfterAddColumns');
+
       return $Data;
    }
 


### PR DESCRIPTION
Adds GetByUser events for filtering out troll content on their own profiles. Adds a 'UserLoaded' event to ProfileController to intercept userdata before logic is done on it.