### PR TITLE
Reset the Children property when flattening categories

### DIFF
--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -739,11 +739,13 @@ class CategoryCollection {
      * @param array &$result The working result.
      */
     private function flattenTreeInternal(array $category, array &$result) {
+        $children = $category['Children'];
+        unset($category['Children']);
         $result[] = $category;
-        if (empty($category['Children'])) {
+        if (empty($children)) {
             return;
         }
-        foreach ($category['Children'] as $child) {
+        foreach ($children as $child) {
             $this->flattenTreeInternal($child, $result);
         }
     }

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -740,7 +740,7 @@ class CategoryCollection {
      */
     private function flattenTreeInternal(array $category, array &$result) {
         $children = val('Children', $category, []);
-        unset($category['Children']);
+        $category['Children'] = [];
         $result[] = $category;
 
         foreach ($children as $child) {

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -739,12 +739,10 @@ class CategoryCollection {
      * @param array &$result The working result.
      */
     private function flattenTreeInternal(array $category, array &$result) {
-        $children = $category['Children'];
+        $children = val('Children', $category, []);
         unset($category['Children']);
         $result[] = $category;
-        if (empty($children)) {
-            return;
-        }
+
         foreach ($children as $child) {
             $this->flattenTreeInternal($child, $result);
         }


### PR DESCRIPTION
Many views will render children if they exist. This PR unsets the children after flattening a category list.