### PR TITLE
Make sure the cached editor Element is still in the DOM

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -84,6 +84,13 @@ if (!function_exists('writeComment')) :
         $Sender->EventArguments['CurrentOffset'] = $CurrentOffset;
         $Sender->EventArguments['Permalink'] = $Permalink;
 
+        // Needed in writeCommentOptions()
+        if (empty($Sender->data('Discussion'))) {
+            $discussionModel = new DiscussionModel();
+            $discussion = $discussionModel->getID($Comment->DiscussionID);
+            $Sender->setData('Discussion', $discussion);
+        }
+
         // DEPRECATED ARGUMENTS (as of 2.1)
         $Sender->EventArguments['Object'] = &$Comment;
         $Sender->EventArguments['Type'] = 'Comment';

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -84,13 +84,6 @@ if (!function_exists('writeComment')) :
         $Sender->EventArguments['CurrentOffset'] = $CurrentOffset;
         $Sender->EventArguments['Permalink'] = $Permalink;
 
-        // Needed in writeCommentOptions()
-        if (empty($Sender->data('Discussion'))) {
-            $discussionModel = new DiscussionModel();
-            $discussion = $discussionModel->getID($Comment->DiscussionID);
-            $Sender->setData('Discussion', $discussion);
-        }
-
         // DEPRECATED ARGUMENTS (as of 2.1)
         $Sender->EventArguments['Object'] = &$Comment;
         $Sender->EventArguments['Type'] = 'Comment';

--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -105,7 +105,7 @@ Gdn_Quotes.prototype.ExploreFold = function(QuoteTree, FoldingLevel, MaxLevel, T
 // Get the currently active editor (last in focus).
 Gdn_Quotes.prototype.GetEditor = function () {
     var editor = $(this.currentEditor);
-    if (!editor.length) {
+    if (!document.contains(this.currentEditor) || !editor.length) {
         editor = $('textarea.TextBox').first();
     }
 


### PR DESCRIPTION
... before returning it.

After a post edit the editor is sometime refreshed. Let's make sure we have the correct editor in hand before returning it!