### PR TITLE
Code cleanup around messages & email checking

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1352,7 +1352,7 @@ EOT;
                 unset($Values['Roles']);
                 $AuthUserID = $this->UserModel->register($Values);
                 if ($AuthUserID == UserModel::REDIRECT_APPROVE) {
-                    $this->Form->setFormValue('Target', '/entry/registerthanks');
+                    $this->Form->setFormValue('Target', '/entry/ registerthanks');
                     $this->_setRedirect();
                     return;
                 } elseif (!$AuthUserID) {
@@ -1362,18 +1362,18 @@ EOT;
                     Gdn::session()->start($AuthUserID);
 
                     if ($this->Form->getFormValue('RememberMe')) {
-                        Gdn::authenticator()->SetIdentity($AuthUserID, true);
+                        Gdn::authenticator()->setIdentity($AuthUserID, true);
                     }
 
                     try {
-                        $this->UserModel->SendWelcomeEmail($AuthUserID, '', 'Register');
+                        $this->UserModel->sendWelcomeEmail($AuthUserID, '', 'Register');
                     } catch (Exception $Ex) {
                     }
 
                     $this->fireEvent('RegistrationSuccessful');
 
                     // ... and redirect them appropriately
-                    $Route = $this->RedirectTo();
+                    $Route = $this->redirectTo();
                     if ($this->_DeliveryType != DELIVERY_TYPE_ALL) {
                         $this->RedirectUrl = url($Route);
                     } else {

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1352,7 +1352,7 @@ EOT;
                 unset($Values['Roles']);
                 $AuthUserID = $this->UserModel->register($Values);
                 if ($AuthUserID == UserModel::REDIRECT_APPROVE) {
-                    $this->Form->setFormValue('Target', '/entry/ registerthanks');
+                    $this->Form->setFormValue('Target', '/entry/registerthanks');
                     $this->_setRedirect();
                     return;
                 } elseif (!$AuthUserID) {

--- a/applications/dashboard/controllers/class.messagecontroller.php
+++ b/applications/dashboard/controllers/class.messagecontroller.php
@@ -26,7 +26,7 @@ class MessageController extends DashboardController {
         $this->permission('Garden.Community.Manage');
         // Use the edit form with no MessageID specified.
         $this->View = 'Edit';
-        $this->Edit();
+        $this->edit();
     }
 
     /**
@@ -43,7 +43,7 @@ class MessageController extends DashboardController {
         if ($TransientKey !== false && $Session->validateTransientKey($TransientKey)) {
             $Message = $this->MessageModel->delete(array('MessageID' => $MessageID));
             // Reset the message cache
-            $this->MessageModel->SetMessageCache();
+            $this->MessageModel->setMessageCache();
         }
 
         if ($this->_DeliveryType === DELIVERY_TYPE_ALL) {

--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -14,7 +14,7 @@
 class MessageModel extends Gdn_Model {
 
     /** @var array Non-standard message location allowed. */
-    private $_SpecialLocations = array('[Base]', '[Admin]', '[NonAdmin]');
+    private $_SpecialLocations = array('[Base]', '[NonAdmin]');
 
     /** @var array Current message data. */
     protected static $Messages;

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -409,15 +409,15 @@ class UserModel extends Gdn_Model {
 
         switch (strtolower($Column)) {
             case 'countdiscussions':
-                Gdn::database()->query(DBAModel::GetCountSQL('count', 'User', 'Discussion', 'CountDiscussions', 'DiscussionID', 'UserID', 'InsertUserID', $Where));
+                Gdn::database()->query(DBAModel::getCountSQL('count', 'User', 'Discussion', 'CountDiscussions', 'DiscussionID', 'UserID', 'InsertUserID', $Where));
                 break;
             case 'countcomments':
-                Gdn::database()->query(DBAModel::GetCountSQL('count', 'User', 'Comment', 'CountComments', 'CommentID', 'UserID', 'InsertUserID', $Where));
+                Gdn::database()->query(DBAModel::getCountSQL('count', 'User', 'Comment', 'CountComments', 'CommentID', 'UserID', 'InsertUserID', $Where));
                 break;
         }
 
         if ($UserID) {
-            $this->ClearCache($UserID);
+            $this->clearCache($UserID);
         }
     }
 
@@ -470,7 +470,7 @@ class UserModel extends Gdn_Model {
                 $LogModel = new LogModel();
 
                 try {
-                    $LogModel->Restore($BanLogID);
+                    $LogModel->restore($BanLogID);
                 } catch (Exception $Ex) {
                     if ($Ex->getCode() != 404) {
                         throw $Ex;
@@ -1538,7 +1538,7 @@ class UserModel extends Gdn_Model {
         }
 
         // If we require confirmation and user is not confirmed
-        $ConfirmEmail = c('Garden.Registration.ConfirmEmail', false);
+        $ConfirmEmail = self::requireConfirmEmail();
         $Confirmed = val('Confirmed', $User);
         if ($ConfirmEmail && !$Confirmed) {
             // Replace permissions with those of the ConfirmEmailRole

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -243,24 +243,6 @@ class DashboardHooks implements Gdn_IPlugin {
     }
 
     /**
-     *
-     *
-     * @since 2.3
-     * @param $sender
-     */
-    public function gdn_session_afterGetSession_handler($sender, $args) {
-        $User = $args['User'];
-
-        RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
-
-        // If we require confirmation and user is not confirmed
-        if (UserModel::requireConfirmEmail() && !val('Confirmed', $User)) {
-
-        }
-
-    }
-
-    /**
      * Method for plugins that want a friendly /sso method to hook into.
      *
      * @param RootController $Sender

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -105,9 +105,8 @@ $Construct
 
 // Modify all users with ConfirmEmail role to be unconfirmed
 if ($UserExists && !$ConfirmedExists) {
-    $ConfirmEmail = c('Garden.Registration.ConfirmEmail', false);
     $ConfirmEmailRoleID = RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
-    if ($ConfirmEmail && !empty($ConfirmEmailRoleID)) {
+    if (UserModel::requireConfirmEmail() && !empty($ConfirmEmailRoleID)) {
         // Select unconfirmed users
         $Users = Gdn::sql()->select('UserID')->from('UserRole')->where('RoleID', $ConfirmEmailRoleID)->get();
         $UserIDs = array();

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -365,7 +365,7 @@ class Gdn_Session {
      * @param bool $Persist If setting an identity, should we persist it beyond browser restart?
      */
     public function start($UserID = false, $SetIdentity = true, $Persist = false) {
-        if (!C('Garden.Installed', false)) {
+        if (!c('Garden.Installed', false)) {
             return;
         }
         // Retrieve the authenticated UserID from the Authenticator module.


### PR DESCRIPTION
No functionality changes.

* Casening.
* Remove last of `[Admin]` location code in messages.
* Remove direct config checks for email confirmation in favor of `UserModel::requireConfirmEmail()`.