### PR TITLE
Enhance the messaging when connecting through SSO.

### DIFF
--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -1,8 +1,9 @@
 
 // This file contains javascript that is specific to the dashboard/entry controller.
 jQuery(document).ready(function($) {
-    $(window).keydown(function(event){
-        if(event.keyCode == 13) { // && gdn.definition('ForceCreateConnectName', false)
+    // For the SSO connect user page, do not allow to submit by pressing enter.
+    $("#dashboard_entry_connect").keydown(function(event){
+        if(event.keyCode == 13) {
             event.preventDefault();
             checkConnectName();
             return false;

--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -1,6 +1,13 @@
 
 // This file contains javascript that is specific to the dashboard/entry controller.
 jQuery(document).ready(function($) {
+    $(window).keydown(function(event){
+        if(event.keyCode == 13 && gdn.definition('ForceCreateConnectName', false)) {
+            event.preventDefault();
+            checkConnectName();
+            return false;
+        }
+    });
 
     // Check to see if the selected email is valid
     $('#Register input[name$=Email], body.register input[name$=Email]').blur(function() {
@@ -72,9 +79,13 @@ jQuery(document).ready(function($) {
                                 fineprint.html(gdn.definition('Choose a name to identify yourself on the site.'));
                             }
                         } else {
-                            $('#ConnectPassword').show();
-                            if (fineprint.length) {
-                                fineprint.html(gdn.definition('Username already exists.'));
+                            // If the username is not available, and the client does not want users to take over existing accounts, generate an error message and empty the input field.
+                            if(gdn.definition('NoConnectName', true) && gdn.definition('ForceCreateConnectName', false)) {
+                                // if there is already an error message on the page, overwrite it with this error message, else inject an error message.
+                                displayErrorMessage($('#Form_ConnectName').val());
+                                $('#Form_ConnectName').val("");
+                            } else {
+                                $('#ConnectPassword').show();
                             }
                         }
                     }
@@ -84,6 +95,17 @@ jQuery(document).ready(function($) {
             }
         } else {
             $('#ConnectPassword').show();
+        }
+    }
+
+    var displayErrorMessage = function(name) {
+        var msg = gdn.getMeta('duplicateUsernameError', 'The name %n is not available please choose another name.');
+        msg = msg.replace(/%n/g, name);
+
+        if($(".Messages.Errors").length) {
+            $(".Messages.Errors").html("<ul><li>" + msg + "</li></ul>");
+        } else {
+            $('#Form_ConnectName').closest('form').prepend("<div class='Messages Errors'><ul><li>" + msg + "</li></ul></div>");
         }
     }
 

--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -76,7 +76,7 @@ jQuery(document).ready(function($) {
                         if (text == 'TRUE') {
                             $('#ConnectPassword').hide();
                             if (fineprint.length) {
-                                fineprint.html(gdn.definition('Choose a name to identify yourself on the site.'));
+                                fineprint.html(gdn.getMeta('entryChooseNameMsg', 'Choose a name to identify yourself on the site.'));
                             }
                         } else {
                             // If the username is not available, and the client does not want users to take over existing accounts, generate an error message and empty the input field.

--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -2,7 +2,7 @@
 // This file contains javascript that is specific to the dashboard/entry controller.
 jQuery(document).ready(function($) {
     $(window).keydown(function(event){
-        if(event.keyCode == 13 && gdn.definition('ForceCreateConnectName', false)) {
+        if(event.keyCode == 13) { // && gdn.definition('ForceCreateConnectName', false)
             event.preventDefault();
             checkConnectName();
             return false;
@@ -80,7 +80,7 @@ jQuery(document).ready(function($) {
                             }
                         } else {
                             // If the username is not available, and the client does not want users to take over existing accounts, generate an error message and empty the input field.
-                            if(gdn.definition('NoConnectName', true) && gdn.definition('ForceCreateConnectName', false)) {
+                            if(gdn.definition('NoConnectName', true)) {// && gdn.definition('ForceCreateConnectName', false)
                                 // if there is already an error message on the page, overwrite it with this error message, else inject an error message.
                                 displayErrorMessage($('#Form_ConnectName').val());
                                 $('#Form_ConnectName').val("");
@@ -110,7 +110,7 @@ jQuery(document).ready(function($) {
     }
 
     checkConnectName();
-    $('#Form_ConnectName').keyup(checkConnectName);
+    $('#Form_ConnectName').blur(checkConnectName);
     $('input[name$=UserSelect]').click(checkConnectName);
 
     // Check to see if passwords match


### PR DESCRIPTION
Using jquery, check the availability of a username that a user chooses when trying to connect as a user for the first time on /entry/connect.

Requires the following: 
 
 - [x] Create a meaningful javascript variable to be added to to gdn.meta to tell the script to hide the password field.
 - [x] Make messaging cleaner by extracting into function.
 - [x] Optionally pass message from gdn.meta for better translation.
 - [x] Stop form from submitting with used username.
 