### PR TITLE
Bring Gdn_Session->getPermissions() back

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -10,6 +10,8 @@
  * @since 2.0
  */
 
+use Vanilla\Permissions;
+
 /**
  * Handles user information throughout a session. This class is a singleton.
  */
@@ -35,7 +37,7 @@ class Gdn_Session {
     /** @var object The current user's transient key. */
     protected $_TransientKey;
 
-    /** @var  Vanilla\Permissions */
+    /** @var Permissions */
     private $permissions;
 
     /**
@@ -53,7 +55,7 @@ class Gdn_Session {
         $this->_Preferences = array();
         $this->_TransientKey = false;
 
-        $this->permissions = new Vanilla\Permissions();
+        $this->permissions = new Permissions();
     }
 
 
@@ -63,7 +65,7 @@ class Gdn_Session {
      * @param array $perms The permissions to add.
      */
     public function addPermissions($perms) {
-        $newPermissions = new Vanilla\Permissions($perms);
+        $newPermissions = new Permissions($perms);
         $this->permissions->merge($newPermissions);
     }
 
@@ -175,14 +177,12 @@ class Gdn_Session {
     }
 
     /**
-     * Returns all "allowed" permissions for the authenticated user in a one-dimensional array of permission names.
+     * Returns the current user's permissions.
      *
-     * @return array
-     * @deprecated We want to make this an accessor for the permissions property.
+     * @return Permissions Returns a {@link Permissions} object with the permissions for the current user.
      */
     public function getPermissions() {
-        deprecated('Gdn_Session->getPermissions()', 'Gdn_Session->getPermissionsArray()');
-        return $this->permissions->getPermissions();
+        return $this->permissions;
     }
 
     /**


### PR DESCRIPTION
Backstory: We added the Permissions class a while back as a better way
to wrangle permissions than just an opaque array. When doing so there
was an incompatibility with Gdn_Session’s getPermissions() method.

We could have come up with a new method, but not using the proper
getter name for the permissions object kind of sucked. So we put a
process in place:

1. Add the getPermissionsArray() method and deprecate getPermissions()
temporarily.
2. Look through our source code for getPermissions() calls and migrate
them to getPermissionsArray(). We’ll eventually want to refactor this
too as manipulating the internal array should be a no-no.
3. Re-introduce getPermissions() in the correct form (this PR).

I recommend doing a final search through our repos for bad calls to getPermissions() and then merging this PR.