### PR TITLE
Abandon the 2.2 namespace and never look back

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@
  */
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.2.18');
+define('APPLICATION_VERSION', '2.2.100');
 
 // Report and track all errors.
 


### PR DESCRIPTION
Fast-forward master version to 2.2.100 so that open source release can occupy 2.2.x.