### PR TITLE
Avoid including root category in /categories/apiv1list

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -550,6 +550,12 @@ class CategoriesController extends VanillaController {
      */
     public function apiV1List() {
         $categories = CategoryModel::categories();
+
+        // Purge the root category, if present.
+        if (val(-1, $categories)) {
+            unset($categories[-1]);
+        }
+
         $this->setData('Categories', $categories);
         $this->render('blank', 'utility', 'dashboard');
     }


### PR DESCRIPTION
The root category is included in the /categories/apiv1list endpoint.

This update checks for the existence of the root category before the data is delivered and purges it if present.