### PR TITLE
Allow column case changes

### DIFF
--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -474,7 +474,8 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         // Returns an array of schema data objects for each field in the specified
         // table. The returned array of objects contains the following properties:
         // Name, PrimaryKey, Type, AllowNull, Default, Length, Enum.
-        $ExistingColumns = $this->existingColumns();
+        $existingColumns = array_change_key_case($this->existingColumns());
+        $columns = array_change_key_case($this->_Columns);
         $AlterSql = array();
 
         // 1. Remove any unnecessary columns if this is an explicit modification
@@ -482,9 +483,9 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
             // array_diff returns values from the first array that aren't present
             // in the second array. In this example, all columns currently in the
             // table that are NOT in $this->_Columns.
-            $RemoveColumns = array_diff(array_keys($ExistingColumns), array_keys($this->_Columns));
+            $RemoveColumns = array_diff(array_keys($existingColumns), array_keys($columns));
             foreach ($RemoveColumns as $Column) {
-                $AlterSql[] = "drop column `$Column`";
+                $AlterSql[] = "drop column `{$columns[$Column]}`";
             }
         }
 
@@ -528,33 +529,28 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         // the second array. In this example, all columns in $this->_Columns that
         // are NOT in the table.
         $PrevColumnName = false;
-        foreach ($this->_Columns as $ColumnName => $Column) {
-            if (!array_key_exists($ColumnName, $ExistingColumns)) {
+        foreach ($columns as $columnKey => $Column) {
+            $ColumnName = val('Name', $Column);
+            if (!array_key_exists($columnKey, $existingColumns)) {
                 // This column name is not in the existing column collection, so add the column
-                $AddColumnSql = 'add '.$this->_defineColumn(val($ColumnName, $this->_Columns));
+                $AddColumnSql = 'add '.$this->_defineColumn($Column);
                 if ($PrevColumnName !== false) {
                     $AddColumnSql .= " after `$PrevColumnName`";
                 }
 
                 $AlterSql[] = $AddColumnSql;
 
-//            if (!$this->Query($AlterSqlPrefix.$AddColumnSql))
-//               throw new Exception(sprintf(T('Failed to add the `%1$s` column to the `%1$s` table.'), $Column, $this->_DatabasePrefix.$this->_TableName));
             } else {
-                $ExistingColumn = $ExistingColumns[$ColumnName];
+                $ExistingColumn = $existingColumns[$columnKey];
 
                 $ExistingColumnDef = $this->_defineColumn($ExistingColumn);
                 $ColumnDef = $this->_defineColumn($Column);
-                $Comment = "/* Existing: $ExistingColumnDef, New: $ColumnDef */\n";
+                $Comment = "-- Existing: $ExistingColumnDef, New: $ColumnDef";
 
-                if ($ExistingColumnDef != $ColumnDef) {  //$Column->Type != $ExistingColumn->Type || $Column->AllowNull != $ExistingColumn->AllowNull || ($Column->Length != $ExistingColumn->Length && !in_array($Column->Type, array('tinyint', 'smallint', 'int', 'bigint', 'float', 'double')))) {
+                if ($ExistingColumnDef !== $ColumnDef) {
                     // The existing & new column types do not match, so modify the column.
-                    $ChangeSql = $Comment.'change `'.$ColumnName.'` '.$this->_defineColumn(val($ColumnName, $this->_Columns));
+                    $ChangeSql = "$Comment\nchange `{$ExistingColumn->Name}` $ColumnDef";
                     $AlterSql[] = $ChangeSql;
-//					if (!$this->Query($AlterSqlPrefix.$ChangeSql))
-//						throw new Exception(sprintf(T('Failed to modify the data type of the `%1$s` column on the `%2$s` table.'),
-//                     $ColumnName,
-//                     $this->_DatabasePrefix.$this->_TableName));
 
                     // Check for a modification from an enum to an int.
                     if (strcasecmp($ExistingColumn->Type, 'enum') == 0 && in_array(strtolower($Column->Type), $this->types('int'))) {


### PR DESCRIPTION
Allows columns to be renamed when just their casing changes. Currently if you change the casing on a column then a new column will be attempted to be added when really the existing column should be changed.

To see the effect of this PR, change the casing of a column in an applications structure file and then go to /utility/structure.