### PR TITLE
Add autoloader registration to the AddonManager

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -92,6 +92,7 @@ $dic->setInstance('Garden\Container\Container', $dic)
         PATH_CACHE
     ])
     ->addAlias('AddonManager')
+    ->addCall('registerAutoloader')
 
     // ApplicationManager
     ->rule('Gdn_ApplicationManager')
@@ -239,7 +240,6 @@ $dic->call(function (
         exit();
     }
 
-    spl_autoload_register([$addonManager, 'autoload']);
 
     /**
      * Extension Managers

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -159,15 +159,6 @@ class AddonManager {
     }
 
     /**
-     * Unregister the autoloader registered with {@link AddonManager::registerAutoloader()}.
-     *
-     * @return bool Returns **true** on success or **false** on failure.
-     */
-    public function unregisterAutoloader() {
-        return spl_autoload_unregister([$this, 'autoload']);
-    }
-
-    /**
      * Lookup an addon by class name.
      *
      * This method should only be used with enabled addons as searching through all addons takes a performance hit.

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -139,6 +139,26 @@ class AddonManager {
     }
 
     /**
+     * Register the autoloader for addons managed through this class.
+     *
+     * @param bool $throw This parameter specifies whether **spl_autoload_register()** should throw exceptions when the autoload_function cannot be registered.
+     * @param bool $prepend If true, **spl_autoload_register()** will prepend the autoloader on the autoload queue instead of appending it.
+     * @return bool Returns **true** on success or **false** on failure.
+     */
+    public function registerAutoloader($throw = true, $prepend = false) {
+        return spl_autoload_register([$this, 'autoload'], $throw, $prepend);
+    }
+
+    /**
+     * Unregister the autoloader registered with {@link AddonManager::registerAutoloader()}.
+     *
+     * @return bool Returns **true** on success or **false** on failure.
+     */
+    public function unregisterAutoloader() {
+        return spl_autoload_unregister([$this, 'autoload']);
+    }
+
+    /**
      * Lookup an addon by class name.
      *
      * This method should only be used with enabled addons as searching through all addons takes a performance hit.

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -159,6 +159,15 @@ class AddonManager {
     }
 
     /**
+     * Unregister the autoloader registered with {@link AddonManager::registerAutoloader()}.
+     *
+     * @return bool Returns **true** on success or **false** on failure.
+     */
+    public function unregisterAutoloader() {
+        return spl_autoload_unregister([$this, 'autoload']);
+    }
+
+    /**
      * Lookup an addon by class name.
      *
      * This method should only be used with enabled addons as searching through all addons takes a performance hit.


### PR DESCRIPTION
Register the AddonManager autoloader right after the first request. In this way the AddonManager will not be created too early and another line from the bootstrap no longer depends on order.

Depends on #5031.