### PR TITLE
Fix TK cookie being unnecessarily set

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -459,6 +459,13 @@ class Gdn_Session {
                     $UserModel->updateVisit($this->UserID);
                 }
 
+                /**
+                 * This checks ensures TK cookies aren't set for API calls, but are set for normal users where
+                 * $SetIdentity may be false on subsequent page loads after logging in.
+                 */
+                if ($SetIdentity || $UserID === false) {
+                    $this->ensureTransientKey();
+                }
             } else {
                 $this->UserID = 0;
                 $this->User = false;
@@ -468,8 +475,6 @@ class Gdn_Session {
                 }
             }
         }
-
-        $this->ensureTransientKey();
 
         // Load guest permissions if necessary
         if ($this->UserID == 0) {


### PR DESCRIPTION
This update adds some additional checks around the call to `Gdn_Session::ensureTransientKey` in `Gdn_Session::start`. One of two conditions must be met:

1. The `$SetIdentity` parameter must be truthy. This parameter is used to save the user's identity. For example, the `Gdn_CookieIdentity` class saves a user's data to browser cookies, depending on this value. It's `false` for API calls. When a user first signs in on the frontend, this value will be `true`. However, it will be `false` for page loads after a user has successfully signed in. Which brings us to...
1. The `$UserID` parameter must be `false`. On the frontend, after a user signs into the site, [subsequent page loads will have this parameter set to `false`](https://github.com/vanilla/vanilla/blob/6653443cc3c4d451c6c9e55d7ebb801514aeabf1/library/core/class.auth.php#L59). The user ID will be [determined by the authenticator](https://github.com/vanilla/vanilla/blob/6653443cc3c4d451c6c9e55d7ebb801514aeabf1/library/core/class.session.php#L425). When dealing with the API, a user ID will be provided directly to the method.

Closes #5278 