### PR TITLE
Don't add NewDiscussionModule to postController

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -899,7 +899,6 @@ class PostController extends VanillaController {
      */
     public function initialize() {
         parent::initialize();
-        $this->addModule('NewDiscussionModule');
 
         $this->CssClass = 'NoPanel';
     }


### PR DESCRIPTION
The NewDiscussionModule has been added in postControllers initialize() method.
a) Panel is hidden so panel modules wouldn't be displayed anyway
b) There is no sense to present "New discussion" while the current action is to create a new discussion
c) Adding a new comment or editing it is done inline so the New discussion is already visible
d) Only when editing an existing discussion it might be useful to present a "New Discussion" button to the user. But I doubt that this has been the intention why this module has been added and if that has been the reason, it should be added in the editDiscussion method itself.

To my opinion, it could be dropped completely here.