### PR TITLE
Fix the basic search pager

### DIFF
--- a/applications/dashboard/controllers/class.searchcontroller.php
+++ b/applications/dashboard/controllers/class.searchcontroller.php
@@ -105,6 +105,8 @@ class SearchController extends Gdn_Controller {
         $this->setData('SearchResults', $ResultSet, true);
         $this->setData('SearchTerm', Gdn_Format::text($Search), true);
 
+        $this->setData('_CurrentRecords', count($ResultSet));
+
         $this->canonicalUrl(url('search', true));
         $this->render();
     }

--- a/applications/dashboard/controllers/class.searchcontroller.php
+++ b/applications/dashboard/controllers/class.searchcontroller.php
@@ -104,36 +104,8 @@ class SearchController extends Gdn_Controller {
 
         $this->setData('SearchResults', $ResultSet, true);
         $this->setData('SearchTerm', Gdn_Format::text($Search), true);
-        if ($ResultSet) {
-            $NumResults = count($ResultSet);
-        } else {
-            $NumResults = 0;
-        }
-        if ($NumResults == $Offset + $Limit) {
-            $NumResults++;
-        }
-
-        // Build a pager
-        $PagerFactory = new Gdn_PagerFactory();
-        $this->Pager = $PagerFactory->getPager('MorePager', $this);
-        $this->Pager->MoreCode = 'More Results';
-        $this->Pager->LessCode = 'Previous Results';
-        $this->Pager->ClientID = 'Pager';
-        $this->Pager->configure(
-            $Offset,
-            $Limit,
-            $NumResults,
-            'dashboard/search/%1$s/%2$s/?Search='.Gdn_Format::url($Search)
-        );
-
-//		if ($this->_DeliveryType != DELIVERY_TYPE_ALL) {
-//         $this->setJson('LessRow', $this->Pager->toString('less'));
-//         $this->setJson('MoreRow', $this->Pager->toString('more'));
-//         $this->View = 'results';
-//      }
 
         $this->canonicalUrl(url('search', true));
-
         $this->render();
     }
 }

--- a/applications/dashboard/views/search/results.php
+++ b/applications/dashboard/views/search/results.php
@@ -79,8 +79,9 @@
 echo '<div class="PageControls Bottom">';
 
 $RecordCount = $this->data('RecordCount');
-if ($RecordCount)
+if ($RecordCount) {
     echo '<span class="Gloss">'.plural($RecordCount, '%s result', '%s results').'</span>';
+}
 
 PagerModule::write(array('Wrapper' => '<div %1$s>%2$s</div>'));
 


### PR DESCRIPTION
The search results view ignores the pager that was being built in the search controller. Instead, just pass along the `_CurrentRecords` tally via the data array.

Closes #2319
Closes #1826