### PR TITLE
Replace HTML comments with Smarty comments

### DIFF
--- a/applications/dashboard/views/default.master.tpl
+++ b/applications/dashboard/views/default.master.tpl
@@ -11,13 +11,15 @@
 
             <div class="SiteSearch">{searchbox}</div>
             <ul class="SiteMenu">
-                <!-- {dashboard_link} -->
+                {* {dashboard_link} *}
                 {discussions_link}
                 {activity_link}
-                <!-- {inbox_link} -->
+                {* {inbox_link} *}
                 {custom_menu}
-                <!-- {profile_link}
-               {signinout_link}  -->
+                {*
+                {profile_link}
+                {signinout_link}
+                *}
             </ul>
         </div>
     </div>


### PR DESCRIPTION
There are three links in the default.master.tpl which have been commented out. Nevertheless they are processed by Smarty and written as HTML. If they aren't already obsolete they should better be commented with Smarty comment tags so that their content is never processed.