### PR TITLE
Return full url to to the default default avatar.

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -990,7 +990,7 @@ class UserModel extends Gdn_Model {
             }
             return $avatar;
         }
-        return 'applications/dashboard/design/images/defaulticon.png';
+        return url('applications/dashboard/design/images/defaulticon.png', true);
     }
 
     /**


### PR DESCRIPTION
In UserModel::joinUsers(), the default avatar is attached to a user if they don't have one. Later, in the userPhoto function, the basename of a user's avatar is changed if it's not a url. This PR changes the return value of the default default avatar from a relative path to a full url, so the basename does not get changed.
Fixes a bug where the default default avatar is a broken image.