### PR TITLE
Add label for Google Plus reaction

### DIFF
--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -279,7 +279,7 @@ class GooglePlusPlugin extends Gdn_Plugin {
         $CssClass = 'ReactButton PopupWindow';
 //      }
 
-        echo ' '.anchor(sprite('ReactGooglePlus', 'ReactSprite'), $Url, $CssClass).' ';
+        echo ' '.anchor(sprite('ReactGooglePlus', 'ReactSprite', t('Share on Google+')), $Url, $CssClass).' ';
     }
 
     /**


### PR DESCRIPTION
The Google Plus reaction is missing a label, like the other social reactions.