### PR TITLE
Moved discussions conflict with a forced inputformat

### DIFF
--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -10,7 +10,7 @@
  */
 
 class ModerationController extends VanillaController {
-   
+
    /**
     * Looks at the user's attributes and form postback to see if any comments
     * have been checked for administration, and if so, puts an inform message on
@@ -22,7 +22,7 @@ class ModerationController extends VanillaController {
       ModerationController::InformCheckedComments($this);
       $this->Render();
    }
-   
+
    /**
     * Looks at the user's attributes and form postback to see if any discussions
     * have been checked for administration, and if so, puts an inform message on
@@ -51,16 +51,16 @@ class ModerationController extends VanillaController {
          if (empty($CheckIDs))
             $CheckIDs = array();
          $CheckIDs = (array)$CheckIDs;
-         
+
          $CheckedComments = Gdn::UserModel()->GetAttribute($Session->User->UserID, 'CheckedComments', array());
          if (!is_array($CheckedComments))
             $CheckedComments = array();
-            
+
          if (!array_key_exists($DiscussionID, $CheckedComments)) {
             $CheckedComments[$DiscussionID] = array();
          } else {
             // Were there checked comments in this discussion before the form was posted?
-            $HadCheckedComments = count($CheckedComments[$DiscussionID]) > 0; 
+            $HadCheckedComments = count($CheckedComments[$DiscussionID]) > 0;
          }
          foreach ($CheckIDs as $Check) {
             if (GetValue('checked', $Check)) {
@@ -70,10 +70,10 @@ class ModerationController extends VanillaController {
                RemoveValueFromArray($CheckedComments[$DiscussionID], $Check['checkId']);
             }
          }
-         
+
          if (count($CheckedComments[$DiscussionID]) == 0)
             unset($CheckedComments[$DiscussionID]);
-            
+
          Gdn::UserModel()->SaveAttribute($Session->User->UserID, 'CheckedComments', $CheckedComments);
       } else if ($Session->IsValid()) {
          // No form posted, just retrieve checked items for display
@@ -81,7 +81,7 @@ class ModerationController extends VanillaController {
          $CheckedComments = Gdn::UserModel()->GetAttribute($Session->User->UserID, 'CheckedComments', array());
          if (!is_array($CheckedComments))
             $CheckedComments = array();
-            
+
       }
 
       // Retrieve some information about the checked items
@@ -97,20 +97,20 @@ class ModerationController extends VanillaController {
             Plural($CountComments, '%s comment', '%s comments')
          ), 'div');
          $ActionMessage = T('Take Action:');
-         
+
          // Can the user delete the comment?
          $DiscussionModel = new DiscussionModel();
          $Discussion = $DiscussionModel->GetID($DiscussionID);
          $PermissionCategory = CategoryModel::Categories(GetValue('CategoryID', $Discussion));
          if ($Session->CheckPermission('Vanilla.Comments.Delete', TRUE, 'Category', GetValue('PermissionCategoryID', $PermissionCategory)))
             $ActionMessage .= ' '.Anchor(T('Delete'), 'vanilla/moderation/confirmcommentdeletes/'.$DiscussionID, 'Delete Popup');
-         
+
          $Sender->EventArguments['SelectionMessage'] = &$SelectionMessage;
          $Sender->EventArguments['ActionMessage'] = &$ActionMessage;
          $Sender->EventArguments['Discussion'] = $Discussion;
          $Sender->FireEvent('BeforeCheckComments');
          $ActionMessage .= ' '.Anchor(T('Cancel'), 'vanilla/moderation/clearcommentselections/'.$DiscussionID.'/{TransientKey}/?Target={SelfUrl}', 'CancelAction');
-         
+
          $Sender->InformMessage(
             $SelectionMessage
             .Wrap($ActionMessage, 'div', array('class' => 'Actions')),
@@ -124,7 +124,7 @@ class ModerationController extends VanillaController {
          $Sender->InformMessage('', array('id' => 'CheckSummary'));
       }
    }
-   
+
    /**
     * Looks at the user's attributes and form postback to see if any discussions
     * have been checked for administration, and if so, adds an inform message to
@@ -139,11 +139,11 @@ class ModerationController extends VanillaController {
          if (empty($CheckIDs))
             $CheckIDs = array();
          $CheckIDs = (array)$CheckIDs;
-         
+
          $CheckedDiscussions = Gdn::UserModel()->GetAttribute($Session->User->UserID, 'CheckedDiscussions', array());
          if (!is_array($CheckedDiscussions))
             $CheckedDiscussions = array();
-            
+
          // Were there checked discussions before the form was posted?
          $HadCheckedDiscussions |= count($CheckedDiscussions) > 0;
 
@@ -155,14 +155,14 @@ class ModerationController extends VanillaController {
                RemoveValueFromArray($CheckedDiscussions, $Check['checkId']);
             }
          }
-         
+
          Gdn::UserModel()->SaveAttribute($Session->User->UserID, 'CheckedDiscussions', $CheckedDiscussions);
       } else if ($Session->IsValid()) {
          // No form posted, just retrieve checked items for display
          $CheckedDiscussions = Gdn::UserModel()->GetAttribute($Session->User->UserID, 'CheckedDiscussions', array());
          if (!is_array($CheckedDiscussions))
             $CheckedDiscussions = array();
-            
+
       }
 
       // Retrieve some information about the checked items
@@ -175,12 +175,12 @@ class ModerationController extends VanillaController {
          $ActionMessage = T('Take Action:');
          $ActionMessage .= ' '.Anchor(T('Delete'), 'vanilla/moderation/confirmdiscussiondeletes/', 'Delete Popup');
          $ActionMessage .= ' '.Anchor(T('Move'), 'vanilla/moderation/confirmdiscussionmoves/', 'Move Popup');
-         
+
          $Sender->EventArguments['SelectionMessage'] = &$SelectionMessage;
          $Sender->EventArguments['ActionMessage'] = &$ActionMessage;
          $Sender->FireEvent('BeforeCheckDiscussions');
          $ActionMessage .= ' '.Anchor(T('Cancel'), 'vanilla/moderation/cleardiscussionselections/{TransientKey}/?Target={SelfUrl}', 'CancelAction');
-         
+
          $Sender->InformMessage(
             $SelectionMessage
             .Wrap($ActionMessage, 'div', array('class' => 'Actions')),
@@ -194,7 +194,7 @@ class ModerationController extends VanillaController {
          $Sender->InformMessage('', array('id' => 'CheckSummary'));
       }
    }
-   
+
    /**
     * Remove all comments checked for administration from the user's attributes.
     */
@@ -219,7 +219,7 @@ class ModerationController extends VanillaController {
 
       Redirect(GetIncomingValue('Target', '/discussions'));
    }
-   
+
    /**
     * Form to confirm that the administrator wants to delete the selected
     * comments (and has permission to do so).
@@ -231,16 +231,16 @@ class ModerationController extends VanillaController {
       $Discussion = $DiscussionModel->GetID($DiscussionID);
       if (!$Discussion)
          return;
-      
+
       // Verify that the user has permission to perform the delete
       $PermissionCategory = CategoryModel::Categories($Discussion->CategoryID);
       $this->Permission('Vanilla.Comments.Delete', TRUE, 'Category', GetValue('PermissionCategoryID', $PermissionCategory));
       $this->Title(T('Confirm'));
-      
+
       $CheckedComments = Gdn::UserModel()->GetAttribute($Session->User->UserID, 'CheckedComments', array());
       if (!is_array($CheckedComments))
          $CheckedComments = array();
-       
+
       $CommentIDs = array();
       $DiscussionIDs = array();
       foreach ($CheckedComments as $DiscID => $Comments) {
@@ -251,9 +251,9 @@ class ModerationController extends VanillaController {
                $CommentIDs[] = str_replace('Comment_', '', $Comment);
          }
       }
-      $CountCheckedComments = count($CommentIDs);  
+      $CountCheckedComments = count($CommentIDs);
       $this->SetData('CountCheckedComments', $CountCheckedComments);
-      
+
       if ($this->Form->AuthenticatedPostBack()) {
          // Delete the selected comments
          $CommentModel = new CommentModel();
@@ -267,10 +267,10 @@ class ModerationController extends VanillaController {
          ModerationController::InformCheckedComments($this);
          $this->RedirectUrl = 'discussions';
       }
-      
+
       $this->Render();
    }
-   
+
    /**
     * Form to confirm that the administrator wants to delete the selected
     * discussions (and has permission to do so).
@@ -279,19 +279,19 @@ class ModerationController extends VanillaController {
       $Session = Gdn::Session();
       $this->Form = new Gdn_Form();
       $DiscussionModel = new DiscussionModel();
-      
+
       // Verify that the user has permission to perform the deletes
       $this->Permission('Vanilla.Discussions.Delete', TRUE, 'Category', 'any');
       $this->Title(T('Confirm'));
-      
+
       $CheckedDiscussions = Gdn::UserModel()->GetAttribute($Session->User->UserID, 'CheckedDiscussions', array());
       if (!is_array($CheckedDiscussions))
          $CheckedDiscussions = array();
 
       $DiscussionIDs = $CheckedDiscussions;
-      $CountCheckedDiscussions = count($DiscussionIDs);  
+      $CountCheckedDiscussions = count($DiscussionIDs);
       $this->SetData('CountCheckedDiscussions', $CountCheckedDiscussions);
-      
+
       // Check permissions on each discussion to make sure the user has permission to delete them
       $AllowedDiscussions = array();
       $DiscussionData = $DiscussionModel->SQL->Select('DiscussionID, CategoryID')->From('Discussion')->WhereIn('DiscussionID', $DiscussionIDs)->Get();
@@ -318,7 +318,7 @@ class ModerationController extends VanillaController {
          Gdn::UserModel()->SaveAttribute($Session->UserID, 'CheckedDiscussions', NULL);
          ModerationController::InformCheckedDiscussions($this, TRUE);
       }
-      
+
       $this->Render();
    }
 
@@ -339,7 +339,7 @@ class ModerationController extends VanillaController {
          $CheckedDiscussions = Gdn::UserModel()->GetAttribute($Session->User->UserID, 'CheckedDiscussions', array());
          if (!is_array($CheckedDiscussions))
             $CheckedDiscussions = array();
-         
+
          $ClearSelection = TRUE;
       }
 
@@ -359,7 +359,7 @@ class ModerationController extends VanillaController {
       $this->SetData('CountAllowed', count($AllowedDiscussions));
       $CountNotAllowed = $CountCheckedDiscussions - count($AllowedDiscussions);
       $this->SetData('CountNotAllowed', $CountNotAllowed);
-      
+
       if ($this->Form->AuthenticatedPostBack()) {
          // Retrieve the category id
          $CategoryID = $this->Form->GetFormValue('CategoryID');
@@ -376,10 +376,10 @@ class ModerationController extends VanillaController {
             // Create the shadow redirect.
             if ($RedirectLink) {
                $Discussion = GetValue($DiscussionID, $DiscussionData);
-               
+
                $DiscussionModel->DefineSchema();
                $MaxNameLength = GetValue('Length', $DiscussionModel->Schema->GetField('Name'));
-               
+
                $RedirectDiscussion = array(
                      'Name' => SliceString(sprintf(T('Moved: %s'), $Discussion['Name']), $MaxNameLength),
                      'DateInserted' => $Discussion['DateLastComment'],
@@ -389,13 +389,26 @@ class ModerationController extends VanillaController {
                      'Format' => 'Html',
                      'Closed' => TRUE
                   );
+
+               // Pass a forced input formatter around this exception.
+               if (C('Garden.ForceInputFormatter')) {
+                  $InputFormat = C('Garden.InputFormatter');
+                  SaveToConfig('Garden.InputFormatter', 'Html', FALSE);
+               }
+
                $RedirectID = $DiscussionModel->Save($RedirectDiscussion);
+
+               // Reset the input formatter
+               if (C('Garden.ForceInputFormatter')) {
+                  SaveToConfig('Garden.InputFormatter', $InputFormat, FALSE);
+               }
+
                if (!$RedirectID) {
                   $this->Form->SetValidationResults($DiscussionModel->ValidationResults());
                   break;
                }
             }
-            
+
             $DiscussionModel->SetField($DiscussionID, 'CategoryID', $CategoryID);
          }
 
@@ -404,7 +417,7 @@ class ModerationController extends VanillaController {
             Gdn::UserModel()->SaveAttribute($Session->UserID, 'CheckedDiscussions', FALSE);
             ModerationController::InformCheckedDiscussions($this);
          }
-         
+
          if ($this->Form->ErrorCount() == 0)
             $this->JsonTarget('', '', 'Refresh');
       }


### PR DESCRIPTION
Current behavior is that `Garden.ForceInputFormatter` with a `Garden.InputFormatter` of something other than `Html` will break the redirect move feature. This sets our InputFormatter to Html for a hot second to sidestep the problem.