### PR TITLE
Fix the default avatar URL

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -994,7 +994,7 @@ class UserModel extends Gdn_Model {
             }
             return $avatar;
         }
-        return url('applications/dashboard/design/images/defaulticon.png', true);
+        return asset('applications/dashboard/design/images/defaulticon.png', true);
     }
 
     /**


### PR DESCRIPTION
Static files must be enclosed in `asset()`, not `url()`.