### PR TITLE
Fix spam deletion by using updated method

### DIFF
--- a/applications/dashboard/models/class.spammodel.php
+++ b/applications/dashboard/models/class.spammodel.php
@@ -193,7 +193,7 @@ class SpamModel extends Gdn_Pluggable {
 
         if ($deleteRow) {
             // Remove the record to the log.
-            $model->delete($id);
+            $model->deleteID($id);
         }
 
         LogModel::insert('Spam', $recordType, $row, $logOptions);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2462,8 +2462,8 @@ class DiscussionModel extends VanillaModel {
         // Execute deletion of discussion and related bits
         $this->SQL->delete('Draft', array('DiscussionID' => $discussionID));
 
-        $Log = val('Log', $o, true);
-        $LogOptions = val('LogOptions', $o, array());
+        $Log = val('Log', $options, true);
+        $LogOptions = val('LogOptions', $options, array());
         if ($Log === true) {
             $Log = 'Delete';
         }


### PR DESCRIPTION
Currently, marking items in the spam queue as Spam is broken.