### PR TITLE
Check for change instead of click in category deletion

### DIFF
--- a/applications/vanilla/js/manage-categories.js
+++ b/applications/vanilla/js/manage-categories.js
@@ -2,7 +2,7 @@
     $(document)
         // Categories->Delete().
         // Hide/reveal the delete options when the DeleteDiscussions checkbox is un/checked.
-        .on('click', '[name$=DeleteDiscussions]', function () {
+        .on('change', '[name$=DeleteDiscussions]', function () {
             if ($(this).prop('checked')) {
                 $('#ReplacementCategory,#ReplacementWarning').slideDown('fast');
                 $('#DeleteDiscussions').slideUp('fast');


### PR DESCRIPTION
Fixes issue where you can't choose which category to move discussions to.

Closes https://github.com/vanilla/vanilla/issues/4660