### PR TITLE
Expand user searching by IP address in dashboard

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2414,11 +2414,11 @@ class UserModel extends Gdn_Model {
             $this->SQL
                 ->orOp()
                 ->beginWhereGroup()
-                ->orWhere('u.LastIPAddress', $IPAddress);
+                ->orWhereIn('u.LastIPAddress', [$IPAddress, inet_pton($IPAddress)]);
 
             // An or is expensive so only do it if the query isn't optimized.
             if (!$Optimize) {
-                $this->SQL->orWhere('u.InsertIPAddress', $IPAddress);
+                $this->SQL->orWhereIn('u.InsertIPAddress', [$IPAddress, inet_pton($IPAddress)]);
             }
 
             $this->SQL->endWhereGroup();

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2411,10 +2411,13 @@ class UserModel extends Gdn_Model {
         if (!empty($RoleID)) {
             $this->SQL->join('UserRole ur2', "u.UserID = ur2.UserID and ur2.RoleID = $RoleID");
         } elseif (isset($IPAddress)) {
+            $this->SQL->join('UserIP uip', 'u.userID = uip.UserID');
+
             $this->SQL
                 ->orOp()
                 ->beginWhereGroup()
-                ->orWhereIn('u.LastIPAddress', [$IPAddress, inet_pton($IPAddress)]);
+                ->orWhereIn('u.LastIPAddress', [$IPAddress, inet_pton($IPAddress)])
+                ->orWhere('uip.IPAddress', inet_pton($IPAddress));
 
             // An or is expensive so only do it if the query isn't optimized.
             if (!$Optimize) {


### PR DESCRIPTION
This update makes the following changes to user search in the dashboard:

1. User IP addresses are searched for the human-readable and packed form. (see https://github.com/vanilla/vanilla/pull/4133)
2. User IP addresses are searched for in the UserIP table. (see https://github.com/vanilla/vanilla/pull/4026)

Closes #3908 