### PR TITLE
Fix profile/discussions more pager

### DIFF
--- a/applications/vanilla/js/discussions.js
+++ b/applications/vanilla/js/discussions.js
@@ -2,8 +2,16 @@ jQuery(document).ready(function($) {
 
     // Set up paging
     if ($.morepager) {
-        $('.MorePager').not('.Message .MorePager').morepager({
+        $('.MorePager').not('.Section-Profile .MorePager').morepager({
             pageContainerSelector: 'ul.Discussions:last, ul.Drafts:last',
+            afterPageLoaded: function() {
+                $(document).trigger('DiscussionPagingComplete');
+            }
+        });
+
+        // profile/discussions paging
+        $('.Section-Profile .MorePager').morepager({
+            pagerInContainer: true,
             afterPageLoaded: function() {
                 $(document).trigger('DiscussionPagingComplete');
             }


### PR DESCRIPTION
On the profile/discussions page, the more pager appears in the container where the paging occurs. The morepager configuration currently appends additional discussions to the end of the container. This results in the more link being anchored in the middle of the discussion list rather than at the end. 

This PR configures morepager to prepend the discussions to the more link. It also removes the unneeded not(.Message .MorePager) filter.

Closes https://github.com/vanilla/vanilla/issues/4939