### PR TITLE
Change order of values in Year select input.

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -834,7 +834,7 @@ class Gdn_Form extends Gdn_Pluggable {
 
         $Years = array();
         $Years[0] = T('Year');
-        for ($i = $StartYear; $i <= $EndYear; ++$i) {
+        for ($i = $EndYear; $i >= $StartYear; --$i) {
             $Years[$i] = $i;
         }
 


### PR DESCRIPTION
Descending years is usually a better user experience than ascending.