### PR TITLE
Update how user bans attributes are managed

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -739,11 +739,13 @@ class UserController extends DashboardController {
 
                 $Banned = $this->Form->getFormValue('Banned');
                 if (!$Banned) {
+                    // Checkbox was unchecked; bitmask to remove any reversible bans.
                     if ($BanReversible) {
                         $reversedBans = ($User['Banned'] & (~(BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL)));
                         $this->Form->setFormValue('Banned', $reversedBans);
                     }
                 } else {
+                    // Bitmask to add a manual ban.
                     $this->Form->setFormValue('Banned', $User['Banned'] | 0x1);
                 }
 

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -738,11 +738,10 @@ class UserController extends DashboardController {
 
                 $Banned = $this->Form->getFormValue('Banned');
                 if (!$Banned) {
-                    if ($User['Banned'] & (BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL)) {
-                        $this->Form->setFormValue(
-                            'Banned',
-                            ($User['Banned'] & (~(BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL)))
-                        );
+                    $hasReversibleBans = ($User['Banned'] & (BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL));
+                    if ($hasReversibleBans) {
+                        $reversedBans = ($User['Banned'] & (~(BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL)));
+                        $this->Form->setFormValue( 'Banned', $reversedBans);
                     }
                 } else {
                     $this->Form->setFormValue(

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -746,7 +746,7 @@ class UserController extends DashboardController {
                     }
                 } else {
                     // Bitmask to add a manual ban.
-                    $this->Form->setFormValue('Banned', $User['Banned'] | 0x1);
+                    $this->Form->setFormValue('Banned', $User['Banned'] | BanModel::BAN_MANUAL);
                 }
 
                 if ($this->Form->save(array('SaveRoles' => true)) !== false) {

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -681,6 +681,7 @@ class UserController extends DashboardController {
 
             $this->fireEvent("BeforeUserEdit");
             $this->setData('AllowEditing', $AllowEditing);
+
             $BanReversible = $User['Banned'] & (BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL);
             $this->setData('BanFlag', $BanReversible ? $User['Banned'] : 1);
             $this->setData('BannedOtherReasons', $User['Banned'] & ~BanModel::BAN_MANUAL);
@@ -738,16 +739,12 @@ class UserController extends DashboardController {
 
                 $Banned = $this->Form->getFormValue('Banned');
                 if (!$Banned) {
-                    $hasReversibleBans = ($User['Banned'] & (BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL));
-                    if ($hasReversibleBans) {
+                    if ($BanReversible) {
                         $reversedBans = ($User['Banned'] & (~(BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL)));
-                        $this->Form->setFormValue( 'Banned', $reversedBans);
+                        $this->Form->setFormValue('Banned', $reversedBans);
                     }
                 } else {
-                    $this->Form->setFormValue(
-                        'Banned',
-                        $User['Banned'] | 0x1
-                    );
+                    $this->Form->setFormValue('Banned', $User['Banned'] | 0x1);
                 }
 
                 if ($this->Form->save(array('SaveRoles' => true)) !== false) {

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -337,7 +337,7 @@ class RoleModel extends Gdn_Model {
      * @param int The UserID to filter to.
      * @return Gdn_DataSet
      */
-    public function  getByUserID($UserID) {
+    public function getByUserID($UserID) {
         return $this->SQL->select()
             ->from('Role')
             ->join('UserRole', 'Role.RoleID = UserRole.RoleID')

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -337,7 +337,7 @@ class RoleModel extends Gdn_Model {
      * @param int The UserID to filter to.
      * @return Gdn_DataSet
      */
-    public function getByUserID($UserID) {
+    public function  getByUserID($UserID) {
         return $this->SQL->select()
             ->from('Role')
             ->join('UserRole', 'Role.RoleID = UserRole.RoleID')

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -509,12 +509,12 @@ class UserModel extends Gdn_Model {
         }
 
         $Banned = $User['Banned'];
-        if (!BanModel::isBanned($Banned, BanModel::BAN_MANUAL)) {
+        if (!BanModel::isBanned($Banned, BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL)) {
             throw new Gdn_UserException(t("The user isn't banned.", "The user isn't banned or is banned by some other function."));
         }
 
         // Unban the user.
-        $NewBanned = BanModel::setBanned($Banned, false, BanModel::BAN_MANUAL);
+        $NewBanned = BanModel::setBanned($Banned, false, BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL);
         $this->setField($UserID, 'Banned', $NewBanned);
 
         // Restore the user's content.
@@ -1946,7 +1946,7 @@ class UserModel extends Gdn_Model {
         }
 
         if (array_key_exists('Banned', $FormPostValues)) {
-            $FormPostValues['Banned'] = forceBool($FormPostValues['Banned'], '0', '1', '0');
+            $FormPostValues['Banned'] = intval($FormPostValues['Banned']);
         }
 
         if (array_key_exists('Confirmed', $FormPostValues)) {

--- a/applications/dashboard/modules/class.profileoptionsmodule.php
+++ b/applications/dashboard/modules/class.profileoptionsmodule.php
@@ -40,7 +40,7 @@ class ProfileOptionsModule extends Gdn_Module {
             // Ban/Unban
             $MayBan = checkPermission('Garden.Moderation.Manage') || checkPermission('Garden.Users.Edit') || checkPermission('Moderation.Users.Ban');
             if ($MayBan && $UserID != $Session->UserID) {
-                if (BanModel::isBanned($Controller->User->Banned, BanModel::BAN_MANUAL)) {
+                if (BanModel::isBanned($Controller->User->Banned, BanModel::BAN_AUTOMATIC | BanModel::BAN_MANUAL)) {
                     $ProfileOptions[] = array('Text' => sprite('SpBan').' '.t('Unban'), 'Url' => "/user/ban?userid=$UserID&unban=1", 'CssClass' => 'Popup');
                 } elseif (!$Controller->User->Admin) {
                     $ProfileOptions[] = array('Text' => sprite('SpBan').' '.t('Ban'), 'Url' => "/user/ban?userid=$UserID", 'CssClass' => 'Popup');

--- a/applications/dashboard/views/user/edit.php
+++ b/applications/dashboard/views/user/edit.php
@@ -53,9 +53,13 @@ if ($this->data('AllowEditing')) { ?>
             ?>
         </li>
         <li>
-            <?php
-            echo $this->Form->CheckBox('Banned', t('Banned'), array('value' => '1'));
-            ?>
+            <?php echo $this->Form->CheckBox('Banned', t('Banned'), array('value' => $this->data('BanFlag'))); ?>
+            <?php if ($this->data('BannedOtherReasons')): ?>
+            <div class="WarningMessage"><?echo t(
+                    'This user is also banned for other reasons and may stay banned.',
+                    'This user is also banned for other reasons and may stay banned or become banned again.'
+                )?></div>
+            <?php endif; ?>
         </li>
         <?php
         $this->fireEvent('CustomUserFields')

--- a/applications/dashboard/views/user/unban.php
+++ b/applications/dashboard/views/user/unban.php
@@ -11,7 +11,10 @@
         echo formatString(t('You are about to unban {User.UserID,user}.'), $this->Data);
 
         if ($this->data('OtherReasons')) {
-            echo "\n".t('This user is also banned for other reasons and may stay banned.');
+            echo "\n".t(
+                    'This user is also banned for other reasons and may stay banned.',
+                    'This user is also banned for other reasons and may stay banned or become banned again.'
+                );
         }
         ?>
     </div>


### PR DESCRIPTION
There's currently no way to manually remove an automatic ban from a user, such as those applied by ban rules.  This update adds the ability to detect and remove automatic bans from the user, based on bitmask comparisons of their ban flag.  The flags are similarly updated with bitmasks to allow plug-in based rules to remain in place.  A notification messages is displayed when viewing a banned user if the ban may persist or reappear.

This update also addresses two other issues in Vanilla:

1. `UserModel::save` will no longer force a boolean value for the `Banned` field.  Any integer value can be used.
2. `UserController::ban` was using an incorrect bit flag when checking for the type of ban.

Closes #3424