### PR TITLE
Improve approval notice compatibility with some themes

### DIFF
--- a/applications/vanilla/js/post.js
+++ b/applications/vanilla/js/post.js
@@ -149,7 +149,16 @@ jQuery(document).ready(function($) {
                         // Redirect to the new discussion
                         document.location = json.RedirectUrl;
                     } else {
-                        $('#Content,.page-content,.site-content').html(json.Data);
+                        var contentContainer = $("#Content");
+
+                        if (contentContainer.length === 1) {
+                            contentContainer.html(json.Data);
+                        } else {
+                            // Hack to emulate a content container.
+                            contentContainer = $(document.createElement("div"));
+                            contentContainer.html(json.Data);
+                            $(frm).replaceWith(contentContainer);
+                        }
                     }
                 }
                 gdn.inform(json);

--- a/applications/vanilla/js/post.js
+++ b/applications/vanilla/js/post.js
@@ -149,7 +149,7 @@ jQuery(document).ready(function($) {
                         // Redirect to the new discussion
                         document.location = json.RedirectUrl;
                     } else {
-                        $('#Content').html(json.Data);
+                        $('#Content,.page-content,.site-content').html(json.Data);
                     }
                 }
                 gdn.inform(json);


### PR DESCRIPTION
`post.js` requires there be an element with an ID of `#Content` to display some content from the server, like the "Your post is pending approval" message.  The issue is that some themes do not have this element.  Some themes have instead implemented tagging their content elements with classes like `site-content`.  This update adds support for these additional content element identifiers in `post.js`.

Closes #4098