### PR TITLE
Improve password requirement message

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -128,7 +128,7 @@ class UserModel extends Gdn_Model {
      */
     public function addPasswordStrength($Controller) {
         $Controller->addJsFile('password.js');
-        $Controller->addDefinition('MinPassLength', c('Garden.Registration.MinPasswordLength'));
+        $Controller->addDefinition('MinPassLength', c('Garden.Password.MinLength'));
         $Controller->addDefinition(
             'PasswordTranslations',
             implode(',', [

--- a/applications/dashboard/views/entry/registerapproval.php
+++ b/applications/dashboard/views/entry/registerapproval.php
@@ -33,7 +33,7 @@
             <li>
                 <?php
                 echo $this->Form->label('Password', 'Password');
-                echo wrap(sprintf(t('Your password must be at least %d characters long.'), c('Garden.Password.MinLength')), 'div', array('class' => 'Gloss'));
+                echo wrap(sprintf(t('Your password must be at least %d characters long.'), c('Garden.Password.MinLength')).' '.t('For a stronger password, increase its length or combine upper and lowercase letters, digits, and symbols.'), 'div', array('class' => 'Gloss'));
                 echo $this->Form->Input('Password', 'password', array('Wrap' => true, 'Strength' => TRUE));
                 ?>
             </li>

--- a/applications/dashboard/views/entry/registerapproval.php
+++ b/applications/dashboard/views/entry/registerapproval.php
@@ -33,7 +33,7 @@
             <li>
                 <?php
                 echo $this->Form->label('Password', 'Password');
-                echo wrap(sprintf(t('Your password must be at least %d characters long.'), c('Garden.Registration.MinPasswordLength')), 'div', array('class' => 'Gloss'));
+                echo wrap(sprintf(t('Your password must be at least %d characters long.'), c('Garden.Password.MinLength')), 'div', array('class' => 'Gloss'));
                 echo $this->Form->Input('Password', 'password', array('Wrap' => true, 'Strength' => TRUE));
                 ?>
             </li>

--- a/applications/dashboard/views/entry/registerbasic.php
+++ b/applications/dashboard/views/entry/registerbasic.php
@@ -33,7 +33,7 @@
             <li>
                 <?php
                 echo $this->Form->label('Password', 'Password');
-                echo wrap(sprintf(t('Your password must be at least %d characters long.'), c('Garden.Password.MinLength')).' '.t('For a stronger password, inscrease its length and use a combination of lower/upper case letters, digits and special characters such as @!#$.'), 'div', array('class' => 'Gloss'));
+                echo wrap(sprintf(t('Your password must be at least %d characters long.'), c('Garden.Password.MinLength')).' '.t('For a stronger password, increase its length or combine upper and lowercase letters, digits, and symbols.'), 'div', array('class' => 'Gloss'));
                 echo $this->Form->Input('Password', 'password', array('Wrap' => true, 'Strength' => TRUE));
                 ?>
             </li>

--- a/applications/dashboard/views/entry/registerbasic.php
+++ b/applications/dashboard/views/entry/registerbasic.php
@@ -33,7 +33,7 @@
             <li>
                 <?php
                 echo $this->Form->label('Password', 'Password');
-                echo wrap(sprintf(t('Your password must be at least %d characters long.'), c('Garden.Registration.MinPasswordLength')), 'div', array('class' => 'Gloss'));
+                echo wrap(sprintf(t('Your password must be at least %d characters long.'), c('Garden.Password.MinLength')).' '.t('For a stronger password, inscrease its length and use a combination of lower/upper case letters, digits and special characters such as @!#$.'), 'div', array('class' => 'Gloss'));
                 echo $this->Form->Input('Password', 'password', array('Wrap' => true, 'Strength' => TRUE));
                 ?>
             </li>


### PR DESCRIPTION
and use the correct config for min length

`Garden.Registration.MinPasswordLength` was used only user for UI display so I replaced it with  `Garden.Password.MinLength` which is used to validate the password length

Fixes #5047
Fixes #2708