### PR TITLE
Added check for dependend plugins when disabling an application.

### DIFF
--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -294,6 +294,24 @@ class Gdn_ApplicationManager {
             }
         }
 
+        // 3. Check to make sure that no other enabled plugins rely on this one
+        $DependendPlugins = array();
+        foreach (Gdn::pluginManager()->enabledPlugins() as $CheckingName => $CheckingInfo) {
+            $RequiredApplications = val('RequiredApplications', $CheckingInfo, false);
+            if (is_array($RequiredApplications) && array_key_exists($applicationName, $RequiredApplications) === true) {
+            	$DependendPlugins[] = $CheckingName;
+            }
+        }
+        if (!empty($DependendPlugins)) {
+            throw new Exception(
+                sprintf(
+                    t('You cannot disable the %1$s application because the following plugins require it in order to function: %2$s'),
+                    $applicationName,
+                    implode(', ', $DependendPlugins)
+                )
+            );
+        }
+        
         // 2. Disable it
         removeFromConfig("EnabledApplications.{$applicationName}");
 


### PR DESCRIPTION
If plugins are found that require a to-be-deactivated application to be enabled, an error is thrown with the names of the dependend plugins in the error message.

This fixes possibly fatal errors caused by enabled plugins that expect certain application classes to be loaded even though the application has been deactivated.

Fixes http://vanillaforums.org/discussion/30540/fatal-error-after-disabling-vanilla-application