### PR TITLE
Fix double encoding of code blocks when using Markdown

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1628,6 +1628,13 @@ EOT;
         } else {
             $Markdown = new MarkdownVanilla();
 
+            /**
+             * By default, code blocks have their contents run through htmlspecialchars. Gdn_Format::htmlFilter
+             * also runs code blocks through htmlspecialchars. Here, the callback is modified to only return the block
+             * contents. The block will still be passed through htmlspecialchars, further down in Gdn_Format::htmlFilter.
+             */
+            $Markdown->code_block_content_func = function($block) { return $block; };
+
             // Vanilla-flavored Markdown.
             if ($Flavored) {
                 $Markdown->addAllFlavor();


### PR DESCRIPTION
This update adds a custom callback for code blocks in `Gdn_Format::markdown`. This custom callback passes through the text, as is, and is done to avoid doubly encoding HTML special characters. More detail can be found in the original issue.

Closes #5490