### PR TITLE
Formalize CSS anchor list event hook, fix utility/css comments

### DIFF
--- a/applications/dashboard/controllers/class.utilitycontroller.php
+++ b/applications/dashboard/controllers/class.utilitycontroller.php
@@ -31,14 +31,15 @@ class UtilityController extends DashboardController {
     );
 
     /**
-     * Gather all of the global styles together.
-     * @param string ThemeType Either `desktop` or `mobile`.
-     * @param string $Filename The basename of the file to
+     * Serve combined CSS assets
+     *
+     * @param string $themeType Either `desktop` or `mobile`.
+     * @param string $filename The basename of the file to serve
      * @since 2.1
      */
-    public function css($ThemeType, $Filename) {
-        $AssetModel = new AssetModel();
-        $AssetModel->ServeCss($ThemeType, $Filename);
+    public function css($themeType, $filename) {
+        $assetModel = new AssetModel();
+        $assetModel->serveCss($themeType, $filename);
     }
 
     /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1675,10 +1675,9 @@ class Gdn_Controller extends Gdn_Pluggable {
             // Only get css & ui components if this is NOT a syndication request
             if ($this->SyndicationMethod == SYNDICATION_NONE && is_object($this->Head)) {
 
-                $CssAnchors = ['style.css', 'admin.css'];
+                $CssAnchors = AssetModel::getAnchors();
 
                 $this->EventArguments['CssFiles'] = &$this->_CssFiles;
-                $this->EventArguments['CssAnchors'] = &$CssAnchors;
                 $this->fireEvent('BeforeAddCss');
 
                 $ETag = AssetModel::eTag();


### PR DESCRIPTION
This allows the list of files that can trigger CSS combining to be hooked and modified, thereby allowing different applications to create their own unique lists of combined files.