### PR TITLE
Correct translation key to the one in Transifex

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -83,7 +83,7 @@ class QuotesPlugin extends Gdn_Plugin {
      */
     public function profileController_quotes_create($Sender) {
         $Sender->permission('Garden.SignIn.Allow');
-        $Sender->title(t("Quotes Settings"));
+        $Sender->title(t("Quote Settings"));
 
         $Args = $Sender->RequestArgs;
         if (sizeof($Args) < 2) {


### PR DESCRIPTION
This line is not getting translated because the key is not correct. In the locales files (and site_core.php) the key is 

> Quote Settings

not 

> Quotes Settings

See [site_core.php](https://github.com/vanilla/locales/blob/master/tx-source/site_core.php#L1008)