### PR TITLE
Add integrity check when downsizing a varchar column

### DIFF
--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -585,7 +585,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
                             Logger::event(
                                 'structure_integrity',
                                 Logger::ALERT,
-                                "Cannot modify {tableName}'s column {column} because it has a value of {maxVarcharLength,number} and the new length is {newLength,number} threshold.",
+                                "Cannot modify {tableName}'s column {column} because it has a value that is {maxVarcharLength,number} and the new length is {newLength,number}.",
                                 [
                                     'tableName' => $this->tableName(),
                                     'column' => $ColumnName,

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -501,6 +501,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         $existingColumns = array_change_key_case($this->existingColumns());
         $columns = array_change_key_case($this->_Columns);
         $AlterSql = array();
+        $InvalidAlterSqlCount = 0;
 
         // 1. Remove any unnecessary columns if this is an explicit modification
         if ($Explicit) {
@@ -569,9 +570,13 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
 
                 $ExistingColumnDef = $this->_defineColumn($ExistingColumn);
                 $ColumnDef = $this->_defineColumn($Column);
-                $Comment = "-- Existing: $ExistingColumnDef, New: $ColumnDef";
+                $Comment = "-- [Existing: $ExistingColumnDef, New: $ColumnDef]";
 
                 if ($ExistingColumnDef !== $ColumnDef) {
+
+                    // The existing & new column types do not match, so modify the column.
+                    $ChangeSql = "$Comment\nchange `{$ExistingColumn->Name}` $ColumnDef";
+
                     if (strcasecmp($ExistingColumn->Type, 'varchar') === 0 && strcasecmp($Column->Type, 'varchar') === 0
                             && $ExistingColumn->Length > $Column->Length) {
 
@@ -579,27 +584,32 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
                             ->firstRow(DATASET_TYPE_ARRAY);
 
                         if ($charLength['MaxLength'] > $Column->Length) {
-                            $this->addIssue("The table's column was not altered because it contains a varchar of length {$charLength['MaxLength']}.", $Comment);
+                            if ($this->CaptureOnly) {
+                                $ChangeSql = str_replace($Comment."\n", $Comment."\n-- [Integrity Error: The column contains data ({$charLength['MaxLength']} characters) that would be truncated]\n-- ", $ChangeSql);
+                                $InvalidAlterSqlCount++;
+                            } else {
+                                $this->addIssue("The table's column was not altered because it contains a varchar of length {$charLength['MaxLength']}.", $Comment);
 
-                            // Log an event to be captured and analysed later.
-                            Logger::event(
-                                'structure_integrity',
-                                Logger::ALERT,
-                                "Cannot modify {tableName}'s column {column} because it has a value that is {maxVarcharLength,number} characters long and the new length is {newLength,number}.",
-                                [
-                                    'tableName' => $this->tableName(),
-                                    'column' => $ColumnName,
-                                    'maxVarcharLength' => $charLength['MaxLength'],
-                                    'newLength' => $Column->Length,
-                                    'oldLength' => $ExistingColumn->Length,
-                                ]
-                            );
-                            continue;
+                                // Log an event to be captured and analysed later.
+                                Logger::event(
+                                    'structure_integrity',
+                                    Logger::ALERT,
+                                    "Cannot modify {tableName}'s column {column} because it has a value that is {maxVarcharLength,number} characters long and the new length is {newLength,number}.",
+                                    [
+                                        'tableName' => $this->tableName(),
+                                        'column' => $ColumnName,
+                                        'maxVarcharLength' => $charLength['MaxLength'],
+                                        'newLength' => $Column->Length,
+                                        'oldLength' => $ExistingColumn->Length,
+                                    ]
+                                );
+
+                                // Skip adding the column to the query.
+                                continue;
+                            }
                         }
                     }
 
-                    // The existing & new column types do not match, so modify the column.
-                    $ChangeSql = "$Comment\nchange `{$ExistingColumn->Name}` $ColumnDef";
                     $AlterSql[] = $ChangeSql;
 
                     // Check for a modification from an enum to an int.
@@ -637,8 +647,12 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
             $AlterSql[] = "convert to $charsetSql";
         }
 
-        if (count($AlterSql) > 0) {
-            if (!$this->executeQuery($AlterSqlPrefix.implode(",\n", $AlterSql), true)) {
+        if (count($AlterSql)) {
+            $BuiltQuery = $AlterSqlPrefix.implode(",\n", $AlterSql);
+            if (count($AlterSql) === $InvalidAlterSqlCount) {
+                $BuiltQuery = '-- '.$BuiltQuery;
+            }
+            if (!$this->executeQuery($BuiltQuery, true)) {
                 throw new Exception(sprintf(T('Failed to alter the `%s` table.'), $this->_DatabasePrefix.$this->_TableName));
             }
         }

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -575,7 +575,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
                     if (strcasecmp($ExistingColumn->Type, 'varchar') === 0 && strcasecmp($Column->Type, 'varchar') === 0
                             && $ExistingColumn->Length > $Column->Length) {
 
-                        $charLength = $this->executeQuery("select max(char_length(`$ColumnName`)) as MaxLength from `$Px{$this->_TableName}`;")
+                        $charLength = $this->Database->query("select max(char_length(`$ColumnName`)) as MaxLength from `$Px{$this->_TableName}`;")
                             ->firstRow(DATASET_TYPE_ARRAY);
 
                         if ($charLength['MaxLength'] > $Column->Length) {

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -572,7 +572,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
                 $Comment = "-- Existing: $ExistingColumnDef, New: $ColumnDef";
 
                 if ($ExistingColumnDef !== $ColumnDef) {
-                    if (strcasecmp($ExistingColumn->Type, 'varchar') === 0&& strcasecmp($Column->Type, 'varchar') === 0
+                    if (strcasecmp($ExistingColumn->Type, 'varchar') === 0 && strcasecmp($Column->Type, 'varchar') === 0
                             && $ExistingColumn->Length > $Column->Length) {
 
                         $charLength = $this->executeQuery("select max(char_length(`$ColumnName`)) as MaxLength from `$Px{$this->_TableName}`;")

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -585,7 +585,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
                             Logger::event(
                                 'structure_integrity',
                                 Logger::ALERT,
-                                "Cannot modify {tableName}'s column {column} because it has a value that is {maxVarcharLength,number} and the new length is {newLength,number}.",
+                                "Cannot modify {tableName}'s column {column} because it has a value that is {maxVarcharLength,number} characters long and the new length is {newLength,number}.",
                                 [
                                     'tableName' => $this->tableName(),
                                     'column' => $ColumnName,

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -585,7 +585,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
                             Logger::event(
                                 'structure_integrity',
                                 Logger::ALERT,
-                                "Cannot modify {tableName}'s column {column} because it has a value of {maxVarcharLength,number} and the new length it {rowThreshold,number} threshold.",
+                                "Cannot modify {tableName}'s column {column} because it has a value of {maxVarcharLength,number} and the new length is {newLength,number} threshold.",
                                 [
                                     'tableName' => $this->tableName(),
                                     'column' => $ColumnName,


### PR DESCRIPTION
Skip the alteration if the column content is larger than the new size.

This will ensure that we do not corrupt data while shrinking column size when fixing https://github.com/vanilla/vanilla/issues/5284