### PR TITLE
Remove double references from functions

### DIFF
--- a/applications/dashboard/views/activity/helper_functions.php
+++ b/applications/dashboard/views/activity/helper_functions.php
@@ -1,6 +1,6 @@
 <?php if (!defined('APPLICATION')) exit();
 
-function writeActivity($Activity, &$Sender, &$Session) {
+function writeActivity($Activity, $Sender, $Session) {
     $Activity = (object)$Activity;
     // If this was a status update or a wall comment, don't bother with activity strings
     $ActivityType = explode(' ', $Activity->ActivityType); // Make sure you strip out any extra css classes munged in here

--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -116,7 +116,7 @@ if (!function_exists('WriteDiscussion')) :
      * @param $Sender
      * @param $Session
      */
-    function writeDiscussion($Discussion, &$Sender, &$Session) {
+    function writeDiscussion($Discussion, $Sender, $Session) {
         $CssClass = CssClass($Discussion);
         $DiscussionUrl = $Discussion->Url;
         $Category = CategoryModel::categories($Discussion->CategoryID);

--- a/applications/vanilla/views/discussions/table_functions.php
+++ b/applications/vanilla/views/discussions/table_functions.php
@@ -32,7 +32,7 @@ if (!function_exists('WriteDiscussionRow')) :
     /**
      * Writes a discussion in table row format.
      */
-    function writeDiscussionRow($Discussion, &$Sender, &$Session, $Alt2) {
+    function writeDiscussionRow($Discussion, $Sender, $Session, $Alt2) {
         if (!property_exists($Sender, 'CanEditDiscussions')) {
             $Sender->CanEditDiscussions = val('PermsDiscussionsEdit', CategoryModel::categories($Discussion->CategoryID)) && c('Vanilla.AdminCheckboxes.Use');
         }

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -542,7 +542,7 @@ class EditorPlugin extends Gdn_Plugin {
      * Placed these components everywhere due to some Web sites loading the
      * editor in some areas where the values were not yet injected into HTML.
      */
-    public function base_render_before(&$Sender) {
+    public function base_render_before($Sender) {
         // Don't render any assets for editor if it's embedded. This effectively
         // disables the editor from embedded comments. Some HTML is still
         // inserted, because of the BeforeBodyBox handler, which does not contain any data relating to embedded content.


### PR DESCRIPTION
Objects are already references. Declaring them as reference parameters is almost always a bug.