### PR TITLE
Require PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - hhvm

--- a/index.php
+++ b/index.php
@@ -8,12 +8,12 @@
  * @since 2.0
  */
 
-if (PHP_VERSION_ID < 50400) {
-    die("Vanilla requires PHP 5.4 or greater.");
+if (PHP_VERSION_ID < 50600) {
+    die("Vanilla requires PHP 5.6 or greater.");
 }
 
 define('APPLICATION', 'Vanilla');
-define('APPLICATION_VERSION', '2.3.102');
+define('APPLICATION_VERSION', '2.4.100');
 
 // Report and track all errors.
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);


### PR DESCRIPTION
Just what it says on the tin.

We have forked for version 2.4 release with the existing PHP 5.4 requirements: https://github.com/vanilla/vanilla/tree/release/2.4

Version 2.5 will require PHP 5.6.