### PR TITLE
Ensure password editing fields toggle appropriately

### DIFF
--- a/applications/dashboard/js/user.js
+++ b/applications/dashboard/js/user.js
@@ -8,7 +8,6 @@ $(document).on('contentLoad', function() {
         if ($(inp2).attr('id') != 'Form_ShowPassword') {
             $(inp).after('<input id="Form_ShowPassword" type="text" class="form-control" value="' + $(inp).val() + '" />');
             inp2 = $(inp).next();
-            $(this).html($(this).data('hideText'));
             $(inp).change(function() {
                 $(inp2).val($(inp).val());
             });

--- a/applications/dashboard/js/user.js
+++ b/applications/dashboard/js/user.js
@@ -1,5 +1,5 @@
 // This file contains javascript that is specific to the /profile controller.
-jQuery(document).ready(function($) {
+$(document).on('contentLoad', function() {
 
     // Reveal password
     $(document).on('click', 'a.RevealPassword', function() {
@@ -8,16 +8,22 @@ jQuery(document).ready(function($) {
         if ($(inp2).attr('id') != 'Form_ShowPassword') {
             $(inp).after('<input id="Form_ShowPassword" type="text" class="form-control" value="' + $(inp).val() + '" />');
             inp2 = $(inp).next();
-            $(inp).hide();
+            $(this).html($(this).data('hideText'));
             $(inp).change(function() {
                 $(inp2).val($(inp).val());
             });
             $(inp2).change(function() {
                 $(inp).val($(inp2).val());
             });
+        }
+        if ($(inp).is(":visible")) {
+            $(this).html($(this).data('hideText'));
+            $(inp).hide();
+            $(inp2).show();
         } else {
-            $(inp).toggle();
-            $(inp2).toggle();
+            $(this).html($(this).data('showText'));
+            $(inp).show();
+            $(inp2).hide();
         }
         return false;
     });
@@ -67,17 +73,11 @@ jQuery(document).ready(function($) {
     // When the password options are clicked, check to see if the admin/mod
     // wishes to set a new password for the user. If that's the case, show the
     // password reset input. Otherwise, hide it.
-    $(document).on('click', '.PasswordOptions', function() {
+    $(document).on('change', '.PasswordOptions', function() {
         if ($("input:radio[name='ResetPassword']:checked").val() == 'Manual') {
             $('#NewPassword').slideDown('fast');
         } else {
             $('#NewPassword').slideUp('fast');
         }
     });
-
-    // Make paging function in the user table
-//   $('.MorePager').morepager({
-//      pageContainerSelector: '#Users',
-//      pagerInContainer: true
-//   });
 });

--- a/applications/dashboard/views/user/edit.php
+++ b/applications/dashboard/views/user/edit.php
@@ -113,20 +113,23 @@ if ($this->data('AllowEditing')) { ?>
             </div>
         </li>
         <?php if (array_key_exists('Manual', $this->ResetOptions)) : ?>
-            <li id="NewPassword" class="form-group">
-                <div class="label-wrap">
-                    <?php echo $this->Form->label('New Password', 'NewPassword'); ?>
+            <li id="NewPassword">
+                <div class="form-group">
+                    <div class="label-wrap">
+                        <?php echo $this->Form->label('New Password', 'NewPassword'); ?>
+                    </div>
+                    <div class="input-wrap">
+                        <?php echo $this->Form->Input('NewPassword', 'password'); ?>
+                    </div>
                 </div>
-                <div class="input-wrap">
-                    <?php echo $this->Form->Input('NewPassword', 'password'); ?>
-                </div>
-            </li>
-            <li class="form-group">
-                <div class="buttons input-wrap no-label">
-                    <?php
-                    echo anchor(t('Generate Password'), '#', 'GeneratePassword btn btn-secondary');
-                    echo anchor(t('Reveal Password'), '#', 'RevealPassword btn btn-secondary');
-                    ?>
+                <div class="form-group">
+                    <div class="buttons input-wrap no-label">
+                        <?php
+                        echo anchor(t('Generate Password'), '#', 'GeneratePassword btn btn-secondary');
+                        echo anchor(t('Reveal Password'), '#', 'RevealPassword btn btn-secondary',
+                            ['data-hide-text' => t('Hide Password'), 'data-show-text' => t('Reveal Password')]);
+                        ?>
+                    </div>
                 </div>
             </li>
         <?php endif; ?>


### PR DESCRIPTION
* Executes on contentLoad to ensure the javascript executes in a modal.
* Listens for a `change` on the radio field instead of `click`, which fixes the interference with iCheck.
* Explicitly checks for visibility of the password input element, so we can toggle the text on the button.
* Reorders the HTML to work with hiding/showing the `NewPassword` element and adds data attributes to aid translation.

Closes https://github.com/vanilla/vanilla/issues/4694