### PR TITLE
Add css to make initial spoiler text the same colour as its background.

### DIFF
--- a/applications/dashboard/design/spoilers.css
+++ b/applications/dashboard/design/spoilers.css
@@ -2,11 +2,17 @@ div.Spoiler {
    margin:4px 0;
    padding: 5px 10px;
    margin-right: 10px;
-   background-color: #808080;
-   background-color: rgba(128, 128, 128, .2);
+   color: #e6e6e6;
+   background-color: #e6e6e6;
    -moz-border-radius: 3px;
    -webkit-border-radius: 3px;
    border-radius: 3px;
+}
+
+div.Spoiler.SpoilerConfigured {
+   background-color: #e6e6e6;
+   background-color: rgba(128, 128, 128, .2);
+   color: inherit;
 }
 
 div.Spoiler div.SpoilerTitle {

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ if (PHP_VERSION_ID < 50400) {
 }
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.2.109');
+define('APPLICATION_VERSION', '2.2.110');
 
 // Report and track all errors.
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);


### PR DESCRIPTION
Spoilers are rendered with js and sometimes, especially when users have slower connections, the spoilers can appear before the spoilers are rendered. This assigns the spoiler color to the same color as its background until the spoiler is rendered. 

Using the same color property as the background is favoured over using transparent to give the added bonus of being able to read the text when highlighting it if javascript is disabled.