### PR TITLE
Pass reference to Data array instead of array

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1336,7 +1336,7 @@ class ActivityModel extends Gdn_Model {
 
         $this->EventArguments['Preference'] = $Preference;
         $this->EventArguments['Options'] = $Options;
-        $this->EventArguments['Data'] = $Data;
+        $this->EventArguments['Data'] = &$Data;
         $this->fireEvent('BeforeCheckPreference');
         if (!empty($Preference)) {
             list($Popup, $Email) = self::notificationPreference($Preference, $Data['NotifyUserID'], 'both');


### PR DESCRIPTION
Any changes you make to $Data during a BeforeCheckPreference event get overwritten by old Data in this line (if either email or popup preferences are present): self::$Queue[$Data['NotifyUserID']][$Data['ActivityType']] = [$Data, $Options];

If the reference is passed, you can change the data while in the event and have the changes persist.

https://open.vanillaforums.com/discussion/comment/245537#Comment_245537