### PR TITLE
Remove the animated scrolling from the Quotes plugin.

### DIFF
--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -124,11 +124,8 @@ Gdn_Quotes.prototype.Quote = function(ObjectID, QuoteLink) {
     // DEPRECATED: cleditor support
     if ($('div.cleditorMain').length) {
         ScrollY = $(this.GetEditor().get(0).editor.$frame).offset().top - 100;
-    } else {
-        ScrollY = this.GetEditor().offset().top - 100;
+        $('html,body').animate({scrollTop: ScrollY}, 800);
     }
-
-    $('html,body').animate({scrollTop: ScrollY}, 800);
 };
 
 

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -491,16 +491,6 @@
              });
              */
 
-            // Handle quotes plugin using triggered event.
-            $('a.ReactButton.Quote').on('click', function(e) {
-                // Stop animation from other plugin and let this one
-                // handle the scroll, otherwise the scrolling jumps
-                // all over, and really distracts the eyes.
-                $('html, body').stop().animate({
-                    scrollTop: $(editor.textarea.element).parent().parent().offset().top
-                }, 800);
-            });
-
             $(editor.textarea.element).on('appendHtml', function(e, data) {
 
                 // The quotes plugin tends to add line breaks to the end of the


### PR DESCRIPTION
The scrolling happens anyway and the scrolling animation doesn't play nice with the WYSIWYG editor.
Fixes bug where quoting would scroll down, then up the page when the WYSIWYG editor was enabled.