### PR TITLE
Fix toolbar staying hidden after previewing comment

### DIFF
--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1459,6 +1459,10 @@
                     $currentEditorToolbar.show();
                 });
 
+                $(document).on('click', '#Form_PostComment', function() {
+                    $currentEditorToolbar.show();
+                });
+
                 switch (format) {
                     case 'wysiwyg':
                     case 'ipb':


### PR DESCRIPTION
We currently hide the toolbar when we click on "preview" for a comment. However, if you then click on "Post Comment", the toolbar didn't show again for the next comment.