### PR TITLE
Upgrade to PHP’s password_* functions for passwords if possible

### DIFF
--- a/library/core/class.passwordhash.php
+++ b/library/core/class.passwordhash.php
@@ -11,8 +11,6 @@
  * @since 2.0
  */
 
-include_once PATH_LIBRARY.'/vendors/phpass/PasswordHash.php';
-
 /**
  * Wrapper for the Portable PHP password hashing framework.
  */
@@ -88,7 +86,6 @@ class Gdn_PasswordHash extends PasswordHash {
      */
     public function checkPassword($Password, $StoredHash, $Method = false, $Username = null) {
         $Result = false;
-        $ResetUrl = Url('entry/passwordrequest'.(Gdn::request()->get('display') ? '?display='.urlencode(Gdn::request()->get('display')) : ''));
         switch (strtolower($Method)) {
             case 'crypt':
                 $Result = (crypt($Password, $StoredHash) === $StoredHash);
@@ -139,9 +136,11 @@ class Gdn_PasswordHash extends PasswordHash {
 
                 break;
             case 'reset':
+                $ResetUrl = url('entry/passwordrequest'.(Gdn::request()->get('display') ? '?display='.urlencode(Gdn::request()->get('display')) : ''));
                 throw new Gdn_UserException(sprintf(T('You need to reset your password.', 'You need to reset your password. This is most likely because an administrator recently changed your account information. Click <a href="%s">here</a> to reset your password.'), $ResetUrl));
                 break;
             case 'random':
+                $ResetUrl = url('entry/passwordrequest'.(Gdn::request()->get('display') ? '?display='.urlencode(Gdn::request()->get('display')) : ''));
                 throw new Gdn_UserException(sprintf(T('You don\'t have a password.', 'Your account does not have a password assigned to it yet. Click <a href="%s">here</a> to reset your password.'), $ResetUrl));
                 break;
             case 'smf':
@@ -231,6 +230,17 @@ class Gdn_PasswordHash extends PasswordHash {
     }
 
     /**
+     * Check a password using Phpass' hash.
+     *
+     * @param string $Password The plaintext password to check.
+     * @param string $StoredHash The password hash stored in the database.
+     * @return bool Returns **true** if the password matches the hash or **false** if it doesn't.
+     */
+    public function checkPhpass($Password, $StoredHash) {
+        return parent::checkPassword($Password, $StoredHash);
+    }
+
+    /**
      * Check a YAF hash.
      *
      * @param string $Password The plaintext password to check.
@@ -279,5 +289,15 @@ class Gdn_PasswordHash extends PasswordHash {
             $result = parent::HashPassword($password);
         }
         return $result;
+    }
+
+    /**
+     * Create a password hash using Phpass's algorithm.
+     *
+     * @param string $password The plaintext password to hash.
+     * @return string Returns a password hash.
+     */
+    public function hashPasswordPhpass($password) {
+        return parent::HashPassword($password);
     }
 }

--- a/library/core/class.passwordhash.php
+++ b/library/core/class.passwordhash.php
@@ -207,7 +207,7 @@ class Gdn_PasswordHash extends PasswordHash {
             // This is a password that uses crypt and can be checked with PHP's built in function.
             $this->Weak = password_needs_rehash($StoredHash, PASSWORD_DEFAULT);
 
-            return password_verify($Password, $StoredHash);
+            return password_verify((string)$Password, $StoredHash);
         }
 
 

--- a/tests/Library/Core/PasswordTest.php
+++ b/tests/Library/Core/PasswordTest.php
@@ -42,6 +42,51 @@ class PasswordTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * An empty password should always fail.
+     */
+    public function testEmptyPassword() {
+        $pw = new Gdn_PasswordHash();
+
+        $hash = $pw->hashPassword('');
+        $this->assertFalse($pw->checkPassword('', $hash, 'Vanilla'));
+    }
+
+    /**
+     * A plaintext password will verify, but be marked as weak.
+     */
+    public function testPlainTextPassword() {
+        $pw = new Gdn_PasswordHash();
+
+        $password = 'password123';
+        $this->assertTrue($pw->checkPassword($password, $password, 'Vanilla'));
+        $this->assertTrue($pw->Weak);
+    }
+
+    /**
+     * A hashed password should not verify if it looks like a crypt password.
+     */
+    public function testNoPlaintextHash() {
+        $pw = new Gdn_PasswordHash();
+
+        $password = 'letmeinPLEASE!!!!';
+        $hash = $pw->hashPassword($password);
+        $this->assertTrue($pw->checkPassword($password, $hash, 'Vanilla'));
+        $this->assertFalse($pw->checkPassword($hash, $hash, 'Vanilla'));
+    }
+
+    /**
+     * Vanilla 1 used MD5 so we should support that, but mark them as weak.
+     */
+    public function testOldMd5Passwords() {
+        $pw = new Gdn_PasswordHash();
+
+        $password = 'don\'tkickmeout';
+        $hash = md5($password);
+        $this->assertTrue($pw->checkPassword($password, $hash, 'Vanilla'));
+        $this->assertTrue($pw->Weak);
+    }
+
+    /**
      * Make sure that the **password_** functions are backwards compatible.
      */
     public function testDifferentHashVerifys() {

--- a/tests/Library/Core/PasswordTest.php
+++ b/tests/Library/Core/PasswordTest.php
@@ -5,7 +5,7 @@
  * @license Proprietary
  */
 
-namespace VanillaTests\Library;
+namespace VanillaTests\Library\Core;
 
 use Gdn_PasswordHash;
 

--- a/tests/Library/PasswordTest.php
+++ b/tests/Library/PasswordTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2015 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace VanillaTests\Library;
+
+use Gdn_PasswordHash;
+
+/**
+ * Test the the {@link Gdn_PasswordHash} class.
+ */
+class PasswordTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * Make sure an empty password fails.
+     */
+    public function testEmptyHash() {
+        $pw = new Gdn_PasswordHash();
+
+        $password = '';
+        $this->assertFalse($pw->checkPassword($password, ''));
+    }
+
+    /**
+     * Make sure improper string passwords don't verify against a hash.
+     *
+     * Since `0 == 'any string'` we want to make sure our passwords are vulnerable to this kind of thing.
+     */
+    public function testBadStringPasswords() {
+        $pw = new Gdn_PasswordHash();
+
+        $hash = $pw->hashPassword('password');
+
+        $this->assertFalse($pw->checkPassword('', $hash, 'Vanilla'));
+        $this->assertFalse($pw->checkPassword(0, $hash, 'Vanilla'));
+        $this->assertFalse($pw->checkPassword(false, $hash, 'Vanilla'));
+        $this->assertFalse($pw->checkPassword(true, $hash, 'Vanilla'));
+        $this->assertFalse($pw->checkPassword(null, $hash, 'Vanilla'));
+    }
+
+    /**
+     * Make sure that the **password_** functions are backwards compatible.
+     */
+    public function testDifferentHashVerifys() {
+        $pwPortable = new Gdn_PasswordHash();
+        $pwPortable->portable_hashes = true;
+
+        $pw = new Gdn_PasswordHash();
+        $pw->portable_hashes = false;
+
+        $password = 'letmein';
+
+        // Hash the password various ways.
+        $hashPortable = $pwPortable->hashPassword($password);
+        $hashPhpass = $pw->hashPasswordPhpass($password);
+        $hash = $pw->hashPassword($password);
+
+        // Make sure the password hashes are different.
+        $this->assertNotEquals(substr($hashPortable, 0, 3), substr($hash, 0, 3));
+
+        // Make sure all of the passwords verify.
+        $this->assertTrue($pwPortable->checkPassword($password, $hashPortable, 'Vanilla'));
+        $this->assertTrue($pwPortable->checkPassword($password, $hashPhpass, 'Vanilla'));
+        $this->assertTrue($pwPortable->checkPassword($password, $hash, 'Vanilla'));
+
+        $this->assertTrue($pw->checkPassword($password, $hashPortable, 'Vanilla'));
+        $this->assertTrue($pw->checkPassword($password, $hashPhpass, 'Vanilla'));
+        $this->assertTrue($pw->checkPassword($password, $hash, 'Vanilla'));
+
+        // Make sure the Phpass can verify the passwords.
+        $this->assertTrue($pw->checkPhpass($password, $hashPortable));
+        $this->assertTrue($pw->checkPhpass($password, $hashPhpass));
+        $this->assertTrue($pw->checkPhpass($password, $hash));
+    }
+}

--- a/tests/Library/PasswordTest.php
+++ b/tests/Library/PasswordTest.php
@@ -73,6 +73,6 @@ class PasswordTest extends \PHPUnit_Framework_TestCase {
         // Make sure the Phpass can verify the passwords.
         $this->assertTrue($pw->checkPhpass($password, $hashPortable));
         $this->assertTrue($pw->checkPhpass($password, $hashPhpass));
-        $this->assertTrue($pw->checkPhpass($password, $hash));
+        $this->assertTrue($pw->checkPhpass($password, $hash)); // mimics back port
     }
 }


### PR DESCRIPTION
Attempt to use PHP 5.5’s password_* functions for password hashing and verification unless portable passwords are required.

- [x] Test on PHP 5.4 and make sure the passwords still verify.
- [x] Generate a password hash on PHP 5.5+ and then make sure PHP 5.4 can still verify it.
- [ ] Test on infrastructure.