### PR TITLE
Temporary freeze phpunit to 5.7 to not crash tests on PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
 install:
   - composer self-update
   - composer install -o
-  - composer require phpunit/phpunit ~5
+  - composer require phpunit/phpunit ~5.7
   - tests/travis/nginx/install-nginx.sh
 
 script:


### PR DESCRIPTION
The error:
https://travis-ci.org/vanilla/vanilla/jobs/210967141#L304
The fix:
https://core.trac.wordpress.org/ticket/39822#comment:9