### PR TITLE
Fixed unread discussion flag when discussion just created

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1785,10 +1785,10 @@ class DiscussionModel extends VanillaModel {
                     $InsertUser = Gdn::userModel()->getID($Fields['InsertUserID']);
                     $this->updateUserDiscussionCount($Fields['InsertUserID'], val('CountDiscussions', $InsertUser, 0) > 100);
 
-                    // Mark the user as participated.
+                    // Mark the user as participated and update DateLastViewed.
                     $this->SQL->replace(
                         'UserDiscussion',
-                        array('Participated' => 1),
+                        array('Participated' => 1, 'DateLastViewed' => Gdn_Format::toDateTime()),
                         array('DiscussionID' => $DiscussionID, 'UserID' => val('InsertUserID', $Fields))
                     );
 


### PR DESCRIPTION
Scenario 1:
1. Create a discussion.
2. Call the getUnread method in DiscussionModel

Expected : The newly created discussion doesn't appear.
Seen : The newly created discussion is fetched.

PS : Even if you click to view the discussion. It's not set to viewed, I noticed after investigation that the LastDateViewed field is null after the discussion is created.