### PR TITLE
Configure color picker to optionally accept empty values

### DIFF
--- a/applications/dashboard/views/modules/configuration.php
+++ b/applications/dashboard/views/modules/configuration.php
@@ -83,7 +83,7 @@ echo $Form->errors();
                 echo $Description;
                 echo '</div>';
                 echo '<div class="input-wrap">';
-                echo $Form->color($Row['Name']);
+                echo $Form->color($Row['Name'], $Row['Options']);
                 echo '</div>';
                 break;
             case 'radiolist':

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -355,20 +355,33 @@ class Gdn_Form extends Gdn_Pluggable {
 
     /**
      * Builds a color-picker form element. Accepts three-character hex values with or without the leading '#',
-     * but the saved value will be coerced into a six-character hex code with the leading '#'.
-     * The hex value to be saved is the value of the input with the color-picker-value class.
+     * but the saved value will be coerced into a six-character hex code with the leading '#'. Also accepts
+     * 'transparent', 'initial' or 'inherit'. Can be configured to accept an empty string if $options['AllowEmpty']
+     * is set to true. The hex value to be saved is the value of the input with the color-picker-value class.
      *
      * @param string $fieldName Name of the field being posted with this input.
+     * @param array $options Currently supports a key of 'AllowEmpty' which signifies whether to accept empty
+     * values for the color picker
      * @return string The form element for a color picker.
      */
-    public function color($fieldName) {
+    public function color($fieldName, $options = []) {
+
+        $allowEmpty = val('AllowEmpty', $options, false);
+
         Gdn::controller()->addJsFile('colorpicker.js');
 
         $valueAttributes['class'] = 'js-color-picker-value color-picker-value Hidden';
         $textAttributes['class'] = 'js-color-picker-text color-picker-text';
         $colorAttributes['class'] = 'js-color-picker-color color-picker-color';
 
-        return '<div id="'.$this->escapeFieldName($fieldName).'" class="js-color-picker color-picker input-group">'
+        // Default starting color for color input. Color inputs require one, Chrome will throw a warning if one
+        // doesn't exist. The javascript will override this.
+        $colorAttributes['value'] = '#ffffff';
+
+        $cssClass = 'js-color-picker color-picker input-group';
+        $dataAttribute = $allowEmpty ? 'data-allow-empty="true"' : 'data-allow-empty="false"';
+
+        return '<div id="'.$this->escapeFieldName($fieldName).'" class="'.$cssClass.'" '.$dataAttribute.'>'
         .$this->input($fieldName, 'text', $valueAttributes)
         .$this->input($fieldName.'-text', 'text', $textAttributes)
         .'<span class="js-color-picker-preview color-picker-preview"></span>'


### PR DESCRIPTION
Configures the color picker to optionally accept empty values and also accepts 'transparent,' 'initial' or 'inherit' as values.

* Adds an options param to the color picker renderer for configuring the 'AllowEmpty' setting.
* Passes the configuration module options data to the color rendering function.

Closes https://github.com/vanilla/vanilla/issues/5040