### PR TITLE
Add no-store header to DiscussionsController

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -28,6 +28,19 @@ class CategoriesController extends VanillaController {
     /** @var object Category object. */
     public $Category;
 
+    public function __construct() {
+        parent::__construct();
+
+        /**
+         * The default Cache-Control header does not include no-store, which can cause issues with outdated category
+         * information (e.g. counts).  The same check is performed here as in Gdn_Controller before the Cache-Control
+         * header is added, but this value includes the no-store specifier.
+         */
+        if (Gdn::session()->isValid()) {
+            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
+        }
+    }
+
     /**
      *
      *

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -28,18 +28,6 @@ class CategoriesController extends VanillaController {
     /** @var object Category object. */
     public $Category;
 
-    public function __construct() {
-        parent::__construct();
-
-        /**
-         * The default Cache-Control header does not include no-store, which can cause issues with outdated category
-         * information (e.g. counts).  The same check is performed here as in Gdn_Controller before the Cache-Control
-         * header is added, but this value includes the no-store specifier.
-         */
-        if (Gdn::session()->isValid()) {
-            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
-        }
-    }
 
     /**
      *
@@ -491,5 +479,14 @@ class CategoriesController extends VanillaController {
         }
 
         $this->CountCommentsPerPage = c('Vanilla.Comments.PerPage', 30);
+
+        /**
+         * The default Cache-Control header does not include no-store, which can cause issues with outdated category
+         * information (e.g. counts).  The same check is performed here as in Gdn_Controller before the Cache-Control
+         * header is added, but this value includes the no-store specifier.
+         */
+        if (Gdn::session()->isValid()) {
+            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
+        }
     }
 }

--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -19,15 +19,6 @@ class CategoryController extends VanillaController {
     public function __construct() {
         parent::__construct();
         $this->CategoryModel = new CategoryModel();
-
-        /**
-         * The default Cache-Control header does not include no-store, which can cause issues with outdated category
-         * information (e.g. counts).  The same check is performed here as in Gdn_Controller before the Cache-Control
-         * header is added, but this value includes the no-store specifier.
-         */
-        if (Gdn::session()->isValid()) {
-            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
-        }
     }
 
     public function follow($CategoryID, $Value, $TKey) {
@@ -40,6 +31,19 @@ class CategoryController extends VanillaController {
         }
 
         $this->render();
+    }
+
+    public function initialize() {
+        parent::initialize();
+
+        /**
+         * The default Cache-Control header does not include no-store, which can cause issues with outdated category
+         * information (e.g. counts).  The same check is performed here as in Gdn_Controller before the Cache-Control
+         * header is added, but this value includes the no-store specifier.
+         */
+        if (Gdn::session()->isValid()) {
+            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
+        }
     }
 
     public function markRead($CategoryID, $TKey) {

--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -19,6 +19,15 @@ class CategoryController extends VanillaController {
     public function __construct() {
         parent::__construct();
         $this->CategoryModel = new CategoryModel();
+
+        /**
+         * The default Cache-Control header does not include no-store, which can cause issues with outdated category
+         * information (e.g. counts).  The same check is performed here as in Gdn_Controller before the Cache-Control
+         * header is added, but this value includes the no-store specifier.
+         */
+        if (Gdn::session()->isValid()) {
+            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
+        }
     }
 
     public function follow($CategoryID, $Value, $TKey) {

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -30,19 +30,6 @@ class DiscussionsController extends VanillaController {
     /** @var array Limit the discussions to just this list of categories, checked for view permission. */
     protected $categoryIDs;
 
-    public function __construct() {
-        parent::__construct();
-
-        /**
-         * The default Cache-Control header does not include no-store, which can cause issues (e.g. inaccurate unread
-         * status or new comment counts) when users visit the discussion list via the browser's back button.  The same
-         * check is performed here as in Gdn_Controller before the Cache-Control header is added, but this value
-         * includes the no-store specifier.
-         */
-        if (Gdn::session()->isValid()) {
-            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
-        }
-    }
 
     /**
      * "Table" layout for discussions. Mimics more traditional forum discussion layout.
@@ -312,6 +299,16 @@ class DiscussionsController extends VanillaController {
         }
 
         $this->CountCommentsPerPage = c('Vanilla.Comments.PerPage', 30);
+
+        /**
+         * The default Cache-Control header does not include no-store, which can cause issues (e.g. inaccurate unread
+         * status or new comment counts) when users visit the discussion list via the browser's back button.  The same
+         * check is performed here as in Gdn_Controller before the Cache-Control header is added, but this value
+         * includes the no-store specifier.
+         */
+        if (Gdn::session()->isValid()) {
+            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
+        }
 
         $this->fireEvent('AfterInitialize');
     }

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -30,6 +30,20 @@ class DiscussionsController extends VanillaController {
     /** @var array Limit the discussions to just this list of categories, checked for view permission. */
     protected $categoryIDs;
 
+    public function __construct() {
+        parent::__construct();
+
+        /**
+         * The default Cache-Control header does not include no-store, which can cause issues (e.g. inaccurate unread
+         * status or new comment counts) when users visit the discussion list via the browser's back button.  The same
+         * check is performed here as in Gdn_Controller before the Cache-Control header is added, but this value
+         * includes the no-store specifier.
+         */
+        if (Gdn::session()->isValid()) {
+            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
+        }
+    }
+
     /**
      * "Table" layout for discussions. Mimics more traditional forum discussion layout.
      *


### PR DESCRIPTION
The default `Cache-Control` header does not include `no-store`, which can cause issues (e.g. inaccurate unread status or new comment counts) when users visit the discussion list via the browser's back button. This update adds `no-store` to the `Cache-Control` header sent by `DiscussionsController`.

Fixes https://github.com/vanilla/vanilla/issues/3056

Issue originates from https://github.com/vanilla/vanilla/pull/2948