### PR TITLE
Update the panel navigation on enabling or disabling a plugin

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -127,6 +127,7 @@ class SettingsController extends DashboardController {
         }
 
         $this->handleAddonToggle($addonName, $addon->getInfo(), 'applications', false, $filter, $action);
+        $this->render('blank', 'utility', 'dashboard');
     }
 
     public function enableApplication($addonName, $filter) {
@@ -158,6 +159,7 @@ class SettingsController extends DashboardController {
         }
 
         $this->handleAddonToggle($addonName, $addon->getInfo(), 'applications', true, $filter, $action);
+        $this->render('blank', 'utility', 'dashboard');
     }
 
     private function handleAddonToggle($addonName, $addonInfo, $type, $isEnabled, $filter = '', $action = '') {
@@ -175,8 +177,6 @@ class SettingsController extends DashboardController {
                 $this->jsonTarget('#'.Gdn_Format::url($addonName).'-addon', $row, 'ReplaceWith');
             }
         }
-
-        $this->render('blank', 'utility', 'dashboard');
     }
 
     /**
@@ -249,6 +249,43 @@ class SettingsController extends DashboardController {
             }
         }
         $this->render();
+    }
+
+    /**
+     * Reload the panel navigation. Updates the panel navigation (the content of the div with the
+     * class '.js-panel-nav') in the page with the navigation for one or more sections in the
+     * Dashboard Nav Module. For instance, I could replace the panel nav with the moderation section nav
+     * by calling reloadPanelNavigation('Moderation').
+     *
+     * @param String|array $sections The section or sections to update the panel nav with.
+     * @param String $activeUrl The highlight url for the panel nav.
+     * @throws Exception
+     */
+    public function reloadPanelNavigation($sections = '', $activeUrl = '') {
+        $dashboardNavModule = DashboardNavModule::getDashboardNav();
+
+        // Coerce into an array
+        if ($sections !== '' && gettype($sections) === 'string') {
+            $sections = [$sections];
+        }
+
+        if ($sections !== '') {
+            $dashboardNavModule->setCurrentSections($sections);
+        }
+
+        if ($activeUrl !== '') {
+            $dashboardNavModule->setHighlightRoute($activeUrl);
+        }
+
+        // Get our plugin nav items the new way.
+        $dashboardNavModule->fireEvent('init');
+
+        // Get our plugin nav items the old way.
+        $navAdapter = new NestedCollectionAdapter($dashboardNavModule);
+        $this->EventArguments['SideMenu'] = $navAdapter;
+        $this->fireEvent('GetAppSettingsMenuItems');
+
+        $this->jsonTarget('.js-panel-nav', $dashboardNavModule->toString());
     }
 
     /**
@@ -1159,7 +1196,7 @@ class SettingsController extends DashboardController {
         }
 
         $this->handleAddonToggle($addonName, $addonInfo, 'locales', true);
-
+        $this->render('blank', 'utility', 'dashboard');
     }
 
     public function disableLocale($addonName, $addonInfo) {
@@ -1172,6 +1209,7 @@ class SettingsController extends DashboardController {
         $this->informMessage(sprintf(t('%s Disabled.'), val('Name', $addonInfo, t('Locale'))));
 
         $this->handleAddonToggle($addonName, $addonInfo, 'locales', false);
+        $this->render('blank', 'utility', 'dashboard');
     }
 
     /**
@@ -1244,6 +1282,8 @@ class SettingsController extends DashboardController {
         }
 
         $this->handleAddonToggle($pluginName, $addon->getInfo(), 'plugins', false, $filter, $action);
+        $this->reloadPanelNavigation('Settings', '/dashboard/settings/plugins');
+        $this->render('blank', 'utility', 'dashboard');
     }
 
     public function enablePlugin($pluginName, $filter = 'all') {
@@ -1276,6 +1316,8 @@ class SettingsController extends DashboardController {
         }
 
         $this->handleAddonToggle($pluginName, $addon->getInfo(), 'plugins', true, $filter, $action);
+        $this->reloadPanelNavigation('Settings', '/dashboard/settings/plugins');
+        $this->render('blank', 'utility', 'dashboard');
     }
 
     /**

--- a/applications/dashboard/modules/class.dashboardnavmodule.php
+++ b/applications/dashboard/modules/class.dashboardnavmodule.php
@@ -14,6 +14,8 @@
 class DashboardNavModule extends SiteNavModule {
 
     const ACTIVE_SECTION_DEFAULT = 'Settings';
+    const SECTION_DEFAULT = 'Settings';
+
 
     public $view = 'nav-dashboard';
 

--- a/applications/dashboard/modules/class.sitenavmodule.php
+++ b/applications/dashboard/modules/class.sitenavmodule.php
@@ -75,7 +75,7 @@ class SiteNavModule extends NavModule {
             'modifiers' => $modifiers,
             'disabled' => $disabled
         ];
-        self::$sectionItems[strtolower($section)][self::LINKS_INDEX][$key] = $args;
+        static::$sectionItems[strtolower($section)][static::LINKS_INDEX][$key] = $args;
         return $this;
     }
 
@@ -116,7 +116,7 @@ class SiteNavModule extends NavModule {
             'sort' => $sort,
             'modifiers' => $modifiers
         ];
-        self::$sectionItems[strtolower($section)][self::GROUPS_INDEX][] = $args;
+        static::$sectionItems[strtolower($section)][static::GROUPS_INDEX][] = $args;
         return $this;
     }
 
@@ -149,7 +149,7 @@ class SiteNavModule extends NavModule {
      * @return $this
      */
     public function addLink($text, $url, $key = '', $cssClass = '', $sort = [], $modifiers = [], $disabled = false) {
-        $this->addLinkToSection(self::SECTION_DEFAULT, $text, $url, $key, $cssClass, $sort, $modifiers, $disabled);
+        $this->addLinkToSection(static::SECTION_DEFAULT, $text, $url, $key, $cssClass, $sort, $modifiers, $disabled);
         return $this;
     }
 
