### PR TITLE
Move role meta query to latest possible and only in Vanilla app

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -757,7 +757,7 @@ class RoleModel extends Gdn_Model {
      * @param string $field optionally the field name from the role table to return.
      * @return array|null|void
      */
-    public function getPublicUserRoles($userID, $field = "Name") {
+    public static function getPublicUserRoles($userID, $field = "Name") {
         if (!$userID) {
             return;
         }

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -438,19 +438,4 @@ class DashboardHooks implements Gdn_IPlugin {
             PermissionModel::resetAllRoles();
         }
     }
-
-    /**
-     * Add user's viewable roles to gdn.meta if user is logged in.
-     * @param $sender
-     * @param $args
-     */
-    public function gdn_dispatcher_afterControllerCreate_handler($sender, $args) {
-        // Function addDefinition returns the value of the definition if you pass only one argument.
-        if (!gdn::controller()->addDefinition('Roles')) {
-            if (Gdn::session()->isValid()) {
-                $roleModel = new RoleModel();
-                gdn::controller()->addDefinition("Roles", $roleModel->getPublicUserRoles(gdn::session()->UserID, "Name"));
-            }
-        }
-    }
 }

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -376,6 +376,13 @@ class VanillaHooks implements Gdn_IPlugin {
             $sender->addDefinition('show', t('show'));
             $sender->addDefinition('hide', t('hide'));
         }
+
+        // Add user's viewable roles to gdn.meta if user is logged in.
+        if (!$sender->addDefinition('Roles')) {
+            if (Gdn::session()->isValid()) {
+                Gdn::controller()->addDefinition("Roles", RoleModel::getPublicUserRoles(Gdn::session()->UserID, "Name"));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
While we don't have a database load problem as in #3686 from adding role data to the page, we do have an infrastructure problem because we're calling the database too early and on too many page loads. We only need this data if Vanilla (the forum app) is loaded and only need it as the page renders in HTML, so here we move the hook as late as possible (which is always a better default anyway).

We also change `getPublicUserRoles()` to a static method because it it's only used in this sort of context-less querying way.