### PR TITLE
Add the EventManager class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
     "autoload-dev": {
         "psr-4": {
             "VanillaTests\\": "tests",
+            "VanillaTests\\Fixtures\\": "tests\\fixtures\\src"
             "GardenTests\\": "tests"
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "autoload-dev": {
         "psr-4": {
             "VanillaTests\\": "tests",
-            "VanillaTests\\Fixtures\\": "tests\\fixtures\\src"
+            "VanillaTests\\Fixtures\\": "tests\\fixtures\\src",
             "GardenTests\\": "tests"
         }
     }

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -121,8 +121,8 @@ class EventManager {
                     $eventName = $basename;
                     break;
                 case '_create':
-                case '_endpoint':
-                    $eventName = $basename.'_endpoint';
+                case '_method':
+                    $eventName = $basename.'_method';
                     break;
                 case '_before':
                 case '_after':

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -201,9 +201,9 @@ class EventManager {
         $args = array_slice(func_get_args(), 1);
 
         // Do some backwards compatible kludges here.
-        if (count($args) === 1 && is_object($args[0]) && property_exists($args[0], 'EventArguments')) {
-            $args[] = $args[0]->EventArguments;
-        }
+//        if (count($args) === 1 && is_object($args[0]) && property_exists($args[0], 'EventArguments')) {
+//            $args[] = $args[0]->EventArguments;
+//        }
 
         $result = [];
         foreach ($handlers as $callback) {

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -113,6 +113,7 @@ class EventManager {
                 continue;
             }
 
+            $method = strtolower($method);
             $suffix = strrchr($method, '_');
             $basename = substr($method, 0, -strlen($suffix));
             switch ($suffix) {

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -233,7 +233,7 @@ class EventManager {
 
         // See if the handlers need to be sorted.
         if (isset($this->toSort[$name])) {
-            uksort($this->handlers[$name], 'strnatcasecmp');
+            $this->sortHandlers($this->handlers[$name]);
 
             // Convert lazy event handlers to callbacks.
             foreach ($this->handlers[$name] as &$handler) {
@@ -246,6 +246,17 @@ class EventManager {
         }
 
         return $this->handlers[$name];
+    }
+
+    /**
+     * Sort an event handler array.
+     *
+     * This method is useful in combination with {@link EventManager::getHandlers()}.
+     *
+     * @param array &$handlers The event handler array.
+     */
+    public function sortHandlers(array &$handlers) {
+        uksort($handlers, 'strnatcasecmp');
     }
 
     /**

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -1,0 +1,341 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Garden;
+
+use Interop\Container\ContainerInterface;
+
+/**
+ * Contains methods for binding and firing to events.
+ *
+ * Addons can create callbacks that bind to events which are called throughout the code to allow extension of the
+ * application and framework.
+ */
+class EventManager {
+    const PRIORITY_LOW = 10;
+    const PRIORITY_NORMAL = 100;
+    const PRIORITY_HIGH = 1000;
+    const PRIORITY_MAX = 1000000;
+
+    const EVENT_META = 'meta';
+
+    /**
+     * @var ContainerInterface An IOC container to create lazy objects.
+     */
+    private $container;
+
+    /**
+     * @var int The number of events bound. This is for generating keys, and may not be accurate.
+     */
+    private $count = 0;
+
+    /**
+     * @var array An array of event handlers.
+     */
+    private $handlers;
+
+    /**
+     * @var array The events that still need to be sorted by priority.
+     */
+    private $toSort = [];
+
+    /**
+     * Construct a new instance of of the {@link EventManager} class.
+     *
+     * @param ContainerInterface|null $container The container used to fetch lazy classes.
+     */
+    public function __construct(ContainerInterface $container = null) {
+        $this->container = $container;
+    }
+
+    /**
+     * Bind an event handler to an event.
+     *
+     * @param string $event The name of the event to bind to.
+     * @param callable $callback The callback of the event.
+     * @param int $priority The priority of the event.
+     */
+    public function bind($event, callable $callback, $priority = EventManager::PRIORITY_NORMAL) {
+        $this->bindInternal($event, $callback, $priority);
+    }
+
+    /**
+     * Bind an event handler to an event.
+     *
+     * @param string $event The name of the event to bind to.
+     * @param callable|LazyEventHandler $callback The callback of the event.
+     * @param int $priority The priority of the event.
+     */
+    private function bindInternal($event, $callback, $priority = EventManager::PRIORITY_NORMAL) {
+        if ($priority > self::PRIORITY_MAX) {
+            trigger_error("Events cannot have a priority greater than ".self::PRIORITY_MAX.'.', E_USER_NOTICE);
+            $priority = self::PRIORITY_MAX;
+        }
+
+        $event = strtolower($event);
+        $sortKey = (self::PRIORITY_MAX - $priority).'e'.$this->count;
+        $this->handlers[$event][$sortKey] = $callback;
+        $this->toSort[$event] = true;
+        $this->count++;
+    }
+
+    /**
+     * Bind a class' declared event handlers.
+     *
+     * Plugin classes declare event handlers in the following way:
+     *
+     * ```
+     * // Bind to a normal event.
+     * public function eventName_handler($arg1, $arg2, ...) { ... }
+     *
+     * // Add/override a method called with Event::callUserFuncArray().
+     * public function ClassName_methodName($sender, $arg1, $arg2) { ... }
+     * public function ClassName_methodName_create($sender, $arg1, $arg2) { ... } // deprecated
+     *
+     * // Call the handler before or after a method called with Event::callUserFuncArray().
+     * public function ClassName_methodName_before($sender, $arg1, $arg2) { ... }
+     * public function ClassName_methodName_after($sender, $arg1, $arg2) { ... }
+     * ```
+     *
+     * @param mixed $class The class name or an object instance.
+     * @param int $priority The priority of the event.
+     * @throws \InvalidArgumentException Throws an exception when binding to a class name with no `instance()` method.
+     */
+    public function bindClass($class, $priority = EventManager::PRIORITY_NORMAL) {
+        $methodNames = get_class_methods($class);
+
+        foreach ($methodNames as $method) {
+            if (strpos($method, '_') == false) { // == instead of === filters out methods starting with _
+                continue;
+            }
+
+            $suffix = strrchr($method, '_');
+            $basename = substr($method, 0, -strlen($suffix));
+            switch ($suffix) {
+                case '_handler':
+                case '_override':
+                    $eventName = $basename;
+                    break;
+                case '_create':
+                case '_endpoint':
+                    $eventName = $basename.'_endpoint';
+                    break;
+                case '_before':
+                case '_after':
+                default:
+                    $eventName = $method;
+                    break;
+            }
+            // Bind the event if we have one.
+            if ($eventName) {
+                $callback = is_string($class) ? new LazyEventHandler($class, $method) : [$class, $method];
+
+                $this->bindInternal($eventName, $callback, $priority);
+            }
+        }
+    }
+
+    /**
+     * Bind a lazy event handler to an event.
+     *
+     * A lazy event handler will fetch the instance from the container when the event is fired.
+     *
+     * @param string $event The name of the event to bind to.
+     * @param string $class The name of the class of the event handler.
+     * @param string $method The name of the method to call.
+     * @param int $priority The priority of the event.
+     */
+    public function bindLazy($event, $class, $method, $priority = EventManager::PRIORITY_NORMAL) {
+        $this->bindInternal($event, new LazyEventHandler($class, $method), $priority);
+    }
+
+    /**
+     * Checks if an event has a handler.
+     *
+     * @param string $event The name of the event.
+     * @return bool Returns **true** if the event has at least one handler, **false** otherwise.
+     */
+    public function hasHandler($event) {
+        return !empty($this->handlers[strtolower($event)]);
+    }
+
+    /**
+     * Fire an event.
+     *
+     * @param string $event The name of the event.
+     * @return mixed Returns the result of the last event handler.
+     */
+    public function fire($event) {
+        $handlers = $this->getHandlers($event);
+
+        if (empty($handlers) && empty($this->handlers[self::EVENT_META])) {
+            return [];
+        }
+
+        // Grab the handlers and call them.
+        $args = array_slice(func_get_args(), 1);
+
+        // Do some backwards compatible kludges here.
+        if (count($args) === 1 && is_object($args[0]) && property_exists($args[0], 'EventArguments')) {
+            $args[] = $args[0]->EventArguments;
+        }
+
+        $result = [];
+        foreach ($handlers as $callback) {
+            $result[] = call_user_func_array($callback, $args);
+        }
+
+        // Call the meta event if it's there.
+        if (!empty($this->handlers[self::EVENT_META])) {
+            $this->callMetaHandlers($event, $args, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get all of the handlers bound to an event.
+     *
+     * @param string $name The name of the event.
+     * @return array Returns the handlers that are watching {@link $name}.
+     */
+    public function getHandlers($name) {
+        $name = strtolower($name);
+
+        if (!isset($this->handlers[$name])) {
+            return [];
+        }
+
+        // See if the handlers need to be sorted.
+        if (isset($this->toSort[$name])) {
+            uksort($this->handlers[$name], 'strnatcasecmp');
+
+            // Convert lazy event handlers to callbacks.
+            foreach ($this->handlers[$name] as &$handler) {
+                if ($handler instanceof LazyEventHandler) {
+                    $handler = [$this->container->get($handler->class), $handler->method];
+                }
+            }
+
+            unset($this->toSort[$name]);
+        }
+
+        return $this->handlers[$name];
+    }
+
+    /**
+     * Call the meta event handlers for an event.
+     *
+     * Event handlers can attach to a special "meta" event to get information about all fired events. When any event is
+     * fired, the meta event handlers are called.
+     *
+     * The use of meta event handlers are intended for debugging-style plugins and should be used sparingly as they
+     * incur a significant performance overhead.
+     *
+     * @param string $event The name of the event being fired.
+     * @param array $args The arguments being called with the event.
+     * @param mixed $result The result of the call.
+     */
+    private function callMetaHandlers($event, array $args, $result) {
+        $metaHandlers = $this->getHandlers(self::EVENT_META);
+        foreach ($metaHandlers as $metaHandler) {
+            call_user_func($metaHandler, $event, $args, $result);
+        }
+    }
+
+    /**
+     * Chain several event handlers together.
+     *
+     * This method will fire the first handler and pass its result as the first argument to the next event handler and
+     * so on. A chained event handler can have more than one parameter, but must have at least one parameter.
+     *
+     * @param string $event The name of the event to fire.
+     * @param mixed $value The value to pass into the filter.
+     * @return mixed The result of the chained event or `$value` if there were no handlers.
+     */
+    public function fireFilter($event, $value) {
+        $handlers = $this->getHandlers($event);
+        if (empty($handlers) && empty($this->handlers[self::EVENT_META])) {
+            return $value; // gotcha, return value
+        }
+
+        $callArgs = $args = array_slice(func_get_args(), 1);
+
+        foreach ($handlers as $callback) {
+            $value = call_user_func_array($callback, $callArgs);
+            $callArgs[0] = $value;
+        }
+
+        // Call the meta event if it's there.
+        if (!empty($this->handlers[self::EVENT_META])) {
+            $this->callMetaHandlers($event, $args, $value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Fire an event with an array of arguments.
+     *
+     * This method is to {@link EventManager::fire()} as {@link call_user_func_array()} is to {@link call_user_funct()}.
+     * The main purpose though is to allow you to have event handlers that can take references.
+     *
+     * @param string $event The name of the event.
+     * @param array $args The arguments for the event handlers.
+     * @return mixed Returns the result of the last event handler.
+     */
+    public function fireArray($event, $args = []) {
+        $handlers = $this->getHandlers($event);
+
+        if (empty($handlers) && empty($this->handlers[self::EVENT_META])) {
+            return [];
+        }
+
+        // Grab the handlers and call them.
+        $result = [];
+        foreach ($handlers as $callback) {
+            $result[] = call_user_func_array($callback, $args);
+        }
+
+        // Call the meta event if it's there.
+        if (!empty($this->handlers[self::EVENT_META])) {
+            $this->callMetaHandlers($event, $args, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the IOC container.
+     *
+     * @return ContainerInterface Returns the container.
+     */
+    public function getContainer() {
+        return $this->container;
+    }
+
+    /**
+     * Set the IOC container.
+     *
+     * @param ContainerInterface $container The new container.
+     *
+     * @return EventManager Returns `$this` for fluent calls.
+     */
+    public function setContainer($container) {
+        $this->container = $container;
+        return $this;
+    }
+
+    /**
+     * For debugging.
+     *
+     * @return array
+     */
+//    public function dumpAllHandlers() {
+//        return $this->handlers;
+//    }
+}

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -141,6 +141,26 @@ class EventManager {
     }
 
     /**
+     * Remove all of the events associated with a class.
+     *
+     * Note that this walks all event handlers so should not be called very often.
+     *
+     * @param string $className The name of the class to unbind.
+     */
+    public function unbindClass($className) {
+        foreach ($this->handlers as $event => $handlers) {
+            foreach ($handlers as $key => $handler) {
+                if (($handler instanceof LazyEventHandler && strcasecmp($handler->class, $className) === 0)
+                    || (is_array($handler) && (
+                        (is_string($handler[0] && strcasecmp($handler, $className) === 0))
+                        || (is_object($handler[0] && is_a($handler[0], $className)))))) {
+                    unset($this->handlers[$event][$key]);
+                }
+            }
+        }
+    }
+
+    /**
      * Bind a lazy event handler to an event.
      *
      * A lazy event handler will fetch the instance from the container when the event is fired.

--- a/library/Garden/LazyEventHandler.php
+++ b/library/Garden/LazyEventHandler.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Garden;
+
+/**
+ * Contains information about a callback that requires a class to be obtained from a container beforehand.
+ *
+ * This class is meant to be used internally by the {@link EventManager}. It contains the least amount of information to
+ * conserve memory. Properties are left public for quicker access.
+ *
+ * This class is basically a tuple. The reasons arrays aren't used are the following:
+ *
+ * 1. Arrays are valid callbacks and these lazy event handlers will live side-by-side with callbacks.
+ * 2. [Objects can use less memory than arrays](https://gist.github.com/nikic/5015323).
+ */
+class LazyEventHandler {
+    /**
+     * @var string The name of the class.
+     */
+    public $class;
+    /**
+     * @var string The name of the method to call.
+     */
+    public $method;
+
+    /**
+     * Instantiate a new instance of the {@link LazyEventHandler} class.
+     *
+     * @param string $class The name of the class.
+     * @param string $method The name of the method.
+     */
+    public function __construct($class, $method) {
+        $this->class = $class;
+        $this->method = $method;
+    }
+}

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -10,6 +10,8 @@
  * @package Core
  * @since 2.0
  */
+use Garden\EventManager;
+use Interop\Container\ContainerInterface;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
 
@@ -19,7 +21,7 @@ use Vanilla\AddonManager;
  * A singleton class used to identify extensions, register them in a central
  * location, and instantiate/call them when necessary.
  */
-class Gdn_PluginManager extends Gdn_Pluggable {
+class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
 
     const ACTION_ENABLE = 1;
 
@@ -51,15 +53,6 @@ class Gdn_PluginManager extends Gdn_Pluggable {
     /** @var array A simple list of plugins that have already been registered. */
     private $registeredPlugins = [];
 
-    /** @var array  An associative array of EventHandlerName => PluginName pairs. */
-    private $eventHandlers = [];
-
-    /** @var array An associative array of MethodOverrideName => PluginName pairs. */
-    private $methodOverrides = [];
-
-    /** @var array An associative array of NewMethodName => PluginName pairs. */
-    private $newMethods = [];
-
     /** @var array An array of the instances of plugins. */
     protected $instances = [];
 
@@ -74,13 +67,21 @@ class Gdn_PluginManager extends Gdn_Pluggable {
     private $addonManager;
 
     /**
+     * @var EventManager
+     */
+    private $eventManager;
+
+    /**
      * Initialize a new instance of the {@link Gdn_PluginManager} class.
      *
      * @param AddonManager $addonManager The addon manager that manages all of the addons.
+     * @param EventManager $eventManager The event manager that handles all plugin events.
      */
-    public function __construct(AddonManager $addonManager = null) {
+    public function __construct(AddonManager $addonManager = null, EventManager $eventManager = null) {
         parent::__construct();
         $this->addonManager = $addonManager;
+
+        $this->eventManager = $eventManager ?: new EventManager($this);
     }
 
     /**
@@ -423,13 +424,17 @@ class Gdn_PluginManager extends Gdn_Pluggable {
                 // Include the plugin here, rather than wait for it to hit the autoloader. This way is much faster.
                 include_once $addon->getClassPath($pluginClass);
 
+                if (!is_a($pluginClass, 'Gdn_IPlugin', true)) {
+                    trigger_error("$pluginClass does not implement Gdn_IPlugin", E_USER_DEPRECATED);
+                }
+
                 // Only register the plugin if it implements the Gdn_IPlugin interface.
                 if (is_a($pluginClass, 'Gdn_IPlugin', true) &&
                     !isset($this->registeredPlugins[$pluginClass])
                 ) {
 
                     // Register this plugin's methods
-                    $this->registerPlugin($pluginClass);
+                    $this->registerPlugin($pluginClass, $addon->getPriority());
                 }
             }
         }
@@ -445,91 +450,41 @@ class Gdn_PluginManager extends Gdn_Pluggable {
     }
 
     /**
+     * Register a plugin's events.
      *
-     *
-     * @param $ClassName
+     * @param string $className The name of the class.
      * @throws Exception
      */
-    public function registerPlugin($ClassName) {
-        $ClassMethods = get_class_methods($ClassName);
-        if ($ClassMethods === null) {
-            throw new Exception("There was an error getting the $ClassName class methods.", 401);
+    public function registerPlugin($className, $priority = EventManager::PRIORITY_NORMAL) {
+        $className = strtolower($className);
+        if (empty($this->registeredPlugins[$className])) {
+            $this->eventManager->bindClass($className, $priority);
         }
-
-        foreach ($ClassMethods as $Method) {
-            $MethodName = strtolower($Method);
-            // Loop through their individual methods looking for event handlers and method overrides.
-            if (isset($MethodName[9])) {
-                $Suffix = trim(strrchr($MethodName, '_'), '_');
-                switch ($Suffix) {
-                    case 'handler':
-                    case 'before':
-                    case 'after':
-                    case 'render':
-                        $this->registerHandler($ClassName, $MethodName);
-                        break;
-                    case 'override':
-                        $this->registerOverride($ClassName, $MethodName);
-                        break;
-                    case 'create':
-                        $this->registerNewMethod($ClassName, $MethodName);
-                        break;
-                }
-            }
-        }
-
-        $this->registeredPlugins[$ClassName] = true;
+        $this->registeredPlugins[$className] = true;
     }
 
     /**
      *
      *
-     * @param $PluginClassName
+     * @param $pluginClassName
      * @return bool
      */
-    public function unregisterPlugin($PluginClassName) {
-        $this->removeFromCollectionByPrefix($PluginClassName, $this->eventHandlers);
-        $this->removeFromCollectionByPrefix($PluginClassName, $this->methodOverrides);
-        $this->removeFromCollectionByPrefix($PluginClassName, $this->newMethods);
-        if (array_key_exists($PluginClassName, $this->registeredPlugins)) {
-            unset($this->registeredPlugins[$PluginClassName]);
-        }
-
+    public function unregisterPlugin($pluginClassName) {
+        $this->eventManager->unbindClass($pluginClassName);
         return true;
-    }
-
-    /**
-     *
-     *
-     * @param $Prefix
-     * @param $Collection
-     */
-    private function removeFromCollectionByPrefix($Prefix, &$Collection) {
-        foreach ($Collection as $Event => $Hooks) {
-            if (is_array($Hooks)) {
-                foreach ($Hooks as $Index => $Hook) {
-                    if (strpos($Hook, $Prefix.'.') === 0) {
-                        unset($Collection[$Event][$Index]);
-                    }
-                }
-            } elseif (is_string($Hooks)) {
-                if (strpos($Hooks, $Prefix.'.') === 0) {
-                    unset($Collection[$Event]);
-                }
-            }
-        }
     }
 
     /**
      * Removes all plugins that are marked as mobile unfriendly.
      */
     public function removeMobileUnfriendlyPlugins() {
-        foreach ($this->enabledPlugins() as $PluginName => $Trash) {
-            $PluginInfo = $this->getPluginInfo($PluginName);
+        $addons = $this->addonManager->getEnabled();
+        $plugins = array_filter($addons, Addon::makeFilterCallback(['oldType' => 'plugin']));
 
-            // Remove plugin hooks from plugins that explicitly claim to not be mobile friendly
-            if (!val('MobileFriendly', $PluginInfo, true)) {
-                $this->unregisterPlugin(val('ClassName', $PluginInfo));
+        /* @var Addon $plugin */
+        foreach ($plugins as $key => $plugin) {
+            if (!$plugin->getInfoValue('mobileFriendly', true) && $plugin->getPluginClass()) {
+                $this->unregisterPlugin($plugin->getPluginClass());
             }
         }
     }
@@ -550,39 +505,49 @@ class Gdn_PluginManager extends Gdn_Pluggable {
     /**
      *
      *
-     * @param $Sender
-     * @param $EventName
-     * @param string $HandlerType
-     * @param array $Options
+     * @param $sender
+     * @param $eventName
+     * @param string $handlerType
+     * @param array $options
      * @return array
      */
-    public function getEventHandlers($Sender, $EventName, $HandlerType = 'Handler', $Options = array()) {
+    public function getEventHandlers($sender, $eventName, $handlerType = 'Handler', $options = array()) {
+        deprecated(__METHOD__);
         // Figure out the classname.
-        if (isset($Options['ClassName'])) {
-            $ClassName = $Options['ClassName'];
-        } elseif (property_exists($Sender, 'ClassName') && $Sender->ClassName)
-            $ClassName = $Sender->ClassName;
-        else {
-            $ClassName = get_class($Sender);
+        if (isset($options['ClassName'])) {
+            $ClassName = $options['ClassName'];
+        } elseif (property_exists($sender, 'ClassName') && $sender->ClassName) {
+            $ClassName = $sender->ClassName;
+        } else {
+            $ClassName = get_class($sender);
+        }
+
+        $handlerType = strtolower($handlerType);
+        switch ($handlerType) {
+            case 'handler':
+                $handlerType = '';
+                break;
+            case 'create':
+            case 'override':
+                $handlerType = '_method';
+                break;
+            default:
+                $handlerType = '_'.$handlerType;
         }
 
         // Build the list of event handler names.
-        $Names = array(
-            "{$ClassName}_{$EventName}_{$HandlerType}",
-            "Base_{$EventName}_{$HandlerType}",
-            "{$ClassName}_{$EventName}_All",
-            "Base_{$EventName}_All");
+        $Names = [
+            "{$ClassName}_{$eventName}{$handlerType}",
+            "Base_{$eventName}{$handlerType}"
+        ];
 
         // Grab the event handlers.
-        $Handlers = array();
+        $Handlers = [];
         foreach ($Names as $Name) {
-            $Name = strtolower($Name);
-            if (isset($this->eventHandlers[$Name])) {
-                $Handlers = array_merge($Handlers, $this->eventHandlers[$Name]);
-            }
+            $Handlers[] = $this->eventManager->getHandlers($Name);
         }
 
-        return $Handlers;
+        return call_user_func('array_merge', $Handlers);
     }
 
     /**
@@ -687,17 +652,33 @@ class Gdn_PluginManager extends Gdn_Pluggable {
      * @param string $EventHandlerType The type of event handler.
      */
     public function registerHandler($HandlerClassName, $HandlerMethodName, $EventClassName = '', $EventName = '', $EventHandlerType = '') {
-        $HandlerKey = $HandlerClassName.'.'.$HandlerMethodName;
-        $EventKey = strtolower($EventClassName == '' ? $HandlerMethodName : $EventClassName.'_'.$EventName.'_'.$EventHandlerType);
+        deprecated(__METHOD__);
 
-        // Create a new array of handler class names if it doesn't exist yet.
-        if (array_key_exists($EventKey, $this->eventHandlers) === false) {
-            $this->eventHandlers[$EventKey] = array();
-        }
+        $key = $this->normalizeEventKey($EventClassName ?: $HandlerClassName, $EventName, $EventHandlerType);
+        $this->eventManager->bindLazy($key, $HandlerClassName, $HandlerMethodName);
+    }
 
-        // Specify this class as a handler for this method if it hasn't been done yet.
-        if (in_array($HandlerKey, $this->eventHandlers[$EventKey]) === false) {
-            $this->eventHandlers[$EventKey][] = $HandlerKey;
+    /**
+     * Generate an event name from a class, event, and type.
+     *
+     * @param string $class The name of the class for the handler.
+     * @param string $event The name of the event.
+     * @param string $type The name of the type.
+     * @return string Returns an event name as a string.
+     */
+    private function normalizeEventKey($class, $event, $type = 'handler') {
+        $key = strtolower($class.'_'.$event);
+        $type = strtolower($type);
+
+        switch ($type) {
+            case 'handler':
+            case '':
+                return $key;
+            case 'create':
+            case 'override':
+                return $key.'_method';
+            default:
+                return $key.'_'.$type;
         }
     }
 
@@ -708,59 +689,45 @@ class Gdn_PluginManager extends Gdn_Pluggable {
      * @param callable $callback The callback to call when the event is fired.
      */
     public function registerCallback($eventName, callable $callback) {
-        if (stringEndsWith($eventName, '_create', true)) {
-            $this->newMethods[strtolower($eventName)] = $callback;
-        } elseif (stringEndsWith($eventName, '_override', true)) {
-            $this->methodOverrides[strtolower($eventName)] = $callback;
-        } else {
-            $this->eventHandlers[strtolower($eventName)][] = $callback;
+        $eventName = strtolower($eventName);
+        $suffix = strrchr($eventName, '_');
+        $basename = substr($eventName, 0, -strlen($suffix));
+
+        switch ($suffix) {
+            case '_handler':
+                $eventName = $basename;
+                break;
+            case '_create':
+            case '_override':
+                $eventName = $basename.'_method';
+                break;
         }
+
+        $this->eventManager->bind($eventName, $callback);
     }
 
     /**
      * Registers a plugin override method.
      *
      * @param string $OverrideClassName The name of the plugin class that will override the existing method.
-     * @param string $OverrideMethodName The name of the plugin method being registered to override the existing method.
-     * @param string $EventClassName The name of the class that will fire the event.
-     * @param string $EventName The name of the event that will fire.
+     * @param string $handlerMethodName The name of the plugin method being registered to override the existing method.
+     * @param string $eventClassName The name of the class that will fire the event.
+     * @param string $eventName The name of the event that will fire.
      */
-    public function registerOverride($OverrideClassName, $OverrideMethodName, $EventClassName = '', $EventName = '') {
-        $OverrideKey = $OverrideClassName.'.'.$OverrideMethodName;
-        $EventKey = strtolower($EventClassName == '' ? $OverrideMethodName : $EventClassName.'_'.$EventName.'_Override');
-
-        // Throw an error if this method has already been overridden.
-        if (array_key_exists($EventKey, $this->methodOverrides) === true) {
-            trigger_error(
-                "The $EventKey is already assigned to {$this->methodOverrides[$EventKey]}. ".
-                "It cannot also be overridden by $OverrideClassName."
-            );
-        }
-
-        // Otherwise, specify this class as the source for the override.
-        $this->methodOverrides[$EventKey] = $OverrideKey;
+    public function registerOverride($handlerClassName, $handlerMethodName, $eventClassName = '', $eventName = '') {
+        $this->registerHandler($handlerClassName, $handlerMethodName, $eventClassName, $eventName, 'method');
     }
 
     /**
      * Registers a plugin new method.
      *
-     * @param string $NewMethodClassName The name of the plugin class that will add a new method.
-     * @param string $NewMethodName The name of the plugin method being added.
-     * @param string $EventClassName The name of the class that will fire the event.
-     * @param string $EventName The name of the event that will fire.
+     * @param string $handlerClassName The name of the plugin class that will add a new method.
+     * @param string $handlerMethodName The name of the plugin method being added.
+     * @param string $eventClassName The name of the class that will fire the event.
+     * @param string $eventName The name of the event that will fire.
      */
-    public function registerNewMethod($NewMethodClassName, $NewMethodName, $EventClassName = '', $EventName = '') {
-        $NewMethodKey = $NewMethodClassName.'.'.$NewMethodName;
-        $EventKey = strtolower($EventClassName == '' ? $NewMethodName : $EventClassName.'_'.$EventName.'_Create');
-
-        // Throw an error if this method has already been created.
-        if (array_key_exists($EventKey, $this->newMethods) === true) {
-            trigger_error('New object methods must be unique. The new "'.$EventKey.'" method has already been assigned by the "'.$this->newMethods[$EventKey].'" plugin. It cannot also be assigned by the "'.$NewMethodClassName.'" plugin.', E_USER_NOTICE);
-            return;
-        }
-
-        // Otherwise, specify this class as the source for the new method.
-        $this->newMethods[$EventKey] = $NewMethodKey;
+    public function registerNewMethod($handlerClassName, $handlerMethodName, $eventClassName = '', $eventName = '') {
+        $this->registerHandler($handlerClassName, $handlerMethodName, $eventClassName, $eventName, 'method');
     }
 
     /**
@@ -791,112 +758,47 @@ class Gdn_PluginManager extends Gdn_Pluggable {
             $Return = true;
         }
 
-        // Look for Wildcard event handlers
-        $WildEventKey = $EventClassName.'_'.$EventName.'_'.$EventHandlerType;
-        if ($this->callEventHandler($Sender, 'Base', 'All', $EventHandlerType, $WildEventKey)) {
-            $Return = true;
-        }
-        if ($this->callEventHandler($Sender, $EventClassName, 'All', $EventHandlerType, $WildEventKey)) {
-            $Return = true;
-        }
-
         return $Return;
-    }
-
-    /**
-     * Trace a message when tracing is turned on.
-     *
-     * @param string $Message The message to trace.
-     * @param string $Type One of the **TRACE_*** constants.
-     */
-    private function trace($Message, $Type = TRACE_INFO) {
-        if ($this->trace) {
-            trace($Message, $Type);
-        }
     }
 
     /**
      * Call a single event handler.
      *
-     * @param object $Sender The object firing the event.
-     * @param string $EventClassName The name of the class firing the event.
-     * @param string $EventName The name of the event being fired.
-     * @param string $EventHandlerType The type of event handler being looked for.
-     * @param array $Options An array of options to modify the call.
+     * @param object $sender The object firing the event.
+     * @param string $className The name of the class firing the event.
+     * @param string $eventName The name of the event being fired.
+     * @param string $handlerType The type of event handler being looked for.
      * @return mixed Returns whatever the event handler returns or **false** of there is not event handler.
      */
-    public function callEventHandler($Sender, $EventClassName, $EventName, $EventHandlerType = 'Handler', $Options = []) {
-        $this->trace("CallEventHandler $EventClassName $EventName $EventHandlerType");
-        $Return = false;
+    public function callEventHandler($sender, $className, $eventName, $handlerType = 'handler') {
+        $eventKey = strtolower("{$className}_{$eventName}");
+        $handlerType = strtolower($handlerType);
+        $originalEventKey = $eventKey.'_'.$handlerType;
 
-        // Backwards compatible for event key.
-        if (is_string($Options)) {
-            $PassedEventKey = $Options;
-        } else {
-            $PassedEventKey = val('EventKey', $Options, null);
+        switch ($handlerType) {
+            case 'handler':
+                // Do nothing.
+                break;
+            case 'create':
+                $eventKey = $originalEventKey.'_method';
+                break;
+            default:
+                $eventKey = $originalEventKey;
         }
 
-        $EventKey = strtolower($EventClassName.'_'.$EventName.'_'.$EventHandlerType);
-        if (!array_key_exists($EventKey, $this->eventHandlers)) {
+
+        $results = $this->eventManager->fire(
+            $eventKey,
+            $sender,
+            isset($sender->EventArguments) ? $sender->EventArguments : []
+        );
+
+        if (isset($sender->Returns)) {
+            $sender->Returns[$originalEventKey] = $results;
+            return true;
+        } else {
             return false;
         }
-
-        if (is_null($PassedEventKey)) {
-            $PassedEventKey = $EventKey;
-        }
-
-        // For "All" events, calculate the stack
-        if ($EventName == 'All') {
-            $Stack = debug_backtrace();
-            // this call
-            array_shift($Stack);
-
-            // plural call
-            array_shift($Stack);
-
-            $EventCaller = array_shift($Stack);
-            $Sender->EventArguments['WildEventStack'] = $EventCaller;
-        }
-
-        $this->trace($this->eventHandlers[$EventKey], 'Event Handlers');
-
-        // Loop through the handlers and execute them
-        foreach ($this->eventHandlers[$EventKey] as $PluginKey) {
-            $callback = null;
-            if (is_array($PluginKey) || $PluginKey instanceof \Closure) {
-                // The event handler is an array or a closure so we can call it directly.
-                $callback = $PluginKey;
-            } else {
-                // Decode how `self::register[Handler|NewMethod|Override]` store event names.
-                $PluginKeyParts = explode('.', $PluginKey);
-                if (count($PluginKeyParts) == 2) {
-                    // The event handler is a class and method name.
-                    list($PluginClassName, $PluginEventHandlerName) = $PluginKeyParts;
-                    $callback = [$this->getPluginInstance($PluginClassName), $PluginEventHandlerName];
-                } elseif (is_callable($PluginKey)) {
-                    // The event handler is a global function.
-                    $callback = $PluginKey;
-                }
-            }
-
-            if (!$callback) {
-                continue;
-            } elseif (isset($Sender->Returns)) {
-                if (array_key_exists($EventKey, $Sender->Returns) === false || is_array($Sender->Returns[$EventKey]) === false) {
-                    $Sender->Returns[$EventKey] = array();
-                }
-
-                $Return = call_user_func($callback, $Sender, $Sender->EventArguments, $PassedEventKey);
-                $Sender->Returns[$EventKey][$PluginKey] = $Return;
-                $Return = true;
-            } elseif (isset($Sender->EventArguments)) {
-                call_user_func($callback, $Sender, $Sender->EventArguments, $PassedEventKey);
-            } else {
-                call_user_func($callback, $Sender, [], $PassedEventKey);
-            }
-        }
-
-        return $Return;
     }
 
     /**
@@ -925,7 +827,7 @@ class Gdn_PluginManager extends Gdn_Pluggable {
      * @return bool Returns **true** if an override exists or **false** otherwise.
      */
     public function hasMethodOverride($ClassName, $MethodName) {
-        return array_key_exists(strtolower($ClassName.'_'.$MethodName.'_Override'), $this->methodOverrides);
+        return $this->eventManager->hasHandler($this->normalizeEventKey($ClassName, $MethodName, 'method'));
     }
 
     /**
@@ -949,57 +851,33 @@ class Gdn_PluginManager extends Gdn_Pluggable {
     /**
      * Get the callback for an event handler.
      *
-     * @param string $ClassName The name of the class throwing the event.
-     * @param string $MethodName The name of the event.
-     * @param string $Type The type of event handler.
-     *  - Create: A new method creation.
-     *  - Override: A method override.
-     * @return callback
+     * @param string $className The name of the class throwing the event.
+     * @param string $methodName The name of the event.
+     * @return callback|null
      * @since 2.1
      */
-    public function getCallback($ClassName, $MethodName, $Type = 'Create') {
-        $EventKey = strtolower("{$ClassName}_{$MethodName}_{$Type}");
+    public function getCallback($className, $methodName) {
+        $eventKey = "{$className}_{$methodName}_method";
+        $handlers = $this->eventManager->getHandlers($eventKey);
 
-        switch (strtolower($Type)) {
-            case 'create':
-                $MethodKey = val($EventKey, $this->newMethods);
-                break;
-            case 'override':
-                $MethodKey = val($EventKey, $this->methodOverrides);
-                break;
-            default:
-                return null;
-        }
-
-        $callback = null;
-        if (is_array($MethodKey) || $MethodKey instanceof \Closure) {
-            // The event handler is an array or a closure so we can call it directly.
-            $callback = $MethodKey;
+        if (!empty($handlers)) {
+            $callback = reset($handlers);
+            return $callback;
         } else {
-            // Decode how `self::register[Handler|NewMethod|Override]` store event names.
-            $PluginKeyParts = explode('.', $MethodKey);
-            if (count($PluginKeyParts) == 2) {
-                // The event handler is a class and method name.
-                list($PluginClassName, $PluginEventHandlerName) = $PluginKeyParts;
-                $callback = [$this->getPluginInstance($PluginClassName), $PluginEventHandlerName];
-            } elseif (is_callable($MethodKey)) {
-                // The event handler is a global function.
-                $callback = $MethodKey;
-            }
+            return null;
         }
-        return $callback;
     }
 
     /**
      * Checks to see if there are any plugins that create the method being executed.
      *
-     * @param string $ClassName The name of the class that called the method being created.
-     * @param string $MethodName The name of the method that is being created.
+     * @param string $className The name of the class that called the method being created.
+     * @param string $methodName The name of the method that is being created.
      * @return bool Returns **true** if the method exists.
      */
-    public function hasNewMethod($ClassName, $MethodName) {
-        $Key = strtolower($ClassName.'_'.$MethodName.'_Create');
-        return array_key_exists($Key, $this->newMethods);
+    public function hasNewMethod($className, $methodName) {
+        $event = "{$className}_{$methodName}_method";
+        return $this->eventManager->hasHandler($event);
     }
 
     /**
@@ -1386,6 +1264,31 @@ class Gdn_PluginManager extends Gdn_Pluggable {
         }
 
         $pluginClassName = $addon->getPluginClass();
-        $this->registerPlugin($pluginClassName);
+        $this->registerPlugin($pluginClassName, $addon->getPriority());
+    }
+
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws \Interop\Container\Exception\NotFoundException  No entry was found for this identifier.
+     * @throws \Interop\Container\Exception\ContainerException Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get($id) {
+        return $this->getPluginInstance($id, self::ACCESS_CLASSNAME);
+    }
+
+    /**
+     * Returns true if the container can return an entry for the given identifier. Returns false otherwise.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return boolean
+     */
+    public function has($id) {
+        return class_exists($id);
     }
 }

--- a/tests/Library/Garden/EventManagerTest.php
+++ b/tests/Library/Garden/EventManagerTest.php
@@ -354,30 +354,30 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase {
     /**
      * Test the old EventArguments kludge.
      */
-    public function testEventArgumentsKludge() {
-        $em = new EventManager();
-
-        $events = [];
-        $em->bind(EventManager::EVENT_META, $this->makeMetaHandler($events));
-
-        $sender = new \stdClass();
-        $sender->EventArguments = ['foo' => 1];
-
-        // fire() has the kludge.
-        $em->fire('foo', $sender);
-        // fireArray() doesn't have the kludge.
-        $em->fireArray('foo', [$sender]);
-        // fireFilter() doesn't have the kludge.
-        $r = $em->fireFilter('foo', $sender);
-
-        $expected = [
-            ['foo', [$sender, $sender->EventArguments], []],
-            ['foo', [$sender], []],
-            ['foo', [$sender], $sender]
-        ];
-
-        $this->assertSame($expected, $events);
-    }
+//    public function testEventArgumentsKludge() {
+//        $em = new EventManager();
+//
+//        $events = [];
+//        $em->bind(EventManager::EVENT_META, $this->makeMetaHandler($events));
+//
+//        $sender = new \stdClass();
+//        $sender->EventArguments = ['foo' => 1];
+//
+//        // fire() has the kludge.
+//        $em->fire('foo', $sender);
+//        // fireArray() doesn't have the kludge.
+//        $em->fireArray('foo', [$sender]);
+//        // fireFilter() doesn't have the kludge.
+//        $r = $em->fireFilter('foo', $sender);
+//
+//        $expected = [
+//            ['foo', [$sender, $sender->EventArguments], []],
+//            ['foo', [$sender], []],
+//            ['foo', [$sender], $sender]
+//        ];
+//
+//        $this->assertSame($expected, $events);
+//    }
 
     /**
      * Get a list of plugin classes suitable for tests.

--- a/tests/Library/Garden/EventManagerTest.php
+++ b/tests/Library/Garden/EventManagerTest.php
@@ -207,11 +207,11 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase {
         $val = $em->fireFilter('filter', '');
         $this->assertSame('filter', $val);
 
-        $val2 = $em->fireFilter('somecontroller_somemethod_endpoint', '');
-        $this->assertSame('someController_someMethod', $val2);
+        $val2 = $em->fireFilter('somecontroller_somemethod_method', '');
+        $this->assertSame('someController_someCreate', $val2);
 
-        $val3 = $em->fireFilter('somecontroller_someendpoint_endpoint', '');
-        $this->assertSame('someController_someEndpoint', $val3);
+        $val3 = $em->fireFilter('somecontroller_someendpoint_method', '');
+        $this->assertSame('someController_someMethod', $val3);
 
         $val4 = $em->fire('setFoo');
         $this->assertSame([], $val4);

--- a/tests/Library/Garden/EventManagerTest.php
+++ b/tests/Library/Garden/EventManagerTest.php
@@ -1,0 +1,425 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Core;
+
+use Garden\EventManager;
+use Vanilla\Addon;
+use Vanilla\AddonManager;
+use VanillaTests\Fixtures\BasicEventHandlers;
+use VanillaTests\Fixtures\Container;
+
+/**
+ * Tests for the {@link EventManager} class.
+ */
+class EventManagerTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * Creates an {@link AddonManager} against Vanilla.
+     *
+     * @return AddonManager Returns the manager.
+     */
+    private static function createVanillaManager() {
+        $manager = new AddonManager(
+            [
+                Addon::TYPE_ADDON => ['/applications', '/plugins'],
+                Addon::TYPE_THEME => '/themes',
+                Addon::TYPE_LOCALE => '/locales'
+            ],
+            PATH_ROOT.'/tests/cache/em/vanilla-manager'
+        );
+
+        return $manager;
+    }
+
+    /**
+     * Test some of the basic property accessors.
+     */
+    public function testGetSet() {
+        $container1 = new Container();
+        $em = new EventManager($container1);
+
+        $this->assertSame($container1, $em->getContainer());
+
+        $container2 = new Container();
+        $this->assertNotSame($container1, $container2);
+
+        $em->setContainer($container2);
+        $this->assertSame($container2, $em->getContainer());
+    }
+
+    /**
+     * Test to see if any events will have overlap when we refactor _overwrite and _handler events to use the same base names.
+     */
+    public function testEventHandlerOverlap() {
+        $pm = new \Gdn_PluginManager();
+        $plugins = $this->providePluginClasses();
+
+        foreach ($plugins as $row) {
+            list($class, $path) = $row;
+
+            // Register the plugin. This will give a warning when there's overlap.
+            require_once $path; // needed because no autoloader registered
+
+            try {
+                $pm->registerPlugin($class);
+            } catch (\PHPUnit_Framework_Error_Notice $ex) {
+                // This is okay.
+                continue;
+            }
+        }
+    }
+
+    /**
+     * Make a closure that pushes a particular value onto an array.
+     *
+     * @param array &$arr The array to push to.
+     * @param mixed $val The value to push.
+     * @return \Closure Returns a closure.
+     */
+    private function makePushHandler(array &$arr, $val) {
+        return function () use (&$arr, $val) {
+            $arr[] = $val;
+        };
+    }
+
+    /**
+     * Make a closure that pushes an event call onto an array.
+     *
+     * This is used to collect meta events for testing.
+     *
+     * @param array &$arr The array to push to.
+     * @return \Closure Returns a closure.
+     */
+    private function makeMetaHandler(array &$arr) {
+        return function ($event, $args, $result) use (&$arr) {
+            $arr[] = [$event, $args, $result];
+        };
+    }
+
+    /**
+     * Test a basic event fire.
+     */
+    public function testFireEvent() {
+        $em = new EventManager();
+
+        $fired = false;
+        $em->bind('test', function () use (&$fired) {
+            $fired = true;
+        });
+        $this->assertFalse($fired);
+
+        $em->fire('test');
+        $this->assertTrue($fired);
+    }
+
+    /**
+     * Test that events fire in the order registered by default.
+     */
+    public function testFireOrderRegistered() {
+        $em = new EventManager();
+
+        $arr = [];
+        $em->bind('test', $this->makePushHandler($arr, 1));
+        $em->bind('test', $this->makePushHandler($arr, 2));
+        $em->bind('test', $this->makePushHandler($arr, 3));
+        $this->assertSame([], $arr);
+
+        $em->fire('test');
+        $this->assertSame([1, 2, 3], $arr);
+    }
+
+    /**
+     * Test event firing from highest to lowest priority.
+     */
+    public function testFirePriorityOrder() {
+        $em = new EventManager();
+
+        $arr = [];
+        $em->bind('test', $this->makePushHandler($arr, 1), EventManager::PRIORITY_LOW);
+        $em->bind('test', $this->makePushHandler($arr, 2), EventManager::PRIORITY_HIGH);
+        $em->bind('test', $this->makePushHandler($arr, 3), EventManager::PRIORITY_NORMAL);
+        $this->assertSame([], $arr);
+
+        $em->fire('test');
+        $this->assertSame([2, 3, 1], $arr);
+    }
+
+    /**
+     * Test a basic call to {@link EventManager::fireFilter()}.
+     */
+    public function testFireFilter() {
+        $em = new EventManager();
+
+        $val = 0;
+        $em->bind('add', function ($val) {
+            return $val + 1;
+        });
+
+        $val2 = $em->fireFilter('add', $val);
+        $this->assertSame(0, $val);
+        $this->assertSame(1, $val2);
+    }
+
+    /**
+     * Filters with no handlers should return their input value.
+     */
+    public function testFireEmptyFilter() {
+        $em = new EventManager();
+
+        $vals = [123, 'foo'];
+        foreach ($vals as $val) {
+            $this->assertSame($val, $em->fireFilter('baz', $val));
+        }
+    }
+
+    /**
+     * Test that firing an event with multiple filters will chain.
+     */
+    public function testFireFilterChaining() {
+        $em = new EventManager();
+
+        $add = function ($val) {
+            return $val + 1;
+        };
+
+        $val = 0;
+        $em->bind('add', $add);
+        $em->bind('add', $add);
+
+        $val2 = $em->fireFilter('add', $val);
+        $this->assertSame(0, $val);
+        $this->assertSame(2, $val2);
+    }
+
+    /**
+     * Test some basic use cases of {@link EventManager::bindClass()}.
+     */
+    public function testBindClassBasics() {
+        $em = new EventManager(new Container());
+
+        $em->bindClass('VanillaTests\Fixtures\BasicEventHandlers');
+
+        $val = $em->fireFilter('filter', '');
+        $this->assertSame('filter', $val);
+
+        $val2 = $em->fireFilter('somecontroller_somemethod_endpoint', '');
+        $this->assertSame('someController_someMethod', $val2);
+
+        $val3 = $em->fireFilter('somecontroller_someendpoint_endpoint', '');
+        $this->assertSame('someController_someEndpoint', $val3);
+
+        $val4 = $em->fire('setFoo');
+        $this->assertSame([], $val4);
+
+        $val5 = $em->fire('event_before');
+        $this->assertSame('event_before', $val5[0]);
+
+        $val6 = $em->fire('event_after');
+        $this->assertSame('event_after', $val6[0]);
+    }
+
+    /**
+     * Calling {@link EventManager::bindClass()} with an instance should create handlers for that instance.
+     */
+    public function testBindClassInstance() {
+        $em = new EventManager();
+
+        $val = 'test';
+        $handlers = new BasicEventHandlers();
+        $this->assertNotSame($val, $handlers->getFoo());
+        $handlers->setFoo($val);
+        $this->assertSame($val, $handlers->getFoo());
+
+        $em->bindClass($handlers);
+        $r = $em->fire('foo');
+        $this->assertSame($val, $r[0]);
+    }
+
+    /**
+     * Test {@link EventManager::fireArray()} with an element as a reference that gets modified.
+     */
+    public function testFireArrayWithReference() {
+        $em = new EventManager();
+
+        $em->bind('test', function (&$val) {
+            $val = 'foo';
+        });
+
+        $val = '';
+        $em->fireArray('test', [&$val]);
+        $this->assertSame('foo', $val);
+    }
+
+    /**
+     * Test {@link EventManager::bindLazy()}.
+     */
+    public function testBindLazy() {
+        $em = new EventManager(new Container());
+
+        $em->bindLazy('getFoo', 'VanillaTests\Fixtures\BasicEventHandlers', 'getFoo');
+
+        $r = $em->fire('getfoo');
+        $this->assertSame('foo', $r[0]);
+    }
+
+    /**
+     * Test some meta event handlers.
+     */
+    public function testMetaHandler() {
+        $em = new EventManager();
+
+        $events = [];
+        $em->bind(EventManager::EVENT_META, $this->makeMetaHandler($events));
+        $em->bind('foo', function ($v = null) {
+            return "foo $v";
+        });
+
+        $em->fireFilter('foo', 'bar');
+        $em->fire('none', 'baz');
+        $em->fireArray('foo', ['baz']);
+
+        $expected = [
+            ['foo', ['bar'], 'foo bar'],
+            ['none', ['baz'], []],
+            ['foo', ['baz'], ['foo baz']],
+        ];
+        $this->assertEquals($expected, $events);
+    }
+
+    /**
+     * Make sure that meta event inception doesn't cause anything crazy.
+     */
+    public function testFireMetaEvent() {
+        $em = new EventManager();
+
+        $events = [];
+        $em->bind(EventManager::EVENT_META, $this->makeMetaHandler($events));
+        $r = $em->fire(EventManager::EVENT_META, 'foo', ['args'], 'result');
+
+        // Since this shouldn't be done we are not specifying a defined behaviour right now.
+        // Let's just make sure that only the two events are fired though.
+        $this->assertSame(2, count($events));
+    }
+
+    /**
+     * Test firing events with no handlers return an empty array of results.
+     */
+    public function testEmptyHandlerResults() {
+        $em = new EventManager();
+
+        $this->assertSame([], $em->fire('noop'));
+        $this->assertSame([], $em->fireArray('noop', []));
+    }
+
+    /**
+     * Test {@link EventManager::hasHandler()}
+     */
+    public function testHasHandler() {
+        $em = new EventManager();
+
+        $em->bind('foo', function () {
+            return 1;
+        });
+
+        $this->assertTrue($em->hasHandler('foo'));
+        $this->assertFalse($em->hasHandler('bar'));
+    }
+
+    /**
+     * Make sure an event with higher than max priority just goes down to max priority.
+     *
+     * @expectedException \PHPUnit_Framework_Error_Notice
+     */
+    public function testMaxPriority() {
+        $em = new EventManager();
+
+        $arr = [];
+        $em->bind('foo', $this->makePushHandler($arr, 1), EventManager::PRIORITY_MAX);
+        $em->bind('foo', $this->makePushHandler($arr, 2), EventManager::PRIORITY_MAX + 1);
+
+        $r = $em->fire('foo');
+        $this->assertSame([1, 2], $arr);
+
+        $arr2 = [];
+        $em->bind('foo', $this->makePushHandler($arr2, 1), EventManager::PRIORITY_MAX - 1);
+        $em->bind('foo', $this->makePushHandler($arr2, 2), EventManager::PRIORITY_MAX + 1);
+        $this->assertSame([2, 1], $arr2);
+    }
+
+    /**
+     * Test the old EventArguments kludge.
+     */
+    public function testEventArgumentsKludge() {
+        $em = new EventManager();
+
+        $events = [];
+        $em->bind(EventManager::EVENT_META, $this->makeMetaHandler($events));
+
+        $sender = new \stdClass();
+        $sender->EventArguments = ['foo' => 1];
+
+        // fire() has the kludge.
+        $em->fire('foo', $sender);
+        // fireArray() doesn't have the kludge.
+        $em->fireArray('foo', [$sender]);
+        // fireFilter() doesn't have the kludge.
+        $r = $em->fireFilter('foo', $sender);
+
+        $expected = [
+            ['foo', [$sender, $sender->EventArguments], []],
+            ['foo', [$sender], []],
+            ['foo', [$sender], $sender]
+        ];
+
+        $this->assertSame($expected, $events);
+    }
+
+    /**
+     * Get a list of plugin classes suitable for tests.
+     *
+     * The result is a data set with each row in the form: [class, path]. The **hasRedefines** element
+     * can be used to determine whether or not the plugin can be included.
+     *
+     * @param bool $includeRedefines Whether or not to include plugins that redefine global functions.
+     * @return array Returns a data provider array.
+     * @throws \Exception Throws an exception when the plugin class path doesn't exist.
+     */
+    public function providePluginClasses($includeRedefines = false) {
+        $am = self::createVanillaManager();
+
+        $result = [];
+
+        $types = [Addon::TYPE_ADDON, Addon::TYPE_THEME];
+        foreach ($types as $type) {
+            $addons = $am->lookupAllByType($type);
+            /** @var Addon $addon */
+            foreach ($addons as $addon) {
+                $pluginClass = $addon->getPluginClass();
+                if (!empty($pluginClass)) {
+                    $path = $addon->getClassPath($pluginClass, Addon::PATH_FULL);
+                    if (empty($path)) {
+                        throw new \Exception("Missing path for $pluginClass.");
+                    }
+
+                    // Kludge: Check for the UserPhoto() function.
+                    $fileContents = file_get_contents($path);
+                    if (preg_match('`function userPhoto`i', $fileContents) && !$includeRedefines) {
+                        continue;
+                    }
+
+                    $result[$pluginClass] = [
+                        $pluginClass,
+                        $path
+                    ];
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/fixtures/src/BasicEventHandlers.php
+++ b/tests/fixtures/src/BasicEventHandlers.php
@@ -16,11 +16,11 @@ class BasicEventHandlers {
     }
 
     public function someController_someMethod_create($val = '') {
-        return $val.'someController_someMethod';
+        return $val.'someController_someCreate';
     }
 
-    public function someController_someEndpoint_endpoint($val = '') {
-        return $val.'someController_someEndpoint';
+    public function someController_someEndpoint_method($val = '') {
+        return $val.'someController_someMethod';
     }
 
     public function setFoo($value) {

--- a/tests/fixtures/src/BasicEventHandlers.php
+++ b/tests/fixtures/src/BasicEventHandlers.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace VanillaTests\Fixtures;
+
+
+class BasicEventHandlers {
+    private $foo = 'foo';
+
+    public function filter_handler($val = '') {
+        return $val.'filter';
+    }
+
+    public function someController_someMethod_create($val = '') {
+        return $val.'someController_someMethod';
+    }
+
+    public function someController_someEndpoint_endpoint($val = '') {
+        return $val.'someController_someEndpoint';
+    }
+
+    public function setFoo($value) {
+        $this->foo = $value;
+        return $this->foo;
+    }
+
+    public function getFoo() {
+        return $this->foo;
+    }
+
+    public function event_before() {
+        return 'event_before';
+    }
+
+    public function event_after() {
+        return 'event_after';
+    }
+
+    public function foo_handler() {
+        return $this->foo;
+    }
+}

--- a/tests/fixtures/src/Container.php
+++ b/tests/fixtures/src/Container.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace VanillaTests\Fixtures;
+
+
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Interop\Container\Exception\NotFoundException;
+
+/**
+ * A basic container for unit testing.
+ */
+class Container extends \ArrayObject implements ContainerInterface {
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws NotFoundException  No entry was found for this identifier.
+     * @throws ContainerException Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get($id) {
+        if (!isset($this[$id])) {
+            $this[$id] = new $id;
+        }
+
+        return $this[$id];
+    }
+
+    /**
+     * Returns true if the container can return an entry for the given identifier. Returns false otherwise.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return boolean
+     */
+    public function has($id) {
+        return class_exists($id);
+    }
+}


### PR DESCRIPTION
The EventManager class replaces the event handling that the Gdn_PluginManager used to do. The goals of the EventManager are the following:

- Add parameter support to events so that we no longer have to use the object polluting EventArguments property.
- Add support for event priorities so that event handlers can be ordered.
- Consolidate event types. Overrides, creates, and handlers are all now one kind of event.
