### PR TITLE
Add option to not include usernames in "to" field of outgoing e-mails

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -607,7 +607,7 @@ class SettingsController extends DashboardController {
             'Garden.Email.SmtpPassword',
             'Garden.Email.SmtpPort',
             'Garden.Email.SmtpSecurity',
-            'Garden.Email.ToNoUsername'
+            'Garden.Email.OmitToName'
         ));
 
         // Set the model on the form.

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -606,7 +606,8 @@ class SettingsController extends DashboardController {
             'Garden.Email.SmtpUser',
             'Garden.Email.SmtpPassword',
             'Garden.Email.SmtpPort',
-            'Garden.Email.SmtpSecurity'
+            'Garden.Email.SmtpSecurity',
+            'Garden.Email.ToNoUsername'
         ));
 
         // Set the model on the form.

--- a/applications/dashboard/views/settings/email.php
+++ b/applications/dashboard/views/settings/email.php
@@ -26,7 +26,7 @@ echo $this->Form->errors();
         </li>
         <li>
             <?php
-            echo $this->Form->CheckBox('Garden.Email.ToNoUsername', 'Do not include usernames in the "to" field of outgoing e-mails.');
+            echo $this->Form->CheckBox('Garden.Email.OmitToName', 'Do not include usernames in the "to" field of outgoing e-mails.');
             ?>
         </li>
         <li>

--- a/applications/dashboard/views/settings/email.php
+++ b/applications/dashboard/views/settings/email.php
@@ -25,6 +25,11 @@ echo $this->Form->errors();
             ?>
         </li>
         <li>
+            <?php
+            echo $this->Form->CheckBox('Garden.Email.ToNoUsername', 'Do not include usernames in the "to" field of outgoing e-mails.');
+            ?>
+        </li>
+        <li>
             <div
                 class="Info"><?php echo t('We will attempt to use the local mail server to send email by default. If you want to use a separate SMTP mail server, you can configure it below.'); ?></div>
         </li>

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -65,7 +65,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * @return Email
      */
     public function bcc($RecipientEmail, $RecipientName = '') {
-        if ($RecipientName != '' && c('Garden.Email.ToNoUsername', false)) {
+        if ($RecipientName != '' && c('Garden.Email.OmitToName', false)) {
             $RecipientName = '';
         }
 
@@ -84,7 +84,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * @return Email
      */
     public function cc($RecipientEmail, $RecipientName = '') {
-        if ($RecipientName != '' && c('Garden.Email.ToNoUsername', false)) {
+        if ($RecipientName != '' && c('Garden.Email.OmitToName', false)) {
             $RecipientName = '';
         }
 
@@ -293,7 +293,7 @@ class Gdn_Email extends Gdn_Pluggable {
 
 
     public function addTo($RecipientEmail, $RecipientName = '') {
-        if ($RecipientName != '' && c('Garden.Email.ToNoUsername', false)) {
+        if ($RecipientName != '' && c('Garden.Email.OmitToName', false)) {
             $RecipientName = '';
         }
 
@@ -311,7 +311,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * an array of email addresses, this value will be ignored.
      */
     public function to($RecipientEmail, $RecipientName = '') {
-        if ($RecipientName != '' && c('Garden.Email.ToNoUsername', false)) {
+        if ($RecipientName != '' && c('Garden.Email.OmitToName', false)) {
             $RecipientName = '';
         }
 

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -65,6 +65,10 @@ class Gdn_Email extends Gdn_Pluggable {
      * @return Email
      */
     public function bcc($RecipientEmail, $RecipientName = '') {
+        if ($RecipientName != '' && c('Garden.Email.ToNoUsername', false)) {
+            $RecipientName = '';
+        }
+
         ob_start();
         $this->PhpMailer->addBCC($RecipientEmail, $RecipientName);
         ob_end_clean();
@@ -80,6 +84,10 @@ class Gdn_Email extends Gdn_Pluggable {
      * @return Email
      */
     public function cc($RecipientEmail, $RecipientName = '') {
+        if ($RecipientName != '' && c('Garden.Email.ToNoUsername', false)) {
+            $RecipientName = '';
+        }
+
         ob_start();
         $this->PhpMailer->addCC($RecipientEmail, $RecipientName);
         ob_end_clean();
@@ -285,6 +293,10 @@ class Gdn_Email extends Gdn_Pluggable {
 
 
     public function addTo($RecipientEmail, $RecipientName = '') {
+        if ($RecipientName != '' && c('Garden.Email.ToNoUsername', false)) {
+            $RecipientName = '';
+        }
+
         ob_start();
         $this->PhpMailer->addAddress($RecipientEmail, $RecipientName);
         ob_end_clean();
@@ -299,6 +311,9 @@ class Gdn_Email extends Gdn_Pluggable {
      * an array of email addresses, this value will be ignored.
      */
     public function to($RecipientEmail, $RecipientName = '') {
+        if ($RecipientName != '' && c('Garden.Email.ToNoUsername', false)) {
+            $RecipientName = '';
+        }
 
         if (is_string($RecipientEmail)) {
             if (strpos($RecipientEmail, ',') > 0) {


### PR DESCRIPTION
Sometimes you don't want to include a forum user's username in the "to" field of your e-mails.  This update adds a new configuration option (`Garden.Email.OmitToName `) and a corresponding new form control on the "Outgoing Email" page of the dashboard.  When enabled, this option stops usernames from being included in the "to" field of outgoing e-mails.  Only the e-mail address will be passed to that field.  By default, the value is false, so Vanilla's current behavior of including usernames is not affected unless explicitly changed.