### PR TITLE
Add braces around unicode categories regex.

### DIFF
--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -229,7 +229,7 @@ if (!function_exists('validateUsernameRegex')) {
         if (is_null($ValidateUsernameRegex)) {
             // Set our default ValidationRegex based on Unicode support.
             // Unicode includes Numbers, Letters, Marks, & Connector punctuation.
-            $DefaultPattern = (unicodeRegexSupport()) ? '\pN\pL\pM\pPc' : '\w';
+            $DefaultPattern = (unicodeRegexSupport()) ? '\p{N}\p{L}\p{M}\p{Pc}' : '\w';
 
             $ValidateUsernameRegex = sprintf(
                 "[%s]%s",


### PR DESCRIPTION
\pPc was being interpreted as \pP.
This fixes bug where usernames with any kind of punctuation character pass the validation.