### PR TITLE
Only use CommentID for SPAM check if available

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -848,15 +848,16 @@ class CommentModel extends VanillaModel {
                 $Fields = $this->Validation->SchemaValidationFields();
                 unset($Fields[$this->PrimaryKey]);
 
+                $CommentData = $CommentID ? array_merge($Fields, ['CommentID' => $CommentID]) : $Fields;
                 // Check for spam
-                $spam = SpamModel::isSpam('Comment', array_merge($Fields, array('CommentID' => $CommentID)));
+                $spam = SpamModel::isSpam('Comment', $CommentData);
                 if ($spam) {
                     return SPAM;
                 }
 
                 $isValid = true;
                 $invalidReturnType = false;
-                $this->EventArguments['CommentData'] = $CommentID ? array_merge($Fields, array('CommentID' => $CommentID)) : $Fields;
+                $this->EventArguments['CommentData'] = $CommentData;
                 $this->EventArguments['IsValid'] = &$isValid;
                 $this->EventArguments['InvalidReturnType'] = &$invalidReturnType;
                 $this->fireEvent('AfterValidateComment');


### PR DESCRIPTION
`CommentModel` always passes `CommentID` to `SpamModel::isSpam` checks, even when `CommentID` isn't present (i.e. a new comment).  This empty value becomes a 0, which is `RecordID` in the log table, if a SPAM comment is detected.  SPAM comments are grouped by this `RecordID` column.  Once you have one of them in the database, the next new comment being flagged as SPAM will overwrite the original record and the pattern will repeat itself until the 0 record is removed from the database.

This update only attempts to join in `CommentID` if a valid ID is present, which avoids these types of ID collision scenarios.