### PR TITLE
Use a valid SPDX license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "vanilla/vanilla",
 	"description": "Vanilla is a powerfully simple discussion forum you can easily customize to make as unique as your community.",
 	"type": "project",
-	"license": "GPLv2",
+	"license": "GPL-2.0",
 	"authors": [
 		{
 			"name": "Todd Burry",


### PR DESCRIPTION
Got this notice when validating the composer.json file:

License "GPLv2" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.