### PR TITLE
Revert "Smarty pocket: Add Sender param."

### DIFF
--- a/library/vendors/SmartyPlugins/function.pocket.php
+++ b/library/vendors/SmartyPlugins/function.pocket.php
@@ -17,12 +17,11 @@
 function smarty_function_pocket($Params, $Smarty) {
    if (!class_exists('PocketsPlugin'))
       return '';
-
+   
    $Name = GetValue('name', $Params);
    unset($Params['name']);
-   $Params['sender'] = $Smarty;
    
    $Result = PocketsPlugin::PocketString($Name, $Params);
-
+   
 	return $Result;
 }


### PR DESCRIPTION
Depending on the smarty instance in pockets is not good functionality because then the pockets can only be called from within smarty.