### PR TITLE
global.js context bug: change `this` to `$elem`

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -676,7 +676,7 @@ jQuery(document).ready(function($) {
          data: { DeliveryType: 'VIEW', DeliveryMethod: 'JSON', TransientKey: gdn.definition('TransientKey') },
          dataType: 'json',
          complete: function() {
-            gdn.enable($elem);
+            gdn.enable($elem.get(0));
             $elem.removeClass(progressClass);
             $elem.attr('href', href);
 

--- a/js/global.js
+++ b/js/global.js
@@ -676,7 +676,7 @@ jQuery(document).ready(function($) {
          data: { DeliveryType: 'VIEW', DeliveryMethod: 'JSON', TransientKey: gdn.definition('TransientKey') },
          dataType: 'json',
          complete: function() {
-            gdn.enable(this);
+            gdn.enable($elem);
             $elem.removeClass(progressClass);
             $elem.attr('href', href);
 


### PR DESCRIPTION
Change proposed here: http://vanillaforums.org/discussion/29836/possible-bug-in-core-global-js#latest
`this` is not in the proper context when the `complete` method is called. `$elem` should be used to reference the element that initiated the $.ajax request.