### PR TITLE
Make BodyBox accept a param indicating whether file upload is allowed.

### DIFF
--- a/applications/conversations/views/messages/add.php
+++ b/applications/conversations/views/messages/add.php
@@ -30,7 +30,7 @@
    }
 
    echo '<div class="P">';
-   echo $this->Form->BodyBox('Body', array('Table' => 'ConversationMessage'));
+   echo $this->Form->BodyBox('Body', array('Table' => 'ConversationMessage', 'FileUpload' => true));
 //      echo Wrap($this->Form->TextBox('Body', array('MultiLine' => TRUE)), 'div', array('class' => 'TextBoxWrapper'));
    echo '</div>';
 
@@ -38,7 +38,7 @@
    echo $this->Form->Button('Start Conversation', array('class' => 'Button Primary DiscussionButton'));
    echo Anchor(T('Cancel'), '/messages/inbox', 'Button Cancel');
    echo '</div>';
-   
+
    echo $this->Form->Close();
    echo '</div>';
    ?>

--- a/applications/conversations/views/messages/addmessage.php
+++ b/applications/conversations/views/messages/addmessage.php
@@ -28,7 +28,7 @@ $this->FireEvent('BeforeMessageForm');
                echo $this->Form->Open(array('id' => 'Form_ConversationMessage', 'action' => Url('/messages/addmessage/')));
                echo $this->Form->Errors();
 //               echo Wrap($this->Form->TextBox('Body', array('MultiLine' => TRUE, 'class' => 'TextBox')), 'div', array('class' => 'TextBoxWrapper'));
-               echo $this->Form->BodyBox('Body', array('Table' => 'ConversationMessage'));
+               echo $this->Form->BodyBox('Body', array('Table' => 'ConversationMessage', 'FileUpload' => true));
                echo '<div class="Buttons">',
                   $this->Form->Button('Send Message', array('class' => 'Button Primary')),
                   '</div>';

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -28,14 +28,14 @@ $this->FireEvent('BeforeCommentForm');
                echo $this->Form->Errors();
 //               $CommentOptions = array('MultiLine' => TRUE, 'format' => GetValueR('Comment.Format', $this));
                $this->FireEvent('BeforeBodyField');
-               
-               echo $this->Form->BodyBox('Body', array('Table' => 'Comment', 'tabindex' => 1));
-               
+
+               echo $this->Form->BodyBox('Body', array('Table' => 'Comment', 'tabindex' => 1, 'FileUpload' => true));
+
                echo '<div class="CommentOptions List Inline">';
                $this->FireEvent('AfterBodyField');
                echo '</div>';
-               
-               
+
+
                echo "<div class=\"Buttons\">\n";
                $this->FireEvent('BeforeFormButtons');
                $CancelText = T('Home');

