### PR TITLE
Update IP Address field types to varbinary(16)

### DIFF
--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -677,7 +677,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         $column = clone $column;
 
         $typeAliases = [
-            'ipaddress' => ['Type' => 'varchar', 'Length' => 15]
+            'ipaddress' => ['Type' => 'varbinary', 'Length' => 16]
         ];
 
         $validColumnTypes = array(


### PR DESCRIPTION
This update alters the `ipaddress` type alias in `Gdn_MySQLStructure` from `varchar(15)` to `varbinary(16)`.

Data seems to remain intact after a utility-update.  Updating data also seems to be unaffected.

Closes #3805 