### PR TITLE
Detect initial setup in permissionmodel->define() and force mappings

### DIFF
--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -258,12 +258,15 @@ class PermissionModel extends Gdn_Model {
             ->get()->firstRow(DATASET_TYPE_ARRAY);
 
         // If this is our initial setup, map missing permissions to off.
+        // Otherwise we'd be left with placeholders in our final query, which would cause a strict mode failure.
         if (!$DefaultRow) {
-            foreach ($DefaultPermissions as $Name => $Value) {
-                if (!is_numeric($Value)) {
-                    $DefaultPermissions[$Name] = 2;
-                }
-            }
+            $DefaultPermissions = array_map(
+                function ($Value) {
+                    // All non-numeric values are converted to "off" flag.
+                    return (is_numeric($Value)) ? $Value : 2;
+                },
+                $DefaultPermissions
+            );
         }
 
         // Set the default permissions on the placeholder.

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -247,6 +247,18 @@ class PermissionModel extends Gdn_Model {
         }
         $Structure->set(false, false);
 
+        // If this is our initial setup, map missing permissions to off.
+        try {
+            // This is going to throw an exception if none exists.
+            $this->getRowDefaults();
+        } catch (Exception $Ex) {
+            foreach ($DefaultPermissions as $Name => $Value) {
+                if (!is_numeric($Value)) {
+                    $DefaultPermissions[$Name] = 2;
+                }
+            }
+        }
+
         // Set the default permissions on the placeholder.
         $this->SQL
             ->set($this->_backtick($DefaultPermissions), '', false)

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -198,12 +198,12 @@ class PermissionModel extends Gdn_Model {
     }
 
     /**
+     * Define one or more permissions with default values.
      *
-     *
-     * @param $PermissionNames
+     * @param array $PermissionNames
      * @param string $Type
-     * @param null $JunctionTable
-     * @param null $JunctionColumn
+     * @param string? $JunctionTable
+     * @param string? $JunctionColumn
      * @throws Exception
      */
     public function define($PermissionNames, $Type = 'tinyint', $JunctionTable = null, $JunctionColumn = null) {
@@ -212,28 +212,33 @@ class PermissionModel extends Gdn_Model {
         $Structure = $this->Database->structure();
         $Structure->table('Permission');
         $DefaultPermissions = array();
-
         $NewColumns = array();
 
         foreach ($PermissionNames as $Key => $Value) {
             if (is_numeric($Key)) {
+                // Only got a permissions name with no default.
                 $PermissionName = $Value;
                 $DefaultPermissions[$PermissionName] = 2;
             } else {
                 $PermissionName = $Key;
 
                 if ($Value === 0) {
+                    // "Off for all"
                     $DefaultPermissions[$PermissionName] = 2;
                 } elseif ($Value === 1)
+                    // "On for all"
                     $DefaultPermissions[$PermissionName] = 3;
                 elseif (!$Structure->columnExists($Value) && array_key_exists($Value, $PermissionNames))
+                    // Mapped to an explicitly-defined permission.
                     $DefaultPermissions[$PermissionName] = $PermissionNames[$Value] ? 3 : 2;
                 else {
-                    $DefaultPermissions[$PermissionName] = "`{$Value}`"; // default to another field
+                    // Mapped to another permission for which we don't have the value.
+                    $DefaultPermissions[$PermissionName] = "`{$Value}`";
                 }
             }
             if (!$Structure->columnExists($PermissionName)) {
-                $NewColumns[$PermissionName] = is_numeric($DefaultPermissions[$PermissionName]) ? $DefaultPermissions[$PermissionName] - 2 : $DefaultPermissions[$PermissionName];
+                $Default = $DefaultPermissions[$PermissionName];
+                $NewColumns[$PermissionName] = is_numeric($Default) ? $Default - 2 : $Default;
             }
 
             // Define the column.
@@ -244,7 +249,7 @@ class PermissionModel extends Gdn_Model {
 
         // Set the default permissions on the placeholder.
         $this->SQL
-            ->set($this->_Backtick($DefaultPermissions), '', false)
+            ->set($this->_backtick($DefaultPermissions), '', false)
             ->replace('Permission', array(), array('RoleID' => 0, 'JunctionTable' => $JunctionTable, 'JunctionColumn' => $JunctionColumn), true);
 
         // Set the default permissions for new columns on all roles.
@@ -257,10 +262,12 @@ class PermissionModel extends Gdn_Model {
             }
 
             $this->SQL
-                ->set($this->_Backtick($NewColumns), '', false)
+                ->set($this->_backtick($NewColumns), '', false)
                 ->put('Permission', array(), $Where);
         }
-        $this->ClearPermissions();
+
+        // Flush permissions cache & loaded schema.
+        $this->clearPermissions();
         if ($this->Schema) {
             // Redefine the schema if it has been defined to reflect the permissions that were just added.
             $this->Schema = null;

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -247,11 +247,18 @@ class PermissionModel extends Gdn_Model {
         }
         $Structure->set(false, false);
 
+        // Detect an initial permission setup by seeing if our placeholder row exists yet.
+        $DefaultRow = $this->SQL
+            ->select('*')
+            ->from('Permission')
+            ->where('RoleID', 0)
+            ->where('JunctionTable is null')
+            ->orderBy('RoleID')
+            ->limit(1)
+            ->get()->firstRow(DATASET_TYPE_ARRAY);
+
         // If this is our initial setup, map missing permissions to off.
-        try {
-            // This is going to throw an exception if none exists.
-            $this->getRowDefaults();
-        } catch (Exception $Ex) {
+        if (!$DefaultRow) {
             foreach ($DefaultPermissions as $Name => $Value) {
                 if (!is_numeric($Value)) {
                     $DefaultPermissions[$Name] = 2;

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -83,7 +83,7 @@ if (file_exists(PATH_CONF.'/bootstrap.early.php')) {
 
 Gdn::config()->caching(true);
 
-Debug(C('Debug', false));
+Debug(true);
 
 // Default request object
 Gdn::factoryInstall(Gdn::AliasRequest, 'Gdn_Request', null, Gdn::FactoryRealSingleton, 'Create');

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -83,7 +83,7 @@ if (file_exists(PATH_CONF.'/bootstrap.early.php')) {
 
 Gdn::config()->caching(true);
 
-Debug(true);
+Debug(C('Debug', false));
 
 // Default request object
 Gdn::factoryInstall(Gdn::AliasRequest, 'Gdn_Request', null, Gdn::FactoryRealSingleton, 'Create');


### PR DESCRIPTION
See #2862

**Summary**: MySQL 5.6+ defaults to strict mode, so we need to support it. Our method of mapping permissions to defaults causes a strict mode failure on initial setup. This works around this problem by detecting this situation and force-mapping the permissions to off.

**Only functional change is the new block starting at 250 ($DefaultRow)**. Everything else is to improve the clarity (docs, casening, line length).