### PR TITLE
Support multiple order by statements in the discussion model (breaks backwards compat of discussion sorting)

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -589,6 +589,9 @@ class DiscussionsController extends VanillaController {
      * Set user preference for sorting discussions.
      */
     public function sort($Target = '') {
+        deprecated("sort");
+        return;
+
         if (!Gdn::session()->isValid()) {
             throw permissionException();
         }

--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -48,8 +48,6 @@ class SettingsController extends Gdn_Controller {
             'Vanilla.Archive.Exclude',
             'Garden.EditContentTimeout',
             'Vanilla.AdminCheckboxes.Use',
-            'Vanilla.Discussions.SortField' => 'd.DateLastComment',
-            'Vanilla.Discussions.UserSortField',
             'Vanilla.Comment.MaxLength',
             'Vanilla.Comment.MinLength'
         ));

--- a/applications/vanilla/js/discussions.js
+++ b/applications/vanilla/js/discussions.js
@@ -1,43 +1,26 @@
 jQuery(document).ready(function($) {
 
     // Set up paging
-    if ($.morepager)
+    if ($.morepager) {
         $('.MorePager').not('.Message .MorePager').morepager({
             pageContainerSelector: 'ul.Discussions:last, ul.Drafts:last',
             afterPageLoaded: function() {
                 $(document).trigger('DiscussionPagingComplete');
             }
         });
+    }
 
-    if ($('.AdminCheck :checkbox').not(':checked').length == 1)
+    if ($('.AdminCheck :checkbox').not(':checked').length == 1) {
         $('.AdminCheck [name="Toggle"]').prop('checked', true).change();
-
-    // Set up sorting
-    $(document).undelegate('.SortDiscussions', 'click');
-    $(document).delegate('.SortDiscussions', 'click', function() {
-        var SendData = {
-            'TransientKey': gdn.definition('TransientKey'),
-            'DiscussionSort': $(this).attr('data-field')
-        };
-        jQuery.ajax({
-            dataType: 'json',
-            type: 'post',
-            url: gdn.url('discussions/sort'),
-            data: SendData,
-            success: function(json) {
-                location.reload();
-            }
-        });
-
-        return false;
-    });
+    }
 
     /* Discussion Checkboxes */
     $('.AdminCheck [name="Toggle"]').click(function() {
-        if ($(this).prop('checked'))
+        if ($(this).prop('checked')) {
             $('.DataList .AdminCheck :checkbox, tbody .AdminCheck :checkbox').prop('checked', true).change();
-        else
+        } else {
             $('.DataList .AdminCheck :checkbox, tbody .AdminCheck :checkbox').prop('checked', false).change();
+        }
     });
     $('.AdminCheck :checkbox').click(function() {
         // retrieve all checked ids

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -356,10 +356,13 @@ class DiscussionModel extends VanillaModel {
 
     /**
      * Returns an array of 'field' => 'direction', values and ensures the safety of field names and directions.
+     *
      * You can safely use return values from this function in the orderBy() SQL function. Use this return value and orderBy()
      * in a loop to support multiple orderby values.
      *
      * If no values are passed, defaults to the fields from getSortField() and the direction from c('Vanilla.Discussions.SortDirection')
+     *
+     * @since 2.3
      *
      * @param string|array $orderFields
      * @param string $orderDirection
@@ -373,24 +376,28 @@ class DiscussionModel extends VanillaModel {
         if (empty($orderDirection)) {
             $orderDirection = c('Vanilla.Discussions.SortDirection', 'desc');
         }
-        switch(gettype($orderFields)) {
+
+        // Force order to asc or desc.
+        if ($orderDirection !== 'desc') {
+            $orderDirection = 'asc';
+        }
+
+        switch (gettype($orderFields)) {
             case 'string':
-                if (in_array($orderFields, self::AllowedSortFields())) {
-                    $orderFields = array($orderFields => ($orderDirection == 'asc') ? 'asc' : 'desc');
-                    break;
+                if (in_array($orderFields, self::allowedSortFields())) {
+                    $orderFields = [$orderFields => $orderDirection];
                 }
+                break;
             case 'array':
-                foreach($orderFields as $orderField => &$direction) {
+                foreach ($orderFields as $orderField => &$direction) {
                     $direction = ($direction == 'asc') ? 'asc' : 'desc';
-                    if (!in_array($orderField, self::AllowedSortFields())) {
+                    if (!in_array($orderField, self::allowedSortFields())) {
                         unset($orderFields[$orderField]);
                     }
                 }
-                if (!empty($orderFields)) {
-                    break;
-                }
+                break;
             default:
-                $orderFields = array(self::DEFAULT_ORDERBY => ($orderDirection == 'asc') ? 'asc' : 'desc');
+                $orderFields = [self::DEFAULT_ORDERBY => $orderDirection];
 
         }
         return $orderFields;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -382,24 +382,20 @@ class DiscussionModel extends VanillaModel {
             $orderDirection = 'asc';
         }
 
-        switch (gettype($orderFields)) {
-            case 'string':
-                if (in_array($orderFields, self::allowedSortFields())) {
-                    $orderFields = [$orderFields => $orderDirection];
+        // Force valid $orderFields.
+        if (is_array($orderFields)) {
+            foreach ($orderFields as $orderField => &$direction) {
+                $direction = ($direction == 'asc') ? 'asc' : 'desc';
+                if (!in_array($orderField, self::allowedSortFields())) {
+                    unset($orderFields[$orderField]);
                 }
-                break;
-            case 'array':
-                foreach ($orderFields as $orderField => &$direction) {
-                    $direction = ($direction == 'asc') ? 'asc' : 'desc';
-                    if (!in_array($orderField, self::allowedSortFields())) {
-                        unset($orderFields[$orderField]);
-                    }
-                }
-                break;
-            default:
-                $orderFields = [self::DEFAULT_ORDERBY => $orderDirection];
-
+            }
+        } elseif (in_array($orderFields, self::allowedSortFields())) {
+            $orderFields = [$orderFields => $orderDirection];
+        } else {
+            $orderFields = [self::DEFAULT_ORDERBY => $orderDirection];
         }
+
         return $orderFields;
     }
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -16,6 +16,9 @@ class DiscussionModel extends VanillaModel {
     /** Cache key. */
     const CACHE_DISCUSSIONVIEWS = 'discussion.%s.countviews';
 
+    /** @var string Default column to order by. */
+    const DEFAULT_ORDERBY = 'd.DateLastComment';
+
     /** @var array */
     protected static $_CategoryPermissions = null;
 
@@ -26,7 +29,7 @@ class DiscussionModel extends VanillaModel {
     public $Watching = false;
 
     /** @var array Column names to allow sorting by. */
-    protected static $AllowedSortFields = array('d.DateLastComment', 'd.DateInserted', 'd.DiscussionID');
+    protected static $AllowedSortFields = array('d.DateLastComment', 'd.DateInserted', 'd.DiscussionID', 'd.Score');
 
     /** @var array Discussion Permissions */
     protected $permissionTypes = array('Add', 'Announce', 'Close', 'Delete', 'Edit', 'Sink', 'View');
@@ -289,10 +292,9 @@ class DiscussionModel extends VanillaModel {
         }
 
         // Get preferred sort order
-        $SortField = self::GetSortField();
+        $orderFields = $this->getOrderFields();
 
-        $this->EventArguments['SortField'] = &$SortField;
-        $this->EventArguments['SortDirection'] = c('Vanilla.Discussions.SortDirection', 'desc');
+        $this->EventArguments['OrderFields'] = &$orderFields;
         $this->EventArguments['Wheres'] = &$Wheres;
         $this->fireEvent('BeforeGet'); // @see 'BeforeGetCount' for consistency in results vs. counts
 
@@ -306,17 +308,9 @@ class DiscussionModel extends VanillaModel {
             $this->SQL->where($Wheres);
         }
 
-        // Whitelist sorting options
-        if (!in_array($SortField, array('d.DiscussionID', 'd.DateLastComment', 'd.DateInserted'))) {
-            trigger_error("You are sorting discussions by a possibly sub-optimal column.", E_USER_NOTICE);
+        foreach ($orderFields as $orderField => $direction) {
+            $this->SQL->orderBy($orderField, $direction);
         }
-
-        $SortDirection = $this->EventArguments['SortDirection'];
-        if ($SortDirection != 'asc') {
-            $SortDirection = 'desc';
-        }
-
-        $this->SQL->orderBy($SortField, $SortDirection);
 
         // Set range and fetch
         $Data = $this->SQL->get();
@@ -361,6 +355,48 @@ class DiscussionModel extends VanillaModel {
     }
 
     /**
+     * Returns an array of 'field' => 'direction', values and ensures the safety of field names and directions.
+     * You can safely use return values from this function in the orderBy() SQL function. Use this return value and orderBy()
+     * in a loop to support multiple orderby values.
+     *
+     * If no values are passed, defaults to the fields from getSortField() and the direction from c('Vanilla.Discussions.SortDirection')
+     *
+     * @param string|array $orderFields
+     * @param string $orderDirection
+     * @return string
+     */
+    protected function getOrderFields($orderFields = '', $orderDirection = '') {
+        // Set default types.
+        if (empty($orderFields)) {
+            $orderFields = self::getSortField();
+        }
+        if (empty($orderDirection)) {
+            $orderDirection = c('Vanilla.Discussions.SortDirection', 'desc');
+        }
+        switch(gettype($orderFields)) {
+            case 'string':
+                if (in_array($orderFields, self::AllowedSortFields())) {
+                    $orderFields = array($orderFields => ($orderDirection == 'asc') ? 'asc' : 'desc');
+                    break;
+                }
+            case 'array':
+                foreach($orderFields as $orderField => &$direction) {
+                    $direction = ($direction == 'asc') ? 'asc' : 'desc';
+                    if (!in_array($orderField, self::AllowedSortFields())) {
+                        unset($orderFields[$orderField]);
+                    }
+                }
+                if (!empty($orderFields)) {
+                    break;
+                }
+            default:
+                $orderFields = array(self::DEFAULT_ORDERBY => ($orderDirection == 'asc') ? 'asc' : 'desc');
+
+        }
+        return $orderFields;
+    }
+
+    /**
      * Get a list of discussions.
      *
      * This method call will remove announcements and may not return exactly {@link $Limit} records for optimization.
@@ -386,13 +422,6 @@ class DiscussionModel extends VanillaModel {
             $OrderDirection = '';
         }
 
-        // Set default types.
-        if (empty($OrderFields)) {
-            $OrderFields = self::getSortField();
-        }
-        if (empty($OrderDirection)) {
-            $OrderDirection = c('Vanilla.Discussions.SortDirection', 'desc');
-        }
         if ($Limit === 0) {
             trigger_error("You should not supply 0 to for $Limit in DiscussionModel->getWhere()", E_USER_NOTICE);
         }
@@ -417,27 +446,21 @@ class DiscussionModel extends VanillaModel {
             }
         }
 
-        $this->EventArguments['SortField'] = &$OrderFields;
-        $this->EventArguments['SortDirection'] = &$OrderDirection;
+        $OrderFields = $this->getOrderFields($OrderFields, $OrderDirection);
+
+        $this->EventArguments['OrderFields'] = &$OrderFields;
         $this->EventArguments['Wheres'] =& $Where;
         $this->fireEvent('BeforeGet');
-
-        // Whitelist sorting options
-        if (!in_array($OrderFields, self::AllowedSortFields())) {
-            $OrderFields = 'd.DateLastComment';
-        }
-
-        $OrderDirection = $this->EventArguments['SortDirection'];
-        if ($OrderDirection != 'asc') {
-            $OrderDirection = 'desc';
-        }
 
         // Build up the base query. Self-join for optimization.
         $Sql->select('d2.*')
             ->from('Discussion d')
             ->join('Discussion d2', 'd.DiscussionID = d2.DiscussionID')
-            ->orderBy($OrderFields, $OrderDirection)
             ->limit($Limit, $Offset);
+
+        foreach ($OrderFields as $orderField => $direction) {
+            $Sql->orderBy($orderField, $direction);
+        }
 
         // Verify permissions (restricting by category if necessary)
         $Perms = self::CategoryPermissions();
@@ -894,9 +917,13 @@ class DiscussionModel extends VanillaModel {
                 ->where('coalesce(w.Dismissed, \'0\')', '0', false);
         }
 
-        $this->SQL
-            ->orderBy(self::GetSortField(), 'desc')
-            ->limit($Limit, $Offset);
+        $orderFields = $this->getOrderFields();
+
+        $this->SQL->limit($Limit, $Offset);
+
+        foreach ($orderFields as $orderField => $direction) {
+            $this->SQL->orderBy($orderField, $direction);
+        }
 
         $Data = $this->SQL->get();
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -368,18 +368,10 @@ class DiscussionModel extends VanillaModel {
      * @param string $orderDirection
      * @return string
      */
-    protected function getOrderFields($orderFields = '', $orderDirection = '') {
-        // Set default types.
-        if (empty($orderFields)) {
-            $orderFields = self::getSortField();
-        }
-        if (empty($orderDirection)) {
-            $orderDirection = c('Vanilla.Discussions.SortDirection', 'desc');
-        }
-
+    protected function getOrderFields($orderFields = 'd.DateLastComment', $orderDirection = 'desc') {
         // Force order to asc or desc.
-        if ($orderDirection !== 'desc') {
-            $orderDirection = 'asc';
+        if ($orderDirection !== 'asc') {
+            $orderDirection = 'desc';
         }
 
         // Force valid $orderFields.
@@ -1513,6 +1505,7 @@ class DiscussionModel extends VanillaModel {
      * @return string Column name.
      */
     public static function getSortField() {
+        deprecated("getSortField", "getOrderFields");
         $SortField = c('Vanilla.Discussions.SortField', 'd.DateLastComment');
         if (c('Vanilla.Discussions.UserSortField')) {
             $SortField = Gdn::session()->GetPreference('Discussions.SortField', $SortField);
@@ -1521,8 +1514,13 @@ class DiscussionModel extends VanillaModel {
         return $SortField;
     }
 
+    /**
+     *
+     *
+     * @param $DiscussionID
+     * @return mixed|null
+     */
     public static function getViewsFallback($DiscussionID) {
-
         // Not found. Check main table.
         $Views = val('CountViews', Gdn::sql()
             ->select('CountViews')

--- a/applications/vanilla/modules/class.discussionsortermodule.php
+++ b/applications/vanilla/modules/class.discussionsortermodule.php
@@ -22,7 +22,7 @@ class DiscussionSorterModule extends Gdn_Module {
     public function __construct($Sender) {
         parent::__construct($Sender, 'Vanilla');
 
-        $this->Visible = c('Vanilla.Discussions.UserSortField');
+        $this->Visible = false;
 
         // Default options
         $this->SortOptions = array(

--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -200,6 +200,7 @@ endif;
 if (!function_exists('WriteDiscussionSorter')):
 
     function writeDiscussionSorter($Selected = null, $Options = null) {
+        deprecated('writeDiscussionSorter');
         if ($Selected === null) {
             $Selected = Gdn::session()->GetPreference('Discussions.SortField', 'DateLastComment');
         }

--- a/applications/vanilla/views/settings/advanced.php
+++ b/applications/vanilla/views/settings/advanced.php
@@ -1,22 +1,4 @@
-<?php if (!defined('APPLICATION')) exit();
-if (!function_exists('DiscussionSortText')) {
-    function discussionSortText($Field) {
-        $Text = FALSE;
-        switch ($Field) {
-            case 'd.DiscussionID' :
-                $Text = t('SortDiscussionsByID', 'ID number (like support tickets)');
-                break;
-            case 'd.DateLastComment' :
-                $Text = t('SortDiscussionsByLastComment', 'Most recent comment (like a forum)');
-                break;
-            case 'd.DateInserted' :
-                $Text = t('SortDiscussionsByDateInserted', 'Start time (like a blog)');
-                break;
-        }
-        return ($Text) ? $Text : $Field;
-    }
-}
-?>
+<?php if (!defined('APPLICATION')) exit(); ?>
     <div class="Help Aside">
         <?php
         echo wrap(t('Need More Help?'), 'h2');
@@ -43,17 +25,6 @@ echo $this->Form->errors();
             <?php
             echo $this->Form->label('Comments per Page', 'Vanilla.Comments.PerPage');
             echo $this->Form->DropDown('Vanilla.Comments.PerPage', $Options, $Fields);
-            ?>
-        </li>
-        <li>
-            <?php
-            $AllowedSortFields = DiscussionModel::AllowedSortFields();
-            $SortFields = array();
-            foreach ($AllowedSortFields as $Field) {
-                $SortFields[$Field] = DiscussionSortText($Field);
-            }
-            echo $this->Form->label('Sort discussions by', 'Vanilla.Discussions.SortField');
-            echo $this->Form->DropDown('Vanilla.Discussions.SortField', $SortFields, $Fields);
             ?>
         </li>
         <li>


### PR DESCRIPTION
Add a function that checks order by values. 
Add order by values in a loop to support multiple order by values.
Adds Score to allowed sort fields.
Gives events the ability to override these values.