### PR TITLE
Use a different method to generate random strings

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3692,7 +3692,7 @@ class UserModel extends Gdn_Model {
      * @return string
      */
     public function setTransientKey($UserID, $ExplicitKey = '') {
-        $Key = $ExplicitKey == '' ? RandomString(12) : $ExplicitKey;
+        $Key = $ExplicitKey == '' ? betterRandomString(16, 'Aa0') : $ExplicitKey;
         $this->saveAttribute($UserID, 'TransientKey', $Key);
         return $Key;
     }

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -138,6 +138,7 @@ class Gdn_Session {
         $Authenticator->authenticateWith()->deauthenticate();
         $this->setCookie('-Vv', null, -3600);
         $this->setCookie('-sid', null, -3600);
+        $this->setCookie('-tk', null, -3600);
 
         Gdn::PluginManager()->CallEventHandlers($this, 'Gdn_Session', 'End');
 
@@ -471,7 +472,7 @@ class Gdn_Session {
     public function ensureTransientKey() {
         if (!$this->_TransientKey) {
             // Generate a transient key in the browser.
-            $tk = substr(md5(microtime()), 0, 16);
+            $tk = betterRandomString(16, 'Aa0');
             setAppCookie('tk', $tk);
             $this->_TransientKey = $tk;
         }


### PR DESCRIPTION
Change to a better random string method for transient keys. Also, expire the transient key cookie on sign out.