### PR TITLE
Update class.discussionmodel.php

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -294,6 +294,7 @@ class DiscussionModel extends VanillaModel {
         $this->EventArguments['SortField'] = &$SortField;
         $this->EventArguments['SortDirection'] = c('Vanilla.Discussions.SortDirection', 'desc');
         $this->EventArguments['Wheres'] = &$Wheres;
+        $this->EventArguments['Sql'] =& $Sql;
         $this->fireEvent('BeforeGet'); // @see 'BeforeGetCount' for consistency in results vs. counts
 
         $IncludeAnnouncements = false;


### PR DESCRIPTION
This will allow plugin owners more control over the sorting order, specifically to have multiple sort orders.  Typical example: sort so that bookmarked discussions are on top of other discussions, alerted discussions (see DiscussionAlert plugin) ahead of bookmarked and ahead or the rest which should be in the "standard" order.