### PR TITLE
Add AllowConnect setting to optionally disable SSO connecting to existing accounts

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -380,6 +380,12 @@ EOT;
         $this->View = 'connect';
         $IsPostBack = $this->Form->isPostBack() && $this->Form->getFormValue('Connect', null) !== null;
         $UserSelect = $this->Form->getFormValue('UserSelect');
+
+        /**
+         * When a user is connecting through SSO he is prompted to choose a username. If he chooses an existing user name
+         * he is then prompted to enter the password for that username 'claiming' it as their own.
+         * By setting ConnectToExistingUser to false, we take away that workflow, forcing the user to choose a unique username.
+         */
         $connectToExistingUser = c('Garden.SSO.ConnectToExistingUser', true);
         $this->setData('ConnectToExistingUser', $connectToExistingUser);
         $this->addDefinition('ConnectToExistingUser', $connectToExistingUser);
@@ -620,10 +626,14 @@ EOT;
             }
 
             if(!$connectToExistingUser) {
+                // Since we are not connecting a joining user to an existing user...
+                // make his name the same as the connect name he chose.
                 $connectName = $this->Form->getFormValue("ConnectName");
                 $this->Form->setFormValue("Name", $connectName);
                 $this->Form->setFormValue("UserSelect", "other");
+                // make sure the photo of the existing user doen't show up on the form.
                 $this->Form->setFormValue("Photo", null);
+                // ignore any existing user(s) found.
                 $ExistingUsers = array();
             }
 

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -381,6 +381,7 @@ EOT;
         $IsPostBack = $this->Form->isPostBack() && $this->Form->getFormValue('Connect', null) !== null;
         $UserSelect = $this->Form->getFormValue('UserSelect');
         $connectToExistingUser = c('Garden.SSO.ConnectToExistingUser', true);
+        $this->setData('ConnectToExistingUser', $connectToExistingUser);
 
         if (!$IsPostBack) {
             // Here are the initial data array values. that can be set by a plugin.
@@ -622,7 +623,6 @@ EOT;
                 $this->Form->setFormValue("Name", $connectName);
                 $this->Form->setFormValue("UserSelect", "other");
                 $this->Form->setFormValue("Photo", null);
-                $this->setData('ConnectToExistingUser', false);
                 $ExistingUsers = array();
             }
 

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -380,6 +380,7 @@ EOT;
         $this->View = 'connect';
         $IsPostBack = $this->Form->isPostBack() && $this->Form->getFormValue('Connect', null) !== null;
         $UserSelect = $this->Form->getFormValue('UserSelect');
+        $connectToExistingUser = c('Garden.SSO.ConnectToExistingUser', true);
 
         if (!$IsPostBack) {
             // Here are the initial data array values. that can be set by a plugin.
@@ -616,6 +617,15 @@ EOT;
                 $this->Form->setFormValue('ConnectName', $this->Form->getFormValue('Name'));
             }
 
