### PR TITLE
Syntax Prettifier: Override code block formatting.

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -905,9 +905,9 @@ class Gdn_Format {
 
                 // Allow the code tag to keep all enclosed HTML encoded.
                 $Mixed = preg_replace_callback('`<code([^>]*)>(.+?)<\/code>`si', function ($Matches) {
-                    $Result = "<code{$Matches[1]}>".
+                    $Result = "<pre><code{$Matches[1]}>".
                         htmlspecialchars($Matches[2]).
-                        '</code>';
+                        '</code></pre>';
                     return $Result;
                 }, $Mixed);
 

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -905,9 +905,9 @@ class Gdn_Format {
 
                 // Allow the code tag to keep all enclosed HTML encoded.
                 $Mixed = preg_replace_callback('`<code([^>]*)>(.+?)<\/code>`si', function ($Matches) {
-                    $Result = "<pre><code{$Matches[1]}>".
+                    $Result = "<code{$Matches[1]}>".
                         htmlspecialchars($Matches[2]).
-                        '</code></pre>';
+                        '</code>';
                     return $Result;
                 }, $Mixed);
 

--- a/plugins/GooglePrettify/class.googleprettify.plugin.php
+++ b/plugins/GooglePrettify/class.googleprettify.plugin.php
@@ -71,6 +71,9 @@ class GooglePrettifyPlugin extends Gdn_Plugin {
 
          $('.Message').livequery(function () {
             $('pre', this).addClass('prettyprint$Class');
+            // Let prettyprint determine styling, rather than the editor.
+            $('code', this).removeClass('CodeInline');
+            $('pre', this).removeClass('CodeBlock');
             if (pp)
                prettyPrint();
             $('pre', this).removeClass('prettyprint')


### PR DESCRIPTION
Adding a code block with html formatting in the advanced editor automatically applies 'CodeInline' and 'CodeBlock' css classes to the pre and code tags. These css rules apply styling that interferes with the prettifier's styling. This removes the offending css classes from the code and pre tags.