### PR TITLE
Exclude &nbsp; as part of the URL when formatting links

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1461,6 +1461,7 @@ EOT;
             $Punc = '';
 
             // Special case where &nbsp; is right after an url and is not part of it!
+            // This can happen in WYSIWYG format if the url is the last text of the body.
             if (stringEndsWith($Url, '&nbsp;')) {
                 $Url = substr($Url, 0, -6);
                 $Punc = '&nbsp;';

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -449,17 +449,17 @@ class Gdn_Format {
         'ŭ' => 'u', 'ũ' => 'u', 'ų' => 'u', 'ŵ' => 'w', 'ý' => 'y', 'ÿ' => 'y',
         'ŷ' => 'y', 'ž' => 'z', 'ż' => 'z', 'ź' => 'z', 'þ' => 't', 'ß' => 'ss',
         'ſ' => 'ss', 'ый' => 'iy', 'А' => 'A', 'Б' => 'B', 'В' => 'V', 'Г' => 'G',
-        'Д' => 'D', 'Е' => 'E', 'Ё' => 'YO', 'Ж' => 'ZH', 'З' => 'Z', 'И' => 'I', 
-		'И' => 'I', 'І' => 'I', 'Й' => 'Y', 'К' => 'K', 'Л' => 'L', 'М' => 'M', 
-		'Н' => 'N', 'О' => 'O', 'П' => 'P', 'Р' => 'R', 'С' => 'S', 'Т' => 'T', 
-		'У' => 'U', 'Ф' => 'F', 'Х' => 'H', 'Ц' => 'C', 'Ч' => 'CH', 'Ш' => 'SH', 
-		'Щ' => 'SCH', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'YU', 
-		'Я' => 'YA', 'Є' => 'YE', 'Ї' => 'YI', 'а' => 'a', 'б' => 'b', 'в' => 'v', 
-		'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh', 'з' => 'z', 
-		'и' => 'i', 'і' => 'i', 'й' => 'y', 'к' => 'k', 'л' => 'l', 'м' => 'm', 
-		'н' => 'n', 'о' => 'o', 'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't', 
-		'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c', 'ч' => 'ch', 'ш' => 'sh', 
-		'щ' => 'sch', 'ъ' => '', 'ы' => 'y', 'ь' => '', 'э' => 'e', 'є' => 'ye', 
+        'Д' => 'D', 'Е' => 'E', 'Ё' => 'YO', 'Ж' => 'ZH', 'З' => 'Z', 'И' => 'I',
+		'И' => 'I', 'І' => 'I', 'Й' => 'Y', 'К' => 'K', 'Л' => 'L', 'М' => 'M',
+		'Н' => 'N', 'О' => 'O', 'П' => 'P', 'Р' => 'R', 'С' => 'S', 'Т' => 'T',
+		'У' => 'U', 'Ф' => 'F', 'Х' => 'H', 'Ц' => 'C', 'Ч' => 'CH', 'Ш' => 'SH',
+		'Щ' => 'SCH', 'Ъ' => '', 'Ы' => 'Y', 'Ь' => '', 'Э' => 'E', 'Ю' => 'YU',
+		'Я' => 'YA', 'Є' => 'YE', 'Ї' => 'YI', 'а' => 'a', 'б' => 'b', 'в' => 'v',
+		'г' => 'g', 'д' => 'd', 'е' => 'e', 'ё' => 'yo', 'ж' => 'zh', 'з' => 'z',
+		'и' => 'i', 'і' => 'i', 'й' => 'y', 'к' => 'k', 'л' => 'l', 'м' => 'm',
+		'н' => 'n', 'о' => 'o', 'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't',
+		'у' => 'u', 'ф' => 'f', 'х' => 'h', 'ц' => 'c', 'ч' => 'ch', 'ш' => 'sh',
+		'щ' => 'sch', 'ъ' => '', 'ы' => 'y', 'ь' => '', 'э' => 'e', 'є' => 'ye',
 		'ю' => 'yu', 'я' => 'ya', 'ї' => 'yi'
     );
 
@@ -1166,9 +1166,9 @@ class Gdn_Format {
             return self::to($Mixed, 'Links');
         } else {
             if (unicodeRegexSupport()) {
-                $Regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:https?|ftp)://[@\p{L}\p{N}\x21\x23-\x27\x2a-\x2e\x3a\x3b\/;\x3f-\x7a\x7e\x3d]+)`iu";
+                $Regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:https?|ftp)://[@\p{L}\p{N}\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`iu";
             } else {
-                $Regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:https?|ftp)://[@a-z0-9\x21\x23-\x27\x2a-\x2e\x3a\x3b\/;\x3f-\x7a\x7e\x3d]+)`i";
+                $Regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:https?|ftp)://[@a-z0-9\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`i";
             }
 
             self::linksCallback(null);
@@ -1459,9 +1459,16 @@ EOT;
         } else {
             // Strip punctuation off of the end of the url.
             $Punc = '';
+
+            // Special case where &nbsp; is right after an url and is not part of it!
+            if (stringEndsWith($Url, '&nbsp;')) {
+                $Url = substr($Url, 0, -6);
+                $Punc = '&nbsp;';
+            }
+
             if (preg_match('`^(.+)([.?,;:])$`', $Url, $Matches)) {
                 $Url = $Matches[1];
-                $Punc = $Matches[2];
+                $Punc = $Matches[2].$Punc;
             }
 
             // Get human-readable text from url.
@@ -1750,7 +1757,7 @@ EOT;
 
         // Do the requested replacement.
         if ($IsCallback) {
-            $Subject = preg_replace_callback($Search, $Replace, $Subject);
+            $Subject = preg_replace_callback($Search, $Replace, $Subject));
         } else {
             $Subject = preg_replace($Search, $Replace, $Subject);
         }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1757,7 +1757,7 @@ EOT;
 
         // Do the requested replacement.
         if ($IsCallback) {
-            $Subject = preg_replace_callback($Search, $Replace, $Subject));
+            $Subject = preg_replace_callback($Search, $Replace, $Subject);
         } else {
             $Subject = preg_replace($Search, $Replace, $Subject);
         }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1462,9 +1462,9 @@ EOT;
 
             // Special case where &nbsp; is right after an url and is not part of it!
             // This can happen in WYSIWYG format if the url is the last text of the body.
-            if (stringEndsWith($Url, '&nbsp;')) {
+            while(stringEndsWith($Url, '&nbsp;')) {
                 $Url = substr($Url, 0, -6);
-                $Punc = '&nbsp;';
+                $Punc .= '&nbsp;';
             }
 
             if (preg_match('`^(.+)([.?,;:])$`', $Url, $Matches)) {


### PR DESCRIPTION
In WYSIWYG mode a &nbsp; is added as the last character of a post.
If the last part of your post is an URL you will end up with the following text: `... http://example.com&nbsp;`
Since our URL regex is pretty lenient the whole thing is taken as the URL and then passed to linksCallback which removes the last punctuations characters (in this case ";") which break the &nbsp; entity.

I think that having a lenient URL regex is good because that way we can parse weird URLs correctly so I decided to try to detect if there is a (or many) &nbsp; at the end of the URL and put it/them as punctuation (it will be removed from the url and put back after the URL is wrapped with an anchor).

EDIT: The last space in WYSIWYG is a &nbsp; so you have to hit space at the end.