### PR TITLE
Add SPAM check when editing discussions or comments

### DIFF
--- a/applications/dashboard/models/class.spammodel.php
+++ b/applications/dashboard/models/class.spammodel.php
@@ -113,14 +113,7 @@ class SpamModel extends Gdn_Pluggable {
             // If this is a discussion or a comment, it needs some special handling.
             if ($RecordType == 'Comment' || $RecordType == 'Discussion') {
                 // Grab the record ID, if available.
-                switch ($RecordType) {
-                    case 'Comment':
-                        $recordID = intval(val('CommentID', $Data, false));
-                        break;
-                    case 'Discussion':
-                        $recordID = intval(val('DiscussionID', $Data, false));
-                        break;
-                }
+                $recordID = intval(val("{$RecordType}ID", $Data));
 
                 /**
                  * If we have a valid record ID, run it through flagForReview.  This will allow us to purge existing
@@ -164,7 +157,7 @@ class SpamModel extends Gdn_Pluggable {
                 break;
             case 'Discussion':
                 $model = new DiscussionModel();
-                $row = (array)$model->getID($id);
+                $row = $model->getID($id, DATASET_TYPE_ARRAY);
 
                 /**
                  * If our discussion has more than three comments, it might be worth saving.  Hold off on deleting and
@@ -173,7 +166,7 @@ class SpamModel extends Gdn_Pluggable {
                 if ($row['CountComments'] > 3) {
                     $deleteRow = false;
                 } elseif ($row['CountComments'] > 0) {
-                    $comments = Gdn::database()->SQL()->getWhere(
+                    $comments = Gdn::database()->sql()->getWhere(
                         'Comment',
                         array('DiscussionID' => $id)
                     )->resultArray();
@@ -186,7 +179,7 @@ class SpamModel extends Gdn_Pluggable {
                 }
                 break;
             default:
-                throw NotFoundException($recordType);
+                throw notFoundException($recordType);
         }
 
         $overrideFields = array('Name', 'Body');

--- a/applications/dashboard/models/class.spammodel.php
+++ b/applications/dashboard/models/class.spammodel.php
@@ -110,9 +110,99 @@ class SpamModel extends Gdn_Pluggable {
                     break;
             }
 
-            LogModel::insert('Spam', $RecordType, $Data, $LogOptions);
+            // If this is a discussion or a comment, it needs some special handling.
+            if ($RecordType == 'Comment' || $RecordType == 'Discussion') {
+                // Grab the record ID, if available.
+                switch ($RecordType) {
+                    case 'Comment':
+                        $recordID = intval(val('CommentID', $Data, false));
+                        break;
+                    case 'Discussion':
+                        $recordID = intval(val('DiscussionID', $Data, false));
+                        break;
+                }
+
+                /**
+                 * If we have a valid record ID, run it through flagForReview.  This will allow us to purge existing
+                 * discussions and comments that have been flagged as SPAM after being edited.  If there's no valid ID,
+                 * just treat it with regular SPAM logging.
+                 */
+                if ($recordID) {
+                    self::flagForReview($RecordType, $recordID, $Data);
+                } else {
+                    LogModel::insert('Spam', $RecordType, $Data, $LogOptions);
+                }
+            } else {
+                LogModel::insert('Spam', $RecordType, $Data, $LogOptions);
+            }
         }
 
         return $Spam;
