### PR TITLE
Ensure Memcached keys are valid

### DIFF
--- a/library/core/class.cache.php
+++ b/library/core/class.cache.php
@@ -673,17 +673,17 @@ abstract class Gdn_Cache {
 
         // Make sure key is valid: no control characters or whitespace and no more than 250 characters.
         // See https://github.com/memcached/memcached/blob/master/doc/protocol.txt
+        $Result = trim($Result);
         if (unicodeRegexSupport()) {
             // No whitespace or control characters.
-            $replacePattern = '/[\p{Z}\p{C}]/u';
+            $Result = preg_replace('/[\p{Z}\p{C}]+/u', '-', $Result);
         } else {
             // No whitespace.
-            $replacePattern = '/[\s]/';
+            $Result = preg_replace('/\s+/', '-', $Result);
         }
-        $Result = preg_replace($replacePattern, '-', $Result);
 
-        // Clean up any leading, trailing and consecutive dashes.
-        $Result = trim(preg_replace('/-+/', '-', $Result), '-');
+        // Clean up any leading or trailing dashes.
+        $Result = trim($Result, '-');
 
         if (strlen($Result) > 250) {
             $Result = substr($Result, 0, 250);

--- a/library/core/class.cache.php
+++ b/library/core/class.cache.php
@@ -672,12 +672,13 @@ abstract class Gdn_Cache {
         }
 
         // Make sure key is valid: no control characters or whitespace and no more than 250 characters.
+        // See https://github.com/memcached/memcached/blob/master/doc/protocol.txt
         if (unicodeRegexSupport()) {
             // No whitespace or control characters.
             $replacePattern = '/[\p{Z}\p{C}]/u';
         } else {
-            // No space, newline, carriage return or tab characters.
-            $replacePattern = '/[\s\n\r\t]/';
+            // No whitespace.
+            $replacePattern = '/[\s]/';
         }
         $Result = preg_replace($replacePattern, '-', $Result);
 

--- a/library/core/class.cache.php
+++ b/library/core/class.cache.php
@@ -682,9 +682,6 @@ abstract class Gdn_Cache {
             $Result = preg_replace('/\s+/', '-', $Result);
         }
 
-        // Clean up any leading or trailing dashes.
-        $Result = trim($Result, '-');
-
         if (strlen($Result) > 250) {
             $Result = substr($Result, 0, 250);
         }

--- a/library/core/class.cache.php
+++ b/library/core/class.cache.php
@@ -671,6 +671,23 @@ abstract class Gdn_Cache {
             $Result = $Prefix.$Key;
         }
 
+        // Make sure key is valid: no control characters or whitespace and no more than 250 characters.
+        if (unicodeRegexSupport()) {
+            // No whitespace or control characters.
+            $replacePattern = '/[\p{Z}\p{C}]/u';
+        } else {
+            // No space, newline, carriage return or tab characters.
+            $replacePattern = '/[\s\n\r\t]/';
+        }
+        $Result = preg_replace($replacePattern, '-', $Result);
+
+        // Clean up any leading, trailing and consecutive dashes.
+        $Result = trim(preg_replace('/-+/', '-', $Result), '-');
+
+        if (strlen($Result) > 250) {
+            $Result = substr($Result, 0, 250);
+        }
+
         return $Result;
     }
 


### PR DESCRIPTION
This update alters `Gdn_Cache::makeKey`, which is used by `Gdn_Memcached::set` and `Gdn_Memcached::get`, to ensure the strings generated are [valid Memcached keys](https://github.com/memcached/memcached/blob/d9dfbe0e2613b9c20cb3c4fdd3c55d1bf3a8c8bd/doc/protocol.txt#L41). This is done by stripping out any whitespace or control characters from the keys and making certain they are no longer than 250 characters.

Closes #4996