### PR TITLE
Allow DiscussionModel::getID to use dataset type

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1352,7 +1352,7 @@ class DiscussionModel extends VanillaModel {
             ->join('UserDiscussion w', 'd.DiscussionID = w.DiscussionID and w.UserID = '.$Session->UserID, 'left')
             ->where('d.DiscussionID', $DiscussionID)
             ->get()
-            ->firstRow($DataSetType);
+            ->firstRow();
 
         if (!$Discussion) {
             return $Discussion;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1352,7 +1352,7 @@ class DiscussionModel extends VanillaModel {
             ->join('UserDiscussion w', 'd.DiscussionID = w.DiscussionID and w.UserID = '.$Session->UserID, 'left')
             ->where('d.DiscussionID', $DiscussionID)
             ->get()
-            ->firstRow();
+            ->firstRow($DataSetType);
 
         if (!$Discussion) {
             return $Discussion;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1369,7 +1369,7 @@ class DiscussionModel extends VanillaModel {
             $this->AddDenormalizedViews($Discussion);
         }
 
-        return $Discussion;
+        return $DataSetType == DATASET_TYPE_ARRAY ? (array)$Discussion : $Discussion;
     }
 
     /**


### PR DESCRIPTION
`DiscussionModel::getID` takes `DataSetType` as a parameter, but doesn't make use of it.

This update passes the `DataSetType `parameter to `firstRow` when querying the database for the discussion row.