### PR TITLE
Allow overriding controller view lookups in fetchViewLocation()

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -734,12 +734,16 @@ class Gdn_Controller extends Gdn_Pluggable {
      * @param string $View The name of the view to fetch. If not specified, it will use the value
      * of $this->View. If $this->View is not specified, it will use the value
      * of $this->RequestMethod (which is defined by the dispatcher class).
-     * @param string $ControllerName The name of the controller that owns the view if it is not $this.
+     * @param bool|string $ControllerName The name of the controller that owns the view if it is not $this.
      *  - If the controller name is FALSE then the name of the current controller will be used.
      *  - If the controller name is an empty string then the view will be looked for in the base views folder.
-     * @param string $ApplicationFolder The name of the application folder that contains the requested controller if it is not $this->ApplicationFolder.
+     * @param bool|string $ApplicationFolder The name of the application folder that contains the requested controller if it is not $this->ApplicationFolder.
+     * @param bool $ThrowError Whether to throw an error.
+     * @param bool $useController Whether to attach a controller to the view location. Some plugins have views that should not be looked up in a controller's view directory.
+     * @return string The resolved location of the view.
+     * @throws Exception
      */
-    public function fetchViewLocation($View = '', $ControllerName = false, $ApplicationFolder = false, $ThrowError = true) {
+    public function fetchViewLocation($View = '', $ControllerName = false, $ApplicationFolder = false, $ThrowError = true, $useController = true) {
         // Accept an explicitly defined view, or look to the method that was called on this controller
         if ($View == '') {
             $View = $this->View;
@@ -799,12 +803,14 @@ class Gdn_Controller extends Gdn_Pluggable {
             // Define the subpath for the view.
             // The $ControllerName used to default to '' instead of FALSE.
             // This extra search is added for backwards-compatibility.
-            if (strlen($ControllerName) > 0) {
+            if (strlen($ControllerName) > 0 && $useController) {
                 $SubPaths[] = "views/$ControllerName/$View";
             } else {
                 $SubPaths[] = "views/$View";
 
-                $SubPaths[] = 'views/'.stringEndsWith($this->ControllerName, 'Controller', true, true)."/$View";
+                if ($useController) {
+                    $SubPaths[] = 'views/'.stringEndsWith($this->ControllerName, 'Controller', true, true)."/$View";
+                }
             }
 
             // Views come from one of four places:

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -427,7 +427,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
             }
 
             // Display all non-hidden fields
-            require_once Gdn::controller()->fetchViewLocation('helper_functions', '', 'plugins/ProfileExtender');
+            require_once Gdn::controller()->fetchViewLocation('helper_functions', '', 'plugins/ProfileExtender', true, false);
             $ProfileFields = array_reverse($ProfileFields);
             extendedProfileFields($ProfileFields, $AllFields, $this->MagicLabels);
         } catch (Exception $ex) {


### PR DESCRIPTION
This fixes an issue where if a plugin has a view (i.e., `helper_functions.php`) and a theme overrides the view with the same name (i.e., `profile/helper_functions`), `fetchViewLocation()` will return the controller-based view when we are in a page with that controller.

This specifically fixes the above issue with in the ProfileExtender by explicitly opting out of any controller view look-ups.

Reproduce this error by: 
1. Overriding `profile/helper_functions` in a theme or plugin.
2. Enabling ProfileExtender.
3. Navigating to any profile page.

Closes https://github.com/vanilla/vanilla/issues/4247
