### PR TITLE
Fix heading categories sometimes being wrapped in an anchor

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -146,7 +146,9 @@ if (!function_exists('WriteListItem')):
                 echo '<div class="Options">'.getOptions($Row).'</div>';
                 echo '<'.$H.' class="CategoryName TitleWrap">';
                 echo CategoryPhoto($Row);
-                echo anchor(htmlspecialchars($Row['Name']), $Row['Url'], 'Title');
+
+                $safeName = htmlspecialchars($Row['Name']);
+                echo $Row['DisplayAs'] === 'Heading' ? $safeName : anchor($safeName, $Row['Url'], 'Title');
 
                 Gdn::controller()->EventArguments['Category'] = $Row;
                 Gdn::controller()->fireEvent('AfterCategoryTitle');
@@ -244,7 +246,8 @@ if (!function_exists('WriteTableRow')):
                     echo CategoryPhoto($Row);
 
                     echo "<{$H}>";
-                    echo anchor(htmlspecialchars($Row['Name']), $Row['Url']);
+                    $safeName = htmlspecialchars($Row['Name']);
+                    echo $Row['DisplayAs'] === 'Heading' ? $safeName : anchor($safeName, $Row['Url']);
                     Gdn::controller()->EventArguments['Category'] = $Row;
                     Gdn::controller()->fireEvent('AfterCategoryTitle');
                     echo "</{$H}>";


### PR DESCRIPTION
When a category is configured to display as "Heading", it isn't supposed to have an anchor.  This is true for most of Vanilla, but [`writeListItem`](https://github.com/vanilla/vanilla/blob/7ae304aa7cb89496bc17925d05798352056b4b6c/applications/vanilla/views/categories/helper_functions.php#L130) and [`writeTableRow`](https://github.com/vanilla/vanilla/blob/7ae304aa7cb89496bc17925d05798352056b4b6c/applications/vanilla/views/categories/helper_functions.php#L225) do not currently account for this adjustment.  Everything gets an anchor.

This update alters the aforementioned functions to only apply an anchor to the title of categories when they are not configured to display as "Heading".

Closes #4634 