### PR TITLE
Method to allow Edit Profile with SSO enabled

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -357,15 +357,21 @@ class ProfileController extends Gdn_Controller {
         $User = Gdn::userModel()->getID($UserID, DATASET_TYPE_ARRAY);
         $this->Form->setModel(Gdn::userModel());
         $this->Form->setData($User);
-        $this->setData('User', $User);
 
-        // Decide if they have ability to edit the username
-        $CanEditUsername = (bool)c("Garden.Profile.EditUsernames") || Gdn::session()->checkPermission('Garden.Users.Edit');
+        // only allow editing if registration method is not connect
+        if (c('Garden.Registration.Method') != 'Connect') {
+            // Decide if they have ability to edit the username
+            $CanEditUsername = (bool)c("Garden.Profile.EditUsernames") ||Gdn::session()->checkPermission('Garden.Users.Edit');
+            // Decide if they have ability to edit the email
+            $EmailEnabled = (bool)c('Garden.Profile.EditEmails', true) && !UserModel::noEmail();
+            $CanEditEmail = ($EmailEnabled && $UserID == Gdn::session()->UserID) || checkPermission('Garden.Users.Edit');
+        } else {
+            $CanEditUsername = false;
+            $CanEditEmail = false;
+            $this->setData('_WarnConnect', true);
+        }
+        // add results to Data
         $this->setData('_CanEditUsername', $CanEditUsername);
-
-        // Decide if they have ability to edit the email
-        $EmailEnabled = (bool)c('Garden.Profile.EditEmails', true) && !UserModel::noEmail();
-        $CanEditEmail = ($EmailEnabled && $UserID == Gdn::session()->UserID) || checkPermission('Garden.Users.Edit');
         $this->setData('_CanEditEmail', $CanEditEmail);
 
         // Decide if they have ability to confirm users

--- a/applications/dashboard/views/profile/edit.php
+++ b/applications/dashboard/views/profile/edit.php
@@ -6,6 +6,13 @@
     echo $this->Form->errors();
     ?>
     <ul>
+        <?php
+        if ($this->data('_WarnConnect')) {
+            echo '<li><div class="Gloss">',
+                t('Editing Username and Email is disabled.', 'Single Sign On is managing users. Editing your Username and Email is disabled.'),
+                '</div></li>';
+        }
+        ?>
         <li class="User-Name">
             <?php
             echo $this->Form->label('Username', 'Name');

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -559,16 +559,7 @@ if (!function_exists('hasEditProfile')) {
         if ($userID != Gdn::session()->UserID) {
             return false;
         }
-
-        $result = checkPermission('Garden.Profiles.Edit') && c('Garden.UserAccount.AllowEdit');
-
-        // $result &= (
-        //     C('Garden.Profile.Titles') ||
-        //     C('Garden.Profile.Locations', false) ||
-        //     C('Garden.Registration.Method') != 'Connect'
-        // );
-
-        return $result;
+        return checkPermission('Garden.Profiles.Edit') && c('Garden.UserAccount.AllowEdit');
     }
 }
 

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -562,11 +562,11 @@ if (!function_exists('hasEditProfile')) {
 
         $result = checkPermission('Garden.Profiles.Edit') && c('Garden.UserAccount.AllowEdit');
 
-        $result &= (
-            C('Garden.Profile.Titles') ||
-            C('Garden.Profile.Locations', false) ||
-            C('Garden.Registration.Method') != 'Connect'
-        );
+        // $result &= (
+        //     C('Garden.Profile.Titles') ||
+        //     C('Garden.Profile.Locations', false) ||
+        //     C('Garden.Registration.Method') != 'Connect'
+        // );
 
         return $result;
     }


### PR DESCRIPTION
Enabling SSO and setting registration method to connect will disable the edit profile link as mentioned in #2707. Although enabling locations or titles will enable the edit profile link, I don't think the edit link should get disabled because of things like the profile extension plugin, setting gender, etc. 

This PR serves as an possible example of what I think might work. 

1. Commented out the section of the core render function that removes the edit link.
2. Change the can edit username and email logic to be disable if registration method is "connect".
3. Set a message that explains why both are disabled.
4. Added logic to display message in the edit profile view. 
