### PR TITLE
Move flood control to a trait and make the models use it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
 install:
   - composer self-update
   - composer install -o
+  - composer require phpunit/phpunit ~5
   - tests/travis/nginx/install-nginx.sh
 
 script:
@@ -35,6 +36,6 @@ script:
   - tests/travis/php-lint.sh ./library
   - tests/travis/php-lint.sh ./plugins
   - tests/travis/php-lint.sh ./themes
-  - phpunit -c phpunit.xml.dist
+  - ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
   - cat /tmp/error.log
   - cat /tmp/access.log

--- a/applications/conversations/models/class.conversationmessagemodel.php
+++ b/applications/conversations/models/class.conversationmessagemodel.php
@@ -213,7 +213,7 @@ class ConversationMessageModel extends ConversationsModel {
 
         // Validate the form posted values
         $MessageID = false;
-        if ($this->validate($FormPostValues) && !$this->isUserSpamming(Gdn::session()->UserID, $this->floodControlStorageObject)) {
+        if ($this->validate($FormPostValues) && !$this->isUserSpamming(Gdn::session()->UserID, $this->floodGate)) {
             $Fields = $this->Validation->schemaValidationFields(); // All fields on the form that relate to the schema
             touchValue('Format', $Fields, c('Garden.InputFormatter', 'Html'));
 

--- a/applications/conversations/models/class.conversationmessagemodel.php
+++ b/applications/conversations/models/class.conversationmessagemodel.php
@@ -209,11 +209,11 @@ class ConversationMessageModel extends ConversationsModel {
         $this->fireEvent('BeforeSaveValidation');
 
         // Determine if spam check should be skipped.
-        $SkipSpamCheck = (!empty($Options['NewConversation']));
+        $this->setFloodControlEnabled(empty($Options['NewConversation']));
 
         // Validate the form posted values
         $MessageID = false;
-        if ($this->validate($FormPostValues) && !$this->checkForSpam('ConversationMessage', $SkipSpamCheck)) {
+        if ($this->validate($FormPostValues) && !$this->isUserSpamming(Gdn::session()->UserID, $this->floodControlStorageObject)) {
             $Fields = $this->Validation->schemaValidationFields(); // All fields on the form that relate to the schema
             touchValue('Format', $Fields, c('Garden.InputFormatter', 'Html'));
 

--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -548,7 +548,7 @@ class ConversationModel extends ConversationsModel {
         $ConversationID = false;
         if ($this->validate($formPostValues)
             && $MessageModel->validate($formPostValues)
-            && !$this->isUserSpamming(Gdn::session()->UserID, $this->floodControlStorageObject)
+            && !$this->isUserSpamming(Gdn::session()->UserID, $this->floodGate)
         ) {
             $Fields = $this->Validation->validationFields(); // All fields on the form that relate to the schema
 

--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -548,7 +548,7 @@ class ConversationModel extends ConversationsModel {
         $ConversationID = false;
         if ($this->validate($formPostValues)
             && $MessageModel->validate($formPostValues)
-            && !$this->checkForSpam('Conversation')
+            && !$this->isUserSpamming(Gdn::session()->UserID, $this->floodControlStorageObject)
         ) {
             $Fields = $this->Validation->validationFields(); // All fields on the form that relate to the schema
 

--- a/applications/conversations/models/class.conversationsmodel.php
+++ b/applications/conversations/models/class.conversationsmodel.php
@@ -18,7 +18,7 @@ abstract class ConversationsModel extends Gdn_Model {
     /**
      * @var \Vanilla\CacheInterface Object used to store the FloodControl data.
      */
-    protected $floodControlStorageObject;
+    protected $floodGate;
 
     /**
      * Class constructor. Defines the related database table name.
@@ -28,7 +28,7 @@ abstract class ConversationsModel extends Gdn_Model {
      */
     public function __construct($Name = '') {
         parent::__construct($Name);
-        $this->floodControlStorageObject = FloodControlHelper::configure($this, $this->Name);
+        $this->floodGate = FloodControlHelper::configure($this, $this->Name);
     }
 
     /**

--- a/applications/conversations/models/class.conversationsmodel.php
+++ b/applications/conversations/models/class.conversationsmodel.php
@@ -13,6 +13,13 @@
  */
 abstract class ConversationsModel extends Gdn_Model {
 
+    use \Vanilla\FloodControlTrait;
+
+    /**
+     * @var \Vanilla\CacheInterface Object used to store the FloodControl data.
+     */
+    protected $floodControlStorageObject;
+
     /**
      * Class constructor. Defines the related database table name.
      *
@@ -21,6 +28,7 @@ abstract class ConversationsModel extends Gdn_Model {
      */
     public function __construct($Name = '') {
         parent::__construct($Name);
+        $this->floodControlStorageObject = FloodControlHelper::configure($this, $this->Name);
     }
 
     /**
@@ -29,90 +37,27 @@ abstract class ConversationsModel extends Gdn_Model {
      * Users cannot post more than $SpamCount comments within $SpamTime
      * seconds or their account will be locked for $SpamLock seconds.
      *
+     * @deprecated
+     *
      * @since 2.2
      * @return bool Whether spam check is positive (TRUE = spammer).
      */
-    public function checkForSpam($Type, $SkipSpamCheck = false) {
-        // If spam checking is disabled or user is an admin, skip
-        $SpamCheckEnabled = val('SpamCheck', $this, true);
-        if ($SkipSpamCheck == true || $SpamCheckEnabled === false || checkPermission('Garden.Moderation.Manage')) {
+    public function checkForSpam($type, $skipSpamCheck = false) {
+        deprecated(__CLASS__.' '.__METHOD__, 'FloodControlTrait::isUserSpamming()');
+
+        if ($skipSpamCheck) {
             return false;
         }
 
-        $Spam = false;
+        $session = Gdn::session();
 
-        // Validate $Type
-        if (!in_array($Type, array('Conversation', 'ConversationMessage'))) {
-            trigger_error(errorMessage(sprintf('Spam check type unknown: %s', $Type), 'ConversationsModel', 'CheckForSpam'), E_USER_ERROR);
-        }
-
-        // Get spam config settings
-        $SpamCount = c("Conversations.$Type.SpamCount", 1);
-        if (!is_numeric($SpamCount) || $SpamCount < 1) {
-            $SpamCount = 1; // 1 spam minimum
-        }
-        $SpamTime = c("Conversations.$Type.SpamTime", 30);
-        if (!is_numeric($SpamTime) || $SpamTime < 30) {
-            $SpamTime = 30; // 30 second minimum spam span
-        }
-        $SpamLock = c("Conversations.$Type.SpamLock", 60);
-        if (!is_numeric($SpamLock) || $SpamLock < 60) {
-            $SpamLock = 60; // 60 second minimum lockout
-        }
-        // Check for a spam lock first.
-        $Now = time();
-        $TimeSpamLock = (int)Gdn::session()->getAttribute("Time{$Type}SpamLock", 0);
-        $WaitTime = $SpamLock - ($Now - $TimeSpamLock);
-        if ($WaitTime > 0) {
-            $Spam = true;
-            $this->Validation->addValidationResult(
-                'Body',
-                '@'.sprintf(
-                    t('A spam block is now in effect on your account. You must wait at least %3$s seconds before attempting to post again.'),
-                    $SpamCount,
-                    $SpamTime,
-                    $WaitTime
-                )
-            );
-            return $Spam;
+        // Validate $type
+        if (!in_array($type, array('Conversation', 'ConversationMessage'))) {
+            trigger_error(ErrorMessage(sprintf('Spam check type unknown: %s', $type), $this->Name, 'checkForSpam'), E_USER_ERROR);
         }
 
-        $CountSpamCheck = Gdn::session()->getAttribute('Count'.$Type.'SpamCheck', 0);
-        $TimeSpamCheck = (int)Gdn::session()->getAttribute('Time'.$Type.'SpamCheck', 0);
-        $SecondsSinceSpamCheck = time() - $TimeSpamCheck;
-
-        // Apply a spam lock if necessary
-        $Attributes = array();
-        if ($SecondsSinceSpamCheck < $SpamTime && $CountSpamCheck >= $SpamCount) {
-            $Spam = true;
-            $this->Validation->addValidationResult(
-                'Body',
-                '@'.sprintf(
-                    t('You have posted %1$s times within %2$s seconds. A spam block is now in effect on your account. You must wait at least %3$s seconds before attempting to post again.'),
-                    $SpamCount,
-                    $SpamTime,
-                    $SpamLock
-                )
-            );
-
-            // Update the 'waiting period' every time they try to post again
-            $Attributes["Time{$Type}SpamLock"] = $Now;
-            $Attributes['Count'.$Type.'SpamCheck'] = 0;
-        } else {
-            if ($SecondsSinceSpamCheck > $SpamTime) {
-                $Attributes['Count'.$Type.'SpamCheck'] = 1;
-                $Attributes['Time'.$Type.'SpamCheck'] = $Now;
-            } else {
-                $Attributes['Count'.$Type.'SpamCheck'] = $CountSpamCheck + 1;
-            }
-        }
-        // Update the user profile after every comment
-        $UserModel = Gdn::userModel();
-        if (Gdn::session()->UserID) {
-            $UserModel->saveAttribute(Gdn::session()->UserID, $Attributes);
-        }
-
-        return $Spam;
+        $storageObject = FloodControlHelper::configure($this, $type);
+        return $this->isUserSpamming($session->User->UserID, $storageObject);
     }
 
     /**

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -13,6 +13,8 @@
  */
 class ActivityModel extends Gdn_Model {
 
+    use \Vanilla\FloodControlTrait;
+
     /** Activity notification level: Everyone. */
     const NOTIFY_PUBLIC = -1;
 
@@ -1103,6 +1105,11 @@ class ActivityModel extends Gdn_Model {
                 $Comment['ActivityID'] = $CommentActivityID;
             }
 
+            $storageObject = FloodControlHelper::configure($this, 'ActivityComment');
+            if ($this->isUserSpamming(Gdn::session()->User->UserID, $storageObject)) {
+                return false;
+            }
+
             // Check for spam.
             $Spam = SpamModel::isSpam('ActivityComment', $Comment);
             if ($Spam) {
@@ -1476,6 +1483,11 @@ class ActivityModel extends Gdn_Model {
         $ActivityID = val('ActivityID', $Activity);
         if (!$ActivityID) {
             if (!$Delete) {
+                $storageObject = FloodControlHelper::configure($this, 'Activity');
+                if ($this->isUserSpamming(Gdn::session()->User->UserID, $storageObject)) {
+                    return false;
+                }
+
                 $this->addInsertFields($Activity);
                 touchValue('DateUpdated', $Activity, $Activity['DateInserted']);
 

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -239,7 +239,13 @@ class VanillaSettingsController extends Gdn_Controller {
             'Vanilla.Discussion.SpamLock',
             'Vanilla.Comment.SpamCount',
             'Vanilla.Comment.SpamTime',
-            'Vanilla.Comment.SpamLock'
+            'Vanilla.Comment.SpamLock',
+            'Vanilla.Activity.SpamCount',
+            'Vanilla.Activity.SpamTime',
+            'Vanilla.Activity.SpamLock',
+            'Vanilla.ActivityComment.SpamCount',
+            'Vanilla.ActivityComment.SpamTime',
+            'Vanilla.ActivityComment.SpamLock',
         );
         if ($IsConversationsEnabled) {
             $ConfigurationFields = array_merge(
@@ -282,6 +288,19 @@ class VanillaSettingsController extends Gdn_Controller {
             $ConfigurationModel->Validation->applyRule('Vanilla.Comment.SpamLock', 'Required');
             $ConfigurationModel->Validation->applyRule('Vanilla.Comment.SpamLock', 'Integer');
 
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamCount', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamCount', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamTime', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamTime', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamLock', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.Activity.SpamLock', 'Integer');
+
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamCount', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamCount', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamTime', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamTime', 'Integer');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamLock', 'Required');
+            $ConfigurationModel->Validation->applyRule('Vanilla.ActivityComment.SpamLock', 'Integer');
 
             if ($IsConversationsEnabled) {
                 $ConfigurationModel->Validation->applyRule('Conversations.Conversation.SpamCount', 'Required');
@@ -747,7 +766,7 @@ class VanillaSettingsController extends Gdn_Controller {
         }
 
         $this->addJsFile('categoryfilter.js', 'vanilla');
-        
+
         $this->setData('ParentID', $parentID);
         $this->setData('Categories', $categories);
         $this->setData('_Limit', $perPage);

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -36,7 +36,7 @@ class CommentModel extends Gdn_Model {
     /**
      * @var \Vanilla\CacheInterface Object used to store the FloodControl data.
      */
-    protected $floodControlStorageObject;
+    protected $floodGate;
 
     /**
      * Class constructor. Defines the related database table name.
@@ -46,7 +46,7 @@ class CommentModel extends Gdn_Model {
      */
     public function __construct() {
         parent::__construct('Comment');
-        $this->floodControlStorageObject = FloodControlHelper::configure($this, 'Comment');
+        $this->floodGate = FloodControlHelper::configure($this, 'Comment');
         $this->pageCache = Gdn::cache()->activeEnabled() && c('Properties.CommentModel.pageCache', false);
         $this->fireEvent('AfterConstruct');
     }
@@ -855,7 +855,7 @@ class CommentModel extends Gdn_Model {
                 $this->setFloodControlEnabled(false);
             }
 
-            $isUserSpamming = $this->isUserSpamming(Gdn::session()->UserID, $this->floodControlStorageObject);
+            $isUserSpamming = $this->isUserSpamming(Gdn::session()->UserID, $this->floodGate);
 
             // If the post is new and it validates, check for spam
             if (!$Insert || !$isUserSpamming) {

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -11,7 +11,9 @@
 /**
  * Manages discussion comments data.
  */
-class CommentModel extends VanillaModel {
+class CommentModel extends Gdn_Model {
+
+    use \Vanilla\FloodControlTrait;
 
     /** Threshold. */
     const COMMENT_THRESHOLD_SMALL = 1000;
@@ -32,6 +34,11 @@ class CommentModel extends VanillaModel {
     public $pageCache;
 
     /**
+     * @var \Vanilla\CacheInterface Object used to store the FloodControl data.
+     */
+    protected $floodControlStorageObject;
+
+    /**
      * Class constructor. Defines the related database table name.
      *
      * @since 2.0.0
@@ -39,6 +46,7 @@ class CommentModel extends VanillaModel {
      */
     public function __construct() {
         parent::__construct('Comment');
+        $this->floodControlStorageObject = FloodControlHelper::configure($this, 'Comment');
         $this->pageCache = Gdn::cache()->activeEnabled() && c('Properties.CommentModel.pageCache', false);
         $this->fireEvent('AfterConstruct');
     }
@@ -805,8 +813,6 @@ class CommentModel extends VanillaModel {
      * @since 2.0.0
      */
     public function save($FormPostValues, $Settings = false) {
-        $Session = Gdn::session();
-
         // Define the primary key in this model's table.
         $this->defineSchema();
 
@@ -843,8 +849,16 @@ class CommentModel extends VanillaModel {
 
         // Validate the form posted values
         if ($this->validate($FormPostValues, $Insert)) {
+            // Backward compatible check for flood control
+            if (!val('SpamCheck', $this, true)) {
+                deprecated('DiscussionModel->SpamCheck attribute', 'FloodControlTrait->setFloodControlEnabled()');
+                $this->setFloodControlEnabled(false);
+            }
+
+            $isUserSpamming = $this->isUserSpamming(Gdn::session()->UserID, $this->floodControlStorageObject);
+
             // If the post is new and it validates, check for spam
-            if (!$Insert || !$this->CheckForSpam('Comment')) {
+            if (!$Insert || !$isUserSpamming) {
                 $Fields = $this->Validation->SchemaValidationFields();
                 unset($Fields[$this->PrimaryKey]);
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -83,7 +83,7 @@ class DiscussionModel extends Gdn_Model {
     /**
      * @var \Vanilla\CacheInterface Object used to store the FloodControl data.
      */
-    protected $floodControlStorageObject;
+    protected $floodGate;
 
     /**
      * Class constructor. Defines the related database table name.
@@ -93,7 +93,7 @@ class DiscussionModel extends Gdn_Model {
      */
     public function __construct() {
         parent::__construct('Discussion');
-        $this->floodControlStorageObject = FloodControlHelper::configure($this, 'Discussion');
+        $this->floodGate = FloodControlHelper::configure($this, 'Discussion');
     }
 
     /**
@@ -1908,7 +1908,7 @@ class DiscussionModel extends Gdn_Model {
                 $this->setFloodControlEnabled(false);
             }
 
-            $isUserSpamming = $this->isUserSpamming(Gdn::session()->UserID, $this->floodControlStorageObject);
+            $isUserSpamming = $this->isUserSpamming(Gdn::session()->UserID, $this->floodGate);
 
             // If the post is new and it validates, make sure the user isn't spamming
             if (!$Insert || !$isUserSpamming) {

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -11,7 +11,7 @@
 /**
  * Manages unpublished drafts of comments and discussions.
  */
-class DraftModel extends VanillaModel {
+class DraftModel extends Gdn_Model {
 
     /**
      * Class constructor. Defines the related database table name.

--- a/applications/vanilla/models/class.vanillamodel.php
+++ b/applications/vanilla/models/class.vanillamodel.php
@@ -27,7 +27,6 @@ abstract class VanillaModel extends Gdn_Model {
      */
     public function __construct($Name = '') {
         parent::__construct($Name);
-        deprecated(__CLASS__, 'Use the FloodControlTrait instead.');
     }
 
     /**

--- a/applications/vanilla/models/class.vanillamodel.php
+++ b/applications/vanilla/models/class.vanillamodel.php
@@ -10,8 +10,12 @@
 
 /**
  * Introduces common methods that child classes can use.
+ *
+ * @deprecated
  */
 abstract class VanillaModel extends Gdn_Model {
+
+    use \Vanilla\FloodControlTrait;
 
     /**
      * Class constructor. Defines the related database table name.
@@ -23,6 +27,7 @@ abstract class VanillaModel extends Gdn_Model {
      */
     public function __construct($Name = '') {
         parent::__construct($Name);
+        deprecated(__CLASS__, 'Use the FloodControlTrait instead.');
     }
 
     /**
@@ -31,84 +36,24 @@ abstract class VanillaModel extends Gdn_Model {
      * Users cannot post more than $SpamCount comments within $SpamTime
      * seconds or their account will be locked for $SpamLock seconds.
      *
-     * @since 2.0.0
-     * @access public
+     * @deprecated
      *
-     * @param string $Type Valid values are 'Comment' or 'Discussion'.
+     * @param string $type Valid values are 'Comment' or 'Discussion'.
      * @return bool Whether spam check is positive (TRUE = spammer).
      */
-    public function checkForSpam($Type) {
-        $Session = Gdn::session();
+    public function checkForSpam($type) {
+        deprecated(__CLASS__.' '.__METHOD__, 'FloodControlTrait::isUserSpamming()');
 
-        // If spam checking is disabled or user is an admin, skip
-        $SpamCheckEnabled = val('SpamCheck', $this, true);
-        if ($SpamCheckEnabled === false || $Session->User->Admin || $Session->checkPermission('Garden.Moderation.Manage')) {
-            return false;
-        }
-
-        $Spam = false;
+        $session = Gdn::session();
 
         // Validate $Type
-        if (!in_array($Type, array('Comment', 'Discussion'))) {
-            trigger_error(ErrorMessage(sprintf('Spam check type unknown: %s', $Type), 'VanillaModel', 'CheckForSpam'), E_USER_ERROR);
+        if (!in_array($type, array('Comment', 'Discussion'))) {
+            trigger_error(ErrorMessage(sprintf('Spam check type unknown: %s', $type), 'VanillaModel', 'CheckForSpam'), E_USER_ERROR);
         }
 
-        $CountSpamCheck = $Session->getAttribute('Count'.$Type.'SpamCheck', 0);
-        $DateSpamCheck = $Session->getAttribute('Date'.$Type.'SpamCheck', 0);
-        $SecondsSinceSpamCheck = time() - Gdn_Format::toTimestamp($DateSpamCheck);
+        $storageObject = FloodControlHelper::configure($this, $type);
+        $isUserSpamming = $this->isUserSpamming($session->User->UserID, $storageObject);
 
-        // Get spam config settings
-        $SpamCount = Gdn::config('Vanilla.'.$Type.'.SpamCount');
-        if (!is_numeric($SpamCount) || $SpamCount < 1) {
-            $SpamCount = 1; // 1 spam minimum
-        }
-        $SpamTime = Gdn::config('Vanilla.'.$Type.'.SpamTime');
-        if (!is_numeric($SpamTime) || $SpamTime < 30) {
-            $SpamTime = 30; // 30 second minimum spam span
-        }
-        $SpamLock = Gdn::config('Vanilla.'.$Type.'.SpamLock');
-        if (!is_numeric($SpamLock) || $SpamLock < 60) {
-            $SpamLock = 60; // 60 second minimum lockout
-        }
-        // Apply a spam lock if necessary
-        $Attributes = array();
-        if ($SecondsSinceSpamCheck < $SpamLock && $CountSpamCheck >= $SpamCount && $DateSpamCheck !== false) {
-            // TODO: REMOVE DEBUGGING INFO AFTER THIS IS WORKING PROPERLY
-            /*
-            echo '<div>SecondsSinceSpamCheck: '.$SecondsSinceSpamCheck.'</div>';
-            echo '<div>SpamLock: '.$SpamLock.'</div>';
-            echo '<div>CountSpamCheck: '.$CountSpamCheck.'</div>';
-            echo '<div>SpamCount: '.$SpamCount.'</div>';
-            echo '<div>DateSpamCheck: '.$DateSpamCheck.'</div>';
-            echo '<div>SpamTime: '.$SpamTime.'</div>';
-            */
-            $Spam = true;
-            $this->Validation->addValidationResult(
-                'Body',
-                '@'.sprintf(
-                    t('You have posted %1$s times within %2$s seconds. A spam block is now in effect on your account. You must wait at least %3$s seconds before attempting to post again.'),
-                    $SpamCount,
-                    $SpamTime,
-                    $SpamLock
-                )
-            );
-
-            // Update the 'waiting period' every time they try to post again
-            $Attributes['Date'.$Type.'SpamCheck'] = Gdn_Format::toDateTime();
-        } else {
-            if ($SecondsSinceSpamCheck > $SpamTime) {
-                $Attributes['Count'.$Type.'SpamCheck'] = 1;
-                $Attributes['Date'.$Type.'SpamCheck'] = Gdn_Format::toDateTime();
-            } else {
-                $Attributes['Count'.$Type.'SpamCheck'] = $CountSpamCheck + 1;
-            }
-        }
-        // Update the user profile after every comment
-        $UserModel = Gdn::userModel();
-        if ($Session->UserID) {
-            $UserModel->saveAttribute($Session->UserID, $Attributes);
-        }
-
-        return $Spam;
+        return $isUserSpamming;
     }
 }

--- a/applications/vanilla/views/vanillasettings/floodcontrol.php
+++ b/applications/vanilla/views/vanillasettings/floodcontrol.php
@@ -53,6 +53,34 @@ echo heading(t('Flood Control'));
                 <?php echo t('minute(s)'); ?>
             </td>
         </tr>
+        <tr>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.Activity.SpamCount', $SpamCount); ?>
+                <?php echo t('activity(ies)'); ?>
+            </td>
+            <td class="Alt">
+                <?php echo $this->Form->DropDown('Vanilla.Activity.SpamTime', $SpamTime); ?>
+                <?php echo t('seconds'); ?>
+            </td>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.Activity.SpamLock', $SpamLock); ?>
+                <?php echo t('minute(s)'); ?>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.ActivityComment.SpamCount', $SpamCount); ?>
+                <?php echo t('activity\'s comment(s)'); ?>
+            </td>
+            <td class="Alt">
+                <?php echo $this->Form->DropDown('Vanilla.ActivityComment.SpamTime', $SpamTime); ?>
+                <?php echo t('seconds'); ?>
+            </td>
+            <td>
+                <?php echo $this->Form->DropDown('Vanilla.ActivityComment.SpamLock', $SpamLock); ?>
+                <?php echo t('minute(s)'); ?>
+            </td>
+        </tr>
 
         <?php if ($ConversationsEnabled): ?>
 

--- a/library/Vanilla/CacheInterface.php
+++ b/library/Vanilla/CacheInterface.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla;
+
+/**
+ * Interface CacheInterface.
+ *
+ * @package Vanilla
+ */
+interface CacheInterface {
+    /*
+     * This should eventually extend https://github.com/php-fig/simple-cache/blob/master/src/CacheInterface.php
+     * when we start refactoring the cache system.
+     */
+
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key     The unique key of this item in the cache.
+     * @param mixed  $default Default value to return if the key does not exist.
+     *
+     * @return mixed The value of the item from the cache, or $default in case of cache miss.
+     */
+    public function get($key, $default = null);
+
+    /**
+     * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+     *
+     * @param string                $key   The key of the item to store.
+     * @param mixed                 $value The value of the item to store, must be serializable.
+     * @param null|int|DateInterval $ttl   Optional. The TTL value of this item. If no value is sent and
+     *                                     the driver supports TTL then the library may set a default value
+     *                                     for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function set($key, $value, $ttl = null);
+
+    /**
+     * Delete an item from the cache by its unique key.
+     *
+     * @param string $key The unique cache key of the item to delete.
+     *
+     * @return bool True if the item was successfully removed. False if there was an error.
+     */
+    public function delete($key);
+
+    /**
+     * Obtains multiple cache items by their unique keys.
+     *
+     * @param iterable $keys    A list of keys that can obtained in a single operation.
+     * @param mixed    $default Default value to return for keys that do not exist.
+     *
+     * @return iterable A list of key => value pairs. Cache keys that do not exist or are stale will have $default as value.
+     */
+    public function getMultiple($keys, $default = null);
+
+    /**
+     * Persists a set of key => value pairs in the cache, with an optional TTL.
+     *
+     * @param iterable              $values A list of key => value pairs for a multiple-set operation.
+     * @param null|int|DateInterval $ttl    Optional. The TTL value of this item. If no value is sent and
+     *                                      the driver supports TTL then the library may set a default value
+     *                                      for it or let the driver take care of that.
+     *
+     * @return bool True on success and false on failure.
+     */
+    public function setMultiple($values, $ttl = null);
+
+    /**
+     * Deletes multiple cache items in a single operation.
+     *
+     * @param iterable $keys A list of string-based keys to be deleted.
+     *
+     * @return bool True if the items were successfully removed. False if there was an error.
+     */
+    public function deleteMultiple($keys);
+
+    /**
+     * Determines whether an item is present in the cache.
+     *
+     * NOTE: It is recommended that has() is only to be used for cache warming type purposes
+     * and not to be used within your live applications operations for get/set, as this method
+     * is subject to a race condition where your has() will return true and immediately after,
+     * another script can remove it making the state of your app out of date.
+     *
+     * @param string $key The cache item key.
+     *
+     * @return bool
+     */
+    public function has($key);
+}

--- a/library/Vanilla/FloodControlTrait.php
+++ b/library/Vanilla/FloodControlTrait.php
@@ -160,10 +160,7 @@ trait FloodControlTrait {
      * @return bool True if the user is spamming, false otherwise.
      */
     public function isUserSpamming($userID, CacheInterface $storageObject) {
-        // The CheckSpam attribute is deprecated and should be removed in 2018.
-        $checkSpam = property_exists($this, 'CheckSpam') ? $this->CheckSpam : true;
-
-        if (!$this->isFloodControlEnabled() || !$checkSpam) {
+        if (!$this->isFloodControlEnabled()) {
             return false;
         }
 

--- a/library/Vanilla/FloodControlTrait.php
+++ b/library/Vanilla/FloodControlTrait.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla;
+
+/**
+ * Utility methods for models that want to implement flood control.
+ *
+ */
+trait FloodControlTrait {
+    /**
+     * @var int Amount of post that can be created before the flood control kicks in.
+     */
+    private $postCountThreshold = 3;
+
+    /**
+     * @var int Time span, in seconds, during which posting will increase the postCount.
+     */
+    private $timeSpan = 30;
+
+    /**
+     * @var int Amount of time, in seconds, of a flood control block.
+     */
+    private $lockTime = 120;
+
+    /**
+     * @var bool Whether flood control is enabled or not.
+     */
+    private $floodControlEnabled = true;
+
+    /**
+     * @var string Key name, in the {@link CacheInterface}, of the current number of posts. Args:[__CLASS__, '$userID'].
+     */
+    private $keyCurrentPostCount;
+
+    /**
+     * @var string Key name, in the {@link CacheInterface}, of the last flood check. Args:[__CLASS__, '$userID'].
+     */
+    private $keyLastDateChecked;
+
+    /**
+     * @return int
+     */
+    public function getPostCountThreshold() {
+        return $this->postCountThreshold;
+    }
+
+    /**
+     * @param int $postCountThreshold
+     * @return FloodControlTrait
+     */
+    public function setPostCountThreshold($postCountThreshold) {
+        $this->postCountThreshold = $this->normalizeInput(__METHOD__, $postCountThreshold, 1);
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeSpan() {
+        return $this->timeSpan;
+    }
+
+    /**
+     * @param int $timeSpan >= 30
+     * @return FloodControlTrait
+     */
+    public function setTimeSpan($timeSpan) {
+        $this->timeSpan = $this->normalizeInput(__METHOD__, $timeSpan, 30);
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLockTime() {
+        return $this->lockTime;
+    }
+
+    /**
+     * @param int $lockTime
+     * @return FloodControlTrait
+     */
+    public function setLockTime($lockTime) {
+        $this->lockTime = $this->normalizeInput(__METHOD__, $lockTime, 60);
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeyCurrentPostCount() {
+        return $this->keyCurrentPostCount ?: $this->getDefaultKeyCurrentPostCount();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultKeyCurrentPostCount() {
+        return 'floodcontrol.%s.%s.currentpostcount';
+    }
+
+    /**
+     * @param string $keyCurrentPostCount
+     * @return FloodControlTrait
+     */
+    public function setKeyCurrentPostCount($keyCurrentPostCount) {
+        $this->keyCurrentPostCount = $keyCurrentPostCount;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getKeyLastDateChecked() {
+        return $this->keyLastDateChecked ?: $this->getDefaultKeyLastDateChecked;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefaultKeyLastDateChecked() {
+        return 'floodcontrol.%s.%s.lastdatechecked';
+    }
+
+    /**
+     * @param string $keyLastDateChecked
+     * @return FloodControlTrait
+     */
+    public function setKeyLastDateChecked($keyLastDateChecked) {
+        $this->keyLastDateChecked = $keyLastDateChecked;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFloodControlEnabled() {
+        return $this->floodControlEnabled;
+    }
+
+    /**
+     * @param bool $floodControlEnabled
+     * @return FloodControlTrait
+     */
+    public function setFloodControlEnabled($floodControlEnabled) {
+        $this->floodControlEnabled = $floodControlEnabled;
+        return $this;
+    }
+
+    /**
+     * Check is a user is spamming
+     *
+     * @param int $userID
+     * @param CacheInterface $storageObject object in which we will store the floodcontrol data.
+     * @return bool True if the user is spamming, false otherwise.
+     */
+    public function isUserSpamming($userID, CacheInterface $storageObject) {
+        // The CheckSpam attribute is deprecated and should be removed in 2018.
+        $checkSpam = property_exists($this, 'CheckSpam') ? $this->CheckSpam : true;
+
+        if (!$this->isFloodControlEnabled() || !$checkSpam) {
+            return false;
+        }
+
+        $userPostCountKey = vsprintf($this->getKeyCurrentPostCount(), [strtolower(__CLASS__), $userID]);
+        $userLastDateCheckedKey = vsprintf($this->getKeyLastDateChecked(), [strtolower(__CLASS__), $userID]);
+
+        $isSpamming = false;
+        $countSpamCheck = $storageObject->get($userPostCountKey, 0);
+        $dateSpamCheck = $storageObject->get($userLastDateCheckedKey, date('Y-m-d H:i:s'));
+        $dateSpamCheckTime = strtotime($dateSpamCheck);
+        if (!$dateSpamCheckTime) {
+            $dateSpamCheckTime = time();
+        }
+        $secondsSinceSpamCheck = time() - $dateSpamCheckTime;
+
+        // Apply a spam lock if necessary
+        $attributes = [];
+        if ($secondsSinceSpamCheck < $this->lockTime && $countSpamCheck >= $this->postCountThreshold) {
+            $isSpamming = true;
+            // Update the 'waiting period' every time they try to post again
+            $attributes[$userLastDateCheckedKey] = date('Y-m-d H:i:s');
+        } else {
+            if ($secondsSinceSpamCheck > $this->timeSpan) {
+                $attributes[$userPostCountKey] = 1;
+                $attributes[$userLastDateCheckedKey] = date('Y-m-d H:i:s');
+            } else {
+                $attributes[$userPostCountKey] = $countSpamCheck + 1;
+            }
+        }
+
+        $storageObject->setMultiple($attributes);
+
+        if ($isSpamming && property_exists($this, 'Validation') && is_a($this->Validation, 'Gdn_Validation')) {
+            $this->Validation->addValidationResult(
+                'Body',
+                '@'.$this->getFloodControlWarningMessage()
+            );
+        }
+
+        return $isSpamming;
+    }
+
+    /**
+     * Get a formatted warning message for spamming user.
+     *
+     * @return string The formatted warning message
+     */
+    protected function getFloodControlWarningMessage() {
+        return sprintf(
+                t('You have posted %1$s times within %2$s seconds. A spam block is now in effect on your account. You must wait at least %3$s seconds before attempting to post again.'),
+                $this->postCountThreshold,
+                $this->timeSpan,
+                $this->lockTime
+            );
+    }
+
+    /**
+     * Takes a value and sets it to its minimum if not valid.
+     *
+     * @param string $caller Function name that called normalizeInput
+     * @param int $value
+     * @param int $minimum
+     * @return int
+     */
+    private function normalizeInput($caller, $value, $minimum) {
+        if (!ctype_digit((string)$value) || $minimum < 1) {
+            trigger_error("$caller value '$value' was normalized to '$minimum' because it was invalid.", E_USER_NOTICE);
+            $value = $minimum;
+        }
+
+        return (int)$value;
+    }
+}

--- a/library/core/caching/class.cachecacheadapter.php
+++ b/library/core/caching/class.cachecacheadapter.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+/**
+ * Class CacheCacheAdapter
+ */
+class CacheCacheAdapter implements \Vanilla\CacheInterface {
+
+    /**
+     * @var Gdn_Cache
+     */
+    private $cacheObject;
+
+    /**
+     * CacheCacheAdapter constructor.
+     *
+     * @param Gdn_Cache $cacheObject
+     */
+    public function __construct(Gdn_Cache $cacheObject) {
+        $this->cacheObject = $cacheObject;
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function get($key, $default = null) {
+        $value = $this->cacheObject->get($key);
+        if ($value === false) {
+            $value = $default;
+        }
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($key, $value, $ttl = null) {
+        $options = [];
+        if ($ttl !== null) {
+            $options[FEATURE_EXPIRY] = $ttl;
+        }
+        return $this->cacheObject->store($key, $value, $ttl);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete($key) {
+        return $this->cacheObject->remove($key);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMultiple($keys, $default = null) {
+        $result = [];
+        foreach($keys as $key) {
+            $result[$key] = $this->get($key, $default);
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setMultiple($values, $ttl = null) {
+        $success = true;
+        foreach($values as $key => $value) {
+            if ($this->set($key, $value, $ttl) === false) {
+                $success = false;
+                break;
+            }
+        }
+        return $success;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteMultiple($keys) {
+        $success = true;
+        foreach($values as $key) {
+            if ($this->delete($key) === false) {
+                $success = false;
+                break;
+            }
+        }
+        return $success;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($key) {
+        return $this->cacheObject->exists($key);
+    }
+
+
+}

--- a/library/core/caching/class.userattributecacheadapter.php
+++ b/library/core/caching/class.userattributecacheadapter.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+/**
+ * Class UserAttributeCacheAdapter
+ */
+class UserAttributeCacheAdapter implements \Vanilla\CacheInterface {
+
+    /**
+     * @var Gdn_Session
+     */
+    private $session;
+
+    /**
+     * @var UserModel
+     */
+    private $userModel;
+
+    /**
+     * UserAttibuteAttributeCacheAdapter constructor.
+     *
+     * @param Gdn_Session $session
+     * @param UserModel $userModel
+     */
+    public function __construct(Gdn_Session $session, UserModel $userModel) {
+        $this->session = $session;
+        $this->userModel = $userModel;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($key, $default = null) {
+        return $this->session->getAttribute($key, $default);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($key, $value, $ttl = null) {
+        return $this->setMultiple([$key => $value]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete($key) {
+        return $this->deleteMultiple([$key]);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMultiple($keys, $default = null) {
+        $result = [];
+        foreach ($keys as $key) {
+            $result[$key] = $this->get($key, $default);
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setMultiple($values, $ttl = null) {
+        $success = $this->session->isValid();
+        if ($success) {
+            try {
+                // This also update the session!
+                $this->userModel->saveAttribute($this->session->UserID, $values);
+            } catch(Exception $e) {
+                $success = false;
+            }
+        }
+        return $success;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteMultiple($keys) {
+        return $this->setMultiple(array_fill_keys($keys, null));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($key) {
+        return $this->get($key) !== null;
+    }
+
+
+}

--- a/library/core/helpers/class.floodcontrolhelper.php
+++ b/library/core/helpers/class.floodcontrolhelper.php
@@ -20,9 +20,24 @@ class FloodControlHelper {
     public static function configure($instance, $type) {
         $session = Gdn::session();
 
-        // Let's deactivate flood control if the user is an admin :)
-        if (!Gdn::session()->isValid() || $session->User->Admin || $session->checkPermission('Garden.Moderation.Manage')) {
+        // The CheckSpam and SpamCheck attributes are deprecated and should be removed in 2018.
+        if (property_exists($instance, 'CheckSpam')) {
+            deprecated(__CLASS__.'->CheckSpam', __CLASS__.'->setFloodControlEnabled()');
+            $instance->setFloodControlEnabled($instance->CheckSpam);
+        }
+        if (property_exists($instance, 'SpamCheck')) {
+            deprecated(__CLASS__.'->SpamCheck', __CLASS__.'->setFloodControlEnabled()');
+            $instance->setFloodControlEnabled($instance->SpamCheck);
+        }
+
+        if (!Gdn::session()->isValid()) {
             $instance->setFloodControlEnabled(false);
+        } elseif ($session->User->Admin || $session->checkPermission('Garden.Moderation.Manage')) {
+            $instance->setFloodControlEnabled(false);
+        }
+
+        // Let's deactivate flood control if the user is an admin :)
+        if (!$instance->isFloodControlEnabled()) {
             return new UserAttributeCacheAdapter(Gdn::session(), Gdn::userModel());
         }
 

--- a/library/core/helpers/class.floodcontrolhelper.php
+++ b/library/core/helpers/class.floodcontrolhelper.php
@@ -56,6 +56,11 @@ class FloodControlHelper {
 
             $keyPostCount = 'Count'.$type.'SpamCheck';
             $keyLastDateChecked = 'Date'.$type.'SpamCheck';
+
+            if ($session->getAttribute('Time'.$type.'SpamCheck')) {
+                // Remove old attribute used in the conversationModel
+                Gdn::userModel()->setAttribute('Time'.$type.'SpamCheck', null);
+            }
         }
 
         $instance

--- a/library/core/helpers/class.floodcontrolhelper.php
+++ b/library/core/helpers/class.floodcontrolhelper.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+/**
+ * Class FloodControlHelper
+ *
+ * Used to configure FloodControlTrait parameters.
+ */
+class FloodControlHelper {
+    /**
+     * @param \Vanilla\FloodControlTrait $instance
+     * @param string $type Type of record that will be used to configure to trait.
+     *
+     * @return \Vanilla\CacheInterface
+     */
+    public static function configure($instance, $type) {
+        $session = Gdn::session();
+
+        // Let's deactivate flood control if the user is an admin :)
+        if (!Gdn::session()->isValid() || $session->User->Admin || $session->checkPermission('Garden.Moderation.Manage')) {
+            $instance->setFloodControlEnabled(false);
+            return new UserAttributeCacheAdapter(Gdn::session(), Gdn::userModel());
+        }
+
+        if (c('Cache.Enabled')) {
+            $storageObject = new CacheCacheAdapter(Gdn::cache());
+
+            $keyPostCount = $instance->getDefaultKeyCurrentPostCount();
+            $keyLastDateChecked = $instance->getDefaultKeyLastDateChecked();
+            // Add the type in the key in case that a model do multiple types (activityModel for example).
+            foreach([&$keyPostCount, &$keyLastDateChecked] as &$key) {
+                $key = str_replace('%s.%s', '%s.'.strtolower($type).'.%s', $key);
+            }
+        } else {
+            // Convert old keys to new ones
+            $storageObject = new UserAttributeCacheAdapter($session, Gdn::userModel());
+
+            $keyPostCount = 'Count'.$type.'SpamCheck';
+            $keyLastDateChecked = 'Date'.$type.'SpamCheck';
+        }
+
+        $instance
+            ->setPostCountThreshold(c('Vanilla.'.$type.'.SpamCount', 1))
+            ->setTimeSpan(c('Vanilla.'.$type.'.SpamTime', 60))
+            ->setLockTime(c('Vanilla.'.$type.'.SpamLock', 60))
+            ->setKeyCurrentPostCount($keyPostCount)
+            ->setKeyLastDateChecked($keyLastDateChecked)
+        ;
+
+        return $storageObject;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5045

This PR adds 
- CacheInterface
    - Ultimately it will inherit the SimpleCache interface from PSR
    - Add a level of abstraction
- FloodControlTrait
    - Receive a CacheInterface (which is either an adapter of UserAttributes or Gdn_Cache). The latter will be used to fix concurrency issues mentioned in vanilla/vanilla-patches/issues/65
- Some folders in library/core
    - Namely, the helpers folder. We can put utility classes in there!

  