### PR TITLE
Fix statistics registration

### DIFF
--- a/applications/dashboard/controllers/class.statisticscontroller.php
+++ b/applications/dashboard/controllers/class.statisticscontroller.php
@@ -55,7 +55,19 @@ class StatisticsController extends DashboardController {
             $Flow = true;
 
             if ($Flow && $this->Form->getFormValue('Reregister')) {
+                $id = Gdn::installationID();
+                $secret = Gdn::installationSecret();
+                Gdn::installationID(false);
+                Gdn::installationSecret(false);
+
                 Gdn::Statistics()->register();
+
+                if (!Gdn::installationID()) {
+                    Gdn::installationID($id);
+                    Gdn::installationSecret($secret);
+                }
+                $this->Form->setFormValue('InstallationID', Gdn::installationID());
+                $this->Form->setFormValue('InstallationSecret', Gdn::installationSecret());
             }
 
             if ($Flow && $this->Form->getFormValue('Save')) {


### PR DESCRIPTION
The statistics re-registration was failing whenever there was an existing ID/secret. You can verify this PR by entering a bogus ID/secret combo to get the bad credentials error and then clicking re-register.