### PR TITLE
Define the GDN_UserIP table

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -142,6 +142,14 @@ if (!$SystemUserID) {
     }
 }
 
+// UserIP Table
+$Construct->table('UserIP')
+    ->column('UserID', 'int', false, 'primary')
+    ->column('IPAddress', 'varbinary(16)', false, 'primary')
+    ->column('DateInserted', 'datetime', false)
+    ->column('DateUpdated', 'datetime', false)
+    ->set($Explicit, $Drop);
+
 // UserRole Table
 $Construct->table('UserRole');
 


### PR DESCRIPTION
Define the GDN_UserIP table for future use. This allows structures to be run before changes that require the table.