### PR TITLE
Drop unneccessary if condition

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1667,11 +1667,8 @@ class CategoryModel extends Gdn_Model {
         // Make sure that the UrlCode is unique among categories.
         $this->SQL->select('CategoryID')
             ->from('Category')
+            ->where('CategoryID <>', $CategoryID)
             ->where('UrlCode', $UrlCode);
-
-        if ($CategoryID) {
-            $this->SQL->where('CategoryID <>', $CategoryID);
-        }
 
         if ($this->SQL->get()->numRows()) {
             $this->Validation->addValidationResult('UrlCode', 'The specified url code is already in use by another category.');


### PR DESCRIPTION
$CategoryID is already set: false = zero for new categories and with the correct value for existing categories. So the where clause can be used either way. Makes the code shorter => more readable...