### PR TITLE
Handle array values for AllIPAddresses in UserModel::save()

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1921,17 +1921,23 @@ class UserModel extends Gdn_Model {
             $this->Validation->applyRule('Email', 'Email');
         }
 
+        // AllIPAdresses is stored as a CSV, so handle the case where an array is submitted.
+        if (array_key_exists('AllIPAddresses', $FormPostValues) && is_array($FormPostValues['AllIPAddresses'])) {
+            $FormPostValues['AllIPAddresses'] = implode(',', $FormPostValues['AllIPAddresses']);
+        }
+
         if ($this->validate($FormPostValues, $Insert) && $UniqueValid) {
-            $Fields = $this->Validation->validationFields(); // All fields on the form that need to be validated (including non-schema field rules defined above)
+            // All fields on the form that need to be validated (including non-schema field rules defined above)
+            $Fields = $this->Validation->validationFields();
             $RoleIDs = val('RoleID', $Fields, 0);
             $Username = val('Name', $Fields);
             $Email = val('Email', $Fields);
-            $Fields = $this->Validation->schemaValidationFields(); // Only fields that are present in the schema
+
+            // Only fields that are present in the schema
+            $Fields = $this->Validation->schemaValidationFields();
+
             // Remove the primary key from the fields collection before saving
             $Fields = removeKeyFromArray($Fields, $this->PrimaryKey);
-            if (array_key_exists('AllIPAddresses', $Fields) && is_array($Fields['AllIPAddresses'])) {
-                $Fields['AllIPAddresses'] = implode(',', $Fields['AllIPAddresses']);
-            }
 
             if (!$Insert && array_key_exists('Password', $Fields) && val('HashPassword', $Settings, true)) {
                 // Encrypt the password for saving only if it won't be hashed in _Insert()


### PR DESCRIPTION
We call Validation->validate() in the save() method, and from what it looks like, it is primed with the schema.
The schema says that column is a string, so if you pass in an array for AllIPAddresses it will error out.
We handle the case of it being an array though, but only AFTER the validate(), so it is never able to do its work.

This PR fixes that issue.