### PR TITLE
Make isTrustedDomain() work with URLs and use urlMatch()

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3727,7 +3727,7 @@ if (!function_exists('isTrustedDomain')) {
                 // Store the trusted domain by its host name.
                 if (strpos($domain, '//') === false) {
                     $domain = '//'.$domain;
-        }
+                }
                 $host = preg_replace('`^(\*?\.)`', '', parse_url($domain, PHP_URL_HOST));
                 $trusted[$host] = $domain;
             }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3532,6 +3532,11 @@ if (!function_exists('trustedDomains')) {
 
         $trustedDomains = array_merge($trustedDomains, $configuredDomains);
 
+        if (!c('Garden.Installed')) {
+            // Bail out here because we don't have a database yet.
+            return $trustedDomains;
+        }
+
         // Build a collection of authentication provider URLs.
         $authProviderModel = new Gdn_AuthenticationProviderModel();
         $providers = $authProviderModel->getProviders();
@@ -3697,32 +3702,45 @@ if (!function_exists('isSafeUrl')) {
 
 if (!function_exists('isTrustedDomain')) {
     /**
-     * Check the provided domain name to determine if it is a trusted domain.
+     * Check to see if a URL or domain name is in a trusted domain.
      *
-     * @param string $domain Domain name to compare against our list of trusted domains.
+     * @param string $url The URL or domain name to check.
      * @return bool True if verified as a trusted domain.  False if unable to verify domain.
      */
-    function isTrustedDomain($domain) {
-        static $trustedDomains = null;
+    function isTrustedDomain($url) {
+        static $trusted = null;
 
-        if (empty($domain)) {
+        if (empty($url)) {
             return false;
         }
 
-        // If we haven't already compiled an array of trusted domains, grab them.
-        if (!is_array($trustedDomains)) {
-            $trustedDomains = trustedDomains();
+        // Short circuit on our own domain.
+        if (urlMatch(Gdn::request()->host(), $url)) {
+            return true;
         }
 
-        /**
-         * Iterate through each of our trusted domains.
-         * Chop off any whitespace from the trusted domain and prepare it for regex.
-         * See if the current trusted domain matches fully against the domain we're
-         *   testing or if it matches its end (e.g. domain.tld should match domain.tld and sub.domain.tld)
-         */
-        foreach ($trustedDomains as $trustedDomain) {
-            $trustedDomain = preg_quote(trim($trustedDomain));
-            if (preg_match("/(^|\.){$trustedDomain}$/i", $domain)) {
+        // If we haven't already compiled an array of trusted domains, grab them.
+        if ($trusted === null) {
+            $trusted = [];
+            $trustedDomains = trustedDomains();
+            foreach ($trustedDomains as $domain) {
+                // Store the trusted domain by its host name.
+                if (strpos($domain, '//') === false) {
+                    $domain = '//'.$domain;
+        }
+                $host = preg_replace('`^(\*?\.)`', '', parse_url($domain, PHP_URL_HOST));
+                $trusted[$host] = $domain;
+            }
+        }
+
+        // Make sure the domain.
+        if (strpos($url, '//') === false) {
+            $url = '//'.$url;
+        }
+
+        // Check the URL against all domains by host part.
+        for ($host = parse_url($url, PHP_URL_HOST); !empty($host); $host = ltrim(strstr($host, '.'), '.')) {
+            if (isset($trusted[$host]) && urlMatch($trusted[$host], $url)) {
                 return true;
             }
         }
@@ -3929,6 +3947,9 @@ if (!function_exists('urlMatch')) {
      * @return bool Returns **true** if {@link $url} matches against {@link $pattern} or **false** otherwise.
      */
     function urlMatch($pattern, $url) {
+        if (empty($pattern)) {
+            return false;
+        }
         $urlParts = parse_url($url);
         $patternParts = parse_url($pattern);
 

--- a/tests/Library/Core/GeneralFunctionsTest.php
+++ b/tests/Library/Core/GeneralFunctionsTest.php
@@ -88,7 +88,14 @@ class GeneralFunctionsTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideTrustedDomainConfigs
      */
     public function testIsTrustedDomainConfig($url, $expected) {
-        saveToConfig('Garden.TrustedDomains', "foo.com\n https://bar.com\nhttps://baz.com/entry/*", false);
+        $trustedDomains = [
+            '*.foo.com',
+            ' https://bar.com',
+            'https://baz.com/entry/*',
+            'example.*',
+            'domain.com'
+        ];
+        saveToConfig('Garden.TrustedDomains', implode("\n", $trustedDomains), false);
 
         $r = isTrustedDomain($url);
         $this->assertSame($expected, $r);
@@ -101,12 +108,15 @@ class GeneralFunctionsTest extends \PHPUnit_Framework_TestCase {
      */
     public function provideTrustedDomainConfigs() {
         $r = [
-            'domain url' => ['http://foo.com', true],
-            'domain domain' => ['foo.com', true],
+            'domain url' => ['http://domain.com', true],
+            'domain domain' => ['domain.com', true],
+            'wildcard domain 1' => ['www.foo.com', true],
+            'wildcard domain 2' => ['https://www.foo.com', true],
+            'wildcard domain 3' => ['example.evildomain.com', false],
             'scheme mismatch' => ['http://bar.com', false],
             'path mismatch' => ['https://bar.com/another', false],
             'wildcard path 1' => ['https://baz.com/entry', true],
-            'wildcard path 2' => ['https://baz.com/entry/signin', true],
+            'wildcard path 2' => ['https://baz.com/entry/signin', true]
         ];
 
         return $r;

--- a/tests/Library/Core/GeneralFunctionsTest.php
+++ b/tests/Library/Core/GeneralFunctionsTest.php
@@ -58,6 +58,7 @@ class GeneralFunctionsTest extends \PHPUnit_Framework_TestCase {
      */
     public function provideUrlMatchTests() {
         $r = [
+            'empty pattern' => ['', 'http://example.com', false],
             'equals' => ['foo.com', 'http://foo.com', true],
             'equals 2' => ['foo.com', 'http://foo.com/', true],
             'wildcard path' => ['foo.com/bar/*', 'http://foo.com/bar', true],
@@ -74,6 +75,40 @@ class GeneralFunctionsTest extends \PHPUnit_Framework_TestCase {
             'bad substring domain' => ['*.foo.com', 'http://xssfoo.com', false],
             'bad substring domain 2' => ['foo.com', 'http://xssfoo.com', false],
         ];
+        return $r;
+    }
+
+    /**
+     * Test some {@link isTrustedDomain()} from the config.
+     *
+     * Note that since isTrustedDomain caches a copy of the trusted domains this unit test might fail if it isn't the only one.
+     *
+     * @param string $url The URL to test.
+     * @param bool $expected The expected result from {@link isTrustedDomain()}.
+     * @dataProvider provideTrustedDomainConfigs
+     */
+    public function testIsTrustedDomainConfig($url, $expected) {
+        saveToConfig('Garden.TrustedDomains', "foo.com\n https://bar.com\nhttps://baz.com/entry/*", false);
+
+        $r = isTrustedDomain($url);
+        $this->assertSame($expected, $r);
+    }
+
+    /**
+     * Provide tests for {@link testIsTrustedDomainConfig()}.
+     *
+     * @return array Returns a data provider.
+     */
+    public function provideTrustedDomainConfigs() {
+        $r = [
+            'domain url' => ['http://foo.com', true],
+            'domain domain' => ['foo.com', true],
+            'scheme mismatch' => ['http://bar.com', false],
+            'path mismatch' => ['https://bar.com/another', false],
+            'wildcard path 1' => ['https://baz.com/entry', true],
+            'wildcard path 2' => ['https://baz.com/entry/signin', true],
+        ];
+
         return $r;
     }
 }


### PR DESCRIPTION
Add the following functionality to isTrustedDomain():

- You can now pass a URL or a domain to isTrustedDomain().
- The domains in the whitelist accept schemes and glob style wildcards.
- The comparison between domains is a bit more efficient.

Note that this breaks some BC where before we accepted regexes in the
domains. IMO freeform regexes should be discouraged more and more. I’m
not sure where they have been used though.