### PR TITLE
Restore redirect after stash

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1129,7 +1129,9 @@ jQuery(document).ready(function($) {
             var href = $(this).attr('href');
             e.preventDefault();
 
-            stash(stash_name, comment);
+            stash(stash_name, comment, function() {
+                window.top.location = href;
+            });
         }
     });
 


### PR DESCRIPTION
When attempting to sign-in with the "Comment As ..." button on an embedded comment form, the redirect-to-sign-in page behavior is not being triggered if the comment body has been filled out.  This is due to the comment data being stashed, which involves stopping the default anchor href behavior.  Previous versions of global.js had the redirect in place, but it looks like it was removed in [this commit](https://github.com/vanilla/vanilla/commit/8e3e07fcceb62b62f6e20e0b0fce7d9865735d68#diff-206bb8e5b8584223b92afae06825d2faL1149).

It's not immediately apparent why it was removed, so this PR only restores the redirect-after-stashing behavior.