### PR TITLE
Use PHP 5.2 function filter_var() for validations

### DIFF
--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -33,8 +33,7 @@ if (!function_exists('ValidateCaptcha')) {
 
 if (!function_exists('ValidateRegex')) {
    function ValidateRegex($Value, $Regex) {
-      preg_match($Regex, $Value, $Matches);
-      return is_array($Matches) && count($Matches) > 0 ? TRUE : FALSE;
+      return (!filter_var($Value, FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => $Regex))) === false);
    }
 }
 
@@ -135,12 +134,11 @@ if (!function_exists('ValidateOldPassword')) {
 
 if (!function_exists('ValidateEmail')) {
    function ValidateEmail($Value, $Field = '') {
-      if (!ValidateRequired($Value))
-         return TRUE;
+      if (!ValidateRequired($Value, $Field)) {
+         return true;
+      }
 
-      $Result = PHPMailer::ValidateAddress($Value);
-      $Result = (bool)$Result;
-      return $Result;
+      return (!filter_var($Value, FILTER_VALIDATE_EMAIL) === false);
    }
 }
 
@@ -245,12 +243,7 @@ if (!function_exists('ValidateMinimumAge')) {
 
 if (!function_exists('ValidateInteger')) {
    function ValidateInteger($Value, $Field = NULL) {
-      if (!$Value || (is_string($Value) && !trim($Value)))
-         return TRUE;
-
-      $Integer = intval($Value);
-      $String = strval($Integer);
-      return $String == $Value ? TRUE : FALSE;
+      return (!$Value || filter_var($Value, FILTER_VALIDATE_INT) === 0 || !filter_var($Value, FILTER_VALIDATE_INT) === false);
    }
 }
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -33,7 +33,7 @@ if (!function_exists('ValidateCaptcha')) {
 
 if (!function_exists('ValidateRegex')) {
    function ValidateRegex($Value, $Regex) {
-      return (!filter_var($Value, FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => $Regex))) === false);
+      return (filter_var($Value, FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => $Regex))) !== false);
    }
 }
 
@@ -138,7 +138,7 @@ if (!function_exists('ValidateEmail')) {
          return true;
       }
 
-      return (!filter_var($Value, FILTER_VALIDATE_EMAIL) === false);
+      return (filter_var($Value, FILTER_VALIDATE_EMAIL) !== false);
    }
 }
 
@@ -243,7 +243,7 @@ if (!function_exists('ValidateMinimumAge')) {
 
 if (!function_exists('ValidateInteger')) {
    function ValidateInteger($Value, $Field = NULL) {
-      return (!$Value || filter_var($Value, FILTER_VALIDATE_INT) === 0 || !filter_var($Value, FILTER_VALIDATE_INT) === false);
+      return (!$Value || filter_var($Value, FILTER_VALIDATE_INT) !== false);
    }
 }
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -248,11 +248,7 @@ if (!function_exists('ValidateInteger')) {
         }
         $Integer = intval($Value);
         $String = strval($Integer);
-        if ($String == $Value) {
-            return true;
-        } else {
-            return false;
-        }
+        return $String == $Value;
     }
 }
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -242,9 +242,18 @@ if (!function_exists('ValidateMinimumAge')) {
 }
 
 if (!function_exists('ValidateInteger')) {
-   function ValidateInteger($Value, $Field = NULL) {
-      return (!$Value || filter_var($Value, FILTER_VALIDATE_INT) !== false);
-   }
+    function ValidateInteger($Value, $Field = null) {
+        if (!$Value || (is_string($Value) && !trim($Value))) {
+            return true;
+        }
+        $Integer = intval($Value);
+        $String = strval($Integer);
+        if ($String == $Value) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }
 
 if (!function_exists('ValidateBoolean')) {


### PR DESCRIPTION
Vanilla requires PHP 5.2 and since this PHP version, there is a native validation function: http://php.net/manual/en/function.filter-var.php

Changes I've made:

ValidateRegex: about 20% faster
ValidateEmail: speed increase not measured, but current implementation calls external class which checks if filter_var() is valid function and uses it afterwards. So basically the previously done "external" check is now done inside of the function. The ValidateRequired check has not been passed the $Field parameter.
ValidateInteger: more than 35% faster for number in quotes, slightly slower (4%) for float, slightly faster for other values



Changes I have not made:
ValidateNoLinks: `return (filter_var($Value, FILTER_VALIDATE_URL) === false);` would have done the job but it is slower than the current implementation and it also works different on other protocols. `mail://bill@microsoft.com` is not a link for the current implementation, but it is a link for filter_var().
ValidateBoolean: FILTER_VALIDATE_BOOLEAN checks for "1", "true", "on", "yes" and "0", "false", "off", "no". This is far more than ValidateBoolean does.