### PR TITLE
Fixes the dashboard's "edit user" so it populates

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -241,7 +241,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         $this->ProfileFields = $this->getProfileFields();
 
         // Get user-specific data
-        $this->UserFields = Gdn::userModel()->GetMeta($Sender->data("User.UserID"), 'Profile.%', 'Profile.');
+        $this->UserFields = Gdn::UserModel()->GetMeta($Sender->User->UserID, 'Profile.%', 'Profile.');
 
         // Fill in user data on form
         foreach ($this->UserFields as $Field => $Value) {


### PR DESCRIPTION
The dashboard's "edit user" wasn't prepopulating with the information saved from additional custom fields when using ProfileExtender to add that additional profile information on the profile page.