### PR TITLE
Bring a wayward semicolon home in bootstrap.php

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -66,8 +66,7 @@ Gdn::setContainer($dic);
 
 $dic->setInstance('Garden\Container\Container', $dic)
     ->rule('Interop\Container\ContainerInterface')
-    ->setAliasOf('Garden\Container\Container')
-;
+    ->setAliasOf('Garden\Container\Container');
 
 // Cache Layer
 Gdn::factoryInstall(Gdn::AliasCache, 'Gdn_Cache', null, Gdn::FactoryRealSingleton, 'Initialize');


### PR DESCRIPTION
A semicolon found its way onto its own line in `boostrap.php`. This update moves it back where it belongs.