### PR TITLE
Limit image processing to valid uploads

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -718,7 +718,14 @@ class EditorPlugin extends Gdn_Plugin {
 
             // Save original file to uploads, then manipulate from this location if
             // it's a photo. This will also call events in Vanilla so other plugins can tie into this.
-            if (empty($imageType)) {
+            $validImageTypes = [
+                IMAGETYPE_GIF,
+                IMAGETYPE_JPEG,
+                IMAGETYPE_PNG
+            ];
+            $validImage = !empty($imageType) && in_array($imageType, $validImageTypes);
+
+            if (!$validImage) {
                 $filePathParsed = $Upload->saveAs(
                     $tmpFilePath,
                     $absoluteFileDestination,
@@ -745,7 +752,7 @@ class EditorPlugin extends Gdn_Plugin {
             // This is a redundant check, because it's in the thumbnail function,
             // but there's no point calling it blindly on every file, so just check here before calling it.
             $generate_thumbnail = false;
-            if (in_array($fileExtension, array('jpg', 'jpeg', 'gif', 'png', 'bmp', 'ico'))) {
+            if ($validImage) {
                 $imageHeight = $tmpheight;
                 $imageWidth = $tmpwidth;
                 $generate_thumbnail = true;


### PR DESCRIPTION
Vanilla currently checks to see if an upload is an image before processing it as an image and generating a thumbnail for it.  However, not all images are handled by Vanilla.  GIF, JPG and PNG are the only image types that are processed.  Other images will fail with an error.

This update alters the upload logic to attach other types of images without attempting additional processing, treating them like any other non-image file, instead of throwing an error during the upload.

Closes #2846