### PR TITLE
Use "==" instead of "===" for permission comparison

### DIFF
--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -78,7 +78,7 @@ class Permissions {
             // Iterate through the row's individual permissions.
             foreach ($row as $permission => $value) {
                 // If the user doesn't have this permission, move on to the next one.
-                if ($value === 0) {
+                if ($value == 0) {
                     continue;
                 }
 


### PR DESCRIPTION
At least for my installation the permission array values are strings, not integers. That's why using equal "==" should be enough.
Using the identical comparator "===" caused false positives and in my test installation the dashboard was accessible even for guests.