### PR TITLE
Fix z-index for token input in modals

### DIFF
--- a/js/library/jquery.tokeninput.js
+++ b/js/library/jquery.tokeninput.js
@@ -32,7 +32,7 @@ var DEFAULT_SETTINGS = {
     animateDropdown: true,
     placeholder: null,
     theme: null,
-    zindex: 999,
+    zindex: 9999,
     resultsLimit: null,
 
     enableHTML: false,


### PR DESCRIPTION
My previous patch (https://github.com/vanilla/vanilla/pull/5478) for token inputs in popups didn't work. Here's a better fix.