### PR TITLE
Tweak popins

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -668,7 +668,7 @@ jQuery(document).ready(function($) {
             });
         });
     };
-    $('.Popin,.js-popin').not('.Message .Popin,.Message .js-popin').popin();
+    $('.Popin, .js-popin').not('.Message .Popin, .Message .js-popin').popin();
 
     var hijackClick = function(e) {
         var $elem = $(this);

--- a/js/global.js
+++ b/js/global.js
@@ -657,7 +657,7 @@ jQuery(document).ready(function($) {
                 url: gdn.url(url),
                 data: {DeliveryType: 'VIEW'},
                 success: function(data) {
-                    $elem.htmlTrigger(data);
+                    $elem.html($.parseHTML(data + '')).trigger('contentLoad');
                 },
                 complete: function() {
                     $elem.removeClass('Progress TinyProgress InProgress');
@@ -668,7 +668,7 @@ jQuery(document).ready(function($) {
             });
         });
     };
-    $('.Popin').not('.Message .Popin').popin();
+    $('.Popin,.js-popin').not('.Message .Popin,.Message .js-popin').popin();
 
     var hijackClick = function(e) {
         var $elem = $(this);


### PR DESCRIPTION
- Allow popins to work off the .js-popin class. This should lead to deprecation of the .Popin class.
- Fire the contentLoad event off the popin instead of its content. The reasoning is that the popin itself is always a direct container.