### PR TITLE
Fix ForceWysiwyg check in Advanced Editor causing markup to generate early

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -669,10 +669,8 @@ class EditorPlugin extends Gdn_Plugin {
         }
 
        // If force Wysiwyg enabled in settings
-        if (c('Garden.InputFormatter', 'Wysiwyg') == 'Wysiwyg'
-         //&& strcasecmp($this->Format, 'wysiwyg') != 0
-         && $this->ForceWysiwyg == true
-        ) {
+        $needsConversion = (!in_array($this->Format, array('Wysiwyg')));
+        if (c('Garden.InputFormatter', 'Wysiwyg') == 'Wysiwyg' && $this->ForceWysiwyg == true && $needsConversion) {
             $wysiwygBody = Gdn_Format::to($Sender->getValue('Body'), $this->Format);
             $Sender->setValue('Body', $wysiwygBody);
 


### PR DESCRIPTION
Advanced Editor was sometimes attempting to force a post to be re-interpreted as Wysiwyg, even when the post was already in that format.  This led to post content being formatted before it was returned to the editor, so the code for YouTube embeds, etc, had been generated.  This caused the post to be updated with this invalid markup when it was saved, which led to some content being lost.

This update backports the current `ForceWysiwyg` check in Advanced Editor to the 2.2 release branch.

Closes #4114 