### PR TITLE
Add default password min length config setting

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -79,6 +79,7 @@ $Configuration['Garden']['Upload']['AllowedFileExtensions']     = array('txt', '
 $Configuration['Garden']['Profile']['MaxHeight']                = 1200;
 $Configuration['Garden']['Profile']['MaxWidth']                 = 800;
 $Configuration['Garden']['Thumbnail']['Size']                   = 120;
+$Configuration['Garden']['Password']['MinLength']               = 6;
 $Configuration['Garden']['Menu']['Sort']                        = array('Dashboard', 'Discussions', 'Questions', 'Activity', 'Applicants', 'Conversations', 'User');
 $Configuration['Garden']['InputFormatter']                      = 'Markdown'; // Html, BBCode, Markdown, Text
 $Configuration['Garden']['Html']['AllowedElements']             = "a, abbr, acronym, address, area, audio, b, bdi, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, details, dfn, div, dl, dt, em, figure, figcaption, font, h1, h2, h3, h4, h5, h6, hgroup, hr, i, img, ins, kbd, li, map, mark, menu, meter, ol, p, pre, q, s, samp, small, span, strike, strong, sub, sup, summary, table, tbody, td, tfoot, th, thead, time, tr, tt, u, ul, var, video, wbr";


### PR DESCRIPTION
Add default password min length config setting. Fixes issue where registration message indicates that the password must be at least 0 characters long.