### PR TITLE
Do not strip quotations marks and ampersand from usernames.

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1092,7 +1092,6 @@ if (!function_exists('userUrl')) {
         }
 
         $UserName = val($Px.'Name', $User);
-        $UserName = preg_replace('/([\?&]+)/', '', $UserName);
 
         $Result = '/profile/'.
             ($Method ? trim($Method, '/').'/' : '').

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1092,6 +1092,9 @@ if (!function_exists('userUrl')) {
         }
 
         $UserName = val($Px.'Name', $User);
+        // Make sure that the name will not be split if the p parameter is set.
+        // Prevent p=/profile/a&b to be translated to $_GET['p'=>'/profile/a?', 'b'=>'']
+        $UserName = str_replace('&', '%26', $UserName);
 
         $Result = '/profile/'.
             ($Method ? trim($Method, '/').'/' : '').


### PR DESCRIPTION
These characters are properly parsed and encoded now.
I added double encoding to `&` to make sure it will work properly with the `p` parameter.

Fix https://github.com/vanilla/vanilla/issues/4308