### PR TITLE
make category all view's count elements consistent with other views

### DIFF
--- a/applications/vanilla/views/categories/all.php
+++ b/applications/vanilla/views/categories/all.php
@@ -68,8 +68,12 @@ foreach ($this->data('Categories') as $CategoryRow) {
                 .'</div>
                   <div class="Meta">
                      <span class="MItem RSS">'.anchor(img('applications/dashboard/design/images/rss.gif', array('alt' => T('RSS Feed'))), '/categories/'.$Category->UrlCode.'/feed.rss', '', array('title' => T('RSS Feed'))).'</span>
-                     <span class="MItem DiscussionCount">'.sprintf(Plural(number_format($Category->CountAllDiscussions), '%s discussion', '%s discussions'), $Category->CountDiscussions).'</span>
-                     <span class="MItem CommentCount">'.sprintf(Plural(number_format($Category->CountAllComments), '%s comment', '%s comments'), $Category->CountComments).'</span>';
+                     <span class="MItem DiscussionCount">'.
+                     sprintf(PluralTranslate($Category->CountDiscussions, '%s discussion html', '%s discussions html', t('%s discussion'), t('%s discussions')), BigPlural($Category->CountDiscussions, '%s discussion'))
+                     .'</span>
+                     <span class="MItem CommentCount">'.
+                     sprintf(PluralTranslate($Category->CountComments, '%s comment html', '%s comments html', t('%s comment'), t('%s comments')), BigPlural($Category->CountComments, '%s comment'))
+                     .'</span>';
             if ($Category->LastTitle != '') {
                 $CatList .= '<span class="MItem LastDiscussionTitle">'.sprintf(
                         t('Most recent: %1$s by %2$s'),


### PR DESCRIPTION
Every other view that displays comment count, discussion count, view count, etc... uses the combination of `PluralTranslate()` and `BigPlural()` to show numbers formatted as 1.2K instead of 1200. This update to category/all makes it consistent with other views, making styling more predictable for these elements. 