### PR TITLE
Allow the Photo field to be set in /profile/edit

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -377,7 +377,7 @@ class ProfileController extends Gdn_Controller {
         $this->fireEvent('BeforeEdit');
 
         // If seeing the form for the first time...
-        if ($this->Form->authenticatedPostBack()) {
+        if ($this->Form->authenticatedPostBack(true)) {
             $this->Form->setFormValue('UserID', $UserID);
 
             if (!$CanEditUsername) {
@@ -429,6 +429,15 @@ class ProfileController extends Gdn_Controller {
 
             if ($CanConfirmEmail && is_bool($Confirmation)) {
                 $this->Form->setFormValue('Confirmed', (int)$Confirmation);
+            }
+
+            // Don't allow non-mods to set an explicit photo.
+            if ($photo = $this->Form->getFormValue('Photo')) {
+                if (!checkPermission('Garden.Users.Edit')) {
+                    $this->Form->removeFormValue('Photo');
+                } elseif (!filter_var($photo, FILTER_VALIDATE_URL)) {
+                    $this->Form->addError('Invalid photo URL.');
+                }
             }
 
             if ($this->Form->save($Settings) !== false) {
@@ -732,7 +741,7 @@ class ProfileController extends Gdn_Controller {
                 if (isUrl($photoUrl) && filter_var($photoUrl, FILTER_VALIDATE_URL)) {
                     $UserPhoto = $photoUrl;
                 } else {
-                    $this->Form->addError('Invalid photo URL');
+                    $this->Form->addError('Invalid photo URL.');
                 }
             } else {
                 $UploadImage = new Gdn_UploadImage();

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -64,7 +64,7 @@ class UserModel extends Gdn_Model {
         $this->addFilterField(array(
             'Admin', 'Deleted', 'CountVisits', 'CountInvitations', 'CountNotifications', 'Preferences', 'Permissions',
             'LastIPAddress', 'AllIPAddresses', 'DateFirstVisit', 'DateLastActive', 'CountDiscussions', 'CountComments',
-            'Score', 'Photo'
+            'Score'
         ));
     }
 

--- a/tests/APIv0/APIv0.php
+++ b/tests/APIv0/APIv0.php
@@ -132,11 +132,19 @@ class APIv0 extends HttpClient {
      * @return string Returns the transient key for the user.
      */
     public function getTK($userID) {
-        $user = $this->queryOne("select * from GDN_User where UserID = :userID", [':userID' => $userID]);
+        $user = $this->queryOne("select * from GDN_User where UserID = :userID", ['userID' => $userID]);
         if (empty($user)) {
             return '';
         }
-        $attributes = @unserialize($user['Attributes']);
+        $attributes = (array)dbdecode($user['Attributes']);
+        if (empty($attributes['TransientKey'])) {
+            $attributes['TransientKey'] = randomString(20);
+            $r = $this->query(
+                "update GDN_User set Attributes = :attributes where UserID = :userID",
+                ['attributes' => dbencode($attributes), 'userID' => $userID],
+                true
+            );
+        }
         return val('TransientKey', $attributes, '');
     }
 

--- a/tests/APIv0/StandardTest.php
+++ b/tests/APIv0/StandardTest.php
@@ -73,6 +73,59 @@ class StandardTest extends BaseTest {
 
         $siteUser['tk'] = $this->api()->getTK($siteUser['UserID']);
         $this->setTestUser($siteUser);
+        return $siteUser;
+    }
+
+    /**
+     * Test that a photo can be saved to a user.
+     *
+     * @param array $admin An admin user with permission to add a photo.
+     * @param array $user The user to test against.
+     * @depends testAddAdminUser
+     * @depends testRegisterBasic
+     */
+    public function testSetPhoto($admin, $user) {
+        $this->api()->setUser($admin);
+
+        $photo = 'http://example.com/u.gif';
+        $r = $this->api()->post('/profile/edit.json?userid='.$user['UserID'], ['Photo' => $photo]);
+
+        $dbUser = $this->api()->queryUserKey($user['UserID'], true);
+        $this->assertSame($photo, $dbUser['Photo']);
+    }
+
+    /**
+     * Test an invalid photo URL on a user.
+     *
+     * @param array $admin The user that will set the photo.
+     * @param array $user The user to test against.
+     * @depends testAddAdminUser
+     * @depends testRegisterBasic
+     */
+    public function testSetInvalidPhoto($admin, $user) {
+        $this->api()->setUser($admin);
+
+        $photo = 'javascript: alert("Xss");';
+        $r = $this->api()->post('/profile/edit.json?userid='.$user['UserID'], ['Photo' => $photo]);
+
+        $dbUser = $this->api()->queryUserKey($user['UserID'], true);
+        $this->assertSame($photo, $dbUser['Photo']);
+    }
+
+    /**
+     * Test a permission error when adding a photo.
+     *
+     * @param array $user The user to test against.
+     * @depends testRegisterBasic
+     */
+    public function testSetPhotoPermission($user) {
+        $this->api()->setUser($user);
+
+        $photo = 'http://example.com/u.gif';
+        $r = $this->api()->post('/profile/edit.json?userid='.$user['UserID'], ['Photo' => $photo]);
+
+        $dbUser = $this->api()->queryUserKey($user['UserID'], true);
+        $this->assertEmpty($dbUser['Photo']);
     }
 
     /**
@@ -181,5 +234,7 @@ class StandardTest extends BaseTest {
         $userRoles = $this->api()->query("select * from GDN_UserRole where UserID = :userID", [':userID' => $dbUser['UserID']]);
         $userRoleIDs = array_column($userRoles, 'RoleID');
         $this->assertEquals($adminUser['RoleID'], $userRoleIDs);
+
+        return $dbUser;
     }
 }


### PR DESCRIPTION
Allow moderators to set the Photo field to a URL in /profile/edit. This was functionality that was originally removed, but is getting eased back in. Since the photo would be previously filtered out that behavior is being reproduced for non-admins.

There is a cursory check to make sure the Photo field is a valid URL, but built in function isn’t exhaustive. Since this functionality is mod-only I think this is okay for now, but a more robust URL validator will need to be added in the future.