### PR TITLE
Use reset to grab first val in SqlDriver::where

### DIFF
--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1991,7 +1991,7 @@ abstract class Gdn_SQLDriver {
         foreach ($Field as $SubField => $SubValue) {
             if (is_array($SubValue)) {
                 if (count($SubValue) == 1) {
-                    list($firstVal) = $SubValue;
+                    $firstVal = reset($SubValue);
                     $this->where($SubField, $firstVal);
                 } else {
                     $this->whereIn($SubField, $SubValue);


### PR DESCRIPTION
`SqlDriver::where` current uses `list` to [grab the first value](https://github.com/vanilla/vanilla/blob/be5c4099669d098707640b8944d947a2e3b7c26c/library/database/class.sqldriver.php#L1994) for field criteria.  If there is no zero index, [list fails because it assumes a numerically-indexed array, complete with a zero index](http://php.net/list).

This update swaps out the call to `list` with `replace`, which [rewinds the internal pointer for the array and returns its first value](http://php.net/reset).