### PR TITLE
Fix bug where comments don’t update the latest post on categories.

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -933,14 +933,12 @@ class CommentModel extends VanillaModel {
             ));
 
             // Update the cache.
-            if ($DiscussionID && $this->pageCache) {
-               $CategoryCache = array(
-                   'LastTitle'         => $Discussion->Name, // kluge so JoinUsers doesn't wipe this out.
-                   'LastUserID'        => $Fields['InsertUserID'],
-                   'LastUrl'           => DiscussionUrl($Discussion).'#latest'
-               );
-               CategoryModel::SetCache($Discussion->CategoryID, $CategoryCache);
-            }
+            $CategoryCache = array(
+                'LastTitle'         => $Discussion->Name, // kluge so JoinUsers doesn't wipe this out.
+                'LastUserID'        => $Fields['InsertUserID'],
+                'LastUrl'           => DiscussionUrl($Discussion).'#latest'
+            );
+            CategoryModel::SetCache($Discussion->CategoryID, $CategoryCache);
 			}
 
 			// Prepare the notification queue.


### PR DESCRIPTION
The issue is caused when memcached is enabled. The logic was looking at a property erroneously and that check was removed.