### PR TITLE
Pass the query string from embedded pages out to the parent frame

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -120,6 +120,7 @@ class DashboardHooks implements Gdn_IPlugin {
             }
 
             $Sender->addDefinition('Path', Gdn::request()->path());
+            $Sender->addDefinition('Query', http_build_query(Gdn::request()->get()));
             // $Sender->addDefinition('MasterView', $Sender->MasterView);
             $Sender->addDefinition('InDashboard', $Sender->MasterView == 'admin' ? '1' : '0');
 

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -120,7 +120,10 @@ class DashboardHooks implements Gdn_IPlugin {
             }
 
             $Sender->addDefinition('Path', Gdn::request()->path());
-            $Sender->addDefinition('Query', http_build_query(Gdn::request()->get()));
+
+            $get = Gdn::request()->get();
+            unset($get['p']); // kludge for old index.php?p=/path
+            $Sender->addDefinition('Query', http_build_query($get));
             // $Sender->addDefinition('MasterView', $Sender->MasterView);
             $Sender->addDefinition('InDashboard', $Sender->MasterView == 'admin' ? '1' : '0');
 

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ if (PHP_VERSION_ID < 50400) {
 }
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.2.111');
+define('APPLICATION_VERSION', '2.2.112');
 
 // Report and track all errors.
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);

--- a/js/embed_local.js
+++ b/js/embed_local.js
@@ -7,8 +7,12 @@ jQuery(document).ready(function($) {
     }
 
     var encodePath = function(path) {
-        var result = encodeURIComponent(path);
+        var parts = path.split('?', 2);
+        var result = encodeURIComponent(parts[0]);
         result = result.replace(/%2F/g, '/');
+        if (parts[1] !== undefined) {
+            result += '?' + parts[1];
+        }
         return result;
     };
 
@@ -25,9 +29,15 @@ jQuery(document).ready(function($) {
         forceEmbedForum = gdn.definition('ForceEmbedForum') == '1',
         isEmbeddedComments = gdn.definition('Embedded', '') != '',
         webroot = gdn.definition('WebRoot'),
-        path = gdn.definition('Path', '~');
-    if (path.length > 0 && path[0] != '/')
+        path = gdn.getMeta('Path', '/'),
+        query = gdn.getMeta('Query', []);
+
+    if (path.length === 0 || path[0] !== '/') {
         path = '/' + path;
+    }
+    if (query.length > 0) {
+        path += '?' + query;
+    }
     /*
      Embedded pages can have very low height settings. As a result, when an
      absolutely positioned popup appears on the page, iframed content doesn't


### PR DESCRIPTION
This is a hopefully more simple version of #3672. The query string is set in the controller hooks and then just joined in the path. Only altering embed_local.js helps with cache busting.