### PR TITLE
Improve saving of embedded comments

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -539,7 +539,6 @@ class PostController extends VanillaController {
             $inputFormatter = $this->Form->getFormValue('Format', c('Garden.InputFormatter'));
 
             switch ($inputFormatter) {
-                case 'Html':
                 case 'Wysiwyg':
                     $this->Form->setFormValue(
                         'Body',

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -530,10 +530,23 @@ class PostController extends VanillaController {
             $this->Form->addError(t('Failed to find discussion for commenting.'));
         }
 
-        // Vanilla Comments save as Text, no matter the format.
-        // Kludge to set format to Text if we're Wysiwyg to preserve newlines.
-        if ($isEmbeddedComments && ($this->Form->getFormValue('Format', c('Garden.InputFormatter')) === 'Wysiwyg')) {
-            $this->Form->setFormValue('Format', 'Text');
+        /**
+         * Special care is taken for embedded comments.  Since we don't currently use an advanced editor for these
+         * comments, we may need to apply certain filters and fixes to the data to maintain its intended display
+         * with the input format (e.g. maintaining newlines).
+         */
+        if ($isEmbeddedComments) {
+            $inputFormatter = $this->Form->getFormValue('Format', c('Garden.InputFormatter'));
+
+            switch ($inputFormatter) {
+                case 'Html':
+                case 'Wysiwyg':
+                    $this->Form->setFormValue(
+                        'Body',
+                        nl2br($this->Form->getFormValue('Body'))
+                    );
+                    break;
+            }
         }
 
         $PermissionCategoryID = val('PermissionCategoryID', $Discussion);


### PR DESCRIPTION
This update adds special considerations for formatting the body of embedded comments.  Since advanced editing capabilities aren't present when adding a comment in the embedded form, we may need to run the body through special handling to ensure the intended display is maintained (e.g. newlines).

Fixes https://github.com/vanilla/vanilla/issues/3430