### PR TITLE
Update TagModel::joinTags to handle iterating Gdn_Dataset

### DIFF
--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -291,8 +291,15 @@ class TagModel extends Gdn_Model {
      * @param $data
      */
     public function joinTags(&$data) {
+        // If we're dealing with an instance of Gdn_Dataset, grab a reference to its results.
+        if ($data instanceof Gdn_DataSet) {
+            $rows = $data->result();
+        } else {
+            $rows = &$data;
+        }
+
         $ids = array();
-        foreach ($data as $row) {
+        foreach ($rows as $row) {
             $discussionId = val('DiscussionID', $row);
             if ($discussionId) {
                 $ids[] = $discussionId;
@@ -308,7 +315,7 @@ class TagModel extends Gdn_Model {
 
         $all_tags = Gdn_DataSet::index($all_tags, 'DiscussionID', array('Unique' => false));
 
-        foreach ($data as &$row) {
+        foreach ($rows as &$row) {
             $discussionId = val('DiscussionID', $row);
             if (isset($all_tags[$discussionId])) {
                 $tags = $all_tags[$discussionId];


### PR DESCRIPTION
`TagModel::joinTags` can potentially use an instance of `Gdn_Dataset` in its loops. One of these loops passes its elements by reference. If `Gdn_Dataset` is the source, the following error is thrown in HHVM: An iterator cannot be used with foreach by reference

This update checks the type of the `$data` param and, if necessary, switches it up for a reference to an instance of `Gdn_Dataset`'s results array.

Closes #5141 