### PR TITLE
Replace MySQL with MySQLi for imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you professionally run a large community or enterprise forum, our cloud solut
 * PHP version 5.3 or newer with `--enable-mbstring`.
 * pdo_mysql module must be enabled.
 * MySQL 5 or newer.
-* If you intend to [Migrate to Vanilla](#migrating-to-vanilla) you will also need php with `--with-mysqli`.
+* If you intend to [Migrate to Vanilla](#migrating-to-vanilla) you will also need PHP with `--with-mysqli`.
 
 Vanilla 2.2 requires PHP 5.3. Running `master` branch requires PHP 5.4, as will future official releases.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you professionally run a large community or enterprise forum, our cloud solut
 * PHP version 5.3 or newer with `--enable-mbstring`.
 * pdo_mysql module must be enabled.
 * MySQL 5 or newer.
+* If you intend to [Migrate to Vanilla](#migrating-to-vanilla) you will also need php with `--with-mysqli`.
 
 Vanilla 2.2 requires PHP 5.3. Running `master` branch requires PHP 5.4, as will future official releases.
 

--- a/applications/dashboard/models/class.importmodel.php
+++ b/applications/dashboard/models/class.importmodel.php
@@ -1274,7 +1274,7 @@ class ImportModel extends Gdn_Model {
 
         Gdn::database()->query("truncate table $Tablename;");
 
-        $Sql = "load data local infile $Path into table $Tablename
+        $sql = "load data local infile $Path into table $Tablename
          character set utf8
          columns terminated by ','
          optionally enclosed by '\"'
@@ -1282,16 +1282,15 @@ class ImportModel extends Gdn_Model {
          lines terminated by '\\n'
          ignore 1 lines";
 
-        // We've got to use the mysql_* functions because PDO doesn't support load data local infile well.
-        $dblink = mysql_connect(c('Database.Host'), c('Database.User'), c('Database.Password'), false, 128);
-        mysql_select_db(c('Database.Name'), $dblink);
-        $Result = mysql_query($Sql, $dblink);
-        if ($Result === false) {
-            $Ex = new Exception(mysql_error($dblink));
-            mysql_close($dblink);
-            throw new $Ex;
+        // We've got to use the mysqli_* functions because PDO doesn't support load data local infile well.
+        $mysqli = new mysqli(c('Database.Host'), c('Database.User'), c('Database.Password'), c('Database.Name'), 128);
+        $result = $mysqli->query($sql);
+        if ($result === false) {
+            $ex = new Exception($mysqli->error);
+            $mysqli->close();
+            throw new $ex;
         }
-        mysql_close($dblink);
+        $mysqli->close();
     }
 
     /**


### PR DESCRIPTION
Fix: https://github.com/vanilla/vanilla/issues/4073

Mysql is removed from PHP7.0
Mysqli is available since 5.3 and we support 5.4 an up so we are good :D