### PR TITLE
Make "In this discussion" plugin work with sql mode ONLY_FULL_GROUP_BY

### DIFF
--- a/plugins/VanillaInThisDiscussion/class.inthisdiscussionmodule.php
+++ b/plugins/VanillaInThisDiscussion/class.inthisdiscussionmodule.php
@@ -40,7 +40,7 @@ class InThisDiscussionModule extends Gdn_Module {
             ->from('User u')
             ->join('Comment c', 'u.UserID = c.InsertUserID')
             ->where('c.DiscussionID', $DiscussionID)
-            ->groupBy('u.UserID, u.Name')
+            ->groupBy('u.UserID, u.Name, u.Photo')
             ->orderBy('c.DateInserted', 'desc')
             ->limit($Limit)
             ->get();


### PR DESCRIPTION
MySQL > 5.7.5 comes with ONLY_FULL_GROUP_BY enabled in sql-mode.
Update the query to comply with this "strict" mode.

Fix: https://github.com/vanilla/vanilla/issues/3974