### PR TITLE
Fix class constructors for forwards compatibility

### DIFF
--- a/library/core/class.passwordhash.php
+++ b/library/core/class.passwordhash.php
@@ -26,7 +26,7 @@ class Gdn_PasswordHash extends PasswordHash {
      */
     function __construct() {
         // 8 iteration to create a Portable hash
-        parent::passwordHash(8, false);
+        parent::__construct(8, false);
     }
 
     /**

--- a/library/vendors/Auth/OpenID/AX.php
+++ b/library/vendors/Auth/OpenID/AX.php
@@ -69,7 +69,7 @@ function Auth_OpenID_AX_checkAlias($alias)
  * @package OpenID
  */
 class Auth_OpenID_AX_Error {
-    function Auth_OpenID_AX_Error($message=null)
+    function __construct($message=null)
     {
         $this->message = $message;
     }
@@ -151,7 +151,7 @@ class Auth_OpenID_AX_AttrInfo {
      * @param string $alias The name that should be given to this
      * attribute in the request.
      */
-    function Auth_OpenID_AX_AttrInfo($type_uri, $count, $required,
+    function __construct($type_uri, $count, $required,
                                      $alias)
     {
         /**
@@ -269,7 +269,7 @@ class Auth_OpenID_AX_FetchRequest extends Auth_OpenID_AX_Message {
 
     var $mode = 'fetch_request';
 
-    function Auth_OpenID_AX_FetchRequest($update_url=null)
+    function __construct($update_url=null)
     {
         /**
          * requested_attributes: The attributes that have been
@@ -312,7 +312,7 @@ class Auth_OpenID_AX_FetchRequest extends Auth_OpenID_AX_Message {
      */
     function getExtensionArgs()
     {
-        $aliases = new Auth_OpenID_NamespaceMap();
+        $aliases =& new Auth_OpenID_NamespaceMap();
 
         $required = array();
         $if_available = array();
@@ -540,7 +540,7 @@ class Auth_OpenID_AX_FetchRequest extends Auth_OpenID_AX_Message {
  */
 class Auth_OpenID_AX_KeyValueMessage extends Auth_OpenID_AX_Message {
 
-    function Auth_OpenID_AX_KeyValueMessage()
+    function __construct()
     {
         $this->data = array();
     }
@@ -793,7 +793,7 @@ class Auth_OpenID_AX_KeyValueMessage extends Auth_OpenID_AX_Message {
 class Auth_OpenID_AX_FetchResponse extends Auth_OpenID_AX_KeyValueMessage {
     var $mode = 'fetch_response';
 
-    function Auth_OpenID_AX_FetchResponse($update_url=null)
+    function __construct($update_url=null)
     {
         $this->Auth_OpenID_AX_KeyValueMessage();
         $this->update_url = $update_url;
@@ -990,7 +990,7 @@ class Auth_OpenID_AX_StoreResponse extends Auth_OpenID_AX_Message {
         return new Auth_OpenID_AX_StoreResponse($succeeded, $error_message);
     }
 
-    function Auth_OpenID_AX_StoreResponse($succeeded=true, $error_message=null)
+    function __construct($succeeded=true, $error_message=null)
     {
         if ($succeeded) {
             $this->mode = $this->SUCCESS_MODE;

--- a/library/vendors/Auth/OpenID/Association.php
+++ b/library/vendors/Auth/OpenID/Association.php
@@ -128,7 +128,7 @@ class Auth_OpenID_Association {
      * this time is 'HMAC-SHA1' and 'HMAC-SHA256', but new types may
      * be defined in the future.
      */
-    function Auth_OpenID_Association(
+    function __construct(
         $handle, $secret, $issued, $lifetime, $assoc_type)
     {
         if (!in_array($assoc_type,
@@ -525,7 +525,7 @@ function &Auth_OpenID_getEncryptedNegotiator()
  * @package OpenID
  */
 class Auth_OpenID_SessionNegotiator {
-    function Auth_OpenID_SessionNegotiator($allowed_types)
+    function __construct($allowed_types)
     {
         $this->allowed_types = array();
         $this->setAllowedTypes($allowed_types);

--- a/library/vendors/Auth/OpenID/Consumer.php
+++ b/library/vendors/Auth/OpenID/Consumer.php
@@ -258,7 +258,7 @@ class Auth_OpenID_Consumer {
      * when creating the internal consumer object.  This is used for
      * testing.
      */
-    function Auth_OpenID_Consumer(&$store, $session = null,
+    function __construct(&$store, $session = null,
                                   $consumer_cls = null)
     {
         if ($session === null) {
@@ -456,7 +456,7 @@ class Auth_OpenID_DiffieHellmanSHA1ConsumerSession {
     var $secret_size = 20;
     var $allowed_assoc_types = array('HMAC-SHA1');
 
-    function Auth_OpenID_DiffieHellmanSHA1ConsumerSession($dh = null)
+    function __construct($dh = null)
     {
         if ($dh === null) {
             $dh = new Auth_OpenID_DiffieHellman();
@@ -1748,7 +1748,7 @@ class Auth_OpenID_AuthRequest {
      * class.  Instances of this class are created by the library when
      * needed.
      */
-    function Auth_OpenID_AuthRequest(&$endpoint, $assoc)
+    function __construct(&$endpoint, $assoc)
     {
         $this->assoc = $assoc;
         $this->endpoint =& $endpoint;
@@ -2027,7 +2027,7 @@ class Auth_OpenID_SuccessResponse extends Auth_OpenID_ConsumerResponse {
     /**
      * @access private
      */
-    function Auth_OpenID_SuccessResponse($endpoint, $message, $signed_args=null)
+    function __construct($endpoint, $message, $signed_args=null)
     {
         $this->endpoint = $endpoint;
         $this->identity_url = $endpoint->claimed_id;
@@ -2130,7 +2130,7 @@ class Auth_OpenID_SuccessResponse extends Auth_OpenID_ConsumerResponse {
 class Auth_OpenID_FailureResponse extends Auth_OpenID_ConsumerResponse {
     var $status = Auth_OpenID_FAILURE;
 
-    function Auth_OpenID_FailureResponse($endpoint, $message = null,
+    function __construct($endpoint, $message = null,
                                          $contact = null, $reference = null)
     {
         $this->setEndpoint($endpoint);
@@ -2155,7 +2155,7 @@ class Auth_OpenID_TypeURIMismatch extends Auth_OpenID_FailureResponse {
  * @package OpenID
  */
 class Auth_OpenID_ServerErrorContainer {
-    function Auth_OpenID_ServerErrorContainer($error_text,
+    function __construct($error_text,
                                               $error_code,
                                               $message)
     {
@@ -2193,7 +2193,7 @@ class Auth_OpenID_ServerErrorContainer {
 class Auth_OpenID_CancelResponse extends Auth_OpenID_ConsumerResponse {
     var $status = Auth_OpenID_CANCEL;
 
-    function Auth_OpenID_CancelResponse($endpoint)
+    function __construct($endpoint)
     {
         $this->setEndpoint($endpoint);
     }
@@ -2219,7 +2219,7 @@ class Auth_OpenID_CancelResponse extends Auth_OpenID_ConsumerResponse {
 class Auth_OpenID_SetupNeededResponse extends Auth_OpenID_ConsumerResponse {
     var $status = Auth_OpenID_SETUP_NEEDED;
 
-    function Auth_OpenID_SetupNeededResponse($endpoint,
+    function __construct($endpoint,
                                              $setup_url = null)
     {
         $this->setEndpoint($endpoint);

--- a/library/vendors/Auth/OpenID/DiffieHellman.php
+++ b/library/vendors/Auth/OpenID/DiffieHellman.php
@@ -47,7 +47,7 @@ class Auth_OpenID_DiffieHellman {
     var $private;
     var $lib = null;
 
-    function Auth_OpenID_DiffieHellman($mod = null, $gen = null,
+    function __construct($mod = null, $gen = null,
                                        $private = null, $lib = null)
     {
         if ($lib === null) {

--- a/library/vendors/Auth/OpenID/Discover.php
+++ b/library/vendors/Auth/OpenID/Discover.php
@@ -36,7 +36,7 @@ function Auth_OpenID_getOpenIDTypeURIs()
  * Object representing an OpenID service endpoint.
  */
 class Auth_OpenID_ServiceEndpoint {
-    function Auth_OpenID_ServiceEndpoint()
+    function __construct()
     {
         $this->claimed_id = null;
         $this->server_url = null;

--- a/library/vendors/Auth/OpenID/DumbStore.php
+++ b/library/vendors/Auth/OpenID/DumbStore.php
@@ -50,7 +50,7 @@ class Auth_OpenID_DumbStore extends Auth_OpenID_OpenIDStore {
      * @param string secret_phrase The phrase used to create the auth
      * key returned by getAuthKey
      */
-    function Auth_OpenID_DumbStore($secret_phrase)
+    function __construct($secret_phrase)
     {
         $this->auth_key = Auth_OpenID_SHA1($secret_phrase);
     }

--- a/library/vendors/Auth/OpenID/FileStore.php
+++ b/library/vendors/Auth/OpenID/FileStore.php
@@ -46,7 +46,7 @@ class Auth_OpenID_FileStore extends Auth_OpenID_OpenIDStore {
      * @param string $directory This is the directory to put the store
      * directories in.
      */
-    function Auth_OpenID_FileStore($directory)
+    function __construct($directory)
     {
         if (!Auth_OpenID::ensureDir($directory)) {
             trigger_error('Not a directory and failed to create: '

--- a/library/vendors/Auth/OpenID/MemcachedStore.php
+++ b/library/vendors/Auth/OpenID/MemcachedStore.php
@@ -41,7 +41,7 @@ class Auth_OpenID_MemcachedStore extends Auth_OpenID_OpenIDStore {
      *
      * @param resource connection Memcache connection resourse
      */
-    function Auth_OpenID_MemcachedStore($connection, $compress = false)
+    function __construct($connection, $compress = false)
     {
         $this->connection = $connection;
         $this->compress = $compress ? MEMCACHE_COMPRESSED : 0;

--- a/library/vendors/Auth/OpenID/Message.php
+++ b/library/vendors/Auth/OpenID/Message.php
@@ -127,7 +127,7 @@ class Auth_OpenID_Mapping {
      * Initialize a mapping.  If $classic_array is specified, its keys
      * and values are used to populate the mapping.
      */
-    function Auth_OpenID_Mapping($classic_array = null)
+    function __construct($classic_array = null)
     {
         $this->keys = array();
         $this->values = array();
@@ -274,7 +274,7 @@ class Auth_OpenID_Mapping {
  * @package OpenID
  */
 class Auth_OpenID_NamespaceMap {
-    function Auth_OpenID_NamespaceMap()
+    function __construct()
     {
         $this->alias_to_namespace = new Auth_OpenID_Mapping();
         $this->namespace_to_alias = new Auth_OpenID_Mapping();
@@ -414,7 +414,7 @@ class Auth_OpenID_NamespaceMap {
  */
 class Auth_OpenID_Message {
 
-    function Auth_OpenID_Message($openid_namespace = null)
+    function __construct($openid_namespace = null)
     {
         // Create an empty Message
         $this->allowed_openid_namespaces = array(

--- a/library/vendors/Auth/OpenID/PAPE.php
+++ b/library/vendors/Auth/OpenID/PAPE.php
@@ -37,7 +37,7 @@ class Auth_OpenID_PAPE_Request extends Auth_OpenID_Extension {
     var $ns_alias = 'pape';
     var $ns_uri = Auth_OpenID_PAPE_NS_URI;
 
-    function Auth_OpenID_PAPE_Request($preferred_auth_policies=null,
+    function __construct($preferred_auth_policies=null,
                                       $max_auth_age=null)
     {
         if ($preferred_auth_policies === null) {
@@ -161,7 +161,7 @@ class Auth_OpenID_PAPE_Response extends Auth_OpenID_Extension {
     var $ns_alias = 'pape';
     var $ns_uri = Auth_OpenID_PAPE_NS_URI;
 
-    function Auth_OpenID_PAPE_Response($auth_policies=null, $auth_time=null,
+    function __construct($auth_policies=null, $auth_time=null,
                                        $nist_auth_level=null)
     {
         if ($auth_policies) {

--- a/library/vendors/Auth/OpenID/Parse.php
+++ b/library/vendors/Auth/OpenID/Parse.php
@@ -108,7 +108,7 @@ class Auth_OpenID_Parse {
     var $_open_tag_expr = "<%s\b";
     var $_close_tag_expr = "<((\/%s\b)|(%s[^>\/]*\/))>";
 
-    function Auth_OpenID_Parse()
+    function __construct()
     {
         $this->_link_find = sprintf("/<link\b(?!:)([^>]*)(?!<)>/%s",
                                     $this->_re_flags);

--- a/library/vendors/Auth/OpenID/SQLStore.php
+++ b/library/vendors/Auth/OpenID/SQLStore.php
@@ -85,7 +85,7 @@ class Auth_OpenID_SQLStore extends Auth_OpenID_OpenIDStore {
      * the name of the table used for storing nonces.  The default
      * value is 'oid_nonces'.
      */
-    function Auth_OpenID_SQLStore($connection,
+    function __construct($connection,
                                   $associations_table = null,
                                   $nonces_table = null)
     {

--- a/library/vendors/Auth/OpenID/SReg.php
+++ b/library/vendors/Auth/OpenID/SReg.php
@@ -418,7 +418,7 @@ class Auth_OpenID_SRegResponse extends Auth_OpenID_SRegBase {
 
     var $ns_alias = 'sreg';
 
-    function Auth_OpenID_SRegResponse($data=null,
+    function __construct($data=null,
                                       $sreg_ns_uri=Auth_OpenID_SREG_NS_URI)
     {
         if ($data === null) {

--- a/library/vendors/Auth/OpenID/Server.php
+++ b/library/vendors/Auth/OpenID/Server.php
@@ -353,7 +353,7 @@ class Auth_OpenID_CheckAuthRequest extends Auth_OpenID_Request {
     var $mode = "check_authentication";
     var $invalidate_handle = null;
 
-    function Auth_OpenID_CheckAuthRequest($assoc_handle, $signed,
+    function __construct($assoc_handle, $signed,
                                           $invalidate_handle = null)
     {
         $this->assoc_handle = $assoc_handle;
@@ -590,7 +590,7 @@ class Auth_OpenID_AssociateRequest extends Auth_OpenID_Request {
           'DH-SHA256' => 'Auth_OpenID_DiffieHellmanSHA256ServerSession');
     }
 
-    function Auth_OpenID_AssociateRequest(&$session, $assoc_type)
+    function __construct(&$session, $assoc_type)
     {
         $this->session =& $session;
         $this->namespace = Auth_OpenID_OPENID2_NS;
@@ -763,7 +763,7 @@ class Auth_OpenID_CheckIDRequest extends Auth_OpenID_Request {
         }
     }
 
-    function Auth_OpenID_CheckIDRequest($identity, $return_to,
+    function __construct($identity, $return_to,
                                         $trust_root = null, $immediate = false,
                                         $assoc_handle = null, $server = null,
                                         $claimed_id = null)

--- a/library/vendors/Auth/Yadis/HTTPFetcher.php
+++ b/library/vendors/Auth/Yadis/HTTPFetcher.php
@@ -23,7 +23,7 @@ define('Auth_OpenID_USER_AGENT',
        'php-openid/'.Auth_OpenID_VERSION.' (php/'.phpversion().')');
 
 class Auth_Yadis_HTTPResponse {
-    function Auth_Yadis_HTTPResponse($final_url = null, $status = null,
+    function __construct($final_url = null, $status = null,
                                          $headers = null, $body = null)
     {
         $this->final_url = $final_url;

--- a/library/vendors/Auth/Yadis/Manager.php
+++ b/library/vendors/Auth/Yadis/Manager.php
@@ -280,7 +280,7 @@ class Auth_Yadis_Manager {
      *
      * @access private
      */
-    function Auth_Yadis_Manager($starting_url, $yadis_url,
+    function __construct($starting_url, $yadis_url,
                                     $services, $session_key)
     {
         // The URL that was used to initiate the Yadis protocol
@@ -387,7 +387,7 @@ class Auth_Yadis_Discovery {
      * @param string $session_key_suffix The optional session key
      * suffix override.
      */
-    function Auth_Yadis_Discovery(&$session, $url,
+    function __construct(&$session, $url,
                                       $session_key_suffix = null)
     {
         /// Initialize a discovery object

--- a/library/vendors/Auth/Yadis/ParanoidHTTPFetcher.php
+++ b/library/vendors/Auth/Yadis/ParanoidHTTPFetcher.php
@@ -27,7 +27,7 @@ require_once "Auth/OpenID.php";
  * @package OpenID
  */
 class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
-    function Auth_Yadis_ParanoidHTTPFetcher()
+    function __construct()
     {
         $this->reset();
     }

--- a/library/vendors/Auth/Yadis/ParseHTML.php
+++ b/library/vendors/Auth/Yadis/ParseHTML.php
@@ -43,7 +43,7 @@ class Auth_Yadis_ParseHTML {
      */
     var $_attr_find = '\b([-\w]+)=(".*?"|\'.*?\'|.+?)[\/\s>]';
 
-    function Auth_Yadis_ParseHTML()
+    function __construct()
     {
         $this->_attr_find = sprintf("/%s/%s",
                                     $this->_attr_find,

--- a/library/vendors/Smarty-2.6.25/libs/Smarty_Compiler.class.php
+++ b/library/vendors/Smarty-2.6.25/libs/Smarty_Compiler.class.php
@@ -78,7 +78,7 @@ class Smarty_Compiler extends Smarty {
     /**
      * The class constructor.
      */
-    function Smarty_Compiler()
+    function __construct()
     {
         // matches double quoted strings:
         // "foobar"

--- a/library/vendors/pclzip/pclzip.lib.php
+++ b/library/vendors/pclzip/pclzip.lib.php
@@ -212,7 +212,7 @@
   //   Note that no real action is taken, if the archive does not exist it is not
   //   created. Use create() for that.
   // --------------------------------------------------------------------------------
-  function PclZip($p_zipname)
+  function __construct($p_zipname)
   {
 
     // ----- Tests the zlib

--- a/library/vendors/phpThumb/phpthumb.ico.php
+++ b/library/vendors/phpThumb/phpthumb.ico.php
@@ -11,7 +11,7 @@
 
 class phpthumb_ico {
 
-	function phpthumb_ico() {
+	function __construct() {
 		return true;
 	}
 

--- a/library/vendors/phpass/PasswordHash.php
+++ b/library/vendors/phpass/PasswordHash.php
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 


### PR DESCRIPTION
PHP 7 deprecates class constructors named with the class name. Renaming them to __constuct() ensures that we will be compatible with future versions of PHP.