### PR TITLE
Moves Visit UserModel event from dispatcher to UserModel

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2864,6 +2864,7 @@ class UserModel extends Gdn_Model {
 
             if (Gdn::session()->newVisit()) {
                 $Fields['CountVisits'] = val('CountVisits', $User, 0) + 1;
+                $this->fireEvent('Visit');
             }
         }
 

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -146,10 +146,6 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
         $Request = is_a($ImportRequest, 'Gdn_Request') ? $ImportRequest : Gdn::request();
 
-        if (Gdn::session()->newVisit()) {
-            Gdn::userModel()->fireEvent('Visit');
-        }
-
         $this->EventArguments['Request'] = &$Request;
 
         // Move this up to allow pre-routing


### PR DESCRIPTION
I've experienced issues with the `Visit` event being fired by `UserModel`.  Specifically, I was unable to successfully obtain an Anniversary badge with the Badges plug-in until I moved this event.  Moving the `UserModel::fireEvent` call from `Gdn_Dispatcher` and putting it in a similar place in `UserModel` seemed to do the trick.