### PR TITLE
Improve install experience for 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,11 @@ install:
   - tests/travis/nginx/install-nginx.sh
 
 script:
-  - tests/travis/php-lint.sh .
+  - tests/travis/php-lint.sh ./applications
+  - tests/travis/php-lint.sh ./conf
+  - tests/travis/php-lint.sh ./library
+  - tests/travis/php-lint.sh ./plugins
+  - tests/travis/php-lint.sh ./themes
   - phpunit -c phpunit.xml.dist
   - cat /tmp/error.log
   - cat /tmp/access.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ php:
 sudo: false
 
 matrix:
+  allow_failures:
+    - php: hhvm
   fast_finish: true
 
 cache:

--- a/applications/dashboard/controllers/class.setupcontroller.php
+++ b/applications/dashboard/controllers/class.setupcontroller.php
@@ -51,7 +51,7 @@ class SetupController extends DashboardController {
             throw new Gdn_UserException('Vanilla is installed!', 409);
         }
 
-        if (!$this->_CheckPrerequisites()) {
+        if (!$this->_checkPrerequisites()) {
             $this->View = 'prerequisites';
         } else {
             $this->View = 'configure';
@@ -347,12 +347,5 @@ class SetupController extends DashboardController {
         }
 
         return $this->Form->errorCount() == 0 ? true : false;
-    }
-
-    /**
-     *
-     */
-    public function testUrlRewrites() {
-        die('ok');
     }
 }

--- a/applications/dashboard/controllers/class.setupcontroller.php
+++ b/applications/dashboard/controllers/class.setupcontroller.php
@@ -266,7 +266,7 @@ class SetupController extends DashboardController {
      * @access private
      * @return bool Whether platform passes requirement check.
      */
-    private function _CheckPrerequisites() {
+    private function _checkPrerequisites() {
         // Make sure we are running at least PHP 5.1
         if (version_compare(phpversion(), ENVIRONMENT_PHP_VERSION) < 0) {
             $this->Form->addError(sprintf(t('You are running PHP version %1$s. Vanilla requires PHP %2$s or greater. You must upgrade PHP before you can continue.'), phpversion(), ENVIRONMENT_PHP_VERSION));
@@ -281,43 +281,46 @@ class SetupController extends DashboardController {
             $this->Form->addError(t('You must have the MySQL driver for PDO enabled in order for Vanilla to connect to your database.'));
         }
 
-        // Make sure that the correct filesystem permissions are in place
+        // Make sure that the correct filesystem permissions are in place.
         $PermissionProblem = false;
 
         // Make sure the appropriate folders are writable.
         $ProblemDirectories = array();
-        if (!is_readable(PATH_CONF) || !IsWritable(PATH_CONF)) {
+        if (!is_readable(PATH_CONF) || !isWritable(PATH_CONF)) {
             $ProblemDirectories[] = PATH_CONF;
         }
 
-        if (!is_readable(PATH_UPLOADS) || !IsWritable(PATH_UPLOADS)) {
+        if (!is_readable(PATH_UPLOADS) || !isWritable(PATH_UPLOADS)) {
             $ProblemDirectories[] = PATH_UPLOADS;
         }
 
-        if (!is_readable(PATH_CACHE) || !IsWritable(PATH_CACHE)) {
+        if (!is_readable(PATH_CACHE) || !isWritable(PATH_CACHE)) {
             $ProblemDirectories[] = PATH_CACHE;
         }
 
+        if (file_exists(PATH_CACHE.'/Smarty/compile') && (!is_readable(PATH_CACHE.'/Smarty/compile') || !isWritable(PATH_CACHE.'/Smarty/compile'))) {
+            $ProblemDirectories[] = PATH_CACHE.'/Smarty/compile';
+        }
+
+        // Display our permission errors.
         if (count($ProblemDirectories) > 0) {
             $PermissionProblem = true;
-
             $PermissionError = t(
                 'Some folders don\'t have correct permissions.',
-                '<p>Some of your folders do not have the correct permissions.</p><p>Using your ftp client, or via command line, make sure that the following permissions are set for your vanilla installation:</p>'
+                '<p>These folders must be readable and writable by the web server:</p>'
             );
-
-            $PermissionHelp = '<pre>chmod -R 777 '.implode("\nchmod -R 777 ", $ProblemDirectories).'</pre>';
+            $PermissionHelp = '<pre>'.implode("\n", $ProblemDirectories).'</pre>';
 
             $this->Form->addError($PermissionError.$PermissionHelp);
         }
 
         // Make sure the config folder is writable.
         if (!$PermissionProblem) {
-            $ConfigFile = Gdn::config()->DefaultPath();
+            $ConfigFile = Gdn::config()->defaultPath();
 
             if (file_exists($ConfigFile)) {
                 // Make sure the config file is writable.
-                if (!is_readable($ConfigFile) || !IsWritable($ConfigFile)) {
+                if (!is_readable($ConfigFile) || !isWritable($ConfigFile)) {
                     $this->Form->addError(sprintf(t('Your configuration file does not have the correct permissions. PHP needs to be able to read and write to this file: <code>%s</code>'), $ConfigFile));
                     $PermissionProblem = true;
                 }
@@ -346,6 +349,9 @@ class SetupController extends DashboardController {
         return $this->Form->errorCount() == 0 ? true : false;
     }
 
+    /**
+     *
+     */
     public function testUrlRewrites() {
         die('ok');
     }

--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -36,7 +36,6 @@ $Configuration['Garden']['Domain']                              = '';
 $Configuration['Garden']['WebRoot']                             = FALSE; // You can set this value if you are using htaccess to direct into the application, but the correct webroot isn't being recognized.
 $Configuration['Garden']['StripWebRoot']                        = FALSE;
 $Configuration['Garden']['Debug']                               = FALSE;
-$Configuration['Garden']['RewriteUrls']                         = FALSE;
 $Configuration['Garden']['Session']['Length']                   = '15 minutes';
 $Configuration['Garden']['Cookie']['Salt']                      = '';
 $Configuration['Garden']['Cookie']['Name']                      = 'Vanilla';

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -940,7 +940,7 @@ class Gdn_Request {
         }
         static $rewrite = null;
         if ($rewrite === null) {
-            $rewrite = val('X_REWRITE', $_SERVER, c('Garden.RewriteUrls', false));
+            $rewrite = val('X_REWRITE', $_SERVER, c('Garden.RewriteUrls', true));
         }
 
         if (!$allowSSL) {


### PR DESCRIPTION
* We automatically provide the Smarty compile folder, so also make sure of its permissions.
* `chmod 777` is bad advice.
* Default to RewriteUrls.
* Remove a dead method and fix a few coding standards issues in the general vicinity.