### PR TITLE
Fix call to getWriteChildrenMethod

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -246,8 +246,7 @@ endif;
 if (!function_exists('WriteTableRow')):
 
     function writeTableRow($Row, $Depth = 1) {
-        $Children = $Row['Children'];
-        $WriteChildren = getWriteChildrenMethod($Children, $Depth);
+        $WriteChildren = getWriteChildrenMethod($Row, $Depth);
         $H = 'h'.($Depth + 1);
         ?>
         <tr class="<?php echo CssClass($Row); ?>">
@@ -272,7 +271,7 @@ if (!function_exists('WriteTableRow')):
                         <div class="ChildCategories">
                             <?php
                             echo wrap(t('Child Categories').': ', 'b');
-                            echo CategoryString($Children, $Depth + 1);
+                            echo categoryString(val('Children', $Row), $Depth + 1);
                             ?>
                         </div>
                     <?php endif; ?>

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -246,6 +246,7 @@ endif;
 if (!function_exists('WriteTableRow')):
 
     function writeTableRow($Row, $Depth = 1) {
+        $Children = $Row['Children'];
         $WriteChildren = getWriteChildrenMethod($Row, $Depth);
         $H = 'h'.($Depth + 1);
         ?>
@@ -271,7 +272,7 @@ if (!function_exists('WriteTableRow')):
                         <div class="ChildCategories">
                             <?php
                             echo wrap(t('Child Categories').': ', 'b');
-                            echo categoryString(val('Children', $Row), $Depth + 1);
+                            echo categoryString($Children, $Depth + 1);
                             ?>
                         </div>
                     <?php endif; ?>


### PR DESCRIPTION
We pass the row's children to the getWriteChildrenMethod function, when it expects the category itself. This PR fixes that.

Fixes issue where comma-delimited child categories are not displaying in table layouts.