### PR TITLE
Validate user name in /messages/add/...

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -110,8 +110,23 @@ class MessagesController extends ConversationsController {
                 $this->fireEvent('AfterConversationSave');
             }
         } else {
+            // Check if valid user name has been passed.
             if ($Recipient != '') {
-                $this->Form->setValue('To', $Recipient);
+                if (!Gdn::userModel()->getByUsername($Recipient)) {
+                    $this->Form->setValidationResults(
+                        [
+                            'RecipientUserID' => [
+                                sprintf(
+                                    '"%s" is an unknown username.',
+                                    $Recipient
+                                )
+                            ]
+                        ]
+                    );
+                    $Recipient = '';
+                } else {
+                    $this->Form->setValue('To', $Recipient);
+                }
             }
         }
         if ($Target = Gdn::request()->get('Target')) {


### PR DESCRIPTION
Usernames passed by url are validated before they are passed to the form. If wrong name has been specified `"wrong name" is an unknown username.` is added to the validation result when the url with the wrong name is called. After posting "You must select at least one recipient." will appear as it does right now when an unknown user is addressed.

Fixes https://github.com/vanilla/vanilla/issues/4220