### PR TITLE
Updates TK check in import

### DIFF
--- a/applications/dashboard/controllers/class.importcontroller.php
+++ b/applications/dashboard/controllers/class.importcontroller.php
@@ -29,10 +29,10 @@ class ImportController extends DashboardController {
      * @since 2.0.0
      * @access public
      */
-    public function go() {
+    public function go($transientKey = '') {
         $this->permission('Garden.Settings.Manage');
-        if (!Gdn::request()->isAuthenticatedPostBack(true)) {
-            throw new Exception('Requires POST', 405);
+        if (!Gdn::session()->validateTransientKey($transientKey) && !Gdn::request()->isAuthenticatedPostBack()) {
+            throw new Gdn_UserException('The CSRF token is invalid.', 403);
         }
         $Imp = new ImportModel();
         $Imp->loadState();
@@ -214,11 +214,12 @@ class ImportController extends DashboardController {
      * @since 2.0.0
      * @access public
      */
-    public function restart() {
+    public function restart($transientKey = '') {
         $this->permission('Garden.Import'); // This permission doesn't exist, so only users with Admin == '1' will succeed.
-        if (!Gdn::request()->isAuthenticatedPostBack(true)) {
-            throw new Exception('Requires POST', 405);
+        if (!Gdn::session()->validateTransientKey($transientKey) && !Gdn::request()->isAuthenticatedPostBack()) {
+            throw new Gdn_UserException('The CSRF token is invalid.', 403);
         }
+
         // Delete the individual table files.
         $Imp = new ImportModel();
         try {

--- a/applications/dashboard/models/class.importmodel.php
+++ b/applications/dashboard/models/class.importmodel.php
@@ -1087,6 +1087,7 @@ class ImportModel extends Gdn_Model {
         $CurrentUser = $this->SQL->getWhere('User', array('UserID' => Gdn::session()->UserID))->firstRow(DATASET_TYPE_ARRAY);
         $CurrentPassword = $CurrentUser['Password'];
         $CurrentHashMethod = $CurrentUser['HashMethod'];
+        $CurrentTransientKey = gdn::session()->transientKey();
 
         // Delete the current user table.
         $this->SQL->Truncate('User');
@@ -1132,6 +1133,7 @@ class ImportModel extends Gdn_Model {
         }
 
         Gdn::session()->start(val('UserID', $User), true);
+        gdn::session()->transientKey($CurrentTransientKey);
 
         return true;
     }

--- a/applications/dashboard/views/import/go.php
+++ b/applications/dashboard/views/import/go.php
@@ -68,9 +68,9 @@ if ($CurrentStep > 0 && !array_key_exists($CurrentStep, $Steps)) {
 
 if ($Complete) {
     include($this->fetchViewLocation('stats', 'import', 'dashboard'));
-    echo anchor(t('Finished'), 'dashboard/import/restart', 'Button');
+    echo anchor(t('Finished'), 'dashboard/import/restart/'.urlencode(Gdn::session()->transientKey()), 'Button');
 } else {
     echo '<noscript><div>',
-    anchor(t('Continue'), strtolower($this->Application).'/import/go', 'Button'),
+    anchor(t('Continue'), strtolower($this->Application).'/import/go/'.urlencode(Gdn::session()->transientKey()), 'Button'),
     '</div></noscript>';
 }

--- a/applications/dashboard/views/import/info.php
+++ b/applications/dashboard/views/import/info.php
@@ -34,13 +34,13 @@ Please review the information below and click <b>Start Import</b> to begin the i
 include($this->fetchViewLocation('stats', 'import', 'dashboard'));
 
 if ($CurrentStep < 1)
-    echo anchor(t('Start Import'), 'dashboard/import/go', 'Button'),
+    echo anchor(t('Start Import'), 'dashboard/import/go/'.urlencode(Gdn::session()->transientKey()), 'Button'),
     ' ',
-    anchor(t('Restart'), 'dashboard/import/restart', 'Button');
+    anchor(t('Restart'), 'dashboard/import/restart/'.urlencode(Gdn::session()->transientKey()), 'Button');
 elseif (!$Complete)
-    echo anchor(t('Continue Import'), 'dashboard/import/go', 'Button'),
+    echo anchor(t('Continue Import'), 'dashboard/import/go/'.urlencode(Gdn::session()->transientKey()), 'Button'),
     ' ',
-    anchor(t('Restart'), 'dashboard/import/restart', 'Button');
+    anchor(t('Restart'), 'dashboard/import/restart/'.urlencode(Gdn::session()->transientKey()), 'Button');
 else
-    echo anchor(t('Finished'), 'dashboard/import/restart', 'Button');
+    echo anchor(t('Finished'), 'dashboard/import/restart/'.urlencode(Gdn::session()->transientKey()), 'Button');
 


### PR DESCRIPTION
The import UI uses styled anchors as buttons when stepping through the process, so the requests are not form posts.  `isAuthenticatedPostback` checks were causing all attempted imports to fail, because of this.

This PR adds the CSRF token into the URL for `ImportController::go` and `ImportController::reset` and checks for them, in addition to the existing `isAuthenticatedPostback` behavior.  In addition, this update makes the user's current CSRF carry through the import process.  This is because the user's `TransientKey` is reset when the "Insert Users Table" step is performed, thus breaking all `validateTransientKey` checks that follow.