### PR TITLE
Make PermissionModel->define() more strict about its received paramters

### DIFF
--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -207,7 +207,7 @@ class PermissionModel extends Gdn_Model {
      * @throws Exception
      */
     public function define($PermissionNames, $Type = 'tinyint', $JunctionTable = null, $JunctionColumn = null) {
-        if (!is_array($PermissionNames)) {Perm
+        if (!is_array($PermissionNames)) {
             trigger_error(__CLASS__.'->'.__METHOD__.' was called with an invalid $PermissionNames parameter.', E_USER_ERROR);
             return;
         }

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -207,7 +207,10 @@ class PermissionModel extends Gdn_Model {
      * @throws Exception
      */
     public function define($PermissionNames, $Type = 'tinyint', $JunctionTable = null, $JunctionColumn = null) {
-        $PermissionNames = (array)$PermissionNames;
+        if (!is_array($PermissionNames)) {Perm
+            trigger_error(__CLASS__.'->'.__METHOD__.' was called with an invalid $PermissionNames parameter.', E_USER_ERROR);
+            return;
+        }
 
         $Structure = $this->Database->structure();
         $Structure->table('Permission');


### PR DESCRIPTION
Fixes #5000

Only accepts arrays now!
Raise a warning and return in other cases.

All immediate usage of PermissionModel->define() is done using arrays but I added a warning for debug purpose.