### PR TITLE
Handle SSO connections that trigger SPAM filters

### DIFF
--- a/applications/dashboard/models/class.logmodel.php
+++ b/applications/dashboard/models/class.logmodel.php
@@ -797,6 +797,17 @@ class LogModel extends Gdn_Pluggable {
                         throw new Exception(Gdn::userModel()->Validation->resultsText());
                     } else {
                         Gdn::userModel()->sendWelcomeEmail($ID, '', 'Register');
+
+                        // If this record has a Source and a SourceID, it has an SSO mapping that needs to be created.
+                        $source = val('Source', $Data);
+                        $sourceID = val('SourceID', $Data);
+                        if ($source && $sourceID) {
+                            Gdn::userModel()->saveAuthentication([
+                                'UserID' => $ID,
+                                'Provider' => $source,
+                                'UniqueID' => $sourceID
+                            ]);
+                        }
                     }
                 } else {
                     $ID = Gdn::sql()


### PR DESCRIPTION
Currently, when a user connects over SSO and triggers a SPAM filter, they're dumped to a page with a single error message: "Tell us why you want to join!". There is no form control to enter any text. It's just the error and the "Connect" button.

This update alters the connect workflow to log the connection attempt if the SPAM filter is triggered. This is done by detecting if the registration failed and `DiscoveryText` becomes a required field. Since the registration is only logged if this field is populated, a generic "SSO connection" message is added to the log entry as the `DiscoveryText`. If the registration fails again with a result that matches the value of `UserModel::REDIRECT_APPROVE`, the attempt is logged and the user is redirected to Vanilla's "thanks for registering" page. This portion of the workflow mirrors what is seen under similar circumstances during a basic registration.

When/if the log entry is restored, the SSO user mapping is also created.

Closes #4991 