### PR TITLE
Category Scaling Part 2

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -210,7 +210,7 @@ class CategoriesController extends VanillaController {
                 ->setJoinUserCategory(true)
                 ->getChildTree(
                     $CategoryIdentifier,
-                    CategoryModel::instance()->getMaxDisplayDepth()
+                    CategoryModel::instance()->getMaxDisplayDepth() ?: 10
                 );
             $this->setData('CategoryTree', $categoryTree);
 
@@ -389,7 +389,7 @@ class CategoriesController extends VanillaController {
             ->setJoinUserCategory(true)
             ->getChildTree(
                 $Category ?: null,
-                $this->CategoryModel->getMaxDisplayDepth()
+                $this->CategoryModel->getMaxDisplayDepth() ?: 10
             );
         if ($this->CategoryModel->Watching) {
             $categoryTree = $this->CategoryModel->filterFollowing($categoryTree);

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -391,8 +391,7 @@ class CategoriesController extends VanillaController {
         }
         $categoryTree = $this->CategoryModel->getChildTree(
             $Category ?: null,
-            $this->CategoryModel->getMaxDisplayDepth(),
-            true
+            $this->CategoryModel->getMaxDisplayDepth()
         );
         $this->CategoryModel->joinRecent($categoryTree);
         $this->setData('CategoryTree', $categoryTree);

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -212,10 +212,12 @@ class CategoriesController extends VanillaController {
             // Load the subtree.
             $this->setData(
                 'CategoryTree',
-                CategoryModel::instance()->getChildTree(
-                    $CategoryIdentifier,
-                    CategoryModel::instance()->getMaxDisplayDepth()
-                )
+                $this->CategoryModel
+                    ->setJoinUserCategory(true)
+                    ->getChildTree(
+                        $CategoryIdentifier,
+                        CategoryModel::instance()->getMaxDisplayDepth()
+                    )
             );
 
             // Add a backwards-compatibility shim for the old categories.
@@ -389,10 +391,12 @@ class CategoriesController extends VanillaController {
                 return $this->CategoryModel->GetFull()->resultArray();
             };
         }
-        $categoryTree = $this->CategoryModel->getChildTree(
-            $Category ?: null,
-            $this->CategoryModel->getMaxDisplayDepth()
-        );
+        $categoryTree = $this->CategoryModel
+            ->setJoinUserCategory(true)
+            ->getChildTree(
+                $Category ?: null,
+                $this->CategoryModel->getMaxDisplayDepth()
+            );
         $this->CategoryModel->joinRecent($categoryTree);
         $this->setData('CategoryTree', $categoryTree);
 

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -513,4 +513,13 @@ class CategoriesController extends VanillaController {
             $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
         }
     }
+
+    /**
+     * Returns the full list of categories for the APIv1.
+     */
+    public function apiV1List() {
+        $categories = CategoryModel::categories();
+        $this->setData('Categories', $categories);
+        $this->render('blank', 'utility', 'dashboard');
+    }
 }

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -169,10 +169,6 @@ class CategoriesController extends VanillaController {
                     saveToConfig('Vanilla.Categories.DoHeadings', false, false);
                 }
 
-                trace($this->deliveryMethod(), 'delivery method');
-                trace($this->deliveryType(), 'delivery type');
-                trace($this->SyndicationMethod, 'syndication');
-
                 if ($this->SyndicationMethod != SYNDICATION_NONE) {
                     // RSS can't show a category list so just tell it to expand all categories.
                     saveToConfig('Vanilla.ExpandCategories', true, false);

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -28,6 +28,10 @@ class CategoriesController extends VanillaController {
     /** @var object Category object. */
     public $Category;
 
+    /**
+     * @var \Closure $categoriesCompatibilityCallback A backwards-compatible callback to get `$this->Data('Categories')`.
+     */
+    private $categoriesCompatibilityCallback;
 
     /**
      *
@@ -137,7 +141,7 @@ class CategoriesController extends VanillaController {
                     break;
                 default:
                     $this->View = 'all';
-                    $this->All();
+                    $this->all();
                     break;
             }
             return;
@@ -145,21 +149,13 @@ class CategoriesController extends VanillaController {
             $Category = CategoryModel::categories($CategoryIdentifier);
 
             if (empty($Category)) {
-                // Try lowercasing before outright failing
-                $LowerCategoryIdentifier = strtolower($CategoryIdentifier);
-                if ($LowerCategoryIdentifier != $CategoryIdentifier) {
-                    $Category = CategoryModel::categories($LowerCategoryIdentifier);
-                    if ($Category) {
-                        redirect("/categories/{$LowerCategoryIdentifier}", 301);
-                    }
-                }
                 throw notFoundException();
             }
             $Category = (object)$Category;
             Gdn_Theme::section($Category->CssClass);
 
             // Load the breadcrumbs.
-            $this->setData('Breadcrumbs', CategoryModel::GetAncestors(val('CategoryID', $Category)));
+            $this->setData('Breadcrumbs', CategoryModel::getAncestors(val('CategoryID', $Category)));
 
             $this->setData('Category', $Category, true);
 
@@ -168,7 +164,7 @@ class CategoriesController extends VanillaController {
 
 
             if ($Category->DisplayAs == 'Categories') {
-                if (val('Depth', $Category) > c('Vanilla.Categories.NavDepth', 0)) {
+                if (val('Depth', $Category) > CategoryModel::instance()->getNavDepth()) {
                     // Headings don't make sense if we've cascaded down one level.
                     saveToConfig('Vanilla.Categories.DoHeadings', false, false);
                 }
@@ -214,8 +210,19 @@ class CategoriesController extends VanillaController {
             }
 
             // Load the subtree.
-            $Categories = CategoryModel::GetSubtree($CategoryIdentifier, false);
-            $this->setData('Categories', $Categories);
+            $this->setData(
+                'CategoryTree',
+                CategoryModel::instance()->getChildTree(
+                    $CategoryIdentifier,
+                    CategoryModel::instance()->getMaxDisplayDepth()
+                )
+            );
+
+            // Add a backwards-compatibility shim for the old categories.
+            $this->categoriesCompatibilityCallback = function () use ($CategoryIdentifier) {
+                $categories = CategoryModel::GetSubtree($CategoryIdentifier, false);
+                return $categories;
+            };
 
             // Setup head
             $this->Menu->highlightRoute('/discussions');
@@ -369,15 +376,19 @@ class CategoriesController extends VanillaController {
         // Get category data
         $this->CategoryModel->Watching = !Gdn::session()->GetPreference('ShowAllCategories');
 
-        if ($Category) {
-            $Subtree = CategoryModel::GetSubtree($Category, false);
-            $this->setData('Category', CategoryModel::categories($this->data('Category.CategoryID')));
-            $CategoryIDs = consolidateArrayValuesByKey($Subtree, 'CategoryID');
-            $Categories = $this->CategoryModel->GetFull($CategoryIDs)->resultArray();
+        if ($CategoryID = val('CategoryID', $Category)) {
+            $this->setData('Category', CategoryModel::categories($CategoryID));
+
+            $this->categoriesCompatibilityCallback = function () use ($Category) {
+                $Subtree = CategoryModel::GetSubtree($Category, false);
+                $CategoryIDs = array_column($Subtree, 'CategoryID');
+                return $this->CategoryModel->GetFull($CategoryIDs)->resultArray();
+            };
         } else {
-            $Categories = $this->CategoryModel->GetFull()->resultArray();
+            $this->categoriesCompatibilityCallback = function () {
+                return $this->CategoryModel->GetFull()->resultArray();
+            };
         }
-        $this->setData('Categories', $Categories);
 
         // Add modules
         $this->addModule('NewDiscussionModule');
@@ -514,6 +525,12 @@ class CategoriesController extends VanillaController {
         }
     }
 
+    public function tree($category = '') {
+        $tree = CategoryModel::instance()->getChildTree($category);
+        $this->setData('Categories', $tree);
+        $this->render('blank', 'utility', 'dashboard');
+    }
+
     /**
      * Returns the full list of categories for the APIv1.
      */
@@ -521,5 +538,26 @@ class CategoriesController extends VanillaController {
         $categories = CategoryModel::categories();
         $this->setData('Categories', $categories);
         $this->render('blank', 'utility', 'dashboard');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function data($Path, $Default = '') {
+        if (isset($this->Data[$Path])) {
+            return $this->Data[$Path];
+        }
+
+        switch ($Path) {
+            case 'Categories':
+                if ($this->categoriesCompatibilityCallback instanceof \Closure) {
+                    deprecated('Categories', 'CategoryTree');
+                    $this->Data['Categories'] = $categories = call_user_func($this->categoriesCompatibilityCallback);
+                    return $categories;
+                }
+                return $Default;
+            default:
+                return parent::data($Path, $Default);
+        }
     }
 }

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -447,7 +447,7 @@ class CategoriesController extends VanillaController {
 
         if ($Category) {
             $Subtree = CategoryModel::GetSubtree($Category, false);
-            $CategoryIDs = consolidateArrayValuesByKey($Subtree, 'CategoryID');
+            $CategoryIDs = array_column($Subtree, 'CategoryID');
             $Categories = $this->CategoryModel->GetFull($CategoryIDs)->resultArray();
         } else {
             $Categories = $this->CategoryModel->GetFull()->resultArray();

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -210,15 +210,13 @@ class CategoriesController extends VanillaController {
             }
 
             // Load the subtree.
-            $this->setData(
-                'CategoryTree',
-                $this->CategoryModel
-                    ->setJoinUserCategory(true)
-                    ->getChildTree(
-                        $CategoryIdentifier,
-                        CategoryModel::instance()->getMaxDisplayDepth()
-                    )
-            );
+            $categoryTree = $this->CategoryModel
+                ->setJoinUserCategory(true)
+                ->getChildTree(
+                    $CategoryIdentifier,
+                    CategoryModel::instance()->getMaxDisplayDepth()
+                );
+            $this->setData('CategoryTree', $categoryTree);
 
             // Add a backwards-compatibility shim for the old categories.
             $this->categoriesCompatibilityCallback = function () use ($CategoryIdentifier) {
@@ -397,6 +395,9 @@ class CategoriesController extends VanillaController {
                 $Category ?: null,
                 $this->CategoryModel->getMaxDisplayDepth()
             );
+        if ($this->CategoryModel->Watching) {
+            $categoryTree = $this->CategoryModel->filterFollowing($categoryTree);
+        }
         $this->CategoryModel->joinRecent($categoryTree);
         $this->setData('CategoryTree', $categoryTree);
 

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -376,8 +376,8 @@ class CategoriesController extends VanillaController {
         // Get category data
         $this->CategoryModel->Watching = !Gdn::session()->GetPreference('ShowAllCategories');
 
-        if ($CategoryID = val('CategoryID', $Category)) {
-            $this->setData('Category', CategoryModel::categories($CategoryID));
+        if ($Category) {
+            $this->setData('Category', CategoryModel::categories($Category));
 
             $this->categoriesCompatibilityCallback = function () use ($Category) {
                 $Subtree = CategoryModel::GetSubtree($Category, false);
@@ -389,6 +389,13 @@ class CategoriesController extends VanillaController {
                 return $this->CategoryModel->GetFull()->resultArray();
             };
         }
+        $categoryTree = $this->CategoryModel->getChildTree(
+            $Category ?: null,
+            $this->CategoryModel->getMaxDisplayDepth(),
+            true
+        );
+        $this->CategoryModel->joinRecent($categoryTree);
+        $this->setData('CategoryTree', $categoryTree);
 
         // Add modules
         $this->addModule('NewDiscussionModule');

--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -23,7 +23,7 @@ class CategoryController extends VanillaController {
 
     public function follow($CategoryID, $Value, $TKey) {
         if (Gdn::session()->validateTransientKey($TKey)) {
-            $this->CategoryModel->SaveUserTree($CategoryID, array('Unfollow' => !(bool)$Value));
+            $this->CategoryModel->SaveUserTree($CategoryID, array('Unfollow' => (int)(!(bool)$Value)));
         }
 
         if ($this->deliveryType() == DELIVERY_TYPE_ALL) {

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -688,6 +688,7 @@ class VanillaSettingsController extends Gdn_Controller {
             $this->Form->setData($ConfigurationModel->Data);
         } else {
             if ($this->Form->save() !== false) {
+                CategoryModel::clearCache();
                 $this->informMessage(t("Your settings have been saved."));
             }
         }

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -322,7 +322,7 @@ class CategoryCollection {
                 $dbCategoryIDs[] = $id;
             }
         }
-        if (!empty($dbCategories)) {
+        if (!empty($dbCategoryIDs)) {
             $dbCategories = $this->sql->getWhere('Category', ['CategoryID' => $dbCategoryIDs])->resultArray();
             foreach ($dbCategories as &$category) {
                 $this->calculateStatic($category);

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -263,7 +263,9 @@ class CategoryCollection {
      * @param array &$category The category to calculate.
      */
     private function calculateStatic(&$category) {
-        call_user_func($this->staticCalculator, $category);
+        if ($category['CategoryID'] > 0) {
+            call_user_func($this->staticCalculator, $category);
+        }
     }
 
     /**
@@ -272,7 +274,9 @@ class CategoryCollection {
      * @param array &$category The category to calculate.
      */
     private function calculateDynamic(&$category) {
-        call_user_func($this->userCalculator, $category);
+        if ($category['CategoryID'] > 0) {
+            call_user_func($this->userCalculator, $category);
+        }
     }
 
     /**
@@ -353,7 +357,6 @@ class CategoryCollection {
      * @param int $parentID The ID of the parent category.
      * @param int $maxDepth The maximum relative depth to grab.
      * @param int $permission The permission column to check.
-     * @param bool $adjustDepth Whether to adjust the depth field on categories.
      */
     public function getTree($parentID = -1, $maxDepth = 3, $permission = 'PermsDiscussionsView') {
         $tree = [];
@@ -453,7 +456,7 @@ class CategoryCollection {
             ->select($select)
             ->from('Category')
             ->where('ParentCategoryID', $parentIDs)
-            ->where('CategoryID <>', -1)
+            ->where('CategoryID >', 0)
             ->limit($this->absoluteLimit)
             ->orderBy('ParentCategoryID, Sort')
             ->get()->resultArray();

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -264,7 +264,7 @@ class CategoryCollection {
      */
     private function calculateStatic(&$category) {
         if ($category['CategoryID'] > 0) {
-            call_user_func($this->staticCalculator, $category);
+            call_user_func_array($this->staticCalculator, [&$category]);
         }
     }
 
@@ -275,7 +275,7 @@ class CategoryCollection {
      */
     private function calculateDynamic(&$category) {
         if ($category['CategoryID'] > 0) {
-            call_user_func($this->userCalculator, $category);
+            call_user_func_array($this->userCalculator, [&$category]);
         }
     }
 

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -158,8 +158,8 @@ class CategoryCollection {
         // Figure out the ID.
         if (is_int($categoryID)) {
             $id = $categoryID;
-        } elseif (isset($this->categorySlugs[$categoryID])) {
-            $id = $this->categorySlugs[$categoryID];
+        } elseif (isset($this->categorySlugs[strtolower($categoryID)])) {
+            $id = $this->categorySlugs[strtolower($categoryID)];
         } else {
             // The ID still might not be found here.
             $id = $this->cache->get($this->cacheKey(self::$CACHE_CATEGORY_SLUG, $categoryID));
@@ -175,7 +175,7 @@ class CategoryCollection {
 
                 if (!empty($category)) {
                     $this->categories[$id] = $category;
-                    $this->categorySlugs[$category['UrlCode']] = $id;
+                    $this->categorySlugs[strtolower($category['UrlCode'])] = $id;
                     return $category;
                 }
 
@@ -190,7 +190,7 @@ class CategoryCollection {
             $this->calculate($category);
 
             $this->categories[(int)$category['CategoryID']] = $category;
-            $this->categorySlugs[$category['UrlCode']] = (int)$category['CategoryID'];
+            $this->categorySlugs[strtolower($category['UrlCode'])] = (int)$category['CategoryID'];
 
             $this->cache->store(
                 $this->cacheKey(self::$CACHE_CATEGORY, $category['CategoryID']),
@@ -208,7 +208,7 @@ class CategoryCollection {
                 $this->categories[$id] = false;
             }
             if (is_string($categoryID)) {
-                $this->categorySlugs[$categoryID] = false;
+                $this->categorySlugs[strtolower($categoryID)] = false;
             }
 
             return null;
@@ -227,8 +227,10 @@ class CategoryCollection {
     private function cacheKey($type, $id) {
         switch ($type) {
             case self::$CACHE_CATEGORY;
-            case self::$CACHE_CATEGORY_SLUG;
                 $r = $this->getCacheInc().$type.$id;
+                return $r;
+            case self::$CACHE_CATEGORY_SLUG;
+                $r = $this->getCacheInc().$type.strtolower($id);
                 return $r;
             default:
                 throw new \InvalidArgumentException("Cache type '$type' is invalid.'", 500);
@@ -289,7 +291,7 @@ class CategoryCollection {
             $cacheCategories = $this->cache->get($keys);
             foreach ($cacheCategories as $key => $category) {
                 $this->categories[(int)$category['CategoryID']] = $category;
-                $this->categorySlugs[$category['UrlCode']] = (int)$category['CategoryID'];
+                $this->categorySlugs[strtolower($category['UrlCode'])] = (int)$category['CategoryID'];
 
                 $categories[(int)$category['CategoryID']] = $category;
             }
@@ -316,7 +318,7 @@ class CategoryCollection {
             );
 
             $this->categories[(int)$category['CategoryID']] = $category;
-            $this->categorySlugs[$category['UrlCode']] = (int)$category['CategoryID'];
+            $this->categorySlugs[strtolower($category['UrlCode'])] = (int)$category['CategoryID'];
 
             $categories[(int)$category['CategoryID']] = $category;
         }
@@ -571,7 +573,7 @@ class CategoryCollection {
             );
 
             $this->categories[(int)$category['CategoryID']] = $category;
-            $this->categorySlugs[$category['UrlCode']] = (int)$category['CategoryID'];
+            $this->categorySlugs[strtolower($category['UrlCode'])] = (int)$category['CategoryID'];
             return true;
         } else {
             return false;

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -364,6 +364,9 @@ class CategoryCollection {
         $parents = [$parentID];
         for ($i = 0; $i < $maxDepth; $i++) {
             $children = $this->getChildrenByParents($parents, $permission);
+            if (empty($children)) {
+                break;
+            }
 
             // Go through the children and wire them up.
             foreach ($children as $child) {

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -11,6 +11,7 @@
  * This is a bridge class to aid in refactoring. This functionality will be rolled into the {@link CategoryModel}.
  */
 class CategoryCollection {
+
     /**
      * @var string The cache key prefix that stores categories by ID.
      */
@@ -19,6 +20,11 @@ class CategoryCollection {
      * @var string The cache key prefix that stores category IDs by slug (URL code).
      */
     private static $CACHE_CATEGORY_SLUG = '/catslug/';
+
+    /**
+     * @var int The absolute select limit of the categories.
+     */
+    private $absoluteLimit = 200;
 
     /**
      * @var Gdn_Cache The cache dependency.
@@ -80,15 +86,6 @@ class CategoryCollection {
     }
 
     /**
-     * Calculate dynamic data on a category.
-     *
-     * @param array &$category The category to calculate.
-     */
-    private function calculate(&$category) {
-        call_user_func($this->calculator, $category);
-    }
-
-    /**
      * Get the calculator.
      *
      * @return callable Returns the calculator.
@@ -113,94 +110,12 @@ class CategoryCollection {
     }
 
     /**
-     * Calculate dynamic data on a category.
-     *
-     * @param array &$category The category to calculate.
-     */
-    private function defaultCalculator(&$category) {
-        $category['CountAllDiscussions'] = $category['CountDiscussions'];
-        $category['CountAllComments'] = $category['CountComments'];
-//        $category['Url'] = self::categoryUrl($category, false, '/');
-        $category['ChildIDs'] = [];
-//        if (val('Photo', $category)) {
-//            $category['PhotoUrl'] = Gdn_Upload::url($category['Photo']);
-//        } else {
-//            $category['PhotoUrl'] = '';
-//        }
-
-        if ($category['DisplayAs'] == 'Default') {
-            if ($category['Depth'] <= $this->config('Vanilla.Categories.NavDepth', 0)) {
-                $category['DisplayAs'] = 'Categories';
-            } elseif ($category['Depth'] == ($this->config('Vanilla.Categories.NavDepth', 0) + 1) && $this->config('Vanilla.Categories.DoHeadings')) {
-                $category['DisplayAs'] = 'Heading';
-            } else {
-                $category['DisplayAs'] = 'Discussions';
-            }
-        }
-
-        if (!val('CssClass', $category)) {
-            $category['CssClass'] = 'Category-'.$category['UrlCode'];
-        }
-
-        if (isset($category['AllowedDiscussionTypes']) && is_string($category['AllowedDiscussionTypes'])) {
-            $category['AllowedDiscussionTypes'] = dbdecode($category['AllowedDiscussionTypes']);
-        }
-    }
-
-    /**
-     * Get the cache increment.
-     *
-     * The cache is flushed after major operations by incrementing a scoped key.
-     */
-    private function getCacheInc() {
-        if ($this->cacheInc === null) {
-            $this->cacheInc = (int)$this->cache->get(self::$CACHE_CATEGORY.'inc');
-        }
-        return $this->cacheInc;
-    }
-
-    /**
      * Flush the entire category cache.
      */
     public function flushCache() {
         $this->categories = [];
         $this->categorySlugs = [];
         $this->cache->increment(self::$CACHE_CATEGORY.'inc', 1, [Gdn_Cache::FEATURE_INITIAL => 1]);
-    }
-
-    /**
-     * Generate a full cache key.
-     *
-     * All cache keys should be generated using this function to support cache increments.
-     *
-     * @param string $type One of the **$CACHE_*** pseudo-constants.
-     * @param string|int $id The identifier in the cache.
-     * @return string Returns the cache key.
-     */
-    private function cacheKey($type, $id) {
-        switch ($type) {
-            case self::$CACHE_CATEGORY;
-            case self::$CACHE_CATEGORY_SLUG;
-                $r = $this->getCacheInc().$type.$id;
-                return $r;
-            default:
-                throw new \InvalidArgumentException("Cache type '$type' is invalid.'", 500);
-        }
-    }
-
-    /**
-     * Get a value from the config.
-     *
-     * @param string $key The config key.
-     * @param mixed $default The default to return if the config isn't found.
-     * @return mixed Returns the config value or {@link $default} if it isn't found.
-     */
-    private function config($key, $default = null) {
-        if ($this->config !== null) {
-            return $this->config->get($key, $default);
-        } else {
-            return $default;
-        }
     }
 
     /**
@@ -221,18 +136,6 @@ class CategoryCollection {
     public function setConfig($config) {
         $this->config = $config;
         return $this;
-    }
-
-    /**
-     * Get the schema.
-     *
-     * @return Gdn_Schema Returns the schema.
-     */
-    private function getSchema() {
-        if ($this->schema === null) {
-            $this->schema = new Gdn_Schema('Category', $this->sql->Database);
-        }
-        return $this->schema;
     }
 
     /**
@@ -313,6 +216,47 @@ class CategoryCollection {
     }
 
     /**
+     * Generate a full cache key.
+     *
+     * All cache keys should be generated using this function to support cache increments.
+     *
+     * @param string $type One of the **$CACHE_*** pseudo-constants.
+     * @param string|int $id The identifier in the cache.
+     * @return string Returns the cache key.
+     */
+    private function cacheKey($type, $id) {
+        switch ($type) {
+            case self::$CACHE_CATEGORY;
+            case self::$CACHE_CATEGORY_SLUG;
+                $r = $this->getCacheInc().$type.$id;
+                return $r;
+            default:
+                throw new \InvalidArgumentException("Cache type '$type' is invalid.'", 500);
+        }
+    }
+
+    /**
+     * Get the cache increment.
+     *
+     * The cache is flushed after major operations by incrementing a scoped key.
+     */
+    private function getCacheInc() {
+        if ($this->cacheInc === null) {
+            $this->cacheInc = (int)$this->cache->get(self::$CACHE_CATEGORY.'inc');
+        }
+        return $this->cacheInc;
+    }
+
+    /**
+     * Calculate dynamic data on a category.
+     *
+     * @param array &$category The category to calculate.
+     */
+    private function calculate(&$category) {
+        call_user_func($this->calculator, $category);
+    }
+
+    /**
      * Get the children of a category.
      *
      * @param int $categoryID The category to get the children for.
@@ -387,32 +331,98 @@ class CategoryCollection {
     }
 
     /**
-     * Insert a new category, handling its tree properties and caching.
+     * Get all of the categories from a root.
      *
-     * This method is currently only to to be used in a support role.
-     *
-     * @param array $category The new category.
+     * @param int $parentID The ID of the parent category.
+     * @param int $depth The max depth to grab.
+     * @param int $adjustDepth Whether to adjust the depth field on categories.
      */
-    public function insert(array $category) {
-        $category += [
-            'DateInserted' => Gdn_Format::toDateTime(),
-            'InsertUserID' => 1,
-            'ParentCategoryID' => -1,
-        ];
+    public function getTree($parentID = -1, $depth = 3, $adjustDepth = false) {
+        $tree = [];
+        $categories = [];
+        $parentID = $parentID ?: -1;
 
-        // Filter out fields that aren't in the table.
-        $category = array_intersect_key($category, $this->getSchema()->fields());
-        $categoryID = $this->sql->insert('Category', $category);
+        $currentDepth = 1;
+        $parents = [$parentID];
+        for ($i = 0; $i < $depth; $i++) {
+            $children = $this->getChildrenByParents($parents);
 
-        if ($categoryID) {
-            // Update my parent's count.
-            $this->sql->put('Category', ['CountCategories+' => 1], ['CategoryID' => $category['ParentCategoryID']]);
+            // Go through the children and wire them up.
+            foreach ($children as $child) {
+                $category = $child;
+                $category['Children'] = [];
 
-            $this->refreshCache($category['CategoryID']);
-            $this->refreshCache($category['ParentCategoryID']);
+                // Skip the fake root.
+                if ($category['CategoryID'] == -1) {
+                    continue;
+                }
+
+                if ($adjustDepth) {
+                    $category['Depth'] = $currentDepth;
+                }
+
+                $categories[$category['CategoryID']] = $category;
+                if (!isset($categories[$category['ParentCategoryID']])) {
+                    $tree[] = &$categories[$category['CategoryID']];
+                } else {
+                    $categories[$category['ParentCategoryID']]['Children'][] = &$categories[$category['CategoryID']];
+                }
+            }
+
+            // Get the IDs for the next depth of children.
+            $parents = array_column($children, 'CategoryID');
+            $currentDepth++;
         }
 
-        return $categoryID;
+        return $tree;
+    }
+
+    /**
+     * Get all of the children of a parent category.
+     *
+     * @param int[] $parentIDs The IDs of the parent categories.
+     * @return array
+     * @throws Exception
+     */
+    private function getChildrenByParents(array $parentIDs) {
+        if ($this->cache->activeEnabled()) {
+            $select = 'CategoryID';
+        } else {
+            $select = '*';
+        }
+
+        $data = $this
+            ->sql
+            ->select($select)
+            ->from('Category')
+            ->where('ParentCategoryID', $parentIDs)
+            ->where('CategoryID <>', -1)
+            ->limit($this->absoluteLimit)
+            ->orderBy('ParentCategoryID, Sort')
+            ->get()->resultArray();
+
+        if ($this->cache->activeEnabled()) {
+            $ids = array_column($data, 'CategoryID');
+            $data = $this->getMulti($ids);
+        } else {
+            array_walk($data, [$this, 'calculate']);
+        }
+        return $data;
+    }
+
+    /**
+     * Flatten a tree that was returned from {@link getTree}.
+     *
+     * @param array $categories The array of root categories.
+     * @return array Returns an array of categories.
+     */
+    public function flattenTree(array $categories) {
+        $result = [];
+
+        foreach ($categories as $category) {
+            $this->flattenTreeInternal($category, $result);
+        }
+        return $result;
     }
 
     /**
@@ -466,6 +476,47 @@ class CategoryCollection {
     }
 
     /**
+     * Insert a new category, handling its tree properties and caching.
+     *
+     * This method is currently only to to be used in a support role.
+     *
+     * @param array $category The new category.
+     */
+    public function insert(array $category) {
+        $category += [
+            'DateInserted' => Gdn_Format::toDateTime(),
+            'InsertUserID' => 1,
+            'ParentCategoryID' => -1,
+        ];
+
+        // Filter out fields that aren't in the table.
+        $category = array_intersect_key($category, $this->getSchema()->fields());
+        $categoryID = $this->sql->insert('Category', $category);
+
+        if ($categoryID) {
+            // Update my parent's count.
+            $this->sql->put('Category', ['CountCategories+' => 1], ['CategoryID' => $category['ParentCategoryID']]);
+
+            $this->refreshCache($category['CategoryID']);
+            $this->refreshCache($category['ParentCategoryID']);
+        }
+
+        return $categoryID;
+    }
+
+    /**
+     * Get the schema.
+     *
+     * @return Gdn_Schema Returns the schema.
+     */
+    private function getSchema() {
+        if ($this->schema === null) {
+            $this->schema = new Gdn_Schema('Category', $this->sql->Database);
+        }
+        return $this->schema;
+    }
+
+    /**
      * Refresh a category in the cache from the database.
      *
      * This function is public for now, but should only be called from within the {@link CategoryModel}. Eventually it
@@ -492,6 +543,74 @@ class CategoryCollection {
             return true;
         } else {
             return false;
+        }
+    }
+
+    /**
+     * Calculate dynamic data on a category.
+     *
+     * This method is passed as a callback by default in {@link setCalculator}, but may not show up as used.
+     *
+     * @param array &$category The category to calculate.
+     */
+    private function defaultCalculator(&$category) {
+        $category['CountAllDiscussions'] = $category['CountDiscussions'];
+        $category['CountAllComments'] = $category['CountComments'];
+//        $category['Url'] = self::categoryUrl($category, false, '/');
+        $category['ChildIDs'] = [];
+//        if (val('Photo', $category)) {
+//            $category['PhotoUrl'] = Gdn_Upload::url($category['Photo']);
+//        } else {
+//            $category['PhotoUrl'] = '';
+//        }
+
+        if ($category['DisplayAs'] == 'Default') {
+            if ($category['Depth'] <= $this->config('Vanilla.Categories.NavDepth', 0)) {
+                $category['DisplayAs'] = 'Categories';
+            } elseif ($category['Depth'] == ($this->config('Vanilla.Categories.NavDepth', 0) + 1) && $this->config('Vanilla.Categories.DoHeadings')) {
+                $category['DisplayAs'] = 'Heading';
+            } else {
+                $category['DisplayAs'] = 'Discussions';
+            }
+        }
+
+        if (!val('CssClass', $category)) {
+            $category['CssClass'] = 'Category-'.$category['UrlCode'];
+        }
+
+        if (isset($category['AllowedDiscussionTypes']) && is_string($category['AllowedDiscussionTypes'])) {
+            $category['AllowedDiscussionTypes'] = dbdecode($category['AllowedDiscussionTypes']);
+        }
+    }
+
+    /**
+     * Get a value from the config.
+     *
+     * @param string $key The config key.
+     * @param mixed $default The default to return if the config isn't found.
+     * @return mixed Returns the config value or {@link $default} if it isn't found.
+     */
+    private function config($key, $default = null) {
+        if ($this->config !== null) {
+            return $this->config->get($key, $default);
+        } else {
+            return $default;
+        }
+    }
+
+    /**
+     * Internal implementation support for {@link CategoryCollection::flattenTree()}.
+     *
+     * @param array $category The current category being examined.
+     * @param array &$result The working result.
+     */
+    private function flatTreeInternal(array $category, array &$result) {
+        $result[] = $category;
+        if (empty($category['Children'])) {
+            return;
+        }
+        foreach ($category['Children'] as $child) {
+            $this->flatTreeInternal($child, $result);
         }
     }
 }

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -604,7 +604,7 @@ class CategoryCollection {
             return;
         }
         foreach ($category['Children'] as $child) {
-            $this->flatTreeInternal($child, $result);
+            $this->flattenTreeInternal($child, $result);
         }
     }
 }

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -263,13 +263,7 @@ class CategoryCollection {
      * @return array Returns an array of categories.
      */
     public function getChildren($categoryID) {
-        $children = $this
-            ->sql
-            ->select('CategoryID')
-            ->getWhere('Category', ['ParentCategoryID' => $categoryID])
-            ->resultArray();
-        $ids = array_column($children, 'CategoryID');
-        $categories = $this->getMulti($ids);
+        $categories = $this->getChildrenByParents([$categoryID]);
         return $categories;
     }
 
@@ -334,17 +328,17 @@ class CategoryCollection {
      * Get all of the categories from a root.
      *
      * @param int $parentID The ID of the parent category.
-     * @param int $depth The max depth to grab.
-     * @param int $adjustDepth Whether to adjust the depth field on categories.
+     * @param int $maxDepth The maximum relative depth to grab.
+     * @param bool $adjustDepth Whether to adjust the depth field on categories.
      */
-    public function getTree($parentID = -1, $depth = 3, $adjustDepth = false) {
+    public function getTree($parentID = -1, $maxDepth = 3, $adjustDepth = false) {
         $tree = [];
         $categories = [];
         $parentID = $parentID ?: -1;
 
         $currentDepth = 1;
         $parents = [$parentID];
-        for ($i = 0; $i < $depth; $i++) {
+        for ($i = 0; $i < $maxDepth; $i++) {
             $children = $this->getChildrenByParents($parents);
 
             // Go through the children and wire them up.
@@ -604,7 +598,7 @@ class CategoryCollection {
      * @param array $category The current category being examined.
      * @param array &$result The working result.
      */
-    private function flatTreeInternal(array $category, array &$result) {
+    private function flattenTreeInternal(array $category, array &$result) {
         $result[] = $category;
         if (empty($category['Children'])) {
             return;

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -31,6 +31,11 @@ class CategoryCollection {
     private $cacheInc;
 
     /**
+     * @var callable The callback used to calculate individual categories.
+     */
+    private $calculator;
+
+    /**
      * @var Gdn_Configuration The config dependency.
      */
     private $config;
@@ -71,6 +76,7 @@ class CategoryCollection {
             $cache = Gdn::cache();
         }
         $this->cache = $cache;
+        $this->setCalculator();
     }
 
     /**
@@ -79,6 +85,39 @@ class CategoryCollection {
      * @param array &$category The category to calculate.
      */
     private function calculate(&$category) {
+        call_user_func($this->calculator, $category);
+    }
+
+    /**
+     * Get the calculator.
+     *
+     * @return callable Returns the calculator.
+     */
+    public function getCalculator() {
+        return $this->calculator;
+    }
+
+    /**
+     * Set the calculator.
+     *
+     * @param callable $calculator The new calculator.
+     * @return CategoryCollection Returns `$this` for fluent calls.
+     */
+    public function setCalculator(callable $calculator = null) {
+        if ($calculator === null) {
+            $this->calculator = [$this, 'defaultCalculator'];
+        } else {
+            $this->calculator = $calculator;
+        }
+        return $this;
+    }
+
+    /**
+     * Calculate dynamic data on a category.
+     *
+     * @param array &$category The category to calculate.
+     */
+    private function defaultCalculator(&$category) {
         $category['CountAllDiscussions'] = $category['CountDiscussions'];
         $category['CountAllComments'] = $category['CountComments'];
 //        $category['Url'] = self::categoryUrl($category, false, '/');

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -59,7 +59,12 @@ class CategoryModel extends Gdn_Model {
     public function __construct() {
         parent::__construct('Category');
         $this->collection = new CategoryCollection();
+        // Inject the calculator dependency.
         $this->collection->setConfig(Gdn::config());
+        $this->collection->setCalculator(function (&$category) {
+            self::calculate($category);
+            self::calculateUser($category);
+        });
     }
 
     /**
@@ -1138,11 +1143,6 @@ class CategoryModel extends Gdn_Model {
         }
 
         $category = $this->collection->get($id);
-        if (!empty($category)) {
-            self::calculate($category);
-            self::calculateUser($category);
-        }
-
         return $category;
     }
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -609,8 +609,6 @@ class CategoryModel extends Gdn_Model {
      */
     public static function getChildren($categoryID) {
         $categories = self::instance()->collection->getChildren($categoryID);
-        self::calculateData($categories);
-        self::joinUserData($categories, false);
         return $categories;
     }
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -630,10 +630,37 @@ class CategoryModel extends Gdn_Model {
         }
     }
 
+    /**
+     * Get a category tree based on, but not including a parent category.
+     *
+     * @param int|string $id The parent category ID or slug.
+     * @param int $depth The maximum depth of categories.
+     * @param string $permission The permission to check to see which categories to get.
+     * @return array Returns an array of categories with child categories in the **Children** key.
+     */
     public function getChildTree($id, $depth = 3, $permission = 'PermsDiscussionsView') {
         $category = $this->getOne($id);
 
         return $this->collection->getTree((int)val('CategoryID', $category), $depth, $permission);
+    }
+
+    /**
+     * Filter a category tree to only the followed categories.
+     *
+     * @param array $categories The category tree to filter.
+     * @return array Returns a category tree.
+     */
+    public function filterFollowing($categories) {
+        $result = [];
+        foreach ($categories as $category) {
+            if (val('Following', $category)) {
+                if (!empty($category['Children'])) {
+                    $category['Children'] = $this->filterFollowing($category['Children']);
+                }
+                $result[] = $category;
+            }
+        }
+        return $result;
     }
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2300,6 +2300,24 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * Get the category nav depth.
+     *
+     * @return int Returns the nav depth as an integer.
+     */
+    public function getNavDepth() {
+        return (int)c('Vanilla.Categories.NavDepth', 0);
+    }
+
+    /**
+     * Get the maximum display depth for categories.
+     *
+     * @return int Returns the display depth as an integer.
+     */
+    public function getMaxDisplayDepth() {
+        return (int)c('Vanilla.Categories.MaxDisplayDepth', 3);
+    }
+
+    /**
      * Recalculate the dynamic tree columns in the category.
      */
     public function recalculateTree() {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1437,8 +1437,6 @@ class CategoryModel extends Gdn_Model {
             if ($includeHeadings || $category['DisplayAs'] !== 'Heading') {
                 $result[$ID] = $category;
             }
-
-            $category = self::instance()->getOne($category['ParentCategoryID']);
         }
         $result = array_reverse($result, true); // order for breadcrumbs
         return $result;

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1652,10 +1652,12 @@ class CategoryModel extends Gdn_Model {
         $Categories = (array)$Categories;
 
         if ($Root) {
-            $Root = (array)$Root;
-            // Make the tree out of this category as a subtree.
-            $DepthAdjust = -$Root['Depth'];
-            $Result = self::_MakeTreeChildren($Root, $Categories, $DepthAdjust);
+            $Result = self::instance()->collection->getTree(
+                (int)val('CategoryID', $Root),
+                self::instance()->getMaxDisplayDepth(),
+                true
+            );
+            self::instance()->joinRecent($Result);
         } else {
             // Make a tree out of all categories.
             foreach ($Categories as $Category) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1743,7 +1743,7 @@ class CategoryModel extends Gdn_Model {
         if ($Root) {
             $Result = self::instance()->collection->getTree(
                 (int)val('CategoryID', $Root),
-                self::instance()->getMaxDisplayDepth()
+                self::instance()->getMaxDisplayDepth() ?: 10
             );
             self::instance()->joinRecent($Result);
         } else {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -539,6 +539,28 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * Cast a category ID or slug to be passed to the various {@link CategoryCollection} methods.
+     *
+     * @param int|string|null $category The category ID or slug.
+     * @return int|string|null Returns the cast category ID.
+     */
+    private static function castID($category) {
+        if (empty($category)) {
+            return null;
+        } elseif (is_numeric($category)) {
+            return (int)$category;
+        } else {
+            return (string)$category;
+        }
+    }
+
+    public function getChildTree($category, $depth = 3, $adjustDepth = false) {
+        $category = self::castID($category);
+
+        return $this->collection->getTree($category, $depth, $adjustDepth);
+    }
+
+    /**
      *
      *
      * @param string $Permission

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -30,7 +30,7 @@ $PermissionCategoryIDExists = $Construct->columnExists('PermissionCategoryID');
 $LastDiscussionIDExists = $Construct->columnExists('LastDiscussionID');
 
 $Construct->PrimaryKey('CategoryID')
-    ->column('ParentCategoryID', 'int', true)
+    ->column('ParentCategoryID', 'int', true, 'key')
     ->column('TreeLeft', 'int', true)
     ->column('TreeRight', 'int', true)
     ->column('Depth', 'int', '0')

--- a/applications/vanilla/views/categories/all.php
+++ b/applications/vanilla/views/categories/all.php
@@ -13,17 +13,13 @@ $CatList = '';
 $DoHeadings = c('Vanilla.Categories.DoHeadings');
 $MaxDisplayDepth = c('Vanilla.Categories.MaxDisplayDepth') + $this->data('Category.Depth', 0);
 $ChildCategories = '';
-$this->EventArguments['NumRows'] = count($this->data('Categories'));
 
-//if (c('Vanilla.Categories.ShowTabs')) {
-////   $ViewLocation = Gdn::controller()->fetchViewLocation('helper_functions', 'Discussions', 'vanilla');
-////   include_once $ViewLocation;
-////   WriteFilterTabs($this);
-//   echo Gdn_Theme::Module('DiscussionFilterModule');
-//}
+$CategoryTree = $this->data('CategoryTree');
+$Categories = CategoryModel::flattenTree($CategoryTree);
+$this->EventArguments['NumRows'] = $Categories;
 
 echo '<ul class="DataList CategoryList'.($DoHeadings ? ' CategoryListWithHeadings' : '').'">';
-foreach ($this->data('Categories') as $CategoryRow) {
+foreach ($Categories as $CategoryRow) {
     $Category = (object)$CategoryRow;
 
     $this->EventArguments['CatList'] = &$CatList;

--- a/applications/vanilla/views/categories/table.php
+++ b/applications/vanilla/views/categories/table.php
@@ -4,7 +4,7 @@
 <?php
 $this->fireEvent('AfterDescription');
 $this->fireEvent('AfterPageTitle');
-$Categories = CategoryModel::MakeTree($this->data('Categories'), $this->data('Category', null));
+$Categories = $this->data('CategoryTree');
 
 if (c('Vanilla.Categories.DoHeadings')) {
     foreach ($Categories as $Category) {


### PR DESCRIPTION
Optimize the various all category type views to use the CategoryCollection instead of iterating all categories. This is the implementation of #3845.

- [x] Category tree functionality.
- [x] Add CountAll* calculation.
- [x] Add recent post joining.
- [x] Implement proper permission checking in the category tree.
- [x] Refactor some of the existing category tree functions to use the CategoryCollection.
- [x] Make the default theme use the proper category collection.
- [x] Make sure the subtree uses the proper category collection.
- [x] Support marking a category as read.
- [x] Support category hiding/unhiding.