### PR TITLE
Fix UTF8 decode/encode in global.js to support multibyte unicode strings

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -43,46 +43,14 @@ jQuery(document).ready(function($) {
 
     var keyString = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
 
+    // See http://ecmanaut.blogspot.de/2006/07/encoding-decoding-utf8-in-javascript.html
     var uTF8Encode = function(string) {
-        string = string.replace(/\x0d\x0a/g, "\x0a");
-        var output = "";
-        for (var n = 0; n < string.length; n++) {
-            var c = string.charCodeAt(n);
-            if (c < 128) {
-                output += String.fromCharCode(c);
-            } else if ((c > 127) && (c < 2048)) {
-                output += String.fromCharCode((c >> 6) | 192);
-                output += String.fromCharCode((c & 63) | 128);
-            } else {
-                output += String.fromCharCode((c >> 12) | 224);
-                output += String.fromCharCode(((c >> 6) & 63) | 128);
-                output += String.fromCharCode((c & 63) | 128);
-            }
-        }
-        return output;
-    };
+        return unescape(encodeURIComponent(string));
+    }
 
-    var uTF8Decode = function(input) {
-        var string = "";
-        var i = 0;
-        var c = c1 = c2 = 0;
-        while (i < input.length) {
-            c = input.charCodeAt(i);
-            if (c < 128) {
-                string += String.fromCharCode(c);
-                i++;
-            } else if ((c > 191) && (c < 224)) {
-                c2 = input.charCodeAt(i + 1);
-                string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
-                i += 2;
-            } else {
-                c2 = input.charCodeAt(i + 1);
-                c3 = input.charCodeAt(i + 2);
-                string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
-                i += 3;
-            }
-        }
-        return string;
+    // See http://ecmanaut.blogspot.de/2006/07/encoding-decoding-utf8-in-javascript.html
+    var uTF8Decode = function(string) {
+        return decodeURIComponent(escape(string));
     }
 
     $.extend({


### PR DESCRIPTION
The replacements finally handle full 3 or 4 byte utf8 unicode representations well.

See http://ecmanaut.blogspot.de/2006/07/encoding-decoding-utf8-in-javascript.html

This fixes http://vanillaforums.org/discussion/30590/issue-unicode-emoji-mangled-by-vanilla-js
