### PR TITLE
Fallback to manual increment in memcached if auto-initializing fails

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2036,8 +2036,6 @@ class CategoryModel extends Gdn_Model {
         if ($rebuild) {
             $this->rebuildTree(true);
         }
-
-        self::clearCache();
     }
 
     /**

--- a/library/core/class.memcached.php
+++ b/library/core/class.memcached.php
@@ -724,6 +724,11 @@ class Gdn_Memcached extends Gdn_Cache {
         $tryBinary = $this->option(Memcached::OPT_BINARY_PROTOCOL, false) & $requireBinary;
         $realKey = $this->makeKey($key, $finalOptions);
         switch ($tryBinary) {
+            case true:
+                $incremented = $this->memcache->increment($realKey, $amount, $initial, $expiry);
+                if ($incremented) {
+                    break;
+                }
             case false:
                 $incremented = $this->memcache->increment($realKey, $amount);
                 if ($incremented === false && $initial) {
@@ -732,9 +737,6 @@ class Gdn_Memcached extends Gdn_Cache {
                         $incremented = $initial;
                     }
                 }
-                break;
-            case true:
-                $incremented = $this->memcache->increment($realKey, $amount, $initial, $expiry);
                 break;
         }
 


### PR DESCRIPTION
`Gdn_Memcached::increment` takes an optional initial value, which it uses to initialize a cache key, if it doesn't already exist.  It passes this value on down to [Memcached::increment](http://php.net/manual/en/memcached.increment.php), which requires the usage of the binary protocol when it receives a value for its `$initial_value` parameter.  `Gdn_Memcached::increment` does some checking to determine if binary protocol is available before passing that parameter.  However, if for whatever reason, that check fails, the initial value just isn't set.

This update alters the switch structure in `Gdn_Memcached::increment` to try the manual initialization of the key value, if the auto-initialization method fails.

I'm also nixing a call to `self::clearCache()`, which shouldn't be necessary with this fix.