### PR TITLE
ButtonBar: Remove livequery dependency

### DIFF
--- a/plugins/ButtonBar/js/buttonbar.js
+++ b/plugins/ButtonBar/js/buttonbar.js
@@ -219,6 +219,21 @@ $.fn.insertRoundTag = function(tagName, opts, props) {
 jQuery(document).ready(function($) {
 
     ButtonBar = {
+
+        // Search for new button bars and handle their events.
+        init: function (selector) {
+            selector = selector || '.ButtonBar';
+
+            $('.ButtonBar')
+                .closest('form')
+                .find('div.TextBoxWrapper textarea')
+                .each(function (i, textarea) {
+                    if ($(textarea).hasClass('BodyBox')) {
+                        ButtonBar.AttachTo(textarea);
+                    }
+                });
+        },
+
         AttachTo: function(TextArea) {
             // Load the buttonbar and bind this textarea to it
             var ThisButtonBar = $(TextArea).closest('form').find('.ButtonBar');
@@ -664,14 +679,7 @@ jQuery(document).ready(function($) {
 
     }
 
-    // Always find new button bars and handle their events
-    if (jQuery().livequery) {
-        $('.ButtonBar').livequery(function() {
-            var TextAreas = $(this).closest('form').find('div.TextBoxWrapper textarea');
-            $.each(TextAreas, function(i, TextArea) {
-                if ($(TextArea).hasClass('BodyBox'))
-                    ButtonBar.AttachTo(TextArea);
-            });
-        });
-    }
+    $(document).on('EditCommentFormLoaded popupReveal', ButtonBar.init);
+    ButtonBar.init();
+
 });

--- a/plugins/ButtonBar/js/buttonbar.js
+++ b/plugins/ButtonBar/js/buttonbar.js
@@ -228,7 +228,10 @@ jQuery(document).ready(function($) {
                 .closest('form')
                 .find('div.TextBoxWrapper textarea')
                 .each(function (i, textarea) {
-                    if ($(textarea).hasClass('BodyBox')) {
+                    var $textarea = $(textarea);
+
+                    if ($textarea.hasClass('BodyBox') && !$textarea.data('ButtonBar')) {
+                        $textarea.data('ButtonBar', '1');
                         ButtonBar.AttachTo(textarea);
                     }
                 });


### PR DESCRIPTION
- Create function ButtonBar.init() which does what the livequery handler did
- Call this function on document.ready, EditCommentFormLoaded and popupReveal