### PR TITLE
Move the form filtering routine in entry/connect

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -398,6 +398,7 @@ EOT;
         // Filter the form data for users here. SSO plugins must reset validated data each postback.
         $filteredData = Gdn::userModel()->filterForm($currentData, true);
         $filteredData = array_replace($filteredData, arrayTranslate($currentData, ['TransientKey', 'hpt']));
+        unset($filteredData['Roles'], $filteredData['RoleID']);
         $this->Form->formValues($filteredData);
 
         try {


### PR DESCRIPTION
Move the form filtering to an earlier spot in entry/connect in order to take some of the responsibility off of individual SSO plugins.