### PR TITLE
Prevent $Activity['HeadlineFormat'] from being overwriten

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1764,6 +1764,16 @@ class DiscussionModel extends VanillaModel {
                     // Use our generic Activity for events, not mentions
                     $this->EventArguments['Activity'] = $Activity;
 
+                    // Notify everyone that has advanced notifications.
+                    if (!c('Vanilla.QueueNotifications')) {
+                        try {
+                            $Fields['DiscussionID'] = $DiscussionID;
+                            $this->NotifyNewDiscussion($Fields, $ActivityModel, $Activity);
+                        } catch (Exception $Ex) {
+                            throw $Ex;
+                        }
+                    }
+
                     // Notifications for mentions
                     foreach ($Usernames as $Username) {
                         $User = $UserModel->GetByUsername($Username);
@@ -1780,16 +1790,6 @@ class DiscussionModel extends VanillaModel {
 
                         $Activity['NotifyUserID'] = val('UserID', $User);
                         $ActivityModel->Queue($Activity, 'Mention');
-                    }
-
-                    // Notify everyone that has advanced notifications.
-                    if (!c('Vanilla.QueueNotifications')) {
-                        try {
-                            $Fields['DiscussionID'] = $DiscussionID;
-                            $this->NotifyNewDiscussion($Fields, $ActivityModel, $Activity);
-                        } catch (Exception $Ex) {
-                            throw $Ex;
-                        }
                     }
 
                     // Throw an event for users to add their own events.


### PR DESCRIPTION
Solves issue: https://github.com/vanilla/vanilla/issues/2871

Notifications for new discussions with advanced notifications were done wrong: at first the HeadlineFormat.Discussion was set to $Activity['HeadlineFormat'], then it was checked if users were mentioned and were to be informed. If yes,  $Activity['HeadlineFormat'] was set to HeadlineFormat.Mention. At last the users with advanced notification were notified but with the last HeadlineFormat.

Simply changing the order to first inform the users with advaanced notification before changing the HeadlineFormat solved the problem.