### PR TITLE
Fix conflicting param usage in CategoryModel::getTreeAsFlat

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -722,7 +722,7 @@ class VanillaSettingsController extends Gdn_Controller {
         }
 
         if ($parentID > 0 && $parentDisplayAs === 'Flat') {
-            $categories = $this->CategoryModel->getTreeAsFlat($parentID, $offset, $limit, null, 'Name', 'asc');
+            $categories = $this->CategoryModel->getTreeAsFlat($parentID, $offset, $limit);
         } else {
             $categories = $collection->getTree($parentID, ['maxdepth' => 10, 'collapsecategories' => true]);
         }

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -722,7 +722,7 @@ class VanillaSettingsController extends Gdn_Controller {
         }
 
         if ($parentID > 0 && $parentDisplayAs === 'Flat') {
-            $categories = $this->CategoryModel->getTreeAsFlat($parentID, $offset, $limit, 'Name', 'asc');
+            $categories = $this->CategoryModel->getTreeAsFlat($parentID, $offset, $limit, null, 'Name', 'asc');
         } else {
             $categories = $collection->getTree($parentID, ['maxdepth' => 10, 'collapsecategories' => true]);
         }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -653,7 +653,7 @@ class CategoryModel extends Gdn_Model {
      * @param string $orderDirection
      * @return array
      */
-    public function getTreeAsFlat($id, $offset = null, $limit = null, $filter = null, $orderFields = 'DateInserted', $orderDirection = 'desc') {
+    public function getTreeAsFlat($id, $offset = null, $limit = null, $filter = null, $orderFields = 'Name', $orderDirection = 'asc') {
         $query = $this->SQL
             ->from('Category')
             ->where('DisplayAs <>', 'Heading')

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -649,15 +649,17 @@ class CategoryModel extends Gdn_Model {
      * @param int|null $offset Offset results by given value.
      * @param int|null $limit Total number of results should not exceed this value.
      * @param string|null $filter Restrict results to only those with names matching this value, if provided.
+     * @param string $orderFields
+     * @param string $orderDirection
      * @return array
      */
-    public function getTreeAsFlat($id, $offset = null, $limit = null, $filter = null) {
+    public function getTreeAsFlat($id, $offset = null, $limit = null, $filter = null, $orderFields = 'DateInserted', $orderDirection = 'desc') {
         $query = $this->SQL
             ->from('Category')
             ->where('DisplayAs <>', 'Heading')
             ->where('ParentCategoryID', $id)
             ->limit($limit, $offset)
-            ->orderBy('DateInserted', 'desc');
+            ->orderBy($orderFields, $orderDirection);
 
         if ($filter) {
             $query->like('Name', $filter);


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/4371 and https://github.com/vanilla/vanilla/pull/4387 have conflicting signatures for `CategoryModel::getTreeAsFlat`.  This causes some issues in category management pages (e.g. no children show up when managing a flat category).

This update fixes the parameter collision and updates the necessary calls.