### PR TITLE
Fix quote button not appearing in embeds

### DIFF
--- a/applications/vanilla/views/discussion/embed.php
+++ b/applications/vanilla/views/discussion/embed.php
@@ -23,6 +23,7 @@ if (!function_exists('WriteComment'))
     <ul class="DataList MessageList Comments">
         <?php
         if ($HasCommentData) {
+            $this->EventArguments['Discussion'] = $Discussion;
             $this->fireEvent('BeforeCommentsRender');
             $CurrentOffset = $this->Offset;
             foreach ($Comments as $Comment) {


### PR DESCRIPTION
Fix a regression bug introduced by: https://github.com/vanilla/vanilla/pull/4925/files#diff-65a59ade5d93c6930c77c9accc6d31ceR242

Long story short, the Discussion argument is missing.