### PR TITLE
Fix the flagging plugin "number of tracked item" query

### DIFF
--- a/plugins/Flagging/class.flagging.plugin.php
+++ b/plugins/Flagging/class.flagging.plugin.php
@@ -28,13 +28,13 @@ class FlaggingPlugin extends Gdn_Plugin {
      * Add Flagging to Dashboard menu.
      */
     public function base_getAppSettingsMenuItems_handler($Sender) {
-        $flaggedItemsResult = Gdn::sql()->select('count(distinct(ForeignURL)) as NumFlagedItems')
+        $flaggedItemsResult = Gdn::sql()->select('count(distinct(ForeignURL)) as NumFlaggedItems')
             ->from('Flag fl')
             ->get()->firstRow(DATASET_TYPE_ARRAY);
 
         $LinkText = t('Flagged Content');
-        if ($flaggedItemsResult['NumFlagedItems']) {
-            $LinkText .= ' <span class="Alert">'.$flaggedItemsResult['NumFlagedItems'].'</span>';
+        if ($flaggedItemsResult['NumFlaggedItems']) {
+            $LinkText .= ' <span class="Alert">'.$flaggedItemsResult['NumFlaggedItems'].'</span>';
         }
         $Menu = $Sender->EventArguments['SideMenu'];
         $Menu->AddItem('Forum', t('Forum'));

--- a/plugins/Flagging/class.flagging.plugin.php
+++ b/plugins/Flagging/class.flagging.plugin.php
@@ -28,10 +28,9 @@ class FlaggingPlugin extends Gdn_Plugin {
      * Add Flagging to Dashboard menu.
      */
     public function base_getAppSettingsMenuItems_handler($Sender) {
-        $NumFlaggedItems = Gdn::sql()->select('fl.ForeignID', 'DISTINCT', 'NumFlaggedItems')
+        $NumFlaggedItems = Gdn::sql()->select('COUNT(DISTINCT(ForeignURL)) as numFlagItems')
             ->from('Flag fl')
-            ->groupBy('ForeignURL')
-            ->get()->numRows();
+            ->get()->firstRow(DATASET_TYPE_ARRAY)['numFlagItems'];
 
         $LinkText = t('Flagged Content');
         if ($NumFlaggedItems) {

--- a/plugins/Flagging/class.flagging.plugin.php
+++ b/plugins/Flagging/class.flagging.plugin.php
@@ -28,13 +28,13 @@ class FlaggingPlugin extends Gdn_Plugin {
      * Add Flagging to Dashboard menu.
      */
     public function base_getAppSettingsMenuItems_handler($Sender) {
-        $NumFlaggedItems = Gdn::sql()->select('COUNT(DISTINCT(ForeignURL)) as numFlagItems')
+        $flaggedItemsResult = Gdn::sql()->select('count(distinct(ForeignURL)) as NumFlagedItems')
             ->from('Flag fl')
-            ->get()->firstRow(DATASET_TYPE_ARRAY)['numFlagItems'];
+            ->get()->firstRow(DATASET_TYPE_ARRAY);
 
         $LinkText = t('Flagged Content');
-        if ($NumFlaggedItems) {
-            $LinkText .= ' <span class="Alert">'.$NumFlaggedItems.'</span>';
+        if ($flaggedItemsResult['NumFlagedItems']) {
+            $LinkText .= ' <span class="Alert">'.$flaggedItemsResult['NumFlagedItems'].'</span>';
         }
         $Menu = $Sender->EventArguments['SideMenu'];
         $Menu->AddItem('Forum', t('Forum'));


### PR DESCRIPTION
- The query returns 0 when `sql-mode` `ONLY_FULL_GROUP_BY` is off.
- The plugin crash when we turn it on when `sql-mode` `ONLY_FULL_GROUP_BY` is turned on.

Fix https://github.com/vanilla/vanilla/issues/3942

This should be fixed in release/2.3 too, when approved.