### PR TITLE
Eliminate as much double translations as possible

### DIFF
--- a/applications/dashboard/controllers/class.importcontroller.php
+++ b/applications/dashboard/controllers/class.importcontroller.php
@@ -127,7 +127,7 @@ class ImportController extends DashboardController {
                 $Upload = new Gdn_Upload();
                 $Validation = new Gdn_Validation();
                 if (count($ImportPaths) > 0) {
-                    $Validation->applyRule('PathSelect', 'Required', t('You must select a file to import.'));
+                    $Validation->applyRule('PathSelect', 'Required', 'You must select a file to import.');
                 }
 
                 if (count($ImportPaths) == 0 || $this->Form->getFormValue('PathSelect') == 'NEW') {

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -388,7 +388,7 @@ class ProfileController extends Gdn_Controller {
                 $this->Form->setFormValue("Name", $User['Name']);
             } else {
                 $UsernameError = t('UsernameError', 'Username can only contain letters, numbers, underscores, and must be between 3 and 20 characters long.');
-                Gdn::userModel()->Validation->applyRule('Name', 'Username', $UsernameError);
+                Gdn::userModel()->Validation->applyRule('Name', 'Username', 'ValidateUsername');
             }
 
             // API

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -204,9 +204,9 @@ class SettingsController extends DashboardController {
         $this->title(t('Avatars'));
 
         $validation = new Gdn_Validation();
-        $validation->applyRule('Garden.Thumbnail.Size', 'Integer', t('Thumbnail size must be an integer.'));
-        $validation->applyRule('Garden.Profile.MaxWidth', 'Integer', t('Max avatar width must be an integer.'));
-        $validation->applyRule('Garden.Profile.MaxHeight', 'Integer', t('Max avatar height must be an integer.'));
+        $validation->applyRule('Garden.Thumbnail.Size', 'Integer', 'Thumbnail size must be an integer.');
+        $validation->applyRule('Garden.Profile.MaxWidth', 'Integer', 'Max avatar width must be an integer.');
+        $validation->applyRule('Garden.Profile.MaxHeight', 'Integer', 'Max avatar height must be an integer.');
 
         $configurationModel = new Gdn_ConfigurationModel($validation);
         $configurationModel->setField(array(
@@ -966,7 +966,7 @@ class SettingsController extends DashboardController {
                     saveToConfig('Garden.EmailTemplate.Image', $imageBaseName);
                     $this->setData('EmailImage', Gdn_UploadImage::url($imageBaseName));
                 } else {
-                    $this->Form->addError(t('There\'s been an error uploading the image. Your email logo can uploaded in one of the following filetypes: gif, jpg, png'));
+                    $this->Form->addError('There\'s been an error uploading the image. Your email logo can uploaded in one of the following filetypes: gif, jpg, png');
                 }
             } catch (Exception $ex) {
                 $this->Form->addError($ex);

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -204,9 +204,9 @@ class SettingsController extends DashboardController {
         $this->title(t('Avatars'));
 
         $validation = new Gdn_Validation();
-        $validation->applyRule('Garden.Thumbnail.Size', 'Integer', t('Thumbnail size must be an integer.'));
-        $validation->applyRule('Garden.Profile.MaxWidth', 'Integer', t('Max avatar width must be an integer.'));
-        $validation->applyRule('Garden.Profile.MaxHeight', 'Integer', t('Max avatar height must be an integer.'));
+        $validation->applyRule('Garden.Thumbnail.Size', 'Integer', 'Thumbnail size must be an integer.');
+        $validation->applyRule('Garden.Profile.MaxWidth', 'Integer', 'Max avatar width must be an integer.');
+        $validation->applyRule('Garden.Profile.MaxHeight', 'Integer', 'Max avatar height must be an integer.');
 
         $configurationModel = new Gdn_ConfigurationModel($validation);
         $configurationModel->setField(array(

--- a/applications/dashboard/controllers/class.setupcontroller.php
+++ b/applications/dashboard/controllers/class.setupcontroller.php
@@ -59,7 +59,7 @@ class SetupController extends DashboardController {
             // Make sure the user has copied the htaccess file over.
             if (!file_exists(PATH_ROOT.'/.htaccess') && !$this->Form->getFormValue('SkipHtaccess')) {
                 $this->setData('NoHtaccess', true);
-                $this->Form->addError(t('You are missing Vanilla\'s .htaccess file.', 'You are missing Vanilla\'s <b>.htaccess</b> file. Sometimes this file isn\'t copied if you are using ftp to upload your files because this file is hidden. Make sure you\'ve copied the <b>.htaccess</b> file before continuing.'));
+                $this->Form->addError('You are missing Vanilla\'s .htaccess file.', 'You are missing Vanilla\'s <b>.htaccess</b> file. Sometimes this file isn\'t copied if you are using ftp to upload your files because this file is hidden. Make sure you\'ve copied the <b>.htaccess</b> file before continuing.');
             }
 
             $ApplicationManager = Gdn::applicationManager();
@@ -152,19 +152,19 @@ class SetupController extends DashboardController {
             } catch (PDOException $Exception) {
                 switch ($Exception->getCode()) {
                     case 1044:
-                        $this->Form->addError(t('The database user you specified does not have permission to access the database. Have you created the database yet? The database reported: <code>%s</code>'), strip_tags($Exception->getMessage()));
+                        $this->Form->addError('The database user you specified does not have permission to access the database. Have you created the database yet? The database reported: <code>%s</code>', strip_tags($Exception->getMessage()));
                         break;
                     case 1045:
-                        $this->Form->addError(t('Failed to connect to the database with the username and password you entered. Did you mistype them? The database reported: <code>%s</code>'), strip_tags($Exception->getMessage()));
+                        $this->Form->addError('Failed to connect to the database with the username and password you entered. Did you mistype them? The database reported: <code>%s</code>', strip_tags($Exception->getMessage()));
                         break;
                     case 1049:
-                        $this->Form->addError(t('It appears as though the database you specified does not exist yet. Have you created it yet? Did you mistype the name? The database reported: <code>%s</code>'), strip_tags($Exception->getMessage()));
+                        $this->Form->addError('It appears as though the database you specified does not exist yet. Have you created it yet? Did you mistype the name? The database reported: <code>%s</code>', strip_tags($Exception->getMessage()));
                         break;
                     case 2005:
-                        $this->Form->addError(t("Are you sure you've entered the correct database host name? Maybe you mistyped it? The database reported: <code>%s</code>"), strip_tags($Exception->getMessage()));
+                        $this->Form->addError("Are you sure you've entered the correct database host name? Maybe you mistyped it? The database reported: <code>%s</code>", strip_tags($Exception->getMessage()));
                         break;
                     default:
-                        $this->Form->addError(sprintf(t('ValidateConnection'), strip_tags($Exception->getMessage())));
+                        $this->Form->addError('@'.sprintf(t('ValidateConnection'), strip_tags($Exception->getMessage())));
                         break;
                 }
             }
@@ -214,10 +214,9 @@ class SetupController extends DashboardController {
                 // Create the administrative user
                 $UserModel = Gdn::userModel();
                 $UserModel->defineSchema();
-                $UsernameError = t('UsernameError', 'Username can only contain letters, numbers, underscores, and must be between 3 and 20 characters long.');
-                $UserModel->Validation->applyRule('Name', 'Username', $UsernameError);
-                $UserModel->Validation->applyRule('Name', 'Required', t('You must specify an admin username.'));
-                $UserModel->Validation->applyRule('Password', 'Required', t('You must specify an admin password.'));
+                $UserModel->Validation->applyRule('Name', 'Username', 'Username can only contain letters, numbers, underscores, and must be between 3 and 20 characters long.');
+                $UserModel->Validation->applyRule('Name', 'Required', 'You must specify an admin username.');
+                $UserModel->Validation->applyRule('Password', 'Required', 'You must specify an admin password.');
                 $UserModel->Validation->applyRule('Password', 'Match');
                 $UserModel->Validation->applyRule('Email', 'Email');
 
@@ -263,16 +262,16 @@ class SetupController extends DashboardController {
     private function _checkPrerequisites() {
         // Make sure we are running at least PHP 5.1
         if (version_compare(phpversion(), ENVIRONMENT_PHP_VERSION) < 0) {
-            $this->Form->addError(sprintf(t('You are running PHP version %1$s. Vanilla requires PHP %2$s or greater. You must upgrade PHP before you can continue.'), phpversion(), ENVIRONMENT_PHP_VERSION));
+            $this->Form->addError('@'.sprintf(t('You are running PHP version %1$s. Vanilla requires PHP %2$s or greater. You must upgrade PHP before you can continue.'), phpversion(), ENVIRONMENT_PHP_VERSION));
         }
 
         // Make sure PDO is available
         if (!class_exists('PDO')) {
-            $this->Form->addError(t('You must have the PDO module enabled in PHP in order for Vanilla to connect to your database.'));
+            $this->Form->addError('You must have the PDO module enabled in PHP in order for Vanilla to connect to your database.');
         }
 
         if (!defined('PDO::MYSQL_ATTR_USE_BUFFERED_QUERY')) {
-            $this->Form->addError(t('You must have the MySQL driver for PDO enabled in order for Vanilla to connect to your database.'));
+            $this->Form->addError('You must have the MySQL driver for PDO enabled in order for Vanilla to connect to your database.');
         }
 
         // Make sure that the correct filesystem permissions are in place.
@@ -315,13 +314,13 @@ class SetupController extends DashboardController {
             if (file_exists($ConfigFile)) {
                 // Make sure the config file is writable.
                 if (!is_readable($ConfigFile) || !isWritable($ConfigFile)) {
-                    $this->Form->addError(sprintf(t('Your configuration file does not have the correct permissions. PHP needs to be able to read and write to this file: <code>%s</code>'), $ConfigFile));
+                    $this->Form->addError('@'.sprintf(t('Your configuration file does not have the correct permissions. PHP needs to be able to read and write to this file: <code>%s</code>'), $ConfigFile));
                     $PermissionProblem = true;
                 }
             } else {
                 // Make sure the config file can be created.
                 if (!is_writeable(dirname($ConfigFile))) {
-                    $this->Form->addError(sprintf(t('Your configuration file cannot be created. PHP needs to be able to create this file: <code>%s</code>'), $ConfigFile));
+                    $this->Form->addError('@'.sprintf(t('Your configuration file cannot be created. PHP needs to be able to create this file: <code>%s</code>'), $ConfigFile));
                     $PermissionProblem = true;
                 }
             }

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -542,7 +542,7 @@ class UserController extends DashboardController {
         $this->Form->validateRule('UserID', 'ValidateRequired');
         $DeleteType = $this->Form->getFormValue('DeleteMethod');
         if (!in_array($DeleteType, array('delete', 'keep', 'wipe'))) {
-            $this->Form->addError(t('DeleteMethod must be one of: delete, keep, wipe.'));
+            $this->Form->addError('DeleteMethod must be one of: delete, keep, wipe.');
         }
 
         $UserID = $this->Form->getFormValue('UserID');
@@ -553,9 +553,9 @@ class UserController extends DashboardController {
         }
 
         if ($User['Admin'] == 2) {
-            $this->Form->addError(t('You cannot delete a system-created user.'));
+            $this->Form->addError('You cannot delete a system-created user.');
         } elseif ($User['Admin'])
-            $this->Form->addError(t('You cannot delete a super-admin.'));
+            $this->Form->addError('You cannot delete a super-admin.');
 
         if ($this->Form->errorCount() == 0) {
             Gdn::userModel()->delete($UserID, array(
@@ -782,7 +782,7 @@ class UserController extends DashboardController {
             }
         }
         if (!$Available) {
-            $this->Form->addError(sprintf(t('%s unavailable'), t('Email')));
+            $this->Form->addError('@'.sprintf(t('%s unavailable'), t('Email')));
         }
 
         $this->render();
@@ -1039,7 +1039,7 @@ class UserController extends DashboardController {
 
             $Provider = $ProviderModel->getProviderByKey($Form->getFormValue('ClientID'));
             if (!$Provider) {
-                $Form->addError(sprintf('%1$s "%2$s" not found.', t('Provider'), $Form->getFormValue('ClientID')));
+                $Form->addError('@'.sprintf(t('%1$s "%2$s" not found.'), t('Provider'), $Form->getFormValue('ClientID')));
             }
 
             if ($Form->errorCount() > 0) {
@@ -1138,7 +1138,7 @@ class UserController extends DashboardController {
             }
         }
         if (!$Available) {
-            $this->Form->addError(sprintf(t('%s unavailable'), t('Name')));
+            $this->Form->addError('@'.sprintf(t('%s unavailable'), t('Name')));
         }
 
         $this->render();

--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -100,6 +100,7 @@ $Definition['PasswordRequest'] = 'Someone has requested to reset your password a
   %3$s
 
 If you did not make this request, disregard this email.';
+$Definition['Your password reset token has expired.'] = 'Your password reset token has expired. Try using the reset request form again.';
 $Definition['EmailNotification'] = '%1$s
 
 Follow the link below to check it out:

--- a/applications/dashboard/views/entry/auth/password.php
+++ b/applications/dashboard/views/entry/auth/password.php
@@ -17,14 +17,14 @@
         <li>
             <?php
             echo $this->Form->label('Password', 'Password');
-            echo $this->Form->Input('Password', 'password', array('class' => 'InputBox Password'));
+            echo $this->Form->input('Password', 'password', array('class' => 'InputBox Password'));
             echo anchor(t('Forgot?'), '/entry/passwordrequest', 'ForgotPassword');
             ?>
         </li>
         <li class="Buttons">
             <?php
             echo $this->Form->button('Sign In');
-            echo $this->Form->CheckBox('RememberMe', t('Keep me signed in'), array('value' => '1', 'id' => 'SignInRememberMe'));
+            echo $this->Form->checkBox('RememberMe', 'Keep me signed in', array('value' => '1', 'id' => 'SignInRememberMe'));
             ?>
         </li>
         <?php if (strcasecmp(c('Garden.Registration.Method'), 'Connect') != 0): ?>

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -80,21 +80,21 @@ $allowConnect = $this->data('AllowConnect');
 			                        echo '<div class="FinePrint">', t('ConnectAccountExists', 'You already have an account here.'), '</div>',
                               wrap(sprintf(t('ConnectRegisteredName', 'Your registered username: <strong>%s</strong>'), htmlspecialchars($Row['Name'])), 'div', array('class' => 'ExistingUsername'));
                               $this->addDefinition('NoConnectName', true);
-                              echo $this->Form->Hidden('UserSelect', array('Value' => $Row['UserID']));
+                              echo $this->Form->hidden('UserSelect', array('Value' => $Row['UserID']));
                           } else {
                               echo $this->Form->label('Username', 'ConnectName');
                               echo '<div class="FinePrint">', t('ConnectChooseName', 'Choose a name to identify yourself on the site.'), '</div>';
       
                               if (count($ExistingUsers) > 0) {
                                   foreach ($ExistingUsers as $Row) {
-                                      echo wrap($this->Form->Radio('UserSelect', $Row['Name'], array('value' => $Row['UserID'])), 'div');
+                                      echo wrap($this->Form->radio('UserSelect', $Row['Name'], array('value' => $Row['UserID'])), 'div');
                                   }
-                                  echo wrap($this->Form->Radio('UserSelect', t('Other'), array('value' => 'other')), 'div');
+                                  echo wrap($this->Form->radio('UserSelect', 'Other', array('value' => 'other')), 'div');
                               }
                           }
       
                           if (!$NoConnectName)
-                              echo $this->Form->Textbox('ConnectName');
+                              echo $this->Form->textbox('ConnectName');
                        }
                     ?>
                 </li>
@@ -103,7 +103,7 @@ $allowConnect = $this->data('AllowConnect');
                     <?php
                     echo $this->Form->label('Password', 'ConnectPassword');
                     echo wrap($PasswordMessage, 'div', array('class' => 'FinePrint'));
-                    echo $this->Form->Input('ConnectPassword', 'password');
+                    echo $this->Form->input('ConnectPassword', 'password');
                     ?>
                 </li>
             </ul>

--- a/applications/dashboard/views/entry/passwordform.php
+++ b/applications/dashboard/views/entry/passwordform.php
@@ -16,14 +16,14 @@
         <li>
             <?php
             echo $this->Form->label('Password', 'Password');
-            echo $this->Form->Input('Password', 'password', array('class' => 'InputBox Password'));
+            echo $this->Form->input('Password', 'password', array('class' => 'InputBox Password'));
             echo anchor(t('Forgot?'), '/entry/passwordrequest', 'ForgotPassword');
             ?>
         </li>
         <li class="Buttons">
             <?php
             echo $this->Form->button('Sign In', array('class' => 'Button Primary'));
-            echo $this->Form->CheckBox('RememberMe', t('Keep me signed in'), array('value' => '1', 'id' => 'SignInRememberMe'));
+            echo $this->Form->checkBox('RememberMe', 'Keep me signed in', array('value' => '1', 'id' => 'SignInRememberMe'));
             ?>
         </li>
         <?php if (strcasecmp(c('Garden.Registration.Method'), 'Connect') != 0): ?>

--- a/applications/dashboard/views/entry/registerapproval.php
+++ b/applications/dashboard/views/entry/registerapproval.php
@@ -34,13 +34,13 @@
                 <?php
                 echo $this->Form->label('Password', 'Password');
                 echo wrap(sprintf(t('Your password must be at least %d characters long.'), c('Garden.Registration.MinPasswordLength')), 'div', array('class' => 'Gloss'));
-                echo $this->Form->Input('Password', 'password', array('Wrap' => true, 'Strength' => TRUE));
+                echo $this->Form->input('Password', 'password', array('Wrap' => true, 'Strength' => TRUE));
                 ?>
             </li>
             <li>
                 <?php
                 echo $this->Form->label('Confirm Password', 'PasswordMatch');
-                echo $this->Form->Input('PasswordMatch', 'password', array('Wrap' => TRUE));
+                echo $this->Form->input('PasswordMatch', 'password', array('Wrap' => TRUE));
                 echo '<span id="PasswordsDontMatch" class="Incorrect" style="display: none;">'.t("Passwords don't match").'</span>';
                 ?>
             </li>
@@ -58,7 +58,7 @@
 
             <li>
                 <?php
-                echo $this->Form->CheckBox('TermsOfService', $TermsOfServiceText, array('value' => '1'));
+                echo $this->Form->checkBox('TermsOfService', '@'.$TermsOfServiceText, array('value' => '1'));
                 ?>
             </li>
             <li class="Buttons">

--- a/applications/dashboard/views/entry/signin.php
+++ b/applications/dashboard/views/entry/signin.php
@@ -29,7 +29,7 @@ echo '<div class="MainForm">';
         <li>
             <?php
             echo $this->Form->label('Password', 'Password');
-            echo $this->Form->Input('Password', 'password', array('class' => 'InputBox Password'));
+            echo $this->Form->input('Password', 'password', array('class' => 'InputBox Password'));
             echo anchor(t('Forgot?'), '/entry/passwordrequest', 'ForgotPassword');
             ?>
         </li>
@@ -61,7 +61,7 @@ echo '</div>';
     <div class="Buttons">
         <?php
         echo $this->Form->button('Sign In', array('class' => 'Button Primary'));
-        echo $this->Form->CheckBox('RememberMe', t('Keep me signed in'), array('value' => '1', 'id' => 'SignInRememberMe'));
+        echo $this->Form->checkBox('RememberMe', 'Keep me signed in', array('value' => '1', 'id' => 'SignInRememberMe'));
         ?>
         <?php if (strcasecmp(c('Garden.Registration.Method'), 'Connect') != 0): ?>
             <div class="CreateAccount">

--- a/applications/dashboard/views/log/confirm.php
+++ b/applications/dashboard/views/log/confirm.php
@@ -24,7 +24,7 @@
             <div class="modal-body">
                 <?php
                 // Give a description of what is done.'
-                $ShowUsers = FALSE;
+                $ShowUsers = false;
                 switch (strtolower($this->data('Action'))) {
                     case 'delete':
                         echo '<div class="alert alert-danger">'.t('Warning: deleting is permanent', 'WARNING: deleted items are removed from this list and cannot be brought back.').'</div>';
@@ -39,14 +39,14 @@
                         echo '<div class="alert alert-danger">'.t('Warning: deleting is permanent', 'WARNING: deleted items are removed from this list and cannot be brought back.').'</div>';
                         echo wrap(t('Marking as spam cannot be undone.', 'Marking something as SPAM will cause it to be deleted forever. Deleting is a good way to keep your forum clean.'), 'p');
                         $AfterHtml = t('Are you ABSOLUTELY sure you want to take this action?');
-                        $ShowUsers = TRUE;
+                        $ShowUsers = true;
                         $UsersHtml = t('You can also ban the users that posted the spam and delete all of their posts.',
                             'Check the box next to the user that posted the spam to also ban them and delete all of their posts. <b>Only do this if you are sure these are spammers.</b>');
                         break;
                     case 'notspam':
                         echo wrap(t('Marking things as NOT spam will put them back in your forum.'), 'p');
                         $AfterHtml = plural($ItemCount, t('Are you sure this isn\'t spam?'), t('Are you sure these %s items aren\'t spam?'));
-                        $ShowUsers = TRUE;
+                        $ShowUsers = true;
                         $UsersHtml = t("Check the box next to the user to mark them as <b>Verified</b> so their posts don't get marked as spam again.");
                         break;
                 }
@@ -57,14 +57,14 @@
                     <?php
                     if (count($this->data('Users')) > 1) {
                         echo '<div class="CheckBoxCell">';
-                        echo $this->Form->CheckBox('SelectAll', t('All'));
+                        echo $this->Form->checkBox('SelectAll', 'All');
                         echo '</div>';
                     }
 
                     foreach ($this->data('Users') as $User) {
                         $RecordUser = Gdn::userModel()->getID($User['UserID'], DATASET_TYPE_ARRAY);
                         echo '<div class="CheckBoxCell">';
-                        echo $this->Form->CheckBox('UserID[]', htmlspecialchars($User['Name']), array('value' => $User['UserID'], 'class' => 'checkbox checkbox-inline'));
+                        echo $this->Form->checkBox('UserID[]', htmlspecialchars($User['Name']), array('value' => $User['UserID'], 'class' => 'checkbox checkbox-inline'));
                         echo ' <span class="Count">'.plural($RecordUser['CountDiscussions'] + $RecordUser['CountComments'], '%s post', '%s posts').'</span>';
 
                         echo '</div>';

--- a/applications/dashboard/views/message/edit.php
+++ b/applications/dashboard/views/message/edit.php
@@ -16,10 +16,10 @@ echo $this->Form->errors();
             </div>
             <div class="input-wrap">
                 <?php
-                echo $this->Form->Radio('CssClass', t('Casual'), array('value' => 'CasualMessage'));
-                echo $this->Form->Radio('CssClass', t('Information'), array('value' => 'InfoMessage'));
-                echo $this->Form->Radio('CssClass', t('Alert'), array('value' => 'AlertMessage'));
-                echo $this->Form->Radio('CssClass', t('Warning'), array('value' => 'WarningMessage'));
+                echo $this->Form->radio('CssClass', 'Casual', array('value' => 'CasualMessage'));
+                echo $this->Form->radio('CssClass', 'Information', array('value' => 'InfoMessage'));
+                echo $this->Form->radio('CssClass', 'Alert', array('value' => 'AlertMessage'));
+                echo $this->Form->radio('CssClass', 'Warning', array('value' => 'WarningMessage'));
                 ?>
             </div>
         </li>
@@ -36,7 +36,7 @@ echo $this->Form->errors();
                 <?php echo $this->Form->label('Page', 'Location'); ?>
             </div>
             <div class="input-wrap">
-                <?php echo $this->Form->DropDown('Location', $this->data('Locations')); ?>
+                <?php echo $this->Form->dropDown('Location', $this->data('Locations')); ?>
             </div>
         </li>
         <li class="form-group">
@@ -44,7 +44,7 @@ echo $this->Form->errors();
                 <?php echo $this->Form->label('Position', 'AssetTarget'); ?>
             </div>
             <div class="input-wrap">
-                <?php echo $this->Form->DropDown('AssetTarget', $this->AssetData); ?>
+                <?php echo $this->Form->dropDown('AssetTarget', $this->AssetData); ?>
             </div>
         </li>
         <li class="form-group">
@@ -52,10 +52,10 @@ echo $this->Form->errors();
                 <?php echo $this->Form->label('Category', 'CategoryID'); ?>
             </div>
             <div class="input-wrap">
-                <?php echo $this->Form->DropDown('CategoryID', $this->data('Categories'), array('IncludeNull' => t('All Categories'))); ?>
+                <?php echo $this->Form->dropDown('CategoryID', $this->data('Categories'), array('IncludeNull' => t('All Categories'))); ?>
             </div>
             <div class="input-wrap no-label padded-top">
-                <?php echo $this->Form->CheckBox('IncludeSubcategories', 'Include Subcategories'); ?>
+                <?php echo $this->Form->checkBox('IncludeSubcategories', 'Include Subcategories'); ?>
             </div>
         </li>
         <li class="form-group">

--- a/applications/dashboard/views/modules/configuration.php
+++ b/applications/dashboard/views/modules/configuration.php
@@ -12,7 +12,7 @@ if ($Sf->RenderAll) {
 }
 
 $Options = array();
-if ($Sf->HasFiles()) {
+if ($Sf->hasFiles()) {
     $Options['enctype'] = 'multipart/form-data';
 }
 
@@ -22,7 +22,7 @@ echo $Form->errors();
 <ul>
     <?php
 
-    foreach ($Sf->Schema() as $Row) {
+    foreach ($Sf->schema() as $Row) {
 
         if (val('no-grid', $Row['Options'])) {
             echo "<li>\n  ";
@@ -30,7 +30,7 @@ echo $Form->errors();
             echo "<li class=\"form-group\">\n  ";
         }
 
-        $LabelCode = $Sf->LabelCode($Row);
+        $LabelCode = $Sf->labelCode($Row);
         $Description = val('Description', $Row, '');
         if (strtolower($Row['Control']) !== 'checkbox' && $Description) {
             $Description = '<div class="info">'.$Description.'</div>';
@@ -48,18 +48,18 @@ echo $Form->errors();
                 break;
             case 'labelcheckbox':
                 echo $Form->label($LabelCode);
-                echo $Form->CheckBox($Row['Name'], '', $Row['Options']);
+                echo $Form->checkBox($Row['Name'], '', $Row['Options']);
                 break;
             case 'checkbox':
                 echo '<div class="label-wrap">';
                 echo $Description;
                 echo '</div>';
                 echo '<div class="input-wrap">';
-                echo $Form->CheckBox($Row['Name'], t($LabelCode), $Row['Options']);
+                echo $Form->checkBox($Row['Name'], $LabelCode, $Row['Options']);
                 echo '</div>';
                 break;
             case 'toggle':
-                echo $Form->toggle($Row['Name'], t($LabelCode), $Row['Options']);
+                echo $Form->toggle($Row['Name'], $LabelCode, $Row['Options']);
                 break;
             case 'dropdown':
                 echo '<div class="label-wrap">';
@@ -67,7 +67,7 @@ echo $Form->errors();
                 echo $Description;
                 echo '</div>';
                 echo '<div class="input-wrap">';
-                echo $Form->DropDown($Row['Name'], $Row['Items'], $Row['Options']);
+                echo $Form->dropDown($Row['Name'], $Row['Items'], $Row['Options']);
                 echo '</div>';
                 break;
             case 'imageupload':
@@ -76,7 +76,7 @@ echo $Form->errors();
                 echo $Description;
                 echo wrap($Form->currentImage($Row['Name'], $Row['Options']), 'div', ['class' => 'image-wrap-label']);
                 echo '</div>';
-                echo $Form->ImageUploadWrap($Row['Name'], $Row['Options']);
+                echo $Form->imageUploadWrap($Row['Name'], $Row['Options']);
                 break;
             case 'radiolist':
                 echo '<div class="label-wrap">';
@@ -84,13 +84,13 @@ echo $Form->errors();
                 echo $Description;
                 echo '</div>';
                 echo '<div class="input-wrap">';
-                echo $Form->RadioList($Row['Name'], $Row['Items'], $Row['Options']);
+                echo $Form->radioList($Row['Name'], $Row['Items'], $Row['Options']);
                 echo '</div>';
                 break;
             case 'checkboxlist':
                 echo $Form->label($LabelCode, $Row['Name']);
                 echo $Description;
-                echo $Form->CheckBoxList($Row['Name'], $Row['Items'], null, $Row['Options']);
+                echo $Form->checkBoxList($Row['Name'], $Row['Items'], null, $Row['Options']);
                 break;
             case 'textbox':
                 echo '<div class="label-wrap">';

--- a/applications/dashboard/views/profile/edit.php
+++ b/applications/dashboard/views/profile/edit.php
@@ -50,7 +50,7 @@
         <?php if ($this->data('_CanEditEmail')): ?>
             <li class="User-ShowEmail">
                 <?php
-                echo $this->Form->CheckBox('ShowEmail', t('Allow other members to see your email?'), array('value' => '1'));
+                echo $this->Form->checkBox('ShowEmail', 'Allow other members to see your email?', array('value' => '1'));
                 ?>
             </li>
         <?php endif ?>
@@ -58,7 +58,7 @@
         <?php if ($this->data('_CanConfirmEmail')): ?>
             <li class="User-ConfirmEmail">
                 <?php
-                echo $this->Form->CheckBox('ConfirmEmail', t("Confirmed email address"), array('value' => '1'));
+                echo $this->Form->checkBox('ConfirmEmail', "Confirmed email address", array('value' => '1'));
                 ?>
             </li>
         <?php endif ?>

--- a/applications/dashboard/views/role/edit.php
+++ b/applications/dashboard/views/role/edit.php
@@ -37,7 +37,7 @@ echo $this->Form->errors();
     </li>
     <li class="form-group row">
         <div class="input-wrap no-label">
-            <?php echo $this->Form->checkBox('PersonalInfo', t('RolePersonalInfo', "This role is personal info. Only users with permission to view personal info will see it."), ['value' => '1']); ?>
+            <?php echo $this->Form->checkBox('PersonalInfo', '@'.t('RolePersonalInfo', "This role is personal info. Only users with permission to view personal info will see it."), ['value' => '1']); ?>
         </div>
     </li>
     <?php

--- a/applications/dashboard/views/settings/emailstyles.php
+++ b/applications/dashboard/views/settings/emailstyles.php
@@ -70,7 +70,7 @@ $Session = Gdn::session();
     </ul>
     <div class="buttons form-footer">
         <?php echo wrap(t('Preview Colors'), 'span', array('class' => 'js-email-preview-button btn btn-secondary')); ?>
-        <?php echo $this->Form->button(t('Save Colors')); ?>
+        <?php echo $this->Form->button('Save Colors'); ?>
     </div>
 </div>
 <?php echo $this->Form->close(); ?>

--- a/applications/dashboard/views/settings/emailstyles.php
+++ b/applications/dashboard/views/settings/emailstyles.php
@@ -1,10 +1,7 @@
 <?php if (!defined('APPLICATION')) exit();
 $Session = Gdn::session();
+echo heading(t('Email Styles'), t('Send a Test Email'), '/dashboard/settings/emailtest', 'js-modal btn btn-primary');
 ?>
-<div class="header-block">
-<h1><?php echo t('Email Styles'); ?></h1>
-<?php echo wrap(anchor(t('Send a Test Email'), '/dashboard/settings/emailtest', 'js-modal btn-primary btn'), 'div'); ?>
-</div>
 <div class="row form-group">
     <div class="label-wrap-wide">
         <?php echo t('Enable HTML emails'); ?>
@@ -26,51 +23,43 @@ $Session = Gdn::session();
     <?php
     echo $this->Form->open(array('enctype' => 'multipart/form-data'));
     echo $this->Form->errors();
-    $emailImage = c('Garden.EmailTemplate.Image');
     ?>
-    <div class="email-image">
-        <?php
-        if ($this->data('EmailImage')) {
-            echo img($this->data('EmailImage'), array('class' => 'js-email-image padded-top'));
-        } else {
-            echo '<img class="js-email-image Hidden"/>';
-        }
-        ?>
-    </div>
-    <div class="buttons padded">
-        <?php
-        echo anchor(t('Upload New Email Logo'), '/dashboard/settings/emailimage', 'js-upload-email-image-button btn btn-primary');
-        ?>
-        <?php
-        $hideCssClass = $emailImage ? '' : ' Hidden';
-        echo anchor(t('Remove Email Logo'), '/dashboard/settings/removeemailimage', 'js-modal-confirm js-hijack btn btn-primary '.$hideCssClass);
-    ?>
-    </div>
     <ul>
+        <?php echo $this->Form->imageUploadPreview(
+            'EmailImage',
+            t('Email Logo'),
+            sprintf(t('Large images will be scaled down.'),
+                    c('Garden.EmailTemplate.ImageMaxWidth', 400),
+                    c('Garden.EmailTemplate.ImageMaxHeight', 300)),
+            $this->data('EmailImage'),
+            '/dashboard/settings/removeemailimage',
+            t('Remove Email Logo'),
+            t('Are you sure you want to delete your email logo?')
+        ); ?>
         <li class="row form-group">
             <div class="label-wrap"><?php echo $this->Form->label('Text Color', 'Garden.EmailTemplate.TextColor'); ?></div>
             <div class="input-wrap"><?php echo $this->Form->color('Garden.EmailTemplate.TextColor', 'text-color'); ?></div>
         </li>
         <li class="row form-group">
             <div class="label-wrap"><?php echo $this->Form->label('Background Color', 'Garden.EmailTemplate.BackgroundColor'); ?></div>
-                <div class="input-wrap"><?php echo $this->Form->color('Garden.EmailTemplate.BackgroundColor', 'background-color'); ?></div>
+            <div class="input-wrap"><?php echo $this->Form->color('Garden.EmailTemplate.BackgroundColor', 'background-color'); ?></div>
         </li>
         <li class="row form-group">
             <div class="label-wrap"><?php echo $this->Form->label('Page Color', 'Garden.EmailTemplate.ContainerBackgroundColor'); ?></div>
-                <div class="input-wrap"><?php echo $this->Form->color('Garden.EmailTemplate.ContainerBackgroundColor', 'container-background-color'); ?></div>
+            <div class="input-wrap"><?php echo $this->Form->color('Garden.EmailTemplate.ContainerBackgroundColor', 'container-background-color'); ?></div>
         </li>
         <li class="row form-group">
             <div class="label-wrap"><?php echo $this->Form->label('Button Background Color', 'Garden.EmailTemplate.ButtonBackgroundColor'); ?></div>
-                <div class="input-wrap"><?php echo $this->Form->color('Garden.EmailTemplate.ButtonBackgroundColor', 'button-background-color'); ?></div>
+            <div class="input-wrap"><?php echo $this->Form->color('Garden.EmailTemplate.ButtonBackgroundColor', 'button-background-color'); ?></div>
         </li>
         <li class="row form-group">
             <div class="label-wrap"><?php echo $this->Form->label('Button Text Color', 'Garden.EmailTemplate.ButtonTextColor'); ?></div>
-                <div class="input-wrap"><?php echo $this->Form->color('Garden.EmailTemplate.ButtonTextColor', 'button-text-color'); ?></div>
+            <div class="input-wrap"><?php echo $this->Form->color('Garden.EmailTemplate.ButtonTextColor', 'button-text-color'); ?></div>
         </li>
     </ul>
     <div class="buttons form-footer">
-        <?php echo wrap(t('Preview Colors'), 'span', array('class' => 'js-email-preview-button btn btn-secondary')); ?>
-        <?php echo $this->Form->button('Save Colors'); ?>
+        <?php echo wrap(t('Preview'), 'span', array('class' => 'js-email-preview-button btn btn-secondary')); ?>
+        <?php echo $this->Form->button('Save'); ?>
     </div>
 </div>
 <?php echo $this->Form->close(); ?>

--- a/applications/dashboard/views/settings/emailtest.php
+++ b/applications/dashboard/views/settings/emailtest.php
@@ -11,4 +11,4 @@ echo $this->Form->errors(); ?>
     <?php echo $this->Form->input('EmailTestAddresses', 'text'); ?>
     </div>
 </div>
-<?php echo $this->Form->close(t('Send')); ?>
+<?php echo $this->Form->close('Send'); ?>

--- a/applications/dashboard/views/setup/configure.php
+++ b/applications/dashboard/views/setup/configure.php
@@ -40,7 +40,7 @@ echo $this->Form->open();
                     <div
                         class="Box"><?php echo t('You are missing Vanilla\'s <b>.htaccess</b> file. Sometimes this file isn\'t copied if you are using ftp to upload your files because this file is hidden. Make sure you\'ve copied the <b>.htaccess</b> file before continuing.'); ?></div>
                     <?php
-                    echo $this->Form->CheckBox('SkipHtaccess', t('Install Vanilla without a .htaccess file.'));
+                    echo $this->Form->checkBox('SkipHtaccess', 'Install Vanilla without a .htaccess file.');
                     ?>
                 </li>
             <?php endif; ?>
@@ -78,7 +78,7 @@ echo $this->Form->open();
             <li class="Last">
                 <?php
                 echo $this->Form->label('Confirm Password', 'PasswordMatch');
-                echo $this->Form->Input('PasswordMatch', 'password');
+                echo $this->Form->input('PasswordMatch', 'password');
                 ?>
             </li>
         </ul>

--- a/applications/dashboard/views/user/add.php
+++ b/applications/dashboard/views/user/add.php
@@ -28,7 +28,7 @@ echo $this->Form->errors();
         </li>
         <li class="form-group">
             <div class="input-wrap no-label">
-                <?php echo $this->Form->checkBox('ShowEmail', t('Email visible to other users')); ?>
+                <?php echo $this->Form->checkBox('ShowEmail', 'Email visible to other users'); ?>
             </div>
         </li>
         <li class="form-group">

--- a/applications/dashboard/views/user/ban.php
+++ b/applications/dashboard/views/user/ban.php
@@ -24,23 +24,23 @@
 
     <?php
 
-    echo '<div class="P">', $this->Form->Radio('Reason', 'Spamming', array('Value' => 'Spam')), '</div>';
-    echo '<div class="P">', $this->Form->Radio('Reason', 'Abusive Behavior', array('Value' => 'Abuse')), '</div>';
+    echo '<div class="P">', $this->Form->radio('Reason', 'Spamming', array('Value' => 'Spam')), '</div>';
+    echo '<div class="P">', $this->Form->radio('Reason', 'Abusive Behavior', array('Value' => 'Abuse')), '</div>';
     echo '<div class="P">',
-    $this->Form->Radio('Reason', 'Other', array('Value' => 'Other')),
+    $this->Form->radio('Reason', 'Other', array('Value' => 'Other')),
     '<div class="TextBoxWrapper">',
     $this->Form->textBox('ReasonText', array('MultiLine' => TRUE)),
     '</div>',
     '</div>';
 
     if ($this->data('_MayDeleteContent'))
-        echo '<div class="P">', $this->Form->CheckBox('DeleteContent', t("Also delete this user's content.")), '</div>';
+        echo '<div class="P">', $this->Form->checkBox('DeleteContent', "Also delete this user's content."), '</div>';
 
     ?>
 
 
     <?php
-    echo '<div class="Buttons P">', $this->Form->button(t('Ban.Action', 'Ban')), '</div>';
+    echo '<div class="Buttons P">', $this->Form->button('@'.t('Ban.Action', 'Ban')), '</div>';
     echo $this->Form->close();
     ?>
 </div>

--- a/applications/dashboard/views/user/edit.php
+++ b/applications/dashboard/views/user/edit.php
@@ -42,23 +42,23 @@ if ($this->data('AllowEditing')) { ?>
         <?php if ($this->data('_CanConfirmEmail')): ?>
             <li class="User-ConfirmEmail form-group">
                 <div class="input-wrap no-label">
-                    <?php echo $this->Form->CheckBox('ConfirmEmail', t("Email is confirmed"), array('value' => '1')); ?>
+                    <?php echo $this->Form->checkBox('ConfirmEmail', 'Email is confirmed', array('value' => '1')); ?>
                 </div>
             </li>
         <?php endif ?>
         <li class="form-group">
             <div class="input-wrap no-label">
-                <?php echo $this->Form->CheckBox('ShowEmail', t('Email visible to other users'), array('value' => '1')); ?>
+                <?php echo $this->Form->checkBox('ShowEmail', 'Email visible to other users', array('value' => '1')); ?>
             </div>
         </li>
         <li class="form-group">
             <div class="input-wrap no-label">
-                <?php echo $this->Form->CheckBox('Verified', t('Verified Label', 'Verified. Bypasses spam and pre-moderation filters.'), array('value' => '1')); ?>
+                <?php echo $this->Form->checkBox('Verified', '@'.t('Verified Label', 'Verified. Bypasses spam and pre-moderation filters.'), array('value' => '1')); ?>
             </div>
         </li>
         <li class="form-group">
             <div class="input-wrap no-label">
-                <?php echo $this->Form->CheckBox('Banned', t('Banned'), array('value' => $this->data('BanFlag'))); ?>
+                <?php echo $this->Form->checkBox('Banned', 'Banned', array('value' => $this->data('BanFlag'))); ?>
                 <?php if ($this->data('BannedOtherReasons')): ?>
                 <div class="text-danger info"><?php echo t(
                         'This user is also banned for other reasons and may stay banned.',
@@ -100,7 +100,7 @@ if ($this->data('AllowEditing')) { ?>
                 <?php echo t('Check all roles that apply to this user:'); ?>
             </div>
             <div class="input-wrap">
-                <?php echo $this->Form->CheckBoxList("RoleID", array_flip($this->data('Roles')), array_flip($this->data('UserRoles'))); ?>
+                <?php echo $this->Form->checkBoxList("RoleID", array_flip($this->data('Roles')), array_flip($this->data('UserRoles'))); ?>
             </div>
         </li>
     <?php endif; ?>
@@ -109,7 +109,7 @@ if ($this->data('AllowEditing')) { ?>
                 <?php echo t('Password Options'); ?>
             </div>
             <div class="input-wrap">
-                <?php echo $this->Form->RadioList('ResetPassword', $this->ResetOptions); ?>
+                <?php echo $this->Form->radioList('ResetPassword', $this->ResetOptions); ?>
             </div>
         </li>
         <?php if (array_key_exists('Manual', $this->ResetOptions)) : ?>
@@ -118,7 +118,7 @@ if ($this->data('AllowEditing')) { ?>
                     <?php echo $this->Form->label('New Password', 'NewPassword'); ?>
                 </div>
                 <div class="input-wrap">
-                    <?php echo $this->Form->Input('NewPassword', 'password'); ?>
+                    <?php echo $this->Form->input('NewPassword', 'password'); ?>
                 </div>
             </li>
             <li class="form-group">

--- a/applications/dashboard/views/user/index.php
+++ b/applications/dashboard/views/user/index.php
@@ -6,39 +6,23 @@ $ViewPersonalInfo = $Session->checkPermission('Garden.PersonalInfo.View');
 helpAsset(t('Heads Up!'), t('Search by user or role.', 'Search for users by name or enter the name of a role to see all users with that role.'));
 helpAsset(t('Need More Help?'), anchor(t("Video tutorial on finding &amp; managing users"), 'settings/tutorials/users'));
 
+if (checkPermission('Garden.Users.Add')) {
+    echo heading(t('Manage Users'), t('Add User'), 'dashboard/user/add', 'js-modal btn btn-primary');
+} else {
+    echo heading(t('Manage Users'));
+}
 ?>
-<div class="header-block">
-    <div class="header-title">
-    <h1><?php echo t('Manage Users'); ?></h1>
-    </div>
-    <div class="header-buttons btn-group">
-    <?php
-    if (checkPermission('Garden.Users.Add')) {
-        echo anchor(t('Add User'), 'dashboard/user/add', 'js-modal btn btn-primary');
-    }
-    ?>
-    </div>
-</div>
 <div class="toolbar">
     <div class="toolbar-main">
         <?php
-        echo $this->Form->open(array('action' => url('/user/browse')));
-        echo $this->Form->errors();
-        echo '<div class="search-wrap input-wrap">';
-        echo '<div class="search-icon-wrap search-icon-search-wrap">'.dashboardSymbol('search').'</div>';
-        echo $this->Form->textBox('Keywords');
-        echo ' ', $this->Form->button('Go', ['class' => 'search-submit']);
-        echo '<a class="search-icon-wrap search-icon-clear-wrap" href="'.url('/user').'">'.dashboardSymbol('close').'</a>';
-        echo '<div class="info search-info">';
+        $info = '';
         $count = $this->data('RecordCount', $this->data('UserCount', null));
         if ($count !== null) {
-            echo ' ', sprintf(plural($count, '%s user found.', '%s users found.'), $count);
+            $info = sprintf(plural($count, '%s user found.', '%s users found.'), $count);
         } elseif ($this->data('UserEstimate', null) !== null) {
-            echo ' ', sprintf(t('Approximately %s users exist.'), $this->data('UserEstimate'));
+            $info = sprintf(t('Approximately %s users exist.'), $this->data('UserEstimate'));
         }
-        echo '</div>';
-        echo '</div>';
-        echo $this->Form->close();
+        echo $this->Form->searchForm('Keywords', '/user/browse', [], $info);
         ?>
     </div>
     <?php PagerModule::write(array('Sender' => $this, 'View' => 'pager-dashboard')); ?>

--- a/applications/dashboard/views/user/index.php
+++ b/applications/dashboard/views/user/index.php
@@ -27,7 +27,7 @@ helpAsset(t('Need More Help?'), anchor(t("Video tutorial on finding &amp; managi
         echo '<div class="search-wrap input-wrap">';
         echo '<div class="search-icon-wrap search-icon-search-wrap">'.dashboardSymbol('search').'</div>';
         echo $this->Form->textBox('Keywords');
-        echo ' ', $this->Form->button(t('Go'), ['class' => 'search-submit']);
+        echo ' ', $this->Form->button('Go', ['class' => 'search-submit']);
         echo '<a class="search-icon-wrap search-icon-clear-wrap" href="'.url('/user').'">'.dashboardSymbol('close').'</a>';
         echo '<div class="info search-info">';
         $count = $this->data('RecordCount', $this->data('UserCount', null));

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -246,7 +246,7 @@ class PostController extends VanillaController {
                 $hasWordCharacter = preg_match('/\w/u', $Name) === 1;
 
                 if (!$hasWordCharacter || ($Name != '' && Gdn_Format::text($Name) == '')) {
-                    $this->Form->addError(t('You have entered an invalid discussion title'), 'Name');
+                    $this->Form->addError('You have entered an invalid discussion title', 'Name');
                 } else {
                     // Trim the name.
                     $FormValues['Name'] = $Name;
@@ -552,7 +552,7 @@ class PostController extends VanillaController {
 
         // If no discussion was found, error out
         if (!$Discussion) {
-            $this->Form->addError(t('Failed to find discussion for commenting.'));
+            $this->Form->addError('Failed to find discussion for commenting.');
         }
 
         /**

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -241,13 +241,21 @@ class PostController extends VanillaController {
                     }
                 }
 
+                $isTitleValid = true;
                 $Name = trim($this->Form->getFormValue('Name', ''));
-                // Let's be super aggressive and disallow titles with no word characters in them!
-                $hasWordCharacter = preg_match('/\w/u', $Name) === 1;
 
-                if (!$hasWordCharacter || ($Name != '' && Gdn_Format::text($Name) == '')) {
-                    $this->Form->addError('You have entered an invalid discussion title', 'Name');
-                } else {
+                if (!$Draft) {
+                    // Let's be super aggressive and disallow titles with no word characters in them!
+                    $hasWordCharacter = preg_match('/\w/u', $Name) === 1;
+
+                    if (!$hasWordCharacter || ($Name != '' && Gdn_Format::text($Name) == '')) {
+
+                        $this->Form->addError('You have entered an invalid discussion title', 'Name');
+                        $isTitleValid = false;
+                    }
+                }
+
+                if ($isTitleValid) {
                     // Trim the name.
                     $FormValues['Name'] = $Name;
                     $this->Form->setFormValue('Name', $Name);
@@ -552,7 +560,7 @@ class PostController extends VanillaController {
 
         // If no discussion was found, error out
         if (!$Discussion) {
-            $this->Form->addError('Failed to find discussion for commenting.');
+            $this->Form->addError(t('Failed to find discussion for commenting.'));
         }
 
         /**
@@ -993,13 +1001,13 @@ function checkOrRadio($FieldName, $LabelCode, $ListOptions, $Attributes = array(
         $Value = array_pop(array_keys($ListOptions));
 
         // This can be represented by a checkbox.
-        return $Form->CheckBox($FieldName, $LabelCode);
+        return $Form->checkBox($FieldName, $LabelCode);
     } else {
         $CssClass = val('ListClass', $Attributes, 'List Inline');
 
         $Result = ' <b>'.t($LabelCode)."</b> <ul class=\"$CssClass\">";
         foreach ($ListOptions as $Value => $Code) {
-            $Result .= ' <li>'.$Form->Radio($FieldName, $Code, array('Value' => $Value, 'class' => 'radio-inline')).'</li> ';
+            $Result .= ' <li>'.$Form->radio($FieldName, $Code, array('Value' => $Value, 'class' => 'radio-inline')).'</li> ';
         }
         $Result .= '</ul>';
         return $Result;

--- a/applications/vanilla/views/discussion/announce.php
+++ b/applications/vanilla/views/discussion/announce.php
@@ -8,9 +8,9 @@ echo $this->Form->errors();
 
 echo '<div class="P">'.t('Where do you want to announce this discussion?').'</div>';
 
-echo '<div class="P">', $this->Form->Radio('Announce', '@'.sprintf(t('In <b>%s.</b>'), $this->data('Category.Name')), array('Value' => '2')), '</div>';
-echo '<div class="P">', $this->Form->Radio('Announce', '@'.sprintf(t('In <b>%s</b> and recent discussions.'), $this->data('Category.Name')), array('Value' => '1')), '</div>';
-echo '<div class="P">', $this->Form->Radio('Announce', '@'.t("Don't announce."), array('Value' => '0')), '</div>';
+echo '<div class="P">', $this->Form->radio('Announce', '@'.sprintf(t('In <b>%s.</b>'), $this->data('Category.Name')), array('Value' => '2')), '</div>';
+echo '<div class="P">', $this->Form->radio('Announce', '@'.sprintf(t('In <b>%s</b> and recent discussions.'), $this->data('Category.Name')), array('Value' => '1')), '</div>';
+echo '<div class="P">', $this->Form->radio('Announce', "Don't announce.", array('Value' => '0')), '</div>';
 
 echo '<div class="Buttons Buttons-Confirm">';
 echo $this->Form->button('OK');

--- a/plugins/Flagging/views/flagging.php
+++ b/plugins/Flagging/views/flagging.php
@@ -11,12 +11,12 @@ echo $this->Form->errors();
     <li class="form-group">
         <?php echo $this->Form->labelWrap('Category to Use', 'Plugins.Flagging.CategoryID'); ?>
         <div class="input-wrap">
-            <?php echo $this->Form->CategoryDropDown('Plugins.Flagging.CategoryID', array('Value' => c('Plugins.Flagging.CategoryID'))); ?>
+            <?php echo $this->Form->categoryDropDown('Plugins.Flagging.CategoryID', array('Value' => c('Plugins.Flagging.CategoryID'))); ?>
         </div>
     </li>
     <li class="form-group">
         <div class="input-wrap no-label">
-            <?php echo $this->Form->checkBox('Plugins.Flagging.UseDiscussions', t('Create Discussions')); ?>
+            <?php echo $this->Form->checkBox('Plugins.Flagging.UseDiscussions', 'Create Discussions'); ?>
         </div>
     </li>
 </ul>

--- a/plugins/Flagging/views/flagging.php
+++ b/plugins/Flagging/views/flagging.php
@@ -1,32 +1,32 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
-
-<h1><?php echo t($this->Data['Title']); ?></h1>
-<?php
-// Settings
-echo $this->Form->open();
-echo $this->Form->errors();
-?>
-<h2><?php echo t('Flagging Settings'); ?></h2>
-<ul>
-    <li class="form-group">
-        <?php echo $this->Form->labelWrap('Category to Use', 'Plugins.Flagging.CategoryID'); ?>
-        <div class="input-wrap">
-            <?php echo $this->Form->categoryDropDown('Plugins.Flagging.CategoryID', array('Value' => c('Plugins.Flagging.CategoryID'))); ?>
-        </div>
-    </li>
-    <li class="form-group">
-        <div class="input-wrap no-label">
-            <?php echo $this->Form->checkBox('Plugins.Flagging.UseDiscussions', 'Create Discussions'); ?>
-        </div>
-    </li>
-</ul>
-<?php echo $this->Form->close('Save'); ?>
+<?php echo heading(t($this->data('Title'))); ?>
+<section>
+    <?php
+    echo subheading(t('Flagging Settings'));
+    echo $this->Form->open();
+    echo $this->Form->errors();
+    ?>
+    <ul>
+        <li class="form-group">
+            <?php echo $this->Form->labelWrap('Category to Use', 'Plugins.Flagging.CategoryID'); ?>
+            <div class="input-wrap">
+                <?php echo $this->Form->categoryDropDown('Plugins.Flagging.CategoryID', array('Value' => c('Plugins.Flagging.CategoryID'))); ?>
+            </div>
+        </li>
+        <li class="form-group">
+            <div class="input-wrap no-label">
+                <?php echo $this->Form->checkBox('Plugins.Flagging.UseDiscussions', 'Create Discussions'); ?>
+            </div>
+        </li>
+    </ul>
+    <?php echo $this->Form->close('Save'); ?>
+</section>
 <?php
 // Flagged Items list
 if (!count($this->FlaggedItems)) {
     echo '<div class="padded">'.t('FlagQueueEmpty', "There are no items awaiting moderation at this time.").'</div>';
 } else { ?>
-<div class="table-wrap padded">
+<div class="table-wrap">
     <table class="table-data js-tj">
         <thead>
         <tr>
@@ -36,7 +36,6 @@ if (!count($this->FlaggedItems)) {
         </tr>
         </thead>
         <tbody>
-        <tr>
             <?php
             foreach ($this->FlaggedItems as $URL => $FlaggedList) {
                 ksort($FlaggedList, SORT_STRING);
@@ -51,17 +50,18 @@ if (!count($this->FlaggedItems)) {
                 $options = anchor(t('Take Action'), $Flag['ForeignURL'], 'btn btn-primary');
                 $options .= anchor(t('Dismiss'), 'plugin/flagging/dismiss/'.$Flag['EncodedURL'], 'btn btn-primary js-modal-confirm js-hijack', ['data-body' => t('Are you sure you want to dismiss this flag?')]);
                 ?>
-                <td class="FlaggedType"><?php echo $type; ?></td>
-                <td class="FlaggedBy"><?php echo $flaggedBy; ?></td>
-                <td class="options">
-                    <div class="btn-group">
-                    <?php echo $options; ?>
-                    </div>
-                </td>
+                <tr>
+                    <td class="FlaggedType"><?php echo $type; ?></td>
+                    <td class="FlaggedBy"><?php echo $flaggedBy; ?></td>
+                    <td class="options">
+                        <div class="btn-group">
+                        <?php echo $options; ?>
+                        </div>
+                    </td>
+                </tr>
                 <?php
             }
             ?>
-        </tr>
         </tbody>
     </table>
 </div>

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -120,7 +120,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         foreach ($ProfileFields as $Name => $Field) {
             // Check both so you can't break register form by requiring omitted field
             if (val('Required', $Field) && val('OnRegister', $Field)) {
-                $Sender->UserModel->Validation->applyRule($Name, 'Required', T('%s is required.', $Field['Label']));
+                $Sender->UserModel->Validation->applyRule($Name, 'Required', '@'.t('%s is required.', $Field['Label']));
             }
         }
 

--- a/plugins/Tagging/views/tagging.php
+++ b/plugins/Tagging/views/tagging.php
@@ -1,44 +1,31 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 
 <?php
-
 $TagType = $this->data('_TagType');
 $TagTypes = $this->data('_TagTypes');
 $CanAddTags = $this->data('_CanAddTags');
 
 $desc = t('Tags are keywords that users can assign to discussions to help categorize their question with similar questions.');
 helpAsset(sprintf(t('About %s'), t('Tagging')), $desc);
+
+if (strtolower($TagType) == 'all' || strtolower($TagType) == 'tags') {
+    // Only show add button if filter type supports adding new tags.
+    echo heading(t($this->data('Title')), t('Add Tag'), '/settings/tags/add?type=Tag', 'js-modal btn btn-primary');
+} else {
+    echo heading(t($this->data('Title')));
+}
 ?>
-<div class="header-block">
-    <h1><?php echo t($this->Data['Title']); ?></h1>
-    <?php if (strtolower($TagType) == 'all' || strtolower($TagType) == 'tags') {
-        // Only show add button if filter type supports adding new tags.
-        ?>
-        <div class="buttons">
-            <?php echo ' '.anchor('Add Tag', '/settings/tags/add?type=Tag', 'js-modal btn btn-primary'); ?>
-        </div>
-    <?php } ?>
-</div>
 <div class="toolbar flex-wrap">
     <div class="search-wrap input-wrap toolbar-main">
         <?php
-        echo $this->Form->open();
-        echo $this->Form->errors();
-        echo '<div class="search-icon-wrap search-icon-search-wrap">'.dashboardSymbol('search').'</div>';
-        echo $this->Form->textBox('Search', ['placeholder' => t('Search for a tag.', 'Search for all or part of a tag.')]);
-        echo ' '.$this->Form->button('Go', ['class' => 'search-submit']);
-        echo '<a class="search-icon-wrap search-icon-clear-wrap" href="'.url('/settings/tagging').'">'.dashboardSymbol('close').'</a>';
-        echo '<div class="info search-info">'.sprintf(t('%s tag(s) found.'), $this->data('RecordCount')).'</div>';
-        echo $this->Form->close();
+        $info = sprintf(t('%s tag(s) found.'), $this->data('RecordCount'));
+        $placeholder = t('Search for a tag.', 'Search for all or part of a tag.');
+        echo $this->Form->searchForm('search', '/settings/tagging', ['placeholder' => $placeholder], $info);
         ?>
     </div>
-
     <div class="btn-group">
-
         <?php foreach ($TagTypes as $TagTypeName => $TagMeta): ?>
-
             <?php
-
             $TagName = ($TagMeta['key'] == '' || strtolower($TagMeta['key']) == 'tags')
                 ? 'Tags'
                 : $TagTypeName;
@@ -61,103 +48,92 @@ helpAsset(sprintf(t('About %s'), t('Tagging')), $desc);
             }
 
             $TabUrl = url('/settings/tagging/?type='.strtolower($TagMeta['key']));
-
             ?>
-
             <a href="<?php echo $TabUrl; ?>" class="<?php echo $CurrentTab; ?> btn btn-secondary">
                 <?php echo ucwords(strtolower($TagName)); ?>
             </a>
-
         <?php endforeach; ?>
-
     </div>
     <?php PagerModule::write(array('Sender' => $this, 'View' => 'pager-dashboard')); ?>
 </div>
 <div class="table-wrap">
     <table class="Tags table-data js-tj">
         <thead>
-            <tr>
-                <th class="column-md"><?php echo t('Tag') ?></th>
-                <th><?php echo t('Type') ?></th>
-                <th class="column-md"><?php echo t('Date Added'); ?></th>
-                <th class="column-xs"><?php echo t('Count'); ?></th>
-                <?php if ($CanAddTags) { ?>
+        <tr>
+            <th class="column-md"><?php echo t('Tag') ?></th>
+            <th><?php echo t('Type') ?></th>
+            <th class="column-md"><?php echo t('Date Added'); ?></th>
+            <th class="column-xs"><?php echo t('Count'); ?></th>
+            <?php if ($CanAddTags) { ?>
                 <th class="column-sm"></th>
-                <?php } ?>
-            </tr>
+            <?php } ?>
+        </tr>
         </thead>
         <?php
         $Session = Gdn::session();
         $TagCount = $this->data('RecordCount');
-        if ($TagCount == 0) {
-            echo t("There are no tags in the system yet.");
-        } else {
-            $Tags = $this->data('Tags'); ?>
-            <tbody>
-            <?php
-            foreach ($Tags as $Tag) {
-                $CssClass = 'TagAdmin';
-                $Title = '';
-                $Special = FALSE;
-                $type = val('Type', $Tag);
-                if (empty($type)) {
-                    $type = t('Tag');
-                }
-                $userModel = new UserModel();
-                $createdBy = $userModel->getID(val('InsertUserID', $Tag));
-                $dateInserted = Gdn_Format::date(val('DateInserted', $Tag), '%e %b %Y');
-                $count = val('CountDiscussions', $Tag, 0);
+        $Tags = $this->data('Tags'); ?>
+        <tbody>
+        <?php
+        foreach ($Tags as $Tag) {
+            $CssClass = 'TagAdmin';
+            $Title = '';
+            $Special = FALSE;
+            $type = val('Type', $Tag);
+            if (empty($type)) {
+                $type = t('Tag');
+            }
+            $userModel = new UserModel();
+            $createdBy = $userModel->getID(val('InsertUserID', $Tag));
+            $dateInserted = Gdn_Format::date(val('DateInserted', $Tag), '%e %b %Y');
+            $count = val('CountDiscussions', $Tag, 0);
 
-                if (val('Type', $Tag)) {
-                    $Special = TRUE;
-                    $CssClass .= " Tag-Special Tag-{$Tag['Type']}";
-                    $Title = t('This is a special tag.');
-                }
+            if (val('Type', $Tag)) {
+                $Special = TRUE;
+                $CssClass .= " Tag-Special Tag-{$Tag['Type']}";
+                $Title = t('This is a special tag.');
+            }
 
-                ?>
-                <tr id="<?php echo "Tag_{$Tag['TagID']}"; ?>" class="<?php echo $CssClass; ?>"
-                     title="<?php echo $Title; ?>">
-                    <td>
+            ?>
+            <tr id="<?php echo "Tag_{$Tag['TagID']}"; ?>" class="<?php echo $CssClass; ?>"
+                title="<?php echo $Title; ?>">
+                <td>
                     <?php
                     $DisplayName = TagFullName($Tag); ?>
                     <div class="media media-sm">
                         <div class="media-body">
-                        <?php
-                        echo '<div class="media-title"><a href="'.url('/discussions/tagged/'.val('Name', $Tag)).'">'.htmlspecialchars($DisplayName).'</a></div>';
-                        echo '<div class="info">'.sprintf(t('Created by %s'), userAnchor($createdBy)).'</div>';
-                        ?>
+                            <?php
+                            echo '<div class="media-title"><a href="'.url('/discussions/tagged/'.val('Name', $Tag)).'">'.htmlspecialchars($DisplayName).'</a></div>';
+                            echo '<div class="info">'.sprintf(t('Created by %s'), userAnchor($createdBy)).'</div>';
+                            ?>
                         </div>
                     </div>
-                    </td>
-                    <td class="type">
-                        <?php echo $type; ?>
-                    </td>
-                    <td class="date">
-                        <?php echo $dateInserted; ?>
-                    </td>
-                    <td class="count">
-                        <?php echo $count; ?>
-                    </td>
-                    <?php if ($CanAddTags) { ?>
+                </td>
+                <td class="type">
+                    <?php echo $type; ?>
+                </td>
+                <td class="date">
+                    <?php echo $dateInserted; ?>
+                </td>
+                <td class="count">
+                    <?php echo $count; ?>
+                </td>
+                <?php if ($CanAddTags) { ?>
                     <td class="options">
                         <div class="btn-group">
-                        <?php
-                        if (!$Special) {
-                            echo anchor(dashboardSymbol('edit'), "/settings/tags/edit/{$Tag['TagID']}", 'js-modal btn btn-icon', ['aria-label' => t('Edit'), 'title' => t('Edit')]);
-                            echo anchor(dashboardSymbol('delete'), "/settings/tags/delete/{$Tag['TagID']}", 'js-modal-confirm js-hijack btn btn-icon', ['aria-label' => t('Delete'), 'title' => t('Delete'), 'data-body' => sprintf(t('Are you sure you want to delete this %s?'), t('tag'))]);
-                        }
-                        ?>
+                            <?php
+                            if (!$Special) {
+                                echo anchor(dashboardSymbol('edit'), "/settings/tags/edit/{$Tag['TagID']}", 'js-modal btn btn-icon', ['aria-label' => t('Edit'), 'title' => t('Edit')]);
+                                echo anchor(dashboardSymbol('delete'), "/settings/tags/delete/{$Tag['TagID']}", 'js-modal-confirm js-hijack btn btn-icon', ['aria-label' => t('Delete'), 'title' => t('Delete'), 'data-body' => sprintf(t('Are you sure you want to delete this %s?'), t('tag'))]);
+                            }
+                            ?>
                         </div>
                     </td>
-                    <?php } ?>
-                </tr>
+                <?php } ?>
+            </tr>
             <?php
-            }
         }
-
         ?>
-
-
-            </tbody>
+        </tbody>
     </table>
 </div>

--- a/plugins/Tagging/views/tagging.php
+++ b/plugins/Tagging/views/tagging.php
@@ -26,7 +26,7 @@ helpAsset(sprintf(t('About %s'), t('Tagging')), $desc);
         echo $this->Form->errors();
         echo '<div class="search-icon-wrap search-icon-search-wrap">'.dashboardSymbol('search').'</div>';
         echo $this->Form->textBox('Search', ['placeholder' => t('Search for a tag.', 'Search for all or part of a tag.')]);
-        echo ' '.$this->Form->button(t('Go'), ['class' => 'search-submit']);
+        echo ' '.$this->Form->button('Go', ['class' => 'search-submit']);
         echo '<a class="search-icon-wrap search-icon-clear-wrap" href="'.url('/settings/tagging').'">'.dashboardSymbol('close').'</a>';
         echo '<div class="info search-info">'.sprintf(t('%s tag(s) found.'), $this->data('RecordCount')).'</div>';
         echo $this->Form->close();


### PR DESCRIPTION
I used grep on the sources and had a closer look at each addError(),
applyRule(), checkBox(), button(), radio(), etc.
I've killed all useless t() calls for them and, when in doubt, I prefixed
some of the inline sprintf() translations with '@' so that they will not
be translated twice.