### PR TITLE
addjsfile fails to find discussion.js on profile page

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -386,7 +386,7 @@ class VanillaHooks implements Gdn_IPlugin {
             $Sender->AddProfileTab(t('Comments'), 'profile/comments/'.$Sender->User->UserID.'/'.rawurlencode($Sender->User->Name), 'Comments', $CommentsLabel);
             // Add the discussion tab's CSS and Javascript.
             $Sender->addJsFile('jquery.gardenmorepager.js');
-            $Sender->addJsFile('discussions.js');
+            $Sender->addJsFile('discussions.js', 'vanilla');
         }
     }
 


### PR DESCRIPTION
class.hooks is being called from dashboard and no default application is specified for the call to
disscussion.js so the application tries to find it in dashboard. adding vanilla as default location fixes
the issues.