### PR TITLE
Add user count to roles page

### DIFF
--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -230,9 +230,23 @@ class RoleController extends DashboardController {
 
         // Grab the total users for each role.
         if (is_array($this->data('Roles'))) {
+            $pastThreshold = Gdn::userModel()->pastUserMegaThreshold();
+            $thresholdTypeExceptions = [
+                'administrator',
+                'moderator',
+                'applicant',
+                'unconfirmed',
+                'guest'
+            ];
             $roles = $this->data('Roles');
             foreach ($roles as &$role) {
-                $role['CountUsers'] = $this->RoleModel->getUserCount($role['RoleID']);
+                if ($pastThreshold && !in_array($role['Type'], $thresholdTypeExceptions)) {
+                    $countUsers = '-';
+                } else {
+                    $countUsers = $this->RoleModel->getUserCount($role['RoleID']);
+                }
+
+                $role['CountUsers'] = $countUsers;
             }
             $this->setData('Roles', $roles);
         }

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -228,6 +228,13 @@ class RoleController extends DashboardController {
             $this->setData('Roles', [$Role]);
         }
 
+        // Grab the total users for each role.
+        if (is_array($this->data('Roles'))) {
+            foreach ($this->data('Roles') as &$role) {
+                $role['CountUsers'] = $this->RoleModel->getUserCount($role['RoleID']);
+            }
+        }
+
         $this->render();
     }
 

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -230,9 +230,11 @@ class RoleController extends DashboardController {
 
         // Grab the total users for each role.
         if (is_array($this->data('Roles'))) {
-            foreach ($this->data('Roles') as &$role) {
+            $roles = $this->data('Roles');
+            foreach ($roles as &$role) {
                 $role['CountUsers'] = $this->RoleModel->getUserCount($role['RoleID']);
             }
+            $this->setData('Roles', $roles);
         }
 
         $this->render();

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -231,13 +231,9 @@ class RoleController extends DashboardController {
         // Grab the total users for each role.
         if (is_array($this->data('Roles'))) {
             $pastThreshold = Gdn::userModel()->pastUserMegaThreshold();
-            $thresholdTypeExceptions = [
-                'administrator',
-                'moderator',
-                'applicant',
-                'unconfirmed',
-                'guest'
-            ];
+            $thresholdTypeExceptions = RoleModel::getDefaultTypes();
+            unset($thresholdTypeExceptions[RoleModel::TYPE_MEMBER]);
+
             $roles = $this->data('Roles');
             foreach ($roles as &$role) {
                 if ($pastThreshold && !in_array($role['Type'], $thresholdTypeExceptions)) {

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -241,7 +241,7 @@ class RoleController extends DashboardController {
             $roles = $this->data('Roles');
             foreach ($roles as &$role) {
                 if ($pastThreshold && !in_array($role['Type'], $thresholdTypeExceptions)) {
-                    $countUsers = '-';
+                    $countUsers = t('View');
                 } else {
                     $countUsers = $this->RoleModel->getUserCount($role['RoleID']);
                 }

--- a/applications/dashboard/views/role/index.php
+++ b/applications/dashboard/views/role/index.php
@@ -23,6 +23,7 @@ echo $this->Form->open();
             <th><?php echo t('Role'); ?></th>
             <th class="column-xl"><?php echo t('Description'); ?></th>
             <th><?php echo t('Default Type'); ?></th>
+            <th><?php echo t('Users'); ?></th>
             <th class="options column-sm"></th>
         </tr>
         </thead>
@@ -44,6 +45,7 @@ echo $this->Form->open();
                         echo t(val('Type', $Role));
                     } ?>
                 </td>
+                <td><?php echo anchor($Role['CountUsers'] ?: 0, '/dashboard/user?Filter='.urlencode($Role['Name'])); ?></td>
                 <td class="options">
                     <div class="btn-group">
                     <?php


### PR DESCRIPTION
This update adds a column to the roles dashboard page: Users.  This column displays the total number of users in the role, along with a link to the user search page, pre-populated with the criteria to search for users of that role.

Closes #2316 