### PR TITLE
Remove 'for' attribute for wrapped radio inputs.

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -1595,6 +1595,7 @@ PASSWORDMETER;
         if ($Label != '') {
             $LabelElement = '<label for="'.arrayValueI('id', $Attributes, $this->EscapeID($FieldName, false)).'" class="'.val('class', $Attributes, 'RadioLabel').'">';
             if ($Display === 'wrap') {
+                $LabelElement = '<label class="'.val('class', $Attributes, 'RadioLabel').'">';
                 $Input = $LabelElement.$Input.' '.t($Label).'</label>';
             } elseif ($Display === 'before') {
                 $Input = $LabelElement.t($Label).'</label> '.$Input;


### PR DESCRIPTION
If the label is wrapped around the input, the 'for' attribute is unnecessary. Fixes issue where multiple forms on the same page have conflicting labels.