### PR TITLE
Fix Typo in Variable Name

### DIFF
--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1379,7 +1379,7 @@ abstract class Gdn_SQLDriver {
     public function options($Key, $Value = null) {
         if (is_array($Key)) {
             foreach ($Key as $K => $V) {
-                $this->Options[$K] = $V;
+                $this->_Options[$K] = $V;
                 return $this;
             }
         } elseif ($Value !== null) {


### PR DESCRIPTION
There is no `$this->Options` and from the context it is obvious that it must be `$this->_Options`.

The only time this array is really used is in class sqldrivers query method, but it is only checked for a value "Slave". So only if someone explicitly queries a slave connection, that error might show up.