### PR TITLE
YouTube embed: More restricitve video ID match

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1278,7 +1278,7 @@ class Gdn_Format {
         // https://www.youtube.com/watch?v=p5kcBxL7-qI
         // https://www.youtube.com/watch?v=bG6b3V2MNxQ#t=33
 
-        $YoutubeUrlMatch = '/https?:\/\/(?:(?:www.)|(?:m.))?(?:(?:youtube.com)|(?:youtu.be))\/(?:(?:playlist?)|(?:(?:watch\?v=)?(?P<videoId>[\w-]*)))(?:\?|\&)?(?:list=(?P<listId>[\w-]*))?(?:t=(?:(?P<minutes>\d)*m)?(?P<seconds>\d)*s)?(?:#t=(?P<start>\d*))?/i';
+        $YoutubeUrlMatch = '/https?:\/\/(?:(?:www.)|(?:m.))?(?:(?:youtube.com)|(?:youtu.be))\/(?:(?:playlist?)|(?:(?:watch\?v=)?(?P<videoId>[\w-]{11})))(?:\?|\&)?(?:list=(?P<listId>[\w-]*))?(?:t=(?:(?P<minutes>\d)*m)?(?P<seconds>\d)*s)?(?:#t=(?P<start>\d*))?/i';
         $VimeoUrlMatch = 'https?://(www\.)?vimeo\.com/(?:channels/[a-z0-9]+/)?(\d+)';
         $TwitterUrlMatch = 'https?://(?:www\.)?twitter\.com/(?:#!/)?(?:[^/]+)/status(?:es)?/([\d]+)';
         $VineUrlMatch = 'https?://(?:www\.)?vine.co/v/([\w]+)';


### PR DESCRIPTION
This prevents URIs that don't point to videos like https://www.youtube.com/user/VanillaForumsTV being matched.

While Google doesn't guarantee it will always be that way, video IDs have always been 11 characters and it probably won't change anytime soon.
More info: http://webapps.stackexchange.com/a/54448

fixes #3377 