### PR TITLE
Fix the quote button not appearing in multiple cases

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -259,7 +259,7 @@ class QuotesPlugin extends Gdn_Plugin {
             $ObjectID = 'Comment_'.$Args['Comment']->CommentID;
         } elseif ($discussion) {
             $Object = $discussion;
-            $ObjectID = 'Discussion_'.$Args['Discussion']->DiscussionID;
+            $ObjectID = 'Discussion_'.$Object->DiscussionID;
         } else {
             return;
         }

--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -239,7 +239,10 @@ class QuotesPlugin extends Gdn_Plugin {
      * Output Quote link.
      */
     protected function addQuoteButton($Sender, $Args) {
-        if (!isset($Args['Discussion'])) {
+
+        // There are some case were Discussion is not set as an event argument so we use the sender data instead.
+        $discussion = $Sender->data('Discussion');
+        if (!$discussion) {
             return;
         }
 
@@ -247,15 +250,15 @@ class QuotesPlugin extends Gdn_Plugin {
         if (!$session->UserID) {
             return;
         }
-        if (!$session->checkPermission('Vanilla.Comments.Add', false, 'Category', $Args['Discussion']->PermissionCategoryID)) {
+        if (!$session->checkPermission('Vanilla.Comments.Add', false, 'Category', $discussion->PermissionCategoryID)) {
             return;
         }
 
         if (isset($Args['Comment'])) {
             $Object = $Args['Comment'];
             $ObjectID = 'Comment_'.$Args['Comment']->CommentID;
-        } elseif (isset($Args['Discussion'])) {
-            $Object = $Args['Discussion'];
+        } elseif ($discussion) {
+            $Object = $discussion;
             $ObjectID = 'Discussion_'.$Args['Discussion']->DiscussionID;
         } else {
             return;

--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -256,7 +256,7 @@ class QuotesPlugin extends Gdn_Plugin {
 
         if (isset($Args['Comment'])) {
             $Object = $Args['Comment'];
-            $ObjectID = 'Comment_'.$Args['Comment']->CommentID;
+            $ObjectID = 'Comment_'.$Object->CommentID;
         } elseif ($discussion) {
             $Object = $discussion;
             $ObjectID = 'Discussion_'.$Object->DiscussionID;


### PR DESCRIPTION
Fix a [regression bug](https://github.com/vanilla/vanilla/pull/4925/files#diff-65a59ade5d93c6930c77c9accc6d31ceR242) where the quote button would not appear in some case because 'Discussion' is not always an event's argument.