### PR TITLE
Optimize arrayValueI()

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -310,9 +310,10 @@ if (!function_exists('arrayValueI')) {
      */
     function arrayValueI($Needle, $Haystack, $Default = false) {
         $Return = $Default;
+        $Needle = strtolower($Needle);
         if (is_array($Haystack)) {
             foreach ($Haystack as $Key => $Value) {
-                if (strtolower($Needle) == strtolower($Key)) {
+                if ($Needle == strtolower($Key)) {
                     $Return = $Value;
                     break;
                 }


### PR DESCRIPTION
`strtolower($Needle)` was called inside of the comparing foreach loop. If it is converted to lowercase outside of the loop it needs only to be done once.