### PR TITLE
Fix a structure issue when using MySQL 5.7 default "sql-mode" (strict)

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -591,18 +591,17 @@ if ($Construct->tableExists('Tag') && $TagCategoryColumnExists) {
 
     $DupTags = Gdn::sql()
         ->select('Name, CategoryID')
-        ->select('TagID', 'min', 'TagID')
-        ->select('TagID', 'count', 'CountTags')
+        ->select('TagID', 'min', 'FirstTagID')
         ->from('Tag')
         ->groupBy('Name')
         ->groupBy('CategoryID')
-        ->having('CountTags >', 1)
+        ->having('count(TagID) >', 1)
         ->get()->resultArray();
 
     foreach ($DupTags as $Row) {
         $Name = $Row['Name'];
         $CategoryID = $Row['CategoryID'];
-        $TagID = $Row['TagID'];
+        $TagID = $Row['FirstTagID'];
         // Get the tags that need to be deleted.
         $DeleteTags = Gdn::sql()->getWhere('Tag', array('Name' => $Name, 'CategoryID' => $CategoryID, 'TagID <> ' => $TagID))->resultArray();
         foreach ($DeleteTags as $DRow) {


### PR DESCRIPTION
```
sql-mode="ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
```

I used the default sql-mode of mysql 5.7.8 to fix a bug and I'm finding more while fixing other issues.