### PR TITLE
Add default value for checkHash in embed.js

### DIFF
--- a/js/embed.js
+++ b/js/embed.js
@@ -92,12 +92,12 @@ window.vanilla.embed = function(host) {
     }
 
     checkHash = function() {
-        var path = window.location.hash.substr(1);
+        var path = window.location.hash.substr(1) || "/";
         if (path != currentPath) {
             currentPath = path;
             window.frames['vanilla' + id].location.replace(vanillaUrl(path));
         }
-    }
+    };
 
     if (!window.gadgets) {
         if (!disablePath) {


### PR DESCRIPTION
If you're navigating an embedded site and happen to use your browser's back button to move all the way up to the root of the forum, a 404 error is encountered.  This is because of an issue in `checkHash` within embed.js that can allow the request path to be set to an empty string (`?p=`) and that doesn't Jive with Vanilla.

This update adds a default value of `/` to `checkHash`'s path polling.