### PR TITLE
Give themes the option to set their layout

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -637,6 +637,36 @@ class SettingsController extends DashboardController {
             $this->informMessage(t("Your changes were saved successfully."));
         }
 
+        // Add warnings for layouts that have been specified by the theme.
+        $themeManager = Gdn::themeManager();
+        $theme = $themeManager->enabledThemeInfo();
+        $layout = val('Layout', $theme);
+
+        $warningText = t('Your theme has specified the layout selected below. Changing the layout may make your theme look broken.');
+        $warningAlert = wrap($warningText, 'div', ['class' => 'alert alert-warning padded']);
+        $dangerText = t('Your theme recommends the %s layout, but you\'ve selected the %s layout. This may make your theme look broken.');
+        $dangerAlert = wrap($dangerText, 'div', ['class' => 'alert alert-danger padded']);
+
+        if (val('Discussions', $layout)) {
+            $dicussionsLayout = strtolower(val('Discussions', $layout));
+            if ($dicussionsLayout != c('Vanilla.Discussions.Layout')) {
+                $discussionsAlert = sprintf($dangerAlert, $dicussionsLayout, c('Vanilla.Discussions.Layout'));
+            } else {
+                $discussionsAlert = $warningAlert;
+            }
+            $this->setData('DiscussionsAlert', $discussionsAlert);
+        }
+
+        if (val('Categories', $layout)) {
+            $categoriesLayout = strtolower(val('Categories', $layout));
+            if ($categoriesLayout != c('Vanilla.Categories.Layout')) {
+                $categoriesAlert = sprintf($dangerAlert, $categoriesLayout, c('Vanilla.Categories.Layout'));
+            } else {
+                $categoriesAlert = $warningAlert;
+            }
+            $this->setData('CategoriesAlert', $categoriesAlert);
+        }
+
         $this->render();
     }
 

--- a/applications/dashboard/views/settings/homepage.php
+++ b/applications/dashboard/views/settings/homepage.php
@@ -92,14 +92,20 @@ function writeHomepageOption($Title, $Url, $iconName, $Current, $Description = '
             ?>
         </div>
         <?php if (Gdn::addonManager()->isEnabled('Vanilla', \Vanilla\Addon::TYPE_ADDON)): ?>
-            <?php echo subheading(t('Discussions Layout'), t('Choose the preferred layout for the discussions page.')); ?>
+            <?php
+            echo subheading(t('Discussions Layout'), t('Choose the preferred layout for the discussions page.'));
+            echo $this->data('DiscussionsAlert', '');
+            ?>
             <div class="LayoutOptions DiscussionsLayout label-selector">
                 <?php
                 echo WriteHomepageOption('Modern Layout', 'modern', 'disc-modern', $CurrentDiscussionLayout, t('Modern non-table-based layout'));
                 echo WriteHomepageOption('Table Layout', 'table', 'disc-table', $CurrentDiscussionLayout, t('Classic table layout used by traditional forums'));
                 ?>
             </div>
-            <?php echo subheading(t('Categories Layout'), t('Choose the preferred layout for the categories page.')); ?>
+            <?php
+            echo subheading(t('Categories Layout'), t('Choose the preferred layout for the categories page.'));
+            echo $this->data('CategoriesAlert', '');
+            ?>
             <div class="LayoutOptions CategoriesLayout label-selector">
                 <?php
                 echo WriteHomepageOption('Modern Layout', 'modern', 'cat-modern', $CurrentCategoriesLayout, t('Modern non-table-based layout'));

--- a/library/core/class.thememanager.php
+++ b/library/core/class.thememanager.php
@@ -39,6 +39,12 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
      */
     private $hasRequest = true;
 
+    /** @var array The layout options for a category list. */
+    private $allowedCategoryLayouts = ['table', 'modern'];
+
+    /** @var array The layout options for a discussions list. */
+    private $allowedDiscussionLayouts = ['table', 'modern', 'mixed'];
+
     /**
      * @var AddonManager
      */
@@ -321,6 +327,16 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
     }
 
     /**
+     * Sets the layout for the theme preview without saving the config values.
+     *
+     * @param string $themeName The name of the theme.
+     */
+    private function preparePreview($themeName) {
+        $themeInfo = $this->getThemeInfo($themeName);
+        $this->setLayout($themeInfo, false);
+    }
+
+    /**
      *
      *
      * @return mixed
@@ -333,7 +349,9 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
             return c('Garden.MobileTheme', 'default');
         } else {
             if ($this->hasPreview()) {
-                return $this->getPreview();
+                $preview = $this->getPreview();
+                $this->preparePreview($preview);
+                return $preview;
             }
             return c('Garden.Theme', 'default');
         }
@@ -346,7 +364,9 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
      */
     public function desktopTheme() {
         if ($this->hasPreview()) {
-            return $this->getPreview();
+            $preview = $this->getPreview();
+            $this->preparePreview($preview);
+            return $preview;
         }
         return c('Garden.Theme', 'default');
     }
