### PR TITLE
Optimize ConcatSep()

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -660,16 +660,7 @@ if (!function_exists('ConcatSep')) {
          array_shift($Strings);
       }
 
-      $Result = '';
-      foreach($Strings as $String) {
-         if(!$String)
-            continue;
-
-         if($Result)
-            $Result .= $Sep;
-         $Result .= $String;
-      }
-      return $Result;
+      return implode($Sep, $Strings);
    }
 }
 


### PR DESCRIPTION
Replaced the foreach loop with php function implode.

It's slightly faster for concatenating 2 strings and gets better the more strings you glue together. For testing I took seven strings and it was 15 vs 11 seconds for 10000000 iterations

~~~
   function ConcatSep($Sep, $Str1, $Str2) {
      if(is_array($Str2)) {
         $Strings = array_merge((array)$Str1, $Str2);
      } else {
         $Strings = func_get_args();
         array_shift($Strings);
      }

      $Result = '';
      foreach($Strings as $String) {
         if(!$String)
            continue;

         if($Result)
            $Result .= $Sep;
         $Result .= $String;
      }
      return $Result;
   }

   function ConcatWithSep($Sep, $Str1, $Str2) {
      if(is_array($Str2)) {
         $Strings = array_merge((array)$Str1, $Str2);
      } else {
         $Strings = func_get_args();
         array_shift($Strings);
      }

      return implode($Sep, $Strings);
   }

$string1 = 'super';
$string2 = array('kali', 'fragi', 'listic', 'expli', 'ali', 'getic');
// $string2 = 'kalifragilisticexplialigetic';
$sep = '-';

$time_start = microtime(true);
$time_end = microtime(true);
$time = $time_end - $time_start;
$test = '';


// test old
$time_start = microtime(true);
for ($k = 0; $k < 10000000; $k++) {
   $test = ConcatSep($sep, $string1, $string2);
}
$time_end = microtime(true);
$time = $time_end - $time_start;
echo "$time seconds for old<br>";

// test new
$time_start = microtime(true);
for ($k = 0; $k < 10000000; $k++) {
   $test = ConcatWithSep($sep, $string1, $string2);
}
$time_end = microtime(true);
$time = $time_end - $time_start;
echo "$time seconds for new<br>";
~~~