### PR TITLE
Fix plugin->isEnabled() method

### DIFF
--- a/library/core/class.plugin.php
+++ b/library/core/class.plugin.php
@@ -344,8 +344,8 @@ abstract class Gdn_Plugin extends Gdn_Pluggable implements Gdn_IPlugin {
      * @return boolean Status of plugin's 2nd level activation
      */
     public function isEnabled() {
-        $PluginName = $this->GetPluginIndex();
-        $EnabledKey = "Plugins.{$PluginName}.Enabled";
+        $PluginName = $this->getPluginIndex();
+        $EnabledKey = "EnabledPlugins.{$PluginName}";
         return (bool)c($EnabledKey, false);
     }
 


### PR DESCRIPTION
The method was using the old config syntax "Plugins.Name.Enabled", but now this is stored as "EnabledPlugins.Name".

This should be backported since it breaks plugins functionality.