### PR TITLE
Allow access tokens in the querystring

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -649,14 +649,15 @@ class DashboardHooks extends Gdn_Plugin {
      * Check the access token.
      */
     private function checkAccessToken() {
-        if (empty($_SERVER['HTTP_AUTHORIZATION']) ||
-            !stringBeginsWith(Gdn::request()->getPath(), '/api/') ||
-            !preg_match('`^Bearer\s+(v[a-z]\.[^\s]+)`i', $_SERVER['HTTP_AUTHORIZATION'], $m)
+        if (!stringBeginsWith(Gdn::request()->getPath(), '/api/') ||
+           ((empty($_SERVER['HTTP_AUTHORIZATION']) || !preg_match('`^Bearer\s+(v[a-z]\.[^\s]+)`i', $_SERVER['HTTP_AUTHORIZATION'], $m)) &&
+                empty($_GET['access_token'])
+           )
         ) {
             return;
         }
 
-        $token = $m[1];
+        $token = empty($_GET['access_token']) ? $m[1] : $_GET['access_token'];
         if ($token) {
             $model = new AccessTokenModel();
 


### PR DESCRIPTION
Allowing access tokens in the URL is something we allow for the APIv2 and is consistent with [RFC6750](https://tools.ietf.org/html/rfc6750#section-2.3). It’s not necessarily a best practice, but will help us on two occasions:

1. Some clients won’t be able to set a custom header.
2. An authorization header incurs a CORS preflight request which should be avoided if possible.