### PR TITLE
Add the Vanilla namespace to composer’s autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,10 @@
 			"library/core/functions.general.php",
 			"library/core/functions.compatibility.php",
 			"library/core/functions.deprecated.php"
-		]
+		],
+		"psr-4": {
+			"Vanilla\\": "library/Vanilla"
+		}
 	},
 	"scripts": {
 		"pre-install-cmd": "Vanilla\\Setup\\ComposerHelper::preUpdate",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6b1df29b6d0beddc179932f4ac1b10b7",
+    "hash": "a5cdd474607b41eec6783bc8072c83a3",
     "content-hash": "b677d81ec1d659d919bd6d9f4202ab83",
     "packages": [
         {


### PR DESCRIPTION
There is a lot of functionality coming that will all be under the Vanilla namespace. This is PR allows us to run multiple PRs that use it without having to add the namespace every time.