### PR TITLE
Fix default value of DashboardNav.SectionLandingPages preferences

### DIFF
--- a/applications/dashboard/modules/class.dashboardnavmodule.php
+++ b/applications/dashboard/modules/class.dashboardnavmodule.php
@@ -249,7 +249,7 @@ class DashboardNavModule extends SiteNavModule {
      */
     private function handleUserPreferencesSectionLandingPage() {
         if ($session = Gdn::session()) {
-            $landingPages = $session->getPreference('DashboardNav.SectionLandingPages');
+            $landingPages = $session->getPreference('DashboardNav.SectionLandingPages', []);
 
             foreach (self::$sectionsInfo as $key => $section) {
                 if (array_key_exists($key, $landingPages)) {


### PR DESCRIPTION
This was causing a warning about array_key_exists second argument not receiving an array!