### PR TITLE
Add $Comment to EventArguments on DeleteComment

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1346,6 +1346,7 @@ class CommentModel extends VanillaModel {
             ->where('CountComments >', $Offset)
             ->put();
 
+        $this->EventArguments['Comment'] = $Comment;
         $this->EventArguments['Discussion'] = $Discussion;
         $this->fireEvent('DeleteComment');
         $this->fireEvent('BeforeDeleteComment');


### PR DESCRIPTION
By now only $CommentID is passed although $Comment is available. If a plugin has to check  anything on e.g. Comment->Body, the plugin would have to get the comment again.