+            if(!$connectToExistingUser) {
+                $connectName = $this->Form->getFormValue("ConnectName");
+                $this->Form->setFormValue("Name", $connectName);
+                $this->Form->setFormValue("UserSelect", "other");
+                $this->Form->setFormValue("Photo", null);
+                $this->setData('ConnectToExistingUser', false);
+                $ExistingUsers = array();
+            }
+
             $this->setData('ExistingUsers', $ExistingUsers);
 
             if (UserModel::noEmail()) {
@@ -707,7 +717,7 @@ EOT;
 
             if (isset($User) && $User) {
                 // Make sure the user authenticates.
-                if (!$User['UserID'] == Gdn::session()->UserID) {
+                if (!$User['UserID'] == Gdn::session()->UserID && $connectToExistingUser) {
                     if ($this->Form->validateRule('ConnectPassword', 'ValidateRequired', sprintf(t('ValidateRequired'), t('Password')))) {
                         try {
                             if (!$PasswordHash->checkPassword($this->Form->getFormValue('ConnectPassword'), $User['Password'], $User['HashMethod'], $this->Form->getFormValue('ConnectName'))) {

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -382,6 +382,7 @@ EOT;
         $UserSelect = $this->Form->getFormValue('UserSelect');
         $connectToExistingUser = c('Garden.SSO.ConnectToExistingUser', true);
         $this->setData('ConnectToExistingUser', $connectToExistingUser);
+        $this->addDefinition('ConnectToExistingUser', $connectToExistingUser);
 
         if (!$IsPostBack) {
             // Here are the initial data array values. that can be set by a plugin.

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -384,11 +384,11 @@ EOT;
         /**
          * When a user is connecting through SSO he is prompted to choose a username. If he chooses an existing user name
          * he is then prompted to enter the password for that username 'claiming' it as their own.
-         * By setting ConnectToExistingUser to false, we take away that workflow, forcing the user to choose a unique username.
+         * By setting AllowConnect to false, we take away that workflow, forcing the user to choose a unique username.
          */
-        $connectToExistingUser = c('Garden.SSO.ConnectToExistingUser', true);
-        $this->setData('ConnectToExistingUser', $connectToExistingUser);
-        $this->addDefinition('ConnectToExistingUser', $connectToExistingUser);
+        $allowConnect = c('Garden.Registration.AllowConnect', true);
+        $this->setData('AllowConnect', $allowConnect);
+        $this->addDefinition('AllowConnect', $allowConnect);
 
         if (!$IsPostBack) {
             // Here are the initial data array values. that can be set by a plugin.
@@ -625,14 +625,12 @@ EOT;
                 $this->Form->setFormValue('ConnectName', $this->Form->getFormValue('Name'));
             }
 
-            if(!$connectToExistingUser) {
+            if(!$allowConnect) {
                 // Since we are not connecting a joining user to an existing user...
-                // make his name the same as the connect name he chose.
-                $connectName = $this->Form->getFormValue("ConnectName");
-                $this->Form->setFormValue("Name", $connectName);
-                $this->Form->setFormValue("UserSelect", "other");
-                // make sure the photo of the existing user doen't show up on the form.
+
+                // make sure the photo of the existing user doesn't show up on the form.
                 $this->Form->setFormValue("Photo", null);
+
                 // ignore any existing user(s) found.
                 $ExistingUsers = array();
             }
@@ -728,7 +726,7 @@ EOT;
 
             if (isset($User) && $User) {
                 // Make sure the user authenticates.
-                if (!$User['UserID'] == Gdn::session()->UserID && $connectToExistingUser) {
+                if (!$User['UserID'] == Gdn::session()->UserID && $allowConnect) {
                     if ($this->Form->validateRule('ConnectPassword', 'ValidateRequired', sprintf(t('ValidateRequired'), t('Password')))) {
                         try {
                             if (!$PasswordHash->checkPassword($this->Form->getFormValue('ConnectPassword'), $User['Password'], $User['HashMethod'], $this->Form->getFormValue('ConnectName'))) {

--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -48,8 +48,8 @@ jQuery(document).ready(function($) {
     });
 
     var checkConnectName = function() {
-        // If config setting ConnectToExistingUser is set to false, hide the password and return.
-        if(!gdn.definition('ConnectToExistingUser', true)) {
+        // If config setting AllowConnect is set to false, hide the password and return.
+        if(!gdn.definition('AllowConnect', true)) {
             $('#ConnectPassword').hide();
             return;
         }

--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -48,6 +48,10 @@ jQuery(document).ready(function($) {
     });
 
     var checkConnectName = function() {
+        if(!gdn.definition('ConnectToExistingUser', true)) {
+            $('#ConnectPassword').hide();
+            return;
+        }
         if (gdn.definition('NoConnectName', false)) {
             $('#ConnectPassword').show();
             return;

--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -48,6 +48,7 @@ jQuery(document).ready(function($) {
     });
 
     var checkConnectName = function() {
+        // If config setting ConnectToExistingUser is set to false, hide the password and return.
         if(!gdn.definition('ConnectToExistingUser', true)) {
             $('#ConnectPassword').hide();
             return;

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -9,7 +9,7 @@ if (!$ConnectPhoto) {
 }
 $ConnectSource = $this->Form->getFormValue('ProviderName');
 // By default, clients will try to connect existing users, turn this off and it forces connecting clients to choose unique usernames.
-$connectToExistingUser = $this->data('ConnectToExistingUser');
+$allowConnect = $this->data('AllowConnect');
 ?>
 <div class="Connect">
     <h1><?php echo stringIsNullOrEmpty($ConnectSource) ? t("Sign In") : sprintf(t('%s Connect'), $ConnectSource); ?></h1>
@@ -73,7 +73,7 @@ $connectToExistingUser = $this->data('ConnectToExistingUser');
                 <?php endif; ?>
                 <li>
                     <?php
-                      if (!$this->Form->getFormValue('ConnectName') || !$connectToExistingUser ) {
+                      if (!$this->Form->getFormValue('ConnectName') || !$allowConnect ) {
                           if (count($ExistingUsers) == 1 && $NoConnectName) {
                               $PasswordMessage = t('ConnectExistingPassword', 'Enter your existing account password.');
                               $Row = reset($ExistingUsers);

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -8,6 +8,7 @@ if (!$ConnectPhoto) {
     $ConnectPhoto = '/applications/dashboard/design/images/usericon.gif';
 }
 $ConnectSource = $this->Form->getFormValue('ProviderName');
+$connectToExistingUser = $this->data('ConnectToExistingUser');
 ?>
 <div class="Connect">
     <h1><?php echo stringIsNullOrEmpty($ConnectSource) ? t("Sign In") : sprintf(t('%s Connect'), $ConnectSource); ?></h1>
@@ -71,7 +72,7 @@ $ConnectSource = $this->Form->getFormValue('ProviderName');
                 <?php endif; ?>
                 <li>
                     <?php
-                      if (!$this->Form->getFormValue('ConnectName')) {
+                      if (!$this->Form->getFormValue('ConnectName') || !$connectToExistingUser ) {
                           if (count($ExistingUsers) == 1 && $NoConnectName) {
                               $PasswordMessage = t('ConnectExistingPassword', 'Enter your existing account password.');
                               $Row = reset($ExistingUsers);
@@ -97,6 +98,7 @@ $ConnectSource = $this->Form->getFormValue('ProviderName');
                     ?>
                 </li>
                 <?php $this->fireEvent('RegisterBeforePassword'); ?>
+                <?php if ($connectToExistingUser) : ?>
                 <li id="ConnectPassword">
                     <?php
                     echo $this->Form->label('Password', 'ConnectPassword');
@@ -104,6 +106,7 @@ $ConnectSource = $this->Form->getFormValue('ProviderName');
                     echo $this->Form->Input('ConnectPassword', 'password');
                     ?>
                 </li>
+                <?php endif; ?>
             </ul>
 
             <?php

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -8,6 +8,7 @@ if (!$ConnectPhoto) {
     $ConnectPhoto = '/applications/dashboard/design/images/usericon.gif';
 }
 $ConnectSource = $this->Form->getFormValue('ProviderName');
+// By default, clients will try to connect existing users, turn this off and it forces connecting clients to choose unique usernames.
 $connectToExistingUser = $this->data('ConnectToExistingUser');
 ?>
 <div class="Connect">

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -98,7 +98,6 @@ $connectToExistingUser = $this->data('ConnectToExistingUser');
                     ?>
                 </li>
                 <?php $this->fireEvent('RegisterBeforePassword'); ?>
-                <?php if ($connectToExistingUser) : ?>
                 <li id="ConnectPassword">
                     <?php
                     echo $this->Form->label('Password', 'ConnectPassword');
@@ -106,7 +105,6 @@ $connectToExistingUser = $this->data('ConnectToExistingUser');
                     echo $this->Form->Input('ConnectPassword', 'password');
                     ?>
                 </li>
-                <?php endif; ?>
             </ul>
 
             <?php


### PR DESCRIPTION
Create a functionality whereby a forum can add a line in their config that would stop users who are connecting through SSO from claiming an existing user by entering the username and password.