### PR TITLE
Add event to dodge Safari's bfcache

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1872,7 +1872,11 @@ jQuery(document).ready(function($) {
         }
     }());
 
-    // A kludge to dodge Safari's back-forward cache (bfcache).
+    /**
+     * A kludge to dodge Safari's back-forward cache (bfcache).  Without this, Safari maintains
+     * the a page's DOM during back/forward navigation and hinders our ability to invalidate
+     * the cached state of content.
+     */
     if (/Apple Computer/.test(navigator.vendor) && /Safari/.test(navigator.userAgent)) {
         jQuery(window).on("pageshow", function(event) {
             if (event.originalEvent.persisted) {

--- a/js/global.js
+++ b/js/global.js
@@ -1872,7 +1872,14 @@ jQuery(document).ready(function($) {
         }
     }());
 
-
+    // A kludge to dodge Safari's back-forward cache (bfcache).
+    if (/Apple Computer/.test(navigator.vendor) && /Safari/.test(navigator.userAgent)) {
+        jQuery(window).on("pageshow", function(event) {
+            if (event.originalEvent.persisted) {
+                window.location.reload();
+            }
+        });
+    }
 });
 
 // Shrink large images to fit into message space, and pop into new window when clicked.


### PR DESCRIPTION
Safari utilizes a back-forward cache (bfcache) which keeps a copy of the page's state between clicking the back/forward buttons.  This conflicts with how we want Vanilla to work with caching, since users hitting their browser's back button from a discussion might expect that discussion to appear as "read" in the discussions list.

This update implements a kludge to force a reload on all pages detected to have "persisted" via Safari's bfcache.  Normal browser caching *should* still be in play. We're only forcing a standard page refresh, instead of allowing the browser to hold onto the state of any given page's DOM between back/forward clicks.