### PR TITLE
Implement basic addon cache validation and clearing

### DIFF
--- a/applications/dashboard/controllers/class.addoncachecontroller.php
+++ b/applications/dashboard/controllers/class.addoncachecontroller.php
@@ -62,7 +62,7 @@ class AddonCacheController extends DashboardController {
      * @param string $type
      * @throws Exception if no type specified.
      */
-    public function verify($type, $target) {
+    public function verify($type) {
         $this->permission('Garden.Settings.Manage');
 
         if ($type === null) {

--- a/applications/dashboard/controllers/class.addoncachecontroller.php
+++ b/applications/dashboard/controllers/class.addoncachecontroller.php
@@ -78,16 +78,16 @@ class AddonCacheController extends DashboardController {
         $updateRequired = (count($new) || count($invalid));
 
         if ($updateRequired) {
-            $clearUrl = '/addoncache/clear';
+            $clearUrl = '/addoncache/clear?Target={SelfUrl}';
+            $actions = wrap(
+                anchor(t('Click here to fix.'), $clearUrl, 'Hijack DismissMessage'),
+                'div',
+                ['class' => 'Actions']
+            );
 
-            if (!empty($target)) {
-                $clearUrl .= '?'.http_build_query(['Target' => $target]);
-            }
-
-            $action = anchor(t('Click here to fix.'), $clearUrl, 'Hijack', ['id' => 'ClearAddonCache']);
             $this->informMessage(
-                t('Your cache needs to be updated.').' '.$action,
-                'Dismissable'
+                t('The addon cache is outdated.').$actions,
+                ['CssClass' => 'Dismissable', 'id' => 'CheckSummary']
             );
         }
 

--- a/applications/dashboard/controllers/class.addoncachecontroller.php
+++ b/applications/dashboard/controllers/class.addoncachecontroller.php
@@ -72,6 +72,13 @@ class AddonCacheController extends DashboardController {
             'UpdateRequired' => (count($new) || count($invalid))
         ]);
 
+        if ($this->data('UpdateRequired')) {
+            $this->informMessage(
+                sprite('Check', 'InformSprite').t('Your cache needs to be updated.'),
+                'Dismissable AutoDismiss HasSprite'
+            );
+        }
+
         $this->deliveryType(DELIVERY_TYPE_DATA);
         $this->deliveryMethod(DELIVERY_METHOD_JSON);
         $this->render('blank', 'utility', 'dashboard');

--- a/applications/dashboard/controllers/class.addoncachecontroller.php
+++ b/applications/dashboard/controllers/class.addoncachecontroller.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Provides endpoint for interfacing with the addon cache.
+ *
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ * @package Dashboard
+ * @since 2.4
+ */
+
+/**
+ * Handles /addoncache endpoint
+ */
+class AddonCacheController extends DashboardController {
+
+    /**
+     * AddonCacheController constructor.
+     *
+     * @throws Gdn_UserException if endpoints are disabled in config.
+     */
+    public function __construct() {
+        if (c('Cache.Addons.DisableEndpoints')) {
+            throw new Gdn_UserException('Addon cache endpoints disabled', 403);
+        }
+
+        parent::__construct();
+    }
+
+    /**
+     * Clear the addon cache.
+     *
+     * @throws Exception if using an invalid method.
+     */
+    public function clear() {
+        $this->permission('Garden.Settings.Manage');
+
+        if (Gdn::request()->isPostBack() === false) {
+            throw new Exception('Requires POST', 405);
+        }
+
+        Gdn::request()->isAuthenticatedPostBack(true);
+
+        $this->setData(['Cleared' => Gdn::addonManager()->clearCache()]);
+
+        $this->deliveryType(DELIVERY_TYPE_DATA);
+        $this->deliveryMethod(DELIVERY_METHOD_JSON);
+        $this->render('blank', 'utility', 'dashboard');
+    }
+
+    /**
+     * Verify the addon cache is current.
+     *
+     * @param string $type
+     * @throws Exception if no type specified.
+     */
+    public function verify($type) {
+        $this->permission('Garden.Settings.Manage');
+
+        if ($type === null) {
+            throw new Exception('Type required');
+        }
+
+        $cached = Gdn::addonManager()->lookupAllByType($type);
+        $current = Gdn::addonManager()->scan($type);
+
+        $new = array_keys(array_diff_key($current, $cached));
+        $invalid = array_keys(array_diff_key($cached, $current));
+
+        $this->setData([
+            'Invalid' => $invalid,
+            'New' => $new,
+            'UpdateRequired' => (count($new) || count($invalid))
+        ]);
+
+        $this->deliveryType(DELIVERY_TYPE_DATA);
+        $this->deliveryMethod(DELIVERY_METHOD_JSON);
+        $this->render('blank', 'utility', 'dashboard');
+    }
+}

--- a/applications/dashboard/controllers/class.addoncachecontroller.php
+++ b/applications/dashboard/controllers/class.addoncachecontroller.php
@@ -80,7 +80,7 @@ class AddonCacheController extends DashboardController {
         if ($updateRequired) {
             $clearUrl = '/addoncache/clear?Target={SelfUrl}';
             $actions = wrap(
-                anchor(t('Click here to fix.'), $clearUrl, 'Hijack DismissMessage'),
+                anchor(t('Click here to fix.'), $clearUrl, 'Hijack js-inform-close'),
                 'div',
                 ['class' => 'Actions']
             );

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -75,6 +75,12 @@ class SettingsController extends DashboardController {
         $this->title(t('Applications'));
         $this->setHighlightRoute('dashboard/settings/applications');
 
+        // Verify addon cache integrity?
+        if ($this->verifyAddonCache()) {
+            $this->addJsFile('addoncache.js');
+            $this->addDefinition('VerifyCache', 'addon');
+        }
+
         if (!in_array($Filter, array('enabled', 'disabled'))) {
             $Filter = 'all';
         }
@@ -1176,6 +1182,12 @@ class SettingsController extends DashboardController {
         $this->title(t('Plugins'));
         $this->setHighlightRoute('dashboard/settings/plugins');
 
+        // Verify addon cache integrity?
+        if ($this->verifyAddonCache()) {
+            $this->addJsFile('addoncache.js');
+            $this->addDefinition('VerifyCache', 'addon');
+        }
+
         if (!in_array($Filter, array('enabled', 'disabled'))) {
             $Filter = 'all';
         }
@@ -1586,6 +1598,12 @@ class SettingsController extends DashboardController {
         $this->addJsFile('addons.js');
         $this->setData('Title', t('Themes'));
 
+        // Verify addon cache integrity?
+        if ($this->verifyAddonCache()) {
+            $this->addJsFile('addoncache.js');
+            $this->addDefinition('VerifyCache', 'theme');
+        }
+
         $this->permission('Garden.Settings.Manage');
         $this->setHighlightRoute('dashboard/settings/themes');
 
@@ -1945,5 +1963,14 @@ class SettingsController extends DashboardController {
         Gdn_Theme::section('Tutorials');
         $this->setData('IsWidePage', true);
         $this->render();
+    }
+
+    /**
+     * Can we attempt to verify the addon cache's integrity?
+     *
+     * @return bool
+     */
+    private function verifyAddonCache() {
+        return !c('Cache.Addons.DisableEndpoints');
     }
 }

--- a/applications/dashboard/js/addoncache.js
+++ b/applications/dashboard/js/addoncache.js
@@ -3,7 +3,7 @@ $(document).ready(function(e) {
 
     if (typeof verifyCache === "string") {
         $.ajax({
-            url: gdn.url("addoncache/verify?Type=" + verifyCache + "&Target=" + window.location.pathname),
+            url: gdn.url("addoncache/verify?Type=" + verifyCache),
             success: function(data) {
                 gdn.inform(data);
             }

--- a/applications/dashboard/js/addoncache.js
+++ b/applications/dashboard/js/addoncache.js
@@ -10,10 +10,3 @@ $(document).ready(function(e) {
         });
     }
 });
-
-$(document).on("click", "#ClearAddonCache", function(event) {
-    // Ditch the inform message window this was in.
-    $(event.target).parents(".InformWrapper").fadeOut("fast", function() {
-        $(this).remove();
-    });
-});

--- a/applications/dashboard/js/addoncache.js
+++ b/applications/dashboard/js/addoncache.js
@@ -1,0 +1,19 @@
+$(document).ready(function(e) {
+    var verifyCache = gdn.getMeta("VerifyCache");
+
+    if (typeof verifyCache === "string") {
+        $.ajax({
+            url: gdn.url("addoncache/verify?Type=" + verifyCache + "&Target=" + window.location.pathname),
+            success: function(data) {
+                gdn.inform(data);
+            }
+        });
+    }
+});
+
+$(document).on("click", "#ClearAddonCache", function(event) {
+    // Ditch the inform message window this was in.
+    $(event.target).parents(".InformWrapper").fadeOut("fast", function() {
+        $(this).remove();
+    });
+});

--- a/js/global.js
+++ b/js/global.js
@@ -924,6 +924,11 @@ jQuery(document).ready(function($) {
         });
     });
 
+    // Trigger handlers for "Close" button click if an anchor with a DismissMessage class is clicked.
+    $(document).on("click", "div.InformWrapper.Dismissable a.DismissMessage", function(event) {
+        $(this).parents("div.InformWrapper").find("a.Close").trigger("click");
+    });
+
     gdn.setAutoDismiss = function() {
         var timerId = $('div.InformMessages').attr('autodismisstimerid');
         if (!timerId) {

--- a/js/global.js
+++ b/js/global.js
@@ -918,15 +918,10 @@ jQuery(document).ready(function($) {
         gdn.stats();
 
     // If a dismissable InformMessage close button is clicked, hide it.
-    $(document).delegate('div.InformWrapper.Dismissable a.Close', 'click', function() {
+    $(document).delegate('div.InformWrapper.Dismissable a.Close, div.InformWrapper .js-inform-close', 'click', function() {
         $(this).parents('div.InformWrapper').fadeOut('fast', function() {
             $(this).remove();
         });
-    });
-
-    // Trigger handlers for "Close" button click if an anchor with a DismissMessage class is clicked.
-    $(document).on("click", "div.InformWrapper.Dismissable a.DismissMessage", function(event) {
-        $(this).parents("div.InformWrapper").find("a.Close").trigger("click");
     });
 
     gdn.setAutoDismiss = function() {


### PR DESCRIPTION
This update does a few things:

1. Adds a new controller, `AddonCacheController`, to handle interfacing with the addon cache via endpoints.
2. Adds two endpoints to the new controller: `verify` and `clear`. The `verify` endpoint scans addons of a particular type and verifies the cache is in sync with the directory contents. The `clear` endpoint nukes the current addon cache.
3. Implements an automatic, asynchronous request for cache validation upon loading up the applications, plug-ins or theme management pages. This request is limited to the type currently being viewed (e.g. only verify the themes cache if you're viewing the themes page). Based on the result, the user is warned their cache is outdated and prompts them to clear it. If they elect to clear it, a second request is sent to the server to clear the cache. If the result was successful, the page is reloaded.
4. A config-based kill switch has been added for this functionality: `Cache.Addons.DisableEndpoints`. If this config value is true, the whole controller is disabled and the checks are not run on addon settings pages.
5. Introduces a new JavaScript action class: `js-close-inform`. Clicking elements with this class will close the inform message element it resides in. This is done to close the cache notification for a user, if they click the link to clear their addon cache. Otherwise, the message remains.

Closes #4989 