### PR TITLE
Deprecate Gdn_DatabaseStructure::query() for Gdn_SqlDriver.

### DIFF
--- a/applications/conversations/settings/structure.php
+++ b/applications/conversations/settings/structure.php
@@ -104,7 +104,7 @@ set CountMessages = (
    select count(MessageID)
    from {$Px}ConversationMessage m
    where c.ConversationID = m.ConversationID)";
-    $Construct->query($UpSql);
+    $SQL->query($UpSql);
 }
 if ($UpdateLastMessageID) {
     // Calculate the count column.
@@ -113,7 +113,7 @@ set LastMessageID = (
    select max(MessageID)
    from {$Px}ConversationMessage m
    where c.ConversationID = m.ConversationID)";
-    $Construct->query($UpSql);
+    $SQL->query($UpSql);
 }
 
 if ($UpdateCountReadMessages) {
@@ -124,7 +124,7 @@ set CountReadMessages = (
   where cm.ConversationID = uc.ConversationID
     and cm.MessageID <= uc.LastMessageID)";
 
-    $Construct->query($UpSql);
+    $SQL->query($UpSql);
 }
 
 // Add extra columns to user table for tracking discussions, comments & replies

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -413,15 +413,15 @@ $Construct
     ->set($Explicit, $Drop);
 
 if (isset($ActivityIndexes['IX_Activity_NotifyUserID'])) {
-    $Construct->query("drop index IX_Activity_NotifyUserID on {$Px}Activity");
+    $SQL->query("drop index IX_Activity_NotifyUserID on {$Px}Activity");
 }
 
 if (isset($ActivityIndexes['FK_Activity_ActivityUserID'])) {
-    $Construct->query("drop index FK_Activity_ActivityUserID on {$Px}Activity");
+    $SQL->query("drop index FK_Activity_ActivityUserID on {$Px}Activity");
 }
 
 if (isset($ActivityIndexes['FK_Activity_RegardingUserID'])) {
-    $Construct->query("drop index FK_Activity_RegardingUserID on {$Px}Activity");
+    $SQL->query("drop index FK_Activity_RegardingUserID on {$Px}Activity");
 }
 
 if (!$EmailedExists) {
@@ -475,7 +475,7 @@ if (!$ActivityCommentExists && $CommentActivityIDExists) {
       select CommentActivityID, Story, 'Text', InsertUserID, DateInserted, InsertIPAddress
       from {$Px}Activity
       where CommentActivityID > 0";
-    $Construct->query($Q);
+    $SQL->query($Q);
     $SQL->delete('Activity', array('CommentActivityID >' => 0));
 }
 
@@ -570,7 +570,7 @@ $Construct->table('Message')
 $Prefix = $SQL->Database->DatabasePrefix;
 
 if ($PhotoIDExists && !$PhotoExists) {
-    $Construct->query("update {$Prefix}User u
+    $SQL->query("update {$Prefix}User u
    join {$Prefix}Photo p
       on u.PhotoID = p.PhotoID
    set u.Photo = p.Name");

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -189,10 +189,10 @@ $Construct
     ->set($Explicit, $Drop);
 
 if (isset($CommentIndexes['FK_Comment_DiscussionID'])) {
-    $Construct->query("drop index FK_Comment_DiscussionID on {$Px}Comment");
+    $SQL->query("drop index FK_Comment_DiscussionID on {$Px}Comment");
 }
 if (isset($CommentIndexes['FK_Comment_DateInserted'])) {
-    $Construct->query("drop index FK_Comment_DateInserted on {$Px}Comment");
+    $SQL->query("drop index FK_Comment_DateInserted on {$Px}Comment");
 }
 
 // Update the participated flag.
@@ -324,18 +324,18 @@ Removed FirstComment from :_Discussion and moved it into the discussion table.
 $Prefix = $SQL->Database->DatabasePrefix;
 
 if ($FirstCommentIDExists && !$BodyExists) {
-    $Construct->query("update {$Prefix}Discussion, {$Prefix}Comment
+    $SQL->query("update {$Prefix}Discussion, {$Prefix}Comment
    set {$Prefix}Discussion.Body = {$Prefix}Comment.Body,
       {$Prefix}Discussion.Format = {$Prefix}Comment.Format
    where {$Prefix}Discussion.FirstCommentID = {$Prefix}Comment.CommentID");
 
-    $Construct->query("delete {$Prefix}Comment
+    $SQL->query("delete {$Prefix}Comment
    from {$Prefix}Comment inner join {$Prefix}Discussion
    where {$Prefix}Comment.CommentID = {$Prefix}Discussion.FirstCommentID");
 }
 
 if (!$LastCommentIDExists || !$LastCommentUserIDExists) {
-    $Construct->query("update {$Prefix}Discussion d
+    $SQL->query("update {$Prefix}Discussion d
    inner join {$Prefix}Comment c
       on c.DiscussionID = d.DiscussionID
    inner join (
@@ -350,7 +350,7 @@ where d.LastCommentUserID is null");
 }
 
 if (!$CountBookmarksExists) {
-    $Construct->query("update {$Prefix}Discussion d
+    $SQL->query("update {$Prefix}Discussion d
    set CountBookmarks = (
       select count(ud.DiscussionID)
       from {$Prefix}UserDiscussion ud

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -377,9 +377,26 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
      * @param string $sql The sql to execute.
      * @return Gdn_Dataset
      */
-    public function query($sql) {
-        deprecated(__CLASS__.'::query()', 'Gdn_SQLDriver::query()');
-        return $this->Database->query($sql);
+    public function query($sql, $checkTreshold = false) {
+
+        $class = null;
+        $internalCall = false;
+
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        if (count($backtrace) > 1) {
+            $class = val('class', $backtrace[1]);
+            if ($class) {
+                $internalCall = is_a($class, __CLASS__, true);
+            }
+        }
+
+        if ($internalCall) {
+            deprecated("$class::query()", "$class::executeQuery()");
+            return $this->executeQuery($sql, $checkTreshold);
+        } else {
+            deprecated(__CLASS__.'::query()', 'Gdn_SQLDriver::query()');
+            return $this->Database->query($sql);
+        }
     }
 
     /**

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -373,11 +373,23 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
     /**
      * Send a query to the database and return the result.
      *
+     * @deprecated
+     * @param string $sql The sql to execute.
+     * @return Gdn_Dataset
+     */
+    public function query($sql) {
+        deprecated(__CLASS__.'::query()', 'Gdn_SQLDriver::query()');
+        return $this->Database->query($sql);
+    }
+
+    /**
+     * Send a query to the database and return the result.
+     *
      * @param string $sql The sql to execute.
      * @param bool $checkThreshold Whether or not to check the alter table threshold before altering the table.
      * @return bool Whether or not the query succeeded.
      */
-    public function query($sql, $checkThreshold = false) {
+    protected function executeQuery($sql, $checkThreshold = false) {
         if ($this->CaptureOnly) {
             if (!property_exists($this->Database, 'CapturedSql')) {
                 $this->Database->CapturedSql = array();

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -375,6 +375,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
      *
      * @deprecated
      * @param string $sql The sql to execute.
+     * @param bool $checkTreshold Should not be used
      * @return Gdn_Dataset
      */
     public function query($sql, $checkTreshold = false) {

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -373,7 +373,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
     /**
      * Send a query to the database and return the result.
      *
-     * @deprecated
+     * @deprecated since 2.3. Was incorrectly public. Replaced by executeQuery().
      * @param string $sql The sql to execute.
      * @param bool $checkTreshold Should not be used
      * @return Gdn_Dataset
@@ -383,6 +383,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
         $class = null;
         $internalCall = false;
 
+        // Detect the origin of this call.
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
         if (count($backtrace) > 1) {
             $class = val('class', $backtrace[1]);
@@ -391,6 +392,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
             }
         }
 
+        // Give appropriate message based on whether we're using it internally.
         if ($internalCall) {
             deprecated("$class::query()", "$class::executeQuery()");
             return $this->executeQuery($sql, $checkTreshold);

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -35,7 +35,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
      */
     public function drop() {
         if ($this->tableExists()) {
-            return $this->query('drop table `'.$this->_DatabasePrefix.$this->_TableName.'`');
+            return $this->executeQuery('drop table `'.$this->_DatabasePrefix.$this->_TableName.'`');
         }
     }
 
@@ -46,7 +46,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
      * @return boolean
      */
     public function dropColumn($Name) {
-        if (!$this->query('alter table `'.$this->_DatabasePrefix.$this->_TableName.'` drop column `'.$Name.'`')) {
+        if (!$this->executeQuery('alter table `'.$this->_DatabasePrefix.$this->_TableName.'` drop column `'.$Name.'`')) {
             throw new Exception(sprintf(T('Failed to remove the `%1$s` column from the `%2$s` table.'), $Name, $this->_DatabasePrefix.$this->_TableName));
         }
 
@@ -153,7 +153,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         // Rename the column
         // The syntax for renaming a column is:
         // ALTER TABLE tablename CHANGE COLUMN oldname newname originaldefinition;
-        if (!$this->query('alter table `'.$OldPrefix.$this->_TableName.'` change column `'.$OldName.'` `'.$NewName.'` '.$this->_defineColumn($OldColumn))) {
+        if (!$this->executeQuery('alter table `'.$OldPrefix.$this->_TableName.'` change column `'.$OldName.'` `'.$NewName.'` '.$this->_defineColumn($OldColumn))) {
             throw new Exception(sprintf(t('Failed to rename table `%1$s` to `%2$s`.'), $OldName, $NewName));
         }
 
@@ -170,7 +170,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
      * @return boolean
      */
     public function renameTable($OldName, $NewName, $UsePrefix = false) {
-        if (!$this->query('rename table `'.$OldName.'` to `'.$NewName.'`')) {
+        if (!$this->executeQuery('rename table `'.$OldName.'` to `'.$NewName.'`')) {
             throw new Exception(sprintf(t('Failed to rename table `%1$s` to `%2$s`.'), $OldName, $NewName));
         }
 
@@ -192,7 +192,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
             $SQLString = $SQL->getSelect();
         }
 
-        $Result = $this->query('create or replace view '.$this->_DatabasePrefix.$Name." as \n".$SQLString);
+        $Result = $this->executeQuery('create or replace view '.$this->_DatabasePrefix.$Name." as \n".$SQLString);
         if (!is_null($SQL)) {
             $SQL->reset();
         }
@@ -309,7 +309,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
 
         $Sql .= ';';
 
-        $Result = $this->query($Sql);
+        $Result = $this->executeQuery($Sql);
         $this->reset();
 
         return $Result;
@@ -532,7 +532,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
                     foreach ($IndexesDb as $IndexName => $IndexSql) {
                         if (StringBeginsWith($IndexSql, 'fulltext', true)) {
                             $DropIndexQuery = "$AlterSqlPrefix drop index $IndexName;\n";
-                            if (!$this->query($DropIndexQuery)) {
+                            if (!$this->executeQuery($DropIndexQuery)) {
                                 throw new Exception(sprintf(t('Failed to drop the index `%1$s` on table `%2$s`.'), $IndexName, $this->_TableName));
                             }
                         }
@@ -540,7 +540,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
                 }
 
                 $EngineQuery = $AlterSqlPrefix.' engine = '.$this->_TableStorageEngine;
-                if (!$this->query($EngineQuery, true)) {
+                if (!$this->executeQuery($EngineQuery, true)) {
                     throw new Exception(sprintf(t('Failed to alter the storage engine of table `%1$s` to `%2$s`.'), $this->_DatabasePrefix.$this->_TableName, $this->_TableStorageEngine));
                 }
             }
@@ -611,7 +611,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         }
 
         if (count($AlterSql) > 0) {
-            if (!$this->query($AlterSqlPrefix.implode(",\n", $AlterSql), true)) {
+            if (!$this->executeQuery($AlterSqlPrefix.implode(",\n", $AlterSql), true)) {
                 throw new Exception(sprintf(T('Failed to alter the `%s` table.'), $this->_DatabasePrefix.$this->_TableName));
             }
         }
@@ -649,7 +649,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         // Modify all of the indexes.
         foreach ($IndexSql as $Name => $Sqls) {
             foreach ($Sqls as $Sql) {
-                if (!$this->query($Sql)) {
+                if (!$this->executeQuery($Sql)) {
                     throw new Exception(sprintf(T('Error.ModifyIndex', 'Failed to add or modify the `%1$s` index in the `%2$s` table.'), $Name, $this->_TableName));
                 }
             }
@@ -658,7 +658,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         // Run any additional Sql.
         foreach ($AdditionalSql as $Description => $Sql) {
             // These queries are just for enum alters. If that changes then pass true as the second argument.
-            if (!$this->query($Sql)) {
+            if (!$this->executeQuery($Sql)) {
                 throw new Exception("Error modifying table: {$Description}.");
             }
         }


### PR DESCRIPTION
Gdn_DatabaseStructure::query() is to be used internally.

- Rename query() to executeQuery and set the method as protected.
- Forward query() to $this->database::query() and deprecate it.