### PR TITLE
Remove the /dashboard prefix from js files

### DIFF
--- a/applications/conversations/js/conversations.js
+++ b/applications/conversations/js/conversations.js
@@ -1,4 +1,4 @@
-// This file contains javascript that is specific to the dashboard/profile controller.
+// This file contains javascript that is specific to the /profile controller.
 jQuery(document).ready(function($) {
 
    // Hijack "add message" clicks and handle via ajax...

--- a/applications/dashboard/js/bans.js
+++ b/applications/dashboard/js/bans.js
@@ -1,4 +1,4 @@
-// This file contains javascript that is specific to the dashboard/routes controller.
+// This file contains javascript that is specific to the /routes controller.
 jQuery(document).ready(function($) {
 
     // Pop add/edit route clicks and reload the page contents when finished.

--- a/applications/dashboard/js/log.js
+++ b/applications/dashboard/js/log.js
@@ -43,15 +43,15 @@ jQuery(document).ready(function($) {
 
     // Restores the
     var restore = function() {
-        handleAction('/dashboard/log/restore');
+        handleAction('/log/restore');
     };
 
     var deleteForever = function() {
-        handleAction('/dashboard/log/delete');
+        handleAction('/log/delete');
     };
 
     var deleteSpam = function() {
-        handleAction('/dashboard/log/deletespam');
+        handleAction('/log/deletespam');
     };
 
     var setExpander = function() {
@@ -106,7 +106,7 @@ jQuery(document).ready(function($) {
         var bar = $.popup({afterSuccess: afterSuccess},
             function(settings) {
                 $.post(
-                    gdn.url('/dashboard/log/confirm/restore'),
+                    gdn.url('/log/confirm/restore'),
                     {'DeliveryType': 'VIEW',
                         'Postback': true,
                         'IDs': IDs,
@@ -128,7 +128,7 @@ jQuery(document).ready(function($) {
         // Popup the confirm.
         var bar = $.popup({afterSuccess: afterSuccess}, function(settings) {
             $.post(
-                gdn.url('/dashboard/log/confirm/delete'),
+                gdn.url('/log/confirm/delete'),
                 {'DeliveryType': 'VIEW',
                     'Postback': true,
                     'IDs': IDs,
@@ -150,7 +150,7 @@ jQuery(document).ready(function($) {
         // Popup the confirm.
         var bar = $.popup({afterSuccess: afterSuccess}, function(settings) {
             $.post(
-                gdn.url('/dashboard/log/confirm/deletespam'),
+                gdn.url('/log/confirm/deletespam'),
                 {'DeliveryType': 'VIEW',
                     'Postback': true,
                     'IDs': IDs,
@@ -172,7 +172,7 @@ jQuery(document).ready(function($) {
         // Popup the confirm.
         var bar = $.popup({afterSuccess: afterSuccess}, function(settings) {
             $.post(
-                gdn.url('/dashboard/log/confirm/notspam'),
+                gdn.url('/log/confirm/notspam'),
                 {'DeliveryType': 'VIEW',
                     'Postback': true,
                     'IDs': IDs,
@@ -203,7 +203,7 @@ jQuery(document).ready(function($) {
         var category = $('#Form_CategoryID').val();
 
         // Ajax us to filtered results
-        $('#LogTable').load(gdn.url('/dashboard/log/moderation?DeliveryType=VIEW&CategoryID=' + category));
+        $('#LogTable').load(gdn.url('/log/moderation?DeliveryType=VIEW&CategoryID=' + category));
 
         return false;
     });

--- a/applications/dashboard/js/messages.js
+++ b/applications/dashboard/js/messages.js
@@ -1,9 +1,9 @@
-// This file contains javascript that is specific to the dashboard/profile controller.
+// This file contains javascript that is specific to the /profile controller.
 jQuery(document).ready(function($) {
 
     $('a.AddMessage, a.EditMessage').popup({
         onUnload: function(settings) {
-            $('#Content').load(gdn.url('/dashboard/message?DeliveryType=VIEW'));
+            $('#Content').load(gdn.url('/message?DeliveryType=VIEW'));
         }
     });
 
@@ -12,7 +12,7 @@ jQuery(document).ready(function($) {
         confirm: true,
         followConfirm: false,
         afterConfirm: function(json, sender) {
-            $('#Content').load(gdn.url('/dashboard/message?DeliveryType=VIEW'));
+            $('#Content').load(gdn.url('/message?DeliveryType=VIEW'));
         }
     });
 

--- a/applications/dashboard/js/previewtheme.js
+++ b/applications/dashboard/js/previewtheme.js
@@ -1,4 +1,4 @@
-// This file contains javascript that is specific to the dashboard/profile controller.
+// This file contains javascript that is specific to the /profile controller.
 jQuery(document).ready(function($) {
 
     // Adapted from getPageSize() by quirksmode.com

--- a/applications/dashboard/js/profile.js
+++ b/applications/dashboard/js/profile.js
@@ -1,4 +1,4 @@
-// This file contains javascript that is specific to the dashboard/profile controller.
+// This file contains javascript that is specific to the /profile controller.
 jQuery(document).ready(function($) {
     // Set the max chars in the about form.
     $('form.About textarea').setMaxChars(1000);

--- a/applications/dashboard/js/routes.js
+++ b/applications/dashboard/js/routes.js
@@ -1,10 +1,10 @@
-// This file contains javascript that is specific to the dashboard/routes controller.
+// This file contains javascript that is specific to the /routes controller.
 jQuery(document).ready(function($) {
 
     // Pop add/edit route clicks and reload the page contents when finished.
     $('a.AddRoute, a.EditRoute').popup({
         onUnload: function(settings) {
-            $('#Content').load(gdn.url('/dashboard/routes?DeliveryType=VIEW'));
+            $('#Content').load(gdn.url('/routes?DeliveryType=VIEW'));
         }
     });
 

--- a/applications/dashboard/js/search.js
+++ b/applications/dashboard/js/search.js
@@ -1,4 +1,4 @@
-// This file contains javascript that is specific to the dashboard/entry controller.
+// This file contains javascript that is specific to the /entry controller.
 jQuery(document).ready(function($) {
     // Set up paging
     if ($.morepager)

--- a/applications/dashboard/js/settings.js
+++ b/applications/dashboard/js/settings.js
@@ -21,8 +21,8 @@ jQuery(document).ready(function($) {
     };
 
     lists.addClass('Loading');
-    var newsUrl = gdn.definition("DashboardNewsFeed", "/dashboard/utility/getfeed/news/5/normal");
-    var releasesUrl = gdn.definition("DashboardReleasesFeed", "/dashboard/utility/getfeed/releases/2/extended");
+    var newsUrl = gdn.definition("DashboardNewsFeed", "/utility/getfeed/news/5/normal");
+    var releasesUrl = gdn.definition("DashboardReleasesFeed", "/utility/getfeed/releases/2/extended");
     if (newsUrl) {
         loadFeed(newsColumn, newsUrl);
     }

--- a/applications/dashboard/js/user.js
+++ b/applications/dashboard/js/user.js
@@ -1,4 +1,4 @@
-// This file contains javascript that is specific to the dashboard/profile controller.
+// This file contains javascript that is specific to the /profile controller.
 jQuery(document).ready(function($) {
 
     // Reveal password

--- a/js/global.js
+++ b/js/global.js
@@ -1047,7 +1047,7 @@ jQuery(document).ready(function($) {
 
         $.ajax({
             type: "POST",
-            url: gdn.url('dashboard/notifications/inform'),
+            url: gdn.url('/notifications/inform'),
             data: {
                 'TransientKey': gdn.definition('TransientKey'),
                 'Path': gdn.definition('Path'),

--- a/js/library/jquery.menu.js
+++ b/js/library/jquery.menu.js
@@ -13,11 +13,11 @@ Usage:
 
 (1)----Make a menu like this:
 <ul id="Menu">
-   <li><a href="/dashboard/people/entry/signin" >Sign In</a></li>
-   <li><a href="/dashboard/people/users" >People</a>
+   <li><a href="/entry/signin" >Sign In</a></li>
+   <li><a href="/users" >People</a>
       <ul>
-         <li><a href="/dashboard/people/user/add" >Add New</a></li>
-         <li><a href="/dashboard/people/settings" >Settings</a></li>
+         <li><a href="/user/add" >Add New</a></li>
+         <li><a href="/settings" >Settings</a></li>
       </ul>
    </li>
 </ul>


### PR DESCRIPTION
The /application prefix for URLs will soon be deprecated. Removing it where possible helps to prevent future bugs.