### PR TITLE
Fix/gravatar default parse

### DIFF
--- a/plugins/Gravatar/default.php
+++ b/plugins/Gravatar/default.php
@@ -62,13 +62,16 @@ class GravatarPlugin extends Gdn_Plugin {
         } else {
             $configuredDefaultAvatar = c('Plugins.Gravatar.DefaultAvatar', c('Garden.DefaultAvatar'));
             if ($configuredDefaultAvatar) {
-                $default = Gdn_Upload::parse($configuredDefaultAvatar);
-            } else {
-                $default = asset(
-                    $size <= 50 ? 'plugins/Gravatar/default.png' : 'plugins/Gravatar/default_250.png',
-                    true
-                );
+                $defaultParsed = Gdn_Upload::parse($configuredDefaultAvatar);
+                $default = val('Url', $defaultParsed);
             }
+        }
+
+        if (empty($default)){
+            $default = asset(
+                $size <= 50 ? 'plugins/Gravatar/default.png' : 'plugins/Gravatar/default_250.png',
+                true
+            );
         }
 
         $query = [

--- a/plugins/Gravatar/default.php
+++ b/plugins/Gravatar/default.php
@@ -60,12 +60,15 @@ class GravatarPlugin extends Gdn_Plugin {
 
             $default = "{$vanilliconBaseUrl}/{$avatarID}_{$vanilliconSize}.png";
         } else {
-            $pluginDefaultAvatar = $size <= 50 ? 'plugins/Gravatar/default.png' : 'plugins/Gravatar/default_250.png';
-
-            $default = asset(
-                c('Plugins.Gravatar.DefaultAvatar', c('Garden.DefaultAvatar', $pluginDefaultAvatar)),
-                true
-            );
+            $configuredDefaultAvatar = c('Plugins.Gravatar.DefaultAvatar', c('Garden.DefaultAvatar'));
+            if ($configuredDefaultAvatar) {
+                $default = Gdn_Upload::parse($configuredDefaultAvatar);
+            } else {
+                $default = asset(
+                    $size <= 50 ? 'plugins/Gravatar/default.png' : 'plugins/Gravatar/default_250.png',
+                    true
+                );
+            }
         }
 
         $query = [


### PR DESCRIPTION
This update changes the way Gravatar handles default avatar URLs by passing them through `Gdn_Upload::parse`.  This function contains an event which will allow plug-ins, specifically CDN plug-ins, to manipulate URLs before they are returned to build the Gravatar URL.

Closes #3891 