### PR TITLE
Add and update lang attributes on HTML tags

### DIFF
--- a/applications/dashboard/views/deverror.master.php
+++ b/applications/dashboard/views/deverror.master.php
@@ -1,6 +1,6 @@
 <?php echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo c('Garden.Locale'); ?>">
 <head>
     <title>Fatal Error</title>
     <meta name="robots" content="noindex"/>

--- a/applications/dashboard/views/deverror.master.php
+++ b/applications/dashboard/views/deverror.master.php
@@ -1,6 +1,6 @@
 <?php echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo Gdn::locale()->language(); ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo Gdn::locale()->language(true); ?>">
 <head>
     <title>Fatal Error</title>
     <meta name="robots" content="noindex"/>

--- a/applications/dashboard/views/deverror.master.php
+++ b/applications/dashboard/views/deverror.master.php
@@ -1,6 +1,6 @@
 <?php echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo c('Garden.Locale'); ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo Gdn::locale()->language(); ?>">
 <head>
     <title>Fatal Error</title>
     <meta name="robots" content="noindex"/>

--- a/applications/dashboard/views/error.master.php
+++ b/applications/dashboard/views/error.master.php
@@ -2,7 +2,7 @@
 @ob_end_clean();
 echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo c('Garden.Locale'); ?>">
 <head>
     <title>Something has gone wrong.</title>
     <meta name="robots" content="noindex"/>

--- a/applications/dashboard/views/error.master.php
+++ b/applications/dashboard/views/error.master.php
@@ -2,7 +2,7 @@
 @ob_end_clean();
 echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo c('Garden.Locale'); ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo Gdn::locale()->language(); ?>">
 <head>
     <title>Something has gone wrong.</title>
     <meta name="robots" content="noindex"/>

--- a/applications/dashboard/views/error.master.php
+++ b/applications/dashboard/views/error.master.php
@@ -2,7 +2,7 @@
 @ob_end_clean();
 echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo Gdn::locale()->language(); ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo Gdn::locale()->language(true); ?>">
 <head>
     <title>Something has gone wrong.</title>
     <meta name="robots" content="noindex"/>

--- a/library/core/class.locale.php
+++ b/library/core/class.locale.php
@@ -363,11 +363,23 @@ class Gdn_Locale extends Gdn_Pluggable {
 
     /**
      * Return the first 2 letters of the current locale (the language code).
+     *
+     * @param bool $iso6391 Attempt to use ISO 639-1 language codes.
+     * @return bool|string Language code on success, false on failure.
      */
-    public function language() {
+    public function language($iso6391 = false) {
         if ($this->Locale == '') {
             return false;
         } else {
+            if ($iso6391) {
+                // ISO 639-1 has some special exceptions for language codes.
+                $locale = strtolower($this->Locale);
+                switch ($locale) {
+                    case 'zh_tw':
+                        return 'zh-Hant';
+                }
+            }
+
             return substr($this->Locale, 0, 2);
         }
     }

--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -87,7 +87,7 @@ class Gdn_Smarty {
         $Locale = Gdn::locale()->Locale;
         $CurrentLocale = array(
             'Key' => $Locale,
-            'Lang' => str_replace('_', '-', $Locale) // mirrors html5 lang attribute
+            'Lang' => str_replace('_', '-', Gdn::locale()->language(true)) // mirrors html5 lang attribute
         );
         if (class_exists('Locale')) {
             $CurrentLocale['Language'] = Locale::getPrimaryLanguage($Locale);

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -298,7 +298,7 @@ function Gdn_ExceptionHandler($Exception) {
             // If the master view wasn't found, assume a panic state and dump the error.
             if ($Master === false) {
                 echo '<!DOCTYPE html>
-   <html>
+   <html lang="'.c('Garden.Locale').'">
    <head>
       <title>Fatal Error</title>
    </head>

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -298,7 +298,7 @@ function Gdn_ExceptionHandler($Exception) {
             // If the master view wasn't found, assume a panic state and dump the error.
             if ($Master === false) {
                 echo '<!DOCTYPE html>
-   <html lang="'.c('Garden.Locale').'">
+   <html lang="'.Gdn::locale()->language().'">
    <head>
       <title>Fatal Error</title>
    </head>

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -298,7 +298,7 @@ function Gdn_ExceptionHandler($Exception) {
             // If the master view wasn't found, assume a panic state and dump the error.
             if ($Master === false) {
                 echo '<!DOCTYPE html>
-   <html lang="'.Gdn::locale()->language().'">
+   <html lang="'.Gdn::locale()->language(true).'">
    <head>
       <title>Fatal Error</title>
    </head>

--- a/themes/2011Compatibility/views/default.master.tpl
+++ b/themes/2011Compatibility/views/default.master.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-ca">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{$CurrentLocale.Lang}">
 <head>
     {asset name='Head'}
 </head>

--- a/themes/EmbedFriendly/views/default.master.tpl
+++ b/themes/EmbedFriendly/views/default.master.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{$CurrentLocale.Lang}">
 <head>
     {asset name='Head'}
 </head>

--- a/themes/bittersweet/views/default.master.tpl
+++ b/themes/bittersweet/views/default.master.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{$CurrentLocale.Lang}">
 <head>
     {asset name="Head"}
 </head>

--- a/themes/mobile/views/default.master.tpl
+++ b/themes/mobile/views/default.master.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-ca">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="{$CurrentLocale.Lang}">
 <head>
     {asset name='Head'}
 </head>


### PR DESCRIPTION
This update ensures all pages have a `lang` attribute on the HTML tag that reflects the site's currently configured locale.

Closes #3698