### PR TITLE
Handle no RoleID or JunctionID in getJunctionPermissions

### DIFF
--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -641,14 +641,18 @@ class PermissionModel extends Gdn_Model {
                 if (isset($JuncIDs)) {
                     $SQL->whereIn("junc.{$JunctionTable}ID", array_column($JuncIDs, "{$JunctionTable}ID"));
                 }
-            } else {
+
+                $JuncData = $SQL->get()->resultArray();
+            } elseif (!empty($JunctionID)) {
                 // Here we are getting permissions for all roles.
-                $SQL->select('r.RoleID, r.Name, r.CanSession')
+                $JuncData = $SQL->select('r.RoleID, r.Name, r.CanSession')
                     ->from('Role r')
                     ->join('Permission p', "p.RoleID = r.RoleID and p.JunctionTable = '$JunctionTable' and p.JunctionColumn = '$JunctionColumn' and p.JunctionID = $JunctionID", 'left')
-                    ->orderBy('r.Sort, r.Name');
+                    ->orderBy('r.Sort, r.Name')
+                    ->get()->resultArray();
+            } else {
+                $JuncData = [];
             }
-            $JuncData = $SQL->get()->resultArray();
 
             // Add all of the necessary information back to the result.
             foreach ($JuncData as $JuncRow) {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1598,6 +1598,11 @@ class UserModel extends Gdn_Model {
         if ($ConfirmEmail && !$Confirmed) {
             // Replace permissions with those of the ConfirmEmailRole
             $ConfirmEmailRoleID = RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
+
+            if (empty($ConfirmEmailRoleID)) {
+                throw new Gdn_UserException(sprintf('No role configured with a type of "%s".', RoleModel::TYPE_UNCONFIRMED));
+            }
+
             $RoleModel = new RoleModel();
             $permissions = new Vanilla\Permissions();
             $RolePermissions = $RoleModel->getPermissions($ConfirmEmailRoleID);

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1599,8 +1599,8 @@ class UserModel extends Gdn_Model {
             // Replace permissions with those of the ConfirmEmailRole
             $ConfirmEmailRoleID = RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
 
-            if (empty($ConfirmEmailRoleID)) {
-                throw new Gdn_UserException(sprintf('No role configured with a type of "%s".', RoleModel::TYPE_UNCONFIRMED));
+            if (!is_array($ConfirmEmailRoleID) || count($ConfirmEmailRoleID) == 0) {
+                throw new Exception(sprintf(t('No role configured with a type of "%s".'), RoleModel::TYPE_UNCONFIRMED), 400);
             }
 
             $RoleModel = new RoleModel();

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1604,11 +1604,11 @@ class UserModel extends Gdn_Model {
             $Permissions = $permissions->compileAndLoad($RolePermissions);
 
             // Ensure Confirm Email role can always sign in
-            if (!in_array('Garden.SignIn.Allow', $Permissions)) {
-                $Permissions[] = 'Garden.SignIn.Allow';
+            if (!$Permissions->has('Garden.SignIn.Allow')) {
+                $Permissions->set('Garden.SignIn.Allow', true);
             }
 
-            $User->Permissions = $Permissions;
+            $User->Permissions = $Permissions->getPermissions();
 
             // Otherwise normal loadings!
         } else {


### PR DESCRIPTION
There are circumstances wherein `PermissionModel::getJunctionPermissions` may not receive a RoleID or a JunctionID in its `$Where` parameter (e.g. site is configured with Garden.Registration.ConfirmEmail, but no "unconfirmed" role).  However, the function currently assumes one or the other will be set.  If RoleID isn't present, it will attempt to use JunctionID, without attempting to verify it is available.  This can cause a fatal error, because the query generated by this function may have an empty value for one of its conditions (e.g. `... where p.junctionid = order by ...`).

This update alters the logic of `PermissionModel::getJunctionPermissions` to the following:  If RoleID is available, use it.  If it isn't, but JunctionID is, use that.  If neither are available,  use an empty result for the junction data.

Closes #4751 

*Bonus: Fixes some issues related to requiring email confirmation, but not having an "unconfirmed" role configured. Users still can't sign in under these conditions, but at least there's a helpful error message for administrators.*