### PR TITLE
Fix mention detector to allow longer usernames

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1550,7 +1550,7 @@ if (!function_exists('GetMentions')) {
 
         // This one grabs mentions that start at the beginning of $String
         preg_match_all(
-            '/(?:^|[\s,\.>\)])@(\w{3,20})\b/i',
+            '/(?:^|[\s,\.>\)])@(\w{3,64})\b/i',
             $String,
             $Matches
         );


### PR DESCRIPTION
Raise the max length from 20 to 64 to match `GdnFormat::Mentions()` which accounts for jsConnect & import names rather than the default {3,20} restriction.