### PR TITLE
Assign Unconfirmed role to new users if confirmation is required

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -916,15 +916,19 @@ class UserModel extends Gdn_Model {
             unset($Fields['Admin']);
         }
 
+        $Roles = val('Roles', $Fields);
+        unset($Fields['Roles']);
+
         // Massage the roles for email confirmation.
         if (self::requireConfirmEmail() && !val('NoConfirmEmail', $Options)) {
-            $ConfirmRoleID = RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
+            $ConfirmRoleIDs = RoleModel::getDefaultRoles(RoleModel::TYPE_UNCONFIRMED);
 
-            if (!empty($ConfirmRoleID)) {
+            if (!empty($ConfirmRoleIDs)) {
                 touchValue('Attributes', $Fields, array());
                 $ConfirmationCode = randomString(8);
                 $Fields['Attributes']['EmailKey'] = $ConfirmationCode;
                 $Fields['Confirmed'] = 0;
+                $Roles = array_merge($Roles, $ConfirmRoleIDs);
             }
         }
 
@@ -939,9 +943,6 @@ class UserModel extends Gdn_Model {
         if (val('Email', $Fields, null) === null) {
             $Fields['Email'] = '';
         }
-
-        $Roles = val('Roles', $Fields);
-        unset($Fields['Roles']);
 
         if (array_key_exists('Attributes', $Fields) && !is_string($Fields['Attributes'])) {
             $Fields['Attributes'] = serialize($Fields['Attributes']);


### PR DESCRIPTION
Backport of https://github.com/vanilla/vanilla/pull/4977 to 2.3

I wouldn't say it is a critical bug, but if admins expect new users to have a Unconfirmed role with **restricted** access rights, but new users immediate gain Member access, it is at least annoying and irritating.

So just in case there will be a minor release, it would be nice if this could be included ;-)