### PR TITLE
Add CategoryModel::getRootDisplayAs

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -255,6 +255,15 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * Get the display type for the root category.
+     *
+     * @return string
+     */
+    public static function getRootDisplayAs() {
+        return c('Vanilla.RootCategory.DisplayAs', 'Categories');
+    }
+
+    /**
      *
      *
      * @since 2.0.18


### PR DESCRIPTION
This update adds `getRootDisplayAs` to `CategoryModel`.  This method will be used to retrieve the value of the `Vanilla.RootCategory.DisplayAs` config key, defaulting to "Categories" (Nested).

Closes #4790 