### PR TITLE
Change the priorization of formatters of To() function

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -255,17 +255,7 @@ class Gdn_Format {
    public static function BBCode($Mixed) {
       if (!is_string($Mixed)) {
          return self::To($Mixed, 'BBCode');
-      } else {
-         // See if there is a custom BBCode formatter.
-         $BBCodeFormatter = Gdn::Factory('BBCodeFormatter');
-         if (is_object($BBCodeFormatter)) {
-            $Result = $BBCodeFormatter->Format($Mixed);
-            $Result = Gdn_Format::Links($Result);
-            $Result = Gdn_Format::Mentions($Result);
-	    $Result = Emoji::instance()->translateToHtml($Result);
-
-            return $Result;
-         }
+      }
 
          $Formatter = Gdn::Factory('HtmlFormatter');
          if (is_null($Formatter)) {
@@ -1564,13 +1554,13 @@ EOT;
    public static function To($Mixed, $FormatMethod) {
       // Process $Mixed based on its type.
       if (is_string($Mixed)) {
-         if (in_array(strtolower($FormatMethod), self::$SanitizedFormats) && method_exists('Gdn_Format', $FormatMethod)) {
-            $Mixed = self::$FormatMethod($Mixed);
+         if ($Formatter = Gdn::Factory($FormatMethod.'Formatter')) {
+            $Mixed = $Formatter->Format($Mixed);
          } elseif (function_exists('format'.$FormatMethod)) {
             $FormatMethod = 'format'.$FormatMethod;
             $Mixed = $FormatMethod($Mixed);
-         } elseif ($Formatter = Gdn::Factory($FormatMethod.'Formatter')) {
-            $Mixed = $Formatter->Format($Mixed);
+         } elseif (in_array(strtolower($FormatMethod), self::$SanitizedFormats) && method_exists('Gdn_Format', $FormatMethod)) {
+            $Mixed = self::$FormatMethod($Mixed);
          } else {
             $Mixed = Gdn_Format::Text($Mixed);
          }


### PR DESCRIPTION
<b>At first: I'm <i>very</i> unsure about this one!</b>

As far as I can tell, by now it wouldn't be possible to override any standard formatter of class.format.php easily. The classes functions are always used first and if they do not implement an alternative way, a plugin author is lost.
Although such an alternative exists for function BBCode(), it leaves the output out of the control of the plugin author since there are three more transformations after the custom result is returned.
function Markdown() doesn't give an alternative at all.

So I think if someone wants to have a custom formatter, it should be used at first. If someone doesn't implement a formatter but simply installs a custom function formatSomething, that function should be used.

(By the way: I do not understand why there are those two possibilities: to me they look as if they would work exactly the same.)

And then - and only if there is no alternative! - the standard functions should be used. The formatting functions aren't even declared with an enclosing `if(!function_exists...` so I think that someone who wants to implement a custom Markdown formatter is lost.