### PR TITLE
Tweak the behavior of sign in popups

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -769,8 +769,8 @@ EOT;
         if ($this->_RealDeliveryType != DELIVERY_TYPE_ALL && $this->deliveryType() != DELIVERY_TYPE_ALL) {
             $this->deliveryMethod(DELIVERY_METHOD_JSON);
             $this->setHeader('Content-Type', 'application/json; charset='.c('Garden.Charset', 'utf-8'));
-        } elseif ($CheckPopup) {
-            $this->addDefinition('CheckPopup', $CheckPopup);
+        } elseif ($CheckPopup || $this->data('CheckPopup')) {
+            $this->addDefinition('CheckPopup', true);
         } else {
             redirect(url($this->RedirectUrl));
         }

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ if (PHP_VERSION_ID < 50400) {
 }
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.2.100.8');
+define('APPLICATION_VERSION', '2.2.101');
 
 // Report and track all errors.
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);

--- a/js/global.js
+++ b/js/global.js
@@ -364,14 +364,14 @@ jQuery(document).ready(function($) {
     );
 
     // If a page loads with a hidden redirect url, go there after a few moments.
-    var RedirectUrl = gdn.definition('RedirectUrl', '');
-    var CheckPopup = gdn.definition('CheckPopup', '');
-    if (RedirectUrl !== '') {
-        if (CheckPopup && window.opener) {
-            window.opener.location.replace(RedirectUrl);
+    var redirectUrl = gdn.getMeta('RedirectUrl', '');
+    var checkPopup = gdn.getMeta('CheckPopup', false);
+    if (redirectUrl !== '') {
+        if (checkPopup && window.opener) {
+            window.opener.location = redirectUrl;
             window.close();
         } else {
-            document.location.replace(RedirectUrl);
+            document.location = redirectUrl;
         }
     }
 


### PR DESCRIPTION
- Allow plugins to force a popup check by using the data array.
- Use `window.location =` instead of `window.location.replace()` to maintain proper history.