### PR TITLE
Fix class definition notices

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -106,12 +106,14 @@ class RoleModel extends Gdn_Model {
 
     /**
      * Returns a resultset of all roles.
+     *
+     * @inheritdoc
      */
-    public function get() {
+    public function get($OrderFields = '', $OrderDirection = 'asc', $Limit = false, $PageNumber = false) {
         return $this->SQL
             ->select()
             ->from('Role')
-            ->orderBy('Sort', 'asc')
+            ->orderBy($OrderFields ?: 'Sort', $OrderDirection)
             ->get();
     }
 
@@ -535,11 +537,11 @@ class RoleModel extends Gdn_Model {
     /**
      * Save role data.
      *
-     * @param array $FormPostValues
-     * @return bool|mixed
-     * @throws Exception
+     * @param array $FormPostValues The role row to save.
+     * @param array|false $Settings Not used.
+     * @return bool|mixed Returns the role ID or false on error.
      */
-    public function save($FormPostValues) {
+    public function save($FormPostValues, $Settings = false) {
         // Define the primary key in this model's table.
         $this->defineSchema();
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1320,14 +1320,16 @@ class UserModel extends Gdn_Model {
      *
      *
      * @param mixed $ID
-     * @param bool|string $DatasetType
+     * @param string|false $DatasetType
+     * @param array $Options Additional options to affect fetching. Currently unused.
      * @return array|bool|null|object|type
      * @throws Exception
      */
-    public function getID($ID, $DatasetType = DATASET_TYPE_OBJECT) {
+    public function getID($ID, $DatasetType = false, $Options = []) {
         if (!$ID) {
             return false;
         }
+        $DatasetType = $DatasetType ?: DATASET_TYPE_OBJECT;
 
         // Check page cache, then memcached
         $User = $this->getUserFromCache($ID, 'userid');

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -962,9 +962,11 @@ class CategoryModel extends Gdn_Model {
      * @since 2.0.0
      *
      * @param int $categoryID The unique ID of category we're getting data for.
+     * @param string $datasetType Not used.
+     * @param array $options Not used.
      * @return object|array SQL results.
      */
-    public function getID($categoryID, $datasetType = DATASET_TYPE_OBJECT) {
+    public function getID($categoryID, $datasetType = DATASET_TYPE_OBJECT, $options = []) {
         $category = $this->SQL->getWhere('Category', array('CategoryID' => $categoryID))->firstRow($datasetType);
         if (val('AllowedDiscussionTypes', $category) && is_string(val('AllowedDiscussionTypes', $category))) {
             setValue('AllowedDiscussionTypes', $category, unserialize(val('AllowedDiscussionTypes', $category)));
@@ -1696,9 +1698,10 @@ class CategoryModel extends Gdn_Model {
      * @access public
      *
      * @param array $FormPostValue The values being posted back from the form.
+     * @param array|false $Settings Additional settings to affect saving.
      * @return int ID of the saved category.
      */
-    public function save($FormPostValues) {
+    public function save($FormPostValues, $Settings = false) {
         // Define the primary key in this model's table.
         $this->defineSchema();
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -781,13 +781,12 @@ class CommentModel extends VanillaModel {
      *
      * Events: BeforeSaveComment, AfterSaveComment.
      *
-     * @since 2.0.0
-     * @access public
-     *
      * @param array $FormPostValues Data from the form model.
+     * @param array $Settings Currently unused.
      * @return int $CommentID
+     * @since 2.0.0
      */
-    public function save($FormPostValues) {
+    public function save($FormPostValues, $Settings = false) {
         $Session = Gdn::session();
 
         // Define the primary key in this model's table.

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1541,9 +1541,10 @@ class DiscussionModel extends VanillaModel {
      * @access public
      *
      * @param array $FormPostValues Data sent from the form model.
+     * @param array $Settings Currently unused.
      * @return int $DiscussionID Unique ID of the discussion.
      */
-    public function save($FormPostValues) {
+    public function save($FormPostValues, $Settings = false) {
         $Session = Gdn::session();
 
         // Define the primary key in this model's table.

--- a/library/vendors/Smarty-2.6.25/libs/Smarty.class.php
+++ b/library/vendors/Smarty-2.6.25/libs/Smarty.class.php
@@ -574,7 +574,7 @@ class Smarty
     /**
      * The class constructor.
      */
-    function Smarty()
+    function __construct()
     {
       $this->assign('SCRIPT_NAME', isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME']
                     : @$GLOBALS['HTTP_SERVER_VARS']['SCRIPT_NAME']);


### PR DESCRIPTION
In PHP 7, methods of subclasses must match the base class. We’ve got a few methods that don’t follow this and they should.