### PR TITLE
Don't assume zero index in Gdn_SQLDriver::where

### DIFF
--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1982,9 +1982,10 @@ abstract class Gdn_SQLDriver {
         }
 
         foreach ($Field as $SubField => $SubValue) {
-            if (is_array($SubValue) && (isset($SubValue[0]) || count($SubValue) == 0)) {
+            if (is_array($SubValue)) {
                 if (count($SubValue) == 1) {
-                    $this->where($SubField, $SubValue[0]);
+                    list($firstVal) = $SubValue;
+                    $this->where($SubField, $firstVal);
                 } else {
                     $this->whereIn($SubField, $SubValue);
                 }


### PR DESCRIPTION
`Gdn_SQLDriver::where` currently assumes the presents of an index of 0 when determining whether the value should be handled as a "where" or a "where in".  This can be problematic when the value being passed is an array and there is no zero index.  In that event, the following error may be triggered:
```
Gdn_SQL->ConditionExpr(VALUE, ARRAY) is not supported.
```

This update drops checking for an element with a zero index and, if necessary, retrieves the first value in the array without hardcoding the index.