### PR TITLE
Allow default caching option value to be reached in Gdn_Cache

### DIFF
--- a/library/core/class.cache.php
+++ b/library/core/class.cache.php
@@ -692,7 +692,7 @@ abstract class Gdn_Cache {
             $ActiveOptions = c($OptionKey, array());
         }
 
-        if (is_null($Option) || !array_key_exists($Option, $ActiveOptions)) {
+        if (is_null($Option)) {
             return $ActiveOptions;
         }
 


### PR DESCRIPTION
`Gdn_Cache::option` takes two parameters: `$Option` and `$Default`.  If `$Option` isn't set in cache configuration array, we should be getting the `$Default` value.  However, there is currently a condition that is preventing this from occurring.

This update removes the aforementioned condition, allowing code execution to reach the call to `val` which follows, allowing the value of `$Default` to be returned if `$Option` is not a key in the cache configuration array.