### PR TITLE
Allow the dirty cache to store null values.

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1104,8 +1104,9 @@ class UserModel extends Gdn_Model {
          $User = parent::GetID($ID, DATASET_TYPE_ARRAY);
 
          // We want to cache a non-existant user no-matter what.
-         if (!$User)
+         if (!$User) {
             $User = NULL;
+         }
 
          $this->UserCache($User, $ID);
       } elseif (!$User) {

--- a/library/core/class.dirtycache.php
+++ b/library/core/class.dirtycache.php
@@ -2,77 +2,79 @@
 
 /**
  * Cache Layer: Dirty
- * 
- * This is a cache implementation that caches nothing and always reports 
+ *
+ * This is a cache implementation that caches nothing and always reports
  * cache misses.
- * 
+ *
  * @author Tim Gunter <tim@vanillaforums.com>
  * @copyright 2003 Vanilla Forums, Inc
  * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
  * @package Garden
  * @since 2.0
  */
- 
+
 class Gdn_Dirtycache extends Gdn_Cache {
    protected $Cache = array();
-   
+
    public function __construct() {
       parent::__construct();
       $this->CacheType = Gdn_Cache::CACHE_TYPE_NULL;
    }
-   
+
    public function AddContainer($Options) {
       return Gdn_Cache::CACHEOP_SUCCESS;
    }
-   
+
    public function Add($Key, $Value, $Options = array()) {
       return $this->Store($Key, $Value, $Options);
    }
-   
+
    public function Store($Key, $Value, $Options = array()) {
       $this->Cache[$Key] = $Value;
       return Gdn_Cache::CACHEOP_SUCCESS;
    }
-   
+
    public function Exists($Key) {
       return Gdn_Cache::CACHEOP_FAILURE;
    }
-   
+
    public function Get($Key, $Options = array()) {
       if (is_array($Key)) {
          $Result = array();
          foreach ($Key as $k) {
-            if (isset($this->Cache[$k]))
+            if (isset($this->Cache[$k])) {
                $Result[$k] = $this->Cache[$k];
+            }
          }
          return $Result;
       } else {
-         if (isset($this->Cache[$Key]))
+         if (array_key_exists($Key, $this->Cache)) {
             return $this->Cache[$Key];
-         else
+         } else {
             return Gdn_Cache::CACHEOP_FAILURE;
+         }
       }
    }
-   
+
    public function Remove($Key, $Options = array()) {
       unset($this->Cache[$Key]);
-      
+
       return Gdn_Cache::CACHEOP_SUCCESS;
    }
-   
+
    public function Replace($Key, $Value, $Options = array()) {
       $this->Cache[$Key] = $Value;
       return Gdn_Cache::CACHEOP_SUCCESS;
    }
-   
+
    public function Increment($Key, $Amount = 1, $Options = array()) {
       return Gdn_Cache::CACHEOP_SUCCESS;
    }
-   
+
    public function Decrement($Key, $Amount = 1, $Options = array()) {
       return Gdn_Cache::CACHEOP_SUCCESS;
    }
-   
+
    public function Flush() {
       return TRUE;
    }


### PR DESCRIPTION
The user model stores null users when a user does not exist so that it isn’t queried again and again. The dirty cache does not properly handle this leading to some cases of the user getting queried too many times on a page.