### PR TITLE
Default to secure cookies if ForceSSL and behind HTTPS

### DIFF
--- a/library/core/functions.compatibility.php
+++ b/library/core/functions.compatibility.php
@@ -585,16 +585,20 @@ if (!function_exists('safeCookie')) {
      * @param integer $expire
      * @param string $path
      * @param string $domain
-     * @param boolean $secure
+     * @param boolean|null $secure
      * @param boolean $httponly
      */
-    function safeCookie($name, $value = null, $expire = 0, $path = null, $domain = null, $secure = false, $httponly = false) {
+    function safeCookie($name, $value = null, $expire = 0, $path = null, $domain = null, $secure = null, $httponly = false) {
         static $context = null;
         if (is_null($context)) {
             $context = requestContext();
         }
 
         if ($context == 'http') {
+            if ($secure === null && c('Garden.ForceSSL') && Gdn::request()->scheme() === 'https') {
+                $secure = true;
+            }
+
             setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
         }
     }


### PR DESCRIPTION
This update alters `safeCookie` defaults to set the secure flag on cookies if the following conditions are met:

1. The `$secure` parameter is `null`. Previous boolean values will continue to work as they have.
1. `Garden.ForceSSL` is enabled.
1. The current request is served via HTTPS.

Closes #4552 