### PR TITLE
Update discussionOptionsToDropdown return value

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -183,18 +183,19 @@ if (!function_exists('discussionOptionsToDropdown')):
     /**
      * @param array $options
      * @param DropdownModule|null $dropdown
-     * @return DropdownModule|null|void
+     * @return DropdownModule
      */
     function discussionOptionsToDropdown($options, $dropdown = null) {
-        if (empty($options)) {
-            return;
-        }
         if (is_null($dropdown)) {
             $dropdown = new DropdownModule();
         }
-        foreach ($options as $option) {
-            $dropdown->addLink(val('Label', $option), val('Url', $option), slugify(val('Label', $option)), val('Class', $option));
+
+        if (!empty($options)) {
+            foreach ($options as $option) {
+                $dropdown->addLink(val('Label', $option), val('Url', $option), slugify(val('Label', $option)), val('Class', $option));
+            }
         }
+
         return $dropdown;
     }
 endif;


### PR DESCRIPTION
Currently, if an empty `$options` array is passed to `discussionOptionsToDropdown` (as is possible in `getDiscussionOptionsDropdown`), an empty value is returned.  This can potentially overwrite the original `DropdownModule` module and break menus on the site.

This tweaks the logic of `discussionOptionsToDropdown` to always return a `DropdownModule` instance.