### PR TITLE
Implement custom Smarty_Security class

### DIFF
--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -104,7 +104,7 @@ class Gdn_Smarty {
         // Assign the controller data last so the controllers override any default data.
         $Smarty->assign($Controller->Data);
 
-        $security = new Gdn_SmartySecurity($Smarty);
+        $security = new SmartySecurityVanilla($Smarty);
 
         $security->php_handling = Smarty::PHP_REMOVE;
         $security->allow_constants = false;

--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -104,7 +104,7 @@ class Gdn_Smarty {
         // Assign the controller data last so the controllers override any default data.
         $Smarty->assign($Controller->Data);
 
-        $security = new Smarty_Security($Smarty);
+        $security = new Gdn_SmartySecurity($Smarty);
 
         $security->php_handling = Smarty::PHP_REMOVE;
         $security->allow_constants = false;
@@ -112,10 +112,10 @@ class Gdn_Smarty {
         $security->secure_dir = [$Path];
         $security->streams = null;
 
-        $security->php_functions =  array_merge(
+        $security->setPhpFunctions(array_merge(
             $security->php_functions,
             array('category', 'checkPermission', 'inSection', 'inCategory', 'multiCheckPermission', 'getValue', 'setValue', 'url')
-        );
+        ));
 
         $security->php_modifiers = array_merge(
             $security->php_functions,

--- a/library/core/class.smartysecurity.php
+++ b/library/core/class.smartysecurity.php
@@ -18,8 +18,8 @@ class Gdn_SmartySecurity extends Smarty_Security {
         if (isset($this->php_functions)) {
             if (empty($this->php_functions)) {
                 return true;
-            } else {
-                return in_array(strtolower($function_name), $this->php_functions);
+            } elseif (in_array(strtolower($function_name), $this->php_functions)) {
+                return true;
             }
         }
 

--- a/library/core/class.smartysecurity.php
+++ b/library/core/class.smartysecurity.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Vanilla implementation of Smarty security policy object.
+ */
+class Gdn_SmartySecurity extends Smarty_Security {
+
+    /**
+     * Check if PHP function is trusted.
+     *
+     * @param  string $function_name
+     * @param  object $compiler compiler object
+     *
+     * @return boolean                 true if function is trusted
+     * @throws SmartyCompilerException if php function is not trusted
+     */
+    public function isTrustedPhpFunction($function_name, $compiler) {
+        if (isset($this->php_functions)) {
+            if (empty($this->php_functions)) {
+                return true;
+            } else {
+                return in_array(strtolower($function_name), $this->php_functions);
+            }
+        }
+
+        $compiler->trigger_template_error("PHP function '{$function_name}' not allowed by security setting");
+
+        return false; // should not, but who knows what happens to the compiler in the future?
+    }
+
+    /**
+     * Set allowed PHP functions.  Normalize casing for comparison.
+     *
+     * @param array $php_functions PHP functions to allow.
+     * @throws Gdn_UserException if $php_functions is not an array.
+     * @return array
+     */
+    public function setPhpFunctions($php_functions) {
+        if (!is_array($php_functions)) {
+            throw new Gdn_UserException('$php_functions must be an array.');
+        }
+
+        $this->php_functions = array_map('strtolower', $php_functions);
+    }
+}

--- a/library/core/class.smartysecurity.php
+++ b/library/core/class.smartysecurity.php
@@ -16,9 +16,7 @@ class Gdn_SmartySecurity extends Smarty_Security {
      */
     public function isTrustedPhpFunction($function_name, $compiler) {
         if (isset($this->php_functions)) {
-            if (empty($this->php_functions)) {
-                return true;
-            } elseif (in_array(strtolower($function_name), $this->php_functions)) {
+            if (empty($this->php_functions) || in_array(strtolower($function_name), $this->php_functions)) {
                 return true;
             }
         }

--- a/library/core/class.smartysecurity.php
+++ b/library/core/class.smartysecurity.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Vanilla implementation of Smarty security policy object.
+ * Vanilla implementation of Smarty security policy.
  */
 class Gdn_SmartySecurity extends Smarty_Security {
 
@@ -30,8 +30,9 @@ class Gdn_SmartySecurity extends Smarty_Security {
      * Set allowed PHP functions.  Normalize casing for comparison.
      *
      * @param array $php_functions PHP functions to allow.
-     * @throws Gdn_UserException if $php_functions is not an array.
+     *
      * @return array
+     * @throws Gdn_UserException if $php_functions is not an array.
      */
     public function setPhpFunctions($php_functions) {
         if (!is_array($php_functions)) {

--- a/library/core/class.smartysecurityvanilla.php
+++ b/library/core/class.smartysecurityvanilla.php
@@ -3,7 +3,7 @@
 /**
  * Vanilla implementation of Smarty security policy.
  */
-class Gdn_SmartySecurity extends Smarty_Security {
+class SmartySecurityVanilla extends Smarty_Security {
 
     /**
      * Check if PHP function is trusted.


### PR DESCRIPTION
`Smarty_Security::isTrustedPhpFunction` is case-sensitive.  We need it to be case-insensitive, especially since we changed our code style guidelines in the last year.

This update extends `Smarty_Security` and overrides `isTrustedPhpFunction` to force casing of function names to lowercase for testing.  This update also adds a new function to the Smarty security class, `setPhpFunctions`, which transforms all PHP function names to lowercase before setting them on the object.

Closes #4014 