### PR TITLE
Decode packed IP in ipAnchor

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -771,7 +771,7 @@ if (!function_exists('ipAnchor')) {
      */
     function ipAnchor($IP, $CssClass = '') {
         if ($IP) {
-            return anchor(formatIP($IP), '/user/browse?keywords='.urlencode($IP), $CssClass);
+            return anchor(formatIP($IP), '/user/browse?keywords='.urlencode(ipDecode($IP)), $CssClass);
         } else {
             return $IP;
         }


### PR DESCRIPTION
`ipAnchor` was not attempting to decode packed IP addresses before creating a URL with them.

This update passes the IP value through `ipDecode` when building the URL.