### PR TITLE
Fix call to test regex for youtube video embeds.

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  */
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.2.100.7');
+define('APPLICATION_VERSION', '2.2.100.8');
 
 // Report and track all errors.
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);

--- a/js/global.js
+++ b/js/global.js
@@ -1228,7 +1228,7 @@ jQuery(document).ready(function($) {
 
         // Verify we have a valid videoid
         var pattern = /^[\w-]+(\?autoplay\=1)(\&start=[\w-]+)?$/;
-        if (!videoid.test(pattern)) {
+        if (!pattern.test(videoid)) {
             return false;
         }
 


### PR DESCRIPTION
The calling object and params were mixed here. The proper function calls are regexObj.test(str) (vs. str.match(regexp) ). This pr fixes broken youtube embeds.