### PR TITLE
Backport PR #3960 to Vanilla 2.3

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -155,27 +155,31 @@ $Construct
 // Fix old default roles that were stored in the config and user-role table.
 if ($RoleTableExists && $UserRoleExists && $RoleTypeExists) {
     $types = $RoleModel->getAllDefaultRoles();
-    if ($v = c('Garden.Registration.ApplicantRoleID')) {
-        $SQL->update('Role')
-            ->set('Type', RoleModel::TYPE_APPLICANT)
-            ->where('RoleID', $types[RoleModel::TYPE_APPLICANT])
-            ->put();
+    if (c('Garden.Registration.ApplicantRoleID')) {
+        $SQL->replace(
+            'Role',
+            array('Type' => RoleModel::TYPE_APPLICANT),
+            array('RoleID' => $types[RoleModel::TYPE_APPLICANT]),
+            true
+        );
 //      RemoveFromConfig('Garden.Registration.ApplicantRoleID');
     }
-
-    if ($v = c('Garden.Registration.DefaultRoles')) {
-        $SQL->update('Role')
-            ->set('Type', RoleModel::TYPE_MEMBER)
-            ->where('RoleID', $types[RoleModel::TYPE_MEMBER])
-            ->put();
+    if (c('Garden.Registration.DefaultRoles')) {
+        $SQL->replace(
+            'Role',
+            array('Type' => RoleModel::TYPE_MEMBER),
+            array('RoleID' => $types[RoleModel::TYPE_MEMBER]),
+            true
+        );
 //      RemoveFromConfig('Garden.Registration.DefaultRoles');
     }
-
-    if ($v = c('Garden.Registration.ConfirmEmailRole')) {
-        $SQL->update('Role')
-            ->set('Type', RoleModel::TYPE_UNCONFIRMED)
-            ->where('RoleID', $types[RoleModel::TYPE_UNCONFIRMED])
-            ->put();
+    if (c('Garden.Registration.ConfirmEmailRole')) {
+        $SQL->replace(
+            'Role',
+            array('Type' => RoleModel::TYPE_UNCONFIRMED),
+            array('RoleID' => $types[RoleModel::TYPE_UNCONFIRMED]),
+            true
+        );
 //      RemoveFromConfig('Garden.Registration.ConfirmEmailRole');
     }
 


### PR DESCRIPTION
Running /utility/structure in 2.3RC1 still keeps on showing
~~~
update GDN_Role `Role`
set Type = 'applicant'
where RoleID = '4';

update GDN_Role `Role`
set Type = 'member'
where RoleID = '8';

update GDN_Role `Role`
set Type = 'unconfirmed'
where RoleID = '3';
~~~

This was fixed for the master branch in  https://github.com/vanilla/vanilla/pull/3960
I backported that changes to the 2.3 branch