### PR TITLE
Fix the return type for delete queries

### DIFF
--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -433,13 +433,13 @@ class Gdn_Database {
         }
 
         // Did this query modify data in any way?
-        if ($ReturnType == 'ID') {
+        if ($ReturnType === 'ID') {
             $this->_CurrentResultSet = $PDO->lastInsertId();
             if (is_a($PDOStatement, 'PDOStatement')) {
                 $PDOStatement->closeCursor();
             }
         } else {
-            if ($ReturnType == 'DataSet') {
+            if ($ReturnType === 'DataSet') {
                 // Create a DataSet to manage the resultset
                 $this->_CurrentResultSet = new Gdn_DataSet();
                 $this->_CurrentResultSet->Connection = $PDO;
@@ -447,6 +447,7 @@ class Gdn_Database {
             } elseif (is_a($PDOStatement, 'PDOStatement')) {
                 $PDOStatement->closeCursor();
             }
+
         }
 
         if (isset($StoreCacheKey)) {

--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -302,11 +302,11 @@ class Gdn_Database {
         // Get the return type.
         if (isset($Options['ReturnType'])) {
             $ReturnType = $Options['ReturnType'];
-        } elseif (preg_match('/^\s*"?(insert)\s+/i', $Sql))
+        } elseif (preg_match('/^\s*"?(insert)\s+/i', $Sql)) {
             $ReturnType = 'ID';
-        elseif (!preg_match('/^\s*"?(update|delete|replace|create|drop|load data|copy|alter|grant|revoke|lock|unlock)\s+/i', $Sql))
+        } elseif (!preg_match('/^\s*"?(update|delete|replace|create|drop|load data|copy|alter|grant|revoke|lock|unlock)\s+/i', $Sql)) {
             $ReturnType = 'DataSet';
-        else {
+        } else {
             $ReturnType = null;
         }
 

--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -177,6 +177,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
      * * Any other value: Nulls are not allowed, and the specified value will be used as the default.
      * @param string $KeyType What type of key is this column on the table? Options
      * are primary, key, and FALSE (not a key).
+     * @return $this
      */
     public function column($Name, $Type, $NullDefault = false, $KeyType = false) {
         if (is_null($NullDefault) || $NullDefault === true) {

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1625,14 +1625,15 @@ abstract class Gdn_SQLDriver {
     }
 
     public function query($Sql, $Type = 'select') {
-        $QueryOptions = array('Type' => $Type, 'Slave' => GetValue('Slave', $this->_Options, null));
+        $QueryOptions = array('Type' => $Type, 'Slave' => val('Slave', $this->_Options, null));
 
         switch ($Type) {
             case 'insert':
                 $ReturnType = 'ID';
                 break;
             case 'update':
-                $ReturnType = null;
+            case 'delete':
+                $ReturnType = '';
                 break;
             default:
                 $ReturnType = 'DataSet';


### PR DESCRIPTION
This PR addresses a couple of issues.

- Delete queries were erroneously returning data sets which would cause a general error on the next query because they were getting fetched improperly.
- Update and delete queries were specifying a null return type which meant that a regular expression would be called on those queries to figure out the return type.
- I threw in a doc block fix and some “==“ to “===“ micro-opts.