### PR TITLE
Add merging and nesting instances to Garden\Schema

### DIFF
--- a/library/Garden/Schema.php
+++ b/library/Garden/Schema.php
@@ -96,6 +96,7 @@ class Schema implements \JsonSerializable {
     /**
      * Build an OpenAPI-compatible specification of the current schema.
      *
+     * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object
      * @return array
      */
     public function dumpSpec() {
@@ -109,8 +110,13 @@ class Schema implements \JsonSerializable {
                 }
 
                 // Massage schema's types into their Open API v2 counterparts, including potential formatting flags.
-                // string, boolean and array pass through without adjustment.
+                // Valid parameter types for OpenAPI v2: string, number, integer, boolean, array or file
                 switch ($parameter['type']) {
+                    case 'string':
+                    case 'boolean':
+                    case 'array':
+                        // string, boolean and array types should not be altered.
+                        break;
                     case 'object':
                         $parameter['type'] = 'array';
                         break;
@@ -911,6 +917,6 @@ class Schema implements \JsonSerializable {
      * which is a value of any type other than a resource.
      */
     public function jsonSerialize() {
-        return $this->getParameters();
+        return $this->schema;
     }
 }

--- a/library/Garden/Schema.php
+++ b/library/Garden/Schema.php
@@ -213,6 +213,36 @@ class Schema implements \JsonSerializable {
     }
 
     /**
+     * Get the schema's currently configured parameters.
+     *
+     * @return array
+     */
+    public function getParameters() {
+        return $this->schema;
+    }
+
+    /**
+     * Merge a schema with this one.
+     *
+     * @param Schema $schema A scheme instance. Its parameters will be merged into the current instance.
+     */
+    public function merge(Schema $schema) {
+        $fn = function (array &$target, array $source) use (&$fn) {
+            foreach ($source as $key => $val) {
+                if (is_array($val) && array_key_exists($key, $target) && is_array($target[$key])) {
+                    $target[$key] = $fn($target[$key], $val);
+                } else {
+                    $target[$key] = $val;
+                }
+            }
+
+            return $target;
+        };
+
+        $fn($this->schema, $schema->getParameters());
+    }
+
+    /**
      * Parse a schema in short form into a full schema array.
      *
      * @param array $arr The array to parse into a schema.
@@ -874,6 +904,6 @@ class Schema implements \JsonSerializable {
      * which is a value of any type other than a resource.
      */
     public function jsonSerialize() {
-        return $this->schema;
+        return $this->getParameters();
     }
 }

--- a/library/Garden/Schema.php
+++ b/library/Garden/Schema.php
@@ -262,6 +262,13 @@ class Schema implements \JsonSerializable {
                 } else {
                     throw new \InvalidArgumentException("Schema at position $key is not a valid param.", 500);
                 }
+            } elseif ($value instanceof Schema) {
+                $param = static::parseShortParam($key);
+                $param['type'] = 'object';
+                $param['properties'] = $value->getParameters();
+
+               $name = $param['name'];
+               $result[$name] = $param;
             } else {
                 // The parameter is defined in the key.
                 $param = static::parseShortParam($key, $value);

--- a/tests/Library/Garden/BasicSchemaTest.php
+++ b/tests/Library/Garden/BasicSchemaTest.php
@@ -323,6 +323,23 @@ class BasicSchemaTest extends SchemaTest {
     }
 
     /**
+     * Test merging basic schemas.
+     */
+    public function testBasicMerge() {
+        $schemaOne = new Schema(['foo:s']);
+        $schemaTwo = new Schema(['bar:s']);
+
+        $schemaOne->merge($schemaTwo);
+
+        $expected = [
+            'foo' => ['name' => 'foo', 'type' => 'string', 'required' => true],
+            'bar' => ['name' => 'bar', 'type' => 'string','required' => true]
+        ];
+
+        $this->assertEquals($expected, $schemaOne->jsonSerialize());
+    }
+
+    /**
      * Provide a variety of valid boolean data.
      *
      * @return array Returns an array of boolean data.

--- a/tests/Library/Garden/NestedSchemaTest.php
+++ b/tests/Library/Garden/NestedSchemaTest.php
@@ -330,6 +330,51 @@ class NestedSchemaTest extends SchemaTest {
     }
 
     /**
+     * Test passing a schema instance as details for a parameter.
+     */
+    public function testSchemaAsParameter() {
+        $userSchema = new Schema([
+            'userID:i',
+            'name:s',
+            'email:s'
+        ]);
+
+        $schema = new Schema([
+            'name:s' => 'The title of the discussion.',
+            'body:s' => 'The body of the discussion.',
+            'insertUser' => $userSchema,
+            'updateUser?' => $userSchema
+        ]);
+
+        $expected = [
+            'name' => ['name' => 'name', 'type' => 'string', 'required' => true, 'description' => 'The title of the discussion.'],
+            'body' => ['name' => 'body', 'type' => 'string', 'required' => true, 'description' => 'The body of the discussion.'],
+            'insertUser' => [
+                'name' => 'insertUser',
+                'type' => 'object',
+                'required' => true,
+                'properties' => [
+                        'userID' => ['name' => 'userID', 'type' => 'integer', 'required' => true],
+                        'name' => ['name' => 'name', 'type' => 'string', 'required' => true],
+                        'email' => ['name' => 'email', 'type' => 'string', 'required' => true]
+                ]
+            ],
+            'updateUser' => [
+                    'name' => 'updateUser',
+                    'type' => 'object',
+                    'required' => false,
+                    'properties' => [
+                        'userID' => ['name' => 'userID', 'type' => 'integer', 'required' => true],
+                        'name' => ['name' => 'name', 'type' => 'string', 'required' => true],
+                        'email' => ['name' => 'email', 'type' => 'string', 'required' => true]
+                    ]
+                ]
+        ];
+
+        $this->assertEquals($expected, $schema->getParameters());
+    }
+
+    /**
      * Get a schema that consists of an array of objects.
      *
      * @return Schema Returns the schema.

--- a/tests/Library/Garden/NestedSchemaTest.php
+++ b/tests/Library/Garden/NestedSchemaTest.php
@@ -242,6 +242,39 @@ class NestedSchemaTest extends SchemaTest {
     }
 
     /**
+     * Test merging nested schemas.
+     */
+    public function testNestedMerge() {
+        $schemaOne = $this->getArrayOfObjectsSchema();
+        $schemaTwo = new Schema([
+            'rows:a' => [
+                'email:s'
+            ]
+        ]);
+
+        $expected = [
+            'rows' => [
+                'name' => 'rows',
+                'type' => 'array',
+                'required' => true,
+                'items' => [
+                    'type' => 'object',
+                    'required' => true,
+                    'properties' => [
+                        'id' => ['name' => 'id', 'type' => 'integer', 'required' => true],
+                        'name' => ['name' => 'name', 'type' => 'string', 'required' => false],
+                        'email' => ['name' => 'email', 'type' => 'string', 'required' => true]
+                    ]
+                ]
+            ]
+        ];
+
+        $schemaOne->merge($schemaTwo);
+
+        $this->assertEquals($expected, $schemaOne->jsonSerialize());
+    }
+
+    /**
      * Test throwing an exception when removing unexpected parameters from validated data.
      *
      * @expectedException \Garden\Exception\ValidationException


### PR DESCRIPTION
This update does a few things:

1. Adds `Garden\Schema::getParameters`, which returns the schema's current parameter array.
1. Adds `Garden\Schema::merge`, which allows one instance's parameters to be consumed by another instance.
1. Implements the ability to specify a `Garden\Schema` instance as a parameter value. In this way, a single schema object can be re-used multiple times as a child in other schemas.
1. Includes tests for the `merge` method and reusing schemas as children.

Closes #5248 
Closes #5250 

Bonus: Fixes some improper type adjustment in `Garden\Schema::dumpSpec`.
