### PR TITLE
Add discussion-specific view permission check.

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -993,7 +993,7 @@ class CommentModel extends VanillaModel {
             $BookmarkData = $DiscussionModel->GetBookmarkUsers($DiscussionID);
             foreach ($BookmarkData->result() as $Bookmark) {
                 // Check user can still see the discussion.
-                if (!$discussionModel->canViewDiscussion($Discussion, $Bookmark->UserID)) {
+                if (!$discussionModel->canView($Discussion, $Bookmark->UserID)) {
                     continue;
                 }
 
@@ -1005,7 +1005,7 @@ class CommentModel extends VanillaModel {
             // Notify users who have participated in the discussion.
             $ParticipatedData = $DiscussionModel->GetParticipatedUsers($DiscussionID);
             foreach ($ParticipatedData->result() as $UserRow) {
-                if (!$discussionModel->canViewDiscussion($Discussion, $UserRow->UserID)) {
+                if (!$discussionModel->canView($Discussion, $UserRow->UserID)) {
                     continue;
                 }
 
@@ -1018,7 +1018,7 @@ class CommentModel extends VanillaModel {
             if ($Discussion != false) {
                 $InsertUserID = val('InsertUserID', $Discussion);
                 // Check user can still see the discussion.
-                if ($discussionModel->canViewDiscussion($Discussion, $InsertUserID)) {
+                if ($discussionModel->canView($Discussion, $InsertUserID)) {
                     $Activity['NotifyUserID'] = $InsertUserID;
                     $Activity['Data']['Reason'] = 'mine';
                     $ActivityModel->Queue($Activity, 'DiscussionComment');
@@ -1042,7 +1042,7 @@ class CommentModel extends VanillaModel {
                 }
 
                 // Check user can still see the discussion.
-                if (!$discussionModel->canViewDiscussion($Discussion, $User->UserID)) {
+                if (!$discussionModel->canView($Discussion, $User->UserID)) {
                     continue;
                 }
 
@@ -1112,7 +1112,7 @@ class CommentModel extends VanillaModel {
             $UserID = $Row['UserID'];
             // Check user can still see the discussion.
             $discussionModel = new DiscussionModel();
-            if (!$discussionModel->canViewDiscussion($Discussion, $UserID)) {
+            if (!$discussionModel->canView($Discussion, $UserID)) {
                 continue;
             }
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1033,7 +1033,7 @@ class CommentModel extends VanillaModel {
 
             // Notify any users who were mentioned in the comment.
             $Usernames = GetMentions($Fields['Body']);
-            $userModel = new UserModel();
+            $userModel = Gdn::userModel();
             foreach ($Usernames as $i => $Username) {
                 $User = $userModel->GetByUsername($Username);
                 if (!$User) {

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2471,12 +2471,12 @@ class DiscussionModel extends VanillaModel {
      * Fires an event that can override the category view permission.
      *
      * @param object|array|integer $discussion The discussion ID or the discussion to test.
-     * @param string|integer $userID The ID of the user to test permission for. If empty, it defaults to Session user.
+     * @param integer $userID The ID of the user to test permission for. If empty, it defaults to Session user.
      * @param string $categoryPermission The category permission to test against the user.
      * @return bool Whether the user can view the discussion.
      * @throws Exception
      */
-    public function canView($discussion, $userID = '', $categoryPermission = 'Vanilla.Discussions.View') {
+    public function canView($discussion, $userID = 0, $categoryPermission = 'Vanilla.Discussions.View') {
         // Default to session user.
         if (!$userID) {
             $userID = val('UserID', Gdn::session(), false);
@@ -2485,7 +2485,7 @@ class DiscussionModel extends VanillaModel {
         if (is_numeric($discussion)) {
             $discussion = $this->getID($discussion);
         }
-        $userModel = new UserModel();
+        $userModel = Gdn::userModel();
         // Get category permission.
         $canView = $userID && $userModel->getCategoryViewPermission($userID, val('CategoryID', $discussion), $categoryPermission);
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2489,7 +2489,7 @@ class DiscussionModel extends VanillaModel {
      * @throws Exception
      */
     public function canView($discussion, $userID = 0) {
-        $canView = $this->hasPermission($discussion, $userID);
+        $canView = $this->checkPermission($discussion, $userID);
         $this->EventArguments['Discussion'] = $discussion;
         $this->EventArguments['UserID'] = $userID;
         $this->EventArguments['CanView'] = &$canView;
@@ -2507,7 +2507,7 @@ class DiscussionModel extends VanillaModel {
      * @return bool Whether the user has the specified permission privileges to the discussion.
      * @throws Exception
      */
-    public function hasPermission($discussion, $userID = 0, $categoryPermission = 'Vanilla.Discussions.View') {
+    public function checkPermission($discussion, $userID = 0, $categoryPermission = 'Vanilla.Discussions.View') {
         // Either the permission string is a full permission, or we prepend 'Vanilla.Discussions.' to the permission.
         if (strpos($categoryPermission, '.') === false) {
             $permission = ucfirst(strtolower($categoryPermission));
@@ -2519,7 +2519,7 @@ class DiscussionModel extends VanillaModel {
         }
         // Default to session user.
         if (!$userID) {
-            $userID = val('UserID', Gdn::session(), false);
+            $userID = Gdn::session()->UserID;
         }
         // Fetch discussion.
         if (is_numeric($discussion)) {

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1790,7 +1790,7 @@ class DiscussionModel extends VanillaModel {
                         }
 
                         // Check user can still see the discussion.
-                        if (!$this->canViewDiscussion($Fields, $User->UserID)) {
+                        if (!$this->canView($Fields, $User->UserID)) {
                             continue;
                         }
 
@@ -1880,7 +1880,7 @@ class DiscussionModel extends VanillaModel {
 
             $UserID = $Row['UserID'];
             // Check user can still see the discussion.
-            if (!$this->canViewDiscussion($Discussion, $UserID)) {
+            if (!$this->canView($Discussion, $UserID)) {
                 continue;
             }
 
@@ -2470,16 +2470,16 @@ class DiscussionModel extends VanillaModel {
      * Tests whether a user has permission to view a specific discussion by checking category-specific permissions.
      * Fires an event that can override the category view permission.
      *
-     * @param object|integer $discussion The discussion ID or the discussion to test.
-     * @param string|integer $userId The ID of the user to test permission for. If empty, it defaults to Session user.
+     * @param object|array|integer $discussion The discussion ID or the discussion to test.
+     * @param string|integer $userID The ID of the user to test permission for. If empty, it defaults to Session user.
      * @param string $categoryPermission The category permission to test against the user.
      * @return bool Whether the user can view the discussion.
      * @throws Exception
      */
-    public function canViewDiscussion($discussion, $userId = '', $categoryPermission = 'Vanilla.Discussions.View') {
+    public function canView($discussion, $userID = '', $categoryPermission = 'Vanilla.Discussions.View') {
         // Default to session user.
-        if (!$userId) {
-            $userId = val('UserID', Gdn::session(), false);
+        if (!$userID) {
+            $userID = val('UserID', Gdn::session(), false);
         }
         // Fetch discussion.
         if (is_numeric($discussion)) {
@@ -2487,13 +2487,13 @@ class DiscussionModel extends VanillaModel {
         }
         $userModel = new UserModel();
         // Get category permission.
-        $canView = $userId && $userModel->getCategoryViewPermission($userId, val('CategoryID', $discussion), $categoryPermission);
+        $canView = $userID && $userModel->getCategoryViewPermission($userID, val('CategoryID', $discussion), $categoryPermission);
 
         // Fire event to override permission ruling.
-        $this->EventArguments['discussion'] = $discussion;
-        $this->EventArguments['userId'] = $userId;
-        $this->EventArguments['categoryPermission'] = $categoryPermission;
-        $this->EventArguments['canView'] = &$canView;
+        $this->EventArguments['Discussion'] = $discussion;
+        $this->EventArguments['UserID'] = $userID;
+        $this->EventArguments['CategoryPermission'] = $categoryPermission;
+        $this->EventArguments['CanView'] = &$canView;
         $this->fireEvent('viewPermission');
 
         return $canView;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1790,7 +1790,7 @@ class DiscussionModel extends VanillaModel {
                         }
 
                         // Check user can still see the discussion.
-                        if (!$UserModel->getCategoryViewPermission($User->UserID, val('CategoryID', $Fields))) {
+                        if (!$this->canViewDiscussion($Fields, $User->UserID)) {
                             continue;
                         }
 
@@ -1880,7 +1880,7 @@ class DiscussionModel extends VanillaModel {
 
             $UserID = $Row['UserID'];
             // Check user can still see the discussion.
-            if (!Gdn::userModel()->GetCategoryViewPermission($UserID, $Category['CategoryID'])) {
+            if (!$this->canViewDiscussion($Discussion, $UserID)) {
                 continue;
             }
 
@@ -2463,5 +2463,39 @@ class DiscussionModel extends VanillaModel {
         }
 
         return self::$AllowedSortFields;
+    }
+
+
+    /**
+     * Tests whether a user has permission to view a specific discussion by checking category-specific permissions.
+     * Fires an event that can override the category view permission.
+     *
+     * @param object|integer $discussion The discussion ID or the discussion to test.
+     * @param string|integer $userId The ID of the user to test permission for. If empty, it defaults to Session user.
+     * @param string $categoryPermission The category permission to test against the user.
+     * @return bool Whether the user can view the discussion.
+     * @throws Exception
+     */
+    public function canViewDiscussion($discussion, $userId = '', $categoryPermission = 'Vanilla.Discussions.View') {
+        // Default to session user.
+        if (!$userId) {
+            $userId = val('UserID', Gdn::session(), false);
+        }
+        // Fetch discussion.
+        if (is_numeric($discussion)) {
+            $discussion = $this->getID($discussion);
+        }
+        $userModel = new UserModel();
+        // Get category permission.
+        $canView = $userId && $userModel->getCategoryViewPermission($userId, val('CategoryID', $discussion), $categoryPermission);
+
+        // Fire event to override permission ruling.
+        $this->EventArguments['discussion'] = $discussion;
+        $this->EventArguments['userId'] = $userId;
+        $this->EventArguments['categoryPermission'] = $categoryPermission;
+        $this->EventArguments['canView'] = &$canView;
+        $this->fireEvent('viewPermission');
+
+        return $canView;
     }
 }


### PR DESCRIPTION
Add new method to test whether a user has permission to view a specific discussion by first checking category-specific permissions and then firing an event so it can be overridden.