### PR TITLE
Standardize our checking of signin popups in the entry controller

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -41,10 +41,9 @@ class EntryController extends Gdn_Controller {
         // Set error message here so it can run thru t()
         $this->UsernameError = t('UsernameError', 'Username can only contain letters, numbers, underscores, and must be between 3 and 20 characters long.');
 
-        switch (isset($_GET['display'])) { // TODO: rm global access
-            case 'popup':
-                $this->MasterView = 'popup';
-                break;
+        // Allow use of a master popup template for easier theming.
+        if (Gdn::request()->get('display') === 'popup') {
+            $this->MasterView = 'popup';
         }
     }
 
@@ -516,8 +515,7 @@ EOT;
             // Sign the user in.
             Gdn::session()->start($UserID, true, (bool)$this->Form->getFormValue('RememberMe', true));
             Gdn::userModel()->fireEvent('AfterSignIn');
-//         $this->_setRedirect(TRUE);
-            $this->_setRedirect($this->Request->get('display') == 'popup');
+            $this->_setRedirect(Gdn::request()->get('display') === 'popup');
         } elseif ($this->Form->getFormValue('Name') || $this->Form->getFormValue('Email')) {
             $NameUnique = c('Garden.Registration.NameUnique', true);
             $EmailUnique = c('Garden.Registration.EmailUnique', true);
@@ -584,8 +582,7 @@ EOT;
                         // Sign the user in.
                         Gdn::session()->start($UserID, true, (bool)$this->Form->getFormValue('RememberMe', true));
                         Gdn::userModel()->fireEvent('AfterSignIn');
-                        //         $this->_setRedirect(TRUE);
-                        $this->_setRedirect($this->Request->get('display') == 'popup');
+                        $this->_setRedirect(Gdn::request()->get('display') === 'popup');
                         $this->render();
                         return;
                     }
@@ -684,7 +681,7 @@ EOT;
                         }
                     }
 
-                    $this->_setRedirect(true);
+                    $this->_setRedirect(Gdn::request()->get('display') === 'popup');
                 }
             }
         }
@@ -772,7 +769,7 @@ EOT;
                 // Sign the appropriate user in.
                 Gdn::session()->start($this->Form->getFormValue('UserID'), true, (bool)$this->Form->getFormValue('RememberMe', true));
                 Gdn::userModel()->fireEvent('AfterSignIn');
-                $this->_setRedirect(true);
+                $this->_setRedirect(Gdn::request()->get('display') === 'popup');
             }
         }
 


### PR DESCRIPTION
**Whereas:** Opening Vanilla's SSO signin in a new tab could cause the new tab to close after login.

**Whereas:** The EntryController used inconsistent logic about when to close itself / detecting if it was in a popup.

**Whereas:** The EntryController did access the global `GET`.

**Therefore:** It is resolved that we shall speak respectfully to the Gdn_Request singleton to resolve these disputes when setting up our redirects and master view.