### PR TITLE
Remove json encoding from Gdn_Controller->_Definitions['ResolvedArgs']

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -694,7 +694,7 @@ class VanillaHooks implements Gdn_IPlugin {
         $Args = Gdn::request()->Post('Args');
         parse_str($Args, $Args);
         $ResolvedPath = trim(Gdn::request()->Post('ResolvedPath'), '/');
-        $ResolvedArgs = @json_decode(Gdn::request()->Post('ResolvedArgs'));
+        $ResolvedArgs = Gdn::request()->Post('ResolvedArgs');
         $DiscussionID = null;
         $DiscussionModel = new DiscussionModel();
 

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -580,9 +580,9 @@ class Gdn_Controller extends Gdn_Pluggable {
                     (isset($this->ReflectArgs['sender']) && $this->ReflectArgs['sender'] instanceof Gdn_Pluggable)
                 )
             ) {
-                $ReflectArgs = json_encode(array_slice($this->ReflectArgs, 1));
+                $ReflectArgs = array_slice($this->ReflectArgs, 1);
             } else {
-                $ReflectArgs = json_encode($this->ReflectArgs);
+                $ReflectArgs = $this->ReflectArgs;
             }
 
             $this->_Definitions['ResolvedArgs'] = $ReflectArgs;


### PR DESCRIPTION
The definition list is already json encoded. This double encoding (and
decoding) serves no purpose.