### PR TITLE
Allow smarty to call isMobile() and userAgentType()

### DIFF
--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -122,10 +122,12 @@ class Gdn_Smarty {
             'checkPermission',
             'inSection',
             'inCategory',
+            'ismobile',
             'multiCheckPermission',
             'getValue',
             'setValue',
-            'url'
+            'url',
+            'useragenttype'
         ]));
 
         $security->php_modifiers = array_merge(


### PR DESCRIPTION
Useful for when the same theme is used on mobile and desktop and we want to conditionally output different stuff within the master view.