### PR TITLE
Add the Cookie class

### DIFF
--- a/library/Garden/Web/Cookie.php
+++ b/library/Garden/Web/Cookie.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Garden\Web;
+
+/**
+ * A class for reading/writing cookies.
+ */
+class Cookie {
+    const EXPIRE_THRESHOLD = 631152000; // 20 years
+
+    /**
+     * @var string[]
+     */
+    private $inCookies;
+
+    /**
+     * @var string[]
+     */
+    private $cookies;
+
+    /**
+     * @var array
+     */
+    private $sets;
+
+    /**
+     * @var string
+     */
+    private $path = '/';
+
+    /**
+     * @var string
+     */
+    private $domain = '';
+
+    /**
+     * @var bool
+     */
+    private $secure = false;
+
+    /**
+     * @var bool
+     */
+    private $flushAll = false;
+
+
+    /**
+     * Construct a {@link Cookie} objects.
+     *
+     * @param array $cookies The initial cookies array or **null** to use the **$_COOKIE** super global.
+     */
+    public function __construct(array $cookies = null) {
+        if ($cookies === null) {
+            $cookies = $_COOKIE;
+        }
+        $this->cookies = $this->inCookies = $cookies;
+        $this->sets = [];
+    }
+
+    /**
+     * Get a cookie value.
+     *
+     * This method returns the current value of the cookie which will be the set value, the initial value from the request.
+     *
+     * @param string $name The name of the cookie to get.
+     * @param mixed $default The default value if the cookie isn't set.
+     * @return null
+     */
+    public function get($name, $default = null) {
+        return isset($this->cookies[$name]) ? $this->cookies[$name][0] : $default;
+    }
+
+    /**
+     * Set a cookie.
+     *
+     * @param string $name The name of the cookie to set.
+     * @param string $value The new value of the cookie.
+     * @param int $expire The time the cookie expires, this can be one of the following:
+     *
+     * - A unix timestamp.
+     * - A number of seconds to expire from now if less than 20 years.
+     * - A value of zero will expire at the end of the browser session.
+     * @param bool $httpOnly Whether or not the cookie should be httpOnly.
+     * @return $this
+     */
+    public function set($name, $value, $expire = 0, $httpOnly = true) {
+        $this->setCookie($name, $value, $expire, $this->path, $this->domain, $httpOnly);
+        return $this;
+    }
+
+    /**
+     * Set a cookie with full options.
+     *
+     * Most code should be able to use the simpler {@link Cookie::set()} method using sensible defaults. This method is
+     * here for two reasons:
+     *
+     * 1. This method is analogous to the {@link setcookie()} function so makes for an easier upgrade path.
+     * 2. This method provides full cookie setting control for uses that go beyond a site with a simple domain/path strategy.
+     *
+     * Note that this method differs where the {@link $path} and {@link $domain} parameters default to this object's path
+     * and domain properties rather than the defaults of the {@link setcookie()} method.
+     *
+     * @param string $name The name of the cookie to set.
+     * @param string $value The new value of the cookie.
+     * @param int $expire The time the cookie expires, this can be one of the following:
+     *
+     * - A unix timestamp.
+     * - A number of seconds to expire from now if less than 20 years.
+     * - A value of zero will expire at the end of the browser session.
+     * @param string|null $path The path of the cookie or **null** to use this object's path.
+     * @param string|null $domain The domain of the cookie or **null** to use this object's path.
+     * @param bool $secure Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client.
+     * @param bool $httpOnly Whether or not the cookie should be httpOnly.
+     * @return $this
+     */
+    public function setCookie($name, $value, $expire = 0, $path = null, $domain = null, $secure = false, $httpOnly = false) {
+        if ($value === null) {
+            $this->delete($name);
+        } else {
+            $this->cookies[$name] = $value;
+            $this->sets[$name] = [
+                $value,
+                $expire > self::EXPIRE_THRESHOLD ? $expire : time() + $expire,
+                $path === null ? $this->path : $path,
+                $domain === null ? $this->domain : $domain,
+                $secure,
+                $httpOnly
+            ];
+        }
+        return $this;
+    }
+
+    /**
+     * Delete a cookie.
+     *
+     * This removes the cookie from the cookies array and will issue a delete cookie request when the cookies are flushed.
+     *
+     * @param string $name The name of the cookie to delete.
+     * @return $this
+     */
+    public function delete($name) {
+        unset($this->cookies[$name]);
+        return $this;
+    }
+
+    /**
+     * Flush the cookies to the response.
+     */
+    public function flush() {
+        $calls = array_merge($this->makeNewCookieCalls(), $this->makeDeleteCookieCalls());
+
+        foreach ($calls as $name => $args) {
+            setcookie($name, ...$args);
+        }
+    }
+
+    /**
+     * Flush cookie delete headers.
+     */
+    private function makeDeleteCookieCalls() {
+        $deletes = array_diff_key($this->inCookies, $this->cookies);
+
+        $expire = time() - 3600;
+        $result = [];
+        foreach ($deletes as $name => $_) {
+            $result[$name] = ['', $expire];
+        }
+        return $result;
+    }
+
+    /**
+     * Flush set-cookie headers.
+     */
+    private function makeNewCookieCalls() {
+        if ($this->flushAll) {
+            $sets = $this->sets;
+        } else {
+            $cookieDiff = array_diff_assoc($this->cookies, $this->inCookies);
+            $sets = [];
+            foreach ($cookieDiff as $name => $_) {
+                $sets[$name] = $this->sets[$name];
+            }
+        }
+
+        return $sets;
+    }
+
+    /**
+     * Encode an array in a format suitable for a cookie header.
+     *
+     * @param array $array The cookie value array.
+     * @return string Returns a string suitable to be passed to a cookie header.
+     */
+    private function cookieEncode(array $array) {
+        $pairs = [];
+        foreach ($array as $key => $value) {
+            $pairs[] = "$key=".rawurlencode($value);
+        }
+
+        $result = implode('; ', $pairs);
+        return $result;
+    }
+
+    /**
+     * Return the all of the current cookies in a format suitable for a "Cookie" HTTP header.
+     *
+     * @return string Returns a cookie string.
+     */
+    public function makeCookieHeader() {
+        return $this->cookieEncode($this->cookies);
+    }
+
+    /**
+     * Return the cookies that will be set in a format suitable for "Set-Cookie" HTTP headers.
+     *
+     * @return array Returns an array of "Set-Cookie" header values.
+     * @throws \Exception TODO.
+     */
+    public function makeSetCookieHeader() {
+        throw new \Exception('Not implemented.', 501);
+    }
+
+    /**
+     * Get the path.
+     *
+     * @return string Returns the path.
+     */
+    public function getPath() {
+        return $this->path;
+    }
+
+    /**
+     * Get the cookie domain.
+     *
+     * @return string Returns the domain.
+     */
+    public function getDomain() {
+        return $this->domain;
+    }
+
+    /**
+     * Set the cookie domain.
+     *
+     * @param string $domain The new cookie domain.
+     * @return $this
+     */
+    public function setDomain($domain) {
+        $this->domain = $domain;
+        return $this;
+    }
+
+    /**
+     * Whether or not HTTP-only cookies should be secure when set.
+     *
+     * @return bool Returns **true** if HTTP-only cookies should be secure or **false** otherwise.
+     */
+    public function isSecure() {
+        return $this->secure;
+    }
+
+    /**
+     * Set whether or not HTTP-only cookies should be secure when set.
+     *
+     * @param bool $secure The new value.
+     * @return $this
+     */
+    public function setSecure($secure) {
+        $this->secure = $secure;
+        return $this;
+    }
+
+    /**
+     * Whether or not only cookie changes will be flushed.
+     *
+     * Usually, a call to {@link Cookie::set()} or {@link Cookie::setCookie()} will cause a "Set-Cookie" header only if
+     * it is different from the value coming in from the request. Setting this property to **true** will flush all of the
+     * calls. If you call a cookie setter method with the same name more than once, only the most recent value will be
+     * flushed in the response.
+     *
+     * @return bool Returns **true** all unique sets are flushed or **false** otherwise.
+     */
+    public function getFlushAll() {
+        return $this->flushAll;
+    }
+
+    /**
+     * Set whether or not only cookie changes will be flushed.
+     *
+     * @param bool $flushAll The new value.
+     * @return $this
+     * @see Cookie::getFlushAll()
+     */
+    public function setFlushAll($flushAll) {
+        $this->flushAll = $flushAll;
+        return $this;
+    }
+}

