### PR TITLE
Fix inability to register when no captcha plug-in enabled

### DIFF
--- a/library/core/class.captcha.php
+++ b/library/core/class.captcha.php
@@ -23,7 +23,15 @@ class Captcha {
      * @return boolean
      */
     public static function enabled() {
-        return !c('Garden.Registration.SkipCaptcha', false);
+        // Detect any available captcha validation handlers.
+        $validateHandlers = Gdn::pluginManager()->getEventHandlers(
+            '',
+            'validate',
+            'Handler',
+            ['ClassName' => 'captcha']
+        );
+
+        return c('Garden.Registration.SkipCaptcha') ? false : count($validateHandlers) > 0;
     }
 
     /**

--- a/library/core/class.captcha.php
+++ b/library/core/class.captcha.php
@@ -17,21 +17,26 @@
  */
 class Captcha {
 
+    private static $enabled;
+
     /**
      * Should we expect captcha submissions?
      *
      * @return boolean
      */
     public static function enabled() {
-        // Detect any available captcha validation handlers.
-        $validateHandlers = Gdn::pluginManager()->getEventHandlers(
-            '',
-            'validate',
-            'Handler',
-            ['ClassName' => 'captcha']
-        );
+        if (!isset(static::$enabled)) {
+            $enabled = !c('Garden.Registration.SkipCaptcha', false);
+            $handlersAvailable = false;
 
-        return c('Garden.Registration.SkipCaptcha') ? false : count($validateHandlers) > 0;
+            Gdn::pluginManager()->fireAs('captcha')->fireEvent('IsEnabled', [
+                'Enabled' => &$handlersAvailable
+            ]);
+
+            static::$enabled = $enabled && $handlersAvailable;
+        }
+
+        return static::$enabled;
     }
 
     /**

--- a/plugins/recaptcha/class.recaptcha.plugin.php
+++ b/plugins/recaptcha/class.recaptcha.plugin.php
@@ -136,6 +136,16 @@ class RecaptchaPlugin extends Gdn_Plugin {
     }
 
     /**
+     * Hook to indicate a captcha service is available.
+     *
+     * @param Gdn_PluginManager $sender
+     * @param array $args
+     */
+    public function captcha_isEnabled_handler($sender, $args) {
+        $args['Enabled'] = true;
+    }
+
+    /**
      * Hook (view) to manage captcha config.
      *
      * THIS METHOD ECHOS DATA


### PR DESCRIPTION
This update alters the behavior of `Captcha::enabled`.  It now considers if any plug-ins have registered captcha validation handlers before determining if captcha is enabled for a site, instead of solely relying on the `Garden.Registration.SkipCaptcha` config check.

Closes #4087