### PR TITLE
Cache the default authentication provider within the request

### DIFF
--- a/library/core/class.authenticationprovidermodel.php
+++ b/library/core/class.authenticationprovidermodel.php
@@ -24,6 +24,11 @@ class Gdn_AuthenticationProviderModel extends Gdn_Model {
     const COLUMN_NAME = 'Name';
 
     /**
+     * @var array The default authentication provider.
+     */
+    private static $default = null;
+
+    /**
      *
      */
     public function __construct() {
@@ -54,11 +59,15 @@ class Gdn_AuthenticationProviderModel extends Gdn_Model {
      * @return array
      */
     public static function getDefault() {
-        $Rows = self::getWhereStatic(array('IsDefault' => 1));
-        if (empty($Rows)) {
-            return false;
+        if (self::$default === null) {
+            $Rows = self::getWhereStatic(array('IsDefault' => 1));
+            if (empty($Rows)) {
+                self::$default = false;
+            } else {
+                self::$default = array_pop($Rows);
+            }
         }
-        return array_pop($Rows);
+        return self::$default;
     }
 
     /**


### PR DESCRIPTION
I noticed the default provider was being queried several times when multiple SSO plugins were enabled.