### PR TITLE
Assume ShowOptions is false if the property is not defined on the sender.

### DIFF
--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -391,7 +391,7 @@ if (!function_exists('OptionsList')):
         $Sender = Gdn::controller();
         $Session = Gdn::session();
 
-        if ($Session->isValid() && $Sender->ShowOptions) {
+        if ($Session->isValid() && !empty($Sender->ShowOptions)) {
             $Sender->Options = '';
 
             // Dismiss an announcement


### PR DESCRIPTION
Mostly useful to stop warning from showing if you use the helper functions outside of discussions.