### PR TITLE
Make settings/tutorials require permissions

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1953,6 +1953,7 @@ class SettingsController extends DashboardController {
      * @param string $Tutorial
      */
     public function tutorials($Tutorial = '') {
+        $this->permission('Garden.Settings.Manage');
         $this->setData('Title', t('Help &amp; Tutorials'));
         $this->setHighlightRoute('dashboard/settings/tutorials');
         $this->setData('CurrentTutorial', $Tutorial);


### PR DESCRIPTION
By now it is possible to access /settings/tutorials without any permissions at all. Though this is not a security problem, it might be disturbing for admins to see that even guests can access parts of the admin area.