### PR TITLE
"Backport" Uncomment FireEvent('BeforeDiscussionName')

### DIFF
--- a/applications/vanilla/views/discussions/table_functions.php
+++ b/applications/vanilla/views/discussions/table_functions.php
@@ -41,10 +41,10 @@ function WriteDiscussionRow($Discussion, &$Sender, &$Session, $Alt2) {
    else {
       $Last = $First;
    }
-//   $Sender->EventArguments['FirstUser'] = &$First;
-//   $Sender->EventArguments['LastUser'] = &$Last;
-//   
-//   $Sender->FireEvent('BeforeDiscussionName');
+   $Sender->EventArguments['FirstUser'] = &$First;
+   $Sender->EventArguments['LastUser'] = &$Last;
+
+   $Sender->FireEvent('BeforeDiscussionName');
    
    $DiscussionName = $Discussion->Name;
    if ($DiscussionName == '')


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/2758

Maybe there will be another Vanilla 2.1 release and this one is so easy to fix that there is no reason to not do it.