### PR TITLE
Check DisplayAs for Heading check rather than config

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -737,7 +737,6 @@ class CategoryModel extends Gdn_Model {
     public static function getByPermission($Permission = 'Discussions.Add', $CategoryID = null, $Filter = array(), $PermFilter = array()) {
         static $Map = array('Discussions.Add' => 'PermsDiscussionsAdd', 'Discussions.View' => 'PermsDiscussionsView');
         $Field = $Map[$Permission];
-        $DoHeadings = c('Vanilla.Categories.DoHeadings');
         $PermFilters = array();
 
         $Result = array();
@@ -777,7 +776,7 @@ class CategoryModel extends Gdn_Model {
                     continue;
                 }
 
-                if ($DoHeadings && $Category['Depth'] <= 1) {
+                if ($Category['DisplayAs'] == 'Heading') {
                     if ($Permission == 'Discussions.Add') {
                         continue;
                     } else {
@@ -1145,7 +1144,6 @@ class CategoryModel extends Gdn_Model {
      */
     public static function joinUserData(&$Categories, $AddUserCategory = true) {
         $IDs = array_keys($Categories);
-        $DoHeadings = c('Vanilla.Categories.DoHeadings');
 
         if ($AddUserCategory) {
             $UserData = self::instance()->getUserCategories();
@@ -1173,7 +1171,7 @@ class CategoryModel extends Gdn_Model {
                 $Categories[$ID]['Following'] = $Following;
 
                 // Calculate the read field.
-                if ($DoHeadings && $Category['Depth'] <= 1) {
+                if ($Category['DisplayAs'] == 'Heading') {
                     $Categories[$ID]['Read'] = false;
                 } elseif ($DateMarkedRead) {
                     if (val('LastDateInserted', $Category)) {


### PR DESCRIPTION
By this point, DisplayAs has been calculated so we can safely check the DisplayAs setting instead of checking config and depth.

Partially addresses https://github.com/vanilla/vanilla/issues/4547