### PR TITLE
Don't let objects creep into makeTreeChildren()

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1494,7 +1494,7 @@ class CategoryModel extends Gdn_Model {
             if (!isset($Categories[$ID])) {
                 continue;
             }
-            $Row = $Categories[$ID];
+            $Row = (array)$Categories[$ID];
             $Row['Depth'] += $DepthAdj;
             $Row['Children'] = self::_MakeTreeChildren($Row, $Categories);
             $Result[] = $Row;

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "eb1c829d8378e09ce4a4286acb621f31",
+    "hash": "e21f678d20055c81d42146c61f83f92b",
     "content-hash": "107049c1fc4107be95224e2829ecf176",
     "packages": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e21f678d20055c81d42146c61f83f92b",
+    "hash": "eb1c829d8378e09ce4a4286acb621f31",
     "content-hash": "107049c1fc4107be95224e2829ecf176",
     "packages": [
         {


### PR DESCRIPTION
Our object pollution knows no boundaries. Make sure we really have an array before using it like one, even this deep in the categories collection.