### PR TITLE
Fix casening error in ProxyRequest

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -546,7 +546,7 @@ class ProxyRequest {
         // Add the response body to the log entry if it isn't too long or we are debugging.
         $logResponseBody = val('LogResponseBody', $Options, null);
         $logResponseBody = $logResponseBody === null ?
-            !in_array($RequestMethod, ['GET', 'OPTIONS']) && strlen($this->responseBody) < self::MAX_LOG_BODYLENGTH :
+            !in_array($RequestMethod, ['GET', 'OPTIONS']) && strlen($this->ResponseBody) < self::MAX_LOG_BODYLENGTH :
             $logResponseBody;
 
         if ($logResponseBody || debug() || (!$this->responseClass('2xx') && val('LogResponseErrorBody', $Options, true))) {


### PR DESCRIPTION
This update corrects a casening error (`$this->responseBody` should be `$this->ResponseBody`) in ProxyRequest.