### PR TITLE
Reinstate Theme Preview

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1748,7 +1748,7 @@ class SettingsController extends DashboardController {
                     throw new Exception(sprintf(t("Could not find a theme identified by '%s'"), $ThemeName));
                 }
 
-                Gdn::session()->setPreference(array('PreviewThemeName' => '', 'PreviewThemeFolder' => '')); // Clear out the preview
+                Gdn::session()->setPreference(array('PreviewMobileThemeName' => '', 'PreviewMobileThemeFolder' => '')); // Clear out the preview
                 Gdn::themeManager()->enableTheme($ThemeName, $IsMobile);
                 $this->EventArguments['ThemeName'] = $ThemeName;
                 $this->EventArguments['ThemeInfo'] = $ThemeInfo;
@@ -1791,42 +1791,73 @@ class SettingsController extends DashboardController {
      * @since 2.0.0
      * @access public
      * @param string $ThemeName Unique ID.
+     * @param string $transientKey
      */
-    public function previewTheme($ThemeName = '') {
+    public function previewTheme($ThemeName = '', $transientKey = '') {
         $this->permission('Garden.Settings.Manage');
-        $ThemeInfo = Gdn::themeManager()->getThemeInfo($ThemeName);
 
-        $PreviewThemeName = $ThemeName;
-        $PreviewThemeFolder = val('Folder', $ThemeInfo);
-        $IsMobile = val('IsMobile', $ThemeInfo);
+        if (Gdn::session()->validateTransientKey($transientKey)) {
+            $ThemeInfo = Gdn::themeManager()->getThemeInfo($ThemeName);
+            $PreviewThemeName = $ThemeName;
+            $displayName = val('Name', $ThemeInfo);
+            $IsMobile = val('IsMobile', $ThemeInfo);
 
-        // If we failed to get the requested theme, cancel preview
-        if ($ThemeInfo === false) {
-            $PreviewThemeName = '';
-            $PreviewThemeFolder = '';
+            // If we failed to get the requested theme, cancel preview
+            if ($ThemeInfo === false) {
+                $PreviewThemeName = '';
+            }
+
+            if ($IsMobile) {
+                Gdn::session()->setPreference(
+                    ['PreviewMobileThemeFolder' => $PreviewThemeName,
+                    'PreviewMobileThemeName' => $displayName]
+                );
+            } else {
+                Gdn::session()->setPreference(
+                    ['PreviewThemeFolder' => $PreviewThemeName,
+                    'PreviewThemeName' => $displayName]
+                );
+            }
+
+            $this->fireEvent('PreviewTheme', ['ThemeInfo' => $ThemeInfo]);
+
+            redirect('/');
+        } else {
+            redirect('settings/themes');
         }
-
-        Gdn::session()->setPreference(array(
-            'PreviewThemeName' => $PreviewThemeName,
-            'PreviewThemeFolder' => $PreviewThemeFolder,
-            'PreviewIsMobile' => $IsMobile
-        ));
-
-        redirect('/');
     }
 
     /**
-     * Closes current theme preview.
+     * Closes theme preview.
      *
      * @since 2.0.0
      * @access public
+     *
+     * @param string $previewThemeFolder
+     * @param string $transientKey
      */
-    public function cancelPreview() {
-        $Session = Gdn::session();
-        $IsMobile = $Session->User->Preferences['PreviewIsMobile'];
-        $Session->setPreference(array('PreviewThemeName' => '', 'PreviewThemeFolder' => '', 'PreviewIsMobile' => ''));
+    public function cancelPreview($previewThemeFolder = '', $transientKey = '') {
+        $this->permission('Garden.Settings.Manage');
+        $isMobile = false;
 
-        if ($IsMobile) {
+        if (Gdn::session()->validateTransientKey($transientKey)) {
+            $themeInfo = Gdn::themeManager()->getThemeInfo($previewThemeFolder);
+            $isMobile = val('IsMobile', $themeInfo);
+
+            if ($isMobile) {
+                Gdn::session()->setPreference(
+                    ['PreviewMobileThemeFolder' => '',
+                    'PreviewMobileThemeName' => '']
+                );
+            } else {
+                Gdn::session()->setPreference(
+                    ['PreviewThemeFolder' => '',
+                    'PreviewThemeName' => '']
+                );
+            }
+        }
+
+        if ($isMobile) {
             redirect('settings/mobilethemes');
         } else {
             redirect('settings/themes');

--- a/applications/dashboard/js/addons.js
+++ b/applications/dashboard/js/addons.js
@@ -116,13 +116,14 @@ jQuery(document).ready(function($) {
     };
 
     // Ajax-test addons before enabling
-    $('a.PreviewAddon').click(function() {
+    $('.js-preview-addon').click(function() {
         gdn.clearAddonErrors();
 
         var url = $(this).attr('href');
         var urlParts = url.split('/');
         var addonName = urlParts[urlParts.length - 1];
         var testUrl = gdn.url('/dashboard/settings/testaddon/Theme/' + addonName + '/' + gdn.definition('TransientKey'));
+        var url = url + '/' + gdn.definition('TransientKey');
 
         $.ajax({
             type: "GET",

--- a/applications/dashboard/views/settings/mobilethemes.php
+++ b/applications/dashboard/views/settings/mobilethemes.php
@@ -6,6 +6,10 @@ $desc = t('Mobile themes allow you to change the look and feel of your site on s
 $desc .= t('They work just like regular themes. Once one has been added to the themes folder, you can enable it here.');
 
 helpAsset(sprintf(t('About %s'), t('Mobile Themes')), $desc);
+helpAsset(t('About Theme Preview'), t('Not getting what you expect when you preview your theme?').' '
+    .t('Theme preview is limited to displaying the theme\'s template and css.').' '
+    .t('Overridden views or themehooks can have unintended side effects and are not previewed.'));
+
 ?>
 <svg display="none">
     <symbol viewBox="0 0 252 281" id="mobile-frame"><g fill-rule="evenodd"><path d="M3.15,15.7582284 C3.15,8.79489615 8.78765609,3.15 15.7571747,3.15 L236.242825,3.15 C243.205576,3.15 248.85,8.78126062 248.85,15.7582284 L248.85,280.35 L3.15,280.35 L3.15,15.7582284 L3.15,15.7582284 L3.15,15.7582284 Z M243.6,279.201172 L243.6,15.7582284 C243.6,11.6862452 240.311573,8.4 236.242825,8.4 L15.7571747,8.4 C11.6900229,8.4 8.4,11.6915185 8.4,15.7582284 L8.60057618,279.102293 L243.6,279.201172 Z M1.13686838e-13,67.7172107 C1.13686838e-13,66.8516641 0.699087095,66.15 1.575,66.15 L3.15,66.15 L3.15,151.2 L1.575,151.2 C0.705151519,151.2 1.13686838e-13,150.490284 1.13686838e-13,149.632789 L1.13686838e-13,67.7172107 L1.13686838e-13,67.7172107 Z M252,67.7263729 C252,66.8557662 251.300913,66.15 250.425,66.15 L248.85,66.15 L248.85,91.35 L250.425,91.35 C251.294848,91.35 252,90.6497064 252,89.7736271 L252,67.7263729 L252,67.7263729 Z M252,99.2263729 C252,98.3557662 251.300913,97.65 250.425,97.65 L248.85,97.65 L248.85,122.85 L250.425,122.85 C251.294848,122.85 252,122.149706 252,121.273627 L252,99.2263729 L252,99.2263729 Z M186.376373,-8.06113616e-15 C185.505766,-7.90120831e-15 184.8,0.699087095 184.8,1.575 L184.8,3.15 L210,3.15 L210,1.575 C210,0.705151519 209.299706,-1.22720842e-14 208.423627,-1.21111511e-14 L186.376373,-8.06113616e-15 L186.376373,-8.06113616e-15 Z M105,23.4015945 C105,22.2961444 105.89666,21.4 106.997492,21.4 L145.002508,21.4 C146.105692,21.4 147,22.290712 147,23.4015945 L147,23.5984055 C147,24.7038556 146.10334,25.6 145.002508,25.6 L106.997492,25.6 C105.894308,25.6 105,24.709288 105,23.5984055 L105,23.4015945 L105,23.4015945 Z"/></g></symbol>
@@ -149,6 +153,7 @@ helpAsset(sprintf(t('About %s'), t('Mobile Themes')), $desc);
             $Upgrade = $NewVersion != '' && version_compare($NewVersion, $Version, '>');
             $PreviewUrl = val('MobileScreenshotUrl', $ThemeInfo, false);
             $Description = val('Description', $ThemeInfo);
+            $allowPreview = val('AllowPreview', $ThemeInfo, true);
             $RequiredApplications = val('RequiredApplications', $ThemeInfo, false);
 
             $ClassCurrentTheme = ($EnabledThemeInfo['Index'] == $ThemeInfo['Index'])
@@ -180,8 +185,14 @@ helpAsset(sprintf(t('About %s'), t('Mobile Themes')), $desc);
                     <div class="image-wrap">
                     <?php echo $PreviewImageHtml; ?>
                         <div class="overlay">
+                            <div class="label-selector-corner-link">
+                                <?php echo anchor(dashboardSymbol('expand', '', 'icon-16'), 'dashboard/settings/themeinfo/'.$ThemeName, 'js-modal', ['data-css-class' => 'modal-center modal-md', 'data-modal-type' => 'noheader']); ?>
+                            </div>
                             <div class="buttons">
                                 <?php echo anchor(t('Apply'), 'dashboard/settings/mobilethemes/'.$ThemeName.'/'.$Session->TransientKey(), 'EnableAddon EnableTheme btn btn-overlay', array('target' => '_top'));
+                                if ($allowPreview) {
+                                    echo anchor(t('Preview'), 'dashboard/settings/previewtheme/'.$ThemeName, 'btn btn-overlay js-preview-addon');
+                                }
                                 $this->EventArguments['ThemeInfo'] = $ThemeInfo;
                                 $this->fireEvent('AfterThemeButtons');
                                 ?>

--- a/applications/dashboard/views/settings/themes.php
+++ b/applications/dashboard/views/settings/themes.php
@@ -11,6 +11,9 @@ $links .= wrap(anchor(t('Quick-Start Guide to Creating Themes for Vanilla'), 'ht
 $links .= '</ul>';
 
 helpAsset(sprintf(t('About %s'), t('Themes')), sprintf(t('ThemeHelp'), '<code style="word-wrap: break-word;">'.PATH_THEMES.'</code>'));
+helpAsset(t('About Theme Preview'), t('Not getting what you expect when you preview your theme?').' '
+    .t('Theme preview is limited to displaying the theme\'s template and css.').' '
+    .t('Overridden views or themehooks can have unintended side effects and are not previewed.'));
 helpAsset(t('Need More Help?'), $links);
 
 ?>
@@ -45,11 +48,10 @@ if ($currentTheme = $this->Data('CurrentTheme')) {
                 $Author = val('Author', $ThemeInfo, '');
                 $AuthorUrl = val('AuthorUrl', $ThemeInfo, '');
                 $NewVersion = val('NewVersion', $ThemeInfo, '');
+                $allowPreview = val('AllowPreview', $ThemeInfo, true);
                 $Upgrade = $NewVersion != '' && version_compare($NewVersion, $Version, '>');
                 $PreviewUrl = val('IconUrl', $ThemeInfo, false);
-
                 $class = $Active ? ' Enabled' : '';
-                $class .= $PreviewUrl ? ' HasPreview' : '';
                 ?>
                 <li class="<?php echo $class; ?> label-selector-item">
                     <div class="theme-wrap">
@@ -68,7 +70,9 @@ if ($currentTheme = $this->Data('CurrentTheme')) {
                                 </div>
                                 <div class="buttons">
                                     <?php echo anchor(t('Apply'), 'dashboard/settings/themes/'.$ThemeName.'/'.$Session->TransientKey(), 'btn btn-overlay EnableAddon EnableTheme', array('target' => '_top'));
-                                    // echo anchor(t('Preview'), 'dashboard/settings/previewtheme/'.$ThemeName, 'btn btn-overlay PreviewAddon', array('target' => '_top'));
+                                    if ($allowPreview) {
+                                        echo anchor(t('Preview'), 'dashboard/settings/previewtheme/'.$ThemeName, 'btn btn-overlay js-preview-addon');
+                                    }
                                     $this->EventArguments['ThemeInfo'] = $ThemeInfo;
                                     $this->fireEvent('AfterThemeButtons'); ?>
                                 </div>

--- a/library/core/class.thememanager.php
+++ b/library/core/class.thememanager.php
@@ -326,7 +326,17 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
      * @return mixed
      */
     public function currentTheme() {
-        return c(!IsMobile() ? 'Garden.Theme' : 'Garden.MobileTheme', 'default');
+        if (IsMobile()) {
+            if ($this->hasMobilePreview()) {
+                return $this->getMobilePreview();
+            }
+            return c('Garden.MobileTheme', 'default');
+        } else {
+            if ($this->hasPreview()) {
+                return $this->getPreview();
+            }
+            return c('Garden.Theme', 'default');
+        }
     }
 
     /**
@@ -335,6 +345,9 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
      * @return mixed
      */
     public function desktopTheme() {
+        if ($this->hasPreview()) {
+            return $this->getPreview();
+        }
         return c('Garden.Theme', 'default');
     }
 
@@ -549,7 +562,47 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
      * @return mixed
      */
     public function mobileTheme() {
+        if ($this->hasMobilePreview()) {
+            return $this->getMobilePreview();
+        }
         return c('Garden.MobileTheme', 'default');
+    }
+
+    /**
+     * Returns the folder name (aka slug) of the previewed theme, or an empty string if there is no previewed theme.
+     *
+     * @return string The folder name of the previewed mobile theme or an empty string.
+     */
+    public function getPreview() {
+        return htmlspecialchars(Gdn::session()->getPreference('PreviewThemeFolder', ''));
+    }
+
+    /**
+     * Returns whether there's a theme being previewed.
+     *
+     * @return bool Whether there's a theme being previewed.
+     */
+    public function hasPreview() {
+        return Gdn::session()->getPreference('PreviewThemeFolder', '') !== '';
+    }
+
+    /**
+     * Returns whether there's a mobile theme being previewed.
+     *
+     * @return bool Whether there's a mobile theme being previewed.
+     */
+    public function hasMobilePreview() {
+        return Gdn::session()->getPreference('PreviewMobileThemeFolder', '') !== '';
+    }
+
+    /**
+     * Returns the folder name (aka slug) of the previewed mobile theme, or an empty string if there is no
+     * previewed mobile theme.
+     *
+     * @return string The folder name of the previewed mobile theme or an empty string.
+     */
+    public function getMobilePreview() {
+        return htmlspecialchars(Gdn::session()->getPreference('PreviewMobileThemeFolder', ''));
     }
 
     /**


### PR DESCRIPTION
Reinstates Theme Preview for both mobile and desktop themes.

Functionality is different than before, in that you can preview both a mobile and desktop theme simultaneously. Caveats are that themehooks and theme view overrides cannot be previewed.

Also proposes new theme property 'AllowPreview', which can be set to false for themes that absolutely can't be previewed in this context. Lithe would be one of these theme, since it requires enabling plugins to work.

Closes https://github.com/vanilla/vanilla/issues/4227