### PR TITLE
Add a new event that allows to filter down the categoryDropDown input

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -327,6 +327,10 @@ class Gdn_Form extends Gdn_Pluggable {
      * @return string
      */
     public function categoryDropDown($FieldName = 'CategoryID', $Options = false) {
+
+        $this->EventArguments['Options'] = &$Options;
+        $this->fireEvent('BeforeCategoryDropDown');
+
         $Value = arrayValueI('Value', $Options); // The selected category id
         $CategoryData = val('CategoryData', $Options);
 


### PR DESCRIPTION
This PR is a better alternative than https://github.com/vanilla/vanilla/pull/3554
With this new event we won't need to modify every view that use the function to enable plugins to filter down the categories.