### PR TITLE
Applicants v2

### DIFF
--- a/applications/dashboard/js/applicants.js
+++ b/applications/dashboard/js/applicants.js
@@ -1,0 +1,28 @@
+jQuery(document).ready(function($) {
+
+    // Approve / Decline an applicant asynchronously.
+    $(document).delegate('a.DeclineApplicant, a.ApproveApplicant', 'click', function() {
+        // Prepare our message.
+        var approvedMsg = gdn.definition('ApprovedTranslation', 'Approved');
+        var declinedMsg = gdn.definition('DeclinedTranslation', 'Declined');
+        var message = ($(this).hasClass('ApproveApplicant')) ? approvedMsg : declinedMsg;
+        message = '<em class="ConfirmApplicant'+message+'">'+message+'</em>';
+
+        // Prepare action & effect.
+        var anchor = this;
+        var container = $(anchor).closest('td');
+        var transientKey = gdn.definition('TransientKey');
+        var data = 'DeliveryType=BOOL&TransientKey=' + transientKey;
+
+        // Do the action.
+        $(container).html('<span class="AfterButtonLoading">&#160;</span>');
+        $.post($(anchor).attr('href'), data, function(response) {
+            if (response == 'TRUE') {
+                //gdn.informMessage(message);
+                // Do the effect.
+                $(container).html(message);
+            }
+        });
+        return false;
+    });
+});

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1293,7 +1293,6 @@ class UserModel extends Gdn_Model {
             ->from('User u')
             ->join('UserRole ur', 'u.UserID = ur.UserID')
             ->where('ur.RoleID', $applicantRoleIDs)
-//         ->groupBy('UserID')
             ->orderBy('DateInserted', 'desc')
             ->get();
     }

--- a/applications/dashboard/views/user/applicants.php
+++ b/applications/dashboard/views/user/applicants.php
@@ -1,63 +1,69 @@
 <?php if (!defined('APPLICATION')) exit();
 $Session = Gdn::session();
 ?>
-    <div class="Help Aside">
-        <?php
-        echo wrap(t('Need More Help?'), 'h2');
-        echo '<ul>';
-        echo wrap(Anchor(t("Video tutorial on user registration"), 'settings/tutorials/user-registration'), 'li');
-        echo '</ul>';
-        ?>
-    </div>
-    <h1><?php echo t('Manage Applicants'); ?></h1>
+<h1><?php echo t('Manage Applicants'); ?></h1>
 <?php
 echo $this->Form->open(array('action' => url('/dashboard/user/applicants')));
 echo $this->Form->errors();
 $NumApplicants = $this->UserData->numRows();
-if ($NumApplicants == 0) { ?>
+
+if ($NumApplicants == 0) : ?>
     <div class="Info"><?php echo t('There are currently no applicants.'); ?></div>
-<?php } else { ?>
+<?php else : ?>
     <?php
-    $AppText = plural($NumApplicants, 'There is currently %s applicant', 'There are currently %s applicants');
+    $AppText = plural($NumApplicants, 'There is currently %s applicant', 'There are currently %s applicants.');
     ?>
     <div class="Info"><?php echo sprintf($AppText, $NumApplicants); ?></div>
-    <table class="CheckColumn">
+    <table>
         <thead>
-        <tr>
-            <td><?php echo t('Action'); ?></td>
-            <th class="Alt"><?php echo t('Applicant'); ?></th>
-            <th><?php echo t('Options'); ?></th>
-        </tr>
+            <tr>
+                <th width="130px"><?php echo t('Action'); ?></th>
+                <th><?php echo t('Applicant'); ?></th>
+                <th><?php echo t('Email'); ?></th>
+                <th><?php echo t('IP Address'); ?></th>
+                <th><?php echo t('Date'); ?></th>
+            </tr>
         </thead>
         <tbody>
         <?php
-        foreach ($this->UserData->Format('Text')->result() as $User) {
-            ?>
-            <tr>
-                <td><?php echo $this->Form->CheckBox('Applicants[]', '', array('value' => $User->UserID)); ?></td>
-                <td class="Alt">
-                    <?php
-                    printf(t('<strong>%1$s</strong> (%2$s) %3$s'), $User->Name, Gdn_Format::Email($User->Email), Gdn_Format::date($User->DateInserted));
-
-                    $this->EventArguments['User'] = $User;
-                    $this->fireEvent("ApplicantInfo");
-                    echo '<blockquote>'.$User->DiscoveryText.'</blockquote>';
-
-                    $this->EventArguments['User'] = $User;
-                    $this->fireEvent("AppendApplicantInfo");
-                    ?></td>
-                <td><?php
-                    echo anchor(t('Approve'), '/user/approve/'.$User->UserID.'/'.$Session->TransientKey())
-                        .' '.anchor(t('Decline'), '/user/decline/'.$User->UserID.'/'.$Session->TransientKey());
-                    ?></td>
+        foreach ($this->UserData->result() as $User) :
+            $this->EventArguments['User'] = $User;
+            $this->EventArguments['ApplicantMeta'] = array();
+            $this->fireEvent("ApplicantInfo"); ?>
+            <tr class="ApplicantMeta">
+                <td style="border-bottom:none;"><?php
+                    echo anchor(t('Approve'), '/user/approve/'.$User->UserID, 'SmallButton ApproveApplicant');
+                    echo anchor(t('Decline'), '/user/decline/'.$User->UserID, 'CancelButton DeclineApplicant');
+                    ?>
+                </td>
+                <td style="border-bottom:none;"><strong><?php echo htmlspecialchars($User->Name); ?></strong></td>
+                <td style="border-bottom:none;"><?php echo anchor($User->Email, 'mailto:'.$User->Email); ?></td>
+                <td style="border-bottom:none;"><?php echo anchor(Gdn_Format::text($User->InsertIPAddress), '/user/browse?Keywords='.Gdn_Format::text($User->InsertIPAddress)); ?></td>
+                <td style="border-bottom:none;"><?php echo Gdn_Format::date($User->DateInserted); ?></td>
             </tr>
-        <?php } ?>
+            <tr>
+                <td></td>
+                <td colspan="4">
+                <?php
+                    // Output a definition list if a plugin passed us ordered data.
+                    if (count($this->EventArguments['ApplicantMeta'])) {
+                        foreach ($this->EventArguments['ApplicantMeta'] as $label => $value) {
+                            echo '<dt>'.htmlspecialchars($label).'</dt><dd>'.htmlspecialchars($value).'</dd>';
+                        }
+                    }
+                    // Only make a blockquote if we got a reason.
+                    if ($User->DiscoveryText) {
+                        echo '<blockquote>'.wrap(t('Reason for joining', 'Reason: '), 'em').Gdn_Format::text($User->DiscoveryText).'</blockquote>';
+                    }
+                    // Opportunity for plugins to do arbitrary appending.
+                    $this->fireEvent("AppendApplicantInfo");
+                    ?>
+                </td>
+            </tr>
+        <?php endforeach; ?>
         </tbody>
     </table>
-    <div class="Info">
     <?php
-    echo $this->Form->button('Approve', array('Name' => 'Submit', 'class' => 'SmallButton'));
-    echo $this->Form->button('Decline', array('Name' => 'Submit', 'class' => 'SmallButton'));
-    ?></div><?php
-}
+endif;
+
 echo $this->Form->close();

