### PR TITLE
Don’t pretty print gdn.meta

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -622,7 +622,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         }
 
         // Output a JavaScript object with all the definitions.
-        $result = 'gdn=window.gdn||{};gdn.meta='.json_encode($this->_Definitions, JSON_PRETTY_PRINT).';';
+        $result = 'gdn=window.gdn||{};gdn.meta='.json_encode($this->_Definitions).';';
         if ($wrap) {
             $result = "<script>$result</script>";
         }


### PR DESCRIPTION
This is just to make the page more compact. I noticed this data gets really long on some pages.