### PR TITLE
Add event 'AfterSaveThemeOptions' to allow reacting on theme option changes

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1383,6 +1383,7 @@ class SettingsController extends DashboardController {
                 }
 
                 saveToConfig($ConfigSaveData);
+                $this->fireEvent['AfterSaveThemeOptions'];
 
                 $this->informMessage(t("Your changes have been saved."));
             }
@@ -1449,6 +1450,7 @@ class SettingsController extends DashboardController {
                 }
 
                 saveToConfig($ConfigSaveData);
+                $this->fireEvent['AfterSaveThemeOptions'];
 
                 $this->informMessage(t("Your changes have been saved."));
             }


### PR DESCRIPTION
I have added that event to themeOptions() as well as mobileThemeOptions() and I have decided to use the same name, because both methods change the same part of the config.

Based on that discussion: https://vanillaforums.org/discussion/31730/theme-options-capability I have seen that there might be a need to react on theme option changes immediately.

Adding hooks on themeOption changes doesn't influence runtime performance of the forum as such, so I think they are uncritical.