### PR TITLE
Revert: Ignore composer files for archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,5 +13,3 @@
 .gitignore export-ignore
 .travis.yml export-ignore
 tests export-ignore
-composer.json export-ignore
-composer.lock export-ignore


### PR DESCRIPTION
Reverts vanilla/vanilla#2850
see: http://vanillaforums.org/discussion/comment/235275/#Comment_235275

Without composer.json you can't run composer from the archive (which is convenient sometimes).