### PR TITLE
Encode the paths that are sent to the parent frame in embedding

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ if (PHP_VERSION_ID < 50400) {
 }
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.2.1011');
+define('APPLICATION_VERSION', '2.2.1012');
 
 // Report and track all errors.
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);

--- a/js/embed_local.js
+++ b/js/embed_local.js
@@ -6,6 +6,12 @@ jQuery(document).ready(function($) {
         }
     }
 
+    var encodePath = function(path) {
+        var result = encodeURIComponent(path);
+        result = result.replace(/%2F/g, '/');
+        return result;
+    };
+
     var currentHeight = null,
         minHeight = 100,
         remotePostMessage = function(message, target) {
@@ -117,12 +123,12 @@ jQuery(document).ready(function($) {
 
     // If not embedded and we should be, redirect to the embedded version.
     if (!inIframe && !inPopup && !inConnect && remoteUrl != '' && ((inDashboard && forceEmbedDashboard) || (!inDashboard && forceEmbedForum)))
-        document.location = remoteUrl + '#' + path;
+        document.location = remoteUrl + '#' + encodePath(path);
 
     if (inIframe) {
         // DO NOT set the parent location if this is a page of embedded comments!!
         if (path != '~' && !isEmbeddedComments)
-            remotePostMessage('location:' + path, '*');
+            remotePostMessage('location:' + encodePath(path), '*');
 
         // Unembed if in the dashboard, in an iframe, and not forcing dashboard embed
         if (inDashboard && !forceEmbedDashboard)


### PR DESCRIPTION
Fix an issue where paths that have special characters don’t always work as deep links.

The most common case of this would be if a path includes an unencoded # symbol. Try adding one into a username somewhere and then click on their name for their profile link.