### PR TITLE
Display heading categories using category layout

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -224,6 +224,7 @@ class CategoriesController extends VanillaController {
 
             switch ($Category->DisplayAs) {
                 case 'Flat':
+                case 'Heading':
                 case 'Categories':
                     if (val('Depth', $Category) > CategoryModel::instance()->getNavDepth()) {
                         // Headings don't make sense if we've cascaded down one level.


### PR DESCRIPTION
The "Heading" category display type uses the discussions layout.  This update alters it to use the categories layout.