### PR TITLE
ButtonBar: Adding support for Wysiwyg input format

### DIFF
--- a/plugins/ButtonBar/class.buttonbar.plugin.php
+++ b/plugins/ButtonBar/class.buttonbar.plugin.php
@@ -12,7 +12,7 @@
 $PluginInfo['ButtonBar'] = array(
    'Name' => 'Button Bar',
    'Description' => 'Adds several simple buttons above comment boxes, allowing additional formatting.',
-   'Version' => '1.6',
+   'Version' => '1.7',
    'MobileFriendly' => TRUE,
    'RequiredApplications' => array('Vanilla' => '2.1'),
    'RequiredTheme' => FALSE,

--- a/plugins/ButtonBar/class.buttonbar.plugin.php
+++ b/plugins/ButtonBar/class.buttonbar.plugin.php
@@ -2,7 +2,7 @@
 
 /**
  * ButtonBar Plugin
- * 
+ *
  * @author Tim Gunter <tim@vanillaforums.com>
  * @copyright 2003 Vanilla Forums, Inc
  * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
@@ -15,7 +15,7 @@ $PluginInfo['ButtonBar'] = array(
    'Version' => '1.6',
    'MobileFriendly' => TRUE,
    'RequiredApplications' => array('Vanilla' => '2.1'),
-   'RequiredTheme' => FALSE, 
+   'RequiredTheme' => FALSE,
    'RequiredPlugins' => FALSE,
    'Author' => "Tim Gunter",
    'AuthorEmail' => 'tim@vanillaforums.com',
@@ -23,14 +23,14 @@ $PluginInfo['ButtonBar'] = array(
 );
 
 class ButtonBarPlugin extends Gdn_Plugin {
-   
-   protected $Formats = array('Html', 'BBCode', 'Markdown');
+
+   protected $Formats = array('Html', 'BBCode', 'Markdown', 'Wysiwyg');
 
    /**
     * Insert ButtonBar resource files on every page so they are available
     * to any new uses of BodyBox in plugins and applications.
-    * 
-    * @param Gdn_Controller $Sender 
+    *
+    * @param Gdn_Controller $Sender
     */
    public function Base_Render_Before($Sender) {
       $Formatter = C('Garden.InputFormatter','Html');
@@ -39,32 +39,32 @@ class ButtonBarPlugin extends Gdn_Plugin {
    public function AssetModel_StyleCss_Handler($Sender) {
       $Sender->AddCssFile('buttonbar.css', 'plugins/ButtonBar');
    }
-      
+
    /**
     * Insert buttonbar resources
-    * 
+    *
     * This method is abstracted because it is invoked by multiple controllers.
-    * 
-    * @param Gdn_Controller $Sender 
+    *
+    * @param Gdn_Controller $Sender
     */
    protected function AttachButtonBarResources($Sender, $Formatter) {
       if (!in_array($Formatter, $this->Formats)) return;
       $Sender->AddJsFile('buttonbar.js', 'plugins/ButtonBar');
       $Sender->AddJsFile('jquery.hotkeys.js', 'plugins/ButtonBar');
-      
+
       $Sender->AddDefinition('ButtonBarLinkUrl', T('ButtonBar.LinkUrlText', 'Enter your URL:'));
       $Sender->AddDefinition('ButtonBarImageUrl', T('ButtonBar.ImageUrlText', 'Enter image URL:'));
       $Sender->AddDefinition('ButtonBarBBCodeHelpText', T('ButtonBar.BBCodeHelp', 'You can use <b><a href="http://en.wikipedia.org/wiki/BBCode" target="_new">BBCode</a></b> in your post.'));
       $Sender->AddDefinition('ButtonBarHtmlHelpText', T('ButtonBar.HtmlHelp', 'You can use <b><a href="http://htmlguide.drgrog.com/cheatsheet.php" target="_new">Simple Html</a></b> in your post.'));
       $Sender->AddDefinition('ButtonBarMarkdownHelpText', T('ButtonBar.MarkdownHelp', 'You can use <b><a href="http://en.wikipedia.org/wiki/Markdown" target="_new">Markdown</a></b> in your post.'));
-      
+
       $Sender->AddDefinition('InputFormat', $Formatter);
    }
-   
+
    /**
     * Attach ButtonBar anywhere 'BodyBox' is used.
-    * 
-    * @param Gdn_Controller $Sender 
+    *
+    * @param Gdn_Controller $Sender
     */
    public function Gdn_Form_BeforeBodyBox_Handler($Sender) {
       $Wrap = false;
@@ -78,26 +78,26 @@ class ButtonBarPlugin extends Gdn_Plugin {
 //   public function PostController_BeforeBodyField_Handler($Sender) {
 //      $this->AttachButtonBar($Sender);
 //   }
-   
+
    /**
     * Attach button bar in place
-    * 
+    *
     * This method is abstracted because it is called from multiple places, due
     * to the way that the comment.php view is invoked both by the DiscussionController
     * and the PostController.
-    * 
-    * @param Gdn_Controller $Sender 
+    *
+    * @param Gdn_Controller $Sender
     */
    protected function AttachButtonBar($Sender, $Wrap = FALSE) {
       $Formatter = C('Garden.InputFormatter','Html');
       if (!in_array($Formatter, $this->Formats)) return;
-      
+
       $View = Gdn::Controller()->FetchView('buttonbar','','plugins/ButtonBar');
-      
+
       if ($Wrap)
          echo Wrap($View, 'div', array('class' => 'P'));
       else
          echo $View;
    }
-   
+
 }

--- a/plugins/ButtonBar/js/buttonbar.js
+++ b/plugins/ButtonBar/js/buttonbar.js
@@ -1,9 +1,9 @@
 /*
  * Caret insert JS
- * 
+ *
  * This code extends the base object with a method called 'insertAtCaret', which
  * allows text to be added to a textArea at the cursor position.
- * 
+ *
  * Thanks to http://technology.hostei.com/?p=3
  */
 jQuery.fn.insertAtCaret = function (tagName) {
@@ -57,10 +57,10 @@ jQuery.fn.insertRoundCaret = function(strStart, strEnd, strReplace) {
          startPos = this.selectionStart;
          endPos = this.selectionEnd;
          scrollTop = this.scrollTop;
-         
+
          if (!strReplace)
             strReplace = this.value.substring(startPos, endPos);
-         
+
          this.value = this.value.substring(0, startPos) + strStart
                     + strReplace + strEnd
                     + this.value.substring(endPos, this.value.length);
@@ -74,7 +74,7 @@ jQuery.fn.insertRoundCaret = function(strStart, strEnd, strReplace) {
          this.value += strStart + strReplace + strEnd;
          this.focus();
       }
-      
+
    });
 }
 
@@ -90,17 +90,17 @@ jQuery.fn.hasSelection = function() {
          sel = this.value.substring(startPos, endPos);
       }
    });
-   
+
    return sel;
 }
 
 /*
  * Caret insert advanced
- * 
- * This code allows insertion on complex tags, and was extended by @Barrakketh 
- * (barrakketh@gmail.com) from http://forums.penny-arcade.com to allow 
+ *
+ * This code allows insertion on complex tags, and was extended by @Barrakketh
+ * (barrakketh@gmail.com) from http://forums.penny-arcade.com to allow
  * parameters.
- * 
+ *
  * Thanks!
  */
 
