### PR TITLE
Make HTML in categories description consistent

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -159,7 +159,7 @@ class CategoriesController extends VanillaController {
             $this->setData('Category', $Category, true);
 
             $this->title(htmlspecialchars(val('Name', $Category, '')));
-            $this->Description(val('Description', $Category), true);
+            $this->description(val('Description', $Category));
 
 
             if ($Category->DisplayAs == 'Categories') {


### PR DESCRIPTION
Since HTML is already allowed in categories/all, descriptions should not be rendered as plain text inside of a category.

fixes #2435