### PR TITLE
Repair logic in the unbindClass() method

### DIFF
--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -164,7 +164,7 @@ class EventManager {
     public function unbindClass($class) {
         foreach ($this->handlers as $event => $handlers) {
             foreach ($handlers as $key => $handler) {
-                if ($handler instanceof LazyEventHandler && strcasecmp($handler->class, $class) === 0) {
+                if ($handler instanceof LazyEventHandler && is_string($class) && strcasecmp($handler->class, $class) === 0) {
                     unset($this->handlers[$event][$key]);
                     continue;
                 }

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -159,15 +159,25 @@ class EventManager {
      *
      * Note that this walks all event handlers so should not be called very often.
      *
-     * @param string $className The name of the class to unbind.
+     * @param string|object $class The name of the class to unbind.
      */
-    public function unbindClass($className) {
+    public function unbindClass($class) {
         foreach ($this->handlers as $event => $handlers) {
             foreach ($handlers as $key => $handler) {
-                if (($handler instanceof LazyEventHandler && strcasecmp($handler->class, $className) === 0)
-                    || (is_array($handler) && (
-                        (is_string($handler[0]) && strcasecmp($handler[0], $className) === 0)
-                        || (is_object($handler[0]) && is_a($handler[0], $className))))) {
+                if ($handler instanceof LazyEventHandler && strcasecmp($handler->class, $class) === 0) {
+                    unset($this->handlers[$event][$key]);
+                    continue;
+                }
+                if (!is_array($handler)) {
+                    continue;
+                }
+                if (is_object($class)) {
+                    if ($handler[0] === $class) {
+                        unset($this->handlers[$event][$key]);
+                    }
+                } elseif (is_string($handler[0]) && strcasecmp($handler[0], $class) === 0) {
+                    unset($this->handlers[$event][$key]);
+                } elseif (is_object($handler[0]) && is_a($handler[0], $class)) {
                     unset($this->handlers[$event][$key]);
                 }
             }

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -166,8 +166,8 @@ class EventManager {
             foreach ($handlers as $key => $handler) {
                 if (($handler instanceof LazyEventHandler && strcasecmp($handler->class, $className) === 0)
                     || (is_array($handler) && (
-                        (is_string($handler[0] && strcasecmp($handler, $className) === 0))
-                        || (is_object($handler[0] && is_a($handler[0], $className)))))) {
+                        (is_string($handler[0]) && strcasecmp($handler[0], $className) === 0)
+                        || (is_object($handler[0]) && is_a($handler[0], $className))))) {
                     unset($this->handlers[$event][$key]);
                 }
             }

--- a/tests/Library/Garden/EventManagerTest.php
+++ b/tests/Library/Garden/EventManagerTest.php
@@ -471,4 +471,99 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase {
         $r = $em->fire('e');
         $this->assertEmpty($r);
     }
+
+    /**
+     * Test unbinding a class from the event manager by instance.
+     */
+    public function testUnbindClassInstance() {
+        $em = new EventManager();
+
+        $handlers = new BasicEventHandlers();
+        $em->bindClass($handlers);
+
+        $this->assertTrue($em->hasHandler('foo'));
+
+        $em->unbindClass($handlers);
+        $this->assertFalse($em->hasHandler('foo'));
+    }
+
+    /**
+     * Test unbinding a class from the event manager by instance.
+     */
+    public function testUnbindClassInstanceName() {
+        $em = new EventManager();
+
+        $handlers = new BasicEventHandlers();
+        $em->bindClass($handlers);
+
+        $this->assertTrue($em->hasHandler('foo'));
+
+        $em->unbindClass(BasicEventHandlers::class);
+        $this->assertFalse($em->hasHandler('foo'));
+    }
+
+    /**
+     * Test unbinding a class from the event manager by class name.
+     */
+    public function testUnbindClassName() {
+        $em = new EventManager(new Container());
+
+        $em->bindClass(BasicEventHandlers::class);
+
+        $this->assertTrue($em->hasHandler('foo'));
+
+        $em->unbindClass(BasicEventHandlers::class);
+        $this->assertFalse($em->hasHandler('foo'));
+    }
+
+    /**
+     * Test unbinding a class from the event manager by class name after the handlers have been fetched..
+     */
+    public function testUnbindClassExpanded() {
+        $em = new EventManager(new Container());
+
+        $em->bindClass(BasicEventHandlers::class);
+
+        $this->assertNotEmpty($em->getHandlers('foo'));
+
+        $em->unbindClass(BasicEventHandlers::class);
+        $this->assertFalse($em->hasHandler('foo'));
+    }
+
+    /**
+     * If multiple instances are bound then I should not unbind both.
+     */
+    public function testUnbindClassInstanceMultiple() {
+        $em = new EventManager();
+
+        $handlers = new BasicEventHandlers();
+        $em->bindClass($handlers);
+        $handlers2 = new BasicEventHandlers();
+        $em->bindClass($handlers2);
+
+        $this->assertTrue($em->hasHandler('foo'));
+
+        $em->unbindClass($handlers);
+        $this->assertTrue($em->hasHandler('foo'));
+
+        $em->unbindClass($handlers2);
+        $this->assertFalse($em->hasHandler('foo'));
+    }
+
+    /**
+     * If multiple instances are bound then I should not unbind both.
+     */
+    public function testUnbindClassInstanceMultipleByName() {
+        $em = new EventManager();
+
+        $handlers = new BasicEventHandlers();
+        $em->bindClass($handlers);
+        $handlers2 = new BasicEventHandlers();
+        $em->bindClass($handlers2);
+
+        $this->assertTrue($em->hasHandler('foo'));
+
+        $em->unbindClass(BasicEventHandlers::class);
+        $this->assertFalse($em->hasHandler('foo'));
+    }
 }


### PR DESCRIPTION
I'm not super familiar with this area, but going by what _appears_ to be the intent of these checks and the notices I'm receiving when scanning the database for updates, I believe this fixes the method to check variable types correctly.