### PR TITLE
Cleanup the Vanilla hooks file & bootstrap

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -337,7 +337,7 @@ class VanillaHooks implements Gdn_IPlugin {
                 $PermissionCategoryID = -1;
             }
 
-            $Result = $PermissionModel->GetUserPermissions($UserID, $Permission, 'Category', 'PermissionCategoryID', 'CategoryID', $PermissionCategoryID);
+            $Result = $PermissionModel->getUserPermissions($UserID, $Permission, 'Category', 'PermissionCategoryID', 'CategoryID', $PermissionCategoryID);
             return (val($Permission, val(0, $Result), false)) ? true : false;
         }
         return false;
@@ -470,7 +470,7 @@ class VanillaHooks implements Gdn_IPlugin {
      */
     public function siteNavModule_default_handler($sender) {
         // Grab the default route so that we don't add a link to it twice.
-        $home = trim(val('Destination', Gdn::router()->GetRoute('DefaultController')), '/');
+        $home = trim(val('Destination', Gdn::router()->getRoute('DefaultController')), '/');
 
         // Add the site discussion links.
         if ($home !== 'categories') {
@@ -703,7 +703,7 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param object $Sender DashboardController.
      */
-    public function base_GetAppSettingsMenuItems_Handler($Sender) {
+    public function base_getAppSettingsMenuItems_Handler($Sender) {
         $Menu = &$Sender->EventArguments['SideMenu'];
         $Menu->addLink('Moderation', t('Flood Control'), 'vanilla/settings/floodcontrol', 'Garden.Settings.Manage', array('class' => 'nav-flood-control'));
         $Menu->addLink('Forum', t('Categories'), 'vanilla/settings/managecategories', 'Garden.Community.Manage', array('class' => 'nav-manage-categories'));

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -527,7 +527,7 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param ProfileController $Sender ProfileController.
      */
-    public function profileController_Comments_Create($Sender, $UserReference = '', $Username = '', $Page = '', $UserID = '') {
+    public function profileController_comments_create($Sender, $UserReference = '', $Username = '', $Page = '', $UserID = '') {
         $Sender->editMode(false);
         $View = $Sender->View;
 

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -703,7 +703,7 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param object $Sender DashboardController.
      */
-    public function base_getAppSettingsMenuItems_Handler($Sender) {
+    public function base_getAppSettingsMenuItems_handler($Sender) {
         $Menu = &$Sender->EventArguments['SideMenu'];
         $Menu->addLink('Moderation', t('Flood Control'), 'vanilla/settings/floodcontrol', 'Garden.Settings.Manage', array('class' => 'nav-flood-control'));
         $Menu->addLink('Forum', t('Categories'), 'vanilla/settings/managecategories', 'Garden.Community.Manage', array('class' => 'nav-manage-categories'));

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -18,7 +18,7 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param DbaController $Sender
      */
-    public function dbaController_CountJobs_Handler($Sender) {
+    public function dbaController_countJobs_handler($Sender) {
         $Counts = array(
             'Discussion' => array('CountComments', 'FirstCommentID', 'LastCommentID', 'DateLastComment', 'LastCommentUserID'),
             'Category' => array('CountDiscussions', 'CountComments', 'LastDiscussionID', 'LastCommentID', 'LastDateInserted')
@@ -28,7 +28,6 @@ class VanillaHooks implements Gdn_IPlugin {
             foreach ($Columns as $Column) {
                 $Name = "Recalculate $Table.$Column";
                 $Url = "/dba/counts.json?".http_build_query(array('table' => $Table, 'column' => $Column));
-
                 $Sender->Data['Jobs'][$Name] = $Url;
             }
         }
@@ -79,7 +78,6 @@ class VanillaHooks implements Gdn_IPlugin {
                 ->groupBy('DiscussionID')
                 ->get()->resultArray();
             $discussionIDs = array_column($discussionIDs, 'DiscussionID');
-
 
             Gdn::userModel()->getDelete('Comment', array('InsertUserID' => $userID), $data);
 
@@ -303,13 +301,13 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param UserModel $Sender UserModel.
      */
-    public function userModel_BeforeDeleteUser_Handler($Sender) {
+    public function userModel_beforeDeleteUser_handler($Sender) {
         $UserID = val('UserID', $Sender->EventArguments);
         $Options = val('Options', $Sender->EventArguments, array());
         $Options = is_array($Options) ? $Options : array();
         $Content =& $Sender->EventArguments['Content'];
 
-        $this->DeleteUserData($UserID, $Options, $Content);
+        $this->deleteUserData($UserID, $Options, $Content);
     }
 
     /**
@@ -321,9 +319,8 @@ class VanillaHooks implements Gdn_IPlugin {
      * @param $Sender UserModel.
      * @return bool Whether user has permission.
      */
-    public function userModel_GetCategoryViewPermission_Create($Sender) {
+    public function userModel_getCategoryViewPermission_create($Sender) {
         static $PermissionModel = null;
-
 
         $UserID = val(0, $Sender->EventArguments, '');
         $CategoryID = val(1, $Sender->EventArguments, '');
@@ -357,7 +354,7 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param object $Sender DashboardController.
      */
-    public function base_Render_Before($Sender) {
+    public function base_render_before($Sender) {
         $Session = Gdn::session();
         if ($Sender->Menu) {
             $Sender->Menu->addLink('Discussions', t('Discussions'), '/discussions', false, array('Standard' => true));
@@ -372,7 +369,7 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param object $Sender ProfileController.
      */
-    public function profileController_AddProfileTabs_Handler($Sender) {
+    public function profileController_addProfileTabs_handler($Sender) {
         if (is_object($Sender->User) && $Sender->User->UserID > 0) {
             $UserID = $Sender->User->UserID;
             // Add the discussion tab
@@ -382,8 +379,8 @@ class VanillaHooks implements Gdn_IPlugin {
                 $DiscussionsLabel .= '<span class="Aside">'.CountString(GetValueR('User.CountDiscussions', $Sender, null), "/profile/count/discussions?userid=$UserID").'</span>';
                 $CommentsLabel .= '<span class="Aside">'.CountString(GetValueR('User.CountComments', $Sender, null), "/profile/count/comments?userid=$UserID").'</span>';
             }
-            $Sender->AddProfileTab(t('Discussions'), 'profile/discussions/'.$Sender->User->UserID.'/'.rawurlencode($Sender->User->Name), 'Discussions', $DiscussionsLabel);
-            $Sender->AddProfileTab(t('Comments'), 'profile/comments/'.$Sender->User->UserID.'/'.rawurlencode($Sender->User->Name), 'Comments', $CommentsLabel);
+            $Sender->addProfileTab(t('Discussions'), 'profile/discussions/'.$Sender->User->UserID.'/'.rawurlencode($Sender->User->Name), 'Discussions', $DiscussionsLabel);
+            $Sender->addProfileTab(t('Comments'), 'profile/comments/'.$Sender->User->UserID.'/'.rawurlencode($Sender->User->Name), 'Comments', $CommentsLabel);
             // Add the discussion tab's CSS and Javascript.
             $Sender->addJsFile('jquery.gardenmorepager.js');
             $Sender->addJsFile('discussions.js', 'vanilla');
@@ -398,23 +395,16 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param ProfileController $Sender
      */
-    public function profileController_AfterPreferencesDefined_Handler($Sender) {
+    public function profileController_afterPreferencesDefined_handler($Sender) {
         $Sender->Preferences['Notifications']['Email.DiscussionComment'] = t('Notify me when people comment on my discussions.');
         $Sender->Preferences['Notifications']['Email.BookmarkComment'] = t('Notify me when people comment on my bookmarked discussions.');
         $Sender->Preferences['Notifications']['Email.Mention'] = t('Notify me when people mention me.');
         $Sender->Preferences['Notifications']['Email.ParticipateComment'] = t('Notify me when people comment on discussions I\'ve participated in.');
 
-
         $Sender->Preferences['Notifications']['Popup.DiscussionComment'] = t('Notify me when people comment on my discussions.');
         $Sender->Preferences['Notifications']['Popup.BookmarkComment'] = t('Notify me when people comment on my bookmarked discussions.');
         $Sender->Preferences['Notifications']['Popup.Mention'] = t('Notify me when people mention me.');
         $Sender->Preferences['Notifications']['Popup.ParticipateComment'] = t('Notify me when people comment on discussions I\'ve participated in.');
-
-//      if (Gdn::session()->checkPermission('Garden.AdvancedNotifications.Allow')) {
-//         $Sender->Preferences['Notifications']['Email.NewDiscussion'] = array(t('Notify me when people start new discussions.'), 'Meta');
-//         $Sender->Preferences['Notifications']['Email.NewComment'] = array(t('Notify me when people comment on a discussion.'), 'Meta');
-////      $Sender->Preferences['Notifications']['Popup.NewDiscussion'] = t('Notify me when people start new discussions.');
-//      }
 
         if (Gdn::session()->checkPermission('Garden.AdvancedNotifications.Allow')) {
             $PostBack = $Sender->Form->authenticatedPostBack();
@@ -446,12 +436,13 @@ class VanillaHooks implements Gdn_IPlugin {
             }
             $Sender->setData('CategoryNotifications', $Categories);
             if ($PostBack) {
-                UserModel::SetMeta($Sender->User->UserID, $Set, 'Preferences.');
+                UserModel::setMeta($Sender->User->UserID, $Set, 'Preferences.');
             }
         }
     }
 
     /**
+     * Add the advanced notifications view to profiles.
      *
      * @param ProfileController $Sender
      */
@@ -471,39 +462,7 @@ class VanillaHooks implements Gdn_IPlugin {
      */
     public function searchModel_Search_Handler($Sender) {
         $SearchModel = new VanillaSearchModel();
-        $SearchModel->Search($Sender);
-    }
-
-    /**
-     * Load forum information into the BuzzData collection.
-     *
-     * @since 2.0.0
-     * @package Vanilla
-     *
-     * @param object $Sender SettingsController.
-     */
-    public function settingsController_DashboardData_Handler($Sender) {
-        /*
-        $DiscussionModel = new DiscussionModel();
-        // Number of Discussions
-        $CountDiscussions = $DiscussionModel->getCount();
-        $Sender->addDefinition('CountDiscussions', $CountDiscussions);
-        $Sender->BuzzData[T('Discussions')] = number_format($CountDiscussions);
-        // Number of New Discussions in the last day
-        $Sender->BuzzData[T('New discussions in the last day')] = number_format($DiscussionModel->getCount(array('d.DateInserted >=' => Gdn_Format::toDateTime(strtotime('-1 day')))));
-        // Number of New Discussions in the last week
-        $Sender->BuzzData[T('New discussions in the last week')] = number_format($DiscussionModel->getCount(array('d.DateInserted >=' => Gdn_Format::toDateTime(strtotime('-1 week')))));
-
-        $CommentModel = new CommentModel();
-        // Number of Comments
-        $CountComments = $CommentModel->getCountWhere();
-        $Sender->addDefinition('CountComments', $CountComments);
-        $Sender->BuzzData[T('Comments')] = number_format($CountComments);
-        // Number of New Comments in the last day
-        $Sender->BuzzData[T('New comments in the last day')] = number_format($CommentModel->getCountWhere(array('DateInserted >=' => Gdn_Format::toDateTime(strtotime('-1 day')))));
-        // Number of New Comments in the last week
-        $Sender->BuzzData[T('New comments in the last week')] = number_format($CommentModel->getCountWhere(array('DateInserted >=' => Gdn_Format::toDateTime(strtotime('-1 week')))));
-        */
+        $SearchModel->search($Sender);
     }
 
     /**
@@ -538,6 +497,8 @@ class VanillaHooks implements Gdn_IPlugin {
     }
 
     /**
+     * Add discussion & comment links to profiles.
+     *
      * @param SiteLinkMenuModule $sender
      */
     public function siteNavModule_profile_handler($sender) {
@@ -569,21 +530,22 @@ class VanillaHooks implements Gdn_IPlugin {
     public function profileController_Comments_Create($Sender, $UserReference = '', $Username = '', $Page = '', $UserID = '') {
         $Sender->editMode(false);
         $View = $Sender->View;
+
         // Tell the ProfileController what tab to load
         $Sender->getUserInfo($UserReference, $Username, $UserID);
         $Sender->_setBreadcrumbs(t('Comments'), userUrl($Sender->User, '', 'comments'));
         $Sender->SetTabView('Comments', 'profile', 'Discussion', 'Vanilla');
 
-        $PageSize = Gdn::config('Vanilla.Discussions.PerPage', 30);
+        $PageSize = c('Vanilla.Discussions.PerPage', 30);
         list($Offset, $Limit) = offsetLimit($Page, $PageSize);
 
         $CommentModel = new CommentModel();
-        $Comments = $CommentModel->GetByUser2($Sender->User->UserID, $Limit, $Offset, $Sender->Request->get('lid'));
+        $Comments = $CommentModel->getByUser2($Sender->User->UserID, $Limit, $Offset, $Sender->Request->get('lid'));
         $TotalRecords = $Offset + $CommentModel->LastCommentCount + 1;
 
         // Build a pager
         $PagerFactory = new Gdn_PagerFactory();
-        $Sender->Pager = $PagerFactory->GetPager('MorePager', $Sender);
+        $Sender->Pager = $PagerFactory->getPager('MorePager', $Sender);
         $Sender->Pager->MoreCode = 'More Comments';
         $Sender->Pager->LessCode = 'Newer Comments';
         $Sender->Pager->ClientID = 'Pager';
@@ -624,25 +586,25 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param ProfileController $Sender ProfileController.
      */
-    public function profileController_Discussions_Create($Sender, $UserReference = '', $Username = '', $Page = '', $UserID = '') {
+    public function profileController_discussions_create($Sender, $UserReference = '', $Username = '', $Page = '', $UserID = '') {
         $Sender->editMode(false);
 
         // Tell the ProfileController what tab to load
         $Sender->getUserInfo($UserReference, $Username, $UserID);
         $Sender->_setBreadcrumbs(t('Discussions'), userUrl($Sender->User, '', 'discussions'));
-        $Sender->SetTabView('Discussions', 'Profile', 'Discussions', 'Vanilla');
+        $Sender->setTabView('Discussions', 'Profile', 'Discussions', 'Vanilla');
         $Sender->CountCommentsPerPage = c('Vanilla.Comments.PerPage', 30);
 
-        list($Offset, $Limit) = offsetLimit($Page, Gdn::config('Vanilla.Discussions.PerPage', 30));
+        list($Offset, $Limit) = offsetLimit($Page, c('Vanilla.Discussions.PerPage', 30));
 
         $DiscussionModel = new DiscussionModel();
-        $Discussions = $DiscussionModel->GetByUser($Sender->User->UserID, $Limit, $Offset, false, Gdn::session()->UserID);
+        $Discussions = $DiscussionModel->getByUser($Sender->User->UserID, $Limit, $Offset, false, Gdn::session()->UserID);
         $CountDiscussions = $Offset + $DiscussionModel->LastDiscussionCount + 1;
         $Sender->DiscussionData = $Sender->setData('Discussions', $Discussions);
 
         // Build a pager
         $PagerFactory = new Gdn_PagerFactory();
-        $Sender->Pager = $PagerFactory->GetPager('MorePager', $Sender);
+        $Sender->Pager = $PagerFactory->getPager('MorePager', $Sender);
         $Sender->Pager->MoreCode = 'More Discussions';
         $Sender->Pager->LessCode = 'Newer Discussions';
         $Sender->Pager->ClientID = 'Pager';
@@ -683,25 +645,26 @@ class VanillaHooks implements Gdn_IPlugin {
      *
      * @param object $Sender SettingsController.
      */
-    public function settingsController_DefineAdminPermissions_Handler($Sender) {
+    public function settingsController_defineAdminPermissions_handler($Sender) {
         if (isset($Sender->RequiredAdminPermissions)) {
             $Sender->RequiredAdminPermissions[] = 'Garden.Settings.Manage';
         }
     }
 
-    public function gdn_Statistics_Tick_Handler($Sender, $Args) {
-        $Path = Gdn::request()->Post('Path');
-        $Args = Gdn::request()->Post('Args');
+    /**
+     * Discussion view counter.
+     *
+     * @param $Sender
+     * @param $Args
+     */
+    public function gdn_statistics_tick_handler($Sender, $Args) {
+        $Path = Gdn::request()->post('Path');
+        $Args = Gdn::request()->post('Args');
         parse_str($Args, $Args);
-        $ResolvedPath = trim(Gdn::request()->Post('ResolvedPath'), '/');
-        $ResolvedArgs = Gdn::request()->Post('ResolvedArgs');
+        $ResolvedPath = trim(Gdn::request()->post('ResolvedPath'), '/');
+        $ResolvedArgs = Gdn::request()->post('ResolvedArgs');
         $DiscussionID = null;
         $DiscussionModel = new DiscussionModel();
-
-//      Gdn::controller()->setData('Path', $Path);
-//      Gdn::controller()->setData('Args', $Args);
-//      Gdn::controller()->setData('ResolvedPath', $ResolvedPath);
-//      Gdn::controller()->setData('ResolvedArgs', $ResolvedArgs);
 
         // Comment permalink
         if ($ResolvedPath == 'vanilla/discussion/comment') {
@@ -720,7 +683,7 @@ class VanillaHooks implements Gdn_IPlugin {
                 $Key = "DiscussionID.ForeignID.page.$ForeignID";
                 $DiscussionID = Gdn::cache()->get($Key);
                 if (!$DiscussionID) {
-                    $Discussion = $DiscussionModel->GetForeignID($ForeignID, 'page');
+                    $Discussion = $DiscussionModel->getForeignID($ForeignID, 'page');
                     $DiscussionID = val('DiscussionID', $Discussion);
                     Gdn::cache()->store($Key, $DiscussionID, array(Gdn_Cache::FEATURE_EXPIRY, 1800));
                 }
@@ -728,7 +691,7 @@ class VanillaHooks implements Gdn_IPlugin {
         }
 
         if ($DiscussionID) {
-            $DiscussionModel->AddView($DiscussionID);
+            $DiscussionModel->addView($DiscussionID);
         }
     }
 
@@ -758,7 +721,7 @@ class VanillaHooks implements Gdn_IPlugin {
     public function setup() {
         $Database = Gdn::database();
         $Config = Gdn::factory(Gdn::AliasConfig);
-        $Drop = false; //Gdn::config('Vanilla.Version') === FALSE ? TRUE : FALSE;
+        $Drop = false;
 
         // Call structure.php to update database
         $Validation = new Gdn_Validation(); // Needed by structure.php to validate permission names

--- a/applications/vanilla/settings/configuration.php
+++ b/applications/vanilla/settings/configuration.php
@@ -1,6 +1,4 @@
-<?php if (!defined('APPLICATION')) {
-    exit();
-      }
+<?php if (!defined('APPLICATION')) exit();
 /**
  * Vanilla default configuration options.
  *

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -1,6 +1,4 @@
-<?php if (!defined('APPLICATION')) {
-    exit();
-      }
+<?php if (!defined('APPLICATION')) exit();
 /**
  * Vanilla database structure.
  *

--- a/applications/vanilla/settings/stub.php
+++ b/applications/vanilla/settings/stub.php
@@ -1,6 +1,4 @@
-<?php if (!defined('APPLICATION')) {
-    exit();
-      }
+<?php if (!defined('APPLICATION')) exit();
 /**
  * Vanilla stub content for a new forum.
  *

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -27,17 +27,18 @@ if (file_exists(PATH_ROOT.'/conf/bootstrap.before.php')) {
  * defined here, in case they've already been set by a zealous bootstrap.before.
  */
 
-// Path to the primary configuration file
+// Path to the primary configuration file.
 if (!defined('PATH_CONF')) {
     define('PATH_CONF', PATH_ROOT.'/conf');
 }
 
-// Include default constants if none were defined elsewhere
+// Include default constants if none were defined elsewhere.
 if (!defined('VANILLA_CONSTANTS')) {
     include(PATH_CONF.'/constants.php');
 }
 
-// Make sure a default time zone is set
+// Make sure a default time zone is set.
+// Do NOT edit this. See config `Garden.GuestTimeZone`.
 date_default_timezone_set('UTC');
 
 // Make sure the mb_* functions are utf8.
@@ -51,7 +52,7 @@ require_once __DIR__.'/vendor/autoload.php';
 // Initialize the autoloader.
 Gdn_Autoloader::start();
 
-// Guard against broken cache files
+// Guard against broken cache files.
 if (!class_exists('Gdn')) {
     // Throwing an exception here would result in a white screen for the user.
     // This error usually indicates the .ini files in /cache are out of date and should be deleted.
@@ -61,13 +62,13 @@ if (!class_exists('Gdn')) {
 // Cache Layer
 Gdn::factoryInstall(Gdn::AliasCache, 'Gdn_Cache', null, Gdn::FactoryRealSingleton, 'Initialize');
 
-// Install the configuration handler
+// Install the configuration handler.
 Gdn::factoryInstall(Gdn::AliasConfig, 'Gdn_Configuration');
 
-// Load default baseline Garden configurations
+// Load default baseline Garden configurations.
 Gdn::config()->load(PATH_CONF.'/config-defaults.php');
 
-// Load installation-specific configuration so that we know what apps are enabled
+// Load installation-specific configuration so that we know what apps are enabled.
 Gdn::config()->load(Gdn::config()->defaultPath(), 'Configuration', true);
 
 /**
@@ -83,7 +84,7 @@ if (file_exists(PATH_CONF.'/bootstrap.early.php')) {
 
 Gdn::config()->caching(true);
 
-Debug(C('Debug', false));
+debug(c('Debug', false));
 
 // Default request object
 Gdn::factoryInstall(Gdn::AliasRequest, 'Gdn_Request', null, Gdn::FactoryRealSingleton, 'Create');
@@ -106,7 +107,7 @@ Gdn::factoryInstall(Gdn::AliasThemeManager, 'Gdn_ThemeManager');
 // PluginManager
 Gdn::factoryInstall(Gdn::AliasPluginManager, 'Gdn_PluginManager');
 
-// Load the configurations for enabled Applications
+// Load the configurations for enabled Applications.
 foreach (Gdn::applicationManager()->enabledApplicationFolders() as $ApplicationName => $ApplicationFolder) {
     Gdn::config()->load(PATH_APPLICATIONS."/{$ApplicationFolder}/settings/configuration.php");
 }
@@ -122,7 +123,7 @@ if (Gdn::config('Garden.Installed', false) === false && strpos(Gdn_Url::request(
     exit();
 }
 
-// Re-apply loaded user settings
+// Re-apply loaded user settings.
 Gdn::config()->overlayDynamic();
 
 /**
@@ -135,7 +136,7 @@ if (file_exists(PATH_CONF.'/bootstrap.late.php')) {
     require_once(PATH_CONF.'/bootstrap.late.php');
 }
 
-if (C('Debug')) {
+if (c('Debug')) {
     debug(true);
 }
 
@@ -150,9 +151,11 @@ Gdn_Cache::trace(debug());
 
 // Default database.
 Gdn::factoryInstall(Gdn::AliasDatabase, 'Gdn_Database', null, Gdn::FactorySingleton, array('Database'));
+
 // Database drivers.
 Gdn::factoryInstall('MySQLDriver', 'Gdn_MySQLDriver', null, Gdn::FactoryInstance);
 Gdn::factoryInstall('MySQLStructure', 'Gdn_MySQLStructure', null, Gdn::FactoryInstance);
+
 // Form class
 Gdn::factoryInstall('Form', 'Gdn_Form', null, Gdn::FactoryInstance);
 
@@ -224,7 +227,7 @@ Gdn_Autoloader::attach(Gdn_Autoloader::CONTEXT_PLUGIN);
  */
 
 // Load the Garden locale system
-$Gdn_Locale = new Gdn_Locale(C('Garden.Locale', 'en'), Gdn::applicationManager()->enabledApplicationFolders(), Gdn::pluginManager()->enabledPluginFolders());
+$Gdn_Locale = new Gdn_Locale(c('Garden.Locale', 'en'), Gdn::applicationManager()->enabledApplicationFolders(), Gdn::pluginManager()->enabledPluginFolders());
 Gdn::factoryInstall(Gdn::AliasLocale, 'Gdn_Locale', null, Gdn::FactorySingleton, $Gdn_Locale);
 unset($Gdn_Locale);
 


### PR DESCRIPTION
* Missed casening, prune dead code, and fix some docs in Vanilla hooks.
* Fix `<?php if (!defined('APPLICATION')) exit();` on a few nearby files from codesniffer.
* Cleanup some comments, casening and spacing in bootstrap.