### PR TITLE
Pass activity array and mail object by reference to event handler

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -876,9 +876,10 @@ class ActivityModel extends Gdn_Model {
 
                 $Email->setEmailTemplate($emailTemplate);
 
-                $Notification = ['ActivityID' => $ActivityID, 'User' => $User, 'Email' => $Email, 'Route' => $Activity->Route, 'Story' => $Story, 'Headline' => $ActivityHeadline, 'Activity' => $Activity];
+                $Notification = ['ActivityID' => $ActivityID, 'User' => $User, 'Email' => &$Email, 'Route' => $Activity->Route, 'Story' => $Story, 'Headline' => $ActivityHeadline, 'Activity' => $Activity];
                 $this->EventArguments = $Notification;
                 $this->fireEvent('BeforeSendNotification');
+                //send notification
                 try {
                     // Only send if the user is not banned
                     if (!val('Banned', $User)) {
@@ -999,7 +1000,7 @@ class ActivityModel extends Gdn_Model {
         $Email->setEmailTemplate($emailTemplate);
 
         // Fire an event for the notification.
-        $Notification = ['ActivityID' => $ActivityID, 'User' => $User, 'Email' => $Email, 'Route' => $Activity['Route'], 'Story' => $Activity['Story'], 'Headline' => $Activity['Headline'], 'Activity' => $Activity];
+        $Notification = ['ActivityID' => $ActivityID, 'User' => $User, 'Email' => &$Email, 'Route' => $Activity['Route'], 'Story' => $Activity['Story'], 'Headline' => $Activity['Headline'], 'Activity' => $Activity];
         $this->EventArguments = $Notification;
         $this->fireEvent('BeforeSendNotification');
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1157,8 +1157,6 @@ class CommentModel extends VanillaModel {
             $Activity['NotifyUserID'] = $UserID;
             $Activity['Emailed'] = val('Emailed', $Prefs, false);
             $Activity['Notified'] = val('Notified', $Prefs, false);
-            $this->EventArguments['Activity'] = &$Activity;
-            $this->fireEvent('BeforeCommentQueue');
             $ActivityModel->Queue($Activity);
         }
     }

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1157,6 +1157,8 @@ class CommentModel extends VanillaModel {
             $Activity['NotifyUserID'] = $UserID;
             $Activity['Emailed'] = val('Emailed', $Prefs, false);
             $Activity['Notified'] = val('Notified', $Prefs, false);
+            $this->EventArguments['Activity'] = &$Activity;
+            $this->fireEvent('BeforeCommentQueue');
             $ActivityModel->Queue($Activity);
         }
     }


### PR DESCRIPTION
In creating a hook to customize emails in a plugin, I ran into a situation where I needed and event handler before queueing an activity in the comment model and I needed to be able to manipulate the the email object in the activity model just before sending notifications.