### PR TITLE
Add bans to the Permissions class

### DIFF
--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -85,7 +85,7 @@ class Permissions {
      * @param bool $prepend If **true**, the ban will be prepended to the ban list instead of appending it.
      * @return $this
      */
-    public function addBan($name, $ban = [], $prepend = false) {
+    public function addBan($name, array $ban = [], $prepend = false) {
         if (substr($name, 0, 1) !== '!') {
             throw new \InvalidArgumentException('Ban names must start with "!".', 500);
         }

--- a/library/Vanilla/Permissions.php
+++ b/library/Vanilla/Permissions.php
@@ -12,11 +12,12 @@ namespace Vanilla;
  * @package Vanilla
  */
 class Permissions {
-
-    /**
-     * @var bool|null The result of all permission checks can be overridden based on this value.
-     */
-    private $overrideAll = null;
+    const BAN_BANNED = '!banned';
+    const BAN_DELETED = '!deleted';
+    const BAN_UPDATING = '!updating';
+    const BAN_PRIVATE = '!private';
+    const BAN_2FA = '!2fa';
+    const BAN_XRF = '!xrf';
 
     /**
      * Global permissions are stored as numerical indexes.
@@ -28,13 +29,15 @@ class Permissions {
     /** @var bool */
     private $isAdmin = false;
 
-    /** @var bool */
-    private $isBanned = false;
+    /**
+     * @var array An array of bans that override all permissions a user may have.
+     */
+    private $bans = [];
 
     /**
      * Permissions constructor.
      *
-     * @param array $permissions
+     * @param array $permissions The internal permissions array, usually from a cache.
      */
     public function __construct($permissions = []) {
         $this->setPermissions($permissions);
@@ -43,21 +46,72 @@ class Permissions {
     /**
      * Add a permission.
      *
-     * @param string $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View)
-     * @param int|array $IDs One or more IDs of foreign objects (e.g. category IDs)
+     * @param string $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View).
+     * @param int|array $ids One or more IDs of foreign objects (e.g. category IDs).
      * @return $this
      */
-    public function add($permission, $IDs) {
-        if (!is_array($IDs)) {
-            $IDs = [$IDs];
+    public function add($permission, $ids) {
+        if (!is_array($ids)) {
+            $ids = [$ids];
         }
 
         if (!array_key_exists($permission, $this->permissions) || !is_array($this->permissions[$permission])) {
             $this->permissions[$permission] = [];
         }
 
-        $this->permissions[$permission] = array_unique(array_merge($this->permissions[$permission], $IDs));
+        $this->permissions[$permission] = array_unique(array_merge($this->permissions[$permission], $ids));
 
+        return $this;
+    }
+
+
+    /**
+     * Add a ban to the ban list.
+     *
+     * Bans override all permissions unless there is an exception. There are two ways a ban can be excepted.
+     *
+     * 1. When calling {@link Permissions::hasAny()} or {@link Permissions::hasAll()} you can pass the name of a ban as
+     * a permission and it will be ignored.
+     * 2. Bans can be added with the "except" key. This takes an array of permission names and will not apply to users
+     * with any of those permissions.
+     *
+     * @param string $name The name of the ban. Use one if the **BAN_*** constants. If you add a ban with the same name
+     * as an existing ban then the existing ban will be removed first.
+     * @param array $ban The ban to add. This as an array with the following optional keys:
+     *
+     * - **msg**: A message associated with the ban.
+     * - **code**: An HTTP response code associated with the ban.
+     * - **except**: An array of permission names that override the ban.
+     * @param bool $prepend If **true**, the ban will be prepended to the ban list instead of appending it.
+     * @return $this
+     */
+    public function addBan($name, $ban = [], $prepend = false) {
+        if (substr($name, 0, 1) !== '!') {
+            throw new \InvalidArgumentException('Ban names must start with "!".', 500);
+        }
+        $name = strtolower($name);
+        $ban += ['msg' => 'Permission denied.', 'code' => 401, 'except' => []];
+
+        unset($this->bans[$name]);
+
+        if ($prepend) {
+            $this->bans = array_merge([$name => $ban], $this->bans);
+        } else {
+            $this->bans[$name] = $ban;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Remove a ban from the ban list.
+     *
+     * @param string $name The name of the ban to remove.
+     * @return $this
+     */
+    public function removeBan($name) {
+        $name = strtolower($name);
+        unset($this->bans[$name]);
         return $this;
     }
 
@@ -100,15 +154,6 @@ class Permissions {
     }
 
     /**
-     * Get the flag to determine if all permission checks are being overridden.
-     *
-     * @return bool|null
-     */
-    public function getOverrideAll() {
-        return $this->overrideAll;
-    }
-
-    /**
      * Grab the current permissions.
      *
      * @return array
@@ -118,38 +163,79 @@ class Permissions {
     }
 
     /**
+     * Determine if the current user is banned.
+     *
+     * @param array $permissions An optional array of permissions being checked. Any permission starting with "!" means
+     * that a ban with that name is ignored.
+     * @return bool Returns **true** if the user is banned or **false** otherwise.
+     * @see Permissions::addBan(), Permissions::getBan()
+     */
+    public function isBanned(array $permissions = []) {
+        $ban = $this->getBan($permissions);
+        return $ban !== null;
+    }
+
+    /**
+     * Get the currently active ban.
+     *
+     * @param array $permissions An optional array of permissions being checked. Any permission starting with "!" means
+     * that a ban with that name is ignored.
+     * @return array|null Returns the currently active ban or **null** if there is no active ban.
+     * @see Permissions::addBan()
+     */
+    public function getBan(array $permissions = []) {
+        $permissions = array_change_key_case(array_flip($permissions));
+
+        foreach ($this->bans as $name => $ban) {
+            if (isset($permissions[$name])) {
+                // The permission check is overriding the ban.
+                continue;
+            } elseif (!empty($ban['except'])) {
+                // There is an exception, so see if any of those permissions apply.
+                foreach ((array)$ban['except'] as $permission) {
+                    if ($this->hasInternal($permission)) {
+                        continue 2;
+                    }
+                }
+            }
+            // There was no exception to the ban so we are banned.
+            $ban['type'] = $name;
+            return $ban;
+        }
+
+        return null;
+    }
+
+    /**
      * Determine if the permission is present.
      *
-     * @param string $permission Permission slug to check the value for (e.g. Vanilla.Discussions.View)
-     * @param int|null $id Foreign object ID to validate the permission against (e.g. a category ID)
+     * @param string $permission Permission slug to check the value for (e.g. Vanilla.Discussions.View).
+     * @param int|null $id Foreign object ID to validate the permission against (e.g. a category ID).
      * @return bool
      */
     public function has($permission, $id = null) {
-        if ($this->overrideAll !== null) {
-            return $this->overrideAll;
-        }
-
-        if ($id === null) {
-            return !empty($this->permissions[$permission]) || (array_search($permission, $this->permissions) !== false);
-        } else {
-            if (array_key_exists($permission, $this->permissions) && is_array($this->permissions[$permission])) {
-                return (array_search($id, $this->permissions[$permission]) !== false);
-            } else {
-                return false;
-            }
-        }
+        return $this->hasAll((array)$permission, $id);
     }
 
     /**
      * Determine if all of the provided permissions are present.
      *
-     * @param array $permissions Permission slugs to check the value for (e.g. Vanilla.Discussions.View)
-     * @param int|null $id Foreign object ID to validate the permissions against (e.g. a category ID)
+     * @param array $permissions Permission slugs to check the value for (e.g. Vanilla.Discussions.View).
+     * @param int|null $id Foreign object ID to validate the permissions against (e.g. a category ID).
      * @return bool
      */
     public function hasAll(array $permissions, $id = null) {
+        // Look for the bans first.
+        if ($this->isBanned($permissions)) {
+            return false;
+        }
+
+        if ($this->isAdmin()) {
+            return true;
+        }
+
         foreach ($permissions as $permission) {
-            if ($this->has($permission, $id) === false) {
+            if ($this->hasInternal($permission, $id) === false) {
                 return false;
             }
         }
@@ -160,18 +246,31 @@ class Permissions {
     /**
      * Determine if any of the provided permissions are present.
      *
-     * @param array $permissions Permission slugs to check the value for (e.g. Vanilla.Discussions.View)
-     * @param int|null $id Foreign object ID to validate the permissions against (e.g. a category ID)
+     * @param array $permissions Permission slugs to check the value for (e.g. Vanilla.Discussions.View).
+     * @param int|null $id Foreign object ID to validate the permissions against (e.g. a category ID).
      * @return bool
      */
     public function hasAny(array $permissions, $id = null) {
+        // Look for the bans first.
+        if ($this->isBanned($permissions)) {
+            return false;
+        }
+
+        if ($this->isAdmin()) {
+            return true;
+        }
+
+        $nullCount = 0;
         foreach ($permissions as $permission) {
-            if ($this->has($permission, $id) === true) {
+            $has = $this->hasInternal($permission, $id);
+            if ($has === true) {
                 return true;
+            } elseif ($has === null) {
+                $nullCount++;
             }
         }
 
-        return false;
+        return $nullCount === count($permissions);
     }
 
     /**
@@ -181,15 +280,6 @@ class Permissions {
      */
     public function isAdmin() {
         return $this->isAdmin === true;
-    }
-
-    /**
-     * Determine if the banned flag is set.
-     *
-     * @return bool
-     */
-    public function isBanned() {
-        return $this->isBanned === true;
     }
 
     /**
@@ -210,7 +300,7 @@ class Permissions {
     /**
      * Set global or replace per-ID permissions.
      *
-     * @param string $permission  Permission slug to set the value for (e.g. Vanilla.Discussions.View)
+     * @param string $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View).
      * @param bool|array $value A single value for global permissions or an array of foreign object IDs for per-ID permissions.
      * @return $this
      */
@@ -227,17 +317,17 @@ class Permissions {
     /**
      * Remove a permission.
      *
-     * @param $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View)
-     * @param int|array $IDs One or more IDs of foreign objects (e.g. category IDs)
+     * @param $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View).
+     * @param int|array $ids One or more IDs of foreign objects (e.g. category IDs).
      * @return $this;
      */
-    public function remove($permission, $IDs) {
+    public function remove($permission, $ids) {
         if (array_key_exists($permission, $this->permissions)) {
-            if (!is_array($IDs)) {
-                $IDs = [$IDs];
+            if (!is_array($ids)) {
+                $ids = [$ids];
             }
 
-            foreach ($IDs as $currentID) {
+            foreach ($ids as $currentID) {
                 $index = array_search($currentID, $this->permissions[$permission]);
 
                 if ($index !== false) {
@@ -252,7 +342,7 @@ class Permissions {
     /**
      * Add a global permission.
      *
-     * @param string $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View)
+     * @param string $permission Permission slug to set the value for (e.g. Vanilla.Discussions.View).
      * @param bool $value Toggle value for the permission: true for granted, false for revoked.
      * @return $this
      */
@@ -277,33 +367,7 @@ class Permissions {
      * @return $this
      */
     public function setAdmin($isAdmin) {
-        $this->isAdmin = ($isAdmin == true);
-        return $this;
-    }
-
-    /**
-     * Set the banned flag.
-     *
-     * @param bool $isBanned Is the user banned?
-     * @return $this
-     */
-    public function setBanned($isBanned) {
-        $this->isBanned = ($isBanned == true);
-        return $this;
-    }
-
-    /**
-     * Get the flag to determine if all permission checks are being overridden.
-     *
-     * @param bool|null $overrideAll
-     * @return $this
-     */
-    public function setOverrideAll($overrideAll) {
-        if ($overrideAll !== null) {
-            $overrideAll = boolval($overrideAll);
-        }
-        $this->overrideAll = $overrideAll;
-
+        $this->isAdmin = (bool)$isAdmin;
         return $this;
     }
 
@@ -316,5 +380,29 @@ class Permissions {
     public function setPermissions(array $permissions) {
         $this->permissions = $permissions;
         return $this;
+    }
+
+    /**
+     * Check just the permissions array, ignoring overrides from admin/bans.
+     *
+     * @param string $permission The permission to check.
+     * @param int|null $id The database ID of a non-global permission or **null** if this is a global check.
+     * @return bool|null Returns **true** if the user has the permission, **false** if they don't, or **null** if the permissions isn't applicable.
+     */
+    private function hasInternal($permission, $id = null) {
+        if (strcasecmp($permission, 'admin') === 0) {
+            return $this->isAdmin();
+        } elseif (substr($permission, 0, 1) === '!') {
+            // This is a ban so skip it.
+            return null;
+        } elseif ($id === null) {
+            return !empty($this->permissions[$permission]) || (array_search($permission, $this->permissions) !== false);
+        } else {
+            if (array_key_exists($permission, $this->permissions) && is_array($this->permissions[$permission])) {
+                return (array_search($id, $this->permissions[$permission]) !== false);
+            } else {
+                return false;
+            }
+        }
     }
 }

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -449,7 +449,7 @@ class Gdn_Session {
                 // Set permission overrides.
                 $this->permissions->setAdmin($this->User->Admin);
                 if (!empty($this->User->Deleted)) {
-                    $this->permissions->addBan(Permissions::BAN_DELETED, ['msg' => t("Your account has been deleted.")]);
+                    $this->permissions->addBan(Permissions::BAN_DELETED, ['msg' => t('Your account has been deleted.')]);
                 }
                 if (!empty($this->User->Banned)) {
                     $this->permissions->addBan(Permissions::BAN_BANNED, ['msg' => t('You are banned.')]);

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -10,6 +10,8 @@
  * @since 2.0
  */
 
+use Vanilla\Permissions;
+
 /**
  * Handles user information throughout a session. This class is a singleton.
  */
@@ -121,14 +123,6 @@ class Gdn_Session {
      * @return boolean Returns **true** if the user has permission or **false** otherwise.
      */
     public function checkPermission($permission, $fullMatch = true, $junctionTable = '', $junctionID = '') {
-        if (is_object($this->User) && $this->permissions->getOverrideAll() === null) {
-            if ($this->User->Banned || val('Deleted', $this->User)) {
-                $this->permissions->setOverrideAll(false);
-            } elseif ($this->User->Admin) {
-                $this->permissions->setOverrideAll(true);
-            }
-        }
-
         if ($junctionID === 'any' || $junctionID === '' || empty($junctionTable) ||
             c("Garden.Permissions.Disabled.{$junctionTable}")) {
             $junctionID = null;
@@ -451,6 +445,16 @@ class Gdn_Session {
                 $UserModel->fireEvent('AfterGetSession');
 
                 $this->permissions->setPermissions($this->User->Permissions);
+
+                // Set permission overrides.
+                $this->permissions->setAdmin($this->User->Admin);
+                if (!empty($this->User->Deleted)) {
+                    $this->permissions->addBan(Permissions::BAN_DELETED, ['msg' => t("Your account has been deleted.")]);
+                }
+                if (!empty($this->User->Banned)) {
+                    $this->permissions->addBan(Permissions::BAN_BANNED, ['msg' => t('You are banned.')]);
+                }
+
                 $this->_Preferences = $this->User->Preferences;
                 $this->_Attributes = $this->User->Attributes;
 


### PR DESCRIPTION
Bans revoke all permissions from a Permissions instance, but with a flexible API.

- Bans are added with the **addBan()** method. You can add as many bans as you want and they stack on top of each other.
- If a Permissions instance has a ban then all permission checks will return false.
- Bans can be bypassed by passing their names as a pseudo permission to any permission check.
- Bans themselves can also specify exceptions when being added so that users with given permissions will not be considered banned.

This implementation uses bans for banned or deleted users. In the future they will be used for private communities, update mode, 2 factor authentication, and XRF prevention.

This supersedes and removes the **setOverrideAll()** method. Bans along with **isAdmin()** handle permission overrides now.