### PR TITLE
Force setting transient key cookie.

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -470,9 +470,13 @@ class Gdn_Session {
      */
     public function ensureTransientKey() {
         if (!$this->_TransientKey) {
+            // Check cookie
+            $this->_TransientKey = getAppCookie('tk');
+        }
+        if (!$this->_TransientKey) {
             // Generate a transient key in the browser.
             $tk = substr(md5(microtime()), 0, 16);
-            setAppCookie('tk', $tk, 0, true);
+            setAppCookie('tk', $tk);
             $this->_TransientKey = $tk;
         }
         return $this->_TransientKey;

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -470,6 +470,10 @@ class Gdn_Session {
      */
     public function ensureTransientKey() {
         if (!$this->_TransientKey) {
+            // Check cookie
+            $this->_TransientKey = getAppCookie('tk');
+        }
+        if (!$this->_TransientKey) {
             // Generate a transient key in the browser.
             $tk = substr(md5(microtime()), 0, 16);
             setAppCookie('tk', $tk);

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -470,13 +470,9 @@ class Gdn_Session {
      */
     public function ensureTransientKey() {
         if (!$this->_TransientKey) {
-            // Check cookie
-            $this->_TransientKey = getAppCookie('tk');
-        }
-        if (!$this->_TransientKey) {
             // Generate a transient key in the browser.
             $tk = substr(md5(microtime()), 0, 16);
-            setAppCookie('tk', $tk);
+            setAppCookie('tk', $tk, 0, true);
             $this->_TransientKey = $tk;
         }
         return $this->_TransientKey;


### PR DESCRIPTION
Force setting the transient key in the cookie to ensure the session class property and cookie are the same.