### PR TITLE
Remove library/vendors from composer classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,7 @@
         "classmap": [
             "library/core/",
             "library/database/",
-            "library/setup/",
-            "library/vendors/"
+            "library/setup/"
         ],
         "files": [
             "library/core/functions.error.php",


### PR DESCRIPTION
The library/vendors directory was recently moved, but references remained in the composer config. This was causing a fatal error when composer was installing dependencies.