### PR TITLE
Add the EventManager::fireDeprecated() method

### DIFF
--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -221,8 +221,8 @@ class EventManager {
      * Fire an event.
      *
      * @param string $event The name of the event.
-     * @param array $args Any arguments to pass along to the event handlers.
-     * @return mixed Returns the result of the last event handler.
+     * @param mixed ...$args Any arguments to pass along to the event handlers.
+     * @return array Returns the result of the event handlers where each handler's result is an item in the array.
      */
     public function fire($event, ...$args) {
         $handlers = $this->getHandlers($event);
@@ -247,6 +247,25 @@ class EventManager {
         }
 
         return $result;
+    }
+
+    /**
+     * Fire a deprecated event.
+     *
+     * This method is the same as {@link EventManager::fire()} except will fire an additional "eventManager_fireDeprecated"
+     * event if any handlers exist. The purpose is to allow applications to refactor events and support old event handlers.
+     *
+     * @param string $event The name of the event.
+     * @param mixed ...$args Any arguments to pass along to the event handlers.
+     * @return array Returns the result of the event handlers.
+     */
+    public function fireDeprecated($event, ...$args) {
+        if ($this->hasHandler($event)) {
+            $this->fire('eventManager_fireDeprecated', $this, $event, $args);
+
+            return $this->fire($event, ...$args);
+        }
+        return [];
     }
 
     /**

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -252,8 +252,8 @@ class EventManager {
     /**
      * Fire a deprecated event.
      *
-     * This method is the same as {@link EventManager::fire()} except will fire an additional "eventManager_fireDeprecated"
-     * event if any handlers exist. The purpose is to allow applications to refactor events and support old event handlers.
+     * This method is the same as {@link EventManager::fire()} except will trigger an *E_USER_DEPRECATED* notice if there
+     * are any event handlers.
      *
      * @param string $event The name of the event.
      * @param mixed ...$args Any arguments to pass along to the event handlers.
@@ -261,8 +261,7 @@ class EventManager {
      */
     public function fireDeprecated($event, ...$args) {
         if ($this->hasHandler($event)) {
-            $this->fire('eventManager_fireDeprecated', $this, $event, $args);
-
+            trigger_error("The $event event is deprecated.", E_USER_DEPRECATED);
             return $this->fire($event, ...$args);
         }
         return [];


### PR DESCRIPTION
This method is in place to allow us to start to remove some events we don’t want anymore.