### PR TITLE
Speed up safeGlob() by surpressing sorting

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3013,12 +3013,13 @@ if (!function_exists('safeGlob')) {
     /**
      * A version of {@link glob()} that always returns an array.
      *
-     * @param string $Pattern The glob pattern.
+     * @param string        $Pattern    The glob pattern.
      * @param array[string] $Extensions An array of file extensions to whitelist.
+     *
      * @return array[string] Returns an array of paths that match the glob.
      */
     function safeGlob($Pattern, $Extensions = array()) {
-        $Result = glob($Pattern);
+        $Result = glob($Pattern, GLOB_NOSORT);
         if (!is_array($Result)) {
             $Result = array();
         }


### PR DESCRIPTION
Just stumbled upon this blog post and thought it might be a quick and easy (though micro) performance win for safeGlob(): https://www.exakat.io/php-likes-sorting/