### PR TITLE
Fetch actual count of item that needs to be moderated

### DIFF
--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -10,7 +10,7 @@ $DashboardCount = 0;
 if ($Session->checkPermission(array('Garden.Settings.Manage', 'Garden.Moderation.Manage', 'Moderation.Spam.Manage', 'Moderation.ModerationQueue.Manage'), false)) {
     $LogModel = new LogModel();
     //$SpamCount = $LogModel->GetOperationCount('spam');
-    $ModerationCount = $LogModel->GetOperationCount('moderate');
+    $ModerationCount = $LogModel->GetOperationCount('moderate,pending');
     $DashboardCount += $ModerationCount;
 }
 // Applicant Count


### PR DESCRIPTION
[The moderation queue is populated by logs that have the operation "moderate" and "pending"](https://github.com/vanilla/vanilla/blob/47f0a92fe8af6bb1c7fc7d1b7cc715a199ff1a37/applications/dashboard/controllers/class.logcontroller.php#L321).

Update the me module to report the correct count!
Fixes https://github.com/vanilla/vanilla/issues/5389