### PR TITLE
Adds IPB to supported formats for Advanced Editor

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -38,7 +38,7 @@ class EditorPlugin extends Gdn_Plugin {
     protected $pluginInfo = array();
 
     /** @var array List of possible formats the editor supports. */
-    protected $Formats = array('Wysiwyg', 'Html', 'Markdown', 'BBCode', 'Text', 'TextEx');
+    protected $Formats = array('Wysiwyg', 'Html', 'Markdown', 'BBCode', 'Text', 'TextEx', 'IPB');
 
     /** @var string Default format being used for current rendering. Can be one of the formats listed in $Formats. */
     protected $Format;

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -587,6 +587,7 @@ class EditorPlugin extends Gdn_Plugin {
         $c->addDefinition('htmlHelpText', t('editor.HtmlHelpText', 'You can use <a href="http://htmlguide.drgrog.com/cheatsheet.php" target="_new">Simple Html</a> in your post.'));
         $c->addDefinition('markdownHelpText', t('editor.MarkdownHelpText', 'You can use <a href="http://en.wikipedia.org/wiki/Markdown" target="_new">Markdown</a> in your post.'));
         $c->addDefinition('textHelpText', t('editor.TextHelpText', 'You are using plain text in your post.'));
+        $c->addDefinition('ipbHelpText', t('editor.IPBHelpText', ''));
         $c->addDefinition('editorWysiwygCSS', $CssPath);
 
         // Set variables for file uploads

--- a/plugins/editor/js/advanced.js
+++ b/plugins/editor/js/advanced.js
@@ -424,7 +424,10 @@ var wysihtml5ParserRules = {
         "del": {},
         "blockquote": {
             "check_attributes": {
-                "cite": "url"
+                "cite": "url",
+                "data-author": "allow",
+                "data-cid": "numbers",
+                "data-time": "allow"
             }
         },
         "style": {


### PR DESCRIPTION
The IPB format is a special mashup of HTML and BBCode.  Processing is facilitated through the IPB Formatter plug-in.

This PR just adds IPB as a supported format to Advanced Editor, so discussions, comments and metadata (e.g. signatures) imported from IPB are easier to edit.