### PR TITLE
Render the json response at dashoard/profile.json

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -491,6 +491,7 @@ class ProfileController extends Gdn_Controller {
         } elseif ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
             safeRedirect(userUrl($this->User, '', 'discussions'));
         }
+        $this->render('blank', 'utility', 'dashboard');
     }
 
     /**

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -491,6 +491,8 @@ class ProfileController extends Gdn_Controller {
         } elseif ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
             safeRedirect(userUrl($this->User, '', 'discussions'));
         }
+
+        // Garden.Profile.ShowActivities is false and the user is expecting an xml or json response, so render blank.
         $this->render('blank', 'utility', 'dashboard');
     }
 


### PR DESCRIPTION
Fixes issue where json is not rendered at API endpoint when`Garden.Profile.ShowActivities` is set to false.

Partially fixed by: https://github.com/vanilla/vanilla/pull/5088
Closes https://github.com/vanilla/vanilla/issues/5082