### PR TITLE
Backport discussionModel::canEdit() to 2.1

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -38,6 +38,42 @@ class DiscussionModel extends VanillaModel {
    public function __construct() {
       parent::__construct('Discussion');
    }
+
+   /**
+     * Determines whether or not the current user can edit a discussion.
+     *
+     * @param object|array $discussion The discussion to examine.
+     * @param int $timeLeft Sets the time left to edit or 0 if not applicable.
+     * @return bool Returns true if the user can edit or false otherwise.
+     */
+    public static function canEdit($discussion, &$timeLeft = 0) {
+        if (!($permissionCategoryID = val('PermissionCategoryID', $discussion))) {
+            $category = CategoryModel::categories(val('CategoryID', $discussion));
+            $permissionCategoryID = val('PermissionCategoryID', $category);
+        }
+
+        // Users with global edit permission can edit.
+        if (Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $permissionCategoryID)) {
+            return true;
+        }
+
+        // Non-mods can't edit if they aren't the author.
+        if (Gdn::session()->UserID != val('InsertUserID', $discussion)) {
+            return false;
+        }
+
+        // Determine if we still have time to edit.
+        $timeInserted = strtotime(val('DateInserted', $discussion));
+        $editContentTimeout = c('Garden.EditContentTimeout', -1);
+
+        $canEdit = $editContentTimeout == -1 || $timeInserted + $editContentTimeout > time();
+
+        if ($canEdit && $editContentTimeout > 0) {
+            $timeLeft = $timeInserted + $editContentTimeout - time();
+        }
+
+        return $canEdit;
+    }
    
    public function Counts($Column, $From = FALSE, $To = FALSE, $Max = FALSE) {
       $Result = array('Complete' => TRUE);

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@
  */
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.1.13');
+define('APPLICATION_VERSION', '2.1.13p1');
 
 // Report and track all errors.
 


### PR DESCRIPTION
Fixes #3240

Please review for PHP 5.3 compatibility in addition to normal review.