### PR TITLE
Add category options to event arguments

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -82,6 +82,7 @@ if (!function_exists('GetOptions')):
             $Options .= '<li rel="Hide">'.anchor(t('Hide'), "/category/follow?categoryid=$CategoryID&value=0&tkey=$TKey").'</li>';
 
         // Allow plugins to add options
+        $Sender->EventArguments['Options'] = &$Options;
         $Sender->fireEvent('CategoryOptions');
 
         if ($Options != '') {


### PR DESCRIPTION
The CategoryOptions event is useless, because the function builds a string that is not exposed.
This adds the string to the event arguments.