### PR TITLE
Fix invalid IP address being recorded & submitted to antispam services

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -445,7 +445,8 @@ class Gdn_Request {
 
                 // Fallback
             } else {
-                $IP = $_SERVER['REMOTE_ADDR'];
+                $IPs = explode(',', $_SERVER['REMOTE_ADDR']);
+                $IP = trim($IPs[0]);
             }
         }
 

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -445,15 +445,14 @@ class Gdn_Request {
 
                 // Fallback
             } else {
-                $IPs = explode(',', $_SERVER['REMOTE_ADDR']);
-                $IP = trim($IPs[0]);
-            }
-        }
+                $remoteAddr = val('REMOTE_ADDR', $_SERVER);
 
-        // Varnish
-        $OriginalIP = val('HTTP_X_ORIGINALLY_FORWARDED_FOR', $_SERVER, null);
-        if (!is_null($OriginalIP)) {
-            $IP = $OriginalIP;
+                if (strpos($remoteAddr, ',') !== false) {
+                    $remoteAddr = substr($remoteAddr, 0, strpos($remoteAddr, ','));
+                }
+
+                $IP = $remoteAddr;
+            }
         }
 
         $IP = forceIPv4($IP);


### PR DESCRIPTION
There were certain situations where Gdn_Request would incorrectly grab a user's IP address, having a comma (and possibly a space) appended to it.  A couple of possible scenarios have been identified that may be responsible:

* X-Originally-Forwarded-For is sent along with the request and contains a comma in its value.  Reading this value happened to fall after the current multi-value IP list check and overwrote whatever value had been established for the IP address up to that point.  After discussing with Tim, I've purged this code, since it is no longer needed.
* The fallback is met when trying to determine the value to use for the request's IP address.  If this value happened to contain a comma-separated list, it was passed along without further processing.  I've added a check to see if a comma is present and, if it is, only grab the first value from the comma-separated list.