### PR TITLE
Update JavaScript mapping of tag object when editing a post

### DIFF
--- a/plugins/Tagging/js/tagging.js
+++ b/plugins/Tagging/js/tagging.js
@@ -15,8 +15,8 @@ var discussionTagging = {
             if (data_tags) {
                 tags = [];
                 if (jQuery.isPlainObject(data_tags)) {
-                    for (name in data_tags) {
-                        tags.push({id: data_tags[name], name: name});
+                    for (var tagID in data_tags) {
+                        tags.push({name: data_tags[tagID], id: tagID});
                     }
                 }
             } else {


### PR DESCRIPTION
When the tag object is built in JavaScript for a post being edited, the mapping is currently reversed: the ID is the name and the value is the ID.  This displays tags as their ID, instead of their label, when editing a discussion.

This update flips the mapping to correctly display the values.