### PR TITLE
Avoid REQUEST_URI double decoding at the request level.

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -301,6 +301,10 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         // /controller
 
         $parts = explode('/', str_replace('\\', '/', $request->path()));
+        // Decode path parts at the dispatcher level.
+        array_walk($parts, function(&$value) {
+            $value = rawurldecode($value);
+        });
 
         // Parse the file extension.
         list($parts, $deliveryMethod) = $this->parseDeliveryMethod($parts);

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -19,7 +19,7 @@
  * @method string requestMethod($method = null) Get/Set the Request Method (REQUEST_METHOD).
  * @method string requestHost($uri = null) Get/Set the Request Host (HTTP_HOST).
  * @method string requestFolder($folder = null) Get/Set the Request script's Folder.
- * @method string requestAddress($ip = null) Get/Set the Request IP address (first existing of HTTP_X_ORIGINALLY_FORWARDED_FOR, 
+ * @method string requestAddress($ip = null) Get/Set the Request IP address (first existing of HTTP_X_ORIGINALLY_FORWARDED_FOR,
  *                HTTP_X_CLUSTER_CLIENT_IP, HTTP_CLIENT_IP, HTTP_X_FORWARDED_FOR, REMOTE_ADDR).
  */
 class Gdn_Request {
@@ -137,6 +137,7 @@ class Gdn_Request {
 
             switch ($key) {
                 case 'URI':
+                    // Simulate REQUEST_URI decoding.
                     $value = !is_null($value) ? rawurldecode($value) : $value;
                     break;
                 case 'SCRIPT':
@@ -542,7 +543,8 @@ class Gdn_Request {
                 $path = '';
             }
 
-            $this->requestURI($path);
+            // Set URI directly to avoid double decoding.
+            $this->_Environment['URI'] = $path;
         }
 
         $possibleScriptNames = [];


### PR DESCRIPTION
I played a bit with the request object and found out that you cannot double encode a character in the URL right now.

`/profile/UserWith%252FSlash` "UserWith/Slash"
is still parsed as
`UserWith/Slash` instead of `UserWith%2FSlash` because we rawurldecode the value in `Request::_environmentElement()`.
While this is something that can be "correct" when making internal requests we should not double decode the URI in `Request::_loadEnvironment()`.

The dispatcher has been updated to compensate for this change.