### PR TITLE
Make activity headline a dynamic translation

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -144,7 +144,7 @@ class ActivityModel extends Gdn_Model {
         $Row['Url'] = ExternalUrl($Row['Route']);
 
         if ($Row['HeadlineFormat']) {
-            $Row['Headline'] = formatString($Row['HeadlineFormat'], $Row);
+            $Row['Headline'] = formatString(t("HeadlineFormat.{$Row['ActivityType']}", $Row['HeadlineFormat']), $Row);
         } else {
             $Row['Headline'] = Gdn_Format::activityHeadline($Row);
         }
@@ -895,7 +895,7 @@ class ActivityModel extends Gdn_Model {
         if (val('HeadlineFormat', $Activity)) {
             $SessionUserID = Gdn::session()->UserID;
             Gdn::session()->UserID = $User['UserID'];
-            $Activity['Headline'] = formatString($Activity['HeadlineFormat'], $Activity);
+            $Activity['Headline'] = formatString(t("HeadlineFormat.{$Activity['ActivityType']}", $Activity['HeadlineFormat']), $Activity);
             Gdn::session()->UserID = $SessionUserID;
         } else {
             if (!isset($Activity['ActivityGender'])) {


### PR DESCRIPTION
This allows people to translate activity `HeadlineFormat` once an for all. Without having to do database changes. 

You can use the core standard. `HeadlineFormat.{ActivityType}` or the actual string (tested) or the actual activity. 

Where there is another definition format e.g. `Plugin.HeadlineFormat.{ActivityType}` they could translate that then `$Definition['`Plugin.HeadlineFormat.{ActivityType}'] = $Definition['HeadlineFormat.{ActivityType}']`. But good to start a convention. 

I hope this get in to 2.2 it would be a bonus if it could make it into any 2.1 updates.