### PR TITLE
Allow HTML translations for 'PermissionErrorMessage'

### DIFF
--- a/applications/dashboard/views/home/unauthorized.php
+++ b/applications/dashboard/views/home/unauthorized.php
@@ -3,7 +3,7 @@
 <div class="SplashInfo">
     <h1><?php echo t('PermissionErrorTitle', 'Permission Problem'); ?></h1>
 
-    <p><?php echo $this->sanitize($this->data('Message', t('PermissionErrorMessage', "You don't have permission to do that."))); ?></p>
+    <p><?php echo $this->data('Message') ? $this->sanitize($this->data('Message')) : t('PermissionErrorMessage', "You don't have permission to do that."); ?></p>
 </div>
 
 <?php if (debug() && $this->data('Trace')): ?>


### PR DESCRIPTION
Only sanitize the message, not the translation of 'PermissionErrorMessage'. Fixes issue where HTML in the translation of 'PermissionErrorMessage' is displayed as HTML.