### PR TITLE
Editor: Use textarea id to calculate width of textarea.

### DIFF
--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1207,7 +1207,7 @@
 
                                 var payloadHeight = payload.original_height;
                                 var payloadWidth = payload.original_width;
-                                var editorWidth = $(editor.textarea.element).width();
+                                var editorWidth = $('#Form_Body').width();
 
                                 // Image max-width is 100%. Change the height to refect scaling down the width.
                                 if (editorWidth < payloadWidth) {

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1207,7 +1207,7 @@
 
                                 var payloadHeight = payload.original_height;
                                 var payloadWidth = payload.original_width;
-                                var editorWidth = $('#Form_Body').width();
+                                var editorWidth = $(this).find('.BodyBox').width();
 
                                 // Image max-width is 100%. Change the height to refect scaling down the width.
                                 if (editorWidth < payloadWidth) {


### PR DESCRIPTION
Fixes bug where editor attempts to calculate the width of the element the image is being placed into before the image has finished uploading.