### PR TITLE
Do not fetch add symbols when delivery method is RSS

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -171,6 +171,7 @@ class DashboardHooks implements Gdn_IPlugin {
                 $Sender->addJsFile('vanilla.embed.local.js');
             } else {
                 $Sender->addJsFile('embed_local.js');
+
             }
         } else {
             $Sender->setHeader('X-Frame-Options', 'SAMEORIGIN');
@@ -187,9 +188,9 @@ class DashboardHooks implements Gdn_IPlugin {
         $Sender->addDefinition("TagHint", t("TagHint", "Start to type..."));
 
         // Add symbols.
-//        if ($Sender->addDefinition('InDashboard')) {
+        if ($Sender->deliveryMethod() === DELIVERY_METHOD_XHTML) {
             $Sender->addAsset('Symbols', $Sender->fetchView('symbols', '', 'Dashboard'));
-//        }
+        }
     }
 
     public function dashboardNavModule_init_handler($sender) {

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -171,7 +171,6 @@ class DashboardHooks implements Gdn_IPlugin {
                 $Sender->addJsFile('vanilla.embed.local.js');
             } else {
                 $Sender->addJsFile('embed_local.js');
-
             }
         } else {
             $Sender->setHeader('X-Frame-Options', 'SAMEORIGIN');


### PR DESCRIPTION
Fix the 'View not found.' error on /discussions.rss