### PR TITLE
Add distinction between comments and discussion in BBCode quotes

### DIFF
--- a/library/core/class.bbcode.php
+++ b/library/core/class.bbcode.php
@@ -128,7 +128,13 @@ class BBCode extends Gdn_Pluggable {
         if (isset($params['url'])) {
             $url = trim($params['url']);
 
-            if (is_numeric($url)) {
+            if (preg_match('/(c|d)-(\d+)/', strtolower($url), $matches)) {
+                if ($matches[1] === 'd') {
+                    $url = "/discussion/$matches[2]";
+                } else {
+                    $url = "/discussion/comment/$matches[2]#Comment_$matches[2]";
+                }
+            } elseif (is_numeric($url)) {
                 $url = "/discussion/comment/$url#Comment_{$url}";
             } elseif (!$bbcode->isValidURL($url)) {
                 $url = '';

--- a/library/core/class.bbcode.php
+++ b/library/core/class.bbcode.php
@@ -130,9 +130,9 @@ class BBCode extends Gdn_Pluggable {
 
             if (preg_match('/(c|d)-(\d+)/', strtolower($url), $matches)) {
                 if ($matches[1] === 'd') {
-                    $url = "/discussion/$matches[2]";
+                    $url = "/discussion/{$matches[2]}";
                 } else {
-                    $url = "/discussion/comment/$matches[2]#Comment_$matches[2]";
+                    $url = "/discussion/comment/{$matches[2]}#Comment_{$matches[2]}";
                 }
             } elseif (is_numeric($url)) {
                 $url = "/discussion/comment/$url#Comment_{$url}";

--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -463,7 +463,7 @@ BLOCKQUOTE;
                 case 'BBCode':
                     $Author = htmlspecialchars($Data->InsertName);
                     if ($ID) {
-                        $IDString = ';'.htmlspecialchars($ID);
+                        $IDString = ';'.($Type === 'comment' ? 'c' : 'd').'-'.htmlspecialchars($ID);
                     }
 
                     $QuoteBody = $Data->Body;


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/4700

The fix is not retroactive.