### PR TITLE
Reindex result of CategoryModel::filterCategoryPermissions

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -503,7 +503,8 @@ class CategoryModel extends Gdn_Model {
             return $categoryIDs;
         } else {
             $permissionCategoryIDs = array_keys($permissionCategories);
-            return array_intersect($categoryIDs, $permissionCategoryIDs);
+            // Reindex the result.  array_intersect leaves the original, potentially incomplete, numeric indexes.
+            return array_values(array_intersect($categoryIDs, $permissionCategoryIDs));
         }
     }
 


### PR DESCRIPTION
`CategoryModel::filterCategoryPermissions` currently returns an array of input category IDs, filtered by the current user's permissions.  It does this by utilizing `array_intersect`, which maintains the original indexes of the array.  We don't care about the original indexes.  On the contrary, we need the category to have complete numeric indexes.  For example, `Gdn_SqlDriver::where` checks to see if an element with an index of 0 exists.  If it does not, it gets passed off to `Gdn_SqlDriver::conditionExpr`, which can potentially throw a fatal error:

> Gdn_SQL->ConditionExpr(VALUE, ARRAY) is not supported.

This update applies `array_values` to the filtered result of `CategoryModel::filterCategoryPermissions`, which creates new, complete numeric indexes for the resulting array.