### PR TITLE
Update MeModule settings to use DropdownModule

### DIFF
--- a/applications/dashboard/library/class.nestedcollection.php
+++ b/applications/dashboard/library/class.nestedcollection.php
@@ -69,7 +69,7 @@ trait NestedCollection {
     /**
      * @var array The item modifiers allowed to be passed in the modifiers array.
      */
-    protected $allowedItemModifiers = ['popinRel', 'icon', 'badge', 'rel', 'description', 'attributes'];
+    protected $allowedItemModifiers = ['popinRel', 'icon', 'badge', 'rel', 'description', 'attributes', 'listItemCssClasses'];
 
     /**
      * @param boolean $forceDivider Whether to separate groups with a <hr> element. Only supported for flattened lists.
@@ -253,6 +253,7 @@ trait NestedCollection {
      * - **popinRel**: string - Endpoint for a popin.
      * - **badge**: string - Info to put into a badge, usually a number.
      * - **icon**: string - Name of the icon for the item, excluding the 'icon-' prefix.
+     * - **listItemCssClasses**: array - Array of class names to be applied to the list item.
      * @param bool $disabled Whether to disable the link.
      * @return $this The calling object.
      * @throws Exception
@@ -275,7 +276,7 @@ trait NestedCollection {
         $this->touchKey($link);
         $link['cssClass'] = $cssClass.' '.$this->buildCssClass($this->linkCssClassPrefix, $link);
 
-        $listItemCssClasses = [];
+        $listItemCssClasses = val('listItemCssClasses', $modifiers, []);
         if ($disabled) {
             $listItemCssClasses[] = 'disabled';
         }

--- a/applications/dashboard/modules/class.dropdownmodule.php
+++ b/applications/dashboard/modules/class.dropdownmodule.php
@@ -144,11 +144,12 @@ class DropdownModule extends Gdn_Module {
      * @param string $icon Icon for the trigger.
      * @return object $this The calling DropdownModule object.
      */
-    public function setTrigger($text = '', $type = 'button', $cssClass = 'btn-default', $icon = 'caret-down') {
+    public function setTrigger($text = '', $type = 'button', $cssClass = 'btn-default', $icon = 'caret-down', $url = '') {
         $this->trigger['text'] = $text;
         $this->trigger['type'] = in_array($type, $this->triggerTypes) ? $type : 'button';
         $this->trigger['icon'] = $icon;
         $this->trigger['cssClass'] = trim($cssClass);
+        $this->trigger['url'] = $url;
         return $this;
     }
 }

--- a/applications/dashboard/views/modules/dropdown.php
+++ b/applications/dashboard/views/modules/dropdown.php
@@ -1,6 +1,20 @@
 
 <span class="ToggleFlyout OptionsMenu <?php echo val('cssClass', $this); ?>">
-    <span class="Button-Options"><span class="OptionsTitle" title="<?php echo t('Options'); ?>"><?php echo val('text', val('trigger', $this)); ?></span><?php echo sprite('SpFlyoutHandle', 'Arrow'); ?></span>
+    <?php if (val('type', val('trigger', $this)) === 'button') : ?>
+    <span class="Button-Options">
+        <span class="OptionsTitle" title="<?php echo t('Options'); ?>">
+            <?php echo val('text', val('trigger', $this)); ?>
+        </span>
+        <?php echo sprite('SpFlyoutHandle', 'Arrow'); ?>
+    </span>
+    <?php else :
+        $text = val('text', val('trigger', $this));
+        $url = val('url', val('trigger', $this));
+        $icon = val('icon', val('trigger', $this));
+        $cssClass = val('cssClass', val('trigger', $this));
+        $alert = !empty($this->data('DashboardCount', '')) ? wrap($this->data('DashboardCount', ''), 'span', ['class' => 'Alert']) : '';
+        echo anchor($icon.$text.$alert, $url, $cssClass);
+    endif; ?>
     <ul class="Flyout MenuItems list-reset <?php echo val('listCssClass', $this); ?>" role="menu" aria-labelledby="<?php echo val('triggerId', $this); ?>">
         <?php foreach (val('items', $this) as $item) {
             if (val('type', $item) == 'group') { ?>
@@ -21,6 +35,9 @@
                             echo icon(val('icon', $item));
                         }
                         echo val('text', $item);
+                        if (val('badge', $item)) {
+                            echo badge(val('badge', $item));
+                        }
                         ?></a>
                 </li>
             <?php }

--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -65,8 +65,10 @@ if ($Session->isValid()):
     $editModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-editprofile'];
     $preferencesModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-preferences'];
 
-    $dropdown->addLinkIf(hasEditProfile(Gdn::session()->UserID), t('Edit Profile'), '/profile/edit', 'profile.edit', '', [], $editModifiers);
-    $dropdown->addLinkIf(!hasEditProfile(Gdn::session()->UserID), t('Preferences'), '/profile/preferences', 'profile.preferences', '', [], $preferencesModifiers);
+    $canEditProfile = (bool)hasEditProfile(Gdn::session()->UserID);
+
+    $dropdown->addLinkIf($canEditProfile, t('Edit Profile'), '/profile/edit', 'profile.edit', '', [], $editModifiers);
+    $dropdown->addLinkIf(!$canEditProfile, t('Preferences'), '/profile/preferences', 'profile.preferences', '', [], $preferencesModifiers);
 
     $applicantModifiers = $ApplicantCount > 0 ? ['badge' => $ApplicantCount] : [];
     $applicantModifiers['listItemCssClasses'] = ['link-applicants'];

--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -59,51 +59,37 @@ if ($Session->isValid()):
     }
 
     // Profile Settings & Logout
