### PR TITLE
Let welcome email fallback to HomepageTitle

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3961,7 +3961,7 @@ class UserModel extends Gdn_Model {
      * @return string The welcome email for the registration type.
      */
     protected function getEmailWelcome($registerType, $user, $data, $password = '') {
-        $appTitle = c('Garden.Title');
+        $appTitle = c('Garden.Title', c('Garden.HomepageTitle'));
 
         // Backwards compatability. See if anybody has overridden the EmailWelcome string.
         if (($emailFormat = t('EmailWelcome'.$registerType, ''))) {


### PR DESCRIPTION
Closes #2325

Avoid situation where you end up with a blank site name in emails due to incomplete setup.