### PR TITLE
Don't reload page after saving addon settings in a popup

### DIFF
--- a/applications/dashboard/js/dashboard.js
+++ b/applications/dashboard/js/dashboard.js
@@ -345,9 +345,8 @@ var DashboardModal = (function() {
 
         defaultSettings: {
             httpmethod: 'get',
-            afterSuccess: function(json, sender) {
-                // Called after the confirm url has been loaded via ajax
-            },
+            afterSuccess: function(json, sender) {},
+            reloadPageOnSave: true
         },
 
         id: '',
@@ -447,7 +446,7 @@ var DashboardModal = (function() {
             }
 
             $.ajax({
-                method: (this.settings.httpmethod === 'post') ? 'POST' : 'GET',
+                method: (self.settings.httpmethod === 'post') ? 'POST' : 'GET',
                 url: self.target,
                 data: ajaxData,
                 dataType: 'json',
@@ -598,11 +597,8 @@ var DashboardModal = (function() {
                 setTimeout(function() {
                     document.location.replace(redirectUrl);
                 }, 300);
-            } else {
+            } else if (this.settings.reloadPageOnSave) {
                 document.location.replace(window.location.href);
-                // Need to ensure editting/deleting/adding view updates
-                // are handled by the controller methods. Until then, we have to reload the page.
-                // $('#' + self.id).modal('hide');
             }
         },
 

--- a/applications/dashboard/js/src/modal.dashboard.js
+++ b/applications/dashboard/js/src/modal.dashboard.js
@@ -22,9 +22,8 @@ var DashboardModal = (function() {
 
         defaultSettings: {
             httpmethod: 'get',
-            afterSuccess: function(json, sender) {
-                // Called after the confirm url has been loaded via ajax
-            },
+            afterSuccess: function(json, sender) {},
+            reloadPageOnSave: true
         },
 
         id: '',
@@ -124,7 +123,7 @@ var DashboardModal = (function() {
             }
 
             $.ajax({
-                method: (this.settings.httpmethod === 'post') ? 'POST' : 'GET',
+                method: (self.settings.httpmethod === 'post') ? 'POST' : 'GET',
                 url: self.target,
                 data: ajaxData,
                 dataType: 'json',
@@ -275,11 +274,8 @@ var DashboardModal = (function() {
                 setTimeout(function() {
                     document.location.replace(redirectUrl);
                 }, 300);
-            } else {
+            } else if (this.settings.reloadPageOnSave) {
                 document.location.replace(window.location.href);
-                // Need to ensure editting/deleting/adding view updates
-                // are handled by the controller methods. Until then, we have to reload the page.
-                // $('#' + self.id).modal('hide');
             }
         },
 

--- a/applications/dashboard/views/settings/helper_functions.php
+++ b/applications/dashboard/views/settings/helper_functions.php
@@ -230,7 +230,7 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
     </div>
     <div class="media-right media-options">
         <?php if ($SettingsUrl != '') {
-            echo wrap(anchor(dashboardSymbol('settings'), $SettingsUrl, 'btn btn-icon-border '.$SettingsPopupClass, ['aria-label' => sprintf(t('Settings for %s'), $ScreenName)]), 'div', ['class' => 'btn-wrap']);
+            echo wrap(anchor(dashboardSymbol('settings'), $SettingsUrl, 'btn btn-icon-border '.$SettingsPopupClass, ['aria-label' => sprintf(t('Settings for %s'), $ScreenName), 'data-reload-page-on-save' => 'false']), 'div', ['class' => 'btn-wrap']);
         }
         ?>
         <div id="<?php echo strtolower($addonName); ?>-toggle">


### PR DESCRIPTION
Add a flag to let the modal know not to refresh after form save and apply it to the addon settings.
Also clean js a bit.

Closes https://github.com/vanilla/vanilla/issues/4476