### PR TITLE
Filter out empty get parameters when building the current query string

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1017,7 +1017,9 @@ class Gdn_Request {
             $path = implode('/', $pathParts);
             // Grab the get parameters too.
             if (!$query) {
-                $query = array_filter($this->getRequestArguments(self::INPUT_GET));
+                $query = array_filter($this->getRequestArguments(self::INPUT_GET), function ($value) {
+                    return $value !== null;
+                });
                 if (!empty($query)) {
                     $query = ($rewrite ? '?' : '&amp;').http_build_query($query);
                 } else {

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1017,13 +1017,9 @@ class Gdn_Request {
             $path = implode('/', $pathParts);
             // Grab the get parameters too.
             if (!$query) {
-                $query = array_filter($this->getRequestArguments(self::INPUT_GET), function ($value) {
-                    return $value !== null;
-                });
+                $query = http_build_query($this->getRequestArguments(self::INPUT_GET));
                 if (!empty($query)) {
-                    $query = ($rewrite ? '?' : '&amp;').http_build_query($query);
-                } else {
-                    unset($query);
+                    $query = ($rewrite ? '?' : '&').$query;
                 }
             }
         }
@@ -1041,11 +1037,11 @@ class Gdn_Request {
             }
         }
 
-        if (isset($query)) {
+        if (!empty($query)) {
             $result .= $query;
         }
 
-        if (isset($hash)) {
+        if (!empty($hash)) {
             $result .= $hash;
         }
 

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1017,8 +1017,8 @@ class Gdn_Request {
             $path = implode('/', $pathParts);
             // Grab the get parameters too.
             if (!$query) {
-                $query = $this->getRequestArguments(self::INPUT_GET);
-                if (count($query) > 0) {
+                $query = array_filter($this->getRequestArguments(self::INPUT_GET));
+                if (!empty($query)) {
                     $query = ($rewrite ? '?' : '&amp;').http_build_query($query);
                 } else {
                     unset($query);


### PR DESCRIPTION
This makes the URL shorter and prevents an empty question mark when URL parameters are null.