### PR TITLE
Improve handling of sign-in redirect and TrustedDomains

### DIFF
--- a/applications/dashboard/controllers/class.homecontroller.php
+++ b/applications/dashboard/controllers/class.homecontroller.php
@@ -154,4 +154,14 @@ class HomeController extends Gdn_Controller {
             $this->RenderException(permissionException());
         }
     }
+
+    /**
+     * Provide a safe landing page for external redirects.
+     *
+     * @since 2.2
+     * @access public
+     */
+     public function leaving() {
+        $this->render();
+     }
 }

--- a/applications/dashboard/views/home/filenotfound.php
+++ b/applications/dashboard/views/home/filenotfound.php
@@ -3,8 +3,7 @@
 <div class="Center SplashInfo">
     <h1><?php echo $this->data('Message', t('Page Not Found')); ?></h1>
 
-    <div
-        id="Message"><?php echo $this->data('Description', t('The page you were looking for could not be found.')); ?></div>
+    <div id="Message"><?php echo $this->data('Description', t('The page you were looking for could not be found.')); ?></div>
 
     <!-- Domain: <?php echo Gdn::config('Garden.Domain', ''); ?> -->
 </div>

--- a/applications/dashboard/views/home/leaving.php
+++ b/applications/dashboard/views/home/leaving.php
@@ -1,0 +1,6 @@
+<?php if (!defined('APPLICATION')) exit(); ?>
+
+<div class="SplashInfo">
+    <h1><?php echo $this->data('Message', sprintf(t('Leaving %s'), c('Garden.Title'))); ?></h1>
+    <p><?php echo $this->data('Description', t("You will be automatically redirected shortly.")); ?></p>
+</div>


### PR DESCRIPTION
* [ ] Add a 'Leaving Vanilla' page that includes a timed redirect.
* [ ] Untrusted `Target` URLs should go thru Leaving page via `safeRedirect()` (see `EntryController::Target()`)
* [ ] Clarify `TrustedDomains` functionality with better copy & placement.
* [ ] Add `TrustedDomains` explanation to SSO & embed docs.

### Considerations:

* Do we want to be able to specify http vs https?
* Should jsConnect auto-add its URLs to TrustedDomains?
* Wildcard domains allowed?

Closes #2800