### PR TITLE
Have modals check for a header-block element for the title

### DIFF
--- a/applications/dashboard/js/dashboard.js
+++ b/applications/dashboard/js/dashboard.js
@@ -624,8 +624,11 @@ var DashboardModal = (function() {
             // Pull out the H1 block from the view to add to the modal title
             if (this.settings.modalType !== 'noheader' && $title.length !== 0) {
                 title = $title.html();
-                $title.remove();
-                $elem.find('.header-block').remove();
+                if ($elem.find('.header-block').length !== 0) {
+                    $elem.find('.header-block').remove();
+                } else {
+                    $title.remove();
+                }
                 body = $elem.html();
             }
 

--- a/applications/dashboard/js/dashboard.js
+++ b/applications/dashboard/js/dashboard.js
@@ -625,6 +625,7 @@ var DashboardModal = (function() {
             if (this.settings.modalType !== 'noheader' && $title.length !== 0) {
                 title = $title.html();
                 $title.remove();
+                $elem.find('.header-block').remove();
                 body = $elem.html();
             }
 

--- a/applications/dashboard/js/src/modal.dashboard.js
+++ b/applications/dashboard/js/src/modal.dashboard.js
@@ -302,6 +302,7 @@ var DashboardModal = (function() {
             if (this.settings.modalType !== 'noheader' && $title.length !== 0) {
                 title = $title.html();
                 $title.remove();
+                $elem.find('.header-block').remove();
                 body = $elem.html();
             }
 

--- a/applications/dashboard/js/src/modal.dashboard.js
+++ b/applications/dashboard/js/src/modal.dashboard.js
@@ -301,8 +301,11 @@ var DashboardModal = (function() {
             // Pull out the H1 block from the view to add to the modal title
             if (this.settings.modalType !== 'noheader' && $title.length !== 0) {
                 title = $title.html();
-                $title.remove();
-                $elem.find('.header-block').remove();
+                if ($elem.find('.header-block').length !== 0) {
+                    $elem.find('.header-block').remove();
+                } else {
+                    $title.remove();
+                }
                 body = $elem.html();
             }
 


### PR DESCRIPTION
Our `heading()` function wraps the h1 in a `.header-block` div. The modal looks for and removes the h1 element from the body to add to title. If the h1 is wrapped in a `.header-block` element, the `.header-block` element is left behind, leaving a gap in the body.

This checks whether a `.header-block` exists and removes it after it removes the title. After this, devs can freely use `heading()` to render their headings without having to worry about how it may look in a modal.