### PR TITLE
Let Form->validate check that the category is properly set

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1816,6 +1816,15 @@ class DiscussionModel extends VanillaModel {
             $this->Validation->applyRule('Body', 'Length');
         }
 
+        // Validate category permissions.
+        $CategoryID = val('CategoryID', $FormPostValues);
+        if ($CategoryID > 0) {
+            $Category = CategoryModel::categories($CategoryID);
+            if ($Category && !CategoryModel::checkPermission($Category, 'Vanilla.Discussions.Add')) {
+                $this->Validation->addValidationResult('CategoryID', 'You do not have permission to post in this category');
+            }
+        }
+
         // Get the DiscussionID from the form so we know if we are inserting or updating.
         $DiscussionID = val('DiscussionID', $FormPostValues, '');
 
@@ -1873,17 +1882,6 @@ class DiscussionModel extends VanillaModel {
         $this->EventArguments['FormPostValues'] = &$FormPostValues;
         $this->EventArguments['DiscussionID'] = $DiscussionID;
         $this->fireEvent('BeforeSaveDiscussion');
-
-        // Validate category permissions.
-        $CategoryID = val('CategoryID', $FormPostValues);
-        if ($CategoryID > 0) {
-            $Category = CategoryModel::categories($CategoryID);
-            if ($Category && !CategoryModel::checkPermission($Category, 'Vanilla.Discussions.Add')) {
-                $this->Validation->addValidationResult('CategoryID', 'You do not have permission to post in this category');
-            }
-        } else {
-            $this->Validation->addValidationResult('CategoryID', 'Invalid CategoryID');
-        }
 
         // Validate the form posted values
         $this->validate($FormPostValues, $Insert);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1816,17 +1816,6 @@ class DiscussionModel extends VanillaModel {
             $this->Validation->applyRule('Body', 'Length');
         }
 
-        // Validate category permissions.
-        $CategoryID = val('CategoryID', $FormPostValues);
-        if ($CategoryID > 0) {
-            $Category = CategoryModel::categories($CategoryID);
-            if ($Category && !CategoryModel::checkPermission($Category, 'Vanilla.Discussions.Add')) {
-                $this->Validation->addValidationResult('CategoryID', 'You do not have permission to post in this category');
-            }
-        } else {
-            $this->Validation->addValidationResult('CategoryID', 'Invalid CategoryID');
-        }
-
         // Get the DiscussionID from the form so we know if we are inserting or updating.
         $DiscussionID = val('DiscussionID', $FormPostValues, '');
 
@@ -1884,6 +1873,17 @@ class DiscussionModel extends VanillaModel {
         $this->EventArguments['FormPostValues'] = &$FormPostValues;
         $this->EventArguments['DiscussionID'] = $DiscussionID;
         $this->fireEvent('BeforeSaveDiscussion');
+
+        // Validate category permissions.
+        $CategoryID = val('CategoryID', $FormPostValues);
+        if ($CategoryID > 0) {
+            $Category = CategoryModel::categories($CategoryID);
+            if ($Category && !CategoryModel::checkPermission($Category, 'Vanilla.Discussions.Add')) {
+                $this->Validation->addValidationResult('CategoryID', 'You do not have permission to post in this category');
+            }
+        } else {
+            $this->Validation->addValidationResult('CategoryID', 'Invalid CategoryID');
+        }
 
         // Validate the form posted values
         $this->validate($FormPostValues, $Insert);


### PR DESCRIPTION
https://github.com/vanilla/vanilla/blob/9656876e959f55758fb1f776d6e6f5d97fb17c11/applications/vanilla/models/class.discussionmodel.php#L1887 will catch it if the category is not set.

The group application uses the BeforeSaveDiscussion event to inject a categoryID