### PR TITLE
Fix code blocks with less-than symbol in Html format posts

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -875,14 +875,14 @@ class Gdn_Format {
         if (!is_string($Mixed)) {
             return self::to($Mixed, 'Html');
         } else {
-            if (c('Garden.Format.ReplaceNewlines', true)) {
-                $Mixed = preg_replace("/(?!<code[^>]*?>)(\015\012|\015|\012)(?![^<]*?<\/code>)/", "<br />", $Mixed);
-                $Mixed = fixNl2Br($Mixed);
-            }
             $Mixed = Gdn_Format::processHTML($Mixed);
 
             // Always filter as the last step.
             $Sanitized = Gdn_Format::htmlFilter($Mixed);
+            if (c('Garden.Format.ReplaceNewlines', true)) {
+                $Sanitized = preg_replace("/(?!<code[^>]*?>)(\015\012|\012|\015)(?![^<]*?<\/code>)/", "<br />", $Sanitized);
+                $Sanitized = fixNl2Br($Sanitized);
+            }
 
             return $Sanitized;
         }


### PR DESCRIPTION
This update moves newline replacement with break tags to come after the markup has been run through `Gdn_Format::htmlFilter` in `Gdn_Format::html`.

Please backport to [release/2017-Q1-6](https://github.com/vanilla/vanilla/tree/release/2017-Q1-6) and [release/2017-Q2-2](https://github.com/vanilla/vanilla/tree/release/2017-Q2-2)