### PR TITLE
Don’t log the ALTER SQL during a structure_threshold event

### DIFF
--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -427,8 +427,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
                 [
                     'tableName' => $this->tableName(),
                     'rowCount' => $this->getRowCountEstimate($this->tableName()),
-                    'rowThreshold' => $this->getAlterTableThreshold(),
-                    'alterSql' => $sql
+                    'rowThreshold' => $this->getAlterTableThreshold()
                 ]
             );
             return true;


### PR DESCRIPTION
The SQL is too verbose to be useful in a log message.