--- a/tests/Library/Garden/Web/CookieTest.php
+++ b/tests/Library/Garden/Web/CookieTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * @author Vanilla Forums Inc.
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Garden\Web;
+
+use Garden\Web\Cookie;
+
+/**
+ * Test the {@link ResourceRoute} class.
+ */
+class CookieTest extends \PHPUnit_Framework_TestCase {
+
+    /**
+     * Parse a Cookie header into its individual cookie key-value pairs.
+     *
+     * @param string $header
+     * @return array
+     */
+    private function cookieDecode($header) {
+        $cookies = [];
+        $pairs = explode(';', $header);
+
+        foreach ($pairs as $currentPair) {
+            list($key, $value) = explode('=', trim($currentPair));
+            $cookies[$key] = $value;
+        }
+
+        return $cookies;
+    }
+
+    /**
+     * Test deleting a cookie.
+     */
+    public function testDelete() {
+        $cookie = new Cookie(['foo' => 'bar']);
+        $cookie->delete('foo');
+        $this->assertNull($cookie->get('foo'));
+    }
+
+    /**
+     * Provide parameters for cookie-setting functions.
+     *
+     * @return array
+     */
+    public function provideCookieSet() {
+        // Parameter order: name, value, expire, path, domain, secure, httpOnly
+        $data = [
+            'simple' => ['foo', 'bar', 0, null, null, false, false],
+            'expires' => ['foo', 'bar', 300, null, null, false, false],
+            'domain' => ['foo', 'bar', 0, null, 'vanillaforums.com', false, false],
+            'path' => ['foo', 'bar', 0, '/site', null, false, false],
+            'secure' => ['foo', 'bar', 0, null, null, true, false],
+            'http-only' => ['foo', 'bar', 0, null, null, false, true],
+            'complex' => ['foo', 'bar', 500, '/site', 'vanillaforums.com', true, true]
+        ];
+        return $data;
+    }
+
+    /**
+     * Test getting a single cookie value.
+     */
+    public function testGet() {
+        $data = ['foo' => 'bar'];
+        $cookie = new Cookie($data);
+
+        $this->assertSame($data['foo'], $cookie->get('foo'));
+        $this->assertNull($cookie->get('does-not-exist'));
+        $this->assertSame('default-value', $cookie->get('does-not-exist', 'default-value'));
+    }
+
+    /**
+     * Test generating a Cookie header.
+     */
+    public function testMakeCookieHeader() {
+        $data = [
+            'foo' => 'bar',
+            'UserID' => 123,
+            'TransientKey' => 'abcdefghij1234567890'
+        ];
+        $cookie = new Cookie($data);
+
+        $header = $cookie->makeCookieHeader();
+        $result = $this->cookieDecode($header);
+
+        ksort($data);
+        ksort($result);
+        $this->assertEquals($data, $result);
+    }
+
+    /**
+     * Test building parameters for deleted cookies.
+     */
+    public function testMakeDeleteCookieCalls() {
+        $data = ['foo' => 'bar'];
+        $cookie = new Cookie($data);
+        $cookie->delete('foo');
+        $result = $cookie->makeDeleteCookieCalls();
+        $this->assertArrayHasKey('foo', $result);
+    }
+
+    /**
+     * Test building parameters for new/modified cookies.
+     */
+    public function testMakeNewCookieCalls() {
+        $data = [
+            'foo' => 'bar',
+            'UserID' => 123
+        ];
+        $cookie = new Cookie($data);
+        $cookie->setFlushAll(false);
+        $cookie->set('foo', 'bar');
+        $cookie->set('forum', 'Vanilla');
+        $cookie->set('UserID', 456);
+        $result = $cookie->makeNewCookieCalls();
+
+        $this->assertArrayHasKey('forum', $result);
+        $this->assertEquals(456, $result['UserID'][0]);
+        $this->assertArrayNotHasKey('foo', $result);
+    }
+
+    /**
+     * Test building parameters for set cookies, even if the key/value already exists.
+     */
+    public function testMakeNewCookieCallsFlushAll() {
+        $data = ['foo' => 'bar'];
+        $cookie = new Cookie($data);
+        $cookie->setFlushAll(true);
+        $cookie->set('foo', 'bar');
+        $result = $cookie->makeNewCookieCalls();
+
+        $this->assertArrayHasKey('foo', $result);
+    }
+
+    /**
+     * Test setting a cookie with limited options.
+     *
+     * @dataProvider provideCookieSet
+     */
+    public function testSet($name, $value, $expire, $path, $domain, $secure, $httpOnly) {
+        $cookie = new Cookie([]);
+        $cookie->set($name, $value, $expire, $secure, $httpOnly);
+
+        $data = $this->cookieDecode($cookie->makeCookieHeader());
+        $this->assertSame($value, $data[$name]);
+
+        $testExpire  = $cookie->calculateExpiry($expire);
+
+        $result = $cookie->makeNewCookieCalls();
+        $this->assertArrayHasKey($name, $result);
+        $this->assertEquals($value, $result[$name][0]);
+        $this->assertEquals($testExpire, $result[$name][1]);
+        $this->assertEquals($httpOnly, $result[$name][5]);
+    }
+
+    /**
+     * Test setting a cookie with full options.
+     *
+     * @dataProvider provideCookieSet
+     */
+    public function testSetCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly) {
+        $cookie = new Cookie([]);
+        $cookie->setCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
+
+        $data = $this->cookieDecode($cookie->makeCookieHeader());
+        $this->assertSame($value, $data[$name]);
+
+        $testExpire  = $cookie->calculateExpiry($expire);
+        $testPath = $path === null ? $cookie->getPath() : $path;
+        $testDomain = $domain === null ? $cookie->getDomain() : $domain;
+
+        $result = $cookie->makeNewCookieCalls();
+        $this->assertArrayHasKey($name, $result);
+        $this->assertEquals($value, $result[$name][0]);
+        $this->assertEquals($testExpire, $result[$name][1]);
+        $this->assertEquals($testPath, $result[$name][2]);
+        $this->assertEquals($testDomain, $result[$name][3]);
+        $this->assertEquals($secure, $result[$name][4]);
+        $this->assertEquals($httpOnly, $result[$name][5]);
+    }
+}


### PR DESCRIPTION
The Vanilla\Web\Cookie class is a utility class for handling reading
and changing cookies throughout the lifecycle of the request.

Currently, we don’t have controlled cookie management. Just a bunch of
ad-hoc calls to **$_COOKIE** and **setcookie()**. This results in
problems such as unnecessary Set-Cookie headers.

What still needs to be done:

- [x] Add unit tests.
- [x] This implementation may have bugs, the above unit tests should
uncover them.

When implemented this class will be shared in the container and then
any class that wants to manipulate cookies can depend on it.