### PR TITLE
Fix token expiry check in Gdn_Authenticator

### DIFF
--- a/library/core/class.authenticator.php
+++ b/library/core/class.authenticator.php
@@ -401,8 +401,8 @@ abstract class Gdn_Authenticator extends Gdn_Pluggable {
             ->where('uat.ForeignUserKey', $UserKey)
             ->where('uat.ProviderKey', $ProviderKey)
             ->beginWhereGroup()
-            ->where('(uat.Timestamp + uat.Lifetime) >=', 'NOW()')
-            ->orWHere('uat.Lifetime', 0)
+            ->where('(uat.Timestamp + uat.Lifetime) >=', 'NOW()', true, false)
+            ->orWhere('uat.Lifetime', 0)
             ->endWhereGroup()
             ->get()
             ->firstRow(DATASET_TYPE_ARRAY);


### PR DESCRIPTION
`Gdn_Authenticator::lookupToken` currently queries user tokens from the `UserAuthenticationToken` table, based partially on the following:

```php
where('(uat.Timestamp + uat.Lifetime) >=', 'NOW()')
```

By default, `Gdn_SQLDriver::where` escapes field values.  This means by the time the query is run, it reads something like:

```sql
where (uat.Timestamp + uat.Lifetime) >= 'NOW()'
```

This update disables escaping of the value field to allow MySQL's `NOW` function to return a proper time for comparison.

Closes #2011 