### PR TITLE
Update packed IP address handling in BanModel

### DIFF
--- a/applications/dashboard/models/class.banmodel.php
+++ b/applications/dashboard/models/class.banmodel.php
@@ -95,12 +95,21 @@ class BanModel extends Gdn_Model {
                 $AllBans[$NewBan['BanID']] = $NewBan;
             }
 
-            $NewUsers = $this->SQL
-                ->select('u.UserID, u.Banned')
-                ->from('User u')
-                ->where($this->banWhere($NewBan))
-                ->where('Admin', 0) // No banning superadmins, pls.
-                ->get()->resultArray();
+            try {
+                $NewUsers = $this->SQL
+                    ->select('u.UserID, u.Banned')
+                    ->from('User u')
+                    ->where($this->banWhere($NewBan))
+                    ->where('Admin', 0)// No banning superadmins, pls.
+                    ->get()->resultArray();
+            } catch (Exception $e) {
+                Logger::log(
+                    Logger::ERROR,
+                    $e->getMessage()
+                );
+                $NewUsers = [];
+            }
+
             $NewUserIDs = array_column($NewUsers, 'UserID');
         } elseif (isset($OldBan['BanID'])) {
             unset($AllBans[$OldBan['BanID']]);
@@ -108,11 +117,19 @@ class BanModel extends Gdn_Model {
 
         if ($OldBan) {
             // Get a list of users affected by the old ban.
-            $OldUsers = $this->SQL
-                ->select('u.UserID, u.LastIPAddress, u.Name, u.Email, u.Banned')
-                ->from('User u')
-                ->where($this->banWhere($OldBan))
-                ->get()->resultArray();
+            try {
+                $OldUsers = $this->SQL
+                    ->select('u.UserID, u.LastIPAddress, u.Name, u.Email, u.Banned')
+                    ->from('User u')
+                    ->where($this->banWhere($OldBan))
+                    ->get()->resultArray();
+            } catch (Exception $e) {
+                Logger::log(
+                    Logger::ERROR,
+                    $e->getMessage()
+                );
+                $OldUsers = [];
+            }
         }
 
         // Check users that need to be unbanned.
@@ -403,11 +420,19 @@ class BanModel extends Gdn_Model {
      * @param array $Data
      */
     public function setCounts(&$Data) {
-        $CountUsers = $this->SQL
-            ->select('UserID', 'count', 'CountUsers')
-            ->from('User u')
-            ->where($this->BanWhere($Data))
-            ->get()->value('CountUsers', 0);
+        try {
+            $CountUsers = $this->SQL
+                ->select('UserID', 'count', 'CountUsers')
+                ->from('User u')
+                ->where($this->BanWhere($Data))
+                ->get()->value('CountUsers', 0);
+        } catch (Exception $e) {
+            Logger::log(
+                Logger::ERROR,
+                $e->getMessage()
+            );
+            $CountUsers = 0;
+        }
 
         $Data['CountUsers'] = $CountUsers;
     }

--- a/applications/dashboard/models/class.banmodel.php
+++ b/applications/dashboard/models/class.banmodel.php
@@ -95,7 +95,7 @@ class BanModel extends Gdn_Model {
                 $AllBans[$NewBan['BanID']] = $NewBan;
             }
 
-            // Protect against lack of inet6_ntoa, which wasn't introduced until MySQL 5.6.3
+            // Protect against a lack of inet6_ntoa, which wasn't introduced until MySQL 5.6.3.
             try {
                 $NewUsers = $this->SQL
                     ->select('u.UserID, u.Banned')
@@ -118,7 +118,7 @@ class BanModel extends Gdn_Model {
 
         if ($OldBan) {
             // Get a list of users affected by the old ban.
-            // Protect against lack of inet6_ntoa, which wasn't introduced until MySQL 5.6.3
+            // Protect against a lack of inet6_ntoa, which wasn't introduced until MySQL 5.6.3.
             try {
                 $OldUsers = $this->SQL
                     ->select('u.UserID, u.LastIPAddress, u.Name, u.Email, u.Banned')
@@ -422,7 +422,7 @@ class BanModel extends Gdn_Model {
      * @param array $Data
      */
     public function setCounts(&$Data) {
-        // Protect against lack of inet6_ntoa, which wasn't introduced until MySQL 5.6.3
+        // Protect against a lack of inet6_ntoa, which wasn't introduced until MySQL 5.6.3.
         try {
             $CountUsers = $this->SQL
                 ->select('UserID', 'count', 'CountUsers')

--- a/applications/dashboard/models/class.banmodel.php
+++ b/applications/dashboard/models/class.banmodel.php
@@ -152,7 +152,7 @@ class BanModel extends Gdn_Model {
                 $Result['u.Email like'] = $Ban['BanValue'];
                 break;
             case 'ipaddress':
-                $Result['u.LastIPAddress like'] = $Ban['BanValue'];
+                $Result['inet6_ntoa(u.LastIPAddress) like'] = $Ban['BanValue'];
                 break;
             case 'name':
                 $Result['u.Name like'] = $Ban['BanValue'];
@@ -202,7 +202,12 @@ class BanModel extends Gdn_Model {
             $Parts = array_map('preg_quote', $Parts);
             $Regex = '`^'.implode('.*', $Parts).'$`i';
 
-            if (preg_match($Regex, val($Fields[$Ban['BanType']], $User))) {
+            $value = val($Fields[$Ban['BanType']], $User);
+            if ($Ban['BanType'] === 'IPAddress') {
+                $value = ipDecode($value);
+            }
+
+            if (preg_match($Regex, $value)) {
                 $Banned[$Ban['BanType']] = true;
                 $BansFound[] = $Ban;
 

--- a/applications/dashboard/models/class.banmodel.php
+++ b/applications/dashboard/models/class.banmodel.php
@@ -95,6 +95,7 @@ class BanModel extends Gdn_Model {
                 $AllBans[$NewBan['BanID']] = $NewBan;
             }
 
+            // Protect against lack of inet6_ntoa, which wasn't introduced until MySQL 5.6.3
             try {
                 $NewUsers = $this->SQL
                     ->select('u.UserID, u.Banned')
@@ -117,6 +118,7 @@ class BanModel extends Gdn_Model {
 
         if ($OldBan) {
             // Get a list of users affected by the old ban.
+            // Protect against lack of inet6_ntoa, which wasn't introduced until MySQL 5.6.3
             try {
                 $OldUsers = $this->SQL
                     ->select('u.UserID, u.LastIPAddress, u.Name, u.Email, u.Banned')
@@ -420,6 +422,7 @@ class BanModel extends Gdn_Model {
      * @param array $Data
      */
     public function setCounts(&$Data) {
+        // Protect against lack of inet6_ntoa, which wasn't introduced until MySQL 5.6.3
         try {
             $CountUsers = $this->SQL
                 ->select('UserID', 'count', 'CountUsers')


### PR DESCRIPTION
This update augments ban checking/enforcement in `BanModel` by updating its ability to handle packed IP addresses.  IP comparisons in PHP are done with `ipDecode`.  IP comparisons in MySQL make use of `inet6_ntoa`, which is available since [MySQL 5.6.3 (released October 3, 2011)](https://dev.mysql.com/doc/relnotes/mysql/5.6/en/news-5-6-3.html)