--- a/applications/vanilla/views/post/discussion.php
+++ b/applications/vanilla/views/post/discussion.php
@@ -13,7 +13,7 @@ if (!$CancelUrl) {
    <?php
 		if ($this->DeliveryType() == DELIVERY_TYPE_ALL)
 			echo Wrap($this->Data('Title'), 'h1', array('class' => 'H'));
-	
+
       echo '<div class="FormWrapper">';
       echo $this->Form->Open();
       echo $this->Form->Errors();
@@ -27,7 +27,7 @@ if (!$CancelUrl) {
 				echo '</div>';
 			echo '</div>';
       }
-      
+
       echo '<div class="P">';
 			echo $this->Form->Label('Discussion Title', 'Name');
 			echo Wrap($this->Form->TextBox('Name', array('maxlength' => 100, 'class' => 'InputBox BigInput')), 'div', array('class' => 'TextBoxWrapper'));
@@ -35,8 +35,8 @@ if (!$CancelUrl) {
 
       $this->FireEvent('BeforeBodyInput');
 		echo '<div class="P">';
-         echo $this->Form->BodyBox('Body', array('Table' => 'Discussion'));
-      
+         echo $this->Form->BodyBox('Body', array('Table' => 'Discussion', 'FileUpload' => true));
+
 //	      echo Wrap($this->Form->TextBox('Body', array('MultiLine' => TRUE, 'format' => $this->Data('Discussion.Format'))), 'div', array('class' => 'TextBoxWrapper'));
 		echo '</div>';
 
@@ -59,7 +59,7 @@ if (!$CancelUrl) {
 	         echo '<ul class="List Inline PostOptions">' . $Options .'</ul>';
 			echo '</div>';
       }
-      
+
       $this->FireEvent('AfterDiscussionFormOptions');
 
       echo '<div class="Buttons">';

--- a/applications/vanilla/views/post/editcomment.php
+++ b/applications/vanilla/views/post/editcomment.php
@@ -8,7 +8,7 @@ $Session = Gdn::Session();
             <?php
             echo $this->Form->Open();
             echo $this->Form->Errors();
-            echo $this->Form->BodyBox('Body', array('Table' => 'Comment', 'tabindex' => 1));
+            echo $this->Form->BodyBox('Body', array('Table' => 'Comment', 'tabindex' => 1, 'FileUpload' => true));
             echo "<div class=\"Buttons\">\n";
             echo Anchor(T('Cancel'), '/', 'Button Cancel').' ';
             echo $this->Form->Button('Save Comment', array('class' => 'Button Primary CommentButton', 'tabindex' => 2));

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -16,7 +16,7 @@ $PluginInfo['editor'] = array(
       'Plugins.Attachments.Upload.Allow' => 'Garden.Profiles.Edit'
    ),
    'SettingsUrl' => '/settings/editor',
-   'SettingsPermission' => 'Garden.Setttings.Manage'
+   'SettingsPermission' => 'Garden.Settings.Manage'
 );
 
 class EditorPlugin extends Gdn_Plugin {
@@ -158,7 +158,7 @@ class EditorPlugin extends Gdn_Plugin {
           'emoji' => true,
           'links' => true,
           'images' => false,
-          'uploads' => true,
+          'uploads' => false,
 
           'sep-align' => true, // separator
           'alignleft' => true,
@@ -387,11 +387,14 @@ class EditorPlugin extends Gdn_Plugin {
     * @param array $editorToolbarAll Holds the "kitchen sink" of editor actions
     * @return array Returns the array of allowed editor toolbar actions
     */
-   protected function getEditorToolbar() {
+   protected function getEditorToolbar($attributes = array()) {
       $editorToolbar        = array();
       $editorToolbarAll     = array();
       $allowedEditorActions = $this->getAllowedEditorActions();
       $allowedEditorActions['emoji'] = Emoji::instance()->hasEditorList();
+      if (val('FileUpload', $attributes)) {
+         $allowedEditorActions['uploads'] = true;
+      }
       $fontColorList        = $this->getFontColorList();
       $fontFormatOptions = $this->getFontFormatOptions();
       $fontFamilyOptions = $this->getFontFamilyOptions();
@@ -684,6 +687,11 @@ class EditorPlugin extends Gdn_Plugin {
       // when in embedded. The only problem is figuring out how to know when
       // content is embedded.
 
+      $attributes = array();
+      if (val('Attributes', $Args)) {
+         $attributes = val('Attributes', $Args);
+      }
+
       // TODO move this property to constructor
       $this->Format = $Sender->GetValue('Format');
 
@@ -717,7 +725,7 @@ class EditorPlugin extends Gdn_Plugin {
           */
          if (!isset($c->Data['_EditorToolbar'])) {
 
-            $editorToolbar = $this->getEditorToolbar();
+            $editorToolbar = $this->getEditorToolbar($attributes);
             $this->EventArguments['EditorToolbar'] =& $editorToolbar;
             $this->FireEvent('InitEditorToolbar');
 


### PR DESCRIPTION
File upload in the advanced editor is on by default. This PR makes that functionality opt-in. Signatures and Activity forms use BodyBox, but should not have file upload functionality.