### PR TITLE
Check permissions earlier when viewing a category

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -207,6 +207,10 @@ class CategoriesController extends VanillaController {
                 throw notFoundException();
             }
             $Category = (object)$Category;
+
+            // Check permission
+            $this->permission('Vanilla.Discussions.View', true, 'Category', val('PermissionCategoryID', $Category));
+
             Gdn_Theme::section($Category->CssClass);
 
             // Load the breadcrumbs.
@@ -300,9 +304,6 @@ class CategoriesController extends VanillaController {
             }
             $Wheres = array('d.CategoryID' => $CategoryIDs);
             $this->setData('_ShowCategoryLink', count($CategoryIDs) > 1);
-
-            // Check permission
-            $this->permission('Vanilla.Discussions.View', true, 'Category', val('PermissionCategoryID', $Category));
 
             // Set discussion meta data.
             $this->EventArguments['PerPage'] = c('Vanilla.Discussions.PerPage', 30);


### PR DESCRIPTION
This update moves the permission check in `CategoriesController::index` to a much higher point in the method.  This should stop needless processing occurring if the current user doesn't even have permission to view the resource.

Previous behavior might've allowed a user to view a category with a display type of Heading, Flat or Nested, even though they didn't have view permissions.  However, the page would likely be empty, due to [`CategoryModel::filterCategoryPermissions`](https://github.com/vanilla/vanilla/blob/ea84fccb2a7b2ade07fa0dace703400c63056fd3/applications/vanilla/models/class.categorymodel.php#L624) removing any categories the user didn't have access to view discussions in.