### PR TITLE
Fix photo removal to always wipe field and selectively attempt file delete

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1803,13 +1803,17 @@ class UserModel extends Gdn_Model {
     public function removePicture($UserID) {
         // Grab the current photo.
         $User = $this->getID($UserID, DATASET_TYPE_ARRAY);
-        if ($Photo = $User['Photo']) {
+        $Photo = $User['Photo'];
+
+        // Only attempt to delete a physical file, not a URL.
+        if (!isUrl($Photo)) {
             $ProfilePhoto = changeBasename($Photo, 'p%s');
             $Upload = new Gdn_Upload();
             $Upload->delete($ProfilePhoto);
-
-            $this->setField($UserID, 'Photo', null);
         }
+
+        // Wipe the Photo field.
+        $this->setField($UserID, 'Photo', null);
     }
 
     /**


### PR DESCRIPTION
Currently `usermodel->removePhoto()` will only set `User.Photo` to `null` if the current value evaluates to `true` (If `Photo` were `0` for instance, it would get stuck), and it blindly attempts to delete a physical file even tho it's acceptable for that field to be a URL. This fixes both of these bad behaviors.