### PR TITLE
Fix invalid markup in emoji img tags

### DIFF
--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -482,9 +482,11 @@ class Emoji {
         $basename = basename($filename, $ext);
         $src = asset($emoji_path);
 
+        $attributes = [$src, $emoji_name, $src, $emoji_name, $dir, $filename, $basename, $ext];
+        $attributes = array_map('htmlspecialchars', $attributes);
         $img = str_replace(
-            array('%1$s', '%2$s', '{src}', '{name}', '{dir}', '{filename}', '{basename}', '{ext}'),
-            array($src, $emoji_name, $src, $emoji_name, $dir, $filename, $basename, $ext),
+            ['%1$s', '%2$s', '{src}', '{name}', '{dir}', '{filename}', '{basename}', '{ext}'],
+            $attributes,
             $this->format
         );
 


### PR DESCRIPTION
When emoji img tags are generated, most of the config values for that emoji are passed straight through. This can be an issue if HTML special characters are included, such as < or >.

This update runs all potential emoji img attributes through `htmlspecialchars` before inserting them into the image tag.