### PR TITLE
Add ability for configuration module to fail on error

### DIFF
--- a/applications/dashboard/modules/class.configurationmodule.php
+++ b/applications/dashboard/modules/class.configurationmodule.php
@@ -136,9 +136,12 @@ class ConfigurationModule extends Gdn_Module {
                 $this->controller()->setData($Name, $Value);
             }
 
-            // Save it to the config.
-            saveToConfig($Data, array('RemoveEmpty' => true));
-            $this->_Sender->informMessage(t('Saved'));
+            // Halt the save if we've had errors assigned.
+            if (!$Form->errorCount()) {
+                // Save it to the config.
+                saveToConfig($Data, array('RemoveEmpty' => true));
+                $this->_Sender->informMessage(t('Saved'));
+            }
         } else {
             // Load the form data from the config.
             $Data = array();
@@ -146,7 +149,7 @@ class ConfigurationModule extends Gdn_Module {
                 $Data[$Row['Name']] = c($Row['Config'], val('Default', $Row, ''));
             }
             $Form->setData($Data);
-            $this->Controller()->Data = array_merge($this->Controller()->Data, $Data);
+            $this->controller()->Data = array_merge($this->controller()->Data, $Data);
         }
     }
 

--- a/applications/dashboard/modules/class.configurationmodule.php
+++ b/applications/dashboard/modules/class.configurationmodule.php
@@ -137,7 +137,7 @@ class ConfigurationModule extends Gdn_Module {
             }
 
             // Halt the save if we've had errors assigned.
-            if (!$Form->errorCount()) {
+            if ($Form->errorCount() == 0) {
                 // Save it to the config.
                 saveToConfig($Data, array('RemoveEmpty' => true));
                 $this->_Sender->informMessage(t('Saved'));


### PR DESCRIPTION
Use case: https://github.com/vanilla/addons/pull/371

If we manually add errors to the ConfigurationModule's form, it should respect that and stop.