### PR TITLE
Update category checking in DiscussionModel::getAnnouncements

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1049,7 +1049,9 @@ class DiscussionModel extends VanillaModel {
         }
         if ($GroupID > 0) {
             $this->SQL->where('d.GroupID', $GroupID);
-        } elseif (is_array($CategoryID) || $CategoryID > 0) {
+        } elseif (is_array($CategoryID)) {
+            $this->SQL->whereIn('d.CategoryID', $CategoryID);
+        } elseif ($CategoryID > 0) {
             $this->SQL->where('d.CategoryID', $CategoryID);
         }
 


### PR DESCRIPTION
`DiscussionModel::getAnnouncements` potentially attempts to pass an array value to `Gdn_MySQLDriver::where`, which will throw the following error: `Gdn_SQL->ConditionExpr(VALUE, ARRAY) is not supported.`

This update alters the logic of `DiscussionModel::getAnnouncements` to pass the `$CategoryID` to `wherein` if its value is an array.