### PR TITLE
Fix issue with formatting “0” in formatString().

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1261,8 +1261,8 @@ if (!function_exists('_formatStringCallback')) {
             $SubFormat = '';
         }
 
-        $Value = valr($Field, $Args, '');
-        if ($Value == '' && !in_array($Format, array('url', 'exurl', 'number', 'plural'))) {
+        $Value = valr($Field, $Args, null);
+        if ($Value === null && !in_array($Format, array('url', 'exurl', 'number', 'plural'))) {
             $Result = '';
         } else {
             switch (strtolower($Format)) {


### PR DESCRIPTION
There was an issue when the context contained a 0 that it would output an empty string. Try this code to test:

```php
die(formatString('"{num}" === 0', ['num' => 0]));
```