### PR TITLE
Fix auto-detection of incoming data type in Gdn_DataSet

### DIFF
--- a/applications/vanilla/modules/class.categoriesmodule.php
+++ b/applications/vanilla/modules/class.categoriesmodule.php
@@ -52,9 +52,8 @@ class CategoriesModule extends Gdn_Module {
             }
         }
 
-        $Data = new Gdn_DataSet($Categories);
-        $Data->DatasetType(DATASET_TYPE_ARRAY);
-        $Data->DatasetType(DATASET_TYPE_OBJECT);
+        $Data = new Gdn_DataSet($Categories, DATASET_TYPE_ARRAY);
+        $Data->datasetType(DATASET_TYPE_OBJECT);
         $this->Data = $Data;
     }
 

--- a/library/database/class.dataset.php
+++ b/library/database/class.dataset.php
@@ -64,7 +64,8 @@ class Gdn_DataSet implements IteratorAggregate, Countable {
         if ($DataSetType !== null) {
             $this->_DatasetType = $DataSetType;
         } elseif ($Result) {
-            if (isset($Result[0]) && is_array($Result[0])) {
+            $firstElement = reset($Result);
+            if (is_array($firstElement)) {
                 $this->_DatasetType = DATASET_TYPE_ARRAY;
             }
         }


### PR DESCRIPTION
[`Gdn_DataSet::__construct`](https://github.com/vanilla/vanilla/blob/8efb18d446977d17bfd5738ec2af0bdff64ef00c/library/database/class.dataset.php#L58) attempts to determine the incoming data type based on the first element of its `$Result` parameter, if no explicit value for `$DataSetType` is provided.  It assumes a numerically-indexed array, starting with 0, when retrieving the first element.  If it cannot locate that element, the data type remains as the class default: `DATASET_TYPE_OBJECT`.  There are occassions (see #4340) where a multi-dimensional array might be passed in as `$Result` with no zero index and no explicitly-defined type parameter.  This leads the instance of `Gdn_DataSet` to assume it is dealing with an array of objects, which can lead to issues.  One such issue is the inability to efficiently invoke `Gdn_DataSet::datasetType` to convert that multi-dimensional array into an array of objects, because the class determines conversion isn't necessary, since it already erroneously flagged as an array of objects.

This update uses [reset](http://php.net/reset) on `$Result` in the `Gdn_DataSet` constructor to obtain the first value, regardless of index.  In addition, it also patches [`CategoriesModule::getData`](https://github.com/vanilla/vanilla/blob/8efb18d446977d17bfd5738ec2af0bdff64ef00c/applications/vanilla/modules/class.categoriesmodule.php#L36) to explicitly define its datatype and avoid having to detect or reset it to begin with.

Closes #4344 