### PR TITLE
Add event before translating

### DIFF
--- a/library/core/class.locale.php
+++ b/library/core/class.locale.php
@@ -355,6 +355,10 @@ class Gdn_Locale extends Gdn_Pluggable {
             }
         }
 
+        $this->EventArguments['Code'] = $Code;
+        $this->EventArguments['Default'] = $Default;
+        $this->fireEvent('BeforeTranslate');
+
         return $Translation;
     }
 


### PR DESCRIPTION
Adds an event before returning a translated string.