### PR TITLE
Call Gdn_Model->coerceData() in CategoryModel->save()

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1883,16 +1883,16 @@ class CategoryModel extends Gdn_Model {
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert)) {
             $Fields = $this->Validation->schemaValidationFields();
+            $Fields = $this->coerceData($Fields);
             unset($Fields['CategoryID']);
-            $AllowDiscussions = val('AllowDiscussions', $Fields) == '1' ? true : false;
-            $Fields['AllowDiscussions'] = $AllowDiscussions ? '1' : '0';
+            $Fields['AllowDiscussions'] = (bool)val('AllowDiscussions', $Fields);
 
             if ($Insert === false) {
                 $OldCategory = $this->getID($CategoryID, DATASET_TYPE_ARRAY);
                 if (null === val('AllowDiscussions', $FormPostValues, null)) {
                     $AllowDiscussions = $OldCategory['AllowDiscussions']; // Force the allowdiscussions property
                 }
-                $Fields['AllowDiscussions'] = $AllowDiscussions ? '1' : '0';
+                $Fields['AllowDiscussions'] = (bool)$AllowDiscussions;
 
                 // Figure out custom points.
                 if ($CustomPoints !== null) {


### PR DESCRIPTION
This prevents strict errors in MySQL 5.7. Vanilla without any plugins is okay, but plugins that add checkboxes especially have issues.