### PR TITLE
Fix category management allowing invalid URL codes

### DIFF
--- a/applications/vanilla/js/manage-categories.js
+++ b/applications/vanilla/js/manage-categories.js
@@ -43,8 +43,14 @@ jQuery(document).ready(function ($) {
     $("#Form_Name").keyup(function (event) {
         if ($('#Form_CodeIsDefined').val() == '0') {
             $('#UrlCode').show();
-            var val = $(this).val().replace(/[ \/\\&.?;,<>'"]+/g, '-');
-            val = val.replace(/\-+/g, '-').toLowerCase();
+            var val = $(this).val();
+            // A slug can't consist only of numbers.
+            if (val.match(/^[0-9]+$/)) {
+                val = '';
+            } else {
+                val = val.replace(/[ \/\\&.?;,<>'"]+/g, '-');
+                val = val.replace(/\-+/g, '-').toLowerCase();
+            }
             $("#Form_UrlCode").val(val);
             $("#UrlCode span").text(val);
         }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2538,8 +2538,8 @@ class CategoryModel extends Gdn_Model {
             $this->Validation->applyRule('UrlCode', 'UrlStringRelaxed');
 
             // Url slugs cannot be the name of a CategoriesController method or fully numeric.
-            $this->Validation->addRule('CategorySlug', 'regex:/^(?!(all|archives|discussions|index|table|[0-9]+)$).*/');
-            $this->Validation->applyRule('UrlCode', 'CategorySlug', 'Url code cannot be numeric or the name of an internal method.');
+            $this->Validation->addRule('CategorySlug', 'function:validateCategoryUrlCode');
+            $this->Validation->applyRule('UrlCode', 'CategorySlug', 'Url code cannot be numeric, contain spaces or be the name of an internal method.');
 
             // Make sure that the UrlCode is unique among categories.
             $this->SQL->select('CategoryID')

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -74,6 +74,35 @@ if (!function_exists('ValidateRequired')) {
     }
 }
 
+if (!function_exists('validateCategoryUrlCode')) {
+    /**
+     * Validate a category URL code.
+     *
+     * @param string $urlCode
+     * @return bool
+     */
+    function validateCategoryUrlCode($urlCode) {
+        $reservedSlugs = ['all', 'archives', 'discussions', 'index', 'table'];
+
+        // Does it contain spaces?
+        if (strpos($urlCode, ' ') !== false) {
+            return false;
+        }
+
+        // Is it only numbers?
+        if (preg_match('/^[0-9]+$/', $urlCode)) {
+            return false;
+        }
+
+        // Is it a reserved slug?
+        if (in_array($urlCode, $reservedSlugs)) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
 if (!function_exists('ValidateMeAction')) {
     /**
      * Validate that a string is a valid "me" action.


### PR DESCRIPTION
This update does a few things to improve category slug management:

1. Adds a `validateCategoryUrlCode` function for...validating a category's URL code. This function verifies the slug doesn't contain spaces, isn't numeric and is not a reserved word.
1. Implements `validateCategoryUrlCode` as part of the `CategoryModel::save` validation routine.
1. Updates the JavaScript responsible for auto-generating category slugs to avoid generating purely numeric values.

Closes #5127