### PR TITLE
Apply jsonFilter to Garden\Web\Data JSON result

### DIFF
--- a/library/Garden/Web/Data.php
+++ b/library/Garden/Web/Data.php
@@ -151,7 +151,9 @@ class Data implements \JsonSerializable {
      * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
      */
     public function jsonSerialize() {
-        return $this->getData();
+        $data = $this->getData();
+        jsonFilter($data);
+        return $data;
     }
 
     /**


### PR DESCRIPTION
The JSON serialized form of `Garden\Web\Data` does not currently go through `jsonFilter`, which will properly format certain field types. This update addresses that.