### PR TITLE
Fix RoleModel::getDefaultRoles for admins and mods

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -236,6 +236,8 @@ class RoleModel extends Gdn_Model {
             case self::TYPE_UNCONFIRMED:
                 $backRoleIDs = (array)c('Garden.Registration.ConfirmEmailRole', null);
                 break;
+            default:
+                $backRoleIDs = array();
         }
         $roleIDs = array_merge($roleIDs, $backRoleIDs);
         $roleIDs = array_unique($roleIDs);


### PR DESCRIPTION
if RoleModels method `getDefaultRole()` is called with a $type not handled in the switch statement, `$backRoleIDs` is undefined. Merging an array with NULL results in NULL, that's why `$roleIDs = array_merge($roleIDs, $backRoleIDs);` didn't work for `TYPE_ADMINISTRATOR` and `TYPE_MODERATOR`
Adding a default to the switch statement that defines $backRoleIDs solves that.