### PR TITLE
Delete duplicate check for active profile tab

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -1270,10 +1270,6 @@ class ProfileController extends Gdn_Controller {
                 $TabHtml = $TabName;
             }
 
-            if (!$CssClass && $TabUrl == Gdn::request()->path()) {
-                $CssClass = 'Active';
-            }
-
             $TabName = array($TabName => array('TabUrl' => $TabUrl, 'CssClass' => $CssClass, 'TabHtml' => $TabHtml));
         }
 


### PR DESCRIPTION
Profile tabs get the css class "Active" based on a loop in views/profile/tabs.php:
~~~
foreach ($SortOrder as $TabCode) {
            $CssClass = $TabCode == $this->_CurrentTab ? 'Active ' : '';
~~~
Therefore this cheek needs not to be here.
Moreover, if you add a profile tab with no class at all, it gets the class "Active Active".

Problem is solved if the check for the active tab is deleted in addProfileTab()