### PR TITLE
Add beforeDiscussionMeta event to be on par with the comments events.

### DIFF
--- a/applications/vanilla/views/discussion/discussion.php
+++ b/applications/vanilla/views/discussion/discussion.php
@@ -27,6 +27,7 @@ $this->fireEvent('BeforeDiscussionDisplay');
 ?>
 <div id="<?php echo 'Discussion_'.$Discussion->DiscussionID; ?>" class="<?php echo $CssClass; ?>">
     <div class="Discussion">
+        <?php $this->fireEvent('BeforeDiscussionMeta'); ?>
         <div class="Item-Header DiscussionHeader">
             <div class="AuthorWrap">
             <span class="Author">


### PR DESCRIPTION
Add the event beforeDiscussionMeta so that we can be able to hook at the same place that every other comments (using beforeCommentMeta) in a discussion.