### PR TITLE
Add forwards-compatible methods to Gdn_Request

### DIFF
--- a/library/Garden/Web/RequestInterface.php
+++ b/library/Garden/Web/RequestInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace Garden\Web;
+
+
+interface RequestInterface {
+    public function getPath();
+
+    public function getMethod();
+
+    public function getQuery();
+
+    public function getBody();
+}

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -380,7 +380,7 @@ class Gdn_Request implements RequestInterface {
      * @return string
      */
     public function getPath() {
-        $path = (string)$this->_environmentElement('URI');
+        $path = (string)$this->_parsedRequestElement('Path');
         if (strpos($path, '/') !== 0) {
             $path = "/{$path}";
         }
@@ -1201,8 +1201,7 @@ class Gdn_Request implements RequestInterface {
      */
     public function setPath($path) {
         $path = trim($path, '/');
-        $path = "/{$path}";
-        $this->_environmentElement('URI', $path);
+        $this->_parsedRequestElement('Path', $path);
         return $this;
     }
 

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -9,6 +9,7 @@
  * @package Core
  * @since 2.0
  */
+use Garden\Web\RequestInterface;
 
 /**
  * Represents a Request to the application, typically from the browser but potentially generated internally, in a format
@@ -22,7 +23,7 @@
  * @method string requestAddress($ip = null) Get/Set the Request IP address (first existing of HTTP_X_ORIGINALLY_FORWARDED_FOR,
  *                HTTP_X_CLUSTER_CLIENT_IP, HTTP_CLIENT_IP, HTTP_X_FORWARDED_FOR, REMOTE_ADDR).
  */
-class Gdn_Request {
+class Gdn_Request implements RequestInterface {
 
     /** Superglobal source. */
     const INPUT_CUSTOM = "custom";
@@ -350,6 +351,27 @@ class Gdn_Request {
      */
     public function getIP() {
         return (string)$this->_environmentElement('ADDRESS');
+    }
+
+
+    /**
+     * Get the HTTP method.
+     *
+     * @return string Returns the HTTP method.
+     */
+    public function getMethod() {
+        return $this->requestMethod();
+    }
+
+    /**
+     * Set the HTTP method.
+     *
+     * @param string $method The new HTTP method.
+     * @return $this
+     */
+    public function setMethod($method) {
+        $this->requestMethod($method);
+        return $this;
     }
 
     /**

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -45,6 +45,27 @@ class Gdn_Request {
     /** Superglobal source. */
     const INPUT_COOKIES = "cookies";
 
+    /** HTTP request method. */
+    const METHOD_HEAD = 'HEAD';
+
+    /** HTTP request method. */
+    const METHOD_GET = 'GET';
+
+    /** HTTP request method. */
+    const METHOD_POST = 'POST';
+
+    /** HTTP request method. */
+    const METHOD_PUT = 'PUT';
+
+    /** HTTP request method. */
+    const METHOD_PATCH = 'PATCH';
+
+    /** HTTP request method. */
+    const METHOD_DELETE = 'DELETE';
+
+    /** HTTP request method. */
+    const METHOD_OPTIONS = 'OPTIONS';
+
     /** @var bool Whether or not _ParseRequest has been called yet. */
     protected $_HaveParsedRequest = false;
 
@@ -126,8 +147,8 @@ class Gdn_Request {
      *  - ADDRESS  -> first existing of HTTP_X_ORIGINALLY_FORWARDED_FOR, HTTP_X_CLUSTER_CLIENT_IP,
      *                HTTP_CLIENT_IP, HTTP_X_FORWARDED_FOR, REMOTE_ADDR
      *
-     * @param $key Key to retrieve or set.
-     * @param $value Value of $Key key to set.
+     * @param string $key Key to retrieve or set.
+     * @param string $value Value of $Key key to set.
      * @return string | null
      */
     protected function _environmentElement($key, $value = null) {
@@ -268,6 +289,123 @@ class Gdn_Request {
     }
 
     /**
+     * Get the POST body of the request.
+     *
+     * @return array
+     */
+    public function getBody() {
+        return (array)$this->getRequestArguments(self::INPUT_POST);
+    }
+
+    /**
+     * Get the file extension of the request.
+     *
+     * @return string
+     */
+    public function getExt() {
+        return (string)$this->_parsedRequestElement('Extension');
+    }
+
+    /**
+     * Get the full path of the request.
+     *
+     * @return string;
+     */
+    public function getFullPath() {
+        return $this->getRoot().$this->getPathExt();
+    }
+
+    /**
+     * Get the hostname of the request.
+     *
+     * @return string
+     */
+    public function getHost() {
+        return (string)$this->_environmentElement('HOST');
+    }
+
+    /**
+     * Get the host and port, but only if the port is not the standard port for the request scheme.
+     *
+     * @return string
+     */
+    public function getHostAndPort() {
+        $host = $this->getHost();
+        $port = $this->getPort();
+
+        // Only append the port if it is non-standard.
+        if (($port == 80 && $this->getScheme() === 'http') || ($port == 443 && $this->getScheme() === 'https')) {
+            $port = '';
+        } else {
+            $port = ':'.$port;
+        }
+
+        return $host.$port;
+    }
+
+    /**
+     * Get the IP address of the request.
+     *
+     * @return string;
+     */
+    public function getIP() {
+        return (string)$this->_environmentElement('ADDRESS');
+    }
+
+    /**
+     * Gets the request path.
+     *
+     * @return string
+     */
+    public function getPath() {
+        $path = (string)$this->_environmentElement('URI');
+        if (strpos($path, '/') !== 0) {
+            $path = "/{$path}";
+        }
+
+        return $path;
+    }
+
+    /**
+     * Get the path and file extenstion.
+     *
+     * @return string
+     */
+    public function getPathExt() {
+        $path = $this->getPath();
+        $extension = $this->getExt();
+
+        return $path.$extension;
+    }
+
+    /**
+     * Gets the port.
+     *
+     * @return int
+     */
+    public function getPort() {
+        return (int)$this->_environmentElement('PORT');
+    }
+
+    /**
+     * Get the request query.
+     *
+     * @return array
+     */
+    public function getQuery() {
+        return (array)$this->getRequestArguments(self::INPUT_GET);
+    }
+
+    /**
+     * Get an item from the query string array.
+     *
+     * @return string
+     */
+    public function getQueryItem($key, $default = null) {
+        return (string)$this->getValueFrom(self::INPUT_GET, $key, '');
+    }
+
+    /**
      * Export an entire dataset (effectively, one of the superglobals) from the request arguments list
      *
      * @param int $paramType Type of data to export. One of the self::INPUT_* constants
@@ -281,6 +419,46 @@ class Gdn_Request {
         } else {
             return $this->_RequestArguments[$paramType];
         }
+    }
+
+    /**
+     * Get the root directory of the request.
+     *
+     * @return string
+     */
+    public function getRoot() {
+        $root = (string)$this->_parsedRequestElement('RootDir');
+        if (strpos($root, '/') !== 0) {
+            $root = "/{$root}";
+        }
+        $root = rtrim($root, '/');
+
+        return $root;
+    }
+
+    /**
+     * Get the request scheme.
+     *
+     * @return string
+     */
+    public function getScheme() {
+        return (string)$this->_environmentElement('SCHEME');
+    }
+
+    /**
+     * Get the full url of the request.
+     *
+     * @return string
+     */
+    public function getUrl() {
+        $scheme = $this->getScheme();
+        $hostAndPort = $this->getHostAndPort();
+        $fullPath = $this->getFullPath();
+
+        $query = $this->getQuery();
+        $queryString = (empty($query) ? '' : '?'.http_build_query($query));
+
+        return "{$scheme}://{$hostAndPort}{$fullPath}{$queryString}";
     }
 
     /**
@@ -845,6 +1023,19 @@ class Gdn_Request {
     }
 
     /**
+     * Merge an array of values into the request query.
+     *
+     * @param array $query
+     * @return self
+     */
+    public function mergeQuery(array $query) {
+        $current = $this->getQuery();
+        $this->setQuery(array_merge($current, $query));
+
+        return $this;
+    }
+
+    /**
      * Attach an array of request arguments to the request.
      *
      * @param int $paramsType type of data to import. One of the self::INPUT_* constants
@@ -909,8 +1100,223 @@ class Gdn_Request {
         return $result;
     }
 
+    /**
+     * Set the POST body for the request.
+     *
+     * @param array $body
+     * @return self
+     */
+    public function setBody(array $body) {
+        $this->setRequestArguments(self::INPUT_POST, $body);
+        return $this;
+    }
+
+    /**
+     * Sets the file extension of the request.
+     *
+     * @param string $extension
+     * @return self
+     */
+    public function setExt($extension) {
+        $extension = '.'.ltrim($extension, '.');
+
+        $this->_parsedRequestElement('Extension', $extension);
+        return $this;
+    }
+
+    /**
+     * Set the full path of the request.
+     *
+     * @param string $fullPath
+     * @return self
+     */
+    public function setFullPath($fullPath) {
+        $fullPath = '/'.trim($fullPath, '/');
+
+        // Try stripping the root out of the path first.
+        $root = $this->getRoot();
+        $rootStartsPath = (strpos($fullPath, $root) === 0);
+        $canTrimRoot = (strlen($fullPath) === strlen($root) || substr($fullPath, strlen($root), 1) === '/');
+
+        if ($root && $rootStartsPath && $canTrimRoot) {
+            $pathWithoutRoot = substr($fullPath, strlen($root));
+            $this->setPathExt($pathWithoutRoot);
+        } else {
+            $this->setRoot('');
+            $this->setPathExt($fullPath);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the hostname of the request.
+     *
+     * @param string $host
+     * @return self
+     */
+    public function setHost($host) {
+        $this->_environmentElement('HOST', $host);
+        return $this;
+    }
+
+    /**
+     * Set the IP address of the request.
+     *
+     * @param string $ip
+     * @return self
+     */
+    public function setIP($ip) {
+        $this->_environmentElement('ADDRESS', $ip);
+        return $this;
+    }
+
+    /**
+     * Sets the request path.
+     *
+     * @param string $path
+     * @return self
+     */
+    public function setPath($path) {
+        $path = trim($path, '/');
+        $path = "/{$path}";
+        $this->_environmentElement('URI', $path);
+        return $this;
+    }
+
+    /**
+     * Parse a path to separate and set the path and file extension of the request.
+     *
+     * @param string $path
+     * @return self
+     */
+    public function setPathExt($path) {
+        $info = pathinfo($path);
+
+        if (isset($info['extension'])) {
+            $this->setExt($info['extension']);
+        }
+
+        $path = ($info['dirname'] === '.' ? $info['filename'] : "{$info['dirname']}/{$info['filename']}");
+        $this->setPath($path);
+
+        return $this;
+    }
+
+    /**
+     * Sets the port.
+     *
+     * @param int|string $port
+     * @return self
+     */
+    public function setPort($port) {
+        $port = intval($port);
+        $this->_environmentElement('PORT', $port);
+
+        // Override the scheme for standard ports.
+        if ($port === 80) {
+            $this->setScheme('http');
+        } elseif ($port === 443) {
+            $this->setScheme('https');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the query for the request.
+     *
+     * @param array $query
+     * @return self
+     */
+    public function setQuery(array $query) {
+        $this->setRequestArguments(self::INPUT_GET, $query);
+        return $this;
+    }
+
+    /**
+     * Sets a value on the request's query.
+     *
+     * @param string $key
+     * @param string $value
+     * @return self
+     */
+    public function setQueryItem($key, $value) {
+        $this->setValueOn(self::INPUT_GET, $key, $value);
+        return $this;
+    }
+
     public function setRequestArguments($paramsType, $paramsData) {
         $this->_RequestArguments[$paramsType] = $paramsData;
+    }
+
+    /**
+     * Set the root directory of the request.
+     *
+     * @param string $root
+     * @return self
+     */
+    public function setRoot($root) {
+        $root = trim($root, '/');
+        if ($root) {
+            $root = "/{$root}";
+        }
+
+        $this->_parsedRequestElement('RootDir', $root);
+        return $this;
+    }
+
+    /**
+     * Set the request scheme.
+     *
+     * @param string $scheme
+     * @return self
+     */
+    public function setScheme($scheme) {
+        $this->_environmentElement('SCHEME', $scheme);
+        return $this;
+    }
+
+    /**
+     * Set the full URL of the request.
+     *
+     * @param string $url
+     * @return Gdn_Request
+     */
+    public function setUrl($url) {
+        // Parse a url and set its components.
+        $components = parse_url($url);
+
+        if ($components === false) {
+            throw new \InvalidArgumentException('Invalid URL.');
+        }
+
+        if (isset($components['scheme'])) {
+            $this->setScheme($components['scheme']);
+        }
+
+        if (isset($components['host'])) {
+            $this->setHost($components['host']);
+        }
+
+        if (isset($components['port'])) {
+            $this->setPort($components['port']);
+        } elseif (isset($components['scheme'])) {
+            $this->setPort($this->getScheme() === 'https' ? 443 : 80);
+        }
+
+        if (isset($components['path'])) {
+            $this->setPathExt($components['path']);
+        }
+
+        if (isset($components['query'])) {
+            parse_str($components['query'], $query);
+            if (is_array($query)) {
+                $this->setQuery($query);
+            }
+        }
+
+        return $this;
     }
 
     public function setValueOn($paramType, $paramName, $paramValue) {

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -449,7 +449,7 @@ class Gdn_Request implements RequestInterface {
      * @return string
      */
     public function getRoot() {
-        $root = (string)$this->_parsedRequestElement('RootDir');
+        $root = (string)$this->_parsedRequestElement('WebRoot');
         if (strpos($root, '/') !== 0) {
             $root = "/{$root}";
         }
@@ -1279,11 +1279,8 @@ class Gdn_Request implements RequestInterface {
      */
     public function setRoot($root) {
         $root = trim($root, '/');
-        if ($root) {
-            $root = "/{$root}";
-        }
 
-        $this->_parsedRequestElement('RootDir', $root);
+        $this->_parsedRequestElement('WebRoot', $root);
         return $this;
     }
 
@@ -1550,7 +1547,6 @@ class Gdn_Request implements RequestInterface {
         return $withDomain.$this->hostAndPort();
     }
 
-
     /**
      * Gets/Sets the relative path to the application's dispatcher.
      *
@@ -1558,9 +1554,7 @@ class Gdn_Request implements RequestInterface {
      * @return string
      */
     public function webRoot($webRoot = null) {
-        static $path = null;
-
-        if ($webRoot !== null || $path === null || !$this->_HaveParsedRequest) {
+        if ($webRoot !== null || !$this->_HaveParsedRequest) {
             $path = (string)$this->_parsedRequestElement('WebRoot', $webRoot);
             $webRootFromConfig = $this->_environmentElement('ConfigWebRoot');
 
@@ -1568,6 +1562,8 @@ class Gdn_Request implements RequestInterface {
             if ($webRootFromConfig && $removeWebRootConfig) {
                 $path = str_replace($webRootFromConfig, '', $webRoot);
             }
+        } else {
+            $path = $this->_parsedRequestElement('WebRoot');
         }
 
         return $path;

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -51,6 +51,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
         ];
     }
 
+    public function testBodyEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setBody(['foo' => 'bar']);
+        $this->assertSame($req->getBody(), $req->getRequestArguments(Gdn_Request::INPUT_POST));
+
+        $req->setRequestArguments(Gdn_Request::INPUT_POST, ['foo' => 'bar']);
+        $this->assertSame($req->getBody(), $req->getRequestArguments(Gdn_Request::INPUT_POST));
+    }
+
     public function testGetUrl() {
         $request = new Gdn_Request();
         $request->setScheme('http');
@@ -62,6 +72,35 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
         $request->setQuery(['foo' => 'bar']);
 
         $this->assertSame('http://localhost:8080/root-dir/path/to/resource.json?foo=bar', $request->getUrl());
+    }
+
+    public function testHostEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setHost('localhost');
+        $this->assertSame($req->getHost(), $req->host());
+
+        $req->host('localhost');
+        $this->assertSame($req->getHost(), $req->host());
+    }
+
+    public function testHostAndPortEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setHost('localhost');
+        $req->setPort(8080);
+        $this->assertSame($req->getHostAndPort(), $req->hostAndPort());
+
+        $req->host('localhost');
+        $req->port(8080);
+        $this->assertSame($req->getHostAndPort(), $req->hostAndPort());
+    }
+
+    public function testIPEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setIP('127.0.0.1');
+        $this->assertSame($req->getIP(), $req->ipAddress());
     }
 
     public function testMergeQuery() {
@@ -105,6 +144,37 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 
         $req->setPath('foo');
         $this->assertSame('/foo', $req->getPath());
+    }
+
+    public function testPortEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setPort(8080);
+        $this->assertSame($req->getPort(), $req->port());
+
+        $req->port(8080);
+        $this->assertSame($req->getPort(), $req->port());
+    }
+
+    public function testQueryEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setQuery(['foo' => 'bar']);
+        $this->assertSame($req->getQuery(), $req->getRequestArguments(Gdn_Request::INPUT_GET));
+
+        $req->setRequestArguments(Gdn_Request::INPUT_GET, ['foo' => 'bar']);
+        $this->assertSame($req->getQuery(), $req->getRequestArguments(Gdn_Request::INPUT_GET));
+
+    }
+
+    public function testQueryItemEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setQuery(['foo' => 'bar']);
+        $this->assertSame($req->getQueryItem('foo'), $req->getValueFrom(Gdn_Request::INPUT_GET, 'foo'));
+
+        $req->setRequestArguments(Gdn_Request::INPUT_GET, ['foo' => 'bar']);
+        $this->assertSame($req->getQueryItem('foo'), $req->getValueFrom(Gdn_Request::INPUT_GET, 'foo'));
     }
 
     public function testSetFullPath() {
@@ -154,6 +224,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($expected['query'], $request->getQuery());
     }
 
+    public function testRootEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setRoot('root-dir');
+        $this->assertSame($req->getRoot(), '/'.$req->webRoot());
+
+        $req->webRoot('root-dir');
+        $this->assertSame($req->getRoot(), '/'.$req->webRoot());
+    }
+
     /**
      * Request root should start with a slash and fix ones that don't. Slash-only roots should be empty strings.
      */
@@ -165,6 +245,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
 
         $req->setRoot('/');
         $this->assertSame('', $req->getRoot());
+    }
+
+    public function testSchemeEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setScheme('https');
+        $this->assertSame($req->getScheme(), $req->scheme());
+
+        $req->scheme('http');
+        $this->assertSame($req->getScheme(), $req->scheme());
     }
 
     public function testUrlEquivalence() {

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -6,7 +6,12 @@
 
 namespace VanillaTests\Library\Core;
 
-class VanillaClassLocatorTest extends \PHPUnit_Framework_TestCase {
+use Gdn_Request;
+
+/**
+ * Test the {@link Gdn_Request} class.
+ */
+class RequestTest extends \PHPUnit_Framework_TestCase {
 
     public function provideUrls() {
         return [
@@ -47,7 +52,7 @@ class VanillaClassLocatorTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testGetUrl() {
-        $request = new \Gdn_Request();
+        $request = new Gdn_Request();
         $request->setScheme('http');
         $request->setHost('localhost');
         $request->setPort(8080);
@@ -60,7 +65,7 @@ class VanillaClassLocatorTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testMergeQuery() {
-        $request = new \Gdn_Request();
+        $request = new Gdn_Request();
         $request->setQuery([
             'One' => 'Alpha',
             'Two' => 'Bravo'
@@ -80,7 +85,7 @@ class VanillaClassLocatorTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testSetFullPath() {
-        $request = new \Gdn_Request();
+        $request = new Gdn_Request();
         $request->setRoot('root-dir');
         $request->setFullPath('/root-dir/path/to/resource.json');
 
@@ -90,7 +95,7 @@ class VanillaClassLocatorTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testSetPathExt() {
-        $request = new \Gdn_Request();
+        $request = new Gdn_Request();
         $request->setPathExt('path/to/resource.json');
 
         $this->assertSame('/path/to/resource', $request->getPath());
@@ -98,7 +103,7 @@ class VanillaClassLocatorTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testSetQueryItem() {
-        $request = new \Gdn_Request();
+        $request = new Gdn_Request();
         $request->setQuery([
             'One' => 'Alpha',
             'Two' => 'Bravo',
@@ -115,7 +120,7 @@ class VanillaClassLocatorTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideUrls
      */
     public function testSetUrl($url, $expected) {
-        $request = new \Gdn_Request();
+        $request = new Gdn_Request();
         $request->setUrl($url);
 
         $this->assertSame($expected['scheme'], $request->getScheme());
@@ -124,5 +129,28 @@ class VanillaClassLocatorTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame($expected['path'], $request->getPath());
         $this->assertSame($expected['extension'], $request->getExt());
         $this->assertSame($expected['query'], $request->getQuery());
+    }
+
+    /**
+     * Request paths should start with a slash and fix ones that don't.
+     */
+    public function testPathFixing() {
+        $req = new Gdn_Request();
+
+        $req->setPath('foo');
+        $this->assertSame('/foo', $req->getPath());
+    }
+
+    /**
+     * The {@link Gdn_Request::path()} and {@link Gdn_Request::getPath()} methods should be compatible.
+     */
+    public function testPathEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setPath('/foo');
+        $this->assertSame($req->getPath(), '/'.$req->path());
+
+        $req->path('/bar');
+        $this->assertSame($req->getPath(), '/'.$req->path());
     }
 }

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Core;
+
+class VanillaClassLocatorTest extends \PHPUnit_Framework_TestCase {
+
+    public function provideUrls() {
+        return [
+            [
+                'http://localhost:8080/path/to/resource.json?foo=bar',
+                [
+                    'scheme' => 'http',
+                    'host' => 'localhost',
+                    'port' => 8080,
+                    'path' => '/path/to/resource',
+                    'extension' => '.json',
+                    'query' => ['foo' => 'bar']
+                ]
+            ],
+            [
+                'https://vanillaforums.com/en',
+                [
+                    'scheme' => 'https',
+                    'host' => 'vanillaforums.com',
+                    'port' => 443,
+                    'path' => '/en',
+                    'extension' => '',
+                    'query' => []
+                ]
+            ],
+            [
+                'http://open.vanillaforums.com',
+                [
+                    'scheme' => 'http',
+                    'host' => 'open.vanillaforums.com',
+                    'port' => 80,
+                    'path' => '/',
+                    'extension' => '',
+                    'query' => []
+                ]
+            ]
+        ];
+    }
+
+    public function testGetUrl() {
+        $request = new \Gdn_Request();
+        $request->setScheme('http');
+        $request->setHost('localhost');
+        $request->setPort(8080);
+        $request->setRoot('/root-dir');
+        $request->setPath('/path/to/resource');
+        $request->setExt('.json');
+        $request->setQuery(['foo' => 'bar']);
+
+        $this->assertSame('http://localhost:8080/root-dir/path/to/resource.json?foo=bar', $request->getUrl());
+    }
+
+    public function testMergeQuery() {
+        $request = new \Gdn_Request();
+        $request->setQuery([
+            'One' => 'Alpha',
+            'Two' => 'Bravo'
+        ]);
+        $request->mergeQuery([
+            'Two' => 'Beta',
+            'Three' => 'Charlie',
+            'Four' => 'Delta'
+        ]);
+
+        $this->assertSame([
+            'One' => 'Alpha',
+            'Two' => 'Beta',
+            'Three' => 'Charlie',
+            'Four' => 'Delta'
+        ], $request->getQuery());
+    }
+
+    public function testSetFullPath() {
+        $request = new \Gdn_Request();
+        $request->setRoot('root-dir');
+        $request->setFullPath('/root-dir/path/to/resource.json');
+
+        //$this->assertSame('/root-dir', $request->getRoot());
+        $this->assertSame('/path/to/resource', $request->getPath());
+        $this->assertSame('.json', $request->getExt());
+    }
+
+    public function testSetPathExt() {
+        $request = new \Gdn_Request();
+        $request->setPathExt('path/to/resource.json');
+
+        $this->assertSame('/path/to/resource', $request->getPath());
+        $this->assertSame('.json', $request->getExt());
+    }
+
+    public function testSetQueryItem() {
+        $request = new \Gdn_Request();
+        $request->setQuery([
+            'One' => 'Alpha',
+            'Two' => 'Bravo',
+            'Three' => 'Charlie'
+        ]);
+        $request->setQueryItem('One', 'Delta');
+
+        $this->assertSame('Delta', $request->getQueryItem('One'));
+    }
+
+    /**
+     * @param string $url
+     * @param array $expected
+     * @dataProvider provideUrls
+     */
+    public function testSetUrl($url, $expected) {
+        $request = new \Gdn_Request();
+        $request->setUrl($url);
+
+        $this->assertSame($expected['scheme'], $request->getScheme());
+        $this->assertSame($expected['host'], $request->getHost());
+        $this->assertSame($expected['port'], $request->getPort());
+        $this->assertSame($expected['path'], $request->getPath());
+        $this->assertSame($expected['extension'], $request->getExt());
+        $this->assertSame($expected['query'], $request->getQuery());
+    }
+}

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -84,6 +84,29 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
         ], $request->getQuery());
     }
 
+    /**
+     * The {@link Gdn_Request::path()} and {@link Gdn_Request::getPath()} methods should be compatible.
+     */
+    public function testPathEquivalence() {
+        $req = new Gdn_Request();
+
+        $req->setPath('/foo');
+        $this->assertSame($req->getPath(), '/'.$req->path());
+
+        $req->path('/bar');
+        $this->assertSame($req->getPath(), '/'.$req->path());
+    }
+
+    /**
+     * Request paths should start with a slash and fix ones that don't.
+     */
+    public function testPathFixing() {
+        $req = new Gdn_Request();
+
+        $req->setPath('foo');
+        $this->assertSame('/foo', $req->getPath());
+    }
+
     public function testSetFullPath() {
         $request = new Gdn_Request();
         $request->setRoot('root-dir');
@@ -132,25 +155,37 @@ class RequestTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Request paths should start with a slash and fix ones that don't.
+     * Request root should start with a slash and fix ones that don't. Slash-only roots should be empty strings.
      */
-    public function testPathFixing() {
+    public function testRootFixing() {
         $req = new Gdn_Request();
 
-        $req->setPath('foo');
-        $this->assertSame('/foo', $req->getPath());
+        $req->setRoot('root-dir');
+        $this->assertSame('/root-dir', $req->getRoot());
+
+        $req->setRoot('/');
+        $this->assertSame('', $req->getRoot());
     }
 
-    /**
-     * The {@link Gdn_Request::path()} and {@link Gdn_Request::getPath()} methods should be compatible.
-     */
-    public function testPathEquivalence() {
+    public function testUrlEquivalence() {
         $req = new Gdn_Request();
 
-        $req->setPath('/foo');
-        $this->assertSame($req->getPath(), '/'.$req->path());
+        $req->setScheme('http');
+        $req->setHost('localhost');
+        $req->setPort(8080);
+        $req->setRoot('root-dir');
+        $req->setPath('path/to/resource.json');
+        $req->setQueryItem('foo', 'bar');
 
-        $req->path('/bar');
-        $this->assertSame($req->getPath(), '/'.$req->path());
+        $this->assertSame($req->getUrl(), $req->url('', true));
+
+        $req->scheme('http');
+        $req->host('localhost');
+        $req->port(8080);
+        $req->webRoot('root-dir');
+        $req->path('path/to/resource.json');
+        $req->setValueOn(Gdn_Request::INPUT_GET, 'foo', 'bar');
+
+        $this->assertSame($req->getUrl(), $req->url('', true));
     }
 }


### PR DESCRIPTION
This update adds forwards-compatible methods to Gdn_Request and tests to support them. For details, see the original issue.

Closes #4162