### PR TITLE
Add tokenizer max tags enforcement and cleanup tag validation

### DIFF
--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -10,7 +10,7 @@
 $PluginInfo['Tagging'] = array(
     'Name' => 'Tagging',
     'Description' => 'Users may add tags to each discussion they create. Existing tags are shown in the sidebar for navigation by tag.',
-    'Version' => '1.9.0',
+    'Version' => '1.9.1',
     'SettingsUrl' => '/dashboard/settings/tagging',
     'SettingsPermission' => 'Garden.Settings.Manage',
     'Author' => "Vanilla Staff",
@@ -36,6 +36,7 @@ $PluginInfo['Tagging'] = array(
  *  1.8.8   Added tabs.
  *  1.8.9   Ability to add tags based on tab.
  *  1.8.12  Fix issues with CSS and js loading.
+ *  1.9.1   Add tokenLimit enforcement; cleanup.
  */
 class TaggingPlugin extends Gdn_Plugin {
 
@@ -607,6 +608,7 @@ class TaggingPlugin extends Gdn_Plugin {
     public function postController_render_before($Sender) {
         $Sender->addDefinition('PluginsTaggingAdd', Gdn::session()->checkPermission('Plugins.Tagging.Add'));
         $Sender->addDefinition('PluginsTaggingSearchUrl', Gdn::request()->Url('plugin/tagsearch'));
+        $Sender->addDefinition('MaxTagsAllowed', c('Plugin.Tagging.Max', 5));
 
         // Make sure that detailed tag data is available to the form.
         $TagModel = TagModel::instance();

--- a/plugins/Tagging/class.tagging.plugin.php
+++ b/plugins/Tagging/class.tagging.plugin.php
@@ -243,13 +243,6 @@ class TaggingPlugin extends Gdn_Plugin {
 
         $Sender->View = c('Vanilla.Discussions.Layout');
 
-        /*
-        // If these don't equal, then there is a category that should be inserted.
-        if ($UseCategories && $Category && $TagRow['FullName'] != val('Name', $Category)) {
-           $Sender->Data['Breadcrumbs'][] = array('Name' => $Category['Name'], 'Url' => TagUrl($TagRow));
-        }
-        $Sender->Data['Breadcrumbs'][] = array('Name' => $TagRow['FullName'], 'Url' => '');
-  */
         // Render the controller.
         $this->View = c('Vanilla.Discussions.Layout') == 'table' && $Sender->SyndicationMethod == SYNDICATION_NONE ? 'table' : 'index';
         $Sender->render($this->View, 'discussions', 'vanilla');
@@ -350,50 +343,45 @@ class TaggingPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Should we limit the discussion query to a specific tagid?
-     * @param DiscussionModel $Sender
-     */
-//   public function DiscussionModel_BeforeGet_handler($Sender) {
-//      if (c('Plugins.Tagging.Enabled') && property_exists($Sender, 'FilterToDiscussionIDs')) {
-//         $Sender->SQL->whereIn('d.DiscussionID', $Sender->FilterToDiscussionIDs)
-//            ->limit(FALSE);
-//      }
-//   }
-
-    /**
      * Validate tags when saving a discussion.
+     *
+     * @param DiscussionModel $Sender
+     * @param array $Args
      */
     public function discussionModel_beforeSaveDiscussion_handler($Sender, $Args) {
         $reservedTags = [];
         $Sender->EventArguments['ReservedTags'] = &$reservedTags;
-        $Sender->FireEvent('ReservedTags');
+        $Sender->fireEvent('ReservedTags');
 
         $FormPostValues = val('FormPostValues', $Args, array());
         $TagsString = trim(strtolower(val('Tags', $FormPostValues, '')));
         $NumTagsMax = c('Plugin.Tagging.Max', 5);
+
         // Tags can only contain unicode and the following ASCII: a-z 0-9 + # _ .
         if (stringIsNullOrEmpty($TagsString) && c('Plugins.Tagging.Required')) {
             $Sender->Validation->addValidationResult('Tags', 'You must specify at least one tag.');
         } else {
+            // Break apart our tags and lowercase them all for comparisons.
             $Tags = TagModel::splitTags($TagsString);
-            // Handle upper/lowercase
             $Tags = array_map('strtolower', $Tags);
             $reservedTags = array_map('strtolower', $reservedTags);
+
+            // Validate our tags.
             if ($reservedTags = array_intersect($Tags, $reservedTags)) {
                 $names = implode(', ', $reservedTags);
                 $Sender->Validation->addValidationResult('Tags', '@'.sprintf(t('These tags are reserved and cannot be used: %s'), $names));
             }
             if (!TagModel::validateTags($Tags)) {
                 $Sender->Validation->addValidationResult('Tags', '@'.t('ValidateTag', 'Tags cannot contain commas.'));
-            } elseif (count($Tags) > $NumTagsMax) {
+            }
+            if (count($Tags) > $NumTagsMax) {
                 $Sender->Validation->addValidationResult('Tags', '@'.sprintf(t('You can only specify up to %s tags.'), $NumTagsMax));
-            } else {
             }
         }
     }
 
     /**
-     *
+     * Handle tag association deletion when a discussion is deleted.
      *
      * @param $Sender
      * @throws Exception

--- a/plugins/Tagging/js/tagging.js
+++ b/plugins/Tagging/js/tagging.js
@@ -34,6 +34,7 @@ var discussionTagging = {
 
             var TagSearch = gdn.definition('PluginsTaggingSearchUrl', gdn.url('plugin/tagsearch'));
             var TagAdd = gdn.definition('PluginsTaggingAdd', false);
+            var MaxTags = gdn.definition('MaxTagsAllowed', false);
 
             $element.find("#Form_Tags").tokenInput(TagSearch, {
                 hintText: gdn.definition("TagHint", "Start to type..."),
@@ -45,6 +46,7 @@ var discussionTagging = {
                 prePopulate: tags,
                 dataFields: ["#Form_CategoryID"],
                 allowFreeTagging: TagAdd,
+                tokenLimit: MaxTags,
                 zindex: 3000
             });
 


### PR DESCRIPTION
Closes #1917 (but backend validation was already happening, this is just for the second part).

The real change is in commit number 3. The others are just cleanup.