### PR TITLE
Prevent messages from being displayed when you do not have view permission

### DIFF
--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -141,6 +141,12 @@ class MessageModel extends Gdn_Model {
             $Prefs[] = 0;
         }
 
+        $category = null;
+        if ($CategoryID !== null) {
+            $categoryModel = new CategoryModel();
+            $category = $categoryModel->getID($CategoryID, DATASET_TYPE_ARRAY);
+        }
+
         $Exceptions = array_map('strtolower', $Exceptions);
 
         list($Application, $Controller, $Method) = explode('/', strtolower($Location));
@@ -162,12 +168,12 @@ class MessageModel extends Gdn_Model {
 
                 if (in_array($MController, $Exceptions)) {
                     $Visible = true;
-                } elseif ($MApplication == $Application && $MController == $Controller && $MMethod == $Method)
+                } elseif ($MApplication == $Application && $MController == $Controller && $MMethod == $Method) {
                     $Visible = true;
-
-                if ($Visible && !self::inCategory($CategoryID, val('CategoryID', $Message), val('IncludeSubcategories', $Message))) {
-                    $Visible = false;
                 }
+
+                $Visible = $Visible && self::inCategory($CategoryID, val('CategoryID', $Message), val('IncludeSubcategories', $Message));
+                $Visible = $Visible && $Session->checkPermission('Vanilla.Discussions.View', true, 'Category', $category['PermissionCategoryID']);
 
                 if ($Visible) {
                     $Result[] = $Message;
@@ -193,8 +199,11 @@ class MessageModel extends Gdn_Model {
             ->orderBy('Sort', 'asc')
             ->get()->resultArray();
 
-        $Result = array_filter($Result, function ($Message) use ($CategoryID) {
-            return MessageModel::inCategory($CategoryID, val('CategoryID', $Message), val('IncludeSubcategories', $Message));
+        $Result = array_filter($Result, function ($Message) use ($Session, $category) {
+            $isInCategory = MessageModel::inCategory(val('CategoryID', $category, null), val('CategoryID', $Message), val('IncludeSubcategories', $Message));
+            $visible = $isInCategory && $Session->checkPermission('Vanilla.Discussions.View', true, 'Category', $category['PermissionCategoryID']);
+
+            return $visible;
         });
 
         return $Result;

--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -142,7 +142,7 @@ class MessageModel extends Gdn_Model {
         }
 
         $category = null;
-        if ($CategoryID !== null) {
+        if (!empty($CategoryID)) {
             $categoryModel = new CategoryModel();
             $category = $categoryModel->getID($CategoryID, DATASET_TYPE_ARRAY);
         }
@@ -173,7 +173,9 @@ class MessageModel extends Gdn_Model {
                 }
 
                 $Visible = $Visible && self::inCategory($CategoryID, val('CategoryID', $Message), val('IncludeSubcategories', $Message));
-                $Visible = $Visible && $Session->checkPermission('Vanilla.Discussions.View', true, 'Category', $category['PermissionCategoryID']);
+                if ($category !== null) {
+                    $Visible = $Visible && $Session->checkPermission('Vanilla.Discussions.View', true, 'Category', $category['PermissionCategoryID']);
+                }
 
                 if ($Visible) {
                     $Result[] = $Message;
@@ -200,9 +202,10 @@ class MessageModel extends Gdn_Model {
             ->get()->resultArray();
 
         $Result = array_filter($Result, function ($Message) use ($Session, $category) {
-            $isInCategory = MessageModel::inCategory(val('CategoryID', $category, null), val('CategoryID', $Message), val('IncludeSubcategories', $Message));
-            $visible = $isInCategory && $Session->checkPermission('Vanilla.Discussions.View', true, 'Category', $category['PermissionCategoryID']);
-
+            $visible = MessageModel::inCategory(val('CategoryID', $category, null), val('CategoryID', $Message), val('IncludeSubcategories', $Message));
+            if ($category !== null) {
+                $visible = $visible && $Session->checkPermission('Vanilla.Discussions.View', true, 'Category', $category['PermissionCategoryID']);
+            }
             return $visible;
         });
 


### PR DESCRIPTION
Do not display messages in the categories  you do not have the Vanilla.Discussions.View permission.