### PR TITLE
Fixed "#ConectPassword" typo in entry.js

### DIFF
--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -48,7 +48,7 @@ jQuery(document).ready(function($) {
 
     var checkConnectName = function() {
         if (gdn.definition('NoConnectName', false)) {
-            $('#ConectPassword').show();
+            $('#ConnectPassword').show();
             return;
         }
 


### PR DESCRIPTION
Found this typo in a JQuery selector in entry.js. I'm not sure what effect it has, but I'm pretty sure it's not supposed to be there.