### PR TITLE
Expand emoji regex to allow all non-whitespace chars

### DIFF
--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -599,7 +599,7 @@ class Emoji {
         $rdelim = preg_quote($this->rdelim, '`');
         $emoji = $this;
 
-        $Text = Gdn_Format::replaceButProtectCodeBlocks("`({$ldelim}[a-z0-9_+-]+{$rdelim})`i", function ($m) use ($emoji) {
+        $Text = Gdn_Format::replaceButProtectCodeBlocks("`({$ldelim}\S+?{$rdelim})`i", function ($m) use ($emoji) {
             $emoji_name = trim($m[1], ':');
             $emoji_path = $emoji->getEmojiPath($emoji_name);
             if ($emoji_path) {


### PR DESCRIPTION
The current emoji regex allows english letters and  some arbitrary characters (`+` and `-` for `:+1:` and `:-1:`) only.

This will recognize any non-whitespace character `[^\r\n\t\f ]` between delimiters (`:`) as an emoji. (Non-greedy so that `:smile::smile:` is recognized as two emoji).