### PR TITLE
Fix TextBoxes Content in ThemeOptions

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -953,7 +953,7 @@ class SettingsController extends DashboardController {
                         $Value = $Default;
                     }
 
-                    $this->Form->setFormValue($this->Form->escapeString('Text_'.$Key), $Value);
+                    $this->Form->setValue($this->Form->escapeString('Text_'.$Key), $Value);
                 }
             }
 


### PR DESCRIPTION
TextBoxes in ThemeOptions have always been empty, regardless of their config value. The reason is that the value has been set to the form, but not to forms $_DataArray.


Thanks to ThemeSteam who spotted this misbehavior!

For anyone interested in this: you can create text inputs in your theme options quite easily (in themes about.php)

~~~
$ThemeInfo['SomeTheme'] = array(
    // ...
    'Options' => array(
        'Text' => array(
            'PanelPosition' => array(
                'Default' => 'left',
                'Description' => 'Please choose between "left", "right", or "none"',
                'Type' => 'TextBox'
            )
        )
    ),
    // ...
~~~

Afterwards you can access such a setting with `c('ThemeOption.PanelPosition')`