### PR TITLE
Add dot-notation behaviour to controller method 'setData'

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1887,28 +1887,36 @@ class Gdn_Controller extends Gdn_Pluggable {
     /**
      * Set data from a method call.
      *
-     * @param string $Key The key that identifies the data.
-     * @param mixed $Value The data.
-     * @param mixed $AddProperty Whether or not to also set the data as a property of this object.
+     * If $key is an array, the behaviour will be the same as calling the method
+     * multiple times for each (key, value) pair in the $key array.
+     * Note that the parameter $value will not be used if $key is an array.
+     *
+     * The $key can also use dot notation in order to set a value deeper inside the Data array.
+     * Works the same way if $addProperty is true, but uses objects instead of arrays.
+     *
+     * @see setvalr
+     *
+     * @param string|array $key The key that identifies the data.
+     * @param mixed $value The data.  Will not be used if $key is an array
+     * @param mixed $addProperty Whether or not to also set the data as a property of this object.
      * @return mixed The $Value that was set.
      */
-    public function setData($Key, $Value = null, $AddProperty = false) {
-        if (is_array($Key)) {
-            $this->Data = array_merge($this->Data, $Key);
-
-            if ($AddProperty === true) {
-                foreach ($Key as $Name => $Value) {
-                    $this->$Name = $Value;
-                }
+    public function setData($key, $value = null, $addProperty = false) {
+        // In the case of $key being an array of (key => value),
+        // it calls itself with each (key => value)
+        if (is_array($key)) {
+            foreach ($key as $k => $v) {
+                $this->setData($k, $v, $addProperty);
             }
             return;
         }
 
-        $this->Data[$Key] = $Value;
-        if ($AddProperty === true) {
-            $this->$Key = $Value;
+        setvalr($key, $this->Data, $value);
+
+        if ($addProperty === true) {
+            setvalr($key, $this, $value);
         }
-        return $Value;
+        return $value;
     }
 
     /**

--- a/tests/Library/Core/ControllerTest.php
+++ b/tests/Library/Core/ControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @author Eric Vachaviolos <eric.v@vanillaforums.com>
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace VanillaTests\Library\Core\ControllerTest;
+
+use Gdn_Controller;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+
+
+class ControllerTest extends PHPUnit_Framework_TestCase {
+
+    /**
+     * Testing that the same key will be used to set data and to get it back.
+     *
+     * @dataProvider getTestDataForSetData
+     */
+    public function testSetDataAndDataUseTheSameKeys($key, $value) {
+        $controller = new Gdn_Controller();
+        $controller->setData($key, $value);
+
+        $keys = is_array($key) ? $key : [$key => $value];
+        foreach ($keys as $key => $value) {
+            $this->assertEquals($value, $controller->data($key));
+        }
+    }
+
+    /**
+     * Testing that using method setData results in the expected Data array
+     *
+     * @dataProvider getTestDataForSetData
+     */
+    public function testCanAddValuesToDataArrayUsingSetData($key, $value, $expectedDataArray) {
+        $controller = new Gdn_Controller();
+        $controller->setData($key, $value);
+
+        // Aserts the Data array match perfectly
+        $this->assertEquals($expectedDataArray, $controller->Data);
+    }
+
+    /**
+     * Testing that method setData can be used to add properties to the controller instance
+     *
+     * @dataProvider getTestDataForSetData
+     */
+    public function testCanAddPropertiesUsingSetData($key, $value, $expectedDataArray) {
+        $controller = new Gdn_Controller();
+        $controller->setData($key, $value, true);
+
+        // Aserts the Data array match perfectly
+        $this->assertEquals($expectedDataArray, $controller->Data, 'Data array doesn\'t match');
+
+        // Asserts the properties one by one
+        $keys = is_array($key) ? $key : [$key => $value];
+        foreach ($keys as $key => $value) {
+            $this->assertEquals($value, valr($key, $controller), 'Controller property doesn\'t match');
+        }
+    }
+
+    /**
+     * Testing that using method setData won't affect previously set keys
+     */
+    public function testSetDataDoesntTouchTheOtherKeys() {
+        $controller = new Gdn_Controller();
+        $controller->setData('precious', 'value');
+        $this->assertEquals('value', $controller->data('precious'));
+
+        $controller->setData('newKey', 'newValue');
+        $this->assertEquals(['precious' => 'value', 'newKey' => 'newValue'], $controller->Data);
+    }
+
+    /**
+     * Provides test data to use in method setData.
+     *
+     * @return array
+     */
+    public function getTestDataForSetData() {
+        return [
+            // $key,             $value,                            $expectedDataArray
+            ['app',             'Vanilla',                          ['app' => 'Vanilla']],
+            ['app name',        'Vanilla',                          ['app name' => 'Vanilla']],
+            ['&^^^&*',          new stdClass(),                     ['&^^^&*' => new stdClass()]],
+            ['test an array',   ['my' => 'value'],                  ['test an array' => ['my' => 'value']]],
+            [['appName' => 'Vanilla', 'appVersion' => '2'], null,   ['appName' => 'Vanilla', 'appVersion' => '2']]
+        ];
+    }
+
+}

--- a/tests/Library/Core/ControllerTest.php
+++ b/tests/Library/Core/ControllerTest.php
@@ -85,7 +85,13 @@ class ControllerTest extends PHPUnit_Framework_TestCase {
             ['app name',        'Vanilla',                          ['app name' => 'Vanilla']],
             ['&^^^&*',          new stdClass(),                     ['&^^^&*' => new stdClass()]],
             ['test an array',   ['my' => 'value'],                  ['test an array' => ['my' => 'value']]],
-            [['appName' => 'Vanilla', 'appVersion' => '2'], null,   ['appName' => 'Vanilla', 'appVersion' => '2']]
+            [['appName' => 'Vanilla', 'appVersion' => '2'], null,   ['appName' => 'Vanilla', 'appVersion' => '2']],
+
+            // test $key with dot-notation
+            ['app.name', 'Vanilla', ['app' => ['name' => 'Vanilla']]],
+
+            // dot-notation inside an array of $keys
+            [['app.name' => 'Vanilla', 'app.version' => '2'], null, ['app' => ['name' => 'Vanilla', 'version' => '2']]],
         ];
     }
 

--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -18,3 +18,31 @@ foreach ($files as $file) {
     $dest = $dir.'/'.basename($file);
     $r = copy($file, $dest);
 }
+
+
+
+
+// ===========================================================================
+// Adding the minimum dependencies to support unit testing for core libraries
+// ===========================================================================
+
+// Path to the primary configuration file.
+if (!defined('PATH_CONF')) {
+    define('PATH_CONF', PATH_ROOT.'/conf');
+}
+
+if (!defined('APPLICATION_VERSION')) {
+    define('APPLICATION_VERSION', '2.2.101.7');
+}
+
+// Loads the constants
+require PATH_CONF . '/constants.php';
+
+// Install the configuration handler.
+Gdn::factoryInstall(Gdn::AliasConfig, 'Gdn_Configuration');
+
+// ThemeManager
+Gdn::factoryInstall(Gdn::AliasThemeManager, 'Gdn_ThemeManager');
+
+// Session
+Gdn::factoryInstall(Gdn::AliasSession, 'Gdn_Session');


### PR DESCRIPTION
Currently, only the method `data` is using the dot-notation while the method `setData` is not.
Therefore a value set by `setData("meta.name", "Vanilla")` cannot be recovered by `data("meta.name")` using the same key `meta.name`.  The only way to get this value back was to access the public `Data` attribute directly like `Data["meta.name"]`.

This PR adds the dot-notation to setData so that both `setData` and `data` have the same behaviour.
The original behaviour of `GDN_Controller::setData()` remains unchanged.

Only consequence though, if one was calling `Data["meta.name"]`, the call would have to be rewritten to `Data["meta"]["name"]`.