### PR TITLE
Remove events from the cache

### DIFF
--- a/library/core/class.cache.php
+++ b/library/core/class.cache.php
@@ -168,11 +168,6 @@ abstract class Gdn_Cache {
             $CacheObject->autorun();
         }
 
-        // This should only fire when cache is loading automatically
-        if (!func_num_args() && Gdn::pluginManager() instanceof Gdn_PluginManager) {
-            Gdn::pluginManager()->fireEvent('AfterActiveCache');
-        }
-
         return $CacheObject;
     }
 
@@ -196,12 +191,6 @@ abstract class Gdn_Cache {
             $ActiveCache = CACHE_METHOD_OVERRIDE;
         } else {
             $ActiveCache = c('Cache.Method', false);
-        }
-
-        // This should only fire when cache is loading automatically
-        if (!func_num_args() && Gdn::pluginManager() instanceof Gdn_PluginManager) {
-            Gdn::pluginManager()->EventArguments['ActiveCache'] = &$ActiveCache;
-            Gdn::pluginManager()->fireEvent('BeforeActiveCache');
         }
 
         return $ActiveCache;


### PR DESCRIPTION
The cache is meant to be an “early” object that is available before event handlers have been registered. We shouldn’t have plugins thinking they can do something to the cache during its activation.

The correct way to change cache behavior is to make a new cache driver.