### PR TITLE
Load nestedSortable from js/library path

### DIFF
--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -621,12 +621,12 @@ class SettingsController extends Gdn_Controller {
         // This now works on latest jQuery version 1.10.2
         //
         // Jan29, 2014, upgraded jQuery UI to 1.10.3 from 1.8.11
-        $this->addJsFile('nestedSortable/jquery-ui.min.js');
+        $this->addJsFile('js/library/nestedSortable/jquery-ui.min.js');
         // Newer nestedSortable, but does not work.
         //$this->addJsFile('js/library/nestedSortable/jquery.mjs.nestedSortable.js');
         // old jquery-ui
         //$this->addJsFile('js/library/nestedSortable.1.3.4/jquery-ui-1.8.11.custom.min.js');
-        $this->addJsFile('nestedSortable.1.3.4/jquery.ui.nestedSortable.js');
+        $this->addJsFile('js/library/nestedSortable.1.3.4/jquery.ui.nestedSortable.js');
 
         $this->title(t('Categories'));
 


### PR DESCRIPTION
Fixes the js from not loading on some instances by letting Garden know to load it from the global js directory.