### PR TITLE
Don't assume presence of AllowDismiss in message module view

### DIFF
--- a/applications/dashboard/views/modules/message.php
+++ b/applications/dashboard/views/modules/message.php
@@ -5,7 +5,7 @@ $Message = $this->_Message;
 if (is_array($Message)) {
     echo '<div class="DismissMessage'.($Message['CssClass'] == '' ? '' : ' '.$Message['CssClass']).'">';
     $Session = Gdn::session();
-    if ($Message['AllowDismiss'] == '1' && $Session->isValid()) {
+    if (val('AllowDismiss', $Message) == '1' && $Session->isValid()) {
         echo anchor('&times;', "/dashboard/message/dismiss/{$Message['MessageID']}/".$Session->TransientKey().'?Target='.$this->_Sender->SelfUrl, 'Dismiss');
     }
 


### PR DESCRIPTION
This update replaces a direct array index value check with a call to `val` in the `MessageModule` view.  The assumption of the "AllowDismiss" key was sometimes throwing a PHP notice.