### PR TITLE
Strip unused parameter from call to discussionModel->save()

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -251,7 +251,7 @@ class PostController extends VanillaController {
                         $DraftID = $this->DraftModel->save($FormValues);
                         $this->Form->setValidationResults($this->DraftModel->validationResults());
                     } else {
-                        $DiscussionID = $this->DiscussionModel->save($FormValues, $this->CommentModel);
+                        $DiscussionID = $this->DiscussionModel->save($FormValues);
                         $this->Form->setValidationResults($this->DiscussionModel->validationResults());
 
                         if ($DiscussionID > 0) {


### PR DESCRIPTION
DiscussionModels save method only expects FormPostValues as a parameter. The postController also added the commentModel as a parameter at one line.