### PR TITLE
Make InThisConversation module store data sanely

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -437,7 +437,7 @@ class MessagesController extends ConversationsController {
         $this->addModule($ClearHistoryModule);
 
         $InThisConversationModule = new InThisConversationModule($this);
-        $InThisConversationModule->setData($this->Conversation->Participants);
+        $InThisConversationModule->setData('Participants', $this->Conversation->Participants);
         $this->addModule($InThisConversationModule);
 
         // Doesn't make sense for people who can't even start conversations to be adding people

--- a/applications/conversations/modules/class.inthisconversationmodule.php
+++ b/applications/conversations/modules/class.inthisconversationmodule.php
@@ -12,19 +12,24 @@
  * Renders a list of people in the specified conversation.
  */
 class InThisConversationModule extends Gdn_Module {
-    public function setData($name, $value = null) {
-        if (is_array($name)) {
-            $this->Data = $name;
-        }
-        return parent::setData($name, $value);
-    }
 
+    /**
+     * Where to render by default.
+     *
+     * @return string
+     */
     public function assetTarget() {
         return 'Panel';
     }
 
+    /**
+     * Render the module.
+     *
+     * @return string HTML.
+     */
     public function toString() {
-        if (is_object($this->Data) && $this->Data->numRows() > 0) {
+        // Verify any participants exist before outputting anything.
+        if (count($this->data('Participants'))) {
             return parent::toString();
         }
 

--- a/applications/conversations/views/modules/inthisconversation.php
+++ b/applications/conversations/views/modules/inthisconversation.php
@@ -2,7 +2,7 @@
 <div class="Box InThisConversation">
     <?php echo panelHeading(t('In this Conversation')); ?>
     <ul class="PanelInfo">
-        <?php foreach ($this->Data->result() as $User): ?>
+        <?php foreach ($this->data('Participants') as $User): ?>
             <li>
                 <?php
                 $Username = htmlspecialchars(val('Name', $User));


### PR DESCRIPTION
We're cramming an object directly into the Data property of a module but then checking if it's an array before actually settings it.

Or we could just use our proper conventions and make this all easier.

Fixes bug where (surprise) InThisConversation has just stopped appearing globally. We probably made a low-level change to our data handling somewhere that's causing this to appear now.