### PR TITLE
Update SplitMerge to overcome Garden.ForceInputFormatter

### DIFF
--- a/plugins/SplitMerge/class.splitmerge.plugin.php
+++ b/plugins/SplitMerge/class.splitmerge.plugin.php
@@ -92,11 +92,19 @@ class SplitMergePlugin extends Gdn_Plugin {
             $Data['Format'] = 'Html';
             $Data['Type'] = 'Discussion';
 
-            // Make sure we can save this new discussion as HTML.
+            // Pass a forced input formatter around this exception.
             if (c('Garden.ForceInputFormatter')) {
+                $inputFormat = c('Garden.InputFormatter');
                 saveToConfig('Garden.InputFormatter', 'Html', false);
             }
+
             $NewDiscussionID = $DiscussionModel->save($Data);
+
+            // Reset the input formatter
+            if (c('Garden.ForceInputFormatter')) {
+                saveToConfig('Garden.InputFormatter', $inputFormat, false);
+            }
+
             $Sender->Form->setValidationResults($DiscussionModel->validationResults());
 
             if ($Sender->Form->errorCount() == 0 && $NewDiscussionID > 0) {

--- a/plugins/SplitMerge/class.splitmerge.plugin.php
+++ b/plugins/SplitMerge/class.splitmerge.plugin.php
@@ -91,6 +91,11 @@ class SplitMergePlugin extends Gdn_Plugin {
             $Data['Body'] = sprintf(t('This discussion was created from comments split from: %s.'), anchor(Gdn_Format::text($Discussion->Name), 'discussion/'.$Discussion->DiscussionID.'/'.Gdn_Format::url($Discussion->Name).'/'));
             $Data['Format'] = 'Html';
             $Data['Type'] = 'Discussion';
+
+            // Make sure we can save this new discussion as HTML.
+            if (c('Garden.ForceInputFormatter')) {
+                saveToConfig('Garden.InputFormatter', 'Html', false);
+            }
             $NewDiscussionID = $DiscussionModel->save($Data);
             $Sender->Form->setValidationResults($DiscussionModel->validationResults());
 


### PR DESCRIPTION
If `Garden.ForceInputFormatter` is enabled, the SplitMerge plug-in may be unable to save the discussions it creates with the proper "Html" format.  Since the content SplitMerge generates for these posts contains HTML, this can lead to posts being rendering escaped markup text.  E.g.

```
This discussion was created from comments split from: <a href="/discussion/1/example-discussion">Example Discussion</a>.
```

This update applies a [method taken from ModerationController](https://github.com/vanilla/vanilla/blob/320e922082771a160ddba16f63435cf3cd35ad8c/applications/vanilla/controllers/class.moderationcontroller.php#L417) to temporarily set `Garden.InputFormat` to "Html" if `Garden.ForceInputFormatter` is enabled.