### PR TITLE
Fix /utility/structure pollution in the Google+ plugin

### DIFF
--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -231,7 +231,9 @@ class GooglePlusPlugin extends Gdn_Plugin {
      *
      */
     public function structure() {
-        Gdn::sql()->put('UserAuthenticationProvider', array('AuthenticationSchemeAlias' => self::ProviderKey), array('AuthenticationSchemeAlias' => 'Google+'));
+        if (Gdn::sql()->getWhere('UserAuthenticationProvider', array('AuthenticationSchemeAlias' => 'Google+'))->firstRow()) {
+            Gdn::sql()->put('UserAuthenticationProvider', array('AuthenticationSchemeAlias' => self::ProviderKey), array('AuthenticationSchemeAlias' => 'Google+'));
+        }
 
         // Save the google+ provider type.
         Gdn::sql()->replace(


### PR DESCRIPTION
Wrap an update statement around a db check so that it doesn’t show up in /utility/structure all the time.