### PR TITLE
Decode IP field data in Gdn_Controller::renderData

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1089,56 +1089,6 @@ class Gdn_Controller extends Gdn_Pluggable {
     }
 
     /**
-     * Encode a value as JSON or throw an exception on error.
-     *
-     * @param mixed $value
-     * @param int|null $options
-     * @return string
-     * @throws Exception
-     */
-    private function jsonEncode($value, $options = null) {
-        $advanced = (PHP_VERSION_ID >= 50500);
-
-        if ($options === null) {
-            if ($advanced) {
-                $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
-            } else {
-                $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
-            }
-        }
-
-        $encoded = json_encode($value, $options);
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            if ($advanced) {
-                switch (json_last_error()) {
-                    case JSON_ERROR_RECURSION:
-                        $errorMessage = 'One or more recursive references in the value to be encoded.';
-                        break;
-                    case JSON_ERROR_INF_OR_NAN:
-                        $errorMessage = 'One or more NAN or INF values in the value to be encoded';
-                        break;
-                    case JSON_ERROR_UNSUPPORTED_TYPE:
-                        $errorMessage = 'A value of a type that cannot be encoded was given.';
-                        break;
-                    default:
-                        $errorMessage = 'An unknown error has occurred.';
-                }
-            } else {
-                $errorMessage = 'An unknown error has occurred.';
-            }
-        } else {
-            $errorMessage = null;
-        }
-
-        if ($errorMessage !== null) {
-            throw new Exception("JSON encoding error: {$errorMessage}", 500);
-        }
-
-        return $encoded;
-    }
-
-    /**
      *
      *
      * @param $Target
@@ -1564,7 +1514,7 @@ class Gdn_Controller extends Gdn_Pluggable {
                 break;
             case DELIVERY_METHOD_JSON:
             default:
-                $jsonData = $this->jsonEncode($Data);
+                $jsonData = jsonEncodeChecked($Data);
 
                 if (($Callback = $this->Request->get('callback', false)) && $this->allowJSONP()) {
                     safeHeader('Content-Type: application/javascript; charset=utf-8', true);

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1470,23 +1470,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
         $this->sendHeaders();
 
-        // Recursively walk the data, decoding any IP address fields.
-        $ipWalk = function(&$inputValues) use (&$ipWalk) {
-            if (is_array($inputValues) || is_object($inputValues)) {
-                foreach ($inputValues as $key => &$val) {
-                    if (is_string($val) && stringEndsWith($key, 'IPAddress', true)) {
-                        $val = ipDecode($val);
-                    } elseif (is_array($val) && stringEndsWith($key, 'IPAddresses', true)) {
-                        array_walk($val, function(&$ip, $i) {
-                            $ip = ipDecode($ip);
-                        });
-                    } elseif (is_array($val) || is_object($val)) {
-                        $ipWalk($val);
-                    }
-                }
-            }
-        };
-        $ipWalk($Data);
+        ipDecodeWalk($Data);
 
         // Check for a special view.
         $ViewLocation = $this->fetchViewLocation(($this->View ? $this->View : $this->RequestMethod).'_'.strtolower($this->deliveryMethod()), false, false, false);

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1074,6 +1074,28 @@ class Gdn_Controller extends Gdn_Pluggable {
     }
 
     /**
+     * Encode a value as JSON or throw an exception on error.
+     *
+     * @param mixed $value
+     * @param int|null $options
+     * @return string
+     * @throws Gdn_UserException
+     */
+    private function jsonEncode($value, $options = null) {
+        if ($options === null) {
+            $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+        }
+
+        $encoded = json_encode($value, $options);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new Gdn_UserException('A JSON encoding error has occurred');
+        }
+
+        return $encoded;
+    }
+
+    /**
      *
      *
      * @param $Target
@@ -1499,31 +1521,7 @@ class Gdn_Controller extends Gdn_Pluggable {
                 break;
             case DELIVERY_METHOD_JSON:
             default:
-                $jsonData = @json_encode($Data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-
-                switch (json_last_error()) {
-                    case JSON_ERROR_NONE:
-                        $jsonError = false; // No error has occurred
-                        break;
-                    case JSON_ERROR_DEPTH:
-                        $jsonError = 'The maximum stack depth has been exceeded.';
-                        break;
-                    case JSON_ERROR_STATE_MISMATCH:
-                        $jsonError = 'Invalid or malformed JSON.';
-                        break;
-                    case JSON_ERROR_CTRL_CHAR:
-                        $jsonError = 'Control character error, possibly incorrectly encoded.';
-                        break;
-                    case JSON_ERROR_SYNTAX:
-                        $jsonError = 'Syntax error.';
-                        break;
-                    default:
-                        $jsonError = 'Unknown error.';
-                }
-
-                if ($jsonError !== false) {
-                    throw new Gdn_UserException("JSON encoding error: {$jsonError}");
-                }
+                $jsonData = $this->jsonEncode($Data);
 
                 if (($Callback = $this->Request->get('callback', false)) && $this->allowJSONP()) {
                     safeHeader('Content-Type: application/javascript; charset=utf-8', true);

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1082,14 +1082,42 @@ class Gdn_Controller extends Gdn_Pluggable {
      * @throws Gdn_UserException
      */
     private function jsonEncode($value, $options = null) {
+        $advanced = (PHP_VERSION_ID >= 50500);
+
         if ($options === null) {
-            $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+            if ($advanced) {
+                $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
+            } else {
+                $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+            }
         }
 
         $encoded = json_encode($value, $options);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new Gdn_UserException('A JSON encoding error has occurred');
+            if ($advanced) {
+                switch (json_last_error()) {
+                    case JSON_ERROR_RECURSION:
+                        $errorMessage = 'One or more recursive references in the value to be encoded.';
+                        break;
+                    case JSON_ERROR_INF_OR_NAN:
+                        $errorMessage = 'One or more NAN or INF values in the value to be encoded';
+                        break;
+                    case JSON_ERROR_UNSUPPORTED_TYPE:
+                        $errorMessage = 'A value of a type that cannot be encoded was given.';
+                        break;
+                    default:
+                        $errorMessage = 'An unknown error has occurred.';
+                }
+            } else {
+                $errorMessage = 'An unknown error has occurred.';
+            }
+        } else {
+            $errorMessage = null;
+        }
+
+        if ($errorMessage !== null) {
+            throw new Exception("JSON encoding error: {$errorMessage}", 500);
         }
 
         return $encoded;

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1048,6 +1048,21 @@ class Gdn_Controller extends Gdn_Pluggable {
     }
 
     /**
+     * Recursively walk through the data, decoding any IP address fields.
+     *
+     * @param array|object $data
+     */
+    private function ipDecodeRecursive(&$data) {
+        walkAllRecursive($data, function(&$val, $key = null, $parent = null) {
+            if (is_string($val)) {
+                if (stringEndsWith($key, 'IPAddress', true) || stringEndsWith($parent, 'IPAddresses', true)) {
+                    $val = ipDecode($val);
+                }
+            }
+        });
+    }
+
+    /**
      * Determines whether a method on this controller is internal and can't be dispatched.
      *
      * @param string $methodName The name of the method.
@@ -1079,7 +1094,7 @@ class Gdn_Controller extends Gdn_Pluggable {
      * @param mixed $value
      * @param int|null $options
      * @return string
-     * @throws Gdn_UserException
+     * @throws Exception
      */
     private function jsonEncode($value, $options = null) {
         $advanced = (PHP_VERSION_ID >= 50500);
@@ -1520,7 +1535,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
         $this->sendHeaders();
 
-        ipDecodeWalk($Data);
+        $this->ipDecodeRecursive($Data);
 
         // Check for a special view.
         $ViewLocation = $this->fetchViewLocation(($this->View ? $this->View : $this->RequestMethod).'_'.strtolower($this->deliveryMethod()), false, false, false);

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1767,6 +1767,23 @@ if (!function_exists('ipDecode')) {
     }
 }
 
