### PR TITLE
Allow form errors in ConfigurationModule

### DIFF
--- a/applications/dashboard/modules/class.configurationmodule.php
+++ b/applications/dashboard/modules/class.configurationmodule.php
@@ -104,6 +104,10 @@ class ConfigurationModule extends Gdn_Module {
         $Form = $this->form();
 
         if ($Form->authenticatedPostBack()) {
+            if ($Form->errorCount() > 0) {
+                return;
+            }
+
             // Grab the data from the form.
             $Data = array();
             $Post = $Form->formValues();


### PR DESCRIPTION
Make it easier to do validations when using the ConfigurationModule. This will allow using a validation before the call to the initialize method:
~~~
$configurationModule = new ConfigurationModule($sender);
if ($sender->Form->authenticatedPostBack()) {
    $sender->Form->validateRule('plugin.field1', 'ValidateRequired');
}
$configurationModule->initialize(...
~~~
That would prevent saving a wrong info to the config and it will give developers the possibility to validate forms as usual.