### PR TITLE
Fix order direction in SQL driver

### DIFF
--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1404,7 +1404,7 @@ abstract class Gdn_SQLDriver {
             return $this;
         }
 
-        if ($Direction && $Direction != 'asc') {
+        if ($Direction && strtolower($Direction) != 'asc') {
             $Direction = 'desc';
         } else {
             $Direction = 'asc';


### PR DESCRIPTION
I just wanted to change the order of a database result and added `orderBy('...', 'ASC')`. This didn't work an took me several hours to find out why. It's because only `asc` is accepted and `ASC` is changed to `desc`.

Since that's confusing and not documented, I propose this tiny change.