### PR TITLE
Add $RequestArgs as parameter for dispatcher function

### DIFF
--- a/library/core/class.plugin.php
+++ b/library/core/class.plugin.php
@@ -327,12 +327,13 @@ abstract class Gdn_Plugin extends Gdn_Pluggable implements Gdn_IPlugin {
             $TestControllerMethod = 'Controller_'.$MethodName;
             if (method_exists($this, $TestControllerMethod)) {
                 $ControllerMethod = $TestControllerMethod;
+                array_shift($RequestArgs);
             }
         }
 
         if (method_exists($this, $ControllerMethod)) {
             $Sender->Plugin = $this;
-            return call_user_func(array($this, $ControllerMethod), $Sender);
+            return call_user_func(array($this, $ControllerMethod), $Sender, $RequestArgs);
         } else {
             $PluginName = get_class($this);
             throw NotFoundException("@{$PluginName}->{$ControllerMethod}()");


### PR DESCRIPTION
Assuming you want to use the dispatcher in a plugin and access the request arguments, you had to always access them with $sender->RequestArguments.
Following code, which I expected to work flawlessly did fail since the $args parameter is not passed to the custom function:
~~~
public function vanillaController_something_create($sender, $args) {
    $this->dispatch($sender, $args);
}

// For example: /vanilla/something/edit/1
public function Controller_Edit($sender, $args) {
    // will fail because $args are not passed, although this is a common way to access request arguments
    $somethingId = $args[0];

   // by now you have to do it like that:
    $somethingId = $sender->RequestArguments[1];
}
~~~