### PR TITLE
NamedParameter() didn't eliminate dashes

### DIFF
--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1355,7 +1355,7 @@ abstract class Gdn_SQLDriver {
     */
    public function NamedParameter($Name, $CreateNew = FALSE, $Value = NULL) {
       // Format the parameter name so it is safe for sql
-      $NiceName = ':'.preg_replace('/([^\w\d_-])/', '', $Name); // Removes everything from the string except letters, numbers, dashes, and underscores
+      $NiceName = ':'.preg_replace('/([^\w\d_])/', '', $Name); // Removes everything from the string except letters, numbers and underscores
 
       if($CreateNew) {
          // Make sure that the new name doesn't already exist.


### PR DESCRIPTION
Dashes are not eliminated by NamedParameter() so that a column name with a dash could cause a PDO error. See here: http://vanillaforums.org/discussion/29710/view-permissions-not-working#latest

Dashes are nor allowed in named parameters, only alphanumerics and underscores: 
https://github.com/php/php-src/blob/master/ext/pdo/pdo_sql_parser.re#L49