### PR TITLE
Fix usage uf undefined var in Vanilla structure

### DIFF
--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -287,7 +287,7 @@ $ActivityModel->DefineType('Discussion');
 $ActivityModel->DefineType('Comment');
 
 $PermissionModel = Gdn::permissionModel();
-$PermissionModel->Database = $Database;
+$PermissionModel->Database = Gdn::database();
 $PermissionModel->SQL = $SQL;
 
 // Define some global vanilla permissions.


### PR DESCRIPTION
$Database had been used although it had not been defined before.