### PR TITLE
Fixing case when /dba/counts sets discussion DateLastComment to 0

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -254,6 +254,7 @@ class DiscussionModel extends Gdn_Model {
                     ->update('Discussion')
                     ->set('DateLastComment', 'DateInserted', false, false)
                     ->where('DateLastComment', null)
+                    ->orWhere('DateLastComment','0000-00-00 00:00:00')
                     ->put();
                 break;
             case 'LastCommentUserID':


### PR DESCRIPTION
/dba/counts sets DateLastComment to 0000-00-00 00:00:00 when current value of DateLastComment is NULL and discussion has no comment.

https://github.com/vanilla/vanilla/blob/master/applications/dashboard/models/class.dbamodel.php#L107

Query on this line becomes the code below, which returns 0 and the case mentioned above and inserts 0000-00-00 00:00:00 into a datetime field.

```
update GDN_Discussion p
                  set p.DateLastComment = (
                     select coalesce(max(c.DateInserted), 0)
                     from GDN_Comment c
                     where p.DiscussionID = c.DiscussionID)
```

Widening the where clause of the update function fixes that problem.

Fixes https://github.com/vanilla/vanilla/issues/5405


