### PR TITLE
Remove debug code from quotes.js

### DIFF
--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -193,6 +193,5 @@ Gdn_Quotes.prototype.ApplyQuoteText = function(QuoteText) {
 })(window);
 
 $(document).on('contentLoad', function (e) {
-    console.log('quotes.contentLoad');
     GdnQuotes.format(e.target);
 });


### PR DESCRIPTION
This update removes a `console.log` call from quotes.js.