### PR TITLE
Allow preview of empty post

### DIFF
--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -38,8 +38,9 @@ jQuery(document).ready(function($) {
         if (preview) {
             type = 'Preview';
             // If there is already a preview showing, kill processing.
-            if ($('div.Preview').length > 0 || jQuery.trim($(textbox).val()) == '')
+            if ($('div.Preview').length > 0) {
                 return false;
+            }
         }
         var draft = $(btn).hasClass('DraftButton');
         if (draft) {


### PR DESCRIPTION
Some JavaScript existed to halt the preview routine if the content was empty.  This can be confusing to some users.  This update removes that condition and allows a preview to be generated, even with no content.