### PR TITLE
Change error handling on dbencode/dbdecode

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2758,8 +2758,12 @@ class DiscussionModel extends VanillaModel {
             return '';
         }
 
-        // Get the array
-        $TagsArray = dbdecode($Tags);
+        // Get the array.
+        if (preg_match('`^(a:)|{|\[`', $Tags)) {
+            $TagsArray = dbdecode($Tags);
+        } else {
+            $TagsArray = $Tags;
+        }
 
         // Compensate for deprecated space-separated format
         if (is_string($TagsArray) && $TagsArray == $Tags) {

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -734,11 +734,7 @@ if (!function_exists('dbdecode')) {
             return null;
         }
 
-        try {
-            $decodedValue = unserialize($value);
-        } catch (Exception $e) {
-            $decodedValue = false;
-        }
+        $decodedValue = @unserialize($value);
 
         return $decodedValue;
     }
@@ -756,11 +752,7 @@ if (!function_exists('dbencode')) {
             return null;
         }
 
-        try {
-            $encodedValue = serialize($value);
-        } catch (Exception $e) {
-            $encodedValue = false;
-        }
+        $encodedValue = serialize($value);
 
         return $encodedValue;
     }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -730,8 +730,11 @@ if (!function_exists('dbdecode')) {
      * @return mixed A decoded value on success or false on failure.
      */
     function dbdecode($value) {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return null;
+        } elseif (is_array($value)) {
+            // This handles a common double decoding scenario.
+            return $value;
         }
 
         $decodedValue = @unserialize($value);
@@ -748,7 +751,7 @@ if (!function_exists('dbencode')) {
      * @return mixed An encoded string representation of the provided value or false on failure.
      */
     function dbencode($value) {
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return null;
         }
 

--- a/tests/Library/Core/DbEncodeDecodeTest.php
+++ b/tests/Library/Core/DbEncodeDecodeTest.php
@@ -10,10 +10,10 @@ namespace VanillaTests\Library\Core;
 /**
  * Test some of the global functions that operate (or mostly operate) on arrays.
  */
-class ArrayFunctionsTest extends \PHPUnit_Framework_TestCase {
+class DbEncodeDecodeTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     *
+     * Test encoding/decoding an array.
      */
     public function testDbEncodeArray() {
         $data = ['Forum' => 'Vanilla'];
@@ -72,6 +72,18 @@ class ArrayFunctionsTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * You should be able to call {@link dbdecode()} on an array and have it just pass through.
+     */
+    public function testDoubleDecodeArray() {
+        $arr = [1, 2, 'foo' => [3, 4]];
+        $encoded = dbencode($arr);
+        $decoded = dbdecode($encoded);
+        $decoded2 = dbdecode($decoded);
+
+        $this->assertSame($arr, $decoded2);
+    }
+
+    /**
      * Make sure we have a bad string for {@link dbdecode()}.
      *
      * @param string $str The bad string to decode.
@@ -87,10 +99,11 @@ class ArrayFunctionsTest extends \PHPUnit_Framework_TestCase {
      *
      * The trick here is that {@link dbdecode()} should not raise an exception or throw an error.
      *
+     * @param mixed $str The bad string to decode.
+     * @dataProvider  provideBadDbDecodeStrings
      * @see testBadDbDecodeString()
      */
-    public function testDbDecodeError() {
-        $str = 'a:3:{i:0;i:1;i:';
+    public function testDbDecodeError($str) {
         $decoded = dbdecode($str);
         $this->assertFalse($decoded);
     }
@@ -104,7 +117,6 @@ class ArrayFunctionsTest extends \PHPUnit_Framework_TestCase {
         $r = [
             ['a:3:{i:0;i:1;i:'],
             ['{"foo": "bar"'],
-            [[1, 2, 3]]
         ];
 
         return $r;

--- a/tests/Library/Core/DbEncodeDecodeTest.php
+++ b/tests/Library/Core/DbEncodeDecodeTest.php
@@ -62,6 +62,7 @@ class DbEncodeDecodeTest extends \PHPUnit_Framework_TestCase {
      */
     public function testDbEncodeNull() {
         $this->assertNull(dbencode(null));
+        $this->assertNull(dbencode(''));
     }
 
     /**
@@ -69,6 +70,7 @@ class DbEncodeDecodeTest extends \PHPUnit_Framework_TestCase {
      */
     public function testDbDecodeNull() {
         $this->assertNull(dbdecode(null));
+        $this->assertNull(dbdecode(''));
     }
 
     /**


### PR DESCRIPTION
- The documentation for serialize does not mention triggering any errors so the exception handling has been removed.
- Change exception handling in dbdecode to @ error suppression to prevent notices in the debug bar.
- Fix the deserialization in discussion tags which has a bunch of mixed data.