### PR TITLE
Return zero applicants when registration type not Approval

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -235,6 +235,10 @@ class RoleModel extends Gdn_Model {
    }
 
    public function GetApplicantCount($Force = FALSE) {
+      if (C('Garden.Registration.Method') != 'Approval') {
+         return 0;
+      }
+
       $CacheKey = 'Moderation.ApplicantCount';
 
       if ($Force)


### PR DESCRIPTION
RoleModel::GetApplicantCount was potentially returning a non-zero value for the total number of applicants awaiting approval, even if the registration was not set to "Approval".  This fix skips the count and returns zero from RoleModel::GetApplicantCount if registration mode isn't explicitly set to "Approval".

Fixes #2036