### PR TITLE
Fix bug with UserModel->definePermissions and caching

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1636,7 +1636,7 @@ class UserModel extends Gdn_Model {
             // Otherwise normal loadings!
         } else {
             if ($User && ($User->Permissions == '' || Gdn::cache()->activeEnabled())) {
-                $User->Permissions = $this->definePermissions($UserID);
+                $User->Permissions = $this->definePermissions($UserID, false);
             }
         }
 


### PR DESCRIPTION
There was a previous bug in the cached version of definePermissions where the $serialize argument was not respected. When we fixed that it cascaded to another bug.