### PR TITLE
Fix incorrect Facebook API call leading to "squished" avatars

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -337,7 +337,7 @@ class FacebookPlugin extends Gdn_Plugin {
             'ConnectUrl' => $this->authorizeUri(false, self::profileConnecUrl()),
             'Profile' => array(
                 'Name' => val('name', $Profile),
-                'Photo' => "//graph.facebook.com/{$Profile['id']}/picture?type=large"
+                'Photo' => "//graph.facebook.com/{$Profile['id']}/picture?width=100&height=100"
             )
         );
     }
@@ -528,7 +528,7 @@ class FacebookPlugin extends Gdn_Plugin {
         $Form->setFormValue('ProviderName', 'Facebook');
         $Form->setFormValue('FullName', val('name', $Profile));
         $Form->setFormValue('Email', val('email', $Profile));
-        $Form->setFormValue('Photo', "//graph.facebook.com/{$ID}/picture?type=large");
+        $Form->setFormValue('Photo', "//graph.facebook.com/{$ID}/picture?width=100&height=100");
         $Form->addHidden('AccessToken', $AccessToken);
 
         if (c('Plugins.Facebook.UseFacebookNames')) {

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -337,7 +337,7 @@ class FacebookPlugin extends Gdn_Plugin {
             'ConnectUrl' => $this->authorizeUri(false, self::profileConnecUrl()),
             'Profile' => array(
                 'Name' => val('name', $Profile),
-                'Photo' => "//graph.facebook.com/{$Profile['id']}/picture?width=100&height=100"
+                'Photo' => "//graph.facebook.com/{$Profile['id']}/picture?width=200&height=200"
             )
         );
     }
@@ -528,7 +528,7 @@ class FacebookPlugin extends Gdn_Plugin {
         $Form->setFormValue('ProviderName', 'Facebook');
         $Form->setFormValue('FullName', val('name', $Profile));
         $Form->setFormValue('Email', val('email', $Profile));
-        $Form->setFormValue('Photo', "//graph.facebook.com/{$ID}/picture?width=100&height=100");
+        $Form->setFormValue('Photo', "//graph.facebook.com/{$ID}/picture?width=200&height=200");
         $Form->addHidden('AccessToken', $AccessToken);
 
         if (c('Plugins.Facebook.UseFacebookNames')) {


### PR DESCRIPTION
Facebook avatars get distorted when you post, so everyone's face is squishy. As an example, compare the following two images, where the left is the incorrect forum behavior, and the right is what it should be:

<img src="http://graph.facebook.com/10102191134460877/picture?type=large" width=100 height=100> <img src="http://graph.facebook.com/10102191134460877/picture?width=200&height=200" width=100 height=100>

This is due to an incorrect API call. We're using `//graph.facebook.com/[userid]/picture?type=large`, which yields a rectangular image in which the longest dimension is 200px. When we try to resize it to 50x50, the aspect ratio changes and faces get squishy.

What we really want is a "large"-size image that's square. Using `//graph.facebook.com/[userid]/picture?width=200&height=200` yields the correct behavior.