### PR TITLE
Make individual comments shareable

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1536,7 +1536,7 @@ if (!function_exists('getRecord')) {
                     $Discussion = $Model->getID($Row['DiscussionID']);
                     if ($Discussion) {
                         $Discussion->Url = DiscussionUrl($Discussion);
-                        $Row['ShareUrl'] = $Discussion->Url;
+                        $Row['ShareUrl'] = $Row['Url'];
                         $Row['Name'] = $Discussion->Name;
                         $Row['Discussion'] = (array)$Discussion;
                     }


### PR DESCRIPTION
The share url for comments was the discussion url which would make share buttons below every comment useless.

fixes #2034