### PR TITLE
Honor the Garden.Registration.SendConnectEmail setting

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -725,7 +725,7 @@ EOT;
                 $User['UserID'] = $UserID;
                 $this->Form->setValidationResults($UserModel->validationResults());
 
-                if ($UserID) {
+                if ($UserID && c('Garden.Registration.SendConnectEmail', false)) {
                     // Send the welcome email.
                     $UserModel->sendWelcomeEmail($UserID, '', 'Connect', array('ProviderName' => $this->Form->getFormValue('ProviderName', $this->Form->getFormValue('Provider', 'Unknown'))));
                 }


### PR DESCRIPTION
There is a code path in entry/connect that always sent the connect email instead of looking at the config setting.