### PR TITLE
Update General Discussion category's depth to 1 on install

### DIFF
--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -68,7 +68,7 @@ if ($SQL->getWhere('Category', array('CategoryID' => -1))->numRows() == 0) {
 }
 
 if ($Drop || !$CategoryExists) {
-    $SQL->insert('Category', array('ParentCategoryID' => -1, 'TreeLeft' => 2, 'TreeRight' => 3, 'InsertUserID' => 1, 'UpdateUserID' => 1, 'DateInserted' => Gdn_Format::toDateTime(), 'DateUpdated' => Gdn_Format::toDateTime(), 'Name' => 'General', 'UrlCode' => 'general', 'Description' => 'General discussions', 'PermissionCategoryID' => -1));
+    $SQL->insert('Category', array('ParentCategoryID' => -1, 'TreeLeft' => 2, 'TreeRight' => 3, 'Depth' => 1, 'InsertUserID' => 1, 'UpdateUserID' => 1, 'DateInserted' => Gdn_Format::toDateTime(), 'DateUpdated' => Gdn_Format::toDateTime(), 'Name' => 'General', 'UrlCode' => 'general', 'Description' => 'General discussions', 'PermissionCategoryID' => -1));
 } elseif ($CategoryExists && !$PermissionCategoryIDExists) {
     if (!c('Garden.Permissions.Disabled.Category')) {
         // Existing installations need to be set up with per/category permissions.


### PR DESCRIPTION
When the "General" category is created on install, it has a depth of 0.  This is because it has no depth of its own and defaults to 0.

This update adds the value of 1 for the `Depth` column of the "General" category on install.

Closes #3976