### PR TITLE
Fix PHP notice with a partial slave database config

### DIFF
--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -498,10 +498,10 @@ class Gdn_Database {
      */
     public function slave() {
         if ($this->_Slave === null) {
-            if (empty($this->_SlaveConfig)) {
+            if (empty($this->_SlaveConfig) || empty($this->_SlaveConfig['Dsn'])) {
                 $this->_Slave = $this->connection();
             } else {
-                $this->_Slave = $this->newPDO($this->_SlaveConfig['Dsn'], $this->_SlaveConfig['User'], $this->_SlaveConfig['Password']);
+                $this->_Slave = $this->newPDO($this->_SlaveConfig['Dsn'], val('User', $this->_SlaveConfig), val('Password', $this->_SlaveConfig));
             }
         }
 


### PR DESCRIPTION
Remove notice when a slave database in configured with no password.

To test a slave configuration you can specify a slave DSN to be the same as the master configuration.

```php
$Configuration['Database']['Slave']['Dsn'] = 'mysql:host=localhost;dbname=xxx';
$Configuration['Database']['Slave']['User'] = 'xxx';
```