### PR TITLE
Remove slicing from the statistics configuration page

### DIFF
--- a/applications/dashboard/controllers/class.statisticscontroller.php
+++ b/applications/dashboard/controllers/class.statisticscontroller.php
@@ -49,7 +49,6 @@ class StatisticsController extends DashboardController {
         $this->addSideMenu('dashboard/statistics');
         //$this->addJsFile('statistics.js');
         $this->title(t('Vanilla Statistics'));
-        $this->enableSlicing($this);
 
         if ($this->Form->authenticatedPostBack()) {
             $Flow = true;

--- a/applications/dashboard/views/statistics/configuration.php
+++ b/applications/dashboard/views/statistics/configuration.php
@@ -64,7 +64,7 @@
         <ul>
             <li>
                 <?php echo $this->Form->label('API Status'); ?>
-                <div class="Slice Async" rel="statistics/verify"></div>
+                <div class="Popin" rel="/statistics/verify"></div>
             </li>
             <li>
                 <?php

--- a/applications/dashboard/views/statistics/verify.php
+++ b/applications/dashboard/views/statistics/verify.php
@@ -1,11 +1,18 @@
-<div class="Slice" rel="statistics/verify">
-    <?php if ($this->data('StatisticsVerified')) { ?>
-        <div class="StatisticsVerification StatisticsOk"><?php echo t("Verified!"); ?></div>
-    <?php } else { ?>
-        <div class="StatisticsVerification StatisticsProblem">
-            <?php echo t("Problem with credentials."); ?>
-            <?php // echo $this->Form->Hidden('ClearCredentials',array('value'=>1)); ?>
-            <p><?php echo $this->Form->button('Re-Register API Key', array('class' => 'SmallButton', 'name' => 'Reregister')); ?></p>
-        </div>
-    <?php } ?>
-</div>
+<?php
+echo $this->Form->open(['action' => url('/statistics')]);
+
+if ($this->data('StatisticsVerified')) {
+?>
+    <div class="StatisticsVerification StatisticsOk"><?php echo t("Verified!"); ?></div>
+<?php
+} else {
+?>
+    <div class="StatisticsVerification StatisticsProblem">
+        <?php echo t("Problem with credentials."); ?>
+        <p><?php echo $this->Form->button('Re-Register API Key', array('class' => 'SmallButton', 'name' => 'Reregister')); ?></p>
+    </div>
+<?php
+}
+
+echo $this->Form->close();
+?>


### PR DESCRIPTION
Use pop-ins instead of slices for the analytics page. Closes #3934.