### PR TITLE
Fire "CategoryWatch" as an event of CategoryModel

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -100,7 +100,7 @@ class CategoryModel extends Gdn_Model {
         }
 
         Gdn::pluginManager()->EventArguments['CategoryIDs'] = & $Watch;
-        Gdn::pluginManager()->fireEvent('CategoryWatch');
+        Gdn::pluginManager()->fireAs('CategoryModel')->fireEvent('CategoryWatch');
 
         if ($AllCount == count($Watch)) {
             return true;


### PR DESCRIPTION
The event CategoryWatch has been fired as an event of the plugin manager. This one closes this issue: https://github.com/vanilla/vanilla/issues/1914