### PR TITLE
Validate TransientKey with strict comparison

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -555,7 +555,7 @@ class Gdn_Session {
 
         if (!isset($Return)) {
             // Checking the postback here is a kludge, but is absolutely necessary until we can test the ValidatePostBack more.
-            $Return = ($ForceValid && Gdn::request()->isPostBack()) || ($ForeignKey == $this->_TransientKey && $this->_TransientKey !== false);
+            $Return = ($ForceValid && Gdn::request()->isPostBack()) || ($ForeignKey === $this->_TransientKey && $this->_TransientKey !== false);
         }
         if (!$Return) {
             if (Gdn::session()->User) {


### PR DESCRIPTION
CSRF validation is currently done with loose comparisons.  This PR updates the CSRF validation to use strict comparison to verify identical types and values.