### PR TITLE
Fix the extenralUrl() function

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -943,15 +943,17 @@ if (!function_exists('externalUrl')) {
      * @return string Returns the external URL.
      */
     function externalUrl($path) {
-        $Format = C('Garden.ExternalUrlFormat');
+        $urlFormat = C('Garden.ExternalUrlFormat');
 
-        if ($Format && !StringBeginsWith($path, 'http')) {
-            $Result = sprintf($Format, ltrim($path, '/'));
+        if ($urlFormat && !isUrl($path)) {
+            $result = sprintf($urlFormat, ltrim($path, '/'));
+        } elseif (stringBeginsWith($path, '//')) {
+            $result = Gdn::request()->scheme().':'.$path;
         } else {
-            $Result = Url($path, true);
+            $result = Url($path, true);
         }
 
-        return $Result;
+        return $result;
     }
 }
 


### PR DESCRIPTION
The externalUrl() function used a check against “http” instead of using
the isUrl() function. Also, external urls should not be schemaless.