### PR TITLE
Make resource routes whitelist instead of blacklist

### DIFF
--- a/library/Garden/Web/ResourceRoute.php
+++ b/library/Garden/Web/ResourceRoute.php
@@ -193,8 +193,7 @@ class ResourceRoute extends Route {
         $regex = '`^(get|post|patch|put|options|delete)(_|$)`i';
 
         // Getters and setters aren't found.
-        if (!(preg_match($regex, $methodName) || strcasecmp($methodName, 'index') === 0)
-            && !(method_exists($controller, 'isPublic') && $controller->isPublic($methodName))) {
+        if (!(preg_match($regex, $methodName) || strcasecmp($methodName, 'index') === 0)) {
             return null;
         }
 
@@ -371,16 +370,10 @@ class ResourceRoute extends Route {
         if (isset($pathArgs[0])) {
             $name = lcfirst($this->filterName($pathArgs[0]));
             $result[] = ["{$method}_{$name}", 0];
-            if (!in_array($name, self::$specialMethods)) {
-                $result[] = [$name, 0];
-            }
         }
         if (isset($pathArgs[1])) {
             $name = lcfirst($this->filterName($pathArgs[1]));
             $result[] = ["{$method}_{$name}", 1];
-            if (!in_array($name, self::$specialMethods)) {
-                $result[] = [$name, 1];
-            }
         }
 
         $result[] = [$method, null];

--- a/tests/Library/Garden/Web/ResourceRouteTest.php
+++ b/tests/Library/Garden/Web/ResourceRouteTest.php
@@ -165,15 +165,6 @@ class ResourceRouteTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Controllers can publicize methods with isPublic().
-     */
-    public function testIsPublic() {
-        $route = $this->createRoute();
-
-        $this->assertNotNull($route->match(new Request('/discussions/i-am-public')));
-    }
-
-    /**
      * A path parameter should be filled with the remaining path.
      *
      * @param string $path A request path.

--- a/tests/fixtures/src/DiscussionsController.php
+++ b/tests/fixtures/src/DiscussionsController.php
@@ -84,14 +84,6 @@ class DiscussionsController {
     public function setSomething($val) {
     }
 
-    public function iAmPublic() {
-
-    }
-
-    public function isPublic($method) {
-        return strcasecmp($method, 'iAmPublic') === 0;
-    }
-
     public function post_noMap($query, $body, $data) {
 
     }


### PR DESCRIPTION
The resource router was blacklisting methods with an **isProtected** method just like the old router. This was a mistake in the old router and we shouldn’t make the same mistake again.

Now we will use a whitelist so that methods will not be accessible as an endpoint unless they meet the following criteria.

- The method is one of the basic HTTP methods or `index`.
- The method matches `<HTTP method>_name`.

The resource router will not map methods like the current router. This means that the resource router will not be used for current Vanilla controllers. The intention is that when we want to update our HTML app then we will move the controllers over one-by-one.