### PR TITLE
Move Markdown customizations out of vendor

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1478,9 +1478,10 @@ EOT;
      * Format a string using Markdown syntax. Also purifies the output html.
      *
      * @param mixed $Mixed An object, array, or string to be formatted.
+     * @param boolean $Flavored Optional. Parse with Vanilla-flavored settings? Default true
      * @return string
      */
-    public static function markdown($Mixed) {
+    public static function markdown($Mixed, $Flavored = true) {
         if (!is_string($Mixed)) {
             return self::to($Mixed, 'Markdown');
         } else {
@@ -1489,7 +1490,14 @@ EOT;
                 return Gdn_Format::display($Mixed);
             } else {
                 require_once(PATH_LIBRARY.'/vendors/markdown/Michelf/MarkdownExtra.inc.php');
-                $Mixed = \Michelf\MarkdownExtra::defaultTransform($Mixed);
+                $Markdown = new MarkdownVanilla;
+
+                // Add Vanilla customizations.
+                if ($Flavored) {
+                    $Markdown->addAllFlavor();
+                }
+
+                $Mixed = $Markdown->transform($Mixed);
                 $Mixed = $Formatter->format($Mixed);
                 $Mixed = Gdn_Format::links($Mixed);
                 $Mixed = Gdn_Format::mentions($Mixed);
@@ -1616,7 +1624,7 @@ EOT;
 
     /**
      * Do a preg_replace, but don't affect things inside <code> tags.
-     * 
+     *
      * The three parameters are identical to the ones you'd pass
      * preg_replace.
      *

--- a/library/core/class.markdownvanilla.php
+++ b/library/core/class.markdownvanilla.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * @copyright 2009-2015 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+/**
+ * Vanilla Markdown Override
+ *
+ * This class extends the Markdown vendor library to add some optional
+ * customizations to the rendering process.
+ *
+ * @author Tim Gunter <tim@vanillaforums.com>
+ * @package core
+ * @since 2.2
+ */
+class MarkdownVanilla extends \Michelf\MarkdownExtra {
+
+    /**
+     * Add all Vanilla customizations to markdown parsing
+     *
+     * @return void
+     */
+    public function addAllFlavor() {
+        $this->addStrikeout();
+        $this->addBreaks();
+        $this->addSpoilers();
+    }
+
+    /**
+     * Add soft breaks to markdown parsing
+     *
+     * @return void
+     */
+    public function addBreaks() {
+        $this->span_gamut = array_replace($this->span_gamut, [
+            "doStrikeout" 			 =>  15,
+            "doSoftBreaks" => 80
+        ]);
+    }
+
+    /**
+     * Add strikeouts to markdown parsing
+     *
+     * @return void
+     */
+    public function addStrikeout() {
+        $this->span_gamut = array_replace($this->span_gamut, [
+            "doStrikeout" => 15
+        ]);
+    }
+
+    /**
+     * Add spoilers to markdown parsing
+     *
+     * @return void
+     */
+    public function addSpoilers() {
+        $this->block_gamut = array_replace($this->block_gamut, [
+            "doSpoilers" => 55
+        ]);
+    }
+
+    /**
+     * Add Spoilers implementation (3 methods).
+     *
+     * @param string $text
+     * @return string
+     */
+	protected function doSpoilers($text) {
+		$text = preg_replace_callback('/
+			  (								# Wrap whole match in $1
+				(?>
+				  ^[ ]*>![ ]?			# ">" at the start of a line
+					.+\n					# rest of the first line
+				  \n*						# blanks
+				)+
+			  )
+			/xm',
+			array(&$this, '_doSpoilers_callback'), $text);
+
+		return $text;
+	}
+	protected function _doSpoilers_callback($matches) {
+		$bq = $matches[1];
+		# trim one level of quoting - trim whitespace-only lines
+		$bq = preg_replace('/^[ ]*>![ ]?|^[ ]+$/m', '', $bq);
+		$bq = $this->runBlockGamut($bq);		# recurse
+
+		$bq = preg_replace('/^/m', "  ", $bq);
+		# These leading spaces cause problem with <pre> content,
+		# so we need to fix that:
+		$bq = preg_replace_callback('{(\s*<pre>.+?</pre>)}sx',
+			array(&$this, '_doSpoilers_callback2'), $bq);
+
+		return "\n". $this->hashBlock("<div class=\"Spoiler\">\n$bq\n</div>")."\n\n";
+	}
+	protected function _doSpoilers_callback2($matches) {
+		$pre = $matches[1];
+		$pre = preg_replace('/^  /m', '', $pre);
+		return $pre;
+	}
+
+    /**
+     * Add Strikeout implementation (2 methods).
+     *
+     * @param string $text
+     * @return string
+     */
+	protected function doStrikeout($text) {
+		$text = preg_replace_callback('/
+		~~ # open
+		(.+?) # $1 = strike text
+		~~ # close
+		/xm',
+		array($this, '_doStrikeout_callback'), $text);
+		return $text;
+	}
+	protected function _doStrikeout_callback($matches) {
+		return $this->hashPart("<s>".$this->runSpanGamut($matches[1])."</s>");
+	}
+
+    /**
+     * Add soft line breaks implementation (2 methods).
+     *
+     * @param string $text
+     * @return string
+     */
+	protected function doSoftBreaks($text) {
+		# Do soft line breaks for 1 return:
+		return preg_replace_callback('/\n{1}/',
+			array($this, '_doSoftBreaks_callback'), $text);
+	}
+	protected function _doSoftBreaks_callback($matches) {
+		return $this->hashPart("<br$this->empty_element_suffix\n");
+	}
+
+}

--- a/library/vendors/markdown/Michelf/Markdown.php
+++ b/library/vendors/markdown/Michelf/Markdown.php
@@ -1,4 +1,15 @@
 <?php
+
+#
+#
+#           DO NOT UPDATE THIS FILE
+#           DO NOT BRING IN A NEW VERSION OF THIS LIBRARY
+#           VANILLA CHANGES WILL BE LOST
+#
+#           Please see /library/core/class.markdownvanilla.php
+#
+#
+
 #
 # Markdown  -  A text-to-HTML conversion tool for web writers
 #

--- a/library/vendors/markdown/Michelf/Markdown.php
+++ b/library/vendors/markdown/Michelf/Markdown.php
@@ -413,9 +413,6 @@ class Markdown implements MarkdownInterface {
 		"doLists"           => 40,
 		"doCodeBlocks"      => 50,
 		"doBlockQuotes"     => 60,
-
-		# Vanilla: add Spoilers
-		"doSpoilers"        => 55,
 		);
 
 	protected function runBlockGamut($text) {
@@ -488,11 +485,7 @@ class Markdown implements MarkdownInterface {
 		"encodeAmpsAndAngles" =>  40,
 
 		"doItalicsAndBold"    =>  50,
-		"doHardBreaks"        =>  60,
-
-		# Vanilla: add strikeout and soft breaks.
-		"doStrikeout" 			 =>  15,
-		"doSoftBreaks" 		 =>  80,
+		"doHardBreaks"        =>  60
 		);
 
 	protected function runSpanGamut($text) {
@@ -3159,65 +3152,6 @@ abstract class _MarkdownExtra_TmpImpl extends \Michelf\Markdown {
 		} else {
 			return $matches[0];
 		}
-	}
-
-	# Vanilla: add Spoilers implementation (3 methods).
-	function doSpoilers($text) {
-		$text = preg_replace_callback('/
-			  (								# Wrap whole match in $1
-				(?>
-				  ^[ ]*>![ ]?			# ">" at the start of a line
-					.+\n					# rest of the first line
-				  \n*						# blanks
-				)+
-			  )
-			/xm',
-			array(&$this, '_doSpoilers_callback'), $text);
-
-		return $text;
-	}
-	function _doSpoilers_callback($matches) {
-		$bq = $matches[1];
-		# trim one level of quoting - trim whitespace-only lines
-		$bq = preg_replace('/^[ ]*>![ ]?|^[ ]+$/m', '', $bq);
-		$bq = $this->runBlockGamut($bq);		# recurse
-
-		$bq = preg_replace('/^/m', "  ", $bq);
-		# These leading spaces cause problem with <pre> content,
-		# so we need to fix that:
-		$bq = preg_replace_callback('{(\s*<pre>.+?</pre>)}sx',
-			array(&$this, '_doSpoilers_callback2'), $bq);
-
-		return "\n". $this->hashBlock("<div class=\"Spoiler\">\n$bq\n</div>")."\n\n";
-	}
-	function _doSpoilers_callback2($matches) {
-		$pre = $matches[1];
-		$pre = preg_replace('/^  /m', '', $pre);
-		return $pre;
-	}
-
-	# Vanilla: add Strikeout implementation (2 methods).
-	protected function doStrikeout($text) {
-		$text = preg_replace_callback('/
-		~~ # open
-		(.+?) # $1 = strike text
-		~~ # close
-		/xm',
-		array($this, '_doStrikeout_callback'), $text);
-		return $text;
-	}
-	protected function _doStrikeout_callback($matches) {
-		return $this->hashPart("<s>".$this->runSpanGamut($matches[1])."</s>");
-	}
-
-	# Vanilla: add soft line breaks implementation (2 methods).
-	protected function doSoftBreaks($text) {
-		# Do soft line breaks for 1 return:
-		return preg_replace_callback('/\n{1}/',
-			array($this, '_doSoftBreaks_callback'), $text);
-	}
-	protected function _doSoftBreaks_callback($matches) {
-		return $this->hashPart("<br$this->empty_element_suffix\n");
 	}
 
 }


### PR DESCRIPTION
This PR moves most of the Vanilla Markdown customizations to a new class that extends the library. It also adds a flag to Gdn_Format::Markdown() to allow call-time toggling of these rules.