### PR TITLE
Put focus into the text box when quoting

### DIFF
--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -277,6 +277,7 @@ function Gdn_Quotes() {
 
             case 'default':
             default:
+                jQuery(Editor).focus();
                 // Do nothing special
                 break;
         }


### PR DESCRIPTION
When quoting text, if you do not use the Advanced Editor WYSIWYG mode your cursor does not got into the comment box after the quoted text is appended. This fixes that.