### PR TITLE
Fix recognition of plus signs in paths

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -133,7 +133,7 @@ class Gdn_Request {
 
             switch ($key) {
                 case 'URI':
-                    $value = !is_null($value) ? urldecode($value) : $value;
+                    $value = !is_null($value) ? rawurldecode($value) : $value;
                     break;
                 case 'SCRIPT':
                     $value = !is_null($value) ? trim($value, '/') : $value;
@@ -722,7 +722,7 @@ class Gdn_Request {
             if ($path === true) {
                 // Encode the path.
                 $parts = explode('/', $result);
-                $parts = array_map('urlencode', $parts);
+                $parts = array_map('rawurlencode', $parts);
                 $result = implode('/', $parts);
             }
         }


### PR DESCRIPTION
The request object double decodes paths somewhere along the way. Since it used urldecode() instead of rawurldecode() a “+” sign in the path would get changed into a space.

The main place where this would happen is with usernames. Put a plus sign in a username and then browse to their profile page.

Whether or not the double decoding itself is a bug is too much of a change to play with here, but since paths are always supposed to use rawurlencode() I think this is a safe fix for now.