### PR TITLE
Fix too-short private message subject allowance

### DIFF
--- a/applications/conversations/settings/structure.php
+++ b/applications/conversations/settings/structure.php
@@ -34,7 +34,7 @@ $Construct
    ->PrimaryKey('ConversationID')
    ->Column('Type', 'varchar(10)', TRUE, 'index')
    ->Column('ForeignID', 'varchar(40)', TRUE)
-   ->Column('Subject', 'varchar(100)', NULL)
+   ->Column('Subject', 'varchar(255)', NULL)
    ->Column('Contributors', 'varchar(255)')
    ->Column('FirstMessageID', 'int', TRUE, 'key')
    ->Column('InsertUserID', 'int', FALSE, 'key')


### PR DESCRIPTION
Expand GDN_Conversation.Subject column to 255 characters from 100 characters.

Groups currently sends an invitation that uses the field. The German translation apparently exceeds the threshold. Reasonable size increase and a fairly conservative database change to make.