### PR TITLE
Support headings when writing a category table

### DIFF
--- a/applications/vanilla/views/categories/flat_table.php
+++ b/applications/vanilla/views/categories/flat_table.php
@@ -1,27 +1,14 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
     <h1 class="H HomepageTitle"><?php echo $this->data('Title'); ?></h1>
-    <div class="P PageDescription"><?php echo $this->Description(); ?></div>
+    <div class="P PageDescription"><?php echo $this->description(); ?></div>
 <?php
 $this->fireEvent('AfterDescription');
 $this->fireEvent('AfterPageTitle');
-$Categories = $this->data('CategoryTree');
+$categories = $this->data('CategoryTree');
 
-if (c('Vanilla.Categories.DoHeadings')) {
-    foreach ($Categories as $Category) {
-        ?>
-        <div id="CategoryGroup-<?php echo $Category['UrlCode']; ?>"
-             class="CategoryGroup <?php echo val('CssClass', $Category); ?>">
-            <h2 class="H"><?php echo htmlspecialchars($Category['Name']); ?></h2>
-            <?php
-            WriteCategoryTable($Category['Children'], 2);
-            ?>
-        </div>
-    <?php
-    }
-} else {
-    WriteCategoryTable($Categories, 1);
-}
+writeCategoryTable($categories, 1);
+
 ?>
-    <div class="PageControls Bottom">
-        <?php PagerModule::write(); ?>
-    </div>
+<div class="PageControls Bottom">
+    <?php PagerModule::write(); ?>
+</div>

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -345,13 +345,13 @@ if (!function_exists('WriteCategoryList')):
     }
 endif;
 
