### PR TITLE
Application manager: Add correct version to application assets.

### DIFF
--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -311,7 +311,7 @@ class Gdn_ApplicationManager {
                 )
             );
         }
-
+        
         // 2. Disable it
         removeFromConfig("EnabledApplications.{$applicationName}");
 

--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -118,7 +118,6 @@ class Gdn_ApplicationManager {
      * @return bool|mixed Returns the application's info, a specific value, or false if the application cannot be found.
      */
     public function getApplicationInfo($applicationName, $key = null) {
-        $applicationName = ucfirst($applicationName);
         $ApplicationInfo = val($applicationName, $this->availableApplications(), null);
         if (is_null($ApplicationInfo)) {
             return false;

--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -118,6 +118,7 @@ class Gdn_ApplicationManager {
      * @return bool|mixed Returns the application's info, a specific value, or false if the application cannot be found.
      */
     public function getApplicationInfo($applicationName, $key = null) {
+        $applicationName = ucfirst($applicationName);
         $ApplicationInfo = val($applicationName, $this->availableApplications(), null);
         if (is_null($ApplicationInfo)) {
             return false;
@@ -311,7 +312,7 @@ class Gdn_ApplicationManager {
                 )
             );
         }
-        
+
         // 2. Disable it
         removeFromConfig("EnabledApplications.{$applicationName}");
 

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -437,7 +437,7 @@ if (!function_exists('asset')) {
                             $Version = val('Version', $PluginInfo, $Version);
                             break;
                         case 'applications':
-                            $AppInfo = Gdn::ApplicationManager()->GetApplicationInfo($Key);
+                            $AppInfo = Gdn::ApplicationManager()->GetApplicationInfo(ucfirst($Key));
                             $Version = val('Version', $AppInfo, $Version);
                             break;
                         case 'themes':


### PR DESCRIPTION
Fixes bug where application assets were being appended with the default APPLICATION_VERSION in the head.