### PR TITLE
Move UserModel field filters from constructor to filterForm

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -60,10 +60,6 @@ class UserModel extends Gdn_Model {
             'LastIPAddress', 'AllIPAddresses', 'DateFirstVisit', 'DateLastActive', 'CountDiscussions', 'CountComments',
             'Score', 'Photo'
         ));
-
-        if (!Gdn::session()->checkPermission('Garden.Moderation.Manage')) {
-            $this->addFilterField(array('Banned', 'Verified', 'Confirmed', 'RankID'));
-        }
     }
 
     /**
@@ -820,6 +816,10 @@ class UserModel extends Gdn_Model {
     public function filterForm($data, $register = false) {
         if (!$register && !Gdn::session()->checkPermission('Garden.Users.Edit') && !c("Garden.Profile.EditUsernames")) {
             $this->removeFilterField('Name');
+        }
+
+        if (!Gdn::session()->checkPermission('Garden.Moderation.Manage')) {
+            $this->addFilterField(array('Banned', 'Verified', 'Confirmed', 'RankID'));
         }
 
         $data = parent::FilterForm($data);


### PR DESCRIPTION
Some permission checks early in the request may incorrectly return a false value, because the current user's session hasn't been fully started.  This error is causing some fields to be unduly stripped from form posts, such as RankID.

This fix moves the permission-based addFilterField calls from the UserModel constructor, back down into the filterForm function. By the time filterForm is called, the proper session setup should've taken place and the permission checks should be accurate.

This essentially reverts commit 7290c664208fbcd222f91d196fe1ef56b78729f3.