### PR TITLE
Refresh tag page content when adding a tag

### DIFF
--- a/plugins/Tagging/js/tagadmin.js
+++ b/plugins/Tagging/js/tagadmin.js
@@ -1,11 +1,11 @@
 jQuery(document).ready(function($) {
-   
-   $('a.TagName').popup({
+
+   $('div.add-new-tag a,a.TagName').popup({
       onUnload: function() {
          $('#Content').load(gdn.url('/dashboard/settings/tagging?DeliveryType=VIEW'));
       }
    });
-   
+
    // Confirm deletes before performing them
 //   $('a.Delete').popup({
 //      confirm: true,


### PR DESCRIPTION
Addresses an issue where adding a new tag would not automatically update the content of the page.  The new tag wasn't displayed until you manually refreshed or revisited the page.

This fix adds another selector to the JS popup call that was being used when editing tags (editing a tag automatically updated the page contents).