### PR TITLE
Restore user count to default user list

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -17,7 +17,7 @@ class UserController extends DashboardController {
     public $Uses = array('Database', 'Form');
 
     /** @var int The number of users when certain optimizations kick in. */
-    public $UserThreshold = 10;
+    public $UserThreshold = 10000;
 
     /** @var Gdn_Form */
     public $Form;
@@ -113,7 +113,7 @@ class UserController extends DashboardController {
                 $this->setData('_CurrentRecords', $count);
             } else {
                 // No users have been searched for, so give the total users overall.
-                $this->setData('RecordCount', $UserModel->searchCount());
+                $this->setData('RecordCount', $UserModel->getCount());
             }
         } else {
             $this->setData('RecordCount', $UserModel->searchCount($Filter));

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -17,7 +17,7 @@ class UserController extends DashboardController {
     public $Uses = array('Database', 'Form');
 
     /** @var int The number of users when certain optimizations kick in. */
-    public $UserThreshold = 10000;
+    public $UserThreshold = 10;
 
     /** @var Gdn_Form */
     public $Form;

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -88,13 +88,13 @@ class UserController extends DashboardController {
         //$Like = trim($Keywords) == '' ? FALSE : array('u.Name' => $Keywords, 'u.Email' => $Keywords);
         list($Offset, $Limit) = offsetLimit($Page, 30);
 
-        $Filter = $this->_GetFilter();
+        $Filter = $this->_getFilter();
         if ($Filter) {
             $Filter['Keywords'] = $Keywords;
         } else {
             $Filter = array('Keywords' => (string)$Keywords);
         }
-        $Filter['Optimize'] = $this->PastUserThreshold();
+        $Filter['Optimize'] = $this->pastUserThreshold();
 
         // Sorting
         if (in_array($Order, array('DateInserted', 'DateFirstVisit', 'DateLastActive'))) {
@@ -106,15 +106,20 @@ class UserController extends DashboardController {
         }
 
         // Get user list
-        $this->UserData = $UserModel->Search($Filter, $Order, $OrderDir, $Limit, $Offset);
+        $this->UserData = $UserModel->search($Filter, $Order, $OrderDir, $Limit, $Offset);
         $this->setData('Users', $this->UserData);
-        if ($this->PastUserThreshold()) {
-            $this->setData('_CurrentRecords', $this->UserData->count());
+        if ($this->pastUserThreshold()) {
+            if ($count = $this->UserData->count()) {
+                $this->setData('_CurrentRecords', $count);
+            } else {
+                // No users have been searched for, so give the total users overall.
+                $this->setData('RecordCount', $UserModel->searchCount());
+            }
         } else {
-            $this->setData('RecordCount', $UserModel->SearchCount($Filter));
+            $this->setData('RecordCount', $UserModel->searchCount($Filter));
         }
 
-        RoleModel::SetUserRoles($this->UserData->result());
+        RoleModel::setUserRoles($this->UserData->result());
 
         // Deliver json data if necessary
         if ($this->_DeliveryType != DELIVERY_TYPE_ALL && $this->_DeliveryMethod == DELIVERY_METHOD_XHTML) {

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -16,8 +16,11 @@ class UserController extends DashboardController {
     /** @var array Models to automatically instantiate. */
     public $Uses = array('Database', 'Form');
 
-    /** @var int The number of users when certain optimizations kick in. */
+    /** @var int The number of users when database optimizations kick in. */
     public $UserThreshold = 10000;
+
+    /** @var int The number of users when extreme database optimizations kick in. */
+    public $UserMegaThreshold = 1000000;
 
     /** @var Gdn_Form */
     public $Form;
@@ -85,9 +88,10 @@ class UserController extends DashboardController {
         }
 
         $UserModel = new UserModel();
-        //$Like = trim($Keywords) == '' ? FALSE : array('u.Name' => $Keywords, 'u.Email' => $Keywords);
+
         list($Offset, $Limit) = offsetLimit($Page, 30);
 
+        // Determine our data filters.
         $Filter = $this->_getFilter();
         if ($Filter) {
             $Filter['Keywords'] = $Keywords;
@@ -108,17 +112,28 @@ class UserController extends DashboardController {
         // Get user list
         $this->UserData = $UserModel->search($Filter, $Order, $OrderDir, $Limit, $Offset);
         $this->setData('Users', $this->UserData);
-        if ($this->pastUserThreshold()) {
-            if ($count = $this->UserData->count()) {
-                $this->setData('_CurrentRecords', $count);
+        $userCount = $this->UserData->count();
+
+        // If & how we display a user count depends on how huge our site is & whether we're searching.
+        // On sites past UserThreshold, zero users will be displayed by default.
+        if ($this->pastUserMegaThreshold()) {
+            // Dang, this site is mega-huge yo.
+
+
+        } elseif ($this->pastUserThreshold()) {
+            // Still big enough to choke an unoptimized query so tread lightly.
+            if ($userCount) {
+                $this->setData('_CurrentRecords', $userCount);
             } else {
                 // No users have been searched for, so give the total users overall.
                 $this->setData('RecordCount', $UserModel->getCount());
             }
         } else {
+            // Pfft, query that sucker however you want.
             $this->setData('RecordCount', $UserModel->searchCount($Filter));
         }
 
+        // Add roles to the user data.
         RoleModel::setUserRoles($this->UserData->result());
 
         // Deliver json data if necessary
@@ -893,11 +908,34 @@ class UserController extends DashboardController {
 
     /**
      * Whether or not we are past the user threshold.
+     *
+     * This is a useful indication that some database operations on the User table will be painfully long.
+     *
+     * @return bool
      */
     protected function pastUserThreshold() {
+        $estimate = $this->countEstimate();
+        return $estimate > $this->UserThreshold;
+    }
+
+    /**
+     * Whether we're wandered into extreme database optimization territory with our user count.
+     *
+     * @return bool
+     */
+    protected function pastUserMegaThreshold() {
+        $estimate = $this->countEstimate();
+        return $estimate > $this->UserMegaThreshold;
+    }
+
+    /**
+     * Approximate the number of users by checking the database table status.
+     *
+     * @return int
+     */
+    protected function countEstimate() {
         $px = Gdn::database()->DatabasePrefix;
-        $countEstimate = Gdn::database()->query("show table status like '{$px}User'")->value('Rows', 0);
-        return $countEstimate > $this->UserThreshold;
+        return Gdn::database()->query("show table status like '{$px}User'")->value('Rows', 0);
     }
 
     /**

--- a/applications/dashboard/views/user/index.php
+++ b/applications/dashboard/views/user/index.php
@@ -23,7 +23,8 @@ $ViewPersonalInfo = $Session->checkPermission('Garden.PersonalInfo.View');
         echo $this->Form->textBox('Keywords');
         echo ' ', $this->Form->button(t('Go'));
         if ($this->data('RecordCount', null) !== null) {
-            echo ' ', sprintf(t('%s user(s) found.'), $this->data('RecordCount'));
+            $count = $this->data('RecordCount');
+            echo ' ', sprintf(plural($count, t('%s user found.'), t('%s users found.')), $count);
         }
         echo '</div>';
 

--- a/applications/dashboard/views/user/index.php
+++ b/applications/dashboard/views/user/index.php
@@ -22,9 +22,11 @@ $ViewPersonalInfo = $Session->checkPermission('Garden.PersonalInfo.View');
         echo '<div>';
         echo $this->Form->textBox('Keywords');
         echo ' ', $this->Form->button(t('Go'));
-        if ($this->data('RecordCount', null) !== null) {
-            $count = $this->data('RecordCount');
+        $count = $this->data('RecordCount', $this->data('UserCount', null));
+        if ($count !== null) {
             echo ' ', sprintf(plural($count, '%s user found.', '%s users found.'), $count);
+        } elseif ($this->data('UserEstimate', null) !== null) {
+            echo ' ', sprintf(t('Approximately %s users exist.'), $this->data('UserEstimate'));
         }
         echo '</div>';
 

--- a/applications/dashboard/views/user/index.php
+++ b/applications/dashboard/views/user/index.php
@@ -24,7 +24,7 @@ $ViewPersonalInfo = $Session->checkPermission('Garden.PersonalInfo.View');
         echo ' ', $this->Form->button(t('Go'));
         if ($this->data('RecordCount', null) !== null) {
             $count = $this->data('RecordCount');
-            echo ' ', sprintf(plural($count, t('%s user found.'), t('%s users found.')), $count);
+            echo ' ', sprintf(plural($count, '%s user found.', '%s users found.'), $count);
         }
         echo '</div>';
 


### PR DESCRIPTION
* Add a new "megasite" threshold for user total (in addition to existing lower "userthreshold").
* Always show a user total when not searching for users. For megasites, we approximate based on table status. Everyone else gets an accurate count. Previously, only sites below userthreshold got any total for this.
* Preserve "next/last" pager with no count for searches once we cross the userthreshold.
* Fix plural case for "X users found." to not hedge with (s).
