### PR TITLE
Update embed.js

### DIFF
--- a/js/embed.js
+++ b/js/embed.js
@@ -154,7 +154,7 @@ window.vanilla.embed = function(host) {
                     currentPath = currentPath.replace('/index.php?p=', ''); // 1
                     currentPath = stripParam(currentPath, 'remote='); // 2
                     currentPath = stripParam(currentPath, 'locale='); // 3
-                    window.location.hash = currentPath;
+                    window.location.hash = encodeURI(currentPath);
                 }
             }
         } else if (message[0] == 'unload') {


### PR DESCRIPTION
Fix bug:
In safari,when the url has utf8 charset.
embed mode will broken.