### PR TITLE
Contain DoHeadings logic for DisplayAs calculations in Category Model

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -221,11 +221,6 @@ class CategoriesController extends VanillaController {
                 case 'Flat':
                 case 'Heading':
                 case 'Categories':
-                    if (val('Depth', $Category) > CategoryModel::instance()->getNavDepth()) {
-                        // Headings don't make sense if we've cascaded down one level.
-                        saveToConfig('Vanilla.Categories.DoHeadings', false, false);
-                    }
-
                     if ($this->SyndicationMethod != SYNDICATION_NONE) {
                         // RSS can't show a category list so just tell it to expand all categories.
                         saveToConfig('Vanilla.ExpandCategories', true, false);
@@ -442,12 +437,6 @@ class CategoriesController extends VanillaController {
             $this->categoriesCompatibilityCallback = function () {
                 return $this->CategoryModel->GetFull()->resultArray();
             };
-        }
-
-        // Compensate for categories displaying as headings by increasing the display depth by one.
-        $maxDisplayDepth = CategoryModel::instance()->getMaxDisplayDepth() ?: 10;
-        if (c('Vanilla.Categories.DoHeadings')) {
-            $maxDisplayDepth++;
         }
 
         $categoryTree = $this->CategoryModel

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -704,15 +704,7 @@ class CategoryCollection {
 //            $category['PhotoUrl'] = '';
 //        }
 
-        if ($category['DisplayAs'] == 'Default') {
-            if ($category['Depth'] <= $this->config('Vanilla.Categories.NavDepth', 0)) {
-                $category['DisplayAs'] = 'Categories';
-            } elseif ($category['Depth'] == ($this->config('Vanilla.Categories.NavDepth', 0) + 1) && $this->config('Vanilla.Categories.DoHeadings')) {
-                $category['DisplayAs'] = 'Heading';
-            } else {
-                $category['DisplayAs'] = 'Discussions';
-            }
-        }
+        CategoryModel::calculateDisplayAs($category);
 
         if (!val('CssClass', $category)) {
             $category['CssClass'] = 'Category-'.$category['UrlCode'];

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -414,6 +414,14 @@ class CategoryModel extends Gdn_Model {
         }
     }
 
+    /**
+     * Maintains backwards compatibilty with `DisplayAs: Default`-type categories by calculating the DisplayAs property
+     * into an expected DisplayAs type: Categories, Heading, or Discussions. Respects the now-deprecated config setting
+     * `Vanilla.Categories.DoHeadings`. Once we can be sure that all instances have their categories' DisplayAs
+     * properties explicitly set in the database (i.e., not `Default`) we can deprecate/remove this function.
+     *
+     * @param $category The category to calculate the DisplayAs property for.
+     */
     public static function calculateDisplayAs(&$category) {
         if ($category['DisplayAs'] === 'Default') {
             if ($category['Depth'] <= c('Vanilla.Categories.NavDepth', 0)) {
@@ -425,9 +433,11 @@ class CategoryModel extends Gdn_Model {
             }
         }
 
-        if (val('Depth', $category) > self::instance()->getNavDepth() && $category['DisplayAs'] == 'Heading') {
+        if ($category['DisplayAs'] == 'Heading' && val('Depth', $category) > self::instance()->getNavDepth()) {
             // Headings don't make sense if we've cascaded down a level.
-            saveToConfig('Vanilla.Categories.DoHeadings', false, false);
+            if (c('Vanilla.Categories.DoHeadings')) {
+                saveToConfig('Vanilla.Categories.DoHeadings', false, false);
+            }
         }
     }
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -403,6 +403,18 @@ class CategoryModel extends Gdn_Model {
             $category['PhotoUrl'] = '';
         }
 
+        self::calculateDisplayAs($category);
+
+        if (!val('CssClass', $category)) {
+            $category['CssClass'] = 'Category-'.$category['UrlCode'];
+        }
+
+        if (isset($category['AllowedDiscussionTypes']) && is_string($category['AllowedDiscussionTypes'])) {
+            $category['AllowedDiscussionTypes'] = dbdecode($category['AllowedDiscussionTypes']);
+        }
+    }
+
+    public static function calculateDisplayAs(&$category) {
         if ($category['DisplayAs'] === 'Default') {
             if ($category['Depth'] <= c('Vanilla.Categories.NavDepth', 0)) {
                 $category['DisplayAs'] = 'Categories';
@@ -413,12 +425,9 @@ class CategoryModel extends Gdn_Model {
             }
         }
 
-        if (!val('CssClass', $category)) {
-            $category['CssClass'] = 'Category-'.$category['UrlCode'];
-        }
-
-        if (isset($category['AllowedDiscussionTypes']) && is_string($category['AllowedDiscussionTypes'])) {
-            $category['AllowedDiscussionTypes'] = dbdecode($category['AllowedDiscussionTypes']);
+        if (val('Depth', $category) > self::instance()->getNavDepth() && $category['DisplayAs'] == 'Heading') {
+            // Headings don't make sense if we've cascaded down a level.
+            saveToConfig('Vanilla.Categories.DoHeadings', false, false);
         }
     }
 


### PR DESCRIPTION
* Removes unused $maxDisplayDepth variable from Categories Controller. 

* Moves the logic for temporarily saving the DoHeadings config to the model where DisplayAs is calculated.

* Moves the DisplayAs calculation into its own function.

Partially addresses https://github.com/vanilla/vanilla/issues/4547