### PR TITLE
Make label of toggle element always use translations

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -605,7 +605,7 @@ class Gdn_Form extends Gdn_Pluggable {
         if ($label) {
             $toggle = '
                 <div class="label-wrap-wide">
-                    <div class="label label-'.$fieldName.'" id="'.$attributes['aria-labelledby'].'">'.$label.'</div>
+                    <div class="label label-'.$fieldName.'" id="'.$attributes['aria-labelledby'].'">'.t($label).'</div>
                 </div>
                 <div class="input-wrap-right">
                     <div class="toggle-wrap">'.


### PR DESCRIPTION
Just as the label in the checkBox() or radio() element, the label in the new toggle element should use the t() function by default.