### PR TITLE
Fix unit tests for new add-ons

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -214,7 +214,7 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
 
             $SearchPluginInfo = $this->scanPluginFile($PluginFile);
 
-            if ($SearchPluginInfo === false) {
+            if (empty($SearchPluginInfo)) {
                 continue;
             }
 
@@ -931,7 +931,9 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
 
         }
         unset($Lines);
-        if ($PluginInfoString != '') {
+        if (empty($PluginInfoString)) {
+            return null;
+        } else {
             eval($PluginInfoString);
         }
 


### PR DESCRIPTION
New add-ons with an addon.json cannot be found using deprecated methods so they shouldn’t be in deprecated method unit tests.

This is a cherry pick from the APIv2 branch.