### PR TITLE
Fix $addonInfo being wild about its key casing in writeAddonMedia()

### DIFF
--- a/applications/dashboard/views/settings/helper_functions.php
+++ b/applications/dashboard/views/settings/helper_functions.php
@@ -106,11 +106,13 @@ function getTutorials($tutorialCode = '') {
 }
 
 function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter) {
+    $capitalCaseSheme = new \Vanilla\Utility\CapitalCaseScheme();
+    $addonInfo = $capitalCaseSheme->convertArrayKeys($addonInfo, ['RegisterPermissions']);
 
-    $Version = Gdn_Format::display(val('Version', $addonInfo, val('version', $addonInfo, '')));
-    $ScreenName = Gdn_Format::display(val('Name', $addonInfo, val('name', $addonInfo, $addonName)));
+    $Version = Gdn_Format::display(val('Version', $addonInfo, ''));
+    $ScreenName = Gdn_Format::display(val('Name', $addonInfo, $addonName));
 
-    $SettingsUrl = $isEnabled ? val('SettingsUrl', $addonInfo, val('settingsUrl', $addonInfo, '')) : '';
+    $SettingsUrl = $isEnabled ? val('SettingsUrl', $addonInfo, '') : '';
     $SettingsPopupClass = 'js-modal';
 
     if (!val('UsePopupSettings', $addonInfo, true)) {
@@ -128,11 +130,11 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
             $authors[] = $Author;
         }
     }
-    foreach (val('authors', $addonInfo, []) as $author) {
-        if (val('homepage', $author)) {
-            $authors[] = anchor(val('name', $author), val('homepage', $author));
+    foreach (val('Authors', $addonInfo, []) as $author) {
+        if (val('Homepage', $author)) {
+            $authors[] = anchor(val('Name', $author), val('Homepage', $author));
         } else {
-            $authors[] = val('name', $author);
+            $authors[] = val('Name', $author);
         }
     }
     $NewVersion = val('NewVersion', $addonInfo, '');
@@ -198,7 +200,7 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
                     $Info[] = anchor(t('Visit Site'), $PluginUrl);
                 }
 
-                if ($meta = val('meta', $addonInfo)) {
+                if ($meta = val('Meta', $addonInfo)) {
                     foreach ($meta as $key => $value) {
                         if (is_numeric($key)) {
                             $Info[] = $value;
@@ -226,7 +228,7 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
                 ?>
             </div>
         </div>
-        <div class="media-description"><?php echo Gdn_Format::html(t(val('Name', $addonInfo, $addonName).' Description', val('Description', $addonInfo, val('description', $addonInfo, '')))); ?></div>
+        <div class="media-description"><?php echo Gdn_Format::html(t(val('Name', $addonInfo, $addonName).' Description', val('Description', $addonInfo, ''))); ?></div>
     </div>
     <div class="media-right media-options">
         <?php if ($SettingsUrl != '') {

--- a/library/Vanilla/Utility/CamelCaseScheme.php
+++ b/library/Vanilla/Utility/CamelCaseScheme.php
@@ -48,10 +48,6 @@ class CamelCaseScheme extends NameScheme {
         // Make sure the first character is lowercase.
         $name = lcfirst($name);
 
-        if (preg_match('`Php`i', $name)) {
-            $foo = 'bar';
-        }
-
         // Fix some known exceptions.
         $name = preg_replace_callback('`(Id|Ip|Php)(?=[A-Z0-9]|$|s$)`', function ($m) {
             return strtoupper($m[1]);

--- a/library/Vanilla/Utility/NameScheme.php
+++ b/library/Vanilla/Utility/NameScheme.php
@@ -24,14 +24,17 @@ abstract class NameScheme {
      * Recursively convert all of the array keys in an array to this name scheme.
      *
      * @param array $array The array to convert.
+     * @param array $keysSkipRecursion Skip recursion for the following keys.
      * @return array Returns the converted array.
      */
-    public function convertArrayKeys(array $array) {
+    public function convertArrayKeys(array $array, array $keysSkipRecursion = []) {
         $result = [];
         foreach ($array as $key => $value) {
             $key = $this->convert($key);
             if (is_array($value)) {
-                $value = $this->convertArrayKeys($value);
+                if (!in_array($key, $keysSkipRecursion)) {
+                    $value = $this->convertArrayKeys($value);
+                }
             }
             $result[$key] = $value;
         }

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -253,7 +253,9 @@ class Gdn_PluginManager extends Gdn_Pluggable {
      */
     public static function calcOldInfoArray(Addon $addon) {
         $info = $addon->getInfo();
-        $info = self::convertArrayKeys($info);
+
+        $capitalCaseSheme = new \Vanilla\Utility\CapitalCaseScheme();
+        $info = $capitalCaseSheme->convertArrayKeys($info, ['RegisterPermissions']);
 
         // This is the basic information from scanPluginFile().
         $name = $addon->getInfoValue('keyRaw', $addon->getKey());
@@ -326,24 +328,6 @@ class Gdn_PluginManager extends Gdn_Pluggable {
         }
 
         return $info;
-    }
-
-    /**
-     * Uppercase the first letters of an info array recursively.
-     *
-     * @param array $array The array to change.
-     * @return array Returns a new changed array.
-     */
-    private static function convertArrayKeys(array $array) {
-        $result = [];
-        foreach ($array as $key => $value) {
-            $key = ucfirst($key);
-            if (is_array($value) && !in_array($key, ['RegisterPermissions'])) {
-                $value = self::convertArrayKeys($value);
-            }
-            $result[$key] = $value;
-        }
-        return $result;
     }
 
     /**


### PR DESCRIPTION
$addonInfo could come either from the PluginManager or the AddonManager.

The AddonManager save the info with CamelCaseScheme and load them as is.
The PluginManager convert $addonInfo to CapitalCaseScheme. (Probably for backward compatibility)

For now I decided to use CapitalCaseScheme->convertArrayKeys in writeAddonMedia() which fix the problem with the keys being either differents.

Fix: https://github.com/vanilla/vanilla/issues/4491
