### PR TITLE
Fix category selector for nested categories in /post

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -124,8 +124,13 @@ class PostController extends VanillaController {
         if ($Category) {
             $this->Category = (object)$Category;
             $this->setData('Category', $Category);
-            $this->ShowCategorySelector = false;
             $this->Form->addHidden('CategoryID', $this->Category->CategoryID);
+            if (val('DisplayAs', $this->Category) == 'Discussions') {
+                $this->ShowCategorySelector = false;
+            } else {
+                // Get all our subcategories to add to the category if we are in a Header or Categories category.
+                $this->Context = CategoryModel::getSubtree($this->CategoryID);
+            }
         } else {
             $this->CategoryID = 0;
             $this->Category = null;

--- a/applications/vanilla/views/post/discussion.php
+++ b/applications/vanilla/views/post/discussion.php
@@ -20,10 +20,14 @@ if (!$CancelUrl) {
     $this->fireEvent('BeforeFormInputs');
 
     if ($this->ShowCategorySelector === true) {
+        $options = ['Value' => val('CategoryID', $this->Category), 'IncludeNull' => true];
+        if ($this->Context) {
+            $options['Context'] = $this->Context;
+        }
         echo '<div class="P">';
         echo '<div class="Category">';
         echo $this->Form->label('Category', 'CategoryID'), ' ';
-        echo $this->Form->categoryDropDown('CategoryID', array('Value' => val('CategoryID', $this->Category), 'IncludeNull' => true));
+        echo $this->Form->categoryDropDown('CategoryID', $options);
         echo '</div>';
         echo '</div>';
     }

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -296,6 +296,12 @@ class Gdn_Form extends Gdn_Pluggable {
         $Value = arrayValueI('Value', $Options); // The selected category id
         $CategoryData = val('CategoryData', $Options);
 
+        if (!$CategoryData && val('Context', $Options)) {
+            $CategoryData = val('Context', $Options);
+        } elseif ($CategoryData && val('Context', $Options)) {
+            $CategoryData = array_intersect_key($CategoryData, val('Context', $Options));
+        }
+
         // Sanity check
         if (is_object($CategoryData)) {
             $CategoryData = (array)$CategoryData;
@@ -376,7 +382,7 @@ class Gdn_Form extends Gdn_Pluggable {
         if (is_array($SafeCategoryData)) {
             foreach ($SafeCategoryData as $CategoryID => $Category) {
                 $Depth = val('Depth', $Category, 0);
-                $Disabled = (($Depth == 1 && $DoHeadings) || !$Category['AllowDiscussions']);
+                $Disabled = (($Depth == 1 && $DoHeadings) || !$Category['AllowDiscussions'] || val('DisplayAs', $Category) != 'Discussions');
                 $Selected = in_array($CategoryID, $Value) && $HasValue;
                 if ($ForceCleanSelection && $Depth > 1) {
                     $Selected = true;

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -283,6 +283,10 @@ class Gdn_Form extends Gdn_Pluggable {
      *   Value         The ID of the category that    FALSE
      *                 is selected.
      *   IncludeNull   Include a blank row?           TRUE
+     *   Context       A set of categories to         []
+     *                 interset with the CategoryData
+     *                 that is relative to the category
+     *                 we're in.
      *   CategoryData  Custom set of categories to    CategoryModel::Categories()
      *                 display.
      *
@@ -339,7 +343,7 @@ class Gdn_Form extends Gdn_Pluggable {
             $SafeCategoryData[$CategoryID] = $Category;
         }
 
-        unset($Options['Filter'], $Options['PermFilter']);
+        unset($Options['Filter'], $Options['PermFilter'], $Options['Context'], $Options['CategoryData']);
 
         // Opening select tag
         $Return = '<select';


### PR DESCRIPTION
Show the categories in the category dropdown that are children of the category in the url.
Show the category selector in any category that is not a DisplayAs: Discussion category.

Closes https://github.com/vanilla/vanilla/issues/4275