### PR TITLE
Throw permission exception when attempting to merge discussion redirects

### DIFF
--- a/plugins/SplitMerge/class.splitmerge.plugin.php
+++ b/plugins/SplitMerge/class.splitmerge.plugin.php
@@ -149,7 +149,7 @@ class SplitMergePlugin extends Gdn_Plugin {
         // Make sure none of the selected discussions are ghost redirects.
         $discussionTypes = array_column($Discussions, 'Type');
         if (in_array('redirect', $discussionTypes)) {
-            throw permissionException('@You cannot merge redirects.');
+            throw Gdn_UserException('You cannot merge redirects.', 400);
         }
 
         // Perform the merge

--- a/plugins/SplitMerge/class.splitmerge.plugin.php
+++ b/plugins/SplitMerge/class.splitmerge.plugin.php
@@ -146,6 +146,12 @@ class SplitMergePlugin extends Gdn_Plugin {
         $Discussions = $DiscussionModel->SQL->whereIn('DiscussionID', $DiscussionIDs)->get('Discussion')->resultArray();
         $Sender->setData('Discussions', $Discussions);
 
+        // Make sure none of the selected discussions are ghost redirects.
+        $discussionTypes = array_column($Discussions, 'Type');
+        if (in_array('redirect', $discussionTypes)) {
+            throw permissionException('@You cannot merge redirects.');
+        }
+
         // Perform the merge
         if ($Sender->Form->authenticatedPostBack()) {
             // Create a new discussion record


### PR DESCRIPTION
Disallow using a discussion redirect as part of a merge. Currently, merging into a redirect is a backdoor delete (sort of). Fixes #2782.