### PR TITLE
Added a background colour to Overlay

### DIFF
--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -2624,6 +2624,7 @@ form.Thumbnail .Warning {
   width: 100%;
   height: 100%;
   z-index: 998;
+  background-color: rgba(0, 0, 0, 0.2);
 }
 
 .MSIE .Overlay {


### PR DESCRIPTION
The default vanilla style does not have a background colour on the overlay. It's not always obvious (especially with a small popup) that you can't click elsewhere.