### PR TITLE
Update SQLDriver::getUpdate to use order and limit parameters

### DIFF
--- a/library/database/class.mysqldriver.php
+++ b/library/database/class.mysqldriver.php
@@ -322,8 +322,11 @@ class Gdn_MySQLDriver extends Gdn_SQLDriver {
      * @param array $Data An associative array of FieldName => Value pairs that should be inserted $Table.
      * @param mixed $Where A where clause (or array containing multiple where clauses) to be applied
      * to the where portion of the update statement.
+     * @param array $orderBy A collection of order by statements.
+     * @param int $limit The number of records to limit the query to.
+     * @return string
      */
-    public function getUpdate($Tables, $Data, $Where) {
+    public function getUpdate($Tables, $Data, $Where, $orderBy = null, $limit = null) {
         if (!is_array($Data)) {
             trigger_error(errorMessage('The data provided is not in a proper format (Array).', 'MySQLDriver', '_GetUpdate'), E_USER_ERROR);
         }
@@ -337,8 +340,6 @@ class Gdn_MySQLDriver extends Gdn_SQLDriver {
 
         if (count($this->_Joins) > 0) {
             $sql .= "\n";
-
-            $Join = $this->_Joins[count($this->_Joins) - 1];
 
             $sql .= implode("\n", $this->_Joins);
         }
@@ -355,6 +356,16 @@ class Gdn_MySQLDriver extends Gdn_SQLDriver {
         } elseif (is_string($Where) && !stringIsNullOrEmpty($Where)) {
             $sql .= ' where '.$Where;
         }
+
+        if (is_array($orderBy) && count($orderBy) > 0) {
+            $sql .= "\norder by ".implode(', ', $orderBy);
+        }
+
+        if (is_numeric($limit)) {
+            $sql .= "\n";
+            $sql = $this->getLimit($sql, $limit, 0);
+        }
+
         return $sql;
     }
 

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -842,13 +842,16 @@ abstract class Gdn_SQLDriver {
      * Returns an update statement for the specified table with the provided
      * $Data.
      *
-     * @param array $Tables The names of the tables to updated data in.
-     * @param array $Data An associative array of FieldName => Value pairs that should be inserted
+     * @param array $tables The names of the tables to updated data in.
+     * @param array $data An associative array of FieldName => Value pairs that should be inserted
      * $Table.
-     * @param mixed $Where A where clause (or array containing multiple where clauses) to be applied
+     * @param mixed $where A where clause (or array containing multiple where clauses) to be applied
+     * @param mixed $orderBy A collection of order by statements.
+     * @param mixed $limit The number of records to limit the query to.
      * to the where portion of the update statement.
+     * @return string
      */
-    public function getUpdate($Tables, $Data, $Where) {
+    public function getUpdate($tables, $data, $where, $orderBy = null, $limit = null) {
         trigger_error(errorMessage('The selected database engine does not perform the requested task.', $this->ClassName, 'GetUpdate'), E_USER_ERROR);
     }
 


### PR DESCRIPTION
[`Gdn_SQLDriver::put`](https://github.com/vanilla/vanilla/blob/0a341172fde05143958592d5ec1beb67bd03f393/library/database/class.sqldriver.php#L1618) makes a call to `Gdn_SQLDriver::getUpdate` with five parameters: from/table, set, where, order by and limit. The problem is [`Gdn_SQLDriver::getUpdate`](https://github.com/vanilla/vanilla/blob/0a341172fde05143958592d5ec1beb67bd03f393/library/database/class.sqldriver.php#L851) only supports three parameters: from/table, set and where.

This update adds support for the remaining two parameters, order by and limit, to `getUpdate` in `Gdn_SQLDriver` and `Gdn_MySQLDriver`. Code was adapted from [`Gdn_SQLDriver::getSelect`](https://github.com/vanilla/vanilla/blob/0a341172fde05143958592d5ec1beb67bd03f393/library/database/class.sqldriver.php#L820) to be relevant to an update statement (e.g. no offset in the limit).

Bonus: Removed an unreferenced variable, `$Join `.

Closes #2136