### PR TITLE
Verify that discussions titles render properly when no word characters are found in them.

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -53,6 +53,8 @@ class DiscussionController extends VanillaController {
      * @param int $Page The current page of comments
      */
     public function index($DiscussionID = '', $DiscussionStub = '', $Page = '') {
+        $this->_Definitions['BlankDiscussionTopicText'] = t('Blank Discussion Topic');
+
         // Setup head
         $Session = Gdn::session();
         $this->addJsFile('jquery.autosize.min.js');
@@ -529,7 +531,7 @@ class DiscussionController extends VanillaController {
             if ($Target) {
                 $this->RedirectUrl = url($Target);
             }
-            
+
             $this->jsonTarget('', '', 'Refresh');
         } else {
             if (!$Discussion->Announce) {

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -52,6 +52,8 @@ class DiscussionsController extends VanillaController {
      * @param int $Page Multiplied by PerPage option to determine offset.
      */
     public function index($Page = false) {
+        $this->_Definitions['BlankDiscussionTopicText'] = t('Blank Discussion Topic');
+
         // Figure out which discussions layout to choose (Defined on "Homepage" settings page).
         $Layout = c('Vanilla.Discussions.Layout');
         switch ($Layout) {

--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -138,6 +138,10 @@ if (!function_exists('WriteDiscussion')) :
         $DiscussionName = $Discussion->Name;
         if ($DiscussionName == '') {
             $DiscussionName = t('Blank Discussion Topic');
+
+        // If there are no word character detected in the title try to fix the link on the client side.
+        } elseif (preg_match('/\w/u', $DiscussionName) == false) {
+            $CssClass .= ' FixEmptyTitle';
         }
         $Sender->EventArguments['DiscussionName'] = &$DiscussionName;
 

--- a/js/global.js
+++ b/js/global.js
@@ -2026,7 +2026,7 @@ jQuery(document).ready(function($) {
 
         /*
          * Render every discussion into the a renderer (which has no styling that will interfere with the title's text)
-          * and check its size.
+         * and check its size.
          */
         $discussionTitles.each(function() {
             var $this = $(this);

--- a/js/global.js
+++ b/js/global.js
@@ -2030,8 +2030,9 @@ jQuery(document).ready(function($) {
          */
         $discussionTitles.each(function() {
             var $this = $(this);
-            if (!!$this.text()) {
-                $renderer.empty().text($this.text());
+            var text = $this.text();
+            if (!!text) {
+                $renderer.empty().text(text);
                 if ($renderer.width() === 0) {
                     $this.text(gdn.definition('BlankDiscussionTopicText', 'Blank Discussion Topic'));
                 }

--- a/js/global.js
+++ b/js/global.js
@@ -2016,6 +2016,31 @@ jQuery(document).ready(function($) {
         });
     }
 
+    var $discussionTitles = $('.FixEmptyTitle .Title a');
+    if ($discussionTitles.length) {
+        var $renderer = $('<div id="#TitleRender"/>').css({
+            position: 'absolute',
+            left: '-9999px',
+            'font-size': '20px'
+        }).prepend('body');
+
+        /*
+         * Render every discussion into the a renderer (which has no styling that will interfere with the title's text)
+          * and check its size.
+         */
+        $discussionTitles.each(function() {
+            var $this = $(this);
+            if (!!$this.text()) {
+                $renderer.empty().text($this.text());
+                if ($renderer.width() === 0) {
+                    $this.text(gdn.definition('BlankDiscussionTopicText', 'Blank Discussion Topic'));
+                }
+            }
+        });
+
+        $renderer.remove();
+    }
+
     $(document).trigger('contentLoad');
 });
 

--- a/js/global.js
+++ b/js/global.js
@@ -2022,7 +2022,7 @@ jQuery(document).ready(function($) {
             position: 'absolute',
             left: '-9999px',
             'font-size': '20px'
-        }).prepend('body');
+        }).prependTo('body');
 
         /*
          * Render every discussion into the a renderer (which has no styling that will interfere with the title's text)


### PR DESCRIPTION
That one was a bit tricky. Emojis were introduced in the Unicode Standard 6.0.

Some system may or may not render them properly.
I decided to implement a client side solution that check if titles are rendered properly by the browser.

Fix #4196

New PR based on https://github.com/vanilla/vanilla/pull/4375