### PR TITLE
Preserve ConnectName when asking for email

### DIFF
--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -71,27 +71,29 @@ $ConnectSource = $this->Form->getFormValue('ProviderName');
                 <?php endif; ?>
                 <li>
                     <?php
-                    if (count($ExistingUsers) == 1 && $NoConnectName) {
-                        $PasswordMessage = t('ConnectExistingPassword', 'Enter your existing account password.');
-                        $Row = reset($ExistingUsers);
-                        echo '<div class="FinePrint">', t('ConnectAccountExists', 'You already have an account here.'), '</div>',
-                        wrap(sprintf(t('ConnectRegisteredName', 'Your registered username: <strong>%s</strong>'), htmlspecialchars($Row['Name'])), 'div', array('class' => 'ExistingUsername'));
-                        $this->addDefinition('NoConnectName', true);
-                        echo $this->Form->Hidden('UserSelect', array('Value' => $Row['UserID']));
-                    } else {
-                        echo $this->Form->label('Username', 'ConnectName');
-                        echo '<div class="FinePrint">', t('ConnectChooseName', 'Choose a name to identify yourself on the site.'), '</div>';
-
-                        if (count($ExistingUsers) > 0) {
-                            foreach ($ExistingUsers as $Row) {
-                                echo wrap($this->Form->Radio('UserSelect', $Row['Name'], array('value' => $Row['UserID'])), 'div');
-                            }
-                            echo wrap($this->Form->Radio('UserSelect', t('Other'), array('value' => 'other')), 'div');
-                        }
-                    }
-
-                    if (!$NoConnectName)
-                        echo $this->Form->Textbox('ConnectName');
+                      if (!$this->Form->getFormValue('ConnectName')) {
+                          if (count($ExistingUsers) == 1 && $NoConnectName) {
+                              $PasswordMessage = t('ConnectExistingPassword', 'Enter your existing account password.');
+                              $Row = reset($ExistingUsers);
+			                        echo '<div class="FinePrint">', t('ConnectAccountExists', 'You already have an account here.'), '</div>',
+                              wrap(sprintf(t('ConnectRegisteredName', 'Your registered username: <strong>%s</strong>'), htmlspecialchars($Row['Name'])), 'div', array('class' => 'ExistingUsername'));
+                              $this->addDefinition('NoConnectName', true);
+                              echo $this->Form->Hidden('UserSelect', array('Value' => $Row['UserID']));
+                          } else {
+                              echo $this->Form->label('Username', 'ConnectName');
+                              echo '<div class="FinePrint">', t('ConnectChooseName', 'Choose a name to identify yourself on the site.'), '</div>';
+      
+                              if (count($ExistingUsers) > 0) {
+                                  foreach ($ExistingUsers as $Row) {
+                                      echo wrap($this->Form->Radio('UserSelect', $Row['Name'], array('value' => $Row['UserID'])), 'div');
+                                  }
+                                  echo wrap($this->Form->Radio('UserSelect', t('Other'), array('value' => 'other')), 'div');
+                              }
+                          }
+      
+                          if (!$NoConnectName)
+                              echo $this->Form->Textbox('ConnectName');
+                       }
                     ?>
                 </li>
                 <?php $this->fireEvent('RegisterBeforePassword'); ?>


### PR DESCRIPTION
Sometimes a person will use Facebook Connect with an account that doesn't have a primary email associated with it. When this happens, Vanilla detects that there's no email, and renders a quick form to have the user type in their email. However, the form in question also makes the user reenter their username - even if there's already a valid username entered and stored in ConnectName.

This is mainly unfortunate if someone has the "Use Facebook names for usernames" setting enabled, because it completely negates it by asking the user to enter another username.

To be clear, here's what happens, even if "Use Facebook names for usernames" enabled.:
<img src="http://i.imgur.com/JpJLzpY.jpg">

The solution is as simple as checking if ConnectName is set before displaying the Username box:
<img src="http://i.imgur.com/vljz3bN.jpg">

The other textboxes on the page have this sort of check in place before displaying them, and this hotfix extends the same check to the username field.