### PR TITLE
Address At.js Issues

### DIFF
--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -559,19 +559,31 @@
       };
 
       Controller.prototype.content = function() {
+        var result = {
+          content: null,
+          offset: 0
+        };
+
         if (this.$inputor.is('textarea, input')) {
-          return this.$inputor.val();
+          result.content = this.$inputor.val();
         } else {
-          return this.$inputor.text();
+          var textNode = $(document.createElement('div'));
+          var html = this.$inputor.html();
+          var breaks = /<br(\s+)?(\/)?>/;
+          result.offset = html.match(breaks) ? html.match(breaks).length : 0;
+          textNode.html(html.replace(breaks, " "));
+          result.content = textNode.text();
         }
+
+        return result;
       };
 
       Controller.prototype.catch_query = function() {
-        var caret_pos, content, end, query, start, subtext;
-        content = this.content();
+        var caret_pos, contents, end, query, start, subtext;
+        contents = this.content();
         ////caret_pos = this.$inputor.caret('pos');
-        caret_pos = this.$inputor.caret('pos', this.setting.cWindow);
-        subtext = content.slice(0, caret_pos);
+        caret_pos = this.$inputor.caret('pos', this.setting.cWindow) + contents.offset;
+        subtext = contents.content.slice(0, caret_pos);
         query = this.callbacks("matcher").call(this, this.at, subtext, this.get_opt('start_with_space'));
         if (typeof query === "string" && query.length <= this.get_opt('max_len', 20)) {
           start = caret_pos - query.length;

--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -704,6 +704,7 @@
           range.setStart(range.endContainer, Math.max(pos, 0));
           range.setEnd(range.endContainer, range.endOffset);
           range.deleteContents();
+          range.insertNode(document.createTextNode('\ufeff'));
           range.insertNode($insert_node[0]);
           range.collapse(false);
 

--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -704,8 +704,8 @@
           range.setStart(range.endContainer, Math.max(pos, 0));
           range.setEnd(range.endContainer, range.endOffset);
           range.deleteContents();
-          range.insertNode(document.createTextNode('\ufeff'));
-          range.insertNode($insert_node[0]);
+          range.insertNode(document.createTextNode(content + " "));
+          //range.insertNode($insert_node[0]);
           range.collapse(false);
 
           ////sel = window.getSelection();


### PR DESCRIPTION
At.js currently has some problems, particularly with WYSIWYG mode.

1. When grabbing the text from a WYSIWYG editor, multiple lines are concatenated into one with no separator, before the pattern matching is done.  This means if you want to start a line with a mention, it's a no-go, because the mention character ends up in the middle of two "words" (e.g. Hello world@vanilla is my name.)
2. After a mention is inserted, the caret/cursor remains inside the mention markup, at least on Webkit-based browsers ([see this similar tale of woe](http://miles-by-motorcycle.com/fv-b-8-665/you-can---t-select-that-----webkit-browser-selections-and-ranges-in-chrome-and-safari)).  The `span` element containing the username also ends up containing all text that follows, even additional mentions. (e.g. How are you `@System`? And how about you `@vanilla`? becomes `How are you <span class="vanilla-mention-@">@System? And how about you <span class="vanilla-mention-@">@vanilla</span></span>`)