### PR TITLE
Hide category from breadcrumb on New Discussion when categories are disabled

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -83,8 +83,12 @@ class DiscussionController extends VanillaController {
         $Category = CategoryModel::categories($this->Discussion->CategoryID);
         $this->permission('Vanilla.Discussions.View', true, 'Category', val('PermissionCategoryID', $Category, -1));
         if (c('Vanilla.Categories.Use', true)) {
-            $this->setData('CategoryID', $this->CategoryID = $this->Discussion->CategoryID, true);
+            $this->CategoryID = $this->Discussion->CategoryID;
+        } else {
+            $this->CategoryID = null;
         }
+        $this->setData('CategoryID', $this->CategoryID);
+
 
         if (strcasecmp(val('Type', $this->Discussion), 'redirect') === 0) {
             $this->redirectDiscussion($this->Discussion);

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -82,7 +82,9 @@ class DiscussionController extends VanillaController {
         // Check permissions.
         $Category = CategoryModel::categories($this->Discussion->CategoryID);
         $this->permission('Vanilla.Discussions.View', true, 'Category', val('PermissionCategoryID', $Category, -1));
-        $this->setData('CategoryID', $this->CategoryID = $this->Discussion->CategoryID, true);
+        if (c('Vanilla.Categories.Use', true)) {
+            $this->setData('CategoryID', $this->CategoryID = $this->Discussion->CategoryID, true);
+        }
 
         if (strcasecmp(val('Type', $this->Discussion), 'redirect') === 0) {
             $this->redirectDiscussion($this->Discussion);

--- a/applications/vanilla/modules/class.newdiscussionmodule.php
+++ b/applications/vanilla/modules/class.newdiscussionmodule.php
@@ -72,7 +72,7 @@ class NewDiscussionModule extends Gdn_Module {
      */
     public function toString() {
         // Set CategoryID if we have one.
-        if ($this->CategoryID === null) {
+        if ($this->CategoryID === null && c('Vanilla.Categories.Use', true)) {
             $this->CategoryID = Gdn::controller()->data('Category.CategoryID', false);
         }
 

--- a/applications/vanilla/modules/class.newdiscussionmodule.php
+++ b/applications/vanilla/modules/class.newdiscussionmodule.php
@@ -72,7 +72,7 @@ class NewDiscussionModule extends Gdn_Module {
      */
     public function toString() {
         // Set CategoryID if we have one.
-        if ($this->CategoryID === null && c('Vanilla.Categories.Use', true)) {
+        if (c('Vanilla.Categories.Use', true) && $this->CategoryID === null) {
             $this->CategoryID = Gdn::controller()->data('Category.CategoryID', false);
         }
 

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -45,7 +45,7 @@ $this->fireEvent('BeforeCommentForm');
 
                     echo '<span class="'.$CancelClass.'">';
                     echo anchor($CancelText, '/');
-                    if ($CategoryID = $this->data('Discussion.CategoryID')) {
+                    if ($CategoryID = $this->data('Discussion.CategoryID') && c('Vanilla.Categories.Use')) {
                         $Category = CategoryModel::categories($CategoryID);
                         if ($Category) {
                             echo ' <span class="Bullet">•</span> '.anchor(htmlspecialchars($Category['Name']), categoryUrl($Category));

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -45,7 +45,7 @@ $this->fireEvent('BeforeCommentForm');
 
                     echo '<span class="'.$CancelClass.'">';
                     echo anchor($CancelText, '/');
-                    if ($CategoryID = $this->data('Discussion.CategoryID') && c('Vanilla.Categories.Use')) {
+                    if ($CategoryID = $this->data('Discussion.CategoryID') && c('Vanilla.Categories.Use', true)) {
                         $Category = CategoryModel::categories($CategoryID);
                         if ($Category) {
                             echo ' <span class="Bullet">•</span> '.anchor(htmlspecialchars($Category['Name']), categoryUrl($Category));

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -45,7 +45,8 @@ $this->fireEvent('BeforeCommentForm');
 
                     echo '<span class="'.$CancelClass.'">';
                     echo anchor($CancelText, '/');
-                    if ($CategoryID = $this->data('Discussion.CategoryID') && c('Vanilla.Categories.Use', true)) {
+                    $CategoryID = $this->data('Discussion.CategoryID');
+                    if (c('Vanilla.Categories.Use', true) && $CategoryID) {
                         $Category = CategoryModel::categories($CategoryID);
                         if ($Category) {
                             echo ' <span class="Bullet">•</span> '.anchor(htmlspecialchars($Category['Name']), categoryUrl($Category));


### PR DESCRIPTION
Although "Vanilla.Categories.Use" is set to false, category is shown in breadcrumbs and was used for "New Discussion" module. Using no categories at all should hide categories in all aspects for users.