### PR TITLE
Add support for inline forms

### DIFF
--- a/applications/conversations/controllers/class.conversationscontroller.php
+++ b/applications/conversations/controllers/class.conversationscontroller.php
@@ -49,6 +49,7 @@ class ConversationsController extends Gdn_Controller {
             $this->addJsFile('jquery.js');
             $this->addJsFile('jquery.form.js');
             $this->addJsFile('jquery.popup.js');
+            $this->addJsFile('jquery.popin.js');
             $this->addJsFile('jquery.gardenhandleajaxform.js');
             $this->addJsFile('jquery.autosize.min.js');
             $this->addJsFile('jquery.tokeninput.js');

--- a/applications/dashboard/controllers/class.dashboardcontroller.php
+++ b/applications/dashboard/controllers/class.dashboardcontroller.php
@@ -35,6 +35,7 @@ class DashboardController extends Gdn_Controller {
         $this->Head = new HeadModule($this);
         $this->addJsFile('jquery.js');
         $this->addJsFile('jquery.form.js');
+        $this->addJsFile('jquery.popin.js');
         $this->addJsFile('jquery.popup.js');
         $this->addJsFile('jquery.gardenhandleajaxform.js');
         $this->addJsFile('magnific-popup.min.js');

--- a/applications/dashboard/controllers/class.statisticscontroller.php
+++ b/applications/dashboard/controllers/class.statisticscontroller.php
@@ -114,7 +114,14 @@ class StatisticsController extends DashboardController {
             Gdn::set('Garden.Analytics.Notify', null);
         }
 
-        $this->render();
+        $this->setData(
+            'FormView',
+            $this->data('AnalyticsEnabled') ? 'configuration' : 'disabled'
+        );
+
+        $this->render(
+            $this->deliveryType() === DELIVERY_TYPE_VIEW ? $this->data('FormView') : ''
+        );
     }
 
     /**

--- a/applications/dashboard/controllers/class.statisticscontroller.php
+++ b/applications/dashboard/controllers/class.statisticscontroller.php
@@ -101,6 +101,9 @@ class StatisticsController extends DashboardController {
             if (!$ConfWritable) {
                 $AnalyticsEnabled = false;
             }
+
+            $this->Form->setFormValue('InstallationID', Gdn::installationID());
+            $this->Form->setFormValue('InstallationSecret', Gdn::installationSecret());
         }
 
         $this->setData('AnalyticsEnabled', $AnalyticsEnabled);

--- a/applications/dashboard/views/statistics/configuration.php
+++ b/applications/dashboard/views/statistics/configuration.php
@@ -59,6 +59,7 @@
         color: #c90000;
     }
 </style>
+<?php echo $this->Form->open(); ?>
 <div class="Configuration">
     <div class="ConfigurationForm">
         <ul>
@@ -89,3 +90,4 @@
         <p><?php echo t("About.DisableStatistics", "If you must disable this data reporting for some business reason, you can do so by adding the following line to your installation's configuration file: <code>\$Configuration['Garden']['Analytics']['Enabled'] = FALSE;</code>"); ?></p>
     </div>
 </div>
+<?php echo $this->Form->close(); ?>

--- a/applications/dashboard/views/statistics/configuration.php
+++ b/applications/dashboard/views/statistics/configuration.php
@@ -64,7 +64,7 @@
         <ul>
             <li>
                 <?php echo $this->Form->label('API Status'); ?>
-                <div class="Popin" rel="/statistics/verify"></div>
+                <div class="Async js-popin" rel="statistics/verify"></div>
             </li>
             <li>
                 <?php
@@ -79,7 +79,7 @@
                 ?>
             </li>
         </ul>
-        <?php echo $this->Form->button('Save', array('class' => 'Button SliceSubmit')); ?>
+        <?php echo $this->Form->button('Save', array('class' => 'Button')); ?>
     </div>
     <div class="ConfigurationHelp">
         <strong><?php echo t("About Vanilla Statistics"); ?></strong>

--- a/applications/dashboard/views/statistics/disabled.php
+++ b/applications/dashboard/views/statistics/disabled.php
@@ -15,6 +15,7 @@
         margin: 20px 0 0 0;
     }
 </style>
+<?php echo $this->Form->open(); ?>
 <div class="StatsDisabled">
     <strong><?php echo t("Vanilla Statistics are currently disabled"); ?></strong>
     <?php
@@ -32,6 +33,5 @@
         echo "<p>".t("Garden.StatisticsReadonly.Resolve", "To solve this problem, assign file mode 777 to your conf/config.php file.")."</p>";
     }
     ?>
-    <p></p>
-
 </div>
+<?php echo $this->Form->close(); ?>

--- a/applications/dashboard/views/statistics/index.php
+++ b/applications/dashboard/views/statistics/index.php
@@ -1,5 +1,5 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
-<div class="js-form">
+
     <style type="text/css">
         body .NotifyMessage {
             margin: 0 20px 20px;
@@ -22,10 +22,6 @@
         ?>
     </div>
     <h1><?php echo $this->data('Title'); ?></h1>
-<?php
-echo $this->Form->open();
-echo $this->Form->errors();
-?>
     <div class="Info">
         <?php echo t("The Vanilla Statistics plugin turns your forum's dashboard into an analytics reporting tool", "Vanilla Statistics turns your forum's dashboard into an analytics reporting tool, allowing you to review activity on your forum over specific time periods. You can <a href=\"http://vanillaforums.org/docs/vanillastatistics\">read more about Vanilla Statistics</a> in our documentation."); ?>
     </div>
@@ -37,14 +33,7 @@ echo $this->Form->errors();
         ?>
     </div>
 <?php } ?>
-<?php
-if ($this->data('AnalyticsEnabled')) {
-    echo $this->fetchView('configuration', 'statistics', 'dashboard');
-} else {
-    echo $this->fetchView('disabled', 'statistics', 'dashboard');
-}
-
-echo $this->Form->close();
-?>
+<div class="js-form">
+    <?php echo $this->fetchView($this->data('FormView'), 'statistics', 'dashboard'); ?>
 </div>
 

--- a/applications/dashboard/views/statistics/index.php
+++ b/applications/dashboard/views/statistics/index.php
@@ -1,4 +1,5 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
+<div class="js-form">
     <style type="text/css">
         body .NotifyMessage {
             margin: 0 20px 20px;
@@ -44,3 +45,6 @@ if ($this->data('AnalyticsEnabled')) {
 }
 
 echo $this->Form->close();
+?>
+</div>
+

--- a/applications/dashboard/views/statistics/verify.php
+++ b/applications/dashboard/views/statistics/verify.php
@@ -15,4 +15,3 @@ if ($this->data('StatisticsVerified')) {
 }
 
 echo $this->Form->close();
-?>

--- a/applications/dashboard/views/statistics/verify.php
+++ b/applications/dashboard/views/statistics/verify.php
@@ -1,17 +1,15 @@
 <?php
-echo $this->Form->open(['action' => url('/statistics')]);
-
 if ($this->data('StatisticsVerified')) {
 ?>
     <div class="StatisticsVerification StatisticsOk"><?php echo t("Verified!"); ?></div>
 <?php
 } else {
 ?>
+    <?php echo $this->Form->open(['action' => url('/statistics')]); ?>
     <div class="StatisticsVerification StatisticsProblem">
         <?php echo t("Problem with credentials."); ?>
         <p><?php echo $this->Form->button('Re-Register API Key', array('class' => 'SmallButton', 'name' => 'Reregister')); ?></p>
     </div>
+    <?php echo $this->Form->close(); ?>
 <?php
 }
-
-echo $this->Form->close();

--- a/applications/vanilla/controllers/class.vanillacontroller.php
+++ b/applications/vanilla/controllers/class.vanillacontroller.php
@@ -27,6 +27,7 @@ class VanillaController extends Gdn_Controller {
         $this->addJsFile('jquery.js');
         $this->addJsFile('jquery.form.js');
         $this->addJsFile('jquery.popup.js');
+        $this->addJsFile('jquery.popin.js');
         $this->addJsFile('jquery.gardenhandleajaxform.js');
         $this->addJsFile('jquery.atwho.js');
         $this->addJsFile('global.js');

--- a/js/global.js
+++ b/js/global.js
@@ -156,6 +156,30 @@
             $("input[name=TransientKey]").val(csrfToken);
         }
     });
+
+    // Hijack form submits.
+    $(document).on('contentLoad', function (e) {
+        $('form', e.target).submit(function (e) {
+            var $form = $(this);
+            var $parent = $form.closest('.js-form');
+
+            if ($parent.length === 0) {
+                return;
+            }
+            e.preventDefault();
+
+            $form.ajaxSubmit({
+                data: { DeliveryType: 'VIEW' },
+                success: function (html) {
+                    $parent.html($.parseHTML(html)).trigger('contentLoad');
+                },
+                error: function (xhr) {
+
+                }
+            });
+
+        });
+    });
 })(window, jQuery);
 
 // Stuff to fire on document.ready().

--- a/js/global.js
+++ b/js/global.js
@@ -157,27 +157,40 @@
         }
     });
 
-    // Hijack form submits.
-    $(document).on('contentLoad', function (e) {
-        $('form', e.target).submit(function (e) {
+    // Hook into form submissions.  Replace element body with server response when we're in a .js-form.
+    $(document).on("contentLoad", function (e) {
+        $("form", e.target).submit(function (e) {
             var $form = $(this);
-            var $parent = $form.closest('.js-form');
 
+            // Traverse up the DOM, starting from the form that triggered the event, looking for the first .js-form.
+            var $parent = $form.closest(".js-form");
+
+            // Bail if we aren't in a .js-form.
             if ($parent.length === 0) {
                 return;
             }
+
+            // Hijack this submission.
             e.preventDefault();
 
-            $form.ajaxSubmit({
-                data: { DeliveryType: 'VIEW' },
-                success: function (html) {
-                    $parent.html($.parseHTML(html)).trigger('contentLoad');
-                },
-                error: function (xhr) {
+            // An object containing extra data that should be submitted along with the form.
+            var data = {
+                DeliveryType: "VIEW"
+            };
 
+            var submitButton = $form.find("input[type=submit]:focus").get(0);
+            if (submitButton) {
+                data[submitButton.name] = submitButton.name;
+            }
+
+            // Send the request, expect HTML and hope for the best.
+            $form.ajaxSubmit({
+                data: data,
+                dataType: "html",
+                success: function (data, textStatus, jqXHR) {
+                    $parent.html(data).trigger('contentLoad');
                 }
             });
-
         });
     });
 })(window, jQuery);

--- a/js/library/jquery.popin.js
+++ b/js/library/jquery.popin.js
@@ -5,7 +5,7 @@
  */
 "use strict";
 
-(function() {
+(function($) {
     $(document).on("contentLoad", function(event) {
         var $target = $(event.target);
 

--- a/js/library/jquery.popin.js
+++ b/js/library/jquery.popin.js
@@ -1,7 +1,7 @@
 /**
- * Popin elements
- * 
- * Allow elements with the .js-popin class to asynchronously load their contents from the server.
+ * An element with the js-popin class can be populated with content from a URL by specifying it in the rel attribute.
+ * @version 1.0
+ * @requires jQuery
  */
 "use strict";
 
@@ -9,17 +9,25 @@
     $(document).on("contentLoad", function(event) {
         var $target = $(event.target);
 
+        // Search the element firing the contentLoad event for any pop-in elements.
         $target.find(".js-popin").each(function(index, element){
             var $element = $(element);
             var rel = $element.attr("rel");
 
+            // Do we have a workable URL?
             if (typeof rel === "string" && rel.length !== 0) {
+                // Slap some styling on the element to indicate the request is in progress.
                 $element.addClass("Loading");
+
+                // Perform the request for content.  We only want content, so skip the master view with DeliveryType.
                 $.get(
                     gdn.url(rel),
                     { DeliveryType: "VIEW" },
                     function(data, textStatus, jqXHR) {
+                        // Remove that progress indicator styling.
                         $element.removeClass("Loading");
+
+                        // Populate the current element with the server's response.
                         $element.html(data);
                     },
                     "html"

--- a/js/library/jquery.popin.js
+++ b/js/library/jquery.popin.js
@@ -1,0 +1,30 @@
+/**
+ * Popin elements
+ * 
+ * Allow elements with the .js-popin class to asynchronously load their contents from the server.
+ */
+"use strict";
+
+(function() {
+    $(document).on("contentLoad", function(event) {
+        var $target = $(event.target);
+
+        $target.find(".js-popin").each(function(index, element){
+            var $element = $(element);
+            var rel = $element.attr("rel");
+
+            if (typeof rel === "string" && rel.length !== 0) {
+                $element.addClass("Loading");
+                $.get(
+                    gdn.url(rel),
+                    { DeliveryType: "VIEW" },
+                    function(data, textStatus, jqXHR) {
+                        $element.removeClass("Loading");
+                        $element.html(data);
+                    },
+                    "html"
+                );
+            }
+        });
+    })
+})(jQuery);


### PR DESCRIPTION
Allows you to add a .js-form class to a form or around a form and that form will be AJAX submitted within the page.

Closes #3933 