### PR TITLE
Fix double spacing in Wysiwyg posts when embedding allowed

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -563,15 +563,17 @@ class PostController extends VanillaController {
              * comments, we may need to apply certain filters and fixes to the data to maintain its intended display
              * with the input format (e.g. maintaining newlines).
              */
-            $inputFormatter = $this->Form->getFormValue('Format', c('Garden.InputFormatter'));
+            if ($isEmbeddedComments) {
+                $inputFormatter = $this->Form->getFormValue('Format', c('Garden.InputFormatter'));
 
-            switch ($inputFormatter) {
-                case 'Wysiwyg':
-                    $this->Form->setFormValue(
-                        'Body',
-                        nl2br($this->Form->getFormValue('Body'))
-                    );
-                    break;
+                switch ($inputFormatter) {
+                    case 'Wysiwyg':
+                        $this->Form->setFormValue(
+                            'Body',
+                            nl2br($this->Form->getFormValue('Body'))
+                        );
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
Embedded comments on a site configured to use Wysiwyg as its post type requires some special considerations in Vanilla. https://github.com/vanilla/vanilla/pull/3275 and https://github.com/vanilla/vanilla/pull/3464 introduced behaviors attempting to fix it. However, there is a lingering issue: commenting on a site configured with Wysiwyg as its input formatter and *allowing* embeds can potentially add unnecessary break tags. These break tags used to add double spacing, but recent updates to Vanilla's formatting chain cause these tags to be encoded and rendered as text.

Vanilla should only be attempting to modify post contents like this if the content is coming from an embedded comment form, so this update just adds that condition. Embedded comments on sites with Wysiwyg configured as its input type should still have their newlines replaced with break tags. Standard commenting should be unaffected.

Closes #5504 

Backport to [release/2017-Q2-2](https://github.com/vanilla/vanilla/tree/release/2017-Q2-2)