### PR TITLE
Recognize Nintendo 3DS and New 3DS browser as mobile

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3906,7 +3906,8 @@ if (!function_exists('userAgentType')) {
             'playstation vita',
             'windows phone',
             'iphone',
-            'ipod'
+            'ipod',
+            'nintendo 3ds'
         );
         $directAgentsMatch = implode('|', $directAgents);
         if (preg_match("/({$directAgentsMatch})/i", $userAgent)) {


### PR DESCRIPTION
Only tested with the 3DS, but the new 3DS should work too, since its user agent string is `New Nintendo 3DS`.