### PR TITLE
Use caching in RoleModel->getUserByID()

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -334,17 +334,15 @@ class RoleModel extends Gdn_Model {
     }
 
     /**
-     * Returns a resultset of role data related to the specified UserID.
+     * Get the roles for a user.
      *
-     * @param int The UserID to filter to.
-     * @return Gdn_DataSet
+     * @param int $userID The user to get the roles for.
+     * @return Gdn_DataSet Returns the roles as a dataset (with array values).
+     * @see UserModel::getRoles()
      */
-    public function getByUserID($UserID) {
-        return $this->SQL->select()
-            ->from('Role')
-            ->join('UserRole', 'Role.RoleID = UserRole.RoleID')
-            ->where('UserRole.UserID', $UserID)
-            ->get();
+    public function getByUserID($userID) {
+        $result = Gdn::userModel()->getRoles($userID);
+        return $result;
     }
 
     /**

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1581,10 +1581,10 @@ class UserModel extends Gdn_Model {
     }
 
     /**
+     * Get the roles for a user.
      *
-     *
-     * @param $UserID
-     * @return Gdn_DataSet
+     * @param int $UserID The user to get the roles for.
+     * @return Gdn_DataSet Returns the roles as a dataset (with array values).
      */
     public function getRoles($UserID) {
         $UserRolesKey = formatString(self::USERROLES_KEY, array('UserID' => $UserID));
@@ -1599,7 +1599,7 @@ class UserModel extends Gdn_Model {
         foreach ($RolesDataArray as $RoleID) {
             $Result[] = RoleModel::roles($RoleID, true);
         }
-        return new Gdn_DataSet($Result);
+        return new Gdn_DataSet($Result, DATASET_TYPE_ARRAY);
     }
 
     /**


### PR DESCRIPTION
This is slightly backwards incompatible in that it returns a data set with DATASET_TYPE_ARRAY instead of DATASET_TYPE_OBJECT, but since all the calls I searched for request the resultArray() then I’m hoping we can get away with leaving this as is.

This should help close #3686.