### PR TITLE
Comment out the attach mappings call for the theme in bootstrap.php

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -213,7 +213,8 @@ unset($hooksPath);
 
 // Themes startup
 Gdn::themeManager()->start();
-Gdn_Autoloader::attach(Gdn_Autoloader::CONTEXT_THEME);
+// No actions are connected to this call, so it could be commeted out for now.
+// Gdn_Autoloader::attach(Gdn_Autoloader::CONTEXT_THEME);
 
 // Plugins startup
 Gdn::pluginManager()->start();


### PR DESCRIPTION
To my opinion the bootstrap should be as lean as possible. By now it makes a call to Autloader->attach() for the theme as well. Looking at the [code in class Autoloader](https://github.com/vanilla/vanilla/blob/master/library/core/class.autoloader.php#L103-L105), you'll find that no action is performed there.
Maybe a comment in the attached method should be added, but by now there is an unused option which is called on every request.

Looking at the caching of  the classes, I doubt that it would be used in the near future. Since there is only one cache for themes and a Vanilla forum can have two different themes at the same time (desktop and mobile), you would have to implement two different caches. But even then you would have to handle the contextOrder other than it is [handled by now](https://github.com/vanilla/vanilla/blob/master/library/core/class.autoloader.php#L577-L582). Only looking at a static array wouldn't be enough. You would always have to take the currentTheme() of the user (mobile/desktop) into consideration.

The themes that uses custom classes have to register their classes by themselves, anyway.