### PR TITLE
Hotfix/display as category

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -190,14 +190,14 @@ class CategoriesController extends VanillaController {
                switch($Layout) {
                   case 'mixed':
                      $this->View = 'discussions';
-                     $this->Discussions($CategoryIdentifier, FALSE);
+                     $this->Discussions($CategoryIdentifier);
                      break;
                   case 'table':
-                     $this->Table($CategoryIdentifier, FALSE);
+                     $this->Table($CategoryIdentifier);
                      break;
                   default:
                      $this->View = 'all';
-                     $this->All($CategoryIdentifier, FALSE);
+                     $this->All($CategoryIdentifier);
                      break;
                }
                return;
@@ -329,6 +329,7 @@ class CategoriesController extends VanillaController {
    /**
     * Show all (nested) categories.
     *
+    * @param string $Category The url code of the parent category.
     * @since 2.0.17
     * @access public
     */
@@ -383,16 +384,16 @@ class CategoriesController extends VanillaController {
    /**
     * Show all categories and few discussions from each.
     *
+    * @param string $Category The url code of the parent category.
     * @since 2.0.0
     * @access public
     */
    public function Discussions($Category = '') {
       // Setup head
       $this->AddCssFile('vanilla.css');
-      $this->Menu->HighlightRoute('/discussions');
       $this->AddJsFile('discussions.js');
-
       $this->Menu->HighlightRoute('/discussions');
+
       if (!$this->Title()) {
          $Title = C('Garden.HomepageTitle');
          if ($Title)

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -109,12 +109,12 @@ class CategoriesController extends VanillaController {
    /**
     * "Table" layout for categories. Mimics more traditional forum category layout.
     */
-   public function Table($Category = '', $isRoot = TRUE) {
+   public function Table($Category = '') {
       if ($this->SyndicationMethod == SYNDICATION_NONE) {
          $this->View = 'table';
       } else
          $this->View = 'all';
-      $this->All($Category, $isRoot);
+      $this->All($Category);
    }
 
    /**
@@ -332,7 +332,7 @@ class CategoriesController extends VanillaController {
     * @since 2.0.17
     * @access public
     */
-   public function All($Category = '', $isRoot = TRUE) {
+   public function All($Category = '') {
       // Setup head.
       $this->Menu->HighlightRoute('/discussions');
       if (!$this->Title()) {
@@ -344,7 +344,7 @@ class CategoriesController extends VanillaController {
       }
       Gdn_Theme::Section('CategoryList');
 
-      if ($isRoot) {
+      if (!$Category) {
          $this->Description(C('Garden.Description', NULL));
       }
 
@@ -386,7 +386,7 @@ class CategoriesController extends VanillaController {
     * @since 2.0.0
     * @access public
     */
-   public function Discussions($Category = '', $isRoot = TRUE) {
+   public function Discussions($Category = '') {
       // Setup head
       $this->AddCssFile('vanilla.css');
       $this->Menu->HighlightRoute('/discussions');
@@ -401,7 +401,7 @@ class CategoriesController extends VanillaController {
             $this->Title(T('All Categories'));
       }
 
-      if ($isRoot) {
+      if (!$Category) {
          $this->Description(C('Garden.Description', NULL));
       }
 

--- a/applications/vanilla/views/categories/all.php
+++ b/applications/vanilla/views/categories/all.php
@@ -11,7 +11,7 @@ $this->FireEvent('AfterPageTitle');
 
 $CatList = '';
 $DoHeadings = C('Vanilla.Categories.DoHeadings');
-$MaxDisplayDepth = C('Vanilla.Categories.MaxDisplayDepth');
+$MaxDisplayDepth = C('Vanilla.Categories.MaxDisplayDepth') + $this->Data('Category')->Depth;
 $ChildCategories = '';
 $this->EventArguments['NumRows'] = count($this->Data('Categories'));
 

--- a/applications/vanilla/views/categories/discussions.php
+++ b/applications/vanilla/views/categories/discussions.php
@@ -9,29 +9,30 @@ $ViewLocation = $this->FetchViewLocation('discussions', 'discussions');
 
       $this->Category = $Category;
       $this->DiscussionData = $this->CategoryDiscussionData[$Category->CategoryID];
-      
+
       if ($this->DiscussionData->NumRows() > 0) : ?>
-      
-   <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">      
+
+   <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">
+      <?php echo GetOptions($Category); ?>
       <h2 class="H"><?php
             echo Anchor(htmlspecialchars($Category->Name), CategoryUrl($Category));
             Gdn::Controller()->EventArguments['Category'] = $Category;
-            Gdn::Controller()->FireEvent('AfterCategoryTitle'); 
+            Gdn::Controller()->FireEvent('AfterCategoryTitle');
       ?></h2>
-      
+
       <ul class="DataList Discussions">
          <?php include($this->FetchViewLocation('discussions', 'discussions')); ?>
       </ul>
-      
+
       <?php if ($this->DiscussionData->NumRows() == $this->DiscussionsPerCategory) : ?>
       <div class="MorePager">
          <?php echo Anchor(T('More Discussions'), '/categories/'.$Category->UrlCode); ?>
       </div>
       <?php endif; ?>
-      
+
    </div>
-   
+
       <?php endif; ?>
-      
+
    <?php endforeach; ?>
 </div>


### PR DESCRIPTION
Fixes bug where site description displays on page for subcategory with 'Display as categories' option enabled.
Fixes bug where CategoryFilterToggle does not work with mixed view.
Fixes bug where subcategories with 'Display as categories' option enabled have no child categories appear due to max display depth not being updated.