### PR TITLE
Change Split action to makes new OP from System user

### DIFF
--- a/plugins/SplitMerge/class.splitmerge.plugin.php
+++ b/plugins/SplitMerge/class.splitmerge.plugin.php
@@ -81,6 +81,7 @@ class SplitMergePlugin extends Gdn_Plugin {
                 }
             }
         }
+
         // Load category data.
         $Sender->ShowCategorySelector = (bool)c('Vanilla.Categories.Use');
         $CountCheckedComments = count($CommentIDs);
@@ -92,6 +93,9 @@ class SplitMergePlugin extends Gdn_Plugin {
             $Data['Body'] = sprintf(t('This discussion was created from comments split from: %s.'), anchor(Gdn_Format::text($Discussion->Name), 'discussion/'.$Discussion->DiscussionID.'/'.Gdn_Format::url($Discussion->Name).'/'));
             $Data['Format'] = 'Html';
             $Data['Type'] = 'Discussion';
+
+            // Use the System user as the author.
+            $Data['InsertUserID'] = Gdn::userModel()->getSystemUserID();
 
             // Pass a forced input formatter around this exception.
             if (c('Garden.ForceInputFormatter')) {


### PR DESCRIPTION
Previously, the moderator performing the action would become the OP. This caused them to start receiving notifications, which turned out to be undesirable in most cases.