### PR TITLE
Search should return results from all categories we have permission to view

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -269,18 +269,17 @@ class CategoryModel extends Gdn_Model {
     /**
      *
      *
-     * @since 2.0.18
-     * @access public
-     * @return array Category IDs.
+     * @param bool $honorHideAllDiscussion Wether of not the HideAllDiscussions flag will be checked on categories.
+     * @return array|bool Category IDs or true if all categories are watched.
      */
-    public static function categoryWatch($AllDiscussions = true) {
+    public static function categoryWatch($honorHideAllDiscussion = true) {
         $Categories = self::categories();
         $AllCount = count($Categories);
 
         $Watch = array();
 
         foreach ($Categories as $CategoryID => $Category) {
-            if ($AllDiscussions && val('HideAllDiscussions', $Category)) {
+            if ($honorHideAllDiscussion && val('HideAllDiscussions', $Category)) {
                 continue;
             }
 
@@ -449,7 +448,7 @@ class CategoryModel extends Gdn_Model {
      * we can deprecate/remove this function.
      *
      * @param bool $stopHeadingCalculation
-     * @return CategoryModel 
+     * @return CategoryModel
      */
     public function setStopHeadingsCalculation($stopHeadingCalculation) {
         self::$stopHeadingsCalculation = $stopHeadingCalculation;

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -269,7 +269,7 @@ class CategoryModel extends Gdn_Model {
     /**
      *
      *
-     * @param bool $honorHideAllDiscussion Whether of not the HideAllDiscussions flag will be checked on categories.
+     * @param bool $honorHideAllDiscussion Whether or not the HideAllDiscussions flag will be checked on categories.
      * @return array|bool Category IDs or true if all categories are watched.
      */
     public static function categoryWatch($honorHideAllDiscussion = true) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -269,7 +269,7 @@ class CategoryModel extends Gdn_Model {
     /**
      *
      *
-     * @param bool $honorHideAllDiscussion Wether of not the HideAllDiscussions flag will be checked on categories.
+     * @param bool $honorHideAllDiscussion Whether of not the HideAllDiscussions flag will be checked on categories.
      * @return array|bool Category IDs or true if all categories are watched.
      */
     public static function categoryWatch($honorHideAllDiscussion = true) {

--- a/applications/vanilla/models/class.vanillasearchmodel.php
+++ b/applications/vanilla/models/class.vanillasearchmodel.php
@@ -48,7 +48,7 @@ class VanillaSearchModel extends Gdn_Model {
     public function discussionSql($SearchModel, $AddMatch = true) {
         // Get permission and limit search categories if necessary.
         if ($AddMatch) {
-            $Perms = CategoryModel::CategoryWatch();
+            $Perms = CategoryModel::CategoryWatch(false);
 
             if ($Perms !== true) {
                 $this->SQL->whereIn('d.CategoryID', $Perms);
@@ -92,7 +92,7 @@ class VanillaSearchModel extends Gdn_Model {
     public function commentSql($SearchModel, $AddMatch = true) {
         if ($AddMatch) {
             // Get permission and limit search categories if necessary.
-            $Perms = CategoryModel::CategoryWatch();
+            $Perms = CategoryModel::CategoryWatch(false);
             if ($Perms !== true) {
                 $this->SQL->whereIn('d.CategoryID', $Perms);
             }


### PR DESCRIPTION
The normal search was not searching in categories that had the flag `HideAllDiscussions`.
I updated categoryWatch doc block and parameter name to be more significative.