### PR TITLE
Fix announcements' data assignation in CategoriesController

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -284,7 +284,7 @@ class CategoriesController extends VanillaController {
             // We don't wan't child categories in announcements.
             $Wheres['d.CategoryID'] = $CategoryID;
             $AnnounceData = $Offset == 0 ? $DiscussionModel->GetAnnouncements($Wheres) : new Gdn_DataSet();
-            $this->setData('AnnounceData', $AnnounceData, true);
+            $this->AnnounceData = $this->setData('Announcements', $AnnounceData);
             $Wheres['d.CategoryID'] = $CategoryIDs;
 
             $this->DiscussionData = $this->setData('Discussions', $DiscussionModel->getWhereRecent($Wheres, $Limit, $Offset));


### PR DESCRIPTION
-`AnnounceData` is always used as a property of the controller.
-`Announcements` is often requested as data of the controller but was not set.