### PR TITLE
Add Target redirect support to NewDiscussion module when guest access is enabled

### DIFF
--- a/applications/vanilla/modules/class.newdiscussionmodule.php
+++ b/applications/vanilla/modules/class.newdiscussionmodule.php
@@ -32,7 +32,7 @@ class NewDiscussionModule extends Gdn_Module {
     public $ShowGuests = false;
 
     /** @var string Where to send users without permission when $SkipPermissions is enabled. */
-    public $GuestUrl = '/entry/signin?Target=';
+    public $GuestUrl = '/entry/signin';
 
     /**
      * Set default button.
@@ -115,9 +115,9 @@ class NewDiscussionModule extends Gdn_Module {
                 $Url .= '/'.rawurlencode(val('UrlCode', $Category));
             }
 
-            // Present a signin redirect for a $PrivilegedGuest using GuestUrl's Target parameter.
+            // Present a signin redirect for a $PrivilegedGuest.
             if (!$HasPermission) {
-                $Url = $this->GuestUrl . $Url;
+                $Url = $this->GuestUrl . '?Target=' . $Url;
             }
 
             $this->addButton(t(val('AddText', $Type)), $Url);

--- a/applications/vanilla/modules/class.newdiscussionmodule.php
+++ b/applications/vanilla/modules/class.newdiscussionmodule.php
@@ -32,7 +32,7 @@ class NewDiscussionModule extends Gdn_Module {
     public $ShowGuests = false;
 
     /** @var string Where to send users without permission when $SkipPermissions is enabled. */
-    public $GuestUrl = '/entry/register';
+    public $GuestUrl = '/entry/register?Target=';
 
     /**
      * Set default button.
@@ -81,7 +81,7 @@ class NewDiscussionModule extends Gdn_Module {
         Gdn::controller()->fireEvent('BeforeNewDiscussionButton');
 
         // Make sure the user has the most basic of permissions first.
-        $PermissionCategory = CategoryModel::PermissionCategory($this->CategoryID);
+        $PermissionCategory = CategoryModel::permissionCategory($this->CategoryID);
         if ($this->CategoryID) {
             $Category = CategoryModel::categories($this->CategoryID);
             $HasPermission = Gdn::session()->checkPermission('Vanilla.Discussions.Add', true, 'Category', val('CategoryID', $PermissionCategory));
@@ -98,7 +98,7 @@ class NewDiscussionModule extends Gdn_Module {
         }
 
         // Grab the allowed discussion types.
-        $DiscussionTypes = CategoryModel::AllowedDiscussionTypes($PermissionCategory);
+        $DiscussionTypes = CategoryModel::allowedDiscussionTypes($PermissionCategory);
 
         foreach ($DiscussionTypes as $Key => $Type) {
             if (isset($Type['AddPermission']) && !Gdn::session()->checkPermission($Type['AddPermission'])) {
@@ -107,16 +107,17 @@ class NewDiscussionModule extends Gdn_Module {
             }
 
             // If user !$HasPermission, they are $PrivilegedGuest so redirect to $GuestUrl.
-            $Url = ($HasPermission) ? val('AddUrl', $Type) : $this->GuestUrl;
+            $Url = ($HasPermission) ? val('AddUrl', $Type) : $this->GuestUrl.val('AddUrl', $Type);
+
             if (!$Url) {
                 continue;
             }
 
-            if (isset($Category) && $HasPermission) {
+            if (isset($Category)) {
                 $Url .= '/'.rawurlencode(val('UrlCode', $Category));
             }
 
-            $this->AddButton(t(val('AddText', $Type)), $Url);
+            $this->addButton(t(val('AddText', $Type)), $Url);
         }
 
         // Add QueryString to URL if one is defined.
@@ -126,6 +127,6 @@ class NewDiscussionModule extends Gdn_Module {
             }
         }
 
-        return parent::ToString();
+        return parent::toString();
     }
 }

--- a/applications/vanilla/modules/class.newdiscussionmodule.php
+++ b/applications/vanilla/modules/class.newdiscussionmodule.php
@@ -32,7 +32,7 @@ class NewDiscussionModule extends Gdn_Module {
     public $ShowGuests = false;
 
     /** @var string Where to send users without permission when $SkipPermissions is enabled. */
-    public $GuestUrl = '/entry/register?Target=';
+    public $GuestUrl = '/entry/signin?Target=';
 
     /**
      * Set default button.

--- a/applications/vanilla/modules/class.newdiscussionmodule.php
+++ b/applications/vanilla/modules/class.newdiscussionmodule.php
@@ -106,15 +106,18 @@ class NewDiscussionModule extends Gdn_Module {
                 continue;
             }
 
-            // If user !$HasPermission, they are $PrivilegedGuest so redirect to $GuestUrl.
-            $Url = ($HasPermission) ? val('AddUrl', $Type) : $this->GuestUrl.val('AddUrl', $Type);
-
+            $Url = val('AddUrl', $Type);
             if (!$Url) {
                 continue;
             }
 
             if (isset($Category)) {
                 $Url .= '/'.rawurlencode(val('UrlCode', $Category));
+            }
+
+            // Present a signin redirect for a $PrivilegedGuest using GuestUrl's Target parameter.
+            if (!$HasPermission) {
+                $Url = $this->GuestUrl . $Url;
             }
 
             $this->addButton(t(val('AddText', $Type)), $Url);

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -72,19 +72,20 @@ $this->fireEvent('BeforeCommentForm');
                         if ($NewOrDraft)
                             echo ' '.anchor(t('Save Draft'), '#', 'Button DraftButton')."\n";
                     }
-                    if ($Session->isValid())
+                    if ($Session->isValid()) {
                         echo $this->Form->button($Editing ? 'Save Comment' : 'Post Comment', $ButtonOptions);
+                    }
                     else {
                         $AllowSigninPopup = c('Garden.SignIn.Popup');
                         $Attributes = array('tabindex' => '-1');
-                        if (!$AllowSigninPopup)
+                        if (!$AllowSigninPopup) {
                             $Attributes['target'] = '_parent';
-
+                        }
                         $AuthenticationUrl = SignInUrl($this->SelfUrl);
                         $CssClass = 'Button Primary Stash';
-                        if ($AllowSigninPopup)
+                        if ($AllowSigninPopup) {
                             $CssClass .= ' SignInPopup';
-
+                        }
                         echo anchor(t('Comment As ...'), $AuthenticationUrl, $CssClass, $Attributes);
                     }
 


### PR DESCRIPTION
Instead of just sending user to /entry/register, the NewDiscussion button will now remember where they were trying to go so they can go back there afterward.