### PR TITLE
Add logging to addon cache verification

### DIFF
--- a/applications/dashboard/controllers/class.addoncachecontroller.php
+++ b/applications/dashboard/controllers/class.addoncachecontroller.php
@@ -89,6 +89,21 @@ class AddonCacheController extends DashboardController {
                 t('The addon cache is outdated.').$actions,
                 ['CssClass' => 'Dismissable', 'id' => 'CheckSummary']
             );
+
+            if (debug()) {
+                Logger::event(
+                    'addoncache_outdated',
+                    Logger::INFO,
+                    'Addon cache outdated',
+                    [
+                        'type' => $type,
+                        'new' => $new,
+                        'invalid' => $invalid,
+                        'current' => array_keys($current),
+                        'cached' => array_keys($cached)
+                    ]
+                );
+            }
         }
 
         $this->deliveryMethod(DELIVERY_METHOD_JSON);


### PR DESCRIPTION
This update adds logging to the `/addoncache/verify` endpoint. If the cache is determined to be outdated and the site is in debug mode, a log entry is added with the details of the scan. Since issues with the addon cache are often addon-specific or caused by improper naming on the file system, the details of this log can be beneficial in troubleshooting on a case-by-case basis.

Closes #5469