### PR TITLE
Add the LogResponseErrorBody option to ProxyRequest

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -549,7 +549,7 @@ class ProxyRequest {
             !in_array($RequestMethod, ['GET', 'OPTIONS']) && strlen($this->responseBody) < self::MAX_LOG_BODYLENGTH :
             $logResponseBody;
 
-        if ($logResponseBody || debug()) {
+        if ($logResponseBody || debug() || (!$this->responseClass('2xx') && val('LogResponseErrorBody', $Options, true))) {
             if (stripos($this->ContentType, 'application/json') !== false) {
                 $body = @json_decode($this->ResponseBody, true);
                 if (!$body) {


### PR DESCRIPTION
This allows code to not log regular responses, but log them when there is an HTTP error.