### PR TITLE
Profile activity: Allow users to curate the activity on their own wall.

### DIFF
--- a/applications/dashboard/controllers/class.activitycontroller.php
+++ b/applications/dashboard/controllers/class.activitycontroller.php
@@ -161,8 +161,11 @@ class ActivityController extends Gdn_Controller {
       }
 
       $comment = $this->ActivityModel->GetComment($ID);
-      $activity = $this->ActivityModel->GetID(val('ActivityID', $comment));
+      if (!$comment) {
+         throw NotFoundException('Comment');
+      }
 
+      $activity = $this->ActivityModel->GetID(val('ActivityID', $comment));
       if (!$activity) {
          throw NotFoundException('Activity');
       }
@@ -171,8 +174,9 @@ class ActivityController extends Gdn_Controller {
          throw PermissionException();
       }
       $this->ActivityModel->DeleteComment($ID);
-      if ($this->DeliveryType() === DELIVERY_TYPE_ALL)
+      if ($this->DeliveryType() === DELIVERY_TYPE_ALL) {
          Redirect($Target);
+      }
 
       $this->Render('Blank', 'Utility', 'Dashboard');
    }

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -488,7 +488,6 @@ class ActivityModel extends Gdn_Model {
       $session = Gdn::Session();
 
       $profileUserId = val('ActivityUserID', $activity);
-//      $insertUserId = val('InsertUserID', $activity);
       $notifyUserId = val('NotifyUserID', $activity);
 
       // User can delete any activity
@@ -510,7 +509,8 @@ class ActivityModel extends Gdn_Model {
          return true;
       }
 
-      // The user inserted the activity
+      // The user inserted the activity --- may be added in later
+//      $insertUserId = val('InsertUserID', $activity);
 //      if ($insertUserId && $insertUserId == $session->UserID) {
 //         return true;
 //      }

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -479,6 +479,45 @@ class ActivityModel extends Gdn_Model {
       return $Result;
    }
 
+
+   /**
+    * @param $activity
+    * @return bool
+    */
+   public static function canDelete($activity) {
+      $session = Gdn::Session();
+
+      $profileUserId = val('ActivityUserID', $activity);
+//      $insertUserId = val('InsertUserID', $activity);
+      $notifyUserId = val('NotifyUserID', $activity);
+
+      // User can delete any activity
+      if ($session->CheckPermission('Garden.Activity.Delete')) {
+         return true;
+      }
+
+      $notifyUserIds = array(ActivityModel::NOTIFY_PUBLIC);
+      if (Gdn::Session()->CheckPermission('Garden.Moderation.Manage')) {
+         $notifyUserIds[] = ActivityModel::NOTIFY_MODS;
+      }
+
+      // Is this a wall post?
+      if (!in_array($notifyUserId, $notifyUserIds)) {
+         return false;
+      }
+      // Is this on the user's wall?
+      if ($profileUserId && $session->UserID == $profileUserId && $session->CheckPermission('Garden.Profiles.Edit')) {
+         return true;
+      }
+
+      // The user inserted the activity
+//      if ($insertUserId && $insertUserId == $session->UserID) {
+//         return true;
+//      }
+
+      return false;
+   }
+
    /**
     * Get notifications for a user since designated ActivityID.
     *

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -501,7 +501,7 @@ class ActivityModel extends Gdn_Model {
       }
 
       // Is this a wall post?
-      if (!in_array($notifyUserId, $notifyUserIds)) {
+      if (!in_array(val('ActivityType', $activity), array('Status', 'WallPost')) || !in_array($notifyUserId, $notifyUserIds)) {
          return false;
       }
       // Is this on the user's wall?

--- a/applications/dashboard/views/activity/helper_functions.php
+++ b/applications/dashboard/views/activity/helper_functions.php
@@ -50,12 +50,8 @@ function WriteActivity($Activity, &$Sender, &$Session) {
    ?>
 <li id="Activity_<?php echo $Activity->ActivityID; ?>" class="<?php echo $CssClass; ?>">
    <?php
-   if (
-      $Session->IsValid()
-      && ($Session->UserID == $Activity->InsertUserID
-         || $Session->CheckPermission('Garden.Activity.Delete'))
-      )
-      echo '<div class="Options">'.Anchor('×', 'dashboard/activity/delete/'.$Activity->ActivityID.'/'.$Session->TransientKey().'?Target='.urlencode($Sender->SelfUrl), 'Delete').'</div>';
+   if (ActivityController::canDelete($Activity->ActivityID, $Session->TransientKey(),  $Sender->ProfileUserID, $Activity->InsertUserID))
+      echo '<div class="Options">'.Anchor('×', 'dashboard/activity/delete/'.$Activity->ActivityID.'/'.$Session->TransientKey().'?Target='.urlencode($Sender->SelfUrl).'&profileUserId='.$Sender->ProfileUserID.'&insertUserId='.$Activity->InsertUserID, 'Delete').'</div>';
 
    if ($PhotoAnchor != '') {
    ?>
@@ -159,8 +155,9 @@ function WriteActivityComment($Comment, &$Sender, &$Session) {
       <div class="Meta">
          <span class="DateCreated"><?php echo Gdn_Format::Date($Comment['DateInserted'], 'html'); ?></span>
          <?php
-            if ($Session->UserID == $Comment['InsertUserID'] || $Session->CheckPermission('Garden.Activity.Delete'))
-               echo Anchor(T('Delete'), "dashboard/activity/deletecomment?id={$Comment['ActivityCommentID']}&tk=".$Session->TransientKey().'&target='.urlencode(Gdn_Url::Request()), 'DeleteComment');
+            if (ActivityController::canDelete($Comment['ActivityCommentID'], $Session->TransientKey(), $Sender->ProfileUserID, val('InsertUserID', $Comment))) {
+               echo Anchor(T('Delete'), "dashboard/activity/deletecomment?id={$Comment['ActivityCommentID']}&tk=".$Session->TransientKey().'&target='.urlencode(Gdn_Url::Request()).'&profileUserId='.$Sender->ProfileUserID.'&insertUserId='.val('InsertUserID', $Comment), 'DeleteComment');
+            }
          ?>
       </div>
    </div>

--- a/applications/dashboard/views/activity/helper_functions.php
+++ b/applications/dashboard/views/activity/helper_functions.php
@@ -50,9 +50,9 @@ function WriteActivity($Activity, &$Sender, &$Session) {
    ?>
 <li id="Activity_<?php echo $Activity->ActivityID; ?>" class="<?php echo $CssClass; ?>">
    <?php
-   if (ActivityController::canDelete($Activity->ActivityID, $Session->TransientKey(),  $Sender->ProfileUserID, $Activity->InsertUserID))
-      echo '<div class="Options">'.Anchor('×', 'dashboard/activity/delete/'.$Activity->ActivityID.'/'.$Session->TransientKey().'?Target='.urlencode($Sender->SelfUrl).'&profileUserId='.$Sender->ProfileUserID.'&insertUserId='.$Activity->InsertUserID, 'Delete').'</div>';
-
+   if (ActivityModel::canDelete($Activity)) {
+      echo '<div class="Options">'.Anchor('×', 'dashboard/activity/delete/'.$Activity->ActivityID.'/'.$Session->TransientKey().'?Target='.urlencode($Sender->SelfUrl), 'Delete').'</div>';
+   }
    if ($PhotoAnchor != '') {
    ?>
    <div class="Author Photo"><?php echo $PhotoAnchor; ?></div>
@@ -102,7 +102,7 @@ function WriteActivity($Activity, &$Sender, &$Session) {
    if (count($Comments) > 0) {
       echo '<ul class="DataList ActivityComments">';
       foreach ($Comments as $Comment) {
-         WriteActivityComment($Comment, $Sender, $Session);
+         WriteActivityComment($Comment, $Activity);
       }
    } else {
       echo '<ul class="DataList ActivityComments Hidden">';
@@ -137,7 +137,8 @@ function WriteActivity($Activity, &$Sender, &$Session) {
 
 if (!function_exists('WriteActivityComment')):
 
-function WriteActivityComment($Comment, &$Sender, &$Session) {
+function WriteActivityComment($Comment, $Activity) {
+   $Session = Gdn::Session();
    $Author = UserBuilder($Comment, 'Insert');
    $PhotoAnchor = UserPhoto($Author, 'Photo');
    $CssClass = 'Item ActivityComment ActivityComment';
@@ -155,8 +156,8 @@ function WriteActivityComment($Comment, &$Sender, &$Session) {
       <div class="Meta">
          <span class="DateCreated"><?php echo Gdn_Format::Date($Comment['DateInserted'], 'html'); ?></span>
          <?php
-            if (ActivityController::canDelete($Comment['ActivityCommentID'], $Session->TransientKey(), $Sender->ProfileUserID, val('InsertUserID', $Comment))) {
-               echo Anchor(T('Delete'), "dashboard/activity/deletecomment?id={$Comment['ActivityCommentID']}&tk=".$Session->TransientKey().'&target='.urlencode(Gdn_Url::Request()).'&profileUserId='.$Sender->ProfileUserID.'&insertUserId='.val('InsertUserID', $Comment), 'DeleteComment');
+            if (ActivityModel::canDelete($Activity)) {
+               echo Anchor(T('Delete'), "dashboard/activity/deletecomment?id={$Comment['ActivityCommentID']}&tk=".$Session->TransientKey().'&target='.urlencode(Gdn_Url::Request()), 'DeleteComment');
             }
          ?>
       </div>


### PR DESCRIPTION
Users with the Garden.Profiles.Edit permission will now be able to delete any activity on their own wall.

Also:
Add function to check whether a user has permission to delete.
Revoke ability for users to delete their own posts on other users' walls.