### PR TITLE
Misspelled fetchPageInfo Fix.

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1342,7 +1342,7 @@ class DiscussionModel extends VanillaModel {
     }
 
     public function fetchPageInfo($Url, $ThrowError = false) {
-        $PageInfo = FetchPageInfo($Url, 3, $ThrowError);
+        $PageInfo = fetchPageInfo($Url, 3, $ThrowError);
 
         $Title = val('Title', $PageInfo, '');
         if ($Title == '') {


### PR DESCRIPTION
fetchPageInfo  - global function defined  in /library/core/functions.general.php - its purpose to content of html page specified by URL parameter.
For some reason it's name is misspeled as FetchPageInfo - that's why in vanilla comments integration blog posts doesn't get right content and title. In my case i think