### PR TITLE
Avoid auto-scrolling to top when in comment embed

### DIFF
--- a/js/embed_local.js
+++ b/js/embed_local.js
@@ -159,8 +159,9 @@ jQuery(document).ready(function($) {
 
         setInterval(setHeight, 300);
 
-        // Scroll to top :D
-        remotePostMessage('scrollto:0', '*');
+        if (isEmbeddedComments === false) {
+            remotePostMessage('scrollto:0', '*');
+        }
 
         // Simulate a page unload when popups are opened (so they are scrolled into view).
         $('body').bind('popupReveal', function() {


### PR DESCRIPTION
This update avoids automatically scrolling to the top of an embedded site when it's a comment embed.

Closes #4550 