### PR TITLE
Execute a count(*) query instead of counting the number of returned rows

### DIFF
--- a/applications/dashboard/models/class.importmodel.php
+++ b/applications/dashboard/models/class.importmodel.php
@@ -2219,12 +2219,13 @@ class ImportModel extends Gdn_Model {
 
         // Any users without roles?
         $UsersWithoutRoles = $this->SQL
+            ->select('*', 'count', 'RowCount')
             ->from('User u')
             ->leftJoin('UserRole ur', 'u.UserID = ur.UserID')
             ->leftJoin('Role r', 'ur.RoleID = r.RoleID')
             ->where('r.Name', null)
             ->get()
-            ->count();
+            ->firstRow()->RowCount;
         $this->stat(
             'Users Without a Valid Role',
             $UsersWithoutRoles


### PR DESCRIPTION
I got an Out of Memory error doing a migration because there was over 700k users with no roles (this is normal in that case).