### PR TITLE
Fix time_zone SQL bug when configuring connection on some systems

### DIFF
--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -154,7 +154,8 @@ class Gdn_Database {
             $PDO->setAttribute(PDO::ATTR_EMULATE_PREPARES, 0);
 
             $encoding = c('Database.CharacterEncoding', 'utf8mb4');
-            $PDO->query("set names '$encoding';set time_zone = '+0:0'");
+            $PDO->query("set names '{$encoding}'");
+            $PDO->query("set time_zone = '+0:0'");
 
             // We only throw exceptions during connect
             $PDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);


### PR DESCRIPTION
This update separates configuring the `names` and `time_zone` values for the database connection. Executing them in one function call can potentially cause a fatal error on some systems.