### PR TITLE
Rollback overzealous language attributes

### DIFF
--- a/applications/dashboard/views/deverror.master.php
+++ b/applications/dashboard/views/deverror.master.php
@@ -1,6 +1,6 @@
 <?php echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo Gdn::locale()->language(true); ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
     <title>Fatal Error</title>
     <meta name="robots" content="noindex"/>

--- a/applications/dashboard/views/error.master.php
+++ b/applications/dashboard/views/error.master.php
@@ -4,7 +4,7 @@ if (ob_get_level()) {
 }
 echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo Gdn::locale()->language(true); ?>">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
     <title>Something has gone wrong.</title>
     <meta name="robots" content="noindex"/>

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -298,7 +298,7 @@ function Gdn_ExceptionHandler($Exception) {
             // If the master view wasn't found, assume a panic state and dump the error.
             if ($Master === false) {
                 echo '<!DOCTYPE html>
-   <html lang="'.Gdn::locale()->language(true).'">
+   <html>
    <head>
       <title>Fatal Error</title>
    </head>


### PR DESCRIPTION
The Gdn::locale() might not be available when errors occur so it should not be referenced in those scenarios.