### PR TITLE
Tweak the way errors are traced

### DIFF
--- a/applications/dashboard/views/modules/trace.php
+++ b/applications/dashboard/views/modules/trace.php
@@ -60,6 +60,9 @@
             if (!in_array($Type, array(TRACE_ERROR, TRACE_INFO, TRACE_NOTICE, TRACE_WARNING))) {
                 $Var = $Type;
                 $Type = TRACE_INFO;
+            } elseif (!$Message) {
+                // Don't show empty messages.
+                continue;
             }
             ?>
             <tr>

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -62,8 +62,8 @@ function Gdn_ErrorHandler($ErrorNumber, $Message, $File, $Line, $Arguments) {
     }
 
     if (($ErrorReporting & $ErrorNumber) !== $ErrorNumber) {
-        if (function_exists('Trace')) {
-            Trace("$Message in $File line $Line", TRACE_NOTICE);
+        if (function_exists('trace')) {
+            trace(new \ErrorException($Message, $ErrorNumber, $ErrorNumber, $File, $Line), TRACE_NOTICE);
         }
 
         // Ignore errors that are below the current error reporting level.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3730,9 +3730,7 @@ if (!function_exists('trace')) {
             return $Traces;
         }
 
-        if ($Value) {
-            $Traces[] = array($Value, $Type);
-        }
+        $Traces[] = array($Value, $Type);
     }
 }
 


### PR DESCRIPTION
- Trace errors as ErrorException objects instead of just their messages.
- Render empty error variables. Before they were ignored in the trace output.