### PR TITLE
Remove afterControllerCreate hook from Dashboard

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -417,19 +417,4 @@ class DashboardHooks implements Gdn_IPlugin {
             PermissionModel::resetAllRoles();
         }
     }
-
-    /**
-     * Add user's viewable roles to gdn.meta if user is logged in.
-     * @param $sender
-     * @param $args
-     */
-    public function gdn_dispatcher_afterControllerCreate_handler($sender, $args) {
-        // Function addDefinition returns the value of the definition if you pass only one argument.
-        if (!gdn::controller()->addDefinition('Roles')) {
-            if (Gdn::session()->isValid()) {
-                $roleModel = new RoleModel();
-                gdn::controller()->addDefinition("Roles", $roleModel->getPublicUserRoles(gdn::session()->UserID, "Name"));
-            }
-        }
-    }
 }


### PR DESCRIPTION
Remove `afterControllerCreate` hook from the Dashboard application.

Relevant applications and plug-ins using the behavior of this hook will need to have it added to their respective add-on code before this PR is merged.

Closes #3686 