### PR TITLE
Profile Extender: Show native fields on profile

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -396,6 +396,14 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
             // Get the custom fields
             $ProfileFields = Gdn::userModel()->getMeta($Sender->User->UserID, 'Profile.%', 'Profile.');
 
+            // Get allowed GDN_User fields.
+            $Blacklist = array_combine($this->ReservedNames, $this->ReservedNames);
+            $NativeFields = array_diff_key((array)$Sender->User, $Blacklist);
+
+            // Combine custom fields (GDN_UserMeta) with GDN_User fields.
+            // This is OK because we're blacklisting our $ReservedNames AND whitelisting $AllFields below.
+            $ProfileFields = array_merge($ProfileFields, $NativeFields);
+
             // Import from CustomProfileFields if available
             if (!count($ProfileFields) && is_object($Sender->User) && c('Plugins.CustomProfileFields.SuggestedFields', false)) {
                 $ProfileFields = Gdn::userModel()->getAttribute($Sender->User->UserID, 'CustomProfileFields', false);


### PR DESCRIPTION
Profile Extender already natively will use column `GDN_User.SomeField` if it exists rather than adding `Profile.SomeField` to `GDN_UserMeta.Name` with a matching `Value` for inserting and updating values.

This was to allow it to work with fields like Title and Location that already exist and have special functionality in Vanilla, including displaying on profiles if populated.

This updates Profile Extender to also allow READING from `GDN_User.SomeField` to display it on the profile even if it's not a special field in Vanilla.

The point of this is that putting a column manually on `GDN_User` will let Profile Extender access it while also making it available over the API.