### PR TITLE
Add the ability for admins to add users without passwords

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -175,12 +175,26 @@ class UserController extends DashboardController {
                 // this themselves
                 $this->Form->setFormValue('RoleID', array_keys($UserNewRoles));
 
+                $noPassword = (bool)$this->Form->getFormValue('NoPassword');
+                if ($noPassword) {
+                    $this->Form->setFormValue('Password', BetterRandomString(15, 'Aa0'));
+                    $this->Form->setFormValue('HashMethod', 'Random');
+                }
+
                 $NewUserID = $this->Form->save(array('SaveRoles' => true, 'NoConfirmEmail' => true));
                 if ($NewUserID !== false) {
-                    $Password = $this->Form->getValue('Password', '');
-                    $UserModel->sendWelcomeEmail($NewUserID, $Password, 'Add');
+                    if ($noPassword) {
+                        $password = T('No password');
+                    } else {
+                        $password = $this->Form->getValue('Password', '');
+                    }
+
+                    $UserModel->sendWelcomeEmail($NewUserID, $password, 'Add');
                     $this->informMessage(t('The user has been created successfully'));
                     $this->RedirectUrl = url('dashboard/user');
+                } elseif ($noPassword) {
+                    $this->Form->setFormValue('Password', '');
+                    $this->Form->setFormValue('HashMethod', '');
                 }
 
                 $this->UserRoleData = $UserNewRoles;

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -177,7 +177,7 @@ class UserController extends DashboardController {
 
                 $noPassword = (bool)$this->Form->getFormValue('NoPassword');
                 if ($noPassword) {
-                    $this->Form->setFormValue('Password', BetterRandomString(15, 'Aa0'));
+                    $this->Form->setFormValue('Password', betterRandomString(15, 'Aa0'));
                     $this->Form->setFormValue('HashMethod', 'Random');
                 }
 

--- a/applications/dashboard/js/user.js
+++ b/applications/dashboard/js/user.js
@@ -30,6 +30,23 @@ jQuery(document).ready(function($) {
         return false;
     });
 
+    // No password.
+    var checkNoPassword = function() {
+        var checked = $(this).prop('checked');
+
+        if (checked) {
+            $('.js-password').prop('disabled', true);
+            $('.js-password-related').hide();
+        } else {
+            $('.js-password').prop('disabled', false);
+            $('.js-password-related').show();
+        }
+    };
+
+    $(document).on('click', '.js-nopassword input[type=checkbox]', checkNoPassword);
+
+    checkNoPassword.apply($('.js-nopassword input[type=checkbox]'));
+
     // Hide/Reveal reset password input
     var hideNewPassword = function() {
             $('#NewPassword').hide();

--- a/applications/dashboard/views/user/add.php
+++ b/applications/dashboard/views/user/add.php
@@ -19,9 +19,10 @@ echo $this->Form->errors();
         <li>
             <?php
             echo $this->Form->label('Password', 'Password');
-            echo $this->Form->Input('Password', 'password');
+            echo $this->Form->Input('Password', 'password', array('class' => 'InputBox js-password '));
+            echo ' '.$this->Form->Checkbox('NoPassword', 'No password', array('class' => 'Inline CheckBoxLabel js-nopassword'));
             ?>
-            <div class="InputButtons">
+            <div class="InputButtons js-password-related">
                 <?php
                 echo anchor(t('Generate Password'), '#', 'GeneratePassword Button SmallButton');
                 echo anchor(t('Reveal Password'), '#', 'RevealPassword Button SmallButton');

--- a/applications/dashboard/views/user/add.php
+++ b/applications/dashboard/views/user/add.php
@@ -19,8 +19,8 @@ echo $this->Form->errors();
         <li>
             <?php
             echo $this->Form->label('Password', 'Password');
-            echo $this->Form->Input('Password', 'password', array('class' => 'InputBox js-password '));
-            echo ' '.$this->Form->Checkbox('NoPassword', 'No password', array('class' => 'Inline CheckBoxLabel js-nopassword'));
+            echo $this->Form->input('Password', 'password', array('class' => 'InputBox js-password '));
+            echo ' '.$this->Form->checkbox('NoPassword', 'No password', array('class' => 'Inline CheckBoxLabel js-nopassword'));
             ?>
             <div class="InputButtons js-password-related">
                 <?php
@@ -37,7 +37,7 @@ echo $this->Form->errors();
         </li>
         <li>
             <?php
-            echo $this->Form->CheckBox('ShowEmail', t('Email visible to other users'));
+            echo $this->Form->checkBox('ShowEmail', t('Email visible to other users'));
             ?>
         </li>
         <?php
@@ -45,7 +45,7 @@ echo $this->Form->errors();
         ?>
         <li>
             <strong><?php echo t('Check all roles that apply to this user:'); ?></strong>
-            <?php echo $this->Form->CheckBoxList("RoleID", array_flip($this->RoleData), array_flip($this->UserRoleData)); ?>
+            <?php echo $this->Form->checkBoxList("RoleID", array_flip($this->RoleData), array_flip($this->UserRoleData)); ?>
         </li>
     </ul>
 <?php echo $this->Form->close('Save');


### PR DESCRIPTION
Adds a checkbox to the add user form that allows no password to be specified. Users added this way must request their own passwords or user SSO and auto-connect.