### PR TITLE
Let class messages add() accept a "Subject" parameter

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -54,8 +54,9 @@ class MessagesController extends ConversationsController {
      * @access public
      *
      * @param string $Recipient Username of the recipient.
+     * @param string $Subject Subject of the message.
      */
-    public function add($Recipient = '') {
+    public function add($Recipient = '', $Subject = '') {
         $this->permission('Conversations.Conversations.Add');
         $this->Form->setModel($this->ConversationModel);
 
@@ -112,6 +113,9 @@ class MessagesController extends ConversationsController {
         } else {
             if ($Recipient != '') {
                 $this->Form->setValue('To', $Recipient);
+            }
+            if ($Subject != '') {
+                $this->Form->setValue('Subject', $Subject);
             }
         }
         if ($Target = Gdn::request()->get('Target')) {


### PR DESCRIPTION
By now only the recipient can be "pre-filled" by adding its name to "/messages/add/recipient". This enhancement allows using "/messages/add/recipient/subject of the message"