### PR TITLE
Set the default ResponseStatus of ProxyRequest to 0 instead of ""

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -226,7 +226,7 @@ class ProxyRequest {
         $this->Options = $Options = array_merge($this->RequestDefaults, $Options);
 
         $this->ResponseHeaders = array();
-        $this->ResponseStatus = 0;
+        $this->ResponseStatus = 400;
         $this->ResponseBody = "";
         $this->RequestBody = "";
         $this->ResponseTime = 0;

--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -143,6 +143,7 @@ class ProxyRequest {
 
         if ($Response == false) {
             $this->ResponseBody = curl_error($Handler);
+            $this->ResponseStatus = 400;
         } else {
             $this->ResponseStatus = curl_getinfo($Handler, CURLINFO_HTTP_CODE);
             $this->ContentType = strtolower(curl_getinfo($Handler, CURLINFO_CONTENT_TYPE));
@@ -226,7 +227,7 @@ class ProxyRequest {
         $this->Options = $Options = array_merge($this->RequestDefaults, $Options);
 
         $this->ResponseHeaders = array();
-        $this->ResponseStatus = 400;
+        $this->ResponseStatus = 0;
         $this->ResponseBody = "";
         $this->RequestBody = "";
         $this->ResponseTime = 0;

--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -226,7 +226,7 @@ class ProxyRequest {
         $this->Options = $Options = array_merge($this->RequestDefaults, $Options);
 
         $this->ResponseHeaders = array();
-        $this->ResponseStatus = "";
+        $this->ResponseStatus = 0;
         $this->ResponseBody = "";
         $this->RequestBody = "";
         $this->ResponseTime = 0;


### PR DESCRIPTION
From https://github.com/vanilla/vanilla/issues/4078:

The following code was throwing a fatal since the error code need to be a "digit" and an empty string was given to it.

```php
throw new Gdn_UserException(val('Exception', $response, 'There was an error performing your request.'), $request->ResponseStatus);
```