### PR TITLE
Improve maintenance mode

### DIFF
--- a/applications/dashboard/controllers/class.utilitycontroller.php
+++ b/applications/dashboard/controllers/class.utilitycontroller.php
@@ -13,6 +13,9 @@
  */
 class UtilityController extends DashboardController {
 
+    /** A flag used to indicate the site was put into maintenance mode in an automated fashion. */
+    const MAINTENANCE_AUTO = 2;
+
     /** @var array Models to automatically instantiate. */
     public $Uses = array('Form');
 
@@ -514,6 +517,38 @@ class UtilityController extends DashboardController {
         $this->addCssFile('vanillicon.css', 'static');
 
         $this->setData('_NoPanel', true);
+        $this->render();
+    }
+
+    /**
+     * Toggle whether or not the site is in maintenance mode.
+     *
+     * @param int $updateMode
+     */
+    public function maintenance($updateMode = 0) {
+        $this->permission('Garden.Settings.Manage');
+        $currentMode = c('Garden.UpdateMode');
+
+        /**
+         * If $updateMode is equal to self::MAINTENANCE_AUTO, it assumed this action was performed via an automated
+         * process.  A bit flag is added to the current value, so the original setting is restored, once maintenance
+         * mode is disabled through this endpoint.
+         */
+        if ($updateMode == self::MAINTENANCE_AUTO) {
+            // Apply the is-auto flag to the current maintenance setting, so the original setting can be retrieved.
+            $updateMode = ($currentMode | $updateMode);
+        } elseif ($updateMode == 0 && ($currentMode & self::MAINTENANCE_AUTO)) {
+            // If the is-auto flag is set, restore the original UpdateMode value.
+            $updateMode = ($currentMode & ~self::MAINTENANCE_AUTO);
+        } else {
+            $updateMode = (bool)$updateMode;
+        }
+
+        // Save the new setting and output the result.
+        saveToConfig('Garden.UpdateMode', $updateMode);
+        $this->setData(['UpdateMode' => $updateMode]);
+        $this->deliveryType(DELIVERY_TYPE_DATA);
+        $this->deliveryMethod(DELIVERY_METHOD_JSON);
         $this->render();
     }
 }

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -191,7 +191,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         $this->fireEvent('BeforeDispatch');
 
         // If we're in update mode and aren't explicitly prevented from blocking, block.
-        if (Gdn::config('Garden.UpdateMode', false) && $this->getCanBlock($request) > self::BLOCK_NEVER) {
+        if (inMaintenanceMode() && $this->getCanBlock($request) > self::BLOCK_NEVER) {
             $request->withURI(Gdn::router()->getDestination('UpdateMode'));
         }
 

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1739,6 +1739,19 @@ if (!function_exists('inArrayI')) {
     }
 }
 
+if (!function_exists('inMaintenanceMode')) {
+    /**
+     * Determine if the site is in maintenance mode.
+     *
+     * @return bool
+     */
+    function inMaintenanceMode() {
+        $updateMode = c('Garden.UpdateMode');
+
+        return (bool)$updateMode;
+    }
+}
+
 if (!function_exists('inSubArray')) {
     /**
      * Loop through {@link $Haystack} looking for subarrays that contain {@link $Needle}.

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -69,7 +69,13 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
         }
 
         $this->databasePrefix($this->Database->DatabasePrefix);
-        $this->setAlterTableThreshold(c('Database.AlterTableThreshold', 0));
+
+        if (inMaintenanceMode()) {
+            $alterTableThreshold = 0;
+        } else {
+            $alterTableThreshold = c('Database.AlterTableThreshold', 0);
+        }
+        $this->setAlterTableThreshold($alterTableThreshold);
 
         $this->reset();
     }


### PR DESCRIPTION
This update performs a few improvements related to maintenance mode:

1. A new function, `inMaintenanceMode`, has been added.  This function returns true/false, depending on whether or not Garden.UpdateMode (maintenance mode) is enabled.
2. The dispatcher's direct call to check the config value of Garden.UpdateMode has been removed in favor of using `inMaintenanceMode`.
3. `Gdn_DatabaseStructure::__construct` now sets its `$alterTableThreshold` property to 0 (disabled) if the site is in maintenance mode.
4. A new utility endpoint has been added: /utility/maintenance.  This endpoint can enable or disable the maintenance mode status for a site, depending on the value of the `$updateMode` parameter it receives.  Additionally, this endpoint has the ability to receive a specific value for `$updateMode` (currently "2") to indicate the action was performed by an automated process.  This is done for the sake of being able to retrieve the current Garden.UpdateMode setting after maintenance mode has been disabled through this same endpoint.  If a site was in maintenance mode (Garden.UpdateMode = 1) and received an authorized request to /utility/maintenance?updateMode=2 (or /utility/maintenance/2), maintenance mode would still be enabled after an authorized request was made to /utility/maintenance/?updateMode=0.  A second call to the latter would fully disable maintenance mode for the site.