### PR TITLE
Fix table error on /utility/structure scans

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -18,6 +18,8 @@ if (!isset($Explicit)) {
     $Explicit = false;
 }
 
+$captureOnly = isset($Structure) && val('CaptureOnly', $Structure);
+
 $Database = Gdn::database();
 $SQL = $Database->sql();
 $Construct = $Database->structure();
@@ -767,7 +769,7 @@ $Construct
     ->set($Explicit, $Drop);
 
 // If the AllIPAddresses column exists, attempt to migrate legacy IP data to the UserIP table.
-if ($AllIPAddressesExists) {
+if (!$captureOnly && $AllIPAddressesExists) {
     $limit = 10000;
     $resetBatch = 100;
 


### PR DESCRIPTION
The UserIP table migration scan is currently setup to run whenever Vanilla's structure routine is invoked.  This is a problem, because the routine may be invoked when we're just doing a capture-only scan (e.g. /utility/structure) and the tables aren't available when they're expected to be.

This update adds a check for determining if we're in capture-only mode, using the `$Structure` variable provided by `UtilityModel::runStructure`, and avoids attempting to migrate IP addresses under such a condition.

Closes #4240