### PR TITLE
Make alternate() use parameters correctly

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -8,14 +8,31 @@
  * @since 2.0
  */
 
+/**
+ * Write alternating strings on each call.
+ *
+ * Useful for adding different classes to alternating lines in a list
+ * or table to enhance their readability.
+ *
+ * @param string $odd The text for the first and every further "odd" call.
+ * @param string $even The text for the second and every further "even" call.
+ * @param string $attributeName The html attribute name that should embrace $even/$odd output.
+ * @return string
+ */
 if (!function_exists('alternate')) {
-    function alternate($Odd = 'Alt', $Even = '', $AttributeName = 'class') {
-        static $i = 0;
-        $Value = $i++ % 2 ? $Odd : $Even;
-        if ($Value != '' && $Even == '' && $AttributeName) {
-            $Value = ' '.$AttributeName.'="'.$Value.'"';
+    function alternate($odd = '', $even = 'Alt', $attributeName = 'class') {
+        static $b = false;
+        if ($b = !$b) {
+            $value = $odd;
+        } else {
+            $value = $even;
         }
-        return $Value;
+
+        if ($value != '' && $attributeName != '') {
+            return ' '.$attributeName.'="'.$value.'"';
+        } else {
+            return $value;
+        }
     }
 }
 


### PR DESCRIPTION
I first thought of changing alternate() when I saw it uses a modulo calculation when handling a bool value would also be enough, but looking closer at it showed that the output of `function alternate($Odd = 'Alt', $Even = '', $AttributeName = 'class')` is in almost any combination of parameters not what you expect.

Called without any parameters, it echos the following:
Odd:
Even: ` class="Alt"`
...
Already here it is faulty: it uses the standard $Odd parameter for the even lines.

If I pass `alternate('odd', 'even')`, I get
Odd:  `even`
Even: `odd` 
That they are mixed up was to be expected after point 1, but I would expect those to be enclosed in class="..."

Even if I pass `alternate('odd', 'even', 'arbitraryName')`, I only get
Odd:  `even`
Even: `odd` 


So it's obviously not as useful as the parameters makes us think it is. That's why I have *totally* rewritten it. Good news is, that the function is neither used in Vanilla nor in any of the many, many plugins and themes that I have downloaded (I did a grep through more than 100 plugins)