### PR TITLE
Add an upgrade warning for PHP and MySQL to all settings pages

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -74,8 +74,9 @@ class DashboardHooks implements Gdn_IPlugin {
                 $MessageModule = new MessageModule($Sender, $Message);
                 if ($SignInOnly) { // Insert special messages even in SignIn popup
                     echo $MessageModule;
-                } elseif ($Sender->deliveryType() == DELIVERY_TYPE_ALL)
+                } elseif ($Sender->deliveryType() == DELIVERY_TYPE_ALL) {
                     $Sender->addModule($MessageModule);
+                }
             }
             $Sender->MessagesLoaded = '1'; // Fixes a bug where render gets called more than once and messages are loaded/displayed redundantly.
         }
@@ -135,6 +136,31 @@ class DashboardHooks implements Gdn_IPlugin {
 
         // Allow global translation of TagHint
         $Sender->addDefinition("TagHint", t("TagHint", "Start to type..."));
+    }
+
+    /**
+     * Aggressively prompt users to upgrade PHP version.
+     *
+     * @param $sender
+     */
+    public function settingsController_render_before($sender) {
+        // Set this in your config to dismiss our upgrade warnings. Not recommended.
+        if (c('Vanilla.WarnedMeToUpgrade') === 'PHP 5.6') {
+            return;
+        }
+
+        if (version_compare(phpversion(), '5.6') < 0) {
+            $UpgradeMessage = ['Content' => 'Upgrade to <b>PHP 5.6</b> or higher immediately. Version '.phpversion().' is no longer supported.', 'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'];
+            $MessageModule = new MessageModule($sender, $UpgradeMessage);
+            $sender->addModule($MessageModule);
+        }
+
+        $mysqlVersion = gdn::sql()->version();
+        if (version_compare($mysqlVersion, '5.6') < 0) {
+            $UpgradeMessage = ['Content' => 'We recommend using <b>MySQL 5.6</b> or higher. Version '.htmlspecialchars($mysqlVersion).' will not support all upcoming Vanilla features.', 'AssetTarget' => 'Content', 'CssClass' => 'InfoMessage'];
+            $MessageModule = new MessageModule($sender, $UpgradeMessage);
+            $sender->addModule($MessageModule);
+        }
     }
 
     /**


### PR DESCRIPTION
For 2.3 release.

Use our MessageModule to add upgrade warnings to all /settings pages in the Dashboard.

We strongly suggest PHP 5.6+ and MySQL 5.6+.

This also allows the messages to be dismissed by the folks who are powerless to do anything about it presently and cannot abide by this message annoying them.