### PR TITLE
Add a CSS class to the div wrapper on QuoteFolding

### DIFF
--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -83,7 +83,7 @@ Gdn_Quotes.prototype.ExploreFold = function(QuoteTree, FoldingLevel, MaxLevel, T
                 .addClass('QuoteFolded')
                 .hide()
                 .before(
-                    '<div><a href="" class="QuoteFolding">' +
+                    '<div class="QuoteFoldingWrapper"><a href="" class="QuoteFolding">' +
                     gdn.definition('&raquo; show previous quotes') +
                     '</a></div>'
                 );


### PR DESCRIPTION
Add a CSS class to the div wrapper on QuoteFolding.

Closes https://github.com/vanilla/vanilla/issues/4876