### PR TITLE
Allow a plugin to contain a master view

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1811,9 +1811,11 @@ class Gdn_Controller extends Gdn_Pluggable {
                 // 2. Garden-wide theme view. eg. /path/to/application/themes/theme_name/views/
                 $MasterViewPaths[] = combinePaths(array(PATH_THEMES, $this->Theme, 'views', $this->MasterView.'.master*'));
             }
-            // 3. Application default. eg. root/app_name/views/
+            // 3. Plugin default. eg. root/plugin_name/views/
+            $MasterViewPaths[] = combinePaths(array(PATH_ROOT, $this->ApplicationFolder, 'views', $this->MasterView.'.master*'));
+            // 4. Application default. eg. root/app_name/views/
             $MasterViewPaths[] = combinePaths(array(PATH_APPLICATIONS, $this->ApplicationFolder, 'views', $this->MasterView.'.master*'));
-            // 4. Garden default. eg. root/dashboard/views/
+            // 5. Garden default. eg. root/dashboard/views/
             $MasterViewPaths[] = combinePaths(array(PATH_APPLICATIONS, 'dashboard', 'views', $this->MasterView.'.master*'));
         }
 


### PR DESCRIPTION
Currently only themes and applications have the privilege of defining a master view. Since plugins are first-class citizens now they should be able to also.