### PR TITLE
Turn off AutoComplete when editing users in dashboard

### DIFF
--- a/applications/dashboard/views/user/edit.php
+++ b/applications/dashboard/views/user/edit.php
@@ -6,7 +6,7 @@
             echo t('Add User');
         ?></h1>
 <?php
-echo $this->Form->open(array('class' => 'User'));
+echo $this->Form->open(array('class' => 'User', 'autocomplete' => 'off'));
 echo $this->Form->errors();
 if ($this->data('AllowEditing')) { ?>
     <ul>


### PR DESCRIPTION
When editing users in the dashboard, certain fields that are empty (e.g. Name) are being auto-filled. If an admin is not careful, they could add it to the user's record. The P.R. fixes that .