### PR TITLE
Uncomment FireEvent('BeforeDiscussionName')

### DIFF
--- a/applications/vanilla/views/discussions/table_functions.php
+++ b/applications/vanilla/views/discussions/table_functions.php
@@ -41,10 +41,10 @@ function WriteDiscussionRow($Discussion, &$Sender, &$Session, $Alt2) {
    else {
       $Last = $First;
    }
-//   $Sender->EventArguments['FirstUser'] = &$First;
-//   $Sender->EventArguments['LastUser'] = &$Last;
-//
-//   $Sender->FireEvent('BeforeDiscussionName');
+   $Sender->EventArguments['FirstUser'] = &$First;
+   $Sender->EventArguments['LastUser'] = &$Last;
+
+   $Sender->FireEvent('BeforeDiscussionName');
 
    $DiscussionName = $Discussion->Name;
    if ($DiscussionName == '')


### PR DESCRIPTION
The event BeforeDiscussionName has been commented out in table view without any obvious reason. Since Linc called that a bug (https://github.com/vanilla/vanilla/issues/2375) I've simply included it again.