### PR TITLE
Add an optional site setting to send users to /leaving when clicking a ugc link

### DIFF
--- a/applications/dashboard/controllers/class.homecontroller.php
+++ b/applications/dashboard/controllers/class.homecontroller.php
@@ -116,7 +116,7 @@ class HomeController extends Gdn_Controller {
      */
     public function leaving($target = '') {
         $this->setData('Target', $target);
-
+        $this->title('Leaving');
         $this->removeCssFile('admin.css');
         $this->addCssFile('style.css');
         $this->addCssFile('vanillicon.css', 'static');

--- a/applications/dashboard/views/home/leaving.php
+++ b/applications/dashboard/views/home/leaving.php
@@ -1,4 +1,7 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
+<h1>
+    <?php echo $this->data('Title'); ?>
+</h1>
 <p>
     <?php echo sprintf(
         t('You are now leaving %1$s. Click the link to continue to %2$s.'),

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -52,6 +52,8 @@ class VanillaSettingsController extends Gdn_Controller {
             'Vanilla.AdminCheckboxes.Use',
             'Vanilla.Comment.MaxLength',
             'Vanilla.Comment.MinLength',
+            'Garden.Format.WarnLeaving',
+            'Garden.Format.DisableUrlEmbeds',
             'Garden.TrustedDomains'
         ));
 
@@ -88,6 +90,7 @@ class VanillaSettingsController extends Gdn_Controller {
             $TrustedDomains = array_unique(array_filter($TrustedDomains));
             $TrustedDomains = implode("\n", $TrustedDomains);
             $this->Form->setFormValue('Garden.TrustedDomains', $TrustedDomains);
+            $this->Form->setFormValue('Garden.Format.DisableUrlEmbeds', $this->Form->getValue('Garden.Format.DisableUrlEmbeds') !== '1');
 
             // Save new settings
             $Saved = $this->Form->save();

--- a/applications/vanilla/views/vanillasettings/advanced.php
+++ b/applications/vanilla/views/vanillasettings/advanced.php
@@ -3,12 +3,33 @@ helpAsset(t('Need More Help?'), anchor(t("Video tutorial on advanced settings"),
 ?>
 <h1><?php echo t('Advanced'); ?></h1>
 <?php
-echo $this->Form->open();
-echo $this->Form->errors();
+/** @var Gdn_Form $form */
+$form = $this->Form;
+echo $form->open();
+echo $form->errors();
 ?>
     <ul>
         <li class="form-group">
-            <?php echo $this->Form->toggle('Vanilla.AdminCheckboxes.Use', 'Enable checkboxes on discussions and comments.'); ?>
+            <?php
+            $checkboxDesc = 'Checkboxes allow admins to perform batch actions on a number of discussions or comments at the same time.';
+            echo $form->toggle('Vanilla.AdminCheckboxes.Use', 'Enable checkboxes on discussions and comments', [], $checkboxDesc);
+            ?>
+        </li>
+        <li class="form-group">
+            <?php
+            $embedsLabel = 'Enable link embeds in discussions and comments';
+            $embedsDesc = 'Allow links to be tranformed into embedded representations in discussions and comments. ';
+            $embedsDesc .= 'For example, a YouTube link will transform into an embedded video.';
+            echo $form->toggle('Garden.Format.DisableUrlEmbeds', $embedsLabel, [], $embedsDesc, true);
+            ?>
+        </li>
+        <li class="form-group">
+            <?php
+            $leavingLabel = 'Warn users if a link in a post will cause them to leave the forum';
+            $leavingDesc = 'Alert users if they click a link in a post that will lead them away from the forum. ';
+            $leavingDesc .= 'Users will not be warned when following links that match a Trusted Domain.';
+            echo $form->toggle('Garden.Format.WarnLeaving', $leavingLabel, [], $leavingDesc);
+            ?>
         </li>
         <li class="form-group">
             <?php
@@ -17,7 +38,7 @@ echo $this->Form->errors();
             ?>
             <div class="label-wrap">
             <?php
-            echo $this->Form->label('Maximum Category Display Depth', 'Vanilla.Categories.MaxDisplayDepth');
+            echo $form->label('Maximum Category Display Depth', 'Vanilla.Categories.MaxDisplayDepth');
             echo wrap(
                 t('CategoryMaxDisplayDepth.Notes', 'Nested categories deeper than this depth will be placed in a comma-delimited list.'),
                 'div',
@@ -26,7 +47,7 @@ echo $this->Form->errors();
             ?>
             </div>
             <div class="input-wrap">
-            <?php echo $this->Form->DropDown('Vanilla.Categories.MaxDisplayDepth', $Options, $Fields); ?>
+            <?php echo $form->DropDown('Vanilla.Categories.MaxDisplayDepth', $Options, $Fields); ?>
             </div>
         </li>
         <li class="form-group">
@@ -35,18 +56,18 @@ echo $this->Form->errors();
             $Fields = array('TextField' => 'Code', 'ValueField' => 'Code');
             ?>
             <div class="label-wrap">
-            <?php echo $this->Form->label('Discussions per Page', 'Vanilla.Discussions.PerPage'); ?>
+            <?php echo $form->label('Discussions per Page', 'Vanilla.Discussions.PerPage'); ?>
             </div>
             <div class="input-wrap">
-            <?php echo $this->Form->DropDown('Vanilla.Discussions.PerPage', $Options, $Fields); ?>
+            <?php echo $form->DropDown('Vanilla.Discussions.PerPage', $Options, $Fields); ?>
             </div>
         </li>
         <li class="form-group">
             <div class="label-wrap">
-            <?php echo $this->Form->label('Comments per Page', 'Vanilla.Comments.PerPage'); ?>
+            <?php echo $form->label('Comments per Page', 'Vanilla.Comments.PerPage'); ?>
             </div>
             <div class="input-wrap">
-            <?php echo $this->Form->DropDown('Vanilla.Comments.PerPage', $Options, $Fields); ?>
+            <?php echo $form->DropDown('Vanilla.Comments.PerPage', $Options, $Fields); ?>
             </div>
         </li>
         <li class="form-group">
@@ -63,35 +84,35 @@ echo $this->Form->errors();
             $Fields = array('TextField' => 'Text', 'ValueField' => 'Code'); ?>
             <div class="label-wrap">
             <?php
-            echo $this->Form->label('Discussion & Comment Editing', 'Garden.EditContentTimeout');
+            echo $form->label('Discussion & Comment Editing', 'Garden.EditContentTimeout');
             echo wrap(t('EditContentTimeout.Notes', 'If a user is in a role that has permission to edit content, those permissions will override this.'), 'div', array('class' => 'info'));
             ?>
             </div>
             <div class="input-wrap">
-            <?php echo $this->Form->DropDown('Garden.EditContentTimeout', $Options, $Fields); ?>
+            <?php echo $form->DropDown('Garden.EditContentTimeout', $Options, $Fields); ?>
             </div>
         </li>
         <li class="form-group">
             <div class="label-wrap">
-            <?php echo $this->Form->label('Max Comment Length', 'Vanilla.Comment.MaxLength'); ?>
+            <?php echo $form->label('Max Comment Length', 'Vanilla.Comment.MaxLength'); ?>
             <div class="info"><?php echo t("It is a good idea to keep the maximum number of characters allowed in a comment down to a reasonable size."); ?></div>
             </div>
             <div class="input-wrap">
-            <?php echo $this->Form->textBox('Vanilla.Comment.MaxLength', array('class' => 'InputBox SmallInput')); ?>
+            <?php echo $form->textBox('Vanilla.Comment.MaxLength', array('class' => 'InputBox SmallInput')); ?>
             </div>
         </li>
         <li class="form-group">
             <div class="label-wrap">
-            <?php echo $this->Form->label('Min Comment Length', 'Vanilla.Comment.MinLength'); ?>
+            <?php echo $form->label('Min Comment Length', 'Vanilla.Comment.MinLength'); ?>
             <div class="info"><?php echo t("You can specify a minimum comment length to discourage short comments."); ?></div>
             </div>
             <div class="input-wrap">
-            <?php echo $this->Form->textBox('Vanilla.Comment.MinLength', array('class' => 'InputBox SmallInput')); ?>
+            <?php echo $form->textBox('Vanilla.Comment.MinLength', array('class' => 'InputBox SmallInput')); ?>
             </div>
         </li>
         <li class="form-group">
             <div class="label-wrap">
-            <?php echo $this->Form->label('Trusted Domains', 'Garden.TrustedDomains'); ?>
+            <?php echo $form->label('Trusted Domains', 'Garden.TrustedDomains'); ?>
                 <div class="info">
                     <p>
                     <?php
@@ -105,8 +126,8 @@ echo $this->Form->errors();
                 </div>
             </div>
             <div class="input-wrap">
-            <?php echo $this->Form->textBox('Garden.TrustedDomains', ['MultiLine' => true]); ?>
+            <?php echo $form->textBox('Garden.TrustedDomains', ['MultiLine' => true]); ?>
             </div>
         </li>
     </ul>
-<?php echo $this->Form->close('Save'); ?>
+<?php echo $form->close('Save'); ?>

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -588,9 +588,10 @@ class Gdn_Form extends Gdn_Pluggable {
      * @param string $label The label for the field.
      * @param array $attributes The attributes for the checkbox input.
      * @param string $info The label description.
+     * @param bool $reverse Whether to reverse the representation of the toggle (positive value is on, neg value is off).
      * @return string And HTML-formatted form field for a toggle.
      */
-    public function toggle($fieldName, $label, $attributes = [], $info = '') {
+    public function toggle($fieldName, $label, $attributes = [], $info = '', $reverse = false) {
         $value = arrayValueI('value', $attributes, true);
         $attributes['value'] = $value;
         if (stringEndsWith($fieldName, '[]')) {
@@ -603,6 +604,14 @@ class Gdn_Form extends Gdn_Pluggable {
             }
         } else {
             if ($this->getValue($fieldName) == $value) {
+                $attributes['checked'] = 'checked';
+            }
+        }
+
+        if ($reverse) {
+            if ($attributes['checked'] === 'checked') {
+                unset($attributes['checked']);
+            } else {
                 $attributes['checked'] = 'checked';
             }
         }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1519,7 +1519,8 @@ EOT;
         $nofollow = (self::$DisplayNoFollow) ? ' rel="nofollow"' : '';
 
         if (c('Garden.Format.WarnLeaving', false)) {
-            if (!matchesTrustedDomain($url)) {
+            $domain = parse_url($url, PHP_URL_HOST);
+            if (isTrustedDomain($domain)) {
                 return '<a href="'.url('/home/leaving?target='.$url).'" class="Popup">'.$text.'</a>'.$punc;
             }
         }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1520,7 +1520,7 @@ EOT;
 
         if (c('Garden.Format.WarnLeaving', false)) {
             $domain = parse_url($url, PHP_URL_HOST);
-            if (isTrustedDomain($domain)) {
+            if (!isTrustedDomain($domain)) {
                 return '<a href="'.url('/home/leaving?target='.$url).'" class="Popup">'.$text.'</a>'.$punc;
             }
         }

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1281,16 +1281,22 @@ class Gdn_Format {
         ];
 
         $key = '';
+        $matches = [];
 
         foreach ($embeds as $embedKey => $value) {
             foreach ($value['regex'] as $regex) {
                 if (preg_match($regex, $url, $matches)) {
-                    if (c('Garden.Format.'.$embedKey, true)) {
-                        $key = $embedKey;
-                    }
+                    $key = $embedKey;
                     break;
                 }
             }
+            if ($key !== '') {
+                break;
+            }
+        }
+
+        if (!c('Garden.Format.'.$key, true)) {
+            return '';
         }
 
         switch ($key) {

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3110,6 +3110,27 @@ if (!function_exists('safeImage')) {
     }
 }
 
+if (!function_exists('matchesTrustedDomain')) {
+    /**
+     * Tests whether a given url matches one of our trusted domains.
+     *
+     * @param string $url The url to test.
+     * @return bool Whether the url matches a trusted domain.
+     */
+    function matchesTrustedDomain($url = '') {
+        $url = url($url, true);
+        $trustedDomains = trustedDomains();
+
+        foreach ($trustedDomains as $trustedDomain) {
+            if (urlMatch($trustedDomain, $url)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
 if (!function_exists('safeRedirect')) {
     /**
      * Redirect, but only to a safe domain.
@@ -3118,20 +3139,12 @@ if (!function_exists('safeRedirect')) {
      * @param int $StatusCode The status of the redirect. Defaults to 302.
      */
     function safeRedirect($Destination = false, $StatusCode = null) {
+        $isTrustedDomain = matchesTrustedDomain($Destination);
+
         if (!$Destination) {
             $Destination = Url('', true);
         } else {
             $Destination = Url($Destination, true);
-        }
-
-        $trustedDomains = TrustedDomains();
-        $isTrustedDomain = false;
-
-        foreach ($trustedDomains as $trustedDomain) {
-            if (urlMatch($trustedDomain, $Destination)) {
-                $isTrustedDomain = true;
-                break;
-            }
         }
 
         if ($isTrustedDomain) {
@@ -3141,7 +3154,7 @@ if (!function_exists('safeRedirect')) {
                 'url' => $Destination
             ]);
 
-            redirect(url("/home/leaving?Target=".urlencode($Destination)));
+            redirect("/home/leaving?Target=".urlencode($Destination));
         }
     }
 }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3119,7 +3119,12 @@ if (!function_exists('matchesTrustedDomain')) {
      */
     function matchesTrustedDomain($url = '') {
         $url = url($url, true);
-        $trustedDomains = trustedDomains();
+
+        static $trustedDomains = [];
+
+        if (empty($trustedDomains)) {
+            $trustedDomains = trustedDomains();
+        }
 
         foreach ($trustedDomains as $trustedDomain) {
             if (urlMatch($trustedDomain, $url)) {

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3110,32 +3110,6 @@ if (!function_exists('safeImage')) {
     }
 }
 
-if (!function_exists('matchesTrustedDomain')) {
-    /**
-     * Tests whether a given url matches one of our trusted domains.
-     *
-     * @param string $url The url to test.
-     * @return bool Whether the url matches a trusted domain.
-     */
-    function matchesTrustedDomain($url = '') {
-        $url = url($url, true);
-
-        static $trustedDomains = [];
-
-        if (empty($trustedDomains)) {
-            $trustedDomains = trustedDomains();
-        }
-
-        foreach ($trustedDomains as $trustedDomain) {
-            if (urlMatch($trustedDomain, $url)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-}
-
 if (!function_exists('safeRedirect')) {
     /**
      * Redirect, but only to a safe domain.
@@ -3144,12 +3118,20 @@ if (!function_exists('safeRedirect')) {
      * @param int $StatusCode The status of the redirect. Defaults to 302.
      */
     function safeRedirect($Destination = false, $StatusCode = null) {
-        $isTrustedDomain = matchesTrustedDomain($Destination);
-
         if (!$Destination) {
             $Destination = Url('', true);
         } else {
             $Destination = Url($Destination, true);
+        }
+
+        $trustedDomains = TrustedDomains();
+        $isTrustedDomain = false;
+
+        foreach ($trustedDomains as $trustedDomain) {
+            if (urlMatch($trustedDomain, $Destination)) {
+                $isTrustedDomain = true;
+                break;
+            }
         }
 
         if ($isTrustedDomain) {


### PR DESCRIPTION
* Breaks the embed code replacement into its own function `embedReplacement($url)`, and optimizes and refactors the embed code replacement.
* ~Adds a `matchesTrustedDomain($url)` function to test whether a given url matches a trusted domain in the `linksCallback` function.~
* Adds a redirect to `/leaving` to any non-trusted link if the `Garden.Format.WarnLeaving` config is set.
* Adds a `reverse` param to the toggle to handle "disable"-type config settings.
* Adds controls for the `Garden.Format.WarnLeaving` and `Garden.Format.DisableUrlEmbeds` config settings to the Advanced settings page in the dashboard.
* Adds a title to the `/leaving` page.

Bonus:
* Fixes double-urling in the SafeRedirect function.
* Fixes Wistia and Twitch embeds

Closes https://github.com/vanilla/vanilla/issues/5334