### PR TITLE
Prevent spam discussions from saving as drafts

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -243,6 +243,10 @@ class PostController extends VanillaController {
                         }
                         if ($DiscussionID == SPAM || $DiscussionID == UNAPPROVED) {
                             $this->StatusMessage = t('DiscussionRequiresApprovalStatus', 'Your discussion will appear after it is approved.');
+
+                            // Clear out the form so that a draft won't save.
+                            $this->Form->formValues(array());
+
                             $this->render('Spam');
                             return;
                         }


### PR DESCRIPTION
If a discussion is posted and is detected as spam then clear out the form so that the drafts autosaver doesn’t pick it up after the fact.