### PR TITLE
Backport PR #3996 to Vanilla 2.3

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -631,7 +631,7 @@ if (!$FullNameColumnExists) {
         ->put();
 
     $Construct->table('Tag')
-        ->column('FullName', 'varchar(255)', false, 'index')
+        ->column('FullName', 'varchar(100)', false, 'index')
         ->set();
 }
 


### PR DESCRIPTION
Prevent column FullName of table Tag to be set to a false length

https://github.com/vanilla/vanilla/pull/3996