### PR TITLE
Fix notice caused by MediaItemModule::setView

### DIFF
--- a/applications/dashboard/modules/class.mediaitemmodule.php
+++ b/applications/dashboard/modules/class.mediaitemmodule.php
@@ -101,9 +101,10 @@ class MediaItemModule extends Gdn_Module {
      * @return MediaItemModule $this
      */
     public function setView($view) {
-        $class = $this->attributes['class'];
+        $class = val('class', $this->attributes, '');
         $class .= ' media '.$view;
         $this->attributes['class'] = $class;
+
         return parent::setView($view);
     }
 


### PR DESCRIPTION
This update addresses a notice potentially being fired if "class" hasn't been set yet in `MediaItemModule::$attributes` by the time `MediaItemModule::setView` is called.