### PR TITLE
Fix empty description on notification preferences page

### DIFF
--- a/applications/dashboard/views/profile/preferences.php
+++ b/applications/dashboard/views/profile/preferences.php
@@ -95,6 +95,9 @@
                     }
                     // Check if there are config values in this row.
                     if ($RowHasConfigValues) {
+                        // Make sure we have complete numeric indexes.
+                        $Settings = array_values($Settings);
+
                         $Description = val($Settings[0], $Descriptions);
                         if (is_array($Description)) {
                             $Description = $Description[0];


### PR DESCRIPTION
If `Garden.Registration.NoEmail` is enabled, the profile page does not properly display description for notification preferences.  This is due to the preferences page assuming a 0-index is available in one of the preference arrays.

This update re-indexes the array before attempting to reference the 0-index to ensure it will be available.