### PR TITLE
Fix editing custom category permissions

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -576,6 +576,8 @@ class VanillaSettingsController extends Gdn_Controller {
         if (!$this->Category) {
             throw notFoundException('Category');
         }
+        // Category data is expected to be in the form of an object.
+        $this->Category = (object)$this->Category;
         $this->Category->CustomPermissions = $this->Category->CategoryID == $this->Category->PermissionCategoryID;
 
         // Restrict "Display As" types based on parent.


### PR DESCRIPTION
When editing a category, the category data being read is expected to be an object.  `CategoryModel::categories` returns an array.  This update casts the result to an object, which resolves issues with reading category values on edit (e.g. custom permissions).