### PR TITLE
Filter form errors rather than htmlspecialchars

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -1769,7 +1769,7 @@ PASSWORDMETER;
         if (is_string($Error)) {
             $ErrorCode = $Error;
         } elseif (is_a($Error, 'Gdn_UserException')) {
-            $ErrorCode = '@'.htmlspecialchars($Error->getMessage());
+            $ErrorCode = '@'.Gdn_Format::htmlFilter($Error->getMessage());
         } elseif (is_a($Error, 'Exception')) {
             // Strip the extra information out of the exception.
             $Parts = explode('|', $Error->getMessage());


### PR DESCRIPTION
Revises 237c4339b0181f5c4d838a8ead351d35b4c47c43 to use purification instead of escaping. As @hgtonight points out, this disabled links in error messages even internally, which are useful and good UI. Needs to be reevaluated against the security condition that prompted the change in the first place.