### PR TITLE
Remove Gdn_Request::path() from smarty's secure_dir variable.

### DIFF
--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -114,7 +114,6 @@ class Gdn_Smarty {
         $security->php_handling = Smarty::PHP_REMOVE;
         $security->allow_constants = false;
         $security->allow_super_globals = false;
-        $security->secure_dir = [$Path];
         $security->streams = null;
 
         $security->setPhpFunctions(array_merge($security->php_functions, [


### PR DESCRIPTION
Sooooo.... Setting this make no sense since path never match directories on disk.

Also, `/profile/name-ending-with-a-dot.` cause an infinite loop because the path is rewritten to `/profile/name-ending-with-a-dot./` and is then evaluated by Smarty's `_realpath()` function: https://github.com/smarty-php/smarty/blob/v3.1.29/libs/Smarty.class.php#L1184

Fun fun fun :)

Please test this carefully! (I tested the change with multiple client themes + Bootstrap 3 and more)