### PR TITLE
RootController: Remove controller name from canonical url

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -469,7 +469,9 @@ class Gdn_Controller extends Gdn_Pluggable {
                     $Parts[] = strtolower($this->ApplicationFolder);
                 }
 
-                $Parts[] = $Controller;
+                if ($Controller != 'root') {
+                    $Parts[] = $Controller;
+                }
 
                 if (strcasecmp($this->RequestMethod, 'index') != 0) {
                     $Parts[] = strtolower($this->RequestMethod);


### PR DESCRIPTION
Since the RootController is intended for plugin methods at the root, it should not include the name in the canonical url, e.g. `mydomain.com/root/method` becomes `mydomain.com/method`