### PR TITLE
Don't assume ChildIDs set in CategoryModel::_MakeTreeChildren

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1828,14 +1828,17 @@ class CategoryModel extends Gdn_Model {
         }
 
         $Result = array();
-        foreach ($Category['ChildIDs'] as $ID) {
-            if (!isset($Categories[$ID])) {
-                continue;
+        $childIDs = val('ChildIDs', $Category);
+        if (is_array($childIDs) && count($childIDs)) {
+            foreach ($childIDs as $ID) {
+                if (!isset($Categories[$ID])) {
+                    continue;
+                }
+                $Row = (array)$Categories[$ID];
+                $Row['Depth'] += $DepthAdj;
+                $Row['Children'] = self::_MakeTreeChildren($Row, $Categories);
+                $Result[] = $Row;
             }
-            $Row = (array)$Categories[$ID];
-            $Row['Depth'] += $DepthAdj;
-            $Row['Children'] = self::_MakeTreeChildren($Row, $Categories);
-            $Result[] = $Row;
         }
         return $Result;
     }


### PR DESCRIPTION
We introduced flat categories with https://github.com/vanilla/vanilla/pull/4198.  Part of this update added `CategoryModel::makeTree` to `CategoriesModule::getData`.  `CategoryModel::makeTree` assumes some data keys are set (namely `ChildIDs`) and that isn't the case with the data we have in the categories module.

This update removes the assumption of the `ChildIDs` key being available in category data used by `CategoryModel::_MakeTreeChildren`, which is used by `CategoryModel::makeTree`.  This removes numerous errors that can be generated when the category is iterated through, potentially two per category: one for an invalid array index and one for an invalid `foreach` source.