### PR TITLE
Scroll to top of embed's iframe only for discussions and on page change

### DIFF
--- a/js/embed_local.js
+++ b/js/embed_local.js
@@ -159,10 +159,6 @@ jQuery(document).ready(function($) {
 
         setInterval(setHeight, 300);
 
-        if (isEmbeddedComments === false) {
-            remotePostMessage('scrollto:0', '*');
-        }
-
         // Simulate a page unload when popups are opened (so they are scrolled into view).
         $('body').bind('popupReveal', function() {
             remotePostMessage('scrollto:' + $('div.Popup').offset().top, '*');
@@ -217,6 +213,8 @@ jQuery(document).ready(function($) {
                     }
                 }
                 return;
+            } else {
+                remotePostMessage('scrollto:0', '*');
             }
         });
     }


### PR DESCRIPTION
This fix is what https://github.com/vanilla/vanilla/pull/4277 should have been.

Closes https://github.com/vanilla/vanilla/issues/5209 and addresses https://github.com/vanilla/vanilla/issues/4185 properly.