### PR TITLE
Fix AllViewed redirect

### DIFF
--- a/plugins/AllViewed/class.allviewed.plugin.php
+++ b/plugins/AllViewed/class.allviewed.plugin.php
@@ -185,6 +185,8 @@ class AllViewedPlugin extends Gdn_Plugin {
             }
 
             $sender->render('blank', 'utility', 'dashboard');
+        } else {
+            throw new Exception('Requires POST', 405);
         }
     }
 

--- a/plugins/AllViewed/class.allviewed.plugin.php
+++ b/plugins/AllViewed/class.allviewed.plugin.php
@@ -178,6 +178,12 @@ class AllViewedPlugin extends Gdn_Plugin {
             $this->recursiveMarkCategoryRead($CategoryModel, CategoryModel::categories(), [-1]);
 
             $sender->informMessage(t('All discussions marked as viewed.'));
+
+            // Didn't use the default async option and landed here directly.
+            if ($sender->deliveryType() == DELIVERY_TYPE_ALL) {
+                redirect('/');
+            }
+
             $sender->render('blank', 'utility', 'dashboard');
         }
     }


### PR DESCRIPTION
When _not_ using the default async MeModule option (i.e. a normal link) you land on a blank page for Mark All Viewed. This simply redirects you to the home page in that case instead.