### PR TITLE
Fix Gdn_Form Field Name Handling

### DIFF
--- a/applications/dashboard/controllers/class.dbacontroller.php
+++ b/applications/dashboard/controllers/class.dbacontroller.php
@@ -27,7 +27,6 @@ class DbaController extends DashboardController {
         Gdn_Theme::section('Dashboard');
         $this->Model = new DBAModel();
         $this->Form = new Gdn_Form();
-        $this->Form->InputPrefix = '';
 
         $this->addJsFile('dba.js');
     }

--- a/applications/dashboard/controllers/class.logcontroller.php
+++ b/applications/dashboard/controllers/class.logcontroller.php
@@ -34,7 +34,6 @@ class LogController extends DashboardController {
     public function confirm($Action, $LogIDs = '') {
         $this->permission(array('Garden.Moderation.Manage', 'Moderation.Spam.Manage', 'Moderation.ModerationQueue.Manage'), false);
 
-        $this->Form->InputPrefix = '';
         $this->Form->IDPrefix = 'Confirm_';
 
         if (trim($LogIDs)) {
@@ -256,7 +255,6 @@ class LogController extends DashboardController {
         $this->addJsFile('log.js');
         $this->addJsFile('jquery.expander.js');
         $this->addJsFile('jquery-ui.js');
-        $this->Form->InputPrefix = '';
     }
 
     /**

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -816,8 +816,6 @@ class ProfileController extends Gdn_Controller {
     public function preference($Key = false) {
         $this->permission('Garden.SignIn.Allow');
 
-        $this->Form->InputPrefix = '';
-
         if ($this->Form->authenticatedPostBack()) {
             $Data = $this->Form->formValues();
             Gdn::userModel()->SavePreference(Gdn::session()->UserID, $Data);

--- a/applications/dashboard/controllers/class.searchcontroller.php
+++ b/applications/dashboard/controllers/class.searchcontroller.php
@@ -34,7 +34,6 @@ class SearchController extends Gdn_Controller {
 
         // Form prep
         $Form->Method = 'get';
-        $Form->InputPrefix = '';
         $this->Form = $Form;
     }
 

--- a/applications/dashboard/views/search/index.php
+++ b/applications/dashboard/views/search/index.php
@@ -2,7 +2,6 @@
     <div class="SearchForm">
         <?php
         $Form = $this->Form;
-        $Form->InputPrefix = '';
         echo $Form->open(array('action' => url('/search'), 'method' => 'get')),
         '<div class="SiteSearch InputAndButton">',
         $Form->textBox('Search'),

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -1815,8 +1815,7 @@ PASSWORDMETER;
      * @return boolean
      */
     public function buttonExists($ButtonCode) {
-        $NameKey = $this->escapeString($ButtonCode);
-        return array_key_exists($NameKey, $this->formValues()) ? true : false;
+        return array_key_exists($ButtonCode, $this->formValues()) ? true : false;
     }
 
     /**
@@ -1840,13 +1839,35 @@ PASSWORDMETER;
     }
 
     /**
-     * Returns the provided fieldname with non-alpha-numeric values stripped.
+     * PHP doesn't allow "." in variable names from external sources such as a
+     * HTML form. Some Vanilla components however rely on variable names such
+     * as "a.b.c". So we need to escape them for backwards compatibility.
      *
-     * @param string $FieldName The field name to escape.
+     * Replaces e.g. "\" with "\\", "-dot-" with "\\-dot-" and "." with "-dot-".
+     *
+     * @see Gdn_Form::unescapeFieldName()
+     *
+     * @param string $string
      * @return string
      */
-    public function escapeFieldName($FieldName) {
-        return $this->escapeString($FieldName);
+    public function escapeFieldName($string) {
+        $search = array('\\', '-dot-', '.');
+        $replace = array('\\\\', '\\-dot-', '-dot-');
+        return str_replace($search, $replace, $string);
+    }
+
+    /**
+     * Replaces e.g. "\\" with "\", "\\-dot-" with "-dot-" and "-dot-" with ".".
+     *
+     * @see Gdn_Form::escapeFieldName()
+     *
+     * @param string $string
+     * @return string
+     */
+    public function unescapeFieldName($string) {
+        $search = array('/(?<!\\\\)(\\\\\\\\)*-dot-/', '/\\\\-dot-/', '/\\\\\\\\/');
+        $replace = array('$1.', '-dot-', '\\\\');
+        return preg_replace($search, $replace, $string);
     }
 
     /**
@@ -2329,9 +2350,6 @@ PASSWORDMETER;
     public function setModel($Model, $DataSet = false) {
         $this->_Model = $Model;
 
-        if ($this->InputPrefix) {
-            $this->InputPrefix = $this->_Model->Name;
-        }
         if ($DataSet !== false) {
             $this->SetData($DataSet);
         }
@@ -2583,21 +2601,7 @@ PASSWORDMETER;
     protected function _nameAttribute($FieldName, $Attributes) {
         // Name from attributes overrides the default.
         $Name = $this->escapeFieldName(arrayValueI('name', $Attributes, $FieldName));
-        return (empty($Name)) ? '' : ' name="'.$Name.'"';
-    }
-
-    /**
-     * Decodes the encoded string from a php-form safe-encoded format to the
-     * format it was in when presented to the form.
-     *
-     * @param string $EscapedString
-     * @return unknown
-     */
-    protected function _unescapeString(
-        $EscapedString
-    ) {
-        $Return = str_replace('-dot-', '.', $EscapedString);
-        return urldecode($Return);
+        return (empty($Name)) ? '' : ' name="'.htmlspecialchars($Name, ENT_COMPAT, c('Garden.Charset', 'UTF-8')).'"';
     }
 
     /**

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -1114,23 +1114,15 @@ class Gdn_Form extends Gdn_Pluggable {
     }
 
     /**
-     * Encodes the string in a php-form safe-encoded format.
+     * @see Gdn_Form::escapeFieldName()
+     * @deprecated
      *
-     * @param string $String The string to encode.
+     * @param string $string
      * @return string
      */
-    public function escapeString($String) {
-        $Array = false;
-        if (substr($String, -2) == '[]') {
-            $String = substr($String, 0, -2);
-            $Array = true;
-        }
-        $Return = urlencode(str_replace(' ', '_', $String));
-        if ($Array === true) {
-            $Return .= '[]';
-        }
-
-        return str_replace('.', '-dot-', $Return);
+    public function escapeString($string) {
+        deprecated('Gd_Form::escapeString()');
+        return $this->escapeFieldName($string);
     }
 
     /**
@@ -1795,7 +1787,7 @@ PASSWORDMETER;
      * @return bool
      */
     public function authenticatedPostBack() {
-        $KeyName = $this->escapeFieldName('TransientKey');
+        $KeyName = 'TransientKey';
         $PostBackKey = Gdn::request()->getValueFrom(Gdn_Request::INPUT_POST, $KeyName, false);
 
         // If this isn't a postback then return false if there isn't a transient key.
@@ -1962,7 +1954,7 @@ PASSWORDMETER;
             $Collection = $this->Method == 'get' ? $Request->get() : $Request->post();
 
             foreach ($Collection as $FieldName => $Value) {
-                $FieldName = $this->_unescapeString($FieldName);
+                $FieldName = $this->unescapeFieldName($FieldName);
                 $this->_FormValues[$FieldName] = $Value;
             }
 
@@ -2601,7 +2593,7 @@ PASSWORDMETER;
     protected function _nameAttribute($FieldName, $Attributes) {
         // Name from attributes overrides the default.
         $Name = $this->escapeFieldName(arrayValueI('name', $Attributes, $FieldName));
-        return (empty($Name)) ? '' : ' name="'.htmlspecialchars($Name, ENT_COMPAT, c('Garden.Charset', 'UTF-8')).'"';
+        return ' name="'.htmlspecialchars($Name, ENT_COMPAT, c('Garden.Charset', 'UTF-8')).'"';
     }
 
     /**

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -34,13 +34,6 @@ class Gdn_Form extends Gdn_Pluggable {
      */
     public $IDPrefix = 'Form_';
 
-    /**
-     * @var string All form-related elements (form, input, select, etc) will have
-     *    this value prefixed on their name attribute. Default is "Form".
-     *    If a model is assigned, the model name is used instead.
-     */
-    public $InputPrefix = '';
-
     /** @var string Form submit method. Options are 'post' or 'get'. */
     public $Method = 'post';
 
@@ -1449,19 +1442,13 @@ PASSWORDMETER;
      * @todo check that missing DataObject parameter
      */
     public function open($Attributes = array()) {
-//      if ($this->InputPrefix)
-//         Trace($this->InputPrefix, 'InputPrefix');
-
         if (!is_array($Attributes)) {
             $Attributes = array();
         }
 
         $Return = '<form';
-        if ($this->InputPrefix != '' || array_key_exists('id', $Attributes)) {
-            $Return .= $this->_idAttribute(
-                $this->InputPrefix,
-                $Attributes
-            );
+        if (array_key_exists('id', $Attributes)) {
+            $Return .= $this->_idAttribute('', $Attributes);
         }
 
         // Method
@@ -1800,10 +1787,10 @@ PASSWORDMETER;
     }
 
     /**
-     * Returns a boolean value indicating if the current page has an authenticated postback.
-     *
-     * It validates the postback by looking at a transient value that was rendered using $this->Open()
-     * and submitted with the form. Ref: http://en.wikipedia.org/wiki/Cross-site_request_forgery
+     * Returns a boolean value indicating if the current page has an
+     * authenticated postback. It validates the postback by looking at a
+     * transient value that was rendered using $this->Open() and submitted with
+     * the form. Ref: http://en.wikipedia.org/wiki/Cross-site_request_forgery
      *
      * @return bool
      */
@@ -1859,11 +1846,7 @@ PASSWORDMETER;
      * @return string
      */
     public function escapeFieldName($FieldName) {
-        $Return = $this->InputPrefix;
-        if ($Return != '') {
-            $Return .= '/';
-        }
-        return $Return.$this->escapeString($FieldName);
+        return $this->escapeString($FieldName);
     }
 
     /**
@@ -1952,22 +1935,14 @@ PASSWORDMETER;
         }
 
         if (!is_array($this->_FormValues)) {
-            $TableName = $this->InputPrefix;
-            if (strlen($TableName) > 0) {
-                $TableName .= '/';
-            }
-            $TableNameLength = strlen($TableName);
             $this->_FormValues = array();
-            $Collection = $this->Method == 'get' ? $_GET : $_POST; // TODO wtf globals
-            $InputType = $this->Method == 'get' ? INPUT_GET : INPUT_POST;
 
+            $Request = Gdn::request();
+            $Collection = $this->Method == 'get' ? $Request->get() : $Request->post();
 
-            foreach ($Collection as $Field => $Value) {
-                $FieldName = substr($Field, $TableNameLength);
+            foreach ($Collection as $FieldName => $Value) {
                 $FieldName = $this->_unescapeString($FieldName);
-                if (substr($Field, 0, $TableNameLength) == $TableName) {
-                    $this->_FormValues[$FieldName] = $Value;
-                }
+                $this->_FormValues[$FieldName] = $Value;
             }
 
             // Make sure that unchecked checkboxes get added to the collection

--- a/library/vendors/SmartyPlugins/function.searchbox.php
+++ b/library/vendors/SmartyPlugins/function.searchbox.php
@@ -16,7 +16,6 @@
 function smarty_function_searchbox($params, &$smarty) {
     $placeholder = array_key_exists('placeholder', $params) ? val('placeholder', $params, '', true) : t('SearchBoxPlaceHolder', 'Search');
     $form = Gdn::factory('Form');
-    $form->InputPrefix = '';
     $result =
         $form->open(array('action' => url('/search'), 'method' => 'get')).
         $form->textBox('Search', array('placeholder' => $placeholder, 'accesskey' => '/')).

--- a/plugins/OpenID/class.openid.plugin.php
+++ b/plugins/OpenID/class.openid.plugin.php
@@ -189,7 +189,6 @@ class OpenIDPlugin extends Gdn_Plugin {
      */
     public function entryController_openID_create($Sender, $Args) {
         $this->EventArguments = $Args;
-        $Sender->Form->InputPrefix = '';
 
         try {
             $OpenID = $this->getOpenID();

--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -646,7 +646,6 @@ class TaggingPlugin extends Gdn_Plugin {
         $TagTypes = $TagModel->getTagTypes();
 
         $Sender->Form->Method = 'get';
-        $Sender->Form->InputPrefix = '';
 
         list($Offset, $Limit) = offsetLimit($Page, 100);
         $Sender->setData('_Limit', $Limit);


### PR DESCRIPTION
Allow empty form element names.
Fix escaping and unescaping of form field names.
Remove unused InputPrefix

Related issue: https://github.com/vanilla/vanilla/issues/2963

Fixes http://vanillaforums.org/discussion/30583/gdn-form-associative-arrays