### PR TITLE
Fix creation of duplicate system user when system not set in config but exists in DB

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1666,26 +1666,32 @@ class UserModel extends Gdn_Model {
      */
     public function getSystemUserID() {
         $SystemUserID = c('Garden.SystemUserID');
-        if ($SystemUserID) {
-            return $SystemUserID;
+        if (!$SystemUserID) {
+            $SystemUser = $this->SQL
+                ->select('UserID')
+                ->from('User u')
+                ->where('u.Name', 'System')
+                ->get()->firstRow(DATASET_TYPE_ARRAY);
+            if($SystemUser) {
+                $SystemUserID = $SystemUser['UserID'];
+            } else {
+                $SystemUser = [
+                    'Name' => t('System'),
+                    'Photo' => asset('/applications/dashboard/design/images/usericon.png', true),
+                    'Password' => randomString('20'),
+                    'HashMethod' => 'Random',
+                    'Email' => 'system@example.com',
+                    'DateInserted' => Gdn_Format::toDateTime(),
+                    'Admin' => '2'
+                ];
+
+                $this->EventArguments['SystemUser'] = &$SystemUser;
+                $this->fireEvent('BeforeSystemUser');
+
+                $SystemUserID = $this->SQL->insert($this->Name, $SystemUser);
+            }
+            saveToConfig('Garden.SystemUserID', $SystemUserID);
         }
-
-        $SystemUser = [
-            'Name' => t('System'),
-            'Photo' => asset('/applications/dashboard/design/images/usericon.png', true),
-            'Password' => randomString('20'),
-            'HashMethod' => 'Random',
-            'Email' => 'system@example.com',
-            'DateInserted' => Gdn_Format::toDateTime(),
-            'Admin' => '2'
-        ];
-
-        $this->EventArguments['SystemUser'] = &$SystemUser;
-        $this->fireEvent('BeforeSystemUser');
-
-        $SystemUserID = $this->SQL->insert($this->Name, $SystemUser);
-
-        saveToConfig('Garden.SystemUserID', $SystemUserID);
         return $SystemUserID;
     }
 


### PR DESCRIPTION
This is a case happening more often then not post migration. When a system user gets deleted from the config but still exists in the database and a user spoofs in as system.

Fixes https://github.com/vanilla/vanilla/issues/5034