### PR TITLE
Set charset and timezone directly in the database object

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -13,10 +13,12 @@ $Configuration['Database']['Name']                             = 'dbname';
 $Configuration['Database']['User']                             = 'dbuser';
 $Configuration['Database']['Password']                         = '';
 $Configuration['Database']['ConnectionOptions']                = array(
-                                                                  12    => FALSE, //PDO::ATTR_PERSISTENT => FALSE,
-                                                                  1000  => TRUE, // PDO::MYSQL_ATTR_USE_BUFFERED_QUERY is missing in some php installations
-                                                                  1002  => "set names 'utf8'; set time_zone = '+0:0';" // PDO::MYSQL_ATTR_INIT_COMMAND is missing in PHP 5.3, so I use the actual value "1002" instead
-                                                               );
+                                                                    // We do not use the constants here to be able to throw a
+                                                                    // graceful error message in the setupController if you did not
+                                                                    // install the needed requirement
+                                                                    12    => FALSE, //PDO::ATTR_PERSISTENT => FALSE,
+                                                                    1000  => TRUE, // PDO::MYSQL_ATTR_USE_BUFFERED_QUERY is missing in some php installations
+                                                                );
 $Configuration['Database']['CharacterEncoding'] = 'utf8';
 $Configuration['Database']['DatabasePrefix']                    = 'GDN_';
 $Configuration['Database']['ExtendedProperties']['Collate']     = 'utf8_unicode_ci';

--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -153,9 +153,8 @@ class Gdn_Database {
             $PDO = new PDO(strtolower($this->Engine).':'.$Dsn, $User, $Password, $this->ConnectionOptions);
             $PDO->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
 
-            if ($this->ConnectionOptions[1002]) {
-                $PDO->query($this->ConnectionOptions[1002]);
-            }
+            $encoding = c('Database.CharacterEncoding', 'utf8mb4');
+            $PDO->query("set names '$encoding';set time_zone = '+0:0'");
 
             // We only throw exceptions during connect
             $PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);

--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -153,7 +153,7 @@ class Gdn_Database {
             $PDO = new PDO(strtolower($this->Engine).':'.$Dsn, $User, $Password, $this->ConnectionOptions);
             $PDO->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
 
-            $encoding = c('Database.CharacterEncoding', 'utf8mb4');
+            $encoding = c('Database.CharacterEncoding', 'utf8');
             $PDO->query("set names '$encoding';set time_zone = '+0:0'");
 
             // We only throw exceptions during connect


### PR DESCRIPTION
Remove Database.ConnectionOptions.1002 and set the encoding and timezone directly in the database object

We default to utf8mb4 because it is compatible with utf8 and won't cause any problems.

Fix https://github.com/vanilla/vanilla/issues/5226