### PR TITLE
Add options for overriding email messages.

### DIFF
--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -94,27 +94,10 @@ $Definition['EmailMembershipApproved'] = 'Hello %1$s,
 You have been approved for membership. Sign in now at the following link:
 
   %2$s';
-$Definition['EmailWelcome'] = '%2$s has created an account for you at %3$s. Your login credentials are:
-
-  Email: %6$s
-  Password: %5$s
-  Url: %4$s';
 $Definition['EmailPassword'] = '%2$s has reset your password at %3$s for your login with email address %6$s. Please contact them if you do not know the new password.
 
   Url: %4$s';
 $Definition['EmailConfirmEmail'] = 'You need to confirm your email address before you can continue. Please confirm your email address by clicking on the following link: {/entry/emailconfirm,exurl,domain}/{User.UserID,rawurlencode}/{EmailKey,rawurlencode}';
-$Definition['EmailWelcomeRegister'] = 'You have successfully registered for an account at {Title}. Here is your information:
-
-  Username: {User.Name}
-  Email: {User.Email}
-
-You can access the site at {/,exurl,domain}.';
-$Definition['EmailWelcomeConnect'] = 'You have successfully connected to {Title}. Here is your information:
-
-  Username: {User.Name}
-  Connected With: {ProviderName}
-
-You can access the site at {/,exurl,domain}.';
 $Definition['PasswordRequest'] = 'Someone has requested to reset your password at %2$s. To reset your password, follow this link:
 
   %3$s

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -876,7 +876,11 @@ class ActivityModel extends Gdn_Model {
                     ->setTitle($ActivityHeadline);
 
                 if ($message = val('Story', $Activity)) {
-                    $emailTemplate->setMessage($message, true);
+                    $prefix = c('Garden.Email.Prefix', '');
+                    if (!empty($prefix)) {
+                        $prefix .= '<br><br>';
+                    }
+                    $emailTemplate->setMessage($prefix.$message, true);
                 }
 
                 $Email->setEmailTemplate($emailTemplate);
@@ -968,7 +972,11 @@ class ActivityModel extends Gdn_Model {
             ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
 
         if ($message = val('Story', $Activity)) {
-            $emailTemplate->setMessage($message, true);
+            $prefix = c('Garden.Email.Prefix', '');
+            if (!empty($prefix)) {
+                $prefix .= '<br><br>';
+            }
+            $emailTemplate->setMessage($prefix.$message, true);
         }
 
         $Email->setEmailTemplate($emailTemplate);
@@ -1229,7 +1237,11 @@ class ActivityModel extends Gdn_Model {
                     ->setButton($url, val('ActionText', $Activity, t('Check it out')))
                     ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
                 if ($message = val('Story', $Activity)) {
-                    $emailTemplate->setMessage($message, true);
+                    $prefix = c('Garden.Email.Prefix', '');
+                    if (!empty($prefix)) {
+                        $prefix .= '<br><br>';
+                    }
+                    $emailTemplate->setMessage($prefix.$message, true);
                 }
                 $Email->setEmailTemplate($emailTemplate);
 

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -877,9 +877,6 @@ class ActivityModel extends Gdn_Model {
 
                 if ($message = val('Story', $Activity)) {
                     $prefix = c('Garden.Email.Prefix', '');
-                    if (!empty($prefix)) {
-                        $prefix .= '<br><br>';
-                    }
                     $emailTemplate->setMessage($prefix.$message, true);
                 }
 
@@ -973,9 +970,6 @@ class ActivityModel extends Gdn_Model {
 
         if ($message = val('Story', $Activity)) {
             $prefix = c('Garden.Email.Prefix', '');
-            if (!empty($prefix)) {
-                $prefix .= '<br><br>';
-            }
             $emailTemplate->setMessage($prefix.$message, true);
         }
 
@@ -1238,9 +1232,6 @@ class ActivityModel extends Gdn_Model {
                     ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
                 if ($message = val('Story', $Activity)) {
                     $prefix = c('Garden.Email.Prefix', '');
-                    if (!empty($prefix)) {
-                        $prefix .= '<br><br>';
-                    }
                     $emailTemplate->setMessage($prefix.$message, true);
                 }
                 $Email->setEmailTemplate($emailTemplate);

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3922,12 +3922,23 @@ class UserModel extends Gdn_Model {
         $Email->send();
     }
 
+    /**
+     * Resolves the welcome email format. Maintains backwards compatibility with the 'EmailWelcome*' translations
+     * for overriding.
+     *
+     * @param string $registerType The registration type. One of 'Connect', 'Register' or 'Add'.
+     * @param object|array $user The user to send the email to.
+     * @param array $data The email data.
+     * @param string $password The user's password.
+     * @return string The welcome email for the registration type.
+     */
     protected function getEmailWelcome($registerType, $user, $data, $password = '') {
         $appTitle = c('Garden.Title');
 
         // Backwards compatability. See if anybody has overridden the EmailWelcome string.
-        $emailWelcome = '%2$s has created an account for you at %3$s. Your login credentials are: Email: %6$s Password: %5$s Url: %4$s';
-        if (preg_replace('/\s+/', '', t('EmailWelcome')) != preg_replace('/\s+/', '', $emailWelcome)) {
+        if (($emailFormat = t('EmailWelcome'.$registerType, ''))) {
+            $welcome = formatString($emailFormat, $data);
+        } elseif (t('EmailWelcome', '')) {
             $welcome = sprintf(
                 t('EmailWelcome'),
                 val('Name', $user),


### PR DESCRIPTION
The recent HTML email feature stopped using the email translation compound strings in favour of smaller, concatenated translations. This allowed us to split up the email into its components (title, button, etc.) However, it broke backwards compatibility for users with custom email translations. 

This PR addresses that issue in 2 ways:

1. If there is a custom translation for the welcome email body, it uses that.
2. For activity-related emails, adds the ability to prepend a string to the email body, using the 'Garden.Email.Prefix' config setting.

This does not restore backwards compatibility, but addresses the need for users to add custom messages to the emails.