### PR TITLE
Allow callbacks to be registered directly in a Gdn_PluginManager object

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -874,13 +874,16 @@ class Gdn_PluginManager extends Gdn_Pluggable {
         foreach ($this->eventHandlers[$EventKey] as $PluginKey) {
             $callback = null;
             if (is_array($PluginKey) || $PluginKey instanceof \Closure) {
+                // The event handler is an array or a closure so we can call it directly.
                 $callback = $PluginKey;
             } else {
                 $PluginKeyParts = explode('.', $PluginKey);
                 if (count($PluginKeyParts) == 2) {
+                    // The event handler is a class and method name.
                     list($PluginClassName, $PluginEventHandlerName) = $PluginKeyParts;
                     $callback = [$this->getPluginInstance($PluginClassName), $PluginEventHandlerName];
                 } elseif (is_callable($PluginKey)) {
+                    // The event handler is a global function.
                     $callback = $PluginKey;
                 }
             }

--- a/tests/Library/Core/PluginManagerTest.php
+++ b/tests/Library/Core/PluginManagerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace VanillaTests\Library\Core;
+
+use Gdn_PluginManager;
+
+/**
+ * Test the {@link Gdn_PluginManager} class.
+ */
+class PluginManagerTest extends \PHPUnit_Framework_Testcase {
+    /**
+     * Test a basic usage of {@link Gdn_PluginManager::registerCallback}.
+     */
+    public function testRegisterCallback() {
+        $pm = new Gdn_PluginManager();
+
+        $called = false;
+        $pm->registerCallback('Foo_Bar_Handler', function () use (&$called) {
+            $called = true;
+        });
+
+        $pm->callEventHandler($this, 'foo', 'bar');
+
+        $this->assertTrue($called);
+    }
+
+    /**
+     * Test event references.
+     *
+     * Since events don't return values well, plugins usually set a reference in their event arguments and check them
+     * after firing event.
+     */
+    public function testEventArgReference() {
+        $arg = false;
+        $sender = (object)['EventArguments' => []];
+        $sender->EventArguments['arg'] =& $arg;
+
+        $pm = new Gdn_PluginManager();
+        $pm->registerCallback('Arg_Ref_Handler', function ($sender, $args) {
+            $args['arg'] = true;
+        });
+
+        $pm->callEventHandler($sender, 'arg', 'ref');
+        $this->assertTrue($arg);
+    }
+}


### PR DESCRIPTION
Add the Gdn_PluginManager->regsterCallback() method to allow callbacks to be registered in a more free-form way.