### PR TITLE
Drop attribute "type" for style tags

### DIFF
--- a/applications/dashboard/views/email/email-basic.tpl
+++ b/applications/dashboard/views/email/email-basic.tpl
@@ -6,7 +6,7 @@
 <!--<![endif]--><meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!--[if (gte mso 9)|(IE)]>
     {literal}
-    <style type="text/css">
+    <style>
         table {
             border-collapse: collapse;
         }

--- a/applications/dashboard/views/email/email-basic.tpl
+++ b/applications/dashboard/views/email/email-basic.tpl
@@ -6,7 +6,7 @@
 <!--<![endif]--><meta name="viewport" content="width=device-width, initial-scale=1.0">
 <!--[if (gte mso 9)|(IE)]>
     {literal}
-    <style>
+    <style type="text/css">
         table {
             border-collapse: collapse;
         }

--- a/applications/dashboard/views/email/src/email-basic.php
+++ b/applications/dashboard/views/email/src/email-basic.php
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <!--<![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
+    <style type="text/css">
         body * {
             margin: 0;
             padding: 0;

--- a/applications/dashboard/views/email/src/email-basic.php
+++ b/applications/dashboard/views/email/src/email-basic.php
@@ -192,7 +192,7 @@
     </style>
     <!--[if (gte mso 9)|(IE)]>
     [[literal]]
-    <style>
+    <style type="text/css">
         table {
             border-collapse: collapse;
         }

--- a/applications/dashboard/views/email/src/email-basic.php
+++ b/applications/dashboard/views/email/src/email-basic.php
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <!--<![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style type="text/css">
+    <style>
         body * {
             margin: 0;
             padding: 0;
@@ -192,7 +192,7 @@
     </style>
     <!--[if (gte mso 9)|(IE)]>
     [[literal]]
-    <style type="text/css">
+    <style>
         table {
             border-collapse: collapse;
         }

--- a/applications/dashboard/views/email/src/email-basic.php
+++ b/applications/dashboard/views/email/src/email-basic.php
@@ -192,7 +192,7 @@
     </style>
     <!--[if (gte mso 9)|(IE)]>
     [[literal]]
-    <style type="text/css">
+    <style>
         table {
             border-collapse: collapse;
         }

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -784,7 +784,7 @@ class DiscussionController extends VanillaController {
 
         // Add some css to help with the transparent bg on embedded comments
         if ($this->Head) {
-            $this->Head->addString('<style type="text/css">
+            $this->Head->addString('<style>
 body { background: transparent !important; }
 </style>');
         }

--- a/container.html
+++ b/container.html
@@ -126,7 +126,7 @@
             }
         });
     </script>
-    <style type="text/css">
+    <style>
         html, body {
             background-color: transparent;
             overflow: hidden;


### PR DESCRIPTION
Vanilla uses html5 and in html5 the default type is "text/css". Based on [that information](http://www.w3schools.com/tags/att_style_type.asp), this type is the only supported type anyway. So even if browsers wouldn't be compatible with html5, they would treat a simple `<style>` tag correctly.