### PR TITLE
Address invalid array_key_exists calls in UserModel::sso

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -641,10 +641,10 @@ class UserModel extends Gdn_Model {
             'client_id' => null), true);
 
         // Remove important missing keys.
-        if (!array_key_exists($Data['photourl'])) {
+        if (!array_key_exists('photourl', $Data)) {
             unset($User['Photo']);
         }
-        if (!array_key_exists($Data['roles'])) {
+        if (!array_key_exists('roles', $Data)) {
             unset($User['Roles']);
         }
 


### PR DESCRIPTION
There were some invalid array_key_exists calls in UserModel::sso that were causing a couple SSO data fields to be erroneously removed.  This update addresses those function calls.