### PR TITLE
Make the library class map subdirectories explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
 	},
 	"autoload": {
 		"classmap": [
-			"library/"
+			"library/core/",
+			"library/database/",
+			"library/setup/",
+			"library/vendors/"
 		],
 		"files": [
 			"library/core/functions.error.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2c673bdfd531550caee5493ce0859da8",
+    "hash": "e21f678d20055c81d42146c61f83f92b",
     "content-hash": "107049c1fc4107be95224e2829ecf176",
     "packages": [
         {


### PR DESCRIPTION
We will be adding some PSR-4 namespaced autoloading into the library directory so the class map needs to be more explicit so as not to scan everything when it comes.