### PR TITLE
Add captcha script in form markup rather than head

### DIFF
--- a/plugins/recaptcha/class.recaptcha.plugin.php
+++ b/plugins/recaptcha/class.recaptcha.plugin.php
@@ -219,7 +219,7 @@ class RecaptchaPlugin extends Gdn_Plugin {
             $language = (in_array(Gdn::locale()->Locale, $whitelist)) ? Gdn::locale()->Locale : false;
         }
 
-        Gdn::controller()->Head->addScript('https://www.google.com/recaptcha/api.js?hl=' . $language);
+        $scriptSrc = 'https://www.google.com/recaptcha/api.js?hl='.$language;
 
         $attributes = array('class' => 'g-recaptcha', 'data-sitekey' => $this->getPublicKey(), 'data-theme' => c('Recaptcha.Theme', 'light'));
 
@@ -228,6 +228,7 @@ class RecaptchaPlugin extends Gdn_Plugin {
         $this->fireEvent('BeforeCaptcha');
 
         echo '<div '. attribute($attributes) . '></div>';
+        echo '<script src="'.$scriptSrc.'"></script>';
     }
 
     /**


### PR DESCRIPTION
By adding the captcha script in the form, we can use captcha in popups.

Closes https://github.com/vanilla/vanilla/issues/4265