### PR TITLE
Adding removal of empty UserMeta rows where value set is empty string

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3174,10 +3174,11 @@ class UserModel extends Gdn_Model {
 
       foreach ($Meta as $Name => $Value) {
          $Name = $Prefix.$Name;
-         if ($Value === NULL)
+         if ($Value === NULL || $Value == '') {
             $Deletes[] = $Name;
-         else
+         } else {
             Gdn::Database()->Query($Sql, array(':UserID' => $UserID, ':Name' => $Name, ':Value' => $Value, ':Value1' => $Value));
+         }
       }
       if (count($Deletes))
          Gdn::SQL()->WhereIn('Name', $Deletes)->Where('UserID',$UserID)->Delete('UserMeta');


### PR DESCRIPTION
Profile Extender was allowing empty values to be set for user meta values.  These created empty user meta rows in the database and it was also reported that this sometimes caused empty fields to be displayed on the user's profile.  This fix updates the check when saving user meta to also account for empty strings when deleting, not just a nulls.

Fixes #1619