### PR TITLE
Fix potential invalid array union in CategoryCollection

### DIFF
--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -398,17 +398,19 @@ class CategoryCollection {
      * - maxdepth: The maximum depth of the tree.
      * - collapsed: Stop when looking at a category of a certain type.
      * - permission: The permission to use when looking at the tree.
+     * @return array
      */
     public function getTree($parentID = -1, $options = []) {
         $tree = [];
         $categories = [];
         $parentID = $parentID ?: -1;
-        $options = array_change_key_case($options) + [
-                'maxdepth' => 3,
-                'collapsecategories' => false,
-                'permission' => 'PermsDiscussionsView'
-            ];
-
+        $defaultOptions = [
+            'maxdepth' => 3,
+            'collapsecategories' => false,
+            'permission' => 'PermsDiscussionsView'
+        ];
+        $options = array_change_key_case($options) ?: [];
+        $options = $options + $defaultOptions ;
 
         $currentDepth = 1;
         $parents = [$parentID];


### PR DESCRIPTION
`CategoryCollection::getTree` creates a union from its default options array and the incoming `$options` parameter.  However, before performing this union, it runs `$options` through `array_change_key_case`.  A potential result of this function is a boolean `false`, which shouldn't be used for an array union.

This update moves `array_change_key_case` out onto its own and falls back to an empty array, should it fail.

Closes #4723
