### PR TITLE
Expose the constructor of Gdn_Request

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -61,9 +61,9 @@ class Gdn_Request {
     protected $_RequestArguments;
 
     /**
-     *
+     * Instantiate a new instance of the {@link Gdn_Request} class.
      */
-    private function __construct() {
+    public function __construct() {
         $this->reset();
     }
 


### PR DESCRIPTION
The bootstrap installs a request that is created with Gdn_Request::create() which just creates a new instance. Allowing other code to create new Gdn_Request objects normally is not too much to ask.