### PR TITLE
Let Location and Title be editted from the dashboard

### DIFF
--- a/applications/dashboard/views/user/add.php
+++ b/applications/dashboard/views/user/add.php
@@ -35,11 +35,30 @@ echo $this->Form->errors();
             echo $this->Form->textBox('Email');
             ?>
         </li>
+
         <li>
             <?php
             echo $this->Form->checkBox('ShowEmail', t('Email visible to other users'));
             ?>
         </li>
+
+        <?php if (c('Garden.Profile.Locations', false)): ?>
+            <li class="User-Location">
+                <?php
+                echo $this->Form->label('Location', 'Location');
+                echo $this->Form->textBox('Location');
+                ?>
+            </li>
+        <?php endif; ?>
+
+        <?php if (c('Garden.Profile.Titles', false)): ?>
+            <li class="User-Title">
+                <?php
+                echo $this->Form->label('Title', 'Title');
+                echo $this->Form->textBox('Title');
+                ?>
+            </li>
+        <?php endif; ?>
         <?php
         $this->fireEvent('CustomUserFields')
         ?>

--- a/applications/dashboard/views/user/edit.php
+++ b/applications/dashboard/views/user/edit.php
@@ -35,6 +35,7 @@ if ($this->data('AllowEditing')) { ?>
             echo $this->Form->textBox('Email', $EmailAttributes);
             ?>
         </li>
+
         <?php if ($this->data('_CanConfirmEmail')): ?>
             <li class="User-ConfirmEmail">
                 <?php
@@ -61,6 +62,25 @@ if ($this->data('AllowEditing')) { ?>
                 )?></div>
             <?php endif; ?>
         </li>
+
+        <?php if (c('Garden.Profile.Locations', false)): ?>
+            <li class="User-Location">
+                <?php
+                echo $this->Form->label('Location', 'Location');
+                echo $this->Form->textBox('Location');
+                ?>
+            </li>
+        <?php endif; ?>
+
+        <?php if (c('Garden.Profile.Titles', false)): ?>
+            <li class="User-Title">
+                <?php
+                echo $this->Form->label('Title', 'Title');
+                echo $this->Form->textBox('Title');
+                ?>
+            </li>
+        <?php endif; ?>
+
         <?php
         $this->fireEvent('CustomUserFields')
         ?>


### PR DESCRIPTION
Users' Location and Title fields can only be editted from their profile. This allows these fields to be editted in the dashboard.

Closes https://github.com/vanilla/vanilla/issues/4256