### PR TITLE
Insert root category with DisplayAs set to Categories

### DIFF
--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -63,7 +63,23 @@ $Construct->PrimaryKey('CategoryID')
 
 $RootCategoryInserted = false;
 if ($SQL->getWhere('Category', array('CategoryID' => -1))->numRows() == 0) {
-    $SQL->insert('Category', array('CategoryID' => -1, 'TreeLeft' => 1, 'TreeRight' => 4, 'InsertUserID' => 1, 'UpdateUserID' => 1, 'DateInserted' => Gdn_Format::toDateTime(), 'DateUpdated' => Gdn_Format::toDateTime(), 'Name' => 'Root', 'UrlCode' => '', 'Description' => 'Root of category tree. Users should never see this.', 'PermissionCategoryID' => -1));
+    $SQL->insert(
+        'Category',
+        [
+            'CategoryID' => -1,
+            'TreeLeft' => 1,
+            'TreeRight' => 4,
+            'InsertUserID' => 1,
+            'UpdateUserID' => 1,
+            'DateInserted' => Gdn_Format::toDateTime(),
+            'DateUpdated' => Gdn_Format::toDateTime(),
+            'Name' => 'Root',
+            'UrlCode' => '',
+            'Description' => 'Root of category tree. Users should never see this.',
+            'PermissionCategoryID' => -1,
+            'DisplayAs' => 'Categories'
+        ]
+    );
     $RootCategoryInserted = true;
 }
 


### PR DESCRIPTION
When the Root category was being inserted, it was populating its `DisplayAs` value with the table default.  This used to be "Default", but is now "Discussions", which isn't proper for Root.

This update explicitly sets Root's `DisplayAs` to "Categories".

Closes #4365