### PR TITLE
Fix opaque photo cropping box

### DIFF
--- a/applications/dashboard/design/cropimage.css
+++ b/applications/dashboard/design/cropimage.css
@@ -46,7 +46,6 @@
 }
 
 .jcrop-tracker {
-    *background-color: gray;
     width: 100%;
     height: 100%;
 }

--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -2623,7 +2623,6 @@ form.Thumbnail .Warning {
 }
 
 .jcrop-tracker {
-  background-color: #444;
   width: 100%;
   height: 100%;
 }

--- a/applications/dashboard/scss/legacy/_style.scss
+++ b/applications/dashboard/scss/legacy/_style.scss
@@ -2616,7 +2616,6 @@ form.Thumbnail .Warning {
 }
 
 .jcrop-tracker {
-  background-color: #444;
   width: 100%;
   height: 100%;
 }

--- a/themes/2011Compatibility/design/custom_red.css
+++ b/themes/2011Compatibility/design/custom_red.css
@@ -1006,10 +1006,6 @@ div.Tabs div.SubTab {
 
 }
 
-.jcrop-tracker {
-    *background-color: gray;
-}
-
 .custom .jcrop-vline,
 .custom .jcrop-hline {
     background: yellow;


### PR DESCRIPTION
When attempting to crop a photo thumbnail, the full-size image has an opaque gray box overlay.  This makes it so you can't see what you're actually cropping.

This update removes some styling rules that were causing the box to be fully opaque.  The cropping box should now be semitransparent.

Closes #3425