### PR TITLE
Don’t allow https urls when Garden.AllowSSL is false.

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -859,6 +859,8 @@ class Gdn_Request {
             $Path = str_replace('https:', 'http:', $Path);
             $Scheme = 'http';
          }
+      } elseif (!$AllowSSL) {
+         $Scheme = 'http';
       } else {
          $Scheme = $this->Scheme();
       }
@@ -872,7 +874,7 @@ class Gdn_Request {
       if (!in_array($Port, array(80, 443)) && (strpos($Host, ':'.$Port) === FALSE))
          $Host .= ':'.$Port;
 
-      if ($WithDomain === '//') {
+      if ($WithDomain === '//' && $AllowSSL) {
          $Parts[] = '//'.$Host;
       } elseif ($WithDomain && $WithDomain !== '/') {
          $Parts[] = $Scheme.'://'.$Host;


### PR DESCRIPTION
This will make sure that only http urls are returned when SSL is forbidden.

Please note that although this is a small change it does risk breaking backwards compatibility and caching scenarios. It needs to be tested in various scenarios. On sites with a custom domain. Make sure it doesn’t break accessing the *.vanillaforums.com version.