### PR TITLE
Activity page length configuration

### DIFF
--- a/applications/dashboard/controllers/class.activitycontroller.php
+++ b/applications/dashboard/controllers/class.activitycontroller.php
@@ -125,7 +125,7 @@ class ActivityController extends Gdn_Controller {
         }
 
         // Which page to load
-        list($Offset, $Limit) = offsetLimit($Page, 30);
+        list($Offset, $Limit) = offsetLimit($Page, c('Garden.Activities.PerPage', 30));
         $Offset = is_numeric($Offset) ? $Offset : 0;
         if ($Offset < 0) {
             $Offset = 0;

--- a/applications/dashboard/settings/configuration.php
+++ b/applications/dashboard/settings/configuration.php
@@ -6,3 +6,4 @@
 // All of the settings defined here can be overridden in the /conf/*.php files.
 
 $Configuration['Garden']['Profile']['EditUsernames'] = false;
+$Configuration['Garden']['Activities']['PerPage'] = 30;


### PR DESCRIPTION
It is currently not possible to change the length of an activity page.

I don't think this warrants a GUI, but I do think it is important.