### PR TITLE
Add '<' to list of ending chars in hashtag regex.

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1411,7 +1411,7 @@ EOT;
          // Handle #hashtag searches
 			if(C('Garden.Format.Hashtags')) {
 				$Mixed = preg_replace(
-					'/(^|[\s,\.>])\#([\w\-]+)(?=[\s,\.!?]|$)/i',
+					'/(^|[\s,\.>])\#([\w\-]+)(?=[\s,\.!?<]|$)/i',
 					'\1'.Anchor('#\2', '/search?Search=%23\2&Mode=like').'\3',
 					$Mixed
 				);


### PR DESCRIPTION
Fixes bug where hashes with a html tag directly after the hashtag string do not pass the regex. NBBC transforms a new line to a <br /> tag, so hashtags at the end of a line were not being processed correctly.