### PR TITLE
Improve compatibility of popup AJAX form submission

### DIFF
--- a/js/library/jquery.form.js
+++ b/js/library/jquery.form.js
@@ -950,13 +950,13 @@ $.fn.formToArray = function(semantic, elements) {
     var els = semantic ? form.getElementsByTagName('*') : form.elements;
     var els2;
 
-    if ( els ) {
+    if (els && !/MSIE [678]/.test(navigator.userAgent)) {
         els = $(els).get();  // convert to standard array
     }
 
     // #386; account for inputs outside the form which use the 'form' attribute
     if ( formId ) {
-        els2 = $('#' + formId + ' :input').get();
+        els2 = $(':input[form=' + formId + ']').get();
         if ( els2.length ) {
             els = (els || []).concat(els2);
         }

--- a/js/library/jquery.form.js
+++ b/js/library/jquery.form.js
@@ -956,7 +956,7 @@ $.fn.formToArray = function(semantic, elements) {
 
     // #386; account for inputs outside the form which use the 'form' attribute
     if ( formId ) {
-        els2 = $(':input[form=' + formId + ']').get();
+        els2 = $('#' + formId + ' :input').get();
         if ( els2.length ) {
             els = (els || []).concat(els2);
         }


### PR DESCRIPTION
The jQuery Form plug-in we use for handling in-page popup window form submissions had some issues with older versions of Internet Explorer.  The issue was addressed, but the version we use does not include that fix.  I've cherrypicked that fix into our version of the plug-in.  I chose not to update the whole plug-in for a couple reasons:

1. The plug-in has been abandoned for about two years.  There are several issues outstanding.  I know what we have works.  I don't know what issues have been introduced and won't be addressed if we go to the new version.
2. The fix is tiny, but the diff between our version and the current version is sizable.  I'd rather make one tiny change with limited impact than risk upgrading the whole library and having it somehow break existing integrations.  If we continue seeing issues it might be worth it to risk an upgrade, but I think our three-year-old version has held up pretty well.

Closes #3680
