### PR TITLE
Fix data capture when logging a discussion edit

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1936,11 +1936,11 @@ class DiscussionModel extends VanillaModel {
                         Gdn::cache()->remove($CacheKey);
                     }
 
+                    // The primary key was removed from the form fields, but we need it for logging.
+                    LogModel::logChange('Edit', 'Discussion', array_merge($Fields, ['DiscussionID' => $DiscussionID]));
+
                     self::serializeRow($Fields);
                     $this->SQL->put($this->Name, $Fields, [$this->PrimaryKey => $DiscussionID]);
-
-                    setValue('DiscussionID', $Fields, $DiscussionID);
-                    LogModel::logChange('Edit', 'Discussion', (array)$Fields, $Stored);
 
                     if (val('CategoryID', $Stored) != val('CategoryID', $Fields)) {
                         $StoredCategoryID = val('CategoryID', $Stored);


### PR DESCRIPTION
When discussion edits are logged, they are attempting to pass along the original data as an object (`$Stored`), when the formatter used by the log view is expecting an array.

This update alters the logging method for discussion edits to match the [existing method for comment edits](https://github.com/vanilla/vanilla/blob/417f98c55869e86068535ad249e808e46b680093/applications/vanilla/models/class.commentmodel.php#L871).

Closes #3945