### PR TITLE
Fix issue where nav is cut off on category add/edit

### DIFF
--- a/applications/vanilla/js/manage-categories.js
+++ b/applications/vanilla/js/manage-categories.js
@@ -60,6 +60,7 @@ jQuery(document).ready(function ($) {
         } else {
             $('.CategoryPermissions').hide();
         }
+        $('.panel-nav .js-fluid-fixed').trigger('reset.FluidFixed');
     };
     $('#Form_CustomPermissions').click(displayCategoryPermissions);
     displayCategoryPermissions();


### PR DESCRIPTION
The nav calculates the page height before the permissions are hidden. This triggers the nav to recalculate the height of the page.