### PR TITLE
Move ability to set avatar to URL into /profile/picture

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -737,11 +737,9 @@ class ProfileController extends Gdn_Controller {
             $this->Form->setFormValue('UserID', $this->User->UserID);
 
             // Set user's Photo attribute to a URL, provided the current user has proper permission to do so.
-            if (Gdn::session()->checkPermission('Garden.Settings.Manage')) {
-                $photoUrl = $this->Form->getFormValue('Url', false);
-                if ($photoUrl && isUrl($photoUrl)) {
-                    $UserPhoto = $photoUrl;
-                }
+            $photoUrl = $this->Form->getFormValue('Url', false);
+            if ($photoUrl && isUrl($photoUrl) && Gdn::session()->checkPermission('Garden.Settings.Manage')) {
+                $UserPhoto = $photoUrl;
             } else {
                 $UploadImage = new Gdn_UploadImage();
                 try {

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -738,8 +738,12 @@ class ProfileController extends Gdn_Controller {
 
             // Set user's Photo attribute to a URL, provided the current user has proper permission to do so.
             $photoUrl = $this->Form->getFormValue('Url', false);
-            if ($photoUrl && isUrl($photoUrl) && Gdn::session()->checkPermission('Garden.Settings.Manage')) {
-                $UserPhoto = $photoUrl;
+            if ($photoUrl && Gdn::session()->checkPermission('Garden.Settings.Manage')) {
+                if (isUrl($photoUrl) && filter_var($photoUrl, FILTER_VALIDATE_URL)) {
+                    $UserPhoto = $photoUrl;
+                } else {
+                    $this->Form->addError('Invalid photo URL');
+                }
             } else {
                 $UploadImage = new Gdn_UploadImage();
                 try {

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -736,10 +736,12 @@ class ProfileController extends Gdn_Controller {
         if ($this->Form->authenticatedPostBack() === true) {
             $this->Form->setFormValue('UserID', $this->User->UserID);
 
-            // Set user's Photo attribute to a URL
-            $photoUrl = $this->Form->getFormValue('Url', false);
-            if ($photoUrl && isUrl($photoUrl)) {
-                $UserPhoto = $photoUrl;
+            // Set user's Photo attribute to a URL, provided the current user has proper permission to do so.
+            if (Gdn::session()->checkPermission('Garden.Settings.Manage')) {
+                $photoUrl = $this->Form->getFormValue('Url', false);
+                if ($photoUrl && isUrl($photoUrl)) {
+                    $UserPhoto = $photoUrl;
+                }
             } else {
                 $UploadImage = new Gdn_UploadImage();
                 try {

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -402,12 +402,6 @@ class ProfileController extends Gdn_Controller {
 
             if (Gdn::session()->checkPermission('Garden.Settings.Manage')) {
 
-                // Set user's Photo attribute to a URL
-                $userPhoto = $this->Form->getFormValue('Photo', false);
-                if ($userPhoto && isUrl($userPhoto)) {
-                    Gdn::userModel()->removeFilterField('Photo');
-                }
-
                 // Role change
 
                 $RequestedRoles = $this->Form->getFormValue('RoleID', null);
@@ -741,28 +735,34 @@ class ProfileController extends Gdn_Controller {
 
         if ($this->Form->authenticatedPostBack() === true) {
             $this->Form->setFormValue('UserID', $this->User->UserID);
-            $UploadImage = new Gdn_UploadImage();
-            try {
-                // Validate the upload
-                $TmpImage = $UploadImage->ValidateUpload('Picture');
 
-                // Generate the target image name.
-                $TargetImage = $UploadImage->GenerateTargetName(PATH_UPLOADS, '', true);
-                $Basename = pathinfo($TargetImage, PATHINFO_BASENAME);
-                $Subdir = stringBeginsWith(dirname($TargetImage), PATH_UPLOADS.'/', false, true);
+            // Set user's Photo attribute to a URL
+            $photoUrl = $this->Form->getFormValue('Url', false);
+            if ($photoUrl && isUrl($photoUrl)) {
+                $UserPhoto = $photoUrl;
+            } else {
+                $UploadImage = new Gdn_UploadImage();
+                try {
+                    // Validate the upload
+                    $TmpImage = $UploadImage->ValidateUpload('Picture');
 
-                // Delete any previously uploaded image.
-                $UploadImage->delete(changeBasename($this->User->Photo, 'p%s'));
+                    // Generate the target image name.
+                    $TargetImage = $UploadImage->GenerateTargetName(PATH_UPLOADS, '', true);
+                    $Basename = pathinfo($TargetImage, PATHINFO_BASENAME);
+                    $Subdir = stringBeginsWith(dirname($TargetImage), PATH_UPLOADS . '/', false, true);
 
-                // Save the uploaded image in profile size.
-                $Props = $UploadImage->SaveImageAs(
-                    $TmpImage,
-                    "userpics/$Subdir/p$Basename",
-                    c('Garden.Profile.MaxHeight', 1000),
-                    c('Garden.Profile.MaxWidth', 250),
-                    array('SaveGif' => c('Garden.Thumbnail.SaveGif'))
-                );
-                $UserPhoto = sprintf($Props['SaveFormat'], "userpics/$Subdir/$Basename");
+                    // Delete any previously uploaded image.
+                    $UploadImage->delete(changeBasename($this->User->Photo, 'p%s'));
+
+                    // Save the uploaded image in profile size.
+                    $Props = $UploadImage->SaveImageAs(
+                        $TmpImage,
+                        "userpics/$Subdir/p$Basename",
+                        c('Garden.Profile.MaxHeight', 1000),
+                        c('Garden.Profile.MaxWidth', 250),
+                        array('SaveGif' => c('Garden.Thumbnail.SaveGif'))
+                    );
+                    $UserPhoto = sprintf($Props['SaveFormat'], "userpics/$Subdir/$Basename");
 
 //            // Save the uploaded image in preview size
 //            $UploadImage->SaveImageAs(
@@ -772,22 +772,23 @@ class ProfileController extends Gdn_Controller {
 //               Gdn::config('Garden.Preview.MaxWidth', 75)
 //            );
 
-                // Save the uploaded image in thumbnail size
-                $ThumbSize = Gdn::config('Garden.Thumbnail.Size', 40);
-                $UploadImage->saveImageAs(
-                    $TmpImage,
-                    "userpics/$Subdir/n$Basename",
-                    $ThumbSize,
-                    $ThumbSize,
-                    array('Crop' => true, 'SaveGif' => c('Garden.Thumbnail.SaveGif'))
-                );
+                    // Save the uploaded image in thumbnail size
+                    $ThumbSize = Gdn::config('Garden.Thumbnail.Size', 40);
+                    $UploadImage->saveImageAs(
+                        $TmpImage,
+                        "userpics/$Subdir/n$Basename",
+                        $ThumbSize,
+                        $ThumbSize,
+                        array('Crop' => true, 'SaveGif' => c('Garden.Thumbnail.SaveGif'))
+                    );
 
-            } catch (Exception $Ex) {
-                // Throw the exception on API calls.
-                if ($this->deliveryType() === DELIVERY_TYPE_DATA) {
-                    throw $Ex;
+                } catch (Exception $Ex) {
+                    // Throw the exception on API calls.
+                    if ($this->deliveryType() === DELIVERY_TYPE_DATA) {
+                        throw $Ex;
+                    }
+                    $this->Form->addError($Ex);
                 }
-                $this->Form->addError($Ex);
             }
             // If there were no errors, associate the image with the user
             if ($this->Form->errorCount() == 0) {

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -120,7 +120,9 @@ class Gdn_Upload extends Gdn_Pluggable {
 
         if (!$Handled) {
             $Path = PATH_UPLOADS.'/'.ltrim($Name, '/');
-            @unlink($Path);
+            if ($Path = realpath($Path)) {
+                @unlink($Path);
+            }
         }
     }
 

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -120,7 +120,7 @@ class Gdn_Upload extends Gdn_Pluggable {
 
         if (!$Handled) {
             $Path = PATH_UPLOADS.'/'.ltrim($Name, '/');
-            if ($Path = realpath($Path)) {
+            if ($Path == realpath($Path)) {
                 @unlink($Path);
             }
         }


### PR DESCRIPTION
Move the ability to set a user's photo to a URL to `/profile/picture` and tighten the security involved in such an action.