### PR TITLE
Add ManageCaptcha config to optionally block key editing

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -921,10 +921,11 @@ class SettingsController extends DashboardController {
             'Garden.Registration.ConfirmEmail'
         );
 
-        if (c('Garden.Registration.ManageCaptcha', true)) {
+        if ($manageCaptcha = c('Garden.Registration.ManageCaptcha', true)) {
             $registrationOptions[] = 'Garden.Registration.CaptchaPrivateKey';
             $registrationOptions[] = 'Garden.Registration.CaptchaPublicKey';
         }
+        $this->setData('_ManageCaptcha', $manageCaptcha);
 
         $ConfigurationModel->setField($registrationOptions);
 

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -914,13 +914,19 @@ class SettingsController extends DashboardController {
         // Create a model to save configuration settings
         $Validation = new Gdn_Validation();
         $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
-        $ConfigurationModel->setField(array(
+
+        $registrationOptions = array(
             'Garden.Registration.Method' => 'Captcha',
-            'Garden.Registration.CaptchaPrivateKey',
-            'Garden.Registration.CaptchaPublicKey',
             'Garden.Registration.InviteExpiration',
             'Garden.Registration.ConfirmEmail'
-        ));
+        );
+
+        if (c('Garden.Registration.ManageCaptcha', true)) {
+            $registrationOptions[] = 'Garden.Registration.CaptchaPrivateKey';
+            $registrationOptions[] = 'Garden.Registration.CaptchaPublicKey';
+        }
+
+        $ConfigurationModel->setField($registrationOptions);
 
         // Set the model on the forms.
         $this->Form->setModel($ConfigurationModel);

--- a/applications/dashboard/views/settings/registration.php
+++ b/applications/dashboard/views/settings/registration.php
@@ -55,6 +55,7 @@ echo Gdn::slice('/dashboard/role/defaultroleswarning');
                 </tbody>
             </table>
         </li>
+        <?php if (c('Garden.Registration.ManageCaptcha', true)) : ?>
         <li id="CaptchaSettings">
             <div
                 class="Info"><?php echo t('The basic registration form requires new users to copy text from a CAPTCHA image.', '<strong>The basic registration form requires</strong> new users to copy text from a CAPTCHA image to keep spammers out of the site. You need an account at <a href="http://recaptcha.net/">recaptcha.net</a>. Signing up is FREE and easy. Once you have signed up, come back here and enter the following settings:'); ?></div>
@@ -77,6 +78,7 @@ echo Gdn::slice('/dashboard/role/defaultroleswarning');
                 </tbody>
             </table>
         </li>
+        <?php endif; ?>
         <li id="InvitationExpiration">
             <?php
             echo $this->Form->label('Invitations will expire', 'Garden.Registration.InviteExpiration');

--- a/applications/dashboard/views/settings/registration.php
+++ b/applications/dashboard/views/settings/registration.php
@@ -55,7 +55,7 @@ echo Gdn::slice('/dashboard/role/defaultroleswarning');
                 </tbody>
             </table>
         </li>
-        <?php if (c('Garden.Registration.ManageCaptcha', true)) : ?>
+        <?php if ($this->Data('_ManageCaptcha')) : ?>
         <li id="CaptchaSettings">
             <div
                 class="Info"><?php echo t('The basic registration form requires new users to copy text from a CAPTCHA image.', '<strong>The basic registration form requires</strong> new users to copy text from a CAPTCHA image to keep spammers out of the site. You need an account at <a href="http://recaptcha.net/">recaptcha.net</a>. Signing up is FREE and easy. Once you have signed up, come back here and enter the following settings:'); ?></div>


### PR DESCRIPTION
Adds config `Garden.Registration.ManageCaptcha` that, when set to `false`, blocks access & editing of the Captcha API key.