### PR TITLE
Verify we have a Path in HeadModule before attempting to open it as a file

### DIFF
--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -420,7 +420,7 @@ if (!class_exists('HeadModule', false)) {
                 // Inline the content of the tag, if necessary.
                 if (val('_hint', $Attributes) == 'inline') {
                     $Path = val('_path', $Attributes);
-                    if (!stringBeginsWith($Path, 'http')) {
+                    if ($Path && !stringBeginsWith($Path, 'http')) {
                         $Attributes[self::CONTENT_KEY] = file_get_contents($Path);
 
                         if (isset($Attributes['src'])) {


### PR DESCRIPTION
Discovered as a notice on vanillaforums.org.

`file_get_contents(): Filename cannot be empty (/var/www/frontend-f3ee4959f7f61e/applications/dashboard/modules/class.headmodule.php line 424)`