### PR TITLE
Make manage categories respect Vanilla.RootCategory.DisplayAs

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -723,17 +723,17 @@ class VanillaSettingsController extends Gdn_Controller {
             $this->setData('Category', $categoryRow);
             $parentID = $categoryRow['CategoryID'];
             $parentDisplayAs = val('DisplayAs', $categoryRow);
-
-            if (in_array($parentDisplayAs, ['Flat'])) {
-                $allowSorting = false;
-                $usePagination = true;
-            }
         } else {
             $parentID = -1;
-            $parentDisplayAs = false;
+            $parentDisplayAs = CategoryModel::getRootDisplayAs();
         }
 
-        if ($parentID > 0 && $parentDisplayAs === 'Flat') {
+        if (in_array($parentDisplayAs, ['Flat'])) {
+            $allowSorting = false;
+            $usePagination = true;
+        }
+
+        if ($parentDisplayAs === 'Flat') {
             $categories = $this->CategoryModel->getTreeAsFlat($parentID, $offset, $limit);
         } else {
             $categories = $collection->getTree($parentID, ['maxdepth' => 10, 'collapsecategories' => true]);


### PR DESCRIPTION
A new config setting was introduced in https://github.com/vanilla/vanilla/pull/4800 which will allow us to control how the root category is displayed.  Specifically, this config allows the root to display as a flat category.

This update alters the way the category management page works.  Now, when `Vanilla.RootCategory.DisplayAs` is configured to be "Flat", the page will show top-level categories in the flat category format.

Closes #4791 