### PR TITLE
Fixed wrong heading for "activity" on profile page

### DIFF
--- a/applications/dashboard/views/profile/activity.php
+++ b/applications/dashboard/views/profile/activity.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit();
 
 echo '<div class="DataListWrap">';
-echo '<h1 class="H">'.t('Activity').'</h1>';
+echo '<h2 class="H">'.t('Activity').'</h2>';
 
 $Session = Gdn::session();
 if ($Session->isValid() && checkPermission('Garden.Profiles.Edit')) {


### PR DESCRIPTION
I wrongfully changed the headings for "activity" in this PR:
https://github.com/vanilla/vanilla/pull/4415

It appears in the profile page, not as the title for an edit profile page.