### PR TITLE
Tweak profile picture removal

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -1019,19 +1019,20 @@ class ProfileController extends Gdn_Controller {
      * @access public
      * @param mixed $UserReference Unique identifier, possibly username or ID.
      * @param string $Username .
-     * @param string $TransientKey Security token.
+     * @param string $tk Security token.
      */
-    public function removePicture($UserReference = '', $Username = '', $TransientKey = '') {
+    public function removePicture($UserReference = '', $Username = '', $tk = '') {
         $this->permission('Garden.SignIn.Allow');
         $Session = Gdn::session();
         if (!$Session->isValid()) {
             $this->Form->addError('You must be authenticated in order to use this form.');
         }
 
-        // Get user data & another permission check
+        // Get user data & another permission check.
         $this->getUserInfo($UserReference, $Username, '', true);
+
         $RedirectUrl = userUrl($this->User, '', 'picture');
-        if ($Session->validateTransientKey($TransientKey) && is_object($this->User)) {
+        if ($Session->validateTransientKey($tk) && is_object($this->User)) {
             $HasRemovePermission = checkPermission('Garden.Users.Edit') || checkPermission('Moderation.Profiles.Edit');
             if ($this->User->UserID == $Session->UserID || $HasRemovePermission) {
                 // Do removal, set message, redirect
@@ -1345,7 +1346,7 @@ class ProfileController extends Gdn_Controller {
             $Module->addLink('Options', sprite('SpDelete').' '.t('Delete Account'), '/user/delete/'.$this->User->UserID, 'Garden.Users.Delete', array('class' => 'Popup DeleteAccountLink'));
 
             if ($this->User->Photo != '' && $AllowImages) {
-                $Module->addLink('Options', sprite('SpDelete').' '.t('Remove Picture'), combinePaths(array(userUrl($this->User, '', 'removepicture'), $Session->transientKey())), array('Garden.Users.Edit', 'Moderation.Profiles.Edit'), array('class' => 'RemovePictureLink'));
+                $Module->addLink('Options', sprite('SpDelete').' '.t('Remove Picture'), userUrl($this->User, '', 'removepicture').'?tk='.$Session->transientKey(), array('Garden.Users.Edit', 'Moderation.Profiles.Edit'), array('class' => 'RemovePictureLink'));
             }
 
             $Module->addLink('Options', sprite('SpPreferences').' '.t('Edit Preferences'), userUrl($this->User, '', 'preferences'), array('Garden.Users.Edit', 'Moderation.Profiles.Edit'), array('class' => 'Popup PreferencesLink'));
@@ -1385,6 +1386,10 @@ class ProfileController extends Gdn_Controller {
 
             if ($this->User->Photo != '' && $AllowImages && !$RemotePhoto) {
                 $Module->addLink('Options', sprite('SpThumbnail').' '.t('Edit My Thumbnail'), '/profile/thumbnail', array('Garden.Profiles.Edit', 'Garden.ProfilePicture.Edit'), array('class' => 'ThumbnailLink'));
+            }
+
+            if ($this->User->Photo != '' && $AllowImages) {
+                $Module->addLink('Options', sprite('SpDelete').' '.t('Remove Picture'), userUrl($this->User, '', 'removepicture').'?tk='.$Session->transientKey(), array('Garden.Profiles.Edit', 'Garden.ProfilePicture.Edit'), array('class' => 'RemovePictureLink'));
             }
         }
 

--- a/applications/dashboard/views/profile/picture.php
+++ b/applications/dashboard/views/profile/picture.php
@@ -47,7 +47,7 @@ $Thumbnail = img($Thumbnail, array('alt' => t('Thumbnail')));
                         <td><?php
                             echo $Picture;
                             if ($this->User->Photo != '' && $AllowImages && !$RemotePhoto) {
-                            echo wrap(Anchor(t('Remove Picture'), CombinePaths(array(userUrl($this->User, '', 'removepicture'), $Session->TransientKey())), 'Button Danger PopConfirm'), 'p');
+                            echo wrap(Anchor(t('Remove Picture'), userUrl($this->User, '', 'removepicture').'?tk='.$Session->TransientKey(), 'Button Danger PopConfirm'), 'p');
                             ?>
                         </td>
                         <td><?php


### PR DESCRIPTION
* Add a link to remove the profile picture in the edit profile menu no matter what. Previously it was just when editing someone else’s profile.
* Change the way the transient key is added to the remove picture URL. This fixes an issue when user URLs have no user IDs.

Note that this tweak breaks index.php?p= style configs, but we are deprecating that behavior.