### PR TITLE
Fixes import steps page when no original query string is present

### DIFF
--- a/applications/dashboard/js/import.js
+++ b/applications/dashboard/js/import.js
@@ -1,6 +1,9 @@
 jQuery(document).ready(function($) {
     var refreshSteps = function() {
-        var url = window.location.href.split('&').shift() + '&DeliveryType=VIEW&DeliveryMethod=JSON';
+        // Have a query string?  Get ready to append.  No query string?  Setup the URL to receive one.
+        var loc = window.location.href+(window.location.href.indexOf('?') > 0 ? '&' : '?');
+        var url = loc+'DeliveryType=VIEW&DeliveryMethod=JSON';
+
         $.ajax({
             type: "POST",
             url: url,


### PR DESCRIPTION
Prior to this fix, the import "Go" page was displaying a popup window of the same page every time the page checked for an update to the current progress of steps.  This was due to the DeliveryType and DeliveryMethod JSON being lost during the status update requests, so the full markup of the page was returned, instead of just the relevant data.  The loss of those parameters occurred when no query string originally existed on the "Go" page.

The original JavaScript just tried to append `&DeliveryType=VIEW&DeliveryMethod=JSON` onto the end of a URL.  If no query string existed, these parameters obviously weren't being passed on.  This fix appends either a ? or a & to the target URL, depending on if a query string already exists, before attempting to pass the parameters.