### PR TITLE
Update Gdn_UploadImage to constant PNG compression

### DIFF
--- a/library/core/class.uploadimage.php
+++ b/library/core/class.uploadimage.php
@@ -16,6 +16,11 @@
 class Gdn_UploadImage extends Gdn_Upload {
 
     /**
+     * Compression level (0-9) for PNGs.
+     */
+    const PNG_COMPRESSION = 9;
+
+    /**
      * Check that we have the necessary tools to allow image uploading.
      *
      * @return bool
@@ -289,7 +294,7 @@ class Gdn_UploadImage extends Gdn_Upload {
             if ($OutputType == 'gif') {
                 imagegif($TargetImage, $TargetPath);
             } elseif ($OutputType == 'png') {
-                imagepng($TargetImage, $TargetPath, 10 - (int)($ImageQuality / 10));
+                imagepng($TargetImage, $TargetPath, Gdn_UploadImage::PNG_COMPRESSION);
             } elseif ($OutputType == 'ico') {
                 self::imageIco($TargetImage, $TargetPath);
             } else {


### PR DESCRIPTION
The default for PNG compression was set to 0, which is *no* compression.  This was causing PNGs to be tremendously large.

This restores compression to PNGs.  The format is lossless, so this should not affect their image quality.