### PR TITLE
Cleanup the API access for role/get

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -116,6 +116,26 @@ class RoleModel extends Gdn_Model {
     }
 
     /**
+     * Get the category specific permissions for a role.
+     *
+     * @param int $roleID The ID of the role to get the permissions for.
+     * @return array Returns an array of permissions.
+     */
+    public function getCategoryPermissions($roleID) {
+        $permissions = Gdn::permissionModel()->getJunctionPermissions(['RoleID' => $roleID], 'Category');
+        $result = [];
+
+        foreach ($permissions as $perm) {
+            $row = ['CategoryID' => $perm['JunctionID']];
+            unset($perm['Name'], $perm['JunctionID'], $perm['JunctionTable'], $perm['JunctionColumn']);
+            $row += $perm;
+            $result[] = $row;
+        }
+
+        return $result;
+    }
+
+    /**
      * Get all of the roles including their ranking permissions.
      *
      * @return Gdn_DataSet Returns all of the roles with the ranking permissions.


### PR DESCRIPTION
Add some additional information when getting a single role as data.

- Return the role as a single “Role” key in the data array.
- Add the role’s permissions to the result.