### PR TITLE
Refactor UserModel to use Vanilla\Permissions

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1103,11 +1103,17 @@ class UserModel extends Gdn_Model {
         }
 
         $Data = Gdn::permissionModel()->cachePermissions($UserID);
-        $Permissions = UserModel::compilePermissions($Data);
+        $permissions = new Vanilla\Permissions();
+        $permissions->compileAndLoad($Data);
 
-        $PermissionsSerialized = dbencode($Permissions);
+        $this->EventArguments['UserID'] = $UserID;
+        $this->EventArguments['Permissions'] = $permissions;
+        $this->fireEvent('loadPermissions');
+
+        $permissionsArray = $permissions->getPermissions();
+        $PermissionsSerialized = dbencode($permissionsArray);
         if (Gdn::cache()->activeEnabled()) {
-            Gdn::cache()->store($UserPermissionsKey, $Permissions);
+            Gdn::cache()->store($UserPermissionsKey, $permissionsArray);
         } else {
             // Save the permissions to the user table
             if ($UserID > 0) {
@@ -1115,7 +1121,7 @@ class UserModel extends Gdn_Model {
             }
         }
 
-        return $Serialize ? $PermissionsSerialized : $Permissions;
+        return $Serialize ? $PermissionsSerialized : $permissionsArray;
     }
 
     /**

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1660,8 +1660,9 @@ class UserModel extends Gdn_Model {
             // Replace permissions with those of the ConfirmEmailRole
             $ConfirmEmailRoleID = RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
             $RoleModel = new RoleModel();
+            $permissions = new Vanilla\Permissions();
             $RolePermissions = $RoleModel->getPermissions($ConfirmEmailRoleID);
-            $Permissions = UserModel::compilePermissions($RolePermissions);
+            $Permissions = $permissions->compileAndLoad($RolePermissions);
 
             // Ensure Confirm Email role can always sign in
             if (!in_array('Garden.SignIn.Allow', $Permissions)) {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -241,15 +241,12 @@ class UserModel extends Gdn_Model {
 
         // Grab the permissions for the user.
         if ($User->UserID == 0) {
-            $Permissions = $this->definePermissions(0, false);
+            $permissions = $this->getPermissions(0);
         } elseif (is_array($User->Permissions)) {
-            $Permissions = $User->Permissions;
+            $permissions = new Vanilla\Permissions($User->Permissions);
         } else {
-            $Permissions = $this->definePermissions($User->UserID, false);
+            $permissions = $this->getPermissions($User->UserID);
         }
-
-        // TODO: Check for junction table permissions.
-        $permissions = new Vanilla\Permissions($Permissions);
 
         return $permissions->has($Permission);
     }
@@ -1616,7 +1613,8 @@ class UserModel extends Gdn_Model {
             // Otherwise normal loadings!
         } else {
             if ($User && ($User->Permissions == '' || Gdn::cache()->activeEnabled())) {
-                $User->Permissions = $this->definePermissions($UserID, false);
+                $userPermissions = $this->getPermissions($UserID);
+                $User->Permissions = $userPermissions->getPermissions();
             }
         }
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -249,8 +249,10 @@ class UserModel extends Gdn_Model {
         }
 
         // TODO: Check for junction table permissions.
-        $Result = in_array($Permission, $Permissions) || array_key_exists($Permission, $Permissions);
-        return $Result;
+        $permissions = new Vanilla\Permissions($Permissions);
+
+        // Secondary check added for backwards compatibility
+        return $permissions->has($Permission) || array_key_exists($Permission, $permissions->getPermissions());
     }
 
     /**

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1129,37 +1129,13 @@ class UserModel extends Gdn_Model {
     /**
      * Take raw permission definitions and create.
      *
-     * @param array $Permissions
+     * @param array $rawPermissions Database rows from the permissions table.
      * @return array Compiled permissions
      */
-    public static function compilePermissions($Permissions) {
-        $Compiled = [];
-        foreach ($Permissions as $i => $Row) {
-            $JunctionID = array_key_exists('JunctionID', $Row) ? $Row['JunctionID'] : null;
-            unset($Row['JunctionColumn'], $Row['JunctionColumn'], $Row['JunctionID'], $Row['RoleID'], $Row['PermissionID']);
-
-            foreach ($Row as $PermissionName => $Value) {
-                if ($Value == 0) {
-                    continue;
-                }
-
-                if (is_numeric($JunctionID) && $JunctionID !== null) {
-                    if (!array_key_exists($PermissionName, $Compiled)) {
-                        $Compiled[$PermissionName] = [];
-                    }
-
-                    if (!is_array($Compiled[$PermissionName])) {
-                        $Compiled[$PermissionName] = [];
-                    }
-
-                    $Compiled[$PermissionName][] = $JunctionID;
-                } else {
-                    $Compiled[] = $PermissionName;
-                }
-            }
-        }
-
-        return $Compiled;
+    public static function compilePermissions($rawPermissions) {
+        $permissions = new Vanilla\Permissions();
+        $permissions->compileAndLoad($rawPermissions);
+        return $permissions->getPermissions();
     }
 
     /**

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -251,8 +251,7 @@ class UserModel extends Gdn_Model {
         // TODO: Check for junction table permissions.
         $permissions = new Vanilla\Permissions($Permissions);
 
-        // Secondary check added for backwards compatibility
-        return $permissions->has($Permission) || array_key_exists($Permission, $permissions->getPermissions());
+        return $permissions->has($Permission);
     }
 
     /**

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -476,8 +476,8 @@ class Gdn_Session {
         }
         // Load guest permissions if necessary
         if ($this->UserID == 0) {
-            $guestPermissions = $UserModel->definePermissions(0, false);
-            $this->permissions->setPermissions($guestPermissions);
+            $guestPermissions = $UserModel->getPermissions(0);
+            $this->permissions->setPermissions($guestPermissions->getPermissions());
         }
     }
 


### PR DESCRIPTION
This update swaps out model-specific permission handling for the `Vanilla\Permissions` class.  More detail can be found in the original issue.

Closes #4826 