### PR TITLE
Remove Html exception for Wysiwyg reinterpretation

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -632,7 +632,7 @@ class EditorPlugin extends Gdn_Plugin {
         }
 
         // If force Wysiwyg enabled in settings
-        $needsConversion = (!in_array($this->Format, array('Html', 'Wysiwyg')));
+        $needsConversion = (!in_array($this->Format, array('Wysiwyg')));
         if (c('Garden.InputFormatter', 'Wysiwyg') == 'Wysiwyg' && $this->ForceWysiwyg == true && $needsConversion) {
             $wysiwygBody = Gdn_Format::to($Sender->getValue('Body'), $this->Format);
             $Sender->setValue('Body', $wysiwygBody);


### PR DESCRIPTION
This update removes the exception for `Html` for being reinterpreted as `Wysiwyg` in Advanced Editor.

Re: https://github.com/vanilla/vanilla/pull/3393#issuecomment-165848168