+if (!function_exists('ipDecodeWalk')) {
+    /**
+     * Recursively walk through the data, decoding any IP address fields.
+     *
+     * @param array|object $data
+     */
+    function ipDecodeWalk(&$data) {
+        walkAll($data, function(&$val, $key = null, $parent = null) {
+            if (is_string($val)) {
+                if (stringEndsWith($key, 'IPAddress', true) || stringEndsWith($parent, 'IPAddresses', true)) {
+                    $val = ipDecode($val);
+                }
+            }
+        });
+    }
+}
+
 if (!function_exists('ipEncode')) {
     /**
      * Encode a human-readable IP address as a packed string.
@@ -3844,5 +3861,24 @@ if (!function_exists('urlMatch')) {
         }
 
         return true;
+    }
+}
+
+if (!function_exists('walkAll')) {
+    /**
+     * Recursively walk through all array elements or object properties.
+     *
+     * @param array|object $input
+     * @param callable $callback
+     * @param string $parent Array key or object property to indicate parent node.
+     */
+    function walkAll(&$input, $callback, $parent = null) {
+        foreach ($input as $key => &$val) {
+            if (is_array($val) || is_object($val)) {
+                walkAll($val, $callback, $key);
+            } else {
+                call_user_func_array($callback, [&$val, $key, $parent]);
+            }
+        }
     }
 }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2095,23 +2095,25 @@ if (!function_exists('jsonEncodeChecked')) {
         $encoded = json_encode($value, $options);
         $errorMessage = null;
 
-        if (json_last_error() !== JSON_ERROR_NONE && $encoded === false) {
+        if (json_last_error() !== JSON_ERROR_NONE) {
             if ($advanced) {
-                switch (json_last_error()) {
-                    case JSON_ERROR_UTF8:
-                        $errorMessage = 'Malformed UTF-8 characters, possibly incorrectly encoded';
-                        break;
-                    case JSON_ERROR_RECURSION:
-                        $errorMessage = 'One or more recursive references in the value to be encoded.';
-                        break;
-                    case JSON_ERROR_INF_OR_NAN:
-                        $errorMessage = 'One or more NAN or INF values in the value to be encoded';
-                        break;
-                    case JSON_ERROR_UNSUPPORTED_TYPE:
-                        $errorMessage = 'A value of a type that cannot be encoded was given.';
-                        break;
-                    default:
-                        $errorMessage = 'An unknown error has occurred.';
+                if ($encoded === false) {
+                    switch (json_last_error()) {
+                        case JSON_ERROR_UTF8:
+                            $errorMessage = 'Malformed UTF-8 characters, possibly incorrectly encoded';
+                            break;
+                        case JSON_ERROR_RECURSION:
+                            $errorMessage = 'One or more recursive references in the value to be encoded.';
+                            break;
+                        case JSON_ERROR_INF_OR_NAN:
+                            $errorMessage = 'One or more NAN or INF values in the value to be encoded';
+                            break;
+                        case JSON_ERROR_UNSUPPORTED_TYPE:
+                            $errorMessage = 'A value of a type that cannot be encoded was given.';
+                            break;
+                        default:
+                            $errorMessage = 'An unknown error has occurred.';
+                    }
                 }
             } else {
                 $errorMessage = 'An unknown error has occurred.';

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2095,7 +2095,7 @@ if (!function_exists('jsonEncodeChecked')) {
         $encoded = json_encode($value, $options);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            if ($advanced) {
+            if ($advanced && $encoded === false) {
                 switch (json_last_error()) {
                     case JSON_ERROR_RECURSION:
                         $errorMessage = 'One or more recursive references in the value to be encoded.';

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1767,23 +1767,6 @@ if (!function_exists('ipDecode')) {
     }
 }
 
-if (!function_exists('ipDecodeWalk')) {
-    /**
-     * Recursively walk through the data, decoding any IP address fields.
-     *
-     * @param array|object $data
-     */
-    function ipDecodeWalk(&$data) {
-        walkAll($data, function(&$val, $key = null, $parent = null) {
-            if (is_string($val)) {
-                if (stringEndsWith($key, 'IPAddress', true) || stringEndsWith($parent, 'IPAddresses', true)) {
-                    $val = ipDecode($val);
-                }
-            }
-        });
-    }
-}
-
 if (!function_exists('ipEncode')) {
     /**
      * Encode a human-readable IP address as a packed string.
@@ -3872,10 +3855,10 @@ if (!function_exists('walkAll')) {
      * @param callable $callback
      * @param string $parent Array key or object property to indicate parent node.
      */
-    function walkAll(&$input, $callback, $parent = null) {
+    function walkAllRecursive(&$input, $callback, $parent = null) {
         foreach ($input as $key => &$val) {
             if (is_array($val) || is_object($val)) {
-                walkAll($val, $callback, $key);
+                walkAllRecursive($val, $callback, $key);
             } else {
                 call_user_func_array($callback, [&$val, $key, $parent]);
             }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3905,15 +3905,18 @@ if (!function_exists('walkAll')) {
      *
      * @param array|object $input
      * @param callable $callback
-     * @param string $parent Array key or object property to indicate parent node.
      */
-    function walkAllRecursive(&$input, $callback, $parent = null) {
-        foreach ($input as $key => &$val) {
-            if (is_array($val) || is_object($val)) {
-                walkAllRecursive($val, $callback, $key);
-            } else {
-                call_user_func_array($callback, [&$val, $key, $parent]);
+    function walkAllRecursive(&$input, $callback) {
+        $walker = function(&$input, $callback, $parent = null) use (&$walker) {
+            foreach ($input as $key => &$val) {
+                if (is_array($val) || is_object($val)) {
+                    call_user_func_array($walker, [&$val, $callback, $key]);
+                } else {
+                    call_user_func_array($callback, [&$val, $key, $parent]);
+                }
             }
-        }
+        };
+
+        call_user_func_array($walker, [&$input, $callback]);
     }
 }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2072,6 +2072,58 @@ if (!function_exists('joinRecords')) {
 
 }
 
+if (!function_exists('jsonEncodeChecked')) {
+    /**
+     * Encode a value as JSON or throw an exception on error.
+     *
+     * @param mixed $value
+     * @param int|null $options
+     * @return string
+     * @throws Exception
+     */
+    function jsonEncodeChecked($value, $options = null) {
+        $advanced = (PHP_VERSION_ID >= 50500);
+
+        if ($options === null) {
+            if ($advanced) {
+                $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
+            } else {
+                $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
+            }
+        }
+
+        $encoded = json_encode($value, $options);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            if ($advanced) {
+                switch (json_last_error()) {
+                    case JSON_ERROR_RECURSION:
+                        $errorMessage = 'One or more recursive references in the value to be encoded.';
+                        break;
+                    case JSON_ERROR_INF_OR_NAN:
+                        $errorMessage = 'One or more NAN or INF values in the value to be encoded';
+                        break;
+                    case JSON_ERROR_UNSUPPORTED_TYPE:
+                        $errorMessage = 'A value of a type that cannot be encoded was given.';
+                        break;
+                    default:
+                        $errorMessage = 'An unknown error has occurred.';
+                }
+            } else {
+                $errorMessage = 'An unknown error has occurred.';
+            }
+        } else {
+            $errorMessage = null;
+        }
+
+        if ($errorMessage !== null) {
+            throw new Exception("JSON encoding error: {$errorMessage}", 500);
+        }
+
+        return $encoded;
+    }
+}
+
 if (!function_exists('now')) {
     /**
      * Get the current time in seconds with a millisecond fraction.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2094,9 +2094,13 @@ if (!function_exists('jsonEncodeChecked')) {
 
         $encoded = json_encode($value, $options);
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            if ($advanced && $encoded === false) {
+        if (json_last_error() !== JSON_ERROR_NONE && $encoded === false) {
+            fwrite(STDERR, 'Test: '.json_last_error());
+            if ($advanced) {
                 switch (json_last_error()) {
+                    case JSON_ERROR_UTF8:
+                        $errorMessage = 'Malformed UTF-8 characters, possibly incorrectly encoded';
+                        break;
                     case JSON_ERROR_RECURSION:
                         $errorMessage = 'One or more recursive references in the value to be encoded.';
                         break;

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2093,9 +2093,9 @@ if (!function_exists('jsonEncodeChecked')) {
         }
 
         $encoded = json_encode($value, $options);
+        $errorMessage = null;
 
         if (json_last_error() !== JSON_ERROR_NONE && $encoded === false) {
-            fwrite(STDERR, 'Test: '.json_last_error());
             if ($advanced) {
                 switch (json_last_error()) {
                     case JSON_ERROR_UTF8:
@@ -2116,8 +2116,6 @@ if (!function_exists('jsonEncodeChecked')) {
             } else {
                 $errorMessage = 'An unknown error has occurred.';
             }
-        } else {
-            $errorMessage = null;
         }
 
         if ($errorMessage !== null) {

--- a/tests/Library/Core/GeneralFunctionsTest.php
+++ b/tests/Library/Core/GeneralFunctionsTest.php
@@ -26,11 +26,16 @@ class GeneralFunctionsTest extends \PHPUnit_Framework_TestCase {
      * Test {@link jsonEncodeChecked()}.
      *
      * @param mixed $data
+     * @param bool $expectException
      * @dataProvider provideJsonEncodeCheckedTests
      */
-    public function testJsonEncodeChecked($data) {
-        if (PHP_VERSION_ID < 50500) {
-            $this->expectException('Exception');
+    public function testJsonEncodeChecked($data, $expectException) {
+        if ($expectException && PHP_VERSION_ID < 50500) {
+            if (version_compare(\PHPUnit_Runner_Version::id(), '5.0', '<')) {
+                $this->setExpectedException('Exception');
+            } else {
+                $this->expectException('Exception');
+            }
         }
 
         jsonEncodeChecked($data);
@@ -40,10 +45,11 @@ class GeneralFunctionsTest extends \PHPUnit_Framework_TestCase {
      * Provide test data for {@link testJsonEncodeChecked}
      */
     public function provideJsonEncodeCheckedTests() {
+        $exampleIPv6Packed = inet_pton('2001:0db8:85a3:0000:0000:8a2e:0370:7334');
         return [
-            [inet_pton('2001:0db8:85a3:0000:0000:8a2e:0370:7334')],
-            [['IPAddress' => inet_pton('2001:0db8:85a3:0000:0000:8a2e:0370:7334')]],
-            [['Alpha' => 'One', 'Beta' => 'Two', 'Charlie' => 'Three']]
+            [$exampleIPv6Packed, true],
+            [['IPAddress' => $exampleIPv6Packed], true],
+            [['Alpha' => 'One', 'Beta' => 'Two', 'Charlie' => 'Three'], false]
         ];
     }
 

--- a/tests/Library/Core/GeneralFunctionsTest.php
+++ b/tests/Library/Core/GeneralFunctionsTest.php
@@ -23,6 +23,31 @@ class GeneralFunctionsTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Test {@link jsonEncodeChecked()}.
+     *
+     * @param mixed $data
+     * @dataProvider provideJsonEncodeCheckedTests
+     */
+    public function testJsonEncodeChecked($data) {
+        if (PHP_VERSION_ID < 50500) {
+            $this->expectException('Exception');
+        }
+
+        jsonEncodeChecked($data);
+    }
+
+    /**
+     * Provide test data for {@link testJsonEncodeChecked}
+     */
+    public function provideJsonEncodeCheckedTests() {
+        return [
+            [inet_pton('2001:0db8:85a3:0000:0000:8a2e:0370:7334')],
+            [['IPAddress' => inet_pton('2001:0db8:85a3:0000:0000:8a2e:0370:7334')]],
+            [['Alpha' => 'One', 'Beta' => 'Two', 'Charlie' => 'Three']]
+        ];
+    }
+
+    /**
      * Provide test data for {@link testUrlMatch()}.
      */
     public function provideUrlMatchTests() {


### PR DESCRIPTION
This update addresses issues with binary values causing JSON encoding to fail in `Gdn_Controller::RenderData`.  It does this by recursively iterating through the `$Data` array and running `ipDecode` against fields with recognizable names (e.g. *IPAddress, *IPAddresses).

*Note: Elements in the `$Data` array can be other arrays ___or objects___, making this not an ideal candidate for `array_walk`/`array_walk_recursive`.  These functions skip over iterating through object properties.  Also, with `array_walk_recursive`, any key that holds an array will not be passed to the callback function. This makes it tough to handle values like "AllIPAddresses", which is an array, itself.*

Closes #4590 