### PR TITLE
Mobile theme options: Render a view

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1011,7 +1011,7 @@ class SettingsController extends DashboardController {
          $this->Form->AddError($Ex);
       }
 
-      $this->Render();
+      $this->Render('themeoptions');
    }
 
    /**


### PR DESCRIPTION
Mobile theme options aren't working, as there is no view. This simply uses the `themeoptions` view to display mobile theme options.