### PR TITLE
Handle clearing problematic user preferences

### DIFF
--- a/applications/dashboard/controllers/class.dashboardcontroller.php
+++ b/applications/dashboard/controllers/class.dashboardcontroller.php
@@ -59,23 +59,6 @@ class DashboardController extends Gdn_Controller {
     }
 
     /**
-     * An endpoint to clear all the navigation preferences for a user.
-     *
-     * @param string $userID
-     */
-    public function clearNavigationPreferences($userID = '') {
-        if ($userID && $userID !== Gdn::session()->UserID) {
-            $this->permission('Garden.Users.Edit');
-        }
-
-        $userModel = new UserModel();
-        $userModel->clearNavigationPreferences($userID);
-
-        $this->informMessage(t('Navigation preferences cleared.'));
-        redirect('/');
-    }
-
-    /**
      * Sets a user's preference for dashboard panel nav collapsing. Collapsed groups are stored in an
      * list, by their 'data-key' attribute on the nav-header <a> element.
      *

--- a/applications/dashboard/controllers/class.dashboardcontroller.php
+++ b/applications/dashboard/controllers/class.dashboardcontroller.php
@@ -59,6 +59,23 @@ class DashboardController extends Gdn_Controller {
     }
 
     /**
+     * An endpoint to clear all the navigation preferences for a user.
+     *
+     * @param string $userID
+     */
+    public function clearNavigationPreferences($userID = '') {
+        if ($userID && $userID !== Gdn::session()->UserID) {
+            $this->permission('Garden.Users.Edit');
+        }
+
+        $userModel = new UserModel();
+        $userModel->clearNavigationPreferences($userID);
+
+        $this->informMessage(t('Navigation preferences cleared.'));
+        redirect('/');
+    }
+
+    /**
      * Sets a user's preference for dashboard panel nav collapsing. Collapsed groups are stored in an
      * list, by their 'data-key' attribute on the nav-header <a> element.
      *

--- a/applications/dashboard/controllers/class.homecontroller.php
+++ b/applications/dashboard/controllers/class.homecontroller.php
@@ -59,6 +59,7 @@ class HomeController extends Gdn_Controller {
         $this->setData('_NoMessages', true);
 
         $Code = $this->data('Code', 400);
+        $this->clearNavigationPreferences();
         safeheader("HTTP/1.0 $Code ".Gdn_Controller::GetStatusMessage($Code), true, $Code);
         Gdn_Theme::section('Error');
 
@@ -89,11 +90,21 @@ class HomeController extends Gdn_Controller {
         Gdn_Theme::section('Error');
 
         if ($this->deliveryMethod() == DELIVERY_METHOD_XHTML) {
+            $this->clearNavigationPreferences();
             safeHeader("HTTP/1.0 404", true, 404);
             $this->render();
         } else {
             $this->RenderException(NotFoundException());
         }
+    }
+
+    /**
+     * Clears the url from the user's navigation preferences.
+     */
+    private function clearNavigationPreferences() {
+        $userModel = new UserModel();
+        $uri = Gdn::request()->getRequestArguments('server')['REQUEST_URI'];
+        $userModel->clearSectionNavigationPreference($uri);
     }
 
     /**
@@ -116,6 +127,7 @@ class HomeController extends Gdn_Controller {
      * @access public
      */
     public function updateMode() {
+        $this->clearNavigationPreferences();
         safeHeader("HTTP/1.0 503", true, 503);
         $this->setData('UpdateMode', true);
         $this->render();
@@ -128,6 +140,7 @@ class HomeController extends Gdn_Controller {
      * @access public
      */
     public function deleted() {
+        $this->clearNavigationPreferences();
         safeHeader("HTTP/1.0 410", true, 410);
         Gdn_Theme::section('Error');
         $this->render();
@@ -213,6 +226,7 @@ class HomeController extends Gdn_Controller {
         Gdn_Theme::section('Error');
 
         if ($this->deliveryMethod() == DELIVERY_METHOD_XHTML) {
+            $this->clearNavigationPreferences();
             safeHeader("HTTP/1.0 401", true, 401);
             $this->render();
         } else {

--- a/applications/dashboard/controllers/class.homecontroller.php
+++ b/applications/dashboard/controllers/class.homecontroller.php
@@ -99,11 +99,13 @@ class HomeController extends Gdn_Controller {
     }
 
     /**
-     * Clears the url from the user's navigation preferences.
+     * Clears the request uri from the user's navigation preferences. This stops the user from getting locked out of
+     * the dashboard if they saved a preference for a page that no longer exists or that they no longer have
+     * permission to view.
      */
     private function clearNavigationPreferences() {
-        $userModel = new UserModel();
         $uri = Gdn::request()->getRequestArguments('server')['REQUEST_URI'];
+        $userModel = new UserModel();
         $userModel->clearSectionNavigationPreference($uri);
     }
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -4524,4 +4524,55 @@ class UserModel extends Gdn_Model {
         }
         return $RoleIDs;
     }
+
+    /**
+     * Clears navigation preferences for a user.
+     *
+     * @param string $userID Optional - defaults to sessioned user
+     */
+    public function clearNavigationPreferences($userID = '') {
+        if (!$userID) {
+            $userID = Gdn::session()->UserID;
+        }
+
+        $this->savePreference($userID, 'DashboardNav.Collapsed', []);
+        $this->savePreference($userID, 'DashboardNav.SectionLandingPages', []);
+        $this->savePreference($userID, 'DashboardNav.DashboardLandingPage', '');
+    }
+
+    /**
+     * Checks if a url is saved as a navigation preference and if so, deletes it.
+     * Also optionally resets the section dashboard landing page.
+     *
+     * @param string $url
+     * @param string $userID
+     * @param bool $resetSectionPreference
+     */
+    public function clearSectionNavigationPreference($url = '', $userID = '', $resetSectionPreference = true) {
+        if (!$userID) {
+            $userID = Gdn::session()->UserID;
+        }
+
+        if ($url == '') {
+            $url = Gdn::request()->url();
+        }
+
+        $user = $this->getID($userID);
+        $preferences = val('Preferences', $user, []);
+        $landingPages = val('DashboardNav.SectionLandingPages', $preferences, []);
+
+        foreach ($landingPages as $section => $landingPage) {
+            $url = strtolower(trim($url, '/'));
+            $landingPage = strtolower(trim($landingPage, '/'));
+            if ($url == $landingPage || stringEndsWith($url, $landingPage)) {
+                unset($landingPages[$section]);
+            }
+        }
+
+        $this->savePreference($userID, 'DashboardNav.SectionLandingPages', $landingPages);
+
+        if ($resetSectionPreference) {
+            $this->savePreference($userID, 'DashboardNav.DashboardLandingPage', '');
+        }
+    }
 }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -4542,11 +4542,12 @@ class UserModel extends Gdn_Model {
 
     /**
      * Checks if a url is saved as a navigation preference and if so, deletes it.
-     * Also optionally resets the section dashboard landing page.
+     * Also optionally resets the section dashboard landing page, which may be desirable if a user no longer has
+     * permission to access pages in that section.
      *
-     * @param string $url
-     * @param string $userID
-     * @param bool $resetSectionPreference
+     * @param string $url The url to search the user navigation preferences for, defaults to the request
+     * @param string $userID The ID of the user to clear the preferences for, defaults to the sessioned user
+     * @param bool $resetSectionPreference Whether to reset the dashboard section landing page
      */
     public function clearSectionNavigationPreference($url = '', $userID = '', $resetSectionPreference = true) {
         if (!$userID) {
@@ -4561,6 +4562,8 @@ class UserModel extends Gdn_Model {
         $preferences = val('Preferences', $user, []);
         $landingPages = val('DashboardNav.SectionLandingPages', $preferences, []);
 
+        // Run through the user's saved landing page per section and if the url matches the passed url,
+        // remove that preference.
         foreach ($landingPages as $section => $landingPage) {
             $url = strtolower(trim($url, '/'));
             $landingPage = strtolower(trim($landingPage, '/'));


### PR DESCRIPTION
Clear the url from a user's preferences if it's one that redirects them to a 404, 401, etc.
Provide an endpoint to manually clear a user's navigation preferences.