### PR TITLE
Fix tabindex for comments, conversations, discussions

### DIFF
--- a/applications/conversations/views/messages/add.php
+++ b/applications/conversations/views/messages/add.php
@@ -30,12 +30,12 @@
     }
 
     echo '<div class="P">';
-    echo $this->Form->bodyBox('Body', array('Table' => 'ConversationMessage', 'FileUpload' => true));
+    echo $this->Form->bodyBox('Body', array('Table' => 'ConversationMessage', 'FileUpload' => true, 'tabindex' => 1));
     //      echo wrap($this->Form->textBox('Body', array('MultiLine' => TRUE)), 'div', array('class' => 'TextBoxWrapper'));
     echo '</div>';
 
     echo '<div class="Buttons">';
-    echo $this->Form->button('Start Conversation', array('class' => 'Button Primary DiscussionButton'));
+    echo $this->Form->button('Start Conversation', array('class' => 'Button Primary DiscussionButton', 'tabindex' => 1));
     echo anchor(t('Cancel'), '/messages/inbox', 'Button Cancel');
     echo '</div>';
 

--- a/applications/conversations/views/messages/addmessage.php
+++ b/applications/conversations/views/messages/addmessage.php
@@ -29,9 +29,9 @@ $this->fireEvent('BeforeMessageForm');
                     echo $this->Form->open(array('id' => 'Form_ConversationMessage', 'action' => url('/messages/addmessage/')));
                     echo $this->Form->errors();
                     //               echo wrap($this->Form->textBox('Body', array('MultiLine' => true, 'class' => 'TextBox')), 'div', array('class' => 'TextBoxWrapper'));
-                    echo $this->Form->bodyBox('Body', array('Table' => 'ConversationMessage', 'FileUpload' => true));
+                    echo $this->Form->bodyBox('Body', array('Table' => 'ConversationMessage', 'FileUpload' => true, 'tabindex' => 1));
                     echo '<div class="Buttons">',
-                    $this->Form->button('Send Message', array('class' => 'Button Primary')),
+                    $this->Form->button('Send Message', array('class' => 'Button Primary', 'tabindex' => 1)),
                     '</div>';
                     echo $this->Form->close();
                     ?>

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -54,7 +54,7 @@ $this->fireEvent('BeforeCommentForm');
                     echo '</span>';
 
                     $ButtonOptions = array('class' => 'Button Primary CommentButton');
-                    $ButtonOptions['tabindex'] = 2;
+                    $ButtonOptions['tabindex'] = 1;
 
                     if (!$Editing && $Session->isValid()) {
                         echo ' '.anchor(t('Preview'), '#', 'Button PreviewButton')."\n";

--- a/applications/vanilla/views/post/discussion.php
+++ b/applications/vanilla/views/post/discussion.php
@@ -16,7 +16,7 @@ if (!$CancelUrl) {
     echo '<div class="FormWrapper">';
     echo $this->Form->open();
     echo $this->Form->errors();
-    
+
     $this->fireEvent('BeforeFormInputs');
 
     if ($this->ShowCategorySelector === true) {
@@ -40,7 +40,7 @@ if (!$CancelUrl) {
     $this->fireEvent('BeforeBodyInput');
 
     echo '<div class="P">';
-    echo $this->Form->bodyBox('Body', array('Table' => 'Discussion', 'FileUpload' => true));
+    echo $this->Form->bodyBox('Body', array('Table' => 'Discussion', 'FileUpload' => true, 'tabindex' => 1));
     echo '</div>';
 
     $Options = '';
@@ -62,7 +62,7 @@ if (!$CancelUrl) {
 
     echo '<div class="Buttons">';
     $this->fireEvent('BeforeFormButtons');
-    echo $this->Form->button((property_exists($this, 'Discussion')) ? 'Save' : 'Post Discussion', array('class' => 'Button Primary DiscussionButton'));
+    echo $this->Form->button((property_exists($this, 'Discussion')) ? 'Save' : 'Post Discussion', array('class' => 'Button Primary DiscussionButton', 'tabindex' => 1));
     if (!property_exists($this, 'Discussion') || !is_object($this->Discussion) || (property_exists($this, 'Draft') && is_object($this->Draft))) {
         echo $this->Form->button('Save Draft', array('class' => 'Button DraftButton'));
     }

--- a/applications/vanilla/views/post/editcomment.php
+++ b/applications/vanilla/views/post/editcomment.php
@@ -15,7 +15,7 @@ $this->fireEvent('BeforeCommentForm');
                 echo "<div class=\"Buttons\">\n";
                 $this->fireEvent('BeforeFormButtons');
                 echo anchor(t('Cancel'), '/', 'Button Cancel').' ';
-                echo $this->Form->button('Save Comment', array('class' => 'Button Primary CommentButton', 'tabindex' => 2));
+                echo $this->Form->button('Save Comment', array('class' => 'Button Primary CommentButton', 'tabindex' => 1));
                 $this->fireEvent('AfterFormButtons');
                 echo "</div>\n";
                 echo $this->Form->close();


### PR DESCRIPTION
So according to the [w3 HTML5 documentation on tabindex](https://www.w3.org/TR/html5/editing.html#sequential-focus-navigation-and-the-tabindex-attribute), setting a tabindex attribute value to a an existing value means that the browser will navigate between them using the document tree order. Setting everything to tabindex 1 here fix all our problems.

That way we can jump from the body to the save button of every comments and discussions even when editing.

Close https://github.com/vanilla/vanilla/issues/3344