### PR TITLE
Quotes: disable Emoji parse for FormatQuote

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -302,11 +302,8 @@ BLOCKQUOTE;
 
    protected function FormatQuote($Type, $ID, &$QuoteData, $Format = FALSE) {
       // Temporarily disable Emoji parsing (prevent double-parsing to HTML)
-      $undoEmoji = false;
-      if (Emoji::instance()->enabled) {
-         $undoEmoji = true;
-         Emoji::instance()->enabled = false;
-      }
+      $emojiEnabled = Emoji::instance()->enabled;
+      Emoji::instance()->enabled = false;
 
       if (!$Format) {
          $Format = C('Garden.InputFormatter');
@@ -427,9 +424,7 @@ BLOCKQUOTE;
       }
 
       // Undo Emoji disable.
-      if ($undoEmoji) {
-         Emoji::instance()->enabled = true;
-      }
+      Emoji::instance()->enabled = $emojiEnabled;
    }
 
    public function Setup() {

--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -151,12 +151,11 @@ class QuotesPlugin extends Gdn_Plugin {
       $QuoteData = array(
           'status' => 'failed'
       );
-//      array_shift($Sender->RequestArgs);
-//      if (sizeof($Sender->RequestArgs)) {
+
       $QuoteData['selector'] = $Selector;
       list($Type, $ID) = explode('_', $Selector);
       $this->FormatQuote($Type, $ID, $QuoteData, $Format);
-//      }
+
       $Sender->SetJson('Quote', $QuoteData);
       $Sender->Render('GetQuote', '', 'plugins/Quotes');
    }
@@ -302,6 +301,13 @@ BLOCKQUOTE;
    }
 
    protected function FormatQuote($Type, $ID, &$QuoteData, $Format = FALSE) {
+      // Temporarily disable Emoji parsing (prevent double-parsing to HTML)
+      $undoEmoji = false;
+      if (Emoji::instance()->enabled) {
+         $undoEmoji = true;
+         Emoji::instance()->enabled = false;
+      }
+
       if (!$Format) {
          $Format = C('Garden.InputFormatter');
       }
@@ -418,6 +424,11 @@ BLOCKQUOTE;
              'type' => $Type,
              'typeid' => $ID
          ));
+      }
+
+      // Undo Emoji disable.
+      if ($undoEmoji) {
+         Emoji::instance()->enabled = true;
       }
    }
 


### PR DESCRIPTION
Fixes bug where Emoji get double-parsed when quoted post is a different input formatter.

To test, make a post with BBCode format containing Emoji. Switch to Html and quote the post. Without this patch, you'll get broken Emoji HTML in the post.