### PR TITLE
Move member $rowCountEstimates from databaseStructure to mysqlStructure.

### DIFF
--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -14,11 +14,6 @@
  */
 abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
     /**
-     * @var array[int] An array of table names to row count estimates.
-     */
-    private $rowCountEstimates;
-
-    /**
      * @var int The maximum number of rows allowed for an alter table.
      */
     private $alterTableThreshold;

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -16,6 +16,10 @@
  * Class Gdn_MySQLStructure
  */
 class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
+    /**
+     * @var array[int] An array of table names to row count estimates.
+     */
+    private $rowCountEstimates;
 
     /**
      *


### PR DESCRIPTION
Since https://github.com/vanilla/vanilla/pull/3605 the property has been set private but is used in the child class (which is now "hiding" the parent property since php allows to declare properties on the fly)

Anyway.. let's just move the property declaration in `Gdn_MySQLStructure` since it is not used in `Gdn_DatabaseStructure`