### PR TITLE
Stop CookieIdentity from deleting nonexistent cookies

### DIFF
--- a/library/core/class.cookieidentity.php
+++ b/library/core/class.cookieidentity.php
@@ -348,6 +348,10 @@ class Gdn_CookieIdentity {
      * @param $CookieName
      */
     protected function _deleteCookie($CookieName) {
+        if (!array_key_exists($CookieName, $_COOKIE)) {
+            return;
+        }
+
         unset($_COOKIE[$CookieName]);
         self::deleteCookie($CookieName, $this->CookiePath, $this->CookieDomain);
     }


### PR DESCRIPTION
`Gdn_CookieIdentity` attempts to delete cookies, even if they do not exist.  This can be problematic, as documented in https://github.com/vanilla/vanilla/issues/4797

This update alters `Gdn_CookieIdentity::_deleteCookie` to check for a cookie's existence before attempting to remove it.

Closes #4807
