### PR TITLE
Remove Gdn_CookieIdentity::_hash()

### DIFF
--- a/library/core/class.cookieidentity.php
+++ b/library/core/class.cookieidentity.php
@@ -317,7 +317,7 @@ class Gdn_CookieIdentity {
         $KeyHash = hash_hmac($CookieHashMethod, $HashKey, $CookieSalt);
         $CheckHash = hash_hmac($CookieHashMethod, $HashKey, $KeyHash);
 
-        if (!compareHashDigest($CookieHash, $CheckHash)) {
+        if (!hash_equals($CheckHash, $CookieHash)) {
             self::deleteCookie($CookieName);
             return false;
         }

--- a/library/core/class.cookieidentity.php
+++ b/library/core/class.cookieidentity.php
@@ -148,18 +148,7 @@ class Gdn_CookieIdentity {
     }
 
     /**
-     * Returns $this->_HashHMAC with the provided data, the default hashing method
-     * (md5), and the server's COOKIE.SALT string as the key.
-     *
-     * @param string $Data The data to place in the hash.
-     */
-    protected static function _hash($Data, $CookieHashMethod, $CookieSalt) {
-        return Gdn_CookieIdentity::_hashHMAC($CookieHashMethod, $Data, $CookieSalt);
-    }
-
-    /**
-     * Returns the provided data hashed with the specified method using the
-     * specified key.
+     * Return the provided data hashed with the specified method using the specified key.
      *
      * @param string $HashMethod The hashing method to use on $Data. Options are MD5 or SHA1.
      * @param string $Data The data to place in the hash.
@@ -289,7 +278,7 @@ class Gdn_CookieIdentity {
         }
 
         // Create the cookie signature
-        $KeyHash = self::_hash($KeyData, $CookieHashMethod, $CookieSalt);
+        $KeyHash = self::_hashHMAC($CookieHashMethod, $KeyData, $CookieSalt);
         $KeyHashHash = self::_hashHMAC($CookieHashMethod, $KeyData, $KeyHash);
         $Cookie = array($KeyData, $KeyHashHash, time());
 
@@ -353,7 +342,7 @@ class Gdn_CookieIdentity {
             self::deleteCookie($CookieName);
             return false;
         }
-        $KeyHash = self::_hash($HashKey, $CookieHashMethod, $CookieSalt);
+        $KeyHash = self::_hashHMAC($CookieHashMethod, $HashKey, $CookieSalt);
         $CheckHash = self::_hashHMAC($CookieHashMethod, $HashKey, $KeyHash);
 
         if (!compareHashDigest($CookieHash, $CheckHash)) {

--- a/library/core/class.cookieidentity.php
+++ b/library/core/class.cookieidentity.php
@@ -148,34 +148,6 @@ class Gdn_CookieIdentity {
     }
 
     /**
-     * Return the provided data hashed with the specified method using the specified key.
-     *
-     * @param string $HashMethod The hashing method to use on $Data. Options are MD5 or SHA1.
-     * @param string $Data The data to place in the hash.
-     * @param string $Key The key to use when hashing the data.
-     */
-    protected static function _hashHMAC($HashMethod, $Data, $Key) {
-        $PackFormats = array('md5' => 'H32', 'sha1' => 'H40');
-
-        if (!isset($PackFormats[$HashMethod])) {
-            return false;
-        }
-
-        $PackFormat = $PackFormats[$HashMethod];
-        // this is the equivalent of "strlen($Key) > 64":
-        if (isset($Key[63])) {
-            $Key = pack($PackFormat, $HashMethod($Key));
-        } else {
-            $Key = str_pad($Key, 64, chr(0));
-        }
-
-        $InnerPad = (substr($Key, 0, 64) ^ str_repeat(chr(0x36), 64));
-        $OuterPad = (substr($Key, 0, 64) ^ str_repeat(chr(0x5C), 64));
-
-        return $HashMethod($OuterPad.pack($PackFormat, $HashMethod($InnerPad.$Data)));
-    }
-
-    /**
      * Generates the user's session cookie.
      *
      * @param int $UserID The unique id assigned to the user in the database.
@@ -278,8 +250,8 @@ class Gdn_CookieIdentity {
         }
 
         // Create the cookie signature
-        $KeyHash = self::_hashHMAC($CookieHashMethod, $KeyData, $CookieSalt);
-        $KeyHashHash = self::_hashHMAC($CookieHashMethod, $KeyData, $KeyHash);
+        $KeyHash = hash_hmac($CookieHashMethod, $KeyData, $CookieSalt);
+        $KeyHashHash = hash_hmac($CookieHashMethod, $KeyData, $KeyHash);
         $Cookie = array($KeyData, $KeyHashHash, time());
 
         // Attach cookie payload
@@ -342,8 +314,8 @@ class Gdn_CookieIdentity {
             self::deleteCookie($CookieName);
             return false;
         }
-        $KeyHash = self::_hashHMAC($CookieHashMethod, $HashKey, $CookieSalt);
-        $CheckHash = self::_hashHMAC($CookieHashMethod, $HashKey, $KeyHash);
+        $KeyHash = hash_hmac($CookieHashMethod, $HashKey, $CookieSalt);
+        $CheckHash = hash_hmac($CookieHashMethod, $HashKey, $KeyHash);
 
         if (!compareHashDigest($CookieHash, $CheckHash)) {
             self::deleteCookie($CookieName);

--- a/library/core/functions.compatibility.php
+++ b/library/core/functions.compatibility.php
@@ -62,7 +62,7 @@ if (!function_exists('hash_equals')) {
      * @param string $known_string The string of known length to compare against.
      * @param string $user_string The user-supplied string.
      * @return bool Returns **true** when the two strings are equal, **false** otherwise.
-     * @see hash_equals()
+     * @see http://php.net/manual/en/function.hash-equals.php
      */
     function hash_equals($known_string, $user_string) {
         if (strlen($known_string) !== strlen($user_string)) {

--- a/library/core/functions.compatibility.php
+++ b/library/core/functions.compatibility.php
@@ -52,6 +52,32 @@ if (!function_exists('gzopen') && function_exists('gzopen64')) {
     }
 }
 
+if (!function_exists('hash_equals')) {
+    /**
+     * Determine whether or not two strings are equal in a time that is independent of partial matches.
+     *
+     * This snippet prevents HMAC Timing attacks (http://codahale.com/a-lesson-in-timing-attacks/).
+     * Thanks to Eric Karulf (ekarulf @ github) for this fix.
+     *
+     * @param string $known_string The string of known length to compare against.
+     * @param string $user_string The user-supplied string.
+     * @return bool Returns **true** when the two strings are equal, **false** otherwise.
+     * @see hash_equals()
+     */
+    function hash_equals($known_string, $user_string) {
+        if (strlen($known_string) !== strlen($user_string)) {
+            return false;
+        }
+
+        $result = 0;
+        for ($i = strlen($known_string) - 1; $i >= 0; $i--) {
+            $result |= ord($known_string[$i]) ^ ord($user_string[$i]);
+        }
+
+        return 0 === $result;
+    }
+}
+
 if (!function_exists('http_build_url')) {
     define('HTTP_URL_REPLACE', 1);  // Replace every part of the first URL when there's one of the second URL
     define('HTTP_URL_JOIN_PATH', 2); // Join relative paths

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -765,16 +765,8 @@ if (!function_exists('compareHashDigest')) {
      * @return bool Returns true if the digests match or false otherwise.
      */
     function compareHashDigest($Digest1, $Digest2) {
-        if (strlen($Digest1) !== strlen($Digest2)) {
-            return false;
-        }
-
-        $Result = 0;
-        for ($i = strlen($Digest1) - 1; $i >= 0; $i--) {
-            $Result |= ord($Digest1[$i]) ^ ord($Digest2[$i]);
-        }
-
-        return 0 === $Result;
+        deprecated('compareHashDigest', 'hash_equals');
+        return hash_equals($Digest1, $Digest2);
     }
 }
 


### PR DESCRIPTION
- Remove the custom implementations of hash_hmac in favor of the built in function.
- Deprecate compareHashDigest() in favor of hash_equals().