### PR TITLE
Decode IP addresses before checking for SPAM

### DIFF
--- a/applications/dashboard/models/class.spammodel.php
+++ b/applications/dashboard/models/class.spammodel.php
@@ -83,6 +83,9 @@ class SpamModel extends Gdn_Pluggable {
             $Data['Body'] = $Data['Story'];
         }
 
+        // Make sure all IP addresses are unpacked.
+        $Data = ipDecodeRecursive($Data);
+
         touchValue('IPAddress', $Data, Gdn::request()->ipAddress());
 
         $Sp = self::_Instance();


### PR DESCRIPTION
This update alters `SpamModel::isSpam` by passing `$Data` through `ipDecodeRecursive` before firing its "CheckSpam" event.  This should ensure all IP address data transmitted will be unpacked/human-readable.