### PR TITLE
Fixing RSS Feed and Breadcrumbs

### DIFF
--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -240,7 +240,7 @@ class TaggingPlugin extends Gdn_Plugin {
         $Sender->Data['Breadcrumbs'][] = array('Name' => $TagRow['FullName'], 'Url' => '');
   */
         // Render the controller.
-        $this->View = c('Vanilla.Discussions.Layout') == 'table' ? 'table' : 'index';
+        $this->View = c('Vanilla.Discussions.Layout') == 'table' && $Sender->SyndicationMethod == SYNDICATION_NONE ? 'table' : 'index';
         $Sender->render($this->View, 'discussions', 'vanilla');
     }
 
@@ -290,11 +290,11 @@ class TaggingPlugin extends Gdn_Plugin {
             $Breadcrumbs = array();
 
             if (is_array($ParentTag) && count(array_filter($ParentTag))) {
-                $Breadcrumbs[] = array('Name' => $ParentTag['FullName'], 'Url' => TagUrl($ParentTag));
+                $Breadcrumbs[] = array('Name' => $ParentTag['FullName'], 'Url' => TagUrl($ParentTag, '', '/'));
             }
 
             if (is_array($CurrentTag) && count(array_filter($CurrentTag))) {
-                $Breadcrumbs[] = array('Name' => $CurrentTag['FullName'], 'Url' => TagUrl($CurrentTag));
+                $Breadcrumbs[] = array('Name' => $CurrentTag['FullName'], 'Url' => TagUrl($CurrentTag, '', '/'));
             }
 
             if (count($Breadcrumbs)) {


### PR DESCRIPTION
- FIX: view not found for RSS feed if table layout is active
- FIX: defective link in breadcrumbs if vanilla is installed in sub directory
- see http://vanillaforums.org/discussion/31419/bugfixing-rss-feeds-for-tagging-plugin-in-vanilla-2-2