### PR TITLE
Add flat category handling to category management

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -298,6 +298,8 @@ class VanillaSettingsController extends Gdn_Controller {
         $this->fireEvent('AddEditCategory');
         $this->setupDiscussionTypes(array());
 
+        $displayAsOptions = CategoryModel::$displayAsOptions;
+
         if ($this->Form->authenticatedPostBack()) {
             // Form was validly submitted
             $IsParent = $this->Form->getFormValue('IsParent', '0');
@@ -329,6 +331,10 @@ class VanillaSettingsController extends Gdn_Controller {
                 $category = CategoryModel::categories($parent);
                 if ($category) {
                     $this->Form->setValue('ParentCategoryID', $category['CategoryID']);
+
+                    if (val('DisplayAs', $category) === 'Flat') {
+                        unset($displayAsOptions['Heading']);
+                    }
                 }
             }
 
@@ -344,6 +350,7 @@ class VanillaSettingsController extends Gdn_Controller {
         }
 
         // Render default view
+        $this->setData('DisplayAsOptions', $displayAsOptions);
         $this->render();
     }
 
@@ -543,13 +550,6 @@ class VanillaSettingsController extends Gdn_Controller {
         $PermissionModel = Gdn::permissionModel();
         $this->Form->setModel($this->CategoryModel);
 
-        $displayAsOptions = [
-            'Discussions' => 'Discussions',
-            'Categories' => 'Nested Categories',
-            'Flat' => 'Flat Categories',
-            'Heading' => 'Heading'
-        ];
-
         if (!$CategoryID && $this->Form->authenticatedPostBack()) {
             if ($ID = $this->Form->getFormValue('CategoryID')) {
                 $CategoryID = $ID;
@@ -564,6 +564,8 @@ class VanillaSettingsController extends Gdn_Controller {
         // Category data is expected to be in the form of an object.
         $this->Category = (object)$this->Category;
         $this->Category->CustomPermissions = $this->Category->CategoryID == $this->Category->PermissionCategoryID;
+
+        $displayAsOptions = categoryModel::$displayAsOptions;
 
         // Restrict "Display As" types based on parent.
         $parentCategory = $this->CategoryModel->getID($this->Category->ParentCategoryID);

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -298,7 +298,7 @@ class VanillaSettingsController extends Gdn_Controller {
         $this->fireEvent('AddEditCategory');
         $this->setupDiscussionTypes(array());
 
-        $displayAsOptions = CategoryModel::$displayAsOptions;
+        $displayAsOptions = CategoryModel::getDisplayAsOptions();
 
         if ($this->Form->authenticatedPostBack()) {
             // Form was validly submitted
@@ -565,7 +565,7 @@ class VanillaSettingsController extends Gdn_Controller {
         $this->Category = (object)$this->Category;
         $this->Category->CustomPermissions = $this->Category->CategoryID == $this->Category->PermissionCategoryID;
 
-        $displayAsOptions = categoryModel::$displayAsOptions;
+        $displayAsOptions = categoryModel::getDisplayAsOptions();
 
         // Restrict "Display As" types based on parent.
         $parentCategory = $this->CategoryModel->getID($this->Category->ParentCategoryID);

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -438,7 +438,7 @@ class CategoryCollection {
                     $categories[$category['ParentCategoryID']]['Children'][] = &$categories[$category['CategoryID']];
                 }
 
-                if (!$options['collapsecategories'] || !in_array($child['DisplayAs'], ['Categories'])) {
+                if (!$options['collapsecategories'] || !in_array($child['DisplayAs'], ['Categories', 'Flat'])) {
                     $parents[] = $child['CategoryID'];
                 }
             }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -42,7 +42,7 @@ class CategoryModel extends Gdn_Model {
     public static $Categories = null;
 
     /** @var array Valid values => labels for DisplayAs column. */
-    public static $displayAsOptions = [
+    private static $displayAsOptions = [
         'Discussions' => 'Discussions',
         'Categories' => 'Nested',
         'Flat' => 'Flat',
@@ -1389,6 +1389,13 @@ class CategoryModel extends Gdn_Model {
         $CategoryData = $this->SQL->get();
         $this->AddCategoryColumns($CategoryData);
         return $CategoryData;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getDisplayAsOptions() {
+        return self::$displayAsOptions;
     }
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -41,6 +41,14 @@ class CategoryModel extends Gdn_Model {
     /** @var array Merged Category data, including Pure + UserCategory. */
     public static $Categories = null;
 
+    /** @var array Valid values => labels for DisplayAs column. */
+    public static $displayAsOptions = [
+        'Discussions' => 'Discussions',
+        'Categories' => 'Nested',
+        'Flat' => 'Flat',
+        'Heading' => 'Heading'
+    ];
+
     /** @var bool Whether or not to explicitly shard the categories cache. */
     public static $ShardCache = false;
 

--- a/applications/vanilla/views/vanillasettings/addcategory.php
+++ b/applications/vanilla/views/vanillasettings/addcategory.php
@@ -76,7 +76,7 @@ Gdn_Theme::assetEnd();
         <?php echo $this->Form->label('Display As', 'DisplayAs'); ?>
         </div>
         <div class="input-wrap">
-        <?php echo $this->Form->DropDown('DisplayAs', ['Default' => 'Default', 'Discussions' => 'Discussions', 'Categories' => 'Nested Categories', 'Flat' => 'Flat Categories', 'Heading' => 'Heading'], ['Wrap' => true]); ?>
+        <?php echo $this->Form->dropDown('DisplayAs', $this->data('DisplayAsOptions'), ['Wrap' => true]); ?>
         </div>
     </li>
     <li class="form-group row">

--- a/applications/vanilla/views/vanillasettings/category-settings-functions.php
+++ b/applications/vanilla/views/vanillasettings/category-settings-functions.php
@@ -76,7 +76,7 @@ function writeCategoryOptions($category) {
 
     $cdd->addGroup(t('Display as'), 'displayas');
 
-    foreach (CategoryModel::$displayAsOptions as $displayAs => $label) {
+    foreach (CategoryModel::getDisplayAsOptions() as $displayAs => $label) {
         $cssClass = strcasecmp($displayAs, $category['DisplayAs']) === 0 ? 'selected': '';
 
         $icon = displayAsSymbol($displayAs);

--- a/applications/vanilla/views/vanillasettings/category-settings-functions.php
+++ b/applications/vanilla/views/vanillasettings/category-settings-functions.php
@@ -18,7 +18,7 @@ function writeCategoryItem($category, $indent = 0) {
         "$i  <div class=\"dd-handle tree-handle\">".symbol('handle', t('Drag'))."</div>",
         "<div class=\"dd-content tree-content\">";
 
-    if (in_array($category['DisplayAs'], ['Categories'])) {
+    if (in_array($category['DisplayAs'], ['Categories', 'Flat'])) {
         echo anchor(
             htmlspecialchars($category['Name']),
             '/vanilla/settings/categories?parent='.urlencode($category['UrlCode'])
@@ -46,6 +46,8 @@ function displayAsSymbol($displayAs) {
             return symbol('heading');
         case 'categories':
             return symbol('nested');
+        case 'flat':
+            return symbol('flat');
         case 'discussions':
         default:
             return symbol('discussions');
@@ -73,14 +75,14 @@ function writeCategoryOptions($category) {
         ->addLink(t('Edit'), "/vanilla/settings/editcategory?categoryid={$category['CategoryID']}", 'edit.edit');
 
     $cdd->addGroup(t('Display as'), 'displayas');
-    $displayasOptions = ['Heading', 'Categories', 'Discussions'];
-    foreach ($displayasOptions as $displayAs) {
+
+    foreach (CategoryModel::$displayAsOptions as $displayAs => $label) {
         $cssClass = strcasecmp($displayAs, $category['DisplayAs']) === 0 ? 'selected': '';
 
         $icon = displayAsSymbol($displayAs);
 
         $cdd->addLink(
-            t($displayAs),
+            t($label),
             '#',
             'displayas.'.strtolower($displayAs),
             'js-displayas '.$cssClass,

--- a/plugins/GettingStarted/default.php
+++ b/plugins/GettingStarted/default.php
@@ -76,7 +76,7 @@ class GettingStartedPlugin extends Gdn_Plugin {
         )).'</p>
         </li>
         <li class="Three'.(c('Plugins.GettingStarted.Categories', '0') == '1' ? ' Done' : '').'">
-        <strong>'.anchor(t('Organize your Categories'), 'vanilla/settings/managecategories').'</strong>
+        <strong>'.anchor(t('Organize your Categories'), 'vanilla/settings/categories').'</strong>
         <p>'.t(
             'Categories are used to organize discussions.',
             'Categories are used to help your users organize their discussions in a way that is meaningful for your community.'


### PR DESCRIPTION
This update adds flat category management capabilities to version 3 of the dashboard application.

Addresses the following items from #4155 

1. Add the "flat" option to the display as dropdown.
2. Rename the "categories" label to "nested".
3. A category with display as of "flat" should display as a link, just like display as "categories". Clicking on the link will nest into it.
4. When a category in this view has child categories then it should display as a link to edit the children.
