### PR TITLE
Remove jQuery UI from all controllers

### DIFF
--- a/applications/dashboard/controllers/class.logcontroller.php
+++ b/applications/dashboard/controllers/class.logcontroller.php
@@ -255,7 +255,6 @@ class LogController extends DashboardController {
         Gdn_Theme::section('Dashboard');
         $this->addJsFile('log.js');
         $this->addJsFile('jquery.expander.js');
-        $this->addJsFile('jquery-ui.js');
         $this->Form->InputPrefix = '';
     }
 

--- a/applications/dashboard/controllers/class.messagecontroller.php
+++ b/applications/dashboard/controllers/class.messagecontroller.php
@@ -140,7 +140,6 @@ class MessageController extends DashboardController {
         $this->addSideMenu('dashboard/message');
         $this->addJsFile('jquery.autosize.min.js');
         $this->addJsFile('jquery.tablednd.js');
-        $this->addJsFile('jquery-ui.js');
         $this->addJsFile('messages.js');
         $this->title(t('Messages'));
 

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -187,7 +187,6 @@ class RoleController extends DashboardController {
 
         $this->addSideMenu('dashboard/role');
         $this->addJsFile('jquery.tablednd.js');
-        $this->addJsFile('jquery-ui.js');
         $this->title(t('Roles & Permissions'));
 
         if (!$RoleID) {

--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -6267,3 +6267,23 @@ Styleguide Attachments
     transition: all 0.2s ease;
     opacity: 1;
 }
+
+/* Effects */
+
+@-webkit-keyframes highlight {
+    0% {background-color: #ff9;}
+    10% {background-color: #ff9;}
+}
+
+@keyframes highlight {
+    0% {background-color: #ff9;}
+    10% {background-color: #ff9;}
+}
+
+.highlight-effect{
+    -webkit-animation: highlight .8s;
+}
+
+.highlight-effect{
+    animation: highlight .8s;
+}

--- a/applications/vanilla/controllers/class.vanillacontroller.php
+++ b/applications/vanilla/controllers/class.vanillacontroller.php
@@ -25,7 +25,6 @@ class VanillaController extends Gdn_Controller {
         // Set up head
         $this->Head = new HeadModule($this);
         $this->addJsFile('jquery.js');
-        $this->addJsFile('jquery-ui.js');
         $this->addJsFile('jquery.livequery.js');
         $this->addJsFile('jquery.form.js');
         $this->addJsFile('jquery.popup.js');

--- a/js/global.js
+++ b/js/global.js
@@ -1922,8 +1922,8 @@ if (typeof String.prototype.trim !== 'function') {
 
 // jQuery UI .effect() replacement using CSS classes.
 jQuery.fn.effect = function(name) {
-    var that = this,
-        name = name + '-effect';
+    var that = this;
+    name = name + '-effect';
 
     return this
         .addClass(name)

--- a/js/global.js
+++ b/js/global.js
@@ -323,18 +323,6 @@ jQuery(document).ready(function($) {
     if ($.fn.handleAjaxForm)
         $('.AjaxForm').not('.Message .AjaxForm').handleAjaxForm();
 
-    // Make the highlight effect themable.
-    if ($.effects && $.effects.highlight) {
-        $.effects.highlight0 = $.effects.highlight;
-
-        $.effects.highlight = function(opts) {
-            var color = $('#HighlightColor').css('backgroundColor');
-            if (color)
-                opts.options.color = color;
-            return $.effects.highlight0.call(this, opts);
-        };
-    }
-
     // Handle ToggleMenu toggling and set up default state
     $('[class^="Toggle-"]').hide(); // hide all toggle containers
     $('.ToggleMenu a').click(function() {
@@ -1931,3 +1919,15 @@ if (typeof String.prototype.trim !== 'function') {
         return this.replace(/^\s+|\s+$/g, '');
     }
 }
+
+// jQuery UI .effect() replacement using CSS classes.
+jQuery.fn.effect = function(name) {
+    var that = this,
+        name = name + '-effect';
+
+    return this
+        .addClass(name)
+        .one('animationend webkitAnimationEnd', function () {
+            that.removeClass(name);
+        });
+};


### PR DESCRIPTION
see #3057

This replaces jQuery UIs .effect() with a shim using CSS animations and
removes the library from all controllers.