### PR TITLE
Add static uploads

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -501,4 +501,33 @@ class DashboardHooks extends Gdn_Plugin {
             PermissionModel::resetAllRoles();
         }
     }
+
+    /**
+     * Copy a file locally so that it can be manipulated by php.
+     *
+     * @param Gdn_Upload $sender The upload object doing the manipulation.
+     * @param array $args Arguments useful for copying the file.
+     * @throws Exception Throws an exception if there was a problem copying the file for local use.
+     */
+    public function gdn_upload_copyLocal_handler($sender, $args) {
+        $parsed = $args['Parsed'];
+        if ($parsed['Type'] !== 'static' || $parsed['Domain'] !== 'v') {
+            return;
+        }
+
+        $remotePath = PATH_ROOT.'/'.$parsed['Name'];
+
+        // Since this is just a temp file we don't want to nest it in a bunch of subfolders.
+        $localPath = paths(PATH_UPLOADS, 'tmp-static', str_replace('/', '-', $parsed['Name']));
+
+        // Make sure the destination path exists
+        if (!file_exists(dirname($localPath))) {
+            mkdir(dirname($localPath), 0777, true);
+        }
+
+        // Copy
+        copy($remotePath, $localPath);
+
+        $args['Path'] = $localPath;
+    }
 }

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -341,31 +341,35 @@ class Gdn_Upload extends Gdn_Pluggable {
 
     /**
      * Returns the url prefix for a given type.
-     * If there is a plugin that wants to store uploads at a different location or in a different way then they register themselves by subscribing to the Gdn_Upload_GetUrls_Handler event.
-     * After that they will be available here.
      *
-     * @param string $Type The type of upload to get the prefix for.
+     * If there is a plugin that wants to store uploads at a different location or in a different way then they register
+     * themselves by subscribing to the Gdn_Upload_GetUrls_Handler event. After that they will be available here.
+     *
+     * @param string $type The type of upload to get the prefix for.
      * @return string The url prefix.
      */
-    public static function urls($Type = null) {
-        static $Urls = null;
+    public static function urls($type = null) {
+        static $urls = null;
 
-        if ($Urls === null) {
-            $Urls = array('' => asset('/uploads', true));
+        if ($urls === null) {
+            $urls = [
+                '' => asset('/uploads', true),
+                'static://v' => rtrim(asset('/', true), '/')
+            ];
 
-            $Sender = new stdClass();
-            $Sender->Returns = array();
-            $Sender->EventArguments = array();
-            $Sender->EventArguments['Urls'] =& $Urls;
+            $sender = new stdClass();
+            $sender->Returns = [];
+            $sender->EventArguments = [];
+            $sender->EventArguments['Urls'] =& $urls;
 
-            Gdn::pluginManager()->callEventHandlers($Sender, 'Gdn_Upload', 'GetUrls');
+            Gdn::pluginManager()->callEventHandlers($sender, 'Gdn_Upload', 'GetUrls');
         }
 
-        if ($Type === null) {
-            return $Urls;
+        if ($type === null) {
+            return $urls;
         }
-        if (isset($Urls[$Type])) {
-            return $Urls[$Type];
+        if (isset($urls[$type])) {
+            return $urls[$type];
         }
         return false;
     }


### PR DESCRIPTION
Add a special schema and domain of static://v that links to files within the application. The reasoning for this is to provide a hook for a static CDN to override some of these files, but default to the local server for OSS and development.