### PR TITLE
Correct field length of GDN_Tag.FullName

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -637,7 +637,7 @@ if (!$FullNameColumnExists) {
         ->put();
 
     $Construct->table('Tag')
-        ->column('FullName', 'varchar(255)', false, 'index')
+        ->column('FullName', 'varchar(100)', false, 'index')
         ->set();
 }
 


### PR DESCRIPTION
**Please be careful with this!**

There has been an error that made the field FullName hold 255 characters right after installation until the first run of /utility/structure. Then it is cut down to 100 characters.
I don't know if the model makes any restrictions, but if not, the FullName could be user for strings longer 100 characters and thus might get cut when utility/structure is run for the first time.

It might be safer to set all values to 255 based on that error.