### PR TITLE
Replace Hide Category with Mute Category

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -154,10 +154,6 @@ class CategoriesController extends VanillaController {
             $this->CategoryModel->joinRecent($categoryTree);
         }
 
-        if ($watching && $this->CategoryModel->Watching) {
-            $categoryTree = $this->CategoryModel->filterFollowing($categoryTree);
-        }
-
         return $categoryTree;
     }
 
@@ -460,9 +456,6 @@ class CategoriesController extends VanillaController {
                 $Category ?: null,
                 ['depth' => $this->CategoryModel->getMaxDisplayDepth() ?: 10]
             );
-        if ($this->CategoryModel->Watching) {
-            $categoryTree = $this->CategoryModel->filterFollowing($categoryTree);
-        }
         $this->CategoryModel->joinRecent($categoryTree);
         $this->setData('CategoryTree', $this->getCategoryTree($Category, null, true, true));
 

--- a/applications/vanilla/modules/class.categoryfollowtogglemodule.php
+++ b/applications/vanilla/modules/class.categoryfollowtogglemodule.php
@@ -10,6 +10,8 @@
 
 /**
  * Allows the user to show all unfollowed categories so they can re-follow them.
+ *
+ * @deprecated 2.2.113 Dropped in favor of muting categories
  */
 class CategoryFollowToggleModule extends Gdn_Module {
 
@@ -39,10 +41,6 @@ class CategoryFollowToggleModule extends Gdn_Module {
     }
 
     public function toString() {
-        if (Gdn::session()->isValid()) {
-            return parent::ToString();
-        }
-
         return '';
     }
 }

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -74,7 +74,7 @@ if (!function_exists('getOptions')):
         $hide = (int)!val('Following', $category);
 
         $dropdown->addLink(t('Mark Read'), url('/category/markread?categoryid='.$categoryID.'&tkey='.$tk), 'mark-read');
-        $dropdown->addLink(t($hide ? 'Unhide' : 'Hide'), url('/category/follow?categoryid='.$categoryID.'&value='.$hide.'&tkey='.$tk), 'hide');
+        $dropdown->addLink(t($hide ? 'Unmute' : 'Mute'), url('/category/follow?categoryid='.$categoryID.'&value='.$hide.'&tkey='.$tk), 'hide');
 
         // Allow plugins to add options
         $sender->EventArguments['CategoryOptionsDropdown'] = &$dropdown;

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ if (PHP_VERSION_ID < 50400) {
 }
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.2.112.3');
+define('APPLICATION_VERSION', '2.2.113');
 
 // Report and track all errors.
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);


### PR DESCRIPTION
This update removes the less-than-intuitive "Hide Category" feature and replaces it with "Mute Category".  Muting a category will still display it in the category list (unlike hiding it), but filter its discussions out of the recent discussions page.  Since we're removing this functionality, `CategoryFollowToggleModule` is being deprecated.  The class still exists, but should not longer render any code when included.

Existing fields, functions and variable naming (following, unfollow, watching, etc.) remain unchanged.  Existing filtering for the recent discussions page remains the same as implemented in [`DiscussionModel::getWhere`](https://github.com/vanilla/vanilla/blob/c5616600b41438fc8de53eb034e7c74ea882cdf7/applications/vanilla/models/class.discussionmodel.php#L601)

Closes #4394 