### PR TITLE
Use canonical emoji name in editor list

### DIFF
--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -192,7 +192,7 @@ class Emoji {
             ':/' => 'confused',
             ':o' => 'open_mouth',
             ':s' => 'confounded',
-            ':p' => 'stuck_out_tongue',
+            ':p' => 'tongue',
             ":'(" => 'cry',
             ':|' => 'neutral',
             'D:' => 'anguished',


### PR DESCRIPTION
Use "tongue" for :stuck_out_tongue: (tongue.png) emoji instead of "stuck_out_tongue", which only exists in the archive.
No functionality change.