### PR TITLE
Update Advanced Editor to show Html as Wysiwyg

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -11,7 +11,7 @@
 $PluginInfo['editor'] = array(
    'Name' => 'Advanced Editor',
    'Description' => 'Enables advanced editing of posts in several formats, including WYSIWYG, simple HTML, Markdown, and BBCode.',
-   'Version' => '1.7.6',
+   'Version' => '1.7.7',
    'Author' => "Dane MacMillan",
    'AuthorUrl' => 'http://www.vanillaforums.org/profile/dane',
    'RequiredApplications' => array('Vanilla' => '>=2.2'),

--- a/plugins/editor/design/editor.css
+++ b/plugins/editor/design/editor.css
@@ -661,7 +661,7 @@ directly on the iframe's bodybox contenteditable. */
  * Html, BBCode, and Markdown views have slight differences than the Wysiwyg,
  * so hide the particular ones.
  */
-.editor-format-html .editor-toggle-source, .editor-format-bbcode .editor-toggle-source, .editor-format-markdown .editor-toggle-source, .editor-format-html .sep-switches, .editor-format-bbcode .sep-switches, .editor-format-markdown .sep-switches, .editor-format-markdown .sep-align, .editor-format-markdown .icon-align-left, .editor-format-markdown .icon-align-center, .editor-format-markdown .icon-align-right, .editor-format-html .editor-image-align, .editor-format-bbcode .editor-image-align, .editor-format-markdown .editor-image-align, .editor-format-bbcode .editor-action-heading1, .editor-format-bbcode .editor-action-heading2, .editor-format-bbcode .editor-action-separator {
+.editor-format-bbcode .editor-toggle-source, .editor-format-markdown .editor-toggle-source, .editor-format-html .sep-switches, .editor-format-bbcode .sep-switches, .editor-format-markdown .sep-switches, .editor-format-markdown .sep-align, .editor-format-markdown .icon-align-left, .editor-format-markdown .icon-align-center, .editor-format-markdown .icon-align-right, .editor-format-html .editor-image-align, .editor-format-bbcode .editor-image-align, .editor-format-markdown .editor-image-align, .editor-format-bbcode .editor-action-heading1, .editor-format-bbcode .editor-action-heading2, .editor-format-bbcode .editor-action-separator {
     /* Defined as important, because some themes have overriden with their own
         !important values. */
     display: none !important;

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1503,6 +1503,7 @@
 
                 switch (format) {
                     case 'wysiwyg':
+                    case 'html':
                     case 'ipb':
                     case 'bbhtml':
                     case 'bbwysiwyg':
@@ -1743,7 +1744,6 @@
                             });
                         break;
 
-                    case 'html':
                     case 'bbcode':
                     case 'markdown':
                     case 'text':

--- a/plugins/editor/scss/editor.scss
+++ b/plugins/editor/scss/editor.scss
@@ -459,7 +459,6 @@ directly on the iframe's bodybox contenteditable. */
  * Html, BBCode, and Markdown views have slight differences than the Wysiwyg,
  * so hide the particular ones.
  */
-.editor-format-html .editor-toggle-source,
 .editor-format-bbcode .editor-toggle-source,
 .editor-format-markdown .editor-toggle-source,
 .editor-format-html .sep-switches,


### PR DESCRIPTION
Advanced Editor currently renders posts with `Html` set as their format as markup.  This update moves to make these posts render in the same way as posts with `Wysiwyg` as their format: in WYSIWYG with a toolbar button to toggle the HTML code view.