### PR TITLE
Update all IP address fields to be able to store IPv6 values

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1060,7 +1060,7 @@ class ActivityModel extends Gdn_Model {
     public function comment($Comment) {
         $Comment['InsertUserID'] = Gdn::session()->UserID;
         $Comment['DateInserted'] = Gdn_Format::toDateTime();
-        $Comment['InsertIPAddress'] = Gdn::request()->ipAddress();
+        $Comment['InsertIPAddress'] = ipEncode(Gdn::request()->ipAddress());
 
         $this->Validation->applyRule('ActivityID', 'Required');
         $this->Validation->applyRule('Body', 'Required');

--- a/applications/dashboard/models/class.logmodel.php
+++ b/applications/dashboard/models/class.logmodel.php
@@ -346,7 +346,7 @@ class LogModel extends Gdn_Pluggable {
             $InsertUserID = Gdn::session()->UserID;
         }
         if (($InsertIPAddress = self::logValue($Data, 'Log_InsertIPAddress')) == null) {
-            $InsertIPAddress = Gdn::request()->ipAddress();
+            $InsertIPAddress = ipEncode(Gdn::request()->ipAddress());
         }
         // Do some known translations for the parent record ID.
         if (($ParentRecordID = self::logValue($Data, 'ParentRecordID')) === null) {

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -702,7 +702,7 @@ class Gdn_Model extends Gdn_Pluggable {
         }
 
         if ($this->Schema->FieldExists($this->Name, 'UpdateIPAddress') && !isset($Fields['UpdateIPAddress'])) {
-            $Fields['UpdateIPAddress'] = Gdn::request()->ipAddress();
+            $Fields['UpdateIPAddress'] = ipEncode(Gdn::request()->ipAddress());
         }
     }
 

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -675,7 +675,7 @@ class Gdn_Model extends Gdn_Pluggable {
         }
 
         if ($this->Schema->fieldExists($this->Name, 'InsertIPAddress') && !isset($Fields['InsertIPAddress'])) {
-            $Fields['InsertIPAddress'] = Gdn::request()->ipAddress();
+            $Fields['InsertIPAddress'] = ipEncode(Gdn::request()->ipAddress());
         }
     }
 

--- a/plugins/StopForumSpam/class.stopforumspam.plugin.php
+++ b/plugins/StopForumSpam/class.stopforumspam.plugin.php
@@ -162,7 +162,7 @@ class StopForumSpamPlugin extends Gdn_Plugin {
             if (substr($Reason, 0, 1) === '{') {
                 $Sender->EventArguments['IsSpam'] = true;
                 $Data['Log_InsertUserID'] = $this->userID();
-                $Data['RecordIPAddress'] = Gdn::request()->ipAddress();
+                $Data['RecordIPAddress'] = ipEncode(Gdn::request()->ipAddress());
                 return;
             }
         }
@@ -173,7 +173,7 @@ class StopForumSpamPlugin extends Gdn_Plugin {
                 $Result = self::check($Data, $Options);
                 if ($Result) {
                     $Data['Log_InsertUserID'] = $this->userID();
-                    $Data['RecordIPAddress'] = Gdn::request()->ipAddress();
+                    $Data['RecordIPAddress'] = ipEncode(Gdn::request()->ipAddress());
                 }
                 break;
             case 'Comment':


### PR DESCRIPTION
This update encodes all IP address values in preparation for storage in `varbinary(16)` fields.

Requires https://github.com/vanilla/vanilla/pull/4133

Closes #3809 