### PR TITLE
Fix client-side form caching via removal of "no-store" from "Cache-Control" header

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -247,7 +247,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
         if (Gdn::session()->isValid()) {
             $this->_Headers = array_merge($this->_Headers, array(
-                'Cache-Control' => 'private, no-cache, no-store, max-age=0, must-revalidate', // PREVENT PAGE CACHING: HTTP/1.1
+                'Cache-Control' => 'private, no-cache, max-age=0, must-revalidate', // PREVENT PAGE CACHING: HTTP/1.1
                 'Expires' => 'Sat, 01 Jan 2000 00:00:00 GMT', // Make sure the client always checks at the server before using it's cached copy.
                 'Pragma' => 'no-cache', // PREVENT PAGE CACHING: HTTP/1.0
             ));


### PR DESCRIPTION
By default, Gdn_Controller sends the following Cache-Control header to prevent caching:
"Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate"

The "no-store" attribute however causes the client browser not to cache form input fields. As a result, users may experience data loss when writing e.g. comments and navigating back and forth in history. Instead of the last cached form content, a blank form field is shown.

See also http://blogs.atlassian.com/2007/12/cache_control_no_store_considered_harmful/

Side-effect: Without no-store, navigating through the browser history is much faster (at least on mozilla based browsers). This is because without no-store, history really means history - pages are not re-loaded but taken from the browser's history cache.

Fixes http://vanillaforums.org/discussion/30584/auto-drafts-vs-usability#latest