### PR TITLE
Replace deprecated draftModel->delete() call

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -271,7 +271,7 @@ class PostController extends VanillaController {
 
                         if ($DiscussionID > 0) {
                             if ($DraftID > 0) {
-                                $this->DraftModel->delete($DraftID);
+                                $this->DraftModel->deleteID($DraftID);
                             }
                         }
                         if ($DiscussionID == SPAM || $DiscussionID == UNAPPROVED) {
@@ -696,7 +696,7 @@ class PostController extends VanillaController {
 
                 $this->Form->setValidationResults($this->CommentModel->validationResults());
                 if ($CommentID > 0 && $DraftID > 0) {
-                    $this->DraftModel->delete($DraftID);
+                    $this->DraftModel->deleteID($DraftID);
                 }
             }
 


### PR DESCRIPTION
draftModel->delete() is deprecated, deleteID() should be used instead

https://github.com/vanilla/vanilla/blob/master/applications/vanilla/models/class.draftmodel.php#L214