### PR TITLE
Rename “Delete Conversation” to “Leave Conversation”

### DIFF
--- a/applications/conversations/js/conversations.js
+++ b/applications/conversations/js/conversations.js
@@ -1,11 +1,6 @@
 // This file contains javascript that is specific to the dashboard/profile controller.
 jQuery(document).ready(function($) {
 
-   $('a.ClearConversation').popup({
-      confirm: true,
-      followConfirm: false
-   });
-
    // Hijack "add message" clicks and handle via ajax...
    $.fn.handleMessageForm = function() {
       this.click(function() {

--- a/applications/conversations/views/modules/clearhistory.php
+++ b/applications/conversations/views/modules/clearhistory.php
@@ -1,3 +1,3 @@
 <?php if (!defined('APPLICATION')) exit();
 if ($this->ConversationID > 0)
-    echo anchor(t('Delete Conversation'), '/messages/clear/'.$this->ConversationID.'/'.Gdn::session()->TransientKey(), 'Button Danger BigButton ClearConversation');
+    echo anchor(t('Leave Conversation'), '/messages/leave/'.$this->ConversationID, 'Button Danger BigButton Popup');


### PR DESCRIPTION
Users don’t really delete conversations so the wording was confusing. This change also moves the confirmation into a proper postback rather than a GET request that validates the CSRF token.