### PR TITLE
Add configurable rating parameter to Gravatar

### DIFF
--- a/plugins/Gravatar/default.php
+++ b/plugins/Gravatar/default.php
@@ -32,9 +32,9 @@ class GravatarPlugin extends Gdn_Plugin {
      * Generate a Gravatar image URL based on the provided e-mail address.
      *
      * @link http://en.gravatar.com/site/implement/images/ Gravatar Image Requests
-     * @param string $email
-     * @param int $size
-     * @return string
+     * @param string $email E-mail address for the user, used to generate the avatar ID.
+     * @param int $size Target image size.
+     * @return string A formatted Gravatar image URL.
      */
     public static function generateUrl($email, $size = 80) {
         $avatarID = md5(strtolower($email));

--- a/plugins/Gravatar/default.php
+++ b/plugins/Gravatar/default.php
@@ -11,7 +11,7 @@
 $PluginInfo['Gravatar'] = array(
     'Name' => 'Gravatar',
     'Description' => 'Implements Gravatar avatars for all users who have not uploaded their own custom profile picture & icon.',
-    'Version' => '1.4.3',
+    'Version' => '1.5',
     'Author' => "Mark O'Sullivan",
     'AuthorEmail' => 'mark@vanillaforums.com',
     'AuthorUrl' => 'http://vanillaforums.com',
@@ -29,10 +29,10 @@ $PluginInfo['Gravatar'] = array(
 class GravatarPlugin extends Gdn_Plugin {
 
     /**
-     * Generate a Gravatar image URL based on the provided e-mail address.
+     * Generate a Gravatar image URL based on the provided email address.
      *
      * @link http://en.gravatar.com/site/implement/images/ Gravatar Image Requests
-     * @param string $email E-mail address for the user, used to generate the avatar ID.
+     * @param string $email Email address for the user, used to generate the avatar ID.
      * @param int $size Target image size.
      * @return string A formatted Gravatar image URL.
      */

--- a/plugins/Gravatar/default.php
+++ b/plugins/Gravatar/default.php
@@ -29,54 +29,81 @@ $PluginInfo['Gravatar'] = array(
 class GravatarPlugin extends Gdn_Plugin {
 
     /**
+     * Generate a Gravatar image URL based on the provided e-mail address.
      *
-     *
-     * @param $Sender
-     * @param $Args
+     * @link http://en.gravatar.com/site/implement/images/ Gravatar Image Requests
+     * @param string $email
+     * @param int $size
+     * @return string
      */
-    public function profileController_afterAddSideMenu_handler($Sender, $Args) {
-        if (!$Sender->User->Photo) {
-            $Email = val('Email', $Sender->User);
-            $Protocol = Gdn::request()->scheme() == 'https' ? 'https://secure.' : 'http://www.';
+    public static function generateUrl($email, $size = 80) {
+        $avatarID = md5(strtolower($email));
 
-            $Url = $Protocol.'gravatar.com/avatar.php?'
-                .'gravatar_id='.md5(strtolower($Email))
-                .'&amp;size='.c('Garden.Profile.MaxWidth', 200);
+        // Figure out our base URLs.  Gravatar doesn't support SVGs, so we're stuck with using Vanillicon v1.
+        if (Gdn::request()->scheme() === 'https') {
+            $baseUrl = 'https://secure.gravatar.com/avatar';
+            $vanilliconBaseUrl = 'https://vanillicon.com';
+        } else {
+            $baseUrl = 'http://www.gravatar.com/avatar';
+            $vanilliconBaseUrl = 'http://vanillicon.com';
+        }
 
-            if (c('Plugins.Gravatar.UseVanillicon', true)) {
-                $Url .= '&default='.urlencode(Gdn::request()->scheme().'://vanillicon.com/'.md5($Email).'_200.png');
+        if (c('Plugins.Gravatar.UseVanillicon', true)) {
+            // Version 1 of Vanillicon only supports three sizes.  Figure out which one is best for this image.
+            if ($size <= 50) {
+                $vanilliconSize = 50;
+            } elseif ($size <= 100) {
+                $vanilliconSize = 100;
             } else {
-                $Url .= '&default='.urlencode(asset(c('Plugins.Gravatar.DefaultAvatar', c('Garden.DefaultAvatar', 'plugins/Gravatar/default_250.png')), true));
+                $vanilliconSize = 200;
             }
 
+            $default = "{$vanilliconBaseUrl}/{$avatarID}_{$vanilliconSize}.png";
+        } else {
+            $pluginDefaultAvatar = $size <= 50 ? 'plugins/Gravatar/default.png' : 'plugins/Gravatar/default_250.png';
 
-            $Sender->User->Photo = $Url;
+            $default = asset(
+                c('Plugins.Gravatar.DefaultAvatar', c('Garden.DefaultAvatar', $pluginDefaultAvatar)),
+                true
+            );
+        }
+
+        $query = [
+            'default' => $default,
+            'rating' => c('Plugins.Gravatar.Rating', 'g'),
+            'size' => $size
+        ];
+
+        return $baseUrl."/{$avatarID}/?".http_build_query($query);
+    }
+
+    /**
+     * Set the Gravatar image on the user's profile.
+     *
+     * @param ProfileController $sender Reference to the current profile controller instance.
+     * @param array $args Additional parameters for the current event.
+     */
+    public function profileController_afterAddSideMenu_handler($sender, $args) {
+        if (!$sender->User->Photo) {
+            $sender->User->Photo = self::generateUrl(
+                val('Email', $sender->User),
+                c('Garden.Profile.MaxWidth', 200)
+            );
         }
     }
 }
 
 if (!function_exists('UserPhotoDefaultUrl')) {
     /**
+     * Calculate the user's default photo url.
      *
-     *
-     * @param $User
-     * @return string
+     * @param array|object $user The user to examine.
+     * @return string Gravatar image URL.
      */
-    function userPhotoDefaultUrl($User) {
-        $Email = val('Email', $User);
-        $Https = Gdn::request()->scheme() == 'https';
-        $Protocol = $Https ? 'https://secure.' : 'http://www.';
-
-        $Url = $Protocol.'gravatar.com/avatar.php?'
-            .'gravatar_id='.md5(strtolower($Email))
-            .'&amp;size='.c('Garden.Thumbnail.Width', 50);
-
-        if (c('Plugins.Gravatar.UseVanillicon', true)) {
-            $Url .= '&default='.urlencode(Gdn::request()->scheme().'://vanillicon.com/'.md5($Email).'.png');
-        } else {
-            $Url .= '&default='.urlencode(Asset(c('Plugins.Gravatar.DefaultAvatar', c('Garden.DefaultAvatar', 'plugins/Gravatar/default.png')), true));
-        }
-
-        return $Url;
+    function userPhotoDefaultUrl($user) {
+        return GravatarPlugin::generateUrl(
+            val('Email', $user),
+            c('Garden.Thumbnail.Width', 50)
+        );
     }
 }


### PR DESCRIPTION
Gravatar allows for a [rating](http://en.gravatar.com/site/implement/images/#rating) parameter in image requests.  The Gravatar plug-in does not currently use this parameter, so it defaults to G.

This update adds a new configuration value, `Plugins.Gravatar.Rating `, which will allow users to set the rating threshold of the images Gravatar serves.

Closes #3873

I also rewrote most of the plug-in.