### PR TITLE
Fix missing translation slug in PostController::notifyNewDiscussion

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -934,6 +934,13 @@ class PostController extends VanillaController {
         // Mark the notification as in progress.
         $this->DiscussionModel->setField($DiscussionID, 'Notified', ActivityModel::SENT_INPROGRESS);
 
+        $discussionType = val('Type', $Discussion);
+        if ($discussionType) {
+            $Code = "HeadlineFormat.Discussion.{$discussionType}";
+        } else {
+            $Code = 'HeadlineFormat.Discussion';
+        }
+
         $HeadlineFormat = t($Code, '{ActivityUserID,user} started a new discussion: <a href="{Url,html}">{Data.Name,text}</a>');
         $Category = CategoryModel::categories(val('CategoryID', $Discussion));
         $Activity = array(


### PR DESCRIPTION
`PostController::notifyNewDiscussion` was using a local variable named `$Code` as the translation slug for the `t` function, without having actually defined it before being used.

This update copies the logic from [DiscussionModel::save](https://github.com/vanilla/vanilla/blob/603163710edd49efcd83915424fca0773bb9d8f3/applications/vanilla/models/class.discussionmodel.php#L2029) to determine what `$Code` should be set to.