### PR TITLE
Revise updating role type based on ConfirmEmailRole config

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -186,12 +186,10 @@ if ($RoleTableExists && $UserRoleExists && $RoleTypeExists) {
     }
 
     if (c('Garden.Registration.ConfirmEmailRole')) {
-        $SQL->replace(
-            'Role',
-            array('Type' => RoleModel::TYPE_UNCONFIRMED),
-            array('RoleID' => $types[RoleModel::TYPE_UNCONFIRMED]),
-            true
-        );
+        $SQL->update('Role')
+            ->set('Type', RoleModel::TYPE_UNCONFIRMED)
+            ->whereIn('RoleID', $types[RoleModel::TYPE_UNCONFIRMED])
+            ->put();
 //      RemoveFromConfig('Garden.Registration.ConfirmEmailRole');
     }
 


### PR DESCRIPTION
If `Garden.Registration.ConfirmEmailRole` is set to a role ID (or IDs) that do not exist in the database, a fatal error is encountered when running the dashboard's structure file.  This is due to...

1. The structure.php attempts to run a `Gdn_SQLDriver::replace` call to [update the role records](https://github.com/vanilla/vanilla/blob/341885917626a70ae8ca585c74e57f85263be219/applications/dashboard/settings/structure.php#L189).
2. `Gdn_SQLDriver::replace` tries to lookup the existing role records to update, finds none, merges our sets+wheres and [passes everything off to `Gdn_SQLDriver::insert`](https://github.com/vanilla/vanilla/blob/341885917626a70ae8ca585c74e57f85263be219/library/database/class.sqldriver.php#L1156).
3. `Gdn_SQLDriver::insert` [passes things off to `Gdn_SQLDriver::set`](https://github.com/vanilla/vanilla/blob/341885917626a70ae8ca585c74e57f85263be219/library/database/class.sqldriver.php#L1071)
4. `Gdn_SQLDriver::set` sees our `RoleID` value is actually an array from our original where conditions and [throws an exception](https://github.com/vanilla/vanilla/blob/341885917626a70ae8ca585c74e57f85263be219/library/database/class.sqldriver.php#L1832), because you can't have an array for a particular field value.

This update alters the query being run, simplifying it to use an update call on records designated by the `Garden.Registration.ConfirmEmailRole` value.

Closes #4063