### PR TITLE
Refactor tagging to support ajax forms

### DIFF
--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -261,6 +261,9 @@ class TaggingPlugin extends Gdn_Plugin {
         if (isset($Sender->Data['Discussions'])) {
             TagModel::instance()->joinTags($Sender->Data['Discussions']);
         }
+
+        $Sender->addJsFile('tagging.js', 'plugins/Tagging');
+        $Sender->addJsFile('jquery.tokeninput.js');
     }
 
     /**
@@ -593,8 +596,6 @@ class TaggingPlugin extends Gdn_Plugin {
      * @param PostController $Sender
      */
     public function postController_render_before($Sender) {
-        $Sender->addJsFile('jquery.tokeninput.js');
-        $Sender->addJsFile('tagging.js', 'plugins/Tagging');
         $Sender->addDefinition('PluginsTaggingAdd', Gdn::session()->checkPermission('Plugins.Tagging.Add'));
         $Sender->addDefinition('PluginsTaggingSearchUrl', Gdn::request()->Url('plugin/tagsearch'));
 

--- a/plugins/Tagging/js/tagging.js
+++ b/plugins/Tagging/js/tagging.js
@@ -1,62 +1,73 @@
-jQuery(document).ready(function($) {
-    var btn = $('div#DiscussionForm form :submit');
-    var parent = $(btn).parents('div#DiscussionForm');
-    var frm = $(parent).find('form');
+var discussionTagging = {
 
-    frm.bind('BeforeDiscussionSubmit', function(e, frm, btn) {
-        var taglist = $(frm).find('input#Form_Tags');
-        taglist.triggerHandler('BeforeSubmit', [frm]);
-    });
+    start: function($page) {
+        var btn = $page.find('div#DiscussionForm form :submit');
+        var parent = $(btn).parents('div#DiscussionForm');
+        var frm = $(parent).find('form');
 
-    var tags;
-    var data_tags = $("#Form_Tags").data('tags');
-    if (data_tags) {
-        tags = [];
-        if (jQuery.isPlainObject(data_tags)) {
-            for (id in data_tags) {
-                tags.push({id: id, name: data_tags[id]});
-            }
-        }
-    } else {
-        tags = $("#Form_Tags").val();
-        if (tags && tags.length) {
-            tags = tags.split(",");
+        frm.bind('BeforeDiscussionSubmit', function (e, frm, btn) {
+            var taglist = $(frm).find('input#Form_Tags');
+            taglist.triggerHandler('BeforeSubmit', [frm]);
+        });
 
-            for (i = 0; i < tags.length; i++) {
-                tags[i] = {id: tags[i], name: tags[i]};
+        var tags;
+        var data_tags = $page.find("#Form_Tags").data('tags');
+
+        if (data_tags) {
+            tags = [];
+            if (jQuery.isPlainObject(data_tags)) {
+                for (id in data_tags) {
+                    tags.push({id: id, name: data_tags[id]});
+                }
             }
         } else {
-            tags = [];
+            tags = $page.find("#Form_Tags").val();
+            if (tags && tags.length) {
+                tags = tags.split(",");
+
+                for (i = 0; i < tags.length; i++) {
+                    tags[i] = {id: tags[i], name: tags[i]};
+                }
+            } else {
+                tags = [];
+            }
         }
+
+        var TagSearch = gdn.definition('PluginsTaggingSearchUrl', gdn.url('plugin/tagsearch'));
+        var TagAdd = gdn.definition('PluginsTaggingAdd', false);
+
+        $page.find("#Form_Tags").tokenInput(TagSearch, {
+            hintText: gdn.definition("TagHint", "Start to type..."),
+            searchingText: '', // search text gives flickery ux, don't like
+            searchDelay: 300,
+            animateDropdown: false,
+            minChars: 1,
+            maxLength: 25,
+            prePopulate: tags,
+            dataFields: ["#Form_CategoryID"],
+            allowFreeTagging: TagAdd,
+            zindex: 3000
+        });
+
+        // Show available link
+        $page.on('click', '.ShowTags a', function () {
+            $page.find('.ShowTags a').hide();
+            $page.find('.AvailableTags').show();
+            return false;
+        });
+
+        // Use available tags
+        $page.on('click', '.AvailableTag', function () {
+            //$(this).hide();
+            var tag = $(this).attr('data-id');
+            $page.find("#Form_Tags").tokenInput('add', {id: tag, name: $(this).text()});
+            return false;
+        });
     }
+}
 
-    var TagSearch = gdn.definition('PluginsTaggingSearchUrl', false);
-    var TagAdd = gdn.definition('PluginsTaggingAdd', false);
-    $("#Form_Tags").tokenInput(TagSearch, {
-        hintText: gdn.definition("TagHint", "Start to type..."),
-        searchingText: '', // search text gives flickery ux, don't like
-        searchDelay: 300,
-        animateDropdown: false,
-        minChars: 1,
-        maxLength: 25,
-        prePopulate: tags,
-        dataFields: ["#Form_CategoryID"],
-        allowFreeTagging: TagAdd
-    });
-
-    // Show available link
-    $(document).on('click', '.ShowTags a', function() {
-        $('.ShowTags a').hide();
-        $('.AvailableTags').show();
-        return false;
-    });
-
-    // Use available tags
-    $(document).on('click', '.AvailableTag', function() {
-        //$(this).hide();
-        var tag = $(this).attr('data-id');
-
-        $("#Form_Tags").tokenInput('add', {id: tag, name: $(this).text()});
-        return false;
+jQuery(document).ready(function($) {
+    $('#DiscussionForm').each(function() {
+        discussionTagging.start($(this));
     });
 });


### PR DESCRIPTION
The discussion form on lithe is ajax-ed in. Refactoring the javascript allows us to re-instantiate the class when the dom is updated. Partially fixes bug where tagging doesn't work on the Lithe mobile theme. Also handles case where multiple forms appear on the same page.