### PR TITLE
Fix Advanced Editor upload incompatibility with MySQL strict mode

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -750,10 +750,10 @@ class EditorPlugin extends Gdn_Plugin {
 
             // Determine if image, and thus requires thumbnail generation, or simply saving the file.
             // Not all files will be images.
-            $thumbHeight = 0;
-            $thumbWidth = 0;
-            $imageHeight = 0;
-            $imageWidth = 0;
+            $thumbHeight = null;
+            $thumbWidth = null;
+            $imageHeight = null;
+            $imageWidth = null;
             $thumbPathParsed = array('SaveName' => '');
             $thumbUrl = '';
 

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -750,10 +750,10 @@ class EditorPlugin extends Gdn_Plugin {
 
             // Determine if image, and thus requires thumbnail generation, or simply saving the file.
             // Not all files will be images.
-            $thumbHeight = '';
-            $thumbWidth = '';
-            $imageHeight = '';
-            $imageWidth = '';
+            $thumbHeight = 0;
+            $thumbWidth = 0;
+            $imageHeight = 0;
+            $imageWidth = 0;
             $thumbPathParsed = array('SaveName' => '');
             $thumbUrl = '';
 


### PR DESCRIPTION
If MySQL is in strict mode it will reject uploads from the advanced
editor with the following error

> PHP Fatal error: Incorrect integer value: '' for column 'ThumbWidth'
  at row 1|Gdn_Database|Query|insert GDN_Media

This is because the advanced editor is trying to insert a string value
into an integer. Setting a default value of 0 for the thumb and image
height and width values corrects this.

* Forum thread on this topic:
  https://vanillaforums.org/discussion/32255/advanced-editor-upload-failing-incorrect-integer-value#latest
 master