### PR TITLE
IndexPhotos is buggy on mobile with table layout.

### DIFF
--- a/plugins/IndexPhotos/class.indexphotos.plugin.php
+++ b/plugins/IndexPhotos/class.indexphotos.plugin.php
@@ -30,7 +30,7 @@ class IndexPhotosPlugin extends Gdn_Plugin {
      * @param $Sender
      */
     public function assetModel_styleCss_handler($Sender) {
-        if (!$this->hasLayoutTables() || IsMobile()) {
+        if (c('Vanilla.Discussions.Layout') != 'table') {
             $Sender->addCssFile('indexphotos.css', 'plugins/IndexPhotos');
         }
     }
@@ -39,7 +39,7 @@ class IndexPhotosPlugin extends Gdn_Plugin {
      * Add OP name to start of discussion meta.
      */
     public function discussionsController_afterDiscussionLabels_handler($Sender, $Args) {
-        if (!$this->hasLayoutTables() || isMobile()) {
+        if (c('Vanilla.Discussions.Layout') != 'table') {
             if (val('FirstUser', $Args)) {
                 echo '<span class="MItem DiscussionAuthor">'.userAnchor(val('FirstUser', $Args)).'</span>';
             }
@@ -53,7 +53,7 @@ class IndexPhotosPlugin extends Gdn_Plugin {
      * @param $Args
      */
     public function categoriesController_afterDiscussionLabels_handler($Sender, $Args) {
-        if (!$this->hasLayoutTables() || isMobile()) {
+        if (c('Vanilla.Discussions.Layout') != 'table') {
             if (val('FirstUser', $Args)) {
                 echo '<span class="MItem DiscussionAuthor">'.userAnchor(val('FirstUser', $Args)).'</span>';
             }
@@ -64,7 +64,7 @@ class IndexPhotosPlugin extends Gdn_Plugin {
      * Trigger on All Discussions.
      */
     public function discussionsController_beforeDiscussionContent_handler($Sender) {
-        if (!$this->hasLayoutTables() || isMobile()) {
+        if (c('Vanilla.Discussions.Layout') != 'table') {
             $this->displayPhoto($Sender);
         }
     }
@@ -73,7 +73,7 @@ class IndexPhotosPlugin extends Gdn_Plugin {
      * Trigger on Categories.
      */
     public function categoriesController_beforeDiscussionContent_handler($Sender) {
-        if (!$this->hasLayoutTables()) {
+        if (c('Vanilla.Discussions.Layout') != 'table') {
             $this->displayPhoto($Sender);
         }
     }
@@ -85,14 +85,5 @@ class IndexPhotosPlugin extends Gdn_Plugin {
         // Build user object & output photo
         $FirstUser = userBuilder($Sender->EventArguments['Discussion'], 'First');
         echo userPhoto($FirstUser, array('LinkClass' => 'IndexPhoto'));
-    }
-
-    /**
-     * Determine whether layout of discussions page is "table" (vs. "modern").
-     *
-     * @return bool If forum is using table layout, returns true
-     */
-    public function hasLayoutTables() {
-        return (c('Vanilla.Discussions.Layout') == 'table');
     }
 }


### PR DESCRIPTION
Throughout the plugin the functionality is capsuled in such an if construct:
`if (!$this->hasLayoutTables() || IsMobile()) {`

So if the plugin is used from mobile, every output is made even when table layout is used, which doesn't makes sense at all. But I do not know where this comes from. Maybe that fix isn't correct...

I've deleted that helper function for determining if layout = 'table' since I thought that this wouldn't be helpful if this is the only thing that is checked now.