### PR TITLE
Tweak unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,6 @@ script:
   - tests/travis/php-lint.sh ./plugins
   - tests/travis/php-lint.sh ./themes
   - ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
+  - ls -lah ./conf
   - cat /tmp/error.log
   - cat /tmp/access.log

--- a/library/Vanilla/Models/AddonModel.php
+++ b/library/Vanilla/Models/AddonModel.php
@@ -190,7 +190,9 @@ class AddonModel implements LoggerAwareInterface {
         // Look for a setup method.
         $called = $this->callPluginMethod($addon, 'setup');
 
-        if (($structure = $addon->getSpecial('structure')) && (!$called || !in_array($structure, get_included_files()))) {
+        // @TODO This if is a kludge because Vanilla's core applications are inconsistent.
+        // Once the InstallModel is in use this code can be cleaned up by manual structure inclusion in addons.
+        if (($structure = $addon->getSpecial('structure')) && (!$called || !in_array($addon->path($structure, Addon::PATH_FULL), get_included_files())) || $addon->getKey() === 'dashboard') {
             $this->logger->info(
                 "Executing structure for {addonKey}.",
                 ['event' => 'addon_structure', 'addonKey' => $addon->getKey(), 'structureType' => 'file']

--- a/library/core/class.gdn.php
+++ b/library/core/class.gdn.php
@@ -619,7 +619,18 @@ class Gdn {
      *
      * @param \Garden\Container\Container $container
      */
-    public static function setContainer(\Garden\Container\Container $container) {
+    public static function setContainer(\Garden\Container\Container $container = null) {
         self::$container = $container;
+
+        /**
+         * Reset all of the cached objects that are fetched from the container.
+         */
+        self::$_Config = null;
+        self::$_Factory = null;
+        self::$_FactoryOverwrite = true;
+        self::$_Locale = null;
+        self::$_Request = null;
+        self::$_PluginManager = null;
+        self::$_Session = null;
     }
 }

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -214,7 +214,7 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
 
             $SearchPluginInfo = $this->scanPluginFile($PluginFile);
 
-            if ($SearchPluginInfo === null) {
+            if (empty($SearchPluginInfo)) {
                 continue;
             }
 
@@ -934,6 +934,8 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
         // Return early!
         if (empty($PluginInfoString)) {
             return null;
+        } else {
+            eval($PluginInfoString);
         }
 
         eval($PluginInfoString);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,9 @@
         <testsuite name="Library">
             <directory suffix="Test.php">./tests/Library/</directory>
         </testsuite>
+        <testsuite name="Models">
+            <directory suffix="Test.php">./tests/Models</directory>
+        </testsuite>
         <testsuite name="APIv0">
             <directory suffix="Test.php">./tests/APIv0</directory>
         </testsuite>

--- a/tests/APIv0/APIv0.php
+++ b/tests/APIv0/APIv0.php
@@ -121,25 +121,22 @@ class APIv0 extends HttpClient {
      *
      * @return \PDO Returns a connection to the database.
      */
-    public function getPDO() {
+    public function getPDO($db = true) {
         static $pdo;
 
         if (!$pdo) {
             $options = [
                 PDO::ATTR_PERSISTENT => false,
-                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-                PDO::MYSQL_ATTR_INIT_COMMAND  => "set names 'utf8mb4'"
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
             ];
-            $pdo = new PDO('mysql:host='.$this->getDbHost(), $this->getDbUser(), $this->getDbPassword(), $options);
-
+            $dsn = "mysql:host=localhost;charset=utf8mb4";
+            if ($db) {
             $dbname = $this->getDbName();
-            $r = $pdo->query("show databases like '$dbname'", PDO::FETCH_COLUMN, 0);
-            $dbnames = $r->fetchColumn(0);
-
-            if (!empty($dbnames)) {
-                $pdo->query("use `$dbname`");
+                $dsn .= ";dbname=$dbname";
             }
-        }
+
+            $pdo = new PDO($dsn, $this->getDbUser(), $this->getDbPassword(), $options);
+            }
 
         return $pdo;
     }
@@ -423,7 +420,7 @@ class APIv0 extends HttpClient {
      * @throws \Exception Throws an exception if the config file cannot be deleted.
      */
     public function uninstall() {
-        $pdo = $this->getPDO();
+        $pdo = $this->getPDO(false);
 
         // Delete the config file.
         $this->deleteConfig();
@@ -551,7 +548,7 @@ class APIv0 extends HttpClient {
 
     public function createDatabase() {
         // Create the database for Vanilla.
-        $pdo = $this->getPDO();
+        $pdo = $this->getPDO(false);
         $dbname = $this->getDbName();
         $pdo->query("create database `$dbname`");
         $pdo->query("use `$dbname`");

--- a/tests/APIv0/APIv0.php
+++ b/tests/APIv0/APIv0.php
@@ -129,7 +129,7 @@ class APIv0 extends HttpClient {
                 PDO::ATTR_PERSISTENT => false,
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
             ];
-            $dsn = "mysql:host=localhost;charset=utf8mb4";
+            $dsn = "mysql:host=".$this->getDbHost().";charset=utf8mb4";
             if ($db) {
             $dbname = $this->getDbName();
                 $dsn .= ";dbname=$dbname";

--- a/tests/APIv0/AltTest.php
+++ b/tests/APIv0/AltTest.php
@@ -28,6 +28,8 @@ class AltTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * Test an alternate install method.
+     *
+     * @large
      */
     public function testAltInstall() {
         $this->api()->uninstall();

--- a/tests/APIv0/SmokeTest.php
+++ b/tests/APIv0/SmokeTest.php
@@ -63,6 +63,8 @@ class SmokeTest extends BaseTest {
 
     /**
      * Test registering a user with the basic method.
+     *
+     * @large
      */
     public function testRegisterBasic() {
         $this->api()->saveToConfig([
@@ -102,6 +104,8 @@ class SmokeTest extends BaseTest {
 
     /**
      * Test adding an admin user.
+     *
+     * @large
      */
     public function testAddAdminUser() {
         $system = $this->api()->querySystemUser(true);
@@ -141,6 +145,8 @@ class SmokeTest extends BaseTest {
 
     /**
      * Test that a category with restricted permissions can be created.
+     *
+     * @large
      */
     public function testCreateRestrictedCategory() {
         $r = $this->api()->post('/vanilla/settings/addcategory.json', [
@@ -177,6 +183,7 @@ class SmokeTest extends BaseTest {
      * @param array $user The user to test against.
      * @depends testAddAdminUser
      * @depends testRegisterBasic
+     * @large
      */
     public function testSetPhoto($admin, $user) {
         $this->api()->setUser($admin);
@@ -197,6 +204,7 @@ class SmokeTest extends BaseTest {
      * @depends testRegisterBasic
      * @expectedException \Exception
      * @expectedExceptionMessage Invalid photo URL.
+     * @large
      */
     public function testSetInvalidPhoto($admin, $user) {
         $this->api()->setUser($admin);
@@ -213,6 +221,7 @@ class SmokeTest extends BaseTest {
      *
      * @param array $user The user to test against.
      * @depends testRegisterBasic
+     * @large
      */
     public function testSetPhotoPermission($user) {
         $this->api()->setUser($user);
@@ -232,6 +241,7 @@ class SmokeTest extends BaseTest {
      *
      * @param array $user The user to test against.
      * @depends testRegisterBasic
+     * @large
      */
     public function testSetPhotoPermissionLocal($user) {
         $this->api()->setUser($user);
@@ -252,6 +262,7 @@ class SmokeTest extends BaseTest {
      * Test that the APIv0 can actually send a correctly formatted user cookie.
      *
      * @depends testRegisterBasic
+     * @large
      */
     public function testUserCookie() {
         $testUser = $this->getTestUser();
@@ -266,6 +277,7 @@ class SmokeTest extends BaseTest {
      * Test posting a discussion.
      *
      * @depends testRegisterBasic
+     * @large
      */
     public function testPostDiscussion() {
         $api = $this->api();
@@ -292,6 +304,7 @@ class SmokeTest extends BaseTest {
      *
      * @throws \Exception Throws an exception when there are no discussions.
      * @depends testPostDiscussion
+     * @large
      */
     public function testPostComment() {
         $this->api()->setUser($this->getTestUser());
@@ -325,6 +338,7 @@ class SmokeTest extends BaseTest {
      * @depends testCreateRestrictedCategory
      * @expectedException \Exception
      * @expectedExceptionMessage You do not have permission to post in this category.
+     * @large
      */
     public function testPostRestrictedDiscussion() {
         $categoryID = $this->getRestrictedCategoryID();
@@ -354,6 +368,7 @@ class SmokeTest extends BaseTest {
      * @depends testCreateRestrictedCategory
      * @expectedException \Exception
      * @expectedExceptionMessage You don't have permission to do that.
+     * @large
      */
     public function testViewRestrictedCategory() {
         $categoryID = $this->getRestrictedCategoryID();

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests;
+
+use Garden\Container\Container;
+use Garden\Container\Reference;
+use Gdn;
+use Interop\Container\ContainerInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Vanilla\Addon;
+use Vanilla\InjectableInterface;
+
+/**
+ * Run bootstrap code for Vanilla tests.
+ *
+ * This class is meant to be re-used. Calling {@link Bootstrap::run()} on a polluted environment should reset it.
+ */
+class Bootstrap {
+    private $baseUrl;
+
+    /**
+     * Bootstrap constructor.
+     *
+     * A different base URL affects
+     *
+     * @param string $baseUrl The base URL of the installation.
+     */
+    public function __construct($baseUrl = 'http://vanilla.test') {
+        $this->baseUrl = str_replace('\\', '/', $baseUrl);
+    }
+
+
+    /**
+     * Run the bootstrap and set the global environment.
+     *
+     * @param Container $container The container to bootstrap.
+     */
+    public function run(Container $container) {
+        $this->initialize($container);
+        $this->setGlobals($container);
+    }
+
+    /**
+     * Initialize the container with Vanilla's environment.
+     *
+     * @param Container $container The container to initialize.
+     */
+    public function initialize(Container $container) {
+        // Set up the dependency injection container.
+        Gdn::setContainer($container);
+
+        $container
+            ->setInstance(Container::class, $container)
+
+            ->rule(ContainerInterface::class)
+            ->setAliasOf(Container::class)
+
+            // Base classes that want to support DI without polluting their constructor implement this.
+            ->rule(InjectableInterface::class)
+            ->addCall('setDependencies')
+
+            // Cache
+            ->rule(\Gdn_Cache::class)
+            ->setShared(true)
+            ->setFactory(['Gdn_Cache', 'initialize'])
+            ->addAlias('Cache')
+
+            // Configuration
+            ->rule(\Gdn_Configuration::class)
+            ->setShared(true)
+            ->addCall('defaultPath', [$this->getConfigPath()])
+            ->addCall('autoSave', [false])
+            ->addCall('load', [PATH_ROOT.'/conf/config-defaults.php'])
+            ->addAlias('Config')
+
+            // AddonManager
+            ->rule(\Vanilla\AddonManager::class)
+            ->setShared(true)
+            ->setConstructorArgs([
+                [
+                    Addon::TYPE_ADDON => ['/applications', '/plugins'],
+                    Addon::TYPE_THEME => '/themes',
+                    Addon::TYPE_LOCALE => '/locales'
+                ],
+                PATH_CACHE
+            ])
+            ->addAlias('AddonManager')
+            ->addCall('registerAutoloader')
+
+            // ApplicationManager
+            ->rule(\Gdn_ApplicationManager::class)
+            ->setShared(true)
+            ->addAlias('ApplicationManager')
+
+            // PluginManager
+            ->rule(\Gdn_PluginManager::class)
+            ->setShared(true)
+            ->addAlias('PluginManager')
+
+            // ThemeManager
+            ->rule(\Gdn_ThemeManager::class)
+            ->setShared(true)
+            ->addAlias('ThemeManager')
+
+            // Logger
+            ->rule(\Vanilla\Logger::class)
+            ->setShared(true)
+            ->addAlias(LoggerInterface::class)
+
+            ->rule(LoggerAwareInterface::class)
+            ->addCall('setLogger')
+
+            // EventManager
+            ->rule(\Garden\EventManager::class)
+            ->setShared(true)
+
+            ->rule(InjectableInterface::class)
+            ->addCall('setDependencies')
+
+            ->rule(\Gdn_Request::class)
+            ->setShared(true)
+            ->addAlias('Request')
+
+            // Database.
+            ->rule('Gdn_Database')
+            ->setShared(true)
+            ->setConstructorArgs([new Reference([\Gdn_Configuration::class, 'Database'])])
+            ->addAlias('Database')
+
+            ->rule(\Gdn_DatabaseStructure::class)
+            ->setClass(\Gdn_MySQLStructure::class)
+            ->setShared(true)
+            ->addAlias(Gdn::AliasDatabaseStructure)
+            ->addAlias('MySQLStructure')
+
+            ->rule(\Gdn_SQLDriver::class)
+            ->setClass(\Gdn_MySQLDriver::class)
+            ->setShared(true)
+            ->addAlias('Gdn_MySQLDriver')
+            ->addAlias('MySQLDriver')
+            ->addAlias(Gdn::AliasSqlDriver)
+
+            ->rule(Gdn::AliasLocale)
+            ->setClass(\VanillaTests\Fixtures\Locale::class)
+
+            ->rule(\Gdn_Session::class)
+            ->setShared(true)
+            ->addAlias('Session')
+
+            ->rule(Gdn::AliasAuthenticator)
+            ->setClass(\Gdn_Auth::class)
+            ->setShared(true)
+
+            ->rule(\Gdn_Router::class)
+            ->addAlias(Gdn::AliasRouter)
+            ->setShared(true)
+
+            ->rule(\Gdn_Dispatcher::class)
+            ->setShared(true)
+            ->addAlias(Gdn::AliasDispatcher)
+
+            ->rule(\Garden\Web\Dispatcher::class)
+            ->setShared(true)
+            ->addCall('addRoute', ['route' => new \Garden\Container\Reference('@api-v2-route'), 'api-v2'])
+
+            ->rule('@api-v2-route')
+            ->setClass(\Garden\Web\ResourceRoute::class)
+            ->setConstructorArgs(['/api/v2/', '%sApiController'])
+
+            ->rule(\Garden\ClassLocator::class)
+            ->setClass(\Vanilla\VanillaClassLocator::class)
+
+            ->rule(\Gdn_Plugin::class)
+            ->setShared(true)
+            ->addCall('setAddonFromManager')
+        ;
+    }
+
+    /**
+     * Set the global variables that have dependencies.
+     *
+     * @param Container $container The container with dependencies.
+     */
+    public function setGlobals(Container $container) {
+        // Set some server globals.
+        $baseUrl = $this->getBaseUrl();
+        $_SERVER['HTTP_HOST'] = parse_url($baseUrl, PHP_URL_HOST);
+        $_SERVER['SERVER_PORT'] = parse_url($baseUrl, PHP_URL_PORT) ?: null;
+        $_SERVER['SCRIPT_NAME'] = parse_url($baseUrl, PHP_URL_PATH);
+        $_SERVER['PATH_INFO'] = '';
+        $_SERVER['HTTPS'] = parse_url($baseUrl, PHP_URL_SCHEME) === 'https';
+
+
+        $GLOBALS['dic'] = $container;
+        Gdn::setContainer($container);
+    }
+
+    /**
+     * Clean up a container and remove its global references.
+     *
+     * @param Container $container The container to clean up.
+     */
+    public static function cleanup(Container $container) {
+        $container->clearInstances();
+
+        if ($GLOBALS['dic'] === $container) {
+            unset($GLOBALS['dic']);
+        }
+        if (Gdn::getContainer() === $container) {
+            Gdn::setContainer(null);
+        }
+    }
+
+    /**
+     * Get the baseUrl.
+     *
+     * @return mixed Returns the baseUrl.
+     */
+    public function getBaseUrl() {
+        return $this->baseUrl;
+    }
+
+    /**
+     * Get the bath of the site's configuration file.
+     *
+     * @return string Returns a path.
+     */
+    public function getConfigPath() {
+        $host = parse_url($this->getBaseUrl(), PHP_URL_HOST);
+        $path = parse_url($this->getBaseUrl(), PHP_URL_PATH);
+        if ($path) {
+            $path = '-'.ltrim(str_replace('/', '-', $path), '-');
+        }
+
+        return PATH_ROOT."/conf/{$host}{$path}.php";
+    }
+}

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -195,7 +195,7 @@ class AddonManagerTest extends \PHPUnit\Framework\TestCase {
         // Kludge: Check for the UserPhoto() function.
         $fileContents = file_get_contents($addon->path($subpath));
         if (preg_match('`function userPhoto`i', $fileContents)) {
-            $this->markTestSkipped("We can't test classes with redeclarations.");
+            $this->markTestSkipped("We can't test classes that redeclare userPhoto().");
             return;
         }
 

--- a/tests/Models/AccessTokenModelTest.php
+++ b/tests/Models/AccessTokenModelTest.php
@@ -2,17 +2,20 @@
 /**
  * @author Todd Burry <todd@vanillaforums.com>
  * @copyright 2009-2017 Vanilla Forums Inc.
- * @license Proprietary
+ * @license GPLv2
  */
 
-namespace VanillaTests\APIv0;
+namespace VanillaTests\Models;
 
 use AccessTokenModel;
+use VanillaTests\SiteTestTrait;
 
 /**
  * Test the {@link AccessTokenModel}.
  */
-class AccessTokenModelTest extends BaseTest {
+class AccessTokenModelTest extends \PHPUnit_Framework_TestCase {
+    use SiteTestTrait;
+
     /**
      * A newly issued token should verify.
      */

--- a/tests/Models/InstallModelTest.php
+++ b/tests/Models/InstallModelTest.php
@@ -5,9 +5,11 @@
  * @license GPLv2
  */
 
-namespace VanillaTests\APIv2;
+namespace VanillaTests\Model;
 
+use Garden\Container\Container;
 use Vanilla\AddonManager;
+use VanillaTests\Bootstrap;
 use VanillaTests\TestInstallModel;
 
 /**
@@ -18,7 +20,10 @@ class InstallTest extends \PHPUnit\Framework\TestCase {
      * Test installing Vanilla with the {@link \Vanilla\Models\InstallModel}.
      */
     public function testInstall() {
-        global $dic;
+        $bootstrap = new Bootstrap();
+        $dic = new Container();
+        $bootstrap->run($dic);
+
 
         /* @var TestInstallModel $installer */
         $installer = $dic->get(TestInstallModel::class);

--- a/tests/SiteTestTrait.php
+++ b/tests/SiteTestTrait.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests;
+
+use Garden\EventManager;
+use Garden\Container\Container;
+
+/**
+ * Allow a class to test against
+ */
+trait SiteTestTrait {
+    /**
+     * @var Container
+     */
+    private static $container;
+
+    protected static function createContainer() {
+        $folder = strtolower(EventManager::classBasename(get_called_class()));
+        $bootstrap = new Bootstrap("http://vanilla.test/$folder");
+
+        $container = new Container();
+        $bootstrap->run($container);
+
+        return $container;
+    }
+
+    public static function setupBeforeClass() {
+        $dic = self::$container = static::createContainer();
+
+
+        /* @var TestInstallModel $installer */
+        $installer = $dic->get(TestInstallModel::class);
+
+        $installer->uninstall();
+        $result = $installer->install([
+            'site' => ['title' => EventManager::classBasename(get_called_class())]
+        ]);
+    }
+
+    public static function teardownAfterClass() {
+        Bootstrap::cleanup(self::container());
+    }
+
+    /**
+     * @return Container
+     */
+    protected static function container() {
+        return self::$container;
+    }
+}

--- a/tests/TestInstallModel.php
+++ b/tests/TestInstallModel.php
@@ -28,25 +28,16 @@ class TestInstallModel extends InstallModel {
     /**
      * {@inheritdoc}
      */
-    public function __construct(\Gdn_Configuration $config, AddonModel $addonModel, ContainerInterface $container) {
+    public function __construct(\Gdn_Configuration $config, AddonModel $addonModel, ContainerInterface $container, \Gdn_Request $request) {
         parent::__construct($config, $addonModel, $container);
-        $this->setBaseUrl(getenv('TEST_BASEURL'));
 
         $this->config->Data = [];
         $this->config->load(PATH_ROOT.'/conf/config-defaults.php');
-        $this->config->load($this->getConfigPath(), 'Configuration', true);
+        $this->config->load($config->defaultPath(), 'Configuration', true);
+
+        $this->setBaseUrl($request->url('/'));
     }
 
-    /**
-     * Get the path to the config file for direct access.
-     *
-     * @return string Returns the path to the database.
-     */
-    public function getConfigPath() {
-        $host = parse_url($this->getBaseUrl(), PHP_URL_HOST);
-        $path = PATH_ROOT."/conf/$host.php";
-        return $path;
-    }
 
     /**
      * Get the base URL of the site.
@@ -65,7 +56,7 @@ class TestInstallModel extends InstallModel {
      */
     public function setBaseUrl($baseUrl) {
         $this->baseUrl = $baseUrl;
-        $this->config->defaultPath($this->getConfigPath());
+//        $this->config->defaultPath($this->getConfigPath());
         return $this;
     }
 
@@ -176,6 +167,7 @@ class TestInstallModel extends InstallModel {
 
         $dbname = $this->getDbName();
         $pdo->query("create database if not exists `$dbname`");
+        $pdo->query("use `$dbname`");
     }
 
     /**
@@ -197,5 +189,8 @@ class TestInstallModel extends InstallModel {
         // Reset the config to defaults.
         $this->config->Data = [];
         $this->config->load(PATH_ROOT.'/conf/config-defaults.php');
+
+        // Clear all database related objects from the container.
+
     }
 }

--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -1,5 +1,6 @@
 <?php
 
+use Garden\Container\Container;
 use Vanilla\Addon;
 use Vanilla\InjectableInterface;
 
@@ -40,124 +41,8 @@ if (!defined('APPLICATION_VERSION')) {
 require PATH_CONF . '/constants.php';
 
 // Set up the dependency injection container.
-$dic = $GLOBALS['dic'] = new \Garden\Container\Container();
-Gdn::setContainer($dic);
-
-$dic->setInstance('Garden\Container\Container', $dic)
-    ->rule('Interop\Container\ContainerInterface')
-    ->setAliasOf('Garden\Container\Container')
-
-    ->rule(InjectableInterface::class)
-    ->addCall('setDependencies')
-
-    // Cache
-    ->rule('Gdn_Cache')
-    ->setShared(true)
-    ->setFactory(['Gdn_Cache', 'initialize'])
-    ->addAlias('Cache')
-
-    // Configuration
-    ->rule('Gdn_Configuration')
-    ->setShared(true)
-    ->addCall('defaultPath', [PATH_ROOT.'/conf/vanilla.test'])
-    ->addCall('load', [PATH_ROOT.'/conf/config-defaults.php'])
-    ->addAlias('Config')
-
-    // AddonManager
-    ->rule(Vanilla\AddonManager::class)
-    ->setShared(true)
-    ->setConstructorArgs([
-        [
-            Addon::TYPE_ADDON => ['/applications', '/plugins'],
-            Addon::TYPE_THEME => '/themes',
-            Addon::TYPE_LOCALE => '/locales'
-        ],
-        PATH_CACHE
-    ])
-    ->addAlias('AddonManager')
-    ->addCall('registerAutoloader')
-
-    // ApplicationManager
-    ->rule('Gdn_ApplicationManager')
-    ->setShared(true)
-    ->addAlias('ApplicationManager')
-
-    // PluginManager
-    ->rule('Gdn_PluginManager')
-    ->setShared(true)
-    ->addAlias('PluginManager')
-
-    // ThemeManager
-    ->rule('Gdn_ThemeManager')
-    ->setShared(true)
-    ->addAlias('ThemeManager')
-
-    // Logger
-    ->rule(\Vanilla\Logger::class)
-    ->setShared(true)
-    ->addAlias(\Psr\Log\LoggerInterface::class)
-
-    ->rule(\Psr\Log\LoggerAwareInterface::class)
-    ->addCall('setLogger')
-
-    // EventManager
-    ->rule(\Garden\EventManager::class)
-    ->setShared(true)
-
-    ->rule(InjectableInterface::class)
-    ->addCall('setDependencies')
-
-    ->rule('Gdn_Request')
-    ->setShared(true)
-    ->addAlias('Request')
-
-    ->rule('Gdn_DatabaseStructure')
-    ->setClass('Gdn_MySQLStructure')
-    ->setShared(true)
-    ->addAlias(Gdn::AliasDatabaseStructure)
-    ->addAlias('MySQLStructure')
-
-    ->rule('Gdn_SQLDriver')
-    ->setClass('Gdn_MySQLDriver')
-    ->setShared(true)
-    ->addAlias('Gdn_MySQLDriver')
-    ->addAlias('MySQLDriver')
-    ->addAlias(Gdn::AliasSqlDriver)
-
-    ->rule(Gdn::AliasLocale)
-    ->setClass(\VanillaTests\Fixtures\Locale::class)
-
-    ->rule('Gdn_Session')
-    ->setShared(true)
-    ->addAlias('Session')
-
-    ->rule(Gdn::AliasAuthenticator)
-    ->setClass('Gdn_Auth')
-    ->setShared(true)
-
-    ->rule('Gdn_Router')
-    ->addAlias(Gdn::AliasRouter)
-    ->setShared(true)
-
-    ->rule('Gdn_Dispatcher')
-    ->setShared(true)
-    ->addAlias(Gdn::AliasDispatcher)
-
-    ->rule(\Garden\Web\Dispatcher::class)
-    ->setShared(true)
-    ->addCall('addRoute', ['route' => new \Garden\Container\Reference('@api-v2-route'), 'api-v2'])
-
-    ->rule('@api-v2-route')
-    ->setClass(\Garden\Web\ResourceRoute::class)
-    ->setConstructorArgs(['/api/v2/', '%sApiController'])
-
-    ->rule(\Garden\ClassLocator::class)
-    ->setClass(\Vanilla\VanillaClassLocator::class)
-
-    ->rule(Gdn_Plugin::class)
-    ->setShared(true)
-    ->addCall('setAddonFromManager')
-;
+$bootstrap = new \VanillaTests\Bootstrap();
+$bootstrap->run(new Container());
 
 // Clear the test cache.
 \Gdn_FileSystem::removeFolder(PATH_ROOT.'/tests/cache');


### PR DESCRIPTION
- Add a bootstrap class to allow container re-initialization.
- Add a SiteTestTrait that allows test classes to install a copy of Vanilla and run internally.
- Move the AccessTokenModelTest out of the APIv2 tests.
- Don't save configurations during unit tests. This is more to work around an issue where the configuration object can only save on destruct which isn't appropriate for unit tests and causes some timing issues too.

Basically, these changes will allow us to move closer to isolating tests against separate installs of Vanilla where a test class can install its own copy of Vanilla without using cURL. This PR started out as a simple cherry pick from the apiv2 branch, but ended up including a lot of yak shaving in order to make builds work on Travis.

*Note to reviewers: The changes to non-testing classes are the ones that need reviewing. I added some line comments to explain what I did and why.*