### PR TITLE
Fix Smarty and dispatcher paths on Windows

### DIFF
--- a/index.php
+++ b/index.php
@@ -24,7 +24,7 @@ ob_start();
 
 // Define the constants we need to get going.
 
-define('DS', '/');
+define('DS', DIRECTORY_SEPARATOR);
 define('PATH_ROOT', getcwd());
 
 // Include the bootstrap to configure the framework.

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -578,7 +578,9 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
                     $Found = false;
                     do {
                         $ControllerPath = $Reflect->getFilename();
-                        $Found = (bool)preg_match('`\/controllers\/`i', $ControllerPath);
+                        $escapedSeparator = str_replace('\\', '\\\\', DS);
+                        $regex = '`'.$escapedSeparator.'controllers'.$escapedSeparator.'`i';
+                        $Found = (bool)preg_match($regex, $ControllerPath);
                         if (!$Found) {
                             $Reflect = $Reflect->getParentClass();
                         }
@@ -589,9 +591,9 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
                 }
 
                 if ($ControllerPath) {
-                    $InterimPath = explode('/controllers/', $ControllerPath);
+                    $InterimPath = explode(DS.'controllers'.DS, $ControllerPath);
                     array_pop($InterimPath); // Get rid of the end. Useless;
-                    $InterimPath = explode('/', trim(array_pop($InterimPath)));
+                    $InterimPath = explode(DS, trim(array_pop($InterimPath)));
                     $Application = array_pop($InterimPath);
                     $AddonType = array_pop($InterimPath);
                     switch ($AddonType) {


### PR DESCRIPTION
Smarty use a constant named `DS` to know how to handle `DIRECTORY_SEPARATOR`.
Having our own `DS` constant defined to '/' was making smarty crash on windows.

Also, the dispatcher had hard coded '/' as directory separators so it did not match `\controllers\`.

This PR address those issues.