### PR TITLE
Backport PR #3711 to Vanilla 2.3

### DIFF
--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -2394,7 +2394,7 @@ a.ChangePicture {
   display: block;
 }
 
-a.ChangePicuture:hover {
+a.ChangePicture:hover {
   color: #fff;
   text-decoration: underline;
 }


### PR DESCRIPTION
Fix typo in style.css
Affects text that is hovered on the profile picture in edit profile.

https://github.com/vanilla/vanilla/pull/3711