### PR TITLE
Do not add extra <br> tags in plain text emails

### DIFF
--- a/applications/dashboard/library/class.emailtemplate.php
+++ b/applications/dashboard/library/class.emailtemplate.php
@@ -474,7 +474,7 @@ class EmailTemplate extends Gdn_Pluggable implements Gdn_IEmailTemplate {
             }
         }
 
-        return Gdn_Format::plainText(Gdn_Format::text(implode('<br>', $email)));
+        return Gdn_Format::plainText(Gdn_Format::text(implode('<br>', $email), false));
     }
 
     /**


### PR DESCRIPTION
Fix https://github.com/vanilla/vanilla/issues/4735

Test code (put in index before `$dispatcher->start();`
```php
$email = new Gdn_Email();
$email->setFormat('text');
$email->from('admin@vanilla.dev');
$email->to('alexandre.c@vanillaforums.com');

$content = "**Plex Media Server 1.2.3 is now available for Plex Pass members.**

**NEW**

- (Web) Updated Plex Web to 2.10.5.
- (Media Flags) Update bundle.
- (Localization) Updated server translations.

**FIXES:**

- (Network) Clients might incorrectly report a server as unclaimed or remote access as unavailable after network timeouts. (#4994)
- (Streaming Brain) In some cases the server could unexpectedly reserve any remaining bandwidth. (#5447)
- (Streaming Brain) Playback failures on Android. (#5537 #5589)
- (Streaming Brain) Issues starting transcode sessions with OpenPHT. (#5546)
- (Streaming Brain) Issues transcoding sidecar subtitles while Direct Playing a video. (#5540)
- (Scanner) Library section analysis wasn't always working. (#5536)
- (Scanner) Issues scanning TV series with numeric names. (#5547)
- (Camera Upload) Duplicate photos could be uploaded in some cases on case-sensitive filesystems. (#5509)
- (Camera Upload) Uploads were failing if the target library path didn't already exist. (#5553)
- (Music) Unplayable music videos might show up after refreshing certain albums. (#5559)
- (Metadata) Issues obtaining preview images from fanart.tv. (#5524)
- (Linux) Transcoder errors caused by an invalid locale configuration on certain systems. (#4717)
- (NAS) Crashes on ReadyNAS 6.6. (#5567)
- (NAS) Issues scanning when paths contained non-ASCII characters. (#5618)";

$email->subject('Test 2');
$email->message($content);

$email->send();
die();
```