### PR TITLE
Remove double translate on registration forms

### DIFF
--- a/applications/dashboard/views/entry/registerbasic.php
+++ b/applications/dashboard/views/entry/registerbasic.php
@@ -62,7 +62,7 @@
             <li>
                 <?php
                 echo $this->Form->CheckBox('TermsOfService', '@'.$TermsOfServiceText, array('value' => '1'));
-                echo $this->Form->CheckBox('RememberMe', t('Remember me on this computer'), array('value' => '1'));
+                echo $this->Form->CheckBox('RememberMe', 'Remember me on this computer', array('value' => '1'));
                 ?>
             </li>
             <li class="Buttons">

--- a/applications/dashboard/views/entry/registercaptcha.php
+++ b/applications/dashboard/views/entry/registercaptcha.php
@@ -68,7 +68,7 @@
             <li>
                 <?php
                 echo $this->Form->CheckBox('TermsOfService', '@'.$TermsOfServiceText, array('value' => '1'));
-                echo $this->Form->CheckBox('RememberMe', t('Remember me on this computer'), array('value' => '1'));
+                echo $this->Form->CheckBox('RememberMe', 'Remember me on this computer', array('value' => '1'));
                 ?>
             </li>
             <li class="Buttons">

--- a/applications/dashboard/views/entry/registerinvitation.php
+++ b/applications/dashboard/views/entry/registerinvitation.php
@@ -51,7 +51,7 @@
             <li>
                 <?php
                 echo $this->Form->CheckBox('TermsOfService', '@'.$TermsOfServiceText, array('value' => '1'));
-                echo $this->Form->CheckBox('RememberMe', t('Remember me on this computer'), array('value' => '1'));
+                echo $this->Form->CheckBox('RememberMe', 'Remember me on this computer', array('value' => '1'));
                 ?>
             </li>
             <li class="Buttons">


### PR DESCRIPTION
Gdn_Form->CheckBox() already translates its string so this code was being translated twice.