### PR TITLE
Move inserting Twitter plugin's UAP to structure

### DIFF
--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -960,6 +960,13 @@ class TwitterPlugin extends Gdn_Plugin {
             throw new Gdn_UserException('This plugin requires curl.');
         }
 
+        $this->structure();
+    }
+
+    /**
+     * Perform any necessary database or configuration updates.
+     */
+    public function structure() {
         // Save the twitter provider type.
         Gdn::sql()->replace(
             'UserAuthenticationProvider',


### PR DESCRIPTION
If the Twitter plug-in is enabled directly via the config, the `UserAuthenticationProvider` is never added, because `setup` is never run.

This update moves inserting the `UserAuthenticationProvider` record to the plug-in's `structure` routine, which will allow it to be created when /utility/update is visited.