### PR TITLE
Remove <br> tags around list items tags and table content tags.

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -472,7 +472,7 @@ if (!function_exists('fixnl2br')) {
      * @since 2.1
      */
     function fixnl2br($Text) {
-        $allblocks = '(?:table|dl|ul|ol|pre|blockquote|address|p|h[1-6]|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary)';
+        $allblocks = '(?:table|dl|ul|ol|pre|blockquote|address|p|h[1-6]|section|article|aside|hgroup|header|footer|nav|figure|figcaption|details|menu|summary|li|tbody|tr|td|th|thead|tbody|tfoot|col|colgroup|caption|dt|dd)';
         $Text = preg_replace('!(?:<br\s*/>){1,2}\s*(<'.$allblocks.'[^>]*>)!', "\n$1", $Text);
         $Text = preg_replace('!(</'.$allblocks.'[^>]*>)\s*(?:<br\s*/>){1,2}!', "$1\n", $Text);
         return $Text;


### PR DESCRIPTION
When formatting html posts, we add br tags in place of line endings. This also adds br tags between table html tags, which causes strange rendering. 