### PR TITLE
Move flood control handling to its own class and add it to activities

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1103,6 +1103,16 @@ class ActivityModel extends Gdn_Model {
                 $Comment['ActivityID'] = $CommentActivityID;
             }
 
+            // Flood control check (spamming)
+            $floodControl = FloodControl::getInstance();
+            if ($floodControl->isCurrentUserSpamming(FloodControl::TYPE_ACTIVITY_COMMENT)) {
+                $this->Validation->addValidationResult(
+                    'Body',
+                    '@'.$floodControl->getWarningMessage(FloodControl::TYPE_ACTIVITY_COMMENT)
+                );
+                return false;
+            }
+
             // Check for spam.
             $Spam = SpamModel::isSpam('ActivityComment', $Comment);
             if ($Spam) {
@@ -1476,6 +1486,16 @@ class ActivityModel extends Gdn_Model {
         $ActivityID = val('ActivityID', $Activity);
         if (!$ActivityID) {
             if (!$Delete) {
+                // Flood control check (spamming)
+                $floodControl = FloodControl::getInstance();
+                if ($floodControl->isCurrentUserSpamming(FloodControl::TYPE_ACTIVITY)) {
+                    $this->Validation->addValidationResult(
+                        'Body',
+                        '@'.$floodControl->getWarningMessage(FloodControl::TYPE_ACTIVITY)
+                    );
+                    return false;
+                }
+
                 $this->addInsertFields($Activity);
                 touchValue('DateUpdated', $Activity, $Activity['DateInserted']);
 

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -242,7 +242,13 @@ class VanillaSettingsController extends Gdn_Controller {
             'Vanilla.Discussion.SpamLock',
             'Vanilla.Comment.SpamCount',
             'Vanilla.Comment.SpamTime',
-            'Vanilla.Comment.SpamLock'
+            'Vanilla.Comment.SpamLock',
+            'Vanilla.Activity.SpamCount',
+            'Vanilla.Activity.SpamTime',
+            'Vanilla.Activity.SpamLock',
+            'Vanilla.ActivityComment.SpamCount',
+            'Vanilla.ActivityComment.SpamTime',
+            'Vanilla.ActivityComment.SpamLock',
         );
         if ($IsConversationsEnabled) {
             $ConfigurationFields = array_merge(
@@ -285,6 +291,19 @@ class VanillaSettingsController extends Gdn_Controller {
             $ConfigurationModel->Validation->applyRule('Vanilla.Comment.SpamLock', 'Required');
             $ConfigurationModel->Validation->applyRule('Vanilla.Comment.SpamLock', 'Integer');
 
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamCount', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamCount', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamTime', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamTime', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamLock', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamLock', 'Integer');
+
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamCount', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamCount', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamTime', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamTime', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamLock', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamLock', 'Integer');
 
             if ($IsConversationsEnabled) {
                 $ConfigurationModel->Validation->applyRule('Conversations.Conversation.SpamCount', 'Required');

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -11,7 +11,7 @@
 /**
  * Manages unpublished drafts of comments and discussions.
  */
-class DraftModel extends VanillaModel {
+class DraftModel extends Gdn_Model {
 
     /**
      * Class constructor. Defines the related database table name.

--- a/applications/vanilla/models/class.vanillamodel.php
+++ b/applications/vanilla/models/class.vanillamodel.php
@@ -18,10 +18,12 @@ abstract class VanillaModel extends Gdn_Model {
      *
      * @since 2.0.0
      * @access public
+     * @deprecated
      *
      * @param string $Name Database table name.
      */
     public function __construct($Name = '') {
+        deprecated('Extending VanillaModel', 'Gdn_Model');
         parent::__construct($Name);
     }
 
@@ -33,80 +35,28 @@ abstract class VanillaModel extends Gdn_Model {
      *
      * @since 2.0.0
      * @access public
+     * @deprecated
      *
-     * @param string $Type Valid values are 'Comment' or 'Discussion'.
-     * @return bool Whether spam check is positive (TRUE = spammer).
+     * @param string $type Valid values are 'Comment' or 'Discussion'.
+     * @return bool Whether spam check is positive (true = spammer).
      */
-    public function checkForSpam($Type) {
-        $Session = Gdn::session();
+    public function checkForSpam($type) {
+        deprecated(__CLASS__.' '.__METHOD__, 'FloodControl::isCurrentUserSpamming()');
 
-        // If spam checking is disabled or user is an admin, skip
-        $SpamCheckEnabled = val('SpamCheck', $this, true);
-        if ($SpamCheckEnabled === false || $Session->User->Admin || $Session->checkPermission('Garden.Moderation.Manage')) {
-            return false;
+        // Flood control check (spamming)
+        $floodControl = FloodControl::getInstance();
+
+        // Respect model attribute
+        if (!val('SpamCheck', $this, true)) {
+            $floodControl->setFloodControlState($type, false);
         }
 
-        $Spam = false;
-
-        // Validate $Type
-        if (!in_array($Type, array('Comment', 'Discussion'))) {
-            trigger_error(ErrorMessage(sprintf('Spam check type unknown: %s', $Type), 'VanillaModel', 'CheckForSpam'), E_USER_ERROR);
-        }
-
-        $CountSpamCheck = $Session->getAttribute('Count'.$Type.'SpamCheck', 0);
-        $DateSpamCheck = $Session->getAttribute('Date'.$Type.'SpamCheck', 0);
-        $SecondsSinceSpamCheck = time() - Gdn_Format::toTimestamp($DateSpamCheck);
-
-        // Get spam config settings
-        $SpamCount = Gdn::config('Vanilla.'.$Type.'.SpamCount');
-        if (!is_numeric($SpamCount) || $SpamCount < 1) {
-            $SpamCount = 1; // 1 spam minimum
-        }
-        $SpamTime = Gdn::config('Vanilla.'.$Type.'.SpamTime');
-        if (!is_numeric($SpamTime) || $SpamTime < 30) {
-            $SpamTime = 30; // 30 second minimum spam span
-        }
-        $SpamLock = Gdn::config('Vanilla.'.$Type.'.SpamLock');
-        if (!is_numeric($SpamLock) || $SpamLock < 60) {
-            $SpamLock = 60; // 60 second minimum lockout
-        }
-        // Apply a spam lock if necessary
-        $Attributes = array();
-        if ($SecondsSinceSpamCheck < $SpamLock && $CountSpamCheck >= $SpamCount && $DateSpamCheck !== false) {
-            // TODO: REMOVE DEBUGGING INFO AFTER THIS IS WORKING PROPERLY
-            /*
-            echo '<div>SecondsSinceSpamCheck: '.$SecondsSinceSpamCheck.'</div>';
-            echo '<div>SpamLock: '.$SpamLock.'</div>';
-            echo '<div>CountSpamCheck: '.$CountSpamCheck.'</div>';
-            echo '<div>SpamCount: '.$SpamCount.'</div>';
-            echo '<div>DateSpamCheck: '.$DateSpamCheck.'</div>';
-            echo '<div>SpamTime: '.$SpamTime.'</div>';
-            */
-            $Spam = true;
+        $isUserSpamming = $floodControl->isCurrentUserSpamming($type);
+        if ($isUserSpamming) {
             $this->Validation->addValidationResult(
                 'Body',
-                '@'.sprintf(
-                    t('You have posted %1$s times within %2$s seconds. A spam block is now in effect on your account. You must wait at least %3$s seconds before attempting to post again.'),
-                    $SpamCount,
-                    $SpamTime,
-                    $SpamLock
-                )
+                '@'.$floodControl->getWarningMessage($type)
             );
-
-            // Update the 'waiting period' every time they try to post again
-            $Attributes['Date'.$Type.'SpamCheck'] = Gdn_Format::toDateTime();
-        } else {
-            if ($SecondsSinceSpamCheck > $SpamTime) {
-                $Attributes['Count'.$Type.'SpamCheck'] = 1;
-                $Attributes['Date'.$Type.'SpamCheck'] = Gdn_Format::toDateTime();
-            } else {
-                $Attributes['Count'.$Type.'SpamCheck'] = $CountSpamCheck + 1;
-            }
-        }
-        // Update the user profile after every comment
-        $UserModel = Gdn::userModel();
-        if ($Session->UserID) {
-            $UserModel->saveAttribute($Session->UserID, $Attributes);
         }
 
         return $Spam;

--- a/applications/vanilla/views/vanillasettings/floodcontrol.php
+++ b/applications/vanilla/views/vanillasettings/floodcontrol.php
@@ -53,6 +53,34 @@ echo heading(t('Flood Control'));
                 <?php echo t('minute(s)'); ?>
             </td>
         </tr>
+        <tr>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.Activity.SpamCount', $SpamCount); ?>
+                <?php echo t('activity(ies)'); ?>
+            </td>
+            <td class="Alt">
+                <?php echo $this->Form->DropDown('Vanilla.Activity.SpamTime', $SpamTime); ?>
+                <?php echo t('seconds'); ?>
+            </td>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.Activity.SpamLock', $SpamLock); ?>
+                <?php echo t('minute(s)'); ?>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.ActivityComment.SpamCount', $SpamCount); ?>
+                <?php echo t('activity\'s comment(s)'); ?>
+            </td>
+            <td class="Alt">
+                <?php echo $this->Form->DropDown('Vanilla.ActivityComment.SpamTime', $SpamTime); ?>
+                <?php echo t('seconds'); ?>
+            </td>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.ActivityComment.SpamLock', $SpamLock); ?>
+                <?php echo t('minute(s)'); ?>
+            </td>
+        </tr>
 
         <?php if ($ConversationsEnabled): ?>
 

--- a/library/core/class.floodcontrol.php
+++ b/library/core/class.floodcontrol.php
@@ -1,0 +1,127 @@
+<?php
+
+final class FloodControl {
+
+    const TYPE_COMMENT = 'Comment';
+    const TYPE_DISCUSSION = 'Discussion';
+    const TYPE_ACTIVITY = 'Activity';
+    const TYPE_ACTIVITY_COMMENT = 'ActivityComment';
+
+    private static $instance;
+
+    private $floodControlStates = [
+        self::TYPE_COMMENT => true,
+        self::TYPE_DISCUSSION => true,
+        self::TYPE_ACTIVITY => true,
+        self::TYPE_ACTIVITY_COMMENT => true,
+    ];
+
+    /**
+     * Get the FloodControl instance.
+     *
+     * @return FloodControl
+     */
+    public static function getInstance() {
+        if (self::$instance === null) {
+            self::$instance = new FloodControl();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Enable or disable flood control check for a specific type.
+     *
+     * @param $type Type of record. Valid values are FloodControl::TYPE_*.
+     * @param $active Whether flood control is active or not.
+     *
+     * @return FloodControl self
+     */
+    public function setFloodControlState($type, $active) {
+        $this->floodControlStates[$type] = $active;
+        return $this;
+    }
+
+    /**
+     * Checks to see if the user is spamming.
+     *
+     * Users cannot post more than $spamCount TYPE within $spamTime
+     * seconds or their account will be locked for $spamLock seconds.
+     *
+     * @param string $type Type of record. Valid values are FloodControl::TYPE_*.
+     * @return bool Whether the current user is spamming or not.
+     */
+    public function isCurrentUserSpamming($type) {
+        // Validate $type
+        if (!isset($this->floodControlStates[$type])) {
+            trigger_error(errorMessage(sprintf('FloodControl type unknown: %s', $type), __CLASS__, __METHOD__), E_USER_ERROR);
+            return false;
+        }
+
+        $session = Gdn::session();
+
+        // If spam checking is disabled or user is an admin, skip
+        $floodControlEnabled = val($type, $this->floodControlStates);
+        if ($floodControlEnabled === false || $session->User->Admin || $session->checkPermission('Garden.Moderation.Manage')) {
+            return false;
+        }
+
+        $spam = false;
+
+        $countSpamCheck = $session->getAttribute('Count'.$type.'SpamCheck', 0);
+        $dateSpamCheck = $session->getAttribute('Date'.$type.'SpamCheck', 0);
+        $secondsSinceSpamCheck = time() - Gdn_Format::toTimestamp($dateSpamCheck);
+
+        // Get spam config settings
+        $spamCount = Gdn::config('Vanilla.'.$type.'.SpamCount');
+        if (!is_numeric($spamCount) || $spamCount < 1) {
+            $spamCount = 1; // 1 spam minimum
+        }
+        $spamTime = Gdn::config('Vanilla.'.$type.'.SpamTime');
+        if (!is_numeric($spamTime) || $spamTime < 30) {
+            $spamTime = 30; // 30 second minimum spam span
+        }
+        $spamLock = Gdn::config('Vanilla.'.$type.'.SpamLock');
+        if (!is_numeric($spamLock) || $spamLock < 60) {
+            $spamLock = 60; // 60 second minimum lockout
+        }
+
+        // Apply a spam lock if necessary
+        $attributes = [];
+        if ($secondsSinceSpamCheck < $spamLock && $countSpamCheck >= $spamCount && $dateSpamCheck !== false) {
+            $spam = true;
+
+            // Update the 'waiting period' every time they try to post again
+            $attributes['Date'.$type.'SpamCheck'] = Gdn_Format::toDateTime();
+        } else {
+            if ($secondsSinceSpamCheck > $spamTime) {
+                $attributes['Count'.$type.'SpamCheck'] = 1;
+                $attributes['Date'.$type.'SpamCheck'] = Gdn_Format::toDateTime();
+            } else {
+                $attributes['Count'.$type.'SpamCheck'] = $countSpamCheck + 1;
+            }
+        }
+
+        // Update the user profile after every comment
+        $userModel = Gdn::userModel();
+        if ($session->UserID) {
+            $userModel->saveAttribute($session->UserID, $attributes);
+        }
+
+        return $spam;
+    }
+
+    /**
+     * Get a formatted warning message for spamming user.
+     *
+     * @param $type Type of record. Valid values are FloodControl::TYPE_*.
+     * @return string The formatted warning message
+     */
+    public function getWarningMessage($type) {
+        return sprintf(
+                t('You have posted %1$s times within %2$s seconds. A spam block is now in effect on your account. You must wait at least %3$s seconds before attempting to post again.'),
+                Gdn::config('Vanilla.'.$type.'.SpamCount', 1),
+                Gdn::config('Vanilla.'.$type.'.SpamTime', 30),
+                Gdn::config('Vanilla.'.$type.'.SpamLock', 60)
+            );
+    }
+}

--- a/library/core/class.floodcontrol.php
+++ b/library/core/class.floodcontrol.php
@@ -7,8 +7,10 @@ final class FloodControl {
     const TYPE_ACTIVITY = 'Activity';
     const TYPE_ACTIVITY_COMMENT = 'ActivityComment';
 
+    /** @var FloodControl */
     private static $instance;
 
+     /** @var Array */
     private $floodControlStates = [
         self::TYPE_COMMENT => true,
         self::TYPE_DISCUSSION => true,


### PR DESCRIPTION
Better version of https://github.com/vanilla/vanilla/pull/5015.
Fixes  https://github.com/vanilla/vanilla/issues/5045 and https://github.com/vanilla/vanilla/pull/5015

- new FloodControl class
- deprecate VanillaModel
- ensure that everything is backward compatible (validation, SpamCheck attribute on the models)