### PR TITLE
Fix dashboardSymbol call in log/edit

### DIFF
--- a/applications/dashboard/views/log/table.php
+++ b/applications/dashboard/views/log/table.php
@@ -104,7 +104,7 @@ include $this->fetchViewLocation('helper_functions');
                     <?php
                     if ($Url) {
                         $attr = ['title' => t('View Post'), 'aria-label' => t('View Post'), 'class' => 'btn btn-icon btn-icon-sm'];
-                        echo anchor(dashboardSymbol('external-link', '', 'icon icon-text'), $Url, '', $attr);
+                        echo anchor(dashboardSymbol('external-link', 'icon icon-text'), $Url, '', $attr);
                     }
                     ?>
                 </td>


### PR DESCRIPTION
dashboardSymbol was refactored, but the call in log/edit was missed.