### PR TITLE
Remove plugins from library/core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,11 @@ install:
   - tests/travis/nginx/install-nginx.sh
 
 script:
-  - tests/travis/php-lint.sh .
+  - tests/travis/php-lint.sh ./applications
+  - tests/travis/php-lint.sh ./conf
+  - tests/travis/php-lint.sh ./library
+  - tests/travis/php-lint.sh ./plugins
+  - tests/travis/php-lint.sh ./themes
   - phpunit -c phpunit.xml.dist
   - cat /tmp/error.log
   - cat /tmp/access.log

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -42,6 +42,18 @@ class SettingsController extends DashboardController {
     }
 
     /**
+     * Handle the tracking of a page tick.
+     */
+    public function analyticsTick() {
+        $this->deliveryMethod(DELIVERY_METHOD_JSON);
+        $this->deliveryType(DELIVERY_TYPE_DATA);
+
+        Gdn::statistics()->tick();
+        $this->fireEvent("AnalyticsTick");
+        $this->render();
+    }
+
+    /**
      * Application management screen.
      *
      * @since 2.0.0

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -49,7 +49,7 @@ class SettingsController extends DashboardController {
         $this->deliveryType(DELIVERY_TYPE_DATA);
 
         Gdn::statistics()->tick();
-        $this->fireEvent("AnalyticsTick");
+        Gdn::statistics()->fireEvent("AnalyticsTick");
         $this->render();
     }
 

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -27,6 +27,11 @@ class DashboardHooks implements Gdn_IPlugin {
     public function base_render_before($Sender) {
         $Session = Gdn::session();
 
+        // Check the statistics.
+        if ($Sender->deliveryType() == DELIVERY_TYPE_ALL) {
+            Gdn::statistics()->check();
+        }
+
         // Enable theme previewing
         if ($Session->isValid()) {
             $PreviewThemeName = htmlspecialchars($Session->getPreference('PreviewThemeName', ''));

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -151,6 +151,15 @@ class VanillaHooks implements Gdn_IPlugin {
     }
 
     /**
+     *
+     *
+     * @param $sender
+     */
+    public function discussionController_beforeCommentBody_handler($sender) {
+        Gdn::regarding()->beforeCommentBody($sender);
+    }
+
+    /**
      * Provide default permissions for roles, based on the value in their Type column.
      *
      * @param PermissionModel $Sender Instance of permission model that fired the event

--- a/library/core/class.gdn.php
+++ b/library/core/class.gdn.php
@@ -431,6 +431,9 @@ class Gdn {
         return self::$_PluginManager; //self::Factory(self::AliasPluginManager);
     }
 
+    /**
+     * @return Gdn_Regarding
+     */
     public static function regarding() {
         return self::factory('Regarding');
     }

--- a/library/core/class.regarding.php
+++ b/library/core/class.regarding.php
@@ -12,7 +12,7 @@
 /**
  * Handles relating external actions to comments and discussions. Flagging, Praising, Reporting, etc.
  */
-class Gdn_Regarding extends Gdn_Pluggable implements Gdn_IPlugin {
+class Gdn_Regarding extends Gdn_Pluggable {
 
     /**
      *
@@ -233,11 +233,9 @@ class Gdn_Regarding extends Gdn_Pluggable implements Gdn_IPlugin {
     }
 
     /**
-     *
-     *
-     * @param $Sender
+     * @param DiscussionController $sender
      */
-    public function discussionController_beforeCommentBody_handler($Sender) {
+    public function beforeCommentBody($Sender) {
         $Context = strtolower($Sender->EventArguments['Type']);
 
         $RegardingID = val('RegardingID', $Sender->EventArguments['Object'], null);

--- a/library/core/class.statistics.php
+++ b/library/core/class.statistics.php
@@ -14,8 +14,7 @@
 /**
  * Handles install-side analytics gathering and sending.
  */
-class Gdn_Statistics extends Gdn_Plugin {
-
+class Gdn_Statistics extends Gdn_Pluggable {
     /** @var mixed  */
     protected $AnalyticsServer;
 
@@ -137,18 +136,6 @@ class Gdn_Statistics extends Gdn_Plugin {
         $Reason = val('Reason', $JsonResponse, null);
         if (!is_null($Reason)) {
             Gdn::controller()->informMessage("Analytics: {$Reason}");
-        }
-    }
-
-    /**
-     *
-     *
-     * @param $Sender
-     */
-    public function base_render_before($Sender) {
-        // If this is a full page request, trigger stats environment check
-        if ($Sender->deliveryType() == DELIVERY_TYPE_ALL) {
-            $this->check();
         }
     }
 
@@ -504,19 +491,6 @@ class Gdn_Statistics extends Gdn_Plugin {
             'Success' => 'DoneRegister',
             'Failure' => 'AnalyticsFailed'
         ));
-    }
-
-    /**
-     *
-     * @param Gdn_Controller $Sender
-     */
-    public function settingsController_analyticsTick_create($Sender) {
-        $Sender->deliveryMethod(DELIVERY_METHOD_JSON);
-        $Sender->deliveryType(DELIVERY_TYPE_DATA);
-
-        Gdn::statistics()->tick();
-        $this->fireEvent("AnalyticsTick");
-        $Sender->render();
     }
 
     /**


### PR DESCRIPTION
Plugins in core is being deprecated so the couple that are there must be refactored into regular hooks classes.