### PR TITLE
Enforce tinyint on Category fields.

### DIFF
--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -564,7 +564,18 @@ class SettingsController extends Gdn_Controller {
                 $this->Form->setFormValue('Photo', $Parts['SaveName']);
             }
             $this->Form->setFormValue('CustomPoints', (bool)$this->Form->getFormValue('CustomPoints'));
-            $this->Form->boolToTinyInt(array('HideAllDiscussions', 'Archived', 'AllowFileUploads'));
+
+            // Enforces tinyint values on boolean fields to comply with strict mode
+            $tinyintFields = array('HideAllDiscussions', 'Archived', 'AllowFileUploads');
+            $values = $this->Form->formValues();
+            foreach ($tinyintFields as $field) {
+                if (array_key_exists($field, $values)) {
+                    $val = val($field, $values, false);
+                    $values[$field] = forceBool($val, false, '1', '0');
+                }
+            }
+            $this->Form->formValues($values);
+
             if ($this->Form->save()) {
                 $Category = CategoryModel::categories($CategoryID);
                 $this->setData('Category', $Category);

--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -564,7 +564,7 @@ class SettingsController extends Gdn_Controller {
                 $this->Form->setFormValue('Photo', $Parts['SaveName']);
             }
             $this->Form->setFormValue('CustomPoints', (bool)$this->Form->getFormValue('CustomPoints'));
-
+            $this->Form->boolToTinyInt(array('HideAllDiscussions', 'Archived', 'AllowFileUploads'));
             if ($this->Form->save()) {
                 $Category = CategoryModel::categories($CategoryID);
                 $this->setData('Category', $Category);

--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -566,15 +566,9 @@ class SettingsController extends Gdn_Controller {
             $this->Form->setFormValue('CustomPoints', (bool)$this->Form->getFormValue('CustomPoints'));
 
             // Enforces tinyint values on boolean fields to comply with strict mode
-            $tinyintFields = array('HideAllDiscussions', 'Archived', 'AllowFileUploads');
-            $values = $this->Form->formValues();
-            foreach ($tinyintFields as $field) {
-                if (array_key_exists($field, $values)) {
-                    $val = val($field, $values, false);
-                    $values[$field] = forceBool($val, false, '1', '0');
-                }
-            }
-            $this->Form->formValues($values);
+            $this->Form->setFormValue('HideAllDiscussions', forceBool($this->Form->getFormValue('HideAllDiscussions'), '0', '1', '0'));
+            $this->Form->setFormValue('Archived', forceBool($this->Form->getFormValue('Archived'), '0', '1', '0'));
+            $this->Form->setFormValue('AllowFileUploads', forceBool($this->Form->getFormValue('AllowFileUploads'), '0', '1', '0'));
 
             if ($this->Form->save()) {
                 $Category = CategoryModel::categories($CategoryID);

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -415,22 +415,6 @@ class Gdn_Form extends Gdn_Pluggable {
     }
 
     /**
-     * Enforces tinyint values on supplied boolean fields to comply with strict mode
-     *
-     * @param array $fields The names of the fields to coerce into boolean tinyint values (1 or 0)
-     */
-    public function boolToTinyInt($fields) {
-        $values = $this->formValues();
-        foreach ($fields as $field) {
-            if (array_key_exists($field, $values)) {
-                $val = val($field, $values, false);
-                $values[$field] = $val ? '1' : '0';
-            }
-        }
-        $this->formValues($values);
-    }
-
-    /**
      * Returns XHTML for a checkbox input element.
      *
      * Cannot consider all checkbox values to be boolean. (2009-04-02 mosullivan)

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -415,6 +415,22 @@ class Gdn_Form extends Gdn_Pluggable {
     }
 
     /**
+     * Enforces tinyint values on supplied boolean fields to comply with strict mode
+     *
+     * @param array $fields The names of the fields to coerce into boolean tinyint values (1 or 0)
+     */
+    public function boolToTinyInt($fields) {
+        $values = $this->formValues();
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $values)) {
+                $val = val($field, $values, false);
+                $values[$field] = $val ? '1' : '0';
+            }
+        }
+        $this->formValues($values);
+    }
+
+    /**
      * Returns XHTML for a checkbox input element.
      *
      * Cannot consider all checkbox values to be boolean. (2009-04-02 mosullivan)


### PR DESCRIPTION
Fixes issue where Categories cannot be saved or edited with strict mode enabled.