### PR TITLE
Only show allowed discussion type in category dropdown

### DIFF
--- a/applications/vanilla/views/post/discussion.php
+++ b/applications/vanilla/views/post/discussion.php
@@ -23,7 +23,8 @@ if (!$CancelUrl) {
         echo '<div class="P">';
         echo '<div class="Category">';
         echo $this->Form->label('Category', 'CategoryID'), ' ';
-        echo $this->Form->categoryDropDown('CategoryID', array('Value' => val('CategoryID', $this->Category), 'IncludeNull' => true));
+        echo $this->Form->categoryDropDown('CategoryID', array('Value' => val('CategoryID', $this->Category),
+			'IncludeNull' => true, 'PermFilter' => array('AllowedDiscussionTypes' => 'Discussion')));
         echo '</div>';
         echo '</div>';
     }


### PR DESCRIPTION
For example, let's say I add/edit a category in the dashboard and I set the discussion types to **only** `Questions` (not including `Discussions`). That category shouldn't show up in the category drop down of the standard discussion post form.

This change makes the category drop down in the PostController->discussion() method only show categories where `Discussion` types are allowed. It should also show categories that have a mix of types allowed.

Plugins that add their own type override the view to provide their own form and specify their own AllowedDiscussionTypes in most cases, so those plugins should still work.

Alternatively, we could use the Type property/data value from the controller. The value is Discussion if it is not set. If it's null, we'd have to check depending on how the type is set in the method. #3423