### PR TITLE
Fix string to match translation for when a user has no notifications.

### DIFF
--- a/applications/dashboard/views/activity/popin.php
+++ b/applications/dashboard/views/activity/popin.php
@@ -36,6 +36,6 @@
             ?>
         </li>
     <?php else: ?>
-        <li class="Item Empty Center"><?php echo t('Notifications will appear here.', sprintf(t('You do not have any %s yet.'), t('notifications'))); ?></li>
+        <li class="Item Empty Center"><?php echo t('Notifications will appear here.', t('You do not have any notifications yet.')); ?></li>
     <?php endif; ?>
 </ul>

--- a/applications/dashboard/views/profile/notifications.php
+++ b/applications/dashboard/views/profile/notifications.php
@@ -10,7 +10,7 @@ if (count($this->data('Activities'))) {
     echo PagerModule::write(array('CurrentRecords' => count($this->data('Activities'))));
 } else {
     ?>
-    <div class="Empty"><?php echo t('Notifications will appear here.', sprintf(t('You do not have any %s yet.'), t('notifications'))); ?></div>
+    <div class="Empty"><?php echo t('Notifications will appear here.', t('You do not have any notifications yet.')); ?></div>
 <?php
 }
 echo '</div>';


### PR DESCRIPTION
We now have a more accurate translation of the string "You do not have any notifications yet." without using sprintf which was causing gender problems in some languages. This PR is to call that string instead of the old one.
