### PR TITLE
Allow all quotes to be collapsed.

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -12,7 +12,7 @@
 $PluginInfo['Quotes'] = array(
     'Name' => 'Quotes',
     'Description' => "Adds an option to each comment for users to easily quote each other.",
-    'Version' => '1.7',
+    'Version' => '1.8',
     'MobileFriendly' => true,
     'RequiredApplications' => array('Vanilla' => '2.1'),
     'HasLocale' => true,

--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -29,7 +29,7 @@ Gdn_Quotes.prototype.Prepare = function () {
     QuoteFoldingLevel = gdn.definition('QuotesFolding', 1);
 
     function folding() {
-        $('.Comment .Message').each(function () {
+        $('.Discussion .Message, .Comment .Message').each(function () {
             // Find the closest child quote
             var Message = $(this),
                 PetQuote = Message.children('.Quote, .UserQuote');

--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -32,7 +32,7 @@ Gdn_Quotes.prototype.Prepare = function () {
         $('.Comment .Message').each(function () {
             // Find the closest child quote
             var Message = $(this),
-                PetQuote = Message.children('.UserQuote');
+                PetQuote = Message.children('.Quote, .UserQuote');
 
             if (Message.data('QuoteFolding') || !PetQuote.length) {
                 return;
@@ -54,7 +54,7 @@ Gdn_Quotes.prototype.Prepare = function () {
             var Anchor = $(this),
                 QuoteTarget = Anchor
                     .closest('.QuoteText')
-                    .children('.UserQuote')
+                    .children('.Quote, .UserQuote')
                     .toggle();
 
             if (QuoteTarget.css('display') != 'none') {
@@ -69,7 +69,7 @@ Gdn_Quotes.prototype.Prepare = function () {
 };
 
 
-// Recursively tranform folded quotes.
+// Recursively transform folded quotes.
 Gdn_Quotes.prototype.ExploreFold = function(QuoteTree, FoldingLevel, MaxLevel, TargetLevel) {
     if (FoldingLevel > MaxLevel || FoldingLevel > TargetLevel) {
         return;
@@ -92,7 +92,7 @@ Gdn_Quotes.prototype.ExploreFold = function(QuoteTree, FoldingLevel, MaxLevel, T
             return;
         }
 
-        FoldQuote = ExamineQuote.children('.QuoteText').children('.UserQuote');
+        FoldQuote = ExamineQuote.children('.QuoteText').children('.Quote, .UserQuote');
         if (!FoldQuote.length) {
             return;
         }


### PR DESCRIPTION
There are some inconsistencies about the quotes markup.
You can have "Quote", "Quote UserQuote", "UserQuote".

This PR aim at making all quotes being able to be collapsed.
There is also the possibility of quotes inside a discussion that was not covered before this PR.

Before merging this PR it may be wise to raise an issue about the quotes' inconsistencies in order to fix the source of the problem. 
Something like [this PR](https://github.com/vanilla/vanilla/pull/3606) could be done