### PR TITLE
Fix sorting and sync problems in the Dashboard menu creation (part 2)

### DIFF
--- a/applications/dashboard/controllers/class.dashboardcontroller.php
+++ b/applications/dashboard/controllers/class.dashboardcontroller.php
@@ -59,10 +59,13 @@ class DashboardController extends Gdn_Controller {
     /**
      * Build and add the Dashboard's side navigation menu.
      *
+     * EXACT COPY OF VanillaController::addSideMenu(). KEEP IN SYNC.
+     * Dashboard is getting rebuilt. No wisecracks about DRY in the meantime.
+     *
      * @since 2.0.0
      * @access public
      *
-     * @param string $CurrentUrl Used to highlight correct route in menu.
+     * @param string|bool $CurrentUrl Path to current location; used to highlight correct item in menu.
      */
     public function addSideMenu($CurrentUrl = false) {
         if (!$CurrentUrl) {
@@ -71,20 +74,25 @@ class DashboardController extends Gdn_Controller {
 
         // Only add to the assets if this is not a view-only request
         if ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
-            // Configure SideMenu module
             $SideMenu = new SideMenuModule($this);
 
+            // Add the heading here so that they sort properly.
+            $SideMenu->addItem('Dashboard', t('Dashboard'), false, array('class' => 'Dashboard'));
+            $SideMenu->addItem('Appearance', t('Appearance'), false, array('class' => 'Appearance'));
+            $SideMenu->addItem('Users', t('Users'), false, array('class' => 'Users'));
+            $SideMenu->addItem('Moderation', t('Moderation'), false, array('class' => 'Moderation'));
+
+            // Hook for initial setup. Do NOT use this for addons.
             $this->EventArguments['SideMenu'] = $SideMenu;
             $this->fireEvent('earlyAppSettingsMenuItems');
 
-            $SideMenu->EventName = 'GetAppSettingsMenuItems';
+            // Module setup.
             $SideMenu->HtmlId = '';
             $SideMenu->highlightRoute($CurrentUrl);
             $SideMenu->Sort = c('Garden.DashboardMenu.Sort');
 
-            // Hook for adding to menu
-//         $this->EventArguments['SideMenu'] = &$SideMenu;
-//         $this->fireEvent('GetAppSettingsMenuItems');
+            // Hook for adding to menu.
+            $this->fireEvent('GetAppSettingsMenuItems');
 
             // Add the module
             $this->addModule($SideMenu, 'Panel');

--- a/applications/dashboard/modules/class.sidemenumodule.php
+++ b/applications/dashboard/modules/class.sidemenumodule.php
@@ -256,27 +256,13 @@ if (!class_exists('SideMenuModule', false)) {
         }
 
         /**
-         *
+         * Render the menu.
          *
          * @param string $HighlightRoute
          * @return string
          * @throws Exception
          */
         public function toString($HighlightRoute = '') {
-            Gdn::controller()->EventArguments['SideMenu'] = $this;
-            if ($this->EventName) {
-                if (strcasecmp($this->EventName, 'getAppSettingsMenuItems') === 0) {
-                    // Add the heading here so that they sort properly.
-                    $this->addItem('Dashboard', t('Dashboard'), false, array('class' => 'Dashboard'));
-                    $this->addItem('Appearance', t('Appearance'), false, array('class' => 'Appearance'));
-                    $this->addItem('Users', t('Users'), false, array('class' => 'Users'));
-                    $this->addItem('Moderation', t('Moderation'), false, array('class' => 'Moderation'));
-                }
-
-                Gdn::controller()->fireEvent($this->EventName);
-            }
-
-
             if ($HighlightRoute == '') {
                 $HighlightRoute = $this->_HighlightRoute;
             }

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -159,23 +159,44 @@ class VanillaSettingsController extends Gdn_Controller {
     }
 
     /**
-     * Configures navigation sidebar in Dashboard.
+     * Build and add the Dashboard's side navigation menu.
+     *
+     * EXACT COPY OF DashboardController::addSideMenu(). KEEP IN SYNC.
+     * Dashboard is getting rebuilt. No wisecracks about DRY in the meantime.
      *
      * @since 2.0.0
      * @access public
      *
-     * @param $CurrentUrl Path to current location in dashboard.
+     * @param string|bool $CurrentUrl Path to current location; used to highlight correct item in menu.
      */
-    public function addSideMenu($CurrentUrl) {
+    public function addSideMenu($CurrentUrl = false) {
+        if (!$CurrentUrl) {
+            $CurrentUrl = strtolower($this->SelfUrl);
+        }
+
         // Only add to the assets if this is not a view-only request
         if ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
             $SideMenu = new SideMenuModule($this);
+
+            // Add the heading here so that they sort properly.
+            $SideMenu->addItem('Dashboard', t('Dashboard'), false, array('class' => 'Dashboard'));
+            $SideMenu->addItem('Appearance', t('Appearance'), false, array('class' => 'Appearance'));
+            $SideMenu->addItem('Users', t('Users'), false, array('class' => 'Users'));
+            $SideMenu->addItem('Moderation', t('Moderation'), false, array('class' => 'Moderation'));
+
+            // Hook for initial setup. Do NOT use this for addons.
+            $this->EventArguments['SideMenu'] = $SideMenu;
+            $this->fireEvent('earlyAppSettingsMenuItems');
+
+            // Module setup.
             $SideMenu->HtmlId = '';
             $SideMenu->highlightRoute($CurrentUrl);
             $SideMenu->Sort = c('Garden.DashboardMenu.Sort');
-            $this->EventArguments['SideMenu'] = &$SideMenu;
+
+            // Hook for adding to menu. USE THIS FOR YOUR ADDON.
             $this->fireAs('SettingsController');
             $this->fireEvent('GetAppSettingsMenuItems');
+
             $this->addModule($SideMenu, 'Panel');
         }
     }

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -705,14 +705,14 @@ class VanillaHooks implements Gdn_IPlugin {
     }
 
     /**
-     * Adds items to dashboard menu.
+     * Adds items to Dashboard menu.
      *
      * @since 2.0.0
      * @package Vanilla
      *
      * @param object $Sender DashboardController.
      */
-    public function base_getAppSettingsMenuItems_handler($Sender) {
+    public function base_earlyAppSettingsMenuItems_handler($Sender) {
         $Menu = &$Sender->EventArguments['SideMenu'];
         $Menu->addLink('Moderation', t('Flood Control'), 'vanilla/settings/floodcontrol', 'Garden.Settings.Manage', array('class' => 'nav-flood-control'));
         $Menu->addLink('Forum', t('Categories'), 'vanilla/settings/managecategories', 'Garden.Community.Manage', array('class' => 'nav-manage-categories'));


### PR DESCRIPTION
1. The Dashboard menu items still are not sorting correctly. This is visible most easily on the Categories page, but there are several other things amiss everywhere. The problem is we need to build it in this order EXACTLY: Dashboard tier-1 -> Vanilla (all) + Dashboard tier-2 -> Plugins etc. Any deviation from this results in wrongly ordered items. We only had 2 events, and because of the new addon manager order were firing things in the order: Dashboard (all) -> Plugins -> Vanilla (all). This fails when Vanilla initiates as in the `vanillasettings` controller, but it also fails to put Vanilla's menu items before plugin items in second-tier ordering. My solution here rather than add a third, even earlier event is to move the manual build of Dash tier-1 into the `addSideMenu()` methods.

2. The `addSideMenu()` methods in the DashboardController and the VanillaSettingsControllers are bloody copies of each other. It sucks but it's been fine for 6 years so whatev. But then they need to actually be EXACT copies and not have too-clever interactions with the module. If you're gonna hack something, make it easy to read and not break.