### PR TITLE
Order user tag search by comment count

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2499,6 +2499,7 @@ class UserModel extends Gdn_Model {
             ->from('User')
             ->like('Name', $Search, 'right')
             ->where('Deleted', 0)
+            ->orderBy('CountComments', 'desc')
             ->limit($Limit)
             ->get()
             ->resultArray();


### PR DESCRIPTION
I found that ordering the tag search results by comment count generally gives better results, as these are the users you are more likely to mention / message.