### PR TITLE
Fix stashing of non-embedded comments written by non-logged-in users.

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -209,6 +209,7 @@ class DiscussionController extends VanillaController {
         // Look in the session stash for a comment
         $StashComment = $Session->Stash('CommentForDiscussionID_'.$this->Discussion->DiscussionID, '', false);
         if ($StashComment) {
+            $this->Form->setValue('Body', $StashComment);
             $this->Form->setFormValue('Body', $StashComment);
         }
 

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -80,7 +80,7 @@ $this->fireEvent('BeforeCommentForm');
                         if (!$AllowSigninPopup)
                             $Attributes['target'] = '_parent';
 
-                        $AuthenticationUrl = SignInUrl($this->data('ForeignUrl', '/'));
+                        $AuthenticationUrl = SignInUrl($this->SelfUrl);
                         $CssClass = 'Button Primary Stash';
                         if ($AllowSigninPopup)
                             $CssClass .= ' SignInPopup';

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  */
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.2.100.4');
+define('APPLICATION_VERSION', '2.2.100.5');
 
 // Report and track all errors.
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);

--- a/js/global.js
+++ b/js/global.js
@@ -1136,19 +1136,24 @@ jQuery(document).ready(function($) {
 
     // When a stash anchor is clicked, look for inputs with values to stash
     $('a.Stash').click(function(e) {
-        // Embedded comments
         var comment = $('#Form_Comment textarea').val(),
-            placeholder = $('#Form_Comment textarea').attr('placeholder'),
-            vanilla_identifier = gdn.definition('vanilla_identifier');
+            placeholder = $('#Form_Comment textarea').attr('placeholder');
 
-        if (vanilla_identifier && comment != '' && comment != placeholder) {
+        // Stash a comment:
+        if (comment != '' && comment != placeholder) {
+            var vanilla_identifier = gdn.definition('vanilla_identifier', false);
+
+            if (vanilla_identifier) {
+                // Embedded comment:
+                var stash_name = 'CommentForForeignID_' + vanilla_identifier;
+            } else {
+                // Non-embedded comment:
+                var stash_name = 'CommentForDiscussionID_' + gdn.definition('DiscussionID'); 
+            }
             var href = $(this).attr('href');
             e.preventDefault();
 
-
-            stash('CommentForForeignID_' + vanilla_identifier, comment, function() {
-                window.top.location = href;
-            });
+            stash(stash_name, comment);
         }
     });
 


### PR DESCRIPTION
Fixes these issues:

The DiscussionController::index() method looks for stashed comments, but fails to correctly put these stashed values into the comment form.

The $('a.Stash').click() event handler in global.js detects a stashed comment, but fails to differ between non-embedded and embedded stashed comments. Also, it redirects automatically to the login form even if c('Garden.SignIn.Popup') is set to true. 

The view vanilla/view/post/comment.php incorrectly asks for $this->data('ForeignUrl') even though this view is for non-embedded comments where the concept of a ForeignUrl doesn't make sense.