### PR TITLE
Handle user preferences and settings controller 302s

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -406,6 +406,24 @@ class DashboardHooks extends Gdn_Plugin {
         }
     }
 
+    /**
+     * Clear user navigation preferences if we can't find the explicit method on the controller.
+     *
+     * @param Gdn_Controller $sender
+     * @param array $args Event arguments. We can expect a 'PathArgs' key here.
+     */
+    public function gdn_dispatcher_methodNotFound_handler($sender, $args) {
+        // If PathArgs is empty, the user hit the root, and we assume they want the index.
+        // If not, they got redirected to the root because their controller method was not
+        // found. We should clear the user prefs in that case.
+        if (!empty($args['PathArgs'])) {
+            if (Gdn::session()->isValid()) {
+                $uri = Gdn::request()->getRequestArguments('server')['REQUEST_URI'];
+                $userModel = new UserModel();
+                $userModel->clearSectionNavigationPreference($uri);
+            }
+        }
+    }
 
     /**
      *

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -464,6 +464,8 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             return ['x'.$method, $pathArgs];
         } elseif ($this->methodExists($controller, 'index')) {
             // "index" is the default controller method if an explicit method cannot be found.
+            $this->EventArguments['PathArgs'] = $pathArgs;
+            $this->fireEvent('MethodNotFound');
             return ['index', $pathArgs];
         } else {
             return ['', $pathArgs];


### PR DESCRIPTION
Clear user navigation preferences if we can't find the explicit method on the controller.
You can test this fix by adding these user preferences to the Preferences field for your user:

```
a:2:{s:33:"DashboardNav.DashboardLandingPage";s:9:"Analytics";s:32:"DashboardNav.SectionLandingPages";a:3:{s:9:"Analytics";s:47:"settings/analytics/dashboard/personal-dashboard";s:10:"Moderation";s:15:"/dashboard/user";s:8:"Settings";s:28:"/vanilla/settings/categories";}}
```