### PR TITLE
Prefill the username when using a connection method

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -623,7 +623,7 @@ EOT;
             }
 
             if (!isset($NameFound) && !$IsPostBack) {
-                $this->Form->setFormValue('ConnectName', $this->Form->getFormValue('Name'));
+                $this->Form->setValue('ConnectName', $this->Form->getFormValue('Name'));
             }
 
             if (!$allowConnect) {


### PR DESCRIPTION
The ConnectName field has not been prefilled because it was set with setFormValue(), but setValue() has to be used.