### PR TITLE
Add function to format IP addresses for display

### DIFF
--- a/applications/dashboard/views/user/users.php
+++ b/applications/dashboard/views/user/users.php
@@ -39,7 +39,7 @@ foreach ($this->UserData->result() as $User) {
         <td class="Alt"><?php echo Gdn_Format::date($User->DateFirstVisit, 'html'); ?></td>
         <td><?php echo Gdn_Format::date($User->DateLastActive, 'html'); ?></td>
         <?php if ($ViewPersonalInfo) : ?>
-            <td><?php echo htmlspecialchars($User->LastIPAddress); ?></td>
+            <td><?php echo formatIP($User->LastIPAddress); ?></td>
         <?php endif; ?>
         <?php
         $this->EventArguments['User'] = $User;

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -563,11 +563,11 @@ if (!function_exists('formatIP')) {
      * Format an IP address for display.
      *
      * @param string $IP An IP address to be formatted.
-     * @param bool $escape Convert special characters to HTML entities.
-     * @return string The formatted IP address.
+     * @param bool $html Format as HTML.
+     * @return string Returns the formatted IP address.
      */
-    function formatIP($IP, $escape = true) {
-        return $escape ? htmlspecialchars($IP) : $IP;
+    function formatIP($IP, $html = true) {
+        return $html ? htmlspecialchars($IP) : $IP;
     }
 }
 

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -563,11 +563,11 @@ if (!function_exists('formatIP')) {
      * Format an IP address for display.
      *
      * @param string $IP An IP address to be formatted.
-     * @param bool $convert Convert special characters to HTML entities.
+     * @param bool $escape Convert special characters to HTML entities.
      * @return string The formatted IP address.
      */
-    function formatIP($IP, $convert = true) {
-        return $convert ? htmlspecialchars($IP) : $IP;
+    function formatIP($IP, $escape = true) {
+        return $escape ? htmlspecialchars($IP) : $IP;
     }
 }
 

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -558,6 +558,19 @@ if (!function_exists('fixnl2br')) {
     }
 }
 
+if (!function_exists('formatIP')) {
+    /**
+     * Format an IP address for display.
+     *
+     * @param string $IP An IP address to be formatted.
+     * @param bool $convert Convert special characters to HTML entities.
+     * @return string The formatted IP address.
+     */
+    function formatIP($IP, $convert = true) {
+        return $convert ? htmlspecialchars($IP) : $IP;
+    }
+}
+
 if (!function_exists('formatPossessive')) {
     /**
      * Format a word using English "possessive" formatting.
@@ -726,7 +739,7 @@ if (!function_exists('ipAnchor')) {
      */
     function ipAnchor($IP, $CssClass = '') {
         if ($IP) {
-            return anchor(htmlspecialchars($IP), '/user/browse?keywords='.urlencode($IP), $CssClass);
+            return anchor(formatIP($IP), '/user/browse?keywords='.urlencode($IP), $CssClass);
         } else {
             return $IP;
         }


### PR DESCRIPTION
This update adds a function to format IP addresses for display.  In addition, it aims to ensure any IP address that might be displayed are done so with either `ipAnchor` or this new function.

Closes #3687