### PR TITLE
Update jsonFilter() date format to RFC3339

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2165,7 +2165,7 @@ if (!function_exists('jsonFilter')) {
                     $fn($childValue, $childKey, $key);
                 });
             } elseif ($value instanceof \DateTimeInterface) {
-                $value = $value->format('c');
+                $value = $value->format(\DateTime::RFC3339);
             } elseif (is_string($value)) {
                 // Only attempt to unpack as an IP address if this field or its parent matches the IP field naming scheme.
                 $isIPField = (stringEndsWith($key, 'IPAddress', true) || stringEndsWith($parentKey, 'IPAddresses', true));

--- a/tests/Library/Core/DataSetTest.php
+++ b/tests/Library/Core/DataSetTest.php
@@ -29,7 +29,7 @@ class DataSetTest extends \PHPUnit_Framework_TestCase {
         $dt = new \DateTimeImmutable('2000-01-01');
         $ds = new Gdn_DataSet([['dt' => $dt, 'IPAddress' => ipEncode('127.0.0.1')]]);
 
-        $expected = json_encode([['dt' => $dt->format('c'), 'IPAddress' => '127.0.0.1']]);
+        $expected = json_encode([['dt' => $dt->format(\DateTime::RFC3339), 'IPAddress' => '127.0.0.1']]);
         $json = json_encode($ds);
         $this->assertEquals($expected, $json);
     }

--- a/tests/Library/Core/JsonFilterTest.php
+++ b/tests/Library/Core/JsonFilterTest.php
@@ -6,27 +6,29 @@
 
 namespace VanillaTests\Library\Core;
 
+use DateTime;
+
 /**
  * Test the jsonFilter function.
  */
 class JsonFilterTest extends \PHPUnit_Framework_TestCase {
 
     public function testJsonFilterDateTime() {
-        $date = new \DateTime();
+        $date = new DateTime('now', new \DateTimeZone('UTC'));
         $data = ['Date' => $date];
         jsonFilter($data);
 
-        $this->assertSame($date->format('c'), $data['Date']);
+        $this->assertSame($date->format(DateTime::RFC3339), $data['Date']);
     }
 
     public function testJsonFilterDateTimeRecursive() {
-        $date = new \DateTime();
+        $date = new DateTime();
         $data = [
             'Dates' => ['FirstDate' => $date]
         ];
         jsonFilter($data);
 
-        $this->assertSame($date->format('c'), $data['Dates']['FirstDate']);
+        $this->assertSame($date->format(DateTime::RFC3339), $data['Dates']['FirstDate']);
     }
 
     public function testJsonFilterEncodedIP() {


### PR DESCRIPTION
RFC3339 is basically the same as “c”, but I’ve seen it as a more common
choice elsewhere.