### PR TITLE
Replace permission names that are inserted into a tinyint column

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -305,7 +305,7 @@ if ($PermissionModel instanceof PermissionModel) {
 
 // Define the set of permissions that Garden uses.
 $PermissionModel->define(array(
-    'Garden.Email.View' => 'Garden.SignIn.Allow',
+    'Garden.Email.View', // => 'Garden.SignIn.Allow',
     'Garden.Settings.Manage',
     'Garden.Settings.View',
     'Garden.SignIn.Allow' => 1,
@@ -316,12 +316,12 @@ $PermissionModel->define(array(
     'Garden.Activity.Delete',
     'Garden.Activity.View' => 1,
     'Garden.Profiles.View' => 1,
-    'Garden.Profiles.Edit' => 'Garden.SignIn.Allow',
-    'Garden.Curation.Manage' => 'Garden.Moderation.Manage',
+    'Garden.Profiles.Edit', // => 'Garden.SignIn.Allow',
+    'Garden.Curation.Manage', // => 'Garden.Moderation.Manage',
     'Garden.Moderation.Manage',
-    'Garden.PersonalInfo.View' => 'Garden.Moderation.Manage',
+    'Garden.PersonalInfo.View', // => 'Garden.Moderation.Manage',
     'Garden.AdvancedNotifications.Allow',
-    'Garden.Community.Manage' => 'Garden.Settings.Manage'
+    'Garden.Community.Manage' // => 'Garden.Settings.Manage'
 ));
 
 $PermissionModel->undefine(array(


### PR DESCRIPTION
Refers to that issue: https://github.com/vanilla/vanilla/issues/2862

Inserting strings into permission table results into an error when database is in strict mode, since permission columns are of type TinyInt. That's why installation would fail if sql_model = strict.

Default value for those columns is '0', which is the value that is inserted if you try to insert a string into an integer column. So I simply commented out the wrong values. I haven't deleted them because I do not know which purpose they should have had...