### PR TITLE
Fix double encoding Open Graph title tag

### DIFF
--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -397,7 +397,7 @@ if (!class_exists('HeadModule', false)) {
                 $this->addTag('meta', array('property' => 'og:site_name', 'content' => $SiteName));
             }
 
-            $Title = Gdn_Format::text($this->title('', true));
+            $Title = htmlEntityDecode(Gdn_Format::text($this->title('', true)));
             if ($Title != '') {
                 $this->addTag('meta', array('property' => 'og:title', 'itemprop' => 'name', 'content' => $Title));
             }


### PR DESCRIPTION
On a discussion page, the `_Title` property of the HeadModule has its HTML entities encoded.  When the  `og:title` tag is built, its attributes are passed through the `attribute` function, which encodes the values again with `htmlspecialchars`.  This ultimately leads to things like ampersands being represented as `&amp;&amp`, which renders as `&amp;`.

This fix decodes the title value before it is passed to `attribute`, where it is then properly encoded.