### PR TITLE
Replace dirname(__FILE__) with __DIR__

### DIFF
--- a/applications/dashboard/models/class.logmodel.php
+++ b/applications/dashboard/models/class.logmodel.php
@@ -199,7 +199,7 @@ class LogModel extends Gdn_Pluggable {
         static $TinyDiff = null;
 
         if ($TinyDiff === null) {
-            require_once(dirname(__FILE__).'/tiny_diff.php');
+            require_once(__DIR__.'/tiny_diff.php');
             $TinyDiff = new Tiny_diff();
         }
 

--- a/applications/dashboard/views/log/edits.php
+++ b/applications/dashboard/views/log/edits.php
@@ -19,8 +19,8 @@ echo $this->Form->open();
 <?php
 
 echo '<div id="LogTable">';
-include dirname(__FILE__).'/table.php';
-echo '</div id="LogTable">';
+include __DIR__.'/table.php';
+echo '</div>';
 ?>
 <?php
 

--- a/applications/dashboard/views/log/moderation.php
+++ b/applications/dashboard/views/log/moderation.php
@@ -31,7 +31,7 @@ echo heading($this->data('Title'));
 <?php
 echo '<div id="LogTable">';
 include dirname(__FILE__).'/table.php';
-echo '</div id="LogTable">';
+echo '</div>';
 ?>
 <?php
 $this->addDefinition('ExpandText', t('more'));

--- a/applications/dashboard/views/log/record.php
+++ b/applications/dashboard/views/log/record.php
@@ -20,8 +20,8 @@ echo $this->Form->open();
 <?php
 
 echo '<div id="LogTable">';
-include dirname(__FILE__).'/table.php';
-echo '</div id="LogTable">';
+include __DIR__.'/table.php';
+echo '</div>';
 ?>
 <?php
 $this->addDefinition('ExpandText', t('more'));

--- a/applications/dashboard/views/log/spam.php
+++ b/applications/dashboard/views/log/spam.php
@@ -19,8 +19,8 @@ echo $this->Form->open();
 <?php
 
 echo '<div id="LogTable">';
-include dirname(__FILE__).'/table.php';
-echo '</div id="LogTable">';
+include __DIR__.'/table.php';
+echo '</div>';
 ?>
 <?php
 

--- a/applications/dashboard/views/settings/bans.php
+++ b/applications/dashboard/views/settings/bans.php
@@ -1,5 +1,4 @@
-<?php if (!defined('APPLICATION')) exit(); ?>
-<?php
+<?php if (!defined('APPLICATION')) exit();
 echo heading($this->data('Title'), t('Add Ban Rule'), '/dashboard/settings/bans/add', 'btn btn-primary js-modal');
 $help = t('You can ban IP addresses, email addresses and usernames.');
 $help .= ' '.t('Specify a partial or full match when creating a ban.');
@@ -17,7 +16,7 @@ if (empty($this->data('Bans', []))) {
     echo hero($title, $body);
 } else {
     echo '<div id="BansTable">';
-    include dirname(__FILE__).'/banstable.php';
+    include __DIR__.'/banstable.php';
     echo '</div>';
 }
 

--- a/applications/vanilla/models/class.vanillasearchmodel.php
+++ b/applications/vanilla/models/class.vanillasearchmodel.php
@@ -30,7 +30,7 @@ class VanillaSearchModel extends Gdn_Model {
             $this->_DiscussionModel = $Value;
         }
         if ($this->_DiscussionModel === false) {
-            require_once(dirname(__FILE__).DS.'class.discussionmodel.php');
+            require_once(__DIR__.DS.'class.discussionmodel.php');
             $this->_DiscussionModel = new DiscussionModel();
         }
         return $this->_DiscussionModel;

--- a/plugins/Debugger/default.php
+++ b/plugins/Debugger/default.php
@@ -79,7 +79,7 @@ class DebuggerPlugin extends Gdn_Plugin {
      */
     public function gdn_pluginManager_afterStart_handler($sender) {
         $tmp = Gdn::factoryOverwrite(true);
-        Gdn::factoryInstall(Gdn::AliasDatabase, 'Gdn_DatabaseDebug', dirname(__FILE__).DS.'class.databasedebug.php', Gdn::FactorySingleton, array('Database'));
+        Gdn::factoryInstall(Gdn::AliasDatabase, 'Gdn_DatabaseDebug', __DIR__.DS.'class.databasedebug.php', Gdn::FactorySingleton, array('Database'));
         Gdn::factoryOverwrite($tmp);
         unset($tmp);
     }

--- a/showpost.php
+++ b/showpost.php
@@ -4,4 +4,4 @@
  * vBulletin into their Vanilla equivalent pages.
  */
 
-include_once dirname(__FILE__).'/showthread.php';
+include_once __DIR__.'/showthread.php';

--- a/themes/default/views
+++ b/themes/default/views
@@ -1,0 +1,1 @@
+/var/www/vanilla/themes/default/views/

--- a/themes/default/views
+++ b/themes/default/views
@@ -1,1 +1,0 @@
-/var/www/vanilla/themes/default/views/

--- a/viewtopic.php
+++ b/viewtopic.php
@@ -4,4 +4,4 @@
  * vBulletin into their Vanilla equivalent pages.
  */
 
-include_once dirname(__FILE__).'/showthread.php';
+include_once __DIR__.'/showthread.php';


### PR DESCRIPTION
dirname(__FILE__) has been used on several places, but since PHP 5.3 the identical magical constant __DIR__ is available and saves one function call.

There were some id attribute relicts in closing divs (in the log views) which I have removed, too.