### PR TITLE
Allow HEAD requests in ProxyRequest->request()

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -518,6 +518,12 @@ class ProxyRequest {
             }
         }
 
+        // Allow HEAD
+        if ($RequestMethod == 'HEAD') {
+            curl_setopt($Handler, CURLOPT_HEADER, true);
+            curl_setopt($Handler, CURLOPT_NOBODY, true);
+        }
+
         // Any extra needed headers
         if (sizeof($SendExtraHeaders)) {
             curl_setopt($Handler, CURLOPT_HTTPHEADER, $SendExtraHeaders);


### PR DESCRIPTION
Setting  $Method => 'HEAD' in request() results in a timeout since the request method doesn't include the head. So it must be handled extra.