### PR TITLE
Assign Unconfirmed role to new users if confirmation is required

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -916,15 +916,19 @@ class UserModel extends Gdn_Model {
             unset($Fields['Admin']);
         }
 
+        $Roles = val('Roles', $Fields);
+        unset($Fields['Roles']);
+
         // Massage the roles for email confirmation.
         if (self::requireConfirmEmail() && !val('NoConfirmEmail', $Options)) {
-            $ConfirmRoleID = RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
+            $ConfirmRoleIDs = RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
 
-            if (!empty($ConfirmRoleID)) {
+            if (!empty($ConfirmRoleIDs)) {
                 touchValue('Attributes', $Fields, []);
                 $ConfirmationCode = randomString(8);
                 $Fields['Attributes']['EmailKey'] = $ConfirmationCode;
                 $Fields['Confirmed'] = 0;
+                $Roles = array_merge($Roles, $ConfirmRoleIDs);
             }
         }
 
@@ -939,9 +943,6 @@ class UserModel extends Gdn_Model {
         if (val('Email', $Fields, null) === null) {
             $Fields['Email'] = '';
         }
-
-        $Roles = val('Roles', $Fields);
-        unset($Fields['Roles']);
 
         if (array_key_exists('Attributes', $Fields) && !is_string($Fields['Attributes'])) {
             $Fields['Attributes'] = dbencode($Fields['Attributes']);


### PR DESCRIPTION
By now the whole "user needs to confirm mail address" process is quite of buggy. Although the Unconfirmed role is explicitly described as the role a user gets if he needs to confirm his mail address, that role is not assigned. Instead of this, new users only get the Member role, which grants them more rights than the admin would have guessed.

That can only be "fixed" if Garden.Registration.DefaultRoles in the config is set to the unconfirmed role ID. But that is only a workaround, which might lead to unwanted behavior later on.
If the admin decides that his users will no longer need to require the mail confirmation by removing the tick from the "Require users to confirm their email addresses (recommended)" checkbox in /dashboard/settings/registration, new users still will be assigned to the Unconfirmed role after registration based on the DefaultRoles setting in the config.

I'd say that the problem described above can only be solved if the Unconfirmed role is assigned **dynamically** based on the "Require users to confirm..." setting.
The UserModels Insert method tests if the user needs to confirm his mail. I've added a line which merges the $ConfirmRoleIDs (if they exist) to the $Roles.