### PR TITLE
Expand phpBB password hash type to support crypt/Blowfish

### DIFF
--- a/library/vendors/phpbb/phpbbhash.php
+++ b/library/vendors/phpbb/phpbbhash.php
@@ -51,14 +51,17 @@
 */
 function phpbb_check_hash($password, $hash)
 {
+	if (preg_match('#^\$2[axy]\$#', $hash)) {
+		return crypt($password, $hash) === $hash;
+	}
+
 	$itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 	if (strlen($hash) == 34)
 	{
-
 		return (_hash_crypt_private($password, $hash, $itoa64) === $hash) ? true : false;
 	}
 
-	return (md5($password) === $hash) ? true : false;
+	return md5($password) === $hash;
 }
 
 /**


### PR DESCRIPTION
phpBB can potentially use the Blowfish hashing algorithm for its passwords.  Vanilla doesn't currently support these password hashes when checking against a password imported from phpBB/a password with phpbb as the `HashMethod`.

This update enables `phpbb_check_hash` to recognize and compare hashes for Blowfish.