### PR TITLE
Kludge AssetModel::viewExtensions() to work with the container

### DIFF
--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -427,37 +427,44 @@ class AssetModel extends Gdn_Model {
     }
 
     /**
-     * Get list of defined view handlers
+     * Get list of defined view handlers.
      *
-     * @staticvar array $handlers
-     * @param boolean $fresh
-     * @return array
+     * This method no longer really works due to factory changes.
+     *
+     * @return array Returns an array keyed by view handler.
+     * @deprecated
      */
-    public static function viewHandlers($fresh = false) {
-        static $handlers = null;
-        if (is_null($handlers) || $fresh) {
-            $factories = Gdn::factory()->search('viewhandler.*');
-            $handlers = array_change_key_case($factories);
+    public static function viewHandlers() {
+        deprecated('AssetModel::viewHandlers()');
+
+        $exts = static::viewExtensions();
+        $result = [];
+        foreach ($exts as $ext) {
+            if ($ext !== 'php') {
+                $result["ViewHandler.$ext"] = [];
+            }
         }
 
-        return $handlers;
+        return $result;
     }
 
     /**
-     * Get list of allowed view extensions
+     * Get list of allowed view extensions.
      *
-     * @param boolean $fresh
-     * @return array list of extensions
+     * @return array Returns an array of file extensions.
      */
-    public static function viewExtensions($fresh = false) {
-        $handlers = self::viewHandlers($fresh);
+    public static function viewExtensions() {
+        // This is a kludge where all known extensions are included.
+        $knownExts = ['tpl', 'mustache'];
 
-        $extensions = ['php'];
-        foreach ($handlers as $handlerTag => $handlerDef) {
-            $extension = explode('.', $handlerTag);
-            $extensions[] = array_pop($extension);
+        $result = ['php'];
+        foreach ($knownExts as $ext) {
+            $handler = "ViewHandler.$ext";
+            if (Gdn::factory()->exists($handler)) {
+                $result[] = $ext;
+            }
         }
-        return $extensions;
+        return $result;
     }
     /**
      * Get the path to a view.


### PR DESCRIPTION
The factory had a method to search the entire factory for items matching a wildcard pattern. This functionality isn't supported in the new container and it won't be added because it's just a bad practice.

To temporarily kludge past this I'm just going to search through our known file extensions. If some OSS plugin adds view handler support we can add that one. Longer term we'll think of a better way to do this.