### PR TITLE
Display advanced notification settings even when Garden.Registration.NoEmail is enabled.

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -367,7 +367,7 @@ class VanillaHooks implements Gdn_IPlugin {
         if ($sender->Menu) {
             $sender->Menu->addLink('Discussions', t('Discussions'), '/discussions', false, ['Standard' => true]);
         }
-        
+
         if (!inSection('Dashboard')) {
             // Spoilers assets
             $sender->addJsFile('spoilers.js', 'vanilla');
@@ -464,7 +464,7 @@ class VanillaHooks implements Gdn_IPlugin {
      * @param ProfileController $Sender
      */
     public function profileController_CustomNotificationPreferences_Handler($Sender) {
-        if (!$Sender->data('NoEmail') && Gdn::session()->checkPermission('Garden.AdvancedNotifications.Allow')) {
+        if (Gdn::session()->checkPermission('Garden.AdvancedNotifications.Allow')) {
             include $Sender->fetchViewLocation('notificationpreferences', 'vanillasettings', 'vanilla');
         }
     }

--- a/applications/vanilla/views/vanillasettings/notificationpreferences.php
+++ b/applications/vanilla/views/vanillasettings/notificationpreferences.php
@@ -1,14 +1,4 @@
-<?php if (!defined('APPLICATION')) return;
-
-if ($Sender->data('NoEmail')) {
-    $emailEnabled = false;
-    $colspan = ' colspan="2" ';
-} else {
-    $emailEnabled = true;
-    $colspan = null;
-}
-?>
-asdfdsgssdgsgs
+<?php if (!defined('APPLICATION')) return; ?>
 <h2><?php echo t('Category Notifications'); ?></h2>
 <div class="DismissMessage InfoMessage">
     <?php
@@ -25,15 +15,10 @@ asdfdsgssdgsgs
     </tr>
     <tr>
         <td style="text-align: left;"><?php echo t('Category'); ?></td>
-        <?php
-        for($i = 0; $i < 2; $i++) {
-            if ($emailEnabled) {
-                echo '<td class="PrefCheckBox BottomHeading">'.t('Email').'</td>';
-            }
-            echo '<td class="PrefCheckBox BottomHeading"'.$colspan.'>'.t('Popup').'</td>';
-
-        }
-        ?>
+        <td class="PrefCheckBox BottomHeading"><?php echo t('Email'); ?></td>
+        <td class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></td>
+        <td class="PrefCheckBox BottomHeading"><?php echo t('Email'); ?></td>
+        <td class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></td>
     </tr>
     </thead>
     <tbody>
@@ -54,23 +39,10 @@ asdfdsgssdgsgs
         <?php else: ?>
             <tr>
                 <td class="<?php echo "Depth_{$Category['Depth']}"; ?>"><?php echo $Category['Name']; ?></td>
-                <?php
-                    $checkboxeIDs = [];
-                    if ($emailEnabled) {
-                        $checkboxeIDs[] = "Email.NewDiscussion.$CategoryID";
-                    }
-                    $checkboxeIDs[] = "Popup.NewDiscussion.$CategoryID";
-                    if ($emailEnabled) {
-                        $checkboxeIDs[] = "Email.NewComment.$CategoryID";
-                    }
-                    $checkboxeIDs[] = "Popup.NewComment.$CategoryID";
-
-
-                    foreach($checkboxeIDs as $checkboxID) {
-                        echo '<td class="PrefCheckBox"'.$colspan.'>'.Gdn::controller()->Form->CheckBox($checkboxID, '', array('value' => 1)).'</td>';
-                    }
-                ?>
-
+                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->CheckBox("Email.NewDiscussion.{$CategoryID}", '', array('value' => 1)); ?></td>
+                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->CheckBox("Popup.NewDiscussion.{$CategoryID}", '', array('value' => 1)); ?></td>
+                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->CheckBox("Email.NewComment.{$CategoryID}", '', array('value' => 1)); ?></td>
+                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->CheckBox("Popup.NewComment.{$CategoryID}", '', array('value' => 1)); ?></td>
             </tr>
         <?php
         endif;

--- a/applications/vanilla/views/vanillasettings/notificationpreferences.php
+++ b/applications/vanilla/views/vanillasettings/notificationpreferences.php
@@ -1,4 +1,14 @@
-<?php if (!defined('APPLICATION')) return; ?>
+<?php if (!defined('APPLICATION')) return;
+
+if ($Sender->data('NoEmail')) {
+    $emailEnabled = false;
+    $colspan = ' colspan="2" ';
+} else {
+    $emailEnabled = true;
+    $colspan = null;
+}
+?>
+asdfdsgssdgsgs
 <h2><?php echo t('Category Notifications'); ?></h2>
 <div class="DismissMessage InfoMessage">
     <?php
@@ -15,10 +25,15 @@
     </tr>
     <tr>
         <td style="text-align: left;"><?php echo t('Category'); ?></td>
-        <td class="PrefCheckBox BottomHeading"><?php echo t('Email'); ?></td>
-        <td class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></td>
-        <td class="PrefCheckBox BottomHeading"><?php echo t('Email'); ?></td>
-        <td class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></td>
+        <?php
+        for($i = 0; $i < 2; $i++) {
+            if ($emailEnabled) {
+                echo '<td class="PrefCheckBox BottomHeading">'.t('Email').'</td>';
+            }
+            echo '<td class="PrefCheckBox BottomHeading"'.$colspan.'>'.t('Popup').'</td>';
+
+        }
+        ?>
     </tr>
     </thead>
     <tbody>
@@ -39,10 +54,23 @@
         <?php else: ?>
             <tr>
                 <td class="<?php echo "Depth_{$Category['Depth']}"; ?>"><?php echo $Category['Name']; ?></td>
-                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->CheckBox("Email.NewDiscussion.{$CategoryID}", '', array('value' => 1)); ?></td>
-                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->CheckBox("Popup.NewDiscussion.{$CategoryID}", '', array('value' => 1)); ?></td>
-                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->CheckBox("Email.NewComment.{$CategoryID}", '', array('value' => 1)); ?></td>
-                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->CheckBox("Popup.NewComment.{$CategoryID}", '', array('value' => 1)); ?></td>
+                <?php
+                    $checkboxeIDs = [];
+                    if ($emailEnabled) {
+                        $checkboxeIDs[] = "Email.NewDiscussion.$CategoryID";
+                    }
+                    $checkboxeIDs[] = "Popup.NewDiscussion.$CategoryID";
+                    if ($emailEnabled) {
+                        $checkboxeIDs[] = "Email.NewComment.$CategoryID";
+                    }
+                    $checkboxeIDs[] = "Popup.NewComment.$CategoryID";
+
+
+                    foreach($checkboxeIDs as $checkboxID) {
+                        echo '<td class="PrefCheckBox"'.$colspan.'>'.Gdn::controller()->Form->CheckBox($checkboxID, '', array('value' => 1)).'</td>';
+                    }
+                ?>
+
             </tr>
         <?php
         endif;


### PR DESCRIPTION
Update advanced notification to take Garden.Registration.NoEmail into account instead of not displaying at all.

Fixes https://github.com/vanilla/vanilla/issues/4112