### PR TITLE
Update JavaScript insert template for emoji

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1794,6 +1794,31 @@ jQuery(document).ready(function($) {
                 tpl: emojiTemplate,
                 insert_tpl: "${atwho-data-value}",
                 callbacks: {
+                    /**
+                     * Default routine from At.js with more tolerant pattern matching.
+                     * @param {string} flag The character sequence used to trigger this match (e.g. :).
+                     * @param {string} subtext The string to be tested.
+                     * @param {bool} should_start_with_space Should the pattern include a test for a whitespace prefix?
+                     * @returns {string|null} String on successful match.  Null on failure to match.
+                     */
+                    matcher: function(flag, subtext, should_start_with_space) {
+                        var match, regexp;
+                        flag = flag.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+                        if (should_start_with_space) {
+                            flag = '(?:^|\\s)' + flag;
+                        }
+
+                        // Allow matches to end with a space, a line feed or the end of the string.
+                        regexp = new RegExp(flag + '([A-Za-z0-9_\+\-]*)(?:\\s|\\n|$)|' + flag + '([^\\x00-\\xff]*)(?:\\s|\\n|$)', 'gi');
+                        match = regexp.exec(subtext);
+
+                        if (match) {
+                            return match[2] || match[1];
+                        } else {
+                            return null;
+                        }
+                    },
+
                     tplEval: function(tpl, map) {
                         console.log(map);
                     }

--- a/js/global.js
+++ b/js/global.js
@@ -1792,6 +1792,7 @@ jQuery(document).ready(function($) {
             .atwho({
                 at: ':',
                 tpl: emojiTemplate,
+                insert_tpl: "${atwho-data-value}",
                 callbacks: {
                     tplEval: function(tpl, map) {
                         console.log(map);


### PR DESCRIPTION
Emoji are wrapped in span tags when using the WYSIWYG editor.  In addition, sometimes autocompletion of emoji fails to trigger, altogether.

This update aims to strip span tags from the emoji insertion template and make the appearance of the autocomplete menu more reliable.

Closes #3719