### PR TITLE
Editor: Use the actual file name for attachment downloads

### DIFF
--- a/plugins/editor/views/attachments.php
+++ b/plugins/editor/views/attachments.php
@@ -39,6 +39,7 @@ $editorkey = $this->data('_editorkey');
             <a class="filename" data-type="<?php echo $attachment['Type']; ?>"
                data-width="<?php echo $attachment['ImageWidth']; ?>"
                data-height="<?php echo $attachment['ImageHeight']; ?>" href="<?php echo $pathParse['Url'] ?>"
+               download="<?php echo htmlspecialchars($attachment['Name']); ?>"
                target="_blank"><?php echo htmlspecialchars($attachment['Name']); ?></a>
             <span class="meta"><?php echo Gdn_Format::Bytes($attachment['Size'], 1); ?></span>
          </div>


### PR DESCRIPTION
When downloading an attachment, this will retain the actual filename (as opposed to a random string).

Note, that this will also show the download prompt for image files.

[More info on the download attribute](https://davidwalsh.name/download-attribute)