### PR TITLE
Fix category depth adjustements

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -726,6 +726,7 @@ class VanillaSettingsController extends Gdn_Controller {
             $categories = $collection->getTree($parentID, ['maxdepth' => 10, 'collapsecategories' => true]);
         }
 
+        $this->setData('ParentID', $parentID);
         $this->setData('Categories', $categories);
         $this->setData('_Limit', $perPage);
         $this->setData('_CurrentRecords', count($categories));
@@ -946,7 +947,7 @@ class VanillaSettingsController extends Gdn_Controller {
 
         if ($this->Request->isAuthenticatedPostBack(true)) {
             $tree = json_decode($this->Request->post('Subtree'), true);
-            $result = $this->CategoryModel->SaveSubtree($tree);
+            $result = $this->CategoryModel->saveSubtree($tree, $this->Request->post('ParentID', -1));
             $this->setData('Result', $result);
         } else {
             throw new Gdn_UserException($this->Request->requestMethod().' is not allowed.', 405);

--- a/applications/vanilla/js/category-settings.js
+++ b/applications/vanilla/js/category-settings.js
@@ -32,7 +32,8 @@
                     url: gdn.url('/vanilla/settings/categoriestree.json'),
                     data: {
                         TransientKey: gdn.getMeta('TransientKey'),
-                        Subtree: JSON.stringify(postTree)
+                        Subtree: JSON.stringify(postTree),
+                        ParentID: $(source).data('parentId')
                     },
                     dataType: 'json',
                     error: function (xhr) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1985,9 +1985,10 @@ class CategoryModel extends Gdn_Model {
      * Save a subtree.
      *
      * @param array $subtree A nested array where each array contains a CategoryID and optional Children element.
+     * @parem int $parentID Parent ID of the subtree
      */
-    public function saveSubtree($subtree) {
-        $this->saveSubtreeInternal($subtree);
+    public function saveSubtree($subtree, $parentID) {
+        $this->saveSubtreeInternal($subtree, $parentID);
     }
 
     /**

--- a/applications/vanilla/views/vanillasettings/categories.php
+++ b/applications/vanilla/views/vanillasettings/categories.php
@@ -21,6 +21,6 @@
     PagerModule::write(['Sender' => $this, 'View' => 'pager-dashboard']);
 } ?></div>
 
-<div class="dd tree tree-categories"><?php
+<div class="dd tree tree-categories" data-parent-id="<?php echo $this->data('ParentID', -1); ?>"><?php
     writeCategoryTree($this->data('Categories', []), 0, $this->data('AllowSorting', true));
 ?></div>


### PR DESCRIPTION
Parent ID was not set properly when moving the first "level" children of a category on the same level of its parent.

This was due to the fact that saveSubtreeInternal was setting the `ParentCategoryID` only if `$parentID` is supplied and it was not!

Fix: https://github.com/vanilla/vanilla/issues/4419