### PR TITLE
Parse index.php with Phing, use APPLICATION_VERSION in build filename

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -8,10 +8,17 @@
     -->
     <resolvepath file=".." propertyName="project.dir" />
 
+    <loadfile property="vanilla.index" file="${project.dir}/index.php"/>
+
     <!-- Take steps to prepare for the build. -->
     <target name="prepare">
         <delete
             file="build.zip" />
+        <propertyregex property="vanilla.version"
+            subject="${vanilla.index}"
+            pattern="define\('APPLICATION_VERSION', '(\d+\.\d+\.\d+)'\)"
+            match="$1"
+            defaultValue="unknown-version" />
     </target>
 
     <!-- Perform any steps to build the contents of the package. -->
@@ -24,11 +31,19 @@
 
     <!-- Build the package. -->
     <target name="dist" depends="build">
+        <if>
+            <equals arg1="${vanilla.version}" arg2="unknown-version" />
+            <then>
+                <property name="project.destfile" value="vanilla.zip" />
+            </then>
+            <else>
+                <property name="project.destfile" value="vanilla-${vanilla.version}.zip" />
+            </else>
+        </if>
         <zip
-            destfile="build.zip"
+            destfile="${project.destfile}"
             basedir="${project.dir}">
             <fileset dir="${project.dir}" includesfile="package-contents.txt" />
         </zip>
-
     </target>
 </project>


### PR DESCRIPTION
This update adds the ability for Phing to grab Vanilla's version number from index.php.  If a valid value is found for the version, it's used to build the output filename (e.g. vanilla-2.1.100.zip).  If a valid value is not found, it falls back to simply vanilla.zip.