### PR TITLE
Remove base64-encoding of JSON data

### DIFF
--- a/applications/conversations/js/conversations.js
+++ b/applications/conversations/js/conversations.js
@@ -28,8 +28,6 @@ jQuery(document).ready(function($) {
                gdn.informError(xhr);
             },
             success: function(json) {
-               json = $.postParseJson(json);
-
                // Remove any old errors from the form
                $(frm).find('div.Errors').remove();
 

--- a/applications/dashboard/js/activity.js
+++ b/applications/dashboard/js/activity.js
@@ -85,8 +85,6 @@ jQuery(document).ready(function($) {
                 gdn.informError(xhr);
             },
             success: function(json) {
-                json = $.postParseJson(json);
-
                 gdn.inform(json);
 
                 // Remove any old errors from the form
@@ -133,8 +131,6 @@ jQuery(document).ready(function($) {
                     gdn.informError(xhr);
                 },
                 success: function(json) {
-                    json = $.postParseJson(json);
-
                     gdn.inform(json);
 
                     if (json['FormSaved'] == true) {

--- a/applications/dashboard/js/applications.js
+++ b/applications/dashboard/js/applications.js
@@ -15,8 +15,6 @@ jQuery(document).ready(function($) {
                 $(btn).after('<span class="Progress">&#160;</span>');
             },
             success: function(json) {
-                json = $.postParseJson(json);
-
                 if (json.FormSaved == true) {
                     gdn.inform(json);
                     if (json.RedirectUrl) {

--- a/applications/dashboard/js/import.js
+++ b/applications/dashboard/js/import.js
@@ -9,8 +9,6 @@ jQuery(document).ready(function($) {
             url: url,
             dataType: 'json',
             success: function(json) {
-                json = $.postParseJson(json);
-
                 // Refresh the view.
                 $('#Content').html(json.Data);
                 bindAjaxForm();
@@ -35,8 +33,6 @@ jQuery(document).ready(function($) {
         $('form').ajaxForm({
             dataType: 'json',
             success: function(json) {
-                json = $.postParseJson(json);
-
                 $('#Content').html(json.Data);
                 bindAjaxForm();
 

--- a/applications/dashboard/js/profile.js
+++ b/applications/dashboard/js/profile.js
@@ -29,7 +29,6 @@ jQuery(document).ready(function($) {
                 $.popup({}, XMLHttpRequest.responseText);
             },
             success: function(json) {
-                json = $.postParseJson(json);
                 $.popup.reveal({popupId: popupId}, json);
             }
         });

--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -101,8 +101,6 @@ jQuery(document).ready(function($) {
                 gdn.informError(xhr, draft);
             },
             success: function(json) {
-                json = $.postParseJson(json);
-
                 var processedTargets = false;
                 // If there are targets, process them
                 if (json.Targets && json.Targets.length > 0) {
@@ -287,8 +285,6 @@ jQuery(document).ready(function($) {
                     gdn.informError(xhr);
                 },
                 success: function(json) {
-                    json = $.postParseJson(json);
-
                     $(msg).after(json.Data);
                     $(msg).hide();
                     $(document).trigger('EditCommentFormLoaded', [container]);
@@ -362,8 +358,6 @@ jQuery(document).ready(function($) {
 //            gdn.informError(xhr, true);
 //         },
 //         success: function(json) {
-//            json = $.postParseJson(json);
-//
 //            if(json.Data && json.LastCommentID) {
 //               gdn.definition('LastCommentID', json.LastCommentID, true);
 //               $(json.Data).appendTo("ul.Comments")

--- a/applications/vanilla/js/post.js
+++ b/applications/vanilla/js/post.js
@@ -52,8 +52,6 @@ jQuery(document).ready(function($) {
                 $.popup({}, XMLHttpRequest.responseText);
             },
             success: function(json) {
-                json = $.postParseJson(json);
-
                 // Remove any old popups if not saving as a draft
                 if (!draft)
                     $('div.Popup').remove();
@@ -121,8 +119,6 @@ jQuery(document).ready(function($) {
                 $.popup({}, XMLHttpRequest.responseText);
             },
             success: function(json) {
-                json = $.postParseJson(json);
-
                 // Remove any old popups if not saving as a draft
                 if (!draft)
                     $('div.Popup').remove();

--- a/js/global.js
+++ b/js/global.js
@@ -47,74 +47,12 @@
 // Stuff to fire on document.ready().
 jQuery(document).ready(function($) {
 
+	/**
+	 * @deprecated since Vanilla 2.2
+	 */
     $.postParseJson = function(json) {
-        if (json.Data) json.Data = $.base64Decode(json.Data);
         return json;
     };
-
-    var keyString = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-
-    // See http://ecmanaut.blogspot.de/2006/07/encoding-decoding-utf8-in-javascript.html
-    var uTF8Encode = function(string) {
-        return unescape(encodeURIComponent(string));
-    };
-
-    // See http://ecmanaut.blogspot.de/2006/07/encoding-decoding-utf8-in-javascript.html
-    var uTF8Decode = function(string) {
-        return decodeURIComponent(escape(string));
-    };
-
-    $.extend({
-        // private property
-        keyStr: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
-        base64Encode: function(input) {
-            var output = "";
-            var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
-            var i = 0;
-            input = uTF8Encode(input);
-            while (i < input.length) {
-                chr1 = input.charCodeAt(i++);
-                chr2 = input.charCodeAt(i++);
-                chr3 = input.charCodeAt(i++);
-                enc1 = chr1 >> 2;
-                enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
-                enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
-                enc4 = chr3 & 63;
-                if (isNaN(chr2)) {
-                    enc3 = enc4 = 64;
-                } else if (isNaN(chr3)) {
-                    enc4 = 64;
-                }
-                output = output + keyString.charAt(enc1) + keyString.charAt(enc2) + keyString.charAt(enc3) + keyString.charAt(enc4);
-            }
-            return output;
-        },
-        base64Decode: function(input) {
-            var output = "";
-            var chr1, chr2, chr3;
-            var enc1, enc2, enc3, enc4;
-            var i = 0;
-            input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
-            while (i < input.length) {
-                enc1 = keyString.indexOf(input.charAt(i++));
-                enc2 = keyString.indexOf(input.charAt(i++));
-                enc3 = keyString.indexOf(input.charAt(i++));
-                enc4 = keyString.indexOf(input.charAt(i++));
-                chr1 = (enc1 << 2) | (enc2 >> 4);
-                chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
-                chr3 = ((enc3 & 3) << 6) | enc4;
-                output = output + String.fromCharCode(chr1);
-                if (enc3 != 64) {
-                    output = output + String.fromCharCode(chr2);
-                }
-                if (enc4 != 64) {
-                    output = output + String.fromCharCode(chr3);
-                }
-            }
-            output = uTF8Decode(output);
-            return output;
-        }
-    });
 
     gdn.focused = true;
     gdn.Libraries = {};
@@ -1025,7 +963,7 @@ jQuery(document).ready(function($) {
     if (informMessageStack) {
         var informMessages;
         try {
-            informMessages = $.parseJSON($.base64Decode(informMessageStack));
+            informMessages = $.parseJSON(informMessageStack);
             informMessageStack = {'InformMessages': informMessages};
             gdn.inform(informMessageStack);
         } catch (e) {

--- a/js/library/jquery.gardenhandleajaxform.js
+++ b/js/library/jquery.gardenhandleajaxform.js
@@ -18,8 +18,6 @@
               }
             },
             success: function(json, status, $frm) {
-               json = $.postParseJson(json);
-               
                if (json.FormSaved == true) {
                   gdn.inform(json);
                   if (json.RedirectUrl) {
@@ -46,9 +44,9 @@
                   for(var i = 0; i < json.Targets.length; i++) {
                      var item = json.Targets[i];
                      if(item.Type == 'Text') {
-                        $(item.Target).text($.base64Decode(item.Data));
+                        $(item.Target).text(item.Data);
                      } else {
-                        $(item.Target).html($.base64Decode(item.Data));
+                        $(item.Target).html(item.Data);
                      }
                   }
                }

--- a/js/library/jquery.gardenmorepager.js
+++ b/js/library/jquery.gardenmorepager.js
@@ -73,8 +73,6 @@
                $.popup({}, XMLHttpRequest.responseText);
             },
             success: function(json) {
-               json = $.postParseJson(json);
-
                if (self.pager_in_container == true) {
                   if (type == 'more') {
                      self.pager_row.before(json.Data);

--- a/js/library/jquery.popup.js
+++ b/js/library/jquery.popup.js
@@ -296,7 +296,6 @@ Copyright 2007 Chris Wanstrath [ chris@ozmm.org ]
                settings.onSave(settings); // Notify the user that it is being saved.
             },
             success: function(json) {
-               json = $.postParseJson(json);
                gdn.inform(json);
                gdn.processTargets(json.Targets);
 
@@ -326,8 +325,6 @@ Copyright 2007 Chris Wanstrath [ chris@ozmm.org ]
                if (typeof(data) == 'object') {
                   if (data.RedirectUrl)
                      setTimeout(function() { document.location.replace(data.RedirectUrl); }, 300);
-
-                  $.postParseJson(data);
                }
                $.popup.reveal(settings, data);
                //$('#'+settings.popupId+' .Content').html(data);

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1278,7 +1278,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
             $this->setJson('FormSaved', $this->_FormSaved);
             $this->setJson('DeliveryType', $this->_DeliveryType);
-            $this->setJson('Data', base64_encode(($View instanceof Gdn_IModule) ? $View->toString() : $View));
+            $this->setJson('Data', ($View instanceof Gdn_IModule) ? $View->toString() : $View);
             $this->setJson('InformMessages', $this->_InformMessages);
             $this->setJson('ErrorMessages', $this->_ErrorMessages);
             $this->setJson('RedirectUrl', $this->RedirectUrl);
@@ -1295,7 +1295,7 @@ class Gdn_Controller extends Gdn_Pluggable {
             exit($this->_Json['Data']);
         } else {
             if (count($this->_InformMessages) > 0 && $this->SyndicationMethod === SYNDICATION_NONE) {
-                $this->addDefinition('InformMessageStack', base64_encode(json_encode($this->_InformMessages)));
+                $this->addDefinition('InformMessageStack', json_encode($this->_InformMessages));
             }
 
             if ($this->RedirectUrl != '' && $this->SyndicationMethod === SYNDICATION_NONE) {

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -622,7 +622,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         }
 
         // Output a JavaScript object with all the definitions.
-        $result = 'gdn=window.gdn||{};gdn.meta='.json_encode($this->_Definitions).';';
+        $result = 'gdn=window.gdn||{};gdn.meta='.json_encode($this->_Definitions, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).';';
         if ($wrap) {
             $result = "<script>$result</script>";
         }
@@ -1290,12 +1290,12 @@ class Gdn_Controller extends Gdn_Pluggable {
                 $this->_Json['Data'] = utf8_encode($this->_Json['Data']);
             }
 
-            $Json = json_encode($this->_Json);
+            $Json = json_encode($this->_Json, JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_PRETTY_PRINT);
             $this->_Json['Data'] = $Json;
             exit($this->_Json['Data']);
         } else {
             if (count($this->_InformMessages) > 0 && $this->SyndicationMethod === SYNDICATION_NONE) {
-                $this->addDefinition('InformMessageStack', json_encode($this->_InformMessages));
+                $this->addDefinition('InformMessageStack', json_encode($this->_InformMessages, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
             }
 
             if ($this->RedirectUrl != '' && $this->SyndicationMethod === SYNDICATION_NONE) {
@@ -1640,11 +1640,11 @@ class Gdn_Controller extends Gdn_Pluggable {
                 if (($Callback = $this->Request->getValueFrom(Gdn_Request::INPUT_GET, 'callback', false)) && $this->allowJSONP()) {
                     safeHeader('Content-Type: application/javascript; charset=utf-8', true);
                     // This is a jsonp request.
-                    exit($Callback.'('.json_encode($Data).');');
+                    exit($Callback.'('.json_encode($Data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).');');
                 } else {
                     safeHeader('Content-Type: application/json; charset=utf-8', true);
                     // This is a regular json request.
-                    exit(json_encode($Data));
+                    exit(json_encode($Data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
                 }
                 break;
 //         case DELIVERY_METHOD_XHTML:


### PR DESCRIPTION
This is a rebase of #3038.

- Remove base64-encoding / decoding of informMessageStack
- Remove base64-encoding / decoding of json-encoded Data
- Remove error prone UTF8-encoding / decoding functions
- Remove error prone base64-encoding / decoding functions
- Deprecate $.postParseJson()