### PR TITLE
Make it possible to skip captcha if it has not been set up correct

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -247,7 +247,7 @@ class Gdn_Form extends Gdn_Pluggable {
      */
     public function captcha() {
         // Stop if captcha isn't configured and CaptchaPassByDefault is true.
-        if (!c('Garden.Registration.CaptchaPrivateKey') && c('Garden.Registration.CaptchaPassByDefault', false)) {
+        if (!c('Garden.Registration.CaptchaPrivateKey') && c('Garden.Registration.CaptchaPassByDefault', true)) {
             return;
         }
         

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -246,6 +246,11 @@ class Gdn_Form extends Gdn_Pluggable {
      * @return string
      */
     public function captcha() {
+        // Stop if captcha isn't configured and CaptchaPassByDefault is true.
+        if (!c('Garden.Registration.CaptchaPrivateKey') && c('Garden.Registration.CaptchaPassByDefault', false)) {
+            return;
+        }
+        
         // Google whitelist
         $Whitelist = array('ar', 'bg', 'ca', 'zh-CN', 'zh-TW', 'hr', 'cs', 'da', 'nl', 'en-GB', 'en', 'fil', 'fi', 'fr', 'fr-CA', 'de', 'de-AT', 'de-CH', 'el', 'iw', 'hi', 'hu', 'id', 'it', 'ja', 'ko', 'lv', 'lt', 'no', 'fa', 'pl', 'pt', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sr', 'sk', 'sl', 'es', 'es-419', 'sv', 'th', 'tr', 'uk', 'vi');
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -29,7 +29,7 @@ if (!function_exists('validateCaptcha')) {
     function validateCaptcha($value = null) {
         $captchaPrivateKey = c('Garden.Registration.CaptchaPrivateKey', '');
         if ($captchaPrivateKey == '') {
-            return c('Garden.Registration.CaptchaPassByDefault', false);
+            return c('Garden.Registration.CaptchaPassByDefault', true);
         }
         require_once PATH_LIBRARY.'/vendors/recaptcha/functions.recaptchalib.php';
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -19,7 +19,7 @@
  * @since 2.0
  */
 
-if (!function_exists('ValidateCaptcha')) {
+if (!function_exists('validateCaptcha')) {
     /**
      * Validate the request captcha.
      *
@@ -27,16 +27,23 @@ if (!function_exists('ValidateCaptcha')) {
      * @return bool Returns true if the captcha is valid or an error message otherwise.
      */
     function validateCaptcha($value = null) {
+        $captchaPrivateKey = c('Garden.Registration.CaptchaPrivateKey', '');
+        if ($captchaPrivateKey == '') {
+            return c('Garden.Registration.CaptchaPassByDefault', false);
+        }
         require_once PATH_LIBRARY.'/vendors/recaptcha/functions.recaptchalib.php';
 
-        $CaptchaPrivateKey = C('Garden.Registration.CaptchaPrivateKey', '');
-        $Response = recaptcha_check_answer(
-            $CaptchaPrivateKey,
-            Gdn::Request()->IpAddress(),
-            Gdn::Request()->Post('recaptcha_challenge_field', ''),
-            Gdn::Request()->Post('recaptcha_response_field', '')
+        $response = recaptcha_check_answer(
+            $captchaPrivateKey,
+            Gdn::request()->ipAddress(),
+            Gdn::request()->post('recaptcha_challenge_field', ''),
+            Gdn::request()->post('recaptcha_response_field', '')
         );
-        return $Response->is_valid ? true : 'The reCAPTCHA value was not entered correctly. Please try again.';
+        if ($response->is_valid) {
+            return true;
+        } else {
+            return 'The reCAPTCHA value was not entered correctly. Please try again.';
+        }
     }
 }
 


### PR DESCRIPTION
When captcha is not configured, new users are seeing the misleading "To use reCAPTCHA you must get an API key from https://www.google.com/recaptcha/admin" and are not able to register. Bad.

Adding a new config setting 'Garden.Registration.CaptchaPassByDefault' which defaults to true would skip the captcha if it isn't set up. That way admins could decide to do without captchas by not configuring it or they can use them as they do by now, but no new users will be rejected before the captcha is configured.