### PR TITLE
Add a config setting to only sync roles on register and fix the sync roles config spelling mistake.

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -455,7 +455,7 @@ EOT;
       $UserID = GetValue('UserID', $Auth);
 
       // Check to synchronise roles upon connecting.
-      if (($this->Data('Trusted') || C('Garden.SSO.SynchRoles')) && $this->Form->GetFormValue('Roles', NULL) !== NULL) {
+      if (($this->Data('Trusted') || C('Garden.SSO.SyncRoles')) && $this->Form->GetFormValue('Roles', NULL) !== NULL) {
          $SaveRoles = TRUE;
 
          // Translate the role names to IDs.

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -468,7 +468,7 @@ EOT;
             $RoleIDs = $this->UserModel->NewUserRoleIDs();
          }
 
-         if (C('Garden.SSO.SyncRolesBehaviour') === 'register') {
+         if (C('Garden.SSO.SyncRolesBehavior') === 'register') {
             $SaveRolesRegister = TRUE;
             $SaveRoles = FALSE;
          }

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -468,9 +468,15 @@ EOT;
             $RoleIDs = $this->UserModel->NewUserRoleIDs();
          }
 
+         if (C('Garden.SSO.SyncRolesBehaviour') === 'register') {
+            $SaveRolesRegister = TRUE;
+            $SaveRoles = FALSE;
+         }
+
          $this->Form->SetFormValue('RoleID', $RoleIDs);
       } else {
          $SaveRoles = FALSE;
+         $SaveRolesRegister = FALSE;
       }
 
       if ($UserID) {
@@ -615,8 +621,7 @@ EOT;
             $User['Attributes'] = $this->Form->GetFormValue('Attributes', NULL);
             $User['Email'] = $this->Form->GetFormValue('ConnectEmail', $this->Form->GetFormValue('Email', NULL));
 
-//            $UserID = $UserModel->InsertForBasic($User, FALSE, array('ValidateEmail' => FALSE, 'NoConfirmEmail' => TRUE, 'SaveRoles' => $SaveRoles));
-            $UserID = $UserModel->Register($User, array('CheckCaptcha' => FALSE, 'ValidateEmail' => FALSE, 'NoConfirmEmail' => TRUE, 'SaveRoles' => $SaveRoles));
+            $UserID = $UserModel->Register($User, array('CheckCaptcha' => FALSE, 'ValidateEmail' => FALSE, 'NoConfirmEmail' => TRUE, 'SaveRoles' => $SaveRolesRegister));
 
             $User['UserID'] = $UserID;
             $this->Form->SetValidationResults($UserModel->ValidationResults());
@@ -709,7 +714,7 @@ EOT;
             $User['Name'] = $User['ConnectName'];
             $User['Password'] = RandomString(50); // some password is required
             $User['HashMethod'] = 'Random';
-            $UserID = $UserModel->Register($User, array('CheckCaptcha' => FALSE, 'NoConfirmEmail' => TRUE, 'SaveRoles' => $SaveRoles));
+            $UserID = $UserModel->Register($User, array('CheckCaptcha' => FALSE, 'NoConfirmEmail' => TRUE, 'SaveRoles' => $SaveRolesRegister));
             $User['UserID'] = $UserID;
             $this->Form->SetValidationResults($UserModel->ValidationResults());
 

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -456,7 +456,7 @@ EOT;
 
       // Check to synchronise roles upon connecting.
       if (($this->Data('Trusted') || C('Garden.SSO.SyncRoles')) && $this->Form->GetFormValue('Roles', NULL) !== NULL) {
-         $SaveRoles = TRUE;
+         $SaveRoles = $SaveRolesRegister = TRUE;
 
          // Translate the role names to IDs.
          $Roles = $this->Form->GetFormValue('Roles', NULL);
@@ -469,7 +469,6 @@ EOT;
          }
 
          if (C('Garden.SSO.SyncRolesBehavior') === 'register') {
-            $SaveRolesRegister = TRUE;
             $SaveRoles = FALSE;
          }
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -556,7 +556,7 @@ class UserModel extends Gdn_Model {
          Trace('Not setting photo.');
       }
 
-      if (C('Garden.SSO.SynchRoles')) {
+      if (C('Garden.SSO.SyncRoles')) {
          // Translate the role names to IDs.
          $Roles = GetValue('Roles', $NewUser, '');
          if (is_string($Roles)) {
@@ -643,7 +643,7 @@ class UserModel extends Gdn_Model {
             TouchValue('CheckCaptcha', $Options, FALSE);
             TouchValue('NoConfirmEmail', $Options, TRUE);
             TouchValue('NoActivity', $Options, TRUE);
-            TouchValue('SaveRoles', $Options, C('Garden.SSO.SynchRoles', false));
+            TouchValue('SaveRoles', $Options, C('Garden.SSO.SyncRoles', false));
 
             Trace($UserData, 'Registering User');
             $UserID = $this->Register($UserData, $Options);

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -213,6 +213,15 @@ $Construct->Table('UserAuthenticationToken')
    ->Column('Lifetime', 'int', FALSE)
    ->Set($Explicit, $Drop);
 
+// Fix the sync roles config spelling mistake.
+if (C('Garden.SSO.SynchRoles')) {
+   SaveToConfig(
+      array('Garden.SSO.SynchRoles' => '', 'Garden.SSO.SyncRoles' => C('Garden.SSO.SynchRoles')),
+      '',
+      array('RemoveEmpty' => true)
+   );
+}
+
 $Construct->Table('Session')
 	->Column('SessionID', 'char(32)', FALSE, 'primary')
 	->Column('UserID', 'int', 0)


### PR DESCRIPTION
The Garden.SSO.SyncRoleBehavior can be set to “register” so that roles will only synchronize when registering and not on subsequent sign ins.