### PR TITLE
Fix stack trace on invalid DeliveryType

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -642,10 +642,6 @@ class Gdn_Controller extends Gdn_Pluggable {
             // Use constants' name pattern instead of a strict whitelist for forwards-compatibility.
             if (defined('DELIVERY_TYPE_'.$Default)) {
                 $this->_DeliveryType = $Default;
-            } else {
-                // Throwing an exception this early pukes a stack trace.
-                // A better solution is to fall back to our default and ignore the stupid.
-                $this->_DeliveryType = DELIVERY_TYPE_ALL;
             }
         }
 

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -643,7 +643,9 @@ class Gdn_Controller extends Gdn_Pluggable {
             if (defined('DELIVERY_TYPE_'.$Default)) {
                 $this->_DeliveryType = $Default;
             } else {
-                throw new Exception(sprintf(t('Attempted to set invalid DeliveryType value (%s).'), $Default));
+                // Throwing an exception this early pukes a stack trace.
+                // A better solution is to fall back to our default and ignore the stupid.
+                $this->_DeliveryType = DELIVERY_TYPE_ALL;
             }
         }
 


### PR DESCRIPTION
If someone sets an invalid DeliveryType, just do nothing instead of gratifying them with a lurid stack trace.