### PR TITLE
Keep the row count around after running queries

### DIFF
--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -424,6 +424,10 @@ class Gdn_Database {
 
         }
 
+        if ($PDOStatement instanceof PDOStatement) {
+            $this->LastInfo['RowCount'] = $PDOStatement->rowCount();
+        }
+
         // Did this query modify data in any way?
         if ($ReturnType == 'ID') {
             $this->_CurrentResultSet = $PDO->lastInsertId();


### PR DESCRIPTION
This will help code know how many rows were affected and possibly take different actions depending on whether or not a query did anything.