### PR TITLE
Add X-Path-Info for improved host compatibility

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,23 +1,25 @@
 # Original
 # If you modify this file then change the above line to: # Modified
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
+
     # Certain hosts may require the following line.
     # If vanilla is in a subfolder then you need to specify it after the /.
     # (ex. You put Vanilla in /forum so change the next line to: RewriteBase /forum)
-    # RewriteBase /
+    RewriteBase /
 
-    RewriteCond %{QUERY_STRING} ^p=/?([^&]+)(&(.+))?$
-    RewriteRule ^index\.php index.php/%1?%3 [E=X_REWRITE:1,L]
+    RewriteCond %{QUERY_STRING} ^p=/?([^&]+)(&([^?]+))?$
+    RewriteRule ^index\.php %1?%3 [E=X_REWRITE:2,L]
 
     # The basic rewrite rule.
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^(.*)$ index.php/$1 [QSA,E=X_REWRITE:1,L]
+    RewriteRule ^(.*)$ index.php [QSA,E=X_REWRITE:2,E=X_PATH_INFO:/$1,L]
 
     # Add the proper X_REWRITE server variable for rewritten requests.
     RewriteCond %{ENV:REDIRECT_X_REWRITE} .+
-    RewriteRule ^index\.php - [QSA,E=X_REWRITE:1,E=!REDIRECT_X_REWRITE,L]
+    RewriteCond %{ENV:REDIRECT_X_PATH_INFO} (.+)
+    RewriteRule ^index\.php - [QSA,E=X_REWRITE:2,E=!REDIRECT_X_REWRITE,E=X_PATH_INFO:%1,E=!REDIRECT_X_PATH_INFO,L]
 
     # 301 redirect urls that start with index.php
     #RewriteCond %{REQUEST_METHOD} GET [NC]

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -514,10 +514,14 @@ class Gdn_Request {
                 safeParseStr($get, $get, $original);
             }
 
-            if (!empty($_SERVER['X_REWRITE'])) {
-                $path = $_SERVER['PATH_INFO'];
-            } elseif (isset($get['_p'])) {
-                $path = $get['_p'];
+            $rewrite = val('X_REWRITE', $_SERVER, false);
+
+            if ($rewrite == 1) {
+                $path = val('PATH_INFO', $_SERVER, '');
+            } elseif ($rewrite == 2) {
+                $path = val('X_PATH_INFO', $_SERVER, '');
+            } elseif (isset($Get['_p'])) {
+                $path = $Get['_p'];
                 unset($_GET['_p']);
             } elseif (isset($get['p'])) {
                 $path = $get['p'];


### PR DESCRIPTION
We're trying to move away from using the p URL parameter.  Path info was our primary means to do this, but it isn't compatible with a few big hosts.  This update introduces X-Path-Info to Gdn_Request and .htaccess, which should improve that compatibility.

This should wait for merging until post-2.2.

Tested on GoDaddy.