### PR TITLE
Protect multi-line code blocks from formatting

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1643,7 +1643,7 @@ EOT;
         $CodeBlockContents = array();
         $CodeBlockHashes = array();
         $Subject = preg_replace_callback(
-            '/<code>.*?<\/code>/i',
+            '/<code>.*?<\/code>/is',
             function ($Matches) use (&$CodeBlockContents, &$CodeBlockHashes) {
                 // Surrounded by whitespace to try to prevent the characters
                 // from being picked up by $Pattern.


### PR DESCRIPTION
The change from #2694 doesn't work if the code block is multiline.

```
<code> @JasonBarnabe :) :smile:
line 2 #search <img src="http://site.com/example.gif" /> </code>
```

[One little "s"](http://php.net/manual/en/reference.pcre.pattern.modifiers.php) fixes this.