### PR TITLE
Add EventListener to comment post button

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -11,7 +11,7 @@
 $PluginInfo['editor'] = array(
    'Name' => 'Advanced Editor',
    'Description' => 'Enables advanced editing of posts in several formats, including WYSIWYG, simple HTML, Markdown, and BBCode.',
-   'Version' => '1.7.7',
+   'Version' => '1.7.8',
    'Author' => "Dane MacMillan",
    'AuthorUrl' => 'http://www.vanillaforums.org/profile/dane',
    'RequiredApplications' => array('Vanilla' => '>=2.2'),

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1492,6 +1492,10 @@
                     $currentEditorToolbar.show();
                 });
 
+                $(document).on('click', 'input.CommentButton', function() {
+                    $currentEditorToolbar.show();
+                });
+
                 switch (format) {
                     case 'wysiwyg':
                     case 'ipb':

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1488,11 +1488,7 @@
                     $currentEditorToolbar.hide();
                 });
 
-                $(document).on('click', 'a.WriteButton', function() {
-                    $currentEditorToolbar.show();
-                });
-
-                $(document).on('click', 'input.CommentButton', function() {
+                $(document).on('click', 'a.WriteButton, input.CommentButton', function() {
                     $currentEditorToolbar.show();
                 });
 


### PR DESCRIPTION
If you were in preview mode and posted your comment then the button bar would stay missing until you toggle preview mode again.  This adds an event listener to the post comment button that makes the button bar re-appear if you post the comment while in preview mode.