### PR TITLE
Don't show empty column labels when a table collapses

### DIFF
--- a/applications/dashboard/js/jquery.tablejengo.js
+++ b/applications/dashboard/js/jquery.tablejengo.js
@@ -87,7 +87,13 @@
                         label = $cell.data('label');
 
                         html = vars.metaTemplate.replace('{data}', html);
-                        html = html.replace('{label}', label);
+                        if (label) {
+                            var labelHtml = vars.metaLabel.replace('{label}', label);
+                            html = html.replace('{label}', labelHtml);
+                        } else {
+                            html = html.replace('{label}', '');
+                        }
+
                         if (!$('.tj-main-cell .tj-meta', this).length) {
                             $('.tj-main-cell', this).append('<div class="tj-meta">' + html + '</div>');
                         } else {
@@ -144,6 +150,7 @@
                 container: settings.container,
                 mainCell: settings.mainCell,
                 metaTemplate: settings.metaTemplate,
+                metaLabel: settings.metaLabel,
                 showEmptyCells: settings.showEmptyCells
             };
 
@@ -160,9 +167,10 @@
         container: 'body',
         mainCell: 'firstcell',
         metaTemplate: '<div class="table-meta-item">' +
-        '<span class="table-meta-item-label">{label}: </span>' +
+        '{label}' +
         '<span class="table-meta-item-data">{data}</span>' +
         '</div>',
+        metaLabel: '<span class="table-meta-item-label">{label}: </span>',
         showEmptyCells: false
     };
 


### PR DESCRIPTION
Fixes issue where table meta for a collapsed table shows a colon `:` but no label when the column has no label.

Closes https://github.com/vanilla/internal/issues/683
Closes https://github.com/vanilla/vanilla/issues/4487