### PR TITLE
Trim ban values to avoid mismatches later

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -481,6 +481,9 @@ class SettingsController extends DashboardController {
                         $this->Form->setFormValue('BanID', $ID);
                     }
 
+                    // Trim the ban value to avoid obvious mismatches.
+                    $this->Form->setFormValue('BanValue', trim($this->Form->getFormValue('BanValue')));
+
                     try {
                         // Save the ban.
                         $NewID = $this->Form->save();


### PR DESCRIPTION
Currently you can accidentally put a space before or after an IP address, which will then match no IP addresses. That's super frustrating and stupid.