### PR TITLE
Tweak Baseline+ theme to work better with Groups

### DIFF
--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -80,6 +80,14 @@ textarea, input[type=text] {
     margin: 0 0 0 230px
 }
 
+/* The group header has a clearfix. The floated panel wreaks havoc in a group discussion
+if the content column isn't floated. */
+.Section-Group .ContentColumn {
+    float: right;
+    margin-left: 0;
+    width: 730px;
+}
+
 /* ==================== Pages that hide the panel and have full-width content */
 body.NoPanel #Panel,
 body.Entry #Panel,
@@ -1907,7 +1915,7 @@ overflow: hidden;
 }
 
 /* Page Controls (new discussion button, pagers, etc) */
-#Content .BoxNewDiscussion {
+.Section-DiscussionList #Content .BoxNewDiscussion {
     display: none; /* display: block to reveal this */
 }
 

--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -80,12 +80,19 @@ textarea, input[type=text] {
     margin: 0 0 0 230px
 }
 
-/* The group header has a clearfix. The floated panel wreaks havoc in a group discussion
-if the content column isn't floated. */
-.Section-Group .ContentColumn {
-    float: right;
-    margin-left: 0;
-    width: 730px;
+.Groups.Section-DiscussionList .Group-Header,
+.Section-Group.Section-Discussion .Group-Header {
+    margin-bottom: 0;
+}
+
+.Groups.Section-DiscussionList #Panel,
+.Section-Group.Section-Discussion #Panel {
+    float: none;
+    position: absolute;
+}
+
+.Groups.Section-DiscussionList .HomepageTitle {
+    display: none;
 }
 
 /* ==================== Pages that hide the panel and have full-width content */

--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -80,21 +80,6 @@ textarea, input[type=text] {
     margin: 0 0 0 230px
 }
 
-.Groups.Section-DiscussionList .Group-Header,
-.Section-Group.Section-Discussion .Group-Header {
-    margin-bottom: 0;
-}
-
-.Groups.Section-DiscussionList #Panel,
-.Section-Group.Section-Discussion #Panel {
-    float: none;
-    position: absolute;
-}
-
-.Groups.Section-DiscussionList .HomepageTitle {
-    display: none;
-}
-
 /* ==================== Pages that hide the panel and have full-width content */
 body.NoPanel #Panel,
 body.Entry #Panel,
@@ -6301,4 +6286,20 @@ Styleguide Attachments
 
 .highlight-effect{
     animation: highlight .8s;
+}
+
+/* Groups section tweaks */
+.Groups.Section-DiscussionList .Group-Header,
+.Section-Group.Section-Discussion .Group-Header {
+    margin-bottom: 0;
+}
+
+.Groups.Section-DiscussionList #Panel,
+.Section-Group.Section-Discussion #Panel {
+    float: none;
+    position: absolute;
+}
+
+.Groups.Section-DiscussionList .HomepageTitle {
+    display: none;
 }

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ if (PHP_VERSION_ID < 50400) {
 }
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.2.101.3');
+define('APPLICATION_VERSION', '2.2.101.4');
 
 // Report and track all errors.
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);


### PR DESCRIPTION
Fixes issue where the group banner's clearfix interferes with the floating panel and where the new discussion button is missing from the group page.