### PR TITLE
Fix configuration file creation and saving

### DIFF
--- a/applications/dashboard/controllers/class.setupcontroller.php
+++ b/applications/dashboard/controllers/class.setupcontroller.php
@@ -269,7 +269,7 @@ class SetupController extends DashboardController {
         // Make sure that the correct filesystem permissions are in place
         $PermissionProblem = false;
 
-        // Make sure the appropriate folders are writeable.
+        // Make sure the appropriate folders are writable.
         $ProblemDirectories = array();
         if (!is_readable(PATH_CONF) || !IsWritable(PATH_CONF)) {
             $ProblemDirectories[] = PATH_CONF;
@@ -296,21 +296,26 @@ class SetupController extends DashboardController {
             $this->Form->addError($PermissionError.$PermissionHelp);
         }
 
-        // Make sure the config folder is writeable
+        // Make sure the config folder is writable.
         if (!$PermissionProblem) {
             $ConfigFile = Gdn::config()->DefaultPath();
-            if (!file_exists($ConfigFile)) {
-                file_put_contents($ConfigFile, '');
-            }
 
-            // Make sure the config file is writeable
-            if (!is_readable($ConfigFile) || !IsWritable($ConfigFile)) {
-                $this->Form->addError(sprintf(t('Your configuration file does not have the correct permissions. PHP needs to be able to read and write to this file: <code>%s</code>'), $ConfigFile));
-                $PermissionProblem = true;
+            if (file_exists($ConfigFile)) {
+                // Make sure the config file is writable.
+                if (!is_readable($ConfigFile) || !IsWritable($ConfigFile)) {
+                    $this->Form->addError(sprintf(t('Your configuration file does not have the correct permissions. PHP needs to be able to read and write to this file: <code>%s</code>'), $ConfigFile));
+                    $PermissionProblem = true;
+                }
+            } else {
+                // Make sure the config file can be created.
+                if (!is_writeable(dirname($ConfigFile))) {
+                    $this->Form->addError(sprintf(t('Your configuration file cannot be created. PHP needs to be able to create this file: <code>%s</code>'), $ConfigFile));
+                    $PermissionProblem = true;
+                }
             }
         }
 
-        // Make sure the cache folder is writeable
+        // Make sure the cache folder is writable
         if (!$PermissionProblem) {
             if (!file_exists(PATH_CACHE.'/Smarty')) {
                 mkdir(PATH_CACHE.'/Smarty');

--- a/library/core/class.configuration.php
+++ b/library/core/class.configuration.php
@@ -995,11 +995,6 @@ class Gdn_ConfigurationSource extends Gdn_Pluggable {
             }
         }
 
-        // If we're not loading config from cache, check that the file exists
-        if (!$LoadedFromCache && !file_exists($File)) {
-            return false;
-        }
-
         // Define the variable properly.
         $$Name = null;
 
@@ -1008,10 +1003,10 @@ class Gdn_ConfigurationSource extends Gdn_Pluggable {
             $$Name = $CachedConfigData;
         }
 
-        if (is_null($$Name) || !is_array($$Name)) {
+        if ((is_null($$Name) || !is_array($$Name)) && file_exists($File)) {
             $LoadedFromCache = false;
             // Include the file.
-            require($File);
+            require $File;
         }
 
         // Make sure the config variable is here and is an array.


### PR DESCRIPTION
- Allow a non-existent config file to be created on save. This prevents the bug where the configuration cannot be written when it doesn’t exist.
- Don’t create an empty config file on setup until it has data.