### PR TITLE
Remove "return false" in "enable" jquery event so that other events can be added to the link

### DIFF
--- a/applications/dashboard/js/addons.js
+++ b/applications/dashboard/js/addons.js
@@ -2,6 +2,7 @@ jQuery(document).ready(function($) {
 
     // Ajax-test addons before enabling
     $('a.EnableAddon').click(function(e) {
+        e.preventDefault();
         gdn.clearAddonErrors();
 
         var url = $(this).attr('href');
@@ -76,7 +77,7 @@ jQuery(document).ready(function($) {
                 }
             }
         });
-        return false;
+        return true;
     });
 
     /**


### PR DESCRIPTION
This has no affect on the execution of the click event, it makes it possible to add events to links. All this needs to be done so that we can attach events in the intercom integration plugin.