-    echo '<span class="ToggleFlyout">';
-    $CDashboard = $DashboardCount > 0 ? wrap($DashboardCount, 'span class="Alert"') : '';
-    echo anchor(sprite('SpOptions', 'Sprite Sprite16').Wrap(t('Account Options'), 'em').$CDashboard, '/profile/edit', 'MeButton FlyoutButton', array('title' => t('Account Options')));
-    echo sprite('SpFlyoutHandle', 'Arrow');
-    echo '<div class="Flyout MenuItems">';
-    echo '<ul>';
-    // echo wrap(Wrap(t('My Account'), 'strong'), 'li');
-    // echo wrap('<hr />', 'li');
-    if (hasEditProfile(Gdn::session()->UserID)) {
-        echo wrap(Anchor(sprite('SpEditProfile').' '.t('Edit Profile'), 'profile/edit', 'EditProfileLink'), 'li', array('class' => 'EditProfileWrap link-editprofile'));
-    } else {
-        echo wrap(Anchor(sprite('SpEditProfile').' '.t('Preferences'), 'profile/preferences', 'EditProfileLink'), 'li', array('class' => 'EditProfileWrap link-preferences'));
-    }
+    $dropdown = new DropdownModule();
+    $dropdown->setData('DashboardCount', $DashboardCount);
+    $dropdown->setTrigger(wrap(t('Account Options'), 'em'), 'anchor', 'MeButton FlyoutButton', '<span class="Sprite Sprite16 SpOptions"></span>', '/profile/edit');
+    $editModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-editprofile'];
+    $preferencesModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-preferences'];
 
