### PR TITLE
Register user using connect name when provided

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -655,6 +655,7 @@ EOT;
                 $User['SourceID'] = $this->Form->getFormValue('UniqueID');
                 $User['Attributes'] = $this->Form->getFormValue('Attributes', null);
                 $User['Email'] = $this->Form->getFormValue('ConnectEmail', $this->Form->getFormValue('Email', null));
+                $User['Name'] = $this->Form->getFormValue('ConnectName', $this->Form->getFormValue('Name', null));
 
                 $UserID = $UserModel->register($User, array('CheckCaptcha' => false, 'ValidateEmail' => false, 'NoConfirmEmail' => true, 'SaveRoles' => $SaveRolesRegister));
 


### PR DESCRIPTION
Let begin by saying
---
The logic of the connect function _should_ be refactored/simplified!

A bit of context
---
When Garden.Registration.NameUnique is set to true and a user tries to connect through SSO using a name that already exist in the forum we give 2 options:
Appropriate yourself the user by providing its password or use a different name.

There is a bug with the latter option... We are always told that the new chosen name exist.

That new name is provided via the field "ConnectName" which is what we use to check that this new name is not already existing. All this is correct. 
But we then create the user using the "Name" field. Which is the name that already exist in the DB and got us to provide a ConnectName in the first place.

In short
---
When registering a user on connect we need to use "ConnectName" if it is provided.