### PR TITLE
Set a default addon type of 'addon'

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -533,7 +533,7 @@ class AddonManager {
      * @param string $type One of the **Addon::TYPE_*** constants.
      * @return bool Returns
      */
-    public function isEnabled($key, $type) {
+    public function isEnabled($key, $type = Addon::TYPE_ADDON) {
         if ($type === Addon::TYPE_ADDON) {
             $key = strtolower($key);
         }


### PR DESCRIPTION
* A hundred addon checks will be made more concise.
* In 90% of use cases this is the value you want.
* It's completely reasonable & predicable that the `AddonManager`'s default assumption is `addon`.