### PR TITLE
Mark built files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,10 @@
 *.md    text eol=lf
 *.yml   text eol=lf
 
+# Mark built files as binary
+*.map binary
+composer.lock binary
+
 # Skip files on archive
 .editorconfig export-ignore
 .gitattributes export-ignore


### PR DESCRIPTION
This prevents them from showing up in merge conflict editors. They can
just be rebuilt when they conflict.