### PR TITLE
Fix RoleModel::getByUserID() should not be called statically.

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -757,12 +757,12 @@ class RoleModel extends Gdn_Model {
      * @param string $field optionally the field name from the role table to return.
      * @return array|null|void
      */
-    public static function getPublicUserRoles($userID, $field = "Name") {
+    public function getPublicUserRoles($userID, $field = "Name") {
         if (!$userID) {
             return;
         }
 
-        $unfilteredRoles = self::getByUserID($userID)->resultArray();
+        $unfilteredRoles = $this->getByUserID($userID)->resultArray();
 
         // Hide personal info roles
         $unformattedRoles = array();

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -380,7 +380,8 @@ class VanillaHooks implements Gdn_IPlugin {
         // Add user's viewable roles to gdn.meta if user is logged in.
         if (!$sender->addDefinition('Roles')) {
             if (Gdn::session()->isValid()) {
-                Gdn::controller()->addDefinition("Roles", RoleModel::getPublicUserRoles(Gdn::session()->UserID, "Name"));
+                $roleModel = new RoleModel();
+                Gdn::controller()->addDefinition("Roles", $roleModel->getPublicUserRoles(Gdn::session()->UserID, "Name"));
             }
         }
     }


### PR DESCRIPTION
Change the calling method "getPublicUserRoles" to a non static method and update every call to it.

Fixes https://github.com/vanilla/vanilla/issues/4252