### PR TITLE
Fixed misspelled function_exists('DiscussionSorter')

### DIFF
--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -197,7 +197,7 @@ if (!function_exists('WriteDiscussion')):
     }
 endif;
 
-if (!function_exists('DiscussionSorter')):
+if (!function_exists('WriteDiscussionSorter')):
 
     function writeDiscussionSorter($Selected = null, $Options = null) {
         if ($Selected === null) {


### PR DESCRIPTION
Replaced misspelled function_exists('DiscussionSorter') with function_exists('WriteDiscussionSorter') in applications/vanilla/views/discussions/helper_functions.php so function WriteDiscussionSorter() can be overwritten.