### PR TITLE
Remove array union operator from HttpException::jsonSerialize

### DIFF
--- a/library/Garden/Web/Exception/HttpException.php
+++ b/library/Garden/Web/Exception/HttpException.php
@@ -157,10 +157,10 @@ abstract class HttpException extends \Exception implements \JsonSerializable {
             return !(strpos($key, 'HTTP_') === 0);
         }, ARRAY_FILTER_USE_KEY);
 
-        $result = [
+        $result = array_replace($context, [
             'message' => $this->getMessage(),
             'status' => $this->getCode()
-        ] + $context;
+        ]);
 
         return $result;
     }


### PR DESCRIPTION
`HttpException::jsonSerialize` currently uses PHP's array union operator (+) to join two arrays: `$context` and `$response`. HHVM does not support this and currently throws the following error:

> Fatal error: Invalid operand type was used: cannot perform this operation with arrays

This update replaces the current method of joining the arrays with a call to `array_replace`, which should emulate the same behavior.