### PR TITLE
Pass config to CategoryCollection in CategoryModel

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -59,6 +59,7 @@ class CategoryModel extends Gdn_Model {
     public function __construct() {
         parent::__construct('Category');
         $this->collection = new CategoryCollection();
+        $this->collection->setConfig(Gdn::config());
     }
 
     /**


### PR DESCRIPTION
`CategoryCollection` was unable to read from the site config and therefore unable to determine the value of `Vanilla.Categories.NavDepth` because its `config` property was never set.

This update executes `CategoryCollection::setConfig` after the object is instantiated in `CategoryModel`.