### PR TITLE
Flagging plugin: fixed broken array references

### DIFF
--- a/plugins/Flagging/views/flag.php
+++ b/plugins/Flagging/views/flag.php
@@ -1,9 +1,9 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 <?php
-$UcContext = ucfirst($this->Data['Plugin.Flagging.Data']['Context']);
-$ElementID = $this->Data['Plugin.Flagging.Data']['ElementID'];
-$URL = $this->Data['Plugin.Flagging.Data']['URL'];
-$Title = sprintf("Flag this %s", ucfirst($this->Data['Plugin.Flagging.Data']['Context']));
+$UcContext = ucfirst($this->data('Plugin.Flagging.Data.Context'));
+$ElementID = $this->data('Plugin.Flagging.Data.ElementID');
+$URL = $this->data('Plugin.Flagging.Data.URL');
+$Title = sprintf("Flag this %s", ucfirst($this->data('Plugin.Flagging.Data.Context')));
 ?>
     <h2><?php echo t($Title); ?></h2>
 <?php
@@ -17,7 +17,7 @@ echo $this->Form->errors();
          please enter a brief reason below, then press 'Flag this!'."); ?>
             </div>
             <?php echo t('FlagLinkContent', 'Link to content:').' '.anchor(t('FlagLinkFormat', "{$UcContext} #{$ElementID}"), $URL); ?> &ndash;
-            <?php echo $this->Data['Plugin.Flagging.Data']['ElementAuthor']; ?>
+            <?php echo $this->data('Plugin.Flagging.Data.ElementAuthor'); ?>
         </li>
         <li>
             <?php

--- a/plugins/Flagging/views/report.php
+++ b/plugins/Flagging/views/report.php
@@ -1,8 +1,8 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
 <?php
-$Flag = $this->Data['Plugin.Flagging.Data'];
-$Report = $this->Data['Plugin.Flagging.Report'];
-$Reason = $this->Data['Plugin.Flagging.Reason'];
+$Flag = $this->data('Plugin.Flagging.Data');
+$Report = $this->data('Plugin.Flagging.Report');
+$Reason = $this->data('Plugin.Flagging.Reason');
 
 printf(t('%s reported%s <strong>%s</strong>'), anchor($Flag['UserName'], '/profile/'.$Flag['UserID'].'/'.$Flag['UserName']), ($Flag['Context'] == 'comment') ? t(' a comment in') : null, anchor($Report['DiscussionName'], $Flag['URL']));
 

--- a/plugins/Flagging/views/reportcomment.php
+++ b/plugins/Flagging/views/reportcomment.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit();
 
-$Flag = $this->Data['Plugin.Flagging.Data'];
-$Reason = $this->Data['Plugin.Flagging.Reason'];
+$Flag = $this->data('Plugin.Flagging.Data');
+$Reason = $this->data('Plugin.Flagging.Reason');
 
 echo anchor($Flag['UserName'], '/profile/'.$Flag['UserID'].'/'.$Flag['UserName']).' '.t('also reported this.'); ?>
 


### PR DESCRIPTION
This fixes an issue where discussions and discussion comments created by flagging actions don't populate the source comment and reason given by the user doing the flagging.

Also fixes comment link URL and display on the popup where the user doing the flagging enters their reason text.