### PR TITLE
Fix quotes that are done on a user with spaces in its name.

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -471,7 +471,11 @@ BQ;
                 case 'Display':
                 case 'Text':
                     $QuoteBody = $Data->Body;
-                    $Quote = '> '.sprintf(t('%s said:'), '@'.$Data->InsertName)."\n".
+                    $insertName = $Data->InsertName;
+                    if (strpos($insertName, ' ') !== false) {
+                        $insertName = '"'.$insertName.'"';
+                    }
+                    $Quote = '> '.sprintf(t('%s said:'), '@'.$insertName)."\n".
                         '> '.str_replace("\n", "\n> ", $QuoteBody)."\n";
 
                     break;


### PR DESCRIPTION
Enclose usernames with spaces in-between double quotes when using markdown.