### PR TITLE
Empower Profile Tabs to Use Smarty

### DIFF
--- a/applications/dashboard/views/profile/index.php
+++ b/applications/dashboard/views/profile/index.php
@@ -4,6 +4,6 @@
     include($this->fetchViewLocation('user'));
     // include($this->fetchViewLocation('tabs'));
     echo Gdn_Theme::Module('ProfileFilterModule');
-    include($this->fetchViewLocation($this->_TabView, $this->_TabController, $this->_TabApplication));
+    echo $this->fetchView($this->_TabView, $this->_TabController, $this->_TabApplication);
     ?>
 </div>


### PR DESCRIPTION
There is a difference in how files are rendered in Vanilla. Sometimes you find `include($this->fetchViewLocation('ViewName'));` and sometimes `echo $this->fetchView('ViewName');`.
Only `fetchView()` handles template files; `fetchViewLocation()` only includes php files.

Since all Vanilla views are php files, this is no problem. Only when a plugin generates a part of a view, this restricts the plugin author. With `profileController->setTabView()` you have the chance to reuse a normal profile page and insert only a small piece of content to it.
But all tab views are inserted through a `include fetchViewLocation()` before the complete (php!) view is handed over to `fetchView()`. Therefore, using a Smarty template for a profile tab added by a plugin, will fail since it is not treated as a Smarty template, but as a php file.

Changing the way the tab view is embedded into the embracing profile view gives more freedom to plugin authors.


I've also looked for other places where a plugin author might be able to influence the file that gets included and where it might be helpful to change the way it is treated, but I only found the entry index.php view. But since `entryController->_registrationView()` doesn't allow file extensions, I guess there would be a bigger change needed.