### PR TITLE
Add support for internal controller methods.

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -282,6 +282,11 @@ class Gdn_Controller extends Gdn_Pluggable {
    protected $_Headers;
 
    /**
+    * @var array An array of internal methods that cannot be dispatched.
+    */
+   protected $internalMethods;
+
+   /**
     * A collection of "inform" messages to be displayed to the user.
     *
     * @since 2.0.18
@@ -331,6 +336,15 @@ class Gdn_Controller extends Gdn_Pluggable {
       $this->CssClass = '';
       $this->Data = array();
       $this->Head = Gdn::Factory('Dummy');
+      $this->internalMethods = array(
+         '__construct', 'addasset', 'addbreadcrumb', 'addcssfile', 'adddefinition', 'addinternalmethod', 'addjsfile', 'addmodule',
+         'allowjsonp', 'canonicalurl', 'clearcssfiles', 'clearjsfiles', 'contenttype', 'cssfiles', 'data',
+         'definitionlist', 'deliverymethod', 'deliverytype', 'description', 'errormessages', 'fetchview',
+         'fetchviewlocation', 'finalize', 'getasset', 'getimports', 'getjson', 'getstatusmessage', 'image',
+         'informmessage', 'intitialize', 'isinternal', 'jsfiles', 'json', 'jsontarget', 'masterview', 'pagename',
+         'permission', 'removecssfile', 'render', 'renderasset', 'renderdata', 'renderexception', 'rendermaster',
+         'sendheaders', 'setdata', 'setformsaved', 'setheader', 'setjson', 'setlastmodified', 'statuscode', 'title'
+      );
       $this->MasterView = '';
       $this->ModuleSortContainer = '';
       $this->OriginalRequestMethod = '';
@@ -449,6 +463,15 @@ class Gdn_Controller extends Gdn_Pluggable {
          $this->_Definitions[$Term] = $Definition;
       }
       return ArrayValue($Term, $this->_Definitions);
+   }
+
+   /**
+    * Add an method to the list of internal methods.
+    *
+    * @param string $methodName The name of the internal method to add.
+    */
+   public function addInternalMethod($methodName) {
+      $this->internalMethods[] = strtolower($methodName);
    }
 
    /**
@@ -1063,6 +1086,17 @@ class Gdn_Controller extends Gdn_Pluggable {
 
    public function JsFiles() {
       return $this->_JsFiles;
+   }
+
+   /**
+    * Determines whether a method on this controller is internal and can't be dispatched.
+    *
+    * @param string $methodName The name of the method.
+    * @return bool Returns true if the method is internal or false otherwise.
+    */
+   public function isInternal($methodName) {
+      $result = in_array(strtolower($methodName), $this->internalMethods);
+      return $result;
    }
 
    /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -342,7 +342,7 @@ class Gdn_Controller extends Gdn_Pluggable {
          'definitionlist', 'deliverymethod', 'deliverytype', 'description', 'errormessages', 'fetchview',
          'fetchviewlocation', 'finalize', 'getasset', 'getimports', 'getjson', 'getstatusmessage', 'image',
          'informmessage', 'intitialize', 'isinternal', 'jsfiles', 'json', 'jsontarget', 'masterview', 'pagename',
-         'permission', 'removecssfile', 'render', 'renderasset', 'renderdata', 'renderexception', 'rendermaster',
+         'permission', 'removecssfile', 'render', 'xrender', 'renderasset', 'renderdata', 'renderexception', 'rendermaster',
          'sendheaders', 'setdata', 'setformsaved', 'setheader', 'setjson', 'setlastmodified', 'statuscode', 'title'
       );
       $this->MasterView = '';

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -337,7 +337,7 @@ class Gdn_Controller extends Gdn_Pluggable {
       $this->Data = array();
       $this->Head = Gdn::Factory('Dummy');
       $this->internalMethods = array(
-         '__construct', 'addasset', 'addbreadcrumb', 'addcssfile', 'adddefinition', 'addinternalmethod', 'addjsfile', 'addmodule',
+         'addasset', 'addbreadcrumb', 'addcssfile', 'adddefinition', 'addinternalmethod', 'addjsfile', 'addmodule',
          'allowjsonp', 'canonicalurl', 'clearcssfiles', 'clearjsfiles', 'contenttype', 'cssfiles', 'data',
          'definitionlist', 'deliverymethod', 'deliverytype', 'description', 'errormessages', 'fetchview',
          'fetchviewlocation', 'finalize', 'getasset', 'getimports', 'getjson', 'getstatusmessage', 'image',
@@ -1095,7 +1095,7 @@ class Gdn_Controller extends Gdn_Pluggable {
     * @return bool Returns true if the method is internal or false otherwise.
     */
    public function isInternal($methodName) {
-      $result = in_array(strtolower($methodName), $this->internalMethods);
+      $result = substr($methodName, 0, 1) === '_' || in_array(strtolower($methodName), $this->internalMethods);
       return $result;
    }
 

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -246,6 +246,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
       $ControllerName = $this->ControllerName();
       if ($ControllerName != '' && class_exists($ControllerName)) {
          // Create it and call the appropriate method/action
+         /* @var Gdn_Controller $Controller */
          $Controller = new $ControllerName();
          Gdn::Controller($Controller);
 
@@ -286,7 +287,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
          // Take enabled plugins into account, as well
          $PluginReplacement = Gdn::PluginManager()->HasNewMethod($this->ControllerName(), $this->ControllerMethod);
-         if (!$PluginReplacement && ($this->ControllerMethod == '' || !method_exists($Controller, $ControllerMethod))) {
+         if (!$PluginReplacement && ($this->ControllerMethod == '' || !method_exists($Controller, $ControllerMethod)) && !$Controller->isInternal($ControllerMethod)) {
             // Check to see if there is an 'x' version of the method.
             if (method_exists($Controller, 'x' . $ControllerMethod)) {
                // $PluginManagerHasReplacementMethod = TRUE;
@@ -344,7 +345,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             } catch (Exception $Ex) {
                $Controller->RenderException($Ex);
             }
-         } elseif (method_exists($Controller, $ControllerMethod)) {
+         } elseif (method_exists($Controller, $ControllerMethod) && !$Controller->isInternal($ControllerMethod)) {
             $Args = ReflectArgs(array($Controller, $ControllerMethod), $this->_ControllerMethodArgs, $ReflectionArguments);
             $this->_ControllerMethodArgs = $Args;
             $Controller->ReflectArgs = $Args;


### PR DESCRIPTION
An internal method is a method that is public, but should not be dispatched to. It’s a method to be used by plugins and the framework, but not accessed from a url.