### PR TITLE
Fix try/catch blocks in UserModel save- and get-IP functions

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1497,7 +1497,7 @@ class UserModel extends Gdn_Model {
 
         try {
             $packedIPs = Gdn::sql()->getWhere('UserIP', ['UserID' => $userID])->resultArray();
-        } catch (Gdn_UserException $e) {
+        } catch (\Exception $e) {
             return $IPs;
         }
 
@@ -2915,7 +2915,7 @@ class UserModel extends Gdn_Model {
         try {
             Gdn::database()->query($query, $values);
             $result = true;
-        } catch (Gdn_UserException $e) {
+        } catch (\Exception $e) {
             $result = false;
         }
 


### PR DESCRIPTION
The try/catch blocks in UserModel's save- and get-IP functions are attempting to catch `Gdn_UserException`, when actually `Exception` is being thrown.

This update alters the catch block in user IP functions to use `Exception`.