### PR TITLE
Add ability to hide category permissions when editing a role

### DIFF
--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -13,12 +13,22 @@
  */
 class RoleController extends DashboardController {
 
+    /** @var bool Should categories be hidden when editing a role? */
+    private $hideCategories;
+
     /** @var array Models to automatically instantiate. */
     public $Uses = array('Database', 'Form', 'RoleModel');
 
     /** @var RoleModel */
     public $RoleModel;
 
+    /**
+     * RoleController constructor.
+     */
+    public function __construct() {
+        parent::__construct();
+        $this->hideCategories = c('Vanilla.HideRoleCategoryPermissions', false);
+    }
     /**
      * Set menu path. Automatically run on every use.
      *
@@ -114,8 +124,6 @@ class RoleController extends DashboardController {
         if ($this->title() == '') {
             $this->title(t('Edit Role'));
         }
-
-        $hideCategories = c('Vanilla.HideCategoriesOnRole', false);
 
         $this->setHighlightRoute('dashboard/role');
         $PermissionModel = Gdn::permissionModel();

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -115,7 +115,7 @@ class RoleController extends DashboardController {
             $this->title(t('Edit Role'));
         }
 
-        $showCategories = c('Vanilla.CategoriesOnRoleEdit', true);
+        $hideCategories = c('Vanilla.HideCategoriesOnRole', false);
 
         $this->setHighlightRoute('dashboard/role');
         $PermissionModel = Gdn::permissionModel();
@@ -137,7 +137,7 @@ class RoleController extends DashboardController {
             $Permissions = $PermissionModel->getPermissionsEdit($RoleID ? $RoleID : 0, $LimitToSuffix);
 
             // Should we be filtering out per-category permissions?
-            if (!$showCategories) {
+            if ($hideCategories) {
                 foreach ($Permissions as $key => $fields) {
                     // Verify this is a category permission.
                     if (preg_match('#^Category/PermissionCategoryID/(?<CategoryID>-?\d+)#', $key, $category)) {
@@ -177,7 +177,7 @@ class RoleController extends DashboardController {
 
             // If the form didn't have category permissions, they'll need to be added before saving.
             $permissions = $this->Form->getFormValue('Permission');
-            if (!$showCategories && is_array($permissions)) {
+            if ($hideCategories && is_array($permissions)) {
 
                 // Grab all the per-category permissions for this role and format them for form fields.
                 $permissionModel = new PermissionModel();

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -639,12 +639,10 @@ class PermissionModel extends Gdn_Model {
                     ->orderBy('junc.Sort')
                     ->orderBy('junc.Name');
 
-                if (isset($JuncIDs)) {
-                    if ($limitToDefault) {
-                        $SQL->where("junc.{$JunctionTable}ID", -1);
-                    } else {
-                        $SQL->whereIn("junc.{$JunctionTable}ID", array_column($JuncIDs, "{$JunctionTable}ID"));
-                    }
+                if ($limitToDefault) {
+                    $SQL->where("junc.{$JunctionTable}ID", -1);
+                } elseif (isset($JuncIDs)) {
+                    $SQL->whereIn("junc.{$JunctionTable}ID", array_column($JuncIDs, "{$JunctionTable}ID"));
                 }
             } else {
                 // Here we are getting permissions for all roles.

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -545,6 +545,7 @@ class PermissionModel extends Gdn_Model {
         $Namespaces = $this->GetAllowedPermissionNamespaces();
         $RoleID = val('RoleID', $Where, null);
         $JunctionID = val('JunctionID', $Where, null);
+        $limitToDefault = val('LimitToDefault', $Options);
         $SQL = $this->SQL;
 
         // Load all of the default junction permissions.
@@ -580,7 +581,7 @@ class PermissionModel extends Gdn_Model {
             unset($Row['PermissionID'], $Row['RoleID'], $Row['JunctionTable'], $Row['JunctionColumn'], $Row['JunctionID']);
 
             // If the junction column is not the primary key then we must figure out and limit the permissions.
-            if ($JunctionColumn != $JunctionTable.'ID') {
+            if ($limitToDefault === false && $JunctionColumn != $JunctionTable.'ID') {
                 $JuncIDs = $SQL
                     ->Distinct(true)
                     ->select("p.{$JunctionTable}ID")
@@ -639,7 +640,7 @@ class PermissionModel extends Gdn_Model {
                     ->orderBy('junc.Name');
 
                 if (isset($JuncIDs)) {
-                    if (val('LimitToDefault', $Options)) {
+                    if ($limitToDefault) {
                         $SQL->where("junc.{$JunctionTable}ID", -1);
                     } else {
                         $SQL->whereIn("junc.{$JunctionTable}ID", array_column($JuncIDs, "{$JunctionTable}ID"));

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -600,7 +600,13 @@ class RoleModel extends Gdn_Model {
                 $Permissions = val('Permission', $FormPostValues);
                 $Permissions = $PermissionModel->pivotPermissions($Permissions, array('RoleID' => $RoleID));
             }
-            $PermissionModel->saveAll($Permissions, array('RoleID' => $RoleID));
+
+            $permissionsWhere = ['RoleID' => $RoleID];
+            if (val('IgnoreCategoryPermissions', $FormPostValues)) {
+                // Include the default category permissions when ignoring the rest.
+                $permissionsWhere['JunctionID'] = [null, -1];
+            }
+            $PermissionModel->saveAll($Permissions, $permissionsWhere);
 
             if (Gdn::cache()->activeEnabled()) {
                 // Don't update the user table if we are just using cached permissions.


### PR DESCRIPTION
This update adds a new config value: `Vanilla.HideRoleCategoryPermissions`.  This config controls whether or not the per-category permissions are displayed when editing a role.  More information can be found on the original issue.

Closes #4827 