### PR TITLE
Only add the download attribute if the download is not an image.

### DIFF
--- a/plugins/editor/views/attachments.php
+++ b/plugins/editor/views/attachments.php
@@ -44,7 +44,7 @@ $editorkey = $this->data('_editorkey');
                 <?php
                 // Only add the download attribute if it's not an image.
                 if (!$attachment['ImageHeight']) {
-                    echo 'download=" '.htmlspecialchars($attachment['Name']).'"';
+                    echo 'download="'.htmlspecialchars($attachment['Name']).'"';
                 }
                 ?>
                 >

--- a/plugins/editor/views/attachments.php
+++ b/plugins/editor/views/attachments.php
@@ -38,9 +38,18 @@ $editorkey = $this->data('_editorkey');
          <div class="file-data">
             <a class="filename" data-type="<?php echo $attachment['Type']; ?>"
                data-width="<?php echo $attachment['ImageWidth']; ?>"
-               data-height="<?php echo $attachment['ImageHeight']; ?>" href="<?php echo $pathParse['Url'] ?>"
-               download="<?php echo htmlspecialchars($attachment['Name']); ?>"
-               target="_blank"><?php echo htmlspecialchars($attachment['Name']); ?></a>
+               data-height="<?php echo $attachment['ImageHeight']; ?>"
+               href="<?php echo $pathParse['Url'] ?>"
+               target="_blank"
+                <?php
+                // Only add the download attribute if it's not an image.
+                if (!$attachment['ImageHeight']) {
+                    echo 'download=" '.htmlspecialchars($attachment['Name']).'"';
+                }
+                ?>
+                >
+                <?php echo htmlspecialchars($attachment['Name']); ?>
+            </a>
             <span class="meta"><?php echo Gdn_Format::Bytes($attachment['Size'], 1); ?></span>
          </div>
          <span class="editor-file-remove" title="<?php echo t('Remove'); ?>"></span>

--- a/plugins/editor/views/attachments.php
+++ b/plugins/editor/views/attachments.php
@@ -37,13 +37,14 @@ $editorkey = $this->data('_editorkey');
          <?php echo $filePreviewCss; ?>
          <div class="file-data">
             <a class="filename" data-type="<?php echo $attachment['Type']; ?>"
-               data-width="<?php echo $attachment['ImageWidth']; ?>"
-               data-height="<?php echo $attachment['ImageHeight']; ?>"
                href="<?php echo $pathParse['Url'] ?>"
                target="_blank"
                 <?php
-                // Only add the download attribute if it's not an image.
-                if (!$attachment['ImageHeight']) {
+                if ($attachment['ImageHeight']) {
+                    echo 'data-width="'.$attachment['ImageWidth'].'"';
+                    echo 'data-height="'.$attachment['ImageHeight'].'"';
+                } else {
+                    // Only add the download attribute if it's not an image.
                     echo 'download="'.htmlspecialchars($attachment['Name']).'"';
                 }
                 ?>


### PR DESCRIPTION
Fixes issue where image attachments were being downloaded on click rather than being opened in a new tab. Downloading an attachment on click is great if it's a document, but is unexpected if it's an image.