### PR TITLE
Formatting Inform Messages excerpt as PlainText

### DIFF
--- a/applications/dashboard/controllers/class.notificationscontroller.php
+++ b/applications/dashboard/controllers/class.notificationscontroller.php
@@ -2,7 +2,7 @@
 
 /**
  * Creates and sends notifications to user.
- * 
+ *
  * @copyright 2003 Vanilla Forums, Inc
  * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
  * @package Garden
@@ -26,9 +26,9 @@ class NotificationsController extends Gdn_Controller {
       $this->AddModule('GuestModule');
       parent::Initialize();
    }
-   
+
    /**
-    * Adds inform messages to response for inclusion in pages dynamically. 
+    * Adds inform messages to response for inclusion in pages dynamically.
     *
     * @since 2.0.18
     * @access public
@@ -36,19 +36,19 @@ class NotificationsController extends Gdn_Controller {
    public function Inform() {
       $this->DeliveryType(DELIVERY_TYPE_BOOL);
       $this->DeliveryMethod(DELIVERY_METHOD_JSON);
-      
+
       // Retrieve all notifications and inform them.
       NotificationsController::InformNotifications($this);
       $this->FireEvent('BeforeInformNotifications');
-      
+
       $this->Render();
    }
-   
+
    /**
     * Grabs all new notifications and adds them to the sender's inform queue.
     *
     * This method gets called by dashboard's hooks file to display new
-    * notifications on every pageload. 
+    * notifications on every pageload.
     *
     * @since 2.0.18
     * @access public
@@ -59,18 +59,18 @@ class NotificationsController extends Gdn_Controller {
       $Session = Gdn::Session();
       if (!$Session->IsValid())
          return;
-      
+
       $ActivityModel = new ActivityModel();
       // Get five pending notifications.
       $Where = array(
-          'NotifyUserID' => Gdn::Session()->UserID, 
+          'NotifyUserID' => Gdn::Session()->UserID,
           'Notified' => ActivityModel::SENT_PENDING);
-      
+
       // If we're in the middle of a visit only get very recent notifications.
       $Where['DateUpdated >'] = Gdn_Format::ToDateTime(strtotime('-5 minutes'));
-      
+
       $Activities = $ActivityModel->GetWhere($Where, 0, 5)->ResultArray();
-      
+
       $ActivityIDs = ConsolidateArrayValuesByKey($Activities, 'ActivityID');
       $ActivityModel->SetNotified($ActivityIDs);
 
@@ -85,10 +85,10 @@ class NotificationsController extends Gdn_Controller {
                'Icon');
          else
             $UserPhoto = '';
-         $Excerpt = Gdn_Format::Display($Activity['Story']);
+         $Excerpt = Gdn_Format::PlainText($Activity['Story']);
          $ActivityClass = ' Activity-'.$Activity['ActivityType'];
-         
-         
+
+
          $Sender->InformMessage(
             $UserPhoto
             .Wrap($Activity['Headline'], 'div', array('class' => 'Title'))


### PR DESCRIPTION
Excerpt was being formatted as Display, which was displaying encoded HTML.  This was specifically an issue with conversation messages, because formatting and image markup was being displayed in a way that made it difficult to see the content of the original message.