### PR TITLE
Promoted Content: Change excerpt formatting.

### DIFF
--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -87,7 +87,7 @@ if (!function_exists('WritePromotedContent')):
                 class="Title"><?php echo anchor(Gdn_Format::text(sliceString($Content['Name'], $Sender->TitleLimit), false), $ContentURL, 'DiscussionLink'); ?></div>
             <div class="Body">
                 <?php
-                echo anchor(sliceString(Gdn_Format::PlainText($Content['Body']), $Sender->BodyLimit), $ContentURL, 'BodyLink');
+                echo anchor(htmlspecialchars(sliceString(Gdn_Format::PlainText($Content['Body']), $Sender->BodyLimit), $ContentURL, 'BodyLink'));
                 $Sender->fireEvent('AfterPromotedBody'); // separate event to account for less space.
                 ?>
             </div>

--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -87,7 +87,7 @@ if (!function_exists('WritePromotedContent')):
                 class="Title"><?php echo anchor(Gdn_Format::text(sliceString($Content['Name'], $Sender->TitleLimit), false), $ContentURL, 'DiscussionLink'); ?></div>
             <div class="Body">
                 <?php
-                echo anchor(strip_tags(Gdn_Format::to(sliceString($Content['Body'], $Sender->BodyLimit), $Content['Format'])), $ContentURL, 'BodyLink');
+                echo anchor(sliceString(Gdn_Format::PlainText($Content['Body']), $Sender->BodyLimit), $ContentURL, 'BodyLink');
                 $Sender->fireEvent('AfterPromotedBody'); // separate event to account for less space.
                 ?>
             </div>


### PR DESCRIPTION
Slicing before stripping tags results in some tags being sliced and therefore, not stripped. This fixes a bug where tags were showing up in promoted content excerpts.