### PR TITLE
Close editor dropdowns when the user clicks outside of a dropdown

### DIFF
--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -346,13 +346,22 @@
                 $(el).removeClass('editor-dropdown-open');
                 $(el).find('.wysihtml5-command-dialog-opened').removeClass('wysihtml5-command-dialog-opened');
             });
-        }
+        };
 
         /**
          * Deal with clashing JS for opening dialogs on click, and do not let
          * more than one dialog/dropdown appear at once.
          */
         var editorSetupDropdowns = function(editorInstance) {
+            $(document).on('click touchstart', function() {
+                editorDropdownsClose();
+            });
+
+            $(document).on('click touchstart', '.editor-dropdown', function(e) {
+                e.stopPropagation();
+            });
+
+
             $('.editor-dropdown .editor-action')
                 .off('click.dd')
                 .on('click.dd', function(e) {


### PR DESCRIPTION
Close editor dropdowns when the user clicks outside of a dropdown.

Closes https://github.com/vanilla/lithe/issues/60