### PR TITLE
Update MarkdownVanilla to sort gamut by priority

### DIFF
--- a/library/core/class.markdownvanilla.php
+++ b/library/core/class.markdownvanilla.php
@@ -26,6 +26,10 @@ class MarkdownVanilla extends \Michelf\MarkdownExtra {
         $this->addStrikeout();
         $this->addBreaks();
         $this->addSpoilers();
+
+		// Sort gamuts by their priority.
+		asort($this->block_gamut);
+		asort($this->span_gamut);
     }
 
     /**


### PR DESCRIPTION
This update makes sure the Markdown handling functions are properly weighted by priority before transformations are done.  This necessary, because our Markdown library only sorts by priority in its constructor.  We potentially add additional handlers after this, but their priority is never accurately accounted for.  This leads to behavior like quotes disrupting the markup before spoilers can be run.