### PR TITLE
Add CORS allow-origin header for trusted domain-originating requests

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1227,6 +1227,23 @@ class Gdn_Controller extends Gdn_Pluggable {
             }
             $this->contentType('application/json; charset='.c('Garden.Charset', 'utf-8'));
             $this->setHeader('X-Content-Type-Options', 'nosniff');
+
+            // Cross-Origin Resource Sharing (CORS)
+
+            /**
+             * Access-Control-Allow-Origin
+             * If a Origin header is sent by the client, attempt to verify it against the list of
+             * trusted domains in Garden.TrustedDomains.  If the value of Origin is verified as
+             * being part of a trusted domain, add the Access-Control-Allow-Origin header to the
+             * response using the client's Origin header value.
+             */
+            $origin = Gdn::request()->getValueFrom(Gdn_Request::INPUT_SERVER, 'HTTP_ORIGIN', false);
+            if ($origin) {
+                $originHost = parse_url($origin, PHP_URL_HOST);
+                if ($originHost && isTrustedDomain($originHost)) {
+                    $this->setHeader('Access-Control-Allow-Origin', $origin);
+                }
+            }
         }
 
         if ($this->_DeliveryMethod == DELIVERY_METHOD_TEXT) {

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3835,6 +3835,46 @@ if (!function_exists('isSafeUrl')) {
 
 }
 
+if (!function_exists('isTrustedDomain')) {
+    /**
+     * Check the provided domain name (or request host, if domain is not supplied)
+     * to determine if it is a trusted domain.
+     *
+     * @param bool|false $domain Domain name to compare against our list of trusted domains.
+     *
+     * @return bool True if verified as a trusted domain.  False if unable to verify domain.
+     */
+    function isTrustedDomain($domain = null) {
+        static $trustedDomains = null;
+
+        // If we weren't provided a host, fall back to the request host.
+        if (!$domain) {
+            $domain = Gdn::request()->host();
+        }
+
+        // If we haven't already compiled an array of trusted domains, grab them.
+        if (!is_array($trustedDomains)) {
+            $trustedDomains = trustedDomains();
+        }
+
+        /**
+         * Iterate through each of our trusted domains.
+         * Chop off any whitespace from the trusted domain and prepare it for regex.
+         * See if the current trusted domain matches fully against the domain we're
+         *   testing or if it matches its end (e.g. domain.tld should match domain.tld and sub.domain.tld)
+         */
+        foreach ($trustedDomains as $trustedDomain) {
+            $trustedDomain = preg_quote(trim($trustedDomain));
+            if (preg_match("/(^|\.){$trustedDomain}$/i", $domain)) {
+                return true;
+            }
+        }
+
+        // No matches?  Must not be a trusted domain.
+        return false;
+    }
+}
+
 if (!function_exists('userAgentType')) {
     /**
      *

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3847,9 +3847,18 @@ if (!function_exists('isTrustedDomain')) {
     function isTrustedDomain($domain = null) {
         static $trustedDomains = null;
 
-        // If we weren't provided a host, fall back to the request host.
+        // If we weren't provided a host, fall back to the referring host, if available.
         if (!$domain) {
-            $domain = Gdn::request()->host();
+            $referrer = Gdn::request()->getValueFrom(Gdn_Request::INPUT_SERVER, 'HTTP_REFERER', false);
+            if ($referrer) {
+                $referrerDomain = parse_url($referrer, PHP_URL_HOST);
+            }
+
+            if (!empty($referrerDomain)) {
+                $domain = $referrerDomain;
+            } else {
+                return false;
+            }
         }
 
         // If we haven't already compiled an array of trusted domains, grab them.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3837,28 +3837,17 @@ if (!function_exists('isSafeUrl')) {
 
 if (!function_exists('isTrustedDomain')) {
     /**
-     * Check the provided domain name (or request host, if domain is not supplied)
-     * to determine if it is a trusted domain.
+     * Check the provided domain name to determine if it is a trusted domain.
      *
-     * @param string|null $domain Domain name to compare against our list of trusted domains.
+     * @param string $domain Domain name to compare against our list of trusted domains.
      *
      * @return bool True if verified as a trusted domain.  False if unable to verify domain.
      */
-    function isTrustedDomain($domain = null) {
+    function isTrustedDomain($domain) {
         static $trustedDomains = null;
 
-        // If we weren't provided a host, fall back to the referring host, if available.
-        if (!$domain) {
-            $referrer = Gdn::request()->getValueFrom(Gdn_Request::INPUT_SERVER, 'HTTP_REFERER', false);
-            if ($referrer) {
-                $referrerDomain = parse_url($referrer, PHP_URL_HOST);
-            }
-
-            if (!empty($referrerDomain)) {
-                $domain = $referrerDomain;
-            } else {
-                return false;
-            }
+        if (empty($domain)) {
+            return false;
         }
 
         // If we haven't already compiled an array of trusted domains, grab them.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3840,7 +3840,7 @@ if (!function_exists('isTrustedDomain')) {
      * Check the provided domain name (or request host, if domain is not supplied)
      * to determine if it is a trusted domain.
      *
-     * @param bool|false $domain Domain name to compare against our list of trusted domains.
+     * @param string|null $domain Domain name to compare against our list of trusted domains.
      *
      * @return bool True if verified as a trusted domain.  False if unable to verify domain.
      */


### PR DESCRIPTION
If delivering JSON and receiving an Origin header from the client, attempt to verify the host of Origin against Garden.TrustedDomains.

Origin values should match if they are a legitimate part of a domain in Garden.TrustedDomains.  For example: If google.com is a trusted domain, we should be able to use it to match mail.google.com, www.google.com or google.com, but not fakegoogle.com.

Adds isTrustedDomain function to determine if a supplied domain is a match for an entry in TrustedDomains.  If no domain is provided, fallback to the request's host.