### PR TITLE
Add basic support for flat categories

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -106,15 +106,76 @@ class CategoriesController extends VanillaController {
     }
 
     /**
-     * "Table" layout for categories. Mimics more traditional forum category layout.
+     * Build a structured tree of children for the specified category.
+     *
+     * @param int|string|object|array|null $category Category or code/ID to build the tree for. Null for all.
+     * @param string|null $displayAs What display should the tree be configured for?
+     * @param bool $recent Join in recent record info?
+     * @param bool $watching Filter categories by "watching" status?
+     * @return array
      */
-    public function table($Category = '') {
-        if ($this->SyndicationMethod == SYNDICATION_NONE) {
-            $this->View = 'table';
-        } else {
-            $this->View = 'all';
+    private function getCategoryTree($category = null, $displayAs = null, $recent = false, $watching = false) {
+        $categoryIdentifier = null;
+
+        if (is_string($category) || is_numeric($category)) {
+            $category = CategoryModel::categories($category);
         }
-        $this->All($Category);
+
+        if ($category) {
+            if ($displayAs === null) {
+                $displayAs = val('DisplayAs', $category, 'Discussions');
+            }
+            $categoryIdentifier = val('CategoryID', $category, null);
+        }
+
+        switch ($displayAs) {
+            case 'Flat':
+                $perPage = c('Vanilla.Categories.PerPage', 30);
+                $page = Gdn::request()->get('Page', null);
+                list($offset, $limit) = offsetLimit($page, $perPage);
+                $categoryTree = $this->CategoryModel->getTreeAsFlat($categoryIdentifier, $offset, $limit);
+                $this->setData('_Limit', $perPage);
+                $this->setData('_CurrentRecords', $this->CategoryModel->getCount([
+                    'ParentCategoryID' => val('CategoryID', $category, -1)
+                ]));
+                break;
+            case 'Categories':
+            case 'Discussions':
+            case 'Default':
+            case 'Nested':
+            default:
+            $categoryTree = $this->CategoryModel
+                    ->setJoinUserCategory(true)
+                    ->getChildTree(
+                        $categoryIdentifier ?: null,
+                        CategoryModel::instance()->getMaxDisplayDepth() ?: 10
+                    );
+        }
+
+        if ($recent) {
+            $this->CategoryModel->joinRecent($categoryTree);
+        }
+
+        if ($watching && $this->CategoryModel->Watching) {
+            $categoryTree = $this->CategoryModel->filterFollowing($categoryTree);
+        }
+
+        return $categoryTree;
+    }
+
+    /**
+     * "Table" layout for categories. Mimics more traditional forum category layout.
+     *
+     * @param string $Category
+     * @param string $displayAs
+     */
+    public function table($Category = '', $displayAs = '') {
+        if ($this->SyndicationMethod == SYNDICATION_NONE) {
+            $this->View = $displayAs === 'Flat' ? 'flat_table' : 'table';
+        } else {
+            $this->View = $displayAs === 'Flat' ? 'flat_all' : 'all';
+        }
+        $this->All($Category, $displayAs);
     }
 
     /**
@@ -163,32 +224,35 @@ class CategoriesController extends VanillaController {
             $this->Description(val('Description', $Category), true);
 
 
-            if ($Category->DisplayAs == 'Categories') {
-                if (val('Depth', $Category) > CategoryModel::instance()->getNavDepth()) {
-                    // Headings don't make sense if we've cascaded down one level.
-                    saveToConfig('Vanilla.Categories.DoHeadings', false, false);
-                }
-
-                if ($this->SyndicationMethod != SYNDICATION_NONE) {
-                    // RSS can't show a category list so just tell it to expand all categories.
-                    saveToConfig('Vanilla.ExpandCategories', true, false);
-                } else {
-                    // This category is an overview style category and displays as a category list.
-                    switch ($Layout) {
-                        case 'mixed':
-                            $this->View = 'discussions';
-                            $this->Discussions($CategoryIdentifier);
-                            break;
-                        case 'table':
-                            $this->table($CategoryIdentifier);
-                            break;
-                        default:
-                            $this->View = 'all';
-                            $this->All($CategoryIdentifier);
-                            break;
+            switch ($Category->DisplayAs) {
+                case 'Flat':
+                case 'Categories':
+                    if (val('Depth', $Category) > CategoryModel::instance()->getNavDepth()) {
+                        // Headings don't make sense if we've cascaded down one level.
+                        saveToConfig('Vanilla.Categories.DoHeadings', false, false);
                     }
-                    return;
-                }
+
+                    if ($this->SyndicationMethod != SYNDICATION_NONE) {
+                        // RSS can't show a category list so just tell it to expand all categories.
+                        saveToConfig('Vanilla.ExpandCategories', true, false);
+                    } else {
+                        // This category is an overview style category and displays as a category list.
+                        switch ($Layout) {
+                            case 'mixed':
+                                $this->View = 'discussions';
+                                $this->Discussions($CategoryIdentifier);
+                                break;
+                            case 'table':
+                                $this->table($CategoryIdentifier, $Category->DisplayAs);
+                                break;
+                            default:
+                                $this->View = 'all';
+                                $this->All($CategoryIdentifier, $Category->DisplayAs);
+                                break;
+                        }
+                        return;
+                    }
+                    break;
             }
 
             Gdn_Theme::section('DiscussionList');
@@ -205,14 +269,9 @@ class CategoriesController extends VanillaController {
                     break;
             }
 
-            // Load the subtree.
-            $categoryTree = $this->CategoryModel
-                ->setJoinUserCategory(true)
-                ->getChildTree(
-                    $CategoryIdentifier,
-                    CategoryModel::instance()->getMaxDisplayDepth() ?: 10
-                );
-            $this->setData('CategoryTree', $categoryTree);
+            $this->setData('CategoryTree', $this->getCategoryTree(
+                $CategoryIdentifier, val('DisplayAs', $Category
+            )));
 
             // Add a backwards-compatibility shim for the old categories.
             $this->categoriesCompatibilityCallback = function () use ($CategoryIdentifier) {
@@ -346,7 +405,7 @@ class CategoriesController extends VanillaController {
      * @since 2.0.17
      * @access public
      */
-    public function all($Category = '') {
+    public function all($Category = '', $displayAs = '') {
         // Setup head.
         $this->Menu->highlightRoute('/discussions');
         if (!$this->title()) {
@@ -402,7 +461,7 @@ class CategoriesController extends VanillaController {
             $categoryTree = $this->CategoryModel->filterFollowing($categoryTree);
         }
         $this->CategoryModel->joinRecent($categoryTree);
-        $this->setData('CategoryTree', $categoryTree);
+        $this->setData('CategoryTree', $this->getCategoryTree($Category, null, true, true));
 
         // Add modules
         $this->addModule('NewDiscussionModule');
@@ -411,6 +470,10 @@ class CategoriesController extends VanillaController {
         $this->addModule($CategoryFollowToggleModule);
 
         $this->canonicalUrl(url('/categories', true));
+
+        if ($this->View === 'all' && $displayAs === 'Flat') {
+            $this->View = 'flat_all';
+        }
 
         $Location = $this->fetchViewLocation('helper_functions', 'categories', false, false);
         if ($Location) {
@@ -459,6 +522,7 @@ class CategoriesController extends VanillaController {
         } else {
             $Categories = $this->CategoryModel->GetFull()->resultArray();
         }
+
         $this->setData('Categories', $Categories);
 
         // Get category data and discussions
@@ -470,6 +534,7 @@ class CategoriesController extends VanillaController {
         $this->setData('Filters', $DiscussionModel->getFilters());
 
         $this->CategoryDiscussionData = array();
+
         foreach ($this->CategoryData->result() as $Category) {
             if ($Category->CategoryID > 0) {
                 $this->CategoryDiscussionData[$Category->CategoryID] = $DiscussionModel->get(0, $this->DiscussionsPerCategory, array('d.CategoryID' => $Category->CategoryID, 'Announce' => 'all'));

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -135,9 +135,7 @@ class CategoriesController extends VanillaController {
                 list($offset, $limit) = offsetLimit($page, $perPage);
                 $categoryTree = $this->CategoryModel->getTreeAsFlat($categoryIdentifier, $offset, $limit);
                 $this->setData('_Limit', $perPage);
-                $this->setData('_CurrentRecords', $this->CategoryModel->getCount([
-                    'ParentCategoryID' => val('CategoryID', $category, -1)
-                ]));
+                $this->setData('_CurrentRecords', count($categoryTree));
                 break;
             case 'Categories':
             case 'Discussions':

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -131,7 +131,7 @@ class CategoriesController extends VanillaController {
         switch ($displayAs) {
             case 'Flat':
                 $perPage = c('Vanilla.Categories.PerPage', 30);
-                $page = Gdn::request()->get('Page', null);
+                $page = Gdn::request()->get('Page', Gdn::request()->get('page', null));
                 list($offset, $limit) = offsetLimit($page, $perPage);
                 $categoryTree = $this->CategoryModel->getTreeAsFlat($categoryIdentifier, $offset, $limit);
                 $this->setData('_Limit', $perPage);

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -582,7 +582,8 @@ class VanillaSettingsController extends Gdn_Controller {
 
         // Restrict "Display As" types based on parent.
         $parentCategory = $this->CategoryModel->getID($this->Category->ParentCategoryID);
-        if (val('DisplayAs', $parentCategory) === 'Flat') {
+        $parentDisplay = val('DisplayAs', $parentCategory);
+        if ($parentDisplay === 'Flat') {
             unset($displayAsOptions['Heading']);
         }
 
@@ -626,6 +627,10 @@ class VanillaSettingsController extends Gdn_Controller {
             $this->Form->setFormValue('HideAllDiscussions', forceBool($this->Form->getFormValue('HideAllDiscussions'), '0', '1', '0'));
             $this->Form->setFormValue('Archived', forceBool($this->Form->getFormValue('Archived'), '0', '1', '0'));
             $this->Form->setFormValue('AllowFileUploads', forceBool($this->Form->getFormValue('AllowFileUploads'), '0', '1', '0'));
+
+            if ($parentDisplay === 'Flat' && $this->Form->getFormValue('DisplayAs') === 'Heading') {
+                $this->Form->addError('Cannot display as heading when parent is flat', 'DisplayAs');
+            }
 
             if ($this->Form->save()) {
                 $Category = CategoryModel::categories($CategoryID);

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -559,6 +559,14 @@ class VanillaSettingsController extends Gdn_Controller {
         $PermissionModel = Gdn::permissionModel();
         $this->Form->setModel($this->CategoryModel);
 
+        $displayAsOptions = [
+            'Default' => 'Default',
+            'Discussions' => 'Discussions',
+            'Categories' => 'Nested Categories',
+            'Flat' => 'Flat Categories',
+            'Heading' => 'Heading'
+        ];
+
         if (!$CategoryID && $this->Form->authenticatedPostBack()) {
             if ($ID = $this->Form->getFormValue('CategoryID')) {
                 $CategoryID = $ID;
@@ -571,6 +579,12 @@ class VanillaSettingsController extends Gdn_Controller {
             throw notFoundException('Category');
         }
         $this->Category->CustomPermissions = $this->Category->CategoryID == $this->Category->PermissionCategoryID;
+
+        // Restrict "Display As" types based on parent.
+        $parentCategory = $this->CategoryModel->getID($this->Category->ParentCategoryID);
+        if (val('DisplayAs', $parentCategory) === 'Flat') {
+            unset($displayAsOptions['Heading']);
+        }
 
         // Set up head
         $this->addJsFile('jquery.alphanumeric.js');
@@ -640,6 +654,7 @@ class VanillaSettingsController extends Gdn_Controller {
         }
 
         // Render default view
+        $this->setData('DisplayAsOptions', $displayAsOptions);
         $this->render();
     }
 

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -629,7 +629,7 @@ class VanillaSettingsController extends Gdn_Controller {
             $this->Form->setFormValue('AllowFileUploads', forceBool($this->Form->getFormValue('AllowFileUploads'), '0', '1', '0'));
 
             if ($parentDisplay === 'Flat' && $this->Form->getFormValue('DisplayAs') === 'Heading') {
-                $this->Form->addError('Cannot display as heading when parent is displayed as flat categories.', 'DisplayAs');
+                $this->Form->addError('Cannot display as a heading when your parent category is displayed flat.', 'DisplayAs');
             }
 
             if ($this->Form->save()) {

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -629,7 +629,7 @@ class VanillaSettingsController extends Gdn_Controller {
             $this->Form->setFormValue('AllowFileUploads', forceBool($this->Form->getFormValue('AllowFileUploads'), '0', '1', '0'));
 
             if ($parentDisplay === 'Flat' && $this->Form->getFormValue('DisplayAs') === 'Heading') {
-                $this->Form->addError('Cannot display as heading when parent is flat', 'DisplayAs');
+                $this->Form->addError('Cannot display as heading when parent is displayed as flat categories.', 'DisplayAs');
             }
 
             if ($this->Form->save()) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -641,8 +641,52 @@ class CategoryModel extends Gdn_Model {
     public function getChildTree($id, $depth = 3, $permission = 'PermsDiscussionsView') {
         $category = $this->getOne($id);
 
-        return $this->collection->getTree((int)val('CategoryID', $category), $depth, $permission);
+        $tree = $this->collection->getTree((int)val('CategoryID', $category), $depth, $permission);
+        self::filterChildren($tree);
+        return $tree;
     }
+
+    /**
+     * @param int|string $id The parent category ID or slug.
+     * @param int|bool $offset
+     * @param int|bool $limit
+     * @return array
+     */
+    public function getTreeAsFlat($id, $offset = null, $limit = null) {
+        $categoryTree = $this->getWhere(
+            ['ParentCategoryID' => $id],
+            'DateInserted',
+            'desc',
+            $limit,
+            $offset
+        )->resultArray();
+        self::calculateData($categoryTree);
+        self::joinUserData($categoryTree);
+
+        // We don't have children, but trees are expected to have this key.
+        foreach ($categoryTree as &$category) {
+            $category['Children'] = [];
+        }
+
+        return $categoryTree;
+    }
+
+    /**
+     * Recursively remove children from categories configured to display as "Categories" or "Flat".
+     *
+     * @param array $categories
+     * @param string $childField
+     */
+    public static function filterChildren(&$categories, $childField = 'Children') {
+        foreach ($categories as &$category) {
+            $children = &$category[$childField];
+            if (in_array($category['DisplayAs'], ['Categories', 'Flat'])) {
+                    $children = [];
+                } elseif (!empty($children)) {
+                    static::filterChildren($children);
+                }
+         }
+      }
 
     /**
      * Filter a category tree to only the followed categories.
@@ -1496,8 +1540,13 @@ class CategoryModel extends Gdn_Model {
         if ($parent === null) {
             return [];
         }
-        $categories = self::instance()->collection->getTree($parent['CategoryID'], 10, '');
-        $categories = self::instance()->flattenTree($categories);
+
+        if (val('DisplayAs', $parent) === 'Flat') {
+            $categories = self::instance()->getTreeAsFlat($parent['CategoryID']);
+        } else {
+            $categories = self::instance()->collection->getTree($parent['CategoryID'], 10, '');
+            $categories = self::instance()->flattenTree($categories);
+        }
 
         if ($includeParent) {
             $parent['Depth'] = 1;

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -654,7 +654,10 @@ class CategoryModel extends Gdn_Model {
      */
     public function getTreeAsFlat($id, $offset = null, $limit = null) {
         $categoryTree = $this->getWhere(
-            ['ParentCategoryID' => $id],
+            [
+                'DisplayAs <>' => 'Heading',
+                'ParentCategoryID' => $id
+            ],
             'DateInserted',
             'desc',
             $limit,

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -666,8 +666,11 @@ class CategoryModel extends Gdn_Model {
         self::calculateData($categoryTree);
         self::joinUserData($categoryTree);
 
-        // We don't have children, but trees are expected to have this key.
         foreach ($categoryTree as &$category) {
+            // Fix the depth to be relative, not global.
+            $category['Depth'] = 1;
+
+            // We don't have children, but trees are expected to have this key.
             $category['Children'] = [];
         }
 

--- a/applications/vanilla/modules/class.categoriesmodule.php
+++ b/applications/vanilla/modules/class.categoriesmodule.php
@@ -40,7 +40,9 @@ class CategoriesModule extends Gdn_Module {
             return;
         }
 
-        $Categories = CategoryModel::categories();
+        $Categories = CategoryModel::makeTree(CategoryModel::categories());
+        CategoryModel::filterChildren($Categories);
+        $Categories = CategoryModel::flattenTree($Categories);
         $Categories2 = $Categories;
 
         // Filter out the categories we aren't watching.

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -49,7 +49,7 @@ $Construct->PrimaryKey('CategoryID')
     ->column('PermissionCategoryID', 'int', '-1')// default to root.
     ->column('PointsCategoryID', 'int', '0')// default to global.
     ->column('HideAllDiscussions', 'tinyint(1)', '0')
-    ->column('DisplayAs', array('Categories', 'Discussions', 'Heading', 'Default'), 'Default')
+    ->column('DisplayAs', array('Categories', 'Discussions', 'Flat', 'Heading', 'Default'), 'Default')
     ->column('InsertUserID', 'int', false, 'key')
     ->column('UpdateUserID', 'int', true)
     ->column('DateInserted', 'datetime')

--- a/applications/vanilla/views/categories/flat_all.php
+++ b/applications/vanilla/views/categories/flat_all.php
@@ -94,3 +94,6 @@ if ($ChildCategories != '')
 echo $CatList;
 ?>
 </ul>
+<div class="PageControls Bottom">
+    <?php PagerModule::write(); ?>
+</div>

--- a/applications/vanilla/views/categories/flat_all.php
+++ b/applications/vanilla/views/categories/flat_all.php
@@ -1,0 +1,96 @@
+<?php if (!defined('APPLICATION')) exit();
+if (!function_exists('GetOptions'))
+    include $this->fetchViewLocation('helper_functions', 'categories');
+
+echo '<h1 class="H HomepageTitle">'.$this->data('Title').'</h1>';
+if ($Description = $this->Description()) {
+    echo wrap($Description, 'div', array('class' => 'P PageDescription'));
+}
+$this->fireEvent('AfterPageTitle');
+
+$CatList = '';
+$DoHeadings = c('Vanilla.Categories.DoHeadings');
+$MaxDisplayDepth = c('Vanilla.Categories.MaxDisplayDepth') + $this->data('Category.Depth', 0);
+$ChildCategories = '';
+
+$CategoryTree = $this->data('CategoryTree');
+$Categories = CategoryModel::flattenTree($CategoryTree);
+$this->EventArguments['NumRows'] = $Categories;
+
+echo '<ul class="DataList CategoryList'.($DoHeadings ? ' CategoryListWithHeadings' : '').'">';
+foreach ($Categories as $CategoryRow) {
+    $Category = (object)$CategoryRow;
+
+    $this->EventArguments['CatList'] = &$CatList;
+    $this->EventArguments['ChildCategories'] = &$ChildCategories;
+    $this->EventArguments['Category'] = &$Category;
+    $this->fireEvent('BeforeCategoryItem');
+    $CssClass = CssClass($CategoryRow);
+
+    $CategoryID = val('CategoryID', $Category);
+
+    if ($Category->CategoryID > 0) {
+        // If we are below the max depth, and there are some child categories
+        // in the $ChildCategories variable, do the replacement.
+        if ($Category->Depth < $MaxDisplayDepth && $ChildCategories != '') {
+            $CatList = str_replace('{ChildCategories}', '<span class="ChildCategories">'.Wrap(t('Child Categories:'), 'b').' '.$ChildCategories.'</span>', $CatList);
+            $ChildCategories = '';
+        }
+
+        if ($Category->Depth >= $MaxDisplayDepth && $MaxDisplayDepth > 0) {
+            if ($ChildCategories != '')
+                $ChildCategories .= ', ';
+            $ChildCategories .= anchor(Gdn_Format::text($Category->Name), CategoryUrl($Category));
+        } else if ($Category->DisplayAs === 'Heading') {
+            $CatList .= '<li id="Category_'.$CategoryID.'" class="CategoryHeading '.$CssClass.'">
+               <div class="ItemContent Category"><div class="Options">'.getOptions($Category, $this).'</div>'.Gdn_Format::text($Category->Name).'</div>
+            </li>';
+        } else {
+            $LastComment = UserBuilder($Category, 'Last');
+            $CatList .= '<li id="Category_'.$CategoryID.'" class="'.$CssClass.'">
+               <div class="ItemContent Category">'
+                .'<div class="Options">'
+                .getOptions($Category, $this)
+                .'</div>'
+                .CategoryPhoto($Category)
+                .'<div class="TitleWrap">'
+                .anchor(Gdn_Format::text($Category->Name), CategoryUrl($Category), 'Title')
+                .'</div>
+                  <div class="CategoryDescription">'
+                .$Category->Description
+                .'</div>
+                  <div class="Meta">
+                     <span class="MItem RSS">'.anchor(img('applications/dashboard/design/images/rss.gif', array('alt' => T('RSS Feed'))), '/categories/'.$Category->UrlCode.'/feed.rss', '', array('title' => T('RSS Feed'))).'</span>
+                     <span class="MItem DiscussionCount">'.
+                     sprintf(PluralTranslate($Category->CountDiscussions, '%s discussion html', '%s discussions html', t('%s discussion'), t('%s discussions')), BigPlural($Category->CountDiscussions, '%s discussion'))
+                     .'</span>
+                     <span class="MItem CommentCount">'.
+                     sprintf(PluralTranslate($Category->CountComments, '%s comment html', '%s comments html', t('%s comment'), t('%s comments')), BigPlural($Category->CountComments, '%s comment'))
+                     .'</span>';
+            if ($Category->LastTitle != '') {
+                $CatList .= '<span class="MItem LastDiscussionTitle">'.sprintf(
+                        t('Most recent: %1$s by %2$s'),
+                        anchor(Gdn_Format::text(sliceString($Category->LastTitle, 40)), $Category->LastUrl),
+                        userAnchor($LastComment)
+                    ).'</span>'
+                    .'<span class="MItem LastCommentDate">'.Gdn_Format::date($Category->LastDateInserted).'</span>';
+            }
+            // If this category is one level above the max display depth, and it
+            // has children, add a replacement string for them.
+            if ($MaxDisplayDepth > 0 && $Category->Depth == $MaxDisplayDepth - 1 && $Category->TreeRight - $Category->TreeLeft > 1)
+                $CatList .= '{ChildCategories}';
+
+            $CatList .= '</div>
+               </div>
+            </li>';
+        }
+    }
+}
+// If there are any remaining child categories that have been collected, do
+// the replacement one last time.
+if ($ChildCategories != '')
+    $CatList = str_replace('{ChildCategories}', '<span class="ChildCategories">'.Wrap(t('Child Categories:'), 'b').' '.$ChildCategories.'</span>', $CatList);
+
+echo $CatList;
+?>
+</ul>

--- a/applications/vanilla/views/categories/flat_all.php
+++ b/applications/vanilla/views/categories/flat_all.php
@@ -1,99 +1,34 @@
 <?php if (!defined('APPLICATION')) exit();
-if (!function_exists('GetOptions'))
-    include $this->fetchViewLocation('helper_functions', 'categories');
 
-echo '<h1 class="H HomepageTitle">'.$this->data('Title').'</h1>';
-if ($Description = $this->Description()) {
-    echo wrap($Description, 'div', array('class' => 'P PageDescription'));
-}
-$this->fireEvent('AfterPageTitle');
-
-$CatList = '';
-$DoHeadings = c('Vanilla.Categories.DoHeadings');
-$MaxDisplayDepth = c('Vanilla.Categories.MaxDisplayDepth') + $this->data('Category.Depth', 0);
-$ChildCategories = '';
-
-$CategoryTree = $this->data('CategoryTree');
-$Categories = CategoryModel::flattenTree($CategoryTree);
-$this->EventArguments['NumRows'] = $Categories;
-
-echo '<ul class="DataList CategoryList'.($DoHeadings ? ' CategoryListWithHeadings' : '').'">';
-foreach ($Categories as $CategoryRow) {
-    $Category = (object)$CategoryRow;
-
-    $this->EventArguments['CatList'] = &$CatList;
-    $this->EventArguments['ChildCategories'] = &$ChildCategories;
-    $this->EventArguments['Category'] = &$Category;
-    $this->fireEvent('BeforeCategoryItem');
-    $CssClass = CssClass($CategoryRow);
-
-    $CategoryID = val('CategoryID', $Category);
-
-    if ($Category->CategoryID > 0) {
-        // If we are below the max depth, and there are some child categories
-        // in the $ChildCategories variable, do the replacement.
-        if ($Category->Depth < $MaxDisplayDepth && $ChildCategories != '') {
-            $CatList = str_replace('{ChildCategories}', '<span class="ChildCategories">'.Wrap(t('Child Categories:'), 'b').' '.$ChildCategories.'</span>', $CatList);
-            $ChildCategories = '';
-        }
-
-        if ($Category->Depth >= $MaxDisplayDepth && $MaxDisplayDepth > 0) {
-            if ($ChildCategories != '')
-                $ChildCategories .= ', ';
-            $ChildCategories .= anchor(Gdn_Format::text($Category->Name), CategoryUrl($Category));
-        } else if ($Category->DisplayAs === 'Heading') {
-            $CatList .= '<li id="Category_'.$CategoryID.'" class="CategoryHeading '.$CssClass.'">
-               <div class="ItemContent Category"><div class="Options">'.getOptions($Category, $this).'</div>'.Gdn_Format::text($Category->Name).'</div>
-            </li>';
-        } else {
-            $LastComment = UserBuilder($Category, 'Last');
-            $CatList .= '<li id="Category_'.$CategoryID.'" class="'.$CssClass.'">
-               <div class="ItemContent Category">'
-                .'<div class="Options">'
-                .getOptions($Category, $this)
-                .'</div>'
-                .CategoryPhoto($Category)
-                .'<div class="TitleWrap">'
-                .anchor(Gdn_Format::text($Category->Name), CategoryUrl($Category), 'Title')
-                .'</div>
-                  <div class="CategoryDescription">'
-                .$Category->Description
-                .'</div>
-                  <div class="Meta">
-                     <span class="MItem RSS">'.anchor(img('applications/dashboard/design/images/rss.gif', array('alt' => T('RSS Feed'))), '/categories/'.$Category->UrlCode.'/feed.rss', '', array('title' => T('RSS Feed'))).'</span>
-                     <span class="MItem DiscussionCount">'.
-                     sprintf(PluralTranslate($Category->CountDiscussions, '%s discussion html', '%s discussions html', t('%s discussion'), t('%s discussions')), BigPlural($Category->CountDiscussions, '%s discussion'))
-                     .'</span>
-                     <span class="MItem CommentCount">'.
-                     sprintf(PluralTranslate($Category->CountComments, '%s comment html', '%s comments html', t('%s comment'), t('%s comments')), BigPlural($Category->CountComments, '%s comment'))
-                     .'</span>';
-            if ($Category->LastTitle != '') {
-                $CatList .= '<span class="MItem LastDiscussionTitle">'.sprintf(
-                        t('Most recent: %1$s by %2$s'),
-                        anchor(Gdn_Format::text(sliceString($Category->LastTitle, 40)), $Category->LastUrl),
-                        userAnchor($LastComment)
-                    ).'</span>'
-                    .'<span class="MItem LastCommentDate">'.Gdn_Format::date($Category->LastDateInserted).'</span>';
-            }
-            // If this category is one level above the max display depth, and it
-            // has children, add a replacement string for them.
-            if ($MaxDisplayDepth > 0 && $Category->Depth == $MaxDisplayDepth - 1 && $Category->TreeRight - $Category->TreeLeft > 1)
-                $CatList .= '{ChildCategories}';
-
-            $CatList .= '</div>
-               </div>
-            </li>';
-        }
+    if (!function_exists('GetOptions')) {
+        include $this->fetchViewLocation('helper_functions', 'categories');
     }
-}
-// If there are any remaining child categories that have been collected, do
-// the replacement one last time.
-if ($ChildCategories != '')
-    $CatList = str_replace('{ChildCategories}', '<span class="ChildCategories">'.Wrap(t('Child Categories:'), 'b').' '.$ChildCategories.'</span>', $CatList);
+?>
 
-echo $CatList;
+<h1 class="H HomepageTitle"><?php echo $this->data('Title'); ?></h1>
+
+<?php
+    if ($description = $this->Description()) {
+        echo wrap($description, 'div', array('class' => 'P PageDescription'));
+    }
+    $this->fireEvent('AfterPageTitle');
+
+    $categories = $this->data('CategoryTree');
+    $doHeadings = c('Vanilla.Categories.DoHeadings');
+    $this->EventArguments['NumRows'] = count($categories);
+?>
+
+<ul class="DataList CategoryList<?php echo $doHeadings ? ' CategoryListWithHeadings' : ''; ?>">
+<?php
+    foreach ($categories as $category) {
+        $this->EventArguments['Category'] = &$category;
+        $this->fireEvent('BeforeCategoryItem');
+
+        writeListItem($category);
+    }
 ?>
 </ul>
+
 <div class="PageControls Bottom">
     <?php PagerModule::write(); ?>
 </div>

--- a/applications/vanilla/views/categories/flat_table.php
+++ b/applications/vanilla/views/categories/flat_table.php
@@ -1,0 +1,27 @@
+<?php if (!defined('APPLICATION')) exit(); ?>
+    <h1 class="H HomepageTitle"><?php echo $this->data('Title'); ?></h1>
+    <div class="P PageDescription"><?php echo $this->Description(); ?></div>
+<?php
+$this->fireEvent('AfterDescription');
+$this->fireEvent('AfterPageTitle');
+$Categories = $this->data('CategoryTree');
+
+if (c('Vanilla.Categories.DoHeadings')) {
+    foreach ($Categories as $Category) {
+        ?>
+        <div id="CategoryGroup-<?php echo $Category['UrlCode']; ?>"
+             class="CategoryGroup <?php echo val('CssClass', $Category); ?>">
+            <h2 class="H"><?php echo htmlspecialchars($Category['Name']); ?></h2>
+            <?php
+            WriteCategoryTable($Category['Children'], 2);
+            ?>
+        </div>
+    <?php
+    }
+} else {
+    WriteCategoryTable($Categories, 1);
+}
+?>
+    <div class="PageControls Bottom">
+        <?php PagerModule::write($pagerOptions); ?>
+    </div>

--- a/applications/vanilla/views/categories/flat_table.php
+++ b/applications/vanilla/views/categories/flat_table.php
@@ -23,5 +23,5 @@ if (c('Vanilla.Categories.DoHeadings')) {
 }
 ?>
     <div class="PageControls Bottom">
-        <?php PagerModule::write($pagerOptions); ?>
+        <?php PagerModule::write(); ?>
     </div>

--- a/applications/vanilla/views/vanillasettings/addcategory.php
+++ b/applications/vanilla/views/vanillasettings/addcategory.php
@@ -62,7 +62,7 @@ echo $this->Form->errors();
         <li>
             <?php
             echo $this->Form->label('Display As', 'DisplayAs');
-            echo $this->Form->DropDown('DisplayAs', array('Default' => 'Default', 'Categories' => 'Categories', 'Discussions' => 'Discussions', 'Heading' => 'Heading'));
+            echo $this->Form->DropDown('DisplayAs', ['Default' => 'Default', 'Discussions' => 'Discussions', 'Categories' => 'Nested Categories', 'Flat' => 'Flat Categories', 'Heading' => 'Heading']);
             ?>
         </li>
         <li>

--- a/applications/vanilla/views/vanillasettings/editcategory.php
+++ b/applications/vanilla/views/vanillasettings/editcategory.php
@@ -56,7 +56,7 @@ echo $this->Form->errors();
     <li>
         <?php
         echo $this->Form->label('Display As', 'DisplayAs');
-        echo $this->Form->DropDown('DisplayAs', ['Default' => 'Default', 'Discussions' => 'Discussions', 'Categories' => 'Nested Categories', 'Flat' => 'Flat Categories', 'Heading' => 'Heading']);
+        echo $this->Form->DropDown('DisplayAs', $this->data('DisplayAsOptions'));
         ?>
     </li>
     <li>

--- a/applications/vanilla/views/vanillasettings/editcategory.php
+++ b/applications/vanilla/views/vanillasettings/editcategory.php
@@ -56,7 +56,7 @@ echo $this->Form->errors();
     <li>
         <?php
         echo $this->Form->label('Display As', 'DisplayAs');
-        echo $this->Form->DropDown('DisplayAs', array('Default' => 'Default', 'Categories' => 'Categories', 'Discussions' => 'Discussions', 'Heading' => 'Heading'));
+        echo $this->Form->DropDown('DisplayAs', ['Default' => 'Default', 'Discussions' => 'Discussions', 'Categories' => 'Nested Categories', 'Flat' => 'Flat Categories', 'Heading' => 'Heading']);
         ?>
     </li>
     <li>


### PR DESCRIPTION
Closes #4153 

- [x] Display as "Flat" shout show up in the add/edit category page.
- [x] When viewing a flat category headings should be filtered out.
- [x] You should not be allowed to choose a display as type of heading underneath a flat category. In the case where one sneaks in because of the above then that's when it gets filtered out.
- [x] The view should treat categories as depth 1. Right now they are adding Depth2, Depth-2 CSS classes if the category is at that global depth.