### PR TITLE
fix call to undefined object in the Category View

### DIFF
--- a/applications/vanilla/views/categories/all.php
+++ b/applications/vanilla/views/categories/all.php
@@ -11,8 +11,7 @@ $this->fireEvent('AfterPageTitle');
 
 $CatList = '';
 $DoHeadings = c('Vanilla.Categories.DoHeadings');
-$CategoryDepth = (isset($this->data('Category')->Depth)) ? $this->data('Category')->Depth : 0;
-$MaxDisplayDepth = c('Vanilla.Categories.MaxDisplayDepth') + $CategoryDepth;
+$MaxDisplayDepth = c('Vanilla.Categories.MaxDisplayDepth') + $this->data('Category.Depth', 0);
 $ChildCategories = '';
 $this->EventArguments['NumRows'] = count($this->data('Categories'));
 

--- a/applications/vanilla/views/categories/all.php
+++ b/applications/vanilla/views/categories/all.php
@@ -11,7 +11,8 @@ $this->fireEvent('AfterPageTitle');
 
 $CatList = '';
 $DoHeadings = c('Vanilla.Categories.DoHeadings');
-$MaxDisplayDepth = c('Vanilla.Categories.MaxDisplayDepth') + $this->data('Category')->Depth;
+$CategoryDepth = (isset($this->data('Category')->Depth)) ? $this->data('Category')->Depth : 0;
+$MaxDisplayDepth = c('Vanilla.Categories.MaxDisplayDepth') + $CategoryDepth;
 $ChildCategories = '';
 $this->EventArguments['NumRows'] = count($this->data('Categories'));
 


### PR DESCRIPTION
Adds an if statment that checks if Category->Depth is set. This will prevent the undefined object notice.