-if (!function_exists('WriteCategoryTable')):
-    function writeCategoryTable($Categories, $Depth = 1, $inTable = false, $inSection = false) {
-        foreach ($Categories as $Category) {
-            $displayAs = val('DisplayAs', $Category);
-            $urlCode = $Category['UrlCode'];
-            $class = val('CssClass', $Category);
-            $name = htmlspecialchars($Category['Name']);
+if (!function_exists('writeCategoryTable')):
+    function writeCategoryTable($categories, $depth = 1, $inTable = false, $inSection = false) {
+        foreach ($categories as $category) {
+            $displayAs = val('DisplayAs', $category);
+            $urlCode = $category['UrlCode'];
+            $class = val('CssClass', $category);
+            $name = htmlspecialchars($category['Name']);
 
             if ($displayAs === 'Heading') :
                 if ($inTable) {
@@ -363,18 +363,18 @@ if (!function_exists('WriteCategoryTable')):
                 <div id="CategoryGroup-<?php echo $urlCode; ?>" class="CategoryGroup <?php echo $class; ?>">
                 <h2 class="H"><?php echo $name; ?></h2>
                 <?php
-                writeCategoryTable($Category['Children'], $Depth + 1, $inTable, $inSection);
+                writeCategoryTable($category['Children'], $depth + 1, $inTable, $inSection);
             else :
                 if (!$inTable) { ?>
                     <div class="DataTableWrap">
                         <table class="DataTable CategoryTable">
                             <thead>
-                            <?php WriteTableHead(); ?>
+                            <?php writeTableHead(); ?>
                             </thead>
                             <tbody>
                     <?php $inTable = true;
                 }
-                WriteTableRow($Category, $Depth);
+                writeTableRow($category, $depth);
             endif;
         }
         if ($inTable) {

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -346,25 +346,42 @@ if (!function_exists('WriteCategoryList')):
 endif;
 
 if (!function_exists('WriteCategoryTable')):
+    function writeCategoryTable($Categories, $Depth = 1, $inTable = false, $inSection = false) {
+        foreach ($Categories as $Category) {
+            $displayAs = val('DisplayAs', $Category);
+            $urlCode = $Category['UrlCode'];
+            $class = val('CssClass', $Category);
+            $name = htmlspecialchars($Category['Name']);
 
-    function writeCategoryTable($Categories, $Depth = 1) {
-        ?>
-        <div class="DataTableWrap">
-            <table class="DataTable CategoryTable">
-                <thead>
-                <?php
-                WriteTableHead();
-                ?>
-                </thead>
-                <tbody>
-                <?php
-                foreach ($Categories as $Category) {
-                    WriteTableRow($Category, $Depth);
+            if ($displayAs === 'Heading') :
+                if ($inTable) {
+                    echo '</tbody></table></div>';
+                    $inTable = false;
                 }
+                $inSection = true;
                 ?>
-                </tbody>
-            </table>
-        </div>
-    <?php
+                <div id="CategoryGroup-<?php echo $urlCode; ?>" class="CategoryGroup <?php echo $class; ?>">
+                <h2 class="H"><?php echo $name; ?></h2>
+                <?php
+                writeCategoryTable($Category['Children'], $Depth + 1, $inTable, $inSection);
+            else :
+                if (!$inTable) { ?>
+                    <div class="DataTableWrap">
+                        <table class="DataTable CategoryTable">
+                            <thead>
+                            <?php WriteTableHead(); ?>
+                            </thead>
+                            <tbody>
+                    <?php $inTable = true;
+                }
+                WriteTableRow($Category, $Depth);
+            endif;
+        }
+        if ($inTable) {
+            echo '</tbody></table></div>';
+        }
+        if ($inSection) {
+            echo '</div>';
+        }
     }
 endif;

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -346,7 +346,7 @@ if (!function_exists('WriteCategoryList')):
 endif;
 
 if (!function_exists('writeCategoryTable')):
-    function writeCategoryTable($categories, $depth = 1, $inTable = false, $inSection = false) {
+    function writeCategoryTable($categories, $depth = 1, $inTable = false) {
         foreach ($categories as $category) {
             $displayAs = val('DisplayAs', $category);
             $urlCode = $category['UrlCode'];
@@ -358,12 +358,12 @@ if (!function_exists('writeCategoryTable')):
                     echo '</tbody></table></div>';
                     $inTable = false;
                 }
-                $inSection = true;
                 ?>
                 <div id="CategoryGroup-<?php echo $urlCode; ?>" class="CategoryGroup <?php echo $class; ?>">
-                <h2 class="H"><?php echo $name; ?></h2>
+                    <h2 class="H"><?php echo $name; ?></h2>
+                    <?php writeCategoryTable($category['Children'], $depth + 1, $inTable); ?>
+                </div>
                 <?php
-                writeCategoryTable($category['Children'], $depth + 1, $inTable, $inSection);
             else :
                 if (!$inTable) { ?>
                     <div class="DataTableWrap">
@@ -379,9 +379,6 @@ if (!function_exists('writeCategoryTable')):
         }
         if ($inTable) {
             echo '</tbody></table></div>';
-        }
-        if ($inSection) {
-            echo '</div>';
         }
     }
 endif;

--- a/applications/vanilla/views/categories/table.php
+++ b/applications/vanilla/views/categories/table.php
@@ -5,5 +5,5 @@
 $this->fireEvent('AfterDescription');
 $this->fireEvent('AfterPageTitle');
 $categories = $this->data('CategoryTree');
-writeCategoryTable($Categories);
+writeCategoryTable($categories);
 ?>

--- a/applications/vanilla/views/categories/table.php
+++ b/applications/vanilla/views/categories/table.php
@@ -1,24 +1,9 @@
 <?php if (!defined('APPLICATION')) return; ?>
     <h1 class="H HomepageTitle"><?php echo $this->data('Title'); ?></h1>
-    <div class="P PageDescription"><?php echo $this->Description(); ?></div>
+    <div class="P PageDescription"><?php echo $this->description(); ?></div>
 <?php
 $this->fireEvent('AfterDescription');
 $this->fireEvent('AfterPageTitle');
-$Categories = $this->data('CategoryTree');
-
-if (c('Vanilla.Categories.DoHeadings')) {
-    foreach ($Categories as $Category) {
-        ?>
-        <div id="CategoryGroup-<?php echo $Category['UrlCode']; ?>"
-             class="CategoryGroup <?php echo val('CssClass', $Category); ?>">
-            <h2 class="H"><?php echo htmlspecialchars($Category['Name']); ?></h2>
-            <?php
-            WriteCategoryTable($Category['Children'], 2);
-            ?>
-        </div>
-    <?php
-    }
-} else {
-    WriteCategoryTable($Categories, 1);
-}
+$categories = $this->data('CategoryTree');
+writeCategoryTable($Categories);
 ?>


### PR DESCRIPTION
The only way to get a table-view category list to display headings is to use the `Vanilla.Categories.DoHeadings` config setting. This rewrites the writeCategoryTable function to respect a category's `DisplayAs: Headings` property and render in the same way as they did with `Vanilla.Categories.DoHeadings` on.

Partially addresses: https://github.com/vanilla/vanilla/issues/4547