### PR TITLE
Fix "View not found" error on preferences page

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -457,7 +457,7 @@ class VanillaHooks implements Gdn_IPlugin {
      */
     public function profileController_CustomNotificationPreferences_Handler($Sender) {
         if (!$Sender->data('NoEmail') && Gdn::session()->checkPermission('Garden.AdvancedNotifications.Allow')) {
-            include $Sender->fetchViewLocation('NotificationPreferences', 'Settings', 'Vanilla');
+            include $Sender->fetchViewLocation('notificationpreferences', 'vanillasettings', 'vanilla');
         }
     }
 


### PR DESCRIPTION
When we merged in https://github.com/vanilla/vanilla/pull/3693, the Vanilla application had its settings folder, under views, renamed to vanillasettings.  Vanilla's `profileController_CustomNotificationPreferences_Handler` hook hadn't been updated to use this renamed directory.  When users visited their preferences page, they were met with a "View not found" error.

This update alters a `fetchViewLocation` call to use the proper view folder name.