### PR TITLE
Make sure new-school form buttons have a value

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -324,7 +324,7 @@ class Gdn_Form extends Gdn_Pluggable {
         $Return .= $this->_attributesToString($Attributes);
 
         if ($elem === 'button') {
-            $Return .= ' value="'.val('value', $Attributes).'">'.htmlspecialchars(t($ButtonCode, val('value', $Attributes))).'</button>';
+            $Return .= ' value="'.val('value', $Attributes, $ButtonCode).'">'.htmlspecialchars(t($ButtonCode, val('value', $Attributes))).'</button>';
         } else {
             $Return .= ' value="'.t($ButtonCode, val('value', $Attributes)).'"';
             $Return .= " />\n";


### PR DESCRIPTION
Old forms output buttons with a value equal to their label. The new buttons should fall back to the same.