### PR TITLE
Support automatic pruning in UserAuthenticationToken table

### DIFF
--- a/applications/dashboard/models/class.userauthenticationtokenmodel.php
+++ b/applications/dashboard/models/class.userauthenticationtokenmodel.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Manage user authentication tokens.
+ *
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+class UserAuthenticationTokenModel extends Gdn_Model {
+    use \Vanilla\PrunableTrait;
+
+    /**
+     * Class constructor. Defines the related database table name.
+     */
+    public function __construct() {
+        parent::__construct('UserAuthenticationToken');
+        $this->setPruneField('Timestamp');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function insert($fields) {
+        $this->prune();
+        return parent::insert($fields);
+    }
+
+    /**
+     * Lookup a token, based on a user ID and a provider authentication key.
+     *
+     * @param int $userID
+     * @param string $authKey
+     * @return bool|array A UserAuthenticationToken row on success, false on failure.
+     */
+    public function getByAuth($userID, $authKey) {
+        $result = false;
+
+        $row = $this->SQL->select('uat.*')
+            ->from('UserAuthenticationToken uat')
+            ->join('UserAuthentication ua', 'ua.ForeignUserKey = uat.ForeignUserKey')
+            ->where('ua.UserID', $userID)
+            ->where('ua.ProviderKey', $authKey)
+            ->limit(1)
+            ->get();
+        if ($row->numRows()) {
+            $result = $row->firstRow(DATASET_TYPE_ARRAY);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Lookup a valid token row, accounting for lifespans.
+     *
+     * @param string $providerKey
+     * @param string $userKey
+     * @param string|null $tokenType
+     * @return array|bool|stdClass
+     */
+    public function lookup($providerKey, $userKey, $tokenType = null) {
+        $row = Gdn::database()->sql()
+            ->select('uat.*')
+            ->from('UserAuthenticationToken uat')
+            ->where('uat.ForeignUserKey', $userKey)
+            ->where('uat.ProviderKey', $providerKey)
+            ->beginWhereGroup()
+            ->where('(uat.Timestamp + uat.Lifetime) >=', 'NOW()', true, false)
+            ->orWhere('uat.Lifetime', 0)
+            ->endWhereGroup()
+            ->get()
+            ->firstRow(DATASET_TYPE_ARRAY);
+        $result = false;
+
+        if ($row && ($tokenType === null || strtolower($tokenType) == strtolower($row['TokenType']))) {
+            $result = $row;
+        }
+
+        return $result;
+    }
+}

--- a/applications/dashboard/models/class.userauthenticationtokenmodel.php
+++ b/applications/dashboard/models/class.userauthenticationtokenmodel.php
@@ -22,6 +22,7 @@ class UserAuthenticationTokenModel extends Gdn_Model {
      */
     public function insert($fields) {
         $this->prune();
+
         return parent::insert($fields);
     }
 

--- a/library/core/class.authenticator.php
+++ b/library/core/class.authenticator.php
@@ -344,7 +344,7 @@ abstract class Gdn_Authenticator extends Gdn_Pluggable {
             'TokenType' => $TokenType,
             'ProviderKey' => $ProviderKey,
             'Lifetime' => $Lifetime,
-            'Authorized' => $Authorized,
+            'Authorized' => ($Authorized ? 1 : 0),
             'ForeignUserKey' => null
         );
 

--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -749,16 +749,21 @@ class TwitterPlugin extends Gdn_Plugin {
     /**
      *
      *
-     * @param $Token
+     * @param $token
      * @return null|OAuthToken
      */
-    public function getOAuthToken($Token) {
-        $Row = Gdn::sql()->getWhere('UserAuthenticationToken', array('Token' => $Token, 'ProviderKey' => self::ProviderKey))->firstRow(DATASET_TYPE_ARRAY);
-        if ($Row) {
-            return new OAuthToken($Row['Token'], $Row['TokenSecret']);
-        } else {
-            return null;
+    public function getOAuthToken($token) {
+        $uatModel = new UserAuthenticationTokenModel();
+        $result = null;
+        $row = $uatModel->getWhere([
+            'Token' => $token,
+            'ProviderKey' => self::ProviderKey
+        ])->firstRow(DATASET_TYPE_ARRAY);
+
+        if ($row) {
+            $result = new OAuthToken($row['Token'], $row['TokenSecret']);
         }
+        return $result;
     }
 
     /**
@@ -801,38 +806,46 @@ class TwitterPlugin extends Gdn_Plugin {
     /**
      *
      *
-     * @param $Token
-     * @param null $Secret
-     * @param string $Type
+     * @param $token
+     * @param null $secret
+     * @param string $type
      */
-    public function setOAuthToken($Token, $Secret = null, $Type = 'request') {
-        if (is_a($Token, 'OAuthToken')) {
-            $Secret = $Token->secret;
-            $Token = $Token->key;
+    public function setOAuthToken($token, $secret = null, $type = 'request') {
+        $uatModel = new UserAuthenticationTokenModel();
+
+        if (is_a($token, 'OAuthToken')) {
+            $secret = $token->secret;
+            $token = $token->key;
         }
 
         // Insert the token.
-        $Data = array(
-            'Token' => $Token,
+        $data = [
+            'Token' => $token,
             'ProviderKey' => self::ProviderKey,
-            'TokenSecret' => $Secret,
-            'TokenType' => $Type,
+            'TokenSecret' => $secret,
+            'TokenType' => $type,
             'Authorized' => false,
-            'Lifetime' => 60 * 5);
-        Gdn::sql()->options('Ignore', true)->insert('UserAuthenticationToken', $Data);
+            'Lifetime' => 60 * 5
+        ];
+        $uatModel->insert($data);
     }
 
     /**
      *
      *
-     * @param $Token
+     * @param $token
      */
-    public function deleteOAuthToken($Token) {
-        if (is_a($Token, 'OAuthToken')) {
-            $Token = $Token->key;
+    public function deleteOAuthToken($token) {
+        $uatModel = new UserAuthenticationTokenModel();
+
+        if (is_a($token, 'OAuthToken')) {
+            $token = $token->key;
         }
 
-        Gdn::sql()->delete('UserAuthenticationToken', array('Token' => $Token, 'ProviderKey' => self::ProviderKey));
+        $uatModel->delete([
+            'Token' => $token,
+            'ProviderKey' => self::ProviderKey
+        ]);
     }
 
     /**

--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -809,25 +809,34 @@ class TwitterPlugin extends Gdn_Plugin {
      * @param $token
      * @param null $secret
      * @param string $type
+     * @return bool
      */
     public function setOAuthToken($token, $secret = null, $type = 'request') {
         $uatModel = new UserAuthenticationTokenModel();
+        $result = false;
 
         if (is_a($token, 'OAuthToken')) {
             $secret = $token->secret;
             $token = $token->key;
         }
 
-        // Insert the token.
-        $data = [
-            'Token' => $token,
-            'ProviderKey' => self::ProviderKey,
+        $set = [
             'TokenSecret' => $secret,
             'TokenType' => $type,
-            'Authorized' => false,
+            'Authorized' => 0,
             'Lifetime' => 60 * 5
         ];
-        $uatModel->insert($data);
+        $where = [
+            'Token' => $token,
+            'ProviderKey' => self::ProviderKey
+        ];
+        $row = $uatModel->getWhere($where, '', '', 1)->firstRow();
+
+        if ($row === false) {
+            $result = $uatModel->insert(array_merge($set, $where));
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
This update adds support for automatic pruning of records in the UserAuthenticationToken table. A new model has been added: `UserAuthenticationTokenModel`. This model implements `Vanilla\PrunableTrait` and calls its `prune` function whenever new records are inserted with `UserAuthenticationTokenModel::insert`.

`Gdn_Authenticator ` and the Twitter plug-in have been updated to use `UserAuthenticationTokenModel`.

Closes #5064 