### PR TITLE
Fix emoji menu not being properly dismissed

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1814,7 +1814,8 @@ jQuery(document).ready(function($) {
                             flag = '(?:^|\\s)' + flag;
                         }
 
-                        regexp = new RegExp(flag + '([A-Za-z0-9_\+\-]*|[^\\x00-\\xff]*)$', 'gi');
+                        // Some browsers append a linefeed to the end of subtext.  We need to allow for it.
+                        regexp = new RegExp(flag + '([A-Za-z0-9_\+\-]*|[^\\x00-\\xff]*)(?:\\n)?$', 'gi');
                         match = regexp.exec(subtext);
 
                         if (match) {

--- a/js/global.js
+++ b/js/global.js
@@ -1814,8 +1814,7 @@ jQuery(document).ready(function($) {
                             flag = '(?:^|\\s)' + flag;
                         }
 
-                        // Allow matches to end with a space, a line feed or the end of the string.
-                        regexp = new RegExp(flag + '([A-Za-z0-9_\+\-]*)(?:\\s|\\n|$)|' + flag + '([^\\x00-\\xff]*)(?:\\s|\\n|$)', 'gi');
+                        regexp = new RegExp(flag + '([A-Za-z0-9_\+\-]*|[^\\x00-\\xff]*)$', 'gi');
                         match = regexp.exec(subtext);
 
                         if (match) {


### PR DESCRIPTION
The current regex for matching emojis allows for matches including trailing whitespace and newlines.  This can cause the autocomplete menu from disappearing if users enter a string like " : ".  The menu would appear when the colon was typed and not disappear when the space was typed after that, as it should.

This update alters emoji regex matching to remove the ability to allow emoji to end with spaces.  The pattern has also been simplified by combining like elements.

Closes #3883