-    if ($Session->checkPermission(array('Garden.Settings.View', 'Garden.Settings.Manage', 'Garden.Moderation.Manage', 'Garden.Users.Approve', 'Moderation.Spam.Manage', 'Moderation.ModerationQueue.Manage'), false)) {
-        echo wrap('<hr />', 'li');
-        $CApplicant = $ApplicantCount > 0 ? ' '.Wrap($ApplicantCount, 'span class="Alert"') : '';
-        $CSpam = ''; //$SpamCount > 0 ? ' '.Wrap($SpamCount, 'span class="Alert"') : '';
-        $CModeration = $ModerationCount > 0 ? ' '.Wrap($ModerationCount, 'span class="Alert"') : '';
+    $dropdown->addLinkIf(hasEditProfile(Gdn::session()->UserID), t('Edit Profile'), '/profile/edit', 'profile.edit', '', [], $editModifiers);
+    $dropdown->addLinkIf(!hasEditProfile(Gdn::session()->UserID), t('Preferences'), '/profile/preferences', 'profile.preferences', '', [], $preferencesModifiers);
 
-        if ($Session->checkPermission('Garden.Users.Approve')) {
-            echo wrap(Anchor(sprite('SpApplicants').' '.t('Applicants').$CApplicant, '/dashboard/user/applicants'), 'li', array('class' => 'link-applicants'));
-        }
+    $applicantModifiers = $ApplicantCount > 0 ? ['badge' => $ApplicantCount] : [];
+    $applicantModifiers['listItemCssClasses'] = ['link-applicants'];
+    $modModifiers = $ModerationCount > 0 ? ['badge' => $ModerationCount] : [];
+    $modModifiers['listItemCssClasses'] = ['link-moderation'];
+    $spamModifiers['listItemCssClasses'] = ['link-spam'];
+    $dashboardModifiers['listItemCssClasses'] = ['link-dashboard'];
+    $signoutModifiers['listItemCssClasses'] = ['link-signout', 'SignInOutWrap', 'SignOutWrap'];
 
-        if ($Session->checkPermission(array('Garden.Settings.Manage', 'Garden.Moderation.Manage', 'Moderation.ModerationQueue.Manage'), false)) {
-            echo wrap(Anchor(sprite('SpSpam').' '.t('Spam Queue').$CSpam, '/dashboard/log/spam'), 'li', array('class' => 'link-spam'));
-        }
+    $spamPermission = $Session->checkPermission(['Garden.Settings.Manage', 'Garden.Moderation.Manage', 'Moderation.ModerationQueue.Manage'], false);
+    $modPermission = $Session->checkPermission(['Garden.Settings.Manage', 'Garden.Moderation.Manage', 'Moderation.ModerationQueue.Manage'], false);
+    $dashboardPermission = $Session->checkPermission(['Garden.Settings.View', 'Garden.Settings.Manage'], false);
 
-        if ($Session->checkPermission(array('Garden.Settings.Manage', 'Garden.Moderation.Manage', 'Moderation.ModerationQueue.Manage'), false)) {
-            echo wrap(Anchor(sprite('SpMod').' '.t('Moderation Queue').$CModeration, '/dashboard/log/moderation'), 'li', array('class' => 'link-moderation'));
-        }
+    $dropdown->addLinkIf('Garden.Users.Approve', t('Applicants'), '/dashboard/user/applicants', 'moderation.applicants', '', [], $applicantModifiers);
+    $dropdown->addLinkIf($spamPermission, t('Spam Queue'), '/dashboard/log/spam', 'moderation.spam', '', [], $spamModifiers);
+    $dropdown->addLinkIf($modPermission, t('Moderation Queue'), '/dashboard/log/moderation', 'moderation.moderation', '', [], $modModifiers);
+    $dropdown->addLinkIf($dashboardPermission, t('Dashboard'), '/dashboard/settings', 'dashboard.dashboard', '', [], $dashboardModifiers);
 
-        if ($Session->checkPermission(array('Garden.Settings.View', 'Garden.Settings.Manage'), false)) {
-            echo wrap(Anchor(sprite('SpDashboard').' '.t('Dashboard'), '/dashboard/settings'), 'li', array('class' => 'link-dashboard'));
-        }
-    }
+    $dropdown->addLink(t('Sign Out'), SignOutUrl(), 'entry.signout', '', [], $signoutModifiers);
 
+    $this->EventArguments['Dropdown'] = &$dropdown;
     $this->fireEvent('FlyoutMenu');
-    echo wrap('<hr />'.anchor(sprite('SpSignOut').' '.t('Sign Out'), SignOutUrl()), 'li', array('class' => 'SignInOutWrap SignOutWrap link-signout'));
-    echo '</ul>';
-    echo '</div>';
-    echo '</span>';
-
-    // Sign Out
-    // echo anchor(sprite('SpSignOut', 'Sprite16').Wrap(t('Sign Out'), 'em'), SignOutUrl(), 'MeButton', array('title' => t('Sign Out')));
+    echo $dropdown;
 
     echo '</div>';
     echo '</div>';

