### PR TITLE
Add jsonFilter function and tests

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2152,6 +2152,23 @@ if (!function_exists('jsonEncodeChecked')) {
     }
 }
 
+if (!function_exists('jsonFilter')) {
+    /**
+     * Prepare data for json_encode.
+     *
+     * @param mixed $value
+     */
+    function jsonFilter(&$value) {
+        if (is_array($value)) {
+            array_walk_recursive($value, __FUNCTION__);
+        } elseif ($value instanceof \DateTimeInterface) {
+            $value = $value->format('r');
+        } elseif ($ip = ipDecode($value)) {
+            $value = $ip;
+        }
+    }
+}
+
 if (!function_exists('now')) {
     /**
      * Get the current time in seconds with a millisecond fraction.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2163,7 +2163,7 @@ if (!function_exists('jsonFilter')) {
             array_walk_recursive($value, __FUNCTION__);
         } elseif ($value instanceof \DateTimeInterface) {
             $value = $value->format('r');
-        } elseif ($ip = ipDecode($value)) {
+        } elseif (is_string($value) && ($ip = ipDecode($value)) !== null) {
             $value = $ip;
         }
     }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2159,12 +2159,20 @@ if (!function_exists('jsonFilter')) {
      * @param mixed $value
      */
     function jsonFilter(&$value) {
+        $fn = function (&$value, $key = '') use (&$fn) {
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('r');
+            } elseif (is_string($value)) {
+                if (stringEndsWith($key, 'IPAddress', true) && ($ip = ipDecode($value)) !== null) {
+                    $value = $ip;
+                }
+            }
+        };
+
         if (is_array($value)) {
-            array_walk_recursive($value, __FUNCTION__);
-        } elseif ($value instanceof \DateTimeInterface) {
-            $value = $value->format('r');
-        } elseif (is_string($value) && ($ip = ipDecode($value)) !== null) {
-            $value = $ip;
+            array_walk_recursive($value, $fn);
+        } else {
+            $fn($value);
         }
     }
 }

--- a/tests/Library/Core/JsonFilterTest.php
+++ b/tests/Library/Core/JsonFilterTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Core;
+
+/**
+ * Test the jsonFilter function.
+ */
+class JsonFilterTest extends \PHPUnit_Framework_TestCase {
+
+    public function testJsonFilterDateTime() {
+        $date = new \DateTime();
+        $data = ['Date' => $date];
+        jsonFilter($data);
+
+        $this->assertSame($date->format('r'), $data['Date']);
+    }
+
+    public function testJsonFilterDateTimeRecursive() {
+        $date = new \DateTime();
+        $data = [
+            'Dates' => ['FirstDate' => $date]
+        ];
+        jsonFilter($data);
+
+        $this->assertSame($date->format('r'), $data['Dates']['FirstDate']);
+    }
+
+    public function testJsonFilterEncodedIP() {
+        $ip = '127.0.0.1';
+        $data = ['IP' => ipEncode($ip)];
+        jsonFilter($data);
+
+        $this->assertSame($ip, $data['IP']);
+    }
+
+    public function testJsonFilterEncodedIPRecursive() {
+        $ip = '127.0.0.1';
+        $data = [
+            'IPs' => ['FirstIP' => ipEncode($ip)]
+        ];
+        jsonFilter($data);
+
+        $this->assertSame($ip, $data['IPs']['FirstIP']);
+    }
+
+    public function testJsonFilterPassThrough() {
+        $data = [
+            'Array' => ['Key' => 'Value'],
+            'Boolean' => true,
+            'Float' => 1.234,
+            'Integer' => 10,
+            'Null' => null,
+            'String' => 'The quick brown fox jumps over the lazy dog.'
+        ];
+
+        $filteredData = $data;
+        jsonFilter($filteredData);
+
+        $this->assertSame($data, $filteredData);
+    }
+}

--- a/tests/Library/Core/JsonFilterTest.php
+++ b/tests/Library/Core/JsonFilterTest.php
@@ -37,6 +37,15 @@ class JsonFilterTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($ip, $data['InsertIPAddress']);
     }
 
+    public function testJsonFilterEncodedIPList() {
+        $ip = ['127.0.0.1', '192.168.0.1', '10.0.0.1'];
+        $encoded = ipEncodeRecursive(['AllIPAddresses' => $ip]);
+
+        jsonFilter($encoded);
+
+        $this->assertSame($ip, $encoded['AllIPAddresses']);
+    }
+
     public function testJsonFilterEncodedIPRecursive() {
         $ip = '127.0.0.1';
         $data = [

--- a/tests/Library/Core/JsonFilterTest.php
+++ b/tests/Library/Core/JsonFilterTest.php
@@ -31,20 +31,20 @@ class JsonFilterTest extends \PHPUnit_Framework_TestCase {
 
     public function testJsonFilterEncodedIP() {
         $ip = '127.0.0.1';
-        $data = ['IP' => ipEncode($ip)];
+        $data = ['InsertIPAddress' => ipEncode($ip)];
         jsonFilter($data);
 
-        $this->assertSame($ip, $data['IP']);
+        $this->assertSame($ip, $data['InsertIPAddress']);
     }
 
     public function testJsonFilterEncodedIPRecursive() {
         $ip = '127.0.0.1';
         $data = [
-            'IPs' => ['FirstIP' => ipEncode($ip)]
+            'Discussion' => ['UpdateIPAddress' => ipEncode($ip)]
         ];
         jsonFilter($data);
 
-        $this->assertSame($ip, $data['IPs']['FirstIP']);
+        $this->assertSame($ip, $data['Discussion']['UpdateIPAddress']);
     }
 
     public function testJsonFilterPassThrough() {


### PR DESCRIPTION
This update adds a global `jsonFilter` function, which is intended to prepare data for conversion to JSON via `json_encode`. Currently supported are:

1. Converting `DateTimeInterface` subclasses (e.g. `DateTime`) from objects to their RFC 2822 representations
2. Converting packed IP addresses to their human-readable forms with `ipDecode`.

Closes #5156 