### PR TITLE
Handle leaving urls already in anchor tags

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1478,6 +1478,15 @@ EOT;
             $inTag--;
         }
 
+        if (c('Garden.Format.WarnLeaving', false) && isset($matches[4]) && $inAnchor) {
+            // This is a the href url value in an anchor tag.
+            $url = $matches[4];
+            $domain = parse_url($url, PHP_URL_HOST);
+            if (!isTrustedDomain($domain)) {
+                return url('/home/leaving?target='.$url).'" class="Popup';
+            }
+        }
+
         if (!isset($matches[4]) || $inTag || $inAnchor) {
             return $matches[0];
         }
@@ -1519,6 +1528,7 @@ EOT;
         $nofollow = (self::$DisplayNoFollow) ? ' rel="nofollow"' : '';
 
         if (c('Garden.Format.WarnLeaving', false)) {
+            // This is a plaintext url we're converting into an anchor.
             $domain = parse_url($url, PHP_URL_HOST);
             if (!isTrustedDomain($domain)) {
                 return '<a href="'.url('/home/leaving?target='.$url).'" class="Popup">'.$text.'</a>'.$punc;


### PR DESCRIPTION
Handle leaving urls already in anchor tags. The linksCallback function adds an anchor to plaintext links in a post. If the anchor already exists, it ignores it.

This replaces the url in the case where the link is already in an anchor.