### PR TITLE
Allow Vanilla to composer install without gd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
         "phpmailer/phpmailer": "~5.2",
         "container-interop/container-interop": "^1.1"
     },
+    "provide": {
+        "ext-gd": "*"
+    },
     "autoload": {
         "classmap": [
             "library/core/",


### PR DESCRIPTION
Vanilla can sometimes be used as purely an API. In this case it doesn’t need GD, but won’t install because chrisjean/php-ico requires it.