### PR TITLE
Set the user photo to an actual user photo in search

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2473,7 +2473,7 @@ class UserModel extends Gdn_Model {
 
         foreach ($Result as &$Row) {
             if ($Row->Photo && !isUrl($Row->Photo)) {
-                $Row->Photo = Gdn_Upload::url($Row->Photo);
+                $Row->Photo = Gdn_Upload::url(changeBasename($Row->Photo, 'n%s'));
             }
 
             $Row->Attributes = dbdecode($Row->Attributes);


### PR DESCRIPTION
The user photo returned from this is not a valid image, as it has no prefix on it. The views usually overlook this by using the userPhoto() function, but it fails when you try using the userPhotoUrl() function on the users page. Because we set a full url here, userPhotoUrl() doesn't change the basename and returns a url to an image without the n or p prefix, an image that doesn't exist.