### PR TITLE
Fix that only allows increase of max_execution_time.

### DIFF
--- a/applications/dashboard/controllers/class.dbacontroller.php
+++ b/applications/dashboard/controllers/class.dbacontroller.php
@@ -43,7 +43,7 @@ class DbaController extends DashboardController {
      * @throws Gdn_UserException
      */
     public function counts($Table = false, $Column = false, $From = false, $To = false, $Max = false) {
-        set_time_limit(300);
+        increaseMaxExecutionTime(300);
         $this->permission('Garden.Settings.Manage');
 
         if ($Table && $Column && strcasecmp($this->Request->requestMethod(), Gdn_Request::INPUT_POST) == 0) {

--- a/applications/dashboard/models/class.importmodel.php
+++ b/applications/dashboard/models/class.importmodel.php
@@ -1302,7 +1302,7 @@ class ImportModel extends Gdn_Model {
      */
     protected function _LoadTableWithInsert($Tablename, $Path) {
         // This option could take a while so set the timeout.
-        set_time_limit(60 * 10);
+        increaseMaxExecutionTime(60 * 10);
 
         // Get the column count of the table.
         $St = Gdn::structure();
@@ -1548,7 +1548,7 @@ class ImportModel extends Gdn_Model {
      */
     public function processImportFile() {
         // This one step can take a while so give it more time.
-        set_time_limit(60 * 10);
+        increaseMaxExecutionTime(60 * 10);
 
         $Path = $this->ImportPath;
         $BasePath = dirname($Path).DS.'import';
@@ -1934,7 +1934,7 @@ class ImportModel extends Gdn_Model {
      */
     public function updateCounts() {
         // This option could take a while so set the timeout.
-        set_time_limit(60 * 10);
+        increaseMaxExecutionTime(60 * 10);
 
         // Define the necessary SQL.
         $Sqls = array();

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -4433,3 +4433,31 @@ if (!function_exists('userAgentType')) {
         return $type = 'desktop';
     }
 }
+
+if (!function_exists('increaseMaxExecutionTime')) {
+    /**
+     * Used to increase php max_execution_time value.
+     *
+     * @param int $maxExecutionTime PHP max execution time in seconds.
+     * @return bool Returns true if max_execution_time was increased (or stayed the same) or false otherwise.
+     */
+    function increaseMaxExecutionTime($maxExecutionTime) {
+
+        $iniMaxExecutionTime = ini_get('max_execution_time');
+
+        // max_execution_time == 0 means no limit.
+        if ($iniMaxExecutionTime === '0') {
+            return true;
+        }
+
+        if (((string)$maxExecutionTime) === '0') {
+            return set_time_limit(0);
+        }
+
+        if (!ctype_digit($iniMaxExecutionTime) || $iniMaxExecutionTime < $maxExecutionTime) {
+            return set_time_limit($maxExecutionTime);
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
I had a really big import to do and it died after a while.

I found this in my error log:

```
016/01/26 13:14:51 [error] 26764#0: *34 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Maximum execution time of 600 seconds exceeded in /var/workspace/htdocs/vanilla/applications/dashboard/models/class.importmodel.php on line 1590
PHP message: PHP Stack trace:
PHP message: PHP   1. {main}() /var/workspace/htdocs/vanilla/index.php:0
PHP message: PHP   2. Gdn_Dispatcher->dispatch() /var/workspace/htdocs/vanilla/index.php:44
PHP message: PHP   3. call_user_func_array() /var/workspace/htdocs/vanilla/library/core/class.dispatcher.php:326
PHP message: PHP   4. ImportController->go() /var/workspace/htdocs/vanilla/library/core/class.dispatcher.php:326
PHP message: PHP   5. ImportModel->runStep() /var/workspace/htdocs/vanilla/applications/dashboard/controllers/class.importcontroller.php:56
PHP message: PHP   6. call_user_func() /var/workspace/htdocs/vanilla/applications/dashboard/models/class.importmodel.php:1666
PHP message: PHP   7. ImportModel->processImportFile() /var/workspace/htdocs/vanilla/applications/dashboard/models/class.importmodel.php:1666
PHP message: PHP   8. fputs() /var/workspace/htdocs/vanilla/applications/dashboard/models/class.importmodel.php:1590" while reading response header from upstream, client: 192.168.11.1, server: vanilla.migration, request: "GET /kongregate_vf/index.php?p=/dashboard/import/go/7CFJnxpxRa4JSzel HTTP/1.1", upstream: "fastcgi://unix:/var/run/php5-fpm.sock:", host: "vanilla.migration", referrer: "http://vanilla.migration/kongregate_vf/index.php?p=/dashboard/import&"
```

My max_execution_time is set to 7200 to avoid those kind of errors so I was displeased to see that the script ended because of a max_execution_time error!

This PR fix the issue by introducing a new function that can only increase that limit.