### PR TITLE
Refactor methods to match base class signatures

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -96,12 +96,16 @@ class MessagesController extends ConversationsController {
             $this->fireEvent('BeforeAddConversation');
 
             $this->Form->setFormValue('RecipientUserID', $RecipientUserIDs);
-            $ConversationID = $this->Form->save($this->ConversationMessageModel);
+            $ConversationID = $this->Form->save();
             if ($ConversationID !== false) {
                 $Target = $this->Form->getFormValue('Target', 'messages/'.$ConversationID);
                 $this->RedirectUrl = url($Target);
 
-                $Conversation = $this->ConversationModel->getID($ConversationID, Gdn::session()->UserID);
+                $Conversation = $this->ConversationModel->getID(
+                    $ConversationID,
+                    false,
+                    ['viewingUserID' => Gdn::session()->UserID]
+                );
                 $NewMessageID = val('FirstMessageID', $Conversation);
                 $this->EventArguments['MessageID'] = $NewMessageID;
                 $this->fireEvent('AfterConversationSave');
@@ -154,7 +158,11 @@ class MessagesController extends ConversationsController {
                 }
             }
 
-            $Conversation = $this->ConversationModel->getID($ConversationID, Gdn::session()->UserID);
+            $Conversation = $this->ConversationModel->getID(
+                $ConversationID,
+                false,
+                ['viewingUserID' => Gdn::session()->UserID]
+            );
 
             $this->EventArguments['Conversation'] = $Conversation;
             $this->EventArguments['ConversationID'] = $ConversationID;

--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -388,7 +388,7 @@ class MessagesController extends ConversationsController {
         }
 
         // Fetch message data
-        $this->MessageData = $this->ConversationMessageModel->get(
+        $this->MessageData = $this->ConversationMessageModel->getRecent(
             $ConversationID,
             $Session->UserID,
             $this->Offset,
@@ -506,7 +506,7 @@ class MessagesController extends ConversationsController {
         // Fetch message data
         $this->setData(
             'MessageData',
-            $this->ConversationMessageModel->get(
+            $this->ConversationMessageModel->getRecent(
                 $ConversationID,
                 Gdn::session()->UserID,
                 0,

--- a/applications/conversations/models/class.conversationmessagemodel.php
+++ b/applications/conversations/models/class.conversationmessagemodel.php
@@ -12,6 +12,10 @@
  * Manages messages in a conversation.
  */
 class ConversationMessageModel extends ConversationsModel {
+    /**
+     * @var ConversationMessageModel The singleton instance of this class.
+     */
+    private static $instance;
 
     /**
      * Class constructor. Defines the related database table name.
@@ -74,9 +78,10 @@ class ConversationMessageModel extends ConversationsModel {
      *
      * @param mixed $ID The value of the primary key in the database.
      * @param string $DatasetType The format of the result dataset.
+     * @param array $options Not used.
      * @return Gdn_DataSet
      */
-    public function getID($ID, $DatasetType = false) {
+    public function getID($ID, $DatasetType = false, $options = []) {
         $Result = $this->getWhere(array("MessageID" => $ID))->firstRow($DatasetType);
         return $Result;
     }
@@ -348,6 +353,16 @@ class ConversationMessageModel extends ConversationsModel {
             $activityModel->saveQueue();
         }
         return $MessageID;
+    }
+
+    /**
+     * Return the singleton instance of this class.
+     */
+    public static function instance() {
+        if (!isset(static::$instance)) {
+            static::$instance = new ConversationMessageModel();
+        }
+        return static::$instance;
     }
 
     /**

--- a/applications/conversations/models/class.conversationmessagemodel.php
+++ b/applications/conversations/models/class.conversationmessagemodel.php
@@ -29,6 +29,14 @@ class ConversationMessageModel extends ConversationsModel {
     }
 
     /**
+     * {@inheritdoc}
+     * @deprecated
+     */
+    public function get($OrderFields = '', $OrderDirection = 'asc', $Limit = false, $PageNumber = false) {
+        throw new \BadMethodCallException('ConversationMessageModel->get() is not supported.', 500);
+    }
+
+    /**
      * Get messages by conversation.
      *
      * Events: BeforeGet.
@@ -43,7 +51,7 @@ class ConversationMessageModel extends ConversationsModel {
      * @param array $Wheres SQL conditions.
      * @return Gdn_DataSet SQL results.
      */
-    public function get($ConversationID, $ViewingUserID, $Offset = '0', $Limit = '', $Wheres = '') {
+    public function getRecent($ConversationID, $ViewingUserID, $Offset = '0', $Limit = '', $Wheres = '') {
         if ($Limit == '') {
             $Limit = Gdn::config('Conversations.Messages.PerPage', 50);
         }
@@ -103,6 +111,20 @@ class ConversationMessageModel extends ConversationsModel {
     }
 
     /**
+     * {@inheritdoc}
+     * @deprecated
+     */
+    public function getCount($wheres = []) {
+        deprecated('ConversationMessageModel->getCount()', 'ConversationMessageModel->getCountByConversation()');
+        $args = func_get_args();
+        return $this->getCountByConversation(
+            val(0, $args, 0),
+            val(1, $args, Gdn::session()->UserID),
+            val(2, $args, '')
+        );
+    }
+
+    /**
      * Get number of messages in a conversation.
      *
      * @since 2.0.0
@@ -113,7 +135,7 @@ class ConversationMessageModel extends ConversationsModel {
      * @param array $Wheres SQL conditions.
      * @return int Number of messages.
      */
-    public function getCount($ConversationID, $ViewingUserID, $Wheres = '') {
+    public function getCountByConversation($ConversationID, $ViewingUserID, $Wheres = '') {
         if (is_array($Wheres)) {
             $this->SQL->where($Wheres);
         }

--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -473,6 +473,8 @@ class ConversationModel extends ConversationsModel {
     public function save($formPostValues, $settings = []) {
         if ($settings instanceof ConversationMessageModel) {
             deprecated('ConversationModel->save(array, ConversationMessageModel)');
+            $MessageModel = $settings;
+            $settings = [];
         } else {
             $MessageModel = ConversationMessageModel::instance();
         }

--- a/applications/conversations/modules/class.inboxmodule.php
+++ b/applications/conversations/modules/class.inboxmodule.php
@@ -28,12 +28,7 @@ class InboxModule extends Gdn_Module {
     public function getData() {
         // Fetch from model.
         $Model = new ConversationModel();
-        $Result = $Model->get(
-            $this->UserID,
-            0,
-            $this->Limit,
-            array()
-        );
+        $Result = $Model->getInbox($this->UserID, $this->Limit, 0);
 
         // Join in the participants.
         $Model->joinParticipants($Result);

--- a/applications/conversations/modules/class.inthisconversationmodule.php
+++ b/applications/conversations/modules/class.inthisconversationmodule.php
@@ -12,9 +12,11 @@
  * Renders a list of people in the specified conversation.
  */
 class InThisConversationModule extends Gdn_Module {
-
-    public function setData($Data) {
-        $this->Data = $Data;
+    public function setData($name, $value = null) {
+        if (is_array($name)) {
+            $this->Data = $name;
+        }
+        return parent::setData($name, $value);
     }
 
     public function assetTarget() {

--- a/applications/dashboard/controllers/class.activitycontroller.php
+++ b/applications/dashboard/controllers/class.activitycontroller.php
@@ -168,7 +168,7 @@ class ActivityController extends Gdn_Controller {
         // Comment submission
         $Session = Gdn::session();
         $Comment = $this->Form->getFormValue('Comment');
-        $Activities = $this->ActivityModel->getWhere(array('NotifyUserID' => $NotifyUserID), $Offset, $Limit)->resultArray();
+        $Activities = $this->ActivityModel->getWhere(array('NotifyUserID' => $NotifyUserID), '', '', $Limit, $Offset)->resultArray();
         $this->ActivityModel->joinComments($Activities);
 
         $this->setData('Filter', strtolower($Filter));
@@ -234,7 +234,7 @@ class ActivityController extends Gdn_Controller {
             throw permissionException();
         }
 
-        $this->ActivityModel->delete($ActivityID);
+        $this->ActivityModel->deleteID($ActivityID);
 
 
         if ($this->_DeliveryType === DELIVERY_TYPE_ALL) {

--- a/applications/dashboard/controllers/class.notificationscontroller.php
+++ b/applications/dashboard/controllers/class.notificationscontroller.php
@@ -72,7 +72,7 @@ class NotificationsController extends Gdn_Controller {
         // If we're in the middle of a visit only get very recent notifications.
         $Where['DateUpdated >'] = Gdn_Format::toDateTime(strtotime('-5 minutes'));
 
-        $Activities = $ActivityModel->getWhere($Where, 0, 5)->resultArray();
+        $Activities = $ActivityModel->getWhere($Where, '', '', 5, 0)->resultArray();
 
         $ActivityIDs = array_column($Activities, 'ActivityID');
         $ActivityModel->setNotified($ActivityIDs);

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -133,8 +133,10 @@ class ProfileController extends Gdn_Controller {
 
         $Activities = $this->ActivityModel->getWhere(
             array('ActivityUserID' => $UserID, 'NotifyUserID' => $NotifyUserIDs),
-            $Offset,
-            $Limit
+            '',
+            '',
+            $Limit,
+            $Offset
         )->resultArray();
         $this->ActivityModel->joinComments($Activities);
         $this->setData('Activities', $Activities);
@@ -595,7 +597,7 @@ class ProfileController extends Gdn_Controller {
         );
 
         $this->ActivityModel = new ActivityModel();
-        $Activities = $this->ActivityModel->getWhere($Where, 0, 5)->resultArray();
+        $Activities = $this->ActivityModel->getWhere($Where, '', '', 5, 0)->resultArray();
         $this->setData('Activities', $Activities);
         $this->ActivityModel->markRead(Gdn::session()->UserID);
 

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -92,7 +92,7 @@ class RoleController extends DashboardController {
             }
             if ($this->Form->errorCount() == 0) {
                 // Go ahead and delete the Role
-                $this->RoleModel->delete($RoleID, $this->Form->getValue('ReplacementRoleID'));
+                $this->RoleModel->deleteAndReplace($RoleID, $this->Form->getValue('ReplacementRoleID'));
                 $this->RedirectUrl = url('dashboard/role');
                 $this->informMessage(t('Deleting role...'));
             }

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -534,7 +534,7 @@ class UserController extends DashboardController {
             }
 
             if ($this->Form->authenticatedPostBack(true) && $Method != '') {
-                $UserModel->delete($UserID, array('DeleteMethod' => $Method));
+                $UserModel->deleteID($UserID, array('DeleteMethod' => $Method));
                 $this->View = 'deletecomplete';
             }
 

--- a/applications/dashboard/models/class.banmodel.php
+++ b/applications/dashboard/models/class.banmodel.php
@@ -230,23 +230,22 @@ class BanModel extends Gdn_Model {
     /**
      * Remove a ban.
      *
-     * @since 2.0.18
-     * @access public
-     *
-     * @param array $Where
-     * @param int $Limit
-     * @param bool $ResetData
+     * @param array|int $where The where clause to delete or an integer value.
+     * @param array|true $options An array of options to control the delete.
+     * @return bool Returns **true** on success or **false** on failure.
      */
-    public function delete($Where = '', $Limit = false, $ResetData = false) {
-        if (isset($Where['BanID'])) {
-            $OldBan = $this->getID($Where['BanID'], DATASET_TYPE_ARRAY);
+    public function delete($where = [], $options = []) {
+        if (isset($where['BanID'])) {
+            $OldBan = $this->getID($where['BanID'], DATASET_TYPE_ARRAY);
         }
 
-        parent::Delete($Where, $Limit, $ResetData);
+        $result = parent::delete($where, $options);
 
         if (isset($OldBan)) {
             $this->ApplyBan(null, $OldBan);
         }
+
+        return $result;
     }
 
 //   public function getBanUsers($Ban) {

--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -42,14 +42,26 @@ class MessageModel extends Gdn_Model {
     /**
      * Returns a single message object for the specified id or FALSE if not found.
      *
-     * @param int $MessageID The MessageID to filter to.
+     * @param int $messageID The MessageID to filter to.
+     * @param string|false $datasetType The format of the message.
+     * @param array $options Options to modify the behavior of the get.
      * @return array Requested message.
      */
-    public function getID($MessageID) {
+    public function getID($messageID, $datasetType = false, $options = array()) {
         if (Gdn::cache()->activeEnabled()) {
-            return self::messages($MessageID);
+            $message = self::messages($messageID);
+            if (!$message) {
+                return $message;
+            }
+            if ($message instanceof Gdn_DataSet) {
+                $message->datasetType($datasetType);
+            } elseif ($datasetType === DATASET_TYPE_OBJECT) {
+                return (object)$message;
+            } else {
+                return (array)$message;
+            }
         } else {
-            return parent::getID($MessageID);
+            return parent::getID($messageID, $datasetType, $options);
         }
     }
 

--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -29,13 +29,14 @@ class MessageModel extends Gdn_Model {
     /**
      * Delete a message.
      *
-     * @param string $Where
-     * @param bool $Limit
-     * @param bool $ResetData
+     * @param array|int $where The where clause to delete or an integer value.
+     * @param array|true $options An array of options to control the delete.
+     * @return bool Returns **true** on success or **false** on failure.
      */
-    public function delete($Where = '', $Limit = false, $ResetData = false) {
-        parent::delete($Where, $Limit, $ResetData);
+    public function delete($where = [], $options = []) {
+        $result = parent::delete($where, $options);
         self::messages(null);
+        return $result;
     }
 
     /**

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3189,13 +3189,29 @@ class UserModel extends Gdn_Model {
     }
 
     /**
+     * Delete a user.
+     *
+     * {@inheritdoc}
+     */
+    public function delete($where = [], $options = []) {
+        if (is_numeric($where)) {
+            deprecated('UserModel->delete(int)', 'UserModel->deleteID(int)');
+
+            $result = $this->deleteID($where, $options);
+            return $result;
+        }
+
+        throw new \BadMethodCallException("UserModel->delete() is not supported.", 400);
+    }
+
+    /**
      * Delete a single user.
      *
-     * @param int $UserID
-     * @param array $Options See DeleteContent(), GetDelete()
+     * @param int $userID
+     * @param array $options See {@link UserModel::deleteContent()}, and {@link UserModel::getDelete()}.
      */
-    public function delete($UserID, $Options = array()) {
-        if ($UserID == $this->getSystemUserID()) {
+    public function deleteID($userID, $options = array()) {
+        if ($userID == $this->getSystemUserID()) {
             $this->Validation->addValidationResult('', 'You cannot delete the system user.');
             return false;
         }
@@ -3203,12 +3219,12 @@ class UserModel extends Gdn_Model {
         $Content = array();
 
         // Remove shared authentications.
-        $this->getDelete('UserAuthentication', array('UserID' => $UserID), $Content);
+        $this->getDelete('UserAuthentication', array('UserID' => $userID), $Content);
 
         // Remove role associations.
-        $this->getDelete('UserRole', array('UserID' => $UserID), $Content);
+        $this->getDelete('UserRole', array('UserID' => $userID), $Content);
 
-        $this->deleteContent($UserID, $Options, $Content);
+        $this->deleteContent($userID, $options, $Content);
 
         // Remove the user's information
         $this->SQL->update('User')
@@ -3217,7 +3233,7 @@ class UserModel extends Gdn_Model {
                 'Photo' => null,
                 'Password' => RandomString('10'),
                 'About' => '',
-                'Email' => 'user_'.$UserID.'@deleted.email',
+                'Email' => 'user_'.$userID.'@deleted.email',
                 'ShowEmail' => '0',
                 'Gender' => 'u',
                 'CountVisits' => 0,
@@ -3236,11 +3252,11 @@ class UserModel extends Gdn_Model {
                 'Admin' => 0,
                 'Deleted' => 1
             ))
-            ->where('UserID', $UserID)
+            ->where('UserID', $userID)
             ->put();
 
         // Remove user's cache rows
-        $this->clearCache($UserID);
+        $this->clearCache($userID);
 
         return true;
     }

--- a/applications/dashboard/modules/class.morepagermodule.php
+++ b/applications/dashboard/modules/class.morepagermodule.php
@@ -123,9 +123,10 @@ class MorePagerModule extends PagerModule {
    /**
     * Builds a string with information about the page list's current position (ie. "1 to 15 of 56").
     *
+    * @param string $formatString Not used.
     * @return string Built string.
     */
-    public function details() {
+    public function details($formatString = '') {
         if ($this->_PropertiesDefined === false) {
             trigger_error(ErrorMessage('You must configure the pager with $Pager->configure() before retrieving the pager details.', 'MorePager', 'Details'), E_USER_ERROR);
         }

--- a/applications/dashboard/modules/class.recentactivitymodule.php
+++ b/applications/dashboard/modules/class.recentactivitymodule.php
@@ -25,7 +25,7 @@ class RecentActivityModule extends Gdn_Module {
         }
 
         $ActivityModel = new ActivityModel();
-        $Data = $ActivityModel->getWhere(array('NotifyUserID' => ActivityModel::NOTIFY_PUBLIC), 0, $Limit);
+        $Data = $ActivityModel->getWhere(array('NotifyUserID' => ActivityModel::NOTIFY_PUBLIC), '', '', $Limit, 0);
         $this->ActivityData = $Data;
     }
 

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -68,7 +68,7 @@ class CategoriesController extends VanillaController {
 
         saveToConfig('Vanilla.Discussions.SortField', 'd.DateInserted', false);
         $DiscussionModel = new DiscussionModel();
-        $Discussions = $DiscussionModel->getWhereRecent($Where, $Offset, $Limit);
+        $Discussions = $DiscussionModel->getWhereRecent($Where, $Limit, $Offset);
         $this->DiscussionData = $this->setData('Discussions', $Discussions);
         $this->setData('_CurrentRecords', count($Discussions));
         $this->setData('_Limit', $Limit);
@@ -277,7 +277,7 @@ class CategoriesController extends VanillaController {
             $this->setData('AnnounceData', $AnnounceData, true);
             $Wheres['d.CategoryID'] = $CategoryIDs;
 
-            $this->DiscussionData = $this->setData('Discussions', $DiscussionModel->getWhereRecent($Wheres, $Offset, $Limit));
+            $this->DiscussionData = $this->setData('Discussions', $DiscussionModel->getWhereRecent($Wheres, $Limit, $Offset));
 
             // Build a pager
             $PagerFactory = new Gdn_PagerFactory();

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -68,7 +68,7 @@ class CategoriesController extends VanillaController {
 
         saveToConfig('Vanilla.Discussions.SortField', 'd.DateInserted', false);
         $DiscussionModel = new DiscussionModel();
-        $Discussions = $DiscussionModel->getWhere($Where, $Offset, $Limit);
+        $Discussions = $DiscussionModel->getWhereRecent($Where, $Offset, $Limit);
         $this->DiscussionData = $this->setData('Discussions', $Discussions);
         $this->setData('_CurrentRecords', count($Discussions));
         $this->setData('_Limit', $Limit);
@@ -277,7 +277,7 @@ class CategoriesController extends VanillaController {
             $this->setData('AnnounceData', $AnnounceData, true);
             $Wheres['d.CategoryID'] = $CategoryIDs;
 
-            $this->DiscussionData = $this->setData('Discussions', $DiscussionModel->getWhere($Wheres, $Offset, $Limit));
+            $this->DiscussionData = $this->setData('Discussions', $DiscussionModel->getWhereRecent($Wheres, $Offset, $Limit));
 
             // Build a pager
             $PagerFactory = new Gdn_PagerFactory();

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -223,7 +223,7 @@ class DiscussionController extends VanillaController {
         // Retrieve & apply the draft if there is one:
         if (Gdn::session()->UserID) {
             $DraftModel = new DraftModel();
-            $Draft = $DraftModel->get($Session->UserID, 0, 1, $this->Discussion->DiscussionID)->firstRow();
+            $Draft = $DraftModel->getByUser($Session->UserID, 0, 1, $this->Discussion->DiscussionID)->firstRow();
             $this->Form->addHidden('DraftID', $Draft ? $Draft->DraftID : '');
             if ($Draft && !$this->Form->isPostBack()) {
                 $this->Form->setValue('Body', $Draft->Body);
@@ -932,7 +932,7 @@ body { background: transparent !important; }
         $Draft = false;
         if (Gdn::session()->UserID && $Discussion) {
             $DraftModel = new DraftModel();
-            $Draft = $DraftModel->get(Gdn::session()->UserID, 0, 1, $Discussion->DiscussionID)->firstRow();
+            $Draft = $DraftModel->getByUser(Gdn::session()->UserID, 0, 1, $Discussion->DiscussionID)->firstRow();
             $this->Form->addHidden('DraftID', $Draft ? $Draft->DraftID : '');
         }
 

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -673,7 +673,7 @@ class DiscussionController extends VanillaController {
         $this->permission('Vanilla.Discussions.Delete', true, 'Category', $Discussion->PermissionCategoryID);
 
         if ($this->Form->authenticatedPostBack()) {
-            if (!$this->DiscussionModel->delete($DiscussionID)) {
+            if (!$this->DiscussionModel->deleteID($DiscussionID)) {
                 $this->Form->addError('Failed to delete discussion');
             }
 

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -19,6 +19,9 @@ class DiscussionController extends VanillaController {
     /** @var array Unique identifier. */
     public $CategoryID;
 
+    /**  @var CommentModel */
+    public $CommentModel;
+
     /** @var DiscussionModel */
     public $DiscussionModel;
 
@@ -145,7 +148,7 @@ class DiscussionController extends VanillaController {
 //      url(ConcatSep('/', 'discussion/'.$this->Discussion->DiscussionID.'/'. Gdn_Format::url($this->Discussion->Name), PageNumber($this->Offset, $Limit, TRUE, Gdn::session()->UserID != 0)), true), Gdn::session()->UserID == 0);
 
         // Load the comments
-        $this->setData('Comments', $this->CommentModel->get($DiscussionID, $Limit, $this->Offset));
+        $this->setData('Comments', $this->CommentModel->getByDiscussion($DiscussionID, $Limit, $this->Offset));
 
         $PageNumber = PageNumber($this->Offset, $Limit);
         $this->setData('Page', $PageNumber);
@@ -736,7 +739,7 @@ class DiscussionController extends VanillaController {
                 }
 
                 // Delete the comment
-                if (!$this->CommentModel->delete($CommentID)) {
+                if (!$this->CommentModel->deleteID($CommentID)) {
                     $this->Form->addError('Failed to delete comment');
                 }
             } else {
@@ -875,7 +878,7 @@ body { background: transparent !important; }
             if (stringBeginsWith(GetValueR('0.0', $CurrentOrderBy), 'c.DateInserted')) {
                 $this->CommentModel->orderBy('c.DateInserted '.$SortComments); // allow custom sort
             }
-            $this->setData('Comments', $this->CommentModel->get($Discussion->DiscussionID, $Limit, $this->Offset), true);
+            $this->setData('Comments', $this->CommentModel->getF($Discussion->DiscussionID, $Limit, $this->Offset), true);
 
             if (count($this->CommentModel->where()) > 0) {
                 $ActualResponses = false;

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -141,7 +141,7 @@ class DiscussionsController extends VanillaController {
         $this->setData('Announcements', $this->AnnounceData !== false ? $this->AnnounceData : array(), true);
 
         // Get Discussions
-        $this->DiscussionData = $DiscussionModel->getWhere($where, $Offset, $Limit);
+        $this->DiscussionData = $DiscussionModel->getWhereRecent($where, $Offset, $Limit);
 
         $this->setData('Discussions', $this->DiscussionData, true);
         $this->setJson('Loading', $Offset.' to '.$Limit);

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -141,7 +141,7 @@ class DiscussionsController extends VanillaController {
         $this->setData('Announcements', $this->AnnounceData !== false ? $this->AnnounceData : array(), true);
 
         // Get Discussions
-        $this->DiscussionData = $DiscussionModel->getWhereRecent($where, $Offset, $Limit);
+        $this->DiscussionData = $DiscussionModel->getWhereRecent($where, $Limit, $Offset);
 
         $this->setData('Discussions', $this->DiscussionData, true);
         $this->setJson('Loading', $Offset.' to '.$Limit);

--- a/applications/vanilla/controllers/class.draftscontroller.php
+++ b/applications/vanilla/controllers/class.draftscontroller.php
@@ -42,8 +42,8 @@ class DraftsController extends VanillaController {
         $Limit = Gdn::config('Vanilla.Discussions.PerPage', 30);
         $Session = Gdn::session();
         $Wheres = array('d.InsertUserID' => $Session->UserID);
-        $this->DraftData = $this->DraftModel->get($Session->UserID, $Offset, $Limit);
-        $CountDrafts = $this->DraftModel->getCount($Session->UserID);
+        $this->DraftData = $this->DraftModel->getByUser($Session->UserID, $Offset, $Limit);
+        $CountDrafts = $this->DraftModel->getCountByUser($Session->UserID);
 
         // Build a pager
         $PagerFactory = new Gdn_PagerFactory();
@@ -97,7 +97,7 @@ class DraftsController extends VanillaController {
                 && ((val('InsertUserID', $Draft) == $Session->UserID) || checkPermission('Garden.Community.Manage'))
             ) {
                 // Delete the draft
-                if (!$this->DraftModel->delete($DraftID)) {
+                if (!$this->DraftModel->deleteID($DraftID)) {
                     $Form->addError('Failed to delete draft');
                 }
             } else {

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -327,7 +327,7 @@ class ModerationController extends VanillaController {
         if ($this->Form->authenticatedPostBack()) {
             // Delete the selected discussions (that the user has permission to delete).
             foreach ($AllowedDiscussions as $DiscussionID) {
-                $Deleted = $DiscussionModel->delete($DiscussionID);
+                $Deleted = $DiscussionModel->deleteID($DiscussionID);
                 if ($Deleted) {
                     $this->jsonTarget("#Discussion_$DiscussionID", '', 'SlideUp');
                 }

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -275,7 +275,7 @@ class ModerationController extends VanillaController {
             // Delete the selected comments
             $CommentModel = new CommentModel();
             foreach ($CommentIDs as $CommentID) {
-                $CommentModel->delete($CommentID);
+                $CommentModel->deleteID($CommentID);
             }
 
             // Clear selections

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -127,17 +127,26 @@ class CommentModel extends VanillaModel {
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function get($OrderFields = '', $OrderDirection = 'asc', $Limit = false, $PageNumber = false) {
+        if (is_numeric($OrderFields)) {
+            deprecated('CommentModel->get($discussionID, ...)', 'CommentModel->getByDiscussion($discussionID, ...)');
+            return $this->getByDiscussion($OrderFields, $OrderDirection, $Limit);
+        }
+
+        throw new \BadMethodCallException('CommentModel->get() is not supported.', 400);
+    }
+
+    /**
      * Get comments for a discussion.
-     *
-     * @since 2.0.0
-     * @access public
      *
      * @param int $DiscussionID Which discussion to get comment from.
      * @param int $Limit Max number to get.
      * @param int $Offset Number to skip.
-     * @return object SQL results.
+     * @return Gdn_DataSet Returns a list of comments.
      */
-    public function get($DiscussionID, $Limit, $Offset = 0) {
+    public function getByDiscussion($DiscussionID, $Limit, $Offset = 0) {
         $this->CommentQuery(true, false);
         $this->EventArguments['DiscussionID'] =& $DiscussionID;
         $this->EventArguments['Limit'] =& $Limit;
@@ -560,17 +569,26 @@ class CommentModel extends VanillaModel {
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getCount($Wheres = '') {
+        if (is_numeric($Wheres)) {
+            deprecated('CommentModel->getCount(int)', 'CommentModel->getCountByDiscussion()');
+            return $this->getCountByDiscussion($Wheres);
+        }
+
+        return parent::getCount($Wheres);
+    }
+
+    /**
      * Count total comments in a discussion specified by ID.
      *
      * Events: BeforeGetCount
      *
-     * @since 2.0.0
-     * @access public
-     *
      * @param int $DiscussionID Unique ID of discussion we're counting comments from.
      * @return object SQL result.
      */
-    public function getCount($DiscussionID) {
+    public function getCountByDiscussion($DiscussionID) {
         $this->fireEvent('BeforeGetCount');
 
         if (!empty($this->_Where)) {
@@ -1273,6 +1291,22 @@ class CommentModel extends VanillaModel {
     /**
      * Delete a comment.
      *
+     * {@inheritdoc}
+     */
+    public function delete($where = [], $options = []) {
+        if (is_numeric($where)) {
+            deprecated('CommentModel->delete(int)', 'CommentModel->deleteID(int)');
+
+            $result = $this->deleteID($where, $options);
+            return $result;
+        }
+
+        throw new \BadMethodCallException("CommentModel->delete() is not supported.", 400);
+    }
+
+    /**
+     * Delete a comment.
+     *
      * This is a hard delete that completely removes it from the database.
      * Events: DeleteComment, BeforeDeleteComment.
      *
@@ -1283,7 +1317,7 @@ class CommentModel extends VanillaModel {
      * @param array $Options Additional options for the delete.
      * @param bool Always returns TRUE.
      */
-    public function delete($CommentID, $Options = array()) {
+    public function deleteID($CommentID, $Options = array()) {
         $this->EventArguments['CommentID'] = $CommentID;
 
         $Comment = $this->getID($CommentID, DATASET_TYPE_ARRAY);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -350,11 +350,12 @@ class DiscussionModel extends VanillaModel {
      * Get a list of the most recent discussions.
      *
      * @param array|false $Where The where condition of the get.
+     * @param bool|false|int $Limit The number of discussion to return.
      * @param int|false $Offset The offset within the total set.
-     * @param int|false $Limit The number of discussion to return.
-     * @return Gdn_DataSet Returns a {@link Gdn_DataSet} of discussions.
+     * @return Gdn_DataSet Returns a <a href='psi_element://Gdn_DataSet'>Gdn_DataSet</a> of discussions.
+     * of discussions.
      */
-    public function getWhereRecent($Where = array(), $Offset = 0, $Limit = false) {
+    public function getWhereRecent($Where = array(), $Limit = false, $Offset = 0) {
         $result = $this->getWhere($Where, '', '', $Limit, $Offset);
         return $result;
     }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -355,7 +355,7 @@ class DiscussionModel extends VanillaModel {
      * @return Gdn_DataSet Returns a <a href='psi_element://Gdn_DataSet'>Gdn_DataSet</a> of discussions.
      * of discussions.
      */
-    public function getWhereRecent($Where = array(), $Limit = false, $Offset = 0) {
+    public function getWhereRecent($Where = array(), $Limit = false, $Offset = false) {
         $result = $this->getWhere($Where, '', '', $Limit, $Offset);
         return $result;
     }
@@ -392,6 +392,9 @@ class DiscussionModel extends VanillaModel {
         }
         if (empty($OrderDirection)) {
             $OrderDirection = c('Vanilla.Discussions.SortDirection', 'desc');
+        }
+        if ($Limit === 0) {
+            trigger_error("You should not supply 0 to for $Limit in DiscussionModel->getWhere()", E_USER_NOTICE);
         }
         if (empty($Limit)) {
             $Limit = c('Vanilla.Discussions.PerPage', 30);

--- a/applications/vanilla/modules/class.draftsmodule.php
+++ b/applications/vanilla/modules/class.draftsmodule.php
@@ -20,7 +20,7 @@ class DraftsModule extends Gdn_Module {
         $Session = Gdn::session();
         if ($Session->isValid()) {
             $DraftModel = new DraftModel();
-            $this->Data = $DraftModel->get($Session->UserID, 0, $Limit, $DiscussionID);
+            $this->Data = $DraftModel->getByUser($Session->UserID, 0, $Limit, $DiscussionID);
         }
         $this->Form = $this->_Sender->Form;
     }

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -408,6 +408,20 @@ class Gdn_Model extends Gdn_Pluggable {
     }
 
     /**
+     * Delete a record by primary key.
+     *
+     * @param mixed $id The primary key value of the record to delete.
+     * @param array $options An array of options to affect the delete behaviour. Reserved for future use.
+     * @return bool Returns **true** if the delete was successful or **false** otherwise.
+     */
+    public function deleteID($id, $options = []) {
+        $r = $this->SQL->delete(
+            [$this->PrimaryKey => $id]
+        );
+        return $r;
+    }
+
+    /**
      * Filter out any potentially insecure fields before they go to the database.
      *
      * @param array $data The array of data to filter.

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -387,22 +387,31 @@ class Gdn_Model extends Gdn_Pluggable {
 
 
     /**
+     * Delete records from a table.
      *
+     * @param array|int $where The where clause to delete or an integer value.
+     * @param int|false $limit A limit to the number of records to delete.
+     * @param array|true $options An array of options to control the delete.
      *
-     * @param unknown_type $Where
-     * @param unknown_type $Limit
-     * @param unknown_type $ResetData
-     * @return Gdn_Dataset
+     *  - reset: Whether or not to reset this SQL statement after the delete. Defaults to false.
+     * @return Gdn_Dataset Returns the result of the delete.
      */
-    public function delete($Where = '', $Limit = false, $ResetData = false) {
-        if (is_numeric($Where)) {
-            $Where = array($this->PrimaryKey => $Where);
+    public function delete($where = [], $limit = false, $options = []) {
+        if (is_numeric($where)) {
+            deprecated('Gdn_Model->delete(int)', 'Gdn_Model->deleteID()');
+            $where = array($this->PrimaryKey => $where);
+        }
+
+        $ResetData = false;
+        if ($options === true || val('reset', $options)) {
+            deprecated('Gdn_Model->delete() with reset true');
+            $ResetData = true;
         }
 
         if ($ResetData) {
-            $Result = $this->SQL->delete($this->Name, $Where, $Limit);
+            $Result = $this->SQL->delete($this->Name, $where, $limit);
         } else {
-            $Result = $this->SQL->noReset()->delete($this->Name, $Where, $Limit);
+            $Result = $this->SQL->noReset()->delete($this->Name, $where, $limit);
         }
         return $Result;
     }

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -545,9 +545,9 @@ class Gdn_Model extends Gdn_Pluggable {
      *
      * @param array|bool $Where A filter suitable for passing to Gdn_SQLDriver::Where().
      * @param string $OrderFields A comma delimited string to order the data.
-     * @param string $OrderDirection One of <b>asc</b> or <b>desc</b>
-     * @param int|bool $Limit
-     * @param int|bool $Offset
+     * @param string $OrderDirection One of **asc** or **desc**.
+     * @param int|false $Limit The database limit.
+     * @param int|false $Offset The database offset.
      * @return Gdn_DataSet
      */
     public function getWhere($Where = false, $OrderFields = '', $OrderDirection = 'asc', $Limit = false, $Offset = false) {

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -390,13 +390,13 @@ class Gdn_Model extends Gdn_Pluggable {
      * Delete records from a table.
      *
      * @param array|int $where The where clause to delete or an integer value.
-     * @param int|false $limit A limit to the number of records to delete.
      * @param array|true $options An array of options to control the delete.
      *
-     *  - reset: Whether or not to reset this SQL statement after the delete. Defaults to false.
+     *  - limit: A limit to the number of records to delete.
+     *  - reset: Deprecated. Whether or not to reset this SQL statement after the delete. Defaults to false.
      * @return Gdn_Dataset Returns the result of the delete.
      */
-    public function delete($where = [], $limit = false, $options = []) {
+    public function delete($where = [], $options = []) {
         if (is_numeric($where)) {
             deprecated('Gdn_Model->delete(int)', 'Gdn_Model->deleteID()');
             $where = array($this->PrimaryKey => $where);
@@ -406,6 +406,11 @@ class Gdn_Model extends Gdn_Pluggable {
         if ($options === true || val('reset', $options)) {
             deprecated('Gdn_Model->delete() with reset true');
             $ResetData = true;
+        } elseif (is_numeric($options)) {
+            deprecated('The $limit parameter is deprecated in Gdn_Model->delete(). Use the limit option.');
+            $limit = $options;
+        } else {
+            $limit = val('limit', $options);
         }
 
         if ($ResetData) {

--- a/plugins/SplitMerge/class.splitmerge.plugin.php
+++ b/plugins/SplitMerge/class.splitmerge.plugin.php
@@ -224,7 +224,7 @@ class SplitMergePlugin extends Gdn_Plugin {
                             $CommentModel->removePageCache($Discussion['DiscussionID']);
                         } else {
                             // Delete discussion that was merged.
-                            $DiscussionModel->delete($Discussion['DiscussionID']);
+                            $DiscussionModel->deleteID($Discussion['DiscussionID']);
                         }
                     } else {
                         $Sender->informMessage($CommentModel->Validation->resultsText());

--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -601,7 +601,7 @@ class TaggingPlugin extends Gdn_Plugin {
         // Make sure that detailed tag data is available to the form.
         $TagModel = TagModel::instance();
 
-        $DiscussionID = val('DiscussionID', $Sender->Data['Discussion']);
+        $DiscussionID = $Sender->data('Discussion.DiscussionID');
 
         if ($DiscussionID) {
             $Tags = $TagModel->getDiscussionTags($DiscussionID, TagModel::IX_EXTENDED);


### PR DESCRIPTION
This will get rid of PHP 7 notices and allow us to use our models in a more OOP way.

- [x] Merge #3375.
- [x] Merge #3378.
- [x] Rebase this PR to master.
- [x] Clean up remaining notices that are easily found.