### PR TITLE
Feature/decho enhancement

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -792,6 +792,36 @@ if (!function_exists('ConsolidateArrayValuesByKey')) {
     }
 }
 
+if (!function_exists('safePrint')) {
+    /**
+     * Return/print human-readable and non casted information about a variable".
+     *
+     * @param mixed $mixed The variable to return/echo.
+     * @param bool $returnData Whether or not return the data instead of echoing it.
+     * @return null\mixed
+     */
+    function safePrint($mixed, $returnData = false) {
+
+        $functionName = __FUNCTION__;
+
+        $wrapCastedValues = function(&$value) use ($functionName) {
+            if ($value === true) { $value = $functionName.'{true}'; }
+            elseif ($value === false) { $value = $functionName.'{false}'; }
+            elseif ($value === null) { $value = $functionName.'{null}'; }
+            elseif ($value === '') { $value = $functionName.'{empty string}'; }
+            elseif ($value === 0) { $value = $functionName.'{0}'; }
+        };
+
+        if (is_string($mixed)) {
+            $wrapCastedValues($mixed);
+        } else {
+            array_walk_recursive($mixed, $wrapCastedValues);
+        }
+
+        return print_r($mixed, $returnData);
+    }
+}
+
 if (!function_exists('decho')) {
     /**
      * Echo debug messages and variables.
@@ -804,11 +834,15 @@ if (!function_exists('decho')) {
         $prefix = stringEndsWith($prefix, ': ', true, true).': ';
 
         if ($public || Gdn::session()->checkPermission('Garden.Debug.Allow')) {
-            echo '<pre style="text-align: left; padding: 0 4px;">'.$prefix;
+            $stack = debug_backtrace();
+
+            $backtrace = __FUNCTION__.' called from '.$stack[0]['file'].' line: '.$stack[0]['line']."\n";
+
+            echo '<pre style="text-align: left; padding: 0 4px;">'.$backtrace.$prefix;
             if (is_string($mixed)) {
                 echo $mixed;
             } else {
-                echo htmlspecialchars(print_r($mixed, true));
+                echo htmlspecialchars(safePrint($mixed, true));
             }
 
             echo '</pre>';

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -792,36 +792,6 @@ if (!function_exists('ConsolidateArrayValuesByKey')) {
     }
 }
 
-if (!function_exists('safePrint')) {
-    /**
-     * Return/print human-readable and non casted information about a variable".
-     *
-     * @param mixed $mixed The variable to return/echo.
-     * @param bool $returnData Whether or not return the data instead of echoing it.
-     * @return null\mixed
-     */
-    function safePrint($mixed, $returnData = false) {
-
-        $functionName = __FUNCTION__;
-
-        $wrapCastedValues = function(&$value) use ($functionName) {
-            if ($value === true) { $value = $functionName.'{true}'; }
-            elseif ($value === false) { $value = $functionName.'{false}'; }
-            elseif ($value === null) { $value = $functionName.'{null}'; }
-            elseif ($value === '') { $value = $functionName.'{empty string}'; }
-            elseif ($value === 0) { $value = $functionName.'{0}'; }
-        };
-
-        if (is_string($mixed)) {
-            $wrapCastedValues($mixed);
-        } else {
-            array_walk_recursive($mixed, $wrapCastedValues);
-        }
-
-        return print_r($mixed, $returnData);
-    }
-}
-
 if (!function_exists('decho')) {
     /**
      * Echo debug messages and variables.
@@ -834,15 +804,11 @@ if (!function_exists('decho')) {
         $prefix = stringEndsWith($prefix, ': ', true, true).': ';
 
         if ($public || Gdn::session()->checkPermission('Garden.Debug.Allow')) {
-            $stack = debug_backtrace();
-
-            $backtrace = __FUNCTION__.' called from '.$stack[0]['file'].' line: '.$stack[0]['line']."\n";
-
-            echo '<pre style="text-align: left; padding: 0 4px;">'.$backtrace.$prefix;
+            echo '<pre style="text-align: left; padding: 0 4px;">'.$prefix;
             if (is_string($mixed)) {
                 echo $mixed;
             } else {
-                echo htmlspecialchars(safePrint($mixed, true));
+                echo htmlspecialchars(print_r($mixed, true));
             }
 
             echo '</pre>';


### PR DESCRIPTION
Improve the decho function.

1. Now print the line and file from which the function was called. (Way easier to track down where you called those multiple dechos while working)
2. Now print "falsy" values wrapped in safePrint{VALUE}. This is a big one because [0,"",'',false,null] are returning nothing on screen when printed using print_r. (Also true return 1 so it's wrapped as well)