### PR TITLE
Unset TransientKey on signout

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -178,6 +178,7 @@ class Gdn_Session {
         }
 
         if ($this->UserID) {
+            Gdn::userModel()->saveAttribute($this->UserID, 'TransientKey', null);
             Logger::event('session_end', Logger::INFO, 'Session ended for {username}.');
         }
 


### PR DESCRIPTION
Vanilla currently recycles CSRF tokens for users.  This update aims to increase the security of Vanilla's CSRF token/transient key by removing it from the user's record when their session is explicitly ended.  The next time the user signs in, a new token will be generated.

Closes #3780