### PR TITLE
Make sure the config locale is canonicalized

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -794,6 +794,13 @@ $Construct
 // This will allow us to change the default later and grandfather existing forums in.
 SaveToConfig('Garden.InputFormatter', C('Garden.InputFormatter'));
 
+// Make sure the default locale is in its canonical form.
+$currentLocale = C('Garden.Locale');
+$canonicalLocale = Gdn_Locale::Canonicalize($currentLocale);
+if ($currentLocale !== $canonicalLocale) {
+   SaveToConfig('Garden.Locale', $canonicalLocale);
+}
+
 // We need to undo cleditor's bad behavior for our reformed users.
 // If you still need to manipulate this, do it in memory instead (SAVE = false).
 if (!C('Garden.Html.SafeStyles')) {

--- a/library/core/class.locale.php
+++ b/library/core/class.locale.php
@@ -106,7 +106,7 @@ class Gdn_Locale extends Gdn_Pluggable {
       // This is a bit of a kludge, but we are deprecating en_CA in favour of just en.
       if ($result === 'en_CA') {
          $result = 'en';
-   }
+      }
 
       return $result;
    }


### PR DESCRIPTION
This will fix sites that have “en-CA”, changing
them to “en”. In the future the “en-CA” kludge
may be removed.