### PR TITLE
Add no-store header to profile controller for signed-in users.

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -87,6 +87,15 @@ class ProfileController extends Gdn_Controller {
             $this->CssClass .= 'EditMode';
         }
 
+        /**
+         * The default Cache-Control header does not include no-store, which can cause issues with outdated session
+         * information (e.g. message button missing). The same check is performed here as in Gdn_Controller before the
+         * Cache-Control header is added, but this value includes the no-store specifier.
+         */
+        if (Gdn::session()->isValid()) {
+            $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
+        }
+
         $this->setData('Breadcrumbs', array());
         $this->CanEditPhotos = c('Garden.Profile.EditPhotos') || Gdn::session()->checkPermission('Garden.Users.Edit');
     }


### PR DESCRIPTION
Fixes issue where session-specific components do not update when users sign in or out.

See https://github.com/vanilla/vanilla/pull/3471
Issue originates from https://github.com/vanilla/vanilla/pull/2948