### PR TITLE
Fix mentions being parsed in code blocks with Markdown

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1642,10 +1642,6 @@ EOT;
                 $Markdown->addAllFlavor();
             }
 
-            // Format mentions prior to Markdown parsing.
-            // Avoids `@_name_` transformed to `@<em>name</em>`.
-            $Mixed = Gdn_Format::mentions($Mixed);
-
             // Markdown parsing.
             $Mixed = $Markdown->transform($Mixed);
 


### PR DESCRIPTION
Some behavior was introduced in https://github.com/vanilla/vanilla/pull/5400 that fixed formatting mentions of users with underscores on either side of their name. However, moving parsing of mentions so early in the process meant that code blocks now had their contents parsed for mentions.

This update reverts the early parsing of mentions.