### PR TITLE
Lower the amount of ProxyRequest response body logging

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -527,8 +527,8 @@ class ProxyRequest {
         curl_setopt($Handler, CURLOPT_URL, $Url);
         curl_setopt($Handler, CURLOPT_PORT, $Port);
 
-        if (val('Log', $Options, false)) {
-            Logger::event('http_request', Logger::DEBUG, '{method} {url}', $logContext);
+        if (val('LogRequest', $Options, false)) {
+            Logger::event('http_request', Logger::INFO, '{method} {url}', $logContext);
         }
 
         $this->curlReceive($Handler);
@@ -544,8 +544,13 @@ class ProxyRequest {
         $logContext['responseTime'] = $this->ResponseTime;
 
         // Add the response body to the log entry if it isn't too long or we are debugging.
-        if (debug() || strlen($this->responseBody) < self::MAX_LOG_BODYLENGTH) {
-            if ($this->ContentType == 'application/json') {
+        $logResponseBody = val('LogResponseBody', $Options, null);
+        $logResponseBody = $logResponseBody === null ?
+            !in_array($RequestMethod, ['GET', 'OPTIONS']) && strlen($this->responseBody) < self::MAX_LOG_BODYLENGTH :
+            $logResponseBody;
+
+        if ($logResponseBody || debug()) {
+            if (stripos($this->ContentType, 'application/json') !== false) {
                 $body = @json_decode($this->ResponseBody, true);
                 if (!$body) {
                     $body = $this->ResponseBody;
@@ -555,11 +560,12 @@ class ProxyRequest {
                 $logContext['responseBody'] = $this->ResponseBody;
             }
         }
+        $logLevel = val('Log', $Options, true) ? Logger::INFO : Logger::DEBUG;
         if (val('Log', $Options, true)) {
             if ($this->responseClass('2xx')) {
-                Logger::event('http_response', Logger::DEBUG, '{responseCode} {method} {url} in {responseTime}s', $logContext);
+                Logger::event('http_response', $logLevel, '{responseCode} {method} {url} in {responseTime}s', $logContext);
             } else {
-                Logger::event('http_response_error', Logger::DEBUG, '{responseCode} {method} {url} in {responseTime}s', $logContext);
+                Logger::event('http_response_error', $logLevel, '{responseCode} {method} {url} in {responseTime}s', $logContext);
             }
         }
 


### PR DESCRIPTION
The response body ends up logging a lot of data. This feature decreases response body logging by default in the following ways:

- Don’t log the response bodies of GET or OPTIONS requests unless it is forced via the `LogResponseBody` option.

- Correct a bug in JSON-encoded responses. This will decrease the amount of escaping in the response and save us some bytes.

- Logging requests is now controlled via the `LogRequest` option and is disabled by default.

- Logging is now done at the INFO level because we intend to stop recording DEBUG level messages except via the debug bar.