### PR TITLE
Fix AllowFileUploads value for category creation

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1375,7 +1375,10 @@ class EditorPlugin extends Gdn_Plugin {
      * @param Gdn_Controller $Sender
      */
     public function settingsController_addEditCategory_handler($Sender) {
-        $Sender->Data['_PermissionFields']['AllowFileUploads'] = array('Control' => 'CheckBox');
+        // Only put the checkbox on edit. On creation the default value will be used.
+        if ($Sender->data('CategoryID')) {
+            $Sender->Data['_PermissionFields']['AllowFileUploads'] = array('Control' => 'CheckBox');
+        }
     }
 
     /**


### PR DESCRIPTION
After this fix: https://github.com/vanilla/vanilla/pull/5497
I realized that AllowFileUploads was not working properly when creating a category normally.
The problem is that the checkbox is created and hidden.



Backport to release/2017-Q1-6