### PR TITLE
Encode mail subject properly (UTF-8 anyone?)

### DIFF
--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -372,7 +372,7 @@ class Gdn_Email extends Gdn_Pluggable {
      * @return Gdn_Email
      */
     public function subject($Subject) {
-        $this->PhpMailer->Subject = $Subject;
+        $this->PhpMailer->Subject = mb_encode_mimeheader($Subject, $this->PhpMailer->CharSet);
         return $this;
     }
 


### PR DESCRIPTION
Having accents in the subject field led to an empty subject when receiving the email since it was not encoded properly.