### PR TITLE
Do not show google sign in button if google authentication not properly configured.

### DIFF
--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -132,17 +132,7 @@ class GooglePlusPlugin extends Gdn_Plugin {
      */
     public function isConfigured() {
         $Result = c('Plugins.GooglePlus.ClientID') && c('Plugins.GooglePlus.Secret');
-        if(!$Result) {
-            return $Result;
-        }
         return $Result;
-        $Url = $this->authorizeUri();
-        $Ping = $this->curl($Url, 'GET', true);
-        if($Ping === 302) {
-            return true;
-        } else {
-            return false;
-        }
     }
 
     /**
@@ -181,7 +171,7 @@ class GooglePlusPlugin extends Gdn_Plugin {
      * @return mixed
      * @throws Gdn_UserException
      */
-    public static function curl($Url, $Method = 'GET', $Ping = fals) {
+    public static function curl($Url, $Method = 'GET', $Data = array()) {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -208,13 +198,9 @@ class GooglePlusPlugin extends Gdn_Plugin {
         }
 
         if ($HttpCode != 200) {
-            if(!$Ping) {
                 $Error = val('error', $Result, $Response);
 
                 throw new Gdn_UserException($Error, $HttpCode);
-            } else {
-                return $HttpCode;
-            }
         }
 
         return $Result;
@@ -360,6 +346,9 @@ class GooglePlusPlugin extends Gdn_Plugin {
      * @param $Args
      */
     public function base_beforeSignInButton_handler($Sender, $Args) {
+        if (!$this->isConfigured()) {
+            return;
+        }
         if (!$this->isDefault()) {
             echo ' '.$this->signInButton('icon').' ';
         }

--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -132,7 +132,17 @@ class GooglePlusPlugin extends Gdn_Plugin {
      */
     public function isConfigured() {
         $Result = c('Plugins.GooglePlus.ClientID') && c('Plugins.GooglePlus.Secret');
+        if(!$Result) {
+            return $Result;
+        }
         return $Result;
+        $Url = $this->authorizeUri();
+        $Ping = $this->curl($Url, 'GET', true);
+        if($Ping === 302) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -171,7 +181,7 @@ class GooglePlusPlugin extends Gdn_Plugin {
      * @return mixed
      * @throws Gdn_UserException
      */
-    public static function curl($Url, $Method = 'GET', $Data = array()) {
+    public static function curl($Url, $Method = 'GET', $Ping = fals) {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -198,9 +208,13 @@ class GooglePlusPlugin extends Gdn_Plugin {
         }
 
         if ($HttpCode != 200) {
-            $Error = val('error', $Result, $Response);
+            if(!$Ping) {
+                $Error = val('error', $Result, $Response);
 
-            throw new Gdn_UserException($Error, $HttpCode);
+                throw new Gdn_UserException($Error, $HttpCode);
+            } else {
+                return $HttpCode;
+            }
         }
 
         return $Result;

--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -198,9 +198,9 @@ class GooglePlusPlugin extends Gdn_Plugin {
         }
 
         if ($HttpCode != 200) {
-                $Error = val('error', $Result, $Response);
+            $Error = val('error', $Result, $Response);
 
-                throw new Gdn_UserException($Error, $HttpCode);
+            throw new Gdn_UserException($Error, $HttpCode);
         }
 
         return $Result;


### PR DESCRIPTION
Google sign in button was showing if the plug in was turned on, even if there was no google clientID provided to the plugin. Added the isConfigured function to the condition for printing out the link, changed the functionality of the isConfigured function so that it pings google with the clientID and returns false if anything but a 200 or 301 is returned.