### PR TITLE
Move setHandlers further down the bootstrap

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -48,7 +48,6 @@ if (function_exists('mb_internal_encoding')) {
 
 // Include the core autoloader.
 require_once __DIR__.'/vendor/autoload.php';
-setHandlers();
 
 // Initialize the autoloader.
 Gdn_Autoloader::start();
@@ -90,6 +89,8 @@ debug(c('Debug', false));
 // Default request object
 Gdn::factoryInstall(Gdn::AliasRequest, 'Gdn_Request', null, Gdn::FactoryRealSingleton, 'Create');
 Gdn::request()->fromEnvironment();
+
+setHandlers();
 
 /**
  * Extension Managers


### PR DESCRIPTION
Our custom error and exception handlers are set before those functions can actually be used.  Trying to use them before all their dependencies have been created causes them to throw their own errors.

This update moves `setHandlers` down the bootstrap to the earliest point in which our error and exception handlers are usable.