### PR TITLE
Allow drafts to be orphaned and rework drafts view

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -125,7 +125,7 @@ class PostController extends VanillaController {
             $this->Category = (object)$Category;
             $this->setData('Category', $Category);
             $this->Form->addHidden('CategoryID', $this->Category->CategoryID);
-            if (val('DisplayAs', $this->Category) == 'Discussions') {
+            if (val('DisplayAs', $this->Category) == 'Discussions' || $DraftID) {
                 $this->ShowCategorySelector = false;
             } else {
                 // Get all our subcategories to add to the category if we are in a Header or Categories category.

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -125,7 +125,7 @@ class PostController extends VanillaController {
             $this->Category = (object)$Category;
             $this->setData('Category', $Category);
             $this->Form->addHidden('CategoryID', $this->Category->CategoryID);
-            if (val('DisplayAs', $this->Category) == 'Discussions' || $DraftID) {
+            if (val('DisplayAs', $this->Category) == 'Discussions' && !$DraftID) {
                 $this->ShowCategorySelector = false;
             } else {
                 // Get all our subcategories to add to the category if we are in a Header or Categories category.

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2650,9 +2650,7 @@ class DiscussionModel extends VanillaModel {
         $this->EventArguments['Discussion'] = $Data;
         $this->fireEvent('DeleteDiscussion');
 
-        // Execute deletion of discussion and related bits
-        $this->SQL->delete('Draft', ['DiscussionID' => $discussionID]);
-
+        // Setup logging.
         $Log = val('Log', $options, true);
         $LogOptions = val('LogOptions', $options, []);
         if ($Log === true) {

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -66,6 +66,7 @@ class DraftModel extends VanillaModel {
         $this->draftQuery();
         $this->SQL
             ->select('d.Name, di.Name', 'coalesce', 'Name')
+            ->select('di.DateInserted', '', 'DiscussionExists')
             ->join('Discussion di', 'd.discussionID = di.DiscussionID', 'left')
             ->where('d.InsertUserID', $UserID)
             ->orderBy('d.DateInserted', 'desc')

--- a/applications/vanilla/views/drafts/drafts.php
+++ b/applications/vanilla/views/drafts/drafts.php
@@ -1,8 +1,6 @@
 <?php if (!defined('APPLICATION')) exit();
-$Session = Gdn::session();
-$ShowOptions = TRUE;
-$Alt = '';
-foreach ($this->DraftData->result() as $Draft) {
+
+foreach ($this->DraftData->resultArray() as $Draft) {
     $Offset = val('CountComments', $Draft, 0);
     if ($Offset > c('Vanilla.Comments.PerPage', 30)) {
         $Offset -= c('Vanilla.Comments.PerPage', 30);
@@ -10,22 +8,27 @@ foreach ($this->DraftData->result() as $Draft) {
         $Offset = 0;
     }
 
-    $EditUrl = !is_numeric($Draft->DiscussionID) || $Draft->DiscussionID <= 0 ? '/post/editdiscussion/0/'.$Draft->DraftID : '/discussion/'.$Draft->DiscussionID.'/'.$Offset.'/#Form_Comment';
-    $Alt = $Alt == ' Alt' ? '' : ' Alt';
-    $Excerpt = SliceString(Gdn_Format::text($Draft->Body), 200);
-    ?>
-    <li class="Item Draft<?php echo $Alt; ?>">
-        <div
-            class="Options"><?php echo anchor(t('Draft.Delete', 'Delete'), 'vanilla/drafts/delete/'.$Draft->DraftID.'/'.$Session->TransientKey().'?Target='.urlencode($this->SelfUrl), 'Delete'); ?></div>
-        <div class="ItemContent">
-            <?php echo anchor(Gdn_Format::text($Draft->Name, false), $EditUrl, 'Title DraftLink'); ?>
+    $draftID = val('DraftID', $Draft);
+    $discussionID = val('DiscussionID', $Draft);
+    $excerpt = sliceString(Gdn_Format::text(val('Body', $Draft)), 200);
 
-            <?php if ($Excerpt): ?>
+    $isDiscussion = (!is_numeric($discussionID) || $discussionID <= 0);
+    $orphaned = !val('DiscussionExists', $Draft);
+
+    $editUrl = ($isDiscussion || $orphaned) ? '/post/editdiscussion/0/'.$draftID : '/discussion/'.$discussionID.'/'.$Offset.'/#Form_Comment';
+    $deleteUrl = 'vanilla/drafts/delete/'.$draftID.'/'.Gdn::session()->transientKey().'?Target='.urlencode($this->SelfUrl);
+    ?>
+    <li class="Item Draft">
+        <div
+            class="Options"><?php
+                echo anchor(t('Draft.Delete', 'Delete'), $deleteUrl, 'Delete'); ?></div>
+        <div class="ItemContent">
+            <?php echo anchor(Gdn_Format::text(val('Name', $Draft), false), $editUrl, 'Title DraftLink'); ?>
+            <?php if ($excerpt) : ?>
                 <div class="Excerpt">
-                    <?php echo anchor($Excerpt, $EditUrl); ?>
+                    <?php echo anchor($excerpt, $editUrl); ?>
                 </div>
             <?php endif; ?>
-
         </div>
     </li>
 <?php


### PR DESCRIPTION
This changes the behavior of what happens to drafts when their parent (live) discussion is deleted. Previously, we silently deleted them all and neglected to update draft counters. Now, we let them become "orphans" that bring up the Post Discussion form.

Rationale:

* Drafts are a "private zone" that should not be touched by moderators.
* Moderators cannot have the intent to delete drafts because they cannot ever see them.
* A restored discussion now restores drafts. The previous behavior was permanently destructive.
* Does not interfere with counters.

We also rework the drafts view to operate on arrays and use some nicer logic.

Closes #1922
Closes #4187