### PR TITLE
Prevent errorneous rendering when OpenID url is invalid

### DIFF
--- a/plugins/OpenID/class.openid.plugin.php
+++ b/plugins/OpenID/class.openid.plugin.php
@@ -194,7 +194,6 @@ class OpenIDPlugin extends Gdn_Plugin {
             $OpenID = $this->getOpenID();
         } catch (Gdn_UserException $ex) {
             $Sender->Form->addError('@'.$ex->getMessage());
-            $Sender->render('Url', '', 'plugins/OpenID');
         }
 
         $Mode = $Sender->Request->get('openid_mode');


### PR DESCRIPTION
When given a wrong url, the url.php view is rendered multiple times. Since it is the default view in the following switch case construct, it doesn't need to be rendered before.