### PR TITLE
Add a hook for manipulating images uploaded in Advanced Editor.

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -729,7 +729,9 @@ class EditorPlugin extends Gdn_Plugin {
             $this->EventArguments['TmpFilePath'] =& $tmpFilePath;
             $this->EventArguments['FileExtension'] = $fileExtension;
             $this->EventArguments['ValidImage'] = $validImage;
-            $this->fireEvent("BeforeSaveUploads");
+            $this->EventArguments['AbsoluteFileDestination'] =& $absoluteFileDestination;
+            $this->EventArguments['DiscussionID'] =& $discussionID;
+            $this->fireEvent('BeforeSaveUploads');
 
             if (!$validImage) {
                 $filePathParsed = $Upload->saveAs(

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -725,6 +725,12 @@ class EditorPlugin extends Gdn_Plugin {
             ];
             $validImage = !empty($imageType) && in_array($imageType, $validImageTypes);
 
+            $this->EventArguments['CategoryID'] = Gdn::request()->post('CategoryID');
+            $this->EventArguments['TmpFilePath'] =& $tmpFilePath;
+            $this->EventArguments['FileExtension'] = $fileExtension;
+            $this->EventArguments['ValidImage'] = $validImage;
+            $this->fireEvent("BeforeSaveUploads");
+
             if (!$validImage) {
                 $filePathParsed = $Upload->saveAs(
                     $tmpFilePath,

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -730,7 +730,7 @@ class EditorPlugin extends Gdn_Plugin {
             $this->EventArguments['FileExtension'] = $fileExtension;
             $this->EventArguments['ValidImage'] = $validImage;
             $this->EventArguments['AbsoluteFileDestination'] =& $absoluteFileDestination;
-            $this->EventArguments['DiscussionID'] =& $discussionID;
+            $this->EventArguments['DiscussionID'] = $discussionID;
             $this->fireEvent('BeforeSaveUploads');
 
             if (!$validImage) {


### PR DESCRIPTION
This would allow plugins to hook into the process before up images are uploaded via the Advanced Editor to perform any operations to the images (i.e. resizing, watermarking, colourization, etc.)