### PR TITLE
Fix Profile Extender checkbox display on registration

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -94,7 +94,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
                 $Sender->RegistrationFields[$Name] = $Field;
             }
         }
-        include_once $Sender->fetchViewLocation('registrationfields', '', 'plugins/ProfileExtender');
+        include $Sender->fetchViewLocation('registrationfields', '', 'plugins/ProfileExtender');
     }
 
     /**
@@ -108,7 +108,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
                 $Sender->RegistrationFields[$Name] = $Field;
             }
         }
-        include_once $Sender->fetchViewLocation('registrationfields', '', 'plugins/ProfileExtender');
+        include $Sender->fetchViewLocation('registrationfields', '', 'plugins/ProfileExtender');
     }
 
     /**


### PR DESCRIPTION
Profile Extender uses `include_once` for its registration page controls.  When the first is executed, used for non-checkbox fields, it ensures the second, used for checkbox fields, is not.

This update swaps out the `include_once` calls to `include`.