### PR TITLE
Move CSRF token into browser cookie

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -427,10 +427,13 @@ class Gdn_Session {
         if (!c('Garden.Installed', false)) {
             return;
         }
+
         // Retrieve the authenticated UserID from the Authenticator module.
         $UserModel = Gdn::authenticator()->getUserModel();
         $this->UserID = $UserID !== false ? $UserID : Gdn::authenticator()->getIdentity();
         $this->User = false;
+
+        $this->ensureTransientKey();
 
         // Now retrieve user information
         if ($this->UserID > 0) {
@@ -450,11 +453,6 @@ class Gdn_Session {
                 $this->permissions->setPermissions($this->User->Permissions);
                 $this->_Preferences = $this->User->Preferences;
                 $this->_Attributes = $this->User->Attributes;
-                $this->_TransientKey = is_array($this->_Attributes) ? val('TransientKey', $this->_Attributes) : false;
-
-                if ($this->_TransientKey === false) {
-                    $this->_TransientKey = $UserModel->setTransientKey($this->UserID);
-                }
 
                 // Save any visit-level information.
                 if ($SetIdentity) {
@@ -464,15 +462,11 @@ class Gdn_Session {
             } else {
                 $this->UserID = 0;
                 $this->User = false;
-                $this->_TransientKey = getAppCookie('tk');
 
                 if ($SetIdentity) {
                     Gdn::authenticator()->setIdentity(null);
                 }
             }
-        } else {
-            // Grab the transient key from the cookie. This doesn't always get set but we'll try it here anyway.
-            $this->_TransientKey = getAppCookie('tk');
         }
         // Load guest permissions if necessary
         if ($this->UserID == 0) {
@@ -525,34 +519,114 @@ class Gdn_Session {
     }
 
     /**
+     * Make sure the transient key matches whats in the user's cookie or create a new one.
      *
-     *
-     * @return bool|object|string
+     * @return string
      */
     public function ensureTransientKey() {
-        if (!$this->_TransientKey) {
-            // Generate a transient key in the browser.
-            $tk = betterRandomString(16, 'Aa0');
-            setAppCookie('tk', $tk);
-            $this->_TransientKey = $tk;
+        $cookieString = getAppCookie('tk');
+        $reset = false;
+
+        if ($cookieString === null) {
+            $reset = true;
+        } else {
+            $cookie = $this->decodeTKCookie($cookieString);
+            if ($cookie === false) {
+                $reset = true;
+            } else {
+                $payload = $this->generateTKPayload(
+                    $cookie['TransientKey'],
+                    $cookie['UserID'],
+                    $cookie['Timestamp']
+                );
+
+                $userInvalid = ($cookie['UserID'] != $this->UserID);
+                $signatureInvalid = $this->generateTKSignature($payload) !== $cookie['Signature'];
+                if ($userInvalid || $signatureInvalid) {
+                    $reset = true;
+                } elseif ($this->transientKey() !== $cookie['TransientKey']) {
+                    $this->transientKey($cookie['TransientKey'], false);
+                }
+            }
         }
-        return $this->_TransientKey;
+
+        if ($reset) {
+            return $this->transientKey(betterRandomString(16, 'Aa0'));
+        } else {
+            return $this->transientKey();
+        }
+    }
+
+    /**
+     * Break down a transient key cookie string into its individual elements.
+     *
+     * @param string $tkCookie
+     * @return array|bool
+     */
+    protected function decodeTKCookie($tkCookie) {
+        if (!is_string($tkCookie)) {
+            return false;
+        }
+
+        $elements = explode(':', $tkCookie);
+
+        if (count($elements) !== 4) {
+            return false;
+        }
+
+        return [
+            'TransientKey' => $elements[0],
+            'UserID' => $elements[1],
+            'Timestamp' => $elements[2],
+            'Signature' => $elements[3]
+        ];
+    }
+
+    /**
+     * Generate the cookie payload value for a transient key.
+     *
+     * @param string $tk
+     * @param int|null $userID
+     * @param int|null $timestamp
+     * @return string
+     */
+    protected function generateTKPayload($tk, $userID = null, $timestamp = null) {
+        $userID = $userID ?: $this->UserID;
+
+        $timestamp = $timestamp ?: time();
+
+        return "{$tk}:{$userID}:{$timestamp}";
+    }
+
+    /**
+     * Generate a signature for a transient key cookie payload value.
+     *
+     * @param string $payload
+     * @return string
+     */
+    protected function generateTKSignature($payload) {
+        return hash_hmac(c('Garden.Cookie.HashMethod'), $payload, c('Garden.Cookie.Salt'));
     }
 
     /**
      * Returns the transient key for the authenticated user.
      *
+     * @param string|null $newKey
+     * @param bool $updateCookie Update the browser cookie when changing the transient key?
      * @return string
      */
-    public function transientKey($NewKey = null) {
-        if (!is_null($NewKey)) {
-            $this->_TransientKey = Gdn::authenticator()->getUserModel()->setTransientKey($this->UserID, $NewKey);
+    public function transientKey($newKey = null, $updateCookie = true) {
+        if (is_string($newKey)) {
+            if ($updateCookie) {
+                $payload = $this->generateTKPayload($newKey);
+                $signature = $this->generateTKSignature($payload);
+                setAppCookie('tk', "{$payload}:{$signature}");
+            }
+
+            $this->_TransientKey = $newKey;
         }
 
-//      if ($this->_TransientKey)
         return $this->_TransientKey;
-//      else
-//         return RandomString(12); // Postbacks will never be authenticated if transientkey is not defined.
     }
 
     /**

--- a/tests/APIv0/APIv0.php
+++ b/tests/APIv0/APIv0.php
@@ -127,26 +127,23 @@ class APIv0 extends HttpClient {
     }
 
     /**
-     * Get the transient key for a user.
+     * Generate a cookie for the user's transient key.
      *
-     * @param int $userID The ID of the user to get the transient key for.
-     * @return string Returns the transient key for the user.
+     * @param int $userID
+     * @param string $tk
+     * @return string
      */
-    public function getTK($userID) {
-        $user = $this->queryOne("select * from GDN_User where UserID = :userID", ['userID' => $userID]);
-        if (empty($user)) {
-            return '';
-        }
-        $attributes = (array)dbdecode($user['Attributes']);
-        if (empty($attributes['TransientKey'])) {
-            $attributes['TransientKey'] = randomString(20);
-            $r = $this->query(
-                "update GDN_User set Attributes = :attributes where UserID = :userID",
-                ['attributes' => dbencode($attributes), 'userID' => $userID],
-                true
-            );
-        }
-        return val('TransientKey', $attributes, '');
+    private function generateTKCookie($userID, $tk) {
+        $timestamp = time();
+
+        $payload = "{$tk}:{$userID}:{$timestamp}";
+        $signature = hash_hmac(
+            $this->getConfig('Garden.Cookie.HashMethod', 'md5'),
+            $payload,
+            $this->getConfig('Garden.Cookie.Salt')
+        );
+
+        return "{$payload}:{$signature}";
     }
 
     /**
@@ -237,7 +234,11 @@ class APIv0 extends HttpClient {
         // Add the cookie of the calling user.
         if ($user = $this->getUser()) {
             $cookieName = $this->getConfig('Garden.Cookie.Name', 'Vanilla');
-            $cookieArray = [$cookieName => $this->vanillaCookieString($user['UserID'])];
+
+            $cookieArray = [
+                $cookieName => $this->vanillaCookieString($user['UserID']),
+                "{$cookieName}-tk" => $this->generateTKCookie($user['UserID'], $user['tk'])
+            ];
 
             $request->setHeader('Cookie', static::cookieEncode($cookieArray));
 
@@ -540,11 +541,11 @@ class APIv0 extends HttpClient {
             $user = $this->queryUserKey($user, true);
         }
 
-        if (empty($user['tk'])) {
-            $user['tk'] = $this->getTK($user['UserID']);
-        }
-
-        $partialUser = ['UserID' => $user['UserID'], 'Name' => $user['Name'], 'tk' => $user['tk']];
+        $partialUser = [
+            'UserID' => $user['UserID'],
+            'Name' => $user['Name'],
+            'tk' => substr(md5(time()), 0, 16)
+        ];
 
         $this->user = $partialUser;
         return $this;

--- a/tests/APIv0/SmokeTest.php
+++ b/tests/APIv0/SmokeTest.php
@@ -96,12 +96,9 @@ class SmokeTest extends BaseTest {
 
         $this->assertEquals($user['Name'], $siteUser['Name']);
 
-        $siteUser['tk'] = $this->api()->getTK($siteUser['UserID']);
         $this->setTestUser($siteUser);
         return $siteUser;
     }
-
-
 
     /**
      * Test adding an admin user.
@@ -139,7 +136,6 @@ class SmokeTest extends BaseTest {
         $userRoleIDs = array_column($userRoles, 'RoleID');
         $this->assertEquals($adminUser['RoleID'], $userRoleIDs);
 
-        $dbUser['tk'] = $this->api()->getTK($dbUser['UserID']);
         return $dbUser;
     }
 


### PR DESCRIPTION
This update moves the anti-CSRF token from a static value stored in the user record to a per-browser cookie.

A few new methods were added to `Gdn_Session`:

* `decodeTKCookie`
* `generateTKPayload`
* `generateTKSignature`

A couple methods were updated in `Gdn_Session`:

* `ensureTransientKey` - There was already an anti-CSRF measure stored with cookies in Vanilla, but it was seemingly only ever used for guests.  It's been updated to work with all users.
* `transientKey` - Setting a transient key with this method now also sets the value in the users cookie by default.

Since the transient key mechanic was fundamentally altered, it broke our existing integration tests.  These tests were looking up values in the database.  Now, since the client tells Vanilla what the transient key should be, a random value is generated and sent along with requests in these tests.

More details available in the original issue.

Closes #3964 

*Warning: This is a security-related update, so please be especially thorough in reviewing it.*