@@ -181,7 +181,7 @@ class SiteNavModule extends NavModule {
      * @return $this
      */
     public function addGroup($text = '', $key = '', $cssClass = '', $sort = [], $modifiers = []) {
-        $this->addGroupToSection(self::SECTION_DEFAULT, $text, $key, $cssClass, $sort, $modifiers);
+        $this->addGroupToSection(static::SECTION_DEFAULT, $text, $key, $cssClass, $sort, $modifiers);
         return $this;
     }
 
@@ -213,7 +213,7 @@ class SiteNavModule extends NavModule {
      * @return $this
      */
     public function addLinkToGlobals($text, $url, $key = '', $cssClass = '', $sort = [], $modifiers = [], $disabled = false) {
-        $this->addLinkToSection(self::SECTION_GLOBAL, $text, $url, $key, $cssClass, $sort, $modifiers, $disabled);
+        $this->addLinkToSection(static::SECTION_GLOBAL, $text, $url, $key, $cssClass, $sort, $modifiers, $disabled);
         return $this;
     }
 
@@ -245,7 +245,7 @@ class SiteNavModule extends NavModule {
      * @return $this
      */
     public function addGroupToGlobals($text = '', $key = '', $cssClass = '', $sort = [], $modifiers = []) {
-        $this->addGroupToSection(self::SECTION_GLOBAL, $text, $key, $cssClass, $sort, $modifiers);
+        $this->addGroupToSection(static::SECTION_GLOBAL, $text, $key, $cssClass, $sort, $modifiers);
         return $this;
     }
 
@@ -273,8 +273,8 @@ class SiteNavModule extends NavModule {
      */
     public function prepare() {
 
-        if (!self::$initStaticFired) {
-            self::$initStaticFired = true;
+        if (!static::$initStaticFired) {
+            static::$initStaticFired = true;
             $this->fireEvent('init');
         }
 
@@ -282,21 +282,21 @@ class SiteNavModule extends NavModule {
             $currentSections = Gdn_Theme::section('', 'get');
             $currentSections = array_map('strtolower', $currentSections);
 
-            $customMenuKeys = array_intersect(array_keys(self::$sectionItems), $currentSections);
+            $customMenuKeys = array_intersect(array_keys(static::$sectionItems), $currentSections);
             $hasCustomMenu = !empty($customMenuKeys);
 
             if (!$hasCustomMenu) {
-                $currentSections = [self::SECTION_DEFAULT];
+                $currentSections = [static::SECTION_DEFAULT];
             }
 
             // Add global items
-            $currentSections[] = self::SECTION_GLOBAL;
+            $currentSections[] = static::SECTION_GLOBAL;
         } else {
             $currentSections = array_map('strtolower', $this->currentSections);
         }
 
         foreach ($currentSections as $currentSection) {
-            if ($section = val(strtolower($currentSection), self::$sectionItems)) {
+            if ($section = val(strtolower($currentSection), static::$sectionItems)) {
                 $this->addSectionItems($section);
             }
         }
@@ -307,7 +307,7 @@ class SiteNavModule extends NavModule {
      * @param array $section
      */
     public function addSectionItems($section) {
-        if ($groups = val(self::GROUPS_INDEX, $section)) {
+        if ($groups = val(static::GROUPS_INDEX, $section)) {
             foreach ($groups as $group) {
                 parent::addGroup(
                     $group['text'],
@@ -319,7 +319,7 @@ class SiteNavModule extends NavModule {
             }
         }
 
-        if ($links = val(self::LINKS_INDEX, $section)) {
+        if ($links = val(static::LINKS_INDEX, $section)) {
             foreach ($links as $link) {
                 parent::addLink(
                     $link['text'],
@@ -340,7 +340,7 @@ class SiteNavModule extends NavModule {
      * @param string $key The key of the item to remove, separated by dots.
      */
     public function removeItem($key) {
-        foreach (self::$sectionItems as &$section) {
+        foreach (static::$sectionItems as &$section) {
             unset($section['links'][$key]);
         }
     }

--- a/applications/dashboard/views/admin.master.php
+++ b/applications/dashboard/views/admin.master.php
@@ -6,7 +6,7 @@ $this->fireAs('dashboard')->fireEvent('render');
 <html lang="<?php echo htmlspecialchars(Gdn::locale()->Locale); ?>">
 <head>
     <?php $this->renderAsset('Head'); ?>
-    <!-- Robots should not see the dashboard, but tell them not to index it just in case. -->
+    <?php // Robots should not see the dashboard, but tell them not to index it just in case. ?>
     <meta name="robots" content="noindex,nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
@@ -98,9 +98,11 @@ Gdn_Theme::assetEnd();
     <div class="main-row pusher<?php echo $this->data('IsWidePage') ? ' main-row-wide' : ''; ?>" id="main-row">
         <div class="panel panel-left js-drawer">
             <div class="panel-nav panel-content-wrapper">
-                <div id="panel-nav" class="js-fluid-fixed panel-content">
+                <div class="js-fluid-fixed panel-content">
                     <?php echo anchor($title.' '.dashboardSymbol('external-link', 'icon-16'), '/', 'title'); ?>
-                    <?php echo $dashboardNav; ?>
+                    <div id="panel-nav" class="js-panel-nav">
+                        <?php echo $dashboardNav; ?>
+                    </div>
                     <aside class="drawer-only">
                         <?php $this->renderAsset('DashboardUserDropDown'); ?>
                     </aside>


### PR DESCRIPTION
Updates the panel navigation when a plugin is enabled or disabled. 

Also: 
* Updates calls to consts in the SiteNavModule from `self::` to `static::` for late-binding to allow child classes to override. This allows the DashboardNavModule to override the default section key.
* Moves the rendering call from `handleAddonToggle()` method to the endpoint instead, so it does not have to be the last call in an endpoint that uses it.

Closes https://github.com/vanilla/vanilla/issues/4473