### PR TITLE
Only double space the message section in plainTextEmail()

### DIFF
--- a/applications/dashboard/library/class.emailtemplate.php
+++ b/applications/dashboard/library/class.emailtemplate.php
@@ -455,22 +455,26 @@ class EmailTemplate extends Gdn_Pluggable implements Gdn_IEmailTemplate {
      * @return string A plaintext email.
      */
     protected function plainTextEmail() {
-        $email = array(
+        $email = [
             'banner' => val('alt', $this->image).' '.val('link', $this->image),
             'title' => $this->getTitle(),
             'lead' => $this->getLead(),
             'message' => $this->getMessage(),
             'button' => sprintf(t('%s: %s'), val('text', $this->button), val('url', $this->button)),
             'footer' => $this->getFooter()
-        );
+        ];
 
         foreach ($email as $key => $val) {
             if (!$val) {
                 unset($email[$key]);
+            } else {
+                if ($key == 'message') {
+                    $email[$key] = "<br>$val<br>";
+                }
             }
         }
 
-        return Gdn_Format::plainText(Gdn_Format::text(implode("<br><br>", $email)));
+        return Gdn_Format::plainText(Gdn_Format::text(implode('<br>', $email)));
     }
 
     /**


### PR DESCRIPTION
[Stronger, Better, Faster, Simpler than this sug-ges-ti-on](https://www.youtube.com/watch?v=gAjR4_CbPpQ):
https://github.com/vanilla/vanilla/issues/4183#issuecomment-252344447

Fix: https://github.com/vanilla/vanilla/issues/4183