### PR TITLE
Fix logo to allow schemaless full URLs

### DIFF
--- a/library/core/class.theme.php
+++ b/library/core/class.theme.php
@@ -385,7 +385,10 @@ class Gdn_Theme {
         $Logo = c('Garden.Logo');
 
         if ($Logo) {
-            $Logo = ltrim($Logo, '/');
+            // Only trim slash from relative paths.
+            if (!stringBeginsWith($Logo, '//')) {
+                $Logo = ltrim($Logo, '/');
+            }
 
             // Fix the logo path.
             if (stringBeginsWith($Logo, 'uploads/')) {


### PR DESCRIPTION
Currently, `Garden.Logo` = `http://example.com/path/to/logo.png` works, but `//example.com/path/to/logo.png` does not. This fix detects schemaless URLs before trimming the leading slash.