### PR TITLE
Eliminate one GetMentions() call

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1708,7 +1708,7 @@ class DiscussionModel extends VanillaModel {
                   $Activity['Story'] = $Story;
 
                // Notify all of the users that were mentioned in the discussion.
-               $Usernames = array_merge(GetMentions($DiscussionName), GetMentions($Story));
+               $Usernames = GetMentions($DiscussionName.' '.$Story);
                $Usernames = array_unique($Usernames);
 
                // Use our generic Activity for events, not mentions


### PR DESCRIPTION
GetMentions was called for discussion body and for discussion title and then the result arrays were merged.
Simplified that to one call to GetMentions() with title _and_ body as arguments.