### PR TITLE
Use the correct permission in category management actions

### DIFF
--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -261,7 +261,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function addCategory() {
         // Check permission
-        $this->permission('Garden.Community.Manage');
+        $this->permission(['Garden.Community.Manage', 'Garden.Settings.Manage'], false);
 
         // Set up head
         $this->addJsFile('jquery.alphanumeric.js');
@@ -332,7 +332,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function getCategory($categoryID) {
         // Check permission
-        $this->permission('Garden.Community.Manage');
+        $this->permission(['Garden.Community.Manage', 'Garden.Settings.Manage'], false);
 
         if (!$categoryID) {
             throw new Gdn_UserException(sprintf(t('ValidationRequired'), 'CategoryID'));
@@ -368,7 +368,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function deleteCategory($CategoryID = false) {
         // Check permission
-        $this->permission('Garden.Community.Manage');
+        $this->permission(['Garden.Community.Manage', 'Garden.Settings.Manage'], false);
 
         // Set up head
         $this->addJsFile('categories.js');
@@ -460,7 +460,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function deleteCategoryPhoto($CategoryID = false, $TransientKey = '') {
         // Check permission
-        $this->permission('Garden.Community.Manage');
+        $this->permission(['Garden.Community.Manage', 'Garden.Settings.Manage'], false);
 
         $RedirectUrl = 'vanilla/settings/editcategory/'.$CategoryID;
 
@@ -513,7 +513,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function editCategory($CategoryID = '') {
         // Check permission
-        $this->permission('Garden.Community.Manage');
+        $this->permission(['Garden.Community.Manage', 'Garden.Settings.Manage'], false);
 
         // Set up models
         $RoleModel = new RoleModel();
@@ -611,7 +611,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function manageCategories() {
         // Check permission
-        $this->permission('Garden.Community.Manage');
+        $this->permission(['Garden.Community.Manage', 'Garden.Settings.Manage'], false);
         $this->addSideMenu('vanilla/settings/managecategories');
 
         $this->addJsFile('categories.js');
@@ -634,7 +634,7 @@ class SettingsController extends Gdn_Controller {
         $CategoryData = $this->CategoryModel->getAll('TreeLeft');
 
         // Set CanDelete per-category so we can override later if we want.
-        $canDelete = checkPermission('Garden.Community.Manage');
+        $canDelete = checkPermission(['Garden.Community.Manage', 'Garden.Settings.Manage']);
         array_walk($CategoryData->result(), function(&$value) use ($canDelete) {
             setvalr('CanDelete', $value, $canDelete);
         });
@@ -710,7 +710,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function sortCategories() {
         // Check permission
-        $this->permission('Garden.Community.Manage');
+        $this->permission(['Garden.Community.Manage', 'Garden.Settings.Manage'], false);
 
         // Set delivery type to true/false
         if (Gdn::request()->isAuthenticatedPostBack()) {

--- a/applications/vanilla/controllers/class.settingscontroller.php
+++ b/applications/vanilla/controllers/class.settingscontroller.php
@@ -368,7 +368,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function deleteCategory($CategoryID = false) {
         // Check permission
-        $this->permission('Garden.Settings.Manage');
+        $this->permission('Garden.Community.Manage');
 
         // Set up head
         $this->addJsFile('categories.js');
@@ -460,7 +460,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function deleteCategoryPhoto($CategoryID = false, $TransientKey = '') {
         // Check permission
-        $this->permission('Garden.Settings.Manage');
+        $this->permission('Garden.Community.Manage');
 
         $RedirectUrl = 'vanilla/settings/editcategory/'.$CategoryID;
 
@@ -634,7 +634,7 @@ class SettingsController extends Gdn_Controller {
         $CategoryData = $this->CategoryModel->getAll('TreeLeft');
 
         // Set CanDelete per-category so we can override later if we want.
-        $canDelete = checkPermission('Garden.Settings.Manage');
+        $canDelete = checkPermission('Garden.Community.Manage');
         array_walk($CategoryData->result(), function(&$value) use ($canDelete) {
             setvalr('CanDelete', $value, $canDelete);
         });
@@ -710,7 +710,7 @@ class SettingsController extends Gdn_Controller {
      */
     public function sortCategories() {
         // Check permission
-        $this->permission('Garden.Settings.Manage');
+        $this->permission('Garden.Community.Manage');
 
         // Set delivery type to true/false
         if (Gdn::request()->isAuthenticatedPostBack()) {


### PR DESCRIPTION
Managing a category is related to `Garden.Community.Manage` not `Garden.Settings.Manage`

With this fix users with `Garden.Community.Manage` won't get permission problem when deleting(categories and categories' photo) and sorting categories 