### PR TITLE
Ensure unconfirmed role has sign-in permissions

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1607,14 +1607,13 @@ class UserModel extends Gdn_Model {
             $permissionsModel = new Vanilla\Permissions();
             $RolePermissions = $RoleModel->getPermissions($ConfirmEmailRoleID);
             $permissionsModel->compileAndLoad($RolePermissions);
-            $Permissions = $permissionsModel->getPermissions();
 
             // Ensure Confirm Email role can always sign in
-            if (!$Permissions->has('Garden.SignIn.Allow')) {
-                $Permissions->set('Garden.SignIn.Allow', true);
+            if (!$permissionsModel->has('Garden.SignIn.Allow')) {
+                $permissionsModel->set('Garden.SignIn.Allow', true);
             }
 
-            $User->Permissions = $Permissions->getPermissions();
+            $User->Permissions = $permissionsModel->getPermissions();
 
             // Otherwise normal loadings!
         } else {


### PR DESCRIPTION
`UserModel::getSession` has an issue with verifying sign-in permissions when the email confirmation is required for users.  It attempts to run a permission check/assignment functions against a permissions array, instead of the permissions object.

This update tweaks the logic to avoid grabbing the permissions array until after the proper checks and updates have been made.