### PR TITLE
Fix contains method not working on "document" node in IE

### DIFF
--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -105,7 +105,7 @@ Gdn_Quotes.prototype.ExploreFold = function(QuoteTree, FoldingLevel, MaxLevel, T
 // Get the currently active editor (last in focus).
 Gdn_Quotes.prototype.GetEditor = function () {
     var editor = $(this.currentEditor);
-    if (!document.contains(this.currentEditor) || !editor.length) {
+    if (!document.body.contains(this.currentEditor) || !editor.length) {
         editor = $('textarea.TextBox').first();
     }
 


### PR DESCRIPTION
https://developer.mozilla.org/en/docs/Web/API/Node/contains
https://connect.microsoft.com/IE/feedback/details/780874/node-contains-is-incorrect

document is a node so contains do not work on it in IE.