### PR TITLE
Deprecate arrayValue() and fix coding standards

### DIFF
--- a/applications/conversations/models/class.conversationmessagemodel.php
+++ b/applications/conversations/models/class.conversationmessagemodel.php
@@ -195,7 +195,7 @@ class ConversationMessageModel extends ConversationsModel {
 
             $MessageID = $this->SQL->insert($this->Name, $Fields);
             $this->LastMessageID = $MessageID;
-            $ConversationID = arrayValue('ConversationID', $Fields, 0);
+            $ConversationID = val('ConversationID', $Fields, 0);
 
             if (!$Conversation) {
                 $Conversation = $this->SQL

--- a/applications/conversations/settings/class.hooks.php
+++ b/applications/conversations/settings/class.hooks.php
@@ -217,7 +217,7 @@ class ConversationsHooks implements Gdn_IPlugin {
 
         $ApplicationInfo = array();
         include(combinePaths(array(PATH_APPLICATIONS.DS.'conversations'.DS.'settings'.DS.'about.php')));
-        $Version = arrayValue('Version', arrayValue('Conversations', $ApplicationInfo, array()), 'Undefined');
+        $Version = val('Version', val('Conversations', $ApplicationInfo, array()), 'Undefined');
         saveToConfig('Conversations.Version', $Version);
     }
 }

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1099,7 +1099,7 @@ EOT;
 
         if ($this->Form->isPostBack() === true) {
             $FormValues = $this->Form->formValues();
-            if (ArrayValue('StopLinking', $FormValues)) {
+            if (val('StopLinking', $FormValues)) {
                 $AuthResponse = Gdn_Authenticator::AUTH_ABORTED;
 
                 $UserEventData = array_merge(array(
@@ -1112,7 +1112,7 @@ EOT;
                 Gdn::request()->withRoute('DefaultController');
                 return Gdn::dispatcher()->dispatch();
 
-            } elseif (ArrayValue('NewAccount', $FormValues)) {
+            } elseif (val('NewAccount', $FormValues)) {
                 $AuthResponse = Gdn_Authenticator::AUTH_CREATED;
 
                 // Try and synchronize the user with the new username/email.
@@ -1146,7 +1146,7 @@ EOT;
                 if ($UserID > 0) {
                     $Data = $FormValues;
                     $Data['UserID'] = $UserID;
-                    $Data['Email'] = arrayValue('SignInEmail', $FormValues, '');
+                    $Data['Email'] = val('SignInEmail', $FormValues, '');
                     $UserID = $this->UserModel->synchronize($UserInfo['UserKey'], $Data);
                 }
             }
@@ -1202,8 +1202,8 @@ EOT;
             $this->Form->addHidden('Consumer', $UserInfo['ConsumerKey']);
         }
 
-        $this->setData('Name', arrayValue('Name', $this->Form->HiddenInputs));
-        $this->setData('Email', arrayValue('Email', $this->Form->HiddenInputs));
+        $this->setData('Name', val('Name', $this->Form->HiddenInputs));
+        $this->setData('Email', val('Email', $this->Form->HiddenInputs));
 
         $this->render();
     }

--- a/applications/dashboard/controllers/class.importcontroller.php
+++ b/applications/dashboard/controllers/class.importcontroller.php
@@ -100,8 +100,8 @@ class ImportController extends DashboardController {
             /*elseif(is_array($Result)) {
 				saveToConfig(array(
 					'Garden.Import.CurrentStep' => $CurrentStep,
-					'Garden.Import.CurrentStepData' => arrayValue('Data', $Result)));
-				$this->setData('CurrentStepMessage', arrayValue('Message', $Result));
+					'Garden.Import.CurrentStepData' => val('Data', $Result)));
+				$this->setData('CurrentStepMessage', val('Message', $Result));
 			}*/
         }
         $Imp->saveState();

--- a/applications/dashboard/controllers/class.routescontroller.php
+++ b/applications/dashboard/controllers/class.routescontroller.php
@@ -88,7 +88,7 @@ class RoutesController extends DashboardController {
             }
 
             if ($ConfigurationModel->validate($FormPostValues)) {
-                $NewRouteName = arrayValue('Route', $FormPostValues);
+                $NewRouteName = val('Route', $FormPostValues);
 
                 if ($this->Route !== false && $NewRouteName != $this->Route['Route']) {
                     Gdn::router()->DeleteRoute($this->Route['Route']);
@@ -96,8 +96,8 @@ class RoutesController extends DashboardController {
 
                 Gdn::router()->SetRoute(
                     $NewRouteName,
-                    arrayValue('Target', $FormPostValues),
-                    arrayValue('Type', $FormPostValues)
+                    val('Target', $FormPostValues),
+                    val('Type', $FormPostValues)
                 );
 
                 $this->informMessage(t("The route was saved successfully."));

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -520,8 +520,8 @@ class SettingsController extends DashboardController {
             // Grab all of the plugins & versions
             $Plugins = Gdn::pluginManager()->availablePlugins();
             foreach ($Plugins as $Plugin => $Info) {
-                $Name = arrayValue('Name', $Info, $Plugin);
-                $Version = arrayValue('Version', $Info, '');
+                $Name = val('Name', $Info, $Plugin);
+                $Version = val('Version', $Info, '');
                 if ($Version != '') {
                     $UpdateData[] = array(
                         'Name' => $Name,
@@ -535,8 +535,8 @@ class SettingsController extends DashboardController {
             $ApplicationManager = Gdn::factory('ApplicationManager');
             $Applications = $ApplicationManager->availableApplications();
             foreach ($Applications as $Application => $Info) {
-                $Name = arrayValue('Name', $Info, $Application);
-                $Version = arrayValue('Version', $Info, '');
+                $Name = val('Name', $Info, $Application);
+                $Version = val('Version', $Info, '');
                 if ($Version != '') {
                     $UpdateData[] = array(
                         'Name' => $Name,
@@ -550,8 +550,8 @@ class SettingsController extends DashboardController {
             $ThemeManager = new Gdn_ThemeManager;
             $Themes = $ThemeManager->availableThemes();
             foreach ($Themes as $Theme => $Info) {
-                $Name = arrayValue('Name', $Info, $Theme);
-                $Version = arrayValue('Version', $Info, '');
+                $Name = val('Name', $Info, $Theme);
+                $Version = val('Version', $Info, '');
                 if ($Version != '') {
                     $UpdateData[] = array(
                         'Name' => $Name,

--- a/applications/dashboard/controllers/class.setupcontroller.php
+++ b/applications/dashboard/controllers/class.setupcontroller.php
@@ -233,7 +233,7 @@ class SetupController extends DashboardController {
                 $Disconnected = !(bool)@fsockopen('ajax.googleapis.com', 80);
 
                 saveToConfig(array(
-                    'Garden.Version' => arrayValue('Version', val('Dashboard', $ApplicationInfo, array()), 'Undefined'),
+                    'Garden.Version' => val('Version', val('Dashboard', $ApplicationInfo, array()), 'Undefined'),
                     'Garden.Cdns.Disable' => $Disconnected,
                     'Garden.CanProcessImages' => function_exists('gd_info'),
                     'EnabledPlugins.GettingStarted' => 'GettingStarted', // Make sure the getting started plugin is enabled

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -780,7 +780,7 @@ class ActivityModel extends Gdn_Model {
         if ((int)$ConfigPreference === 2) {
             $Preference = true; // This preference is forced on.
         }        if ($ConfigPreference !== false) {
-            $Preference = arrayValue($Type.'.'.$ActivityType, $Preferences, $ConfigPreference);
+            $Preference = val($Type.'.'.$ActivityType, $Preferences, $ConfigPreference);
         } else {
             $Preference = false;
         }
@@ -820,7 +820,7 @@ class ActivityModel extends Gdn_Model {
                 $Preference = $Force;
             } else {
                 $Preferences = $User->Preferences;
-                $Preference = arrayValue('Email.'.$Activity->ActivityType, $Preferences, Gdn::config('Preferences.Email.'.$Activity->ActivityType));
+                $Preference = val('Email.'.$Activity->ActivityType, $Preferences, Gdn::config('Preferences.Email.'.$Activity->ActivityType));
             }
             if ($Preference) {
                 $ActivityHeadline = Gdn_Format::text(Gdn_Format::activityHeadline($Activity, $Activity->ActivityUserID, $Activity->RegardingUserID), false);
@@ -1296,11 +1296,11 @@ class ActivityModel extends Gdn_Model {
         }
 
         $ActivityType = self::getActivityType($Activity['ActivityType']);
-        $ActivityTypeID = arrayValue('ActivityTypeID', $ActivityType);
+        $ActivityTypeID = val('ActivityTypeID', $ActivityType);
         if (!$ActivityTypeID) {
             trace("There is no $ActivityType activity type.", TRACE_WARNING);
             $ActivityType = self::getActivityType('Default');
-            $ActivityTypeID = arrayValue('ActivityTypeID', $ActivityType);
+            $ActivityTypeID = val('ActivityTypeID', $ActivityType);
         }
 
         $Activity['ActivityTypeID'] = $ActivityTypeID;

--- a/applications/dashboard/models/class.invitationmodel.php
+++ b/applications/dashboard/models/class.invitationmodel.php
@@ -104,7 +104,7 @@ class InvitationModel extends Gdn_Model {
         // Validate the form posted values
         if ($this->validate($FormPostValues, true) === true) {
             $Fields = $this->Validation->ValidationFields(); // All fields on the form that need to be validated
-            $Email = arrayValue('Email', $Fields, '');
+            $Email = val('Email', $Fields, '');
 
             // Make sure this user has a spare invitation to send.
             $InviteCount = $UserModel->GetInvitationCount($UserID);

--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -252,7 +252,7 @@ class MessageModel extends Gdn_Model {
      */
     public function save($FormPostValues, $Settings = false) {
         // The "location" is packed into a single input with a / delimiter. Need to explode it into three different fields for saving
-        $Location = arrayValue('Location', $FormPostValues, '');
+        $Location = val('Location', $FormPostValues, '');
         if ($Location != '') {
             $Location = explode('/', $Location);
             $Application = val(0, $Location, '');

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -514,8 +514,8 @@ class PermissionModel extends Gdn_Model {
      */
     public function getJunctionPermissions($Where, $JunctionTable = null, $LimitToSuffix = '', $Options = array()) {
         $Namespaces = $this->GetAllowedPermissionNamespaces();
-        $RoleID = arrayValue('RoleID', $Where, null);
-        $JunctionID = arrayValue('JunctionID', $Where, null);
+        $RoleID = val('RoleID', $Where, null);
+        $JunctionID = val('JunctionID', $Where, null);
         $SQL = $this->SQL;
 
         // Load all of the default junction permissions.
@@ -962,11 +962,11 @@ class PermissionModel extends Gdn_Model {
                     $Parts = explode('/', $Key);
                     $JunctionTable = $Parts[0];
                     $JunctionColumn = $Parts[1];
-                    $JunctionID = arrayValue('JunctionID', $Overrides, $Parts[2]);
+                    $JunctionID = val('JunctionID', $Overrides, $Parts[2]);
                     if (count($Parts) >= 4) {
                         $RoleID = $Parts[3];
                     } else {
-                        $RoleID = arrayValue('RoleID', $Overrides, null);
+                        $RoleID = val('RoleID', $Overrides, null);
                     }
                 } else {
                     // This is a global permission.
@@ -975,7 +975,7 @@ class PermissionModel extends Gdn_Model {
                     $JunctionTable = null;
                     $JunctionColumn = null;
                     $JunctionID = null;
-                    $RoleID = arrayValue('RoleID', $Overrides, null);
+                    $RoleID = val('RoleID', $Overrides, null);
                 }
 
                 // Check for a row in the result for these permissions.
@@ -1341,7 +1341,7 @@ class PermissionModel extends Gdn_Model {
      * @param bool $IncludeRole
      */
     protected function _UnpivotPermissionsRow($Row, &$Result, $IncludeRole = false) {
-        $GlobalName = arrayValue('Name', $Row);
+        $GlobalName = val('Name', $Row);
 
         // Loop through each permission in the row and place them in the correct place in the grid.
         foreach ($Row as $PermissionName => $Value) {

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -523,7 +523,7 @@ class RoleModel extends Gdn_Model {
         // Define the primary key in this model's table.
         $this->defineSchema();
 
-        $RoleID = arrayValue('RoleID', $FormPostValues);
+        $RoleID = val('RoleID', $FormPostValues);
         $Insert = $RoleID > 0 ? false : true;
         if ($Insert) {
             // Figure out the next role ID.
@@ -538,7 +538,7 @@ class RoleModel extends Gdn_Model {
 
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert)) {
-            $Permissions = arrayValue('Permission', $FormPostValues);
+            $Permissions = val('Permission', $FormPostValues);
             $Fields = $this->Validation->schemaValidationFields();
 
             if ($Insert === false) {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1988,7 +1988,7 @@ class UserModel extends Gdn_Model {
                 if ($UserID > 0) {
                     // If they are changing the username & email, make sure they aren't
                     // already being used (by someone other than this user)
-                    if (ArrayValue('Name', $Fields, '') != '' || arrayValue('Email', $Fields, '') != '') {
+                    if (val('Name', $Fields, '') != '' || val('Email', $Fields, '') != '') {
                         if (!$this->validateUniqueFields($Username, $Email, $UserID)) {
                             return false;
                         }
@@ -2002,7 +2002,7 @@ class UserModel extends Gdn_Model {
                     $this->SQL->put($this->Name, $Fields, array($this->PrimaryKey => $UserID));
 
                     // Record activity if the person changed his/her photo.
-                    $Photo = arrayValue('Photo', $FormPostValues);
+                    $Photo = val('Photo', $FormPostValues);
                     if ($Photo !== false) {
                         if (val('CheckExisting', $Settings)) {
                             $User = $this->getID($UserID);
@@ -2512,7 +2512,7 @@ class UserModel extends Gdn_Model {
         // the user's email from the invitation:
         $InviteUserID = 0;
         $InviteUsername = '';
-        $InvitationCode = arrayValue('InvitationCode', $FormPostValues, '');
+        $InvitationCode = val('InvitationCode', $FormPostValues, '');
 
         $Invitation = $this->SQL->getWhere('Invitation', array('Code' => $InvitationCode))->firstRow();
 
@@ -2550,8 +2550,8 @@ class UserModel extends Gdn_Model {
             }
 
             $Fields = $this->Validation->ValidationFields(); // All fields on the form that need to be validated (including non-schema field rules defined above)
-            $Username = arrayValue('Name', $Fields);
-            $Email = arrayValue('Email', $Fields);
+            $Username = val('Name', $Fields);
+            $Email = val('Email', $Fields);
             $Fields = $this->Validation->SchemaValidationFields(); // Only fields that are present in the schema
             $Fields = RemoveKeyFromArray($Fields, $this->PrimaryKey);
 
@@ -2651,8 +2651,8 @@ class UserModel extends Gdn_Model {
             }
 
             $Fields = $this->Validation->ValidationFields(); // All fields on the form that need to be validated (including non-schema field rules defined above)
-            $Username = arrayValue('Name', $Fields);
-            $Email = arrayValue('Email', $Fields);
+            $Username = val('Name', $Fields);
+            $Email = val('Email', $Fields);
             $Fields = $this->Validation->SchemaValidationFields(); // Only fields that are present in the schema
             $Fields = RemoveKeyFromArray($Fields, $this->PrimaryKey);
 
@@ -2724,15 +2724,15 @@ class UserModel extends Gdn_Model {
 
         if ($this->validate($FormPostValues, true) === true) {
             $Fields = $this->Validation->ValidationFields(); // All fields on the form that need to be validated (including non-schema field rules defined above)
-            $Username = arrayValue('Name', $Fields);
-            $Email = arrayValue('Email', $Fields);
+            $Username = val('Name', $Fields);
+            $Email = val('Email', $Fields);
             $Fields = $this->Validation->SchemaValidationFields(); // Only fields that are present in the schema
             $Fields['Roles'] = $RoleIDs;
             $Fields = RemoveKeyFromArray($Fields, $this->PrimaryKey);
 
             // If in Captcha registration mode, check the captcha value
             if ($CheckCaptcha && Gdn::config('Garden.Registration.Method') == 'Captcha') {
-                $CaptchaPublicKey = arrayValue('Garden.Registration.CaptchaPublicKey', $FormPostValues, '');
+                $CaptchaPublicKey = val('Garden.Registration.CaptchaPublicKey', $FormPostValues, '');
                 $CaptchaValid = ValidateCaptcha($CaptchaPublicKey);
                 if ($CaptchaValid !== true) {
                     $this->Validation->addValidationResult('Garden.Registration.CaptchaPublicKey', 'The reCAPTCHA value was not entered correctly. Please try again.');
@@ -2783,7 +2783,7 @@ class UserModel extends Gdn_Model {
         $this->defineSchema();
 
         // Set the hour offset based on the client's clock.
-        $ClientHour = arrayValue('ClientHour', $Fields, '');
+        $ClientHour = val('ClientHour', $Fields, '');
         if (is_numeric($ClientHour) && $ClientHour >= 0 && $ClientHour < 24) {
             $HourOffset = $ClientHour - date('G', time());
             $Fields['HourOffset'] = $HourOffset;
@@ -3684,7 +3684,7 @@ class UserModel extends Gdn_Model {
 //      if ($Data !== FALSE) {
 //         $Attributes = Gdn_Format::Unserialize($Data->Attributes);
 //         if (is_array($Attributes))
-//            $Result = arrayValue($Attribute, $Attributes, $DefaultValue);
+//            $Result = val($Attribute, $Attributes, $DefaultValue);
 //
 //      }
 
@@ -3876,7 +3876,7 @@ class UserModel extends Gdn_Model {
     public function synchronize($UserKey, $Data) {
         $UserID = 0;
 
-        $Attributes = arrayValue('Attributes', $Data);
+        $Attributes = val('Attributes', $Data);
         if (is_string($Attributes)) {
             $Attributes = @unserialize($Attributes);
         }
@@ -3891,10 +3891,10 @@ class UserModel extends Gdn_Model {
             // Prepare the user data.
             $UserData['Name'] = $Data['Name'];
             $UserData['Password'] = RandomString(16);
-            $UserData['Email'] = arrayValue('Email', $Data, 'no@email.com');
-            $UserData['Gender'] = strtolower(substr(ArrayValue('Gender', $Data, 'u'), 0, 1));
-            $UserData['HourOffset'] = arrayValue('HourOffset', $Data, 0);
-            $UserData['DateOfBirth'] = arrayValue('DateOfBirth', $Data, '');
+            $UserData['Email'] = val('Email', $Data, 'no@email.com');
+            $UserData['Gender'] = strtolower(substr(val('Gender', $Data, 'u'), 0, 1));
+            $UserData['HourOffset'] = val('HourOffset', $Data, 0);
+            $UserData['DateOfBirth'] = val('DateOfBirth', $Data, '');
             $UserData['CountNotifications'] = 0;
             $UserData['Attributes'] = $Attributes;
             $UserData['InsertIPAddress'] = Gdn::request()->ipAddress();

--- a/applications/dashboard/modules/class.menumodule.php
+++ b/applications/dashboard/modules/class.menumodule.php
@@ -214,19 +214,19 @@ if (!class_exists('MenuModule', false)) {
                                 $Group .= "</li>\r\n";
                             }
 
-                            $Url = arrayValue('Url', $Link);
+                            $Url = val('Url', $Link);
                             if (substr($Link['Text'], 0, 1) === '\\') {
                                 $Text = substr($Link['Text'], 1);
                             } else {
                                 $Text = str_replace('{Username}', $Username, $Link['Text']);
                             }
-                            $Attributes = arrayValue('Attributes', $Link, array());
-                            $AnchorAttributes = arrayValue('AnchorAttributes', $Link, array());
+                            $Attributes = val('Attributes', $Link, array());
+                            $AnchorAttributes = val('AnchorAttributes', $Link, array());
                             if ($Url !== false) {
                                 $Url = url(str_replace(array('{Username}', '{UserID}', '{Session_TransientKey}'), array(urlencode($Username), $UserID, $Session_TransientKey), $Link['Url']));
                                 $CurrentLink = $Url == url($HighlightRoute);
 
-                                $CssClass = arrayValue('class', $Attributes, '');
+                                $CssClass = val('class', $Attributes, '');
                                 if ($CurrentLink) {
                                     $Attributes['class'] = $CssClass.' Highlight';
                                 }

--- a/applications/dashboard/modules/class.settingsmodule.php
+++ b/applications/dashboard/modules/class.settingsmodule.php
@@ -33,16 +33,16 @@ class SettingsModule extends Gdn_Module {
                 $ApplicationManager = Gdn::Factory('ApplicationManager');
 
                 if ($IsRemovable = !array_key_exists($Name, $ApplicationManager->EnabledApplications())) {
-                    $ApplicationInfo = arrayValue($Name, $ApplicationManager->AvailableApplications(), array());
-                    $ApplicationFolder = arrayValue('Folder', $ApplicationInfo, '');
+                    $ApplicationInfo = val($Name, $ApplicationManager->AvailableApplications(), array());
+                    $ApplicationFolder = val('Folder', $ApplicationInfo, '');
 
                     $IsRemovable = IsWritable(PATH_APPLICATIONS.DS.$ApplicationFolder);
                 }
                 break;
             case self::TYPE_PLUGIN:
                 if ($IsRemovable = !array_key_exists($Name, Gdn::pluginManager()->EnabledPlugins())) {
-                    $PluginInfo = arrayValue($Name, Gdn::pluginManager()->AvailablePlugins(), false);
-                    $PluginFolder = arrayValue('Folder', $PluginInfo, false);
+                    $PluginInfo = val($Name, Gdn::pluginManager()->AvailablePlugins(), false);
+                    $PluginFolder = val('Folder', $PluginInfo, false);
 
                     $IsRemovable = IsWritable(PATH_PLUGINS.DS.$PluginFolder);
                 }

--- a/applications/dashboard/views/entry/handshake.php
+++ b/applications/dashboard/views/entry/handshake.php
@@ -13,8 +13,8 @@
         //T('There is already an account with the same username (%1$s) or email (%2$s) as you. You can either create a new account, or you can enter the credentials for your existing forum account.'),
         echo wrap(t("This is the first time you've visited the discussion forums."), 'strong');
         echo wrap(t("You can either create a new account, or enter your credentials if you have an existing account."), 'div');
-        // arrayValue('Name', $this->Data),
-        // arrayValue('Email', $this->Data)
+        // val('Name', $this->Data),
+        // val('Email', $this->Data)
         // );
         ?></div>
     <ul class="NewAccount">

--- a/applications/dashboard/views/message/index.php
+++ b/applications/dashboard/views/message/index.php
@@ -36,8 +36,8 @@ $Session = Gdn::session();
                 <td class="Info nowrap"><?php
                     printf(
                         t('%1$s on %2$s'),
-                        arrayValue($Message->AssetTarget, $this->_GetAssetData(), 'Custom Location'),
-                        arrayValue($Message->Location, $this->_GetLocationData(), 'Custom Page')
+                        val($Message->AssetTarget, $this->_GetAssetData(), 'Custom Location'),
+                        val($Message->Location, $this->_GetLocationData(), 'Custom Page')
                     );
 
                     if (val('CategoryID', $Message) && $Category = CategoryModel::categories($Message->CategoryID)) {

--- a/applications/dashboard/views/modules/profilefilter.php
+++ b/applications/dashboard/views/modules/profilefilter.php
@@ -5,7 +5,7 @@ $Session = Gdn::session();
 
 // Get the tab sort order from the user-prefs.
 //$SortOrder = FALSE;
-//$SortOrder = arrayValue('ProfileTabOrder', $Controller->User->Preferences, false);
+//$SortOrder = val('ProfileTabOrder', $Controller->User->Preferences, false);
 // If not in the user prefs, get the sort order from the application prefs.
 //if ($SortOrder === FALSE)
 $SortOrder = c('Garden.ProfileTabOrder');

--- a/applications/dashboard/views/profile/tabs.php
+++ b/applications/dashboard/views/profile/tabs.php
@@ -2,7 +2,7 @@
 
 // Get the tab sort order from the user-prefs.
 $SortOrder = FALSE;
-$SortOrder = arrayValue('ProfileTabOrder', $this->User->Preferences, false);
+$SortOrder = val('ProfileTabOrder', $this->User->Preferences, false);
 // If not in the user prefs, get the sort order from the application prefs.
 if ($SortOrder === FALSE)
     $SortOrder = Gdn::config('Garden.ProfileTabOrder');

--- a/applications/dashboard/views/settings/applications.php
+++ b/applications/dashboard/views/settings/applications.php
@@ -47,20 +47,20 @@ $DisabledCount = $AppCount - $EnabledCount;
         $State = strtolower($Css);
         if ($this->Filter == 'all' || $this->Filter == $State) {
             $Alt = $Alt ? FALSE : TRUE;
-            $Version = arrayValue('Version', $AppInfo, '');
-            $ScreenName = arrayValue('Name', $AppInfo, $AppName);
-            $SettingsUrl = $State == 'enabled' ? arrayValue('SettingsUrl', $AppInfo, '') : '';
-            $AppUrl = arrayValue('Url', $AppInfo, '');
-            $Author = arrayValue('Author', $AppInfo, '');
-            $AuthorUrl = arrayValue('AuthorUrl', $AppInfo, '');
-            $NewVersion = arrayValue('NewVersion', $AppInfo, '');
+            $Version = val('Version', $AppInfo, '');
+            $ScreenName = val('Name', $AppInfo, $AppName);
+            $SettingsUrl = $State == 'enabled' ? val('SettingsUrl', $AppInfo, '') : '';
+            $AppUrl = val('Url', $AppInfo, '');
+            $Author = val('Author', $AppInfo, '');
+            $AuthorUrl = val('AuthorUrl', $AppInfo, '');
+            $NewVersion = val('NewVersion', $AppInfo, '');
             $Upgrade = $NewVersion != '' && version_compare($NewVersion, $Version, '>');
             $RowClass = $Css;
             if ($Alt) $RowClass .= ' Alt';
             ?>
             <tr class="More <?php echo $RowClass; ?>">
                 <th><?php echo $ScreenName; ?></th>
-                <td><?php echo arrayValue('Description', $AppInfo, ''); ?></td>
+                <td><?php echo val('Description', $AppInfo, ''); ?></td>
             </tr>
             <tr class="<?php echo ($Upgrade ? 'More ' : '').$RowClass; ?>">
                 <td class="Info"><?php
@@ -76,7 +76,7 @@ $DisabledCount = $AppCount - $EnabledCount;
                     }
                     ?></td>
                 <td class="Alt Info"><?php
-                    $RequiredApplications = arrayValue('RequiredApplications', $AppInfo, false);
+                    $RequiredApplications = val('RequiredApplications', $AppInfo, false);
                     $Info = '';
                     if ($Version != '')
                         $Info = sprintf(t('Version %s'), $Version);

--- a/applications/dashboard/views/settings/plugins.php
+++ b/applications/dashboard/views/settings/plugins.php
@@ -75,11 +75,11 @@ $DisabledCount = $PluginCount - $EnabledCount;
             $Alt = $Alt ? FALSE : TRUE;
             $Version = Gdn_Format::Display(val('Version', $PluginInfo, ''));
             $ScreenName = Gdn_Format::Display(val('Name', $PluginInfo, $PluginName));
-            $SettingsUrl = $State == 'enabled' ? arrayValue('SettingsUrl', $PluginInfo, '') : '';
-            $PluginUrl = arrayValue('PluginUrl', $PluginInfo, '');
-            $Author = arrayValue('Author', $PluginInfo, '');
-            $AuthorUrl = arrayValue('AuthorUrl', $PluginInfo, '');
-            $NewVersion = arrayValue('NewVersion', $PluginInfo, '');
+            $SettingsUrl = $State == 'enabled' ? val('SettingsUrl', $PluginInfo, '') : '';
+            $PluginUrl = val('PluginUrl', $PluginInfo, '');
+            $Author = val('Author', $PluginInfo, '');
+            $AuthorUrl = val('AuthorUrl', $PluginInfo, '');
+            $NewVersion = val('NewVersion', $PluginInfo, '');
             $Upgrade = $NewVersion != '' && version_compare($NewVersion, $Version, '>');
             $RowClass = $Css;
             if ($Alt) $RowClass .= ' Alt';
@@ -105,8 +105,8 @@ $DisabledCount = $PluginCount - $EnabledCount;
 
                     ?></td>
                 <td class="Alt Info"><?php
-                    $RequiredApplications = arrayValue('RequiredApplications', $PluginInfo, false);
-                    $RequiredPlugins = arrayValue('RequiredPlugins', $PluginInfo, false);
+                    $RequiredApplications = val('RequiredApplications', $PluginInfo, false);
+                    $RequiredPlugins = val('RequiredPlugins', $PluginInfo, false);
                     $Info = '';
                     if ($Version != '')
                         $Info = sprintf(t('Version %s'), $Version);

--- a/applications/dashboard/views/settings/registration.php
+++ b/applications/dashboard/views/settings/registration.php
@@ -114,7 +114,7 @@ echo Gdn::slice('/dashboard/role/defaultroleswarning');
                         $CssClass .= ' Last';
 
                     $CssClass = trim($CssClass);
-                    $CurrentValue = arrayValue($Role['RoleID'], $this->ExistingRoleInvitations, false);
+                    $CurrentValue = val($Role['RoleID'], $this->ExistingRoleInvitations, false);
                     ?>
                     <tr<?php echo $CssClass != '' ? ' class="'.$CssClass.'"' : ''; ?>>
                         <th><?php echo $Role['Name']; ?></th>

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -53,6 +53,14 @@ class PostController extends VanillaController {
         $this->render();
     }
 
+    /**
+     * Get available announcement options for discussions.
+     *
+     * @since 2.1
+     * @access public
+     *
+     * @return array
+     */
     public function announceOptions() {
         $Result = array(
             '0' => '@'.t("Don't announce.")
@@ -108,7 +116,7 @@ class PostController extends VanillaController {
             if (is_numeric($CategoryUrlCode)) {
                 $Category = CategoryModel::categories($CategoryUrlCode);
             } else {
-                $Category = $CategoryModel->GetByCode($CategoryUrlCode);
+                $Category = $CategoryModel->getByCode($CategoryUrlCode);
             }
 
             if ($Category) {
@@ -157,7 +165,7 @@ class PostController extends VanillaController {
         touchValue('Type', $this->Data, 'Discussion');
 
         // See if we should hide the category dropdown.
-        $AllowedCategories = CategoryModel::GetByPermission('Discussions.Add', $this->Form->getValue('CategoryID', $this->CategoryID), array('Archived' => 0, 'AllowDiscussions' => 1), array('AllowedDiscussionTypes' => $this->Data['Type']));
+        $AllowedCategories = CategoryModel::getByPermission('Discussions.Add', $this->Form->getValue('CategoryID', $this->CategoryID), array('Archived' => 0, 'AllowDiscussions' => 1), array('AllowedDiscussionTypes' => $this->Data['Type']));
         if (count($AllowedCategories) == 1) {
             $AllowedCategory = array_pop($AllowedCategories);
             $this->ShowCategorySelector = false;
@@ -180,20 +188,20 @@ class PostController extends VanillaController {
                 if ($this->Category !== null) {
                     $this->Form->setData(array('CategoryID' => $this->Category->CategoryID));
                 }
-                $this->PopulateForm($this->Form);
+                $this->populateForm($this->Form);
             }
 
         } elseif ($this->Form->authenticatedPostBack()) { // Form was submitted
             // Save as a draft?
             $FormValues = $this->Form->formValues();
             $FormValues = $this->DiscussionModel->filterForm($FormValues);
-            $this->deliveryType(GetIncomingValue('DeliveryType', $this->_DeliveryType));
+            $this->deliveryType(Gdn::request()->getValue('DeliveryType', $this->_DeliveryType));
             if ($DraftID == 0) {
                 $DraftID = $this->Form->getFormValue('DraftID', 0);
             }
 
-            $Draft = $this->Form->ButtonExists('Save Draft') ? true : false;
-            $Preview = $this->Form->ButtonExists('Preview') ? true : false;
+            $Draft = $this->Form->buttonExists('Save Draft') ? true : false;
+            $Preview = $this->Form->buttonExists('Preview') ? true : false;
             if (!$Preview) {
                 if (!is_object($this->Category) && is_array($CategoryData) && isset($FormValues['CategoryID'])) {
                     $this->Category = val($FormValues['CategoryID'], $CategoryData);
@@ -261,7 +269,7 @@ class PostController extends VanillaController {
                 $this->Comment->InsertName = $Session->User->Name;
                 $this->Comment->InsertPhoto = $Session->User->Photo;
                 $this->Comment->DateInserted = Gdn_Format::date();
-                $this->Comment->Body = arrayValue('Body', $FormValues, '');
+                $this->Comment->Body = val('Body', $FormValues, '');
                 $this->Comment->Format = val('Format', $FormValues, c('Garden.InputFormatter'));
 
                 $this->EventArguments['Discussion'] = &$this->Discussion;
@@ -311,7 +319,7 @@ class PostController extends VanillaController {
         $this->fireEvent('BeforeDiscussionRender');
 
         if ($this->CategoryID) {
-            $Breadcrumbs = CategoryModel::GetAncestors($this->CategoryID);
+            $Breadcrumbs = CategoryModel::getAncestors($this->CategoryID);
         } else {
             $Breadcrumbs = array();
         }
@@ -319,7 +327,7 @@ class PostController extends VanillaController {
 
         $this->setData('Breadcrumbs', $Breadcrumbs);
 
-        $this->setData('_AnnounceOptions', $this->AnnounceOptions());
+        $this->setData('_AnnounceOptions', $this->announceOptions());
 
         // Render view (posts/discussion.php or post/preview.php)
         $this->render();
@@ -356,7 +364,7 @@ class PostController extends VanillaController {
 
         // Set view and render
         $this->View = 'Discussion';
-        $this->Discussion($this->CategoryID);
+        $this->discussion($this->CategoryID);
     }
 
     /**
@@ -397,7 +405,7 @@ class PostController extends VanillaController {
         }
 
         if (!$Discussion && $vanilla_url != '' && $vanilla_identifier != '') {
-            $Discussion = $Discussion = $this->DiscussionModel->GetForeignID($vanilla_identifier, $vanilla_type);
+            $Discussion = $Discussion = $this->DiscussionModel->getForeignID($vanilla_identifier, $vanilla_type);
 
             if ($Discussion) {
                 $this->DiscussionID = $DiscussionID = $Discussion->DiscussionID;
@@ -481,7 +489,7 @@ class PostController extends VanillaController {
                 $EmbedUser = Gdn::userModel()->getID($EmbedUserID);
             }
             if (!$EmbedUserID || !$EmbedUser) {
-                $EmbedUserID = Gdn::userModel()->GetSystemUserID();
+                $EmbedUserID = Gdn::userModel()->getSystemUserID();
             }
 
             $EmbeddedDiscussionData = array(
@@ -510,7 +518,7 @@ class PostController extends VanillaController {
                 $this->Discussion = $Discussion = $this->DiscussionModel->getID($DiscussionID, DATASET_TYPE_OBJECT, array('Slave' => false));
                 // Update the category discussion count
                 if ($vanilla_category_id > 0) {
-                    $this->DiscussionModel->UpdateDiscussionCount($vanilla_category_id, $DiscussionID);
+                    $this->DiscussionModel->updateDiscussionCount($vanilla_category_id, $DiscussionID);
                 }
 
             }
@@ -617,7 +625,7 @@ class PostController extends VanillaController {
                 // The comment is now half-saved.
                 if (is_numeric($CommentID) && $CommentID > 0) {
                     if (in_array($this->deliveryType(), array(DELIVERY_TYPE_ALL, DELIVERY_TYPE_DATA))) {
-                        $this->CommentModel->Save2($CommentID, $Inserted, true, true);
+                        $this->CommentModel->save2($CommentID, $Inserted, true, true);
                     } else {
                         $this->jsonTarget('', url("/post/comment2.json?commentid=$CommentID&inserted=$Inserted"), 'Ajax');
                     }
@@ -663,9 +671,9 @@ class PostController extends VanillaController {
                         $this->Comment->InsertName = $Session->User->Name;
                         $this->Comment->InsertPhoto = $Session->User->Photo;
                         $this->Comment->DateInserted = Gdn_Format::date();
-                        $this->Comment->Body = arrayValue('Body', $FormValues, '');
+                        $this->Comment->Body = val('Body', $FormValues, '');
                         $this->Comment->Format = val('Format', $FormValues, c('Garden.InputFormatter'));
-                        $this->AddAsset('Content', $this->fetchView('preview'));
+                        $this->addAsset('Content', $this->fetchView('preview'));
                     } else {
                         // If this was a draft save, notify the user about the save
                         $this->informMessage(sprintf(t('Draft saved at %s'), Gdn_Format::date()));
@@ -675,7 +683,7 @@ class PostController extends VanillaController {
                 // Handle ajax-based requests
                 if ($this->Form->errorCount() > 0) {
                     // Return the form errors
-                    $this->ErrorMessage($this->Form->errors());
+                    $this->errorMessage($this->Form->errors());
                 } else {
                     // Make sure that the ajax request form knows about the newly created comment or draft id
                     $this->setJson('CommentID', $CommentID);
@@ -688,14 +696,14 @@ class PostController extends VanillaController {
                         $this->Comment->InsertName = $Session->User->Name;
                         $this->Comment->InsertPhoto = $Session->User->Photo;
                         $this->Comment->DateInserted = Gdn_Format::date();
-                        $this->Comment->Body = arrayValue('Body', $FormValues, '');
+                        $this->Comment->Body = val('Body', $FormValues, '');
                         $this->View = 'preview';
                     } elseif (!$Draft) { // If the comment was not a draft
                         // If Editing a comment
                         if ($Editing) {
                             // Just reload the comment in question
                             $this->Offset = 1;
-                            $Comments = $this->CommentModel->GetIDData($CommentID, array('Slave' => false));
+                            $Comments = $this->CommentModel->getIDData($CommentID, array('Slave' => false));
                             $this->setData('Comments', $Comments);
                             $this->setData('Discussion', $Discussion);
                             // Load the discussion

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1642,10 +1642,10 @@ class CategoryModel extends Gdn_Model {
         $this->defineSchema();
 
         // Get data from form
-        $CategoryID = arrayValue('CategoryID', $FormPostValues);
-        $NewName = arrayValue('Name', $FormPostValues, '');
-        $UrlCode = arrayValue('UrlCode', $FormPostValues, '');
-        $AllowDiscussions = arrayValue('AllowDiscussions', $FormPostValues, '');
+        $CategoryID = val('CategoryID', $FormPostValues);
+        $NewName = val('Name', $FormPostValues, '');
+        $UrlCode = val('UrlCode', $FormPostValues, '');
+        $AllowDiscussions = val('AllowDiscussions', $FormPostValues, '');
         $CustomPermissions = (bool)GetValue('CustomPermissions', $FormPostValues);
         $CustomPoints = val('CustomPoints', $FormPostValues, null);
 
@@ -1685,7 +1685,7 @@ class CategoryModel extends Gdn_Model {
         if ($this->validate($FormPostValues, $Insert)) {
             $Fields = $this->Validation->SchemaValidationFields();
             $Fields = RemoveKeyFromArray($Fields, 'CategoryID');
-            $AllowDiscussions = arrayValue('AllowDiscussions', $Fields) == '1' ? true : false;
+            $AllowDiscussions = val('AllowDiscussions', $Fields) == '1' ? true : false;
             $Fields['AllowDiscussions'] = $AllowDiscussions ? '1' : '0';
 
             if ($Insert === false) {

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -810,7 +810,7 @@ class CommentModel extends VanillaModel {
         }
 
         // Validate $CommentID and whether this is an insert
-        $CommentID = arrayValue('CommentID', $FormPostValues);
+        $CommentID = val('CommentID', $FormPostValues);
         $CommentID = is_numeric($CommentID) && $CommentID > 0 ? $CommentID : false;
         $Insert = $CommentID === false;
         if ($Insert) {

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1554,7 +1554,7 @@ class DiscussionModel extends VanillaModel {
         }
 
         // Get the DiscussionID from the form so we know if we are inserting or updating.
-        $DiscussionID = arrayValue('DiscussionID', $FormPostValues, '');
+        $DiscussionID = val('DiscussionID', $FormPostValues, '');
 
         // See if there is a source ID.
         if (val('SourceID', $FormPostValues)) {
@@ -1576,13 +1576,13 @@ class DiscussionModel extends VanillaModel {
             unset($FormPostValues['DiscussionID']);
             // If no categoryid is defined, grab the first available.
             if (!val('CategoryID', $FormPostValues) && !c('Vanilla.Categories.Use')) {
-                $FormPostValues['CategoryID'] = val('CategoryID', CategoryModel::DefaultCategory(), -1);
+                $FormPostValues['CategoryID'] = val('CategoryID', CategoryModel::defaultCategory(), -1);
             }
 
-            $this->AddInsertFields($FormPostValues);
+            $this->addInsertFields($FormPostValues);
 
             // The UpdateUserID used to be required. Just add it if it still is.
-            if (!$this->Schema->GetProperty('UpdateUserID', 'AllowNull', true)) {
+            if (!$this->Schema->getProperty('UpdateUserID', 'AllowNull', true)) {
                 $FormPostValues['UpdateUserID'] = $FormPostValues['InsertUserID'];
             }
 
@@ -1590,19 +1590,19 @@ class DiscussionModel extends VanillaModel {
             $FormPostValues['DateLastComment'] = $FormPostValues['DateInserted'];
         } else {
             // Add the update fields.
-            $this->AddUpdateFields($FormPostValues);
+            $this->addUpdateFields($FormPostValues);
         }
 
         // Set checkbox values to zero if they were unchecked
-        if (ArrayValue('Announce', $FormPostValues, '') === false) {
+        if (val('Announce', $FormPostValues, '') === false) {
             $FormPostValues['Announce'] = 0;
         }
 
-        if (ArrayValue('Closed', $FormPostValues, '') === false) {
+        if (val('Closed', $FormPostValues, '') === false) {
             $FormPostValues['Closed'] = 0;
         }
 
-        if (ArrayValue('Sink', $FormPostValues, '') === false) {
+        if (val('Sink', $FormPostValues, '') === false) {
             $FormPostValues['Sink'] = 0;
         }
 
@@ -1623,9 +1623,9 @@ class DiscussionModel extends VanillaModel {
 
         if (count($ValidationResults) == 0) {
             // If the post is new and it validates, make sure the user isn't spamming
-            if (!$Insert || !$this->CheckForSpam('Discussion')) {
+            if (!$Insert || !$this->checkForSpam('Discussion')) {
                 // Get all fields on the form that relate to the schema
-                $Fields = $this->Validation->SchemaValidationFields();
+                $Fields = $this->Validation->schemaValidationFields();
 
                 // Get DiscussionID if one was sent
                 $DiscussionID = intval(val('DiscussionID', $Fields, 0));
@@ -1646,21 +1646,21 @@ class DiscussionModel extends VanillaModel {
                     // Clear the cache if necessary.
                     $CacheKeys = array();
                     if (val('Announce', $Stored) != val('Announce', $Fields)) {
-                        $CacheKeys[] = $this->GetAnnouncementCacheKey();
-                        $CacheKeys[] = $this->GetAnnouncementCacheKey(val('CategoryID', $Stored));
+                        $CacheKeys[] = $this->getAnnouncementCacheKey();
+                        $CacheKeys[] = $this->getAnnouncementCacheKey(val('CategoryID', $Stored));
                     }
                     if (val('CategoryID', $Stored) != val('CategoryID', $Fields)) {
-                        $CacheKeys[] = $this->GetAnnouncementCacheKey(val('CategoryID', $Fields));
+                        $CacheKeys[] = $this->getAnnouncementCacheKey(val('CategoryID', $Fields));
                     }
                     foreach ($CacheKeys as $CacheKey) {
-                        Gdn::cache()->Remove($CacheKey);
+                        Gdn::cache()->remove($CacheKey);
                     }
 
-                    self::SerializeRow($Fields);
+                    self::serializeRow($Fields);
                     $this->SQL->put($this->Name, $Fields, array($this->PrimaryKey => $DiscussionID));
 
                     setValue('DiscussionID', $Fields, $DiscussionID);
-                    LogModel::LogChange('Edit', 'Discussion', (array)$Fields, $Stored);
+                    LogModel::logChange('Edit', 'Discussion', (array)$Fields, $Stored);
 
                     if (val('CategoryID', $Stored) != val('CategoryID', $Fields)) {
                         $StoredCategoryID = val('CategoryID', $Stored);
@@ -1677,20 +1677,20 @@ class DiscussionModel extends VanillaModel {
                     }
 
                     // Check for spam.
-                    $Spam = SpamModel::IsSpam('Discussion', $Fields);
+                    $Spam = SpamModel::isSpam('Discussion', $Fields);
                     if ($Spam) {
                         return SPAM;
                     }
 
                     // Check for approval
-                    $ApprovalRequired = CheckRestriction('Vanilla.Approval.Require');
+                    $ApprovalRequired = checkRestriction('Vanilla.Approval.Require');
                     if ($ApprovalRequired && !val('Verified', Gdn::session()->User)) {
                         LogModel::insert('Pending', 'Discussion', $Fields);
                         return UNAPPROVED;
                     }
 
                     // Create discussion
-                    $this->SerializeRow($Fields);
+                    $this->serializeRow($Fields);
                     $DiscussionID = $this->SQL->insert($this->Name, $Fields);
                     $Fields['DiscussionID'] = $DiscussionID;
 
@@ -1704,21 +1704,21 @@ class DiscussionModel extends VanillaModel {
                             'LastDateInserted' => $Fields['DateInserted'],
                             'LastUrl' => DiscussionUrl($Fields)
                         );
-                        CategoryModel::SetCache($Fields['CategoryID'], $CategoryCache);
+                        CategoryModel::setCache($Fields['CategoryID'], $CategoryCache);
 
                         // Clear the cache if necessary.
                         if (val('Announce', $Fields)) {
-                            Gdn::cache()->Remove($this->GetAnnouncementCacheKey(val('CategoryID', $Fields)));
+                            Gdn::cache()->remove($this->getAnnouncementCacheKey(val('CategoryID', $Fields)));
 
                             if (val('Announce', $Fields) == 1) {
-                                Gdn::cache()->Remove($this->GetAnnouncementCacheKey());
+                                Gdn::cache()->remove($this->getAnnouncementCacheKey());
                             }
                         }
                     }
 
                     // Update the user's discussion count.
                     $InsertUser = Gdn::userModel()->getID($Fields['InsertUserID']);
-                    $this->UpdateUserDiscussionCount($Fields['InsertUserID'], val('CountDiscussions', $InsertUser, 0) > 100);
+                    $this->updateUserDiscussionCount($Fields['InsertUserID'], val('CountDiscussions', $InsertUser, 0) > 100);
 
                     // Mark the user as participated.
                     $this->SQL->replace(
@@ -1732,8 +1732,8 @@ class DiscussionModel extends VanillaModel {
                     $FormPostValues['DiscussionID'] = $DiscussionID;
 
                     // Do data prep.
-                    $DiscussionName = arrayValue('Name', $Fields, '');
-                    $Story = arrayValue('Body', $Fields, '');
+                    $DiscussionName = val('Name', $Fields, '');
+                    $Story = val('Body', $Fields, '');
                     $NotifiedUsers = array();
 
                     $UserModel = Gdn::userModel();
@@ -1766,7 +1766,7 @@ class DiscussionModel extends VanillaModel {
                     }
 
                     // Notify all of the users that were mentioned in the discussion.
-                    $Usernames = GetMentions($DiscussionName.' '.$Story);
+                    $Usernames = getMentions($DiscussionName.' '.$Story);
 
                     // Use our generic Activity for events, not mentions
                     $this->EventArguments['Activity'] = $Activity;
@@ -1775,7 +1775,7 @@ class DiscussionModel extends VanillaModel {
                     if (!c('Vanilla.QueueNotifications')) {
                         try {
                             $Fields['DiscussionID'] = $DiscussionID;
-                            $this->NotifyNewDiscussion($Fields, $ActivityModel, $Activity);
+                            $this->notifyNewDiscussion($Fields, $ActivityModel, $Activity);
                         } catch (Exception $Ex) {
                             throw $Ex;
                         }
@@ -1783,20 +1783,20 @@ class DiscussionModel extends VanillaModel {
 
                     // Notifications for mentions
                     foreach ($Usernames as $Username) {
-                        $User = $UserModel->GetByUsername($Username);
+                        $User = $UserModel->getByUsername($Username);
                         if (!$User) {
                             continue;
                         }
 
                         // Check user can still see the discussion.
-                        if (!$UserModel->GetCategoryViewPermission($User->UserID, val('CategoryID', $Fields))) {
+                        if (!$UserModel->getCategoryViewPermission($User->UserID, val('CategoryID', $Fields))) {
                             continue;
                         }
 
                         $Activity['HeadlineFormat'] = t('HeadlineFormat.Mention', '{ActivityUserID,user} mentioned you in <a href="{Url,html}">{Data.Name,text}</a>');
 
                         $Activity['NotifyUserID'] = val('UserID', $User);
-                        $ActivityModel->Queue($Activity, 'Mention');
+                        $ActivityModel->queue($Activity, 'Mention');
                     }
 
                     // Throw an event for users to add their own events.
@@ -1807,7 +1807,7 @@ class DiscussionModel extends VanillaModel {
                     $this->fireEvent('BeforeNotification');
 
                     // Send all notifications.
-                    $ActivityModel->SaveQueue();
+                    $ActivityModel->saveQueue();
                 }
 
                 // Get CategoryID of this discussion
@@ -1817,11 +1817,11 @@ class DiscussionModel extends VanillaModel {
 
                 // Update discussion counter for affected categories.
                 if ($Insert || $StoredCategoryID) {
-                    $this->IncrementNewDiscussion($Discussion);
+                    $this->incrementNewDiscussion($Discussion);
                 }
 
                 if ($StoredCategoryID) {
-                    $this->UpdateDiscussionCount($StoredCategoryID);
+                    $this->updateDiscussionCount($StoredCategoryID);
                 }
 
                 // Fire an event that the discussion was saved.

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -131,7 +131,7 @@ class DraftModel extends VanillaModel {
         }
 
         // Get the DraftID from the form so we know if we are inserting or updating.
-        $DraftID = arrayValue('DraftID', $FormPostValues, '');
+        $DraftID = val('DraftID', $FormPostValues, '');
         $Insert = $DraftID == '' ? true : false;
 
         if (!$DraftID) {
@@ -145,7 +145,7 @@ class DraftModel extends VanillaModel {
 
         if ($Insert) {
             // If no categoryid is defined, grab the first available.
-            if (ArrayValue('CategoryID', $FormPostValues) === false) {
+            if (val('CategoryID', $FormPostValues) === false) {
                 $FormPostValues['CategoryID'] = $this->SQL->get('Category', '', '', 1)->firstRow()->CategoryID;
             }
 
@@ -155,22 +155,22 @@ class DraftModel extends VanillaModel {
         $this->AddUpdateFields($FormPostValues);
 
         // Remove checkboxes from the fields if they were unchecked
-        if (ArrayValue('Announce', $FormPostValues, '') === false) {
+        if (val('Announce', $FormPostValues, '') === false) {
             unset($FormPostValues['Announce']);
         }
 
-        if (ArrayValue('Closed', $FormPostValues, '') === false) {
+        if (val('Closed', $FormPostValues, '') === false) {
             unset($FormPostValues['Closed']);
         }
 
-        if (ArrayValue('Sink', $FormPostValues, '') === false) {
+        if (val('Sink', $FormPostValues, '') === false) {
             unset($FormPostValues['Sink']);
         }
 
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert)) {
             $Fields = $this->Validation->SchemaValidationFields(); // All fields on the form that relate to the schema
-            $DraftID = intval(ArrayValue('DraftID', $Fields, 0));
+            $DraftID = intval(val('DraftID', $Fields, 0));
 
             // If the post is new and it validates, make sure the user isn't spamming
             if ($DraftID > 0) {

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -325,8 +325,8 @@ class VanillaHooks implements Gdn_IPlugin {
         static $PermissionModel = null;
 
 
-        $UserID = arrayValue(0, $Sender->EventArguments, '');
-        $CategoryID = arrayValue(1, $Sender->EventArguments, '');
+        $UserID = val(0, $Sender->EventArguments, '');
+        $CategoryID = val(1, $Sender->EventArguments, '');
         $Permission = val(2, $Sender->EventArguments, 'Vanilla.Discussions.View');
         if ($UserID && $CategoryID) {
             if ($PermissionModel === null) {

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -409,5 +409,5 @@ include(PATH_APPLICATIONS.DS.'vanilla'.DS.'settings'.DS.'stub.php');
 // Set current Vanilla.Version
 $ApplicationInfo = array();
 include(CombinePaths(array(PATH_APPLICATIONS.DS.'vanilla'.DS.'settings'.DS.'about.php')));
-$Version = arrayValue('Version', arrayValue('Vanilla', $ApplicationInfo, array()), 'Undefined');
+$Version = val('Version', val('Vanilla', $ApplicationInfo, array()), 'Undefined');
 saveToConfig('Vanilla.Version', $Version);

--- a/library/core/authenticators/class.passwordauthenticator.php
+++ b/library/core/authenticators/class.passwordauthenticator.php
@@ -75,7 +75,7 @@ class Gdn_PasswordAuthenticator extends Gdn_Authenticator {
             if ($SignInPermission === false && !$UserData->Banned) {
                 $PermissionModel = Gdn::Authenticator()->GetPermissionModel();
                 foreach ($PermissionModel->GetUserPermissions($UserID) as $Permissions) {
-                    $SignInPermission |= ArrayValue('Garden.SignIn.Allow', $Permissions, false);
+                    $SignInPermission |= val('Garden.SignIn.Allow', $Permissions, false);
                 }
             }
 

--- a/library/core/class.authenticator.php
+++ b/library/core/class.authenticator.php
@@ -162,7 +162,7 @@ abstract class Gdn_Authenticator extends Gdn_Pluggable {
 
         if ($DataSource == $this) {
             foreach ($this->_DataHooks as $DataTarget => $DataHook) {
-                $this->_DataHooks[$DataTarget]['value'] = arrayValue($DataTarget, $DirectSupplied);
+                $this->_DataHooks[$DataTarget]['value'] = val($DataTarget, $DirectSupplied);
             }
 
             return;

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -338,7 +338,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         if (!is_null($Definition)) {
             $this->_Definitions[$Term] = $Definition;
         }
-        return arrayValue($Term, $this->_Definitions);
+        return val($Term, $this->_Definitions);
     }
 
     /**
@@ -775,7 +775,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         $ViewPath2 = viewLocation($View, $ControllerName, $ApplicationFolder);
 
         $LocationName = concatSep('/', strtolower($ApplicationFolder), $ControllerName, $View);
-        $ViewPath = arrayValue($LocationName, $this->_ViewLocations, false);
+        $ViewPath = val($LocationName, $this->_ViewLocations, false);
         if ($ViewPath === false) {
             // Define the search paths differently depending on whether or not we are in a plugin or application.
             $ApplicationFolder = trim($ApplicationFolder, '/');
@@ -1064,7 +1064,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         if (!is_null($Value)) {
             $this->_Json[$Key] = $Value;
         }
-        return arrayValue($Key, $this->_Json, null);
+        return val($Key, $this->_Json, null);
     }
 
     /**

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -183,7 +183,7 @@ class Gdn_Form extends Gdn_Pluggable {
         $Return = '<input type="'.$Type.'"';
         $Return .= $this->_idAttribute($ButtonCode, $Attributes);
         $Return .= $this->_nameAttribute($ButtonCode, $Attributes);
-        $Return .= ' value="'.t($ButtonCode, arrayValue('value', $Attributes)).'"';
+        $Return .= ' value="'.t($ButtonCode, val('value', $Attributes)).'"';
         $Return .= $this->_attributesToString($Attributes);
         $Return .= " />\n";
         return $Return;
@@ -2001,20 +2001,20 @@ PASSWORDMETER;
                         ) ===
                             false
                         ) { // Saving dates in the format: YYYY-MM-DD
-                            $Year = arrayValue(
+                            $Year = val(
                                 $DateFields[$i].
                                 '_Year',
                                 $this->_FormValues,
                                 0
                             );
                         }
-                        $Month = arrayValue(
+                        $Month = val(
                             $DateFields[$i].
                             '_Month',
                             $this->_FormValues,
                             0
                         );
-                        $Day = arrayValue(
+                        $Day = val(
                             $DateFields[$i].
                             '_Day',
                             $this->_FormValues,
@@ -2066,7 +2066,7 @@ PASSWORDMETER;
      * @return unknown
      */
     public function getFormValue($FieldName, $Default = '') {
-        return arrayValue($FieldName, $this->formValues(), $Default);
+        return val($FieldName, $this->formValues(), $Default);
     }
 
     /**
@@ -2088,7 +2088,7 @@ PASSWORDMETER;
         if ($this->isMyPostBack()) {
             $Return = $this->getFormValue($FieldName, $Default);
         } else {
-            $Return = arrayValue($FieldName, $this->_DataArray, $Default);
+            $Return = val($FieldName, $this->_DataArray, $Default);
         }
         return $Return;
     }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1856,9 +1856,9 @@ EOT;
             $Year = $Matches[1];
             $Month = $Matches[2];
             $Day = $Matches[3];
-            $Hour = arrayValue(4, $Matches, 0);
-            $Minute = arrayValue(5, $Matches, 0);
-            $Second = arrayValue(6, $Matches, 0);
+            $Hour = val(4, $Matches, 0);
+            $Minute = val(5, $Matches, 0);
+            $Second = val(6, $Matches, 0);
             return mktime($Hour, $Minute, $Second, $Month, $Day, $Year);
         } elseif (preg_match('/^(\d{4})-(\d{1,2})-(\d{1,2})$/', $DateTime, $Matches)) {
             $Year = $Matches[1];

--- a/library/core/class.gdn.php
+++ b/library/core/class.gdn.php
@@ -272,7 +272,7 @@ class Gdn {
 
         $PropertyName = $Config['PropertyName'];
         $SourceAlias = $Config['SourceAlias'];
-        $Override = ArrayValue('Override', $Config, true);
+        $Override = val('Override', $Config, true);
 
         self::factoryInstallDependency($Alias, $PropertyName, $SourceAlias, $Override);
     }
@@ -302,8 +302,8 @@ class Gdn {
         }
 
         $FactoryType = $Config['FactoryType'];
-        $Data = ArrayValue('Data', $Config, null);
-        $Override = ArrayValue('Override', $Config, true);
+        $Data = val('Data', $Config, null);
+        $Override = val('Override', $Config, true);
 
         self::factoryInstall($Alias, $Config['ClassName'], $Config['Path'], $FactoryType, $Data, $Override);
 

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -892,7 +892,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
      */
     public function callMethodOverride($Sender, $ClassName, $MethodName) {
         $EventKey = strtolower($ClassName.'_'.$MethodName.'_Override');
-        $OverrideKey = ArrayValue($EventKey, $this->_MethodOverrideCollection, '');
+        $OverrideKey = val($EventKey, $this->_MethodOverrideCollection, '');
         $OverrideKeyParts = explode('.', $OverrideKey);
         if (count($OverrideKeyParts) != 2) {
             return false;
@@ -929,7 +929,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
     public function callNewMethod($Sender, $ClassName, $MethodName) {
         $Return = false;
         $EventKey = strtolower($ClassName.'_'.$MethodName.'_Create');
-        $NewMethodKey = ArrayValue($EventKey, $this->_NewMethodCollection, '');
+        $NewMethodKey = val($EventKey, $this->_NewMethodCollection, '');
         $NewMethodKeyParts = explode('.', $NewMethodKey);
         if (count($NewMethodKeyParts) != 2) {
             return false;
@@ -1153,17 +1153,17 @@ class Gdn_PluginManager extends Gdn_Pluggable {
 
         // Required Themes
         $EnabledThemes = Gdn::themeManager()->enabledThemeInfo();
-        $RequiredThemes = ArrayValue('RequiredTheme', $PluginInfo, false);
+        $RequiredThemes = val('RequiredTheme', $PluginInfo, false);
         CheckRequirements($PluginName, $RequiredThemes, $EnabledThemes, 'theme');
 
         // Required Applications
         $EnabledApplications = Gdn::applicationManager()->enabledApplications();
-        $RequiredApplications = ArrayValue('RequiredApplications', $PluginInfo, false);
+        $RequiredApplications = val('RequiredApplications', $PluginInfo, false);
         CheckRequirements($PluginName, $RequiredApplications, $EnabledApplications, 'application');
 
         // Include the plugin, instantiate it, and call its setup method
-        $PluginClassName = ArrayValue('ClassName', $PluginInfo, false);
-        $PluginFolder = ArrayValue('Folder', $PluginInfo, false);
+        $PluginClassName = val('ClassName', $PluginInfo, false);
+        $PluginFolder = val('Folder', $PluginInfo, false);
         if ($PluginFolder == '') {
             throw new Exception(T('The plugin folder was not properly defined.'));
         }
@@ -1255,7 +1255,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
         // Get all available plugins and compile their requirements
         foreach ($this->enabledPlugins() as $CheckingName => $Trash) {
             $CheckingInfo = $this->getPluginInfo($CheckingName);
-            $RequiredPlugins = ArrayValue('RequiredPlugins', $CheckingInfo, false);
+            $RequiredPlugins = val('RequiredPlugins', $CheckingInfo, false);
             if (is_array($RequiredPlugins) && array_key_exists($PluginName, $RequiredPlugins) === true) {
                 throw new Exception(sprintf(T('You cannot disable the %1$s plugin because the %2$s plugin requires it in order to function.'), $PluginName, $CheckingName));
             }
@@ -1351,9 +1351,9 @@ class Gdn_PluginManager extends Gdn_Pluggable {
                 break;
         }
 
-        $PluginInfo = ArrayValue($PluginName, $this->availablePlugins(), false);
-        $PluginFolder = ArrayValue('Folder', $PluginInfo, false);
-        $PluginClassName = ArrayValue('ClassName', $PluginInfo, false);
+        $PluginInfo = val($PluginName, $this->availablePlugins(), false);
+        $PluginFolder = val('Folder', $PluginInfo, false);
+        $PluginClassName = val('ClassName', $PluginInfo, false);
 
         if ($PluginFolder !== false && $PluginClassName !== false && class_exists($PluginClassName) === false) {
             if ($ForAction !== self::ACTION_DISABLE) {

--- a/library/core/class.router.php
+++ b/library/core/class.router.php
@@ -51,7 +51,7 @@ class Gdn_Router extends Gdn_Pluggable {
     public function getRoute($Route, $Indexed = true) {
         if ($Indexed && is_numeric($Route) && $Route !== false) {
             $Keys = array_keys($this->Routes);
-            $Route = arrayValue($Route, $Keys);
+            $Route = val($Route, $Keys);
         }
 
         $Decoded = $this->_decodeRouteKey($Route);

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -305,7 +305,7 @@ class Gdn_Session {
         // WARNING: THIS DOES NOT CHECK THE DEFAULT CONFIG-DEFINED SETTINGS.
         // IF A USER HAS NEVER SAVED THEIR PREFERENCES, THIS WILL RETURN
         // INCORRECT VALUES.
-        return ArrayValue($PreferenceName, $this->_Preferences, $DefaultValue);
+        return val($PreferenceName, $this->_Preferences, $DefaultValue);
     }
 
     /**
@@ -318,7 +318,7 @@ class Gdn_Session {
      */
     public function getAttribute($AttributeName, $DefaultValue = false) {
         if (is_array($this->_Attributes)) {
-            return ArrayValue($AttributeName, $this->_Attributes, $DefaultValue);
+            return val($AttributeName, $this->_Attributes, $DefaultValue);
         }
         return $DefaultValue;
     }
@@ -390,7 +390,7 @@ class Gdn_Session {
                 $this->_Permissions = Gdn_Format::unserialize($this->User->Permissions);
                 $this->_Preferences = Gdn_Format::unserialize($this->User->Preferences);
                 $this->_Attributes = Gdn_Format::unserialize($this->User->Attributes);
-                $this->_TransientKey = is_array($this->_Attributes) ? arrayValue('TransientKey', $this->_Attributes) : false;
+                $this->_TransientKey = is_array($this->_Attributes) ? val('TransientKey', $this->_Attributes) : false;
 
                 if ($this->_TransientKey === false) {
                     $this->_TransientKey = $UserModel->setTransientKey($this->UserID);

--- a/library/core/class.thememanager.php
+++ b/library/core/class.thememanager.php
@@ -567,8 +567,8 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
 
         $NewThemeInfo = $this->getThemeInfo($ThemeName);
         $ThemeName = val('Index', $NewThemeInfo, $ThemeName);
-        $RequiredApplications = arrayValue('RequiredApplications', $NewThemeInfo, false);
-        $ThemeFolder = arrayValue('Folder', $NewThemeInfo, '');
+        $RequiredApplications = val('RequiredApplications', $NewThemeInfo, false);
+        $ThemeFolder = val('Folder', $NewThemeInfo, '');
         checkRequirements($ThemeName, $RequiredApplications, $EnabledApplications, 'application'); // Applications
 
         // If there is a hooks file, include it and run the setup method.

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -452,7 +452,7 @@ class Gdn_Validation {
             $this->_ValidationFields = array();
         }
 
-        $Value = arrayValue($FieldName, $PostedFields, null);
+        $Value = val($FieldName, $PostedFields, null);
         $this->_ValidationFields[$FieldName] = $Value;
     }
 
@@ -623,7 +623,7 @@ class Gdn_Validation {
                                 // If $ValidationResult is not FALSE, assume it is an error message
                                 $ErrorCode = $ValidationResult === false ? $Function : $ValidationResult;
                                 // If there is a custom error, use it above all else
-                                $ErrorCode = arrayValue($FieldName.'.'.$RuleName, $this->_CustomErrors, $ErrorCode);
+                                $ErrorCode = val($FieldName.'.'.$RuleName, $this->_CustomErrors, $ErrorCode);
                                 // Add the result
                                 $this->addValidationResult($FieldName, $ErrorCode);
                                 // Only add one error per field
@@ -633,7 +633,7 @@ class Gdn_Validation {
                             if (ValidateRegex($FieldValue, $Regex) !== true) {
                                 $ErrorCode = 'Regex';
                                 // If there is a custom error, use it above all else
-                                $ErrorCode = arrayValue($FieldName.'.'.$RuleName, $this->_CustomErrors, $ErrorCode);
+                                $ErrorCode = val($FieldName.'.'.$RuleName, $this->_CustomErrors, $ErrorCode);
                                 // Add the result
                                 $this->addValidationResult($FieldName, $ErrorCode);
                             }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -357,8 +357,10 @@ if (!function_exists('arrayValue')) {
      * @param string $needle The key to look for in the $Haystack associative array.
      * @param array $haystack The associative array in which to search for the $Needle key.
      * @param string $default The default value to return if the requested value is not found. Default is false.
+     * @deprecated since 2.3
      */
     function arrayValue($needle, $haystack, $default = false) {
+        deprecated('arrayValue', 'val');
         $result = val($needle, $haystack, $default);
         return $result;
     }
@@ -413,7 +415,7 @@ if (!function_exists('asset')) {
         if (IsUrl($Destination)) {
             $Result = $Destination;
         } else {
-            $Result = Gdn::Request()->UrlDomain($WithDomain).Gdn::Request()->AssetRoot().'/'.ltrim($Destination, '/');
+            $Result = Gdn::request()->urlDomain($WithDomain).Gdn::request()->assetRoot().'/'.ltrim($Destination, '/');
         }
 
         if ($AddVersion) {
@@ -433,16 +435,16 @@ if (!function_exists('asset')) {
 
                     switch ($Type) {
                         case 'plugins':
-                            $PluginInfo = Gdn::PluginManager()->GetPluginInfo($Key);
+                            $PluginInfo = Gdn::pluginManager()->getPluginInfo($Key);
                             $Version = val('Version', $PluginInfo, $Version);
                             break;
                         case 'applications':
-                            $AppInfo = Gdn::ApplicationManager()->GetApplicationInfo(ucfirst($Key));
+                            $AppInfo = Gdn::applicationManager()->getApplicationInfo(ucfirst($Key));
                             $Version = val('Version', $AppInfo, $Version);
                             break;
                         case 'themes':
                             if ($ThemeVersion === null) {
-                                $ThemeInfo = Gdn::ThemeManager()->GetThemeInfo(Theme());
+                                $ThemeInfo = Gdn::themeManager()->getThemeInfo(Theme());
                                 if ($ThemeInfo !== false) {
                                     $ThemeVersion = val('Version', $ThemeInfo, $Version);
                                 } else {
@@ -618,7 +620,7 @@ if (!function_exists('checkRequirements')) {
                     $MissingRequirements[] = "$RequiredItemName $RequiredVersion";
                 } elseif ($RequiredVersion && $RequiredVersion != '*') { // * means any version
                     // If the item exists and is enabled, check the version
-                    $EnabledVersion = ArrayValue('Version', ArrayValue($RequiredItemName, $EnabledItems, array()), '');
+                    $EnabledVersion = val('Version', val($RequiredItemName, $EnabledItems, array()), '');
                     // Compare the versions.
                     if (version_compare($EnabledVersion, $RequiredVersion, '<')) {
                         $MissingRequirements[] = "$RequiredItemName $RequiredVersion";
@@ -2693,7 +2695,7 @@ if (!function_exists('proxyHead')) {
             curl_setopt($Handler, CURLOPT_PORT, $Port);
             curl_setopt($Handler, CURLOPT_HEADER, 1);
             curl_setopt($Handler, CURLOPT_NOBODY, 1);
-            curl_setopt($Handler, CURLOPT_USERAGENT, ArrayValue('HTTP_USER_AGENT', $_SERVER, 'Vanilla/2.0'));
+            curl_setopt($Handler, CURLOPT_USERAGENT, val('HTTP_USER_AGENT', $_SERVER, 'Vanilla/2.0'));
             curl_setopt($Handler, CURLOPT_RETURNTRANSFER, 1);
             curl_setopt($Handler, CURLOPT_HTTPHEADER, $Headers);
 
@@ -2728,7 +2730,7 @@ if (!function_exists('proxyHead')) {
             $HostHeader = $Host.($Port != 80) ? ":{$Port}" : '';
             $Header = array(
                 'Host' => $HostHeader,
-                'User-Agent' => ArrayValue('HTTP_USER_AGENT', $_SERVER, 'Vanilla/2.0'),
+                'User-Agent' => val('HTTP_USER_AGENT', $_SERVER, 'Vanilla/2.0'),
                 'Accept' => '*/*',
                 'Accept-Charset' => 'utf-8',
                 'Referer' => $Referer,
@@ -2841,7 +2843,7 @@ if (!function_exists('proxyRequest')) {
             curl_setopt($Handler, CURLOPT_PORT, $Port);
             curl_setopt($Handler, CURLOPT_SSL_VERIFYPEER, false);
             curl_setopt($Handler, CURLOPT_HEADER, 1);
-            curl_setopt($Handler, CURLOPT_USERAGENT, ArrayValue('HTTP_USER_AGENT', $_SERVER, 'Vanilla/2.0'));
+            curl_setopt($Handler, CURLOPT_USERAGENT, val('HTTP_USER_AGENT', $_SERVER, 'Vanilla/2.0'));
             curl_setopt($Handler, CURLOPT_RETURNTRANSFER, 1);
 
             if ($Cookie != '') {
@@ -2895,7 +2897,7 @@ if (!function_exists('proxyRequest')) {
                 // If you've got basic authentication enabled for the app, you're going to need to explicitly define
                 // the user/pass for this fsock call.
                 // "Authorization: Basic ". base64_encode ("username:password")."\r\n" .
-                ."User-Agent: ".ArrayValue('HTTP_USER_AGENT', $_SERVER, 'Vanilla/2.0')."\r\n"
+                ."User-Agent: ".val('HTTP_USER_AGENT', $_SERVER, 'Vanilla/2.0')."\r\n"
                 ."Accept: */*\r\n"
                 ."Accept-Charset: utf-8;\r\n"
                 ."Referer: {$Referer}\r\n"

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -148,10 +148,10 @@ if (!function_exists('validateConnection')) {
      * @deprecated
      */
     function validateConnection($value, $field, $data) {
-        $DatabaseHost = ArrayValue('Database.Host', $data, '~~Invalid~~');
-        $DatabaseName = ArrayValue('Database.Name', $data, '~~Invalid~~');
-        $DatabaseUser = ArrayValue('Database.User', $data, '~~Invalid~~');
-        $DatabasePassword = ArrayValue('Database.Password', $data, '~~Invalid~~');
+        $DatabaseHost = val('Database.Host', $data, '~~Invalid~~');
+        $DatabaseName = val('Database.Name', $data, '~~Invalid~~');
+        $DatabaseUser = val('Database.User', $data, '~~Invalid~~');
+        $DatabasePassword = val('Database.Password', $data, '~~Invalid~~');
         $ConnectionString = getConnectionString($DatabaseName, $DatabaseHost);
         try {
             $Connection = new PDO(
@@ -176,7 +176,7 @@ if (!function_exists('validateOldPassword')) {
      * @return bool Returns true if the value validates or false otherwise.
      */
     function validateOldPassword($value, $field, $data) {
-        $OldPassword = ArrayValue('OldPassword', $data, '');
+        $OldPassword = val('OldPassword', $data, '');
         $Session = Gdn::Session();
         $UserModel = new UserModel();
         $UserID = $Session->UserID;
@@ -306,9 +306,9 @@ if (!function_exists('validateDate')) {
                 $Year = $Matches[1];
                 $Month = $Matches[2];
                 $Day = $Matches[3];
-                $Hour = ArrayValue(4, $Matches, 0);
-                $Minutes = ArrayValue(5, $Matches, 0);
-                $Seconds = ArrayValue(6, $Matches, 0);
+                $Hour = val(4, $Matches, 0);
+                $Minutes = val(5, $Matches, 0);
+                $Seconds = val(6, $Matches, 0);
 
                 return checkdate($Month, $Day, $Year) && $Hour < 24 && $Minutes < 61 && $Seconds < 61;
             }
@@ -544,7 +544,7 @@ if (!function_exists('validateMatch')) {
      * @deprecated
      */
     function validateMatch($value, $field, $data) {
-        $MatchValue = ArrayValue($field->Name.'Match', $data);
+        $MatchValue = val($field->Name.'Match', $data);
         return $value == $MatchValue ? true : false;
     }
 }

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -109,7 +109,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
 
         // Handle enums and sets as types.
         if (is_array($Type)) {
-            if (count($Type) === 2 && is_array(arrayValue(1, $Type))) {
+            if (count($Type) === 2 && is_array(val(1, $Type))) {
                 // The type is specified as the first element in the array.
                 $Column->Type = $Type[0];
                 $Column->Enum = $Type[1];
@@ -148,8 +148,8 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
             $Null = false;
             $Default = null;
         } elseif (is_array($NullDefault)) {
-            $Null = arrayValue('Null', $NullDefault);
-            $Default = arrayValue('Default', $NullDefault, null);
+            $Null = val('Null', $NullDefault);
+            $Default = val('Default', $NullDefault, null);
         } else {
             $Null = false;
             $Default = $NullDefault;

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -114,8 +114,8 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         $this->Database->DatabasePrefix = $OldPrefix;
 
         // Get the definition for this column
-        $OldColumn = arrayValue($OldName, $Schema);
-        $NewColumn = arrayValue($NewName, $Schema);
+        $OldColumn = val($OldName, $Schema);
+        $NewColumn = val($NewName, $Schema);
 
         // Make sure that one column, or the other exists
         if (!$OldColumn && !$NewColumn) {
@@ -233,7 +233,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         }
         // Build the rest of the keys.
         foreach ($Indexes as $IndexType => $IndexGroups) {
-            $CreateString = arrayValue($IndexType, array('FK' => 'key', 'IX' => 'index'));
+            $CreateString = val($IndexType, array('FK' => 'key', 'IX' => 'index'));
             foreach ($IndexGroups as $IndexGroup => $ColumnNames) {
                 if (!$IndexGroup) {
                     foreach ($ColumnNames as $ColumnName) {
@@ -371,7 +371,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
 
         // Make the multi-column keys into sql statements.
         foreach ($Indexes as $ColumnKeyType => $IndexGroups) {
-            $CreateType = arrayValue($ColumnKeyType, array('index' => 'index', 'key' => 'key', 'unique' => 'unique index', 'fulltext' => 'fulltext index', 'primary' => 'primary key'));
+            $CreateType = val($ColumnKeyType, array('index' => 'index', 'key' => 'key', 'unique' => 'unique index', 'fulltext' => 'fulltext index', 'primary' => 'primary key'));
 
             if ($ColumnKeyType == 'primary') {
                 $Result['PRIMARY'] = 'primary key (`'.implode('`, `', $IndexGroups['']).'`)';

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -748,7 +748,7 @@ abstract class Gdn_SQLDriver {
             $Field = $Expr['Field'];
             $Function = $Expr['Function'];
             $Alias = $Expr['Alias'];
-            $CaseOptions = ArrayValue('CaseOptions', $Expr);
+            $CaseOptions = val('CaseOptions', $Expr);
             if ($Field != '*' && !is_numeric($Field)) {
                 $Field = $this->escapeIdentifier($Field);
             }
@@ -936,7 +936,7 @@ abstract class Gdn_SQLDriver {
         if (is_null($Fields)) {
             // Group by every item in the select that isn't a function.
             foreach ($this->_Selects as $Alias => $Select) {
-                if (ArrayValue('Function', $Select) == '') {
+                if (val('Function', $Select) == '') {
                     $this->_GroupBys[] = $Select['Field'];
                 }
             }

--- a/library/vendors/SmartyPlugins/function.asset.php
+++ b/library/vendors/SmartyPlugins/function.asset.php
@@ -21,10 +21,10 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
  * @return The rendered asset.
  */
 function smarty_function_asset($Params, &$Smarty) {
-	$Name = ArrayValue('name', $Params);
-	$Tag = ArrayValue('tag', $Params, '');
-	$Id = ArrayValue('id', $Params, $Name);
-	$Class = ArrayValue('class', $Params, '');
+	$Name = val('name', $Params);
+	$Tag = val('tag', $Params, '');
+	$Id = val('id', $Params, $Name);
+	$Class = val('class', $Params, '');
 	if ($Class != '')
 		$Class = ' class="'.$Class.'"';
 	

--- a/library/vendors/SmartyPlugins/function.event.php
+++ b/library/vendors/SmartyPlugins/function.event.php
@@ -10,6 +10,6 @@ Contact Vanilla Forums Inc. at support [at] vanillaforums [dot] com
 
 
 function smarty_function_event($Params, &$Smarty) {
-	$Name = ArrayValue('name', $Params);
+	$Name = val('name', $Params);
 	$Smarty->Controller->FireEvent($Name);
 }

--- a/library/vendors/SmartyPlugins/function.include_file.php
+++ b/library/vendors/SmartyPlugins/function.include_file.php
@@ -15,7 +15,7 @@
  * @return The rendered asset.
  */
 function smarty_function_include_file($Params, &$Smarty) {
-   $Name = ltrim(ArrayValue('name', $Params), '/');
+   $Name = ltrim(val('name', $Params), '/');
    if (strpos($Name, '..') !== false) {
       return '<!-- Error, moving up directory path not allowed -->';
    }

--- a/plugins/Debugger/class.databasedebug.php
+++ b/plugins/Debugger/class.databasedebug.php
@@ -100,7 +100,7 @@ class Gdn_DatabaseDebug extends Gdn_Database {
         foreach ($Trace as $Info) {
             $Class = val('class', $Info, '');
             if ($Class === '' || stringEndsWith($Class, 'Model', true) || stringEndsWith($Class, 'Plugin', true)) {
-                $Type = arrayValue('type', $Info, '');
+                $Type = val('type', $Info, '');
 
                 $Method = $Class.$Type.$Info['function'].'('.self::formatArgs($Info['args']).')';
                 break;


### PR DESCRIPTION
* Replace all instances of `arrayValue()` with `val()`
* Set `arrayValue()` to deprecated status.
* Fix casening in random places.
* Replace an instance of `GetIncomingValue()` with `Gdn::request()->getValue()`.