### PR TITLE
Add npm and grunt files to phing ignore list

### DIFF
--- a/build/package-exclude.txt
+++ b/build/package-exclude.txt
@@ -3,3 +3,9 @@ applications/dashboard/styleguide/**
 applications/dashboard/template/**
 applications/dashboard/scss/**
 applications/dashboard/js/src/**
+applications/dashboard/bower_components/**
+applications/dashboard/bower.json
+applications/dashboard/Gruntfile.js
+applications/dashboard/node_modules/**
+applications/dashboard/npm-shrinkwrap.json
+applications/dashboard/package.json


### PR DESCRIPTION
With these exclusions:

     [copy] Copying 2017 files to /git/vanilla/build/package

Without them:

     [copy] Copying 37649 files to /git/vanilla/build/package

Slow clap for npm & grunt.