### PR TITLE
Fix docs around deprecated subtree view & remove notice

### DIFF
--- a/applications/vanilla/views/categories/subtree.php
+++ b/applications/vanilla/views/categories/subtree.php
@@ -1,7 +1,7 @@
 <?php if (!defined('APPLICATION')) exit();
-// This view is deprecated as of 2016-09-30.
-deprecated('vanilla/categories/subtree view');
-
+/**
+ * @deprecated view as of 2016-09-30.
+ */
 if (isset($this->CategoryModel) && $this->CategoryModel instanceof CategoryModel) {
     $childCategories = $this->data('CategoryTree', []);
     $this->CategoryModel->joinRecent($childCategories);

--- a/applications/vanilla/views/discussions/index.php
+++ b/applications/vanilla/views/discussions/index.php
@@ -14,7 +14,7 @@ $this->fireEvent('AfterPageTitle');
 
 $subtreeView = $this->fetchViewLocation('subtree', 'categories', 'vanilla', false);
 if ($subtreeView) {
-    // This use on subtree is deprecated.
+    // This use of subtree is deprecated.
     include $subtreeView;
 } elseif (isset($this->CategoryModel) && $this->CategoryModel instanceof CategoryModel) {
     $childCategories = $this->data('CategoryTree', []);

--- a/applications/vanilla/views/discussions/index.php
+++ b/applications/vanilla/views/discussions/index.php
@@ -14,6 +14,7 @@ $this->fireEvent('AfterPageTitle');
 
 $subtreeView = $this->fetchViewLocation('subtree', 'categories', 'vanilla', false);
 if ($subtreeView) {
+    // This use on subtree is deprecated.
     include $subtreeView;
 } elseif (isset($this->CategoryModel) && $this->CategoryModel instanceof CategoryModel) {
     $childCategories = $this->data('CategoryTree', []);


### PR DESCRIPTION
This deprecated notice was added with the best of intentions, but I'm removing it because it's not OK to force Vanilla into throwing unavoidable Notices. I downgrade it to a docblock here and document its use elsewhere (which is what triggered the notice).

Forcing notices trains developers to ignore them.