### PR TITLE
Allow users to save upload URLs as photo

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -438,10 +438,12 @@ class ProfileController extends Gdn_Controller {
 
             // Don't allow non-mods to set an explicit photo.
             if ($photo = $this->Form->getFormValue('Photo')) {
-                if (!Gdn_Upload::isUploadUri($photo) && !checkPermission('Garden.Users.Edit')) {
-                    $this->Form->removeFormValue('Photo');
-                } elseif (!filter_var($photo, FILTER_VALIDATE_URL)) {
-                    $this->Form->addError('Invalid photo URL.');
+                if (!Gdn_Upload::isUploadUri($photo)) {
+                    if (!checkPermission('Garden.Users.Edit')) {
+                        $this->Form->removeFormValue('Photo');
+                    } elseif (!filter_var($photo, FILTER_VALIDATE_URL)) {
+                        $this->Form->addError('Invalid photo URL.');
+                    }
                 }
             }
 

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -438,7 +438,7 @@ class ProfileController extends Gdn_Controller {
 
             // Don't allow non-mods to set an explicit photo.
             if ($photo = $this->Form->getFormValue('Photo')) {
-                if (!Gdn_Upload::isUploaded($photo) && !checkPermission('Garden.Users.Edit')) {
+                if (!Gdn_Upload::isUploadUri($photo) && !checkPermission('Garden.Users.Edit')) {
                     $this->Form->removeFormValue('Photo');
                 } elseif (!filter_var($photo, FILTER_VALIDATE_URL)) {
                     $this->Form->addError('Invalid photo URL.');

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -438,7 +438,7 @@ class ProfileController extends Gdn_Controller {
 
             // Don't allow non-mods to set an explicit photo.
             if ($photo = $this->Form->getFormValue('Photo')) {
-                if (!checkPermission('Garden.Users.Edit')) {
+                if (!Gdn_Upload::isUploaded($photo) && !checkPermission('Garden.Users.Edit')) {
                     $this->Form->removeFormValue('Photo');
                 } elseif (!filter_var($photo, FILTER_VALIDATE_URL)) {
                     $this->Form->addError('Invalid photo URL.');

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -289,7 +289,7 @@ class Gdn_Upload extends Gdn_Pluggable {
     public static function isUploadUri($uri) {
         $parsed = Gdn_Upload::parse($uri);
 
-        return empty($parsed['Type']) || $parsed['Type'] !== 'external';
+        return (empty($parsed['Type']) || $parsed['Type'] !== 'external') && !empty($parsed['Url']);
     }
 
     /**

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -289,15 +289,7 @@ class Gdn_Upload extends Gdn_Pluggable {
     public static function isUploadUri($uri) {
         $parsed = Gdn_Upload::parse($uri);
 
-        if (empty($parsed['Type'])) {
-            // This is a local file upload.
-            return true;
-        } elseif (empty($parsed['Domain'])) {
-            return false;
-        }
-        $prefixes = Gdn_Upload::urls();
-
-        return !empty($prefixes["{$parsed['Type']}://{$parsed['Domain']}"]);
+        return empty($parsed['Type']) || $parsed['Type'] !== 'external';
     }
 
     /**

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -281,23 +281,23 @@ class Gdn_Upload extends Gdn_Pluggable {
     }
 
     /**
-     * Determine if a URL matches the format of a valid type/domain upload.
+     * Determine if a URI matches the format of a valid type/domain upload.
      *
-     * @param string $url A full file URL to test.
-     * @return bool
+     * @param string $uri The URI to test. This would be the value saved in the database (ex. GDN_User.Photo).
+     * @return bool Returns **true** if {@link uri} looks like an uploaded file or **false** otherwise.
      */
-    public static function isUploaded($url) {
-        $parsed = Gdn_Upload::parse($url);
-        $type = val('Type', $parsed);
-        $domain = val('Domain', $parsed);
+    public static function isUploadUri($uri) {
+        $parsed = Gdn_Upload::parse($uri);
 
-        $prefixes = array_keys(Gdn_Upload::urls());
-
-        if (!$type || !$domain) {
+        if (empty($parsed['Type'])) {
+            // This is a local file upload.
+            return true;
+        } elseif (empty($parsed['Domain'])) {
             return false;
         }
+        $prefixes = Gdn_Upload::urls();
 
-        return in_array("{$type}://{$domain}", $prefixes);
+        return !empty($prefixes["{$parsed['Type']}://{$parsed['Domain']}"]);
     }
 
     /**

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -281,6 +281,26 @@ class Gdn_Upload extends Gdn_Pluggable {
     }
 
     /**
+     * Determine if a URL matches the format of a valid type/domain upload.
+     *
+     * @param string $url
+     * @return bool
+     */
+    public static function isUploaded($url) {
+        $parsed = Gdn_Upload::parse($url);
+        $type = val('Type', $parsed);
+        $domain = val('Domain', $parsed);
+
+        $prefixes = array_keys(Gdn_Upload::urls());
+
+        if (!$type || !$domain) {
+            return false;
+        }
+
+        return in_array("{$type}://{$domain}", $prefixes);
+    }
+
+    /**
      *
      *
      * @param $Source

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -283,7 +283,7 @@ class Gdn_Upload extends Gdn_Pluggable {
     /**
      * Determine if a URL matches the format of a valid type/domain upload.
      *
-     * @param string $url
+     * @param string $url A full file URL to test.
      * @return bool
      */
     public static function isUploaded($url) {

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -289,7 +289,7 @@ class Gdn_Upload extends Gdn_Pluggable {
     public static function isUploadUri($uri) {
         $parsed = Gdn_Upload::parse($uri);
 
-        return (empty($parsed['Type']) || $parsed['Type'] !== 'external') && !empty($parsed['Url']);
+        return !empty($parsed['Url']) && val('Type', $parsed) !== 'external';
     }
 
     /**

--- a/tests/APIv0/StandardTest.php
+++ b/tests/APIv0/StandardTest.php
@@ -167,10 +167,11 @@ class StandardTest extends BaseTest {
 
         $dbUser = $this->api()->queryUserKey($user['UserID'], true);
 
-        $photo = $user['Photo'].'.png';
+        $photo = 'http://foo.com/bar.png';
         $r = $this->api()->post('/profile/edit.json?userid='.$user['UserID'], ['Photo' => $photo]);
 
         $dbUser2 = $this->api()->queryUserKey($user['UserID'], true);
+        $this->assertNotEquals($photo, $dbUser2['Photo']);
         $this->assertSame($dbUser['Photo'], $dbUser2['Photo']);
     }
 

--- a/tests/APIv0/StandardTest.php
+++ b/tests/APIv0/StandardTest.php
@@ -191,8 +191,8 @@ class StandardTest extends BaseTest {
         $r = $this->api()->post('/profile/edit.json?userid='.$user['UserID'], ['Photo' => $photo]);
 
         $dbUser2 = $this->api()->queryUserKey($user['UserID'], true);
-        $this->assertNotEquals($photo, $dbUser2['Photo']);
-        $this->assertSame($dbUser['Photo'], $dbUser2['Photo']);
+        $this->assertSame($photo, $dbUser2['Photo']);
+        $this->assertNotEquals($dbUser['Photo'], $dbUser2['Photo']);
     }
 
     /**

--- a/tests/APIv0/StandardTest.php
+++ b/tests/APIv0/StandardTest.php
@@ -188,6 +188,7 @@ class StandardTest extends BaseTest {
 
         // This is a valid upload URL and should be allowed.
         $photo = 'userpics/679/FPNH7GFCMGBA.jpg';
+        $this->assertNotEquals($dbUser['Photo'], $photo);
         $r = $this->api()->post('/profile/edit.json?userid='.$user['UserID'], ['Photo' => $photo]);
 
         $dbUser2 = $this->api()->queryUserKey($user['UserID'], true);

--- a/tests/APIv0/StandardTest.php
+++ b/tests/APIv0/StandardTest.php
@@ -176,6 +176,26 @@ class StandardTest extends BaseTest {
     }
 
     /**
+     * Test setting an uploaded photo that isn't a valid URL.
+     *
+     * @param array $user The user to test against.
+     * @depends testRegisterBasic
+     */
+    public function testSetPhotoPermissionLocal($user) {
+        $this->api()->setUser($user);
+
+        $dbUser = $this->api()->queryUserKey($user['UserID'], true);
+
+        // This is a valid upload URL and should be allowed.
+        $photo = 'userpics/679/FPNH7GFCMGBA.jpg';
+        $r = $this->api()->post('/profile/edit.json?userid='.$user['UserID'], ['Photo' => $photo]);
+
+        $dbUser2 = $this->api()->queryUserKey($user['UserID'], true);
+        $this->assertNotEquals($photo, $dbUser2['Photo']);
+        $this->assertSame($dbUser['Photo'], $dbUser2['Photo']);
+    }
+
+    /**
      * Test that the APIv0 can actually send a correctly formatted user cookie.
      *
      * @depends testRegisterBasic


### PR DESCRIPTION
This update adds `Gdn_Upload::isUploaded` to determine if a URL matches a valid type/domain pattern (e.g. `cf://uploads`) provided by an upload plug-in.  This function is then used in `ProfileController::edit` to allow those types of URLs to be saved by users as their photo.