### PR TITLE
Update RootController::fetchViewLocation to match parent

### DIFF
--- a/applications/dashboard/controllers/class.rootcontroller.php
+++ b/applications/dashboard/controllers/class.rootcontroller.php
@@ -25,10 +25,11 @@ class RootController extends Gdn_Controller {
      * @param bool $ControllerName
      * @param bool $ApplicationFolder
      * @param bool $ThrowError
+     * @param bool $useController
      * @return bool|mixed
      * @throws Exception
      */
-    public function fetchViewLocation($View = '', $ControllerName = false, $ApplicationFolder = false, $ThrowError = true) {
+    public function fetchViewLocation($View = '', $ControllerName = false, $ApplicationFolder = false, $ThrowError = true, $useController = true) {
         if (!$ControllerName) {
             $ControllerName = '';
         }

--- a/applications/dashboard/controllers/class.rootcontroller.php
+++ b/applications/dashboard/controllers/class.rootcontroller.php
@@ -21,18 +21,19 @@ class RootController extends Gdn_Controller {
     /**
      * Get the file location of a view.
      *
-     * @param string $View
-     * @param bool $ControllerName
-     * @param bool $ApplicationFolder
-     * @param bool $ThrowError
+     * @param string $view
+     * @param bool $controllerName
+     * @param bool $applicationFolder
+     * @param bool $throwError
      * @param bool $useController
      * @return bool|mixed
      * @throws Exception
      */
-    public function fetchViewLocation($View = '', $ControllerName = false, $ApplicationFolder = false, $ThrowError = true, $useController = true) {
-        if (!$ControllerName) {
-            $ControllerName = '';
+    public function fetchViewLocation($view = '', $controllerName = false, $applicationFolder = false, $throwError = true, $useController = true) {
+        if (!$controllerName) {
+            $controllerName = '';
         }
-        return parent::fetchViewLocation($View, $ControllerName, $ApplicationFolder, $ThrowError);
+
+        return parent::fetchViewLocation($view, $controllerName, $applicationFolder, $throwError, $useController);
     }
 }


### PR DESCRIPTION
Since https://github.com/vanilla/vanilla/commit/791ef112f27d879395b024a56a7339825bcdfbcb, `Gdn_Controller::fetchViewLocation` has had an additional parameter: `$useController`. `RootController` extends `Gdn_Controller`, but it's `fetchViewLocation` does not include this new parameter, which can throw a warning.

This update adds the `$useController` parameter to `RootController::fetchViewLocation`.  In addition, since it's such a small function, I've taken the opportunity to update the coding standards.