### PR TITLE
Backport PR #4097 to Vanilla 2.3

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -355,7 +355,6 @@ class VanillaHooks implements Gdn_IPlugin {
      * @param object $Sender DashboardController.
      */
     public function base_render_before($Sender) {
-        $Session = Gdn::session();
         if ($Sender->Menu) {
             $Sender->Menu->addLink('Discussions', t('Discussions'), '/discussions', false, array('Standard' => true));
         }


### PR DESCRIPTION
Delete unneeded variable declaration from base_render_before() call.

https://github.com/vanilla/vanilla/pull/4097