### PR TITLE
Add analytics event to JavaScript

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -811,8 +811,7 @@ jQuery(document).ready(function($) {
                 gdn.inform(json);
             },
             complete: function(jqXHR, textStatus) {
-                /** @link https://bugs.jquery.com/ticket/7818#comment:26 */
-                jQuery(gdn).triggerHandler('analyticsTick', [SendData, jqXHR, textStatus]);
+                jQuery(document).triggerHandler('analyticsTick', [SendData, jqXHR, textStatus]);
             }
         });
     };

--- a/js/global.js
+++ b/js/global.js
@@ -809,6 +809,10 @@ jQuery(document).ready(function($) {
             data: SendData,
             success: function(json) {
                 gdn.inform(json);
+            },
+            complete: function(jqXHR, textStatus) {
+                /** @link https://bugs.jquery.com/ticket/7818#comment:26 */
+                jQuery(gdn).triggerHandler('analyticsTick', [SendData, jqXHR, textStatus]);
             }
         });
     };


### PR DESCRIPTION
This update adds a JavaScript event to `gdn.stats`, allowing handlers to attach to when a call is made to `/settings/analyticstick`.  This will allow add-ons to use existing code to determine if and when custom analytics JavaScript should be triggered.