### PR TITLE
Add event before notFoundException in /discussion/index

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -64,6 +64,8 @@ class DiscussionController extends VanillaController {
         }
 
         if (!is_object($this->Discussion)) {
+            $this->EventArguments['DiscussionID'] = $DiscussionID;
+            $this->fireEvent('BeforeNotFound');
             throw notFoundException('Discussion');
         }
 

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -65,7 +65,7 @@ class DiscussionController extends VanillaController {
 
         if (!is_object($this->Discussion)) {
             $this->EventArguments['DiscussionID'] = $DiscussionID;
-            $this->fireEvent('BeforeNotFound');
+            $this->fireEvent('DiscussionNotFound');
             throw notFoundException('Discussion');
         }
 


### PR DESCRIPTION
If a discussion was not found with /discussion/(discussion ID), Vanilla would immediately move to throw notFoundException.  This update adds an event just prior to this, so that custom handling of "discussion not found" behavior can be made with plug-ins.