### PR TITLE
Strip unneeded variable declaration.

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -355,18 +355,17 @@ class VanillaHooks implements Gdn_IPlugin {
     /**
      * Adds 'Discussion' item to menu.
      *
-     * 'Base_Render_Before' will trigger before every pageload across apps.
-     * If you abuse this hook, Tim with throw a Coke can at your head.
+     * 'base_render_before' will trigger before every pageload across apps.
+     * If you abuse this hook, Tim will throw a Coke can at your head.
      *
      * @since 2.0.0
      * @package Vanilla
      *
-     * @param object $Sender DashboardController.
+     * @param Gdn_Controller $sender The sending controller object.
      */
-    public function base_render_before($Sender) {
-        $Session = Gdn::session();
-        if ($Sender->Menu) {
-            $Sender->Menu->addLink('Discussions', t('Discussions'), '/discussions', false, array('Standard' => true));
+    public function base_render_before($sender) {
+        if ($sender->Menu) {
+            $sender->Menu->addLink('Discussions', t('Discussions'), '/discussions', false, ['Standard' => true]);
         }
     }
 


### PR DESCRIPTION
`$session` has been declared in Vanillas base_render_before() hook although it is not used there.
I've also made a few casening and spelling corrections.