### PR TITLE
Fix activity notifications falsely flagging as sent

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -853,10 +853,6 @@ class SettingsController extends DashboardController {
                     } else {
                         $this->Form->addError(t('Error sending email. Please review the addresses and try again.'));
                     }
-                } catch (phpmailerException $e) {
-                    if (debug()) {
-                        throw $e;
-                    }
                 } catch (Exception $e) {
                     if (debug()) {
                         throw $e;

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -846,10 +846,21 @@ class SettingsController extends DashboardController {
                 $emailer = $this->getTestEmail();
                 $emailer->to($addresses);
                 $emailer->subject(sprintf(t('Test email from %s'), c('Garden.Title')));
-                if ($emailer->send()) {
-                    $this->informMessage(t("The email has been sent."));
-                } else {
-                    $this->Form->addError(t('Error sending email. Please review the addresses and try again.'));
+
+                try {
+                    if ($emailer->send()) {
+                        $this->informMessage(t("The email has been sent."));
+                    } else {
+                        $this->Form->addError(t('Error sending email. Please review the addresses and try again.'));
+                    }
+                } catch (phpmailerException $e) {
+                    if (debug()) {
+                        throw $e;
+                    }
+                } catch (Exception $e) {
+                    if (debug()) {
+                        throw $e;
+                    }
                 }
             }
         }

--- a/applications/dashboard/models/class.invitationmodel.php
+++ b/applications/dashboard/models/class.invitationmodel.php
@@ -193,7 +193,18 @@ class InvitationModel extends Gdn_Model {
                 ->setTitle(sprintf(t('Join %s'), $AppTitle));
 
             $Email->setEmailTemplate($emailTemplate);
-            $Email->send();
+
+            try {
+                $Email->send();
+            } catch (phpmailerException $e) {
+                if (debug()) {
+                    throw $e;
+                }
+            } catch (Exception $e) {
+                if (debug()) {
+                    throw $e;
+                }
+            }
         }
     }
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3237,10 +3237,6 @@ class UserModel extends Gdn_Model {
 
                 try {
                     $Email->send();
-                } catch (phpmailerException $e) {
-                    if (debug()) {
-                        throw $e;
-                    }
                 } catch (Exception $e) {
                     if (debug()) {
                         throw $e;
@@ -3910,10 +3906,6 @@ class UserModel extends Gdn_Model {
 
         try {
             $Email->send();
-        } catch (phpmailerException $e) {
-            if (debug()) {
-                throw $e;
-            }
         } catch (Exception $e) {
             if (debug()) {
                 throw $e;
@@ -3976,10 +3968,6 @@ class UserModel extends Gdn_Model {
 
         try {
             $Email->send();
-        } catch (phpmailerException $e) {
-            if (debug()) {
-                throw $e;
-            }
         } catch (Exception $e) {
             if (debug()) {
                 throw $e;
@@ -4066,10 +4054,6 @@ class UserModel extends Gdn_Model {
 
         try {
             $Email->send();
-        } catch (phpmailerException $e) {
-            if (debug()) {
-                throw $e;
-            }
         } catch (Exception $e) {
             if (debug()) {
                 throw $e;
@@ -4228,10 +4212,6 @@ class UserModel extends Gdn_Model {
 
             try {
                 $Email->send();
-            } catch (phpmailerException $e) {
-                if (debug()) {
-                    throw $e;
-                }
             } catch (Exception $e) {
                 if (debug()) {
                     throw $e;

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3234,7 +3234,18 @@ class UserModel extends Gdn_Model {
                     ->setTitle(t('Membership Approved'));
 
                 $Email->setEmailTemplate($emailTemplate);
-                $Email->send();
+
+                try {
+                    $Email->send();
+                } catch (phpmailerException $e) {
+                    if (debug()) {
+                        throw $e;
+                    }
+                } catch (Exception $e) {
+                    if (debug()) {
+                        throw $e;
+                    }
+                }
 
                 // Report that the user was approved.
                 $ActivityModel = new ActivityModel();
@@ -3896,7 +3907,18 @@ class UserModel extends Gdn_Model {
             ->setButton($url, t('Confirm My Email Address'));
 
         $Email->setEmailTemplate($emailTemplate);
-        $Email->send();
+
+        try {
+            $Email->send();
+        } catch (phpmailerException $e) {
+            if (debug()) {
+                throw $e;
+            }
+        } catch (Exception $e) {
+            if (debug()) {
+                throw $e;
+            }
+        }
     }
 
     /**
@@ -3951,7 +3973,18 @@ class UserModel extends Gdn_Model {
         $emailTemplate->setTitle(t('Welcome Aboard!'));
 
         $Email->setEmailTemplate($emailTemplate);
-        $Email->send();
+
+        try {
+            $Email->send();
+        } catch (phpmailerException $e) {
+            if (debug()) {
+                throw $e;
+            }
+        } catch (Exception $e) {
+            if (debug()) {
+                throw $e;
+            }
+        }
     }
 
     /**
@@ -4030,7 +4063,18 @@ class UserModel extends Gdn_Model {
             ->setButton(externalUrl('/'), t('Access the Site'));
 
         $Email->setEmailTemplate($emailTemplate);
-        $Email->send();
+
+        try {
+            $Email->send();
+        } catch (phpmailerException $e) {
+            if (debug()) {
+                throw $e;
+            }
+        } catch (Exception $e) {
+            if (debug()) {
+                throw $e;
+            }
+        }
     }
 
     /**
@@ -4182,7 +4226,18 @@ class UserModel extends Gdn_Model {
                 ->setButton(externalUrl('/entry/passwordreset/'.$User->UserID.'/'.$PasswordResetKey), t('Change My Password'));
             $Email->setEmailTemplate($emailTemplate);
 
-            $Email->send();
+            try {
+                $Email->send();
+            } catch (phpmailerException $e) {
+                if (debug()) {
+                    throw $e;
+                }
+            } catch (Exception $e) {
+                if (debug()) {
+                    throw $e;
+                }
+            }
+
             $NoEmail = false;
         }
 

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -16,6 +16,9 @@
  */
 class Gdn_Email extends Gdn_Pluggable {
 
+    /** Error: The email was not attempted to be sent.. */
+    const ERR_SKIPPED = 1;
+
     /** @var PHPMailer */
     public $PhpMailer;
 
@@ -322,7 +325,7 @@ class Gdn_Email extends Gdn_Pluggable {
         $this->fireEvent('BeforeSendMail');
 
         if (c('Garden.Email.Disabled')) {
-            return;
+            throw new Exception('Email disabled', self::ERR_SKIPPED);
         }
 
         if (c('Garden.Email.UseSmtp')) {
@@ -341,8 +344,6 @@ class Gdn_Email extends Gdn_Pluggable {
             if (!empty($Username)) {
                 $this->PhpMailer->SMTPAuth = true;
             }
-
-
         } else {
             $this->PhpMailer->isMail();
         }
@@ -354,7 +355,7 @@ class Gdn_Email extends Gdn_Pluggable {
 
         if (!empty($this->Skipped) && $this->PhpMailer->countRecipients() == 0) {
             // We've skipped all recipients.
-            return true;
+            throw new Exception('No valid email recipients.', self::ERR_SKIPPED);
         }
 
         $this->PhpMailer->throwExceptions(true);

--- a/plugins/Flagging/class.flagging.plugin.php
+++ b/plugins/Flagging/class.flagging.plugin.php
@@ -365,8 +365,19 @@ class FlaggingPlugin extends Gdn_Plugin {
                     $Email = new Gdn_Email();
                     $Email->to($User->Email)
                         ->subject(sprintf(t('[%1$s] %2$s'), Gdn::config('Garden.Title'), $Subject))
-                        ->message($EmailBody)
-                        ->send();
+                        ->message($EmailBody);
+
+                    try {
+                        $Email->send();
+                    } catch (phpmailerException $e) {
+                        if (debug()) {
+                            throw $e;
+                        }
+                    } catch (Exception $e) {
+                        if (debug()) {
+                            throw $e;
+                        }
+                    }
                 }
             }
 

--- a/plugins/Flagging/class.flagging.plugin.php
+++ b/plugins/Flagging/class.flagging.plugin.php
@@ -369,10 +369,6 @@ class FlaggingPlugin extends Gdn_Plugin {
 
                     try {
                         $Email->send();
-                    } catch (phpmailerException $e) {
-                        if (debug()) {
-                            throw $e;
-                        }
                     } catch (Exception $e) {
                         if (debug()) {
                             throw $e;


### PR DESCRIPTION
This update...

1. Adds a new status for the `Emailed` column of the Activity table: `SENT_SKIPPED`.  This is used to indicate when sending an email has been skipped, instead of an error occurring. 
2. Adds try/catch blocks around all the `Gdn_Email::send` calls I could find that didn't already have them, because that function can (and does) throw exceptions, even before this update.
3. Appeases my IDE by tweaking some docs and default parameter types.

Closes #4397 