### PR TITLE
Fix link to filtered users from roles page

### DIFF
--- a/applications/dashboard/views/role/index.php
+++ b/applications/dashboard/views/role/index.php
@@ -45,7 +45,7 @@ echo $this->Form->open();
                         echo t(val('Type', $Role));
                     } ?>
                 </td>
-                <td><?php echo anchor($Role['CountUsers'] ?: 0, '/dashboard/user?Filter='.urlencode($Role['Name'])); ?></td>
+                <td><?php echo anchor($Role['CountUsers'] ?: 0, '/dashboard/user?Keywords='.urlencode($Role['Name'])); ?></td>
                 <td class="options">
                     <div class="btn-group">
                     <?php


### PR DESCRIPTION
When viewing the role management page, the link behind total number of users in the role is currently broken. It points to the user search page in the dashboard, using the `Filter` param for keywords. However, that page currently uses the `Keywords` param for searches. This update fixes that parameter name.

Closes #4994