### PR TITLE
Lock the current database encoding

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -860,4 +860,3 @@ touchFolder(PATH_CACHE.'/Smarty/compile');
 // Lock the current database character Encoding
 saveToConfig('Database.CharacterEncoding', c('Database.CharacterEncoding'));
 saveToConfig('Database.ExtendedProperties.Collate', c('Database.ExtendedProperties.Collate'));
-saveToConfig('Database.ConnectionOptions.1002', c('Database.ConnectionOptions.1002'));

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -856,3 +856,8 @@ if (c('Garden.Registration.CaptchaPublicKey')) {
 // Make sure the smarty folders exist.
 touchFolder(PATH_CACHE.'/Smarty/cache');
 touchFolder(PATH_CACHE.'/Smarty/compile');
+
+// Lock the current database character Encoding
+saveToConfig('Database.CharacterEncoding', c('Database.CharacterEncoding'));
+saveToConfig('Database.ExtendedProperties.Collate', c('Database.ExtendedProperties.Collate'));
+saveToConfig('Database.ConnectionOptions.1002', c('Database.ConnectionOptions.1002'));


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5227
Depends on https://github.com/vanilla/vanilla/pull/5257

We will need to run this everywhere to lock the current settings!
Some coordination will be needed!