### PR TITLE
Use toLocaleString to format numbers in VanillaStats plug-in

### DIFF
--- a/plugins/VanillaStats/js/vanillastats.js
+++ b/plugins/VanillaStats/js/vanillastats.js
@@ -159,7 +159,7 @@ var vanillaStats = (function() {
                                         if (d % 1 !== 0) {
                                             return '';
                                         }
-                                        return d;
+                                        return d.toLocaleString();
                                     }
                                 }
                             }
@@ -852,7 +852,7 @@ var vanillaStats = (function() {
         if (typeof count !== "number") {
             countString = "-";
         } else {
-            countString = count.toString(10);
+            countString = count.toLocaleString();
         }
 
         var containerElement = document.getElementById(containerID);


### PR DESCRIPTION
This update alters the VanillaStats plug-in's JavaScript to use `toLocaleString` on the number values it displays on the chart and in the sparkline widgets.  This formats the numbers with commas.