### PR TITLE
Fix profile/discussions pagination double query 

### DIFF
--- a/applications/dashboard/js/activity.js
+++ b/applications/dashboard/js/activity.js
@@ -154,12 +154,4 @@ jQuery(document).ready(function($) {
         }
         return false;
     });
-
-    // Set up paging
-    if ($.morepager)
-        $('.MorePager').not('.Message .MorePager').morepager({
-            pageContainerSelector: 'ul.DataList:first',
-            pagerInContainer: true
-        });
-
 });

--- a/applications/vanilla/js/discussions.js
+++ b/applications/vanilla/js/discussions.js
@@ -10,7 +10,7 @@ jQuery(document).ready(function($) {
         });
 
         // profile/discussions paging
-        $('.Section-Profile .MorePager').morepager({
+        $('.Section-Profile .Discussions .MorePager').morepager({
             pagerInContainer: true,
             afterPageLoaded: function() {
                 $(document).trigger('DiscussionPagingComplete');


### PR DESCRIPTION
- Made the selector more precise for the discussion's pager.
- Removed activity's pager code since it was unused. [The code was old](https://github.com/vanilla/vanilla/blame/ee1f67687653a82632b1f2b0dbc86571910a9398/applications/dashboard/js/activity.js#L164) and we are now using a Next, Previous pager for that section.

Fixes https://github.com/vanilla/vanilla/issues/5062