### PR TITLE
Fix profile extender to not choke on DOB field w/ non-standard slug.

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -205,14 +205,13 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
             // Verify field form type
             if (!isset($Field['FormType'])) {
                 $Fields[$Name]['FormType'] = 'TextBox';
-            } elseif (!array_key_exists($Field['FormType'], $this->FormTypes))
+            } elseif (!array_key_exists($Field['FormType'], $this->FormTypes)) {
                 unset($this->ProfileFields[$Name]);
-        }
-
-        // Special case for birthday field
-        if (isset($Fields['DateOfBirth'])) {
-            $Fields['DateOfBirth']['FormType'] = 'Date';
-            $Fields['DateOfBirth']['Label'] = t('Birthday');
+            } elseif ($Fields[$Name]['FormType'] == 'DateOfBirth') {
+                // Special case for birthday field
+                $Fields[$Name]['FormType'] = 'Date';
+                $Fields[$Name]['Label'] = t('Birthday');
+            }
         }
 
         return $Fields;


### PR DESCRIPTION
If an existing field gets edited into a DOB field, it could have a different config slug, which shouldn't matter.