### PR TITLE
Allow php logging when enabled in php.ini

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -50,7 +50,6 @@ $Configuration['Garden']['Authenticator']['SignOutUrl']         = '/entry/signou
 $Configuration['Garden']['Authenticator']['EnabledSchemes']     = array('password');
 $Configuration['Garden']['Authenticator']['SyncScreen']         = "smart";
 $Configuration['Garden']['Authenticators']['password']['Name']  = "Password";
-$Configuration['Garden']['Errors']['LogEnabled']                = FALSE;
 $Configuration['Garden']['Errors']['LogFile']                   = '';
 //$Configuration['Garden']['Errors']['MasterView']                = 'deverror.master.php'; // Used at installation time and you should use it too view when debugging
 $Configuration['Garden']['SignIn']['Popup']                     = TRUE; // Should the sign-in link pop up or go to it's own page? (SSO requires going to it's own external page)

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -400,6 +400,14 @@ if (!function_exists('errorLog')) {
      * @param string|\Exception $message
      */
     function errorLog($message) {
+        $errorLogFile = class_exists('Gdn', false) ? Gdn::config('Garden.Errors.LogFile', '') : '';
+
+        // Log only if the PHP setting "log_errors" is enabled
+        // OR if the Garden config "Garden.Errors.LogFile" is provided
+        if (!$errorLogFile && !ini_get('log_errors')) {
+            return;
+        }
+
         // Make sure the message can be converted to a string otherwise bail out
         if (!is_string($message) && !method_exists($message, '__toString')) {
             return;
@@ -408,14 +416,6 @@ if (!function_exists('errorLog')) {
         if (!is_string($message)) {
             // Cast the $message to a string
             $message = (string) $message;
-        }
-
-        $errorLogFile = Gdn::config('Garden.Errors.LogFile');
-
-        // Log only if the PHP setting "log_errors" is enabled
-        // OR if the Garden config "Garden.Errors.LogFile" is provided
-        if (!($errorLogFile || ini_get('log_errors'))) {
-            return;
         }
 
         $destination = null;

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -74,11 +74,13 @@ function Gdn_ErrorHandler($ErrorNumber, $Message, $File, $Line, $Arguments) {
         throw new Gdn_ErrorException($Message, $ErrorNumber, $File, $Line, $Arguments);
     }
 
-    // All other unprocessed non-fatal PHP errors are possibly Traced and delegated back to the native PHP handler.
+    // All other unprocessed non-fatal PHP errors are possibly Traced and logged to the PHP error log file
+    $nonFatalErrorException = new \ErrorException($Message, $ErrorNumber, $ErrorNumber, $File, $Line);
     if (function_exists('trace')) {
-        trace(new \ErrorException($Message, $ErrorNumber, $ErrorNumber, $File, $Line), TRACE_NOTICE);
+        trace($nonFatalErrorException, TRACE_NOTICE);
     }
-    return false;
+
+    errorLog(formatErrorException($nonFatalErrorException));
 }
 
 /**

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -43,25 +43,25 @@ class Gdn_ErrorException extends ErrorException {
 /**
  *
  *
- * @param $ErrorNumber
- * @param $Message
- * @param $File
- * @param $Line
- * @param $Arguments
+ * @param $errorNumber
+ * @param $message
+ * @param $file
+ * @param $line
+ * @param $arguments
  * @return bool|void
  * @throws Gdn_ErrorException
  */
-function Gdn_ErrorHandler($ErrorNumber, $Message, $File, $Line, $Arguments) {
-    $ErrorReporting = error_reporting();
+function Gdn_ErrorHandler($errorNumber, $message, $file, $line, $arguments) {
+    $errorReporting = error_reporting();
 
     // Don't do anything for @supressed errors.
-    if ($ErrorReporting === 0) {
+    if ($errorReporting === 0) {
         return;
     }
 
-    if (($ErrorReporting & $ErrorNumber) !== $ErrorNumber) {
+    if (($errorReporting & $errorNumber) !== $errorNumber) {
         if (function_exists('trace')) {
-            trace(new \ErrorException($Message, $ErrorNumber, $ErrorNumber, $File, $Line), TRACE_NOTICE);
+            trace(new \ErrorException($message, $errorNumber, $errorNumber, $file, $line), TRACE_NOTICE);
         }
 
         // Ignore errors that are below the current error reporting level.
@@ -69,13 +69,13 @@ function Gdn_ErrorHandler($ErrorNumber, $Message, $File, $Line, $Arguments) {
     }
 
     $fatalErrorBitmask = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
-    if ($ErrorNumber & $fatalErrorBitmask) {
+    if ($errorNumber & $fatalErrorBitmask) {
         // Convert all fatal errors to an exception
-        throw new Gdn_ErrorException($Message, $ErrorNumber, $File, $Line, $Arguments);
+        throw new Gdn_ErrorException($message, $errorNumber, $file, $line, $arguments);
     }
 
     // All other unprocessed non-fatal PHP errors are possibly Traced and logged to the PHP error log file
-    $nonFatalErrorException = new \ErrorException($Message, $ErrorNumber, $ErrorNumber, $File, $Line);
+    $nonFatalErrorException = new \ErrorException($message, $errorNumber, $errorNumber, $file, $line);
     if (function_exists('trace')) {
         trace($nonFatalErrorException, TRACE_NOTICE);
     }

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -376,7 +376,7 @@ function Gdn_ExceptionHandler($Exception) {
     }
 }
 
-if (!function_exists('ErrorMessage')) {
+if (!function_exists('errorMessage')) {
     /**
      * Returns an error message formatted in a way that the custom ErrorHandler
      * function can understand (allows a little more information to be displayed
@@ -537,7 +537,7 @@ if (!function_exists('formatPHPErrorLog')) {
     }
 }
 
-if (!function_exists('LogException')) {
+if (!function_exists('logException')) {
     /**
      * Log an exception.
      *
@@ -557,7 +557,7 @@ if (!function_exists('LogException')) {
     }
 }
 
-if (!function_exists('LogMessage')) {
+if (!function_exists('logMessage')) {
     /**
      * Logs errors to a file. This function does not throw errors because it is
      * a last-ditch effort after errors have already been rendered.
@@ -588,7 +588,7 @@ if (!function_exists('LogMessage')) {
     }
 }
 
-if (!function_exists('Boop')) {
+if (!function_exists('boop')) {
     /**
      * Logs a message or print_r()'s an array to the screen.
      *
@@ -618,7 +618,7 @@ if (!function_exists('Boop')) {
     }
 }
 
-if (!function_exists('CleanErrorArguments')) {
+if (!function_exists('cleanErrorArguments')) {
     /**
      *
      *

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -426,7 +426,11 @@ if (!function_exists('errorLog')) {
             // appends to a file
             $messageType = 3;
             $destination = $errorLogFile;
-            $message .= PHP_EOL;
+
+            // Need to prepend the date when appending to an error log file
+            // and also add a newline manually
+            $date = date('d-M-Y H:i:s e');
+            $message = sprintf('[%s] %s', $date, $message) . PHP_EOL;
         }
 
         @error_log($message, $messageType, $destination);

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -83,7 +83,7 @@ function Gdn_ExceptionHandler($Exception) {
         if ($Exception instanceof \ErrorException) {
             errorLog(formatErrorException($Exception));
         } else {
-            errorLog(formatException($Exception));
+            errorLog(formatException($Exception, true));
         }
 
         $ErrorNumber = $Exception->getCode();
@@ -472,17 +472,27 @@ if (!function_exists('formatException')) {
      *
      * @access private
      * @param mixed $exception The Exception to format
+     * @param boolean $uncaught Whether the exception was uncaught or not
      * @return string The formatted error message
      */
-    function formatException($exception) {
+    function formatException($exception, $uncaught = false) {
         if (!($exception instanceof \Exception) && !($exception instanceof \Throwable)) {
             // Not an Exception or a Throwable type (PHP7)
             return '';
         }
 
-        $errorMessage = 'Uncaught ' . (string) $exception . PHP_EOL . '  thrown';
+        $errorMessage = (string) $exception;
 
-        return formatPHPErrorLog($errorMessage, 'PHP Fatal error', $exception->getFile(), $exception->getLine());
+        if ($uncaught) {
+            $errorType = 'PHP Fatal error';
+            $errorMessage = 'Uncaught ' . $errorMessage;
+        } else {
+            $errorType = 'APP Log';
+            $errorMessage = 'Caught ' . $errorMessage;
+        }
+        $errorMessage .= PHP_EOL . '  thrown';
+
+        return formatPHPErrorLog($errorMessage, $errorType, $exception->getFile(), $exception->getLine());
     }
 }
 

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -388,7 +388,7 @@ if (!function_exists('LogException')) {
         if (!class_exists('Gdn', false)) {
             return;
         }
-        if (!Gdn::config('Garden.Errors.LogEnabled', false)) {
+        if (!ini_get('log_errors')) {
             return;
         }
 
@@ -436,8 +436,7 @@ if (!function_exists('LogMessage')) {
     function logMessage($File, $Line, $Object, $Method, $Message, $Code = '') {
         // Figure out where to save the log
         if (class_exists('Gdn', false)) {
-            $LogErrors = Gdn::Config('Garden.Errors.LogEnabled', false);
-            if ($LogErrors === true) {
+            if (ini_get('log_errors')) {
                 $Log = "[Garden] $File, $Line, $Object.$Method()";
                 if ($Message <> '') {
                     $Log .= ", $Message";

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -68,7 +68,17 @@ function Gdn_ErrorHandler($ErrorNumber, $Message, $File, $Line, $Arguments) {
         return false;
     }
 
-    throw new Gdn_ErrorException($Message, $ErrorNumber, $File, $Line, $Arguments);
+    $fatalErrorBitmask = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
+    if ($ErrorNumber & $fatalErrorBitmask) {
+        // Convert all fatal errors to an exception
+        throw new Gdn_ErrorException($Message, $ErrorNumber, $File, $Line, $Arguments);
+    }
+
+    // All other unprocessed non-fatal PHP errors are possibly Traced and delegated back to the native PHP handler.
+    if (function_exists('trace')) {
+        trace(new \ErrorException($Message, $ErrorNumber, $ErrorNumber, $File, $Line), TRACE_NOTICE);
+    }
+    return false;
 }
 
 /**

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -566,28 +566,21 @@ if (!function_exists('LogMessage')) {
      * @param string Any additional information that could be useful to debuggers.
      */
     function logMessage($File, $Line, $Object, $Method, $Message, $Code = '') {
-        // Figure out where to save the log
-        if (class_exists('Gdn', false)) {
-            if (ini_get('log_errors')) {
-                $Log = "[Garden] $File, $Line, $Object.$Method()";
-                if ($Message <> '') {
-                    $Log .= ", $Message";
-                }
-                if ($Code <> '') {
-                    $Log .= ", $Code";
-                }
-
-                // Fail silently (there could be permission issues on badly set up servers).
-                $ErrorLogFile = Gdn::config('Garden.Errors.LogFile');
-                if ($ErrorLogFile == '') {
-                    @error_log($Log);
-                } else {
-                    $Date = date(Gdn::config('Garden.Errors.LogDateFormat', 'd M Y - H:i:s'));
-                    $Log = "$Date: $Log\n";
-                    @error_log($Log, 3, $ErrorLogFile);
-                }
-            }
+        if (!class_exists('Gdn', false)) {
+            return;
         }
+
+        // Prepare the log message
+        $Log = "[Garden] $File, $Line, $Object.$Method()";
+        if ($Message <> '') {
+            $Log .= ", $Message";
+        }
+        if ($Code <> '') {
+            $Log .= ", $Code";
+        }
+
+        // Attempt to log the message in the PHP logs
+        errorLog($Log);
     }
 }
 

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -543,36 +543,13 @@ if (!function_exists('LogException')) {
         if (!class_exists('Gdn', false)) {
             return;
         }
-        if (!ini_get('log_errors')) {
-            return;
-        }
 
         if ($Ex instanceof Gdn_UserException) {
             return;
         }
 
-        try {
-            $Px = Gdn::request()->host().' Garden ';
-        } catch (Exception $Ex) {
-            $Px = 'Garden ';
-        }
-
-        $ErrorLogFile = Gdn::config('Garden.Errors.LogFile');
-        if (!$ErrorLogFile) {
-            $Type = 0;
-        } else {
-            $Type = 3;
-            $Date = date(Gdn::config('Garden.Errors.LogDateFormat', 'd M Y - H:i:s'));
-            $Px = "$Date $Px";
-        }
-
-        $Message = 'Exception: '.$Ex->getMessage().' in '.$Ex->getFile().' on '.$Ex->getLine();
-        @error_log($Px.$Message, $Type, $ErrorLogFile);
-
-        $TraceLines = explode("\n", $Ex->getTraceAsString());
-        foreach ($TraceLines as $i => $Line) {
-            @error_log("$Px  $Line", $Type, $ErrorLogFile);
-        }
+        // Attempt to log the exception in the PHP logs
+        errorLog(formatException($Ex));
     }
 }
 


### PR DESCRIPTION
### Fixes issue https://github.com/vanilla/vanilla/issues/4019.

**First part** in allowing php logging to flow normally to the server error logs.

Before this change, in order to enable PHP logging to flow to the error log file, the config key `Garden.Errors.LogEnabled` needed to be set to true.  This makes it harder for a sysadmin to troubleshoot an installation since `php.ini` settings on the server such as `log_errors` is not respected and `error_reporting` is overridden in `index.php`. 

### Changes
- Config `Garden.Errors.LogEnabled` as been removed.  
Detection is now based on `ini_get('log_errors')` value.
- PHP errors and exceptions are formatted the same way as the native PHP error handler would.
- `Non-Fatal errors` are not converted to exception anymore, preventing the request to halt for `E_NOTICE` for example.

### TODO
- The `php.ini` server setting `error_reporting` should not be overridden by default.
