### PR TITLE
Fix Facebook API call to pull email

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -599,7 +599,7 @@ class FacebookPlugin extends Gdn_Plugin {
      * @return mixed
      */
     public function getProfile($AccessToken) {
-        $Url = "https://graph.facebook.com/me?access_token=$AccessToken";
+        $Url = "https://graph.facebook.com/me?access_token=$AccessToken&fields=name,id,email";
 //      $C = curl_init();
 //      curl_setopt($C, CURLOPT_RETURNTRANSFER, true);
 //      curl_setopt($C, CURLOPT_SSL_VERIFYPEER, false);


### PR DESCRIPTION
When using Facebook connect, Vanilla tries to obtain the user's email, but doesn't succeed due to a malformed API call.

As a result, FB connect doesn't work as expected: it connects your FB account, but then requires you to manually type in your email and username again. This is particularly problematic in that it completely nullifies the "Use Facebook names as usernames" option. The user is forced to manually type in a username.

The problem is calling /me without specifying any fields. The default action is only to return the name and id. By specifying fields=name,id,email, the problem is completely solved.

Detailed writeup here: http://vanillaforums.org/discussion/31226/bugfix-facebook-connect-does-not-auto-pull-email-address-due-to-incorrect-api-call#latest