### PR TITLE
Remove coupling and allow overriding EmailTemplate

### DIFF
--- a/applications/dashboard/library/class.emailtemplate.php
+++ b/applications/dashboard/library/class.emailtemplate.php
@@ -6,7 +6,7 @@
  * Compiles the data for an email, applies appropriate content filters and renders the email.
  *
  */
-class EmailTemplate extends Gdn_Pluggable {
+class EmailTemplate extends Gdn_Pluggable implements Gdn_IEmailTemplate {
 
     /**
      * Delimiter for plaintext email.
@@ -26,14 +26,17 @@ class EmailTemplate extends Gdn_Pluggable {
      * @var string The HTML formatted email title.
      */
     protected $title;
+
     /**
      * @var string The HTML formatted email lead (sub-title, appears under title).
      */
     protected $lead;
+
     /**
      * @var string The HTML formatted email message (the body of the email).
      */
     protected $message;
+
     /**
      * @var array An array representing a footer with the following keys:
      * 'text' => The HTML-formatted footer text.
@@ -41,6 +44,7 @@ class EmailTemplate extends Gdn_Pluggable {
      * 'backgroundColor' => The hex color code of the footer background, must include the leading '#'.
      */
     protected $footer;
+
     /**
      * @var array An array representing a button with the following keys:
      * 'url' => The href value of the button.
@@ -49,6 +53,7 @@ class EmailTemplate extends Gdn_Pluggable {
      * 'backgroundColor' => The hex color code of the button background, must include the leading '#'.
      */
     protected $button;
+
     /**
      * @var array An array representing an image with the following keys:
      * 'source' => The image source url.
@@ -56,31 +61,38 @@ class EmailTemplate extends Gdn_Pluggable {
      * 'alt' => The alt value of the image tag.
      */
     protected $image;
+
     /**
      * @var string The path to the email view.
      */
     protected $view;
+
     /**
      * @var bool Whether to render in plaintext.
      */
     protected $plaintext = false;
+
     // Colors
     /**
      * @var string The hex color code of the text, must include the leading '#'.
      */
     protected $textColor = self::DEFAULT_TEXT_COLOR;
-   /**
-    * @var string The hex color code of the background, must include the leading '#'.
-    */
+
+    /**
+     * @var string The hex color code of the background, must include the leading '#'.
+     */
     protected $backgroundColor = self::DEFAULT_BACKGROUND_COLOR;
+
     /**
      * @var string The hex color code of the container background, must include the leading '#'.
      */
     protected $containerBackgroundColor = self::DEFAULT_CONTAINER_BACKGROUND_COLOR;
+
     /**
      * @var string The default hex color code of the button text, must include the leading '#'.
      */
     protected $defaultButtonTextColor = self::DEFAULT_BUTTON_TEXT_COLOR;
+
     /**
      * @var string The default hex color code of the button background, must include the leading '#'.
      */
@@ -94,11 +106,48 @@ class EmailTemplate extends Gdn_Pluggable {
      * @throws Exception
      */
     function __construct($message = '', $title = '', $lead = '', $view = 'email-basic') {
+        parent::__construct();
+
         $this->setMessage($message);
         $this->setTitle($title);
         $this->setLead($lead);
 
+        // Set templating defaults
+        $this->setTextColor(c('Garden.EmailTemplate.TextColor', self::DEFAULT_TEXT_COLOR));
+        $this->setBackgroundColor(c('Garden.EmailTemplate.BackgroundColor', self::DEFAULT_BACKGROUND_COLOR));
+        $this->setContainerBackgroundColor(c('Garden.EmailTemplate.ContainerBackgroundColor', self::DEFAULT_CONTAINER_BACKGROUND_COLOR));
+        $this->setDefaultButtonBackgroundColor(c('Garden.EmailTemplate.ButtonBackgroundColor', self::DEFAULT_BUTTON_BACKGROUND_COLOR));
+        $this->setDefaultButtonTextColor(c('Garden.EmailTemplate.ButtonTextColor', self::DEFAULT_BUTTON_TEXT_COLOR));
+
+        $this->setDefaultEmailImage();
+
+        // Set default view
         $this->view = AssetModel::viewLocation($view, 'email', 'dashboard');
+    }
+
+    /**
+     * Sets the default image for the email template.
+     */
+    protected function setDefaultEmailImage() {
+        if (!$this->getImage()) {
+            $image = $this->getDefaultEmailImage();
+            $this->setImageArray($image);
+        }
+    }
+
+    /**
+     * Retrieves default values for the email image.
+     *
+     * @return array An array representing an image.
+     */
+    public function getDefaultEmailImage() {
+        $image = array();
+        if (c('Garden.EmailTemplate.Image', '')) {
+            $image['source'] = Gdn_UploadImage::url(c('Garden.EmailTemplate.Image'));
+        }
+        $image['link'] = url('/', true);
+        $image['alt'] = c('Garden.LogoTitle', c('Garden.Title', ''));
+        return $image;
     }
 
     /**
@@ -173,7 +222,7 @@ class EmailTemplate extends Gdn_Pluggable {
      * @param bool $convertNewlines Whether to convert new lines to html br tags.
      * @return EmailTemplate $this The calling object.
      */
-    public function setMessage($message, $convertNewlines = false){
+    public function setMessage($message, $convertNewlines = false) {
         $this->message = $this->formatContent($message, $convertNewlines);
         return $this;
     }

--- a/applications/dashboard/library/interface.iemailtemplate.php
+++ b/applications/dashboard/library/interface.iemailtemplate.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+/**
+ * Email Template Base Class
+ *
+ * @package Core
+ * @since 2.3
+ */
+interface Gdn_IEmailTemplate {
+
+    /**
+     * Set message string
+     *
+     * @param string $message The HTML formatted email message (the body of the email).
+     * @param bool $convertNewlines Whether to convert new lines to html br tags.
+     * @return EmailTemplate $this The calling object.
+     */
+    public function setMessage($message, $convertNewlines = false);
+
+    /**
+     * Get message string
+     *
+     * @return string The HTML formatted email message (the body of the email).
+     */
+    public function getMessage();
+
+    /**
+     * Returns the formatted text of the email
+     *
+     * @return string
+     */
+    public function toString();
+
+    /**
+     * Get plaintext setting
+     * 
+     * @return bool Whether to render in plaintext.
+     */
+    public function isPlaintext();
+
+    /**
+     * Set format to plaintext
+     *
+     * @param bool $plainText Whether to render in plaintext.
+     */
+    public function setPlaintext($plainText);
+
+
+}

--- a/applications/dashboard/library/interface.iemailtemplate.php
+++ b/applications/dashboard/library/interface.iemailtemplate.php
@@ -30,15 +30,8 @@ interface Gdn_IEmailTemplate {
     public function getMessage();
 
     /**
-     * Returns the formatted text of the email
-     *
-     * @return string
-     */
-    public function toString();
-
-    /**
      * Get plaintext setting
-     * 
+     *
      * @return bool Whether to render in plaintext.
      */
     public function isPlaintext();
@@ -50,5 +43,11 @@ interface Gdn_IEmailTemplate {
      */
     public function setPlaintext($plainText);
 
+    /**
+     * Returns the formatted text of the email
+     *
+     * @return string
+     */
+    public function toString();
 
 }

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -259,7 +259,7 @@ class Gdn_Email extends Gdn_Pluggable {
 
         // if we change email templates after construct, inform it of the current format
         if ($this->format) {
-            $this->setFormat($format);
+            $this->setFormat($this->format);
         }
         return $this;
     }

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -1,21 +1,18 @@
 <?php
 /**
- * Gdn_Email.
- *
- * @author Mark O'Sullivan <markm@vanillaforums.com>
- * @author Todd Burry <todd@vanillaforums.com>
  * @copyright 2009-2016 Vanilla Forums Inc.
  * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
- * @package Core
- * @since 2.0
  */
 
 /**
- * Object Representation of an email.
+ * Email layer abstraction
  *
- * All public methods return $this for
- * chaining purposes. ie. $Email->Subject('Hi')->Message('Just saying hi!')-
- * To('joe@vanillaforums.com')->Send();
+ * This class implements fluid method chaining.
+ *
+ * @author Mark O'Sullivan <markm@vanillaforums.com>
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @package Core
+ * @since 2.0
  */
 class Gdn_Email extends Gdn_Pluggable {
 
@@ -50,21 +47,19 @@ class Gdn_Email extends Gdn_Pluggable {
         $this->clear();
         $this->addHeader('Precedence', 'list');
         $this->addHeader('X-Auto-Response-Suppress', 'All');
-        $this->emailTemplate = new EmailTemplate();
+        $this->setEmailTemplate(new EmailTemplate());
+
         $this->resolveFormat();
-        if ($this->format === 'html') {
-            $this->setDefaultEmailColors();
-            $this->setDefaultEmailImage();
-        }
         parent::__construct();
     }
 
     /**
-     * Sets the format property based on the passed argument if it exists, then the config variable and defaults to html.
+     * Sets the format property based on the config, and defaults to html.
      */
     protected function resolveFormat() {
-        if (in_array(strtolower(c('Garden.Email.Format')), self::$supportedFormats)) {
-            $this->setFormat(c('Garden.Email.Format'));
+        $configFormat = c('Garden.Email.Format', 'text');
+        if (in_array(strtolower($configFormat), self::$supportedFormats)) {
+            $this->setFormat($configFormat);
         } else {
             $this->setFormat('text');
         }
@@ -74,6 +69,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * Sets the format property, the email mime type and the email template format property.
      *
      * @param string $format The format of the email. Must be in the $supportedFormats array.
+     * @return Gdn_Email
      */
     public function setFormat($format) {
         if (strtolower($format) === 'html') {
@@ -85,81 +81,18 @@ class Gdn_Email extends Gdn_Pluggable {
             $this->mimeType('text/plain');
             $this->emailTemplate->setPlaintext(true);
         }
+        return $this;
     }
 
     /**
-     * Sets the email template default color properties based on config settings.
-     */
-    protected function setDefaultEmailColors() {
-        if ($textColor = c('Garden.EmailTemplate.TextColor')) {
-            $this->emailTemplate->setTextColor($textColor);
-        }
-        if ($backgroundColor = c('Garden.EmailTemplate.BackgroundColor')) {
-            $this->emailTemplate->setBackgroundColor($backgroundColor);
-        }
-        if ($containerBackgroundColor = c('Garden.EmailTemplate.ContainerBackgroundColor')) {
-            $this->emailTemplate->setContainerBackgroundColor($containerBackgroundColor);
-        }
-        if ($buttonBackgroundColor = c('Garden.EmailTemplate.ButtonBackgroundColor')) {
-            $this->emailTemplate->setDefaultButtonBackgroundColor($buttonBackgroundColor);
-        }
-        if ($buttonTextColor = c('Garden.EmailTemplate.ButtonTextColor')) {
-            $this->emailTemplate->setDefaultButtonTextColor($buttonTextColor);
-        }
-    }
-
-    /**
-     * Sets the default image for the email template.
-     */
-    protected function setDefaultEmailImage() {
-        if (!$this->emailTemplate->getImage()) {
-            $image = $this->getDefaultEmailImage();
-            $this->emailTemplate->setImageArray($image);
-        }
-    }
-
-    /**
-     * Retrieves default values for the email image.
+     * Get email format
      *
-     * @return array An array representing an image.
-     */
-    public function getDefaultEmailImage() {
-        $image = array();
-        if (c('Garden.EmailTemplate.Image', '')) {
-            $image['source'] = Gdn_UploadImage::url(c('Garden.EmailTemplate.Image'));
-        }
-        $image['link'] = url('/', true);
-        $image['alt'] = c('Garden.LogoTitle', c('Garden.Title', ''));
-        return $image;
-    }
-
-    /**
-     * If the email title is not set, tries to find a title for the email template
-     * by using the email subject.
-     */
-    public function resolveEmailTitle() {
-        if ((!$this->emailTemplate->getTitle())) {
-            if ($title = $this->getEmailTitleFromSubject()) {
-                $this->emailTemplate->setTitle($title);
-            }
-        }
-    }
-
-    /**
-     * Returns the default title for an email based on its subject.
-     * If the subject is prepended by the forum title, it removes this.
+     * Returns 'text' or 'html'.
      *
-     * @return string The email title or an empty string if the subject is not set.
+     * @return string
      */
-    protected function getEmailTitleFromSubject() {
-        if ($title = $this->PhpMailer->Subject) {
-            $prefix = '[' . c('Garden.Title') . '] ';
-            if (strpos($title, $prefix) === 0) {
-                $title = substr($title, strlen($prefix));
-            }
-            return $title;
-        }
-        return '';
+    public function getFormat() {
+        return $this->format;
     }
 
     /**
@@ -168,9 +101,11 @@ class Gdn_Email extends Gdn_Pluggable {
      * @param string $Name
      * @param string $Value
      * @since 2.1
+     * @return Gdn_Email
      */
     public function addHeader($Name, $Value) {
         $this->PhpMailer->addCustomHeader("$Name:$Value");
+        return $this;
     }
 
     /**
@@ -179,7 +114,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * @param mixed $RecipientEmail An email (or array of emails) to add to the "Bcc" recipient collection.
      * @param string $RecipientName The recipient name associated with $RecipientEmail. If $RecipientEmail is
      * an array of email addresses, this value will be ignored.
-     * @return Email
+     * @return Gdn_Email
      */
     public function bcc($RecipientEmail, $RecipientName = '') {
         if ($RecipientName != '' && c('Garden.Email.OmitToName', false)) {
@@ -198,7 +133,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * @param mixed $RecipientEmail An email (or array of emails) to add to the "Cc" recipient collection.
      * @param string $RecipientName The recipient name associated with $RecipientEmail. If $RecipientEmail is
      * an array of email addresses, this value will be ignored.
-     * @return Email
+     * @return Gdn_Email
      */
     public function cc($RecipientEmail, $RecipientName = '') {
         if ($RecipientName != '' && c('Garden.Email.OmitToName', false)) {
@@ -215,7 +150,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * Clears out all previously specified values for this object and restores
      * it to the state it was in when it was instantiated.
      *
-     * @return Email
+     * @return Gdn_Email
      */
     public function clear() {
         $this->PhpMailer->clearAllRecipients();
@@ -235,7 +170,8 @@ class Gdn_Email extends Gdn_Pluggable {
      *
      * @param string $SenderEmail
      * @param string $SenderName
-     * @return Email
+     * @param boolean $bOverrideSender optional. default false.
+     * @return Gdn_Email
      */
     public function from($SenderEmail = '', $SenderName = '', $bOverrideSender = false) {
         if ($SenderEmail == '') {
@@ -262,10 +198,12 @@ class Gdn_Email extends Gdn_Pluggable {
     /**
      * Allows the definition of a masterview other than the default: "email.master".
      *
+     * @deprecated since version 2.2
      * @param string $MasterView
-     * @return Email
+     * @return Gdn_Email
      */
     public function masterView($MasterView) {
+        deprecated(__METHOD__);
         return $this;
     }
 
@@ -273,7 +211,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * The message to be sent.
      *
      * @param string $Message The body of the message to be sent.
-     * @return Email
+     * @return Gdn_Email
      */
     public function message($Message) {
         $this->emailTemplate->setMessage($Message, true);
@@ -314,25 +252,30 @@ class Gdn_Email extends Gdn_Pluggable {
 
     /**
      * @param EmailTemplate $emailTemplate The email body renderer.
-     * @return Email
+     * @return Gdn_Email
      */
     public function setEmailTemplate($emailTemplate) {
         $this->emailTemplate = $emailTemplate;
+
+        // if we change email templates after construct, inform it of the current format
+        if ($this->format) {
+            $this->setFormat($format);
+        }
         return $this;
     }
 
     /**
      *
      *
-     * @param $Template
+     * @param $template
      * @return bool|mixed|string
      */
-    public static function getTextVersion($Template) {
-        if (stristr($Template, '<!-- //TEXT VERSION FOLLOWS//')) {
-            $EmailParts = explode('<!-- //TEXT VERSION FOLLOWS//', $Template);
-            $TextVersion = array_pop($EmailParts);
-            $TextVersion = trim(strip_tags(preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/s', '', $TextVersion)));
-            return $TextVersion;
+    public static function getTextVersion($template) {
+        if (stristr($template, '<!-- //TEXT VERSION FOLLOWS//')) {
+            $emailParts = explode('<!-- //TEXT VERSION FOLLOWS//', $template);
+            $textVersion = array_pop($emailParts);
+            $textVersion = trim(strip_tags(preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/s', '', $textVersion)));
+            return $textVersion;
         }
         return false;
     }
@@ -340,18 +283,18 @@ class Gdn_Email extends Gdn_Pluggable {
     /**
      *
      *
-     * @param $Template
+     * @param $template
      * @return mixed|string
      */
-    public static function getHTMLVersion($Template) {
-        if (stristr($Template, '<!-- //TEXT VERSION FOLLOWS//')) {
-            $EmailParts = explode('<!-- //TEXT VERSION FOLLOWS//', $Template);
-            $TextVersion = array_pop($EmailParts);
-            $Message = array_shift($EmailParts);
-            $Message = trim($Message);
-            return $Message;
+    public static function getHTMLVersion($template) {
+        if (stristr($template, '<!-- //TEXT VERSION FOLLOWS//')) {
+            $emailParts = explode('<!-- //TEXT VERSION FOLLOWS//', $template);
+            array_pop($emailParts);
+            $message = array_shift($emailParts);
+            $message = trim($message);
+            return $message;
         }
-        return $Template;
+        return $template;
     }
 
     /**
@@ -360,7 +303,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * Only accept text/plain or text/html.
      *
      * @param string $MimeType The mime-type of the email.
-     * @return Email
+     * @return Gdn_Email
      */
     public function mimeType($MimeType) {
         $this->PhpMailer->isHTML($MimeType === 'text/html');
@@ -368,7 +311,9 @@ class Gdn_Email extends Gdn_Pluggable {
     }
 
     /**
+     * @param string $EventName
      * @todo add port settings
+     * @return boolean
      */
     public function send($EventName = '') {
         $this->formatMessage($this->emailTemplate->toString());
@@ -422,6 +367,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * Adds subject of the message to the email.
      *
      * @param string $Subject The subject of the message.
+     * @return Gdn_Email
      */
     public function subject($Subject) {
         $this->PhpMailer->Subject = $Subject;
@@ -444,7 +390,8 @@ class Gdn_Email extends Gdn_Pluggable {
      *
      * @param mixed $RecipientEmail An email (or array of emails) to add to the "To" recipient collection.
      * @param string $RecipientName The recipient name associated with $RecipientEmail. If $RecipientEmail is
-     * an array of email addresses, this value will be ignored.
+     *   an array of email addresses, this value will be ignored.
+     * @return Gdn_Email
      */
     public function to($RecipientEmail, $RecipientName = '') {
         if ($RecipientName != '' && c('Garden.Email.OmitToName', false)) {


### PR DESCRIPTION
This PR removes coupling between Gdn_Email and EmailTemplate classes in the dashboard application, and adds an IEmailTemplate interface to mediate the replacement of EmailTemplate with other versions with different functionality.