### PR TITLE
Support a JSON content type in the request

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -870,7 +870,7 @@ class Gdn_Request {
                 break;
 
             case self::INPUT_POST:
-                $argumentData = $_POST;
+                $argumentData = $this->decodePost($_POST, $_SERVER, 'php://input');
                 break;
 
             case self::INPUT_SERVER:
@@ -895,6 +895,30 @@ class Gdn_Request {
 
         }
         $this->_RequestArguments[$paramsType] = $argumentData;
+    }
+
+    /**
+     * Decode the environment's post depending on content type.
+     *
+     * @param array $post Usually the {@link $_POST} super-global.
+     * @param array $server Usually the {@link $_SERVER} super-global.
+     * @param array $inputFile Usually **php://input** for the raw input stream.
+     */
+    private function decodePost($post, $server, $inputFile) {
+        $contentType = !isset($server['CONTENT_TYPE']) ? 'application/x-www-form-urlencoded' : $server['CONTENT_TYPE'];
+
+        if (stripos($contentType, 'json') !== false) {
+            // Decode the JSON from the content type.
+            $result = json_decode(file_get_contents($inputFile), true);
+
+            if ($result === null) {
+                $result = $post;
+            }
+        } else {
+            $result = $post;
+        }
+
+        return $result;
     }
 
     public function setRequestArguments($paramsType, $paramsData) {

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -902,9 +902,9 @@ class Gdn_Request {
      *
      * @param array $post Usually the {@link $_POST} super-global.
      * @param array $server Usually the {@link $_SERVER} super-global.
-     * @param array $inputFile Usually **php://input** for the raw input stream.
+     * @param string $inputFile Usually **php://input** for the raw input stream.
      */
-    private function decodePost($post, $server, $inputFile) {
+    private function decodePost($post, $server, $inputFile = 'php://input') {
         $contentType = !isset($server['CONTENT_TYPE']) ? 'application/x-www-form-urlencoded' : $server['CONTENT_TYPE'];
 
         if (stripos($contentType, 'json') !== false) {


### PR DESCRIPTION
Allow requests to be made with an application/json content type. In these cases the raw input will be json-decoded and passed as the post.