--- a/applications/dashboard/views/user/applicants.php
+++ b/applications/dashboard/views/user/applicants.php
@@ -11,7 +11,7 @@ if ($NumApplicants == 0) : ?>
     <div class="Info"><?php echo t('There are currently no applicants.'); ?></div>
 <?php else : ?>
     <?php
-    $AppText = plural($NumApplicants, 'There is currently %s applicant', 'There are currently %s applicants.');
+    $AppText = plural($NumApplicants, 'There is currently %s applicant.', 'There are currently %s applicants.');
     ?>
     <div class="Info"><?php echo sprintf($AppText, $NumApplicants); ?></div>
     <table>

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -277,14 +277,14 @@ class PostController extends VanillaController {
                 $this->fireEvent('BeforeDiscussionPreview');
 
                 if ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
-                    $this->AddAsset('Content', $this->fetchView('preview'));
+                    $this->addAsset('Content', $this->fetchView('preview'));
                 } else {
                     $this->View = 'preview';
                 }
             }
             if ($this->Form->errorCount() > 0) {
                 // Return the form errors
-                $this->ErrorMessage($this->Form->errors());
+                $this->errorMessage($this->Form->errors());
             } elseif ($DiscussionID > 0 || $DraftID > 0) {
                 // Make sure that the ajax request form knows about the newly created discussion or draft id
                 $this->setJson('DiscussionID', $DiscussionID);
@@ -300,9 +300,9 @@ class PostController extends VanillaController {
                         $this->fireEvent('AfterDiscussionSave');
 
                         if ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
-                            redirect(DiscussionUrl($Discussion)).'?new=1';
+                            redirect(discussionUrl($Discussion)).'?new=1';
                         } else {
-                            $this->RedirectUrl = DiscussionUrl($Discussion, '', true).'?new=1';
+                            $this->RedirectUrl = discussionUrl($Discussion, '', true).'?new=1';
                         }
                     } else {
                         // If this was a draft save, notify the user about the save


### PR DESCRIPTION
Approving applicants is an awful process and always has been. Either you have to wait for the page to reload with the entire applicant list every time you click a button, or you have to pick either "allow" or "deny" and only check those, then do the others in a second batch. AND, if you choose the former, the two links are RIGHT NEXT TO EACH OTHER and in exactly the same style, making it super easy toclick the wrong one, which has absolutely no undo. It's madness.

What's been changed:

* Redo the Applicants page as a table of user data instead of cramming it all in 1 column.
* Add IP address (linked to search) & link the email address.
* Move the Approve / Decline options to the left.
* Make Approve / Decline actions asyncronous - no more pageloads!
* Clicking either option immediately gives a "wait" animation which is then replaced with a "Approved" or "Declined" message on success, so you can click lots of them in a row without it shifting around or being delayed by stuff like emails being sent.
* Eliminate the checkbox options (now redundant).
* Make the `approve()` & `decline()` methods postbacks.
* Improve the system for plugins to hook into the applicant page, including an optional built-in definition list. Does not break backwards compatibility of these hooks.

Need frontend help with:

* [ ] Inline styles `border-bottom:none;` - probably should be abstracted to `tr.ApplicantMeta td` rule in CSS?
* [ ] Maybe add a style to `.ConfirmApplicantApprove` and `.ConfirmApplicantDeny` so the feedback messages are nicer.

Closes #1627

<img width="947" alt="screen shot 2016-01-24 at 9 04 02 pm" src="https://cloud.githubusercontent.com/assets/117672/12540963/0d498faa-c2de-11e5-89d5-f26a0f568053.png">

To test this, I strongly recommend creating a dozen or more applicants (at least) to simulate having many users to work thru. Then back up you GDN_User and GDN_UserRole tables so you can reset between tests.