### PR TITLE
Allow query strings to pass through simple routes

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -806,7 +806,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         if (!empty($matchRoute)) {
             $dest = $matchRoute['FinalDestination'];
 
-            if (strpos($dest, '\\?') === false) {
+            if (strpos($dest, '?') === false) {
                 // The rewrite rule doesn't include a query string so keep the current one intact.
                 $request->path($dest);
             } else {

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -804,7 +804,15 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
         // We have a route. Take action.
         if (!empty($matchRoute)) {
-            $request->pathAndQuery($matchRoute['FinalDestination']);
+            $dest = $matchRoute['FinalDestination'];
+
+            if (strpos($dest, '/?') === false) {
+                // The rewrite rule doesn't include a query string so keep the current one intact.
+                $request->path($dest);
+            } else {
+                // The rewrite rule has a query string so rewrite that too.
+                $request->pathAndQuery($dest);
+            }
 
             switch ($matchRoute['Type']) {
                 case 'Internal':

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -806,7 +806,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         if (!empty($matchRoute)) {
             $dest = $matchRoute['FinalDestination'];
 
-            if (strpos($dest, '/?') === false) {
+            if (strpos($dest, '\\?') === false) {
                 // The rewrite rule doesn't include a query string so keep the current one intact.
                 $request->path($dest);
             } else {

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -732,7 +732,7 @@ class Gdn_Request {
      */
     public function path($path = null) {
         if (is_string($path)) {
-            $result = $this->_parsedRequestElement('Path', $path);
+            $result = $this->_parsedRequestElement('Path', ltrim($path, '/'));
         } else {
             $result = $this->_parsedRequestElement('Path');
             if ($path === true) {


### PR DESCRIPTION
When a route’s destination does not include a querystring then the requests original querystring will pass through a rewrite rule.

Example:

```
/test -> /discussions
```

Going to /test?page=p2 will rewrite to /discussions?page=p2

However consider this example:

```
/page1 -> /discussions?page=p1
```

Going to /page1?page=p2 will rewrite to /discussions?page=p1


There is also a change in Gdn_Request to make Gdn_Request->path(/foo) automatically strip out the trailing slash. This mirrors the functionality of Gdn_Request->pathAndQuery() and really seems like the correct behavior. However, since this is low-level functionality it does carry some risk and should be carefully reviewed.