### PR TITLE
Add the title of a discussion to a comment in the user comments module.

### DIFF
--- a/applications/vanilla/views/modules/usercomments.php
+++ b/applications/vanilla/views/modules/usercomments.php
@@ -13,7 +13,9 @@ if (sizeof($this->data('Comments'))) {
         <li id="<?php echo 'Comment_'.$comment->CommentID; ?>" class="Item">
             <?php $this->fireEvent('BeforeItemContent'); ?>
             <div class="ItemContent">
-                <div class="Message"><?php
+                <div class="Message">
+                    <h2><?php echo anchor(Gdn_Format::text($comment->DiscussionName), $permalink); ?></h2>
+                    <?php
                     echo SliceString(Gdn_Format::plainText($comment->Body, $comment->Format), 250);
                     ?></div>
                 <div class="Meta">


### PR DESCRIPTION
The display of comments in the user comments module looked sparse without a linkable title to the discussion, especially when you display the UserComments next to the UserDiscussions that does have a link to the discussion. This PR adds a title to the comment.