### PR TITLE
Make Gdn_DataSet implement JsonSerializable

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2165,7 +2165,7 @@ if (!function_exists('jsonFilter')) {
                     $fn($childValue, $childKey, $key);
                 });
             } elseif ($value instanceof \DateTimeInterface) {
-                $value = $value->format('r');
+                $value = $value->format('c');
             } elseif (is_string($value)) {
                 // Only attempt to unpack as an IP address if this field or its parent matches the IP field naming scheme.
                 $isIPField = (stringEndsWith($key, 'IPAddress', true) || stringEndsWith($parentKey, 'IPAddresses', true));

--- a/library/database/class.dataset.php
+++ b/library/database/class.dataset.php
@@ -691,7 +691,8 @@ class Gdn_DataSet implements IteratorAggregate, Countable, JsonSerializable {
      * which is a value of any type other than a resource.
      */
     public function jsonSerialize() {
-        // TODO: 
-        return $this->resultArray();
+        $result = $this->resultArray();
+        jsonFilter($result);
+        return $result;
     }
 }

--- a/library/database/class.dataset.php
+++ b/library/database/class.dataset.php
@@ -15,7 +15,7 @@
 /**
  * Class Gdn_DataSet
  */
-class Gdn_DataSet implements IteratorAggregate, Countable {
+class Gdn_DataSet implements IteratorAggregate, Countable, JsonSerializable {
 
     /** Inner join. */
     const JOIN_INNER = 'inner';
@@ -681,5 +681,17 @@ class Gdn_DataSet implements IteratorAggregate, Countable {
             return array_values($ColumnName);
         }
         return $DefaultValue;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     */
+    public function jsonSerialize() {
+        // TODO: 
+        return $this->resultArray();
     }
 }

--- a/tests/Library/Core/DataSetTest.php
+++ b/tests/Library/Core/DataSetTest.php
@@ -33,4 +33,16 @@ class DataSetTest extends \PHPUnit_Framework_TestCase {
         $json = json_encode($ds);
         $this->assertEquals($expected, $json);
     }
+
+    /**
+     * Test json serialization does not affect original data.
+     */
+    public function testJsonSerializeOriginal() {
+        $dt = new \DateTimeImmutable('2000-01-01');
+        $data = [['dt' => $dt, 'IPAddress' => ipEncode('127.0.0.1')]];
+        $ds = new Gdn_DataSet($data);
+
+        json_encode($ds); // The result isn't used, but make sure Gdn_DataSet::jsonSerialize is executed.
+        $this->assertEquals($data, $ds->result());
+    }
 }

--- a/tests/Library/Core/DataSetTest.php
+++ b/tests/Library/Core/DataSetTest.php
@@ -27,9 +27,9 @@ class DataSetTest extends \PHPUnit_Framework_TestCase {
      */
     public function testJsonSerialize() {
         $dt = new \DateTimeImmutable('2000-01-01');
-        $ds = new Gdn_DataSet([['dt' => $dt, 'ip' => ipEncode('127.0.0.1')]]);
+        $ds = new Gdn_DataSet([['dt' => $dt, 'IPAddress' => ipEncode('127.0.0.1')]]);
 
-        $expected = json_encode([['dt' => $dt->format('c'), 'ip' => '127.0.0.1']]);
+        $expected = json_encode([['dt' => $dt->format('c'), 'IPAddress' => '127.0.0.1']]);
         $json = json_encode($ds);
         $this->assertEquals($expected, $json);
     }

--- a/tests/Library/Core/DataSetTest.php
+++ b/tests/Library/Core/DataSetTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace VanillaTests\Library\Core;
+
+use Gdn_DataSet;
+
+/**
+ * Test the {@link Gdn_DataSet} class.
+ */
+class DataSetTest extends \PHPUnit_Framework_TestCase {
+    /**
+     * A basic test of newing up a dataset.
+     */
+    public function testNewingUp() {
+        $ds = new Gdn_DataSet([['foo' => 123, 'bar' => 'baz'], ['foo' => 345, 'bar' => 'sme']]);
+
+        $this->assertSame(2, $ds->numRows());
+    }
+
+    /**
+     * Test json serialization.
+     */
+    public function testJsonSerialize() {
+        $dt = new \DateTimeImmutable('2000-01-01');
+        $ds = new Gdn_DataSet([['dt' => $dt, 'ip' => ipEncode('127.0.0.1')]]);
+
+        $expected = json_encode([['dt' => $dt->format('c'), 'ip' => '127.0.0.1']]);
+        $json = json_encode($ds);
+        $this->assertEquals($expected, $json);
+    }
+}

--- a/tests/Library/Core/JsonFilterTest.php
+++ b/tests/Library/Core/JsonFilterTest.php
@@ -16,7 +16,7 @@ class JsonFilterTest extends \PHPUnit_Framework_TestCase {
         $data = ['Date' => $date];
         jsonFilter($data);
 
-        $this->assertSame($date->format('r'), $data['Date']);
+        $this->assertSame($date->format('c'), $data['Date']);
     }
 
     public function testJsonFilterDateTimeRecursive() {
@@ -26,7 +26,7 @@ class JsonFilterTest extends \PHPUnit_Framework_TestCase {
         ];
         jsonFilter($data);
 
-        $this->assertSame($date->format('r'), $data['Dates']['FirstDate']);
+        $this->assertSame($date->format('c'), $data['Dates']['FirstDate']);
     }
 
     public function testJsonFilterEncodedIP() {


### PR DESCRIPTION
This will make returning datasets from API controllers easier.

- [x] Wrap the result in jsonFilter() after #5165. Be careful not to alter the underlying result (which I'd add a unit test for).

Closes #5254