### PR TITLE
Fix the flood control check

### DIFF
--- a/applications/conversations/models/class.conversationmessagemodel.php
+++ b/applications/conversations/models/class.conversationmessagemodel.php
@@ -209,7 +209,9 @@ class ConversationMessageModel extends ConversationsModel {
         $this->fireEvent('BeforeSaveValidation');
 
         // Determine if spam check should be skipped.
-        $this->setFloodControlEnabled(empty($Options['NewConversation']));
+        if (!$Session->User->Admin && !$Session->checkPermission('Garden.Moderation.Manage')) {
+            $this->setFloodControlEnabled(empty($Options['NewConversation']));
+        }
 
         // Validate the form posted values
         $MessageID = false;

--- a/library/Vanilla/FloodControlTrait.php
+++ b/library/Vanilla/FloodControlTrait.php
@@ -169,16 +169,12 @@ trait FloodControlTrait {
 
         $isSpamming = false;
         $countSpamCheck = $storageObject->get($userPostCountKey, 0);
-        $dateSpamCheck = $storageObject->get($userLastDateCheckedKey, date('Y-m-d H:i:s'));
-        $dateSpamCheckTime = strtotime($dateSpamCheck);
-        if (!$dateSpamCheckTime) {
-            $dateSpamCheckTime = time();
-        }
-        $secondsSinceSpamCheck = time() - $dateSpamCheckTime;
+        $dateSpamCheck = $storageObject->get($userLastDateCheckedKey, null);
+        $secondsSinceSpamCheck = time() - (int)strtotime($dateSpamCheck);
 
         // Apply a spam lock if necessary
         $attributes = [];
-        if ($secondsSinceSpamCheck < $this->lockTime && $countSpamCheck >= $this->postCountThreshold) {
+        if ($dateSpamCheck !== null && $secondsSinceSpamCheck < $this->lockTime && $countSpamCheck >= $this->postCountThreshold) {
             $isSpamming = true;
             // Update the 'waiting period' every time they try to post again
             $attributes[$userLastDateCheckedKey] = date('Y-m-d H:i:s');


### PR DESCRIPTION
As the title says.
Make sure that admins are not affected when enabling flood control for conversation messages.
The fix is already backported.