### PR TITLE
Move anchor id for comments to a seperate tag

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -97,7 +97,8 @@ if (!function_exists('writeComment')) :
 
         // First comment template event
         $Sender->fireEvent('BeforeCommentDisplay'); ?>
-        <li class="<?php echo $CssClass; ?>" id="<?php echo 'Comment_'.$Comment->CommentID; ?>">
+        <li class="<?php echo $CssClass; ?>">
+            <span id="<?php echo 'Comment_'.$Comment->CommentID; ?>" class="anchor"/>
             <div class="Comment">
 
                 <?php


### PR DESCRIPTION
This is a somewhat speculative pull request. It might be that you think the downside mentioned below is to much of a problem to pull it in, but as I note below I couldn't find any other way of doing this. I've already signed the CLA should you want to pull it in.

Reason for doing this is to be able to use Vanilla on a site with a `position:fixed` header. Without any changes, links to a comment will cause the start of the comment to be hidden under the header. It isn't possible to use CSS tricks with the `li` tag because it has its own styling (see http://nicolasgallagher.com/jump-links-and-viewport-positioning/demo/) so it needs to be moved into its own tag.

The following CSS can then be used:

```
#latest,
span.anchor {
	display: block;
	position: relative;
	top: -50px;
	visibility: hidden;
}
```

The downside is that if there is any external Javascript that uses that id and the fact that it is an `li` tag, it will now break.

I couldn't see any other way to do this though since the comment view isn't particularly easy to provide a theme override for.