### PR TITLE
Fix for plugins controllers on windows

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -630,7 +630,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
                 if ($ControllerPath) {
                     $InterimPath = explode('/controllers/', $ControllerPath);
                     array_pop($InterimPath); // Get rid of the end. Useless;
-                    $InterimPath = explode('/', trim(array_pop($InterimPath)));
+                    $InterimPath = explode('/', str_replace('\\', '/', trim(array_pop($InterimPath))));
                     $Application = array_pop($InterimPath);
                     $AddonType = array_pop($InterimPath);
                     switch ($AddonType) {


### PR DESCRIPTION
Controllers in plugins don't work on windows, because the plugin path that the dispatcher gets from the autoloader can contain backslashes.

Further explanation:

This is how application controllers are saved in the controller maps:

    discussionscontroller = "Z:\web\vanilla-master/applications/vanilla/controllers/class.discussionscontroller.php"

This is how plugin controllers are saved in the core library map:

    testcontroller = "Z:\web\vanilla-master\plugins\test/controllers/class.testcontroller.php"

The path is not being properly split and the dispatcher doesn't recognize it as a plugin controller and throws a 404.