@@ -110,13 +110,13 @@ jQuery.fn.hasSelection = function() {
 //      var closer = opts.closer || ']';
 //      var closetype = opts.closetype || 'full';
 //      var shortporp = opts.shortprop;
-//      
+//
 //      strStart = opener + tagName;
 //      strEnd = '';
-//      
+//
 //      if (shortprop)
 //         strStart = strStart + '="' + opt + '"';
-//      
+//
 //      if (props) {
 //         for ( var param in props) {
 //            strStart = strStart + ' ' + param + '="' + props[param] + '"';
@@ -148,24 +148,24 @@ $.fn.insertRoundTag = function(tagName, opts, props){
    var shortprop = opts.shortprop;
    var focusprop = opts.center;
    var hasFocused = false;
-   
+
    strStart = prefix + opener + opentag;
    strEnd = '';
-   
+
    if (shortprop) {
       strStart = strStart + '="' + shortprop;
       if (focusprop == 'short') {
          strEnd = strEnd + '"';
          hasFocused = true;
       }
-      else 
+      else
          strStart = strStart + '"';
    }
    if (props) {
       var focusing = false;
       for ( var param in props) {
          if (hasFocused) {strEnd = strEnd + ' ' + param + '="' + props[param] + '"';continue;}
-         
+
          if (!hasFocused) {
             strStart = strStart + ' ' + param + '="' + props[param];
             if (param == focusprop) {
@@ -173,7 +173,7 @@ $.fn.insertRoundTag = function(tagName, opts, props){
                hasFocused = true;
             }
          }
-         
+
          if (focusing) {
             strEnd = strEnd + '"';
             focusing = false;
@@ -182,7 +182,7 @@ $.fn.insertRoundTag = function(tagName, opts, props){
          }
       }
    }
-   
+
    strReplace = '';
    if (prefix) {
       var selection = $(this).hasSelection();
@@ -190,17 +190,17 @@ $.fn.insertRoundTag = function(tagName, opts, props){
          strReplace = selection.replace(/\n/g, '\n'+prefix);
       }
    }
-   
+
    if (replace != false) {
       strReplace = replace;
    }
-   
+
    if (closetype == 'full') {
       if (!hasFocused)
          strStart = strStart + closer;
       else
          strEnd = strEnd + closer;
-      
+
       strEnd = strEnd + opener + closeslice + closetag + closer + suffix;
    } else {
       if (closeslice && closeslice.length)
@@ -214,42 +214,47 @@ $.fn.insertRoundTag = function(tagName, opts, props){
 }
 
 jQuery(document).ready(function($) {
-   
+
    ButtonBar = {
       AttachTo: function(TextArea) {
          // Load the buttonbar and bind this textarea to it
          var ThisButtonBar = $(TextArea).closest('form').find('.ButtonBar');
          $(ThisButtonBar).data('ButtonBarTarget', TextArea);
-         
+
          var format = $(TextArea).attr('format');
          if (!format)
             format = gdn.definition('InputFormat', 'Html');
-         if (format == 'Raw')
-            format = 'Html';
-         
+
+         switch (format) {
+            case 'Raw':
+            case 'Wysiwyg':
+               format = 'Html';
+               break;
+         }
+
          // Apply the page's InputFormat to this textarea.
          $(TextArea).data('InputFormat', format);
-         
+
          // Build button UIs
          $(ThisButtonBar).find('.ButtonWrap').each(function(i, el){
             var Operation = $(el).find('span').text();
-            
+
             var UIOperation = Operation.charAt(0).toUpperCase() + Operation.slice(1);
             $(el).attr('title', UIOperation);
-            
+
             var Action = "ButtonBar"+UIOperation;
             $(el).addClass(Action);
          });
-         
+
          // Attach shortcut keys
          ButtonBar.BindShortcuts(TextArea);
-         
+
          // Attach events
          $(ThisButtonBar).find('.ButtonWrap').mousedown(function(event){
             var MyButtonBar = $(event.target).closest('.ButtonBar');
             var Button = $(event.target).find('span').closest('.ButtonWrap');
             if ($(Button).hasClass('ButtonOff')) return;
-            
+
             var TargetTextArea = $(MyButtonBar).data('ButtonBarTarget');
             if (!TargetTextArea) return false;
 
@@ -257,10 +262,10 @@ jQuery(document).ready(function($) {
             ButtonBar.Perform(TargetTextArea, Operation, event);
             return false;
          });
-      
+
          ButtonBar.Prepare(ThisButtonBar, TextArea);
       },
-      
+
       BindShortcuts: function(TextArea) {
          ButtonBar.BindShortcut(TextArea, 'bold', 'ctrl+B');
          ButtonBar.BindShortcut(TextArea, 'italic', 'ctrl+I');
@@ -272,25 +277,25 @@ jQuery(document).ready(function($) {
          ButtonBar.BindShortcut(TextArea, 'quickurl', 'ctrl+shift+L');
          ButtonBar.BindShortcut(TextArea, 'post', 'tab');
       },
-      
+
       BindShortcut: function(TextArea, Operation, Shortcut, ShortcutMode, OpFunction) {
          if (OpFunction == undefined)
             OpFunction = function(e){ButtonBar.Perform(TextArea, Operation, e);}
-         
+
          if (ShortcutMode == undefined)
             ShortcutMode = 'keydown';
-         
+
          $(TextArea).bind(ShortcutMode,Shortcut,OpFunction);
-         
+
          var UIOperation = Operation.charAt(0).toUpperCase() + Operation.slice(1);
          var Action = "ButtonBar"+UIOperation;
-         
+
          var ButtonBarObj = $(TextArea).closest('form').find('.ButtonBar');
          var Button = $(ButtonBarObj).find('.'+Action);
          Button.attr('title', Button.attr('title')+', '+Shortcut);
-         
+
       },
-      
+
       DisableButton: function(ButtonBarObj, Operation) {
          $(ButtonBarObj).find('.ButtonWrap').each(function(i,Button){
             var ButtonOperation = $(Button).find('span').text();
@@ -298,17 +303,17 @@ jQuery(document).ready(function($) {
                $(Button).addClass('ButtonOff');
          });
       },
-      
+
       Prepare: function(ButtonBarObj, TextArea) {
          var InputFormat = $(TextArea).data('InputFormat');
          var PrepareMethod = 'Prepare'+InputFormat;
          if (ButtonBar[PrepareMethod] == undefined)
             return;
-         
+
          // Call preparer
          ButtonBar[PrepareMethod](ButtonBarObj, TextArea);
       },
-      
+
       PrepareBBCode: function(ButtonBarObj, TextArea) {
          var HelpText = gdn.definition('ButtonBarBBCodeHelpText', 'ButtonBar.BBCodeHelp');
          $("<div></div>")
@@ -316,46 +321,46 @@ jQuery(document).ready(function($) {
             .html(HelpText)
             .insertAfter(TextArea);
       },
-      
+
       PrepareHtml: function(ButtonBarObj, TextArea) {
          ButtonBar.DisableButton(ButtonBarObj, 'spoiler');
-         
+
          var HelpText = gdn.definition('ButtonBarHtmlHelpText', 'ButtonBar.HtmlHelp');
          $("<div></div>")
             .addClass('ButtonBarMarkupHint')
             .html(HelpText)
             .insertAfter(TextArea);
       },
-      
+
       PrepareMarkdown: function(ButtonBarObj, TextArea) {
          ButtonBar.DisableButton(ButtonBarObj, 'underline');
          ButtonBar.DisableButton(ButtonBarObj, 'spoiler');
-         
+
          var HelpText = gdn.definition('ButtonBarMarkdownHelpText', 'ButtonBar.MarkdownHelp');
          $("<div></div>")
             .addClass('ButtonBarMarkupHint')
             .html(HelpText)
             .insertAfter(TextArea);
       },
-      
+
       Perform: function(TextArea, Operation, Event) {
          Event.preventDefault();
-         
+
          var InputFormat = $(TextArea).data('InputFormat');
          var PerformMethod = 'Perform'+InputFormat;
          if (ButtonBar[PerformMethod] == undefined)
             return;
-         
+
          // Call performer
          ButtonBar[PerformMethod](TextArea,Operation);
-         
+
          switch (Operation) {
             case 'post':
                $(TextArea).closest('form').find('.CommentButton').focus();
                break;
          }
       },
-      
+
       PerformBBCode: function(TextArea, Operation) {
          bbcodeOpts = {
             opener: '[',
@@ -384,17 +389,17 @@ jQuery(document).ready(function($) {
 
             case 'image':
                var thisOpts = $.extend(bbcodeOpts,{});
-               
+
                var PromptText = gdn.definition('ButtonBarImageUrl', 'ButtonBar.ImageUrlText');
                NewURL = prompt(PromptText);
-               thisOpts.replace = NewURL; 
-                           
+               thisOpts.replace = NewURL;
+
                $(TextArea).insertRoundTag('img',thisOpts);
                break;
 
             case 'quickurl':
                var thisOpts = $.extend(bbcodeOpts,{});
-               
+
                var hasSelection = $(TextArea).hasSelection();
                console.log("sel: "+hasSelection);
                var NewURL = '';
@@ -403,9 +408,9 @@ jQuery(document).ready(function($) {
                   NewURL = hasSelection;
                else
                   NewURL = prompt(PromptText,'http://');
-               
+
                thisOpts.shortprop = NewURL;
-               
+
                $(TextArea).insertRoundTag('url',thisOpts);
                break;
 
@@ -419,24 +424,24 @@ jQuery(document).ready(function($) {
 
             case 'url':
                var thisOpts = $.extend(bbcodeOpts, {});
-               
+
                var PromptText = gdn.definition('ButtonBarLinkUrl', 'ButtonBar.LinkUrlText');
                var NewURL = prompt(PromptText,'http://');
                var GuessText = NewURL.replace('http://','').replace('www.','');
                thisOpts.shortprop = NewURL;
-               
+
                var CurrentSelectText = GuessText;
                var CurrentSelect = $(TextArea).hasSelection();
                if (CurrentSelect)
                   CurrentSelectText = CurrentSelect.toString();
-               
+
                thisOpts.replace = CurrentSelectText;
-               
+
                $(TextArea).insertRoundTag('url',thisOpts);
                break;
          }
       },
-      
+
       PerformHtml: function(TextArea, Operation) {
          var htmlOpts = {
             opener: '<',
@@ -480,11 +485,11 @@ jQuery(document).ready(function($) {
                var thisOpts = $.extend(htmlOpts, {
                   closetype: 'short'
                });
-               
+
                var PromptText = gdn.definition('ButtonBarImageUrl', 'ButtonBar.ImageUrlText');
                NewURL = prompt(PromptText);
-               urlOpts.src = NewURL;         
-               
+               urlOpts.src = NewURL;
+
                $(TextArea).insertRoundTag('img',thisOpts,urlOpts);
                break;
 
@@ -493,7 +498,7 @@ jQuery(document).ready(function($) {
                var thisOpts = $.extend(htmlOpts, {
                   center: 'href'
                });
-               
+
                var hasSelection = $(TextArea).hasSelection();
                var NewURL = '';
                var PromptText = gdn.definition('ButtonBarLinkUrl', 'ButtonBar.LinkUrlText');
@@ -502,9 +507,9 @@ jQuery(document).ready(function($) {
                   delete thisOpts.center;
                } else
                   NewURL = prompt(PromptText,'http://');
-               
+
                urlOpts.href = NewURL;
-               
+
                $(TextArea).insertRoundTag('a',thisOpts,urlOpts);
                break;
 
@@ -519,25 +524,25 @@ jQuery(document).ready(function($) {
             case 'url':
                var urlOpts = {};
                var thisOpts = $.extend(htmlOpts, {});
-               
+
                var PromptText = gdn.definition('ButtonBarLinkUrl', 'ButtonBar.LinkUrlText');
                var NewURL = prompt(PromptText,'http://');
                var GuessText = NewURL.replace('http://','').replace('www.','');
                urlOpts.href = NewURL;
-               
+
                var CurrentSelectText = GuessText;
-               
+
                var CurrentSelect = $(TextArea).hasSelection();
                if (CurrentSelect)
                   CurrentSelectText = CurrentSelect.toString();
-               
+
                thisOpts.replace = CurrentSelectText;
-               
+
                $(TextArea).insertRoundTag('a',thisOpts,urlOpts);
                break;
          }
       },
-      
+
       PerformMarkdown: function(TextArea, Operation) {
          var markdownOpts = {
             opener: '',
@@ -597,7 +602,7 @@ jQuery(document).ready(function($) {
                   opentag:'(',
                   closetag:')'
                });
-               
+
                var hasSelection = $(TextArea).hasSelection();
                var PromptText = gdn.definition('ButtonBarLinkUrl', 'ButtonBar.LinkUrlText');
                if (hasSelection !== false)
@@ -606,10 +611,10 @@ jQuery(document).ready(function($) {
                   var NewURL = prompt(PromptText,'http://');
                   thisOpts.prepend = NewURL;
                }
-               
+
                var GuessText = NewURL.replace('http://','').replace('www.','');
                thisOpts.prefix = '['+GuessText+']';
-               
+
                $(TextArea).insertRoundTag('',thisOpts);
                break;
 
@@ -633,12 +638,12 @@ jQuery(document).ready(function($) {
                var PromptText = gdn.definition('ButtonBarLinkUrl', 'ButtonBar.LinkUrlText');
                var NewURL = prompt(PromptText,'http://');
                var GuessText = NewURL.replace('http://','').replace('www.','');
-               
+
                var CurrentSelectText = GuessText;
                var CurrentSelect = $(TextArea).hasSelection();
                if (CurrentSelect)
                   CurrentSelectText = CurrentSelect.toString();
-               
+
                var thisOpts = $.extend(markdownOpts, {
                   prefix: '['+CurrentSelectText+']',
                   opentag:'(',
@@ -651,9 +656,9 @@ jQuery(document).ready(function($) {
                break;
          }
       }
-      
+
    }
-   
+
    // Always find new button bars and handle their events
    if(jQuery().livequery) {
       $('.ButtonBar').livequery(function(){


### PR DESCRIPTION
If you happened to have InputFormatter configured to Wysiwyg, probably after using Advanced Editor, the Button Bar plug-in would not display.  This fix adds support for the Wysiwyg format by having ButtonBar treat it as Html.

Fixes #2517 

Also some IDE-assisted whitespace fixes to class.buttonbar.plugin.php and buttonbar.js