### PR TITLE
Fix attachment placement when editing a post.

### DIFF
--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -300,6 +300,8 @@ jQuery(document).ready(function($) {
                 }
             });
         } else {
+            resetCommentForm($(parent).find('form'));
+            clearCommentForm($(parent).find('form'));
             $(parent).find('div.EditCommentForm').remove();
             $(parent).find('span.TinyProgress').remove();
             $(msg).show();

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -822,7 +822,7 @@
             var editorKey = 'editor-uploads-';
             var editorForm = $dndCueWrapper.closest('form');
 
-            var savedUploadsContainer = '';
+            var savedUploadsContainer = savedContainer = '';
             var mainCommentForm = '';
             if (editorForm) {
                 var formCommentId = $(editorForm).find('#Form_CommentID');
@@ -847,20 +847,30 @@
                 // Build editorKey
                 if (formCommentId.length
                     && parseInt(formCommentId[0].value) > 0) {
+                    var type = 'CommentID';
+                    var id = formCommentId[0].value;
                     editorKey += 'commentid' + formCommentId[0].value;
                 } else if (formDiscussionId.length
                     && parseInt(formDiscussionId[0].value) > 0) {
+                    var type = 'DiscussionID';
+                    var id = formDiscussionId[0].value;
                     editorKey += 'discussionid' + formDiscussionId[0].value;
                 } else if (formConversationId.length
                     && parseInt(formConversationId[0].value) > 0) {
+                    var type = 'ConversationID';
+                    var id = formConversationId[0].value;
                     editorKey += 'conversationid' + formConversationId[0].value;
                 }
 
-                // Make saved files editable
+                // Make saved files editable from the form
                 if (!mainCommentBox && editorKey != 'editor-uploads-') {
                     var savedContainer = $('#' + editorKey);
                     if (savedContainer.length && savedContainer.html().trim() != '') {
-                        savedUploadsContainer = savedContainer;
+                        savedContainer.hide();
+                        // Move existing uploads into preview container for better UX.
+                        var form = $('#Form_' + type + ':input[value="' + id + '"]').parents().find('.bodybox-wrap');
+                        form.children('.editor-upload-previews').html(savedContainer.html());
+                        savedUploadsContainer = form.children('.editor-upload-previews');
                     }
                 }
             }
@@ -949,11 +959,13 @@
                 // Turn read-only mode on. Event is fired from conversations.js
                 // and discussion.js.
                 $(editorForm).on('clearCommentForm', function(e) {
-                    $(savedUploadsContainer).addClass('editor-upload-readonly');
+                    $(savedContainer).addClass('editor-upload-readonly');
+                    $(savedContainer).show();
                 });
 
                 $(editorForm).on('clearMessageForm', function(e) {
-                    $(savedUploadsContainer).addClass('editor-upload-readonly');
+                    $(savedContainer).addClass('editor-upload-readonly');
+                    $(savedContainer).show();
                 });
 
                 $(savedUploadsContainer)


### PR DESCRIPTION
Moves attachment editing to a more sane place in the bodybox form.
Also trigger reset and clear functions when clearing comment form.
Fixes bug where selecting the edit comment option from a comment's options dropdown twice shows makes the upload preview not read-only.