--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -65,10 +65,8 @@ if ($Session->isValid()):
     $editModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-editprofile'];
     $preferencesModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-preferences'];
 
-    $canEditProfile = (bool)hasEditProfile(Gdn::session()->UserID);
-
-    $dropdown->addLinkIf($canEditProfile, t('Edit Profile'), '/profile/edit', 'profile.edit', '', [], $editModifiers);
-    $dropdown->addLinkIf(!$canEditProfile, t('Preferences'), '/profile/preferences', 'profile.preferences', '', [], $preferencesModifiers);
+    $dropdown->addLinkIf(hasEditProfile(Gdn::session()->UserID), t('Edit Profile'), '/profile/edit', 'profile.edit', '', [], $editModifiers);
+    $dropdown->addLinkIf(!hasEditProfile(Gdn::session()->UserID), t('Preferences'), '/profile/preferences', 'profile.preferences', '', [], $preferencesModifiers);
 
     $applicantModifiers = $ApplicantCount > 0 ? ['badge' => $ApplicantCount] : [];
     $applicantModifiers['listItemCssClasses'] = ['link-applicants'];

--- a/plugins/AllViewed/class.allviewed.plugin.php
+++ b/plugins/AllViewed/class.allviewed.plugin.php
@@ -80,20 +80,18 @@ class AllViewedPlugin extends Gdn_Plugin {
      * @access public
      *
      * @param MeModule $sender
+     * @param array $args
      */
-    public function meModule_flyoutMenu_handler($sender) {
-        // Add "Mark All Viewed" to menu
-        if (Gdn::session()->isValid()) {
-            echo wrap(anchor(sprite('SpMarkAllViewed').' '.t('Mark All Viewed'), '/discussions/markallviewed', 'Hijack'), 'li', ['class' => 'MarkAllViewed']);
-
-            $CategoryID = (int)(empty(Gdn::controller()->CategoryID) ? 0 : Gdn::controller()->CategoryID);
-            if ($CategoryID > 0) {
-                echo wrap(
-                    anchor(sprite('SpMarkCategoryViewed').' '.t('Mark Category Viewed'), "/discussions/markcategoryviewed/{$CategoryID}", 'Hijack'),
-                    'li',
-                    ['class' => 'MarkCategoryViewed']
-                );
-            }
+    public function meModule_flyoutMenu_handler($sender, $args) {
+        if (val('Dropdown', $args, false) && Gdn::session()->isValid()) {
+            /** @var DropdownModule $dropdown */
+            $dropdown = $args['Dropdown'];
+            $dropdown->addGroup('', 'discussions', '', ['after' => 'profile']); // Add links after profile menu items
+            $allModifiers['listItemCssClasses'] = ['MarkAllViewed', 'link-mark-all-viewed'];
+            $dropdown->addLink(t('Mark All Viewed'), '/discussions/markallviewed', 'discussions.markallviewed', 'Hijack', [], $allModifiers);
+            $categoryID = (int)(empty(Gdn::controller()->CategoryID) ? 0 : Gdn::controller()->CategoryID);
+            $categoryModifiers['listItemCssClasses'] = ['MarkCategoryViewed', 'link-mark-category-viewed'];
+            $dropdown->addLinkIf($categoryID > 0, t('Mark Category Viewed'), "/discussions/markcategoryviewed/{$categoryID}", 'discussions.markcategoryviewed', 'Hijack', [], $categoryModifiers);
         }
     }
 


### PR DESCRIPTION
Updates MeModule settings to use DropdownModule to make it configurable and sortable.

Also:
* Removes sprites from the dropdown menu.
* Adds the ability to add a list item CSS class to an item.
* Updates MarkAllViewed's way of adding an item to the menu.
* Adds the ability to add a url for the dropdown trigger.

Other than removing the sprites, this update does not affect the markup of the MeModule menu and should not affect any themes.