### PR TITLE
Differentiate the ways users can be banned.

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -333,16 +333,18 @@ class UserController extends DashboardController {
       if (!$User)
          throw NotFoundException($User);
 
-//      $this->Form = new Gdn_Form();
-
       $UserModel = Gdn::UserModel();
 
-      // Block banning the superadmin or System accounts
+      // Block banning the super admin or system accounts.
       $User = $UserModel->GetID($UserID);
-      if (GetValue('Admin', $User) == 2)
-         throw ForbiddenException("@You may not ban a System user.");
-      elseif (GetValue('Admin', $User))
-         throw ForbiddenException("@You may not ban a user with the Admin flag set.");
+      if (GetValue('Admin', $User) == 2) {
+         throw ForbiddenException("@You may not ban a system user.");
+      } elseif (GetValue('Admin', $User)) {
+         throw ForbiddenException("@You may not ban a super admin.");
+      }
+
+      // Is the user banned for other reasons?
+      $this->SetData('OtherReasons', BanModel::isBanned(val('Banned', $User, 0), ~BanModel::BAN_AUTOMATIC));
 
 
       if ($this->Form->AuthenticatedPostBack()) {

--- a/applications/dashboard/locale/en-CA/definitions.php
+++ b/applications/dashboard/locale/en-CA/definitions.php
@@ -23,8 +23,8 @@ $Definition['Apply for Membership'] = 'Register';
 
 $Definition['BanReason.1'] = 'Banned by a community manager.';
 $Definition['BanReason.2'] = 'Banned by IP address, email, or name.';
-$Definition['BanReason.3'] = 'Temporarily banned by a community manager.';
-$Definition['BanReason.4'] = 'Banned by warnings.';
+$Definition['BanReason.4'] = 'Temporarily banned by a community manager.';
+$Definition['BanReason.8'] = 'Banned by warnings.';
 
 // THESE ARE RELATED TO VALIDATION FUNCTIONS IN /garden/library/core/validation.functions.php
 $Definition['ValidateRegex'] = '%s does not appear to be in the correct format.';

--- a/applications/dashboard/locale/en-CA/definitions.php
+++ b/applications/dashboard/locale/en-CA/definitions.php
@@ -21,6 +21,11 @@ if (!function_exists('FormatPossessive')) {
 
 $Definition['Apply for Membership'] = 'Register';
 
+$Definition['BanReason.1'] = 'Banned by a community manager.';
+$Definition['BanReason.2'] = 'Banned by IP address, email, or name.';
+$Definition['BanReason.3'] = 'Temporarily banned by a community manager.';
+$Definition['BanReason.4'] = 'Banned by warnings.';
+
 // THESE ARE RELATED TO VALIDATION FUNCTIONS IN /garden/library/core/validation.functions.php
 $Definition['ValidateRegex'] = '%s does not appear to be in the correct format.';
 $Definition['ValidateRequired'] = '%s is required.';

--- a/applications/dashboard/models/class.banmodel.php
+++ b/applications/dashboard/models/class.banmodel.php
@@ -38,16 +38,6 @@ class BanModel extends Gdn_Model {
    protected static $instance;
 
    /**
-    * @var array An array that maps ban reasons to their bit position.
-    */
-   protected $reasons = array(
-      self::BAN_MANUAL => 'manual',
-      self::BAN_AUTOMATIC => 'automatic',
-      self::BAN_TEMPORARY => 'temporary',
-      self::BAN_WARNING => 'warning'
-   );
-
-   /**
     * Defines the related database table name.
     */
    public function  __construct() {
@@ -138,8 +128,9 @@ class BanModel extends Gdn_Model {
 
       // Check users that need to be banned.
       foreach ($NewUsers as $User) {
-         if ($User['Banned'])
+         if (self::isBanned($User['Banned'], BanModel::BAN_AUTOMATIC)) {
             continue;
+         }
          $this->SaveUser($User, TRUE, $NewBan);
       }
    }
@@ -268,6 +259,25 @@ class BanModel extends Gdn_Model {
 
 
    /**
+    * Explode a banned bit mask into an array of ban constants.
+    * @param int $banned The banned bit mask to explode.
+    * @return array Returns an array of the set bits.
+    */
+   public static function explodeBans($banned) {
+      $result = array();
+
+      for ($i = 1; $i <= 8; $i++) {
+         $bit = pow(2, $i - 1);
+         if (($banned &  $bit) === $bit) {
+            $result[] = $bit;
+         }
+      }
+
+      return $result;
+   }
+
+
+   /**
     * Check whether or not a banned value is banned for a given reason.
     *
     * @param int $banned The banned value.
@@ -279,7 +289,7 @@ class BanModel extends Gdn_Model {
       if (!$reason) {
          return (bool)$banned;
       } else {
-         return ($banned & $reason) === $reason;
+         return ($banned & $reason) > 0;
       }
    }
 

--- a/applications/dashboard/models/class.banmodel.php
+++ b/applications/dashboard/models/class.banmodel.php
@@ -4,7 +4,7 @@
  *
  * @package Dashboard
  */
- 
+
 /**
  * Manage banning of users.
  *
@@ -12,16 +12,61 @@
  * @package Dashboard
  */
 class BanModel extends Gdn_Model {
+   /**
+    * Manually banned by a moderator.
+    */
+   const BAN_MANUAL = 0x1;
+   /**
+    * Automatically banned by an IP ban, name, or email ban.
+    */
+   const BAN_AUTOMATIC = 0x2;
+   /**
+    * Reserved for future functionality.
+    */
+   const BAN_TEMPORARY = 0x4;
+   /**
+    * Banned by the warnings plugin.
+    */
+   const BAN_WARNING = 0x8;
+
    /* @var array */
    protected static $_AllBans;
+
+   /**
+    * @var BanModel The singleton instance of this class.
+    */
+   protected static $instance;
+
+   /**
+    * @var array An array that maps ban reasons to their bit position.
+    */
+   protected $reasons = array(
+      self::BAN_MANUAL => 'manual',
+      self::BAN_AUTOMATIC => 'automatic',
+      self::BAN_TEMPORARY => 'temporary',
+      self::BAN_WARNING => 'warning'
+   );
 
    /**
     * Defines the related database table name.
     */
    public function  __construct() {
       parent::__construct('Ban');
+      $this->FireEvent('Init');
    }
-   
+
+   /**
+    * Get the singleton instance of the {@link BanModel} class.
+    *
+    * @return BanModel Returns the singleton instance of this class.
+    */
+   public static function instance() {
+      if (!isset(self::$instance)) {
+         self::$instance = new BanModel();
+      }
+      return self::$instance;
+   }
+
    /*
     * Get and store list of current bans.
     *
@@ -36,7 +81,7 @@ class BanModel extends Gdn_Model {
 //      $AllBans =& self::$_AllBans;
       return self::$_AllBans;
    }
-   
+
    /**
     * Convert bans to new type.
     *
@@ -55,9 +100,9 @@ class BanModel extends Gdn_Model {
 
       $NewUsers = array();
       $NewUserIDs = array();
-      
+
       $AllBans = $this->AllBans();
-      
+
       if ($NewBan) {
          // Get a list of users affected by the new ban.
          if (isset($NewBan['BanID']))
@@ -98,7 +143,7 @@ class BanModel extends Gdn_Model {
          $this->SaveUser($User, TRUE, $NewBan);
       }
    }
-   
+
    /**
     * Ban users that meet conditions given.
     *
@@ -107,7 +152,7 @@ class BanModel extends Gdn_Model {
     * @param array $Ban Data about the ban.
     *    Valid keys are BanType and BanValue. BanValue is what is to be banned.
     *    Valid values for BanType are email, ipaddress or name.
-    */ 
+    */
    public function BanWhere($Ban) {
       $Result = array('u.Admin' => 0, 'u.Deleted' => 0);
       $Ban['BanValue'] = str_replace('*', '%', $Ban['BanValue']);
@@ -125,7 +170,7 @@ class BanModel extends Gdn_Model {
       }
       return $Result;
    }
-   
+
    /**
     * Add ban data to all Get requests.
     *
@@ -156,7 +201,7 @@ class BanModel extends Gdn_Model {
       $Bans = self::AllBans();
       $Fields = array('Name' => 'Name', 'Email' => 'Email', 'IPAddress' => 'LastIPAddress');
       $Banned = array();
-      
+
       if (!$BansFound)
          $BansFound = array();
 
@@ -188,13 +233,13 @@ class BanModel extends Gdn_Model {
       }
       return count($Banned) == 0;
    }
-   
+
    /**
     * Remove a ban.
     *
     * @since 2.0.18
     * @access public
-    * 
+    *
     * @param array $Where
     * @param int $Limit
     * @param bool $ResetData
@@ -220,13 +265,47 @@ class BanModel extends Gdn_Model {
 //
 //      return $Result;
 //   }
-   
+
+
+   /**
+    * Check whether or not a banned value is banned for a given reason.
+    *
+    * @param int $banned The banned value.
+    * @param int $reason The reason for the banning or an empty string to check if banned for any reason.
+    * This should be one of the `BanModel::BAN_*` constants.
+    * @return bool Returns true if the value is banned or false otherwise.
+    */
+   public static function isBanned($banned, $reason = 0) {
+      if (!$reason) {
+         return (bool)$banned;
+      } else {
+         return ($banned & $reason) === $reason;
+      }
+   }
+
+   /**
+    * Set the banned mask value for a reason and return the new value.
+    *
+    * @param int $banned The current banned value.
+    * @param bool $value The new ban value for the given reason.
+    * @param int $reason The reason for the banning. This should be one of the `BanModel::BAN_*` constants.
+    * @return int Returns the new banned value.
+    */
+   public static function setBanned($banned, $value, $reason) {
+      if ($value) {
+         $banned = $banned | $reason;
+      } else {
+         $banned = $banned & ~$reason;
+      }
+      return $banned;
+   }
+
    /**
     * Save data about ban from form.
     *
     * @since 2.0.18
     * @access public
-    * 
+    *
     * @param array $FormPostValues
     * @param array $Settings
     */
@@ -238,7 +317,7 @@ class BanModel extends Gdn_Model {
          $CurrentBan = $this->GetID($CurrentBanID, DATASET_TYPE_ARRAY);
       else
          $CurrentBan = NULL;
-    
+
       $this->SetCounts($FormPostValues);
       $BanID = parent::Save($FormPostValues, $Settings);
       $FormPostValues['BanID'] = $BanID;
@@ -258,14 +337,18 @@ class BanModel extends Gdn_Model {
     *
     * @param array $User
     * @param bool $BannedValue Whether user is banned.
+    * @param array|false $Ban An array representing the specific auto-ban.
     */
    public function SaveUser($User, $BannedValue, $Ban = FALSE) {
+      $BannedValue = (bool)$BannedValue;
       $Banned = $User['Banned'];
 
-      if ($Banned == $BannedValue)
+      if (static::isBanned($Banned, self::BAN_AUTOMATIC) === $BannedValue) {
          return;
-      
-      Gdn::UserModel()->SetField($User['UserID'], 'Banned', $BannedValue);
+      }
+
+      $NewBanned = static::setBanned($Banned, $BannedValue, self::BAN_AUTOMATIC);
+      Gdn::UserModel()->SetField($User['UserID'], 'Banned', $NewBanned);
 
       // Add the activity.
       $ActivityModel = new ActivityModel();
@@ -275,14 +358,14 @@ class BanModel extends Gdn_Model {
           'RegardingUserID' => Gdn::Session()->UserID,
           'NotifyUserID' => ActivityModel::NOTIFY_MODS
           );
-      
+
       $BannedString = $BannedValue ? 'banned' : 'unbanned';
       if ($Ban) {
          $Activity['HeadlineFormat'] = '{ActivityUserID,user} was '.$BannedString.' (based on {Data.BanType}: {Data.BanValue}).';
          $Activity['Data'] = ArrayTranslate($Ban, array('BanType', 'BanValue'));
          $Activity['Story'] = $Ban['Notes'];
          $Activity['RecordType'] = 'Ban';
-         
+
          if (isset($Ban['BanID'])) {
             $Activity['BanID'] = $Ban['BanID'];
          }
@@ -291,7 +374,7 @@ class BanModel extends Gdn_Model {
       }
       $ActivityModel->Save($Activity);
    }
-   
+
    /**
     * Set number of banned users in $Data.
     *

--- a/applications/dashboard/modules/class.profileoptionsmodule.php
+++ b/applications/dashboard/modules/class.profileoptionsmodule.php
@@ -40,7 +40,7 @@ class ProfileOptionsModule extends Gdn_Module {
          // Ban/Unban
          $MayBan = CheckPermission('Garden.Moderation.Manage') || CheckPermission('Garden.Users.Edit') || CheckPermission('Moderation.Users.Ban');
          if ($MayBan && $UserID != $Session->UserID) {
-            if ($Controller->User->Banned) {
+            if (BanModel::isBanned($Controller->User->Banned, BanModel::BAN_MANUAL)) {
                $ProfileOptions[] = array('Text' => Sprite('SpBan').' '.T('Unban'), 'Url' => "/user/ban?userid=$UserID&unban=1", 'CssClass' => 'Popup');
             } elseif (!$Controller->User->Admin) {
                $ProfileOptions[] = array('Text' => Sprite('SpBan').' '.T('Ban'), 'Url' => "/user/ban?userid=$UserID", 'CssClass' => 'Popup');

--- a/applications/dashboard/modules/class.userbanmodule.php
+++ b/applications/dashboard/modules/class.userbanmodule.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2014 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+class UserBanModule extends GDN_Module {
+
+   /**
+    * @var int The ban(s) to exclude from the reasons.
+    */
+   public $ExcludeBans = 0;
+
+   /**
+    * @var string The translation code for the the summary.
+    */
+   public $Summary;
+
+   /**
+    * @var int UserID The user ID we are looking at. Default to the current user.
+    */
+   public $UserID;
+
+   /**
+    * Initialize a new instance of the {@link UserBanModule} class.
+    */
+   public function __construct() {
+      parent::__construct();
+      $this->_ApplicationFolder = 'dashboard';
+   }
+
+   protected function getData() {
+      $userID = $this->UserID ?: Gdn::Session()->UserID;
+      $user = Gdn::UserModel()->GetID($userID);
+
+      $banned = val('Banned', $user);
+      $bits = BanModel::explodeBans($banned);
+      $reasons = array();
+
+      foreach ($bits as $bit) {
+         if (($bit & $this->ExcludeBans) === 0) {
+            $reasons[$bit] = T("BanReason.$bit");
+         }
+      }
+      $this->SetData('Reasons', $reasons);
+
+      if (!$this->Summary) {
+         if ($this->ExcludeBans) {
+            $summary = "Also banned for the following:";
+         } else {
+            $summary = "Banned for the following:";
+         }
+      }
+      $this->SetData('Summary', $this->Summary ?: $summary);
+
+      $this->EventArguments['User'] = $user;
+      $this->FireEvent('GetData');
+   }
+
+   public function ToString() {
+      if (!Gdn::Session()->CheckPermission('Garden.Moderation.Manage')) {
+         // Only moderators can view the reasons for being banned.
+         return '';
+      }
+
+      $this->getData();
+
+      if (empty($this->Data['Reasons'])) {
+         return '';
+      } else {
+         return parent::ToString();
+      }
+   }
+}

--- a/applications/dashboard/views/modules/userban.php
+++ b/applications/dashboard/views/modules/userban.php
@@ -1,0 +1,12 @@
+<div class="Hero Hero-Bans">
+   <div class="Message">
+      <?php
+      echo T($this->Data('Summary'));
+      ?>
+      <ul>
+         <?php foreach ($this->Data('Reasons', array()) as $Reason) {?>
+            <li><?php echo $Reason; ?></li>
+         <?php } ?>
+      </ul>
+   </div>
+</div>

--- a/applications/dashboard/views/profile/user.php
+++ b/applications/dashboard/views/profile/user.php
@@ -27,6 +27,9 @@ $Session = Gdn::Session();
 
       echo '</div>';
    }
+
+   echo Gdn_Theme::Module('UserBanModule', array('UserID' => $this->User->UserID));
+
    $this->FireEvent('BeforeUserInfo');
    echo Gdn_Theme::Module('UserInfoModule');
    $this->FireEvent('AfterUserInfo');

--- a/applications/dashboard/views/user/unban.php
+++ b/applications/dashboard/views/user/unban.php
@@ -9,9 +9,13 @@ echo $this->Form->Errors();
 <div class="DismissMessage WarningMessage">
    <?php
    echo FormatString(T('You are about to unban {User.UserID,user}.'), $this->Data);
+
+   if ($this->Data('OtherReasons')) {
+      echo "\n".T('This user is also banned for other reasons and may stay banned.');
+   }
    ?>
 </div>
-   
+
 <?php
 
 if ($LogID = $this->Data('User.Attributes.BanLogID')) {


### PR DESCRIPTION
Currently, there is no way to know the difference between a  user being banned manually and then by IP address. This can cause issue where users get blanked banned/unbanned when they aren't supposed to. This feature adds the following.

* Adds a bit mask to the banned flag to keep track of the various ways users get banned.
* Allows CMs to manually ban/unban users that have been caught by an IP ban, but keep that IP ban in effect.
* Adds some hooks for future bans by warnings and temporary banning.