### PR TITLE
Bind addon events to the EventManager directly

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -979,7 +979,7 @@ class AddonManager {
                 // Include the plugin here, rather than wait for it to hit the autoloader. This way is much faster.
                 include_once $addon->getClassPath($pluginClass);
 
-                $this->bindEvents($addon, $eventManager);
+                $this->bindAddonEvents($addon, $eventManager);
             }
         }
     }

--- a/library/core/class.plugin.php
+++ b/library/core/class.plugin.php
@@ -71,6 +71,18 @@ abstract class Gdn_Plugin extends Gdn_Pluggable implements Gdn_IPlugin {
     }
 
     /**
+     * Set the addon associated with the plugin from the given {@link \Vanilla\AddonManager}.
+     *
+     * @param \Vanilla\AddonManager $addonManager The addon manager to search.
+     */
+    public function setAddonFromManager(\Vanilla\AddonManager $addonManager) {
+        $addon = $addonManager->lookupByClassname(get_called_class());
+        if ($addon instanceof Addon) {
+            $this->setAddon($addon);
+        }
+    }
+
+    /**
      * Gets the case-sensitive plugin key.
      *
      * @return string


### PR DESCRIPTION
Depends on #5031.

Register plugin events to the EventManager directly, bypassing the need for Gdn_PluginManager. A side-effect of this PR is that plugins are now created through the container which means that plugin authors can declare dependencies for their plugins too--that's a beautiful thing.