### PR TITLE
Discussions: Show view counter only if analytics are enabled

### DIFF
--- a/applications/vanilla/views/discussions/table_functions.php
+++ b/applications/vanilla/views/discussions/table_functions.php
@@ -17,9 +17,11 @@ if (!function_exists('WriteDiscussionHeading')) :
             <td class="BigCount CountReplies">
                 <div class="Wrap"><?php echo t('Replies'); ?></div>
             </td>
+<?php if (C('Garden.Analytics.Enabled', true)) { ?>
             <td class="BigCount CountViews">
                 <div class="Wrap"><?php echo t('Views'); ?></div>
             </td>
+<?php } ?>
             <td class="BlockColumn BlockColumn-User LastUser">
                 <div class="Wrap"><?php echo t('Most Recent Comment', 'Most Recent'); ?></div>
             </td>
@@ -130,6 +132,7 @@ if (!function_exists('writeDiscussionRow')) :
                     ?>
                 </div>
             </td>
+<?php if (C('Garden.Analytics.Enabled', true)) { ?>
             <td class="BigCount CountViews">
                 <div class="Wrap">
                     <?php
@@ -141,6 +144,7 @@ if (!function_exists('writeDiscussionRow')) :
                     ?>
                 </div>
             </td>
+<?php } ?>
             <td class="BlockColumn BlockColumn-User LastUser">
                 <div class="Block Wrap">
                     <?php


### PR DESCRIPTION
The view counter is only increased if `Garden.Analytics.Enabled` is `true` (cp. https://vanillaforums.org/discussion/31374/enable-viewcount-on-discussions-but-disable-remote-analytics).

However, if analytics are disabled, it doesn't make any sense to show the view counter of discussions in the list of discussions. Therefore, I propose to introduce a respective query.