### PR TITLE
Make dashboard asset compilation readme clearer

### DIFF
--- a/applications/dashboard/README.md
+++ b/applications/dashboard/README.md
@@ -18,7 +18,11 @@ Once you have Homebrew, this will get everything else you need globally:
 $ brew install node
 
 $ brew install ruby
+```
 
+**Restart Terminal.**
+
+```sh
 $ gem install sass
 
 $ gem install scss-lint

--- a/applications/dashboard/README.md
+++ b/applications/dashboard/README.md
@@ -1,29 +1,53 @@
-# Dashboard Asset Compilation
+# Dashboard asset compilation setup
 
-## Compiling assets
+We don't change CSS files directly. We use Sass for better-structured CSS, which requires a build process. You only need to do this if you're developing the core product. Otherwise, put any changes you want to make to Vanilla's CSS [in your theme instead](http://docs.vanillaforums.com/developer/theming/quickstart/).
 
-The following instructions assume that... 
+## Dependencies
 
-* You already have [Sass](http://sass-lang.com/install) and [SCSS-Lint](https://github.com/brigade/scss-lint) installed on your computer. 
+You will need:
 
-* You have already installed Node.js on your computer. If this is not the case, please download and install the latest stable release from the official [Node.js download page](http://nodejs.org/download/). If you are using [Homebrew](http://brew.sh/), you can also install Node.js via the command line:
+* [Homebrew](http://brew.sh/) (macOS only. Optional but strongly recommended.)
+* Ruby (**not** the default install if using macOS)
+* [Sass](http://sass-lang.com/install)
+* [SCSS-Lint](https://github.com/brigade/scss-lint)
+* [Node.js](http://nodejs.org/download/) (latest stable; do **not** install using `sudo`.)
+
+Once you have Homebrew, this will get everything else you need globally:
+
 ```sh
 $ brew install node
-```
-> __Notice__: It is important that you install Node in a way that does not require you to `sudo`.
 
-Once you have Node.js up and running, you will need to install the local dependencies using [npm](http://npmjs.org):
+$ brew install ruby
+
+$ gem install sass
+
+$ gem install scss-lint
+```
+
+Then install the local dependencies using [npm](http://npmjs.org):
 
 ```sh
+$ cd /path/to/vanilla
+
+$ cd applications/dashboard
+
 $ npm install
 ```
 
-### Tasks
+## Tasks
 
-#### Build - `npm run build`
+__Build__ (run one time)
+
+```sh
+$ npm run build
+```
 
 Compiles all theme assets using Grunt. SCSS stylesheets will be compiled to [`design/admin.css`](design/admin.css) and Javascript in the `js/src` directory will be concatenated and output to [`js/dashboard.js`](js/dashboard.js).
 
-#### Watch - `npm run watch`
+__Watch__ (run continuously)
+
+```sh
+$ npm run watch
+```
 
 Watches the assets for changes and runs the appropriate Grunt tasks. Also starts a LiveReload server that will push the changes to your Vanilla installation automatically. To make use of this, you may want to install and use [LiveReload's browser extensions](http://livereload.com/extensions/).


### PR DESCRIPTION
Addresses issues I found while setting this up:

* Was not clear it needed not-default Ruby.
* Was not clear you needed to be in that sub-directory, but only when you got to `npm install`.
* Some steps required clicking links when it's just 1 more command that could've been inline.
* Clarifies who the doc is for.