### PR TITLE
Fix categories with custom permissions created with the API not having file uploads by default

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -362,7 +362,7 @@ class VanillaSettingsController extends Gdn_Controller {
             // Enforces tinyint values on boolean fields to comply with strict mode
             $this->Form->setFormValue('HideAllDiscussions', forceBool($this->Form->getFormValue('HideAllDiscussions'), '0', '1', '0'));
             $this->Form->setFormValue('Archived', forceBool($this->Form->getFormValue('Archived'), '0', '1', '0'));
-            $this->Form->setFormValue('AllowFileUploads', forceBool($this->Form->getFormValue('AllowFileUploads'), '0', '1', '0'));
+            $this->Form->setFormValue('AllowFileUploads', forceBool($this->Form->getFormValue('AllowFileUploads'), '1', '1', '0'));
 
             $upload = new Gdn_Upload();
             $tmpImage = $upload->validateUpload('Photo_New', false);
@@ -678,7 +678,7 @@ class VanillaSettingsController extends Gdn_Controller {
             // Enforces tinyint values on boolean fields to comply with strict mode
             $this->Form->setFormValue('HideAllDiscussions', forceBool($this->Form->getFormValue('HideAllDiscussions'), '0', '1', '0'));
             $this->Form->setFormValue('Archived', forceBool($this->Form->getFormValue('Archived'), '0', '1', '0'));
-            $this->Form->setFormValue('AllowFileUploads', forceBool($this->Form->getFormValue('AllowFileUploads'), '0', '1', '0'));
+            $this->Form->setFormValue('AllowFileUploads', forceBool($this->Form->getFormValue('AllowFileUploads'), '1', '1', '0'));
 
             if ($parentDisplay === 'Flat' && $this->Form->getFormValue('DisplayAs') === 'Heading') {
                 $this->Form->addError('Cannot display as a heading when your parent category is displayed flat.', 'DisplayAs');


### PR DESCRIPTION
This fixes an issue with API calls.

Backport to release/2017-Q1-6 and up.