### PR TITLE
Add data coercion to Gdn_Model

### DIFF
--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -161,6 +161,12 @@ class RoleController extends DashboardController {
         } else {
             $this->removeRankPermissions();
 
+            // Make sure the role's checkbox has a false value so that the role model can handle a sparse update of
+            // column from other places.
+            if (!$this->Form->getFormValue('PersonalInfo')) {
+                $this->Form->setFormValue('PersonalInfo', false);
+            }
+
             // If the form has been posted back...
             // 2. Save the data (validation occurs within):
             if ($RoleID = $this->Form->save()) {

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -548,9 +548,6 @@ class RoleModel extends Gdn_Model {
         $RoleID = val('RoleID', $FormPostValues);
         $Insert = $RoleID > 0 ? false : true;
 
-        // Strict-mode.
-        setValue('PersonalInfo', $FormPostValues, forceBool(val('PersonalInfo', $FormPostValues), '0', '1', '0'));
-
         if ($Insert) {
             // Figure out the next role ID.
             $MaxRoleID = $this->SQL->select('r.RoleID', 'MAX')->from('Role r')->get()->value('RoleID', 0);
@@ -565,6 +562,7 @@ class RoleModel extends Gdn_Model {
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert)) {
             $Fields = $this->Validation->schemaValidationFields();
+            $Fields = $this->coerceData($Fields);
 
             if ($Insert === false) {
                 $this->update($Fields, array('RoleID' => $RoleID));

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -623,7 +623,7 @@ class Gdn_Model extends Gdn_Pluggable {
                         break;
                     case 'datetime':
                     case 'timestamp':
-                        // Should already have been validated.
+                        $value = $value ?: null;
                         break;
                     case 'varchar':
                     case 'text':

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -602,7 +602,11 @@ class Gdn_Model extends Gdn_Pluggable {
                     case 'tinyint':
                     case 'smallint':
                     case 'bigint':
-                        $value = (int)$value;
+                        if ($value === '' || $value === null) {
+                            $value = null;
+                        } else {
+                            $value = (int)$value;
+                        }
                         break;
                     case 'enum':
                         $enums = array_change_key_case(array_combine($column->Enum, $column->Enum));
@@ -616,10 +620,18 @@ class Gdn_Model extends Gdn_Pluggable {
                         }
                         break;
                     case 'float':
-                        $value = (float)$value;
+                        if ($value === '' || $value === null) {
+                            $value = null;
+                        } else {
+                            $value = (float)$value;
+                        }
                         break;
                     case 'double':
-                        $value = (double)$value;
+                        if ($value === '' || $value === null) {
+                            $value = null;
+                        } else {
+                            $value = (double)$value;
+                        }
                         break;
                     case 'datetime':
                     case 'timestamp':

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -188,9 +188,10 @@ class Gdn_Model extends Gdn_Pluggable {
     }
 
     /**
-     * Connects to the database and defines the schema associated with
-     * $this->Name. Also instantiates and automatically defines
-     * $this->Validation.
+     * Connects to the database and defines the schema associated with $this->Name.
+     *
+     * Also instantiates and automatically defines $this->Validation.
+     *
      * @return Gdn_Schema Returns the schema for this model.
      */
     public function defineSchema() {
@@ -198,7 +199,6 @@ class Gdn_Model extends Gdn_Pluggable {
             $this->Schema = new Gdn_Schema($this->Name, $this->Database);
             $this->PrimaryKey = $this->Schema->primaryKey($this->Name, $this->Database);
             if (is_array($this->PrimaryKey)) {
-                //print_r($this->PrimaryKey);
                 $this->PrimaryKey = $this->PrimaryKey[0];
             }
 
@@ -257,6 +257,7 @@ class Gdn_Model extends Gdn_Pluggable {
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert) === true) {
             $Fields = $this->Validation->validationFields();
+            $Fields = $this->coerceData($Fields, false);
             unset($Fields[$this->PrimaryKey]); // Don't try to insert or update the primary key
             if ($Insert === false) {
                 $this->update($Fields, array($this->PrimaryKey => $PrimaryKeyVal));
@@ -575,6 +576,69 @@ class Gdn_Model extends Gdn_Pluggable {
         return $this->Validation->validate($FormPostValues, $Insert);
     }
 
+    /**
+     * Coerce the data in a given row to conform to the data types in this model's schema.
+     *
+     * This method doesn't do full data cleansing yet because that is too much of a change at this point. For this
+     * reason this method has been kept protected. The main purpose here is to clean the data enough to work better with
+     * MySQL's strict mode.
+     *
+     * @param array $row The row of data to coerce.
+     * @param bool $strip Whether or not to strip missing columns.
+     * @return array Returns a new data row with cleansed data.
+     */
+    protected function coerceData($row, $strip = true) {
+        $columns = array_change_key_case($this->defineSchema()->fields());
+
+        $result = [];
+        foreach ($row as $key => $value) {
+            $name = strtolower($key);
+
+            if (isset($columns[$name])) {
+                $column = $columns[$name];
+
+                switch ($column->Type) {
+                    case 'int':
+                    case 'tinyint':
+                    case 'smallint':
+                    case 'bigint':
+                        $value = (int)$value;
+                        break;
+                    case 'enum':
+                        $enums = array_change_key_case(array_combine($column->Enum, $column->Enum));
+                        if (isset($enums[strtolower($value)])) {
+                            $value = $enums[strtolower($value)];
+                        } elseif (!$value) {
+                            $value = null;
+                        } else {
+                            trigger_error("Enum value of '$value' not valid for {$column->Key}", E_USER_NOTICE);
+                            $value = null;
+                        }
+                        break;
+                    case 'float':
+                        $value = (float)$value;
+                        break;
+                    case 'double':
+                        $value = (double)$value;
+                        break;
+                    case 'datetime':
+                    case 'timestamp':
+                        // Should already have been validated.
+                        break;
+                    case 'varchar':
+                    case 'text':
+                    case 'mediumtext':
+                    case 'longtext':
+                        // Should already have been validated.
+                        break;
+                }
+                $result[$column->Name] = $value;
+            } elseif (!$strip) {
+                $result[$key] = $value;
+            }
+        }
+        return $result;
+    }
 
     /**
      * Adds $this->InsertUserID and $this->DateInserted fields to an associative


### PR DESCRIPTION
The Gdn_Model->coerceData() method will partially clean up a data array based on the model’s schema. This helps against databases that use MySQL’s strict mode.

Fixes #3507.