### PR TITLE
Add ability to move a category to another of its parents

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -722,7 +722,10 @@ class VanillaSettingsController extends Gdn_Controller {
      * @param int $categoryID Unique ID for the category to move.
      * @throws Exception if category is not found.
      */
-    public function movecategory($categoryID) {
+    public function moveCategory($categoryID) {
+        // Check permission
+        $this->permission(['Garden.Community.Manage', 'Garden.Settings.Manage'], false);
+
         $category = CategoryModel::categories($categoryID);
 
         if (!$category) {

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -716,6 +716,37 @@ class VanillaSettingsController extends Gdn_Controller {
         $this->render();
     }
 
+    /**
+     * Move a category to a different parent.
+     *
+     * @param int $categoryID Unique ID for the category to move.
+     * @throws Exception if category is not found.
+     */
+    public function movecategory($categoryID) {
+        $category = CategoryModel::categories($categoryID);
+
+        if (!$category) {
+            throw notFoundException();
+        }
+
+        $this->Form->setModel($this->CategoryModel);
+        $this->Form->addHidden('CategoryID', $categoryID);
+        $this->setData('Category', $category);
+
+        $parentCategories = CategoryModel::getAncestors($categoryID);
+        array_pop($parentCategories);
+        if (!empty($parentCategories)) {
+            $this->setData('ParentCategories', array_column($parentCategories, 'Name', 'CategoryID'));
+        }
+
+        if ($this->Form->authenticatedPostBack()) {
+            $this->Form->save();
+        } else {
+            $this->Form->setData($category);
+        }
+
+        $this->render();
+    }
 
     /**
      * Enable or disable the use of categories in Vanilla.

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -743,6 +743,11 @@ class VanillaSettingsController extends Gdn_Controller {
         }
 
         if ($this->Form->authenticatedPostBack()) {
+            // Verify we're only attempting to save specific values.
+            $this->Form->formValues([
+                'CategoryID' => $this->Form->getValue('CategoryID'),
+                'ParentCategoryID' => $this->Form->getValue('ParentCategoryID'),
+            ]);
             $this->Form->save();
         } else {
             $this->Form->setData($category);

--- a/applications/vanilla/views/vanillasettings/managecategories.php
+++ b/applications/vanilla/views/vanillasettings/managecategories.php
@@ -131,6 +131,7 @@ if (c('Vanilla.Categories.Use')) {
                   </td>
                   <td class="Buttons">'
                 .anchor(t('Edit'), 'vanilla/settings/editcategory/'.$Category->CategoryID, 'SmallButton')
+                .anchor(t('Move'), "vanilla/settings/movecategory/{$Category->CategoryID}", 'Popup SmallButton')
                 .(val('CanDelete', $Category) ? anchor(t('Delete'), 'vanilla/settings/deletecategory/'.$Category->CategoryID, 'SmallButton') : '')
                 .'</td>
                </tr>

--- a/applications/vanilla/views/vanillasettings/movecategory.php
+++ b/applications/vanilla/views/vanillasettings/movecategory.php
@@ -1,0 +1,25 @@
+<?php if (!defined('APPLICATION')) exit(); ?>
+<?php $parentCategories = $this->data('ParentCategories'); ?>
+<h1><?php echo t('Move Category'); ?></h1>
+<div class="Info">
+    <?php echo sprintf(
+        t('Move %s to one of its parent categories.'),
+        val('Name', $this->data('Category'))
+    ); ?>
+</div>
+<?php if (empty($parentCategories)): ?>
+<div class="Warning"><?php echo t('No parent categories available.'); ?></div>
+<?php else: ?>
+<?php echo $this->Form->open(); ?>
+<ul>
+    <li>
+        <?php
+            echo $this->Form->label('Parent Category', 'ParentCategoryID');
+            echo $this->Form->dropdown(
+                'ParentCategoryID', $parentCategories
+            );
+        ?>
+    </li>
+</ul>
+<?php echo $this->Form->close('Save'); ?>
+<?php endif; ?>


### PR DESCRIPTION
This update allows a user to move a category from its current parent to another of its parents/ancestors from the Manage Categories dashboard area.

Closes #4157