### PR TITLE
Add event argument for showing/hiding the Vanilla version

### DIFF
--- a/applications/dashboard/views/admin.master.php
+++ b/applications/dashboard/views/admin.master.php
@@ -128,9 +128,12 @@ Gdn_Theme::assetEnd();
                 </div>
                 <div class="footer-nav nav">
                     <?php
+                    $showVanillaVersion = true;
+                    $this->EventArguments['ShowVanillaVersion'] = &$showVanillaVersion;
                     $this->fireAs('dashboard')->fireEvent('footerNav');
-                    ?>
+                    if ($showVanillaVersion) : ?>
                     <div class="vanilla-version footer-nav-item nav-item"><?php echo t('Version').' '.APPLICATION_VERSION ?></div>
+                    <?php endif; ?>
                 </div>
             </footer>
         </div>


### PR DESCRIPTION
Add event argument for showing/hiding the Vanilla Version in the dashboard footer.

Relies on https://github.com/vanilla/vanillainfrastructure/pull/84
Closes https://github.com/vanilla/vanillainfrastructure/issues/80