### PR TITLE
Make the assignment of the config data be non destructive

### DIFF
--- a/applications/dashboard/modules/class.configurationmodule.php
+++ b/applications/dashboard/modules/class.configurationmodule.php
@@ -141,7 +141,7 @@ class ConfigurationModule extends Gdn_Module {
                 $Data[$Row['Name']] = c($Row['Config'], val('Default', $Row, ''));
             }
             $Form->setData($Data);
-            $this->Controller()->Data = $Data;
+            $this->Controller()->Data = array_merge($this->Controller()->Data, $Data);
         }
     }
 


### PR DESCRIPTION
If "Title" and "Description" have been assigned to the controller _before_ the call to function initialize(), they have been overwritten. Now they will be merged to the config data that is assigned to the controller.