### PR TITLE
Send range dates as UTC when fetching Vanilla Stats summaries

### DIFF
--- a/plugins/VanillaStats/js/vanillastats.js
+++ b/plugins/VanillaStats/js/vanillastats.js
@@ -714,7 +714,13 @@ var vanillaStats = (function() {
     };
 
     VanillaStats.prototype.getSummaries = function(container) {
-        var dateRange = this.getRange();
+        var rangeFrom = this.getRange("from");
+        var rangeTo = this.getRange("to");
+        var dateRange = {
+            from: rangeFrom instanceof Date ? rangeFrom.toUTCString() : rangeFrom,
+            to: rangeTo instanceof Date ? rangeTo.toUTCString() : rangeTo
+        };
+
         $.ajax({
             url: gdn.url('/dashboard/settings/dashboardsummaries?DeliveryType=VIEW'),
             data: {range: dateRange},


### PR DESCRIPTION
This update forces formatting selected dates in the target range as UTC strings in Vanilla Stats, instead of relying on the browser's date-object-to-string conversion, which can lead to inconsistent date formatting.

Closes #4560 