### PR TITLE
Make "AS" in "select X as Y" case insensitive

### DIFF
--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1749,15 +1749,13 @@ abstract class Gdn_SQLDriver {
 
             // Try and figure out an alias for the field.
             if ($Alias == '' || ($Count > 1 && $i > 0)) {
-                if (preg_match('/^([^\s]+)\s+(?:as\s+)?`?([^`]+)`?$/', $Field, $Matches) > 0) {
+                if (preg_match('/^([^\s]+)\s+(?:as\s+)?`?([^`]+)`?$/i', $Field, $Matches) > 0) {
                     // This is an explicit alias in the select clause.
                     $Field = $Matches[1];
                     $Alias = $Matches[2];
-                } elseif (preg_match('/^[^\.]+\.`?([^`]+)`?$/', $Field, $Matches) > 0) {
-                    // This is an alias from the field name.
-                    $Alias = $Matches[1];
                 } else {
-                    $Alias = '';
+                    // This is an alias from the field name.
+                    $Alias = trim(strstr($Field, '.'), ' .`');
                 }
                 // Make sure we aren't selecting * as an alias.
                 if ($Alias == '*') {


### PR DESCRIPTION
The regex which searches for the SQL keyword "AS" in the SELECT string is not case insensitive. `->select('Name AS UserName`')` would output a column named "AS UserName".

I've also stripped down the rest of the if condition, where there was an unneeded regex when a normal string operation does the trick.
I've tested it with following examples:
~~~
$test[1] = 'ColumnWithoutAlias';
$test[2] = 'Column   `AliasWithoutAs`';
$test[3] = 'Column    as AliasLowerCaseAs';
$test[4] = 'Column AS AliasLowerCaseAs';
$test[5] = 'Column aS     AliasMixedCaseAs';
$test[6] = 'Table.`Column`';
$test[7] = 'Table.Column';
~~~
They all show the expected result.

If strstr() fails it returns `false`and `trim(false)` return an empty string. Therefore there is no need for the former else section of this condition.



I've already checked that the regex used for "table AS alias" in the from() method is case insensitive, just in case you thought about checking that, too  ;-)

