### PR TITLE
Change the protection level of Gdn_DatabaseStructure->rowCountEstimates

### DIFF
--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -16,7 +16,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
     /**
      * @var array[int] An array of table names to row count estimates.
      */
-    private $rowCountEstimates;
+    protected $rowCountEstimates;
 
     /**
      * @var int The maximum number of rows allowed for an alter table.


### PR DESCRIPTION
Since subclasses set the property then it should be protected, not private.