### PR TITLE
Unify empty state messages

### DIFF
--- a/applications/dashboard/views/activity/popin.php
+++ b/applications/dashboard/views/activity/popin.php
@@ -33,6 +33,6 @@
             ?>
         </li>
     <?php else: ?>
-        <li class="Item Empty Center"><?php echo t('You do not have any notifications yet.'); ?></li>
+        <li class="Item Empty Center"><?php echo sprintf(t('You do not have any %s yet.'), t('notifications')); ?></li>
     <?php endif; ?>
 </ul>

--- a/applications/dashboard/views/profile/notifications.php
+++ b/applications/dashboard/views/profile/notifications.php
@@ -10,7 +10,7 @@ if (count($this->data('Activities'))) {
     echo PagerModule::write(array('CurrentRecords' => count($this->data('Activities'))));
 } else {
     ?>
-    <div class="Empty"><?php echo t('You do not have any notifications yet.'); ?></div>
+    <div class="Empty"><?php echo sprintf(t('You do not have any %s yet.'), t('notifications')); ?></div>
 <?php
 }
 echo '</div>';

--- a/applications/vanilla/views/drafts/index.php
+++ b/applications/vanilla/views/drafts/index.php
@@ -19,6 +19,6 @@ if ($this->DraftData->numRows() > 0) {
     echo $this->Pager->toString('more');
 } else {
     ?>
-    <div class="Empty"><?php echo t('You do not have any drafts.'); ?></div>
+    <div class="Empty"><?php echo sprintf(t('You do not have any %s yet.'), t('drafts')); ?></div>
 <?php
 }


### PR DESCRIPTION
We already have two uses of

     sprintf(t('You do not have any %s yet.'), t('messages'));
and one of 

     sprintf(t('You do not have any %s yet.'), t('bookmarks'));

This brings the other uses of empty state message into compliance with that format, eliminating 2 translations.