### PR TITLE
Fix username validation after manual entry during SSO

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -505,13 +505,15 @@ EOT;
             $AutoConnect = c('Garden.Registration.AutoConnect');
 
             if ($IsPostBack && $this->Form->getFormValue('ConnectName')) {
-                $this->Form->setFormValue('Name', $this->Form->getFormValue('ConnectName'));
+                $searchName = $this->Form->getFormValue('ConnectName');
+            } else {
+                $searchName = $this->Form->getFormValue('Name');
             }
 
             // Get the existing users that match the name or email of the connection.
             $Search = false;
-            if ($this->Form->getFormValue('Name') && $NameUnique) {
-                $UserModel->SQL->orWhere('Name', $this->Form->getFormValue('Name'));
+            if ($searchName && $NameUnique) {
+                $UserModel->SQL->orWhere('Name', $searchName);
                 $Search = true;
             }
             if ($this->Form->getFormValue('Email') && ($EmailUnique || $AutoConnect)) {
@@ -531,6 +533,10 @@ EOT;
 
             // Check to automatically link the user.
             if ($AutoConnect && count($ExistingUsers) > 0) {
+                if ($IsPostBack && $this->Form->getFormValue('ConnectName')) {
+                    $this->Form->setFormValue('Name', $this->Form->getFormValue('ConnectName'));
+                }
+
                 foreach ($ExistingUsers as $Row) {
                     if (strcasecmp($this->Form->getFormValue('Email'), $Row['Email']) === 0) {
                         $UserID = $Row['UserID'];


### PR DESCRIPTION
When an SSO user association is initially made without sending across a name for the user, the user enters their own name.  That name is supposed to be validated, but Vanilla was skipping over that process, due [to the setting of Name to ConnectName prior to the AutoConnect process](https://github.com/vanilla/vanilla/commit/3cf773bbc413150c387a74ce99e9a1056d60556a).  [In later logic](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.entrycontroller.php#L612-L614), since the Name field is set in the Form data, the user is automatically created without validating the name.

This PR moves the setting of the Name field to the value of ConnectName into the AutoConnect block, so it is only run if an existing user is found and being updated.  This allows newly created users entering their own names to have their entries subject to username validation rules.  The intention of the original code placement is maintained by using a separate variable to perform user searches based on name.