### PR TITLE
Wrap discussion options in url()

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -193,7 +193,7 @@ if (!function_exists('discussionOptionsToDropdown')):
 
         if (!empty($options)) {
             foreach ($options as $option) {
-                $dropdown->addLink(val('Label', $option), val('Url', $option), slugify(val('Label', $option)), val('Class', $option));
+                $dropdown->addLink(val('Label', $option), url(val('Url', $option)), slugify(val('Label', $option)), val('Class', $option));
             }
         }
 


### PR DESCRIPTION
Wrap discussion options in url function in discussion option adapter.
Fixes issue where urls to some discussion options are unexpected.

Closes https://github.com/vanilla/vanilla/issues/4253