### PR TITLE
Add additional line break to welcome e-mail

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3981,19 +3981,19 @@ class UserModel extends Gdn_Model {
                     $welcome = formatString(t('You have successfully connected to {Title}.'), $data).' '.
                         t('Find your account information below.').'<br></p>'.
                         '<p>'.sprintf(t('%s: %s'), t('Username'), val('Name', $user)).'<br>'.
-                        formatString(t('Connected With: {ProviderName}'), $data).'</p>';
+                        formatString(t('Connected With: {ProviderName}'), $data).'<br></p>';
                     break;
                 case 'Register' :
                     $welcome = formatString(t('You have successfully registered for an account at {Title}.'), $data).' '.
                         t('Find your account information below.').'<br></p>'.
                         '<p>'.sprintf(t('%s: %s'), t('Username'), val('Name', $user)).'<br>'.
-                        sprintf(t('%s: %s'), t('Email'), val('Email', $user)).'</p>';
+                        sprintf(t('%s: %s'), t('Email'), val('Email', $user)).'<br></p>';
                     break;
                 default :
                     $welcome = sprintf(t('%s has created an account for you at %s.'), val('Name', val('Sender', $data)), $appTitle).' '.
                         t('Find your account information below.').'<br></p>'.
                         '<p>'.sprintf(t('%s: %s'), t('Email'), val('Email', $user)).'<br>'.
-                        sprintf(t('%s: %s'), t('Password'), $password).'</p>';
+                        sprintf(t('%s: %s'), t('Password'), $password).'<br></p>';
             }
         }
         return $welcome;


### PR DESCRIPTION
The plain-text version of Vanilla's welcome email has no line break character after the account information portion.  If the site requires users to confirm their e-mail, the "You need to confirm your email" text runs into the end of the user's email address and creates an invalid hyperlink.

This update adds a line break to the end of the account information portion of the email, which ensures that any text immediately following it (e.g. email confirmation prompts) is placed on a new line. 

Closes #3920