### PR TITLE
Garden.TrustedDomain should be formatted as a string in config

### DIFF
--- a/applications/dashboard/controllers/class.embedcontroller.php
+++ b/applications/dashboard/controllers/class.embedcontroller.php
@@ -112,8 +112,8 @@ class EmbedController extends DashboardController {
       } else {
          // Format the trusted domains as an array based on newlines & spaces
          $TrustedDomains = $this->Form->GetValue('Garden.TrustedDomains');
-         $TrustedDomains = explode(' ', str_replace("\n", ' ', $TrustedDomains));
-         $TrustedDomains = array_unique(array_map('trim', $TrustedDomains));
+         $TrustedDomains = explode("\n", $TrustedDomains);
+         $TrustedDomains = array_unique(array_filter(array_map('trim', $TrustedDomains)));
          $TrustedDomains = implode("\n", $TrustedDomains);
          $this->Form->SetFormValue('Garden.TrustedDomains', $TrustedDomains);
          if ($this->Form->Save() !== FALSE) {

--- a/applications/dashboard/controllers/class.embedcontroller.php
+++ b/applications/dashboard/controllers/class.embedcontroller.php
@@ -1,8 +1,8 @@
 <?php if (!defined('APPLICATION')) exit();
- 
+
 /**
  * Manages the embedding of a forum on a foreign page.
- * 
+ *
  * @copyright 2003 Vanilla Forums, Inc
  * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
  * @package Garden
@@ -12,31 +12,31 @@
 class EmbedController extends DashboardController {
    /**
     * Models to include.
-    * 
+    *
     * @since 2.0.18
     * @access public
     * @var array
     */
    public $Uses = array('Database', 'Form');
-   
+
    public function Index() {
       Redirect('embed/comments');
    }
-   
+
    public function Initialize() {
       parent::Initialize();
       Gdn_Theme::Section('Dashboard');
    }
-   
+
    /**
     * Display the embedded forum.
-    * 
+    *
     * @since 2.0.18
     * @access public
     */
    public function Comments($Toggle = '', $TransientKey = '') {
       $this->Permission('Garden.Settings.Manage');
-      
+
       try {
          if ($this->Toggle($Toggle, $TransientKey))
             Redirect('embed/comments');
@@ -49,7 +49,7 @@ class EmbedController extends DashboardController {
       $Validation = new Gdn_Validation();
       $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
       $ConfigurationModel->SetField(array('Garden.Embed.CommentsPerPage', 'Garden.Embed.SortComments', 'Garden.Embed.PageToForum'));
-      
+
       $this->Form->SetModel($ConfigurationModel);
       if ($this->Form->AuthenticatedPostBack() === FALSE) {
          // Apply the config settings to the form.
@@ -58,14 +58,14 @@ class EmbedController extends DashboardController {
          if ($this->Form->Save() !== FALSE)
             $this->InformMessage(T("Your settings have been saved."));
       }
-      
+
       $this->Title(T('Blog Comments'));
       $this->Render();
    }
-   
+
    public function Forum($Toggle = '', $TransientKey = '') {
       $this->Permission('Garden.Settings.Manage');
-      
+
       try {
          if ($this->Toggle($Toggle, $TransientKey))
             Redirect('embed/forum');
@@ -77,17 +77,17 @@ class EmbedController extends DashboardController {
       $this->Title('Embed Forum');
       $this->Render();
    }
-   
+
    public function Advanced($Toggle = '', $TransientKey = '') {
       $this->Permission('Garden.Settings.Manage');
-      
+
       try {
          if ($this->Toggle($Toggle, $TransientKey))
             Redirect('embed/advanced');
       } catch (Gdn_UserException $Ex) {
          $this->Form->AddError($Ex);
       }
-      
+
       $this->Title('Advanced Embed Settings');
 
       $this->AddSideMenu('dashboard/embed/advanced');
@@ -96,14 +96,15 @@ class EmbedController extends DashboardController {
       $Validation = new Gdn_Validation();
       $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
       $ConfigurationModel->SetField(array('Garden.TrustedDomains', 'Garden.Embed.RemoteUrl', 'Garden.Embed.ForceDashboard', 'Garden.Embed.ForceForum', 'Garden.SignIn.Popup'));
-      
+
       $this->Form->SetModel($ConfigurationModel);
       if ($this->Form->AuthenticatedPostBack() === FALSE) {
          // Format trusted domains as a string
          $TrustedDomains = GetValue('Garden.TrustedDomains', $ConfigurationModel->Data);
-         if (is_array($TrustedDomains))
+         if (is_array($TrustedDomains)) {
             $TrustedDomains = implode("\n", $TrustedDomains);
-         
+         }
+
          $ConfigurationModel->Data['Garden.TrustedDomains'] = $TrustedDomains;
 
          // Apply the config settings to the form.
@@ -113,23 +114,25 @@ class EmbedController extends DashboardController {
          $TrustedDomains = $this->Form->GetValue('Garden.TrustedDomains');
          $TrustedDomains = explode(' ', str_replace("\n", ' ', $TrustedDomains));
          $TrustedDomains = array_unique(array_map('trim', $TrustedDomains));
+         $TrustedDomains = implode("\n", $TrustedDomains);
          $this->Form->SetFormValue('Garden.TrustedDomains', $TrustedDomains);
-         if ($this->Form->Save() !== FALSE)
+         if ($this->Form->Save() !== FALSE) {
             $this->InformMessage(T("Your settings have been saved."));
-         
+         }
+
          // Reformat array as string so it displays properly in the form
-         $this->Form->SetFormValue('Garden.TrustedDomains', implode("\n", $TrustedDomains));
+         $this->Form->SetFormValue('Garden.TrustedDomains', $TrustedDomains);
       }
-      
+
       $this->Permission('Garden.Settings.Manage');
       $this->Render();
    }
-   
-   /** 
+
+   /**
     * Handle toggling this version of embedding on and off. Take care of disabling the other version of embed (the old plugin).
     * @param type $Toggle
     * @param type $TransientKey
-    * @return boolean 
+    * @return boolean
     */
    private function Toggle($Toggle = '', $TransientKey = '') {
       if (in_array($Toggle, array('enable', 'disable')) && Gdn::Session()->ValidateTransientKey($TransientKey)) {
@@ -140,13 +143,13 @@ class EmbedController extends DashboardController {
          SaveToConfig('Garden.Embed.Allow', $Toggle == 'enable' ? TRUE : FALSE);
          return TRUE;
       }
-      return FALSE;      
+      return FALSE;
    }
-   
-   
+
+
    /**
     * Allow for a custom embed theme.
-    * 
+    *
     * @since 2.0.18
     * @access public
     */

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1883,6 +1883,10 @@ EOT;
 
          // Only allow external redirects to trusted domains.
          $TrustedDomains = C('Garden.TrustedDomains', TRUE);
+         // Trusted domains were previously saved in config as an array.
+         if ($TrustedDomains && $TrustedDomains !== TRUE && !is_array($TrustedDomains)) {
+            $TrustedDomains = explode("\n", $TrustedDomains);
+         }
 
          if (is_array($TrustedDomains)) {
             // Add this domain to the trusted hosts.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3347,7 +3347,10 @@ if (!function_exists('TrustedDomains')) {
     * @return array
     */
    function TrustedDomains() {
-      $Result = (array)C('Garden.TrustedDomains', array());
+      $Result = C('Garden.TrustedDomains', array());
+      if (!is_array($Result)) {
+         $Result = explode("\n", $Result);
+      }
 
       // This domain is safe.
       $Result[] = Gdn::Request()->Host();


### PR DESCRIPTION
* Stores Garden.TrustedDomain as a string rather than an array.
* Preserves backwards compatibility with stored arrays.
* Better input cleanup.

/embed/settings is currently broken on cloud, possibly due to our config override resetting the schema and disallowing arrays.