### PR TITLE
Fix typo in Autoloaders $contextOrder array

### DIFF
--- a/library/core/class.autoloader.php
+++ b/library/core/class.autoloader.php
@@ -578,7 +578,7 @@ class Gdn_Autoloader {
             self::CONTEXT_THEME,
             self::CONTEXT_LOCALE,
             self::CONTEXT_PLUGIN,
-            self::CONTEXT_APPLICATION,
+            self::CONTEXT_APPLICATION
         );
 
         self::$maps = array();


### PR DESCRIPTION
Last element of array has been CONTEXT_CORE and I cannot tell if it shouldn't be still there. I simply guess that there would have been a serious breakdown if it would be needed here. Therefore it is the remaining comma has to be corrected.