### PR TITLE
Fixed misspeled fetchPageInfo

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -426,7 +426,7 @@ class PostController extends VanillaController {
             $this->Form->addHidden('vanilla_url', $vanilla_url);
             $this->Form->addHidden('vanilla_category_id', $vanilla_category_id);
 
-            $PageInfo = FetchPageInfo($vanilla_url);
+            $PageInfo = fetchPageInfo($vanilla_url);
 
             if (!($Title = $this->Form->getFormValue('Name'))) {
                 $Title = val('Title', $PageInfo, '');


### PR DESCRIPTION
fetchPageInfo  - global function defined  in /library/core/functions.general.php - its purpose to content of html page specified by URL parameter.
For some reason it's name is misspeled as FetchPageInfo - that's why in vanilla comments integration blog posts doesn't get right content and title. In my case i think