### PR TITLE
Added a class for buttons in create link flyout.

### DIFF
--- a/plugins/editor/views/editor.php
+++ b/plugins/editor/views/editor.php
@@ -52,8 +52,8 @@ foreach ($this->data('_EditorToolbar') as $button) {
                '<div class="editor-insert-dialog Flyout MenuItems" data-wysihtml5-dialog="createLink">
                      <input class="InputBox editor-input-url" data-wysihtml5-dialog-field="href" value="http://" />
                       <div class="MenuButtons">
-                      <input type="button" data-wysihtml5-dialog-action="save" class="Button editor-dialog-fire-close" value="'.t('OK').'"/>
-                      <input type="button" data-wysihtml5-dialog-action="cancel" class="Button Cancel editor-dialog-fire-close" value="'.t('Cancel').'"/>
+                      <input type="button" data-wysihtml5-dialog-action="save" class="Button Flyout-Button editor-dialog-fire-close" value="'.t('OK').'"/>
+                      <input type="button" data-wysihtml5-dialog-action="cancel" class="Button Flyout-Button Cancel editor-dialog-fire-close" value="'.t('Cancel').'"/>
                       </div>
                    </div>'
                , 'div', array('class' => 'editor-dropdown editor-dropdown-link'));


### PR DESCRIPTION
Selecting buttons in CSS is already pretty messy in Vanilla. I'd like all flyout buttons to have a "Flyout-Button" class. Usually, designers want those buttons to be smaller than the rest. 