### PR TITLE
Add BeforeCheckPreference event to ActivityModel

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1304,6 +1304,10 @@ class ActivityModel extends Gdn_Model {
             }
         }
 
+        $this->EventArguments['Preference'] = $Preference;
+        $this->EventArguments['Options'] = $Options;
+        $this->EventArguments['Data'] = $Data;
+        $this->fireEvent('BeforeCheckPreference');
         if (!empty($Preference)) {
             list($Popup, $Email) = self::notificationPreference($Preference, $Data['NotifyUserID'], 'both');
             if (!$Popup && !$Email) {


### PR DESCRIPTION
While trying to write a plugin which uses Pushbullet for sending notifications to users, I've found no way to queue activities for users who have neither the Email nor the Notification preference set, based on the rigid `if (!$Popup && !$Email) return` preference check
I needed an event before that check so that I could queue an activity based on my custom preferences ("BeforeCheckPreference"). I would have prefered a "BeforeQueue" event right before the `self::$Queue[...] = ...` but that would have required a logic change in that method and I wanted to be least invasive.

What would it take to ensure this change is in your next release (even if it would be a 2.2.bugfix)?