### PR TITLE
Redundantly set the data type in the categories module

### DIFF
--- a/applications/vanilla/modules/class.categoriesmodule.php
+++ b/applications/vanilla/modules/class.categoriesmodule.php
@@ -53,6 +53,7 @@ class CategoriesModule extends Gdn_Module {
         }
 
         $Data = new Gdn_DataSet($Categories);
+        $Data->DatasetType(DATASET_TYPE_ARRAY);
         $Data->DatasetType(DATASET_TYPE_OBJECT);
         $this->Data = $Data;
     }


### PR DESCRIPTION
`Gdn_DataSet` has an issue with its type property that currently requires a hack of setting, then resetting, the data type to properly re-cast its data.

This update adds such a fix to the categories module.