### PR TITLE
Fix caching of data when rearranging categories

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2036,6 +2036,8 @@ class CategoryModel extends Gdn_Model {
         if ($rebuild) {
             $this->rebuildTree(true);
         }
+
+        self::clearCache();
     }
 
     /**


### PR DESCRIPTION
This update adds a call to `CategoryModel::clearCache` at the end of `CategoryModel:: saveSubtreeInternal`, which should ensure there is no lingering category data (e.g. sorting) after the structure has been modified.