### PR TITLE
Never duplicate user search results even if they match twice

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2462,6 +2462,7 @@ class UserModel extends Gdn_Model {
             ->where('u.Deleted', 0)
             ->orderBy($OrderFields, $OrderDirection)
             ->limit($Limit, $Offset)
+            ->groupBy('u.UserID')
             ->get();
 
         $Result = &$Data->result();


### PR DESCRIPTION
IP search can match per IP address entry. It's foreseeable this will happen for other conditions in the future too, so let's group our results on UserID so we never get duplicates.