### PR TITLE
Fix the Gdn_Controller->ResolvedPath compatibility bug

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1035,10 +1035,6 @@ class Gdn_Controller extends Gdn_Pluggable {
         if (is_object($this->Menu)) {
             $this->Menu->Sort = Gdn::config('Garden.Menu.Sort');
         }
-
-        $ResolvedPath = strtolower(combinePaths(array(Gdn::dispatcher()->application(), Gdn::dispatcher()->ControllerName, Gdn::dispatcher()->ControllerMethod)));
-        $this->ResolvedPath = $ResolvedPath;
-
         $this->FireEvent('Initialize');
     }
 

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -724,6 +724,9 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         // The method has been found, set it on the controller.
         $controller->RequestMethod = $controllerMethod;
         $controller->RequestArgs = $pathArgs;
+        $controller->ResolvedPath = ($routeArgs['addon'] ? $routeArgs['addon']->getKey().'/' : '').
+            strtolower(stringEndsWith($controllerName, 'Controller', true, true)).'/'.
+            strtolower($controllerMethod);
 
         $reflectionArguments = $request->get();
         $this->EventArguments['Arguments'] = &$reflectionArguments;


### PR DESCRIPTION
This should set the ResolvedPath correctly, with the following caveats:

- The property is set in the dispatcher rather than Gdn_Controller->initialize(). This should be more robust.
- The property is set a bit later due to when the controller method is determine. This could cause issues.
- Plugins with controllers will just use the plugin name rather than “plugins/pluginname” in the resolved path.