### PR TITLE
Add homepage detection

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -29,6 +29,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
     /** @var string The name of the controller to be dispatched. */
     public $ControllerName;
+
     /** @var stringThe method of the controller to be called. */
     public $ControllerMethod;
 
@@ -48,6 +49,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
     /** @var string The name of the application folder that contains the controller that has been requested. */
     private $applicationFolder;
+
     /**
      * @var array An associative collection of AssetName => Strings that will get passed
      * into the controller once it has been instantiated.
@@ -81,6 +83,9 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
      * @var AddonManager $addonManager The addon manager that manages all of the addons.
      */
     private $addonManager;
+
+    /** @var bool */
+    private $isHomepage = false;
 
     /**
      * Class constructor.
@@ -360,6 +365,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         }
 
         if (in_array($request->path(), ['', '/'])) {
+            $this->isHomepage = true;
             $defaultController = Gdn::router()->getRoute('DefaultController');
             $request->pathAndQuery($defaultController['Destination']);
         }
@@ -618,6 +624,24 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             }
         }
         return false;
+    }
+
+    /**
+     * Set whether the current dispatch is to our virtual homepage.
+     *
+     * We track this because Path is always set to our DefaultController, which means there's no way to
+     * differentiate whether this is a direct call to the controller or a homepage visit.
+     *
+     * @see analyzeRequest()
+     *
+     * @param $value bool
+     * @return bool
+     */
+    public function isHomepage($value = null) {
+        if ($value !== null) {
+            $this->isHomepage = ($value) ? true : false;
+        }
+        return $this->isHomepage;
     }
 
     /**

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -372,6 +372,9 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
         $parts = explode('/', str_replace('\\', '/', $request->path()));
 
+        // We need to save this state now because it's lost after this method.
+        $this->passData('isHomepage', $this->isHomepage);
+
         /**
          * The application folder is either the first argument or is not provided. The controller is therefore
          * either the second argument or the first, depending on the result of the previous statement. Check that.
@@ -386,7 +389,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             $this->findController(0, $parts);
 
             // 3] See if there is a plugin trying to create a root method.
-            list($MethodName, $DeliveryMethod) = $this->_splitDeliveryMethod(GetValue(0, $parts), true);
+            list($MethodName, $DeliveryMethod) = $this->_splitDeliveryMethod(val(0, $parts), true);
             if ($MethodName && Gdn::pluginManager()->hasNewMethod('RootController', $MethodName, true)) {
                 $this->deliveryMethod = $DeliveryMethod;
                 $parts[0] = $MethodName;
@@ -624,24 +627,6 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             }
         }
         return false;
-    }
-
-    /**
-     * Set whether the current dispatch is to our virtual homepage.
-     *
-     * We track this because Path is always set to our DefaultController, which means there's no way to
-     * differentiate whether this is a direct call to the controller or a homepage visit.
-     *
-     * @see analyzeRequest()
-     *
-     * @param $value bool
-     * @return bool
-     */
-    public function isHomepage($value = null) {
-        if ($value !== null) {
-            $this->isHomepage = ($value) ? true : false;
-        }
-        return $this->isHomepage;
     }
 
     /**

--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -20,8 +20,8 @@ class Gdn_Smarty {
     /**
      *
      *
-     * @param $Path
-     * @param $Controller
+     * @param string $Path
+     * @param Gdn_Controller $Controller
      */
     public function init($Path, $Controller) {
         $Smarty = $this->smarty();
@@ -101,9 +101,10 @@ class Gdn_Smarty {
         $Smarty->assign('Assets', (array)$Controller->Assets);
         // 2016-07-07 Linc: Request used to return blank for homepage.
         // Now it returns defaultcontroller. This restores BC behavior.
-        $Path = (Gdn::controller()->data('isHomepage')) ? "" : Gdn::request()->path();
+        $isHomepage = val('isHomepage', $Controller->Data);
+        $Path = ($isHomepage) ? "" : Gdn::request()->path();
         $Smarty->assign('Path', $Path);
-        $Smarty->assign('Homepage', Gdn::controller()->data('isHomepage')); // true/false
+        $Smarty->assign('Homepage', $isHomepage); // true/false
 
         // Assign the controller data last so the controllers override any default data.
         $Smarty->assign($Controller->Data);

--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -101,9 +101,9 @@ class Gdn_Smarty {
         $Smarty->assign('Assets', (array)$Controller->Assets);
         // 2016-07-07 Linc: Request used to return blank for homepage.
         // Now it returns defaultcontroller. This restores BC behavior.
-        $Path = (Gdn::dispatcher()->isHomepage()) ? "" : Gdn::request()->path();
+        $Path = (Gdn::controller()->data('isHomepage')) ? "" : Gdn::request()->path();
         $Smarty->assign('Path', $Path);
-        $Smarty->assign('Homepage', Gdn::dispatcher()->isHomepage()); // true/false
+        $Smarty->assign('Homepage', Gdn::controller()->data('isHomepage')); // true/false
 
         // Assign the controller data last so the controllers override any default data.
         $Smarty->assign($Controller->Data);

--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -100,6 +100,7 @@ class Gdn_Smarty {
 
         $Smarty->assign('Assets', (array)$Controller->Assets);
         $Smarty->assign('Path', Gdn::request()->path());
+        $Smarty->assign('Homepage', Gdn::dispatcher()->isHomepage()); // true/false
 
         // Assign the controller data last so the controllers override any default data.
         $Smarty->assign($Controller->Data);

--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -99,7 +99,10 @@ class Gdn_Smarty {
         $Smarty->assign('CurrentLocale', $CurrentLocale);
 
         $Smarty->assign('Assets', (array)$Controller->Assets);
-        $Smarty->assign('Path', Gdn::request()->path());
+        // 2016-07-07 Linc: Request used to return blank for homepage.
+        // Now it returns defaultcontroller. This restores BC behavior.
+        $Path = (Gdn::dispatcher()->isHomepage()) ? "" : Gdn::request()->path();
+        $Smarty->assign('Path', $Path);
         $Smarty->assign('Homepage', Gdn::dispatcher()->isHomepage()); // true/false
 
         // Assign the controller data last so the controllers override any default data.


### PR DESCRIPTION
In #4158 we lost the ability to have a blank path for homepage requests because we now have a unified request object that takes the path of the defaultcontroller in that case.

This change adds homepage detection in the dispatcher before this overwrite is done. Then this condition is passed onto Smarty as a new `$Homepage` variable, which is a boolean.