### PR TITLE
Add ability to override public field rendering in Profile Extender

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -427,21 +427,9 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
             }
 
             // Display all non-hidden fields
+            require_once Gdn::controller()->fetchViewLocation('helper_functions', '', 'plugins/ProfileExtender');
             $ProfileFields = array_reverse($ProfileFields);
-            foreach ($ProfileFields as $Name => $Value) {
-                // Skip empty and hidden fields.
-                if (!$Value || !val('OnProfile', $AllFields[$Name])) {
-                    continue;
-                }
-
-                // Non-magic fields must be plain text, but we'll auto-link
-                if (!in_array($Name, $this->MagicLabels)) {
-                    $Value = Gdn_Format::links(Gdn_Format::text($Value));
-                }
-
-                echo ' <dt class="ProfileExtend Profile'.Gdn_Format::alphaNumeric($Name).'">'.Gdn_Format::text($AllFields[$Name]['Label']).'</dt> ';
-                echo ' <dd class="ProfileExtend Profile'.Gdn_Format::alphaNumeric($Name).'">'.Gdn_Format::htmlFilter($Value).'</dd> ';
-            }
+            extendedProfileFields($ProfileFields, $AllFields, $this->MagicLabels);
         } catch (Exception $ex) {
             // No errors
         }

--- a/plugins/ProfileExtender/views/helper_functions.php
+++ b/plugins/ProfileExtender/views/helper_functions.php
@@ -1,0 +1,31 @@
+<?php
+
+if (!function_exists('extendedProfileFields')) {
+    /**
+     * Output markup for extended profile fields.
+     *
+     * @param array $profileFields Formatted profile fields.
+     * @param array $allFields Extended profile field data.
+     * @param array $magicLabels "Magic" labels configured on the Profile Extender plug-in class.
+     */
+    function extendedProfileFields($profileFields, $allFields, $magicLabels = []) {
+        foreach ($profileFields as $name => $value) {
+            // Skip empty and hidden fields.
+            if (!$value || !val('OnProfile', $allFields[$name])) {
+                continue;
+            }
+
+            // Non-magic fields must be plain text, but we'll auto-link
+            if (!in_array($name, $magicLabels)) {
+                $value = Gdn_Format::links(Gdn_Format::text($value));
+            }
+
+            $class = 'Profile'.Gdn_Format::alphaNumeric($name);
+            $label = Gdn_Format::text($allFields[$name]['Label']);
+            $filteredVal = Gdn_Format::htmlFilter($value);
+
+            echo " <dt class=\"ProfileExtend {$class}\">{$label}</dt> ";
+            echo " <dd class=\"ProfileExtend {$class}\">{$filteredVal}</dd> ";
+        }
+    }
+}


### PR DESCRIPTION
This update moves rendering of Profile Extender fields on the profile view into a helper function, which can then be overridden.

Closes #4178