### PR TITLE
Forgotten translation on notFoundException()

### DIFF
--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -661,7 +661,7 @@ function setHandlers() {
 function notFoundException($RecordType = 'Page') {
     Gdn::dispatcher()
         ->passData('RecordType', $RecordType)
-        ->passData('Description', sprintf(T('The %s you were looking for could not be found.'), strtolower($RecordType)));
+        ->passData('Description', sprintf(T('The %s you were looking for could not be found.'), T(strtolower($RecordType))));
     return new Gdn_UserException(sprintf(T('%s not found.'), T($RecordType)), 404);
 }
 


### PR DESCRIPTION
Hi,

I realized a missing translation on `not Found Exception()` while I was working with the 404 page and I saw the word "page" as is, without the proper translation for my locale.

Cheers!

**In another subject**: That kind of translation is not very friendly with some languages like spanish. The use of `The %s` for spanish translators is very difficul, because in spanish we don't have a explicit translate for `The`. We have to explicitly define the gender (`La` for woman or `El` for man) of the person/thing/subject that we are talking about ([further reading](http://www.spanishdict.com/blog/el-vs-la-a-guide-to-your-spanish-nouns/)).

For instance: *The %s you were looking for could not be found.*

In 404 pages, `%s` will be `página` (female noun). So the translation in that case is:

`La página que estabas buscando no pudo ser encontrada`

But, if we are talking about an `user` (male noun):

`El usuario que estabas buscando no pudo ser encontrada`

So, at least in spanish is little messy trying to find a translation for every possible scenario. If you use `La` when you have to use `El`, it reads and sounds awful, and Vanilla uses the same string for both cases ([404](https://github.com/nikoskip/vanilla/blob/master/applications/vanilla/controllers/class.categoriescontroller.php#L241) and [user not found](https://github.com/nikoskip/vanilla/blob/master/applications/dashboard/controllers/class.profilecontroller.php#L1538)):

At least in 404 pages, in [the view file](https://github.com/nikoskip/vanilla/blob/master/applications/dashboard/views/home/filenotfound.php#L6), the translation is properly configurated, already including the whole text, without placeholders (easy to translate!). But that translation is a fallback in case `Description` isn't there, but it does. The same text, but with a placeholder instead of `page`.