### PR TITLE
Prevent unneeded recurring updates in dashboards structure()

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -155,27 +155,33 @@ $Construct
 // Fix old default roles that were stored in the config and user-role table.
 if ($RoleTableExists && $UserRoleExists && $RoleTypeExists) {
     $types = $RoleModel->getAllDefaultRoles();
-    if ($v = c('Garden.Registration.ApplicantRoleID')) {
-        $SQL->update('Role')
-            ->set('Type', RoleModel::TYPE_APPLICANT)
-            ->where('RoleID', $types[RoleModel::TYPE_APPLICANT])
-            ->put();
+    if (c('Garden.Registration.ApplicantRoleID')) {
+        $SQL->replace(
+            'Role',
+            array('Type' => RoleModel::TYPE_APPLICANT),
+            array('RoleID' => $types[RoleModel::TYPE_APPLICANT]),
+            true
+        );
 //      RemoveFromConfig('Garden.Registration.ApplicantRoleID');
     }
 
-    if ($v = c('Garden.Registration.DefaultRoles')) {
-        $SQL->update('Role')
-            ->set('Type', RoleModel::TYPE_MEMBER)
-            ->where('RoleID', $types[RoleModel::TYPE_MEMBER])
-            ->put();
+    if (c('Garden.Registration.DefaultRoles')) {
+        $SQL->replace(
+            'Role',
+            array('Type' => RoleModel::TYPE_MEMBER),
+            array('RoleID' => $types[RoleModel::TYPE_MEMBER]),
+            true
+        );
 //      RemoveFromConfig('Garden.Registration.DefaultRoles');
     }
 
-    if ($v = c('Garden.Registration.ConfirmEmailRole')) {
-        $SQL->update('Role')
-            ->set('Type', RoleModel::TYPE_UNCONFIRMED)
-            ->where('RoleID', $types[RoleModel::TYPE_UNCONFIRMED])
-            ->put();
+    if (c('Garden.Registration.ConfirmEmailRole')) {
+        $SQL->replace(
+            'Role',
+            array('Type' => RoleModel::TYPE_UNCONFIRMED),
+            array('RoleID' => $types[RoleModel::TYPE_UNCONFIRMED]),
+            true
+        );
 //      RemoveFromConfig('Garden.Registration.ConfirmEmailRole');
     }
 


### PR DESCRIPTION
I've replaced the unconditional update statements with a replace statement. They have been executed on **every** /utility/structure run and thus the scan running database structure upgrades always showed something to do which has already been done.

See here: https://vanillaforums.org/discussion/32127/utility-structure-needed-once-upgrade-to-2-2-1-done#latest