### PR TITLE
Add TagModel->addDiscussion()

### DIFF
--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -10,7 +10,7 @@
 $PluginInfo['Tagging'] = array(
     'Name' => 'Tagging',
     'Description' => 'Users may add tags to each discussion they create. Existing tags are shown in the sidebar for navigation by tag.',
-    'Version' => '1.8.12',
+    'Version' => '1.9.0',
     'SettingsUrl' => '/dashboard/settings/tagging',
     'SettingsPermission' => 'Garden.Settings.Manage',
     'Author' => "Vanilla Staff",

--- a/plugins/Tagging/class.tagmodel.php
+++ b/plugins/Tagging/class.tagmodel.php
@@ -319,11 +319,47 @@ class TagModel extends Gdn_Model {
      * Add existing tags to a discussion.
      *
      * @param int $discussionID The ID of the discussion to add the tags to.
-     * @param string|array $tags An array of tag IDs or a CSV of tag names.
-     * @throws Throws an exception if some of the tags don't exist.
+     * @param array $tags An array of tag IDs.
+     * @throws Gdn_UserException Throws an exception if some of the tags don't exist.
      */
     public function addDiscussion($discussionID, $tags) {
-        // TODO:
+        $tagIDs = array_unique($tags);
+
+        $validTags = $this->SQL->select('*')
+            ->from('Tag')
+            ->where('TagID', $tagIDs)
+            ->get()->resultArray();
+
+        if (count($tagIDs) != count($validTags)) {
+            throw new Gdn_UserException('Non existing tag(s) supplied.');
+        }
+
+        $tagsToAdd = $tagIDs;
+
+        $currentTags = $this->getDiscussionTags($discussionID, TagModel::IX_TAGID);
+        if ($currentTags) {
+            $tagsToAdd = array_diff($tagsToAdd, array_keys($currentTags));
+        }
+
+        if (!empty($tagsToAdd)) {
+            $now = Gdn_Format::toDateTime();
+
+            // Insert new tags
+            foreach($tagsToAdd as $tagID) {
+                $this->SQL
+                    ->options('Ignore', true)
+                    ->insert(
+                        'TagDiscussion',
+                        ['DiscussionID' => $discussionID, 'TagID' => $tagID, 'DateInserted' => $now, 'CategoryID' => $validTags[$tagID]['CategoryID']]
+                    );
+            }
+
+            // Increment the tag counts.
+            $this->SQL->update('Tag')
+                ->set('CountDiscussions', 'CountDiscussions + 1', false)
+                ->whereIn('TagID', $tagsToAdd)
+                ->put();
+        }
     }
 
     /**

--- a/plugins/Tagging/class.tagmodel.php
+++ b/plugins/Tagging/class.tagmodel.php
@@ -316,6 +316,17 @@ class TagModel extends Gdn_Model {
     }
 
     /**
+     * Add existing tags to a discussion.
+     *
+     * @param int $discussionID The ID of the discussion to add the tags to.
+     * @param string|array $tags An array of tag IDs or a CSV of tag names.
+     * @throws Throws an exception if some of the tags don't exist.
+     */
+    public function addDiscussion($discussionID, $tags) {
+        // TODO:
+    }
+
+    /**
      *
      *
      * @param $discussion_id


### PR DESCRIPTION
This method should add existing tags to a discussion. It should not wipe out tags that have already been assigned to the discussion.

- [x] Add the tags to the discussions.
- [x] Make sure the method doesn't fail when some of the tags are already assigned to the discussion.
- [x] Make sure the counts are properly updated in the tag table.