### PR TITLE
Readd default photo value to joinUsers function.

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -952,6 +952,8 @@ class UserModel extends Gdn_Model {
                         if ($Column == 'Photo') {
                             if ($Value && !isUrl($Value)) {
                                 $Value = Gdn_Upload::url(changeBasename($Value, 'n%s'));
+                            } elseif (!$Value) {
+                                $Value = UserModel::getDefaultAvatarUrl($User);
                             }
                         }
                         setValue($Px.$Column, $Row, $Value);

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -892,6 +892,7 @@ if (!function_exists('userPhoto')) {
         $Photo = val('Photo', $User, val('PhotoUrl', $User));
         $Name = val('Name', $User);
         $Title = htmlspecialchars(val('Title', $Options, $Name));
+        $Href = url(userUrl($User));
 
         if ($FullUser && $FullUser['Banned']) {
             $Photo = c('Garden.BannedPhoto', 'http://cdn.vanillaforums.com/images/banned_large.png');
@@ -904,7 +905,6 @@ if (!function_exists('userPhoto')) {
             } else {
                 $PhotoUrl = $Photo;
             }
-            $Href = url(userUrl($User));
         } else {
             $PhotoUrl = UserModel::getDefaultAvatarUrl($User, 'thumbnail');
         }


### PR DESCRIPTION
Some views take care of possible missing avatars, some do not. This fixes a regression bug where some default avatars or vanillicons were not showing up (in conversations and activity).
Also moves placement of url variable assignment outside of if statement, so it gets assigned no matter what.