### PR TITLE
Remove AllIPAddresses querying from calculated user fields

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3734,7 +3734,11 @@ class UserModel extends Gdn_Model {
             setValue('PhotoUrl', $User, $PhotoUrl);
         }
 
-        setValue('AllIPAddresses', $User, $this->getIPs(val('UserID', $User)));
+        // We store IPs in the UserIP table. To avoid unnecessary queries, the full list is not built here. Shim for BC.
+        setValue('AllIPAddresses', $User, [
+            val('InsertIPAddress', $User),
+            val('LastIPAddress', $User)
+        ]);
 
         setValue('_CssClass', $User, '');
         if (val('Banned', $User)) {


### PR DESCRIPTION
`Gdn_UserModel::setCalculatedFields` currently queries the `UserIP` table whenever a user record is fetched.  This can double our queries when retrieving user records and may potentially cause unnecessary stress on larger forums due to the increased database traffic.

This update removes querying the `UserIP` table from `Gdn_UserModel::setCalculatedFields`.  Instead, a simple array comprised of the user's `InsertIPAddress` and `LastIPAddress` fields is used as a simple backwards-compatibility shim.

Closes #4093