### PR TITLE
Clean up the bootstrap

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -90,7 +90,7 @@ Gdn::config()->load(PATH_CONF.'/config-defaults.php');
 Gdn::config()->load(Gdn::config()->defaultPath(), 'Configuration', true);
 
 // Default request object
-Gdn::factoryInstall(Gdn::AliasRequest, 'Gdn_Request', null, Gdn::FactoryRealSingleton, 'Create');
+Gdn::factoryInstall(Gdn::AliasRequest, 'Gdn_Request', null, Gdn::FactorySingleton);
 Gdn::request()->fromEnvironment();
 
 /**
@@ -198,7 +198,7 @@ Gdn::factoryInstall(Gdn::AliasRouter, 'Gdn_Router');
 Gdn::factoryInstall(Gdn::AliasDispatcher, 'Gdn_Dispatcher', '', Gdn::FactorySingleton, [Gdn::addonManager()]);
 
 // Smarty Templating Engine
-Gdn::factoryInstall('Smarty', 'Smarty', PATH_LIBRARY.'/vendors/smarty/libs/Smarty.class.php');
+Gdn::factoryInstall('Smarty', 'Smarty');
 Gdn::factoryInstall('ViewHandler.tpl', 'Gdn_Smarty');
 
 // Slice handler


### PR DESCRIPTION
There are two small changes here:

1. Smarty is now a composer library loaded via the autoloader so a hard-coded path is not necessary (and also a bug).

2. I’m trying to get rid of some of the peculiarities of the factory in order to replace it with a more flexible dependency injection container. Converting the Gdn_Request from a “real singleton” to a “singleton” helps here. Note that Gdn_Request::Create() just news up a Gdn_Request object anyway.