### PR TITLE
Respect format coming from params on comment preview

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -697,6 +697,7 @@ class PostController extends VanillaController {
                         $this->Comment->InsertPhoto = $Session->User->Photo;
                         $this->Comment->DateInserted = Gdn_Format::date();
                         $this->Comment->Body = val('Body', $FormValues, '');
+                        $this->Comment->Format = val('Format', $FormValues, c('Garden.InputFormatter'));
                         $this->View = 'preview';
                     } elseif (!$Draft) { // If the comment was not a draft
                         // If Editing a comment


### PR DESCRIPTION
I have a [plugin](https://github.com/JasonBarnabe/ChooseYourOwnFormat) that lets users choose whether to post in Markdown or HTML.

In 2.2, Vanilla is not reading the `Format` parameter on an AJAX comment preview. It reads it correctly when posting the comment, as well as posting or previewing discussions, but just not previewing comments. This PR fixes that.