### PR TITLE
Redirect default Vanilla settings page to new category management

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -159,8 +159,7 @@ class VanillaSettingsController extends Gdn_Controller {
      * @access public
      */
     public function index() {
-        $this->View = 'managecategories';
-        $this->ManageCategories();
+        redirect('/vanilla/settings/categories');
     }
 
     /**


### PR DESCRIPTION
`VanillaSettingsController::index` currently just calls the old category management page.

This update redirects `/vanilla/settings` requests to `/vanilla/settings/categories`.