### PR TITLE
Use category URL for category RSS link

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -224,7 +224,7 @@ class CategoriesController extends VanillaController {
             $this->Menu->highlightRoute('/discussions');
             if ($this->Head) {
                 $this->addJsFile('discussions.js');
-                $this->Head->AddRss($this->SelfUrl.'/feed.rss', $this->Head->title());
+                $this->Head->addRss(categoryUrl($Category) . '/feed.rss', $this->Head->title());
             }
 
             // Set CategoryID


### PR DESCRIPTION
Use `categoryUrl()` instead of `$this->SelfUrl` for the category RSS link to include the domain and avoid having an RSS link with the page number in it. This is consistent with the `addRss()` usage on the `/discussions` index.