### PR TITLE
Fix setAppCookie not isolating cookies between subdirectory sites

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3209,7 +3209,8 @@ if (!function_exists('setAppCookie')) {
         }
 
         // Create the cookie.
-        safeCookie($Key, $Value, $Expire, '/', $Domain, null, true);
+        $path = c('Garden.Cookie.Path', '/');
+        safeCookie($Key, $Value, $Expire, $path, $Domain, null, true);
         $_COOKIE[$Key] = $Value;
     }
 }


### PR DESCRIPTION
The `setAppCookie` function has the cookie path hardcoded to "/". It should be using the site's configured `Garden.Cookie.Path` value. This update should make it do just that.

Closes #5565 

Backport to [release/2017-Q1-6](https://github.com/vanilla/vanilla/tree/release/2017-Q1-6) and [release/2017-Q2-2](https://github.com/vanilla/vanilla/tree/release/2017-Q2-2).