### PR TITLE
Unify countString() usage

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -495,7 +495,7 @@ class VanillaHooks implements Gdn_IPlugin {
         if (Gdn::session()->isValid()) {
             $sender->addLink('favorites.bookmarks', array('text' => t('My Bookmarks'),
                 'url' => '/discussions/bookmarked', 'icon' => icon('star'),
-                'badge' => countString(Gdn::session()->User->CountBookmarks, url('/discussions/userbookmarkcount'))));
+                'badge' => countString(Gdn::session()->User->CountBookmarks, '/discussions/userbookmarkcount')));
             $sender->addLink('favorites.discussions', array('text' => t('My Discussions'),
                 'url' => '/discussions/mine', 'icon' => icon('discussion'),
                 'badge' => countString(Gdn::session()->User->CountDiscussions)));

--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -405,7 +405,7 @@ if (!function_exists('writeFilterTabs')) :
         }
 
         if (c('Vanilla.Discussions.ShowCounts', true)) {
-            $Bookmarked .= countString($CountBookmarks, url('/discussions/UserBookmarkCount'));
+            $Bookmarked .= countString($CountBookmarks, '/discussions/UserBookmarkCount');
             $MyDiscussions .= countString($CountDiscussions);
             $MyDrafts .= countString($CountDrafts);
         }

--- a/applications/vanilla/views/modules/discussionfilter.php
+++ b/applications/vanilla/views/modules/discussionfilter.php
@@ -26,7 +26,7 @@ if (!function_exists('FilterCountString')) {
     }
 }
 if (c('Vanilla.Discussions.ShowCounts', true)) {
-    $Bookmarked .= FilterCountString($CountBookmarks, url('/discussions/UserBookmarkCount'));
+    $Bookmarked .= FilterCountString($CountBookmarks, '/discussions/UserBookmarkCount');
     $MyDiscussions .= FilterCountString($CountDiscussions);
     $MyDrafts .= FilterCountString($CountDrafts);
 }

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -317,7 +317,7 @@ if (!function_exists('countString')) {
             return "<span class=\"$CssClass\">$Number</span>";
         } elseif ($Number === null && $Url) {
             $CssClass = trim($CssClass.' Popin TinyProgress', ' ');
-            $Url = htmlspecialchars($Url);
+            $Url = htmlspecialchars(url($Url));
             return "<span class=\"$CssClass\" rel=\"$Url\"></span>";
         } else {
             return '';


### PR DESCRIPTION
Count popins would fail on installs in subfolders, because the ajax url was passed through url() inconsistently.

fixes #1904