### PR TITLE
Remove the invite feature from the GettingStarted page

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1784,52 +1784,6 @@ class SettingsController extends DashboardController {
 
         $this->setData('Title', t('Getting Started'));
         $this->addSideMenu('dashboard/settings/gettingstarted');
-        $this->TextEnterEmails = t('TextEnterEmails', 'Type email addresses separated by commas here');
-
-        if ($this->Form->authenticatedPostBack()) {
-            // Do invitations to new members.
-            $Message = $this->Form->getFormValue('InvitationMessage');
-            $Message = trim($Message);
-            $Recipients = $this->Form->getFormValue('Recipients');
-            if ($Recipients == $this->TextEnterEmails) {
-                $Recipients = '';
-            }
-
-            $Recipients = explode(',', $Recipients);
-            $CountRecipients = 0;
-            foreach ($Recipients as $Recipient) {
-                if (trim($Recipient) != '') {
-                    $CountRecipients++;
-                    if (!validateEmail($Recipient)) {
-                        $this->Form->addError(sprintf(t('%s is not a valid email address'), $Recipient));
-                    }
-                }
-            }
-            if ($CountRecipients == 0) {
-                $this->Form->addError(t('You must provide at least one recipient'));
-            }
-            if ($this->Form->errorCount() == 0) {
-                $Email = new Gdn_Email();
-                $Email->subject(t('Check out my new community!'));
-                $emailTemplate = $Email->getEmailTemplate();
-                $emailTemplate->setMessage($Message, true)
-                    ->setButton(externalUrl('/'), t('Check it out'));
-                $Email->setEmailTemplate($emailTemplate);
-                foreach ($Recipients as $Recipient) {
-                    if (trim($Recipient) != '') {
-                        $Email->to($Recipient);
-                        try {
-                            $Email->send();
-                        } catch (Exception $ex) {
-                            $this->Form->addError($ex);
-                        }
-                    }
-                }
-            }
-            if ($this->Form->errorCount() == 0) {
-                $this->informMessage(t('Your invitations were sent successfully.'));
-            }
-        }
 
         $this->render();
     }

--- a/applications/dashboard/views/settings/gettingstarted.php
+++ b/applications/dashboard/views/settings/gettingstarted.php
@@ -182,10 +182,6 @@ function tutLink($TutorialCode, $WriteTitle = TRUE, $ThumbnailSize = 'medium') {
         }
     </style>
     <h1><?php echo t('Getting Started with Vanilla'); ?></h1>
-<?php
-echo $this->Form->open();
-echo $this->Form->errors();
-?>
     <div class="Info">
         <div class="Welcome">
             <h2><?php echo t('Getting Started with Vanilla'); ?></h2>
@@ -244,4 +240,3 @@ echo $this->Form->errors();
             <p><?php echo t('Invite your friends to register to your new forum!'); ?></p>
         </div>
     </div>
-<?php echo $this->Form->close(); ?>

--- a/applications/dashboard/views/settings/gettingstarted.php
+++ b/applications/dashboard/views/settings/gettingstarted.php
@@ -238,5 +238,7 @@ function tutLink($TutorialCode, $WriteTitle = TRUE, $ThumbnailSize = 'medium') {
             <h2><?php echo t('Encourage your friends to join your new community!'); ?></h2>
 
             <p><?php echo t('Invite your friends to register to your new forum!'); ?></p>
+            <?php $registrationURL = url('entry/register', true); ?>
+            <p><?php echo sprintf(t('Simply tell them to go to the following URL and register: %s'), anchor($registrationURL, $registrationURL)); ?></p>
         </div>
     </div>

--- a/applications/dashboard/views/settings/gettingstarted.php
+++ b/applications/dashboard/views/settings/gettingstarted.php
@@ -241,31 +241,7 @@ echo $this->Form->errors();
             <div class="NumberPoint"><?= t('4'); ?></div>
             <h2><?php echo t('Encourage your friends to join your new community!'); ?></h2>
 
-            <div class="TextBoxWrapper">
-                <?php
-                $Attribs = array('Multiline' => true, 'class' => 'Message');
-                if (!$this->Form->authenticatedPostBack())
-                    $Attribs['value'] = t('Check out the new community forum I\'ve just set up.');
-                echo $this->Form->textBox('InvitationMessage', $Attribs);
-                echo $this->Form->textBox('Recipients', array('class' => 'RecipientBox'));
-                ?>
-            </div>
-            <script type="text/javascript">
-                jQuery(document).ready(function($) {
-                    if ($('input.RecipientBox').val() == '')
-                        $('input.RecipientBox').val("<?php echo $this->TextEnterEmails; ?>");
-
-                    $('input.RecipientBox').focus(function() {
-                        if ($(this).val() == "<?php echo $this->TextEnterEmails; ?>")
-                            $(this).val('');
-                    });
-                    $('input.RecipientBox').blur(function() {
-                        if ($(this).val() == '')
-                            $(this).val("<?php echo $this->TextEnterEmails; ?>");
-                    });
-                });
-            </script>
-            <?php echo $this->Form->button(t('Send Invitations!')); ?>
+            <p><?php echo t('Invite your friends to register to your new forum!'); ?></p>
         </div>
     </div>
 <?php echo $this->Form->close(); ?>


### PR DESCRIPTION
The email feature was intended to be used to invite 10 or so peoples but was used to mass invite.
Since it is bugged and we do not want to promote mass import we are removing it.


Fixes: https://github.com/vanilla/vanilla/issues/4064