### PR TITLE
Add button enter key handler to wysiwyg-format editor.

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -11,7 +11,7 @@
 $PluginInfo['editor'] = array(
    'Name' => 'Advanced Editor',
    'Description' => 'Enables advanced editing of posts in several formats, including WYSIWYG, simple HTML, Markdown, and BBCode.',
-   'Version' => '1.7.5',
+   'Version' => '1.7.6',
    'Author' => "Dane MacMillan",
    'AuthorUrl' => 'http://www.vanillaforums.org/profile/dane',
    'RequiredApplications' => array('Vanilla' => '>=2.2'),

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -421,17 +421,13 @@
                         return false;
                     }
 
-                    // Make exception for non-wysiwyg, as wysihtml5 has custom
-                    // key handler.
-                    if (!$(this).closest('.editor').hasClass('editor-format-wysiwyg')) {
-                        // Fire event programmatically to do what needs to be done in
-                        // ButtonBar code.
-                        $(this).parent().find('.Button').trigger('click.insertData');
+                    // Fire event programmatically to do what needs to be done in
+                    // ButtonBar code.
+                    $(this).parent().find('.Button').trigger('click.insertData');
 
-                        e.stopPropagation();
-                        e.preventDefault();
-                        return false;
-                    }
+                    e.stopPropagation();
+                    e.preventDefault();
+                    return false;
                 }
             });
 


### PR DESCRIPTION
If wysihtml5 has a custom key handler, it's failing here. This fixes a bug where clicking enter from the fileupload dropdown submits the post.