### PR TITLE
Use backwards compatible Smarty 3 to avoid theme breaks

### DIFF
--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -151,7 +151,7 @@ class Gdn_Smarty {
      */
     public function smarty() {
         if (is_null($this->_Smarty)) {
-            $Smarty = new Smarty();
+            $Smarty = new SmartyBC();
 
             $Smarty->setCacheDir(PATH_CACHE.'/Smarty/cache');
             $Smarty->setCompileDir(PATH_CACHE.'/Smarty/compile');


### PR DESCRIPTION
This fixes things like `register_function` being renamed. They already made a compatibility layer, so let's use it.