### PR TITLE
Add messaging to inform user if username exists and check on keyup.

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -394,6 +394,9 @@ EOT;
         // Fire ConnectData event & error handling.
         $currentData = $this->Form->formValues();
 
+        $this->addDefinition('Username already exists.', t('Username already exists.'));
+        $this->addDefinition('Choose a name to identify yourself on the site.', t('Choose a name to identify yourself on the site.'));
+
         // Filter the form data for users here. SSO plugins must reset validated data each postback.
         $filteredData = Gdn::userModel()->filterForm($currentData, true);
         $filteredData = array_replace($filteredData, arrayTranslate($currentData, ['TransientKey', 'hpt']));

--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -1,3 +1,4 @@
+
 // This file contains javascript that is specific to the dashboard/entry controller.
 jQuery(document).ready(function($) {
 
@@ -51,7 +52,7 @@ jQuery(document).ready(function($) {
             $('#ConnectPassword').show();
             return;
         }
-
+        var fineprint = $('#Form_ConnectName').siblings('.FinePrint');
         var selectedName = $('input[name$=UserSelect]:checked').val();
         if (!selectedName || selectedName == 'other') {
             var name = $('#Form_ConnectName').val();
@@ -65,10 +66,17 @@ jQuery(document).ready(function($) {
                         gdn.informError(xhr, true)
                     },
                     success: function(text) {
-                        if (text == 'TRUE')
+                        if (text == 'TRUE') {
                             $('#ConnectPassword').hide();
-                        else
+                            if (fineprint.length) {
+                                fineprint.html(gdn.definition('Choose a name to identify yourself on the site.'));
+                            }
+                        } else {
                             $('#ConnectPassword').show();
+                            if (fineprint.length) {
+                                fineprint.html(gdn.definition('Username already exists.'));
+                            }
+                        }
                     }
                 });
             } else {
@@ -80,7 +88,7 @@ jQuery(document).ready(function($) {
     }
 
     checkConnectName();
-    $('#Form_ConnectName').blur(checkConnectName);
+    $('#Form_ConnectName').keyup(checkConnectName);
     $('input[name$=UserSelect]').click(checkConnectName);
 
     // Check to see if passwords match


### PR DESCRIPTION
If somebody is connecting to a Vanilla account that already exists, we need their password to confirm that they can connect to the existing Vanilla account. Currently, the ajax username checking is tied to the blur event and if the user just hits the 'Connect' button after they type in an existing username, the password field never shows up. But the validation sees an empty password field.

This checks the username on keyup to see whether the username exists or not and adds the password field if necessary. It also adds a helpful message indicating so.