### PR TITLE
Add Discussion to $sender's data if it is not set already

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -85,7 +85,7 @@ if (!function_exists('writeComment')) :
         $Sender->EventArguments['Permalink'] = $Permalink;
 
         // Needed in writeCommentOptions()
-        if ($Sender->data('Discussion', null) === null) {
+        if (empty($Sender->data('Discussion'))) {
             $discussionModel = new DiscussionModel();
             $discussion = $discussionModel->getID($Comment->DiscussionID);
             $Sender->setData('Discussion', $discussion);

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -85,7 +85,7 @@ if (!function_exists('writeComment')) :
         $Sender->EventArguments['Permalink'] = $Permalink;
 
         // Needed in writeCommentOptions()
-        if (empty($Sender->data('Discussion'))) {
+        if ($Sender->data('Discussion', null) === null) {
             $discussionModel = new DiscussionModel();
             $discussion = $discussionModel->getID($Comment->DiscussionID);
             $Sender->setData('Discussion', $discussion);

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -84,6 +84,13 @@ if (!function_exists('writeComment')) :
         $Sender->EventArguments['CurrentOffset'] = $CurrentOffset;
         $Sender->EventArguments['Permalink'] = $Permalink;
 
+        // Needed in writeCommentOptions()
+        if (empty($Sender->data('Discussion'))) {
+            $discussionModel = new DiscussionModel();
+            $discussion = $discussionModel->getID($Comment->DiscussionID);
+            $Sender->setData('Discussion', $discussion);
+        }
+
         // DEPRECATED ARGUMENTS (as of 2.1)
         $Sender->EventArguments['Object'] = &$Comment;
         $Sender->EventArguments['Type'] = 'Comment';

--- a/plugins/adobe
+++ b/plugins/adobe
@@ -1,1 +1,0 @@
-../../adobe/plugins/adobe/

--- a/plugins/adobe
+++ b/plugins/adobe
@@ -1,0 +1,1 @@
+../../adobe/plugins/adobe/


### PR DESCRIPTION
`getCommentOptions()` use `Gdn::controller()->data('Discussion');` to ultimately check if an user can delete it's own comment. This "data" is not set in the post controller which cause the delete option not to appear in the dropdown.