### PR TITLE
Don't show Google+ login when not configured

### DIFF
--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -455,7 +455,9 @@ class GooglePlusPlugin extends Gdn_Plugin {
      * @param Gdn_Controller $Sender
      */
     public function entryController_signIn_handler($Sender, $Args) {
-//      if (!$this->IsEnabled()) return;
+        if (!$this->isConfigured()) {
+            return;
+        }
 
         if (isset($Sender->Data['Methods'])) {
             $Url = $this->authorizeUri();


### PR DESCRIPTION
The option to login with google+ is not shown in guest module when ClientID and secret are not configured. But in entry/signin that check wasn't there.