### PR TITLE
Add isEnabled convenience function

### DIFF
--- a/applications/dashboard/controllers/class.socialcontroller.php
+++ b/applications/dashboard/controllers/class.socialcontroller.php
@@ -69,14 +69,14 @@ class SocialController extends DashboardController {
 
             $ConnectionName = $PluginInfo['Index'];
 
-            if (Gdn::pluginManager()->CheckPlugin($PluginKey)) {
+            if (isEnabled($PluginKey)) {
                 $Configured = Gdn::pluginManager()->GetPluginInstance($ConnectionName, Gdn_PluginManager::ACCESS_PLUGINNAME)->IsConfigured();
             } else {
                 $Configured = null;
             }
 
             $Connections[$PluginKey] = array_merge($Connections[$PluginKey], $PluginInfo, array(
-                'Enabled' => Gdn::pluginManager()->CheckPlugin($PluginKey),
+                'Enabled' => isEnabled($PluginKey),
                 'Configured' => $Configured
             ), array(
                 'Icon' => sprintf("/plugins/%s/icon.png", $PluginInfo['Folder'])

--- a/applications/dashboard/views/settings/homepage.php
+++ b/applications/dashboard/views/settings/homepage.php
@@ -69,7 +69,7 @@ function writeHomepageOption($Title, $Url, $CssClass, $Current, $Description = '
             }
             //echo WriteHomepageOption('Activity', 'activity', 'SpActivity', $CurrentTarget);
 
-            if (Gdn::pluginManager()->CheckPlugin('Reactions')) {
+            if (isEnabled('Reactions')) {
                 echo WriteHomepageOption('Best Of', 'bestof', 'SpBestOf', $CurrentTarget);
             }
             ?>

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1725,6 +1725,26 @@ if (!function_exists('inSubArray')) {
     }
 }
 
+if (!function_exists('isEnabled')) {
+    /**
+     * Determine whether or not an addon is enabled.
+     *
+     * @see AddonManager::isEnabled().
+     *
+     * @param string $key The addon key.
+     * @param string $type One of the **Addon::TYPE_*** constants.
+     * @return bool
+     */
+    function isEnabled($key, $type = null) {
+        // Add a useful assumption that we're talking about addons.
+        if (is_null($type)) {
+            $type = \Vanilla\Addon::TYPE_ADDON;
+        }
+
+        return AddonManager::isEnabled($key, $type);
+    }
+}
+
 if (!function_exists('isMobile')) {
     /**
      * Determine whether or not the site is in mobile mode.


### PR DESCRIPTION
Whereas: 

* A hundred addon checks will be made more concise.
* Nearly all existing checks of this nature are for an addon, not locale or theme.

Therefore:

I bring you `isEnabled()` with _optional_ type.