### PR TITLE
Remove cache from getUnreadCount in DiscussionModel and some improvements

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -239,7 +239,7 @@ class DiscussionsController extends VanillaController {
         $DiscussionModel->Watching = true;
 
         // Get Discussion Count
-        $CountDiscussions = $DiscussionModel->GetUnreadCount();
+        $CountDiscussions = $DiscussionModel->GetUnreadCount()->CountDiscussions;
         $this->setData('CountDiscussions', $CountDiscussions);
 
         // Get Discussions

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1272,7 +1272,7 @@ class DiscussionModel extends VanillaModel {
      * @param array $Wheres SQL conditions.
      * @param bool $ForceNoAnnouncements Not used.
      * @return stdObject containing:
-     *           CountDiscussion => Number of unread discussions.
+     *           CountDiscussions => Number of unread discussions.
      *           CountComments => Number of unread comments.
      */
     public function getUnreadCount($Wheres = '', $ForceNoAnnouncements = false) {


### PR DESCRIPTION
I noticed that the getUnreadCount was not working properly due to the categories cache. So I suggest this patch that improves the method by adding a count for both unread discussions and comments.