### PR TITLE
Make formatMeAction obey Garden.Format.MeActions in config

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -506,7 +506,7 @@ endif;
 
 if (!function_exists('FormatMeAction')):
     function formatMeAction($Comment) {
-        if (!IsMeAction($Comment) || !!C('Garden.Format.MeActions'))
+        if (!IsMeAction($Comment) || !C('Garden.Format.MeActions'))
             return;
 
         // Maxlength (don't let people blow up the forum)

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -506,7 +506,7 @@ endif;
 
 if (!function_exists('FormatMeAction')):
     function formatMeAction($Comment) {
-        if (!IsMeAction($Comment))
+        if (!IsMeAction($Comment) || !!C('Garden.Format.MeActions'))
             return;
 
         // Maxlength (don't let people blow up the forum)


### PR DESCRIPTION
The `formatMeAction` function was running regardless of whether Garden.Format.MeActions was true or false.

I am a bit confused as to the purpose of this code, as there is a MeActions format handler in `/library/core/class.format.php`

I don't use MeActions on any of my forums so I haven't tested what happens when you switch the config on, but it seems like it might double up the AuthorAction markup.