### PR TITLE
Rework cookie expiration check

### DIFF
--- a/library/core/class.cookieidentity.php
+++ b/library/core/class.cookieidentity.php
@@ -375,7 +375,7 @@ class Gdn_CookieIdentity {
         $Key = explode('-', $Payload[0]);
         $Expiration = array_pop($Key);
         $UserID = implode('-', $Key);
-        $Payload = array_slice($Payload, -4);
+        $Payload = array_slice($Payload, 4);
         $Payload = array_merge(array($UserID, $Expiration), $Payload);
 
         return $Payload;


### PR DESCRIPTION
* `array_slice` was used wrong in `getCookiePayload` (it had an inverted offset so it returned only last element instead of all remaining payload).
* `checkCookie` call in `getCookiePayload` is redundant and would then create loop if used from `checkCookie`.
* `checkCookie` should call `getCookiePayload` to get secure expiration.