### PR TITLE
Add support for OriginalFilename to uploads

### DIFF
--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -291,6 +291,7 @@ class Gdn_Upload extends Gdn_Pluggable {
         $Parsed = self::parse($Target);
         $this->EventArguments['Parsed'] =& $Parsed;
         $this->EventArguments['Options'] = $Options;
+        $this->EventArguments['OriginalFilename'] = val('OriginalFilename', $Options);
         $Handled = false;
         $this->EventArguments['Handled'] =& $Handled;
         $this->fireAs('Gdn_Upload')->fireEvent('SaveAs');

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -736,7 +736,14 @@ class EditorPlugin extends Gdn_Plugin {
             // Save original file to uploads, then manipulate from this location if
             // it's a photo. This will also call events in Vanilla so other plugins can tie into this.
             if (empty($imageType)) {
-                $filePathParsed = $Upload->saveAs($tmpFilePath, $absoluteFileDestination, array('source' => 'content'));
+                $filePathParsed = $Upload->saveAs(
+                    $tmpFilePath,
+                    $absoluteFileDestination,
+                    array(
+                        'OriginalFilename' => $fileName,
+                        'source' => 'content'
+                    )
+                );
             } else {
                 $filePathParsed = Gdn_UploadImage::saveImageAs($tmpFilePath, $absoluteFileDestination, '', '', array('SaveGif' => true));
                 $tmpwidth = $filePathParsed['Width'];


### PR DESCRIPTION
Adds OriginalFilename to uploads, so that the file's original name can be referenced in Gdn_Upload::saveAs

Recap of current issue:

1. Non-image uploads made with the Advanced Editor plug-in eventually make their way to be saved: [class.editor.plugin.php:739](https://github.com/vanilla/vanilla/blob/7963683ee411e8935baa7ebd4f2dcc7abf6f25b9/plugins/editor/class.editor.plugin.php#L739)
2. Gdn_Upload::saveAs fires an event prior to the save: [class.upload.php:296](https://github.com/vanilla/vanilla/blob/8ab35aca6fec97aa117cc1295c4ba9434f41876f/library/core/class.upload.php#L296)
3. The CloudFiles plug-in hooks into this event: [class.cloudfiles.plugin.php](https://github.com/vanilla/vanillainfrastructure/blob/6741cdec7b6c470f88989e8b9ab7bd05127d7019/plugins/cloudfiles/class.cloudfiles.plugin.php#L421)
4. The `Content-Disposition` header is set by the CloudFiles plug-in, if a valid value for OriginalFilename is found: [class.cloudfiles.plugin.php:442](https://github.com/vanilla/vanillainfrastructure/blob/6741cdec7b6c470f88989e8b9ab7bd05127d7019/plugins/cloudfiles/class.cloudfiles.plugin.php#L442)

This downloading/file-naming behavior only affects images, so it's probably not a widespread/widely-noticed issue.  It doesn't seem to affect all files on all sites.  Files uploaded via the FileUpload plug-in are seem to be okay.  Files uploaded with the editor plug-in aren't getting the `OriginalFilename` parameter that is needed.

It looks like the FileUpload plug-in includes `OriginalFilename` as one of the event arguments when it masquerades as `Gdn_Upload` when firing the `saveAs` event: [class.fileupload.plugin.php:829](https://github.com/vanilla/addons/blob/07074138b58667d5c347ab72ca034fd68746add8/plugins/FileUpload/class.fileupload.plugin.php#L829)

This would explain why FileUpload uploads are downloading with the proper filename, but Advanced Editor uploads are not.