### PR TITLE
Add event BeforeDeleteComment right after DeleteComment

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1273,7 +1273,7 @@ class CommentModel extends VanillaModel {
      * Delete a comment.
      *
      * This is a hard delete that completely removes it from the database.
-     * Events: DeleteComment.
+     * Events: DeleteComment, BeforeDeleteComment.
      *
      * @since 2.0.0
      * @access public
@@ -1301,6 +1301,7 @@ class CommentModel extends VanillaModel {
 
         $this->EventArguments['Discussion'] = $Discussion;
         $this->fireEvent('DeleteComment');
+        $this->fireEvent('BeforeDeleteComment');
 
         // Log the deletion.
         $Log = val('Log', $Options, 'Delete');


### PR DESCRIPTION
Event names should communicate in which state of a process they are. So "BeforeDeleteComment" is clear while "DeleteComment" is not determined. I suggest to make "DeleteComment" deprecated as of version 2.somethinginthefuture.