### PR TITLE
Check Conversation.Add permission before showing "Message" button on other users profile

### DIFF
--- a/applications/conversations/settings/class.hooks.php
+++ b/applications/conversations/settings/class.hooks.php
@@ -103,7 +103,10 @@ class ConversationsHooks implements Gdn_IPlugin {
      * Add "Message" option to profile options.
      */
     public function profileController_beforeProfileOptions_handler($Sender, $Args) {
-        if (!$Sender->EditMode && Gdn::session()->isValid() && Gdn::session()->UserID != $Sender->User->UserID) {
+        if (!$Sender->EditMode &&
+            Gdn::session()->UserID != $Sender->User->UserID &&
+            Gdn::session()->checkPermission('Conversations.Add')
+        ) {
             $Sender->EventArguments['MemberOptions'][] = array(
                 'Text' => sprite('SpMessage').' '.t('Message'),
                 'Url' => '/messages/add/'.$Sender->User->Name,


### PR DESCRIPTION
This solves https://github.com/vanilla/vanilla/issues/3536
I've dropped the session->isValid check, since the permission would also fail for invalid sessions.