### PR TITLE
Fix Logger::removeLogger() bad comparison

### DIFF
--- a/library/Vanilla/Logger.php
+++ b/library/Vanilla/Logger.php
@@ -52,7 +52,7 @@ class Logger implements LoggerInterface {
      * A lower number is more severe.
      *
      * @param string|int $level The string log level or an actual priority.
-     * @return int Returns the numeric log level or `-1` if the level is invalid.
+     * @return int Returns the numeric log level or `8` if the level is invalid.
      */
     public static function levelPriority($level) {
         static $priorities = array(

--- a/library/Vanilla/Logger.php
+++ b/library/Vanilla/Logger.php
@@ -100,7 +100,7 @@ class Logger implements LoggerInterface {
      */
     public function removeLogger(LoggerInterface $logger, $trigger = true) {
         foreach ($this->loggers as $i => $addedLogger) {
-            if ($addedLogger === $logger) {
+            if ($addedLogger[0] === $logger) {
                 unset($this->loggers[$i]);
                 return $this;
             }


### PR DESCRIPTION
Logger::removeLogger incorrectly compares a [LoggerInterface, int] tuple to a passed LoggerInterface object using ===, which will always fail. This PR correctly addresses the first field of the tuple so that we are comparing LoggerInterface instances directly.