### PR TITLE
Enhance the role/add and role/edit endpoints for API access

### DIFF
--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -164,6 +164,11 @@ class RoleController extends DashboardController {
             // If the form has been posted back...
             // 2. Save the data (validation occurs within):
             if ($RoleID = $this->Form->save()) {
+                if ($this->deliveryType() === DELIVERY_TYPE_DATA) {
+                    $this->index($RoleID);
+                    return;
+                }
+
                 $this->informMessage(t('Your changes have been saved.'));
                 $this->RedirectUrl = url('dashboard/role');
                 // Reload the permission data.


### PR DESCRIPTION
- Allow permissions to be set in an optional “Permissions” key.
- Return a more API-friendly role after adding/editing a role via API.