### PR TITLE
Update Gdn_Format::text to deal with the love bug

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1847,20 +1847,32 @@ EOT;
     /**
      * Takes a mixed variable, formats it for display on the screen as plain text.
      *
-     * @param mixed $Mixed An object, array, or string to be formatted.
-     * @return mixed
+     * @param mixed $mixed An object, array, or string to be formatted.
+     * @return string
      */
-    public static function text($Mixed, $AddBreaks = true) {
-        if (!is_string($Mixed)) {
-            return self::to($Mixed, 'Text');
-        } else {
-            $Result = htmlspecialchars(strip_tags(preg_replace('`<br\s?/?>`', "\n",
-                html_entity_decode($Mixed, ENT_QUOTES, 'UTF-8'))), ENT_NOQUOTES, 'UTF-8');
-            if ($AddBreaks && c('Garden.Format.ReplaceNewlines', true)) {
-                $Result = nl2br(trim($Result));
-            }
-            return $Result;
+    public static function text($mixed, $addBreaks = true) {
+        if (!is_string($mixed)) {
+            return self::to($mixed, 'Text');
         }
+
+        $result = html_entity_decode($mixed, ENT_QUOTES, 'UTF-8');
+        $result = preg_replace('`<br\s?/?>`', "\n", $result);
+        /**
+         * We need special handling for invalid markup here, because if we don't compensate
+         * things like <3, they'll lead to invalid markup and strip_tags will truncate the
+         * text.
+         */
+        $result = preg_replace_callback('/<(?![a-z])/i', function($invalidOpening) {
+            return '&lt;';
+        }, $result);
+        $result = strip_tags($result);
+        $result = htmlspecialchars($result, ENT_NOQUOTES, 'UTF-8', false);
+
+        if ($addBreaks && c('Garden.Format.ReplaceNewlines', true)) {
+            $result = nl2br(trim($result));
+        }
+
+        return $result;
     }
 
     /**

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1862,7 +1862,7 @@ EOT;
          * things like <3, they'll lead to invalid markup and strip_tags will truncate the
          * text.
          */
-        $result = preg_replace_callback('/<(?![a-z\/])/i', '&lt;', $result);
+        $result = preg_replace('/<(?![a-z\/])/i', '&lt;', $result);
         $result = strip_tags($result);
         $result = htmlspecialchars($result, ENT_NOQUOTES, 'UTF-8', false);
 

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1862,9 +1862,7 @@ EOT;
          * things like <3, they'll lead to invalid markup and strip_tags will truncate the
          * text.
          */
-        $result = preg_replace_callback('/<(?![a-z])/i', function($invalidOpening) {
-            return '&lt;';
-        }, $result);
+        $result = preg_replace_callback('/<(?![a-z\/])/i', '&lt;', $result);
         $result = strip_tags($result);
         $result = htmlspecialchars($result, ENT_NOQUOTES, 'UTF-8', false);
 


### PR DESCRIPTION
`strip_tags` hates what it perceives to be invalid markup.  When you use a "less-than" sign, followed by a non-whitespace character, it's taken to mean an opening tag.  If you have an opening tag that is never fully completed/closed, you have invalid markup.  When users use "<3" in their messages, `strip_tags` immediately truncates the message just before the "heart".

This is an issue for plain-text e-mails. The message text is cutoff, because it is passed through `EmailTemplate::plainTextEmail`, which then passes the content through to `Gdn_Format::text` where it has a run in with `strip_tags`.  This is also an issue for anywhere in Vanilla which uses `Gdn_Format::text` to display user input.

This update implements a simple routine to convert the opening character of what it detects to be an invalid tag (any < not immediately followed by a letter).  The following call to `htmlspecialchars` has been updated to avoid double encoding of entities.

Closes #3787
Closes #2320