### PR TITLE
Remove ShowCustomPoints property on Vanilla Settings Controller

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -28,9 +28,6 @@ class VanillaSettingsController extends Gdn_Controller {
     /** @var array An array of category records. */
     public $OtherCategories;
 
-    /** @var bool */
-    public $ShowCustomPoints = false;
-
     /**
      * Advanced settings.
      *

--- a/applications/vanilla/views/vanillasettings/editcategory.php
+++ b/applications/vanilla/views/vanillasettings/editcategory.php
@@ -67,19 +67,14 @@ helpAsset(sprintf(t('About %s'), t('Categories')), t('Categories are used to org
     <li class="form-group">
         <?php echo $form->toggle('HideAllDiscussions', 'Hide from the recent discussions page.'); ?>
     </li>
-    <?php if ($this->ShowCustomPoints): ?>
-        <li class="form-group">
-            <?php echo $form->toggle('CustomPoints', 'Track points for this category separately.'); ?>
-        </li>
-    <?php endif; ?>
     <?php if ($this->data('Operation') == 'Edit'): ?>
         <li class="form-group">
             <?php
             echo $form->toggle('Archived', 'This category is archived.');
             ?>
         </li>
-        <?php $this->fireEvent('AfterCategorySettings'); ?>
     <?php endif; ?>
+    <?php $this->fireEvent('AfterCategorySettings'); ?>
     <?php if (count($this->PermissionData) > 0) { ?>
         <li id="Permissions" class="form-group">
             <?php echo $form->toggle('CustomPermissions', 'This category has custom permissions.'); ?>


### PR DESCRIPTION
* Removes the CustomPoints field from the add/edit category form in favour of adding it to the plugin that uses it.
* Moves the 'AfterCategorySettings' event to fire no matter whether we're adding or editing a category.

Relies on https://github.com/vanilla/internal/pull/912