### PR TITLE
Category Scaling Part 1

### DIFF
--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -143,8 +143,7 @@ class MessageModel extends Gdn_Model {
 
         $category = null;
         if (!empty($CategoryID)) {
-            $categoryModel = new CategoryModel();
-            $category = $categoryModel->getID($CategoryID, DATASET_TYPE_ARRAY);
+            $category = CategoryModel::categories($CategoryID);
         }
 
         $Exceptions = array_map('strtolower', $Exceptions);
@@ -174,7 +173,7 @@ class MessageModel extends Gdn_Model {
 
                 $Visible = $Visible && self::inCategory($CategoryID, val('CategoryID', $Message), val('IncludeSubcategories', $Message));
                 if ($category !== null) {
-                    $Visible = $Visible && $Session->checkPermission('Vanilla.Discussions.View', true, 'Category', $category['PermissionCategoryID']);
+                    $Visible &= CategoryModel::checkPermission($category, 'Vanilla.Discussions.View');
                 }
 
                 if ($Visible) {

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -86,15 +86,15 @@ class DiscussionController extends VanillaController {
         $OffsetProvided = $Page != '';
         list($Offset, $Limit) = offsetLimit($Page, $Limit);
 
-        // Check permissions
-        $this->permission('Vanilla.Discussions.View', true, 'Category', $this->Discussion->PermissionCategoryID);
+        // Check permissions.
+        $Category = CategoryModel::categories($this->Discussion->CategoryID);
+        $this->permission('Vanilla.Discussions.View', true, 'Category', val('PermissionCategoryID', $Category, -1));
         $this->setData('CategoryID', $this->CategoryID = $this->Discussion->CategoryID, true);
 
         if (strcasecmp(val('Type', $this->Discussion), 'redirect') === 0) {
             $this->redirectDiscussion($this->Discussion);
         }
 
-        $Category = CategoryModel::categories($this->Discussion->CategoryID);
         $this->setData('Category', $Category);
 
         if ($CategoryCssClass = val('CssClass', $Category)) {

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -285,6 +285,23 @@ class CategoryCollection {
     }
 
     /**
+     * Get the children of a category.
+     *
+     * @param int $categoryID The category to get the children for.
+     * @return array Returns an array of categories.
+     */
+    public function getChildren($categoryID) {
+        $children = $this
+            ->sql
+            ->select('CategoryID')
+            ->getWhere('Category', ['ParentCategoryID' => $categoryID])
+            ->resultArray();
+        $ids = array_column($children, 'CategoryID');
+        $categories = $this->getMulti($ids);
+        return $categories;
+    }
+
+    /**
      * Get several categories by ID.
      *
      * @param array $categoryIDs An array of category IDs.

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -391,10 +391,13 @@ class CategoryCollection {
     /**
      * Refresh a category in the cache from the database.
      *
+     * This function is public for now, but should only be called from within the {@link CategoryModel}. Eventually it
+     * will be privatized.
+     *
      * @param int $categoryID The category to refresh.
      * @return bool Returns **true** if the category was refreshed or **false** otherwise.
      */
-    private function refreshCache($categoryID) {
+    public function refreshCache($categoryID) {
         $category = $this->sql->getWhere('Category', ['CategoryID' => $categoryID])->firstRow(DATASET_TYPE_ARRAY);
         if ($category) {
             $this->calculate($category);

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+/**
+ * Manages categories as a whole.
+ *
+ * This is a bridge class to aid in refactoring. This functionality will be rolled into the {@link CategoryModel}.
+ */
+class CategoryCollection {
+    /**
+     * @var string The cache key prefix that stores categories by ID.
+     */
+    private static $CACHE_CATEGORY = 'cat/';
+    /**
+     * @var string The cache key prefix that stores category IDs by slug (URL code).
+     */
+    private static $CACHE_CATEGORY_SLUG = 'catslug/';
+
+    /**
+     * @var Gdn_Cache The cache dependency.
+     */
+    private $cache;
+
+    /**
+     * @var Gdn_Configuration The config dependency.
+     */
+    private $config;
+
+    /**
+     * @var Gdn_SQLDriver The database layer dependency.
+     */
+    private $sql;
+
+    /**
+     * @var array The categories that have been retrieved, indexed by categoryID.
+     */
+    private $categories = [];
+
+    /**
+     * @var array An array that maps category slug to category ID.
+     */
+    private $categorySlugs = [];
+
+    /**
+     * @var Gdn_Schema The category table schema.
+     */
+    private $schema;
+
+    /**
+     * Initialize a new instance of the {@link CategoryCollection} class.
+     *
+     * @param Gdn_SQLDriver|null $sql The database layer dependency.
+     * @param Gdn_Cache|null $cache The cache layer dependency.
+     */
+    public function __construct(Gdn_SQLDriver $sql = null, Gdn_Cache $cache = null) {
+        if ($sql === null) {
+            $sql = Gdn::sql();
+        }
+        $this->sql = $sql;
+
+        if ($cache === null) {
+            $cache = Gdn::cache();
+        }
+        $this->cache = $cache;
+    }
+
+    /**
+     * Calculate dynamic data on a category.
+     *
+     * @param array &$category The category to calculate.
+     */
+    private function calculate(&$category) {
+        $category['CountAllDiscussions'] = $category['CountDiscussions'];
+        $category['CountAllComments'] = $category['CountComments'];
+//        $category['Url'] = self::categoryUrl($category, false, '/');
+        $category['ChildIDs'] = array();
+//        if (val('Photo', $category)) {
+//            $category['PhotoUrl'] = Gdn_Upload::url($category['Photo']);
+//        } else {
+//            $category['PhotoUrl'] = '';
+//        }
+
+        if ($category['DisplayAs'] == 'Default') {
+            if ($category['Depth'] <= $this->config('Vanilla.Categories.NavDepth', 0)) {
+                $category['DisplayAs'] = 'Categories';
+            } elseif ($category['Depth'] == ($this->config('Vanilla.Categories.NavDepth', 0) + 1) && $this->config('Vanilla.Categories.DoHeadings')) {
+                $category['DisplayAs'] = 'Heading';
+            } else {
+                $category['DisplayAs'] = 'Discussions';
+            }
+        }
+
+        if (!val('CssClass', $category)) {
+            $category['CssClass'] = 'Category-'.$category['UrlCode'];
+        }
+
+        if (isset($category['AllowedDiscussionTypes']) && is_string($category['AllowedDiscussionTypes'])) {
+            $category['AllowedDiscussionTypes'] = dbdecode($category['AllowedDiscussionTypes']);
+        }
+    }
+
+    /**
+     * Generate a full cache key.
+     *
+     * All cache keys should be generated using this function to support cache increments.
+     *
+     * @param string $type One of the **$CACHE_*** pseudo-constants.
+     * @param string|int $id The identifier in the cache.
+     * @return string Returns the cache key.
+     */
+    private function cacheKey($type, $id) {
+        return $type.$id;
+    }
+
+    /**
+     * Get a value from the config.
+     *
+     * @param string $key The config key.
+     * @param mixed $default The default to return if the config isn't found.
+     * @return mixed Returns the config value or {@link $default} if it isn't found.
+     */
+    private function config($key, $default) {
+        if ($this->config !== null) {
+            return $this->config($key, $default);
+        } else {
+            return $default;
+        }
+    }
+
+    /**
+     * Get the config.
+     *
+     * @return Gdn_Configuration Returns the config.
+     */
+    public function getConfig() {
+        return $this->config;
+    }
+
+    /**
+     * Set the config.
+     *
+     * @param Gdn_Configuration $config The config.
+     * @return CategoryCollection Returns `$this` for fluent calls.
+     */
+    public function setConfig($config) {
+        $this->config = $config;
+        return $this;
+    }
+
+    /**
+     * Get the schema.
+     *
+     * @return Gdn_Schema Returns the schema.
+     */
+    private function getSchema() {
+        if ($this->schema === null) {
+            $this->schema = new Gdn_Schema('Category', $this->sql->Database);
+        }
+        return $this->schema;
+    }
+
+    /**
+     * Strip the ID part of the end of a cache key.
+     *
+     * @param string $key The key to strip.
+     * @return string Returns the ID portion of the key.
+     */
+    private function stripKey($key) {
+        return substr(strrchr($key, '/'), 1);
+
+    }
+
+    /**
+     * Lookup a category by its URL slug.
+     *
+     * @param string $code The URL slug of the category.
+     * @return array|null Returns a category or **null** if one isn't found.
+     */
+    public function getByUrlCode($code) {
+        return $this->get($code);
+    }
+
+    /**
+     * Lookup a category by either ID or slug.
+     *
+     * @param int $categoryID The category ID to get.
+     * @return array|null Returns a category or **null** if one isn't found.
+     */
+    public function get($categoryID) {
+        // Figure out the ID.
+        if (is_int($categoryID)) {
+            $id = $categoryID;
+        } elseif (isset($this->categorySlugs[$categoryID])) {
+            $id = $this->categorySlugs[$categoryID];
+        } else {
+            // The ID still might not be found here.
+            $id = $this->cache->get($this->cacheKey(self::$CACHE_CATEGORY_SLUG, $categoryID));
+        }
+
+        if ($id) {
+            $id = (int)$id;
+
+            if (isset($this->categories[$id])) {
+                return $this->categories[$id];
+            } else {
+                $category = $this->cache->get($this->cacheKey(self::$CACHE_CATEGORY, $id));
+
+                if (!empty($category)) {
+                    $this->categories[$id] = $category;
+                    $this->categorySlugs[$category['UrlCode']] = $id;
+                    return $category;
+                }
+
+                $category = $this->sql->getWhere('Category', ['CategoryID' => $id])->firstRow(DATASET_TYPE_ARRAY);
+            }
+        } else {
+            $category = $this->sql->getWhere('Category', ['UrlCode' => $categoryID])->firstRow(DATASET_TYPE_ARRAY);
+        }
+
+        if (!empty($category)) {
+            // This category came from the database, so must be calculated.
+            $this->calculate($category);
+
+            $this->categories[(int)$category['CategoryID']] = $category;
+            $this->categorySlugs[$category['UrlCode']] = (int)$category['CategoryID'];
+
+            $this->cache->store(
+                $this->cacheKey(self::$CACHE_CATEGORY, $category['CategoryID']),
+                $category
+            );
+            $this->cache->store(
+                $this->cacheKey(self::$CACHE_CATEGORY_SLUG, $category['UrlCode']),
+                (int)$category['CategoryID']
+            );
+
+            return $category;
+        } else {
+            // Mark the category as not found for future searches.
+            if ($id) {
+                $this->categories[$id] = false;
+            }
+            if (is_string($categoryID)) {
+                $this->categorySlugs[$categoryID] = false;
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * Get several categories by ID.
+     *
+     * @param array $categoryIDs An array of category IDs.
+     * @return array Returns an array of categories, indexed by ID.
+     */
+    public function getMulti(array $categoryIDs) {
+        $categories = array_fill_keys($categoryIDs, null);
+
+        // Look in our internal cache.
+        $internalCategories = array_intersect_key($this->categories, $categories);
+        $categories = array_replace($categories, $internalCategories);
+
+        // Look in the global cache.
+        $diff = array_diff_key($categories, $internalCategories);
+        $keys = [];
+        foreach (array_diff_key($categories, $internalCategories) as $id => $null) {
+            $keys[] = $this->cacheKey(self::$CACHE_CATEGORY, $id);
+        }
+        if (!empty($keys)) {
+            $cacheCategories = $this->cache->get($keys);
+            foreach ($cacheCategories as $key => $category) {
+                $this->categories[(int)$category['CategoryID']] = $category;
+                $this->categorySlugs[$category['UrlCode']] = (int)$category['CategoryID'];
+
+                $categories[(int)$category['CategoryID']] = $category;
+            }
+        }
+
+        // Look in the database.
+        $dbCategoryIDs = [];
+        foreach ($categories as $id => $row) {
+            if (!$row) {
+                $dbCategoryIDs[] = $id;
+            }
+        }
+        $dbCategories = $this->sql->getWhere('Category', ['CategoryID' => $dbCategoryIDs])->resultArray();
+        foreach ($dbCategories as &$category) {
+            $this->calculate($category);
+
+            $this->cache->store(
+                $this->cacheKey(self::$CACHE_CATEGORY, $category['CategoryID']),
+                $category
+            );
+            $this->cache->store(
+                $this->cacheKey(self::$CACHE_CATEGORY_SLUG, $category['UrlCode']),
+                (int)$category['CategoryID']
+            );
+
+            $this->categories[(int)$category['CategoryID']] = $category;
+            $this->categorySlugs[$category['UrlCode']] = (int)$category['CategoryID'];
+
+            $categories[(int)$category['CategoryID']] = $category;
+        }
+
+        return $categories;
+    }
+
+    /**
+     * Insert a new category, handling its tree properties and caching.
+     *
+     * This method is currently only to to be used in a support role.
+     *
+     * @param array $category The new category.
+     */
+    public function insert(array $category) {
+        $category += [
+            'DateInserted' => Gdn_Format::toDateTime(),
+            'InsertUserID' => 1,
+            'ParentCategoryID' => -1,
+        ];
+
+        // Filter out fields that aren't in the table.
+        $category = array_intersect_key($category, $this->getSchema()->fields());
+        $categoryID = $this->sql->insert('Category', $category);
+
+        if ($categoryID) {
+            // Update my parent's count.
+            $this->sql->put('Category', ['CountCategories+' => 1], ['CategoryID' => $category['ParentCategoryID']]);
+
+            $this->refreshCache($category['CategoryID']);
+            $this->refreshCache($category['ParentCategoryID']);
+        }
+
+        return $categoryID;
+    }
+
+    /**
+     * Update an existing category, handling its tree properties and caching.
+     *
+     * @param array $category The category to update.
+     * @return bool Returns **true** if the category updated or **false** otherwise.
+     */
+    public function update(array $category) {
+        if (empty($category['CategoryID'])) {
+            throw new Gdn_UserException("Category ID is required.");
+        }
+
+        $category += [
+            'DateUpdated' => Gdn_Format::toDateTime(),
+            'UpdateUserID' => 1,
+        ];
+
+        // Get the current category.
+        $oldCategory = $this->get($category['CategoryID']);
+
+        if (!$oldCategory) {
+            $inserted = $this->insert($category);
+            if ($inserted) {
+                return $category['CategoryID'];
+            } else {
+                return false;
+            }
+        } else {
+            $this->sql->put('Category', $category, ['CategoryID' => $category['CategoryID']]);
+            $this->refreshCache($category['CategoryID']);
+
+            // Did my parent change?
+            if ((int)$oldCategory['ParentCategoryID'] !== (int)$category['ParentCategoryID']) {
+                // Increment the new parent and decrement the old parent.
+                $this->sql->put(
+                    'Category',
+                    ['CountCategories-' => 1],
+                    ['CategoryID' => $oldCategory['ParentCategoryID']]
+                );
+                $this->sql->put(
+                    'Category',
+                    ['CountCategories+' => 1],
+                    ['CategoryID' => $category['ParentCategoryID']]
+                );
+                $this->refreshCache($oldCategory['ParentCategoryID']);
+                $this->refreshCache($category['ParentCategoryID']);
+            }
+            return true;
+        }
+    }
+
+    /**
+     * Refresh a category in the cache from the database.
+     *
+     * @param int $categoryID The category to refresh.
+     * @return bool Returns **true** if the category was refreshed or **false** otherwise.
+     */
+    private function refreshCache($categoryID) {
+        $category = $this->sql->getWhere('Category', ['CategoryID' => $categoryID])->firstRow(DATASET_TYPE_ARRAY);
+        if ($category) {
+            $this->calculate($category);
+            $this->cache->store(
+                $this->cacheKey(self::$CACHE_CATEGORY, $category['CategoryID']),
+                $category
+            );
+            $this->cache->store(
+                $this->cacheKey(self::$CACHE_CATEGORY_SLUG, $category['UrlCode']),
+                (int)$category['CategoryID']
+            );
+
+            $this->categories[(int)$category['CategoryID']] = $category;
+            $this->categorySlugs[$category['UrlCode']] = (int)$category['CategoryID'];
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -82,7 +82,7 @@ class CategoryCollection {
         $category['CountAllDiscussions'] = $category['CountDiscussions'];
         $category['CountAllComments'] = $category['CountComments'];
 //        $category['Url'] = self::categoryUrl($category, false, '/');
-        $category['ChildIDs'] = array();
+        $category['ChildIDs'] = [];
 //        if (val('Photo', $category)) {
 //            $category['PhotoUrl'] = Gdn_Upload::url($category['Photo']);
 //        } else {
@@ -126,7 +126,7 @@ class CategoryCollection {
     public function flushCache() {
         $this->categories = [];
         $this->categorySlugs = [];
-        $r = $this->cache->increment(self::$CACHE_CATEGORY.'inc', 1, [Gdn_Cache::FEATURE_INITIAL => 1]);
+        $this->cache->increment(self::$CACHE_CATEGORY.'inc', 1, [Gdn_Cache::FEATURE_INITIAL => 1]);
     }
 
     /**
@@ -156,9 +156,9 @@ class CategoryCollection {
      * @param mixed $default The default to return if the config isn't found.
      * @return mixed Returns the config value or {@link $default} if it isn't found.
      */
-    private function config($key, $default) {
+    private function config($key, $default = null) {
         if ($this->config !== null) {
-            return $this->config($key, $default);
+            return $this->config->get($key, $default);
         } else {
             return $default;
         }
@@ -194,17 +194,6 @@ class CategoryCollection {
             $this->schema = new Gdn_Schema('Category', $this->sql->Database);
         }
         return $this->schema;
-    }
-
-    /**
-     * Strip the ID part of the end of a cache key.
-     *
-     * @param string $key The key to strip.
-     * @return string Returns the ID portion of the key.
-     */
-    private function stripKey($key) {
-        return substr(strrchr($key, '/'), 1);
-
     }
 
     /**
@@ -315,7 +304,6 @@ class CategoryCollection {
         $categories = array_replace($categories, $internalCategories);
 
         // Look in the global cache.
-        $diff = array_diff_key($categories, $internalCategories);
         $keys = [];
         foreach (array_diff_key($categories, $internalCategories) as $id => $null) {
             $keys[] = $this->cacheKey(self::$CACHE_CATEGORY, $id);

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -363,6 +363,7 @@ class CategoryModel extends Gdn_Model {
      */
     public static function clearCache() {
         Gdn::cache()->remove(self::CACHE_KEY);
+        self::instance()->collection->flushCache();
     }
 
     /**
@@ -1665,6 +1666,7 @@ class CategoryModel extends Gdn_Model {
             }
         }
         $this->SetCache();
+        $this->collection->flushCache();
     }
 
     /**
@@ -2017,6 +2019,8 @@ class CategoryModel extends Gdn_Model {
      * @param array $Data
      */
     public static function setCache($ID = false, $Data = false) {
+        self::instance()->collection->refreshCache((int)$ID);
+
         $Categories = Gdn::cache()->get(self::CACHE_KEY);
         self::$Categories = null;
 
@@ -2047,7 +2051,6 @@ class CategoryModel extends Gdn_Model {
         self::BuildCache($ID);
 
         self::JoinUserData(self::$Categories, true);
-        self::instance()->collection->refreshCache((int)$ID);
     }
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -281,7 +281,7 @@ class CategoryModel extends Gdn_Model {
     /**
      * Build and augment the category cache.
      *
-     * @param integer $CategoryID restrict JoinRecentPosts to this ID
+     * @param int $CategoryID The category to
      *
      */
     protected static function buildCache($CategoryID = null) {
@@ -2047,6 +2047,7 @@ class CategoryModel extends Gdn_Model {
         self::BuildCache($ID);
 
         self::JoinUserData(self::$Categories, true);
+        self::instance()->collection->refreshCache((int)$ID);
     }
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -152,6 +152,28 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * @param $Category
+     */
+    private static function calculateUser(&$Category) {
+        $Category['Url'] = url($Category['Url'], '//');
+        if ($Photo = val('Photo', $Category)) {
+            $Category['PhotoUrl'] = Gdn_Upload::url($Photo);
+        }
+
+        if (!empty($Category['LastUrl'])) {
+            $Category['LastUrl'] = url($Category['LastUrl'], '//');
+        }
+        $Category['PermsDiscussionsView'] = Gdn::session()->checkPermission('Vanilla.Discussions.View', true, 'Category', $Category['PermissionCategoryID']);
+        $Category['PermsDiscussionsAdd'] = Gdn::session()->checkPermission('Vanilla.Discussions.Add', true, 'Category', $Category['PermissionCategoryID']);
+        $Category['PermsDiscussionsEdit'] = Gdn::session()->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $Category['PermissionCategoryID']);
+        $Category['PermsCommentsAdd'] = Gdn::session()->checkPermission('Vanilla.Comments.Add', true, 'Category', $Category['PermissionCategoryID']);
+
+        $Code = $Category['UrlCode'];
+        $Category['Name'] = TranslateContent("Categories.".$Code.".Name", $Category['Name']);
+        $Category['Description'] = TranslateContent("Categories.".$Code.".Description", $Category['Description']);
+    }
+
+    /**
      *
      *
      * @since 2.0.18
@@ -835,8 +857,6 @@ class CategoryModel extends Gdn_Model {
                 $UserData = array();
             }
 
-//         Gdn::controller()->setData('UserData', $UserData);
-
             foreach ($IDs as $ID) {
                 $Category = $Categories[$ID];
 
@@ -876,28 +896,9 @@ class CategoryModel extends Gdn_Model {
         }
 
         // Add permissions.
-        $Session = Gdn::session();
         foreach ($IDs as $CID) {
-            $Category = $Categories[$CID];
-            $Categories[$CID]['Url'] = url($Category['Url'], '//');
-            if ($Photo = val('Photo', $Category)) {
-                $Categories[$CID]['PhotoUrl'] = Gdn_Upload::url($Photo);
-            }
-
-            if (!empty($Category['LastUrl'])) {
-                $Categories[$CID]['LastUrl'] = url($Category['LastUrl'], '//');
-            }
-            $Categories[$CID]['PermsDiscussionsView'] = $Session->checkPermission('Vanilla.Discussions.View', true, 'Category', $Category['PermissionCategoryID']);
-            $Categories[$CID]['PermsDiscussionsAdd'] = $Session->checkPermission('Vanilla.Discussions.Add', true, 'Category', $Category['PermissionCategoryID']);
-            $Categories[$CID]['PermsDiscussionsEdit'] = $Session->checkPermission('Vanilla.Discussions.Edit', true, 'Category', $Category['PermissionCategoryID']);
-            $Categories[$CID]['PermsCommentsAdd'] = $Session->checkPermission('Vanilla.Comments.Add', true, 'Category', $Category['PermissionCategoryID']);
-        }
-
-        // Translate name and description
-        foreach ($IDs as $ID) {
-            $Code = $Categories[$ID]['UrlCode'];
-            $Categories[$ID]['Name'] = TranslateContent("Categories.".$Code.".Name", $Categories[$ID]['Name']);
-            $Categories[$ID]['Description'] = TranslateContent("Categories.".$Code.".Description", $Categories[$ID]['Description']);
+            $Category = &$Categories[$CID];
+            self::calculateUser($Category);
         }
     }
 
@@ -1118,6 +1119,9 @@ class CategoryModel extends Gdn_Model {
      */
     private function getOne($id) {
         $category = $this->collection->get($id);
+        self::calculate($category);
+        self::calculateUser($category);
+
         return $category;
     }
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -256,41 +256,50 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * Calculate the dynamic fields of a category.
+     *
+     * @param array &$category The category to calculate.
+     */
+    private static function calculate(&$category) {
+        $category['CountAllDiscussions'] = $category['CountDiscussions'];
+        $category['CountAllComments'] = $category['CountComments'];
+        $category['Url'] = self::categoryUrl($category, false, '/');
+        $category['ChildIDs'] = array();
+        if (val('Photo', $category)) {
+            $category['PhotoUrl'] = Gdn_Upload::url($category['Photo']);
+        } else {
+            $category['PhotoUrl'] = '';
+        }
+
+        if ($category['DisplayAs'] == 'Default') {
+            if ($category['Depth'] <= c('Vanilla.Categories.NavDepth', 0)) {
+                $category['DisplayAs'] = 'Categories';
+            } elseif ($category['Depth'] == (c('Vanilla.Categories.NavDepth', 0) + 1) && c('Vanilla.Categories.DoHeadings')) {
+                $category['DisplayAs'] = 'Heading';
+            } else {
+                $category['DisplayAs'] = 'Discussions';
+            }
+        }
+
+        if (!val('CssClass', $category)) {
+            $category['CssClass'] = 'Category-'.$category['UrlCode'];
+        }
+
+        if (isset($category['AllowedDiscussionTypes']) && is_string($category['AllowedDiscussionTypes'])) {
+            $category['AllowedDiscussionTypes'] = dbdecode($category['AllowedDiscussionTypes']);
+        }
+    }
+
+    /**
      * Build calculated category data on the passed set.
      *
      * @since 2.0.18
      * @access public
      * @param array $Data Dataset.
      */
-    protected static function calculateData(&$Data) {
+    private static function calculateData(&$Data) {
         foreach ($Data as &$Category) {
-            $Category['CountAllDiscussions'] = $Category['CountDiscussions'];
-            $Category['CountAllComments'] = $Category['CountComments'];
-            $Category['Url'] = self::categoryUrl($Category, false, '/');
-            $Category['ChildIDs'] = array();
-            if (val('Photo', $Category)) {
-                $Category['PhotoUrl'] = Gdn_Upload::url($Category['Photo']);
-            } else {
-                $Category['PhotoUrl'] = '';
-            }
-
-            if ($Category['DisplayAs'] == 'Default') {
-                if ($Category['Depth'] <= c('Vanilla.Categories.NavDepth', 0)) {
-                    $Category['DisplayAs'] = 'Categories';
-                } elseif ($Category['Depth'] == (c('Vanilla.Categories.NavDepth', 0) + 1) && c('Vanilla.Categories.DoHeadings')) {
-                    $Category['DisplayAs'] = 'Heading';
-                } else {
-                    $Category['DisplayAs'] = 'Discussions';
-                }
-            }
-
-            if (!val('CssClass', $Category)) {
-                $Category['CssClass'] = 'Category-'.$Category['UrlCode'];
-            }
-
-            if (isset($Category['AllowedDiscussionTypes']) && is_string($Category['AllowedDiscussionTypes'])) {
-                $Category['AllowedDiscussionTypes'] = dbdecode($Category['AllowedDiscussionTypes']);
-            }
+            self::calculate($Category);
         }
 
         $Keys = array_reverse(array_keys($Data));

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -520,6 +520,18 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * Get the child categories of a category.
+     *
+     * @param int $categoryID The category to get the children of.
+     */
+    public static function getChildren($categoryID) {
+        $categories = self::instance()->collection->getChildren($categoryID);
+        self::calculateData($categories);
+        self::joinUserData($categories, false);
+        return $categories;
+    }
+
+    /**
      *
      *
      * @param string $Permission

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1118,9 +1118,15 @@ class CategoryModel extends Gdn_Model {
      * @param string|int $id The category code or ID.
      */
     private function getOne($id) {
+        if (is_numeric($id)) {
+            $id = (int)$id;
+        }
+
         $category = $this->collection->get($id);
-        self::calculate($category);
-        self::calculateUser($category);
+        if (!empty($category)) {
+            self::calculate($category);
+            self::calculateUser($category);
+        }
 
         return $category;
     }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -25,6 +25,11 @@ class CategoryModel extends Gdn_Model {
     /** Cache key. */
     const MASTER_VOTE_KEY = 'Categories.Rebuild.Vote';
 
+    /**
+     * @var CategoryModel $instance;
+     */
+    private static $instance;
+
     /** @var bool */
     public $Watching = false;
 
@@ -48,6 +53,18 @@ class CategoryModel extends Gdn_Model {
      */
     public function __construct() {
         parent::__construct('Category');
+    }
+
+    /**
+     * The shared instance of this object.
+     *
+     * @return CategoryModel Returns the instance.
+     */
+    public static function instance() {
+        if (self::$instance === null) {
+            self::$instance = new CategoryModel();
+        }
+        return self::$instance;
     }
 
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1376,6 +1376,17 @@ class DiscussionModel extends VanillaModel {
     }
 
     /**
+     * Get the count of discussions for an individual category.
+     *
+     * @param int $categoryID The category to get the count of.
+     * @return int Returns the count of discussions.
+     */
+    public function getCountForCategory($categoryID) {
+        $category = CategoryModel::categories((int)$categoryID);
+        return (int)val('CountDiscussions', $category, 0);
+    }
+
+    /**
      * Count how many discussions match the given criteria.
      *
      * @since 2.0.0
@@ -1389,6 +1400,8 @@ class DiscussionModel extends VanillaModel {
         $Wheres = $this->combineWheres($this->getWheres(), $Wheres);
         if (is_array($Wheres) && count($Wheres) == 0) {
             $Wheres = '';
+        } elseif (is_array($Wheres) && count($Wheres) === 1 && isset($Wheres['d.CategoryID'])) {
+            return $this->getCountForCategory($Wheres['d.CategoryID']);
         }
 
         // Check permission and limit to categories as necessary

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -24,6 +24,7 @@ $Px = $Construct->DatabasePrefix();
 
 $Construct->table('Category');
 $CategoryExists = $Construct->TableExists();
+$CountCategoriesExists = $Construct->columnExists('CountCategories');
 $PermissionCategoryIDExists = $Construct->columnExists('PermissionCategoryID');
 
 $LastDiscussionIDExists = $Construct->columnExists('LastDiscussionID');
@@ -32,7 +33,8 @@ $Construct->PrimaryKey('CategoryID')
     ->column('ParentCategoryID', 'int', true)
     ->column('TreeLeft', 'int', true)
     ->column('TreeRight', 'int', true)
-    ->column('Depth', 'int', true)
+    ->column('Depth', 'int', '0')
+    ->column('CountCategories', 'int', '0')
     ->column('CountDiscussions', 'int', '0')
     ->column('CountComments', 'int', '0')
     ->column('DateMarkedRead', 'datetime', null)
@@ -76,8 +78,8 @@ if ($Drop || !$CategoryExists) {
 }
 
 if ($CategoryExists) {
-    $CategoryModel = new CategoryModel();
-    $CategoryModel->RebuildTree();
+    CategoryModel::instance()->rebuildTree();
+    CategoryModel::instance()->recalculateTree();
     unset($CategoryModel);
 }
 

--- a/applications/vanilla/views/categories/subtree.php
+++ b/applications/vanilla/views/categories/subtree.php
@@ -1,13 +1,14 @@
 <?php
 
-$Category = $this->data('Category');
-if (!$Category)
+$CategoryID = $this->data('Category.CategoryID');
+if (!$CategoryID) {
     return;
+}
 
-$SubCategories = CategoryModel::MakeTree(CategoryModel::categories(), $Category);
-
-if (!$SubCategories)
+$SubCategories = CategoryModel::getChildren($CategoryID);
+if (empty($SubCategories)) {
     return;
+}
 
 require_once $this->fetchViewLocation('helper_functions', 'categories', 'vanilla');
 

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -48,7 +48,7 @@ $this->fireEvent('BeforeCommentForm');
                     if ($CategoryID = $this->data('Discussion.CategoryID')) {
                         $Category = CategoryModel::categories($CategoryID);
                         if ($Category) {
-                            echo ' <span class="Bullet">•</span> '.anchor(htmlspecialchars($Category['Name']), $Category['Url']);
+                            echo ' <span class="Bullet">•</span> '.anchor(htmlspecialchars($Category['Name']), categoryUrl($Category));
                         }
                     }
                     echo '</span>';

--- a/library/core/class.memcached.php
+++ b/library/core/class.memcached.php
@@ -726,7 +726,7 @@ class Gdn_Memcached extends Gdn_Cache {
         switch ($tryBinary) {
             case false:
                 $incremented = $this->memcache->increment($realKey, $amount);
-                if (is_null($incremented) && $initial) {
+                if ($incremented === false && $initial) {
                     $incremented = $this->memcache->set($realKey, $initial);
                     if ($incremented) {
                         $incremented = $initial;


### PR DESCRIPTION
Help scale categories for communities with too many categories to iterate every page load. The entire category table is still loaded when necessary so there are only some pages that this optimization will work. Some testing tips:

- The checklist below can be used as a testing checklist too!.
- Make sure you turn off the categories in the side panel when testing this PR.
- In the debug bar, you should see the following message when all categories have been loaded: **CategoryModel::loadAllCategories**.
- If you are seeing the above message all the time then some plugin may be loading all of the categories. It would be helpful to figure out which one and post it here so the plugin can be refactored, if possible.
- It is imperative to test this PR with caching ON.
- There is some messy stuff in this PR and that's unavoidable. The idea is to slowly refactor functionality until we are completely in the clear.

Implementation Checklist:

- [x] Don't load the entire category list when in a discussion.
- [x] Don't show the category dropdown when posting to a category, hence not loading the category list.
- [x] Saving a category shouldn't show stale data when caching is on.
- [x] Sorting categories shouldn't show stale data when caching is on.
- [x] Looking at an individual category shouldn't load the entire category list.

I'm marking this PR as a blocker because I'll be basing another PR off of it.