+    }
+
+    /**
+     * Insert a SPAM Queue entry for the specified record and delete the record, if possible.
+     *
+     * @param string $recordType The type of record we're flagging: Discussion or Comment.
+     * @param int $id ID of the record we're flagging.
+     * @param object|array $data Properties used for updating/overriding the record's current values.
+     *
+     * @throws Exception If an invalid record type is specified, throw an exception.
+     */
+    protected static function flagForReview($recordType, $id, $data) {
+        // We're planning to purge the spammy record.
+        $deleteRow = true;
+
+        /**
+         * We're only handling two types of content: discussions and comments.  Both need some special setup.
+         * Error out if we're not dealing with a discussion or comment.
+         */
+        switch ($recordType) {
+            case 'Comment':
+                $model = new CommentModel();
+                $row = $model->getID($id, DATASET_TYPE_ARRAY);
+                break;
+            case 'Discussion':
+                $model = new DiscussionModel();
+                $row = (array)$model->getID($id);
+
+                /**
+                 * If our discussion has more than three comments, it might be worth saving.  Hold off on deleting and
+                 * just flag it.  If we have between 0 and 3 comments, save them along with the discussion.
+                 */
+                if ($row['CountComments'] > 3) {
+                    $deleteRow = false;
+                } elseif ($row['CountComments'] > 0) {
+                    $comments = Gdn::database()->SQL()->getWhere(
+                        'Comment',
+                        array('DiscussionID' => $id)
+                    )->resultArray();
+
+                    if (!array_key_exists('_Data', $row)) {
+                        $row['_Data'] = array();
+                    }
+
+                    $row['_Data']['Comment'] = $comments;
+                }
+                break;
+            default:
+                throw NotFoundException($recordType);
+        }
+
+        $overrideFields = array('Name', 'Body');
+        foreach ($overrideFields as $fieldName) {
+            if (($fieldValue = val($fieldName, $data, false)) !== false) {
+                $row[$fieldName] = $fieldValue;
+            }
+        }
+
+        $logOptions = array('GroupBy' => array('RecordID'));
+
+        if ($deleteRow) {
+            // Remove the record to the log.
+            $model->delete($id);
+        }
+
+        LogModel::insert('Spam', $recordType, $row, $logOptions);
     }
 }

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -831,13 +831,13 @@ class CommentModel extends VanillaModel {
                 $Fields = $this->Validation->SchemaValidationFields();
                 $Fields = RemoveKeyFromArray($Fields, $this->PrimaryKey);
 
-                if ($Insert === false) {
-                    // Check for spam
-                    $Spam = SpamModel::IsSpam('Comment', $Fields);
-                    if ($Spam) {
-                        return SPAM;
-                    }
+                // Check for spam
+                $Spam = SpamModel::IsSpam('Comment', $Fields);
+                if ($Spam) {
+                    return SPAM;
+                }
 
+                if ($Insert === false) {
                     // Log the save.
                     LogModel::LogChange('Edit', 'Comment', array_merge($Fields, array('CommentID' => $CommentID)));
                     // Save the new value.
@@ -847,12 +847,6 @@ class CommentModel extends VanillaModel {
                     // Make sure that the comments get formatted in the method defined by Garden.
                     if (!val('Format', $Fields) || c('Garden.ForceInputFormatter')) {
                         $Fields['Format'] = Gdn::config('Garden.InputFormatter', '');
-                    }
-
-                    // Check for spam
-                    $Spam = SpamModel::IsSpam('Comment', $Fields);
-                    if ($Spam) {
-                        return SPAM;
                     }
 
                     // Check for approval

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -832,7 +832,7 @@ class CommentModel extends VanillaModel {
                 $Fields = RemoveKeyFromArray($Fields, $this->PrimaryKey);
 
                 // Check for spam
-                $spam = SpamModel::isSpam('Comment', $Fields);
+                $spam = SpamModel::isSpam('Comment', array_merge($Fields, array('CommentID' => $CommentID)));
                 if ($spam) {
                     return SPAM;
                 }

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -827,7 +827,7 @@ class CommentModel extends VanillaModel {
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert)) {
             // If the post is new and it validates, check for spam
-            if (!$this->CheckForSpam('Comment')) {
+            if (!$Insert || !$this->CheckForSpam('Comment')) {
                 $Fields = $this->Validation->SchemaValidationFields();
                 $Fields = RemoveKeyFromArray($Fields, $this->PrimaryKey);
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -827,11 +827,17 @@ class CommentModel extends VanillaModel {
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert)) {
             // If the post is new and it validates, check for spam
-            if (!$Insert || !$this->CheckForSpam('Comment')) {
+            if (!$this->CheckForSpam('Comment')) {
                 $Fields = $this->Validation->SchemaValidationFields();
                 $Fields = RemoveKeyFromArray($Fields, $this->PrimaryKey);
 
                 if ($Insert === false) {
+                    // Check for spam
+                    $Spam = SpamModel::IsSpam('Comment', $Fields);
+                    if ($Spam) {
+                        return SPAM;
+                    }
+
                     // Log the save.
                     LogModel::LogChange('Edit', 'Comment', array_merge($Fields, array('CommentID' => $CommentID)));
                     // Save the new value.

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -832,8 +832,8 @@ class CommentModel extends VanillaModel {
                 $Fields = RemoveKeyFromArray($Fields, $this->PrimaryKey);
 
                 // Check for spam
-                $Spam = SpamModel::IsSpam('Comment', $Fields);
-                if ($Spam) {
+                $spam = SpamModel::isSpam('Comment', $Fields);
+                if ($spam) {
                     return SPAM;
                 }
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1629,8 +1629,8 @@ class DiscussionModel extends VanillaModel {
                 $Fields = $this->Validation->schemaValidationFields();
 
                 // Check for spam.
-                $Spam = SpamModel::isSpam('Discussion', $Fields);
-                if ($Spam) {
+                $spam = SpamModel::isSpam('Discussion', $Fields);
+                if ($spam) {
                     return SPAM;
                 }
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1628,6 +1628,12 @@ class DiscussionModel extends VanillaModel {
                 // Get all fields on the form that relate to the schema
                 $Fields = $this->Validation->schemaValidationFields();
 
+                // Check for spam.
+                $Spam = SpamModel::isSpam('Discussion', $Fields);
+                if ($Spam) {
+                    return SPAM;
+                }
+
                 // Get DiscussionID if one was sent
                 $DiscussionID = intval(val('DiscussionID', $Fields, 0));
 
@@ -1636,12 +1642,6 @@ class DiscussionModel extends VanillaModel {
                 $StoredCategoryID = false;
 
                 if ($DiscussionID > 0) {
-                    // Check for spam.
-                    $Spam = SpamModel::isSpam('Discussion', $Fields);
-                    if ($Spam) {
-                        return SPAM;
-                    }
-
                     // Updating
                     $Stored = $this->getID($DiscussionID, DATASET_TYPE_OBJECT);
 
@@ -1681,12 +1681,6 @@ class DiscussionModel extends VanillaModel {
 
                     if (c('Vanilla.QueueNotifications')) {
                         $Fields['Notified'] = ActivityModel::SENT_PENDING;
-                    }
-
-                    // Check for spam.
-                    $Spam = SpamModel::isSpam('Discussion', $Fields);
-                    if ($Spam) {
-                        return SPAM;
                     }
 
                     // Check for approval

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1636,6 +1636,12 @@ class DiscussionModel extends VanillaModel {
                 $StoredCategoryID = false;
 
                 if ($DiscussionID > 0) {
+                    // Check for spam.
+                    $Spam = SpamModel::isSpam('Discussion', $Fields);
+                    if ($Spam) {
+                        return SPAM;
+                    }
+
                     // Updating
                     $Stored = $this->getID($DiscussionID, DATASET_TYPE_OBJECT);
 

--- a/applications/vanilla/views/post/spam.php
+++ b/applications/vanilla/views/post/spam.php
@@ -5,10 +5,11 @@ echo $this->Form->close();
 ?>
 <div class="Info">
     <?php
-    if ($this->RequestMethod == 'discussion')
+    if ($this->RequestMethod == 'discussion' || $this->RequestMethod == 'editdiscussion') {
         $Message = t('DiscussionRequiresApproval', "Your discussion will appear after it is approved.");
-    else
+    } else {
         $Message = t('CommentRequiresApproval', "Your comment will appear after it is approved.");
+    }
     echo '<div>', $Message, '</div>';
 
     if ($this->data('DiscussionUrl'))


### PR DESCRIPTION
When comments or discussions are edited, they aren't passed through the SPAM filter.  This means there is a very real possibility a spammer could create a legitimate discussion, have it pass the SPAM filter, then go back and edit it with something that wouldn't have been able to pass in the first place.

The SpamModel::IsSpam blocks for discussions and comments have been moved above the insert- and update-specific routines, so it should be able to hit them both.

The $this->CheckForSpam condition is not used in this fix, because it is not pluggable. SpamModel::IsSpam uses a handy CheckSpam event, so plug-ins like Akismet can do their thing.