### PR TITLE
Fix parseCoreVersion()

### DIFF
--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -345,7 +345,7 @@ class UpdateModel extends Gdn_Model {
                 }
             }
 
-            if ($Application !== false && $Version !== false) {
+            if ($Application !== false && $Version !== '') {
                 break;
             }
         }


### PR DESCRIPTION
This method currently does not work. It stops after finding `'APPLICATION'`. This PR changes the logic check to continue to match the new default set in d248335abf9538deea372e87a35405c68c517986. ( #3768)