### PR TITLE
Implement an alter table threshold

### DIFF
--- a/applications/dashboard/controllers/class.utilitycontroller.php
+++ b/applications/dashboard/controllers/class.utilitycontroller.php
@@ -251,9 +251,16 @@ class UtilityController extends DashboardController {
             $this->setData('CapturedSql', array());
         }
 
+        $issues = Gdn::structure()->getIssues();
+
         if ($this->Form->errorCount() == 0 && !$captureOnly && $FoundStructureFile) {
-            $this->setData('Status', 'The structure was successfully executed.');
+            if (empty($issues)) {
+                $this->setData('Status', 'The structure was successfully executed.');
+            } else {
+                $this->setData('Status', 'The structure completed with issues.');
+            }
         }
+        $this->setData('Issues', $issues);
     }
 
     /**

--- a/applications/dashboard/views/utility/structure.php
+++ b/applications/dashboard/views/utility/structure.php
@@ -46,6 +46,23 @@ switch ($this->data('Step')) {
         break;
     case 'run':
         // Display the status message from running the structure.
+        if (!empty($this->Data['Issues'])) {
+            echo '<pre class="Sql">';
+
+            $first = true;
+            foreach ($this->Data['Issues'] as $row) {
+                if ($first) {
+                    $first = false;
+                } else {
+                    echo "\n\n";
+                }
+
+                echo htmlspecialchars("/* {$row['table']}: {$row['message']} */\n");
+                echo htmlspecialchars($row['sql']);
+            }
+
+            echo '</pre>';
+        }
 
         echo '<div class="Buttons">',
             $this->Form->button('Scan', ['value' => t('Rescan')]),

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -384,7 +384,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
             }
             $this->Database->CapturedSql[] = $sql;
             return true;
-        } elseif ($checkThreshold && $this->getRowCountEstimate($this->tableName()) >= $this->getAlterTableThreshold()) {
+        } elseif ($checkThreshold && $this->getAlterTableThreshold() && $this->getRowCountEstimate($this->tableName()) >= $this->getAlterTableThreshold()) {
             // Log an event to be captured and analysed later.
             Logger::event(
                 'structure_threshold',

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -13,6 +13,15 @@
  * Used by any given database driver to build, modify, and create tables and views.
  */
 abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
+    /**
+     * @var array[int] An array of table names to row count estimates.
+     */
+    protected $rowCountEstimates;
+
+    /**
+     * @var int The maximum number of rows allowed for an alter table.
+     */
+    protected $alterTableThreshold;
 
     /** @var string  */
     protected $_DatabasePrefix = '';
@@ -60,8 +69,31 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
         }
 
         $this->databasePrefix($this->Database->DatabasePrefix);
+        $this->setAlterTableThreshold(c('Database.AlterTableThreshold', 0));
 
         $this->reset();
+    }
+
+    /**
+     * Get the alter table threshold.
+     *
+     * The alter table threshold is the maximum estimated rows a table can have where alter tables are allowed.
+     *
+     * @return int Returns the threshold as an integer. A value of zero means no threshold.
+     */
+    public function getAlterTableThreshold() {
+        return $this->alterTableThreshold;
+    }
+
+    /**
+     * Set the alterTableThreshold.
+     *
+     * @param int $alterTableThreshold
+     * @return Gdn_MySQLStructure Returns `$this` for fluent calls.
+     */
+    public function setAlterTableThreshold($alterTableThreshold) {
+        $this->alterTableThreshold = $alterTableThreshold;
+        return $this;
     }
 
     /**
@@ -313,6 +345,17 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
     }
 
     /**
+     * Get the estimated number of rows in a table.
+     *
+     * @param string $tableName The name of the table to look up, without its prefix.
+     * @return int|null Returns the estimated number of rows or **null** if the information doesn't exist.
+     */
+    public function getRowCountEstimate($tableName) {
+        // This method is basically abstract.
+        return null;
+    }
+
+    /**
      * Defines a primary key column on a table.
      *
      * @param string $Name The name of the column.
@@ -330,18 +373,33 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
     /**
      * Send a query to the database and return the result.
      *
-     * @param string $Sql The sql to execute.
-     * @return bool Whethor or not the query succeeded.
+     * @param string $sql The sql to execute.
+     * @param bool $checkThreshold Whether or not to check the alter table threshold before altering the table.
+     * @return bool Whether or not the query succeeded.
      */
-    public function query($Sql) {
+    public function query($sql, $checkThreshold = false) {
         if ($this->CaptureOnly) {
             if (!property_exists($this->Database, 'CapturedSql')) {
                 $this->Database->CapturedSql = array();
             }
-            $this->Database->CapturedSql[] = $Sql;
+            $this->Database->CapturedSql[] = $sql;
+            return true;
+        } elseif ($checkThreshold && $this->getRowCountEstimate($this->tableName()) >= $this->getAlterTableThreshold()) {
+            // Log an event to be captured and analysed later.
+            Logger::event(
+                'structure_threshold',
+                Logger::ALERT,
+                "Cannot alter table {tableName}. Its count of {rowCount,number} is past the {rowThreshold,number} threshold.",
+                [
+                    'tableName' => $this->tableName(),
+                    'rowCount' => $this->getRowCountEstimate($this->tableName()),
+                    'rowThreshold' => $this->getAlterTableThreshold(),
+                    'alterSql' => $sql
+                ]
+            );
             return true;
         } else {
-            $Result = $this->Database->query($Sql);
+            $Result = $this->Database->query($sql);
             return $Result;
         }
     }


### PR DESCRIPTION
Add an optional alter table row threshold which represents the maximum number of rows a table is allowed to have for an in-application alter to be allowed to run. If a table is too large then the admin is expected to copy the SQL from the structure endpoint into their RDBMS.

By default this threshold is turned off, but may be turned on by config.