### PR TITLE
decho function enhancement

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -804,19 +804,29 @@ if (!function_exists('safePrint')) {
 
         $functionName = __FUNCTION__;
 
-        $replaceCastedValues = function(&$value) use ($functionName) {
-            if ($value === true) { $value = $functionName.'{true}'; }
-            elseif ($value === false) { $value = $functionName.'{false}'; }
-            elseif ($value === null) { $value = $functionName.'{null}'; }
-            elseif ($value === '') { $value = $functionName.'{empty string}'; }
-            elseif ($value === 0) { $value = $functionName.'{0}'; }
+        $replaceCastedValues = function(&$value) use (&$replaceCastedValues, $functionName) {
+            if (is_array($value) || is_object($value)) {
+                foreach($value as &$content) {
+                    $replaceCastedValues($content);
+                }
+                unset($content);
+                return;
+            }
+
+            if ($value === '') {
+                $value = $functionName.'{empty string}';
+            } elseif ($value === true) {
+                $value = $functionName.'{true}';
+            } elseif ($value === false) {
+                $value = $functionName.'{false}';
+            } elseif ($value === null) {
+                $value = $functionName.'{null}';
+            } elseif ($value === 0) {
+                $value = $functionName.'{0}';
+            }
         };
 
-        if (is_string($mixed)) {
-            $replaceCastedValues($mixed);
-        } else {
-            array_walk_recursive($mixed, $replaceCastedValues);
-        }
+        $replaceCastedValues($mixed);
 
         return print_r($mixed, $returnData);
     }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -805,7 +805,14 @@ if (!function_exists('safePrint')) {
         $functionName = __FUNCTION__;
 
         $replaceCastedValues = function(&$value) use (&$replaceCastedValues, $functionName) {
-            if (is_array($value) || is_object($value)) {
+            $isObject = is_object($value);
+
+            // Replace original object by a shallow copy of itself to keep it from being modified.
+            if ($isObject) {
+                $value = clone $value;
+            }
+
+            if ($isObject || is_array($value)) {
                 foreach($value as &$content) {
                     $replaceCastedValues($content);
                 }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -853,7 +853,10 @@ if (!function_exists('decho')) {
         if ($public || Gdn::session()->checkPermission('Garden.Debug.Allow')) {
             $stack = debug_backtrace();
 
-            $backtrace = __FUNCTION__.' called from '.$stack[0]['file'].' line: '.$stack[0]['line']."\n";
+            $backtrace = 'Line '.$stack[0]['line'].' in '.$stack[0]['file']."\n";
+            if (defined('PATH_ROOT')) {
+                $backtrace = str_replace(PATH_ROOT, '', $backtrace);
+            }
 
             echo '<pre style="text-align: left; padding: 0 4px;">'.$backtrace.$prefix;
             if (is_string($mixed)) {


### PR DESCRIPTION
Improve the decho function

1. Prepend the file and line from which the function was called from to the output.
2. Replace "falsy" values by their string representation wrapped by "safePrint{}". This is done to circumvent the fact that print_r (and echo) print nothing for [false,null,0,(empty string)] and we cannot easily know what is the value when nothing is printed. (Also true become 1 so it's replaced as well) 