### PR TITLE
Adds auto-focus on username field when loading /entry/signin

### DIFF
--- a/applications/dashboard/views/entry/signin.php
+++ b/applications/dashboard/views/entry/signin.php
@@ -23,7 +23,7 @@ echo '<div class="MainForm">';
         <li>
             <?php
             echo $this->Form->label('Email/Username', 'Email');
-            echo $this->Form->textBox('Email', array('autocorrect' => 'off', 'autocapitalize' => 'off', 'Wrap' => TRUE));
+            echo $this->Form->textBox('Email', array('autofocus' => true, 'autocorrect' => 'off', 'autocapitalize' => 'off', 'Wrap' => TRUE));
             ?>
         </li>
         <li>

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -2628,7 +2628,7 @@ PASSWORDMETER;
             foreach ($Attributes as $Attribute => $Value) {
                 // Ignore reserved attributes
                 if (!in_array(strtolower($Attribute), $ReservedAttributes)) {
-                    $Return .= ' '.$Attribute.($Value===true ? '' : '="'.htmlspecialchars($Value, ENT_COMPAT, 'UTF-8').'"');
+                    $Return .= ' '.$Attribute.($Value === true ? '' : '="'.htmlspecialchars($Value, ENT_COMPAT, 'UTF-8').'"');
                 }
             }
         }

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -2618,6 +2618,7 @@ PASSWORDMETER;
             'yearrange',
             'fields',
             'inlineerrors',
+            'wrap',
             'categorydata'
         );
         $Return = '';

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -2627,7 +2627,7 @@ PASSWORDMETER;
             foreach ($Attributes as $Attribute => $Value) {
                 // Ignore reserved attributes
                 if (!in_array(strtolower($Attribute), $ReservedAttributes)) {
-                    $Return .= ' '.$Attribute.'="'.htmlspecialchars($Value, ENT_COMPAT, 'UTF-8').'"';
+                    $Return .= ' '.$Attribute.($Value===true ? '' : '="'.htmlspecialchars($Value, ENT_COMPAT, 'UTF-8').'"');
                 }
             }
         }


### PR DESCRIPTION
fixes #3429

In this context, this pull request also
- introduces boolean HTML attributes for form elements (required for `autofocus` attribute)
- adds `wrap` to `ReservedAttributes` an hence removes it from the output. `Wrap` is used internally as virtual attribute and is not in standard HTML.