### PR TITLE
Allow disabling commenting ajax so that page will refresh on submission

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -57,6 +57,10 @@ class DiscussionController extends VanillaController {
         $this->addJsFile('discussion.js');
         Gdn_Theme::section('Discussion');
 
+        if (c("Vanilla.Discussion.DisableAjax")) {
+            $this->addDefinition("disableAjax", "true");
+        }
+
         // Load the discussion record
         $DiscussionID = (is_numeric($DiscussionID) && $DiscussionID > 0) ? $DiscussionID : 0;
         if (!array_key_exists('Discussion', $this->Data)) {

--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -87,6 +87,12 @@ jQuery(document).ready(function($) {
             action += 'discussionid=' + discussionID;
         }
 
+        if (gdn.definition('disableAjax', true) && type == 'Post') {
+            $(frm).append("<input type='hidden' name='Type' value='" + type + "' />");
+            $(frm).submit();
+            return false;
+        }
+
         $(frm).find(':submit').attr('disabled', 'disabled');
         $(parent).find('a.Back').after('<span class="TinyProgress">&#160;</span>');
         // Also add a spinner for comments being edited


### PR DESCRIPTION
In order to test, add 
$Configuration['Vanilla']['Discussion']['DisableAjax'] = true; 
to config.