### PR TITLE
Update conversation activity headline.

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -593,13 +593,14 @@ class ConversationModel extends ConversationsModel {
                 'RecordType' => 'Conversation',
                 'RecordID' => $ConversationID,
                 'Story' => val('Body', $formPostValues),
+                'ActionText' => t('Reply'),
                 'Format' => val('Format', $formPostValues, c('Garden.InputFormatter')),
                 'Route' => "/messages/$ConversationID#Message_$MessageID"
             );
 
             $Subject = val('Subject', $Fields);
             if ($Subject) {
-                $Activity['HeadlineFormat'] = $Subject;
+                $Activity['Story'] = sprintf(t('Re: %s'), $Subject).'<br>'.val('Body', $formPostValues);
             }
 
             $ActivityModel = new ActivityModel();

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -872,7 +872,7 @@ class ActivityModel extends Gdn_Model {
 
                 $url = externalUrl(val('Route', $Activity) == '' ? '/' : val('Route', $Activity));
                 $emailTemplate = $Email->getEmailTemplate()
-                    ->setButton($url, t('Check it out'))
+                    ->setButton($url, val('ActionText', $Activity, t('Check it out')))
                     ->setTitle($ActivityHeadline);
 
                 if ($message = val('Story', $Activity)) {
@@ -964,7 +964,7 @@ class ActivityModel extends Gdn_Model {
         $url = externalUrl(val('Route', $Activity) == '' ? '/' : val('Route', $Activity));
 
         $emailTemplate = $Email->getEmailTemplate()
-            ->setButton($url, t('Check it out'))
+            ->setButton($url, val('ActionText', $Activity, t('Check it out')))
             ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
 
         if ($message = val('Story', $Activity)) {
@@ -1226,7 +1226,7 @@ class ActivityModel extends Gdn_Model {
                 $url = externalUrl(val('Route', $Activity) == '' ? '/' : val('Route', $Activity));
 
                 $emailTemplate = $Email->getEmailTemplate()
-                    ->setButton($url, t('Check it out'))
+                    ->setButton($url, val('ActionText', $Activity, t('Check it out')))
                     ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
                 if ($message = val('Story', $Activity)) {
                     $emailTemplate->setMessage($message, true);


### PR DESCRIPTION
Especially with HTML emails, the activity notification can make it look as if the forum is sending the conversation message to the user, rather than another user. This preserves the 'username sent you a message' headline and appends the conversation subject to the body. 

It also updates the email call to action text and allows future activity items to update this text, as well.