### PR TITLE
Add input control for Vanilla.Categories.MaxDisplayDepth

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -41,6 +41,7 @@ class VanillaSettingsController extends Gdn_Controller {
         $Validation = new Gdn_Validation();
         $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
         $ConfigurationModel->setField(array(
+            'Vanilla.Categories.MaxDisplayDepth',
             'Vanilla.Discussions.PerPage',
             'Vanilla.Comments.PerPage',
             'Garden.Html.AllowedElements',
@@ -68,6 +69,8 @@ class VanillaSettingsController extends Gdn_Controller {
             $this->Form->setData($ConfigurationModel->Data);
         } else {
             // Define some validation rules for the fields being saved
+            $ConfigurationModel->Validation->applyRule('Vanilla.Categories.MaxDisplayDepth', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Categories.MaxDisplayDepth', 'Integer');
             $ConfigurationModel->Validation->applyRule('Vanilla.Discussions.PerPage', 'Required');
             $ConfigurationModel->Validation->applyRule('Vanilla.Discussions.PerPage', 'Integer');
             $ConfigurationModel->Validation->applyRule('Vanilla.Comments.PerPage', 'Required');

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -227,8 +227,10 @@ if (!function_exists('WriteTableRow')):
     function writeTableRow($Row, $Depth = 1) {
         $Children = $Row['Children'];
         $WriteChildren = FALSE;
+        $maxDisplayDepth = c('Vanilla.Categories.MaxDisplayDepth');
+
         if (!empty($Children)) {
-            if (($Depth + 1) >= c('Vanilla.Categories.MaxDisplayDepth')) {
+            if ($maxDisplayDepth > 0 && ($Depth + 1) >= $maxDisplayDepth) {
                 $WriteChildren = 'list';
             } else {
                 $WriteChildren = 'rows';

--- a/applications/vanilla/views/vanillasettings/advanced.php
+++ b/applications/vanilla/views/vanillasettings/advanced.php
@@ -9,6 +9,25 @@ echo $this->Form->errors();
     <ul>
         <li class="form-group">
             <?php
+            $Options = ['1' => '1', '2' => '2', '3' => '3', '4' => '4', '5' => '5', '0' => 'No limit'];
+            $Fields = ['TextField' => 'Code', 'ValueField' => 'Code'];
+            ?>
+            <div class="label-wrap">
+            <?php
+            echo $this->Form->label('Maximum Category Display Depth', 'Vanilla.Categories.MaxDisplayDepth');
+            echo wrap(
+                t('CategoryMaxDisplayDepth.Notes', 'Nested categories deeper than this depth will be placed in a comma-delimited list.'),
+                'div',
+                ['class' => 'info']
+            );
+            ?>
+            </div>
+            <div class="input-wrap">
+            <?php echo $this->Form->DropDown('Vanilla.Categories.MaxDisplayDepth', $Options, $Fields); ?>
+            </div>
+        </li>
+        <li class="form-group">
+            <?php
             $Options = array('10' => '10', '15' => '15', '20' => '20', '25' => '25', '30' => '30', '40' => '40', '50' => '50', '100' => '100');
             $Fields = array('TextField' => 'Code', 'ValueField' => 'Code');
             ?>


### PR DESCRIPTION
This update restores the long-lost form control for setting `Vanilla.Categories.MaxDisplayDepth`.  Prior to Vanilla's dashboard refresh, this control was found on the categories page.  Now, it can be found in Vanilla's settings, on the Advanced page.

Closes #4625 