### PR TITLE
Add default null to Conversations Contributors column to comply with strict mode.

### DIFF
--- a/applications/conversations/settings/structure.php
+++ b/applications/conversations/settings/structure.php
@@ -37,7 +37,7 @@ $Construct
     ->column('Type', 'varchar(10)', true, 'index')
     ->column('ForeignID', 'varchar(40)', true)
     ->column('Subject', 'varchar(255)', null)
-    ->column('Contributors', 'varchar(255)')
+    ->column('Contributors', 'varchar(255)', true)
     ->column('FirstMessageID', 'int', true, 'key')
     ->column('InsertUserID', 'int', false, 'key')
     ->column('DateInserted', 'datetime', null, 'key')


### PR DESCRIPTION
Solves issue where starting a conversation with a new user when the database is in strict mode causes an error. Addresses https://github.com/vanilla/vanilla/issues/3465