### PR TITLE
Fix inline doc for trusted domain wildcards

### DIFF
--- a/applications/vanilla/views/vanillasettings/advanced.php
+++ b/applications/vanilla/views/vanillasettings/advanced.php
@@ -101,7 +101,7 @@ echo $this->Form->errors();
                     );
                     ?>
                     </p>
-                    <p><strong><?php echo t('Note'); ?>:</strong> <?php echo t('Specify one domain per line. Use * for wildcard matches.'); ?></p>
+                    <p><strong><?php echo t('Note'); ?>:</strong> <?php echo t('Specify one domain per line. All subdomains are allowed if none is specified.'); ?></p>
                 </div>
             </div>
             <div class="input-wrap">


### PR DESCRIPTION
From dashboard inline docs:

> Use * as a wildcard.

This is incorrect.

From `isTrustedDomain()`:

 > See if the current trusted domain matches fully against the domain we're testing or if it matches its end (e.g. domain.tld should match domain.tld and sub.domain.tld)

Fixed this in the dashboard.