### PR TITLE
Add appSettingsMenuBeforeRender event

### DIFF
--- a/applications/dashboard/modules/class.sidemenumodule.php
+++ b/applications/dashboard/modules/class.sidemenumodule.php
@@ -263,19 +263,25 @@ if (!class_exists('SideMenuModule', false)) {
          * @throws Exception
          */
         public function toString($HighlightRoute = '') {
+            $isAppSettingsMenu = $this->EventName && (strcasecmp($this->EventName, 'getAppSettingsMenuItems') === 0);
             Gdn::controller()->EventArguments['SideMenu'] = $this;
-            if ($this->EventName) {
-                if (strcasecmp($this->EventName, 'getAppSettingsMenuItems') === 0) {
-                    // Add the heading here so that they sort properly.
-                    $this->addItem('Dashboard', t('Dashboard'), false, array('class' => 'Dashboard'));
-                    $this->addItem('Appearance', t('Appearance'), false, array('class' => 'Appearance'));
-                    $this->addItem('Users', t('Users'), false, array('class' => 'Users'));
-                    $this->addItem('Moderation', t('Moderation'), false, array('class' => 'Moderation'));
-                }
 
+            if ($isAppSettingsMenu) {
+                // Add the heading here so that they sort properly.
+                $this->addItem('Dashboard', t('Dashboard'), false, array('class' => 'Dashboard'));
+                $this->addItem('Appearance', t('Appearance'), false, array('class' => 'Appearance'));
+                $this->addItem('Users', t('Users'), false, array('class' => 'Users'));
+                $this->addItem('Moderation', t('Moderation'), false, array('class' => 'Moderation'));
+            }
+
+            if ($this->EventName) {
                 Gdn::controller()->fireEvent($this->EventName);
             }
 
+            if ($isAppSettingsMenu) {
+                Gdn::pluginManager()->EventArguments['SideMenu'] = $this;
+                Gdn::pluginManager()->fireEvent('appSettingsMenuBeforeRender');
+            }
 
             if ($HighlightRoute == '') {
                 $HighlightRoute = $this->_HighlightRoute;


### PR DESCRIPTION
This update adds a new event, appSettingsMenuBeforeRender, which can be used to modify the dashboard menu items just prior to the `SideMenuModule` being rendered.  The implementation is atypical due to the existing specialized handling of the getAppSettingsMenuItems event.