### PR TITLE
Fixes issues where images no longer uploaded as content

### DIFF
--- a/library/core/class.uploadimage.php
+++ b/library/core/class.uploadimage.php
@@ -304,7 +304,7 @@ class Gdn_UploadImage extends Gdn_Upload {
             copy($Source, $TargetPath);
         }
 
-        // Allow a plugin to move the file to a differnt location.
+        // Allow a plugin to move the file to a different location.
         $Sender = new stdClass();
         $Sender->EventArguments = array();
         $Sender->EventArguments['Path'] = $TargetPath;
@@ -312,6 +312,8 @@ class Gdn_UploadImage extends Gdn_Upload {
         $Parsed['Width'] = $Width;
         $Parsed['Height'] = $Height;
         $Sender->EventArguments['Parsed'] =& $Parsed;
+        $Sender->EventArguments['Options'] = $Options;
+        $Sender->EventArguments['OriginalFilename'] = val('OriginalFilename', $Options);
         $Sender->Returns = array();
         Gdn::pluginManager()->callEventHandlers($Sender, 'Gdn_Upload', 'SaveAs');
         return $Sender->EventArguments['Parsed'];

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -748,13 +748,23 @@ class EditorPlugin extends Gdn_Plugin {
                 $filePathParsed = $Upload->saveAs(
                     $tmpFilePath,
                     $absoluteFileDestination,
-                    array(
+                    [
                         'OriginalFilename' => $fileName,
                         'source' => 'content'
-                    )
+                    ]
                 );
             } else {
-                $filePathParsed = Gdn_UploadImage::saveImageAs($tmpFilePath, $absoluteFileDestination, '', '', array('SaveGif' => true));
+                $filePathParsed = Gdn_UploadImage::saveImageAs(
+                    $tmpFilePath,
+                    $absoluteFileDestination,
+                    '',
+                    '',
+                    [
+                        'OriginalFilename' => $fileName,
+                        'source' => 'content',
+                        'SaveGif' => true
+                    ]
+                );
                 $tmpwidth = $filePathParsed['Width'];
                 $tmpheight = $filePathParsed['Height'];
             }

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -11,7 +11,7 @@
 $PluginInfo['editor'] = array(
    'Name' => 'Advanced Editor',
    'Description' => 'Enables advanced editing of posts in several formats, including WYSIWYG, simple HTML, Markdown, and BBCode.',
-   'Version' => '1.8.0',
+   'Version' => '1.8.1',
    'Author' => "Dane MacMillan",
    'AuthorUrl' => 'http://www.vanillaforums.org/profile/dane',
    'RequiredApplications' => array('Vanilla' => '>=2.2'),


### PR DESCRIPTION
A bug was introduced in #2711 that caused uploaded images and files to be treated differently. We need to be able to send editor content to a different container and this broke that.