### PR TITLE
Trim user-entered API keys and config strings

### DIFF
--- a/applications/dashboard/modules/class.configurationmodule.php
+++ b/applications/dashboard/modules/class.configurationmodule.php
@@ -121,7 +121,12 @@ class ConfigurationModule extends Gdn_Module {
                     $Form->saveImage($Name, arrayTranslate($Row, array('Prefix', 'Size')));
                 }
 
-                $Value = trim($Form->getFormValue($Name));
+                $Value = $Form->getFormValue($Name);
+
+                // Trim all incoming values by default.
+                if (val('Trim', $Row, true)) {
+                    $Value = trim($Value);
+                }
 
                 if ($Value == val('Default', $Value, '')) {
                     $Value = '';

--- a/applications/dashboard/modules/class.configurationmodule.php
+++ b/applications/dashboard/modules/class.configurationmodule.php
@@ -80,7 +80,7 @@ class ConfigurationModule extends Gdn_Module {
 
         if ($HasFiles === null) {
             $HasFiles = false;
-            foreach ($this->Schema() as $K => $Row) {
+            foreach ($this->schema() as $K => $Row) {
                 if (strtolower(val('Control', $Row)) == 'imageupload') {
                     $HasFiles = true;
                     break;
@@ -98,10 +98,10 @@ class ConfigurationModule extends Gdn_Module {
      */
     public function initialize($Schema = null) {
         if ($Schema !== null) {
-            $this->Schema($Schema);
+            $this->schema($Schema);
         }
 
-        $Form = $this->Form();
+        $Form = $this->form();
 
         if ($Form->authenticatedPostBack()) {
             // Grab the data from the form.
@@ -113,22 +113,22 @@ class ConfigurationModule extends Gdn_Module {
                 $Config = $Row['Config'];
 
                 // For API calls make this a sparse save.
-                if ($this->Controller()->deliveryType() === DELIVERY_TYPE_DATA && !array_key_exists($Name, $Post)) {
+                if ($this->controller()->deliveryType() === DELIVERY_TYPE_DATA && !array_key_exists($Name, $Post)) {
                     continue;
                 }
 
                 if (strtolower(val('Control', $Row)) == 'imageupload') {
-                    $Form->SaveImage($Name, arrayTranslate($Row, array('Prefix', 'Size')));
+                    $Form->saveImage($Name, arrayTranslate($Row, array('Prefix', 'Size')));
                 }
 
-                $Value = $Form->getFormValue($Name);
+                $Value = trim($Form->getFormValue($Name));
 
                 if ($Value == val('Default', $Value, '')) {
                     $Value = '';
                 }
 
                 $Data[$Config] = $Value;
-                $this->Controller()->setData($Name, $Value);
+                $this->controller()->setData($Name, $Value);
             }
 
             // Save it to the config.

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -441,8 +441,8 @@ class FacebookPlugin extends Gdn_Plugin {
         $Sender->permission('Garden.Settings.Manage');
         if ($Sender->Form->authenticatedPostBack()) {
             $Settings = array(
-                'Plugins.Facebook.ApplicationID' => $Sender->Form->getFormValue('ApplicationID'),
-                'Plugins.Facebook.Secret' => $Sender->Form->getFormValue('Secret'),
+                'Plugins.Facebook.ApplicationID' => trim($Sender->Form->getFormValue('ApplicationID')),
+                'Plugins.Facebook.Secret' => trim($Sender->Form->getFormValue('Secret')),
                 'Plugins.Facebook.UseFacebookNames' => $Sender->Form->getFormValue('UseFacebookNames'),
                 'Plugins.Facebook.SocialSignIn' => $Sender->Form->getFormValue('SocialSignIn'),
                 'Plugins.Facebook.SocialReactions' => $Sender->Form->getFormValue('SocialReactions'),

--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -298,7 +298,7 @@ class TwitterPlugin extends Gdn_Plugin {
      * @param bool $Query
      */
     public function authorize($Query = false) {
-        // Aquire the request token.
+        // Acquire the request token.
         $Consumer = new OAuthConsumer(c('Plugins.Twitter.ConsumerKey'), c('Plugins.Twitter.Secret'));
         $RedirectUri = $this->redirectUri();
         if ($Query) {
@@ -925,8 +925,8 @@ class TwitterPlugin extends Gdn_Plugin {
         $Sender->permission('Garden.Settings.Manage');
         if ($Sender->Form->authenticatedPostBack()) {
             $Settings = array(
-                'Plugins.Twitter.ConsumerKey' => $Sender->Form->getFormValue('ConsumerKey'),
-                'Plugins.Twitter.Secret' => $Sender->Form->getFormValue('Secret'),
+                'Plugins.Twitter.ConsumerKey' => trim($Sender->Form->getFormValue('ConsumerKey')),
+                'Plugins.Twitter.Secret' => trim($Sender->Form->getFormValue('Secret')),
                 'Plugins.Twitter.SocialSignIn' => $Sender->Form->getFormValue('SocialSignIn'),
                 'Plugins.Twitter.SocialReactions' => $Sender->Form->getFormValue('SocialReactions'),
                 'Plugins.Twitter.SocialSharing' => $Sender->Form->getFormValue('SocialSharing')


### PR DESCRIPTION
* Trim incoming values to ConfigurationModule generally - I cannot think of a use case where you'd ever purposefully enter a space at the start or end of a config value, but it can seriously mess up folks when it's a copy/paste error.
* Trim Twitter & Facebook API keys entered by user (since they don't use ConfigurationModule yet).
* Fix some misc casening in config module.

See #1509