### PR TITLE
Enhance isUrl() to also identify data urls as urls

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1884,7 +1884,9 @@ if (!function_exists('isTimestamp')) {
 
 if (!function_exists('isUrl')) {
     /**
-     * Determine whether or not a string is a url in the form http://, https://, or //.
+     * Determine whether or not a string is a url.
+     *
+     * Valid urls must begin with http://, https://, // or data:image.
      *
      * @param string $Str The string to check.
      * @return bool
@@ -1898,6 +1900,9 @@ if (!function_exists('isUrl')) {
             return true;
         }
         if (preg_match('`^https?://`i', $Str)) {
+            return true;
+        }
+        if (substr(strtolower($Str), 0, 10) == 'data:image') {
             return true;
         }
         return false;


### PR DESCRIPTION
I've stumbled upon this when I was trying to write a plugin that generates a SVG avatar. Using userPhotoDefaultUrl() to return a data url does not work, since isUrl() doesn't recognize this format and prepends the upload path before the data url.

The isUrl() function can only be overwritten in the bootstrap.before.php which is quite uncomfortable for plugins.

I'm not sure if this would cause any problems anywhere, but as far as I know Vanilla doesn't use inline images.

But in the profile the isUrl() is sometimes used to determine if the profile picture is a "$RemotePhoto". This would give a false positive, though...