### PR TITLE
Fixed descending ordering of years in Gdn_Form::Date()

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -834,7 +834,7 @@ class Gdn_Form extends Gdn_Pluggable {
 
         $Years = array();
         $Years[0] = T('Year');
-        for ($i = $EndYear; $i >= $StartYear; --$i) {
+        for ($i = $StartYear; $i <= $EndYear; ++$i) {
             $Years[$i] = $i;
         }
 


### PR DESCRIPTION
While days and month where sorted in ascending order, the years where
unexpectedly sorted in descending order. This commit fixed this strange
behavior.