### PR TITLE
Fix redundant calls to url for category options

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -73,8 +73,8 @@ if (!function_exists('getOptions')):
         $tk = urlencode(Gdn::session()->TransientKey());
         $hide = (int)!val('Following', $category);
 
-        $dropdown->addLink(t('Mark Read'), url('/category/markread?categoryid='.$categoryID.'&tkey='.$tk), 'mark-read');
-        $dropdown->addLink(t($hide ? 'Unmute' : 'Mute'), url('/category/follow?categoryid='.$categoryID.'&value='.$hide.'&tkey='.$tk), 'hide');
+        $dropdown->addLink(t('Mark Read'), "/category/markread?categoryid={$categoryID}&tkey={$tk}", 'mark-read');
+        $dropdown->addLink(t($hide ? 'Unmute' : 'Mute'), "/category/follow?categoryid={$categoryID}&value={$hide}&tkey={$tk}", 'hide');
 
         // Allow plugins to add options
         $sender->EventArguments['CategoryOptionsDropdown'] = &$dropdown;


### PR DESCRIPTION
The [`getOptions`](https://github.com/vanilla/vanilla/blob/a3423c6869eef3dd009db5253511880f6f1b61f2/applications/vanilla/views/categories/helper_functions.php#L76) categories helper function passes its URLs to `DropdownModule::addLink` through [`url`](https://github.com/vanilla/vanilla/blob/a3423c6869eef3dd009db5253511880f6f1b61f2/library/core/functions.general.php#L3546).  However, the view for `DropdownModule` also [passes the URL values through `url`](https://github.com/vanilla/vanilla/blob/a3423c6869eef3dd009db5253511880f6f1b61f2/applications/dashboard/views/modules/dropdown.php#L19).  If add-ons are hooking in and modifying URLs, this can cause them to be doubly affected and potentially result in invalid URLs.

This update nixes the call to `url` in the categories `getOptions` function, when links are being added to the dropdown.  Handling of the URLs is still accomplished in the `DropdownModule` view.

Closes #4618 