### PR TITLE
Replace some serialization calls with their DB-encoding counterparts

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1145,8 +1145,8 @@ EOT;
                         $CookiePayload = array(
                             'Sync' => 'Failed'
                         );
-                        $SerializedCookiePayload = Gdn_Format::serialize($CookiePayload);
-                        $Authenticator->remember($UserInfo['ConsumerKey'], $SerializedCookiePayload);
+                        $encodedCookiePayload = dbencode($CookiePayload);
+                        $Authenticator->remember($UserInfo['ConsumerKey'], $encodedCookiePayload);
 
                         // This resets vanilla's internal "where am I" to the homepage. Needed.
                         Gdn::request()->withRoute('DefaultController');

--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -195,7 +195,7 @@ class UpdateModel extends Gdn_Model {
                     unset($Requirements[$Type]);
                 }
             }
-            $Addon['Requirements'] = serialize($Requirements);
+            $Addon['Requirements'] = dbencode($Requirements);
 
             $Addon['Checked'] = true;
             $Addon['Path'] = $Path;

--- a/library/core/class.configuration.php
+++ b/library/core/class.configuration.php
@@ -304,7 +304,7 @@ class Gdn_Configuration extends Gdn_Pluggable {
         }
 
         if (is_string($Value)) {
-            $Result = Gdn_Format::unserialize($Value);
+            $Result = dbdecode($Value);
         } else {
             $Result = $Value;
         }
@@ -1292,7 +1292,7 @@ class Gdn_ConfigurationSource extends Gdn_Pluggable {
         }
 
         if (is_string($Value)) {
-            $Result = Gdn_Format::unserialize($Value);
+            $Result = dbdecode($Value);
         } else {
             $Result = $Value;
         }

--- a/library/core/class.configuration.php
+++ b/library/core/class.configuration.php
@@ -304,7 +304,7 @@ class Gdn_Configuration extends Gdn_Pluggable {
         }
 
         if (is_string($Value)) {
-            $Result = dbdecode($Value);
+            $Result = Gdn_Format::unserialize($Value);
         } else {
             $Result = $Value;
         }
@@ -1292,7 +1292,7 @@ class Gdn_ConfigurationSource extends Gdn_Pluggable {
         }
 
         if (is_string($Value)) {
-            $Result = dbdecode($Value);
+            $Result = Gdn_Format::unserialize($Value);
         } else {
             $Result = $Value;
         }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -937,7 +937,7 @@ class Gdn_Format {
      */
     public static function image($Body) {
         if (is_string($Body)) {
-            $Image = @unserialize($Body);
+            $Image = dbdecode($Body);
 
             if (!$Image) {
                 return Gdn_Format::html($Body);

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -932,8 +932,10 @@ class Gdn_Format {
     }
 
     /**
-     * Format a serialized string of image properties as html.
-     * @param string $Body a serialized array of image properties (Image, Thumbnail, Caption)
+     * Format an encoded string of image properties as html.
+     *
+     * @param string $Body a encoded array of image properties (Image, Thumbnail, Caption)
+     * @return string
      */
     public static function image($Body) {
         if (is_string($Body)) {


### PR DESCRIPTION
This update removes some serialization calls and replaces them with their DB-encoding counterparts (e.g. `dbencode`, `dbdecode`).

Closes #3749
