### PR TITLE
Use a cache-busting hash from the config instead of addon version numbers

### DIFF
--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -40,6 +40,20 @@ class AssetModel extends Gdn_Model {
     }
 
     /**
+     * Return the cache-busting hash for the application.
+     *
+     * The cache buster is concatenated from two configuration values. One of the hashes is updated locally on structure
+     * and whenever a plugin is enabled/disabled. The other one is meant to represent the code as a whole and can be
+     * updated by an external code-pusher.
+     *
+     * @return string Returns a hash as a string.
+     */
+    public static function getCacheBuster() {
+        $result = c('Garden.ETagB').c('Garden.ETagA', 'x');
+        return $result;
+    }
+
+    /**
      * Add to the list of CSS files to serve.
      *
      * @param $filename
@@ -496,6 +510,19 @@ class AssetModel extends Gdn_Model {
         ksort($data);
         $result = substr(md5(implode(',', array_keys($data))), 0, 8).$suffix;
         return $result;
+    }
+
+    /**
+     * Refresh the cache buster hash.
+     *
+     * @param string $hash An optional hash to use for the local portion of the cache buster.
+     */
+    public static function refreshCacheBuster($hash = '') {
+        if (empty($hash)) {
+            $hash = substr(sha1(microtime(true)), 0, 8);
+        }
+        saveToConfig('Garden.ETagA', $hash);
+        Logger::event('cachebuster_refresh', Logger::DEBUG, "The etaga was refreshed to {etaga}", ['etaga' => $hash]);
     }
 
     /**

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -766,6 +766,8 @@ if ($currentLocale !== $canonicalLocale) {
     saveToConfig('Garden.Locale', $canonicalLocale);
 }
 
+AssetModel::refreshCacheBuster();
+
 // We need to undo cleditor's bad behavior for our reformed users.
 // If you still need to manipulate this, do it in memory instead (SAVE = false).
 if (!c('Garden.Html.SafeStyles')) {

--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -211,6 +211,7 @@ class Gdn_ApplicationManager {
             'The {addonName} application was enabled.',
             array('addonName' => $applicationName)
         );
+        AssetModel::refreshCacheBuster();
 
         // Redefine the locale manager's settings $Locale->Set($CurrentLocale, $EnabledApps, $EnabledPlugins, true);
         $Locale = Gdn::locale();
@@ -321,6 +322,7 @@ class Gdn_ApplicationManager {
             'The {addonName} application was disabled.',
             array('addonName' => $applicationName)
         );
+        AssetModel::refreshCacheBuster();
 
         // Clear the object caches.
         Gdn_Autoloader::smartFree(Gdn_Autoloader::CONTEXT_APPLICATION, $ApplicationInfo);

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -1216,6 +1216,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
             'The {addonName} plugin was enabled.',
             array('addonName' => $PluginName)
         );
+        AssetModel::refreshCacheBuster();
 
         $this->EnabledPlugins[$PluginName] = true;
 
@@ -1272,6 +1273,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
                 array('addonName' => $PluginName)
             );
         }
+        AssetModel::refreshCacheBuster();
 
         // Redefine the locale manager's settings $Locale->Set($CurrentLocale, $EnabledApps, $EnabledPlugins, TRUE);
         Gdn::locale()->refresh();

--- a/library/core/class.thememanager.php
+++ b/library/core/class.thememanager.php
@@ -410,6 +410,7 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
         }
         $oldTheme = $this->enabledTheme();
         RemoveFromConfig('Garden.Theme');
+        AssetModel::refreshCacheBuster();
         $newTheme = $this->enabledTheme();
 
         if ($oldTheme != $newTheme) {
@@ -525,6 +526,7 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
                     removeFromConfig('Garden.ThemeOptions');
                 }
             }
+            AssetModel::refreshCacheBuster();
         }
 
         if ($oldTheme !== $ThemeName) {

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -429,45 +429,10 @@ if (!function_exists('asset')) {
         }
 
         if ($AddVersion) {
-            if (strpos($Result, '?') === false) {
-                $Result .= '?';
-            } else {
-                $Result .= '&';
+            if (!$Version) {
+                $Version = AssetModel::getCacheBuster();
             }
-
-            // Figure out which version to put after the asset.
-            if (is_null($Version)) {
-                $Version = APPLICATION_VERSION;
-                if (preg_match('`^/([^/]+)/([^/]+)/`', $Destination, $Matches)) {
-                    $Type = $Matches[1];
-                    $Key = $Matches[2];
-                    static $ThemeVersion = null;
-
-                    switch ($Type) {
-                        case 'plugins':
-                            $PluginInfo = Gdn::pluginManager()->getPluginInfo($Key);
-                            $Version = val('Version', $PluginInfo, $Version);
-                            break;
-                        case 'applications':
-                            $AppInfo = Gdn::applicationManager()->getApplicationInfo(ucfirst($Key));
-                            $Version = val('Version', $AppInfo, $Version);
-                            break;
-                        case 'themes':
-                            if ($ThemeVersion === null) {
-                                $ThemeInfo = Gdn::themeManager()->getThemeInfo(Theme());
-                                if ($ThemeInfo !== false) {
-                                    $ThemeVersion = val('Version', $ThemeInfo, $Version);
-                                } else {
-                                    $ThemeVersion = $Version;
-                                }
-                            }
-                            $Version = $ThemeVersion;
-                            break;
-                    }
-                }
-            }
-
-            $Result .= 'v='.urlencode($Version);
+            $Result .= (strpos($Result, '?') === false ? '?' : '&').'v='.urlencode($Version);
         }
         return $Result;
     }


### PR DESCRIPTION
This allows us to make use of the code-pusher’s cluster-wide etagb and remove the race condition when pushing code to multiple servers.