### PR TITLE
Improve asset cache busting on deployed servers

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -342,54 +342,8 @@ if (!function_exists('asset')) {
         }
 
         if ($AddVersion) {
-            if (strpos($Result, '?') === false) {
-                $Result .= '?';
-            } else {
-                $Result .= '&';
-            }
-
-            // Figure out which version to put after the asset.
-            if (is_null($Version)) {
-                $Version = APPLICATION_VERSION;
-                if (preg_match('`^/([^/]+)/([^/]+)/`', $Destination, $Matches)) {
-                    $Type = $Matches[1];
-                    $Key = $Matches[2];
-                    static $ThemeVersion = null;
-
-                    switch ($Type) {
-                        case 'plugins':
-                            $PluginInfo = Gdn::pluginManager()->getPluginInfo($Key);
-                            $Version = val('Version', $PluginInfo, $Version);
-                            break;
-                        case 'applications':
-                            $AppInfo = Gdn::applicationManager()->getApplicationInfo(ucfirst($Key));
-                            $Version = val('Version', $AppInfo, $Version);
-                            break;
-                        case 'themes':
-                            if ($ThemeVersion === null) {
-                                $ThemeInfo = Gdn::themeManager()->getThemeInfo(Theme());
-                                if ($ThemeInfo !== false) {
-                                    $ThemeVersion = val('Version', $ThemeInfo, $Version);
-                                } else {
-                                    $ThemeVersion = $Version;
-                                }
-                            }
-                            $Version = $ThemeVersion;
-                            break;
-                    }
-                }
-            }
-
-            // Add a timestamp component to the version if available.
-            if ($timestamp = c('Garden.Deployed')) {
-                $graced = $timestamp + 30;
-                if (time() >= $graced) {
-                    $timestamp = $graced;
-                }
-                $Version .= '.'.dechex($timestamp);
-            }
-
-            $Result .= 'v='.urlencode($Version);
+            $Version = assetVersion($Destination, $Version);
+            $Result .= (strpos($Result, '?') === false ? '?' : '&').'v='.urlencode($Version);
         }
         return $Result;
     }
