### PR TITLE
Always invalidate identity if the session's user is invalid

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -425,8 +425,6 @@ class Gdn_Session {
         $this->UserID = $UserID !== false ? $UserID : Gdn::authenticator()->getIdentity();
         $this->User = false;
 
-        $this->ensureTransientKey();
-
         // Now retrieve user information
         if ($this->UserID > 0) {
             // Instantiate a UserModel to get session info
@@ -470,6 +468,9 @@ class Gdn_Session {
                 }
             }
         }
+
+        $this->ensureTransientKey();
+
         // Load guest permissions if necessary
         if ($this->UserID == 0) {
             $guestPermissions = $UserModel->getPermissions(0);


### PR DESCRIPTION
Fix https://github.com/vanilla/vanilla/issues/5407

ensureTransientKey compare the current UserID with the cookie saved UserID.
Since it is possible the the UserID is set to 0 if the user does not exist I moved the function call after the check.