### PR TITLE
Fix category display depth when configured to display headings

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -385,11 +385,18 @@ class CategoriesController extends VanillaController {
                 return $this->CategoryModel->GetFull()->resultArray();
             };
         }
+
+        // Compensate for categories displaying as headings by increasing the display depth by one.
+        $maxDisplayDepth = CategoryModel::instance()->getMaxDisplayDepth() ?: 10;
+        if (c('Vanilla.Categories.DoHeadings')) {
+            $maxDisplayDepth++;
+        }
+
         $categoryTree = $this->CategoryModel
             ->setJoinUserCategory(true)
             ->getChildTree(
                 $Category ?: null,
-                $this->CategoryModel->getMaxDisplayDepth() ?: 10
+                $maxDisplayDepth
             );
         if ($this->CategoryModel->Watching) {
             $categoryTree = $this->CategoryModel->filterFollowing($categoryTree);


### PR DESCRIPTION
When categories are configured to display root categories as headings, the headings are taken into account for the category display depth.  This does not seem to be how things were prior to recent category component refactors.

### Recreate the issue
1. Create a category structure at least three levels deep (not counting the root).
2. Configure "Place nested categories in a comma-delimited list when they are" to "more than 1 level deep".
3. Enable "Display root categories as headings".
4. Set "Categories Layout" to "Table Layout".
5. Visit `/categories` on your forum.  Your third level is not be displayed.


### Fix
This update increments the display depth by one in `CategoriesController::all` if `Vanilla.Categories.DoHeadings` is enabled.