### PR TITLE
Postback checks and tweaks in Profile controller

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -168,8 +168,8 @@ class ProfileController extends Gdn_Controller {
      * @param mixed $UserID
      */
     public function clear($UserID = '') {
-        if (empty($_POST)) { // TODO: rm global
-            throw permissionException('Javascript');
+        if (!Gdn::request()->isAuthenticatedPostBack(true)) {
+            throw new Exception('Requires POST', 405);
         }
 
         $UserID = is_numeric($UserID) ? $UserID : 0;
@@ -188,29 +188,6 @@ class ProfileController extends Gdn_Controller {
             $this->jsonTarget('#Status', '', 'Remove');
             $this->render('Blank', 'Utility');
         }
-    }
-
-    /**
-     *
-     *
-     * @param $Type
-     * @param string $UserReference
-     * @param string $Username
-     * @throws Exception
-     */
-    public function connect($Type, $UserReference = '', $Username = '') {
-        $this->permission('Garden.SignIn.Allow');
-        $this->getUserInfo($UserReference, $Username, '', true);
-
-        // Fire an event and let whatever plugin handle the connection.
-        // This will fire an event in the form ProfileController_FacebookConnect_Handler(...).
-        $Connected = false;
-        $this->EventArguments['Connected'] =& $Connected;
-
-
-        $this->fireEvent(ucfirst($Type).'Connect');
-
-
     }
 
     /**

--- a/applications/dashboard/views/profile/user.php
+++ b/applications/dashboard/views/profile/user.php
@@ -23,7 +23,7 @@ $Session = Gdn::session();
     if ($this->User->About != '') {
         echo '<div id="Status" itemprop="description">'.Wrap(Gdn_Format::Display($this->User->About));
         if ($this->User->About != '' && ($Session->UserID == $this->User->UserID || $Session->checkPermission('Garden.Users.Edit')))
-            echo ' - '.anchor(t('clear'), '/profile/clear/'.$this->User->UserID.'/'.$Session->TransientKey(), 'Hijack');
+            echo ' - '.anchor(t('clear'), '/profile/clear/'.$this->User->UserID, 'Hijack');
 
         echo '</div>';
     }


### PR DESCRIPTION
Remove event firing connect method, as Connect plugins create their own endpoints.
Also check for authenticated posts on clear method and remove transient key from clear url.