### PR TITLE
Remove "type" attribute from script tags

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -351,13 +351,6 @@ class EntryController extends Gdn_Controller {
                 redirectUrl($Url, 302);
             } else {
                 $this->setData('Url', $Url);
-                $Script = <<<EOT
-<script type="text/javascript">
-   window.location = "$Url";
-</script>
-EOT;
-
-
                 $this->render('Redirect', 'Utility');
                 die();
             }

--- a/applications/dashboard/views/entry/signout.php
+++ b/applications/dashboard/views/entry/signout.php
@@ -13,7 +13,7 @@ $Session = Gdn::session();
 
             <?php if ($Session->isValid()) { ?>
                 <p id="SignoutWrap">
-                    <script language="javascript">
+                    <script>
                         jQuery(document).ready(function($) {
                             var url = $('#SignoutLink').attr('href');
                             if (url) {

--- a/applications/dashboard/views/settings/homepage.php
+++ b/applications/dashboard/views/settings/homepage.php
@@ -39,7 +39,7 @@ function writeHomepageOption($Title, $Url, $iconName, $Current, $Description = '
 
 ?>
     <h1><?php echo t('Homepage'); ?></h1>
-    <script type="text/javascript">
+    <script>
         jQuery(document).ready(function($) {
 
             $('.HomeOptions a').click(function() {

--- a/applications/dashboard/views/user/ban.php
+++ b/applications/dashboard/views/user/ban.php
@@ -1,5 +1,5 @@
 <?php if (!defined('APPLICATION')) return; ?>
-<script language="javascript">
+<script>
     jQuery(document).ready(function($) {
         $('#Form_ReasonText').focus(function() {
             $('#Form_Reason2').prop('checked', true);

--- a/themes/mobile/class.mobilethemehooks.php
+++ b/themes/mobile/class.mobilethemehooks.php
@@ -38,7 +38,7 @@ class MobileThemeHooks implements Gdn_IPlugin {
         if (isMobile() && is_object($Sender->Head)) {
             $Sender->Head->addTag('meta', array('name' => 'viewport', 'content' => "width=device-width,minimum-scale=1.0,maximum-scale=1.0"));
             $Sender->Head->addString('
-<script type="text/javascript">
+<script>
    // If not looking for a specific comment, hide the address bar in iphone
    var hash = window.location.href.split("#")[1];
    if (typeof(hash) == "undefined") {
@@ -129,7 +129,7 @@ class MobileThemeHooks implements Gdn_IPlugin {
         // Make sure that discussion clicks (anywhere in a discussion row) take the user to the discussion.
         if (property_exists($Sender, 'Head') && is_object($Sender->Head)) {
             $Sender->Head->addString('
-<script type="text/javascript">
+<script>
    jQuery(document).ready(function($) {
       $("ul.DataList li.Item").click(function() {
          var href = $(this).find(".Title a").attr("href");


### PR DESCRIPTION
Vanilla uses html5 and in html5 the type="text/javascript" is optional.
Also removed an unused `$Script` variable definition from applications/dashboard/controllers/class.entrycontroller.php