### PR TITLE
Improve AssetModel::jsPath() deprecated "path" message.

### DIFF
--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -433,9 +433,9 @@ class AssetModel extends Gdn_Model {
         foreach ($paths as $info) {
             if (file_exists($info[0])) {
                 if (!empty($info[2])) {
-                    // This path is deprecate. The script should be moved into the /js/ sub-directory
+                    // This path is deprecate. The script should be moved into a /js/ sub-directory
                     unset($info[2]);
-                    deprecated("File path '$filename'", "'js/$filename'");
+                    deprecated("The file path '$folder/$filename'", "'$folder/js/$filename'");
                 }
 
                 return $info;

--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -433,9 +433,9 @@ class AssetModel extends Gdn_Model {
         foreach ($paths as $info) {
             if (file_exists($info[0])) {
                 if (!empty($info[2])) {
-                    // This path is deprecated.
+                    // This path is deprecate. The script should be moved into the /js/ sub-directory
                     unset($info[2]);
-                    deprecated("The js file '$filename' in folder '$folder'");
+                    deprecated("File path '$filename'", "'js/$filename'");
                 }
 
                 return $info;


### PR DESCRIPTION
The old error message was confusing:
`The js file 'filename.js' in folder 'something' is deprecated`

Now it shows:
`The file path 'something/filename.js' is deprecated. Use 'something/js/filename.js' instead.`

I saw that while fixing https://github.com/vanilla/addons/pull/334