### PR TITLE
Move Dashboard menu population to earlyAppSettingsMenuItems

### DIFF
--- a/applications/dashboard/controllers/class.dashboardcontroller.php
+++ b/applications/dashboard/controllers/class.dashboardcontroller.php
@@ -73,6 +73,10 @@ class DashboardController extends Gdn_Controller {
         if ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
             // Configure SideMenu module
             $SideMenu = new SideMenuModule($this);
+
+            $this->EventArguments['SideMenu'] = $SideMenu;
+            $this->fireEvent('earlyAppSettingsMenuItems');
+
             $SideMenu->EventName = 'GetAppSettingsMenuItems';
             $SideMenu->HtmlId = '';
             $SideMenu->highlightRoute($CurrentUrl);

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -149,7 +149,7 @@ class DashboardHooks implements Gdn_IPlugin {
     /**
      * @param $Sender
      */
-    public function base_getAppSettingsMenuItems_handler($Sender) {
+    public function base_earlyAppSettingsMenuItems_handler($Sender) {
         // SideMenuModule menu
         $Menu = &$Sender->EventArguments['SideMenu'];
         $Menu->addItem('Dashboard', t('Dashboard'), false, array('class' => 'Dashboard'));


### PR DESCRIPTION
This update moves to populate Dashboard's menu items by way of a new earlyAppSettingsMenuItems event, which will run before the existing getAppSettingsMenuItems.  This is done to allow other addons to be able to modify Dashboard's menu items, regardless of the addon's configured priority.