### PR TITLE
Add the “Dir” and “IconUrl” keys to plugin info and use them

### DIFF
--- a/applications/dashboard/views/settings/plugins.php
+++ b/applications/dashboard/views/settings/plugins.php
@@ -82,9 +82,12 @@ $DisabledCount = $PluginCount - $EnabledCount;
             $NewVersion = val('NewVersion', $PluginInfo, '');
             $Upgrade = $NewVersion != '' && version_compare($NewVersion, $Version, '>');
             $RowClass = $Css;
-            if ($Alt) $RowClass .= ' Alt';
-            $IconPath = '/plugins/'.GetValue('Folder', $PluginInfo, '').'/icon.png';
-            $IconPath = file_exists(PATH_ROOT.$IconPath) ? $IconPath : 'applications/dashboard/design/images/plugin-icon.png';
+            if ($Alt) {
+                $RowClass .= ' Alt';
+            }
+
+            $IconPath = val('IconUrl', $PluginInfo, '/applications/dashboard/design/images/plugin-icon.png');
+
             ?>
             <tr <?php echo 'id="'.Gdn_Format::url(strtolower($PluginName)).'-plugin"', ' class="More '.$RowClass.'"'; ?>>
                 <td rowspan="2" class="Less"><?php echo img($IconPath, array('class' => 'PluginIcon')); ?></td>

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -350,6 +350,13 @@ class Gdn_PluginManager extends Gdn_Pluggable {
             $SearchPluginInfo['RealFile'] = $RealPluginFile;
             $SearchPluginInfo['RealRoot'] = dirname($RealPluginFile);
             $SearchPluginInfo['SearchPath'] = $SearchPath;
+            $SearchPluginInfo['Dir'] = "/plugins/$PluginFolderName";
+
+            $iconUrl = $SearchPluginInfo['Dir'].'/'.val('Icon', $SearchPluginInfo, 'icon.png');
+            if (file_exists(PATH_ROOT.$iconUrl)) {
+                $SearchPluginInfo['IconUrl'] = $iconUrl;
+            }
+
             $PluginInfo[$PluginFolderName] = $SearchPluginInfo;
 
             $PluginClassName = val('ClassName', $SearchPluginInfo);


### PR DESCRIPTION
The “Dir” key defines the application root relative directory of the plugin. This is useful to build both file paths and URLs for the plugin’s assets. The “IconUrl” key defines the application root relative path of the plugin’s icon, if any, and can be passed right to asset().

These two keys will be standardized across all addons.