### PR TITLE
Extend drafts to store types and attributes and add events for save

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -162,6 +162,10 @@ class PostController extends VanillaController {
             $this->title(t('New Discussion'));
         }
 
+        if (isset($this->Draft) && $this->Draft->Type) {
+            $this->setData('Type', $this->Draft->Type);
+        }
+
         touchValue('Type', $this->Data, 'Discussion');
 
         // See if we should hide the category dropdown.

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -162,11 +162,7 @@ class PostController extends VanillaController {
             $this->title(t('New Discussion'));
         }
 
-        if (isset($this->Draft) && $this->Draft->Type) {
-            $this->setData('Type', $this->Draft->Type);
-        }
-
-        touchValue('Type', $this->Data, 'Discussion');
+        touchValue('Type', $this->Data, val('Type', $this->Draft, 'Discussion'));
 
         // See if we should hide the category dropdown.
         $AllowedCategories = CategoryModel::getByPermission('Discussions.Add', $this->Form->getValue('CategoryID', $this->CategoryID), array('Archived' => 0, 'AllowDiscussions' => 1), array('AllowedDiscussionTypes' => $this->Data['Type']));

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -167,6 +167,11 @@ class DraftModel extends VanillaModel {
             unset($FormPostValues['Sink']);
         }
 
+        // Prep and fire event
+        $this->EventArguments['FormPostValues'] = &$FormPostValues;
+        $this->EventArguments['DraftID'] = $DraftID;
+        $this->fireEvent('BeforeSaveDraft');
+
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert)) {
             $Fields = $this->Validation->SchemaValidationFields(); // All fields on the form that relate to the schema
@@ -183,6 +188,12 @@ class DraftModel extends VanillaModel {
                 $DraftID = $this->SQL->insert($this->Name, $Fields);
                 $this->UpdateUser($Session->UserID);
             }
+
+            // Fire an event that the draft was saved
+            $this->EventArguments['FormPostValues'] = $FormPostValues;
+            $this->EventArguments['Fields'] = $Fields;
+            $this->EventArguments['DraftID'] = $DraftID;
+            $this->fireEvent('AfterSaveDraft');
         }
 
         return $DraftID;

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -190,9 +190,8 @@ class DraftModel extends VanillaModel {
             }
 
             // Fire an event that the draft was saved
-            $this->EventArguments['FormPostValues'] = $FormPostValues;
             $this->EventArguments['Fields'] = $Fields;
-            $this->EventArguments['DraftID'] = $DraftID;
+            $this->EventArguments['DraftID'] = $DraftID; // Pass updated draft ID
             $this->fireEvent('AfterSaveDraft');
         }
 

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -225,6 +225,7 @@ $Construct->table('User')
 
 $Construct->table('Draft')
     ->PrimaryKey('DraftID')
+    ->column('Type', 'varchar(10)', true, 'index')
     ->column('DiscussionID', 'int', true, 'key')
     ->column('CategoryID', 'int', true, 'key')
     ->column('InsertUserID', 'int', false, 'key')
@@ -238,6 +239,7 @@ $Construct->table('Draft')
     ->column('Format', 'varchar(20)', true)
     ->column('DateInserted', 'datetime')
     ->column('DateUpdated', 'datetime', true)
+    ->column('Attributes', 'text', true)
     ->set($Explicit, $Drop);
 
 // Insert some activity types


### PR DESCRIPTION
I've noticed that the DraftModel doesn't store the discussion type, which is set by addons, such as QnA when asking a question, while creating/editing a new discussion via the PostController.

When a draft is saved and the user wants to edit it, the type and additional related form data has been lost and the draft has reverted to a standard discussion, so the post view for the custom type won't show up when the draft is opened for editing.

Relevant vanillaforums.org discussion: http://vanillaforums.org/discussion/31426/storing-discussion-type-with-drafts