### PR TITLE
Add some more error checking to OpenID urls before discovery.

### DIFF
--- a/applications/dashboard/locale/en-CA/definitions.php
+++ b/applications/dashboard/locale/en-CA/definitions.php
@@ -51,6 +51,7 @@ $Definition['ValidateVersion'] = 'The %s field is not a valid version number. Se
 $Definition['ValidateBanned'] = 'That %s is not allowed.';
 $Definition['ValidateString'] = '%s is not a valid string.';
 $Definition['ValidateUrlStringRelaxed'] = '%s can not contain slashes, quotes or tag characters.';
+$Definition['ValidateUrl'] = 'The %s field is not a valid url.';
 $Definition['ErrorPermission'] = 'Sorry, permission denied.';
 $Definition['InviteErrorPermission'] = 'Sorry, permission denied.';
 $Definition['PermissionRequired.Garden.Moderation.Manage'] = 'You need to be a moderator to do that.';

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -124,6 +124,7 @@ class Gdn_Validation {
       $this->AddRule('PhoneInt', 'function:ValidatePhoneInt');
       $this->AddRule('ZipCode', 'function:ValidateZipCode');
       $this->AddRule('Format', 'function:ValidateFormat');
+      $this->AddRule('Url', 'function:ValidateUrl');
    }
 
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -440,6 +440,22 @@ if (!function_exists('ValidatePhoneInt')) {
    }
 }
 
+if (!function_exists('ValidateUrl')) {
+   /**
+    * Check to see if a value represents a valid url.
+    *
+    * @param string $Value The value to validate.
+    * @return bool Returns true if the value is a value url or false otherwise.
+    */
+   function ValidateUrl($Value) {
+      if (empty($Value)) {
+         return true;
+      }
+      $Valid = (bool)filter_var($Value, FILTER_VALIDATE_URL);
+      return $Valid;
+   }
+}
+
 /**
  * Validate US zip code (5-digit or 9-digit with hyphen).
  */

--- a/plugins/OpenID/class.openid.plugin.php
+++ b/plugins/OpenID/class.openid.plugin.php
@@ -12,7 +12,7 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 $PluginInfo['OpenID'] = array(
 	'Name' => 'OpenID',
    'Description' => 'Allows users to sign in with OpenID. Must be enabled before using &lsquo;Google Sign In&rsquo; and &lsquo;Steam&rsquo; plugins.',
-   'Version' => '1.0.2',
+   'Version' => '1.2.0',
    'RequiredApplications' => array('Vanilla' => '2.0.14'),
    'RequiredTheme' => FALSE,
    'RequiredPlugins' => FALSE,
@@ -63,9 +63,20 @@ class OpenIDPlugin extends Gdn_Plugin {
       $OpenID = new LightOpenID();
 
       if ($url = Gdn::Request()->Get('url')) {
+         if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            throw new Gdn_UserException(sprintf(T('ValidateUrl'), 'OpenID'), 400);
+         }
+
+         // Don't allow open ID on a non-standard scheme.
          $scheme = parse_url($url, PHP_URL_SCHEME);
          if (!in_array($scheme, array('http', 'https'))) {
-            throw new Gdn_UserException(sprintf(T('Invalid url scheme: %s.'), $scheme), 400);
+            throw new Gdn_UserException(sprintf(T('ValidateUrl'), 'OpenID'), 400);
+         }
+
+         // Don't allow open ID on a non-standard port.
+         $port = parse_url($url, PHP_URL_PORT);
+         if ($port && !in_array($port, array(80, 8080, 443))) {
+            throw new Gdn_UserException(T('OpenID is not allowed on non-standard ports.'));
          }
 
          $OpenID->identity = $url;
@@ -165,7 +176,14 @@ class OpenIDPlugin extends Gdn_Plugin {
    public function EntryController_OpenID_Create($Sender, $Args) {
       $this->EventArguments = $Args;
       $Sender->Form->InputPrefix = '';
-      $OpenID = $this->GetOpenID();
+
+
+      try {
+         $OpenID = $this->GetOpenID();
+      } catch (Gdn_UserException $ex) {
+         $Sender->Form->AddError('@'.$ex->getMessage());
+         $Sender->Render('Url', '', 'plugins/OpenID');
+      }
 
       $Mode = $Sender->Request->Get('openid_mode');
       switch($Mode) {

--- a/plugins/OpenID/views/url.php
+++ b/plugins/OpenID/views/url.php
@@ -2,8 +2,8 @@
 echo '<div class="Connect">';
 echo '<h1>', $this->Data('Title'), '</h1>';
 $Form = $this->Form; //new Gdn_Form();
-$Form->Method = 'get';
-echo $Form->Open();
+//$Form->Method = 'get';
+echo $Form->Open(array('Action' => Url(Gdn::Request()->Path()), 'Method' => 'get'));
 echo $Form->Errors();
 ?>
 <div>
@@ -11,7 +11,7 @@ echo $Form->Errors();
       <li>
          <?php
             echo $Form->Label('Enter Your OpenID Url', 'Url');
-            echo $Form->TextBox('Url', array('Name' => 'url'));
+            echo $Form->TextBox('url');
          ?>
       </li>
    </ul>


### PR DESCRIPTION
Prevent users from using OpenID to examine non-standard urls.