### PR TITLE
Remove calls to viewLocation() from Gdn_Controller

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -772,8 +772,6 @@ class Gdn_Controller extends Gdn_Pluggable {
             $View .= '_rss';
         }
 
-        $ViewPath2 = viewLocation($View, $ControllerName, $ApplicationFolder);
-
         $LocationName = concatSep('/', strtolower($ApplicationFolder), $ControllerName, $View);
         $ViewPath = arrayValue($LocationName, $this->_ViewLocations, false);
         if ($ViewPath === false) {
@@ -849,10 +847,6 @@ class Gdn_Controller extends Gdn_Pluggable {
             Gdn::dispatcher()->passData('ViewPaths', $ViewPaths);
             throw NotFoundException('View');
 //         trigger_error(ErrorMessage("Could not find a '$View' view for the '$ControllerName' controller in the '$ApplicationFolder' application.", $this->ClassName, 'FetchViewLocation'), E_USER_ERROR);
-        }
-
-        if ($ViewPath2 != $ViewPath) {
-            Trace("View paths do not match: $ViewPath != $ViewPath2", TRACE_WARNING);
         }
 
         return $ViewPath;
@@ -1817,8 +1811,6 @@ class Gdn_Controller extends Gdn_Pluggable {
         // Master views come from one of four places:
         $MasterViewPaths = array();
 
-        $MasterViewPath2 = viewLocation($this->masterView().'.master', '', $this->ApplicationFolder);
-
         if (strpos($this->MasterView, '/') !== false) {
             $MasterViewPaths[] = combinePaths(array(PATH_ROOT, str_replace('/', DS, $this->MasterView).'.master*'));
         } else {
@@ -1844,10 +1836,6 @@ class Gdn_Controller extends Gdn_Pluggable {
                 $MasterViewPath = $Paths[0];
                 break;
             }
-        }
-
-        if ($MasterViewPath != $MasterViewPath2) {
-            trace("Master views differ. Controller: $MasterViewPath, ViewLocation(): $MasterViewPath2", TRACE_WARNING);
         }
 
         $this->EventArguments['MasterViewPath'] = &$MasterViewPath;

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3771,8 +3771,10 @@ if (!function_exists('viewLocation')) {
      * @param string $Controller The name of the controller invoking the view or blank.
      * @param string $Folder The application folder or plugins/plugin folder.
      * @return string|false The path to the view or false if it wasn't found.
+     * @deprecated
      */
     function viewLocation($View, $Controller, $Folder) {
+        deprecated('viewLocation()');
         $Paths = array();
 
         if (strpos($View, '/') !== false) {


### PR DESCRIPTION
Gdn_Controller::fetchViewLocation() makes a call to viewLocation() without using its return value (only for creating a trace() in case its return value diverges from the view location it determines on its own).

Each call to viewLocation() results in one or more calls to file_exist(). On a test installation, a normal request resulted in about 75 calls to file_exist() with unique path argument which translated into a delay of about max. 10 milliseconds.

This PR makes Vanilla faster and cleans-up the codebase. You need to check for references to viewLocation() in your proprietary code.

* Removed calls to viewLocation() from Gdn_Controller::fetchViewLocation()
and Gdn_Controller::renderMaster(). 