### PR TITLE
Replace "×" with "&times;" to avoid character encoding issues

### DIFF
--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -170,8 +170,8 @@ reason at all.
 You must be at least 13 years of age to use this service.";
 
 $Definition['Warning: This is for advanced users.'] = '<b>Warning</b>: This is for advanced users and requires that you make additional changes to your web server. This is usually only available if you have dedicated or vps hosting. Do not attempt this if you do not know what you are doing.';
-$Definition['Activity.Delete'] = '×';
-$Definition['Draft.Delete'] = '×';
+$Definition['Activity.Delete'] = '&times;';
+$Definition['Draft.Delete'] = '&times;';
 $Definition['ConnectName'] = 'Username';
 //$Definition['EmbededDiscussionFormat'] = '<div class="EmbeddedContent">{Image}<strong>{Title}</strong>
 //<p>{Excerpt}</p>

--- a/applications/dashboard/views/activity/helper_functions.php
+++ b/applications/dashboard/views/activity/helper_functions.php
@@ -51,7 +51,7 @@ function writeActivity($Activity, &$Sender, &$Session) {
 <li id="Activity_<?php echo $Activity->ActivityID; ?>" class="<?php echo $CssClass; ?>">
    <?php
     if (ActivityModel::canDelete($Activity)) {
-        echo '<div class="Options">'.anchor('×', 'dashboard/activity/delete/'.$Activity->ActivityID.'/'.$Session->TransientKey().'?Target='.urlencode($Sender->SelfUrl), 'Delete').'</div>';
+        echo '<div class="Options">'.anchor('&times;', 'dashboard/activity/delete/'.$Activity->ActivityID.'/'.$Session->TransientKey().'?Target='.urlencode($Sender->SelfUrl), 'Delete').'</div>';
     }
     if ($PhotoAnchor != '') {
         ?>

--- a/applications/dashboard/views/modules/message.php
+++ b/applications/dashboard/views/modules/message.php
@@ -6,7 +6,7 @@ if (is_array($Message)) {
     echo '<div class="DismissMessage'.($Message['CssClass'] == '' ? '' : ' '.$Message['CssClass']).'">';
     $Session = Gdn::session();
     if ($Message['AllowDismiss'] == '1' && $Session->isValid()) {
-        echo anchor('×', "/dashboard/message/dismiss/{$Message['MessageID']}/".$Session->TransientKey().'?Target='.$this->_Sender->SelfUrl, 'Dismiss');
+        echo anchor('&times;', "/dashboard/message/dismiss/{$Message['MessageID']}/".$Session->TransientKey().'?Target='.$this->_Sender->SelfUrl, 'Dismiss');
     }
 
     // echo Gdn_Format::to($this->_Message->Content, 'Html');

--- a/js/global.js
+++ b/js/global.js
@@ -944,7 +944,7 @@ jQuery(document).ready(function($) {
 
                 // If the message is dismissable, add a close button
                 if (css.indexOf('Dismissable') > 0)
-                    message = '<a class="Close"><span>×</span></a>' + message;
+                    message = '<a class="Close"><span>&times;</span></a>' + message;
 
                 message = '<div class="InformMessage">' + message + '</div>';
                 // Insert any transient keys into the message (prevents csrf attacks in follow-on action urls).

--- a/js/library/jquery.popup.js
+++ b/js/library/jquery.popup.js
@@ -365,7 +365,7 @@ Copyright 2007 Chris Wanstrath [ chris@ozmm.org ]
           <div class="Content"> \
           </div> \
           <div class="Footer"> \
-            <a href="#" class="Close"><span>×</span></a> \
+            <a href="#" class="Close"><span>&times;</span></a> \
           </div> \
         </div> \
       </div> \

--- a/plugins/GettingStarted/default.php
+++ b/plugins/GettingStarted/default.php
@@ -58,7 +58,7 @@ class GettingStartedPlugin extends Gdn_Plugin {
 
             $Session = Gdn::session();
             $WelcomeMessage = '<div class="GettingStarted">'
-                .anchor('×', '/dashboard/plugin/dismissgettingstarted/'.$Session->transientKey(), 'Dismiss')
+                .anchor('&times;', '/dashboard/plugin/dismissgettingstarted/'.$Session->transientKey(), 'Dismiss')
                 ."<h1>".t("Here's how to get started:")."</h1>"
                 .'<ul>
       <li class="One'.(c('Plugins.GettingStarted.Dashboard', '0') == '1' ? ' Done' : '').'">

--- a/plugins/Tagging/views/tagging.php
+++ b/plugins/Tagging/views/tagging.php
@@ -109,7 +109,7 @@ $CanAddTags = $this->data('_CanAddTags');
                             'TagName Tag_'.str_replace(' ', '_', $Tag['Name'])
                         );
 
-                        echo ' '.anchor('×', "/settings/tags/delete/{$Tag['TagID']}", 'Delete Popup');
+                        echo ' '.anchor('&times;', "/settings/tags/delete/{$Tag['TagID']}", 'Delete Popup');
                     }
                     ?>
                 </div>


### PR DESCRIPTION
The multiply character is used as a "Close" symbol in the UI. I replaced it with it's html entity counterpart.
I think generally the source code should rely as much on ascii as possible and avoid using unicode characters.