### PR TITLE
Added class to ActivateSlider buttons

### DIFF
--- a/applications/dashboard/views/profile/connection_functions.php
+++ b/applications/dashboard/views/profile/connection_functions.php
@@ -55,9 +55,9 @@ function connectButton($Row) {
 
     $Result = '<span class="ActivateSlider ActivateSlider-'.$CssClass.'">';
     if ($Connected) {
-        $Result .= anchor(t('Connected'), $DisconnectUrl, 'Button Primary Hijack');
+        $Result .= anchor(t('Connected'), $DisconnectUrl, 'Button Primary Hijack ActivateSlider-Button');
     } else {
-        $Result .= anchor(t('Connect'), $ConnectUrl, 'Button', array('target' => '_top'));
+        $Result .= anchor(t('Connect'), $ConnectUrl, 'Button ActivateSlider-Button', array('target' => '_top'));
     }
     $Result .= '</span>';
 


### PR DESCRIPTION
The buttons in ". ActivateSlider" on /profile/connections really need an extra class. They always inherit the styling from ". Button", but are completely different. 