### PR TITLE
Change order of list fix in markdown processor

### DIFF
--- a/library/core/class.markdownvanilla.php
+++ b/library/core/class.markdownvanilla.php
@@ -75,7 +75,7 @@ class MarkdownVanilla extends \Michelf\MarkdownExtra {
      */
     public function addListFix() {
         $this->block_gamut = array_replace($this->block_gamut, [
-            'doListFix' => 39
+            'doListFix' => 5
         ]);
     }
 


### PR DESCRIPTION
The doListFix operation adds a newline before and unordered list if one doesn't already exist (see https://github.com/vanilla/vanilla/pull/4066). The doHeaders implementation in the Markdown library interferes with this.

This PR changes the order so that the doListFix operation comes before the doHeaders operation.

Fixes issue where list items appearing directly after a heading are wrapped in `<p>` tags.

Closes https://github.com/vanilla/vanilla/issues/5041