### PR TITLE
Remove Message restrictions from global.js

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -342,8 +342,8 @@ jQuery(document).ready(function($) {
         //$('a.Popup').popup();
         //$('a.PopConfirm').popup({'confirm' : true, 'followConfirm' : true});
 
-        $('a.Popup:not(.Message a.Popup):not(.dashboard a.Popup):not(.Section-Dashboard a.Popup)').popup();
-        $('a.PopConfirm:not(.Message a.PopConfirm)').popup({'confirm': true, 'followConfirm': true});
+        $('a.Popup:not(.dashboard a.Popup):not(.Section-Dashboard a.Popup)').popup();
+        $('a.PopConfirm').popup({'confirm': true, 'followConfirm': true});
     }
 
     $(document).delegate(".PopupWindow:not(.Message .PopupWindow)", 'click', function() {
@@ -376,14 +376,14 @@ jQuery(document).ready(function($) {
     // This turns any anchor with the "Popdown" class into an in-page pop-up, but
     // it does not hijack forms in the popup.
     if ($.fn.popup)
-        $('a.Popdown:not(.Message a.Popdown)').popup({hijackForms: false});
+        $('a.Popdown').popup({hijackForms: false});
 
     // This turns SignInPopup anchors into in-page popups
     if ($.fn.popup)
-        $('a.SignInPopup:not(.Message a.SignInPopup)').popup({containerCssClass: 'SignInPopup'});
+        $('a.SignInPopup').popup({containerCssClass: 'SignInPopup'});
 
     if ($.fn.popup)
-        $(document).delegate('.PopupClose:not(.Message .PopupClose)', 'click', function(event) {
+        $(document).delegate('.PopupClose', 'click', function(event) {
             var Popup = $(event.target).parents('.Popup');
             if (Popup.length) {
                 var PopupID = Popup.prop('id');
@@ -392,7 +392,7 @@ jQuery(document).ready(function($) {
         });
 
     // Make sure that message dismissalls are ajax'd
-    $(document).delegate('a.Dismiss:not(.Message a.Dismiss)', 'click', function() {
+    $(document).delegate('a.Dismiss', 'click', function() {
         var anchor = this;
         var container = $(anchor).parent();
         var transientKey = gdn.definition('TransientKey');
@@ -410,7 +410,7 @@ jQuery(document).ready(function($) {
     // without a refresh. The form must be within an element with the "AjaxForm"
     // class.
     if ($.fn.handleAjaxForm)
-        $('.AjaxForm').not('.Message .AjaxForm').handleAjaxForm();
+        $('.AjaxForm').handleAjaxForm();
 
     // Handle ToggleMenu toggling and set up default state
     $('[class^="Toggle-"]').hide(); // hide all toggle containers
@@ -712,7 +712,7 @@ jQuery(document).ready(function($) {
             });
         });
     };
-    $('.Popin, .js-popin').not('.Message .Popin, .Message .js-popin').popin();
+    $('.Popin, .js-popin').popin();
 
     var hijackClick = function(e) {
         var $elem = $(this);
@@ -761,7 +761,7 @@ jQuery(document).ready(function($) {
 
         return false;
     };
-    $(document).delegate('.Hijack:not(.DismissMessage .Hijack)', 'click', hijackClick);
+    $(document).delegate('.Hijack', 'click', hijackClick);
 
 
     // Activate ToggleFlyout and ButtonGroup menus
@@ -779,7 +779,7 @@ jQuery(document).ready(function($) {
         return false;
     });
     var lastOpen = null;
-    $(document).delegate('.ToggleFlyout:not(.Message .ToggleFlyout)', 'click', function(e) {
+    $(document).delegate('.ToggleFlyout', 'click', function(e) {
 
         var $flyout = $('.Flyout', this);
         var isHandle = false;


### PR DESCRIPTION
Using HTMLawed, we have a whitelist of CSS classes that are allowed to be applied to user-generated content. As such, there's no need to have the restrictions added in this pull-request any longer: https://github.com/vanilla/vanilla/pull/2012

Further, this fixes the Groups issue which was addressed here: https://github.com/vanilla/internal/pull/706
which was introduced by a misunderstanding of the overloaded `Message` term here: https://github.com/vanilla/vanilla/commit/952324939824d5b4554dc086951d7ecd60387bf2#diff-206bb8e5b8584223b92afae06825d2faR764  which was originally a problem because .Hijack wasn't working in the Message setting page in the dashboard.

All apologies for the run-on sentence.