### PR TITLE
Fix critical permissions errors introduced in #4877

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1599,9 +1599,10 @@ class UserModel extends Gdn_Model {
             // Replace permissions with those of the ConfirmEmailRole
             $ConfirmEmailRoleID = RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
             $RoleModel = new RoleModel();
-            $permissions = new Vanilla\Permissions();
+            $permissionsModel = new Vanilla\Permissions();
             $RolePermissions = $RoleModel->getPermissions($ConfirmEmailRoleID);
-            $Permissions = $permissions->compileAndLoad($RolePermissions);
+            $permissionsModel->compileAndLoad($RolePermissions);
+            $Permissions = $permissionsModel->getPermissions();
 
             // Ensure Confirm Email role can always sign in
             if (!in_array('Garden.SignIn.Allow', $Permissions)) {

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -136,12 +136,12 @@ class Gdn_Session {
 
         if (is_array($permission)) {
             if ($fullMatch) {
-                return $this->permissions->hasAll($permission);
+                return $this->permissions->hasAll($permission, $junctionID);
             } else {
-                return $this->permissions->hasAny($permission);
+                return $this->permissions->hasAny($permission, $junctionID);
             }
         } else {
-            return $this->permissions->has($permission);
+            return $this->permissions->has($permission, $junctionID);
         }
     }
 


### PR DESCRIPTION
This update fixes:

* An instance of `Vanilla\Permissions` was attempting to be read as an array in `UserModel::getSession`.
* JunctionID not being passed in category permission checks, resulting in global permission grants if you had said permission in _any_ category instead of the specified one.

