### PR TITLE
Add parent-relative redirect after editing a category

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -669,7 +669,8 @@ class VanillaSettingsController extends Gdn_Controller {
                 $this->setData('Category', $Category);
 
                 if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
-                    redirect('vanilla/settings/categories');
+                    $destination = $this->categoryPageByParent($parentCategory);
+                    redirect($destination);
                 } elseif ($this->deliveryType() === DELIVERY_TYPE_DATA && method_exists($this, 'getCategory')) {
                     $this->Data = [];
                     $this->getCategory($CategoryID);
@@ -760,6 +761,38 @@ class VanillaSettingsController extends Gdn_Controller {
         require_once $this->fetchViewLocation('category-settings-functions');
         $this->addAsset('Content', $this->fetchView('symbols'));
         $this->render();
+    }
+
+    /**
+     * Move through the category's parents to determine the proper management page URL.
+     *
+     * @param array|object $category
+     * @return string
+     */
+    private function categoryPageByParent($category) {
+        $default = 'vanilla/settings/categories';
+        $parentID = val('ParentCategoryID', $category);
+
+        if ($parentID === -1) {
+            return $default;
+        }
+
+        $parent = CategoryModel::categories($parentID);
+        if (!$parent) {
+            return $default;
+        }
+
+        switch (val('DisplayAs', $parent)) {
+            case 'Categories':
+            case 'Flat':
+                $urlCode = val('UrlCode', $parent);
+                return "vanilla/settings/categories?parent={$urlCode}";
+            case 'Discussions':
+            case 'Heading':
+                return $this->categoryPageByParent($parent);
+            default:
+                return $default;
+        }
     }
 
     /**


### PR DESCRIPTION
This update alters the way editing a category works.  When a category is saved, its parents are checked to determine which management page the user should be redirected to: the root list or a parent's subset of categories.

The following rules are used:

* If the parent is the root, redirect to the root page.
* If the parent is configured to display as flat/nested, redirect to that category's subset.
* If the parent is heading/discussions, check another level higher.
* If all else fails, go to the root page.

Closes #4794