### PR TITLE
Remove calls to removeKeyFromArray()

### DIFF
--- a/applications/dashboard/models/class.attachmentmodel.php
+++ b/applications/dashboard/models/class.attachmentmodel.php
@@ -327,7 +327,7 @@ class AttachmentModel extends Gdn_Model {
             $Fields = $this->Validation->validationFields();
 
             if ($Insert === false) {
-                $Fields = removeKeyFromArray($Fields, $this->PrimaryKey); // Don't try to update the primary key
+                unset($Fields[$this->PrimaryKey]); // Don't try to update the primary key
                 $this->update($Fields, array($this->PrimaryKey => $PrimaryKeyVal));
             } else {
                 $PrimaryKeyVal = $this->insert($Fields);

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -630,7 +630,7 @@ class RoleModel extends Gdn_Model {
      * @param string $RolesColumn
      */
     public static function setUserRoles(&$Users, $UserIDColumn = 'UserID', $RolesColumn = 'Roles') {
-        $UserIDs = array_unique(ConsolidateArrayValuesByKey($Users, $UserIDColumn));
+        $UserIDs = array_unique(array_column($Users, $UserIDColumn));
 
         // Try and get all of the mappings from the cache.
         $Keys = array();

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2028,7 +2028,7 @@ class UserModel extends Gdn_Model {
             $Fields = $this->Validation->schemaValidationFields();
 
             // Remove the primary key from the fields collection before saving
-            $Fields = removeKeyFromArray($Fields, $this->PrimaryKey);
+            unset($Fields[$this->PrimaryKey]);
 
             if (!$Insert && array_key_exists('Password', $Fields) && val('HashPassword', $Settings, true)) {
                 // Encrypt the password for saving only if it won't be hashed in _Insert()

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -846,7 +846,7 @@ class CommentModel extends VanillaModel {
             // If the post is new and it validates, check for spam
             if (!$Insert || !$this->CheckForSpam('Comment')) {
                 $Fields = $this->Validation->SchemaValidationFields();
-                $Fields = RemoveKeyFromArray($Fields, $this->PrimaryKey);
+                unset($Fields[$this->PrimaryKey]);
 
                 // Check for spam
                 $spam = SpamModel::isSpam('Comment', array_merge($Fields, array('CommentID' => $CommentID)));

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -189,8 +189,8 @@ class DraftModel extends VanillaModel {
 
             // If the post is new and it validates, make sure the user isn't spamming
             if ($DraftID > 0) {
-                // Update the draft
-                $Fields = RemoveKeyFromArray($Fields, 'DraftID'); // Remove the primary key from the fields for saving
+                // Update the draft.
+                unset($Fields['DraftID']); // remove the primary key from the fields for saving
                 $this->SQL->put($this->Name, $Fields, array($this->PrimaryKey => $DraftID));
             } else {
                 // Insert the draft

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -554,10 +554,7 @@ class Gdn_Form extends Gdn_Pluggable {
             $TextField = ArrayValueI('TextField', $Attributes, 'text');
             foreach ($DataSet->result() as $Data) {
                 $Instance = $Attributes;
-                $Instance = removeKeyFromArray(
-                    $Instance,
-                    array('TextField', 'ValueField')
-                );
+                unset($Instance['TextField'], $Instance['ValueField']);
                 $Instance['value'] = $Data->$ValueField;
                 $Instance['id'] = $FieldName.$i;
                 if (is_array($CheckedValues) && in_array(
@@ -579,7 +576,7 @@ class Gdn_Form extends Gdn_Pluggable {
             foreach ($DataSet as $Text => $ID) {
                 // Set attributes for this instance
                 $Instance = $Attributes;
-                $Instance = removeKeyFromArray($Instance, array('TextField', 'ValueField'));
+                unset($Instance['TextField'], $Instance['ValueField']);
 
                 $Instance['id'] = $FieldName.$i;
 
@@ -657,7 +654,7 @@ class Gdn_Form extends Gdn_Pluggable {
             foreach ($DataSet->result() as $Data) {
                 // Define the checkbox
                 $Instance = $Attributes;
-                $Instance = removeKeyFromArray($Instance, array('TextField', 'ValueField'));
+                unset($Instance['TextField'], $Instance['ValueField']);
                 $Instance['value'] = $Data->$ValueField;
                 $Instance['id'] = $FieldName.$i;
                 if (is_array($CheckedValues) && in_array(

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -257,7 +257,7 @@ class Gdn_Model extends Gdn_Pluggable {
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert) === true) {
             $Fields = $this->Validation->validationFields();
-            $Fields = removeKeyFromArray($Fields, $this->PrimaryKey); // Don't try to insert or update the primary key
+            unset($Fields[$this->PrimaryKey]); // Don't try to insert or update the primary key
             if ($Insert === false) {
                 $this->update($Fields, array($this->PrimaryKey => $PrimaryKeyVal));
             } else {


### PR DESCRIPTION
The function is deprecated because it too closely matching the unset() language feature.