### PR TITLE
Fix @mention behaviour

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1740,7 +1740,7 @@ jQuery(document).ready(function($) {
                         // but it's the only way, as spaces make searching
                         // more ambiguous.
                         // \xA0 non-breaking space
-                        regexp = new RegExp(flag + '\"?([\\sA-Za-z0-9_\+\-]*)\"?$|' + flag + '\"?([^\\x00-\\xff]*)\"?$', 'gi');
+                        regexp = new RegExp(flag + '([^"]\\S*)$|' + flag + '"([^"\\n]*)"$', 'gi');
 
                         match = regexp.exec(subtext);
                         if (match) {

--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -488,8 +488,7 @@
             if (!view.visible()) {
               return;
             }
-            e.preventDefault();
-            view.choose();
+            view.choose(e);
             break;
           default:
             $.noop();
@@ -822,7 +821,7 @@
           $menu.find('.cur').removeClass('cur');
           return $(e.currentTarget).addClass('cur');
         }).on('click', function(e) {
-          _this.choose();
+          _this.choose(e);
           return e.preventDefault();
         });
         return this.$el.on('mouseenter.atwho-view', 'ul', function(e) {
@@ -836,13 +835,15 @@
         return this.$el.is(":visible");
       };
 
-      View.prototype.choose = function() {
+      View.prototype.choose = function(event) {
         var $li, content;
-        $li = this.$el.find(".cur");
-        content = this.context.insert_content_for($li);
-        this.context.insert(this.context.callbacks("before_insert").call(this.context, content, $li), $li);
-        this.context.trigger("inserted", [$li]);
-        return this.hide();
+        if (($li = this.$el.find(".cur")).length) {
+          event.preventDefault();
+          content = this.context.insert_content_for($li);
+          this.context.insert(this.context.callbacks("before_insert").call(this.context, content, $li), $li);
+          this.context.trigger("inserted", [$li]);
+          return this.hide();
+        }
       };
 
       View.prototype.reposition = function(rect) {


### PR DESCRIPTION
fixes #2478

This fixes 2 problems:
- The original regex didn't make a difference between mentions between quotes and normal mentions. When you kept typing (without hitting return), it would still be searching for matches.
- When hitting enter without a match, it would choose an empty string and clear the mention. This was fixed in At.js. I copied over that part. 