### PR TITLE
Remove error prone magic_quotes support

### DIFF
--- a/applications/dashboard/controllers/class.sessioncontroller.php
+++ b/applications/dashboard/controllers/class.sessioncontroller.php
@@ -21,8 +21,8 @@ class SessionController extends DashboardController {
     public function stash() {
         $this->deliveryType(DELIVERY_TYPE_BOOL);
         $this->deliveryMethod(DELIVERY_METHOD_JSON);
-        $Name = TrueStripSlashes(val('Name', $_POST, ''));
-        $Value = TrueStripSlashes(val('Value', $_POST, ''));
+        $Name = val('Name', $_POST, '');
+        $Value = val('Value', $_POST, '');
         $Response = Gdn::session()->Stash($Name, $Value);
         if ($Name != '' && $Value == '') {
             $this->setJson('Unstash', $Response);

--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -70,9 +70,6 @@ class AssetModel extends Gdn_Model {
         }
 
         $RequestETags = val('HTTP_IF_NONE_MATCH', $_SERVER);
-        if (get_magic_quotes_gpc()) {
-            $RequestETags = stripslashes($RequestETags);
-        }
         $RequestETags = explode(',', $RequestETags);
         foreach ($RequestETags as $RequestETag) {
             if ($RequestETag == $ETag) {

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -1965,8 +1965,6 @@ PASSWORDMETER;
             return;
         }
 
-        $MagicQuotes = get_magic_quotes_gpc();
-
         if (!is_array($this->_FormValues)) {
             $TableName = $this->InputPrefix;
             if (strlen($TableName) > 0) {
@@ -1982,16 +1980,6 @@ PASSWORDMETER;
                 $FieldName = substr($Field, $TableNameLength);
                 $FieldName = $this->_unescapeString($FieldName);
                 if (substr($Field, 0, $TableNameLength) == $TableName) {
-                    if ($MagicQuotes) {
-                        if (is_array($Value)) {
-                            foreach ($Value as $i => $v) {
-                                $Value[$i] = stripcslashes($v);
-                            }
-                        } else {
-                            $Value = stripcslashes($Value);
-                        }
-                    }
-
                     $this->_FormValues[$FieldName] = $Value;
                 }
             }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3148,7 +3148,11 @@ if (!function_exists('removeKeysFromNestedArray')) {
 }
 
 if (!function_exists('removeQuoteSlashes')) {
+    /**
+     * @deprecated
+     */
     function removeQuoteSlashes($String) {
+        deprecated('removeQuoteSlashes()');
         return str_replace("\\\"", '"', $String);
     }
 }
@@ -3618,11 +3622,19 @@ if (!function_exists('trace')) {
 
 if (!function_exists('trueStripSlashes')) {
     if (get_magic_quotes_gpc()) {
+        /**
+         * @deprecated
+         */
         function trueStripSlashes($String) {
+            deprecated('trueStripSlashes()');
             return stripslashes($String);
         }
     } else {
+        /**
+         * @deprecated
+         */
         function trueStripSlashes($String) {
+            deprecated('trueStripSlashes()');
             return $String;
         }
     }

--- a/plugins/OpenID/class.lightopenid.php
+++ b/plugins/OpenID/class.lightopenid.php
@@ -653,14 +653,8 @@ class LightOpenID {
         $server = $this->discover($this->claimed_id);
 
         foreach (explode(',', $this->data['openid_signed']) as $item) {
-            # Checking whether magic_quotes_gpc is turned on, because
-            # the function may fail if it is. For example, when fetching
-            # AX namePerson, it might containg an apostrophe, which will be escaped.
-            # In such case, validation would fail, since we'd send different data than OP
-            # wants to verify. stripslashes() should solve that problem, but we can't
-            # use it when magic_quotes is off.
             $value = $this->data['openid_'.str_replace('.', '_', $item)];
-            $params['openid.'.$item] = get_magic_quotes_gpc() ? stripslashes($value) : $value;
+            $params['openid.'.$item] = $value;
 
         }
 

--- a/plugins/OpenID/class.openid.plugin.php
+++ b/plugins/OpenID/class.openid.plugin.php
@@ -62,12 +62,6 @@ class OpenIDPlugin extends Gdn_Plugin {
      * @return LightOpenID
      */
     public function getOpenID() {
-        if (get_magic_quotes_gpc()) {
-            foreach ($_GET as $Name => $Value) {
-                $_GET[$Name] = stripslashes($Value);
-            }
-        }
-
         $OpenID = new LightOpenID();
 
         if ($url = Gdn::request()->get('url')) {


### PR DESCRIPTION
Removed or made deprecate all code related to handling PHP's deprecated magic quotes.
Exception: Vendor libraries. I didn't touch them.

* Made TrueStripSlashes() and removeQuoteSlashes() from functions.general.php deprecated and removedreferences to it.
* Removed all "if ($MagicQuotes) ..." or similar code.