### PR TITLE
Ensure web root is added to addon settings URL

### DIFF
--- a/applications/dashboard/views/settings/helper_functions.php
+++ b/applications/dashboard/views/settings/helper_functions.php
@@ -161,7 +161,7 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
         $attr['aria-label'] = sprintf(t('Settings for %s'), $screenName);
         $attr['data-reload-page-on-save'] = false;
 
-        $media->addButton(dashboardSymbol('settings'), $settingsUrl, $attr);
+        $media->addButton(dashboardSymbol('settings'), url($settingsUrl), $attr);
     }
 
     // Toggle


### PR DESCRIPTION
When an addon row is added in the dashboard, it's settings URL is passed straight through. This means it's never modified to be relevant to the current site config. If the site is hosted in a subdirectory, the subdirectory is never prepended as part of the web root.

This update wraps URLs for addon settings buttons in the `url` function to ensure links are properly adjusted.