### PR TITLE
Add flood control to Activity and ActivityComment

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -11,7 +11,7 @@
 /**
  * Activity data management.
  */
-class ActivityModel extends Gdn_Model {
+class ActivityModel extends VanillaModel {
 
     /** Activity notification level: Everyone. */
     const NOTIFY_PUBLIC = -1;
@@ -1103,6 +1103,11 @@ class ActivityModel extends Gdn_Model {
                 $Comment['ActivityID'] = $CommentActivityID;
             }
 
+            // Make sure the user isn't spamming (flood control)
+            if ($this->isSpamming('ActivityComment')) {
+                return false;
+            }
+
             // Check for spam.
             $Spam = SpamModel::isSpam('ActivityComment', $Comment);
             if ($Spam) {
@@ -1476,6 +1481,10 @@ class ActivityModel extends Gdn_Model {
         $ActivityID = val('ActivityID', $Activity);
         if (!$ActivityID) {
             if (!$Delete) {
+                // Make sure the user isn't spamming (flood control)
+                if ($this->isSpamming('Activity')) {
+                    return false;
+                }
                 $this->addInsertFields($Activity);
                 touchValue('DateUpdated', $Activity, $Activity['DateInserted']);
 

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -11,7 +11,7 @@
 /**
  * Activity data management.
  */
-class ActivityModel extends VanillaModel {
+class ActivityModel extends \Vanilla\VanillaModel {
 
     /** Activity notification level: Everyone. */
     const NOTIFY_PUBLIC = -1;

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -236,7 +236,13 @@ class VanillaSettingsController extends Gdn_Controller {
             'Vanilla.Discussion.SpamLock',
             'Vanilla.Comment.SpamCount',
             'Vanilla.Comment.SpamTime',
-            'Vanilla.Comment.SpamLock'
+            'Vanilla.Comment.SpamLock',
+            'Vanilla.Activity.SpamCount',
+            'Vanilla.Activity.SpamTime',
+            'Vanilla.Activity.SpamLock',
+            'Vanilla.ActivityComment.SpamCount',
+            'Vanilla.ActivityComment.SpamTime',
+            'Vanilla.ActivityComment.SpamLock',
         );
         if ($IsConversationsEnabled) {
             $ConfigurationFields = array_merge(
@@ -278,6 +284,20 @@ class VanillaSettingsController extends Gdn_Controller {
             $ConfigurationModel->Validation->applyRule('Vanilla.Comment.SpamTime', 'Integer');
             $ConfigurationModel->Validation->applyRule('Vanilla.Comment.SpamLock', 'Required');
             $ConfigurationModel->Validation->applyRule('Vanilla.Comment.SpamLock', 'Integer');
+
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamCount', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamCount', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamTime', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamTime', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamLock', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamLock', 'Integer');
+
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamCount', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamCount', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamTime', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamTime', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamLock', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamLock', 'Integer');
 
 
             if ($IsConversationsEnabled) {

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -843,8 +843,8 @@ class CommentModel extends VanillaModel {
 
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert)) {
-            // If the post is new and it validates, check for spam
-            if (!$Insert || !$this->CheckForSpam('Comment')) {
+            // If the post is new and it validates, make sure the user isn't spamming (flood control)
+            if (!$Insert || !$this->isSpamming('Comment')) {
                 $Fields = $this->Validation->SchemaValidationFields();
                 unset($Fields[$this->PrimaryKey]);
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -11,7 +11,7 @@
 /**
  * Manages discussion comments data.
  */
-class CommentModel extends VanillaModel {
+class CommentModel extends \Vanilla\VanillaModel {
 
     /** Threshold. */
     const COMMENT_THRESHOLD_SMALL = 1000;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -11,7 +11,7 @@
 /**
  * Manages discussions data.
  */
-class DiscussionModel extends VanillaModel {
+class DiscussionModel extends \Vanilla\VanillaModel {
 
     use StaticInitializer;
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1890,8 +1890,8 @@ class DiscussionModel extends VanillaModel {
         }
 
         if (count($ValidationResults) == 0) {
-            // If the post is new and it validates, make sure the user isn't spamming
-            if (!$Insert || !$this->checkForSpam('Discussion')) {
+            // If the post is new and it validates, make sure the user isn't spamming (flood control)
+            if (!$Insert || !$this->isSpamming('Discussion')) {
                 // Get all fields on the form that relate to the schema
                 $Fields = $this->Validation->schemaValidationFields();
 

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -11,7 +11,7 @@
 /**
  * Manages unpublished drafts of comments and discussions.
  */
-class DraftModel extends VanillaModel {
+class DraftModel extends \Vanilla\VanillaModel {
 
     /**
      * Class constructor. Defines the related database table name.

--- a/applications/vanilla/models/class.vanillamodel.php
+++ b/applications/vanilla/models/class.vanillamodel.php
@@ -34,10 +34,10 @@ abstract class VanillaModel extends Gdn_Model {
      * @since 2.0.0
      * @access public
      *
-     * @param string $Type Valid values are 'Comment' or 'Discussion'.
-     * @return bool Whether spam check is positive (TRUE = spammer).
+     * @param string $Type Valid values are ['Activity', 'ActivityComment', 'Comment', 'Discussion'].
+     * @return bool Whether spam check is positive (true = spammer).
      */
-    public function checkForSpam($Type) {
+    public function isSpamming($Type) {
         $Session = Gdn::session();
 
         // If spam checking is disabled or user is an admin, skip
@@ -49,7 +49,7 @@ abstract class VanillaModel extends Gdn_Model {
         $Spam = false;
 
         // Validate $Type
-        if (!in_array($Type, array('Comment', 'Discussion'))) {
+        if (!in_array($Type, ['Activity', 'ActivityComment', 'Comment', 'Discussion'])) {
             trigger_error(ErrorMessage(sprintf('Spam check type unknown: %s', $Type), 'VanillaModel', 'CheckForSpam'), E_USER_ERROR);
         }
 

--- a/applications/vanilla/views/vanillasettings/floodcontrol.php
+++ b/applications/vanilla/views/vanillasettings/floodcontrol.php
@@ -53,6 +53,34 @@ echo heading(t('Flood Control'));
                 <?php echo t('minute(s)'); ?>
             </td>
         </tr>
+        <tr>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.Activity.SpamCount', $SpamCount); ?>
+                <?php echo t('activity(ies)'); ?>
+            </td>
+            <td class="Alt">
+                <?php echo $this->Form->DropDown('Vanilla.Activity.SpamTime', $SpamTime); ?>
+                <?php echo t('seconds'); ?>
+            </td>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.Activity.SpamLock', $SpamLock); ?>
+                <?php echo t('minute(s)'); ?>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.ActivityComment.SpamCount', $SpamCount); ?>
+                <?php echo t('activity\'s comment(s)'); ?>
+            </td>
+            <td class="Alt">
+                <?php echo $this->Form->DropDown('Vanilla.ActivityComment.SpamTime', $SpamTime); ?>
+                <?php echo t('seconds'); ?>
+            </td>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.ActivityComment.SpamLock', $SpamLock); ?>
+                <?php echo t('minute(s)'); ?>
+            </td>
+        </tr>
 
         <?php if ($ConversationsEnabled): ?>
 

--- a/composer.lock
+++ b/composer.lock
@@ -79,16 +79,16 @@
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v5.2.17",
+            "version": "v5.2.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "208913c6042967ba404f4bfa0819bf5bef79dbec"
+                "reference": "b18cb98131bd83103ccb26a888fdfe3177b8a663"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/208913c6042967ba404f4bfa0819bf5bef79dbec",
-                "reference": "208913c6042967ba404f4bfa0819bf5bef79dbec",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/b18cb98131bd83103ccb26a888fdfe3177b8a663",
+                "reference": "b18cb98131bd83103ccb26a888fdfe3177b8a663",
                 "shasum": ""
             },
             "require": {
@@ -135,7 +135,7 @@
                 }
             ],
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
-            "time": "2016-12-09 10:03:48"
+            "time": "2017-01-09 09:33:47"
         },
         {
             "name": "psr/log",
@@ -186,16 +186,16 @@
         },
         {
             "name": "smarty/smarty",
-            "version": "v3.1.30",
+            "version": "v3.1.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smarty-php/smarty.git",
-                "reference": "ed2b7f1146cfda13df1eea8a5f707a1b771b6e7e"
+                "reference": "c7d42e4a327c402897dd587871434888fde1e7a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/ed2b7f1146cfda13df1eea8a5f707a1b771b6e7e",
-                "reference": "ed2b7f1146cfda13df1eea8a5f707a1b771b6e7e",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/c7d42e4a327c402897dd587871434888fde1e7a9",
+                "reference": "c7d42e4a327c402897dd587871434888fde1e7a9",
                 "shasum": ""
             },
             "require": {
@@ -208,10 +208,8 @@
                 }
             },
             "autoload": {
-                "classmap": [
-                    "libs/Smarty.class.php",
-                    "libs/SmartyBC.class.php",
-                    "libs/sysplugins/"
+                "files": [
+                    "libs/bootstrap.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -237,7 +235,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-08-07 18:46:49"
+            "time": "2016-12-14 21:57:25"
         },
         {
             "name": "tburry/pquery",

--- a/library/Vanilla/VanillaModel.php
+++ b/library/Vanilla/VanillaModel.php
@@ -8,10 +8,14 @@
  * @since 2.0
  */
 
+namespace Vanilla;
+
+use Vanilla\Utility\CamelCaseScheme;
+
 /**
  * Introduces common methods that child classes can use.
  */
-abstract class VanillaModel extends Gdn_Model {
+abstract class VanillaModel extends \Gdn_Model {
 
     /**
      * Class constructor. Defines the related database table name.
@@ -38,7 +42,7 @@ abstract class VanillaModel extends Gdn_Model {
      * @return bool Whether spam check is positive (true = spammer).
      */
     public function isSpamming($Type) {
-        $Session = Gdn::session();
+        $Session = \Gdn::session();
 
         // If spam checking is disabled or user is an admin, skip
         $SpamCheckEnabled = val('SpamCheck', $this, true);
@@ -55,18 +59,18 @@ abstract class VanillaModel extends Gdn_Model {
 
         $CountSpamCheck = $Session->getAttribute('Count'.$Type.'SpamCheck', 0);
         $DateSpamCheck = $Session->getAttribute('Date'.$Type.'SpamCheck', 0);
-        $SecondsSinceSpamCheck = time() - Gdn_Format::toTimestamp($DateSpamCheck);
+        $SecondsSinceSpamCheck = time() - \Gdn_Format::toTimestamp($DateSpamCheck);
 
         // Get spam config settings
-        $SpamCount = Gdn::config('Vanilla.'.$Type.'.SpamCount');
+        $SpamCount = c('Vanilla.'.$Type.'.SpamCount');
         if (!is_numeric($SpamCount) || $SpamCount < 1) {
             $SpamCount = 1; // 1 spam minimum
         }
-        $SpamTime = Gdn::config('Vanilla.'.$Type.'.SpamTime');
+        $SpamTime = c('Vanilla.'.$Type.'.SpamTime');
         if (!is_numeric($SpamTime) || $SpamTime < 30) {
             $SpamTime = 30; // 30 second minimum spam span
         }
-        $SpamLock = Gdn::config('Vanilla.'.$Type.'.SpamLock');
+        $SpamLock = c('Vanilla.'.$Type.'.SpamLock');
         if (!is_numeric($SpamLock) || $SpamLock < 60) {
             $SpamLock = 60; // 60 second minimum lockout
         }
@@ -94,17 +98,17 @@ abstract class VanillaModel extends Gdn_Model {
             );
 
             // Update the 'waiting period' every time they try to post again
-            $Attributes['Date'.$Type.'SpamCheck'] = Gdn_Format::toDateTime();
+            $Attributes['Date'.$Type.'SpamCheck'] = \Gdn_Format::toDateTime();
         } else {
             if ($SecondsSinceSpamCheck > $SpamTime) {
                 $Attributes['Count'.$Type.'SpamCheck'] = 1;
-                $Attributes['Date'.$Type.'SpamCheck'] = Gdn_Format::toDateTime();
+                $Attributes['Date'.$Type.'SpamCheck'] = \Gdn_Format::toDateTime();
             } else {
                 $Attributes['Count'.$Type.'SpamCheck'] = $CountSpamCheck + 1;
             }
         }
         // Update the user profile after every comment
-        $UserModel = Gdn::userModel();
+        $UserModel = \Gdn::userModel();
         if ($Session->UserID) {
             $UserModel->saveAttribute($Session->UserID, $Attributes);
         }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/4795

You will need to run `composer update` to update the autoloader.
`ActivityModel` now extends `VanillaModel` in order to have the renamed function `isSpamming`