### PR TITLE
Add Vanilla\Permissions class

### DIFF
--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -172,10 +172,10 @@ class Permissions {
      * @return $this
      */
     public function merge(Permissions $source) {
-        $this->permissions = array_merge_recursive(
+        $this->setPermissions(array_merge_recursive(
             $this->permissions,
             $source->getPermissions()
-        );
+        ));
 
         return $this;
     }

--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @copyright 2009-2016 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla;
+
+class Permissions {
+
+    /** @var array */
+    private $permissions = [];
+
+    /** @var bool */
+    private $isAdmin = false;
+
+    /** @var bool */
+    private $isBanned = false;
+
+    /**
+     * Permissions constructor.
+     *
+     * @param array $permissions
+     */
+    public function __construct($permissions = []) {
+    }
+
+    /**
+     * @param string $permission
+     * @param int|array|null $id
+     */
+    public function add($permission, $id = null) {
+    }
+
+    /**
+     * @param string $permission
+     * @param int|null $id
+     */
+    public function has($permission, $id = null) {
+    }
+
+    /**
+     * @param array $permissions
+     * @param int|null $id
+     */
+    public function hasAll($permissions, $id = null) {
+    }
+
+    /**
+     * @param array $permissions
+     * @param int|null $id
+     */
+    public function hasAny(array $permissions, $id = null) {
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAdmin() {
+        return $this->isAdmin === true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isBanned() {
+        return $this->isBanned === true;
+    }
+
+    /**
+     * @param array $permissions
+     */
+    public function loadAndCompile($permissions) {
+    }
+
+    /**
+     * @param Permissions $permissions
+     */
+    public function merge(Permissions $permissions) {
+    }
+
+    /**
+     * @param string $permission
+     * @param bool|array $value
+     */
+    public function overwrite($permission, $value) {
+    }
+
+    /**
+     * @param $permission
+     * @param int|array|null $id
+     */
+    public function remove($permission, $id = null) {
+    }
+
+
+    /**
+     * @param string $permission
+     * @param bool $value
+     * @param int|array $id
+     */
+    public function set($permission, $value, $id = null) {
+    }
+
+    /**
+     * @param bool $isAdmin
+     * @return $this
+     */
+    public function setAdmin($isAdmin) {
+        $this->isAdmin = ($isAdmin == true);
+        return $this;
+    }
+
+    /**
+     * @param bool $isBanned
+     * @return $this
+     */
+    public function setBanned($isBanned) {
+        $this->isBanned = ($isBanned == true);
+        return $this;
+    }
+}

--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -23,37 +23,101 @@ class Permissions {
      * @param array $permissions
      */
     public function __construct($permissions = []) {
+        $this->setPermissions($permissions);
     }
 
     /**
+     * Add a permission.
+     *
      * @param string $permission
-     * @param int|array|null $id
+     * @param int|array $IDs
+     * @return $this
      */
-    public function add($permission, $id = null) {
+    public function add($permission, $IDs) {
+        if (!is_array($IDs)) {
+            $IDs = [$IDs];
+        }
+
+        foreach ($IDs as $currentID) {
+            if (!is_numeric($currentID)) {
+                throw new \InvalidArgumentException("Invalid ID: {$currentID}");
+            }
+        }
+
+        if (!array_key_exists($permission, $this->permissions) || !is_array($this->permissions[$permission])) {
+            $this->permissions[$permission] = [];
+        }
+
+        $this->permissions[$permission] = array_unique(array_merge($this->permissions[$permission], $IDs));
+
+        return $this;
     }
 
     /**
+     * Grab the current permissions.
+     *
+     * @return array
+     */
+    public function getPermissions() {
+        return $this->permissions;
+    }
+
+    /**
+     * Determine if the permission is present.
+     *
      * @param string $permission
      * @param int|null $id
+     * @return bool
      */
     public function has($permission, $id = null) {
+        if ($id === null) {
+            return (array_search($permission, $this->permissions) !== false);
+        } else {
+            if (array_key_exists($permission, $this->permissions) && is_array($this->permissions[$permission])) {
+                return (array_search($id, $this->permissions[$permission]) !== false);
+            } else {
+                return false;
+            }
+        }
     }
 
     /**
+     * Determine if all of the provided permissions are present.
+     *
      * @param array $permissions
      * @param int|null $id
+     * @return bool
      */
-    public function hasAll($permissions, $id = null) {
+    public function hasAll(array $permissions, $id = null) {
+        foreach ($permissions as $permission) {
+            if ($this->has($permission, $id) === false) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
+     * Determine if any of the provided permissions are present.
+     * 
      * @param array $permissions
      * @param int|null $id
+     * @return bool
      */
     public function hasAny(array $permissions, $id = null) {
+        foreach ($permissions as $permission) {
+            if ($this->has($permission, $id) === true) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
+     * Determine if the admin flag is set.
+     *
      * @return bool
      */
     public function isAdmin() {
@@ -61,6 +125,8 @@ class Permissions {
     }
 
     /**
+     * Determine if the banned flag is set.
+     *
      * @return bool
      */
     public function isBanned() {
@@ -68,18 +134,54 @@ class Permissions {
     }
 
     /**
+     * Compile raw permission rows into a formatted array of granted permissions.
+     *
      * @param array $permissions
+     * @return $this
      */
-    public function loadAndCompile($permissions) {
+    public function compileAndLoad(array $permissions) {
+        foreach ($permissions as $row) {
+            // Store the junction ID, if we have one.
+            $junctionID = array_key_exists('JunctionID', $row) ? $row['JunctionID'] : null;
+
+            // Clear out any non-permission fields.
+            unset(
+                $row['PermissionID'],
+                $row['RoleID'],
+                $row['JunctionTable'],
+                $row['JunctionColumn'],
+                $row['JunctionID']
+            );
+
+            // Iterate through the row's individual permissions.
+            foreach ($row as $permission => $value) {
+                // If the user doesn't have this permission, move on to the next one.
+                if ($value === 0) {
+                    continue;
+                }
+
+                if ($junctionID === null) {
+                    $this->set($permission, true);
+                } else {
+                    $this->add($permission, $junctionID);
+                }
+            }
+        }
+
+        return $this;
     }
 
     /**
+     * Merge in permissions from another instance.
+     *
      * @param Permissions $permissions
      */
     public function merge(Permissions $permissions) {
     }
 
     /**
+     * Set global and all per-category settings for a permission.
+     *
      * @param string $permission
      * @param bool|array $value
      */
@@ -87,22 +189,56 @@ class Permissions {
     }
 
     /**
+     * Remove a permission.
+     *
      * @param $permission
-     * @param int|array|null $id
+     * @param int|array $IDs
+     * @return $this;
      */
-    public function remove($permission, $id = null) {
+    public function remove($permission, $IDs) {
+        if (array_key_exists($permission, $this->permissions)) {
+            if (!is_array($IDs)) {
+                $IDs = [$IDs];
+            }
+
+            foreach ($IDs as $currentID) {
+                if (is_numeric($currentID)) {
+                    $index = array_search($currentID, $this->permissions[$permission]);
+
+                    if ($index !== false) {
+                        unset($this->permissions[$permission][$index]);
+                    }
+                }
+            }
+        }
+
+        return $this;
     }
 
-
     /**
+     * Add a global permission.
+     *
      * @param string $permission
      * @param bool $value
-     * @param int|array $id
+     * @return $this
      */
-    public function set($permission, $value, $id = null) {
+    public function set($permission, $value) {
+        $exists = array_search($permission, $this->permissions);
+
+        if ($value) {
+            if (!$exists) {
+                $this->permissions[] = $permission;
+            }
+        } elseif ($exists) {
+            unset($this->permissions[$permission]);
+        }
+
+        return $this;
     }
 
     /**
+     * Set the admin flag.
+     *
      * @param bool $isAdmin
      * @return $this
      */
@@ -112,11 +248,23 @@ class Permissions {
     }
 
     /**
+     * Set the banned flag.
      * @param bool $isBanned
      * @return $this
      */
     public function setBanned($isBanned) {
         $this->isBanned = ($isBanned == true);
+        return $this;
+    }
+
+    /**
+     * Set the permission array.
+     *
+     * @param array $permissions
+     * @return $this
+     */
+    public function setPermissions(array $permissions) {
+        $this->permissions = $permissions;
         return $this;
     }
 }

--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -1,14 +1,23 @@
 <?php
 /**
  * @copyright 2009-2016 Vanilla Forums Inc.
- * @license GPLv2
+ * @license GNU GPLv2
  */
 
 namespace Vanilla;
 
+/**
+ * Compile, manage and check user permissions.
+ *
+ * @package Vanilla
+ */
 class Permissions {
 
-    /** @var array */
+    /**
+     * Global permissions are stored as numerical indexes.
+     * Per-ID permissions are stored as associative keys. The key is the permission name and the values are the IDs.
+     * @var array
+     */
     private $permissions = [];
 
     /** @var bool */
@@ -29,8 +38,8 @@ class Permissions {
     /**
      * Add a permission.
      *
-     * @param string $permission
-     * @param int|array $IDs
+     * @param string $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View)
+     * @param int|array $IDs One or more IDs of foreign objects (e.g. category IDs)
      * @return $this
      */
     public function add($permission, $IDs) {
@@ -50,7 +59,7 @@ class Permissions {
     /**
      * Compile raw permission rows into a formatted array of granted permissions.
      *
-     * @param array $permissions
+     * @param array $permissions Rows from the Permissions database table.
      * @return $this
      */
     public function compileAndLoad(array $permissions) {
@@ -97,8 +106,8 @@ class Permissions {
     /**
      * Determine if the permission is present.
      *
-     * @param string $permission
-     * @param int|null $id
+     * @param string $permission Permission slug to check the value for (e.g. Vanilla.Discussions.View)
+     * @param int|null $id Foreign object ID to validate the permission against (e.g. a category ID)
      * @return bool
      */
     public function has($permission, $id = null) {
@@ -116,8 +125,8 @@ class Permissions {
     /**
      * Determine if all of the provided permissions are present.
      *
-     * @param array $permissions
-     * @param int|null $id
+     * @param array $permissions Permission slugs to check the value for (e.g. Vanilla.Discussions.View)
+     * @param int|null $id Foreign object ID to validate the permissions against (e.g. a category ID)
      * @return bool
      */
     public function hasAll(array $permissions, $id = null) {
@@ -133,8 +142,8 @@ class Permissions {
     /**
      * Determine if any of the provided permissions are present.
      *
-     * @param array $permissions
-     * @param int|null $id
+     * @param array $permissions Permission slugs to check the value for (e.g. Vanilla.Discussions.View)
+     * @param int|null $id Foreign object ID to validate the permissions against (e.g. a category ID)
      * @return bool
      */
     public function hasAny(array $permissions, $id = null) {
@@ -168,7 +177,7 @@ class Permissions {
     /**
      * Merge in data from another Permissions instance.
      *
-     * @param Permissions $source
+     * @param Permissions $source The source Permissions instance to import permissions from.
      * @return $this
      */
     public function merge(Permissions $source) {
@@ -183,8 +192,8 @@ class Permissions {
     /**
      * Set global or replace per-ID permissions.
      *
-     * @param string $permission
-     * @param bool|array $value
+     * @param string $permission  Permission slug to set the value for (e.g. Vanilla.Discussions.View)
+     * @param bool|array $value A single value for global permissions or an array of foreign object IDs for per-ID permissions.
      * @return $this
      */
     public function overwrite($permission, $value) {
@@ -200,8 +209,8 @@ class Permissions {
     /**
      * Remove a permission.
      *
-     * @param $permission
-     * @param int|array $IDs
+     * @param $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View)
+     * @param int|array $IDs One or more IDs of foreign objects (e.g. category IDs)
      * @return $this;
      */
     public function remove($permission, $IDs) {
@@ -225,8 +234,8 @@ class Permissions {
     /**
      * Add a global permission.
      *
-     * @param string $permission
-     * @param bool $value
+     * @param string $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View)
+     * @param bool $value Toggle value for the permission: true for granted, false for revoked.
      * @return $this
      */
     public function set($permission, $value) {
@@ -246,7 +255,7 @@ class Permissions {
     /**
      * Set the admin flag.
      *
-     * @param bool $isAdmin
+     * @param bool $isAdmin Is the user an administrator?
      * @return $this
      */
     public function setAdmin($isAdmin) {
@@ -256,7 +265,8 @@ class Permissions {
 
     /**
      * Set the banned flag.
-     * @param bool $isBanned
+     *
+     * @param bool $isBanned Is the user banned?
      * @return $this
      */
     public function setBanned($isBanned) {
@@ -267,7 +277,7 @@ class Permissions {
     /**
      * Set the permission array.
      *
-     * @param array $permissions
+     * @param array $permissions A properly-formatted permissions array.
      * @return $this
      */
     public function setPermissions(array $permissions) {

--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -38,12 +38,6 @@ class Permissions {
             $IDs = [$IDs];
         }
 
-        foreach ($IDs as $currentID) {
-            if (!is_numeric($currentID)) {
-                throw new \InvalidArgumentException("Invalid ID: {$currentID}");
-            }
-        }
-
         if (!array_key_exists($permission, $this->permissions) || !is_array($this->permissions[$permission])) {
             $this->permissions[$permission] = [];
         }
@@ -100,7 +94,7 @@ class Permissions {
 
     /**
      * Determine if any of the provided permissions are present.
-     * 
+     *
      * @param array $permissions
      * @param int|null $id
      * @return bool
@@ -172,20 +166,35 @@ class Permissions {
     }
 
     /**
-     * Merge in permissions from another instance.
+     * Merge in data from another Permissions instance.
      *
-     * @param Permissions $permissions
+     * @param Permissions $source
+     * @return $this
      */
-    public function merge(Permissions $permissions) {
+    public function merge(Permissions $source) {
+        $this->permissions = array_merge_recursive(
+            $this->permissions,
+            $source->getPermissions()
+        );
+
+        return $this;
     }
 
     /**
-     * Set global and all per-category settings for a permission.
+     * Set global or replace per-ID permissions.
      *
      * @param string $permission
      * @param bool|array $value
+     * @return $this
      */
     public function overwrite($permission, $value) {
+        if ($value === true || $value === false) {
+            $this->set($permission, $value);
+        } elseif (is_array($value)) {
+            $this->permissions[$permission] = $value;
+        }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This update adds the `Vanilla\Permissions` class, which will serve as a central object for handling permissions.  More detail can be found in the associated issue.

Closes #4828