### PR TITLE
Add legacy IP data migration

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2894,12 +2894,20 @@ class UserModel extends Gdn_Model {
      *
      * @param int $userID Unique ID of the user.
      * @param string $IP Human-readable IP address.
+     * @param string $dateUpdated Force an update timesetamp.
      * @return bool Was the operation successful?
      */
-    public function saveIP($userID, $IP) {
+    public function saveIP($userID, $IP, $dateUpdated = false) {
+        if (!filter_var($IP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4|FILTER_FLAG_IPV6)) {
+            return false;
+        }
+
         $packedIP = ipEncode($IP);
         $px = Gdn::database()->DatabasePrefix;
-        $currentDateTime = Gdn_Format::toDateTime();
+
+        if (!$dateUpdated) {
+            $dateUpdated = Gdn_Format::toDateTime();
+        }
 
         $query = "insert into {$px}UserIP (UserID, IPAddress, DateInserted, DateUpdated)
             values (:UserID, :IPAddress, :DateInserted, :DateUpdated)
@@ -2907,9 +2915,9 @@ class UserModel extends Gdn_Model {
         $values = [
             ':UserID' => $userID,
             ':IPAddress' => $packedIP,
-            ':DateInserted' => $currentDateTime,
-            ':DateUpdated' => $currentDateTime,
-            ':DateUpdated2' => $currentDateTime
+            ':DateInserted' => Gdn_Format::toDateTime(),
+            ':DateUpdated' => $dateUpdated,
+            ':DateUpdated2' => $dateUpdated
         ];
 
         try {

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -765,6 +765,55 @@ $Construct
     ->column('UpdateIPAddress', 'ipaddress', true)
     ->set($Explicit, $Drop);
 
+// Migrate legacy IP data into UserIP table in batches of 10,000.
+$limit = 10000;
+$offset = 1;
+$legacyIPAddresses = $SQL->select(['UserID', 'AllIPAddresses', 'InsertIPAddress', 'LastIPAddress', 'DateLastActive'])
+    ->from('User')
+    ->where('AllIPAddresses is not null')
+    ->get()
+    ->resultArray();
+
+do {
+    foreach ($legacyIPAddresses as $currentLegacy) {
+        $allIPAddresses = explode(',', $currentLegacy['AllIPAddresses']);
+        $dateLastActive = val('DateLastActive', $currentLegacy);
+        $insertIPAddress = val('InsertIPAddress', $currentLegacy);
+        $lastIPAddress = val('LastIPAddress', $currentLegacy);
+        $userID = val('UserID', $currentLegacy);
+
+        if (!empty($lastIPAddress)) {
+            Gdn::userModel()->saveIP(
+                $userID,
+                $lastIPAddress,
+                $dateLastActive
+            );
+        }
+
+        if ($insertIPAddress !== $lastIPAddress && in_array($insertIPAddress, $allIPAddresses)) {
+            Gdn::userModel()->saveIP(
+                $userID,
+                $insertIPAddress
+            );
+        }
+
+        $this->SQL->update('User')
+            ->set('AllIPAddresses', null)
+            ->where('UserID', $userID)
+            ->limit(1)
+            ->put();
+    }
+
+    $offset += $limit;
+    $legacyIPAddresses = $SQL->select(['UserID', 'AllIPAddresses', 'InsertIPAddress', 'LastIPAddress', 'DateLastActive'])
+        ->from('User')
+        ->where('AllIPAddresses is not null')
+        ->limit($limit, $offset)
+        ->get()
+        ->resultArray();
+} while (count($legacyIPAddresses) > 0);
+unset($allIPAddresses, $dateLastActive, $insertIPAddress, $lastIPAddress, $userID, $offset);
+
 // Save the current input formatter to the user's config.
 // This will allow us to change the default later and grandfather existing forums in.
 saveToConfig('Garden.InputFormatter', c('Garden.InputFormatter'));

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -403,55 +403,6 @@ if (!$LastDiscussionIDExists) {
         ->put();
 }
 
-// Migrate legacy IP data into UserIP table in batches of 10,000.
-$limit = 10000;
-$offset = 1;
-$legacyIPAddresses = $SQL->select(['UserID', 'AllIPAddresses', 'InsertIPAddress', 'LastIPAddress', 'DateLastActive'])
-    ->from('User')
-    ->where('AllIPAddresses is not null')
-    ->get()
-    ->resultArray();
-
-do {
-    foreach ($legacyIPAddresses as $currentLegacy) {
-        $allIPAddresses = explode(',', $currentLegacy['AllIPAddresses']);
-        $dateLastActive = val('DateLastActive', $currentLegacy);
-        $insertIPAddress = val('InsertIPAddress', $currentLegacy);
-        $lastIPAddress = val('LastIPAddress', $currentLegacy);
-        $userID = val('UserID', $currentLegacy);
-
-        if (!empty($lastIPAddress)) {
-            Gdn::userModel()->saveIP(
-                $userID,
-                $lastIPAddress,
-                $dateLastActive
-            );
-        }
-
-        if ($insertIPAddress !== $lastIPAddress && in_array($insertIPAddress, $allIPAddresses)) {
-            Gdn::userModel()->saveIP(
-                $userID,
-                $insertIPAddress
-            );
-        }
-
-        $this->SQL->update('User')
-            ->set('AllIPAddresses', null)
-            ->where('UserID', $userID)
-            ->limit(1)
-            ->put();
-    }
-
-    $offset += $limit;
-    $legacyIPAddresses = $SQL->select(['UserID', 'AllIPAddresses', 'InsertIPAddress', 'LastIPAddress', 'DateLastActive'])
-        ->from('User')
-        ->where('AllIPAddresses is not null')
-        ->limit($limit, $offset)
-        ->get()
-        ->resultArray();
-} while (count($legacyIPAddresses) > 0);
-unset($allIPAddresses, $dateLastActive, $insertIPAddress, $lastIPAddress, $userID, $offset);
-
 // Add stub content
 include(PATH_APPLICATIONS.DS.'vanilla'.DS.'settings'.DS.'stub.php');
 

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -403,6 +403,55 @@ if (!$LastDiscussionIDExists) {
         ->put();
 }
 
+// Migrate legacy IP data into UserIP table in batches of 10,000.
+$limit = 10000;
+$offset = 1;
+$legacyIPAddresses = $SQL->select(['UserID', 'AllIPAddresses', 'InsertIPAddress', 'LastIPAddress', 'DateLastActive'])
+    ->from('User')
+    ->where('AllIPAddresses is not null')
+    ->get()
+    ->resultArray();
+
+do {
+    foreach ($legacyIPAddresses as $currentLegacy) {
+        $allIPAddresses = explode(',', $currentLegacy['AllIPAddresses']);
+        $dateLastActive = val('DateLastActive', $currentLegacy);
+        $insertIPAddress = val('InsertIPAddress', $currentLegacy);
+        $lastIPAddress = val('LastIPAddress', $currentLegacy);
+        $userID = val('UserID', $currentLegacy);
+
+        if (!empty($lastIPAddress)) {
+            Gdn::userModel()->saveIP(
+                $userID,
+                $lastIPAddress,
+                $dateLastActive
+            );
+        }
+
+        if ($insertIPAddress !== $lastIPAddress && in_array($insertIPAddress, $allIPAddresses)) {
+            Gdn::userModel()->saveIP(
+                $userID,
+                $insertIPAddress
+            );
+        }
+
+        $this->SQL->update('User')
+            ->set('AllIPAddresses', null)
+            ->where('UserID', $userID)
+            ->limit(1)
+            ->put();
+    }
+
+    $offset += $limit;
+    $legacyIPAddresses = $SQL->select(['UserID', 'AllIPAddresses', 'InsertIPAddress', 'LastIPAddress', 'DateLastActive'])
+        ->from('User')
+        ->where('AllIPAddresses is not null')
+        ->limit($limit, $offset)
+        ->get()
+        ->resultArray();
+} while (count($legacyIPAddresses) > 0);
+unset($allIPAddresses, $dateLastActive, $insertIPAddress, $lastIPAddress, $userID, $offset);
+
 // Add stub content
 include(PATH_APPLICATIONS.DS.'vanilla'.DS.'settings'.DS.'stub.php');
 


### PR DESCRIPTION
This update adds capabilities to the Vanilla application's structure to migrate legacy IP data from the `User` table into the `UserIP` table.  Migration can be done with `/utility/update`.

The migration is done in batches of 10,000. The `InsertIPAddress` and `LastIPAddress` fields are analyzed and inserted into the `UserIP` table, if they are valid.  The `AllIPAddresses` column is wiped out after this operation and acts as a marker of which user records have been updated.

In addition, `UserModel::saveIP` has been updated to verify IPs with `filter_var`, because the `$IP` parameter is expected to be a human-readable address.  A new parameter, `$dateUpdated` has also been added to this function to force a specific `DateUpdated` column value.

Closes #3907