### PR TITLE
Automatically update CSRF token with AJAX requests

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -269,13 +269,11 @@ class DashboardHooks implements Gdn_IPlugin {
      * @param Gdn_Dispatcher $sender
      */
     public function gdn_dispatcher_sendHeaders_handler($sender) {
-        $headers = array_change_key_case(getallheaders(), CASE_UPPER);
-
         $csrfToken = Gdn::request()->post(
             Gdn_Session::CSRF_NAME,
             Gdn::request()->get(
                 Gdn_Session::CSRF_NAME,
-                val('X-CSRF-TOKEN', $headers)
+                Gdn::request()->getValueFrom(Gdn_Request::INPUT_SERVER, 'HTTP_X_CSRF_TOKEN')
             )
         );
 

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -266,6 +266,25 @@ class DashboardHooks implements Gdn_IPlugin {
     }
 
     /**
+     * @param Gdn_Dispatcher $sender
+     */
+    public function gdn_dispatcher_sendHeaders_handler($sender) {
+        $headers = array_change_key_case(getallheaders(), CASE_UPPER);
+
+        $csrfToken = Gdn::request()->post(
+            Gdn_Session::CSRF_NAME,
+            Gdn::request()->get(
+                Gdn_Session::CSRF_NAME,
+                val('X-CSRF-TOKEN', $headers)
+            )
+        );
+
+        if ($csrfToken && Gdn::session()->isValid() && !Gdn::session()->validateTransientKey($csrfToken)) {
+            safeHeader('X-CSRF-Token: '.Gdn::session()->transientKey());
+        }
+    }
+
+    /**
      * Method for plugins that want a friendly /sso method to hook into.
      *
      * @param RootController $Sender

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -806,7 +806,7 @@ class PostController extends VanillaController {
                 }
             }
         } elseif ($this->Request->isPostBack()) {
-            throw new Gdn_UserException('Invalid CSRF token.', 401);
+            throw new Gdn_UserException(t('Invalid CSRF token.', 'Invalid CSRF token. Please try again.'), 401);
         } else {
             // Load form
             if (isset($this->Comment)) {

--- a/js/global.js
+++ b/js/global.js
@@ -149,6 +149,12 @@
         }
     });
 
+    $(document).ajaxComplete(function(event, jqXHR, ajaxOptions) {
+        var csrfToken = jqXHR.getResponseHeader("X-CSRF-Token");
+        if (csrfToken) {
+            gdn.setMeta("TransientKey", csrfToken);
+        }
+    });
 })(window, jQuery);
 
 // Stuff to fire on document.ready().

--- a/js/global.js
+++ b/js/global.js
@@ -153,6 +153,7 @@
         var csrfToken = jqXHR.getResponseHeader("X-CSRF-Token");
         if (csrfToken) {
             gdn.setMeta("TransientKey", csrfToken);
+            $("input[name=TransientKey]").val(csrfToken);
         }
     });
 })(window, jQuery);

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -131,6 +131,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
     public function start() {
         $this->fireEvent('AppStartup');
+        header_register_callback([$this, 'sendHeaders']);
     }
 
     /**
@@ -795,6 +796,13 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
                 }
             }
         }
+    }
+
+    /**
+     * Trigger an event allowing addons to modify response headers.
+     */
+    public function sendHeaders() {
+        $this->fireEvent('SendHeaders');
     }
 }
 

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -131,7 +131,11 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
     public function start() {
         $this->fireEvent('AppStartup');
-        header_register_callback([$this, 'sendHeaders']);
+
+        // Register callback allowing addons to modify response headers before PHP sends them.
+        header_register_callback(function() {
+            $this->fireEvent('SendHeaders');
+        });
     }
 
     /**
@@ -796,13 +800,6 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
                 }
             }
         }
-    }
-
-    /**
-     * Trigger an event allowing addons to modify response headers.
-     */
-    public function sendHeaders() {
-        $this->fireEvent('SendHeaders');
     }
 }
 

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -1825,7 +1825,7 @@ PASSWORDMETER;
         $result = Gdn::session()->validateTransientKey($postBackKey);
 
         if (!$result && $throw && Gdn::request()->isPostBack()) {
-            throw new Gdn_UserException('The CSRF token is invalid.', 403);
+            throw new Gdn_UserException(t('Invalid CSRF token.', 'Invalid CSRF token. Please try again.'), 403);
         }
 
         return $result;

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -362,7 +362,7 @@ class Gdn_Request {
         $result = Gdn::session()->validateTransientKey($transientKey, false);
 
         if (!$result && $throw) {
-            throw new Gdn_UserException('The CSRF token is invalid.', 403);
+            throw new Gdn_UserException(t('Invalid CSRF token.', 'Invalid CSRF token. Please try again.'), 403);
         }
 
         return $result;

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -15,6 +15,11 @@
  */
 class Gdn_Session {
 
+    /**
+     * Parameter name for incoming CSRF tokens.
+     */
+    const CSRF_NAME = 'TransientKey';
+
     /** @var int Unique user identifier. */
     public $UserID;
 


### PR DESCRIPTION
This update does a few things:

1. Registers a new function, `Gdn_Dispatcher::sendHeaders`, as a callback with `header_register_callback` in `Gdn_Dispatcher::start`.  This function only fires an event.
2. Adds a new hook, `gdn_dispatcher_sendHeaders_handler`, to the Dashboard application.  This hook checks to see if a transient key was supplied.  If it was and it is invalid, the valid transient key is sent back to the client in a X-CSRF-Token header.
3. Creates a new JavaScript hook: `ajaxComplete`.  This hook checks the headers of any completed AJAX requests fired by jQuery.  If a X-CSRF-Token header is present, its value is grabbed and used to update the CSRF token value in the `gdn.meta` collection.

Closes #3962