### PR TITLE
Remove some deprecated language features in the OpenID library

### DIFF
--- a/library/vendors/Auth/OpenID/AX.php
+++ b/library/vendors/Auth/OpenID/AX.php
@@ -888,7 +888,7 @@ class Auth_OpenID_AX_FetchResponse extends Auth_OpenID_AX_KeyValueMessage {
             $ax_args['update_url'] = $update_url;
         }
 
-        Auth_OpenID::update(&$ax_args, $kv_args);
+        Auth_OpenID::update($ax_args, $kv_args);
 
         return $ax_args;
     }
@@ -960,7 +960,7 @@ class Auth_OpenID_AX_StoreRequest extends Auth_OpenID_AX_KeyValueMessage {
     {
         $ax_args = $this->_newArgs();
         $kv_args = $this->_getExtensionKVArgs($aliases);
-        Auth_OpenID::update(&$ax_args, $kv_args);
+        Auth_OpenID::update($ax_args, $kv_args);
         return $ax_args;
     }
 }

--- a/library/vendors/Auth/OpenID/Consumer.php
+++ b/library/vendors/Auth/OpenID/Consumer.php
@@ -268,9 +268,9 @@ class Auth_OpenID_Consumer {
         $this->session =& $session;
 
         if ($consumer_cls !== null) {
-            $this->consumer =& new $consumer_cls($store);
+            $this->consumer = new $consumer_cls($store);
         } else {
-            $this->consumer =& new Auth_OpenID_GenericConsumer($store);
+            $this->consumer = new Auth_OpenID_GenericConsumer($store);
         }
 
         $this->_token_key = $this->session_key_prefix . $this->_token_suffix;

--- a/library/vendors/Auth/OpenID/Server.php
+++ b/library/vendors/Auth/OpenID/Server.php
@@ -1097,7 +1097,7 @@ class Auth_OpenID_CheckIDRequest extends Auth_OpenID_Request {
                                   in OpenID 1.x immediate mode.');
                 }
 
-                $setup_request =& new Auth_OpenID_CheckIDRequest(
+                $setup_request = new Auth_OpenID_CheckIDRequest(
                                                 $this->identity,
                                                 $this->return_to,
                                                 $this->trust_root,
@@ -1677,9 +1677,9 @@ class Auth_OpenID_Server {
     function Auth_OpenID_Server(&$store, $op_endpoint=null)
     {
         $this->store =& $store;
-        $this->signatory =& new Auth_OpenID_Signatory($this->store);
-        $this->encoder =& new Auth_OpenID_SigningEncoder($this->signatory);
-        $this->decoder =& new Auth_OpenID_Decoder($this);
+        $this->signatory = new Auth_OpenID_Signatory($this->store);
+        $this->encoder = new Auth_OpenID_SigningEncoder($this->signatory);
+        $this->decoder = new Auth_OpenID_Decoder($this);
         $this->op_endpoint = $op_endpoint;
         $this->negotiator =& Auth_OpenID_getDefaultNegotiator();
     }

--- a/library/vendors/Auth/Yadis/XRDS.php
+++ b/library/vendors/Auth/Yadis/XRDS.php
@@ -352,7 +352,7 @@ class Auth_Yadis_XRDS {
         $services = $this->parser->evalXPath('xrd:Service', $this->xrdNode);
 
         foreach ($services as $node) {
-            $s =& new Auth_Yadis_Service();
+            $s = new Auth_Yadis_Service();
             $s->element = $node;
             $s->parser =& $this->parser;
 


### PR DESCRIPTION
These changes are a result of passing PHP’s code linter over our source code. If you want to add lint checking to your local machine you can try the bash script [here](https://gist.github.com/tburry/53b374492b24beae1b0b).