### PR TITLE
Support for HTTPS termination by Amazon Cloudfront

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -490,6 +490,11 @@ class Gdn_Request {
             $scheme = 'https';
         }
 
+        // Amazon CloudFront terminated SSL
+        if (isset($_SERVER['CLOUDFRONT_FORWARDED_PROTO']) && strtolower($_SERVER['CLOUDFRONT_FORWARDED_PROTO']) == 'https') {
+            $scheme = 'https';
+        }
+
         // Varnish
         $originalProto = val('HTTP_X_ORIGINALLY_FORWARDED_PROTO', $_SERVER, null);
         if (!is_null($originalProto)) {


### PR DESCRIPTION
Feature request to correctly detect Amazon Cloudfront's `CLOUDFRONT_FORWARDED_PROTO` HTTPS protocol header.