### PR TITLE
Allow a CSS class to be added to error pages programmatically

### DIFF
--- a/applications/dashboard/controllers/class.homecontroller.php
+++ b/applications/dashboard/controllers/class.homecontroller.php
@@ -53,6 +53,9 @@ class HomeController extends Gdn_Controller {
         $this->MasterView = 'default';
 
         $this->CssClass = 'SplashMessage NoPanel';
+        if ($this->data('CssClass')) {
+            $this->CssClass .= ' '.$this->data('CssClass');
+        }
 
         $this->setData('_NoMessages', true);
 


### PR DESCRIPTION
Add the ability to add an additional CSS class to home/error via the data array. This allows the CSS class to be modified in re-dispatches.