### PR TITLE
Fix regression in 2.1 re: Img function

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -504,8 +504,8 @@ if (!function_exists('Img')) {
     * Returns an img tag.
     */
    function Img($Image, $Attributes = '', $WithDomain = FALSE) {
-      if ($Attributes == '')
-         $Attributes = array();
+      if ($Attributes != '')
+         $Attributes = Attribute($Attributes);
 
       if (!IsUrl($Image))
          $Image = SmartAsset($Image, $WithDomain);


### PR DESCRIPTION
The attributes array was not being passed through the attribute function before echoing.

This fix is similar to the master branch.