### PR TITLE
Remove remaining livequery uses from global.js

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -880,9 +880,9 @@ jQuery(document).ready(function($) {
     }
 
     // Handle autodismissals
-    $('div.InformWrapper.AutoDismiss:first').livequery(function() {
-        gdn.setAutoDismiss();
-    });
+	$(document).on('informMessage', function() {
+		gdn.setAutoDismiss();
+	});
 
     // Prevent autodismiss if hovering any inform messages
     $(document).delegate('div.InformWrapper', 'mouseover mouseout', function(e) {
@@ -1181,11 +1181,6 @@ jQuery(document).ready(function($) {
 
     var d = new Date()
     var hourOffset = -Math.round(d.getTimezoneOffset() / 60);
-
-    // Set the ClientHour if there is an input looking for it.
-    $('input:hidden[name$=HourOffset]').livequery(function() {
-        $(this).val(hourOffset);
-    });
 
     // Ajax/Save the ClientHour if it is different from the value in the db.
     var setHourOffset = parseInt(gdn.definition('SetHourOffset', hourOffset));
@@ -1864,9 +1859,10 @@ jQuery(document).ready(function($) {
     // calls this function directly when in wysiwyg format, as it needs to
     // handle an iframe, and the editor instance needs to be referenced.
     if ($.fn.atwho && gdn.atCompleteInit) {
-        $('.BodyBox').livequery(function() {
-            gdn.atCompleteInit(this, '');
+        $(document).on('EditCommentFormLoaded popupReveal', function() {
+            gdn.atCompleteInit('.BodyBox', '');
         });
+        gdn.atCompleteInit('.BodyBox', '');
     }
 
 


### PR DESCRIPTION
- Bound autodismiss to the proper event
- There is not input with the name of "HourOffset" anywhere (the hour offset is set using ajax + definitions)
- Bound the gdn.atCompleteInit call to the proper events