### PR TITLE
Remove HTML entity escaping from current theme title

### DIFF
--- a/applications/dashboard/views/modules/media-callout.php
+++ b/applications/dashboard/views/modules/media-callout.php
@@ -13,7 +13,7 @@
         <?php } ?>
         <div class="media-heading">
             <h3 class="media-title theme-name">
-                <?php echo $this->getTitleUrl() != '' ? anchor(htmlspecialchars($this->getTitle()), $this->getTitleUrl()) : htmlspecialchars($this->getTitle()); ?>
+                <?php echo $this->getTitleUrl() != '' ? anchor($this->getTitle(), $this->getTitleUrl()) : $this->getTitle(); ?>
             </h3>
             <?php if ($this->getMeta()) { ?>
                 <div class="info">


### PR DESCRIPTION
The "Current Theme" slot uses `htmlspecialchars()` to wrap the theme's title. The theme options below do not, nor does the theme descriptions. This isn't a relevant security vector, and there are valid reasons for wanting HTML entities in your theme name. Also, this was surreptitiously added in Dashboard v3 - it did not do this previously. Therefore, this use is inconsistent and unnecessary. 