### PR TITLE
Fix incorrect User being set on profiles for Smarty templates

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -357,7 +357,6 @@ class ProfileController extends Gdn_Controller {
         $User = Gdn::userModel()->getID($UserID, DATASET_TYPE_ARRAY);
         $this->Form->setModel(Gdn::userModel());
         $this->Form->setData($User);
-        $this->setData('User', $User);
 
         // Decide if they have ability to edit the username
         $CanEditUsername = (bool)c("Garden.Profile.EditUsernames") || Gdn::session()->checkPermission('Garden.Users.Edit');

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -241,7 +241,8 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         $this->ProfileFields = $this->getProfileFields();
 
         // Get user-specific data
-        $this->UserFields = Gdn::userModel()->GetMeta($Sender->User->UserID, 'Profile.%', 'Profile.');
+        $UserID = (isset($Sender->User)) ? $Sender->User->UserID : $Sender->Data['User']['UserID'];
+        $this->UserFields = Gdn::userModel()->GetMeta($UserID, 'Profile.%', 'Profile.');
         // Fill in user data on form
         foreach ($this->UserFields as $Field => $Value) {
             $Sender->Form->setValue($Field, $Value);

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -241,8 +241,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         $this->ProfileFields = $this->getProfileFields();
 
         // Get user-specific data
-        $this->UserFields = Gdn::userModel()->GetMeta($Sender->data("User.UserID"), 'Profile.%', 'Profile.');
-
+        $this->UserFields = Gdn::userModel()->GetMeta($Sender->User->UserID, 'Profile.%', 'Profile.');
         // Fill in user data on form
         foreach ($this->UserFields as $Field => $Value) {
             $Sender->Form->setValue($Field, $Value);

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -241,8 +241,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         $this->ProfileFields = $this->getProfileFields();
 
         // Get user-specific data
-        $UserID = (isset($Sender->User)) ? $Sender->User->UserID : $Sender->Data['User']['UserID'];
-        $this->UserFields = Gdn::userModel()->GetMeta($UserID, 'Profile.%', 'Profile.');
+        $this->UserFields = Gdn::userModel()->GetMeta($Sender->Form->getValue('UserID'), 'Profile.%', 'Profile.');
         // Fill in user data on form
         foreach ($this->UserFields as $Field => $Value) {
             $Sender->Form->setValue($Field, $Value);


### PR DESCRIPTION
The $User object is used by Smarty to check if a User is logged in. This User object is being overwritten by the removed line and the data is not used by the profile because the same data is stored in the $Profile object. This change should fix  #2993.