### PR TITLE
Fix arrow and alerts in MeModule settings dropdown

### DIFF
--- a/applications/dashboard/views/modules/dropdown.php
+++ b/applications/dashboard/views/modules/dropdown.php
@@ -1,5 +1,5 @@
 
-<span class="ToggleFlyout OptionsMenu <?php echo val('cssClass', $this); ?>">
+<span class="ToggleFlyout <?php echo val('cssClass', $this); ?>">
     <?php if (val('type', val('trigger', $this)) === 'button') : ?>
     <span class="Button-Options">
         <span class="OptionsTitle" title="<?php echo t('Options'); ?>">
@@ -36,7 +36,7 @@
                         }
                         echo val('text', $item);
                         if (val('badge', $item)) {
-                            echo badge(val('badge', $item));
+                            echo ' '.wrap(val('badge', $item), 'span', ['class' => 'Alert']);
                         }
                         ?></a>
                 </li>

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -69,7 +69,7 @@ if (!function_exists('getOptions')):
         $sender = Gdn::controller();
         $categoryID = val('CategoryID', $category);
 
-        $dropdown = new DropdownModule();
+        $dropdown = new DropdownModule('dropdown', '', 'OptionsMenu');
         $tk = urlencode(Gdn::session()->TransientKey());
         $hide = (int)!val('Following', $category);
 

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -188,7 +188,7 @@ if (!function_exists('discussionOptionsToDropdown')):
      */
     function discussionOptionsToDropdown($options, $dropdown = null) {
         if (is_null($dropdown)) {
-            $dropdown = new DropdownModule();
+            $dropdown = new DropdownModule('dropdown', '', 'OptionsMenu');
         }
 
         if (!empty($options)) {
@@ -311,7 +311,7 @@ if (!function_exists('getDiscussionOptionsDropdown')):
      * @throws Exception
      */
     function getDiscussionOptionsDropdown($discussion = null) {
-        $dropdown = new DropdownModule();
+        $dropdown = new DropdownModule('dropdown', '', 'OptionsMenu');
         $sender = Gdn::controller();
         $session = Gdn::session();
 


### PR DESCRIPTION
Fix styling issues with the MeModule settings dropdown.

After https://github.com/vanilla/vanilla/pull/5100, the MeModule settings dropdown was rendering with the arrow looking real weird because of the OptionMenu class on the wrapper and the badges didn't have the correct styling due to the incorrect badge class being applied.

Closes https://github.com/vanilla/vanilla/issues/5252