### PR TITLE
Create flat strings that can accommodate gender when being translated.

### DIFF
--- a/applications/conversations/views/messages/all.php
+++ b/applications/conversations/views/messages/all.php
@@ -27,7 +27,7 @@ echo '</div>';
                 include $ViewLocation;
             else:
                 ?>
-                <li class="Item Empty Center"><?php echo sprintf(t('You do not have any %s yet.'), t('messages')); ?></li>
+                <li class="Item Empty Center"><?php echo t('You do not have any messages yet.'); ?></li>
             <?php
             endif;
             ?>

--- a/applications/conversations/views/messages/popin.php
+++ b/applications/conversations/views/messages/popin.php
@@ -49,6 +49,6 @@
             ?>
         </li>
     <?php else: ?>
-        <li class="Item Empty Center"><?php echo sprintf(t('You do not have any %s yet.'), t('messages')); ?></li>
+        <li class="Item Empty Center"><?php echo t('You do not have any messages yet.'); ?></li>
     <?php endif; ?>
 </ul>

--- a/applications/dashboard/views/activity/popin.php
+++ b/applications/dashboard/views/activity/popin.php
@@ -33,6 +33,6 @@
             ?>
         </li>
     <?php else: ?>
-        <li class="Item Empty Center"><?php echo sprintf(t('You do not have any %s yet.'), t('notifications')); ?></li>
+        <li class="Item Empty Center"><?php echo t('You do not have any notifications yet.'); ?></li>
     <?php endif; ?>
 </ul>

--- a/applications/dashboard/views/profile/notifications.php
+++ b/applications/dashboard/views/profile/notifications.php
@@ -10,7 +10,7 @@ if (count($this->data('Activities'))) {
     echo PagerModule::write(array('CurrentRecords' => count($this->data('Activities'))));
 } else {
     ?>
-    <div class="Empty"><?php echo sprintf(t('You do not have any %s yet.'), t('notifications')); ?></div>
+    <div class="Empty"><?php echo t('You do not have any notifications yet.'); ?></div>
 <?php
 }
 echo '</div>';

--- a/applications/vanilla/views/discussions/popin.php
+++ b/applications/vanilla/views/discussions/popin.php
@@ -36,6 +36,6 @@
             ?>
         </li>
     <?php else: ?>
-        <li class="Item Empty Center"><?php echo sprintf(t('You do not have any %s yet.'), t('bookmarks')); ?></li>
+        <li class="Item Empty Center"><?php echo t('You do not have any bookmarks yet.'); ?></li>
     <?php endif; ?>
 </ul>

--- a/applications/vanilla/views/drafts/index.php
+++ b/applications/vanilla/views/drafts/index.php
@@ -18,6 +18,6 @@ if ($this->DraftData->numRows() > 0) {
     echo $this->Pager->toString('more');
 } else {
     ?>
-    <div class="Empty"><?php echo sprintf(t('You do not have any %s yet.'), t('drafts')); ?></div>
+    <div class="Empty"><?php echo t('You do not have any drafts yet.'); ?></div>
 <?php
 }


### PR DESCRIPTION
Currently we have certain phrases that we concatenate using sprintf() which reduces duplication in our translation array. This causes problems when, in some languages, the subject of the sentences changes other words in the phrase: 

e.g. sprintf(t('You do not have any %s yet.'), t('notifications'));

In French "You do not have any" could be "Vous n'avez aucun" or "Vous n'avez aucune" based on the value of %s.

This PR would allow us to change the complete phrase.