### PR TITLE
Add CSV export for Profile Extender's extra fields

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -914,7 +914,7 @@ class UserController extends DashboardController {
      *
      * @return bool
      */
-    protected function pastUserThreshold() {
+    public function pastUserThreshold() {
         $estimate = $this->countEstimate();
         return $estimate > $this->UserThreshold;
     }
@@ -924,7 +924,7 @@ class UserController extends DashboardController {
      *
      * @return bool
      */
-    protected function pastUserMegaThreshold() {
+    public function pastUserMegaThreshold() {
         $estimate = $this->countEstimate();
         return $estimate > $this->UserMegaThreshold;
     }

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -16,12 +16,6 @@ class UserController extends DashboardController {
     /** @var array Models to automatically instantiate. */
     public $Uses = array('Database', 'Form');
 
-    /** @var int The number of users when database optimizations kick in. */
-    public $UserThreshold = 10000;
-
-    /** @var int The number of users when extreme database optimizations kick in. */
-    public $UserMegaThreshold = 1000000;
-
     /** @var Gdn_Form */
     public $Form;
 
@@ -98,7 +92,7 @@ class UserController extends DashboardController {
         } else {
             $Filter = array('Keywords' => (string)$Keywords);
         }
-        $Filter['Optimize'] = $this->pastUserThreshold();
+        $Filter['Optimize'] = Gdn::userModel()->pastUserThreshold();
 
         // Sorting
         if (in_array($Order, array('DateInserted', 'DateFirstVisit', 'DateLastActive'))) {
@@ -115,7 +109,7 @@ class UserController extends DashboardController {
 
         // Figure out our number of results and users.
         $showUserCount = $this->UserData->count();
-        if (!$this->pastUserThreshold()) {
+        if (!Gdn::userModel()->pastUserThreshold()) {
             // Pfft, query that sucker however you want.
             $this->setData('RecordCount', $UserModel->searchCount($Filter));
         } else {
@@ -125,7 +119,7 @@ class UserController extends DashboardController {
             } else {
                 // No search was done. Just give the total users overall. First, zero-out our pager.
                 $this->setData('_CurrentRecords', 0);
-                if (!$this->pastUserMegaThreshold()) {
+                if (!Gdn::userModel()->pastUserMegaThreshold()) {
                     // Restoring this semi-optimized counter is our compromise to let non-mega sites know their exact total users.
                     $this->setData('UserCount', $UserModel->getCount());
                 } else {
@@ -907,37 +901,7 @@ class UserController extends DashboardController {
         return '/dashboard/user?'.http_build_query($Get);
     }
 
-    /**
-     * Whether or not we are past the user threshold.
-     *
-     * This is a useful indication that some database operations on the User table will be painfully long.
-     *
-     * @return bool
-     */
-    public function pastUserThreshold() {
-        $estimate = $this->countEstimate();
-        return $estimate > $this->UserThreshold;
-    }
 
-    /**
-     * Whether we're wandered into extreme database optimization territory with our user count.
-     *
-     * @return bool
-     */
-    public function pastUserMegaThreshold() {
-        $estimate = $this->countEstimate();
-        return $estimate > $this->UserMegaThreshold;
-    }
-
-    /**
-     * Approximate the number of users by checking the database table status.
-     *
-     * @return int
-     */
-    protected function countEstimate() {
-        $px = Gdn::database()->DatabasePrefix;
-        return Gdn::database()->query("show table status like '{$px}User'")->value('Rows', 0);
-    }
 
     /**
      * Convenience function for listing users. At time of this writing, it is

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -49,6 +49,12 @@ class UserModel extends Gdn_Model {
     /** @var */
     public $SessionColumns;
 
+    /** @var int The number of users when database optimizations kick in. */
+    public $UserThreshold = 10000;
+
+    /** @var int The number of users when extreme database optimizations kick in. */
+    public $UserMegaThreshold = 1000000;
+
     /**
      * Class constructor. Defines the related database table name.
      */
@@ -60,6 +66,38 @@ class UserModel extends Gdn_Model {
             'LastIPAddress', 'AllIPAddresses', 'DateFirstVisit', 'DateLastActive', 'CountDiscussions', 'CountComments',
             'Score', 'Photo'
         ));
+    }
+
+    /**
+     * Whether or not we are past the user threshold.
+     *
+     * This is a useful indication that some database operations on the User table will be painfully long.
+     *
+     * @return bool
+     */
+    public function pastUserThreshold() {
+        $estimate = $this->countEstimate();
+        return $estimate > $this->UserThreshold;
+    }
+
+    /**
+     * Whether we're wandered into extreme database optimization territory with our user count.
+     *
+     * @return bool
+     */
+    public function pastUserMegaThreshold() {
+        $estimate = $this->countEstimate();
+        return $estimate > $this->UserMegaThreshold;
+    }
+
+    /**
+     * Approximate the number of users by checking the database table status.
+     *
+     * @return int
+     */
+    public function countEstimate() {
+        $px = Gdn::database()->DatabasePrefix;
+        return Gdn::database()->query("show table status like '{$px}User'")->value('Rows', 0);
     }
 
     /**

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -521,6 +521,25 @@ if (!function_exists('discussionUrl')) {
     }
 }
 
+if (!function_exists('exportCSV')) {
+    /**
+     * Create a CSV given a list of column names & rows.
+     *
+     * @param array $columnNames
+     * @param array $data
+     */
+    function exportCSV($columnNames, $data = array()) {
+        $output = fopen("php://output",'w');
+        header("Content-Type:application/csv");
+        header("Content-Disposition:attachment;filename=profiles_export.csv");
+        fputcsv($output, $columnNames);
+        foreach($data as $row) {
+            fputcsv($output, $row);
+        }
+        fclose($output);
+    }
+}
+
 if (!function_exists('fixnl2br')) {
     /**
      * Removes the break above and below tags that have a natural margin.

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -523,7 +523,9 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
             ->select('u.CountDiscussions')
             ->select('u.CountComments')
             ->select('u.Points')
-            ->from('User u');
+            ->from('User u')
+            ->where('u.Deleted', 0)
+            ->where('u.Admin <', 2);
 
         $i = 0;
         foreach ($fields as $slug => $fieldData) {

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -541,28 +541,11 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         $users = Gdn::sql()->get()->resultArray();
 
         // Serve a CSV of the results.
-        self::exportCsv($columnNames, $users);
+        exportCSV($columnNames, $users);
         die();
 
         // Useful for query debug.
         //$sender->render('blank');
-    }
-
-    /**
-     * Create a CSV given a list of column names & rows.
-     *
-     * @param array $columnNames
-     * @param array $data
-     */
-    private static function exportCsv($columnNames, $data = array()) {
-        $output = fopen("php://output",'w');
-        header("Content-Type:application/csv");
-        header("Content-Disposition:attachment;filename=profiles_export.csv");
-        fputcsv($output, $columnNames);
-        foreach($data as $row) {
-            fputcsv($output, $row);
-        }
-        fclose($output);
     }
 
     /**

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -506,8 +506,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
     public function utilityController_exportProfiles_create($sender) {
         // Clear our ability to do this.
         $sender->permission('Garden.Settings.Manage');
-        $userController = new UserController();
-        if ($userController->pastUserMegaThreshold()) {
+        if (Gdn::userModel()->pastUserMegaThreshold()) {
             throw new Gdn_UserException('You have too many users to export automatically.');
         }
 

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -316,7 +316,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
             $Fields = $this->getProfileFields();
             if (!$Name = val('Name', $FormPostValues)) {
                 // Make unique name from label for new fields
-                $Name = $TestSlug = preg_replace('`[^0-9a-zA-Z]`', '', val('Label', $FormPostValues));
+                $Name = $TestSlug = substr(preg_replace('`[^0-9a-zA-Z]`', '', val('Label', $FormPostValues)), 0, 50);
                 $i = 1;
                 while (array_key_exists($Name, $Fields) || in_array($Name, $this->ReservedNames)) {
                     $Name = $TestSlug.$i++;

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -70,7 +70,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
     /**
      * Add the Dashboard menu item.
      */
-    public function base_GetAppSettingsMenuItems_handler($Sender) {
+    public function base_getAppSettingsMenuItems_handler($Sender) {
         $Menu = &$Sender->EventArguments['SideMenu'];
         $Menu->addLink('Users', t('Profile Fields'), 'settings/profileextender', 'Garden.Settings.Manage');
     }
@@ -78,8 +78,8 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
     /**
      * Add non-checkbox fields to registration forms.
      */
-    public function entryController_RegisterBeforePassword_handler($Sender) {
-        $ProfileFields = $this->GetProfileFields();
+    public function entryController_registerBeforePassword_handler($Sender) {
+        $ProfileFields = $this->getProfileFields();
         $Sender->RegistrationFields = array();
         foreach ($ProfileFields as $Name => $Field) {
             if (val('OnRegister', $Field) && val('FormType', $Field) != 'CheckBox') {
@@ -92,7 +92,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
     /**
      * Add checkbox fields to registration forms.
      */
-    public function entryController_RegisterFormBeforeTerms_handler($Sender) {
+    public function entryController_registerFormBeforeTerms_handler($Sender) {
         $ProfileFields = $this->getProfileFields();
         $Sender->RegistrationFields = array();
         foreach ($ProfileFields as $Name => $Field) {
@@ -189,7 +189,6 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
      */
     private function getProfileFields() {
         $Fields = c('ProfileExtender.Fields', array());
-
         if (!is_array($Fields)) {
             $Fields = array();
         }
@@ -241,7 +240,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         $this->ProfileFields = $this->getProfileFields();
 
         // Get user-specific data
-        $this->UserFields = Gdn::userModel()->GetMeta($Sender->Form->getValue('UserID'), 'Profile.%', 'Profile.');
+        $this->UserFields = Gdn::userModel()->getMeta($Sender->Form->getValue('UserID'), 'Profile.%', 'Profile.');
         // Fill in user data on form
         foreach ($this->UserFields as $Field => $Value) {
             $Sender->Form->setValue($Field, $Value);
@@ -314,7 +313,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
             }
 
             // Merge updated data into config
-            $Fields = $this->GetProfileFields();
+            $Fields = $this->getProfileFields();
             if (!$Name = val('Name', $FormPostValues)) {
                 // Make unique name from label for new fields
                 $Name = $TestSlug = preg_replace('`[^0-9a-zA-Z]`', '', val('Label', $FormPostValues));
@@ -333,7 +332,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
             }
         } elseif (isset($Args[0])) {
             // Editing
-            $Data = $this->GetProfileField($Args[0]);
+            $Data = $this->getProfileField($Args[0]);
             if (isset($Data['Options']) && is_array($Data['Options'])) {
                 $Data['Options'] = implode("\n", $Data['Options']);
             }


### PR DESCRIPTION
Writing these queries manually has grown tiresome. This is a simple endpoint that dumps a CSV file of some standard user fields + all their Profile Extender data. Admin-only, and we size-check the user table before proceeding.

* Move user table size calculating from UserController to UserModel (for accessibility, but also because duh).
* Add a new `exportCSV()` function for rendering.
* Add utility endpoint on the Profile Extender plugin for exporting all custom user data.
* Fix issue in Profile Extender where database field size in UserMeta can truncate the Name, causing it to be disjointed from config-saved value (thereby corrupting the data, essentially). 