### PR TITLE
Add RedirectURL to JSON approval registration response

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1364,6 +1364,10 @@ EOT;
                     foreach ($Data as $Row) {
                         $ActivityModel->add($AuthUserID, 'Applicant', $Story, $Row['UserID'], '', '/dashboard/user/applicants', 'Only');
                     }
+
+                    if ($this->deliveryType() !== DELIVERY_TYPE_ALL) {
+                        $this->RedirectUrl = url('/entry/registerthanks');
+                    }
                 }
             } catch (Exception $Ex) {
                 $this->Form->addError($Ex);


### PR DESCRIPTION
If registration takes place in a popup, `FormSaved` is set to `true` in the JSON response (as it should be).  This field triggers behavior that closes the window and, if `RedirectUrl` is set, sends the user to the new URL.

When approval registration is enabled and a user successfully registers in a popup, the site responds back with `FormSaved` but no `RedirectUrl`.  This would normally render the registerthanks view when delivering all assets.  When delivering JSON, to the user it just closes the popup window.  This update adds a `RedirectUrl` value of "/entry/registerthanks" to successful approval registrations when not delivering all assets.  This redirects the user to the "Your application will be reviewed..." page.

Closes #4278