@@ -471,6 +491,25 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
     }
 
     /**
+     * Set the layout config settings based on a theme's specifications.
+     *
+     * @param array $themeInfo A theme info array.
+     * @param bool $save Whether to save the layout to config.
+     */
+    private function setLayout($themeInfo, $save = true) {
+        if ($layout = val('Layout', $themeInfo, false)) {
+            $discussionsLayout = strtolower(val('Discussions', $layout, ''));
+            $categoriesLayout = strtolower(val('Categories', $layout, ''));
+            if ($discussionsLayout && in_array($discussionsLayout, $this->allowedDiscussionLayouts)) {
+                saveToConfig('Vanilla.Discussions.Layout', $discussionsLayout, $save);
+            }
+            if ($categoriesLayout && in_array($categoriesLayout, $this->allowedCategoryLayouts)) {
+                saveToConfig('Vanilla.Categories.Layout', $categoriesLayout, $save);
+            }
+        }
+    }
+
+    /**
      *
      *
      * @param $ThemeName
@@ -491,6 +530,7 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
         if ($ThemeFolder == '') {
             throw new Exception(t('The theme folder was not properly defined.'));
         } else {
+            $this->setLayout($ThemeInfo);
             $Options = valr("{$ThemeName}.Options", $this->AvailableThemes());
             if ($Options) {
                 if ($IsMobile) {

--- a/library/core/class.thememanager.php
+++ b/library/core/class.thememanager.php
@@ -40,10 +40,10 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
     private $hasRequest = true;
 
     /** @var array The layout options for a category list. */
-    private $allowedCategoryLayouts = ['table', 'modern'];
+    private $allowedCategoriesLayouts = ['table', 'modern', 'mixed'];
 
     /** @var array The layout options for a discussions list. */
-    private $allowedDiscussionLayouts = ['table', 'modern', 'mixed'];
+    private $allowedDiscussionsLayouts = ['table', 'modern'];
 
     /**
      * @var AddonManager
@@ -500,10 +500,10 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
         if ($layout = val('Layout', $themeInfo, false)) {
             $discussionsLayout = strtolower(val('Discussions', $layout, ''));
             $categoriesLayout = strtolower(val('Categories', $layout, ''));
-            if ($discussionsLayout && in_array($discussionsLayout, $this->allowedDiscussionLayouts)) {
+            if ($discussionsLayout && in_array($discussionsLayout, $this->allowedDiscussionsLayouts)) {
                 saveToConfig('Vanilla.Discussions.Layout', $discussionsLayout, $save);
             }
-            if ($categoriesLayout && in_array($categoriesLayout, $this->allowedCategoryLayouts)) {
+            if ($categoriesLayout && in_array($categoriesLayout, $this->allowedCategoriesLayouts)) {
                 saveToConfig('Vanilla.Categories.Layout', $categoriesLayout, $save);
             }
         }


### PR DESCRIPTION
This allows a theme to set its expected layout in its about.php array. This layout will be saved to config when the theme is enabled. 

When previewing a theme, it will preview with the expected layout.

To test, edit the about.php of a theme and add
```
'Layout'      => [
    'Categories'  => 'modern',
    'Discussions' => 'modern'
]
```
Clear your cache and then enable the theme. Ensure that the layout on `/settings/homepage` has changed to what has been specified in the theme. Preview the theme and make sure that no matter what the config is set as, the theme previews with the settings specified in about.php.

Closes https://github.com/vanilla/vanilla/issues/4666