### PR TITLE
Make addons mobile-friendly by default (opt out, not in)

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -556,8 +556,8 @@ class Gdn_PluginManager extends Gdn_Pluggable {
         foreach ($this->enabledPlugins() as $PluginName => $Trash) {
             $PluginInfo = $this->getPluginInfo($PluginName);
 
-            // Remove plugin hooks from plugins that dont explicitly claim to be friendly with mobile themes
-            if (!val('MobileFriendly', $PluginInfo)) {
+            // Remove plugin hooks from plugins that explicitly claim to not be mobile friendly
+            if (array_key_exists('MobileFriendly', $PluginInfo) && !val('MobileFriendly', $PluginInfo)) {
                 $this->unregisterPlugin(val('ClassName', $PluginInfo));
             }
         }

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -557,7 +557,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
             $PluginInfo = $this->getPluginInfo($PluginName);
 
             // Remove plugin hooks from plugins that explicitly claim to not be mobile friendly
-            if (array_key_exists('MobileFriendly', $PluginInfo) && !val('MobileFriendly', $PluginInfo)) {
+            if (!val('MobileFriendly', $PluginInfo, true)) {
                 $this->unregisterPlugin(val('ClassName', $PluginInfo));
             }
         }


### PR DESCRIPTION
Changes the way mobile friendliness is determined in a plugin's settings, as MobileFriendly should be the rule, not the exception.
Before we would need to mark a plugin as 'MobileFriendly' => true for it to work on mobile.
This pr would make is necessary to mark 'MobileFriendly' => false to disable it on mobile.