### PR TITLE
Update Facebook API to use versioned endpoint

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -32,6 +32,8 @@ $PluginInfo['Facebook'] = array(
  */
 class FacebookPlugin extends Gdn_Plugin {
 
+    const API_VERSION = '2.7';
+
     /** Authentication table key. */
     const ProviderKey = 'Facebook';
 
@@ -82,7 +84,7 @@ class FacebookPlugin extends Gdn_Plugin {
      */
     public function api($Path, $Post = false) {
         // Build the url.
-        $Url = 'https://graph.facebook.com/'.ltrim($Path, '/');
+        $Url = 'https://graph.facebook.com/v'.self::API_VERSION.'/'.ltrim($Path, '/');
         $AccessToken = $this->accessToken();
         if (!$AccessToken) {
             throw new Gdn_UserException("You don't have a valid Facebook connection.");


### PR DESCRIPTION
As of v2.1, unversioned Graph API endpoints are [deprecated](https://developers.facebook.com/docs/apps/changelog#v2_1_deprecations).  This update alters API endpoints to use versioned URLs and implements the current API version.

Please note: After verifying the functionality, please visit the [API Upgrade Tool](https://developers.facebook.com/tools/api_versioning/) to verify no upgrade notices were generated.

Closes #4129