### PR TITLE
Allow draft saves on new posts

### DIFF
--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -147,9 +147,9 @@ class DraftModel extends VanillaModel {
         }
 
         // Get the DraftID from the form so we know if we are inserting or updating.
-        $DraftID = val('DraftID', $formPostValues, '');
-        $Insert = $DraftID == '' ? true : false;
-
+        $DraftID = (int) val('DraftID', $formPostValues, 0);
+        $Insert = $DraftID === 0 ? true : false;
+        
         if (!$DraftID) {
             unset($formPostValues['DraftID']);
         }
@@ -161,7 +161,7 @@ class DraftModel extends VanillaModel {
 
         if ($Insert) {
             // If no categoryid is defined, grab the first available.
-            if (val('CategoryID', $formPostValues) === false) {
+            if (!is_numeric(val('CategoryID', $formPostValues, false))) {
                 $formPostValues['CategoryID'] = $this->SQL->get('Category', '', '', 1)->firstRow()->CategoryID;
             }
 

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -149,7 +149,7 @@ class DraftModel extends VanillaModel {
         // Get the DraftID from the form so we know if we are inserting or updating.
         $DraftID = (int) val('DraftID', $formPostValues, 0);
         $Insert = $DraftID === 0 ? true : false;
-        
+
         if (!$DraftID) {
             unset($formPostValues['DraftID']);
         }


### PR DESCRIPTION
Currently when adding a new draft, the draft ID form value will be retrieved as the string '0' and if there's no category, the category ID will be retrieved as and empty string. The DraftModel expects its falsey values for draft ID to be an empty string and Category ID to be === false. As such, we never reach the if ($Insert) block on line 162.

This PR adjusts the $Insert calculation and category ID check to ensure we properly calculate the category ID on a draft if it doesn't exist.

Closes https://github.com/vanilla/vanilla/issues/4880