### PR TITLE
Refactor Gdn_Session permission checking to use Vanilla\Permissions

### DIFF
--- a/applications/dashboard/modules/class.menumodule.php
+++ b/applications/dashboard/modules/class.menumodule.php
@@ -160,14 +160,12 @@ if (!class_exists('MenuModule', false)) {
             $Session_TransientKey = '';
             $Permissions = array();
             $Session = Gdn::session();
-            $HasPermissions = false;
             $Admin = false;
             if ($Session->isValid() === true) {
                 $UserID = $Session->User->UserID;
                 $Username = $Session->User->Name;
                 $Session_TransientKey = $Session->TransientKey();
-                $Permissions = $Session->GetPermissions();
-                $HasPermissions = count($Permissions) > 0;
+                $Permissions = $Session->getPermissionsArray();
                 $Admin = $Session->User->Admin > 0 ? true : false;
             }
 

--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -13,6 +13,9 @@ namespace Vanilla;
  */
 class Permissions {
 
+    /** The "ID" used to specify we should check for global or any per-ID permission. */
+    const ANY = 'any';
+
     /**
      * Global permissions are stored as numerical indexes.
      * Per-ID permissions are stored as associative keys. The key is the permission name and the values are the IDs.
@@ -113,6 +116,10 @@ class Permissions {
     public function has($permission, $id = null) {
         if ($id === null) {
             return (array_search($permission, $this->permissions) !== false);
+        } elseif ($id === self::ANY) {
+            $hasGlobal = $this->has($permission);
+            $hasAnyID = (array_key_exists($permission, $this->permissions) && count($this->permissions[$permission]));
+            return $hasGlobal || $hasAnyID;
         } else {
             if (array_key_exists($permission, $this->permissions) && is_array($this->permissions[$permission])) {
                 return (array_search($id, $this->permissions[$permission]) !== false);

--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -12,10 +12,6 @@ namespace Vanilla;
  * @package Vanilla
  */
 class Permissions {
-
-    /** The "ID" used to specify we should check for global or any per-ID permission. */
-    const ANY = 'any';
-
     /**
      * Global permissions are stored as numerical indexes.
      * Per-ID permissions are stored as associative keys. The key is the permission name and the values are the IDs.
@@ -115,11 +111,7 @@ class Permissions {
      */
     public function has($permission, $id = null) {
         if ($id === null) {
-            return (array_search($permission, $this->permissions) !== false);
-        } elseif ($id === self::ANY) {
-            $hasGlobal = $this->has($permission);
-            $hasAnyID = (array_key_exists($permission, $this->permissions) && count($this->permissions[$permission]));
-            return $hasGlobal || $hasAnyID;
+            return !empty($this->permissions[$permission]) || (array_search($permission, $this->permissions) !== false);
         } else {
             if (array_key_exists($permission, $this->permissions) && is_array($this->permissions[$permission])) {
                 return (array_search($id, $this->permissions[$permission]) !== false);

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -131,7 +131,7 @@ class Gdn_Session {
 
         // Allow wildcard permission checks (e.g. 'any' Category)
         if ($junctionID === 'any') {
-            $junctionID = Vanilla\Permissions::ANY;
+            $junctionID = null;
         }
 
         // Junction (e.g. category) permissions
@@ -153,7 +153,7 @@ class Gdn_Session {
                     return $this->permissions->hasAny($permission);
                 }
             } else {
-                return $this->permissions->has($permission, Vanilla\Permissions::ANY);
+                return $this->permissions->has($permission);
             }
         }
     }

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -129,32 +129,19 @@ class Gdn_Session {
             }
         }
 
-        // Allow wildcard permission checks (e.g. 'any' Category)
-        if ($junctionID === 'any') {
+        if ($junctionID === 'any' || $junctionID == '' || empty($junctionTable) ||
+            c("Garden.Permissions.Disabled.{$junctionTable}")) {
             $junctionID = null;
         }
 
-        // Junction (e.g. category) permissions
-        if ($junctionTable && !c("Garden.Permissions.Disabled.{$junctionTable}")) {
-            if (is_array($permission)) {
-                if ($fullMatch) {
-                    return $this->permissions->hasAll($permission, $junctionID);
-                } else {
-                    return $this->permissions->hasAny($permission, $junctionID);
-                }
+        if (is_array($permission)) {
+            if ($fullMatch) {
+                return $this->permissions->hasAll($permission);
             } else {
-                return $this->permissions->has($permission, $junctionID);
+                return $this->permissions->hasAny($permission);
             }
         } else {
-            if (is_array($permission)) {
-                if ($fullMatch) {
-                    return $this->permissions->hasAll($permission);
-                } else {
-                    return $this->permissions->hasAny($permission);
-                }
-            } else {
-                return $this->permissions->has($permission);
-            }
+            return $this->permissions->has($permission);
         }
     }
 

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -188,12 +188,22 @@ class Gdn_Session {
     }
 
     /**
-     * Returns all "allowed" permissions for the authenticated user in a
-     * one-dimensional array of permission names.
+     * Returns all "allowed" permissions for the authenticated user in a one-dimensional array of permission names.
+     *
+     * @return array
+     * @deprecated We want to make this an accessor for the permissions property.
+     */
+    public function getPermissions() {
+        deprecated('Gdn_Session->getPermissions()', 'Gdn_Session->getPermissionsArray()');
+        return $this->permissions->getPermissions();
+    }
+
+    /**
+     * Returns all "allowed" permissions for the authenticated user in a one-dimensional array of permission names.
      *
      * @return array
      */
-    public function getPermissions() {
+    public function getPermissionsArray() {
         return $this->permissions->getPermissions();
     }
 

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -130,15 +130,9 @@ class Gdn_Session {
         }
 
         // Allow wildcard permission checks (e.g. 'any' Category)
-        if ($JunctionID == 'any') {
-            $JunctionID = '';
-        }
-
         if ($JunctionID === '') {
-            $JunctionID = null;
+            $JunctionID = Vanilla\Permissions::ANY;
         }
-
-        $allPermissions = $this->permissions->getPermissions();
 
         // Junction (e.g. category) permissions
         if ($JunctionTable && !c("Garden.Permissions.Disabled.{$JunctionTable}")) {
@@ -149,12 +143,7 @@ class Gdn_Session {
                     return $this->permissions->hasAny($Permission, $JunctionID);
                 }
             } else {
-                if ($JunctionID !== null) {
-                    return $this->permissions->has($Permission, $JunctionID);
-                } else {
-                    // Backwards-compatible support for a null JunctionID meaning "permission on any ID"
-                    return array_key_exists($Permission, $allPermissions) && count($allPermissions[$Permission]);
-                }
+                return $this->permissions->has($Permission, $JunctionID);
             }
         } else {
             if (is_array($Permission)) {
@@ -164,8 +153,7 @@ class Gdn_Session {
                     return $this->permissions->hasAny($Permission);
                 }
             } else {
-                // Backwards-compatible permission check
-                return $this->permissions->has($Permission) || array_key_exists($Permission, $allPermissions);
+                return $this->permissions->has($Permission, Vanilla\Permissions::ANY);
             }
         }
     }

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -38,6 +38,9 @@ class Gdn_Session {
     /** @var object The current user's transient key. */
     protected $_TransientKey;
 
+    /** @var  Vanilla\Permissions */
+    private $permissions;
+
     /**
      * @var DateTimeZone The current timezone of the user.
      */
@@ -53,6 +56,8 @@ class Gdn_Session {
         $this->_Permissions = array();
         $this->_Preferences = array();
         $this->_TransientKey = false;
+
+        $this->permissions = new Vanilla\Permissions();
     }
 
 

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -109,18 +109,18 @@ class Gdn_Session {
     }
 
     /**
-     * Checks the currently authenticated user's permissions for the specified
-     * permission. Returns a boolean value indicating if the action is
-     * permitted.
+     * Checks the currently authenticated user's permissions for the specified permission.
      *
-     * @param mixed $Permission The permission (or array of permissions) to check.
-     * @param int $JunctionID The JunctionID associated with $Permission (ie. A discussion category identifier).
-     * @param bool $FullMatch If $Permission is an array, $FullMatch indicates if all permissions specified are required. If false, the user only needs one of the specified permissions.
-     * @param string $JunctionTable The name of the junction table for a junction permission.
-     * @param int|string $JunctionID The ID of the junction permission.
-     * @return boolean
+     * Returns a boolean value indicating if the action is permitted.
+     *
+     * @param string|array $permission The permission (or array of permissions) to check.
+     * @param bool $fullMatch If $Permission is an array, $FullMatch indicates if all permissions specified are required.
+     * If false, the user only needs one of the specified permissions.
+     * @param string $junctionTable The name of the junction table for a junction permission.
+     * @param int|string $junctionID The JunctionID associated with $Permission (ie. A discussion category identifier).
+     * @return boolean Returns **true** if the user has permission or **false** otherwise.
      */
-    public function checkPermission($Permission, $FullMatch = true, $JunctionTable = '', $JunctionID = '') {
+    public function checkPermission($permission, $fullMatch = true, $junctionTable = '', $junctionID = '') {
         if (is_object($this->User)) {
             if ($this->User->Banned || val('Deleted', $this->User)) {
                 return false;
@@ -130,30 +130,30 @@ class Gdn_Session {
         }
 
         // Allow wildcard permission checks (e.g. 'any' Category)
-        if ($JunctionID === '') {
-            $JunctionID = Vanilla\Permissions::ANY;
+        if ($junctionID === 'any') {
+            $junctionID = Vanilla\Permissions::ANY;
         }
 
         // Junction (e.g. category) permissions
-        if ($JunctionTable && !c("Garden.Permissions.Disabled.{$JunctionTable}")) {
-            if (is_array($Permission)) {
-                if ($FullMatch) {
-                    return $this->permissions->hasAll($Permission, $JunctionID);
+        if ($junctionTable && !c("Garden.Permissions.Disabled.{$junctionTable}")) {
+            if (is_array($permission)) {
+                if ($fullMatch) {
+                    return $this->permissions->hasAll($permission, $junctionID);
                 } else {
-                    return $this->permissions->hasAny($Permission, $JunctionID);
+                    return $this->permissions->hasAny($permission, $junctionID);
                 }
             } else {
-                return $this->permissions->has($Permission, $JunctionID);
+                return $this->permissions->has($permission, $junctionID);
             }
         } else {
-            if (is_array($Permission)) {
-                if ($FullMatch) {
-                    return $this->permissions->hasAll($Permission);
+            if (is_array($permission)) {
+                if ($fullMatch) {
+                    return $this->permissions->hasAll($permission);
                 } else {
-                    return $this->permissions->hasAny($Permission);
+                    return $this->permissions->hasAny($permission);
                 }
             } else {
-                return $this->permissions->has($Permission, Vanilla\Permissions::ANY);
+                return $this->permissions->has($permission, Vanilla\Permissions::ANY);
             }
         }
     }

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -129,7 +129,7 @@ class Gdn_Session {
             }
         }
 
-        if ($junctionID === 'any' || $junctionID == '' || empty($junctionTable) ||
+        if ($junctionID === 'any' || $junctionID === '' || empty($junctionTable) ||
             c("Garden.Permissions.Disabled.{$junctionTable}")) {
             $junctionID = null;
         }

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -139,6 +139,8 @@ class Gdn_Session {
         }
 
         $allPermissions = $this->permissions->getPermissions();
+
+        // Junction (e.g. category) permissions
         if ($JunctionTable && !c("Garden.Permissions.Disabled.{$JunctionTable}")) {
             if (is_array($Permission)) {
                 if ($FullMatch) {
@@ -150,6 +152,7 @@ class Gdn_Session {
                 if ($JunctionID !== null) {
                     return $this->permissions->has($Permission, $JunctionID);
                 } else {
+                    // Backwards-compatible support for a null JunctionID meaning "permission on any ID"
                     return array_key_exists($Permission, $allPermissions) && count($allPermissions[$Permission]);
                 }
             }
@@ -161,6 +164,7 @@ class Gdn_Session {
                     return $this->permissions->hasAny($Permission);
                 }
             } else {
+                // Backwards-compatible permission check
                 return $this->permissions->has($Permission) || array_key_exists($Permission, $allPermissions);
             }
         }

--- a/tests/Library/Vanilla/PermissionsTest.php
+++ b/tests/Library/Vanilla/PermissionsTest.php
@@ -101,6 +101,10 @@ class PermissionsTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertTrue($permissions->has('Vanilla.Discussions.Add', 10));
         $this->assertFalse($permissions->has('Vanilla.Discussions.Add', 100));
+
+        $this->assertTrue($permissions->has('Vanilla.Discussions.Add', Permissions::ANY));
+        $this->assertTrue($permissions->has('Vanilla.Discussions.View', Permissions::ANY));
+        $this->assertFalse($permissions->has('Vanilla.Discussions.Edit', Permissions::ANY));
     }
 
     public function testMerge() {

--- a/tests/Library/Vanilla/PermissionsTest.php
+++ b/tests/Library/Vanilla/PermissionsTest.php
@@ -186,4 +186,24 @@ class PermissionsTest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($permissions->has('Vanilla.Comments.Add'));
         $this->assertFalse($permissions->has('Vanilla.Comments.Edit'));
     }
+
+    /**
+     * Test permissions with the {@link Permissions::ANY} constant.
+     */
+    public function testAnyIDPermission() {
+        $perms = new Permissions();
+
+        $this->assertFalse($perms->has('foo', Permissions::ANY));
+
+        $perms->set('foo', true);
+        $this->assertTrue($perms->has('foo', Permissions::ANY));
+
+        $perms->set('foo', false);
+        $this->assertFalse($perms->has('foo', Permissions::ANY));
+
+        $perms->add('bar', [1, 2]);
+        $this->assertFalse($perms->has('bar'));
+        $this->assertFalse($perms->has('bar', 3));
+        $this->assertTrue($perms->has('bar', Permissions::ANY));
+    }
 }

--- a/tests/Library/Vanilla/PermissionsTest.php
+++ b/tests/Library/Vanilla/PermissionsTest.php
@@ -15,7 +15,6 @@ class PermissionsTest extends \PHPUnit_Framework_TestCase {
 
         $permissions->add('Vanilla.Discussions.Add', 10);
         $this->assertTrue($permissions->has('Vanilla.Discussions.Add', 10));
-        $this->assertFalse($permissions->has('Vanilla.Discussions.Add'));
     }
 
     public function testCompileAndLoad() {
@@ -46,7 +45,6 @@ class PermissionsTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($permissions->has('Vanilla.Discussions.View'));
         $this->assertFalse($permissions->has('Garden.Settings.Manage'));
         $this->assertTrue($permissions->has('Vanilla.Discussions.Add', 10));
-        $this->assertFalse($permissions->has('Vanilla.Discussions.Add'));
     }
 
     public function testHasAny() {
@@ -102,9 +100,9 @@ class PermissionsTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($permissions->has('Vanilla.Discussions.Add', 10));
         $this->assertFalse($permissions->has('Vanilla.Discussions.Add', 100));
 
-        $this->assertTrue($permissions->has('Vanilla.Discussions.Add', Permissions::ANY));
-        $this->assertTrue($permissions->has('Vanilla.Discussions.View', Permissions::ANY));
-        $this->assertFalse($permissions->has('Vanilla.Discussions.Edit', Permissions::ANY));
+        $this->assertTrue($permissions->has('Vanilla.Discussions.Add', null));
+        $this->assertTrue($permissions->has('Vanilla.Discussions.View', null));
+        $this->assertFalse($permissions->has('Vanilla.Discussions.Edit'));
     }
 
     public function testMerge() {
@@ -120,7 +118,6 @@ class PermissionsTest extends \PHPUnit_Framework_TestCase {
 
         $this->assertTrue($permissions->has('Garden.SignIn.Allow'));
         $this->assertTrue($permissions->has('Garden.Profiles.View'));
-        $this->assertFalse($permissions->has('Vanilla.Discussions.Add'));
         $this->assertTrue($permissions->has('Vanilla.Discussions.Add', 10));
         $this->assertTrue($permissions->has('Vanilla.Discussions.Add', 20));
         $this->assertTrue($permissions->has('Vanilla.Discussions.Add', 30));
@@ -183,28 +180,22 @@ class PermissionsTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($permissions->has('Vanilla.Comments.Add', 10));
         $this->assertTrue($permissions->has('Vanilla.Comments.Edit', 10));
         $this->assertFalse($permissions->has('Garden.Settings.Manage'));
-        $this->assertFalse($permissions->has('Vanilla.Comments.Add'));
-        $this->assertFalse($permissions->has('Vanilla.Comments.Edit'));
     }
 
     /**
-     * Test permissions with the {@link Permissions::ANY} constant.
+     * Test permissions with the any.
      */
     public function testAnyIDPermission() {
         $perms = new Permissions();
 
-        $this->assertFalse($perms->has('foo', Permissions::ANY));
+        $this->assertFalse($perms->has('foo'));
 
         $perms->set('foo', true);
-        $this->assertTrue($perms->has('foo', Permissions::ANY));
-
-        $perms->set('foo', false);
-        $this->assertFalse($perms->has('foo', Permissions::ANY));
+        $this->assertTrue($perms->has('foo'));
 
         $perms->add('bar', [1, 2]);
-        $this->assertFalse($perms->has('bar'));
         $this->assertFalse($perms->has('bar', 3));
-        $this->assertTrue($perms->has('bar', Permissions::ANY));
+        $this->assertTrue($perms->has('bar'));
     }
 
     /**
@@ -214,6 +205,6 @@ class PermissionsTest extends \PHPUnit_Framework_TestCase {
         $perms = new Permissions();
         $perms->add('foo', 1);
         $perms->remove('foo', 1);
-        $this->assertFalse($perms->has('foo', Permissions::ANY));
+        $this->assertFalse($perms->has('foo'));
     }
 }

--- a/tests/Library/Vanilla/PermissionsTest.php
+++ b/tests/Library/Vanilla/PermissionsTest.php
@@ -206,4 +206,14 @@ class PermissionsTest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($perms->has('bar', 3));
         $this->assertTrue($perms->has('bar', Permissions::ANY));
     }
+
+    /**
+     * Make sure that removing all permissions will return false for an any permission scenario.
+     */
+    public function testAddRemovePermission() {
+        $perms = new Permissions();
+        $perms->add('foo', 1);
+        $perms->remove('foo', 1);
+        $this->assertFalse($perms->has('foo', Permissions::ANY));
+    }
 }


### PR DESCRIPTION
This update moves to replace internal permission checking in `Gdn_Session` with an instance of `Vanilla\Permissions`.  More details may be found in the original issue.

Closes #4834 