### PR TITLE
Update validation in Garden\Schema to handle unexpected parameters

### DIFF
--- a/library/Garden/Schema.php
+++ b/library/Garden/Schema.php
@@ -148,16 +148,13 @@ class Schema implements \JsonSerializable {
     /**
      * Filter fields not in the schema.  The action taken is determined by the configured validation behavior.
      *
-     * @param array $data
-     * @param array $schema
-     * @param Validation $validation
-     * @param string $path
-     * @throws ValidationException when configured to do so and an unexpected parameter is encountered
-     * @return Schema
+     * @param array &$data The data to filter.
+     * @param array $schema The schema array.  Its configured parameters are used to filter $data.
+     * @param Validation &$validation This argument will be filled with the validation result.
+     * @param string $path The path to current parameters for nested objects.
+     * @return Schema Returns the current instance for fluent calls.
      */
     protected function filterData(array &$data, array $schema, Validation &$validation, $path = '') {
-        $filtered = false;
-
         foreach ($data as $key => $val) {
             if (array_key_exists($key, $schema)) {
                 continue;
@@ -200,7 +197,7 @@ class Schema implements \JsonSerializable {
     /**
      * Return a Schema::VALIDATE_* constant representing the currently configured validation behavior.
      *
-     * @return int
+     * @return int Returns a Schema::VALIDATE_* constant to indicate this instance's validation behavior.
      */
     public function getValidationBehavior() {
         return $this->validationBehavior;
@@ -495,7 +492,7 @@ class Schema implements \JsonSerializable {
      * Set the validation behavior for the schema, which determines how invalid properties are handled.
      *
      * @param int $validationBehavior One of the Schema::VALIDATE_* constants.
-     * @return Schema
+     * @return Schema Returns the current instance for fluent calls.
      */
     public function setValidationBehavior($validationBehavior) {
         switch ($validationBehavior) {

--- a/library/Garden/Schema.php
+++ b/library/Garden/Schema.php
@@ -150,10 +150,11 @@ class Schema implements \JsonSerializable {
      *
      * @param array $data
      * @param array $schema
+     * @param string $path
      * @throws ValidationException when configured to do so and an unexpected parameter is encountered
      * @return Schema
      */
-    protected function filterData(array &$data, array $schema) {
+    protected function filterData(array &$data, array $schema, $path = '') {
         $validation = new Validation();
         $filtered = false;
 
@@ -164,7 +165,7 @@ class Schema implements \JsonSerializable {
                 $filtered = true;
             }
 
-            $errorMessage = sprintft('Unexpected parameter: %1$s.', $key);
+            $errorMessage = sprintft('Unexpected parameter: %1$s.', $path.$key);
             $validation->addError(
                 'unexpected_parameter',
                 $key,
@@ -453,7 +454,7 @@ class Schema implements \JsonSerializable {
             $validation = new Validation();
         }
 
-        $this->filterData($data, $schema);
+        $this->filterData($data, $schema, $path);
 
         // Loop through the schema fields and validate each one.
         foreach ($schema as $name => $field) {

--- a/library/Garden/Schema.php
+++ b/library/Garden/Schema.php
@@ -149,14 +149,16 @@ class Schema implements \JsonSerializable {
      * Filter fields not in the schema.  The action taken is determined by the configured validation behavior.
      *
      * @param array $data
+     * @param array $schema
+     * @throws ValidationException when configured to do so and an unexpected parameter is encountered
      * @return Schema
      */
-    protected function filterData(array &$data) {
+    protected function filterData(array &$data, array $schema) {
         $validation = new Validation();
         $filtered = false;
 
         foreach ($data as $key => $val) {
-            if (array_key_exists($key, $this->schema)) {
+            if (array_key_exists($key, $schema)) {
                 continue;
             } elseif ($filtered === false) {
                 $filtered = true;
@@ -451,7 +453,7 @@ class Schema implements \JsonSerializable {
             $validation = new Validation();
         }
 
-        $this->filterData($data);
+        $this->filterData($data, $schema);
 
         // Loop through the schema fields and validate each one.
         foreach ($schema as $name => $field) {

--- a/tests/Library/Garden/BasicSchemaTest.php
+++ b/tests/Library/Garden/BasicSchemaTest.php
@@ -355,7 +355,7 @@ class BasicSchemaTest extends SchemaTest {
             [
                 'i:id',
                 's:name' => 'The name of the object.',
-                'description?',
+                's:description?',
                 'ts:timestamp?',
                 'dt:date?',
                 'f:amount?',

--- a/tests/Library/Garden/BasicSchemaTest.php
+++ b/tests/Library/Garden/BasicSchemaTest.php
@@ -70,7 +70,7 @@ class BasicSchemaTest extends SchemaTest {
         $data = [
             'id' => 123,
             'name' => 'foo',
-            'descriptiom' => 456,
+            'description' => 456,
             'timestamp' => time(),
             'date' => new \DateTime(),
             'amount' => 5.99,

--- a/tests/Library/Garden/BasicSchemaTest.php
+++ b/tests/Library/Garden/BasicSchemaTest.php
@@ -346,6 +346,57 @@ class BasicSchemaTest extends SchemaTest {
     }
 
     /**
+     * Call validate on an instance of Schema where the data contains unexpected parameters.
+     * *
+     * @param int $validationBehavior
+     */
+    protected function doValidationBehavior($validationBehavior) {
+        $schema = new Schema([
+            'i:userID' => 'The ID of the user.',
+            's:name' => 'The username of the user.',
+            's:email' => 'The email of the user.',
+        ]);
+        $schema->setValidationBehavior($validationBehavior);
+
+        $data = [
+            'userID' => 123,
+            'name' => 'foo',
+            'email' => 'user@example.com',
+            'admin' => true,
+            'role' => 'Administrator'
+        ];
+
+        $schema->validate($data);
+        $this->assertArrayNotHasKey('admin', $data);
+        $this->assertArrayNotHasKey('role', $data);
+    }
+
+    /**
+     * Test throwing an exception when removing unexpected parameters from validated data.
+     *
+     * @expectedException \Garden\Exception\ValidationException
+     */
+    public function testValidateException() {
+        $this->doValidationBehavior(Schema::VALIDATE_EXCEPTION);
+    }
+
+    /**
+     * Test triggering a notice when removing unexpected parameters from validated data.
+     *
+     * @expectedException \PHPUnit_Framework_Error_Notice
+     */
+    public function testValidateNotice() {
+        $this->doValidationBehavior(Schema::VALIDATE_NOTICE);
+    }
+
+    /**
+     * Test silently removing unexpected parameters from validated data.
+     */
+    public function testValidateRemove() {
+        $this->doValidationBehavior(Schema::VALIDATE_REMOVE);
+    }
+
+    /**
      * Get a schema of atomic types.
      *
      * @return Schema Returns the schema of atomic types.

--- a/tests/Library/Garden/NestedSchemaTest.php
+++ b/tests/Library/Garden/NestedSchemaTest.php
@@ -242,6 +242,31 @@ class NestedSchemaTest extends SchemaTest {
     }
 
     /**
+     * Test throwing an exception when removing unexpected parameters from validated data.
+     *
+     * @expectedException \Garden\Exception\ValidationException
+     */
+    public function testValidateException() {
+        $this->doValidationBehavior(Schema::VALIDATE_EXCEPTION);
+    }
+
+    /**
+     * Test triggering a notice when removing unexpected parameters from validated data.
+     *
+     * @expectedException \PHPUnit_Framework_Error_Notice
+     */
+    public function testValidateNotice() {
+        $this->doValidationBehavior(Schema::VALIDATE_NOTICE);
+    }
+
+    /**
+     * Test silently removing unexpected parameters from validated data.
+     */
+    public function testValidateRemove() {
+        $this->doValidationBehavior(Schema::VALIDATE_REMOVE);
+    }
+
+    /**
      * Get a schema that consists of an array of objects.
      *
      * @return Schema Returns the schema.
@@ -274,5 +299,35 @@ class NestedSchemaTest extends SchemaTest {
         ]);
 
         return $schema;
+    }
+
+    /**
+     * Call validate on an instance of Schema where the data contains unexpected parameters.
+     *
+     * @param int $validationBehavior
+     */
+    protected function doValidationBehavior($validationBehavior) {
+        $schema = new Schema([
+            'i:groupID' => 'The ID of the group.',
+            's:name' => 'The name of the group.',
+            's:description' => 'A description of the group.',
+            'o:member' => [
+                's:email' => 'The ID of the new member.'
+            ]
+        ]);
+        $schema->setValidationBehavior($validationBehavior);
+
+        $data = [
+            'groupID' => 123,
+            'name' => 'Group Foo',
+            'description' => 'A group for testing.',
+            'member' => [
+                'email' => 'user@example.com',
+                'role' => 'Leader',
+            ]
+        ];
+
+        $schema->validate($data);
+        $this->assertArrayNotHasKey('role', $data['member']);
     }
 }


### PR DESCRIPTION
This update makes a couple changes to `Garden\Schema`:

1. Adds `filterData` function, which removes fields from a `$data` array that aren't explicitly a configured part of the schema.
2. Adds `VALIDATE_*` class constants to assign and detect validation behavior.

In addition, test have been added for each new validation behavior for both basic and nested schemas.

Closes #4703 
Closes #4707