### PR TITLE
Render BBCode-style spoilers in non-BBCode posts.

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1019,7 +1019,7 @@ class Gdn_Format {
     }
 
     /**
-     * Backwards compatibility. In the Spoilers plugin, we would render BBCode-style spoilers in any format post
+     * For backwards compatibility. In the Spoilers plugin, we would render BBCode-style spoilers in any format post
      * and allow a title.
      *
      * @param string $html
@@ -1034,7 +1034,7 @@ class Gdn_Format {
 
     /**
      * Callback function replacing opening spoiler tags with an optional title.
-     * Replaces [spoiler] or [spoiler=Title] tags, where Title is the attribution.
+     * Replaces [spoiler] or [spoiler=Title] tags, where Title is included in the attribution.
      *
      * @param array $matches Matches from a regular expression.
      * @return string The html-formatted opening spoiler tag.

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -979,7 +979,9 @@ class Gdn_Format {
                 require_once(PATH_LIBRARY.'/vendors/simplehtmldom/simple_html_dom.php');
             }
             $html = str_get_html($html);
-            $html->find('.Spoiler,.UserSpoiler', 0)->outertext = t($replaceWith);
+            foreach($html->find('.Spoiler,.UserSpoiler') as $spoilerBlock) {
+                $spoilerBlock->outertext = t($replaceWith);
+            }
         }
         return $html;
     }
@@ -1010,8 +1012,10 @@ class Gdn_Format {
                 require_once(PATH_LIBRARY.'/vendors/simplehtmldom/simple_html_dom.php');
             }
             $html = str_get_html($html);
-            $spoiler = $html->find('.Spoiler', 0)->innertext;
-            $html->find('.Spoiler', 0)->outertext = spoilerWrap($spoiler);
+            foreach($html->find('.Spoiler') as $spoilerBlock) {
+                $spoiler = $spoilerBlock->innertext;
+                $spoilerBlock->outertext = spoilerWrap($spoiler);
+            }
         } elseif (strpos($html, '[spoiler') !== false) {
             $html = self::legacySpoilers($html);
         }


### PR DESCRIPTION
Fixes a backwards-compatibility issue with the Spoilers plugin rendering BBCode spoiler tags in non-BBCode format posts. Also fixes issue where only the first Spoiler in a post gets rendered properly.