### PR TITLE
Handle CodeSpan properly in MarkdowVanilla

### DIFF
--- a/library/core/class.markdownvanilla.php
+++ b/library/core/class.markdownvanilla.php
@@ -221,17 +221,7 @@ class MarkdownVanilla extends \Michelf\MarkdownExtra {
      * @return string
      */
     protected function makeCodeSpan($code) {
-        if ($this->code_span_content_func) {
-            $code = call_user_func($this->code_span_content_func, $code);
-        } else {
-            $code = htmlspecialchars(trim($code), ENT_NOQUOTES);
-        }
-
-        # Vanilla: add 2 lines below to do <pre><code> if there are newlines in the code.
-        if (strpos($code, "\n")) {
-            return $this->hashPart("<pre><code>$code</code></pre>");
-        } else {
-            return $this->hashPart("<code>$code</code>");
-        }
+        $code = str_replace(["\r", "\n"], ' ', $code);
+        return parent::makeCodeSpan($code);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/2445
Replace https://github.com/vanilla/htmlawed/pull/7

Here is my test post:

`````
```
This is a paragraph.

`echo 'one';
echo 'two';`
```

This is a paragraph.

`echo 'one';
echo 'two';`

-------
````
This is a paragraph.

```
echo 'one';
echo 'two';
```
````
This is a paragraph.

```
echo 'one';
echo 'two';
```
-------
````
This is a paragraph.

```echo 'one';
echo 'two';
```
````
This is a paragraph.

```echo 'one';
echo 'two';
```
`````

and the result: 
![screen shot 2017-04-04 at 1 59 24 pm](https://cloud.githubusercontent.com/assets/2412909/24671288/fc2b5b32-193e-11e7-9a95-75cf1cd4fda8.png)
