### PR TITLE
Unregister plugin after it has been disabled.

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -1237,6 +1237,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
             return false;
         }
 
+        $pluginClassName = $addon->getPluginClass();
         $pluginName = $addon->getRawKey();
         $enabled = $this->addonManager->isEnabled($pluginName, Addon::TYPE_ADDON);
 
@@ -1253,6 +1254,9 @@ class Gdn_PluginManager extends Gdn_Pluggable {
         saveToConfig("EnabledPlugins.{$pluginName}", false);
 
         $this->addonManager->stopAddon($addon);
+
+        // 4. Unregister the plugin properly.
+        $this->unregisterPlugin($pluginClassName);
 
         if ($enabled) {
             Logger::event(


### PR DESCRIPTION
Fix a case when plugins are enabled right after being disabled because its hooks have not removed from the plugin manager. 

Log model on configuration save?

<img width="502" alt="screen shot 2016-08-26 at 3 26 08 pm" src="https://cloud.githubusercontent.com/assets/2412909/18018327/31e0abe0-6ba4-11e6-9ad5-c9376f853e6c.png">

Fixes https://github.com/vanilla/addons/issues/369