### PR TITLE
Update response in VanillaSettingsController::categoriesTree

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -948,8 +948,10 @@ class VanillaSettingsController extends Gdn_Controller {
 
         if ($this->Request->isAuthenticatedPostBack(true)) {
             $tree = json_decode($this->Request->post('Subtree'), true);
-            $result = $this->CategoryModel->saveSubtree($tree, $this->Request->post('ParentID', -1));
-            $this->setData('Result', $result);
+            $this->CategoryModel->saveSubtree($tree, $this->Request->post('ParentID', -1));
+
+            $this->setData('Result', (count($this->CategoryModel->Validation->results()) === 0));
+            $this->setData('Validation', $this->CategoryModel->Validation->resultsArray());
         } else {
             throw new Gdn_UserException($this->Request->requestMethod().' is not allowed.', 405);
         }


### PR DESCRIPTION
`VanillaSettingsController::categoriesTree` currently assigns `Response` to the return value of `CategoryModel::saveSubtree`, which does not return a value.  This means the `Response` data is always `null`.

`CategoryModel::saveSubtree` calls `CategoryModel::saveSubtreeInternal`, which can flag validation errors.  These are not currently accounted for.

This update uses the validation object of `CategoryModel` to determine the value of `Response`: `true` if no errors, `false` when errors/results are added.  In addition, the full validation result array is being added under the `Validation` key.