### PR TITLE
Prevent duplicate class on SocialSignInButton

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1090,6 +1090,7 @@ if (!function_exists('socialSignInButton')) {
         TouchValue('title', $Attributes, sprintf(T('Sign In with %s'), $Name));
         $Title = $Attributes['title'];
         $Class = val('class', $Attributes, '');
+        unset($Attributes['class']);
 
         switch ($Type) {
             case 'icon':


### PR DESCRIPTION
Currently the sign in button write something like this `class="SocialIcon SocialIcon-Twitter js-extern" class="js-extern"` which is not valid.