### PR TITLE
Create support for mapping response keys in SSO

### DIFF
--- a/library/core/class.authenticationprovidermodel.php
+++ b/library/core/class.authenticationprovidermodel.php
@@ -50,6 +50,7 @@ class Gdn_AuthenticationProviderModel extends Gdn_Model {
         if (is_array($Attributes)) {
             $Row = array_merge($Attributes, $Row);
         }
+        $Row['KeyMap'] = self::getKeyMap($Attributes);
         unset($Row['Attributes']);
     }
 
@@ -161,6 +162,26 @@ class Gdn_AuthenticationProviderModel extends Gdn_Model {
         }
 
         return false;
+    }
+
+    /**
+     * Loop through the provider and extract into an array any keys that start with $mapKey
+     *
+     * @param array $provider The array of all the values stored in a row of AuthenticationProvider table
+     * @param string $mapKey The prefix of keys that are to be returned as an array.
+     * @return array
+     */
+    public static function getKeyMap($provider = [], $mapKey = 'ProfileKeys') {
+        $map = [];
+        foreach ($provider as $providerKey => $value) {
+            if (stringBeginsWith($providerKey, $mapKey, false)) {
+                $subArrayKey = str_replace($mapKey, '', $providerKey);
+                if ($subArrayKey) {
+                    $map[$subArrayKey]= $value;
+                }
+            }
+        }
+        return $map;
     }
 
     /**

--- a/library/core/class.authenticationprovidermodel.php
+++ b/library/core/class.authenticationprovidermodel.php
@@ -177,7 +177,7 @@ class Gdn_AuthenticationProviderModel extends Gdn_Model {
             if (stringBeginsWith($providerKey, $mapKey, false)) {
                 $subArrayKey = str_replace($mapKey, '', $providerKey);
                 if ($subArrayKey) {
-                    $map[$subArrayKey]= $value;
+                    $map[$value]= $subArrayKey;
                 }
             }
         }


### PR DESCRIPTION
In many of our SSO integrations the client will send back responses with keys that do not correspond with vanilla keys. This PR allows us to store a map of key names in GDN_AuthenticationProvider.Attributes that can be added to the provider array as $provider['KeyMap'].

Usage: create a plugin with a  settings form that saves to GDN_AuthenticationProvider. Include fields with names that are prefixed with "ProfileKeys" (e.g. "ProfileKeysPhoto"). When you update your provider settings fill in the ProfileKeysPhoto field with "picture". Now your provider will have an array $provider['KeyMap'] with a key value pair "Photo" => "picture". An SSO response with the value 'picture': 'https://imgur.com/mypic' can now be mapped to "Photo" by an SSO plugin.

This change is backwards compatible. If plugins are not saving translation keys it is ignored.