### PR TITLE
Let discussion type opt out of new discussion module.

### DIFF
--- a/applications/vanilla/modules/class.newdiscussionmodule.php
+++ b/applications/vanilla/modules/class.newdiscussionmodule.php
@@ -113,6 +113,9 @@ class NewDiscussionModule extends Gdn_Module {
 
             if (isset($Category)) {
                 $Url .= '/'.rawurlencode(val('UrlCode', $Category));
+            } elseif (!val('Global', $Type, true)) {
+                unset($DiscussionTypes[$Key]);
+                continue;
             }
 
             // Present a signin redirect for a $PrivilegedGuest.


### PR DESCRIPTION
Allows discussion types to add a property to opt out of being added to the default NewDiscussionModule dropdown.