### PR TITLE
Add js-hijack CSS class as hijack selector

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -769,7 +769,7 @@ jQuery(document).ready(function($) {
 
         return false;
     };
-    $(document).delegate('.Hijack', 'click', hijackClick);
+    $(document).delegate('.Hijack, .js-hijack', 'click', hijackClick);
 
 
     // Activate ToggleFlyout and ButtonGroup menus

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -193,7 +193,7 @@ if (!function_exists('popin')) {
      * @return string Popin HTML string.
      */
     function popin($rel) {
-        return ' <span class="badge Popin js-popin" rel="'.$rel.'"></span> ';
+        return ' <span class="badge js-popin" rel="'.$rel.'"></span> ';
     }
 }
 


### PR DESCRIPTION
Any CSS class prefixed with `js` should signify that it is there for javascript purposes and should not be styled on. Going forward, this PR allows us to use `js-hijack` for hijacking rather than `Hijack`.

Also removes superfluous .Popin class from the popin badge rendering function.

Closes https://github.com/vanilla/vanilla/issues/3937