### PR TITLE
Create modules see a user's most recent comments and posts

### DIFF
--- a/applications/vanilla/modules/class.usercommentsmodule.php
+++ b/applications/vanilla/modules/class.usercommentsmodule.php
@@ -16,12 +16,14 @@ class UserCommentsModule extends Gdn_Module {
     /** @var int Display limit. */
     public $limit = 10;
 
-    /** @var  int The ID of the user for whom you are showing the comments. */
+    /** @var int The ID of the user for whom you are showing the comments. */
     public $userID = null;
 
     /**
+     * Construct the module. This module is designed to run in the profile controller. If it is not in the
+     * profile controller and no UserID was declared when it was instantiated do not populate $this->userID.
      *
-     *
+     * @param GDN_Controller $sender
      * @throws Exception
      */
     public function __construct($sender) {
@@ -30,7 +32,7 @@ class UserCommentsModule extends Gdn_Module {
         $this->fireEvent('Init');
         //If you are being executed from the profile controller, get the UserID.
         if (strtolower(val('ControllerName', $sender)) === 'profilecontroller') {
-            $this->userID = $sender->User->UserID;
+            $this->userID = valr('User.UserID', $sender);
         }
     }
 
@@ -42,6 +44,10 @@ class UserCommentsModule extends Gdn_Module {
     public function getData($limit = false) {
         if (!$limit) {
             $limit = $this->limit;
+        }
+
+        if (!$this->userID) {
+            return;
         }
 
         $userModel = new UserModel();

--- a/applications/vanilla/modules/class.usercommentsmodule.php
+++ b/applications/vanilla/modules/class.usercommentsmodule.php
@@ -16,12 +16,6 @@ class UserCommentsModule extends Gdn_Module {
     /** @var int Display limit. */
     public $limit = 10;
 
-    /** @var bool Whether to show the discussion author avatar. */
-    private $showPhotos = false;
-
-    /** @var array Limit the discussions to just this list of categories, checked for view permission. */
-    protected $categoryIDs;
-
     /** @var  int The ID of the user for whom you are showing the comments. */
     public $userID = null;
 
@@ -41,22 +35,6 @@ class UserCommentsModule extends Gdn_Module {
     }
 
     /**
-     * @param $showPhotos Whether to show the comment author avatar.
-     * @return CommentsModule
-     */
-    public function setShowPhotos($showPhotos) {
-        $this->showPhotos = $showPhotos;
-        return $this;
-    }
-
-    /**
-     * @return bool Whether to show the comment author avatar.
-     */
-    public function getShowPhotos() {
-        return $this->showPhotos;
-    }
-
-    /**
      * Get the data for the module.
      *
      * @param int|bool $limit Override the number of comments to display.
@@ -65,14 +43,27 @@ class UserCommentsModule extends Gdn_Module {
         if (!$limit) {
             $limit = $this->limit;
         }
+
+        $userModel = new UserModel();
+        $this->setData('User', $userModel->getID($this->userID));
         $commentsModel = new CommentModel();
         $this->setData('Comments', $commentsModel->getByUser2($this->userID, $limit));
     }
 
+    /**
+     * Set where the module will be shown.
+     *
+     * @return string
+     */
     public function assetTarget() {
         return 'Panel';
     }
 
+    /**
+     * Output the module as a string.
+     *
+     * @return string|void
+     */
     public function toString() {
         // If there is no userID show nothing.
         if (!$this->userID) {
@@ -84,23 +75,5 @@ class UserCommentsModule extends Gdn_Module {
         }
 
         return parent::toString();
-    }
-
-    /**
-     * Get a list of category IDs to limit.
-     *
-     * @return array
-     */
-    public function getCategoryIDs() {
-        return $this->categoryIDs;
-    }
-
-    /**
-     * Set a list of category IDs to limit.
-     *
-     * @param array $categoryIDs
-     */
-    public function setCategoryIDs($categoryIDs) {
-        $this->categoryIDs = $categoryIDs;
     }
 }

--- a/applications/vanilla/modules/class.usercommentsmodule.php
+++ b/applications/vanilla/modules/class.usercommentsmodule.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * User comments module.
+ *
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ * @package Vanilla
+ * @since 2.3
+ */
+
+/**
+ * Renders recently posted comments from a specific user
+ */
+class UserCommentsModule extends Gdn_Module {
+
+    /** @var int Display limit. */
+    public $limit = 10;
+
+    /** @var bool Whether to show the discussion author avatar. */
+    private $showPhotos = false;
+
+    /** @var array Limit the discussions to just this list of categories, checked for view permission. */
+    protected $categoryIDs;
+
+    /** @var  int The ID of the user for whom you are showing the comments. */
+    public $userID = null;
+
+    /**
+     *
+     *
+     * @throws Exception
+     */
+    public function __construct($sender) {
+        parent::__construct();
+        $this->_ApplicationFolder = 'vanilla';
+        $this->fireEvent('Init');
+        //If you are being executed from the profile controller, get the UserID.
+        if (strtolower(val('ControllerName', $sender)) === 'profilecontroller') {
+            $this->userID = $sender->User->UserID;
+        }
+    }
+
+    /**
+     * @param $showPhotos Whether to show the comment author avatar.
+     * @return CommentsModule
+     */
+    public function setShowPhotos($showPhotos) {
+        $this->showPhotos = $showPhotos;
+        return $this;
+    }
+
+    /**
+     * @return bool Whether to show the comment author avatar.
+     */
+    public function getShowPhotos() {
+        return $this->showPhotos;
+    }
+
+    /**
+     * Get the data for the module.
+     *
+     * @param int|bool $limit Override the number of comments to display.
+     */
+    public function getData($limit = false) {
+        if (!$limit) {
+            $limit = $this->limit;
+        }
+        $commentsModel = new CommentModel();
+        $this->setData('Comments', $commentsModel->getByUser2($this->userID, $limit));
+    }
+
+    public function assetTarget() {
+        return 'Panel';
+    }
+
+    public function toString() {
+        // If there is no userID show nothing.
+        if (!$this->userID) {
+            return;
+        }
+
+        if (!$this->data('Comments')) {
+            $this->getData();
+        }
+
+        return parent::toString();
+    }
+
+    /**
+     * Get a list of category IDs to limit.
+     *
+     * @return array
+     */
+    public function getCategoryIDs() {
+        return $this->categoryIDs;
+    }
+
+    /**
+     * Set a list of category IDs to limit.
+     *
+     * @param array $categoryIDs
+     */
+    public function setCategoryIDs($categoryIDs) {
+        $this->categoryIDs = $categoryIDs;
+    }
+}

--- a/applications/vanilla/modules/class.usercommentsmodule.php
+++ b/applications/vanilla/modules/class.usercommentsmodule.php
@@ -53,7 +53,7 @@ class UserCommentsModule extends Gdn_Module {
         $userModel = new UserModel();
         $this->setData('User', $userModel->getID($this->userID));
         $commentsModel = new CommentModel();
-        $this->setData('Comments', $commentsModel->getByUser2($this->userID, $limit));
+        $this->setData('Comments', $commentsModel->getByUser2($this->userID, $limit, 0));
     }
 
     /**

--- a/applications/vanilla/modules/class.userdiscussionsmodule.php
+++ b/applications/vanilla/modules/class.userdiscussionsmodule.php
@@ -16,12 +16,6 @@ class UserDiscussionsModule extends Gdn_Module {
     /** @var int Display limit. */
     public $limit = 10;
 
-    /** @var bool Whether to show the discussion author avatar. */
-    private $showPhotos = false;
-
-    /** @var array Limit the discussions to just this list of categories, checked for view permission. */
-    protected $categoryIDs;
-
     /** @var  int The ID of the user for whom you are showing the comments. */
     public $userID = null;
 
@@ -41,22 +35,6 @@ class UserDiscussionsModule extends Gdn_Module {
     }
 
     /**
-     * @param $showPhotos Whether to show the comment author avatar.
-     * @return CommentsModule
-     */
-    public function setShowPhotos($showPhotos) {
-        $this->showPhotos = $showPhotos;
-        return $this;
-    }
-
-    /**
-     * @return bool Whether to show the comment author avatar.
-     */
-    public function getShowPhotos() {
-        return $this->showPhotos;
-    }
-
-    /**
      * Get the data for the module.
      *
      * @param int|bool $limit Override the number of comments to display.
@@ -65,15 +43,28 @@ class UserDiscussionsModule extends Gdn_Module {
         if (!$limit) {
             $limit = $this->limit;
         }
+        $userModel = new UserModel();
+        $this->setData('User', $userModel->getID($this->userID));
+
         $discussionModel = new DiscussionModel();
         $discussions  = $discussionModel->getByUser($this->userID, $limit, 0, false);
         $this->setData('Discussions', $discussions);
     }
 
+    /**
+     * Set where the module will be shown.
+     *
+     * @return string
+     */
     public function assetTarget() {
         return 'Panel';
     }
 
+    /**
+     * Output the module as a string.
+     *
+     * @return string|void
+     */
     public function toString() {
         // If there is no userID show nothing.
         if (!$this->userID) {
@@ -83,26 +74,7 @@ class UserDiscussionsModule extends Gdn_Module {
         if (!$this->data('Discussions')) {
             $this->getData();
         }
-//        $this->view = 'discussions';
 
         return parent::toString();
-    }
-
-    /**
-     * Get a list of category IDs to limit.
-     *
-     * @return array
-     */
-    public function getCategoryIDs() {
-        return $this->categoryIDs;
-    }
-
-    /**
-     * Set a list of category IDs to limit.
-     *
-     * @param array $categoryIDs
-     */
-    public function setCategoryIDs($categoryIDs) {
-        $this->categoryIDs = $categoryIDs;
     }
 }

--- a/applications/vanilla/modules/class.userdiscussionsmodule.php
+++ b/applications/vanilla/modules/class.userdiscussionsmodule.php
@@ -16,12 +16,14 @@ class UserDiscussionsModule extends Gdn_Module {
     /** @var int Display limit. */
     public $limit = 10;
 
-    /** @var  int The ID of the user for whom you are showing the comments. */
+    /** @var int The ID of the user for whom you are showing the comments. */
     public $userID = null;
 
     /**
+     * Construct the module. This module is designed to run in the profile controller. If it is not in the
+     * profile controller and no UserID was declared when it was instantiated do not populate $this->userID.
      *
-     *
+     * @param GDN_Controller $sender
      * @throws Exception
      */
     public function __construct($sender) {
@@ -30,7 +32,7 @@ class UserDiscussionsModule extends Gdn_Module {
         $this->fireEvent('Init');
         //If you are being executed from the profile controller, get the UserID.
         if (strtolower(val('ControllerName', $sender)) === 'profilecontroller') {
-            $this->userID = $sender->User->UserID;
+            $this->userID = valr('User.UserID', $sender);
         }
     }
 
@@ -43,6 +45,11 @@ class UserDiscussionsModule extends Gdn_Module {
         if (!$limit) {
             $limit = $this->limit;
         }
+
+        if (!$this->userID) {
+            return;
+        }
+
         $userModel = new UserModel();
         $this->setData('User', $userModel->getID($this->userID));
 

--- a/applications/vanilla/modules/class.userdiscussionsmodule.php
+++ b/applications/vanilla/modules/class.userdiscussionsmodule.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * User discussions module
+ *
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ * @package Vanilla
+ * @since 2.3
+ */
+
+/**
+ * Renders recent discussions started by a specified user.
+ */
+class UserDiscussionsModule extends Gdn_Module {
+
+    /** @var int Display limit. */
+    public $limit = 10;
+
+    /** @var bool Whether to show the discussion author avatar. */
+    private $showPhotos = false;
+
+    /** @var array Limit the discussions to just this list of categories, checked for view permission. */
+    protected $categoryIDs;
+
+    /** @var  int The ID of the user for whom you are showing the comments. */
+    public $userID = null;
+
+    /**
+     *
+     *
+     * @throws Exception
+     */
+    public function __construct($sender) {
+        parent::__construct();
+        $this->_ApplicationFolder = 'vanilla';
+        $this->fireEvent('Init');
+        //If you are being executed from the profile controller, get the UserID.
+        if (strtolower(val('ControllerName', $sender)) === 'profilecontroller') {
+            $this->userID = $sender->User->UserID;
+        }
+    }
+
+    /**
+     * @param $showPhotos Whether to show the comment author avatar.
+     * @return CommentsModule
+     */
+    public function setShowPhotos($showPhotos) {
+        $this->showPhotos = $showPhotos;
+        return $this;
+    }
+
+    /**
+     * @return bool Whether to show the comment author avatar.
+     */
+    public function getShowPhotos() {
+        return $this->showPhotos;
+    }
+
+    /**
+     * Get the data for the module.
+     *
+     * @param int|bool $limit Override the number of comments to display.
+     */
+    public function getData($limit = false) {
+        if (!$limit) {
+            $limit = $this->limit;
+        }
+        $discussionModel = new DiscussionModel();
+        $discussions  = $discussionModel->getByUser($this->userID, $limit, 0, false);
+        $this->setData('Discussions', $discussions);
+    }
+
+    public function assetTarget() {
+        return 'Panel';
+    }
+
+    public function toString() {
+        // If there is no userID show nothing.
+        if (!$this->userID) {
+            return;
+        }
+
+        if (!$this->data('Discussions')) {
+            $this->getData();
+        }
+//        $this->view = 'discussions';
+
+        return parent::toString();
+    }
+
+    /**
+     * Get a list of category IDs to limit.
+     *
+     * @return array
+     */
+    public function getCategoryIDs() {
+        return $this->categoryIDs;
+    }
+
+    /**
+     * Set a list of category IDs to limit.
+     *
+     * @param array $categoryIDs
+     */
+    public function setCategoryIDs($categoryIDs) {
+        $this->categoryIDs = $categoryIDs;
+    }
+}

--- a/applications/vanilla/views/modules/usercomments.php
+++ b/applications/vanilla/views/modules/usercomments.php
@@ -1,11 +1,13 @@
 <?php if (!defined('APPLICATION')) exit();
 $user = $this->data('User');
-echo '<div class="DataListWrap">';
-echo '<h2 class="H">'.t('Recent Comments').'</h2>';
-echo '<ul class="DataList SearchResults">';
+?>
+<div class="DataListWrap">
+    <h2 class="H"><?php echo t('Recent Comments'); ?></h2>
+    <ul class="DataList SearchResults">
+<?php
 if (sizeof($this->data('Comments'))) {
     foreach ($this->data('Comments') as $comment) {
-        $permalink = '/discussion/comment/'.$comment->CommentID.'/#Comment_'.$comment->CommentID;
+        $permalink = commentUrl($comment);
         $this->EventArguments['User'] = $user;
         ?>
         <li id="<?php echo 'Comment_'.$comment->CommentID; ?>" class="Item">
@@ -28,6 +30,7 @@ if (sizeof($this->data('Comments'))) {
 } else {
     echo '<li class="Item Empty">'.t('This user has not commented yet.').'</li>';
 }
-echo '</ul>';
-echo anchor('All Comments', 'profile/comments/'.$user->UserID.'/'.rawurlencode($user->Name));
-echo '</div>';
+?>
+    </ul>
+    <?php echo anchor('All Comments', 'profile/comments/'.$user->UserID.'/'.rawurlencode($user->Name)); ?>
+</div>

--- a/applications/vanilla/views/modules/usercomments.php
+++ b/applications/vanilla/views/modules/usercomments.php
@@ -1,25 +1,25 @@
 <?php if (!defined('APPLICATION')) exit();
+$user = $this->data('User');
 echo '<div class="DataListWrap">';
 echo '<h2 class="H">'.t('Recent Comments').'</h2>';
 echo '<ul class="DataList SearchResults">';
 if (sizeof($this->data('Comments'))) {
-    foreach ($this->data('Comments') as $Comment) {
-        $Permalink = '/discussion/comment/'.$Comment->CommentID.'/#Comment_'.$Comment->CommentID;
-        $User = UserBuilder($Comment, 'Insert');
-        $this->EventArguments['User'] = $User;
+    foreach ($this->data('Comments') as $comment) {
+        $permalink = '/discussion/comment/'.$comment->CommentID.'/#Comment_'.$comment->CommentID;
+        $this->EventArguments['User'] = $user;
         ?>
-        <li id="<?php echo 'Comment_'.$Comment->CommentID; ?>" class="Item">
+        <li id="<?php echo 'Comment_'.$comment->CommentID; ?>" class="Item">
             <?php $this->fireEvent('BeforeItemContent'); ?>
             <div class="ItemContent">
                 <div class="Message"><?php
-                    echo SliceString(Gdn_Format::plainText($Comment->Body, $Comment->Format), 250);
+                    echo SliceString(Gdn_Format::plainText($comment->Body, $comment->Format), 250);
                     ?></div>
                 <div class="Meta">
                 <span class="MItem"><?php echo t('Comment in', 'in').' '; ?>
-                    <b><?php echo anchor(Gdn_Format::text($Comment->DiscussionName), $Permalink); ?></b></span>
-                    <span class="MItem"><?php printf(t('Comment by %s'), userAnchor($User)); ?></span>
+                    <b><?php echo anchor(Gdn_Format::text($comment->DiscussionName), $permalink); ?></b></span>
+                    <span class="MItem"><?php printf(t('Comment by %s'), userAnchor($user)); ?></span>
                     <span
-                        class="MItem"><?php echo anchor(Gdn_Format::date($Comment->DateInserted), $Permalink); ?></span>
+                        class="MItem"><?php echo anchor(Gdn_Format::date($comment->DateInserted), $permalink); ?></span>
                 </div>
             </div>
         </li>
@@ -29,4 +29,5 @@ if (sizeof($this->data('Comments'))) {
     echo '<li class="Item Empty">'.t('This user has not commented yet.').'</li>';
 }
 echo '</ul>';
+echo anchor('All Comments', 'profile/comments/'.$user->UserID.'/'.rawurlencode($user->Name));
 echo '</div>';

--- a/applications/vanilla/views/modules/usercomments.php
+++ b/applications/vanilla/views/modules/usercomments.php
@@ -1,0 +1,32 @@
+<?php if (!defined('APPLICATION')) exit();
+echo '<div class="DataListWrap">';
+echo '<h2 class="H">'.t('Recent Comments').'</h2>';
+echo '<ul class="DataList SearchResults">';
+if (sizeof($this->data('Comments'))) {
+    foreach ($this->data('Comments') as $Comment) {
+        $Permalink = '/discussion/comment/'.$Comment->CommentID.'/#Comment_'.$Comment->CommentID;
+        $User = UserBuilder($Comment, 'Insert');
+        $this->EventArguments['User'] = $User;
+        ?>
+        <li id="<?php echo 'Comment_'.$Comment->CommentID; ?>" class="Item">
+            <?php $this->fireEvent('BeforeItemContent'); ?>
+            <div class="ItemContent">
+                <div class="Message"><?php
+                    echo SliceString(Gdn_Format::plainText($Comment->Body, $Comment->Format), 250);
+                    ?></div>
+                <div class="Meta">
+                <span class="MItem"><?php echo t('Comment in', 'in').' '; ?>
+                    <b><?php echo anchor(Gdn_Format::text($Comment->DiscussionName), $Permalink); ?></b></span>
+                    <span class="MItem"><?php printf(t('Comment by %s'), userAnchor($User)); ?></span>
+                    <span
+                        class="MItem"><?php echo anchor(Gdn_Format::date($Comment->DateInserted), $Permalink); ?></span>
+                </div>
+            </div>
+        </li>
+        <?php
+    }
+} else {
+    echo '<li class="Item Empty">'.t('This user has not commented yet.').'</li>';
+}
+echo '</ul>';
+echo '</div>';

--- a/applications/vanilla/views/modules/userdiscussions.php
+++ b/applications/vanilla/views/modules/userdiscussions.php
@@ -1,12 +1,14 @@
 <?php if (!defined('APPLICATION')) exit();
 require_once Gdn::controller()->fetchViewLocation('helper_functions', 'discussions', 'Vanilla');
 $user = $this->data('User');
-echo '<div class="DataListWrap">';
-echo '<h2 class="H">'.t('Recent Discussions').'</h2>';
-echo '<ul class="DataList SearchResults">';
+?>
+<div class="DataListWrap">
+    <h2 class="H"><?php echo t('Recent Discussions'); ?></h2>
+    <ul class="DataList SearchResults">
+<?php
 if (sizeof($this->data('Discussions'))) {
     foreach ($this->data('Discussions') as $discussion) {
-        $permalink = '/discussion/'.$discussion->DiscussionID;
+        $permalink = discussionUrl($discussion);
         $this->EventArguments['User'] = $user;
         ?>
         <li id="<?php echo 'Discussion_'.$discussion->DiscussionID; ?>" class="Item">
@@ -28,6 +30,7 @@ if (sizeof($this->data('Discussions'))) {
 } else {
     echo '<li class="Item Empty">'.t('This user has not made any discussions yet.').'</li>';
 }
-echo '</ul>';
-echo anchor('All Discussions', 'profile/discussions/'.$user->UserID.'/'.rawurlencode($user->Name));
-echo '</div>';
+?>
+</ul>
+<?php echo anchor('All Discussions', 'profile/discussions/'.$user->UserID.'/'.rawurlencode($user->Name)); ?>
+</div>

--- a/applications/vanilla/views/modules/userdiscussions.php
+++ b/applications/vanilla/views/modules/userdiscussions.php
@@ -1,0 +1,34 @@
+<?php if (!defined('APPLICATION')) exit();
+
+require_once Gdn::Controller()->fetchViewLocation('helper_functions', 'discussions', 'vanilla');
+
+echo '<div class="DataListWrap">';
+echo '<h2 class="H">'.t('Recent Discussions').'</h2>';
+echo '<ul class="DataList SearchResults">';
+if (sizeof($this->data('Discussions'))) {
+    foreach ($this->data('Discussions') as $discussion) {
+        $permalink = '/discussion/'.$discussion->DiscussionID;
+        $user = userBuilder($discussion, 'Insert');
+        $this->EventArguments['User'] = $user;
+        ?>
+        <li id="<?php echo 'Comment_'.$discussion->CommentID; ?>" class="Item">
+            <?php $this->fireEvent('BeforeItemContent'); ?>
+            <div class="ItemContent">
+                <div class="Message"><?php
+                    echo '<h2>'.anchor(Gdn_Format::text($discussion->Name), $permalink).'</h2>';
+                    echo SliceString(Gdn_Format::plainText($discussion->Body, $discussion->Format), 250);
+                    ?></div>
+                <div class="Meta">
+                <span class="MItem"><?php echo t('Posted in', 'in').' '; ?>
+                    <b><?php echo categoryLink($discussion); ?></b></span>
+                    <span class="MItem"><?php echo anchor(Gdn_Format::date($discussion->DateInserted), $permalink); ?></span>
+                </div>
+            </div>
+        </li>
+        <?php
+    }
+} else {
+    echo '<li class="Item Empty">'.t('This user has not commented yet.').'</li>';
+}
+echo '</ul>';
+echo '</div>';

--- a/applications/vanilla/views/modules/userdiscussions.php
+++ b/applications/vanilla/views/modules/userdiscussions.php
@@ -1,17 +1,15 @@
 <?php if (!defined('APPLICATION')) exit();
-
-require_once Gdn::Controller()->fetchViewLocation('helper_functions', 'discussions', 'vanilla');
-
+require_once $this->fetchViewLocation('discussions');
+$user = $this->data('User');
 echo '<div class="DataListWrap">';
 echo '<h2 class="H">'.t('Recent Discussions').'</h2>';
 echo '<ul class="DataList SearchResults">';
 if (sizeof($this->data('Discussions'))) {
     foreach ($this->data('Discussions') as $discussion) {
         $permalink = '/discussion/'.$discussion->DiscussionID;
-        $user = userBuilder($discussion, 'Insert');
         $this->EventArguments['User'] = $user;
         ?>
-        <li id="<?php echo 'Comment_'.$discussion->CommentID; ?>" class="Item">
+        <li id="<?php echo 'Discussion_'.$discussion->DiscussionID; ?>" class="Item">
             <?php $this->fireEvent('BeforeItemContent'); ?>
             <div class="ItemContent">
                 <div class="Message"><?php
@@ -28,7 +26,8 @@ if (sizeof($this->data('Discussions'))) {
         <?php
     }
 } else {
-    echo '<li class="Item Empty">'.t('This user has not commented yet.').'</li>';
+    echo '<li class="Item Empty">'.t('This user has not made any discussions yet.').'</li>';
 }
 echo '</ul>';
+echo anchor('All Discussions', 'profile/discussions/'.$user->UserID.'/'.rawurlencode($user->Name));
 echo '</div>';

--- a/applications/vanilla/views/modules/userdiscussions.php
+++ b/applications/vanilla/views/modules/userdiscussions.php
@@ -1,5 +1,5 @@
 <?php if (!defined('APPLICATION')) exit();
-require_once $this->fetchViewLocation('discussions');
+require_once Gdn::controller()->fetchViewLocation('helper_functions', 'discussions', 'Vanilla');
 $user = $this->data('User');
 echo '<div class="DataListWrap">';
 echo '<h2 class="H">'.t('Recent Discussions').'</h2>';


### PR DESCRIPTION
At present, in the profile controller there are ways of viewing all of a user's posts or comments but there is no way of having a limited widget view of the most recent. This pull request would create two modules to do that.