### PR TITLE
Fix empty Table Jenga label still appearing

### DIFF
--- a/applications/dashboard/js/jquery.tablejenga.js
+++ b/applications/dashboard/js/jquery.tablejenga.js
@@ -87,7 +87,13 @@
                         label = $cell.data('label');
 
                         html = vars.metaTemplate.replace('{data}', html);
-                        html = html.replace('{label}', label);
+                        if (label) {
+                            var labelHtml = vars.metaLabel.replace('{label}', label);
+                            html = html.replace('{label}', labelHtml);
+                        } else {
+                            html = html.replace('{label}', '');
+                        }
+
                         if (!$('.tj-main-cell .tj-meta', this).length) {
                             $('.tj-main-cell', this).append('<div class="tj-meta">' + html + '</div>');
                         } else {
@@ -144,6 +150,7 @@
                 container: settings.container,
                 mainCell: settings.mainCell,
                 metaTemplate: settings.metaTemplate,
+                metaLabel: settings.metaLabel,
                 showEmptyCells: settings.showEmptyCells
             };
 
@@ -160,9 +167,10 @@
         container: 'body',
         mainCell: 'firstcell',
         metaTemplate: '<div class="table-meta-item">' +
-        '<span class="table-meta-item-label">{label}: </span>' +
+        '{label}' +
         '<span class="table-meta-item-data">{data}</span>' +
         '</div>',
+        metaLabel: '<span class="table-meta-item-label">{label}: </span>',
         showEmptyCells: false
     };
 


### PR DESCRIPTION
Fix issue where empty labels appear in table jenga. This was originally fixed here https://github.com/vanilla/vanilla/commit/2341115ce5304f8b7860fc04129e24e95e2d626c but mistakenly reverted here: https://github.com/vanilla/vanilla/commit/23bc9bb693ee2b6e04973c43e95da3fcfdea0596