### PR TITLE
Fix issue with Gdn_UserException and non-integer codes

### DIFF
--- a/library/core/class.userexception.php
+++ b/library/core/class.userexception.php
@@ -21,6 +21,6 @@ class Gdn_UserException extends Exception {
      * @param Exception $Previous The previous exception used for exception chaining.
      */
     public function __construct($Message, $Code = 400, $Previous = null) {
-        parent::__construct($Message, $Code, $Previous);
+        parent::__construct($Message, (int)$Code, $Previous);
     }
 }


### PR DESCRIPTION
Fixes the “Wrong parameters for Gdn_UserException” error we are seeing in the logs.