### PR TITLE
Provide a helper function for determining if a discussion can be edited.

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -138,16 +138,11 @@ class PostController extends VanillaController {
 
       // Check permission
       if (isset($this->Discussion)) {
-
-         // Permission to edit
-         if ($this->Discussion->InsertUserID != $Session->UserID)
-            $this->Permission('Vanilla.Discussions.Edit', TRUE, 'Category', $this->Category->PermissionCategoryID);
-
          // Make sure that content can (still) be edited.
-         $EditContentTimeout = C('Garden.EditContentTimeout', -1);
-         $CanEdit = $EditContentTimeout == -1 || strtotime($this->Discussion->DateInserted) + $EditContentTimeout > time();
-         if (!$CanEdit)
-            $this->Permission('Vanilla.Discussions.Edit', TRUE, 'Category', $this->Category->PermissionCategoryID);
+         $CanEdit = DiscussionModel::canEdit($this->Discussion);
+         if (!$CanEdit) {
+            throw PermissionException('Vanilla.Discussions.Edit');
+         }
 
          // Make sure only moderators can edit closed things
          if ($this->Discussion->Closed)

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -189,22 +189,15 @@ function GetDiscussionOptions($Discussion = NULL) {
 		$CategoryID = GetValue('CategoryID', $Sender->Discussion);
    $PermissionCategoryID = GetValue('PermissionCategoryID', $Discussion, GetValue('PermissionCategoryID', $Discussion));
 
-   // Determine if we still have time to edit
-   $EditContentTimeout = C('Garden.EditContentTimeout', -1);
-	$CanEdit = $EditContentTimeout == -1 || strtotime($Discussion->DateInserted) + $EditContentTimeout > time();
-   $CanEdit = ($CanEdit && $Session->UserID == $Discussion->InsertUserID) || $Session->CheckPermission('Vanilla.Discussions.Edit', TRUE, 'Category', $PermissionCategoryID);
-
-	$TimeLeft = '';
-
-	if ($CanEdit && $EditContentTimeout > 0 && !$Session->CheckPermission('Vanilla.Discussions.Edit', TRUE, 'Category', $PermissionCategoryID)) {
-		$TimeLeft = strtotime($Discussion->DateInserted) + $EditContentTimeout - time();
-		$TimeLeft = $TimeLeft > 0 ? ' ('.Gdn_Format::Seconds($TimeLeft).')' : '';
-	}
-
 	// Build the $Options array based on current user's permission.
    // Can the user edit the discussion?
-   if ($CanEdit)
+   $CanEdit = DiscussionModel::canEdit($Discussion, $TimeLeft);
+   if ($CanEdit) {
+      if ($TimeLeft) {
+         $TimeLeft = ' ('.Gdn_Format::Seconds($TimeLeft).')';
+      }
       $Options['EditDiscussion'] = array('Label' => T('Edit').$TimeLeft, 'Url' => '/vanilla/post/editdiscussion/'.$Discussion->DiscussionID);
+   }
 
    // Can the user announce?
    if ($Session->CheckPermission('Vanilla.Discussions.Announce', TRUE, 'Category', $PermissionCategoryID))

--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -398,13 +398,8 @@ function OptionsList($Discussion) {
       if (C('Vanilla.Discussions.Dismiss', 1) && $Discussion->Announce == '1' && $Discussion->Dismissed != '1')
          $Sender->Options .= '<li>'.Anchor(T('Dismiss'), "vanilla/discussion/dismissannouncement?discussionid={$Discussion->DiscussionID}", 'DismissAnnouncement Hijack') . '</li>';
 
-      // Determine if we still have time to edit
-      $EditContentTimeout = C('Garden.EditContentTimeout', -1);
-      $CanEdit = $EditContentTimeout == -1 || strtotime($Discussion->DateInserted) + $EditContentTimeout > time();
-      $CanEdit = ($CanEdit && $Session->UserID == $Discussion->InsertUserID) || $Session->CheckPermission('Vanilla.Discussions.Edit', TRUE, 'Category', $Discussion->PermissionCategoryID);
-
       // Edit discussion
-      if ($CanEdit) {
+      if (DiscussionModel::canEdit($Discussion)) {
          $Sender->Options .= '<li>'.Anchor(T('Edit'), 'vanilla/post/editdiscussion/'.$Discussion->DiscussionID, 'EditDiscussion') . '</li>';
       }
 


### PR DESCRIPTION
Moves the more complex logic of discussion edit permissions into a single place to reduce inconsistency errors.