### PR TITLE
Fix code block handling in Html and Markdown formats

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -876,7 +876,7 @@ class Gdn_Format {
             return self::to($Mixed, 'Html');
         } else {
             if (c('Garden.Format.ReplaceNewlines', true)) {
-                $Mixed = preg_replace("/(\015\012)|(\015)|(\012)/", "<br />", $Mixed);
+                $Mixed = preg_replace("/(?!<code[^>]*?>)(\015\012|\015|\012)(?![^<]*?<\/code>)/", "<br />", $Mixed);
                 $Mixed = fixNl2Br($Mixed);
             }
             $Mixed = Gdn_Format::processHTML($Mixed);

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1633,7 +1633,9 @@ EOT;
              * also runs code blocks through htmlspecialchars. Here, the callback is modified to only return the block
              * contents. The block will still be passed through htmlspecialchars, further down in Gdn_Format::htmlFilter.
              */
-            $Markdown->code_block_content_func = function($block) { return $block; };
+            $codeCallback = function($block) { return $block; };
+            $Markdown->code_block_content_func = $codeCallback;
+            $Markdown->code_span_content_func = $codeCallback;
 
             // Vanilla-flavored Markdown.
             if ($Flavored) {


### PR DESCRIPTION
The Html format replaces all newlines with break tags. However, tags that retain whitespace formatting, such as the `code` tag, do not need this replacement. Due to the additional handling of code blocks in `Gdn_Format::htmlFilter`, these break tags (and their newlines) are removed. This update alters the regex used to replace newlines with break tags, avoiding replacing newlines between `code` tags.

This update also adds protection for code span contents to Markdown. Previously, only code blocks were protected.