### PR TITLE
Ensure our LatestItem data is never greater than the total number of comments.

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -138,6 +138,9 @@ class DiscussionController extends VanillaController {
             $LatestItem = 0;
         } elseif ($LatestItem < $this->Discussion->CountComments) {
             $LatestItem += 1;
+        } elseif ($LatestItem > $this->Discussion->CountComments) {
+            // If ever the CountCommentWatch is greater than the actual number of comments.
+            $LatestItem = $this->Discussion->CountComments;
         }
 
         $this->setData('_LatestItem', $LatestItem);


### PR DESCRIPTION
If the CountComments in the UserDiscussion table ever gets ahead of the total number of comments, this sets the latest comment to the last comment in a discussion.