### PR TITLE
Add AfterConversationMessageBodyFormat event to PMs

### DIFF
--- a/applications/conversations/views/messages/messages.php
+++ b/applications/conversations/views/messages/messages.php
@@ -43,8 +43,10 @@ foreach ($Messages as $Message) {
             <div class="Message">
                 <?php
                 $this->fireEvent('BeforeConversationMessageBody');
-                echo Gdn_Format::to($Message->Body, $Format);
                 $this->EventArguments['Message'] = &$Message;
+                $Message->FormatBody = Gdn_Format::to($Message->Body, $Format);
+                $this->fireEvent('AfterConversationMessageBodyFormat');
+                echo $Message->FormatBody;
                 $this->fireEvent('AfterConversationMessageBody');
                 ?>
             </div>


### PR DESCRIPTION
Discussions/Comments fire a AfterCommentBodyFormat event, private messages don't fire any event yet after formatting.
That makes it hard for plugins to add HTML to private messages in a consistent manner.

This change will make sure discussions/comments and private messages exhibit the same behaviour.