### PR TITLE
Add category ID to dropdown trigger data attributes in category settings

### DIFF
--- a/applications/dashboard/modules/class.dropdownmodule.php
+++ b/applications/dashboard/modules/class.dropdownmodule.php
@@ -142,13 +142,16 @@ class DropdownModule extends Gdn_Module {
      * @param string $type One of the triggerTypes - currently supports 'anchor' or 'button'.
      * @param string $cssClass CSS class for the trigger.
      * @param string $icon Icon for the trigger.
+     * @param array $attributes The attributes to add to the trigger.
+     * @param string $url If the trigger has a fallback href for non-js users, add the url here.
      * @return object $this The calling DropdownModule object.
      */
-    public function setTrigger($text = '', $type = 'button', $cssClass = 'btn-default', $icon = 'caret-down', $url = '') {
+    public function setTrigger($text = '', $type = 'button', $cssClass = 'btn-default', $icon = 'caret-down', $attributes = [], $url = '') {
         $this->trigger['text'] = $text;
         $this->trigger['type'] = in_array($type, $this->triggerTypes) ? $type : 'button';
         $this->trigger['icon'] = $icon;
         $this->trigger['cssClass'] = trim($cssClass);
+        $this->trigger['attributes'] = $attributes;
         $this->trigger['url'] = $url;
         return $this;
     }

--- a/applications/dashboard/modules/class.dropdownmodule.php
+++ b/applications/dashboard/modules/class.dropdownmodule.php
@@ -142,8 +142,8 @@ class DropdownModule extends Gdn_Module {
      * @param string $type One of the triggerTypes - currently supports 'anchor' or 'button'.
      * @param string $cssClass CSS class for the trigger.
      * @param string $icon Icon for the trigger.
-     * @param array $attributes The attributes to add to the trigger.
      * @param string $url If the trigger has a fallback href for non-js users, add the url here.
+     * @param array $attributes The attributes to add to the trigger.
      * @return object $this The calling DropdownModule object.
      */
     public function setTrigger($text = '', $type = 'button', $cssClass = 'btn-default', $icon = 'caret-down', $url = '', $attributes = []) {

--- a/applications/dashboard/modules/class.dropdownmodule.php
+++ b/applications/dashboard/modules/class.dropdownmodule.php
@@ -146,7 +146,7 @@ class DropdownModule extends Gdn_Module {
      * @param string $url If the trigger has a fallback href for non-js users, add the url here.
      * @return object $this The calling DropdownModule object.
      */
-    public function setTrigger($text = '', $type = 'button', $cssClass = 'btn-default', $icon = 'caret-down', $attributes = [], $url = '') {
+    public function setTrigger($text = '', $type = 'button', $cssClass = 'btn-default', $icon = 'caret-down', $url = '', $attributes = []) {
         $this->trigger['text'] = $text;
         $this->trigger['type'] = in_array($type, $this->triggerTypes) ? $type : 'button';
         $this->trigger['icon'] = $icon;

--- a/applications/dashboard/views/modules/dropdown-twbs.php
+++ b/applications/dashboard/views/modules/dropdown-twbs.php
@@ -1,6 +1,6 @@
 <div class="dropdown <?php echo val('cssClass', $this); ?>">
     <?php $trigger = val('trigger', $this); ?>
-    <<?php echo val('type', $trigger); ?> class="dropdown-toggle <?php echo val('cssClass', $trigger); ?>" id="<?php echo val('triggerId', $this); ?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <<?php echo val('type', $trigger); ?> class="dropdown-toggle <?php echo val('cssClass', $trigger); ?>" id="<?php echo val('triggerId', $this); ?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" <?php echo attribute(val('attributes', $trigger)); ?>>
         <?php echo val('text', $trigger); ?>
     </<?php echo val('type', $trigger); ?>>
     <div class="dropdown-menu <?php echo val('listCssClass', $this); ?>" role="menu" aria-labelledby="<?php echo val('triggerId', $this); ?>">

--- a/applications/vanilla/js/category-settings.js
+++ b/applications/vanilla/js/category-settings.js
@@ -65,7 +65,7 @@
                 var svg = svgMap[displayAs] || displayAs;
                 var options = '';
                 svg = ' <svg class="icon icon-16 icon-' + svg + '" viewBox="0 0 16 16"><use xlink:href="#' + svg + '" /></svg> ';
-                $('.tree-item[data-id="' + categoryID + '"] .dropdown-toggle').each(function() {
+                $('.dropdown-toggle[data-id="' + categoryID + '"]').each(function() {
                     $(this).html(svg);
                     options = $('.tree-item[data-id="' + categoryID + '"] .options').html();
                 });

--- a/applications/vanilla/js/categoryfilter.js
+++ b/applications/vanilla/js/categoryfilter.js
@@ -60,7 +60,7 @@
 
         var dropdownTemplate = ' \
         <div class="dropdown dropdown-category-options"> \
-            <button class="dropdown-toggle btn" id="" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> \
+            <button class="dropdown-toggle btn" id="" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-id="{categoryID}"> \
             {text} \
             </button> \
             <div class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby=""> \
@@ -98,7 +98,8 @@
 
         options.items = menuItems;
         options.text = options.trigger.text;
-        return renderTemplate(options, dropdownTemplate, ['text', 'items']);
+        options.categoryID = options.trigger.attributes['data-id'];
+        return renderTemplate(options, dropdownTemplate, ['text', 'items', 'categoryID']);
     };
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -724,7 +724,7 @@ class CategoryModel extends Gdn_Model {
         $triggerIcon = dashboardSymbol(self::displayAsIconName($category['DisplayAs']));
 
         $cdd = new DropdownModule('', '', 'dropdown-category-options', 'dropdown-menu-right');
-        $cdd->setTrigger($triggerIcon, 'button', 'btn','caret-down', ['data-id' => val('CategoryID', $category)]);
+        $cdd->setTrigger($triggerIcon, 'button', 'btn','caret-down', '', ['data-id' => val('CategoryID', $category)]);
         $cdd->setView('dropdown-twbs');
         $cdd->setForceDivider(true);
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -724,7 +724,7 @@ class CategoryModel extends Gdn_Model {
         $triggerIcon = dashboardSymbol(self::displayAsIconName($category['DisplayAs']));
 
         $cdd = new DropdownModule('', '', 'dropdown-category-options', 'dropdown-menu-right');
-        $cdd->setTrigger($triggerIcon, 'button', 'btn');
+        $cdd->setTrigger($triggerIcon, 'button', 'btn','caret-down', ['data-id' => val('CategoryID', $category)]);
         $cdd->setView('dropdown-twbs');
         $cdd->setForceDivider(true);
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -724,7 +724,7 @@ class CategoryModel extends Gdn_Model {
         $triggerIcon = dashboardSymbol(self::displayAsIconName($category['DisplayAs']));
 
         $cdd = new DropdownModule('', '', 'dropdown-category-options', 'dropdown-menu-right');
-        $cdd->setTrigger($triggerIcon, 'button', 'btn','caret-down', '', ['data-id' => val('CategoryID', $category)]);
+        $cdd->setTrigger($triggerIcon, 'button', 'btn', 'caret-down', '', ['data-id' => val('CategoryID', $category)]);
         $cdd->setView('dropdown-twbs');
         $cdd->setForceDivider(true);
 


### PR DESCRIPTION
Add an attributes param to the trigger and render the attributes on the the dropdown-twbs view.

Fixes issue where all children of a category have their trigger updated when their parent's display as property is set.