### PR TITLE
Fix ProfileRequest Params in Class OAuth2

### DIFF
--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -384,7 +384,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
         $redirectUrls = Gdn::request()->url('/entry/'. $this->getProviderKey(), true, true);
         $sender->setData('redirectUrls', $redirectUrls);
 
-        $sender->render('settings', '', 'plugins/'.$view);
+        $sender->render('settings', '', $view);
     }
 
 

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -229,7 +229,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
      *
      * @return $this Return this object for chaining purposes.
      */
-    public function setRequestProfileParams($params = []) {
+    public function setRequestProfileParams(array $params) {
         $this->requestProfileParams = $params;
         return $this;
     }

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -46,7 +46,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
     protected $requestAccessTokenParams = [];
 
     /** @var array optional additional get params to be passed in the request for profile */
-    protected $profileRequestParams = [];
+    protected $requestProfileParams = [];
 
     /** @var  @var string optional set the settings view */
     protected $settingsView;
@@ -208,9 +208,11 @@ class Gdn_OAuth2 extends Gdn_Plugin {
 
 
     /**
-     * Set additional params to be added to the post array in the accessToken request.
+     * Set additional params to be to be merged with the default parameters
+     * in the access token request.
      *
-     * @param string $params.
+     * @param array $params Params to add to the access token request.
+     *
      * @return $this Return this object for chaining purposes.
      */
     public function setRequestAccessTokenParams($params) {
@@ -220,13 +222,15 @@ class Gdn_OAuth2 extends Gdn_Plugin {
 
 
     /**
-     * Set additional params to be added to the get string in the getProfile request.
+     * Set additional params to be to be merged with the default parameters
+     * in the getProfile request.
      *
-     * @param string $params.
+     * @param array $params Params to add to the get profile request.
+     *
      * @return $this Return this object for chaining purposes.
      */
-    public function setGetProfileParams($params) {
-        $this->getProfileParams = $params;
+    public function setRequestProfileParams($params = []) {
+        $this->requestProfileParams = $params;
         return $this;
     }
 
@@ -687,7 +691,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
         $defaultParams = array(
             'access_token' => $this->accessToken()
         );
-        $requestParams = array_merge($defaultParams, $this->profileRequestParams);
+        $requestParams = array_merge($defaultParams, $this->requestProfileParams);
 
         // Request the profile from the Authentication Provider
         $rawProfile = $this->api($uri, 'GET', $requestParams, $this->getProfileRequestOptions());


### PR DESCRIPTION
There has been a protected property called `$profileRequestParams` which couldn't be set anywhere and there had been a method `setGetProfileParams()` which was setting a never used (or even declared) property `$getProfileParams`.

I assume they should be connected because then they would allow plugin authors to add additional parameters to profile requests.

I've changed their names completely to reflect the already existing `$requestAccessTokenParams` and `setRequestAccessTokenParams()` to `$requestProfileParams` and `setRequestProfileParams()` accordingly.

<hr>

The default settings view has been 'plugins/oauth2'  and in the render() call it has prefixed with 'plugins/' a second time. That prefixing in the render call
a) results to "plugins/plugins/oauth2" for default view, which is obviously wrong and
b) hinders themes and addons to use the settings method of the class because no view could be set.