@@ -400,35 +354,42 @@ if (!function_exists('assetVersion')) {
      * Get a version string for a given asset.
      *
      * @param string $Destination The path of the asset.
+     * @param string|null $Version A known version for the asset or **null** to grab it from the addon's info array.
      * @return string Returns a version string.
      */
-    function assetVersion($Destination) {
+    function assetVersion($Destination, $Version = null) {
         // Figure out which version to put after the asset.
-        $Version = APPLICATION_VERSION;
-        $Matches = null;
-        if (preg_match('`^/([^/]+)/([^/]+)/`', $Destination, $Matches)) {
-            $Type = $Matches[1];
-            $Key = $Matches[2];
-            static $ThemeVersion = null;
+        if (is_null($Version)) {
+            $Version = APPLICATION_VERSION;
+            if (preg_match('`^/([^/]+)/([^/]+)/`', $Destination, $Matches)) {
+                $Type = $Matches[1];
+                $Key = $Matches[2];
+                static $ThemeVersion = null;
 
-            switch ($Type) {
-                case 'plugins':
-                    $PluginInfo = Gdn::PluginManager()->GetPluginInfo($Key);
-                    $Version = GetValue('Version', $PluginInfo, $Version);
-                    break;
-                case 'themes':
-                    if ($ThemeVersion === null) {
-                        $ThemeInfo = Gdn::ThemeManager()->GetThemeInfo(Theme());
-                        if ($ThemeInfo !== false) {
-                            $ThemeVersion = GetValue('Version', $ThemeInfo, $Version);
-                        } else {
-                            $ThemeVersion = $Version;
+                switch ($Type) {
+                    case 'plugins':
+                        $PluginInfo = Gdn::pluginManager()->getPluginInfo($Key);
+                        $Version = val('Version', $PluginInfo, $Version);
+                        break;
+                    case 'applications':
+                        $AppInfo = Gdn::applicationManager()->getApplicationInfo(ucfirst($Key));
+                        $Version = val('Version', $AppInfo, $Version);
+                        break;
+                    case 'themes':
+                        if ($ThemeVersion === null) {
+                            $ThemeInfo = Gdn::themeManager()->getThemeInfo(Theme());
+                            if ($ThemeInfo !== false) {
+                                $ThemeVersion = val('Version', $ThemeInfo, $Version);
+                            } else {
+                                $ThemeVersion = $Version;
+                            }
                         }
-                    }
-                    $Version = $ThemeVersion;
-                    break;
+                        $Version = $ThemeVersion;
+                        break;
+                }
             }
         }
+
         // Add a timestamp component to the version if available.
         if ($timestamp = c('Garden.Deployed')) {
             $graced = $timestamp + 30;

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -353,38 +353,38 @@ if (!function_exists('assetVersion')) {
     /**
      * Get a version string for a given asset.
      *
-     * @param string $Destination The path of the asset.
-     * @param string|null $Version A known version for the asset or **null** to grab it from the addon's info array.
+     * @param string $destination The path of the asset.
+     * @param string|null $version A known version for the asset or **null** to grab it from the addon's info array.
      * @return string Returns a version string.
      */
-    function assetVersion($Destination, $Version = null) {
+    function assetVersion($destination, $version = null) {
         // Figure out which version to put after the asset.
-        if (is_null($Version)) {
-            $Version = APPLICATION_VERSION;
-            if (preg_match('`^/([^/]+)/([^/]+)/`', $Destination, $Matches)) {
-                $Type = $Matches[1];
-                $Key = $Matches[2];
-                static $ThemeVersion = null;
+        if (is_null($version)) {
+            $version = APPLICATION_VERSION;
+            if (preg_match('`^/([^/]+)/([^/]+)/`', $destination, $matches)) {
+                $type = $matches[1];
+                $key = $matches[2];
+                static $themeVersion = null;
 
-                switch ($Type) {
+                switch ($type) {
                     case 'plugins':
-                        $PluginInfo = Gdn::pluginManager()->getPluginInfo($Key);
-                        $Version = val('Version', $PluginInfo, $Version);
+                        $pluginInfo = Gdn::pluginManager()->getPluginInfo($key);
+                        $version = val('Version', $pluginInfo, $version);
                         break;
                     case 'applications':
-                        $AppInfo = Gdn::applicationManager()->getApplicationInfo(ucfirst($Key));
-                        $Version = val('Version', $AppInfo, $Version);
+                        $applicationInfo = Gdn::applicationManager()->getApplicationInfo(ucfirst($key));
+                        $version = val('Version', $applicationInfo, $version);
                         break;
                     case 'themes':
-                        if ($ThemeVersion === null) {
-                            $ThemeInfo = Gdn::themeManager()->getThemeInfo(Theme());
-                            if ($ThemeInfo !== false) {
-                                $ThemeVersion = val('Version', $ThemeInfo, $Version);
+                        if ($themeVersion === null) {
+                            $themeInfo = Gdn::themeManager()->getThemeInfo(Theme());
+                            if ($themeInfo !== false) {
+                                $themeVersion = val('Version', $themeInfo, $version);
                             } else {
-                                $ThemeVersion = $Version;
+                                $themeVersion = $version;
                             }
                         }
-                        $Version = $ThemeVersion;
+                        $version = $themeVersion;
                         break;
                 }
             }
@@ -396,9 +396,9 @@ if (!function_exists('assetVersion')) {
             if (time() >= $graced) {
                 $timestamp = $graced;
             }
-            $Version .= '.'.dechex($timestamp);
+            $version .= '.'.dechex($timestamp);
         }
-        return $Version;
+        return $version;
     }
 }
 


### PR DESCRIPTION
Add an extra cache-busting hash to the end of asset versions based on the "Garden.Deployed" config setting. The config setting must be a timestamp and is usually set by some mechanism other than the app. When the app encounters the timestamp it gives it a grace period. Before the grace period has passed, the original timestamp is used. Once the grace period is expired then the timestamp + 30 is used. In this way there is a waiting period for race conditions to be resolved on multi-server setups.

Eventually, the versions themselves may be removed in favor of the deployed time entirely.