### PR TITLE
Fix plugin scanning logic

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -214,7 +214,7 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
 
             $SearchPluginInfo = $this->scanPluginFile($PluginFile);
 
-            if ($SearchPluginInfo === false) {
+            if ($SearchPluginInfo === null) {
                 continue;
             }
 
@@ -902,7 +902,6 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
         }
 
         $ParseVariableName = '$'.$VariableName;
-        ${$VariableName} = array();
 
         foreach ($Lines as $Line) {
             $TrimmedLine = trim($Line);
@@ -936,8 +935,8 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
         }
 
         // Define the folder name and assign the class name for the newly added item.
-        $var = ${$VariableName};
-        if (isset($var) && is_array($var)) {
+        $var = isset(${$VariableName}) ? ${$VariableName} : null;
+        if (is_array($var)) {
             reset($var);
             $name = key($var);
             $var = current($var);

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -881,11 +881,11 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
     }
 
     /**
+     * Return the plugin's information.
      *
-     *
-     * @param $PluginFile
+     * @param string $PluginFile
      * @param null $VariableName
-     * @return null|void
+     * @return array|null Return the plugin's information or null
      */
     public function scanPluginFile($PluginFile, $VariableName = null) {
         // Find the $PluginInfo array
@@ -949,10 +949,6 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
             touchValue('Folder', $var, $name);
 
             return $var;
-        } elseif ($VariableName !== null) {
-            if (isset($var)) {
-                return $var;
-            }
         }
 
         return null;

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -930,9 +930,13 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
 
         }
         unset($Lines);
-        if ($PluginInfoString != '') {
-            eval($PluginInfoString);
+
+        // Return early!
+        if (empty($PluginInfoString)) {
+            return null;
         }
+
+        eval($PluginInfoString);
 
         // Define the folder name and assign the class name for the newly added item.
         $var = isset(${$VariableName}) ? ${$VariableName} : null;


### PR DESCRIPTION
Make sure that nothing is returned if $PluginInfo is not defined in the plugin's class.
Test $PluginInfo properly in indexSearchPath