### PR TITLE
Treat \n as EOL for mentions

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1709,7 +1709,10 @@ jQuery(document).ready(function($) {
                         // but it's the only way, as spaces make searching
                         // more ambiguous.
                         // \xA0 non-breaking space
-                        regexp = new RegExp(flag + '\"?([\\sA-Za-z0-9_\+\-]*)\"?$|' + flag + '\"?([^\\x00-\\xff]*)\"?$', 'gi');
+                        // Skip \n which is \x0A and threat is as EOL
+                        //https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/RegExp#character-classes
+                        var whiteSpaceNoLineFeed = '\\f\\r\\t\\v\​\u00a0\\u1680​\\u180e'; //\u2000​-\u200a​\u2028\u2029\u202f\u205f​\u3000\ufeff  <- was throwing error.
+                        regexp = new RegExp(flag + '\"?(['+whiteSpaceNoLineFeed+'A-Za-z0-9_\+\-]*)\"?(?:\\n|$)|' + flag + '\"?([^\\x00-\\x09\\x0B-\\xff]*)\"?(?:\\n|$)', 'gi');
 
                         match = regexp.exec(subtext);
                         if (match) {

--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -569,9 +569,9 @@
         } else {
           var textNode = $(document.createElement('div'));
           var html = this.$inputor.html();
-          var breaks = /<br(\s+)?(\/)?>/;
+          var breaks = /<br(\s+)?(\/)?>/g;
           result.offset = html.match(breaks) ? html.match(breaks).length : 0;
-          textNode.html(html.replace(breaks, " "));
+          textNode.html(html.replace(breaks, "\n"));
           result.content = textNode.text();
         }
 


### PR DESCRIPTION
\n are replaced by spaces in the atwho.matcher function.
This cause problems with the mention auto-complete feature since space are registered as part of a search. This cause every searches at EOL to have a space appended to them which returns no result in 98% of the cases.

This PR update the code logic to treat \n as EOL. 