### PR TITLE
Allow CI build to succeed when HHVM job fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ php:
 sudo: false
 
 matrix:
+  allow_failures:
+    - php: hhvm
   fast_finish: true
 
 cache:


### PR DESCRIPTION
This update alters Vanilla's Travis CI config file to allow the HHVM job to fail without considering the whole build to be a failure.

Based on information available at [Customizing the Build - Travis-CI](https://docs.travis-ci.com/user/customizing-the-build#Rows-that-are-Allowed-to-Fail)

Closes #4511 