### PR TITLE
Default avatar path

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -174,7 +174,7 @@ class SettingsController extends DashboardController {
      * @return bool Whether the avatar has been uploaded from the dashboard.
      */
     public function isUploadedDefaultAvatar($avatar) {
-        return (strpos($avatar, 'uploads/'.self::DEFAULT_AVATAR_FOLDER) !== false);
+        return (strpos($avatar, '/'.self::DEFAULT_AVATAR_FOLDER.'/') !== false);
     }
 
     /**
@@ -197,8 +197,7 @@ class SettingsController extends DashboardController {
             $upload = new Gdn_Upload();
             $thumbnailSize = c('Garden.Thumbnail.Size', 40);
             $basename = changeBasename($avatar, "p%s");
-            $path = parseUrl($basename, PHP_URL_PATH);
-            $path = str_replace('/uploads', '', $path);
+            $path = substr($basename, strpos($basename, self::DEFAULT_AVATAR_FOLDER));
             $source = $upload->copyLocal($path);
 
             //Set up cropping.
@@ -237,10 +236,8 @@ class SettingsController extends DashboardController {
 
                     // Update crop properties.
                     $basename = changeBasename($avatar, "p%s");
-                    $path = parseUrl($basename, PHP_URL_PATH);
-                    $path = str_replace('/uploads', '', $path);
+                    $path = substr($basename, strpos($basename, self::DEFAULT_AVATAR_FOLDER));
                     $source = $upload->copyLocal($path);
-
                     $crop = new CropImageModule($this, $this->Form, $thumbnailSize, $thumbnailSize, $source);
                     $crop->setSize($thumbnailSize, $thumbnailSize);
                     $crop->setExistingCropUrl(changeBasename($avatar, "n%s"));

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -979,7 +979,7 @@ class UserModel extends Gdn_Model {
             return UserPhotoDefaultUrl($user);
         }
         if ($avatar = c('Garden.DefaultAvatar', false)) {
-            if (strpos($avatar, 'uploads/defaultavatar') !== false) {
+            if (strpos($avatar, '/defaultavatar/') !== false) {
                 if($size == 'thumbnail') {
                     return changeBasename($avatar, 'n%s');
                 } elseif ($size == 'profile') {

--- a/applications/dashboard/modules/class.cropimagemodule.php
+++ b/applications/dashboard/modules/class.cropimagemodule.php
@@ -214,10 +214,10 @@ class CropImageModule extends Gdn_Module {
 
         // Constants
         $sourceSize = getimagesize($source);
-        $form->addHidden('WidthSource', $sourceSize[0]);
-        $form->addHidden('HeightSource', $sourceSize[1]);
-        $form->addHidden('CropSizeWidth', $width);
-        $form->addHidden('CropSizeHeight', $height);
+        $form->addHidden('WidthSource', $sourceSize[0], true);
+        $form->addHidden('HeightSource', $sourceSize[1], true);
+        $form->addHidden('CropSizeWidth', $width, true);
+        $form->addHidden('CropSizeHeight', $height, true);
     }
 
     /**


### PR DESCRIPTION
Apparently paths to Vanilla's uploads don't always contain 'uploads'. Checks to see if the directory 'defaultavatar' exists, rather than 'uploads/defaultavatar'. Also forces hidden form values to update when a new avatar is uploaded.