### PR TITLE
Allow Gdn_PluginManager->registerCallback() to properly register “create” and “override” style callbacks

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -883,6 +883,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
                 // The event handler is an array or a closure so we can call it directly.
                 $callback = $PluginKey;
             } else {
+                // Decode how `self::register[Handler|NewMethod|Override]` store event names.
                 $PluginKeyParts = explode('.', $PluginKey);
                 if (count($PluginKeyParts) == 2) {
                     // The event handler is a class and method name.
@@ -991,6 +992,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
             // The event handler is an array or a closure so we can call it directly.
             $callback = $MethodKey;
         } else {
+            // Decode how `self::register[Handler|NewMethod|Override]` store event names.
             $PluginKeyParts = explode('.', $MethodKey);
             if (count($PluginKeyParts) == 2) {
                 // The event handler is a class and method name.

--- a/tests/Library/Core/PluginManagerTest.php
+++ b/tests/Library/Core/PluginManagerTest.php
@@ -49,4 +49,38 @@ class PluginManagerTest extends \PHPUnit_Framework_Testcase {
         $pm->callEventHandler($sender, 'arg', 'ref');
         $this->assertTrue($arg);
     }
+
+    /**
+     * Registering "create" callbacks behaves differently than "handler" callbacks.
+     */
+    public function testRegisterCallbackCreate() {
+        $pm = new Gdn_PluginManager();
+
+        $called = false;
+        $pm->registerCallback('Foo_Bar_Create', function () use (&$called) {
+            $called = true;
+        });
+
+        $this->assertTrue($pm->hasNewMethod('foo', 'bar'));
+
+        $pm->callNewMethod($this, 'foo', 'bar');
+        $this->assertTrue($called);
+    }
+
+    /**
+     * Registering "override" callbacks behaves differently than "handler" callbacks.
+     */
+    public function testRegisterCallbackOverride() {
+        $pm = new Gdn_PluginManager();
+
+        $called = false;
+        $pm->registerCallback('Foo_Bar_Override', function () use (&$called) {
+            $called = true;
+        });
+
+        $this->assertTrue($pm->hasMethodOverride('foo', 'bar'));
+
+        $pm->callMethodOverride($this, 'foo', 'bar');
+        $this->assertTrue($called);
+    }
 }


### PR DESCRIPTION
Since the Gdn_PluginManager stores different types of event handlers into different arrays, registering a new callback must respect this.

Previously, `registerCallback()` also stored `_override` and `_create` types as `_handler`s.