### PR TITLE
Consider `code` elements with a class name when protecting code blocks

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1670,7 +1670,7 @@ EOT;
         $CodeBlockContents = array();
         $CodeBlockHashes = array();
         $Subject = preg_replace_callback(
-            '/<code>.*?<\/code>/is',
+            '/<code.*?>.*?<\/code>/is',
             function ($Matches) use (&$CodeBlockContents, &$CodeBlockHashes) {
                 // Surrounded by whitespace to try to prevent the characters
                 // from being picked up by $Pattern.


### PR DESCRIPTION
- The `replaceButProtectCodeBlocks` method will handily protect the contents of `code` elements from the formatting methods, but it only works with a plain `<code>` element - it cannot have any attributes on it.

- If the code output uses a class name, which my markdown parser does to add language information (GFM) for the syntax highlighter then the code block is no longer protected.

- For example:
\`\`\`js
    ...
\```

  would result in:
    \<code class="language-js">
      ...
    \</code>

- This change allows the element to have attributes

**edited** Formatting