### PR TITLE
Fix newest comment data for zero-comment discussions in table view

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -328,12 +328,12 @@ class DiscussionModel extends VanillaModel {
             }
         }
 
+        // Change discussions returned based on additional criteria
+        $this->AddDiscussionColumns($Data);
+
         // Join in the users.
         Gdn::userModel()->joinUsers($Data, array('FirstUserID', 'LastUserID'));
         CategoryModel::JoinCategories($Data);
-
-        // Change discussions returned based on additional criteria
-        $this->AddDiscussionColumns($Data);
 
         if (c('Vanilla.Views.Denormalize', false)) {
             $this->AddDenormalizedViews($Data);
@@ -1372,12 +1372,12 @@ class DiscussionModel extends VanillaModel {
             return $Discussion;
         }
 
+        $this->Calculate($Discussion);
+
         // Join in the users.
         $Discussion = array($Discussion);
         Gdn::userModel()->joinUsers($Discussion, array('LastUserID', 'InsertUserID'));
         $Discussion = $Discussion[0];
-
-        $this->Calculate($Discussion);
 
         if (c('Vanilla.Views.Denormalize', false)) {
             $this->AddDenormalizedViews($Discussion);


### PR DESCRIPTION
In the table layout for discussions, the column for the newest comment is not displayed correctly, if there is no comment. This can be solved by changing the calls to methods working on the user data of the discussions.

For more details and an alternative solution see http://vanillaforums.org/discussion/31381/discussionstable-display-error-if-there-is-no-comment

This should also fix #3397