### PR TITLE
Do not append webRoot again on double URL encoding

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -19,7 +19,7 @@
  * @method string requestMethod($method = null) Get/Set the Request Method (REQUEST_METHOD).
  * @method string requestHost($uri = null) Get/Set the Request Host (HTTP_HOST).
  * @method string requestFolder($folder = null) Get/Set the Request script's Folder.
- * @method string requestAddress($ip = null) Get/Set the Request IP address (first existing of HTTP_X_ORIGINALLY_FORWARDED_FOR, 
+ * @method string requestAddress($ip = null) Get/Set the Request IP address (first existing of HTTP_X_ORIGINALLY_FORWARDED_FOR,
  *                HTTP_X_CLUSTER_CLIENT_IP, HTTP_CLIENT_IP, HTTP_X_FORWARDED_FOR, REMOTE_ADDR).
  */
 class Gdn_Request {
@@ -990,8 +990,12 @@ class Gdn_Request {
             $parts[] = '';
         }
 
-        if ($withDomain !== '/' && $this->webRoot() != '') {
-            $parts[] = $this->webRoot();
+        $webRoot = '';
+        if ($withDomain !== '/') {
+            $webRoot = $this->webRoot();
+            if ($webRoot) {
+                $parts[] = $webRoot;
+            }
         }
 
         // Strip out the hash.
@@ -1023,7 +1027,13 @@ class Gdn_Request {
                 }
             }
         }
-        $parts[] = ltrim($path, '/');
+
+        // Prevent the addition of webRoot a second time if the path was already encoded.
+        $path = ltrim($path, '/');
+        if ($webRoot && strpos($path, $webRoot.'/') === 0) {
+            $path = str_replace($webRoot, null, $path);
+        }
+        $parts[] = $path;
 
         $result = implode('/', $parts);
 


### PR DESCRIPTION
Prevent webroot from being appended 2 times to a path.

Example: `webroot='x'` + `anchor('Link', url('/path/to/something.html))` = `'/x/x/path/to/something.html'`

It should be = to `'/x/path/to/something.html'`

Prevent this https://github.com/vanilla/multisite/issues/36 from happening.