### PR TITLE
Ensure Garden.Email.Prefix displays even if there is no email message.

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -875,18 +875,18 @@ class ActivityModel extends Gdn_Model {
                     ->setButton($url, val('ActionText', $Activity, t('Check it out')))
                     ->setTitle($ActivityHeadline);
 
-		$message = '';
+                $message = '';
 
-		if ($prefix = c('Garden.Email.Prefix', '')) {
-		    $message = $prefix;
-		}
+                if ($prefix = c('Garden.Email.Prefix', '')) {
+                    $message = $prefix;
+                }
 
-		if ($story = val('Story', $Activity)) {
-		    $message .= $story;
-		}
+                if ($story = val('Story', $Activity)) {
+                    $message .= $story;
+                }
 
-		if ($message) {
-		    $emailTemplate->setMessage($message, true);
+                if ($message) {
+                    $emailTemplate->setMessage($message, true);
                 }
 
                 $Email->setEmailTemplate($emailTemplate);
@@ -977,18 +977,18 @@ class ActivityModel extends Gdn_Model {
             ->setButton($url, val('ActionText', $Activity, t('Check it out')))
             ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
 
-	$message = '';
+        $message = '';
 
-	if ($prefix = c('Garden.Email.Prefix', '')) {
-	    $message = $prefix;
-	}
+        if ($prefix = c('Garden.Email.Prefix', '')) {
+            $message = $prefix;
+        }
 
-	if ($story = val('Story', $Activity)) {
-	    $message .= $story;
-	}
+        if ($story = val('Story', $Activity)) {
+            $message .= $story;
+        }
 
-	if ($message) {
-	    $emailTemplate->setMessage($message, true);
+        if ($message) {
+            $emailTemplate->setMessage($message, true);
         }
 
         $Email->setEmailTemplate($emailTemplate);
@@ -1229,7 +1229,7 @@ class ActivityModel extends Gdn_Model {
             if ($Force) {
                 $Preference = $Force;
             } else {
-            //            $Preferences = Gdn_Format::Unserialize($User->Preferences);
+                //            $Preferences = Gdn_Format::Unserialize($User->Preferences);
                 $ConfigPreference = c('Preferences.Email.'.$Activity->ActivityType, '0');
                 if ($ConfigPreference !== false) {
                     $Preference = val('Email.'.$Activity->ActivityType, $User->Preferences, $ConfigPreference);
@@ -1249,18 +1249,18 @@ class ActivityModel extends Gdn_Model {
                     ->setButton($url, val('ActionText', $Activity, t('Check it out')))
                     ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
 
-		$message = '';
+                $message = '';
 
-		if ($prefix = c('Garden.Email.Prefix', '')) {
-		    $message = $prefix;
-		}
+                if ($prefix = c('Garden.Email.Prefix', '')) {
+                    $message = $prefix;
+                }
 
-		if ($story = val('Story', $Activity)) {
-		    $message .= $story;
-		}
+                if ($story = val('Story', $Activity)) {
+                    $message .= $story;
+                }
 
-		if ($message) {
-		    $emailTemplate->setMessage($message, true);
+                if ($message) {
+                    $emailTemplate->setMessage($message, true);
                 }
 
                 $Email->setEmailTemplate($emailTemplate);

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1231,7 +1231,7 @@ class ActivityModel extends Gdn_Model {
             if ($Force) {
                 $Preference = $Force;
             } else {
-                //            $Preferences = Gdn_Format::Unserialize($User->Preferences);
+            //            $Preferences = Gdn_Format::Unserialize($User->Preferences);
                 $ConfigPreference = c('Preferences.Email.'.$Activity->ActivityType, '0');
                 if ($ConfigPreference !== false) {
                     $Preference = val('Email.'.$Activity->ActivityType, $User->Preferences, $ConfigPreference);

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -875,17 +875,7 @@ class ActivityModel extends Gdn_Model {
                     ->setButton($url, val('ActionText', $Activity, t('Check it out')))
                     ->setTitle($ActivityHeadline);
 
-                $message = '';
-
-                if ($prefix = c('Garden.Email.Prefix', '')) {
-                    $message = $prefix;
-                }
-
-                if ($story = val('Story', $Activity)) {
-                    $message .= $story;
-                }
-
-                if ($message) {
+                if ($message = $this->getEmailMessage($Activity)) {
                     $emailTemplate->setMessage($message, true);
                 }
 
@@ -916,6 +906,28 @@ class ActivityModel extends Gdn_Model {
                 }
             }
         }
+    }
+
+
+    /**
+     * Takes an array representing an activity and builds the email message based on the activity's story and
+     * the contents of the global config Garden.Email.Prefix.
+     *
+     * @param array $activity The activity to build the email for.
+     * @return string The email message.
+     */
+    private function getEmailMessage($activity) {
+        $message = '';
+
+        if ($prefix = c('Garden.Email.Prefix', '')) {
+            $message = $prefix;
+        }
+
+        if ($story = val('Story', $activity)) {
+            $message .= $story;
+        }
+
+        return $message;
     }
 
     /**
@@ -977,17 +989,7 @@ class ActivityModel extends Gdn_Model {
             ->setButton($url, val('ActionText', $Activity, t('Check it out')))
             ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
 
-        $message = '';
-
-        if ($prefix = c('Garden.Email.Prefix', '')) {
-            $message = $prefix;
-        }
-
-        if ($story = val('Story', $Activity)) {
-            $message .= $story;
-        }
-
-        if ($message) {
+        if ($message = $this->getEmailMessage($Activity)) {
             $emailTemplate->setMessage($message, true);
         }
 
@@ -1249,17 +1251,7 @@ class ActivityModel extends Gdn_Model {
                     ->setButton($url, val('ActionText', $Activity, t('Check it out')))
                     ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
 
-                $message = '';
-
-                if ($prefix = c('Garden.Email.Prefix', '')) {
-                    $message = $prefix;
-                }
-
-                if ($story = val('Story', $Activity)) {
-                    $message .= $story;
-                }
-
-                if ($message) {
+                if ($message = $this->getEmailMessage($Activity)) {
                     $emailTemplate->setMessage($message, true);
                 }
 

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -875,9 +875,18 @@ class ActivityModel extends Gdn_Model {
                     ->setButton($url, val('ActionText', $Activity, t('Check it out')))
                     ->setTitle($ActivityHeadline);
 
-                if ($message = val('Story', $Activity)) {
-                    $prefix = c('Garden.Email.Prefix', '');
-                    $emailTemplate->setMessage($prefix.$message, true);
+		$message = '';
+
+		if ($prefix = c('Garden.Email.Prefix', '')) {
+		    $message = $prefix;
+		}
+
+		if ($story = val('Story', $Activity)) {
+		    $message .= $story;
+		}
+
+		if ($message) {
+		    $emailTemplate->setMessage($message, true);
                 }
 
                 $Email->setEmailTemplate($emailTemplate);
@@ -968,9 +977,18 @@ class ActivityModel extends Gdn_Model {
             ->setButton($url, val('ActionText', $Activity, t('Check it out')))
             ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
 
-        if ($message = val('Story', $Activity)) {
-            $prefix = c('Garden.Email.Prefix', '');
-            $emailTemplate->setMessage($prefix.$message, true);
+	$message = '';
+
+	if ($prefix = c('Garden.Email.Prefix', '')) {
+	    $message = $prefix;
+	}
+
+	if ($story = val('Story', $Activity)) {
+	    $message .= $story;
+	}
+
+	if ($message) {
+	    $emailTemplate->setMessage($message, true);
         }
 
         $Email->setEmailTemplate($emailTemplate);
@@ -1230,10 +1248,21 @@ class ActivityModel extends Gdn_Model {
                 $emailTemplate = $Email->getEmailTemplate()
                     ->setButton($url, val('ActionText', $Activity, t('Check it out')))
                     ->setTitle(Gdn_Format::plainText(val('Headline', $Activity)));
-                if ($message = val('Story', $Activity)) {
-                    $prefix = c('Garden.Email.Prefix', '');
-                    $emailTemplate->setMessage($prefix.$message, true);
+
+		$message = '';
+
+		if ($prefix = c('Garden.Email.Prefix', '')) {
+		    $message = $prefix;
+		}
+
+		if ($story = val('Story', $Activity)) {
+		    $message .= $story;
+		}
+
+		if ($message) {
+		    $emailTemplate->setMessage($message, true);
                 }
+
                 $Email->setEmailTemplate($emailTemplate);
 
                 if (!array_key_exists($User->UserID, $this->_NotificationQueue)) {


### PR DESCRIPTION
Makes sure that the config setting is respected in Activity emails with no message.