### PR TITLE
Allow for optional headers in imported CSV.

### DIFF
--- a/applications/dashboard/models/class.importmodel.php
+++ b/applications/dashboard/models/class.importmodel.php
@@ -2185,10 +2185,13 @@ class ImportModel extends Gdn_Model {
 
         // Figure out the current position.
         $fPosition = val('CurrentLoadPosition', $this->Data, 0);
+
         if ($fPosition == 0 && $skipHeader) {
             // Skip the header row.
             $Row = self::FGetCSV2($fp);
+        }
 
+        if ($fPosition == 0) {
             $Px = Gdn::database()->DatabasePrefix.self::TABLE_PREFIX;
             Gdn::database()->query("truncate table {$Px}{$Tablename}");
         } else {


### PR DESCRIPTION
When we extracted the functionality of inserting a table from a CSV we fixed the condition 'skip_header' to truncating the table which meant that if you wanted to skip a header you could truncate the table, otherwise you couldn't.