### PR TITLE
Fix CSRF check when deleting a ban

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -499,7 +499,7 @@ class SettingsController extends DashboardController {
                 $this->View = 'Ban';
                 break;
             case 'delete':
-                if ($this->Form->authenticatedPostBack()) {
+                if (Gdn::session()->validateTransientKey(Gdn::request()->get('TransientKey'))) {
                     $BanModel->delete(array('BanID' => $ID));
                     $this->View = 'BanDelete';
                 }

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -499,7 +499,7 @@ class SettingsController extends DashboardController {
                 $this->View = 'Ban';
                 break;
             case 'delete':
-                if (Gdn::session()->validateTransientKey(Gdn::request()->get('TransientKey'))) {
+                if ($this->Request->isAuthenticatedPostBack()) {
                     $BanModel->delete(array('BanID' => $ID));
                     $this->View = 'BanDelete';
                 }

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -499,7 +499,7 @@ class SettingsController extends DashboardController {
                 $this->View = 'Ban';
                 break;
             case 'delete':
-                if ($this->Request->isAuthenticatedPostBack()) {
+                if ($this->Form->authenticatedPostBack()) {
                     $BanModel->delete(array('BanID' => $ID));
                     $this->View = 'BanDelete';
                 }

--- a/applications/dashboard/js/bans.js
+++ b/applications/dashboard/js/bans.js
@@ -12,7 +12,7 @@ jQuery(document).ready(function($) {
     $('a.Delete').popup({
         confirm: true,
         followConfirm: false,
-        requestMethod: 'POST',
+        doPost: true,
         afterConfirm: function(json, sender) {
             $(sender).parents('tr').remove();
         }

--- a/applications/dashboard/js/bans.js
+++ b/applications/dashboard/js/bans.js
@@ -12,6 +12,7 @@ jQuery(document).ready(function($) {
     $('a.Delete').popup({
         confirm: true,
         followConfirm: false,
+        requestMethod: 'POST',
         afterConfirm: function(json, sender) {
             $(sender).parents('tr').remove();
         }

--- a/applications/dashboard/views/settings/banstable.php
+++ b/applications/dashboard/views/settings/banstable.php
@@ -34,9 +34,9 @@ PagerModule::write(array('Sender' => $this, 'Limit' => 20, 'CurrentRecords' => c
                 <td><?php echo htmlspecialchars($Row['Notes']); ?></td>
                 <td>
                     <?php
-                    echo anchor(t('Edit'), '/dashboard/settings/bans/edit?id='.$Row['BanID'], array('class' => 'SmallButton Edit'));
+                    echo Gdn_Theme::link("/dashboard/settings/bans/edit?id={$Row['BanID']}", t('Edit'), null, array('class' => 'SmallButton Edit'));
                     echo ' ';
-                    echo anchor(t('Delete'), '/dashboard/settings/bans/delete?id='.$Row['BanID'], array('class' => 'SmallButton Delete'));
+                    echo Gdn_Theme::link("/dashboard/settings/bans/delete?id={$Row['BanID']}", t('Delete'), null, array('class' => 'SmallButton Delete', 'TK' => 'true'));
                     ?>
                 </td>
             </tr>

--- a/applications/dashboard/views/settings/banstable.php
+++ b/applications/dashboard/views/settings/banstable.php
@@ -36,7 +36,7 @@ PagerModule::write(array('Sender' => $this, 'Limit' => 20, 'CurrentRecords' => c
                     <?php
                     echo Gdn_Theme::link("/dashboard/settings/bans/edit?id={$Row['BanID']}", t('Edit'), null, array('class' => 'SmallButton Edit'));
                     echo ' ';
-                    echo Gdn_Theme::link("/dashboard/settings/bans/delete?id={$Row['BanID']}", t('Delete'), null, array('class' => 'SmallButton Delete', 'TK' => 'true'));
+                    echo Gdn_Theme::link("/dashboard/settings/bans/delete?id={$Row['BanID']}", t('Delete'), null, array('class' => 'SmallButton Delete'));
                     ?>
                 </td>
             </tr>

--- a/js/library/jquery.popup.js
+++ b/js/library/jquery.popup.js
@@ -191,13 +191,13 @@ Copyright 2007 Chris Wanstrath [ chris@ozmm.org ]
              } else {
                 // request the target via ajax
                 var ajaxData = {'DeliveryType' : settings.deliveryType, 'DeliveryMethod' : 'JSON'};
-                if (settings.requestMethod.toLowerCase() == 'post') {
+                if (settings.doPost) {
                    ajaxData.TransientKey = gdn.definition('TransientKey');
                 }
                 $.popup.loading(settings);
 
                 $.ajax({
-                   method: settings.requestMethod,
+                   method: settings.doPost ? 'POST' : 'GET',
                    url: target,
                    data: ajaxData,
                    dataType: 'json',
@@ -219,12 +219,12 @@ Copyright 2007 Chris Wanstrath [ chris@ozmm.org ]
        } else {
           if (target) {
              var ajaxData = { 'DeliveryType': settings.deliveryType };
-             if (settings.requestMethod.toLowerCase() == 'post') {
+             if (settings.doPost) {
                 ajaxData.TransientKey = gdn.definition('TransientKey');
              }
 
              $.ajax({
-                method: settings.requestMethod,
+                method: settings.doPost ? 'POST' : 'GET',
                 url: target,
                 data: ajaxData,
                 error: function(request, textStatus, errorThrown) {
@@ -348,7 +348,7 @@ Copyright 2007 Chris Wanstrath [ chris@ozmm.org ]
 
    $.popup.settings = {
       targetUrl:        false,        // Use this URL instead of one provided by the matched element?
-      requestMethod:    'GET',        // The HTTP method to use for the request (e.g. "POST", "GET", "PUT")
+      doPost:           false,        // Use POST, instead of GET, when performing an AJAX request?
       confirm:          false,        // Pop up a confirm message?
       followConfirm:    false,        // Follow the confirm url after OK, or request it with ajax?
       afterConfirm:     function(json, sender) {

--- a/js/library/jquery.popup.js
+++ b/js/library/jquery.popup.js
@@ -190,11 +190,16 @@ Copyright 2007 Chris Wanstrath [ chris@ozmm.org ]
                 document.location = target;
              } else {
                 // request the target via ajax
+                var ajaxData = {'DeliveryType' : settings.deliveryType, 'DeliveryMethod' : 'JSON'};
+                if (settings.requestMethod.toLowerCase() == 'post') {
+                   ajaxData.TransientKey = gdn.definition('TransientKey');
+                }
                 $.popup.loading(settings);
+
                 $.ajax({
-                   type: "GET",
+                   method: settings.requestMethod,
                    url: target,
-                   data: {'DeliveryType' : settings.deliveryType, 'DeliveryMethod' : 'JSON'},
+                   data: ajaxData,
                    dataType: 'json',
                    error: function(xhr) {
                       gdn.informError(xhr);
@@ -213,12 +218,15 @@ Copyright 2007 Chris Wanstrath [ chris@ozmm.org ]
           });
        } else {
           if (target) {
+             var ajaxData = { 'DeliveryType': settings.deliveryType };
+             if (settings.requestMethod.toLowerCase() == 'post') {
+                ajaxData.TransientKey = gdn.definition('TransientKey');
+             }
+
              $.ajax({
-                type: 'GET',
+                method: settings.requestMethod,
                 url: target,
-                data: {
-                   'DeliveryType': settings.deliveryType
-                },
+                data: ajaxData,
                 error: function(request, textStatus, errorThrown) {
                    $.popup.reveal(settings, request.responseText);
                 },
@@ -340,6 +348,7 @@ Copyright 2007 Chris Wanstrath [ chris@ozmm.org ]
 
    $.popup.settings = {
       targetUrl:        false,        // Use this URL instead of one provided by the matched element?
+      requestMethod:    'GET',        // The HTTP method to use for the request (e.g. "POST", "GET", "PUT")
       confirm:          false,        // Pop up a confirm message?
       followConfirm:    false,        // Follow the confirm url after OK, or request it with ajax?
       afterConfirm:     function(json, sender) {


### PR DESCRIPTION
How the "delete ban" workflow currently happens:

1. User clicks "Delete" on a record row on /settings/bans.
2. User clicks "Okay" in the popup to confirm the deletion.
3. `SettingsController::bans` checks to see if `isAuthenticatedPostback` and fails, because the request is not sent with POST, nor does it contain the session's `TransientKey`.

This update adds the transient key to the delete link by way of the `Gdn_Theme::link` function and has `SettingsController::bans` check for a valid transient key in the URL parameters before committing the deletion.