### PR TITLE
Simplify parsing orders in formatters

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1948,7 +1948,7 @@ EOT;
      * Takes a mixed variable, formats it for display on the screen as plain text.
      *
      * @param mixed $mixed An object, array, or string to be formatted.
-     * @return string
+     * @return string Sanitized HTML.
      */
     public static function text($mixed, $addBreaks = true) {
         if (!is_string($mixed)) {
@@ -1977,13 +1977,17 @@ EOT;
      * Process as plain text + our magic formatting.
      *
      * @param string $Str
-     * @return string
+     * @return string Sanitized HTML.
      * @since 2.1
      */
     public static function textEx($Str) {
         $Str = self::text($Str);
         $Str = Gdn_Format::processHTML($Str);
-        return $Str;
+
+        // Always filter as the last step.
+        $Sanitized = Gdn_Format::htmlFilter($Str);
+
+        return $Sanitized;
     }
 
     /**

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -263,10 +263,10 @@ class Gdn_Format {
     }
 
     /**
-     * Takes a mixed variable.
+     * Format BBCode into HTML.
      *
      * @param mixed $Mixed An object, array, or string to be formatted.
-     * @return string
+     * @return string Sanitized HTML.
      */
     public static function bbCode($Mixed) {
         if (!is_string($Mixed)) {

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1620,35 +1620,37 @@ EOT;
     }
 
     /**
-     * Format a string using Markdown syntax. Also purifies the output HTML.
+     * Format a string using Markdown syntax.
      *
      * @param mixed $Mixed An object, array, or string to be formatted.
-     * @param boolean $Flavored Optional. Parse with Vanilla-flavored settings? Default true
-     * @return string
+     * @param boolean $Flavored Optional. Parse with Vanilla-flavored settings? Default true.
+     * @return string Sanitized HTML.
      */
     public static function markdown($Mixed, $Flavored = true) {
         if (!is_string($Mixed)) {
             return self::to($Mixed, 'Markdown');
         } else {
-            $Formatter = Gdn::factory('HtmlFormatter');
-            if (is_null($Formatter)) {
-                return Gdn_Format::display($Mixed);
-            } else {
-                $Markdown = new MarkdownVanilla();
+            $Markdown = new MarkdownVanilla();
 
-                // Add Vanilla customizations.
-                if ($Flavored) {
-                    $Markdown->addAllFlavor();
-                }
-
-                // Format mentions early since @_name_ would be transformed to @<em>name</em>
-                $Mixed = Gdn_Format::mentions($Mixed);
-
-                $Mixed = $Markdown->transform($Mixed);
-                $Mixed = $Formatter->format($Mixed);
-                $Mixed = Gdn_Format::processHTML($Mixed, false);
-                return $Mixed;
+            // Vanilla-flavored Markdown.
+            if ($Flavored) {
+                $Markdown->addAllFlavor();
             }
+
+            // Format mentions prior to Markdown parsing.
+            // Avoids `@_name_` transformed to `@<em>name</em>`.
+            $Mixed = Gdn_Format::mentions($Mixed);
+
+            // Markdown parsing.
+            $Mixed = $Markdown->transform($Mixed);
+
+            // Vanilla magic formatting.
+            $Mixed = Gdn_Format::processHTML($Mixed);
+
+            // Always filter as the last step.
+            $Sanitized = Gdn_Format::htmlFilter($Mixed);
+
+            return $Sanitized;
         }
     }
 


### PR DESCRIPTION
There were a number of problematic inconsistencies & overlaps with our text processing. This change set goes method-by-method and refactors these issues and makes it very clear that you will always get the same result: uniformly sanitized output.

Key issues resolved:

* Inconsistent ways of sanitizing final output, making it difficult to ascertain whether it was truly sanitized.
* Not always sanitizing as the ultimate step in HTML transformations, which is critical.
* Redundant checking of `isHTML()` and getting of the HTMLformatter. This is handled in the newer `filterHTML()`.
* Unclear documentation.

These changes should have no noticeable effects on the vast majority of user-generated content.

Removing the whitespace (`?w=1`) will help on this one since I eliminated a couple large logic blocks.