### PR TITLE
Path issues/typo

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -657,7 +657,7 @@ class FacebookPlugin extends Gdn_Plugin {
         if ($NewValue !== null) {
             $this->_RedirectUri = $NewValue;
         } elseif ($this->_RedirectUri === null) {
-            $RedirectUri = url('/entry/connect/facebook', true);
+            $RedirectUri = url('entry/connect/facebook', true);
             if (strpos($RedirectUri, '=') !== false) {
                 $p = strrchr($RedirectUri, '=');
                 $Uri = substr($RedirectUri, 0, -strlen($p));

--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -655,7 +655,7 @@ class TwitterPlugin extends Gdn_Plugin {
             'Icon' => $this->getWebResource('icon.png', '/'),
             'Name' => 'Twitter',
             'ProviderKey' => self::ProviderKey,
-            'ConnectUrl' => '/entry/twauthorize/profile',
+            'ConnectUrl' => 'entry/twauthorize/profile',
             'Profile' => array(
                 'Name' => '@'.GetValue('screen_name', $Profile),
                 'Photo' => val('profile_image_url_https', $Profile)


### PR DESCRIPTION
The path was preceded by a forward slash, breaking the route on redirect. Impacts both Facebook and Twitter OAuth plugins.