### PR TITLE
Updating non-unicode fallback regex in Gdn_Format::Url

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1710,7 +1710,7 @@ EOT;
       if (unicodeRegexSupport()) {
          $Mixed = preg_replace('`[\pP\pS\s]`u', '-', $Mixed);
       } else {
-         $Mixed = preg_replace('`[\s_[^\w\d]]`', '-', $Mixed);
+         $Mixed = preg_replace('`[^\w\d]`', '-', $Mixed);
       }
 
       // Lowercase, no trailing or repeat hyphens

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1710,7 +1710,7 @@ EOT;
       if (unicodeRegexSupport()) {
          $Mixed = preg_replace('`[\pP\pS\s]`u', '-', $Mixed);
       } else {
-         $Mixed = preg_replace('`[^\w\d]`', '-', $Mixed);
+         $Mixed = preg_replace('`[\W_]`', '-', $Mixed);
       }
 
       // Lowercase, no trailing or repeat hyphens


### PR DESCRIPTION
The non-unicode fallback in Gdn_Format::Url was using invalid regex.  This fix updates the regex to replace any non-alphanumeric characters and underscores.

Fixes #2017