### PR TITLE
Fix necessity to add image to email styles form

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -769,32 +769,34 @@ class SettingsController extends DashboardController {
             $this->Form->setData($configurationModel->Data);
         } else {
             $image = c('Garden.EmailTemplate.Image');
-            try {
-                $upload = new Gdn_UploadImage();
-                // Validate the upload
-                $tmpImage = $upload->validateUpload('EmailImage');
-                if ($tmpImage) {
-                    // Generate the target image name
-                    $targetImage = $upload->generateTargetName(PATH_UPLOADS);
-                    $imageBaseName = pathinfo($targetImage, PATHINFO_BASENAME);
-                    // Delete any previously uploaded images.
-                    if ($image) {
-                        $upload->delete($image);
-                    }
-                    // Save the uploaded image
-                    $parts = $upload->saveImageAs(
-                        $tmpImage,
-                        $imageBaseName,
-                        c('Garden.EmailTemplate.ImageMaxWidth', 400),
-                        c('Garden.EmailTemplate.ImageMaxHeight', 300)
-                    );
+            $upload = new Gdn_UploadImage();
+            if ($upload->isUpload('EmailImage')) {
+                try {
+                    $tmpImage = $upload->validateUpload('EmailImage');
 
-                    $imageBaseName = $parts['SaveName'];
-                    saveToConfig('Garden.EmailTemplate.Image', $imageBaseName);
-                    $this->setData('EmailImage', Gdn_UploadImage::url($imageBaseName));
+                    if ($tmpImage) {
+                        // Generate the target image name
+                        $targetImage = $upload->generateTargetName(PATH_UPLOADS);
+                        $imageBaseName = pathinfo($targetImage, PATHINFO_BASENAME);
+                        // Delete any previously uploaded images.
+                        if ($image) {
+                            $upload->delete($image);
+                        }
+                        // Save the uploaded image
+                        $parts = $upload->saveImageAs(
+                            $tmpImage,
+                            $imageBaseName,
+                            c('Garden.EmailTemplate.ImageMaxWidth', 400),
+                            c('Garden.EmailTemplate.ImageMaxHeight', 300)
+                        );
+
+                        $imageBaseName = $parts['SaveName'];
+                        saveToConfig('Garden.EmailTemplate.Image', $imageBaseName);
+                        $this->setData('EmailImage', Gdn_UploadImage::url($imageBaseName));
+                    }
+                } catch (Exception $ex) {
+                    $this->Form->addError($ex);
                 }
-            } catch (Exception $ex) {
-                $this->Form->addError($ex);
             }
 
             if ($this->Form->save() !== false) {

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -772,7 +772,7 @@ class SettingsController extends DashboardController {
             try {
                 $upload = new Gdn_UploadImage();
                 // Validate the upload
-                $tmpImage = $upload->validateUpload('EmailImage', false);
+                $tmpImage = $upload->validateUpload('EmailImage');
                 if ($tmpImage) {
                     // Generate the target image name
                     $targetImage = $upload->generateTargetName(PATH_UPLOADS);
@@ -792,8 +792,6 @@ class SettingsController extends DashboardController {
                     $imageBaseName = $parts['SaveName'];
                     saveToConfig('Garden.EmailTemplate.Image', $imageBaseName);
                     $this->setData('EmailImage', Gdn_UploadImage::url($imageBaseName));
-                } else {
-                    $this->Form->addError(t('There\'s been an error uploading the image. Your email logo can uploaded in one of the following filetypes: gif, jpg, png'));
                 }
             } catch (Exception $ex) {
                 $this->Form->addError($ex);

--- a/applications/dashboard/js/dashboard.js
+++ b/applications/dashboard/js/dashboard.js
@@ -1015,7 +1015,9 @@ var DashboardModal = (function() {
             var $preview = $(input).parents('.js-image-preview-form-group').find('.js-image-preview-new .js-image-preview');
             var reader = new FileReader();
             reader.onload = function (e) {
-                $preview.attr('src', e.target.result);
+                if (e.target.result.startsWith("data:image")) {
+                    $preview.attr('src', e.target.result);
+                }
             }
             reader.readAsDataURL(input.files[0]);
         }

--- a/applications/dashboard/js/src/main.js
+++ b/applications/dashboard/js/src/main.js
@@ -353,7 +353,9 @@
             var $preview = $(input).parents('.js-image-preview-form-group').find('.js-image-preview-new .js-image-preview');
             var reader = new FileReader();
             reader.onload = function (e) {
-                $preview.attr('src', e.target.result);
+                if (e.target.result.startsWith("data:image")) {
+                    $preview.attr('src', e.target.result);
+                }
             }
             reader.readAsDataURL(input.files[0]);
         }

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -371,6 +371,16 @@ class Gdn_Upload extends Gdn_Pluggable {
     }
 
     /**
+     * Check to see whether the user has selected a file for uploading.
+     * 
+     * @param $inputName The input name of the file.
+     * @return bool Whether a file has been selected for the fiels.
+     */
+    public function isUpload($inputName) {
+        return val('name', val($inputName, $_FILES, '')) !== '';
+    }
+
+    /**
      * Validates the uploaded file. Returns the temporary name of the uploaded file.
      */
     public function validateUpload($InputName, $ThrowException = true) {


### PR DESCRIPTION
Rely on UploadImage to validate the image and throw an error if the upload is incorrect and remove adding a form error if no image is found.

Closes https://github.com/vanilla/vanilla/issues/4919