### PR TITLE
Ensure $newUpload always set in SettingsController::defaultAvatar

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -274,6 +274,7 @@ class SettingsController extends DashboardController {
         } else if ($this->Form->save() !== false) {
             $upload = new Gdn_UploadImage();
             $newAvatar = false;
+            $newUpload = false;
             if ($tmpAvatar = $upload->validateUpload('DefaultAvatar', false)) {
                 // New upload
                 $newUpload = true;


### PR DESCRIPTION
This update is a minor fix to soothe Scrutnizer.