### PR TITLE
Support the MySQL timestamp type

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -15,7 +15,7 @@ $Configuration['Database']['Password']                         = '';
 $Configuration['Database']['ConnectionOptions']                = array(
                                                                   12    => FALSE, //PDO::ATTR_PERSISTENT => FALSE,
                                                                   1000  => TRUE,  // PDO::MYSQL_ATTR_USE_BUFFERED_QUERY is missing in some php installations
-                                                                  1002  => "set names 'utf8'" // PDO::MYSQL_ATTR_INIT_COMMAND is missing in PHP 5.3, so I use the actual value "1002" instead
+                                                                  1002  => "set names 'utf8'; set time_zone = '+0:0';" // PDO::MYSQL_ATTR_INIT_COMMAND is missing in PHP 5.3, so I use the actual value "1002" instead
                                                                );
 $Configuration['Database']['CharacterEncoding']                = 'utf8';
 $Configuration['Database']['DatabasePrefix']                    = 'GDN_';

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -83,7 +83,7 @@ class Gdn_Validation {
         $this->addRule('Decimal', 'function:ValidateDecimal');
         $this->addRule('String', 'function:ValidateString');
         $this->addRule('Time', 'function:ValidateTime');
-        $this->addRule('Timestamp', 'function:ValidateTimestamp');
+        $this->addRule('Timestamp', 'function:ValidateDate');
         $this->addRule('Length', 'function:ValidateLength');
         $this->addRule('Enum', 'function:ValidateEnum');
         $this->addRule('MinimumAge', 'function:ValidateMinimumAge');

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -486,7 +486,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
      *  - <b>all</b>: All recognized types.
      */
     public function types($Class = 'all') {
-        $Date = array('datetime', 'date');
+        $Date = array('datetime', 'date', 'timestamp');
         $Decimal = array('decimal', 'numeric');
         $Float = array('float', 'double');
         $Int = array('int', 'tinyint', 'smallint', 'mediumint', 'bigint');


### PR DESCRIPTION
The timestamp type is very close to the DateTime type, but stores dates internally in UTC which makes for easier conversion when looking at the data internally.