### PR TITLE
Add View link to manage category page

### DIFF
--- a/applications/vanilla/views/vanillasettings/category-settings-functions.php
+++ b/applications/vanilla/views/vanillasettings/category-settings-functions.php
@@ -74,6 +74,7 @@ function writeCategoryOptions($category) {
     $cdd->setForceDivider(true);
 
     $cdd->addGroup('', 'edit')
+        ->addLink(t('View'), $category['Url'], 'edit.view')
         ->addLink(t('Edit'), "/vanilla/settings/editcategory?categoryid={$category['CategoryID']}", 'edit.edit');
 
     $cdd->addGroup(t('Display as'), 'displayas');


### PR DESCRIPTION
This update adds a "View" item to the menu for each category on the Manage Categories page of the dashboard.  This menu item takes the user to the public-facing category page.

Closes #4428