### PR TITLE
Swap short param syntax order in Garden\Schema

### DIFF
--- a/library/Garden/Schema.php
+++ b/library/Garden/Schema.php
@@ -314,10 +314,10 @@ class Schema implements \JsonSerializable {
             }
             $name = $parts[0];
         } else {
-            $name = $parts[1];
+            $name = $parts[0];
 
-            if (isset(self::$types[$parts[0]])) {
-                $type = self::$types[$parts[0]];
+            if (isset(self::$types[$parts[1]])) {
+                $type = self::$types[$parts[1]];
             } else {
                 throw new \InvalidArgumentException("Invalid type {$parts[1]} for field $name.", 500);
             }

--- a/tests/Library/Garden/BasicSchemaTest.php
+++ b/tests/Library/Garden/BasicSchemaTest.php
@@ -92,7 +92,7 @@ class BasicSchemaTest extends SchemaTest {
      * @dataProvider provideBooleanData
      */
     public function testBooleanSchema($input, $expected) {
-        $schema = Schema::create(['b:bool']);
+        $schema = Schema::create(['bool:b']);
         $expected = ['bool' => $expected];
 
         // Test some false data.
@@ -106,7 +106,7 @@ class BasicSchemaTest extends SchemaTest {
      * Test an array type.
      */
     public function testArrayType() {
-        $schema = Schema::create(['a:arr']);
+        $schema = Schema::create(['arr:a']);
 
         $expectedSchema = [
             'arr' => ['name' => 'arr', 'type' => 'array', 'required' => true]
@@ -122,7 +122,7 @@ class BasicSchemaTest extends SchemaTest {
 
         // Array with a description and not a type.
         $expectedSchema['arr']['description'] = 'Hello world!';
-        $schema = Schema::create(['a:arr' => 'Hello world!']);
+        $schema = Schema::create(['arr:a' => 'Hello world!']);
         $this->assertEquals($expectedSchema, $schema->jsonSerialize());
 
         // Array with an items type.
@@ -130,12 +130,12 @@ class BasicSchemaTest extends SchemaTest {
         $expectedSchema['arr']['items']['type'] = 'integer';
         $expectedSchema['arr']['items']['required'] = true;
 
-        $schema = Schema::create(['a:arr' => 'i']);
+        $schema = Schema::create(['arr:a' => 'i']);
         $this->assertEquals($expectedSchema, $schema->jsonSerialize());
 
         // Test the longer syntax.
         $expectedSchema['arr']['description'] = 'Hello world!';
-        $schema = Schema::create(['a:arr' => [
+        $schema = Schema::create(['arr:a' => [
             'description' => 'Hello world!',
             'items' => ['type' => 'integer', 'required' => true]
         ]]);
@@ -161,7 +161,7 @@ class BasicSchemaTest extends SchemaTest {
      */
     public function testNotRequired($shortType, $longType) {
         $schema = new Schema([
-            "$shortType:col?"
+            "col:$shortType?"
         ]);
 
         $emptyData = ['col' => ''];
@@ -194,7 +194,7 @@ class BasicSchemaTest extends SchemaTest {
         }
 
         $schema = new Schema([
-            "$shortType:col"
+            "col:$shortType"
         ]);
 
         $emptyData = ['col' => ''];
@@ -212,7 +212,7 @@ class BasicSchemaTest extends SchemaTest {
      */
     public function testRequiredEmptyBool() {
         $schema = new Schema([
-            'b:col'
+            'col:b'
         ]);
         /* @var Validation $validation */
         $emptyData = ['col' => ''];
@@ -236,7 +236,7 @@ class BasicSchemaTest extends SchemaTest {
      */
     public function testRequiredEmptyString() {
         $schema = new Schema([
-            's:col' => ['minLength' => 0]
+            'col:s' => ['minLength' => 0]
         ]);
 
         /* @var Validation $validation */
@@ -311,7 +311,7 @@ class BasicSchemaTest extends SchemaTest {
      */
     public function testInvalidValues($type, $value) {
         $schema = new Schema([
-            "$type:col?"
+            "col:$type?"
         ]);
         $strval = print_r($value, true);
 
@@ -352,9 +352,9 @@ class BasicSchemaTest extends SchemaTest {
      */
     protected function doValidationBehavior($validationBehavior) {
         $schema = new Schema([
-            'i:userID' => 'The ID of the user.',
-            's:name' => 'The username of the user.',
-            's:email' => 'The email of the user.',
+            'userID:i' => 'The ID of the user.',
+            'name:s' => 'The username of the user.',
+            'email:s' => 'The email of the user.',
         ]);
         $schema->setValidationBehavior($validationBehavior);
 
@@ -404,14 +404,14 @@ class BasicSchemaTest extends SchemaTest {
     public function getAtomicSchema() {
         $schema = Schema::create(
             [
-                'i:id',
-                's:name' => 'The name of the object.',
-                's:description?',
-                'ts:timestamp?',
-                'dt:date?',
-                'f:amount?',
-                '=:64ish?',
-                'b:enabled?',
+                'id:i',
+                'name:s' => 'The name of the object.',
+                'description:s?',
+                'timestamp:ts?',
+                'date:dt?',
+                'amount:f?',
+                '64ish:=?',
+                'enabled:b?',
             ]
         );
 

--- a/tests/Library/Garden/NestedSchemaTest.php
+++ b/tests/Library/Garden/NestedSchemaTest.php
@@ -20,9 +20,9 @@ class NestedSchemaTest extends SchemaTest {
      */
     public function testBasicNested() {
         $schema = Schema::create([
-            'o:obj' => [
-                'i:id',
-                's:name?'
+            'obj:o' => [
+                'id:i',
+                'name:s?'
             ]
         ]);
 
@@ -58,9 +58,9 @@ class NestedSchemaTest extends SchemaTest {
      */
     public function testDoubleNested() {
         $schema = Schema::create([
-            'o:obj' => [
-                'o:obj?' => [
-                    'i:id'
+            'obj:o' => [
+                'obj:o?' => [
+                    'id:i'
                 ]
             ]
         ]);
@@ -135,7 +135,7 @@ class NestedSchemaTest extends SchemaTest {
      * Test a variety of array item validation scenarios.
      */
     public function testArrayItemsType() {
-        $schema = Schema::create(['a:arr' => 'i']);
+        $schema = Schema::create(['arr:a' => 'i']);
 
         $validData = ['arr' => [1, '2', 3]];
         $this->assertTrue($schema->isValid($validData));
@@ -273,9 +273,9 @@ class NestedSchemaTest extends SchemaTest {
      */
     public function getArrayOfObjectsSchema() {
         $schema = new Schema([
-            'a:rows' => [
-                'i:id',
-                's:name?'
+            'rows:a' => [
+                'id:i',
+                'name:s?'
             ]
         ]);
 
@@ -289,12 +289,12 @@ class NestedSchemaTest extends SchemaTest {
      */
     public function getNestedSchema() {
         $schema = Schema::create([
-            'i:id',
-            's:name',
-            'o:addr' => [
-                's:street?',
-                's:city',
-                'i:zip?'
+            'id:i',
+            'name:s',
+            'addr:o' => [
+                'street:s?',
+                'city:s',
+                'zip:i?'
             ]
         ]);
 
@@ -308,11 +308,11 @@ class NestedSchemaTest extends SchemaTest {
      */
     protected function doValidationBehavior($validationBehavior) {
         $schema = new Schema([
-            'i:groupID' => 'The ID of the group.',
-            's:name' => 'The name of the group.',
-            's:description' => 'A description of the group.',
-            'o:member' => [
-                's:email' => 'The ID of the new member.'
+            'groupID:i' => 'The ID of the group.',
+            'name:s' => 'The name of the group.',
+            'description:s' => 'A description of the group.',
+            'member:o' => [
+                'email:s' => 'The ID of the new member.'
             ]
         ]);
         $schema->setValidationBehavior($validationBehavior);


### PR DESCRIPTION
This update swaps around the order of the name and type specifiers in `Garden\Schema`'s short param syntax.  Unit tests have been updated accordingly.

Closes #5132