### PR TITLE
Allow editor to find and delete locally copied scratch files from both s3 and cf

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1509,7 +1509,7 @@ class EditorPlugin extends Gdn_Plugin {
             ));
 
             // Remove cf scratch copy, typically in cftemp, if there was actually a file pulled in from CF.
-            if (strpos($local_path, 'cftemp') !== false) {
+            if (strpos($local_path, 'temp') !== false) {
                 if (!unlink($local_path)) {
                     // Maybe add logging for local cf copies not deleted.
                 }

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1508,11 +1508,9 @@ class EditorPlugin extends Gdn_Plugin {
                 'ThumbPath' => $filepath_parsed['SaveName']
             ));
 
-            // Remove cf scratch copy, typically in cftemp, if there was actually a file pulled in from CF.
-            if (strpos($local_path, 'temp') !== false) {
-                if (!unlink($local_path)) {
-                    // Maybe add logging for local cf copies not deleted.
-                }
+            // Remove cf scratch copy, typically in /uploads/cftemp/ or /uploads/cloudtemp/, if there was actually a file pulled in from CF.
+            if (preg_match('`/uploads/[^/]+temp/`', $local_path)) {
+                unlink($local_path);
             }
 
             $url = $filepath_parsed['Url'];

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1493,7 +1493,7 @@ class EditorPlugin extends Gdn_Plugin {
             $thumb_width = round($thumb_payload['result_width']);
 
             // Move the thumbnail to its proper location. Calling SaveAs with
-            // cloudfiles enabled will trigger the move to cloudfiles, so use
+            // a cloud storage plugin enabled will trigger the move to the cloud, so use
             // same path for each arg in SaveAs. The file will be removed from the local filesystem.
             $parsed = Gdn_Upload::parse($thumb_destination_path);
             $target = $thumb_destination_path; // $parsed['Name'];
@@ -1508,7 +1508,7 @@ class EditorPlugin extends Gdn_Plugin {
                 'ThumbPath' => $filepath_parsed['SaveName']
             ));
 
-            // Remove cf scratch copy, typically in /uploads/cftemp/ or /uploads/cloudtemp/, if there was actually a file pulled in from CF.
+            // Remove cloud scratch copy, typically in /uploads/cftemp/ or /uploads/cloudtemp/, if there was actually a file pulled in from cloud storage.
             if (preg_match('`/uploads/[^/]+temp/`', $local_path)) {
                 unlink($local_path);
             }

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1509,7 +1509,8 @@ class EditorPlugin extends Gdn_Plugin {
             ));
 
             // Remove cloud scratch copy, typically in /uploads/cftemp/ or /uploads/cloudtemp/, if there was actually a file pulled in from cloud storage.
-            if (preg_match('`/uploads/[^/]+temp/`', $local_path)) {
+            $uploadFolder = basename(PATH_UPLOADS);
+            if (preg_match("`/{$uploadFolder}/[^/]+temp/`", $local_path)) {
                 unlink($local_path);
             }
 


### PR DESCRIPTION
The cloudfiles plugin stored its scratch files in /uploads/cftemp/ and the editor was specifically checking for that path slug. s3files stores its scratch files in /uploads/cloudtemp/ and so the "cftemp" check was failing and files were not being deleted.

This fixes that problem, not in a great way but ok for now.