### PR TITLE
Make sure that we reset the Gdn_DatabaseStructure when switching table

### DIFF
--- a/library/database/class.databasestructure.php
+++ b/library/database/class.databasestructure.php
@@ -525,6 +525,7 @@ abstract class Gdn_DatabaseStructure extends Gdn_Pluggable {
             return $this->_TableName;
         }
 
+        $this->reset();
         $this->_TableName = $Name;
         if ($CharacterEncoding == '') {
             $CharacterEncoding = Gdn::config('Database.CharacterEncoding', '');


### PR DESCRIPTION
If we call `Gdn_DatabaseStructure->columnExists()` and switch table the `_ExistingColumns` attribute is not reset and cause an error!

Example:
```php
// Check for a column exist on the Permission table
$Construct->table('Permission');
$Construct->columnExists('Vanilla.Tagging.Add');

// Define the log table
$Construct->table('Log')
    ->primaryKey('LogID')
    ->column('Operation', array('Delete', 'Edit', 'Spam', 'Moderate', 'Pending', 'Ban', 'Error'), false, 'index')
    ->column('RecordType', array('Discussion', 'Comment', 'User', 'Registration', 'Activity', 'ActivityComment', 'Configuration', 'Group', 'Event'), false, 'index')
    ->column('TransactionLogID', 'int', null)
    ->column('RecordID', 'int', null, 'index')
    ->column('RecordUserID', 'int', null, 'index')// user responsible for the record; indexed for user deletion
    ->column('RecordDate', 'datetime')
    ->column('RecordIPAddress', 'ipaddress', null, 'index')
    ->column('InsertUserID', 'int')// user that put record in the log
    ->column('DateInserted', 'datetime', false, 'index')// date item added to log
    ->column('InsertIPAddress', 'ipaddress', null)
    ->column('OtherUserIDs', 'varchar(255)', null)
    ->column('DateUpdated', 'datetime', null)
    ->column('ParentRecordID', 'int', null, 'index')
    ->column('CategoryID', 'int', null, 'key')
    ->column('Data', 'mediumtext', null)// the data from the record.
    ->column('CountGroup', 'int', null)
    ->engine('InnoDB')
    ->set($Explicit, $Drop);
```

![screen shot 2017-03-06 at 1 22 57 pm](https://cloud.githubusercontent.com/assets/2412909/23623429/0b1d97bc-0270-11e7-97f5-c213b58f6436.png)
