### PR TITLE
ProfileExtender: Do not display fields for banned users

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -359,6 +359,10 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
     * Display custom fields on Profile.
     */
    public function UserInfoModule_OnBasicInfo_Handler($Sender) {
+      if ($Sender->User->Banned) {
+         return;
+      }
+
       try {
          // Get the custom fields
          $ProfileFields = Gdn::UserModel()->GetMeta($Sender->User->UserID, 'Profile.%', 'Profile.');


### PR DESCRIPTION
The Profile Extender plug-in was displaying custom fields for users, even after they were banned.  This fix bails out of displaying those fields if the user is flagged as banned.

Fixes #1667 