### PR TITLE
Remove linebreaks in meta description

### DIFF
--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -378,7 +378,7 @@ if (!class_exists('HeadModule', false)) {
                 $this->addTag('meta', array('property' => 'og:url', 'content' => $CanonicalUrl));
             }
 
-            if ($Description = $this->_Sender->Description()) {
+            if ($Description = Gdn_Format::reduceWhiteSpaces($this->_Sender->Description())) {
                 $this->addTag('meta', array('name' => 'description', 'property' => 'og:description', 'itemprop' => 'description', 'content' => $Description));
             }
 

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1634,6 +1634,15 @@ EOT;
         }
     }
 
+   /**
+    * Reduces multiple whitespaces including line breaks and tabs to one single space character.
+    *
+    * @param string $String The string which should be optimized
+    */
+    public static function reduceWhiteSpaces($String) {
+        return trim(preg_replace('/\s+/', ' ', $String));
+    }
+
     /**
      * Do a preg_replace, but don't affect things inside <code> tags.
      *


### PR DESCRIPTION
The meta description in the header of a discussion is derived from the beginning of the discussion text and therefore often contains linebreaks. However, these should not be included in the meta description tag. Therefore, a new helper function `Gdn_Format::reduceWhiteSpaces` is introduced and used by the `HeadModule`.

If you don't think, this function will be ever used anywhere else, then I can move it's functionality directly into the `HeadModule`.