### PR TITLE
Expose block exceptions

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -28,6 +28,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
     /** Free to be blocked. */
     const BLOCK_ANY = 2;
 
+    /** @var array List of exceptions not to block */
     private $blockExceptions = [
         '/^utility(\/.*)?$/' => self::BLOCK_NEVER,
         '/^asset(\/.*)?$/' => self::BLOCK_NEVER,
@@ -608,7 +609,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
         $canBlock = self::BLOCK_ANY;
 
-        $blockExceptions = getBlockPermissions();
+        $blockExceptions = $this->getBlockExceptions();
 
         $PathRequest = $request->path();
         foreach ($blockExceptions as $BlockException => $BlockLevel) {
@@ -632,7 +633,12 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         return $canBlock;
     }
 
-    public function getBlockPermissions() {
+    /**
+     * Return the list of paths that potentially cannot be blocked.
+     *
+     * @return array
+     */
+    public function getBlockExceptions() {
         static $eventTriggered = false;
 
         if (!$eventTriggered) {


### PR DESCRIPTION
Backport to `release/2017-Q1-6` & `release/2017-Q2-2`

Needed by some custom plugins.
Gdn::dispatcher() returns Gdn_Dispatcher::BLOCK_PERMISSION for any path is the session is valid...