### PR TITLE
Cleanup Flagging e-mail view

### DIFF
--- a/plugins/Flagging/views/reportemail.php
+++ b/plugins/Flagging/views/reportemail.php
@@ -1,18 +1,22 @@
-<?php if (!defined('APPLICATION')) exit(); ?>
-<?php
-$Flag = $this->Data['Plugin.Flagging.Data'];
-$Report = $this->Data['Plugin.Flagging.Report'];
-$DiscussionID = $this->Data['Plugin.Flagging.DiscussionID'];
-$Reason = $this->Data['Plugin.Flagging.Reason'];
+<?php if (!defined('APPLICATION')) exit();
 
-echo t('Discussion'); ?>: <?php if (isset($Report['DiscussionName'])) echo $Report['DiscussionName']; ?>
+$discussionID = $this->data('Plugin.Flagging.DiscussionID');
+$flag         = $this->data('Plugin.Flagging.Data');
+$report       = $this->data('Plugin.Flagging.Report');
+$reason       = $this->data('Plugin.Flagging.Reason');
 
-<?php echo ExternalUrl($Flag['URL']); ?>
+echo t('Discussion'); ?>: <?php echo val('DiscussionName', $report); ?>
 
 
-<?php echo t('Reason').': '.$Reason; ?>
+<?php echo externalUrl($flag['URL']); ?>
 
 
-<?php echo t('FlaggedBy', 'Reported by:').' '.$Flag['UserName']; ?>
+<?php echo t('Reason') . ": {$reason}"; ?>
 
-<?php if ($DiscussionID) echo t('FlagDiscuss', 'Discuss it').': '.ExternalUrl('discussion/'.$DiscussionID); ?>
+
+<?php echo t('FlaggedBy', 'Reported by:') . " {$flag['UserName']}"; ?>
+
+
+<?php if ($discussionID) {
+    echo t('FlagDiscuss', 'Discuss it') . ': ' . externalUrl('discussion/' . $DiscussionID);
+} ?>


### PR DESCRIPTION
E-mail notifications from the Flagging plug-in have been broken since https://github.com/vanilla/vanilla/commit/54f25f33af8c93d95acfa50dd9dd8182d8fa92f1.  This is due to the e-mail view previously referencing the controller's data array, directly, instead of through its `data` function. The data slugs are converted into multi-dimensional arrays when going in with `setData`, while the e-mail view expected the slugs to remain in the dot-notation format.

This update cleans up the e-mail view a little bit and updates it to use the controller's `data` function.