### PR TITLE
Create an endpoint for accessing promoted content

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -630,8 +630,7 @@ class DiscussionsController extends VanillaController {
          $this->SetData('Errors', $Status);
       }
 
-      // Deliver JSON results.
-      $this->DeliveryMethod(DELIVERY_METHOD_JSON);
-      $this->Render();
+      $this->DeliveryMethod();
+      $this->Render('promotedcontent', 'modules', 'vanilla');
    }
 }

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -626,6 +626,11 @@ class DiscussionsController extends VanillaController {
          // Good parameters.
          $PromotedModule->GetData();
          $this->SetData('Content', $PromotedModule->Data('Content'));
+
+         // Pass display properties to the view.
+         $this->Group = $PromotedModule->Group;
+         $this->TitleLimit = $PromotedModule->TitleLimit;
+         $this->BodyLimit = $PromotedModule->BodyLimit;
       } else {
          $this->SetData('Errors', $Status);
       }

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -610,4 +610,28 @@ class DiscussionsController extends VanillaController {
       $this->DeliveryMethod(DELIVERY_METHOD_JSON);
       $this->Render();
    }
+
+   /**
+    * Endpoint for the PromotedContentModule's data.
+    *
+    * Parameters & values must be lowercase and via GET.
+    *
+    * @see PromotedContentModule
+    */
+   public function Promoted() {
+      // Create module & set data.
+      $PromotedModule = new PromotedContentModule();
+      $Status = $PromotedModule->Load(Gdn::Request()->Get());
+      if ($Status === true) {
+         // Good parameters.
+         $PromotedModule->GetData();
+         $this->SetData('Content', $PromotedModule->Data('Content'));
+      } else {
+         $this->SetData('Errors', $Status);
+      }
+
+      // Deliver JSON results.
+      $this->DeliveryMethod(DELIVERY_METHOD_JSON);
+      $this->Render();
+   }
 }

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -346,6 +346,14 @@ class PromotedContentModule extends Gdn_Module {
          $CategoryID = GetValue('CategoryID', $Parameters, NULL);
       }
 
+      // Allow category names, and validate category exists.
+      // Disallow multiple categories.
+      if (is_array($CategoryID)) {
+         $CategoryID = array_shift($CategoryID);
+      }
+      $Category = CategoryModel::Categories($CategoryID);
+      $CategoryID = val('CategoryID', $Category);
+
       if (!$CategoryID) {
          return false;
       }

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -201,7 +201,9 @@ class PromotedContentModule extends Gdn_Module {
       }
 
       // Check cache
