### PR TITLE
add (optional) MinLength for sliceParagraph

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3740,7 +3740,7 @@ if (!function_exists('sliceParagraph')) {
      * @param int $MinLength The intended minimum length of the string (slice on sentence if paragraph is too short)
      * @return string
      */
-    function sliceParagraph($String, $MaxLength = 500, $Suffix = '…', $MinLength = 20) {
+    function sliceParagraph($String, $MaxLength = 500, $Suffix = '…', $MinLength = 50) {
         if ($MaxLength >= strlen($String)) {
             return $String;
         }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3735,12 +3735,15 @@ if (!function_exists('sliceParagraph')) {
      * The purpose of this function is to provide a string that is reaonably easy to consume by a human.
      *
      * @param string $String The string to slice.
-     * @param int $MaxLength The maximum length of the string.
+     * @param int|array $Limits Either int $MaxLength or array($MaxLength, $MinLength); whereas $MaxLength The maximum length of the string; $MinLength The intended minimum length of the string (slice on sentence if paragraph is too short).
      * @param string $Suffix The suffix if the string must be sliced mid-sentence.
-     * @param int $MinLength The intended minimum length of the string (slice on sentence if paragraph is too short)
      * @return string
      */
-    function sliceParagraph($String, $MaxLength = 500, $Suffix = '…', $MinLength = 50) {
+    function sliceParagraph($String, $Limits = 500, $Suffix = '…') {
+        if(is_int($Limits)) {
+            $Limits = array($Limits, 32);
+        }
+        list($MaxLength, $MinLength) = $Limits;
         if ($MaxLength >= strlen($String)) {
             return $String;
         }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3737,9 +3737,10 @@ if (!function_exists('sliceParagraph')) {
      * @param string $String The string to slice.
      * @param int $MaxLength The maximum length of the string.
      * @param string $Suffix The suffix if the string must be sliced mid-sentence.
+     * @param int $MinLength The intended minimum length of the string (slice on sentence if paragraph is too short)
      * @return string
      */
-    function sliceParagraph($String, $MaxLength = 500, $Suffix = '…') {
+    function sliceParagraph($String, $MaxLength = 500, $Suffix = '…', $MinLength = 20) {
         if ($MaxLength >= strlen($String)) {
             return $String;
         }
@@ -3749,7 +3750,7 @@ if (!function_exists('sliceParagraph')) {
         // See if there is a paragraph.
         $Pos = strrpos(SliceString($String, $MaxLength, ''), "\n\n");
 
-        if ($Pos === false) {
+        if ($Pos === false || $Pos<$MinLength) {
             // There was no paragraph so try and split on sentences.
             $Sentences = preg_split('`([.!?:]\s+)`', $String, null, PREG_SPLIT_DELIM_CAPTURE);
 

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3750,7 +3750,7 @@ if (!function_exists('sliceParagraph')) {
         // See if there is a paragraph.
         $Pos = strrpos(SliceString($String, $MaxLength, ''), "\n\n");
 
-        if ($Pos === false || $Pos<$MinLength) {
+        if ($Pos === false || $Pos < $MinLength) {
             // There was no paragraph so try and split on sentences.
             $Sentences = preg_split('`([.!?:]\s+)`', $String, null, PREG_SPLIT_DELIM_CAPTURE);
 


### PR DESCRIPTION
In my forum, I have several discussions beginning with a short greeting, like:

```
Hi folks,

foo bar is great. Bla bla bla.
```

The `DiscussionController` uses `sliceParagraph` for setting an appropriate `description` in the `meta` tags of the discussion page. Hence, the result is currently `Hi folks,` which is not very useful (and e.g. google webmaster tools complain about a too short description).

Therefore, I propose to add a new parameter `MinLength`. If the found paragraph is shorter than this value, then the string is sliced on a sentence.

In the example, the result will be `Hi folks, foo bar is great.` which has clearly more benefit.