### PR TITLE
Update drop column query builder in MySQLStructure

### DIFF
--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -508,7 +508,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
             // table that are NOT in $this->_Columns.
             $RemoveColumns = array_diff(array_keys($existingColumns), array_keys($columns));
             foreach ($RemoveColumns as $Column) {
-                $AlterSql[] = "drop column `{$columns[$Column]}`";
+                $AlterSql[] = "drop column `$Column`";
             }
         }
 


### PR DESCRIPTION
Vanilla's routine for dropping a column in `MySQLStructure` diffs existing vs target table structure, iterates through the list of columns to drop, then tries to use those column names as indexes in the array it already determined they don't exist in.  Additionally, `$Column` contains details about columns as an array of `stdClass` objects, not just their names.  Trying include a member of `$Column` directly into a string is invalid.

```php
$RemoveColumns = array_diff(array_keys($existingColumns), array_keys($columns));
foreach ($RemoveColumns as $Column) {
    $AlterSql[] = "drop column `{$columns[$Column]}`";
}
```

Our current logic can lead to errors like ```Can't drop ``; check that the column/key exists``` when an existing column is being removed from a table.

This update reverts to using `$Column`, which is the name of the current column to drop, instead of `$columns[$Column]`.