-      $SelectorRoleCacheKey = "modules.promotedcontent.role.{$RoleID}";
+      sort($RoleID);
+      $RoleIDKey = implode('-', $RoleID);
+      $SelectorRoleCacheKey = "modules.promotedcontent.role.{$RoleIDKey}";
       $Content = Gdn::Cache()->Get($SelectorRoleCacheKey);
 
       if ($Content == Gdn_Cache::CACHEOP_FAILURE) {

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -21,6 +21,7 @@ class PromotedContentModule extends Gdn_Module {
     *  - rank        Author's Rank
     *  - category    Content's Category
     *  - score       Content's Score
+    *  - promoted
     * @var string
     */
    public $Selector;
@@ -133,11 +134,10 @@ class PromotedContentModule extends Gdn_Module {
 
       // Validate selection.
       $validation->applyRule('selection', 'String');
-      $validation->applyRule('selection', 'Required');
 
       // Validate selector.
       $validation->applyRule('selector', 'Required');
-      $selectorWhitelist = array('role', 'rank', 'category', 'score');
+      $selectorWhitelist = array('role', 'rank', 'category', 'score', 'promoted');
       if (isset($Parameters['selector']) && !in_array($Parameters['selector'], $selectorWhitelist)) {
          $validation->AddValidationResult('selector', 'Invalid selector.');
       }

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -561,7 +561,7 @@ class PromotedContentModule extends Gdn_Module {
       }
 
       $Interleaved = array_reverse($Interleaved);
-      return $Interleaved;
+      return array_values($Interleaved);
    }
 
    /**

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -266,13 +266,26 @@ class PromotedContentModule extends Gdn_Module {
     * @return array|false
     */
    protected function SelectByRank($Parameters) {
+      // Must have Ranks enabled.
+      if (!class_exists('RankModel')) {
+         return false;
+      }
+
       if (!is_array($Parameters)) {
          $RankID = $Parameters;
       } else {
          $RankID = GetValue('RankID', $Parameters, NULL);
       }
 
-      if (!$RankID) {
+      // Check for Rank passed by name.
+      if (!is_numeric($RankID)) {
+         $RankModel = new RankModel();
+         $Rank = $RankModel->GetWhere(array('Name' => $RankID))->FirstRow();
+         $RankID = val('RankID', $Rank);
+      }
+
+      // Disallow blank or multiple ranks.
+      if (!$RankID || is_array($RankID)) {
          return false;
       }
 
@@ -347,14 +360,11 @@ class PromotedContentModule extends Gdn_Module {
       }
 
       // Allow category names, and validate category exists.
-      // Disallow multiple categories.
-      if (is_array($CategoryID)) {
-         $CategoryID = array_shift($CategoryID);
-      }
       $Category = CategoryModel::Categories($CategoryID);
       $CategoryID = val('CategoryID', $Category);
 
-      if (!$CategoryID) {
+      // Disallow invalid or multiple categories.
+      if (!$CategoryID || is_array($CategoryID)) {
          return false;
       }
 

--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -28,7 +28,7 @@ class PromotedContentModule extends Gdn_Module {
 
    /**
     * Parameters for the selector method
-    * @var mixed
+    * @var string|int
     */
    public $Selection;
 
@@ -120,7 +120,7 @@ class PromotedContentModule extends Gdn_Module {
     *
     * @param array $Parameters.
     *
-    * @return mixed true on success or string (message) on error.
+    * @return string|true True on success or string (message) on error.
     */
    public function Validate($Parameters = array()) {
       $validation = new Gdn_Validation();
@@ -168,7 +168,7 @@ class PromotedContentModule extends Gdn_Module {
    /**
     * Select content based on author RoleID.
     *
-    * @param mixed $Parameters
+    * @param array|int $Parameters
     *
     * @return array|false
     */
@@ -259,7 +259,7 @@ class PromotedContentModule extends Gdn_Module {
    /**
     * Select content based on author RankID.
     *
-    * @param mixed $Parameters
+    * @param array|int $Parameters
     *
     * @return array|false
     */
@@ -333,7 +333,7 @@ class PromotedContentModule extends Gdn_Module {
    /**
     * Select content based on its CategoryID.
     *
-    * @param mixed $Parameters
+    * @param array|int $Parameters
     *
     * @return array|false
     */
@@ -407,7 +407,7 @@ class PromotedContentModule extends Gdn_Module {
    /**
     * Select content based on its Score.
     *
-    * @param mixed $Parameters
+    * @param array|int $Parameters
     *
     * @return array|false
     */

--- a/applications/vanilla/views/discussions/promoted.php
+++ b/applications/vanilla/views/discussions/promoted.php
@@ -1,0 +1,1 @@
+<?php if (!defined('APPLICATION')) exit();

--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -91,7 +91,7 @@ function WritePromotedContent($Content, $Sender) {
       <div class="Body">
       <?php
          echo Anchor(strip_tags(Gdn_Format::To(SliceString($Content['Body'], $Sender->BodyLimit), $Content['Format'])), $ContentURL, 'BodyLink');
-         $Sender->FireEvent('AfterBody'); // seperate event to account for less space.
+         $Sender->FireEvent('AfterPromotedBody'); // separate event to account for less space.
       ?>
       </div>
    </div>

--- a/applications/vanilla/views/modules/promotedcontent.php
+++ b/applications/vanilla/views/modules/promotedcontent.php
@@ -1,5 +1,5 @@
 <?php if (!defined('APPLICATION')) exit();
-require_once $this->FetchViewLocation('helper_functions');
+require_once $this->FetchViewLocation('helper_functions', 'modules', 'vanilla');
 
 ?>
 <div class="Box BoxPromoted">

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1395,6 +1395,8 @@ class Gdn_Controller extends Gdn_Pluggable {
       if ($CleanOutut) {
          // Remove values that should not be transmitted via api
          $Remove = array('Password', 'HashMethod', 'TransientKey', 'Permissions', 'Attributes', 'AccessToken');
+
+         // Remove PersonalInfo values for unprivileged requests.
          if (!Gdn::Session()->CheckPermission('Garden.Moderation.Manage')) {
             $Remove[] = 'InsertIPAddress';
             $Remove[] = 'UpdateIPAddress';
@@ -1404,6 +1406,22 @@ class Gdn_Controller extends Gdn_Pluggable {
             if (C('Api.Clean.Email', TRUE))
                $Remove[] = 'Email';
             $Remove[] = 'DateOfBirth';
+            $Remove[] = 'Preferences';
+            $Remove[] = 'Banned';
+            $Remove[] = 'Admin';
+            $Remove[] = 'Confirmed';
+            $Remove[] = 'Verified';
+            $Remove[] = 'DiscoveryText';
+            $Remove[] = 'InviteUserID';
+            $Remove[] = 'DateSetInvitations';
+            $Remove[] = 'CountInvitations';
+            $Remove[] = 'CountNotifications';
+            $Remove[] = 'CountBookmarks';
+            $Remove[] = 'CountDrafts';
+            $Remove[] = 'HourOffset';
+            $Remove[] = 'Gender';
+            $Remove[] = 'Punished';
+            $Remove[] = 'Troll';
          }
          $Data = RemoveKeysFromNestedArray($Data, $Remove);
       }


### PR DESCRIPTION
* Add `Promoted` endpoint on `DiscussionsController` to access `PromotedContentModule`.
* Filter additional user info from API calls that should be PersonalInfo by default. It would otherwise be exposed by this endpoint.
* Refactor PromotedContentModule to allow controller access  via `Load` & `Validate` methods.
* Make the `SelectBy*` methods all work the same if only `selection` value is passed as `$Parameters`.
* Fix array index issue in `Prepare`.
* Fix passing ID array in `SelectByCategory`.
* Fix misc coding standards & docs throughout `PromotedContentModule`.
* Fix caching of multiple RoleIDs in selection (array to string conversion error).
* Allow Ranks & Categories to be selected by Name.
* Remove date keying of `Content` array.