### PR TITLE
Reign in various checks to Garden.Profile.EditPhotos

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -19,6 +19,9 @@ class ProfileController extends Gdn_Controller {
     /** @var object User data to use in building profile. */
     public $User;
 
+    /** @var bool Can the current user edit the profile user's photo? */
+    public $CanEditPhotos;
+
     /** @var string Name of current tab. */
     public $CurrentTab;
 
@@ -97,7 +100,7 @@ class ProfileController extends Gdn_Controller {
         }
 
         $this->setData('Breadcrumbs', array());
-        $this->CanEditPhotos = c('Garden.Profile.EditPhotos') || Gdn::session()->checkPermission('Garden.Users.Edit');
+        $this->CanEditPhotos = Gdn::session()->checkRankedPermission(c('Garden.Profile.EditPhotos', true)) || Gdn::session()->checkPermission('Garden.Users.Edit');
     }
 
     /**
@@ -689,7 +692,7 @@ class ProfileController extends Gdn_Controller {
      * @param string $Username .
      */
     public function picture($UserReference = '', $Username = '', $UserID = '') {
-        if (!Gdn::session()->checkRankedPermission(c('Garden.Profile.EditPhotos', true))) {
+        if (!$this->CanEditPhotos) {
             throw forbiddenException('@Editing user photos has been disabled.');
         }
 
@@ -1104,7 +1107,7 @@ class ProfileController extends Gdn_Controller {
      * @param string $Username .
      */
     public function thumbnail($UserReference = '', $Username = '') {
-        if (!c('Garden.Profile.EditPhotos', true)) {
+        if (!$this->CanEditPhotos) {
             throw forbiddenException('@Editing user photos has been disabled.');
         }
 
@@ -1320,7 +1323,7 @@ class ProfileController extends Gdn_Controller {
         $Module->addItem('Options', '', false, array('class' => 'SideMenu'));
 
         // Check that we have the necessary tools to allow image uploading
-        $AllowImages = c('Garden.Profile.EditPhotos', true) && Gdn_UploadImage::canUploadImages();
+        $AllowImages = $this->CanEditPhotos && Gdn_UploadImage::canUploadImages();
 
         // Is the photo hosted remotely?
         $RemotePhoto = isUrl($this->User->Photo);

--- a/applications/dashboard/modules/class.userphotomodule.php
+++ b/applications/dashboard/modules/class.userphotomodule.php
@@ -13,9 +13,15 @@
  */
 class UserPhotoModule extends Gdn_Module {
 
+    /**
+     * @var bool Can the current user edit this user's photo?
+     */
+    public $CanEditPhotos;
+
     public function __construct() {
         parent::__construct();
         $this->_ApplicationFolder = 'dashboard';
+        $this->CanEditPhotos = Gdn::session()->checkRankedPermission(c('Garden.Profile.EditPhotos', true)) || Gdn::session()->checkPermission('Garden.Users.Edit');
     }
 
     public function assetTarget() {
@@ -23,7 +29,6 @@ class UserPhotoModule extends Gdn_Module {
     }
 
     public function toString() {
-        $this->CanEditPhotos = c('Garden.Profile.EditPhotos');
         return parent::ToString();
     }
 }

--- a/applications/dashboard/views/modules/userphoto.php
+++ b/applications/dashboard/views/modules/userphoto.php
@@ -27,7 +27,8 @@ if ($Photo) {
     <div class="Photo PhotoWrap PhotoWrapLarge <?php echo val('_CssClass', $User); ?>">
         <?php
         $Img = img($Photo, array('class' => 'ProfilePhotoLarge'));
-        if (!$User->Banned && c('Garden.Profile.EditPhotos', true) && (Gdn::session()->UserID == $User->UserID || Gdn::session()->checkPermission('Garden.Users.Edit')))
+        $canEditPhotos = Gdn::session()->checkRankedPermission(c('Garden.Profile.EditPhotos', true)) || Gdn::session()->checkPermission('Garden.Users.Edit');
+        if (!$User->Banned && $canEditPhotos && (Gdn::session()->UserID == $User->UserID || Gdn::session()->checkPermission('Garden.Users.Edit')))
             echo anchor(Wrap(t('Change Picture')), '/profile/picture?userid='.$User->UserID, 'ChangePicture');
 
         echo $Img;


### PR DESCRIPTION
This update simplifies and unifies checks for `Garden.Profile.EditPhotos`.  Instead of using a half dozen different methods, we now only use one:
```
Gdn::session()->checkRankedPermission(c('Garden.Profile.EditPhotos', true)) || Gdn::session()->checkPermission('Garden.Users.Edit')
```

This check is performed once and saved in an object, where applicable.  This updated check performs the following:

1. Load the config value for `Garden.Profile.EditPhotos`, defaulting to `true`.
2. Pass the config value to `checkRankedPermission`.
3. If the config value is a boolean, use that as the value for the permission check.  If the config value is a string, try to use it as a permission slug and verify the current user has that permission.
4. If `checkRankedPermission` winds up evaluating to false, check to see if the current user has the `Garden.Users.Edit` permission and use that to determine if the user can edit photos.