### PR TITLE
Update Gdn_Upload::copyLocal to be called in non-static manner

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1395,7 +1395,8 @@ class EditorPlugin extends Gdn_Plugin {
         }
 
         // Get actual path to the file.
-        $local_path = Gdn_Upload::copyLocal($media['Path']);
+        $upload = new Gdn_UploadImage();
+        $local_path = $upload->copyLocal(val('Path', $media));
         if (!file_exists($local_path)) {
             throw notFoundException('File');
         }


### PR DESCRIPTION
Visiting `/utility/mediathumbnail/[media ID]` currently throws the following error:

>Using $this when not in object context

This is due to `Gdn_Upload::copyLocal` being called in `utilityController_mediaThumbnail_create` hook of the Advanced Editor plug-in.  This update alters the call to be non-static and also uses `Gdn_UploadImage`, since it's a more relevant class for handling image uploads.