### PR TITLE
Ensure $Discussion is passed by reference in calculate()

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -736,7 +736,7 @@ class DiscussionModel extends VanillaModel {
             $Discussion->LastDate = $Discussion->DateInserted;
         }
 
-        $this->EventArguments['Discussion'] = $Discussion;
+        $this->EventArguments['Discussion'] = &$Discussion;
         $this->fireEvent('SetCalculatedFields');
     }
 


### PR DESCRIPTION
`$Discussion ` is not passed by reference all the way through the calls beginning from the `getWhere()` method; the discussion data cannot be modified from the `SetCalculatedFields` event when the `getWhere()` method is used when it should be able to.

Currently, you can workaround this by running the code via the `AfterAddColumns` (adding fields via a for loop), but it should be able to be done via the method described above as well.

---

For example, this code: https://github.com/austins/Vanilla-App-Articles/blob/54e2b0d59ec60caeac75920d1b8750c0d6ba49bb/settings/class.hooks.php#L57

The discussion can't be modified unless the reference operator is added.