### PR TITLE
Add start event to Gdn_Session

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -424,6 +424,7 @@ class Gdn_Session {
                 if ($SetIdentity) {
                     Gdn::authenticator()->setIdentity($this->UserID, $Persist);
                     Logger::event('session_start', Logger::INFO, 'Session started for {username}.');
+                    Gdn::pluginManager()->callEventHandlers($this, 'Gdn_Session', 'Start');
                 }
 
                 $UserModel->EventArguments['User'] =& $this->User;


### PR DESCRIPTION
Add an event to the start of a user's session to act as a counterpart to the [end event](https://github.com/vanilla/vanilla/blob/a4ddd914389ce34ffead54dbbf40a8ecb7b4b717/library/core/class.session.php#L184) in `Gdn_Session`.