### PR TITLE
Allow forced embed on mobile

### DIFF
--- a/applications/dashboard/controllers/class.embedcontroller.php
+++ b/applications/dashboard/controllers/class.embedcontroller.php
@@ -114,7 +114,16 @@ class EmbedController extends DashboardController {
 
         $Validation = new Gdn_Validation();
         $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
-        $ConfigurationModel->setField(array('Garden.TrustedDomains', 'Garden.Embed.RemoteUrl', 'Garden.Embed.ForceDashboard', 'Garden.Embed.ForceForum', 'Garden.SignIn.Popup'));
+        $ConfigurationModel->setField(
+            array(
+                'Garden.TrustedDomains',
+                'Garden.Embed.RemoteUrl',
+                'Garden.Embed.ForceDashboard',
+                'Garden.Embed.ForceForum',
+                'Garden.Embed.ForceMobile',
+                'Garden.SignIn.Popup'
+            )
+        );
 
         $this->Form->setModel($ConfigurationModel);
         if ($this->Form->authenticatedPostBack() === false) {

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -103,7 +103,7 @@ class DashboardHooks implements Gdn_IPlugin {
             }
 
             // Force embedding?
-            if (!IsSearchEngine() && !IsMobile() && strtolower($Sender->ControllerName) != 'entry') {
+            if (!IsSearchEngine() && strtolower($Sender->ControllerName) != 'entry') {
                 $Sender->addDefinition('ForceEmbedForum', c('Garden.Embed.ForceForum') ? '1' : '0');
                 $Sender->addDefinition('ForceEmbedDashboard', c('Garden.Embed.ForceDashboard') ? '1' : '0');
             }

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -104,7 +104,13 @@ class DashboardHooks implements Gdn_IPlugin {
 
             // Force embedding?
             if (!IsSearchEngine() && strtolower($Sender->ControllerName) != 'entry') {
-                $Sender->addDefinition('ForceEmbedForum', c('Garden.Embed.ForceForum') ? '1' : '0');
+                if (IsMobile()) {
+                    $forceEmbedForum = c('Garden.Embed.ForceMobile') ? '1' : '0';
+                } else {
+                    $forceEmbedForum = c('Garden.Embed.ForceForum') ? '1' : '0';
+                }
+
+                $Sender->addDefinition('ForceEmbedForum', $forceEmbedForum);
                 $Sender->addDefinition('ForceEmbedDashboard', c('Garden.Embed.ForceDashboard') ? '1' : '0');
             }
 

--- a/applications/dashboard/views/embed/advanced.php
+++ b/applications/dashboard/views/embed/advanced.php
@@ -68,6 +68,8 @@ $AllowEmbed = c('Garden.Embed.Allow');
 
     <p><?php echo $this->Form->CheckBox('Garden.Embed.ForceForum', "Force the forum to only be accessible through this url"); ?></p>
 
+    <p><?php echo $this->Form->Checkbox('Garden.Embed.ForceMobile', "Force the forum to only be accessible through this url when viewed on a mobile device."); ?></p>
+
     <p><?php echo $this->Form->CheckBox('Garden.Embed.ForceDashboard', "Force the dashboard to only be accessible through this url <em>(not recommended)</em>"); ?></p>
 
     <h2>Sign In Settings</h2>


### PR DESCRIPTION
Vanilla explicitly avoids forced embedding of a forum when viewing on a mobile device.  This update removes that restriction, allowing mobile browsers to also be forced into embedding.

I'm not sure if this was put in place 3+ years ago for UE or compatibility.  I didn't run into any issues with compatibility and I figure the UE for this kind of advanced implementation should be the responsibility of the admin/developer/designer, if they want to pursue it.