### PR TITLE
Fix quote plugin's stray bullet item

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -230,7 +230,6 @@ class QuotesPlugin extends Gdn_Plugin {
      * Add 'Quote' option to Discussion.
      */
     public function base_AfterFlag_handler($Sender, $Args) {
-        echo Gdn_Theme::BulletItem('Flags');
         $this->addQuoteButton($Sender, $Args);
     }
 
@@ -252,6 +251,7 @@ class QuotesPlugin extends Gdn_Plugin {
             return;
         }
 
+        echo Gdn_Theme::BulletItem('Flags');
         echo anchor(sprite('ReactQuote', 'ReactSprite').' '.t('Quote'), url("post/quote/{$Object->DiscussionID}/{$ObjectID}", true), 'ReactButton Quote Visible').' ';
     }
 


### PR DESCRIPTION
A bullet item is now only shown if the quote button is visible. Guests no longer see a 'stray' bullet item. Fixes http://vanillaforums.org/discussion/30497/issue-quote-plugin-shows-stray-bullet-item-for-guests