### PR TITLE
Remove js concat functionality from Grunt workflow.

### DIFF
--- a/applications/dashboard/Gruntfile.js
+++ b/applications/dashboard/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function (grunt) {
             }
             , js: {
                 files: ['js/src/**/*.js']
-                , tasks: ['jshint', 'concat']
+                , tasks: ['jshint']
             }
             , gruntfile: {
                 files: ['Gruntfile.js']
@@ -99,15 +99,6 @@ module.exports = function (grunt) {
                    ,'design/style.css']
         },
 
-        concat: {
-            dist: {
-                src: (dependencies.js || []).concat([
-                    'js/src/main.js'
-                ])
-                , dest: 'js/dashboard.js'
-            }
-        },
-
         imagemin: {
             dist: {
                 files: [{
@@ -132,7 +123,6 @@ module.exports = function (grunt) {
         , 'scsslint'
         , 'sass'
         , 'autoprefixer'
-        , 'concat'
         , 'jshint'
         , 'csslint'
         , 'imagemin'

--- a/applications/dashboard/package.json
+++ b/applications/dashboard/package.json
@@ -6,7 +6,6 @@
     "grunt": "0.4.x",
     "grunt-autoprefixer": "3.0.x",
     "grunt-cli": "0.1.x",
-    "grunt-contrib-concat": "0.5.x",
     "grunt-contrib-csslint": "0.5.x",
     "grunt-contrib-imagemin": "1.0.x",
     "grunt-contrib-jshint": "0.11.x",


### PR DESCRIPTION
We can add it back in if we ever need it. Saves us some hassle in the meantime.