### PR TITLE
Fix embed-comments when installed in subdirectory

### DIFF
--- a/js/embed.js
+++ b/js/embed.js
@@ -231,7 +231,7 @@ window.vanilla.embed = function(host) {
         var result = '';
 
         if (embed_type == 'comments') {
-            result = '//' + host + '/discussion/embed/'
+            result = '//' + host + path + '/discussion/embed/'
             + '&vanilla_identifier=' + encodeURIComponent(foreign_id)
             + '&vanilla_url=' + encodeURIComponent(foreign_url);
 


### PR DESCRIPTION
I had vanilla installed in a subdirectory of my domain and wanted to embed the forum using the comments approach on an external site. This didn't work without adding the path variable like in this patch.