### PR TITLE
Allow creation of separate values and labels in dropdowns in profile extender plugin.

### DIFF
--- a/plugins/ProfileExtender/views/profilefields.php
+++ b/plugins/ProfileExtender/views/profilefields.php
@@ -4,10 +4,16 @@ if (is_array($this->ProfileFields)) {
     foreach ($this->ProfileFields as $Name => $Field) {
         $Options = array();
         if ($Field['FormType'] == 'Dropdown') {
-            if(is_array($Field['OptionsLabels'])) {
-                $Options = array_combine($Field['Options'], $Field['OptionsLabels']);
-            } else {
-                $Options = array_combine($Field['Options'], $Field['Options']);
+            $values = $Field['Options'];
+            $labels = (array_key_exists('OptionsLabels', $Field)) ? $Field['OptionsLabels'] : false;
+
+            // If the config provides an array of labels nested in the profile field ($Field['OptionsLabels']),
+            // combine the arrays to create a drop-down with different values and labels.
+            if(is_array($labels)) {
+                // WARNING: If $values and $labels are of different length, $Options will be null.
+                $Options = array_combine($values, $labels);
+            } else { //
+                $Options = array_combine($values, $values);
             }
         }
 

--- a/plugins/ProfileExtender/views/profilefields.php
+++ b/plugins/ProfileExtender/views/profilefields.php
@@ -3,8 +3,13 @@
 if (is_array($this->ProfileFields)) {
     foreach ($this->ProfileFields as $Name => $Field) {
         $Options = array();
-        if ($Field['FormType'] == 'Dropdown')
-            $Options = array_combine($Field['Options'], $Field['Options']);
+        if ($Field['FormType'] == 'Dropdown') {
+            if(is_array($Field['OptionsLabels'])) {
+                $Options = array_combine($Field['Options'], $Field['OptionsLabels']);
+            } else {
+                $Options = array_combine($Field['Options'], $Field['Options']);
+            }
+        }
 
         if ($Field['FormType'] == 'TextBox' && !empty($Field['Options'])) {
             $Options = $Field['Options'];

--- a/plugins/ProfileExtender/views/profilefields.php
+++ b/plugins/ProfileExtender/views/profilefields.php
@@ -5,16 +5,11 @@ if (is_array($this->ProfileFields)) {
         $Options = array();
         if ($Field['FormType'] == 'Dropdown') {
             $values = $Field['Options'];
-            $labels = (array_key_exists('OptionsLabels', $Field)) ? $Field['OptionsLabels'] : false;
+            $labels = val('OptionsLabels', $Field, $Field['Options']);
 
             // If the config provides an array of labels nested in the profile field ($Field['OptionsLabels']),
             // combine the arrays to create a drop-down with different values and labels.
-            if(is_array($labels)) {
-                // WARNING: If $values and $labels are of different length, $Options will be null.
-                $Options = array_combine($values, $labels);
-            } else { //
-                $Options = array_combine($values, $values);
-            }
+            $Options = array_combine($values, $labels);
         }
 
         if ($Field['FormType'] == 'TextBox' && !empty($Field['Options'])) {

--- a/plugins/ProfileExtender/views/registrationfields.php
+++ b/plugins/ProfileExtender/views/registrationfields.php
@@ -3,8 +3,19 @@
 if (is_array($Sender->RegistrationFields)) {
     foreach ($Sender->RegistrationFields as $Name => $Field) {
         $Options = array();
-        if ($Field['FormType'] == 'Dropdown')
-            $Options = array_combine($Field['Options'], $Field['Options']);
+        if ($Field['FormType'] == 'Dropdown') {
+            $values = $Field['Options'];
+            $labels = (array_key_exists('OptionsLabels', $Field)) ? $Field['OptionsLabels'] : false;
+
+            // If the config provides an array of labels nested in the profile field ($Field['OptionsLabels']),
+            // combine the arrays to create a drop-down with different values and labels.
+            if(is_array($labels)) {
+                // WARNING: If $values and $labels are of different length, $Options will be null.
+                $Options = array_combine($values, $labels);
+            } else { //
+                $Options = array_combine($values, $values);
+            }
+        }
 
         if ($Field['FormType'] == 'CheckBox') {
             echo wrap($Sender->Form->{$Field['FormType']}($Name, $Field['Label']), 'li');

--- a/plugins/ProfileExtender/views/registrationfields.php
+++ b/plugins/ProfileExtender/views/registrationfields.php
@@ -5,16 +5,11 @@ if (is_array($Sender->RegistrationFields)) {
         $Options = array();
         if ($Field['FormType'] == 'Dropdown') {
             $values = $Field['Options'];
-            $labels = (array_key_exists('OptionsLabels', $Field)) ? $Field['OptionsLabels'] : false;
+            $labels = val('OptionsLabels', $Field, $Field['Options']);
 
             // If the config provides an array of labels nested in the profile field ($Field['OptionsLabels']),
             // combine the arrays to create a drop-down with different values and labels.
-            if(is_array($labels)) {
-                // WARNING: If $values and $labels are of different length, $Options will be null.
-                $Options = array_combine($values, $labels);
-            } else { //
-                $Options = array_combine($values, $values);
-            }
+            $Options = array_combine($values, $labels);
         }
 
         if ($Field['FormType'] == 'CheckBox') {


### PR DESCRIPTION
This will allow us to manually include an array in the config file called OptionsLabel which is merged with the Options array to create dropdowns which have different values and labels. Presently when you create a dropdown we take the array of options provided by the user and merge it to itself to make something like:
&lt;option value='Canada'&gt;Canada&lt;/option&gt;

This PR provides the opportunity for someone to manually include an array in the config that would be merged with the options to provide user friendly labels:

&lt;option value='ca'&gt;Canada&lt;/option&gt;

If no OptionsLabel array is present, it continues to work as it always has.