### PR TITLE
Interpret plain text as JSON

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1142,7 +1142,7 @@ class Gdn_Request implements RequestInterface {
     private function decodePost($post, $server, $inputFile = 'php://input') {
         $contentType = !isset($server['CONTENT_TYPE']) ? 'application/x-www-form-urlencoded' : $server['CONTENT_TYPE'];
 
-        if (stripos($contentType, 'json') !== false) {
+        if (stripos($contentType, 'application/json') !== false || stripos($contentType, 'text/plain') !== false) {
             // Decode the JSON from the content type.
             $result = json_decode(file_get_contents($inputFile), true);
 


### PR DESCRIPTION
I’m hoping to get thoughts on this so let me explain. This PR is to help CORS requests avoid preflights. In order to avoid a preflight (among other things) the content type must be one of the following:

- application/x-www-form-urlencoded
- multipart/form-data
- text/plain

We know we’d have to transmit JSON as text/plain. The question is whether or not to force a querystring parameter for its content type. My thinking is we can treat text/plain as JSON and force an actual text/plain post to use a different content type or a querystring parameter. This would save us the hassle of seeing application/json in every single cross-domain querystring.