### PR TITLE
Cast simple_html_dom object to a string before returning it.

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -981,8 +981,7 @@ class Gdn_Format {
             $htmlDom = str_get_html($html);
 
             foreach($htmlDom->find('.Spoiler,.UserSpoiler') as $spoilerBlock) {
-                $spoiler = $spoilerBlock->innertext;
-                $spoilerBlock->outertext = spoilerWrap($spoiler);
+                $spoilerBlock->outertext = t($replaceWith);
             }
             $html = (string)$htmlDom;
         }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -980,7 +980,7 @@ class Gdn_Format {
             }
             $htmlDom = str_get_html($html);
 
-            foreach($htmlDom->find('.Spoiler.UserSpoiler') as $spoilerBlock) {
+            foreach($htmlDom->find('.Spoiler,.UserSpoiler') as $spoilerBlock) {
                 $spoiler = $spoilerBlock->innertext;
                 $spoilerBlock->outertext = spoilerWrap($spoiler);
             }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -980,7 +980,7 @@ class Gdn_Format {
             }
             $htmlDom = str_get_html($html);
 
-            foreach($htmlDom->find('.Spoiler.UserSpoiler') as &$spoilerBlock) {
+            foreach($htmlDom->find('.Spoiler.UserSpoiler') as $spoilerBlock) {
                 $spoiler = $spoilerBlock->innertext;
                 $spoilerBlock->outertext = spoilerWrap($spoiler);
             }
@@ -1017,7 +1017,7 @@ class Gdn_Format {
             }
             $htmlDom = str_get_html($html);
 
-            foreach($htmlDom->find('.Spoiler') as &$spoilerBlock) {
+            foreach($htmlDom->find('.Spoiler') as $spoilerBlock) {
                 $spoiler = $spoilerBlock->innertext;
                 $spoilerBlock->outertext = spoilerWrap($spoiler);
             }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -978,11 +978,13 @@ class Gdn_Format {
             if (!function_exists('str_get_html')) {
                 require_once(PATH_LIBRARY.'/vendors/simplehtmldom/simple_html_dom.php');
             }
-            $dom = new simple_html_dom();
-            $html = $dom->load($html);
-            foreach($dom->find('.Spoiler,.UserSpoiler') as $spoilerBlock) {
-                $spoilerBlock->outertext = t($replaceWith);
+            $htmlDom = str_get_html($html);
+
+            foreach($htmlDom->find('.Spoiler.UserSpoiler') as &$spoilerBlock) {
+                $spoiler = $spoilerBlock->innertext;
+                $spoilerBlock->outertext = spoilerWrap($spoiler);
             }
+            $html = $htmlDom;
         }
 
         return $html;
@@ -1013,12 +1015,13 @@ class Gdn_Format {
             if (!function_exists('str_get_html')) {
                 require_once(PATH_LIBRARY.'/vendors/simplehtmldom/simple_html_dom.php');
             }
-            $htmlDom = new simple_html_dom();
-            $htmlDom->load($html);
-            foreach($htmlDom->find('.Spoiler') as $spoilerBlock) {
+            $htmlDom = str_get_html($html);
+
+            foreach($htmlDom->find('.Spoiler') as &$spoilerBlock) {
                 $spoiler = $spoilerBlock->innertext;
                 $spoilerBlock->outertext = spoilerWrap($spoiler);
             }
+            $html = $htmlDom;
         } elseif (strpos($html, '[spoiler') !== false) {
             $html = self::legacySpoilers($html);
         }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -984,7 +984,7 @@ class Gdn_Format {
                 $spoiler = $spoilerBlock->innertext;
                 $spoilerBlock->outertext = spoilerWrap($spoiler);
             }
-            $html = $htmlDom;
+            $html = (string)$htmlDom;
         }
 
         return $html;
@@ -1021,7 +1021,7 @@ class Gdn_Format {
                 $spoiler = $spoilerBlock->innertext;
                 $spoilerBlock->outertext = spoilerWrap($spoiler);
             }
-            $html = $htmlDom;
+            $html = (string)$htmlDom;
         } elseif (strpos($html, '[spoiler') !== false) {
             $html = self::legacySpoilers($html);
         }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -978,11 +978,13 @@ class Gdn_Format {
             if (!function_exists('str_get_html')) {
                 require_once(PATH_LIBRARY.'/vendors/simplehtmldom/simple_html_dom.php');
             }
-            $html = str_get_html($html);
-            foreach($html->find('.Spoiler,.UserSpoiler') as $spoilerBlock) {
+            $dom = new simple_html_dom();
+            $html = $dom->load($html);
+            foreach($dom->find('.Spoiler,.UserSpoiler') as $spoilerBlock) {
                 $spoilerBlock->outertext = t($replaceWith);
             }
         }
+
         return $html;
     }
 
@@ -1011,8 +1013,9 @@ class Gdn_Format {
             if (!function_exists('str_get_html')) {
                 require_once(PATH_LIBRARY.'/vendors/simplehtmldom/simple_html_dom.php');
             }
-            $html = str_get_html($html);
-            foreach($html->find('.Spoiler') as $spoilerBlock) {
+            $htmlDom = new simple_html_dom();
+            $htmlDom->load($html);
+            foreach($htmlDom->find('.Spoiler') as $spoilerBlock) {
                 $spoiler = $spoilerBlock->innertext;
                 $spoilerBlock->outertext = spoilerWrap($spoiler);
             }


### PR DESCRIPTION
Fixes issue where spoilers destroy search results.