### PR TITLE
Make proxyRequest::curlHeader handle responses with multiple identical fields correct

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -116,10 +116,17 @@ class ProxyRequest {
      * @return int
      */
     public function curlHeader(&$Handler, $HeaderString) {
-        $Line = explode(':', trim($HeaderString));
+        $Line = explode(':', $HeaderString);
         $Key = trim(array_shift($Line));
         $Value = trim(implode(':', $Line));
-        if (!empty($Key)) {
+        // Prevent overwriting existing $this->ResponseHeaders[$Key] entries.
+        if (array_key_exists($Key, $this->ResponseHeaders)) {
+            if (!is_array($this->ResponseHeaders[$Key])) {
+                // Transform ResponseHeader to an array.
+                $this->ResponseHeaders[$Key] = array($this->ResponseHeaders[$Key]);
+            }
+            $this->ResponseHeaders[$Key][] = $Value;
+        } elseif (!empty($Key)) {
             $this->ResponseHeaders[$Key] = $Value;
         }
         return strlen($HeaderString);


### PR DESCRIPTION
When requesting the HEAD of a site that has e.g. multiple "Link:" lines, only the last of those lines made it to proxyRequest->ResponseHeaders array. It is a flat array so `proxyRequest->ResponseHeaders['Link'] = ...` is called for every Link line.

I've made it do a check for double entries and to transform the entry to an array if needed.