### PR TITLE
Verify presence of CategoryModel in discussion views

### DIFF
--- a/applications/vanilla/views/discussions/index.php
+++ b/applications/vanilla/views/discussions/index.php
@@ -15,7 +15,7 @@ $this->fireEvent('AfterPageTitle');
 $subtreeView = $this->fetchViewLocation('subtree', 'categories', 'vanilla', false);
 if ($subtreeView) {
     include $subtreeView;
-} else {
+} elseif (isset($this->CategoryModel) && $this->CategoryModel instanceof CategoryModel) {
     $childCategories = $this->data('CategoryTree', []);
     $this->CategoryModel->joinRecent($childCategories);
     if ($childCategories) {

--- a/applications/vanilla/views/discussions/table.php
+++ b/applications/vanilla/views/discussions/table.php
@@ -26,7 +26,7 @@ $this->fireEvent('AfterDescription');
 $subtreeView = $this->fetchViewLocation('subtree', 'categories', 'vanilla', false);
 if ($subtreeView) {
     include $subtreeView;
-} else {
+} elseif (isset($this->CategoryModel) && $this->CategoryModel instanceof CategoryModel) {
     $childCategories = $this->data('CategoryTree', []);
     $this->CategoryModel->joinRecent($childCategories);
     if ($childCategories) {


### PR DESCRIPTION
This update verifies the `CategoryModel` property is present and an instance of `CategoryModel` before attempting to use it in discussion views.  Prior to this update, there was a potential to reach a "Call to a member function joinRecent() on null" error.