### PR TITLE
Add CategoryData as reserved attribute

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -2377,7 +2377,9 @@ PASSWORDMETER;
          'includenull',
          'yearrange',
          'fields',
-         'inlineerrors');
+         'inlineerrors',
+         'categorydata'
+      );
       $Return = '';
 
       // Build string from array


### PR DESCRIPTION
This prevents the option from appearing as an attribute in the select tag when using the CategoryDropdown with custom data:

    categorydata="Array"