### PR TITLE
Fix ProfileExtender dropping data when email confirmation is used with applicant registration

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1746,7 +1746,7 @@ class UserModel extends Gdn_Model {
 
         // Throw an event to allow plugins to block the registration.
         unset($this->EventArguments['User']);
-        $this->EventArguments['User'] = $FormPostValues;
+        $this->EventArguments['RegisteringUser'] =& $FormPostValues;
         $this->EventArguments['Valid'] =& $Valid;
         $this->fireEvent('BeforeRegister');
 

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -466,7 +466,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
      * @param $Args array
      */
     public function userModel_afterInsertUser_handler($Sender, $Args) {
-        $this->updateUserFields($Args['InsertUserID'], $Args['User']);
+        $this->updateUserFields($Args['InsertUserID'], $Args['RegisteringUser']);
     }
 
     /**


### PR DESCRIPTION
Rename the event arg 'Users' in the `register()` method to `RegisteringUser` (and pass by reference for greater utility) to prevent naming conflict with the event arg in `setCalculatedFields()` which will overwrite this arg when sending a confirmation email for applicant users.