### PR TITLE
Fix issue involving posting new announcements

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1705,6 +1705,10 @@ class DiscussionModel extends VanillaModel {
                         // Clear the cache if necessary.
                         if (val('Announce', $Fields)) {
                             Gdn::cache()->Remove($this->GetAnnouncementCacheKey(val('CategoryID', $Fields)));
+
+                            if (val('Announce', $Fields) == 1) {
+                                Gdn::cache()->Remove($this->GetAnnouncementCacheKey());
+                            }
                         }
                     }
 


### PR DESCRIPTION
This issue manifests itself when memcache is enabled and a new discussion is posted as an announcement. The discussion does not show up in in the announcements list and is thus removed from the recent discussions list.