### PR TITLE
Use SCRIPT_NAME instead of PHP_SELF to determine web root

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -646,10 +646,10 @@ class Gdn_Request {
          */
 
         // Attempt to get the web root from the server.
-        $webRoot = val('SCRIPT_NAME', $_SERVER, '');
+        $webRoot = str_replace('\\', '/', val('SCRIPT_NAME', $_SERVER, ''));
         if (($pos = strrpos($webRoot, '/index.php')) !== false) {
             $webRoot = substr($webRoot, 0, $pos);
-            }
+        }
 
         $parsedWebRoot = trim($webRoot, '/');
         $this->webRoot($parsedWebRoot);

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -70,7 +70,7 @@ class Gdn_Request {
      *
      * The asset root represents the folder that static assets are served from.
      *
-     * @param $assetRoot Optional An asset root to set
+     * @param string? $assetRoot An asset root to set.
      * @return string Returns the current asset root.
      */
     public function assetRoot($assetRoot = null) {
@@ -645,21 +645,11 @@ class Gdn_Request {
          * Resolve WebRoot
          */
 
-        // Attempt to get the webroot from the server
-        $webRoot = false;
-        if (!$webRoot) {
-            $webRoot = explode('/', val('PHP_SELF', $_SERVER, ''));
-
-            // Look for index.php to figure out where the web root is.
-            $key = array_search('index.php', $webRoot);
-            if ($key !== false) {
-                $webRoot = implode('/', array_slice($webRoot, 0, $key));
-            } else {
-                // Could not determine webroot.
-                $webRoot = '';
+        // Attempt to get the web root from the server.
+        $webRoot = val('SCRIPT_NAME', $_SERVER, '');
+        if (($pos = strrpos($webRoot, '/index.php')) !== false) {
+            $webRoot = substr($webRoot, 0, $pos);
             }
-
-        }
 
         $parsedWebRoot = trim($webRoot, '/');
         $this->webRoot($parsedWebRoot);
@@ -1116,7 +1106,7 @@ class Gdn_Request {
     /**
      * Gets/Sets the relative path to the application's dispatcher.
      *
-     * @param $webRoot Optional Webroot to set
+     * @param string? $webRoot The new web root to set.
      * @return string
      */
     public function webRoot($webRoot = null) {


### PR DESCRIPTION
The SCRIPT_NAME variable is part of the CGI spec while PHP_SELF is not. Additionally, PHP_SELF includes PATH_INFO which we don’t want.