### PR TITLE
Add "Drop" type to routes

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -480,6 +480,10 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
                     safeHeader("HTTP/1.1 404 Not Found");
                     $this->Request = $MatchRoute['FinalDestination'];
                     break;
+
+                case 'Block':
+                    die();
+
                 case 'Test':
                     $Request->pathAndQuery($MatchRoute['FinalDestination']);
                     $this->Request = $Request->path(false);

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -481,7 +481,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
                     $this->Request = $MatchRoute['FinalDestination'];
                     break;
 
-                case 'Block':
+                case 'Drop':
                     die();
 
                 case 'Test':

--- a/library/core/class.router.php
+++ b/library/core/class.router.php
@@ -35,7 +35,7 @@ class Gdn_Router extends Gdn_Pluggable {
             'Permanent'     => 'Permanent (301)',
             'NotAuthorized' => 'Not Authorized (401)',
             'NotFound'      => 'Not Found (404)',
-            'Block'         => 'Block Request',
+            'Drop'         => 'Drop Request',
             'Test'          => 'Test'
         );
         $this->ReservedRoutes = array('DefaultController', 'DefaultForumRoot', 'Default404', 'DefaultPermission', 'UpdateMode');

--- a/library/core/class.router.php
+++ b/library/core/class.router.php
@@ -35,7 +35,7 @@ class Gdn_Router extends Gdn_Pluggable {
             'Permanent'     => 'Permanent (301)',
             'NotAuthorized' => 'Not Authorized (401)',
             'NotFound'      => 'Not Found (404)',
-            'Drop'         => 'Drop Request',
+            'Drop'          => 'Drop Request',
             'Test'          => 'Test'
         );
         $this->ReservedRoutes = array('DefaultController', 'DefaultForumRoot', 'Default404', 'DefaultPermission', 'UpdateMode');

--- a/library/core/class.router.php
+++ b/library/core/class.router.php
@@ -30,12 +30,13 @@ class Gdn_Router extends Gdn_Pluggable {
     public function __construct() {
         parent::__construct();
         $this->RouteTypes = array(
-            'Internal' => 'Internal',
-            'Temporary' => 'Temporary (302)',
-            'Permanent' => 'Permanent (301)',
+            'Internal'      => 'Internal',
+            'Temporary'     => 'Temporary (302)',
+            'Permanent'     => 'Permanent (301)',
             'NotAuthorized' => 'Not Authorized (401)',
-            'NotFound' => 'Not Found (404)',
-            'Test' => 'Test'
+            'NotFound'      => 'Not Found (404)',
+            'Block'         => 'Block Request',
+            'Test'          => 'Test'
         );
         $this->ReservedRoutes = array('DefaultController', 'DefaultForumRoot', 'Default404', 'DefaultPermission', 'UpdateMode');
         $this->_loadRoutes();


### PR DESCRIPTION
This update adds a new route type: drop.

A request matching a route of this type will immediately be killed.

Closes #3524 