### PR TITLE
Add AfterConnectSave event

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -522,6 +522,9 @@ class EntryController extends Gdn_Controller {
 
                 // Synchronize the user's data.
                 $UserModel->save($Data, ['NoConfirmEmail' => true, 'FixUnique' => true, 'SaveRoles' => $SaveRoles]);
+                $this->EventArguments['Form'] = $this->Form;
+                $this->EventArguments['UserID'] = $UserID;
+                $this->fireEvent('AfterConnectSave');
             }
 
             // Always save the attributes because they may contain authorization information.
@@ -600,6 +603,9 @@ class EntryController extends Gdn_Controller {
 
                                 // Update the user.
                                 $UserModel->save($Data, ['NoConfirmEmail' => true, 'FixUnique' => true, 'SaveRoles' => $SaveRoles]);
+                                $this->EventArguments['Form'] = $this->Form;
+                                $this->EventArguments['UserID'] = $UserID;
+                                $this->fireEvent('AfterConnectSave');
                             }
 
                             // Always save the attributes because they may contain authorization information.
@@ -708,6 +714,11 @@ class EntryController extends Gdn_Controller {
                     'SaveRoles' => $SaveRolesRegister
                 ]);
                 $User['UserID'] = $UserID;
+
+                $this->EventArguments['Form'] = $this->Form;
+                $this->EventArguments['UserID'] = $UserID;
+                $this->fireEvent('AfterConnectSave');
+
                 $this->Form->setValidationResults($UserModel->validationResults());
 
                 // Save the association to the new user.
@@ -809,6 +820,11 @@ class EntryController extends Gdn_Controller {
                     'SaveRoles' => $SaveRolesRegister
                 ]);
                 $User['UserID'] = $UserID;
+
+                $this->EventArguments['Form'] = $this->Form;
+                $this->EventArguments['UserID'] = $UserID;
+                $this->fireEvent('AfterConnectSave');
+
                 $this->Form->setValidationResults($UserModel->validationResults());
 
                 // Send the welcome email.

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -522,7 +522,6 @@ class EntryController extends Gdn_Controller {
 
                 // Synchronize the user's data.
                 $UserModel->save($Data, ['NoConfirmEmail' => true, 'FixUnique' => true, 'SaveRoles' => $SaveRoles]);
-                $this->EventArguments['Form'] = $this->Form;
                 $this->EventArguments['UserID'] = $UserID;
                 $this->fireEvent('AfterConnectSave');
             }
@@ -603,7 +602,6 @@ class EntryController extends Gdn_Controller {
 
                                 // Update the user.
                                 $UserModel->save($Data, ['NoConfirmEmail' => true, 'FixUnique' => true, 'SaveRoles' => $SaveRoles]);
-                                $this->EventArguments['Form'] = $this->Form;
                                 $this->EventArguments['UserID'] = $UserID;
                                 $this->fireEvent('AfterConnectSave');
                             }
@@ -715,7 +713,6 @@ class EntryController extends Gdn_Controller {
                 ]);
                 $User['UserID'] = $UserID;
 
-                $this->EventArguments['Form'] = $this->Form;
                 $this->EventArguments['UserID'] = $UserID;
                 $this->fireEvent('AfterConnectSave');
 
@@ -821,7 +818,6 @@ class EntryController extends Gdn_Controller {
                 ]);
                 $User['UserID'] = $UserID;
 
-                $this->EventArguments['Form'] = $this->Form;
                 $this->EventArguments['UserID'] = $UserID;
                 $this->fireEvent('AfterConnectSave');
 


### PR DESCRIPTION
This update adds a new event to `EntryController`: AfterConnectSave.  This event will allow plug-ins to perform actions against a user after they have successfully connected via SSO, and `UserModel::save` or `UserModel::register` has been executed, under the following conditions:

1. [Logging in as a user with an existing UserAuthentication entry.](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.entrycontroller.php#L524)
2. [Connecting to an existing user where Garden.Registration.AutoConnect is enabled.](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.entrycontroller.php#L602)
3. A new user is registered for the connection. (see [here](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.entrycontroller.php#L704) and [here](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.entrycontroller.php#L806)).

`Garden.Registration.ConnectSynchronize` is required for the event to be triggered on existing users.