### PR TITLE
Dashboard - Fix init logic for having a “fixed” panel

### DIFF
--- a/applications/dashboard/js/jquery.fluidfixed.js
+++ b/applications/dashboard/js/jquery.fluidfixed.js
@@ -97,7 +97,7 @@
              */
 
             var containerOuterHeight = vars.containerHeight + vars.offsetTop + vars.offsetBottom;
-            var fixObject = containerOuterHeight < vars.documentHeight;
+            var fixObject = containerOuterHeight < vars.documentHeight && containerOuterHeight < vars.windowHeight;
 
             var handleScroll = fixObject
                 && containerOuterHeight > vars.windowHeight // Element height is higher than the window height


### PR DESCRIPTION
The init function for the jquery.fluidfixed plugin didn't take into consideration the window height.

Fixes: https://github.com/vanilla/vanilla/issues/4868