### PR TITLE
Fix links in discussions filter module always being disabled

### DIFF
--- a/applications/vanilla/modules/class.discussionssortfiltermodule.php
+++ b/applications/vanilla/modules/class.discussionssortfiltermodule.php
@@ -193,8 +193,9 @@ class DiscussionsSortFilterModule extends Gdn_Module {
                     val('name', $filter),
                     $pathAndQuery,
                     $key,
-                    '', array(), false,
-                    array('rel' => 'nofollow')
+                    '',
+                    [],
+                    ['rel' => 'nofollow']
                 );
             }
             $dropdowns[] = $dropdown;


### PR DESCRIPTION
[`DiscussionsSortFilterModule::getFilterDropdowns`](https://github.com/vanilla/vanilla/blob/9d8a5a3441ab9c634b7f9b7e5136079f6e0b02a0/applications/vanilla/modules/class.discussionssortfiltermodule.php#L165) uses `DropdownModule`.  `DropdownModule` uses [`NestedCollection`](https://github.com/vanilla/vanilla/blob/9d8a5a3441ab9c634b7f9b7e5136079f6e0b02a0/applications/dashboard/modules/class.dropdownmodule.php#L73). The parameters used in [`DiscussionsSortFilterModule::getFilterDropdowns`](https://github.com/vanilla/vanilla/blob/9d8a5a3441ab9c634b7f9b7e5136079f6e0b02a0/applications/vanilla/modules/class.discussionssortfiltermodule.php#L192) do not match up with the signature of [`NestedCollection::addLink` ](https://github.com/vanilla/vanilla/blob/9d8a5a3441ab9c634b7f9b7e5136079f6e0b02a0/applications/dashboard/library/class.nestedcollection.php#L260).  It looks like `$disabled` and `$modifiers ` are swapped, leaving us with a constant truthy value for `$disabled` on all links added in `DiscussionsSortFilterModule::getFilterDropdowns`.

This update moves the modifiers array up to the proper `$modifiers` parameter position and drops the `$disabled` parameter, since it defaults to `false`.