### PR TITLE
Readd empty string to $types array after Tagging move

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -255,7 +255,7 @@ class VanillaHooks implements Gdn_IPlugin {
         }
 
         // Let plugins have their information getting saved.
-        $Types = [];
+        $Types = [''];
 
         // We fire as TaggingPlugin since this code was taken from the old TaggingPlugin and we do not
         // want to break any hooks


### PR DESCRIPTION
Readd empty string to $types array after Tagging move. Fixes issue where you cannot delete a tag from a discussion.