### PR TITLE
Improve load time of Vanilla Statistics dashboard summaries

### DIFF
--- a/plugins/VanillaStats/class.vanillastats.plugin.php
+++ b/plugins/VanillaStats/class.vanillastats.plugin.php
@@ -177,13 +177,10 @@ class VanillaStatsPlugin extends Gdn_Plugin {
                 ->limit(5, 0)
                 ->get();
 
-            $Structure = Gdn::structure()->table('Comment');
-
-            // If row count > than 10M and range is greater than 3 months.
-            $rowCountEstimate = $Structure->getRowCountEstimate('Comment');
+            // If the date range is greater than 90 days clamp it.
             $toDateTime = new DateTime($range['to']);
             $dateDiff = date_diff($toDateTime, new DateTime($range['from']));
-            if ($rowCountEstimate >= 10000000 && $dateDiff->format('%a') > 90) {
+            if ($dateDiff->format('%a') > 90) {
                 $range['from'] = $toDateTime->sub(new DateInterval('P3M'))->format(MYSQL_DATE_FORMAT);
                 $Sender->setData('UserDataRangeClamped', true);
             } else {
@@ -191,7 +188,7 @@ class VanillaStatsPlugin extends Gdn_Plugin {
             }
 
             // Load the most active users during the date range.
-            $UserModel->SQL
+            $UserData = $UserModel->SQL
                 ->select('InsertUserID as UserID')
                 ->select('CommentID', 'count', 'CountComments')
                 ->from('Comment')
@@ -199,27 +196,8 @@ class VanillaStatsPlugin extends Gdn_Plugin {
                 ->where('DateInserted <=', $range['to'])
                 ->groupBy('InsertUserID')
                 ->orderBy('CountComments', 'desc')
-                ->limit(5, 0);
-
-            // We need to help the MySQL optimiser in some weird cases.
-            $Indexes = $Structure->indexSqlDb();
-            if (isset($Indexes['IX_Comment_DateInserted'])) {
-                $UserModel->SQL->from('Comment2');
-            }
-
-            // Make a copy before calling reset();
-            $NamedParameters = array_merge([], $UserModel->SQL->namedParameters());
-            $Query = $UserModel->SQL->getSelect();
-            $UserModel->SQL->reset();
-
-            // Force index usage. The MySQL optimizer can sometime, depending on the data structure,
-            // use FK_Comment_InsertUserID instead of IX_Comment_DateInserted which is way slower on large DateInserted range.
-            if (isset($Indexes['IX_Comment_DateInserted'])) {
-                $Query = preg_replace('/(\nfrom .+Comment.+?)(,.+Comment2.+)(\nwhere)/', "$1\nforce index (IX_Comment_DateInserted)$3", $Query);
-            }
-
-            $Query = $UserModel->SQL->applyParameters($Query, $NamedParameters);
-            $UserData = $UserModel->SQL->query($Query);
+                ->limit(5, 0)
+                ->get();
         }
 
         $Sender->setData('DiscussionData', $DiscussionData);

--- a/plugins/VanillaStats/class.vanillastats.plugin.php
+++ b/plugins/VanillaStats/class.vanillastats.plugin.php
@@ -42,12 +42,18 @@ class VanillaStatsPlugin extends Gdn_Plugin {
     /** @var string  */
     public $VanillaID;
 
+    /** @var bool */
+    private $dashboardSummariesEnabled;
+
     /**
      * VanillaStatsPlugin constructor.
      */
     public function __construct() {
         $this->AnalyticsServer = c('Garden.Analytics.Remote', 'analytics.vanillaforums.com');
         $this->VanillaID = Gdn::installationID();
+
+        $isVanillaAnalyticEnabled = Gdn::addonManager()->isEnabled('vanillaanalytics', Vanilla\Addon::TYPE_ADDON);
+        $this->dashboardSummariesEnabled = c('Garden.Analytics.DashboardSummaries', !$isVanillaAnalyticEnabled);
     }
 
     /**
@@ -141,8 +147,7 @@ class VanillaStatsPlugin extends Gdn_Plugin {
             $sender->addDefinition('ExpandText', t('more'));
             $sender->addDefinition('CollapseText', t('less'));
 
-            $isVanillaAnalyticEnabled = Gdn::addonManager()->isEnabled('vanillaanalytics', Vanilla\Addon::TYPE_ADDON);
-            $sender->addDefinition('DashboardSummaries', c('Garden.Analytics.DashboardSummaries', !$isVanillaAnalyticEnabled));
+            $sender->addDefinition('DashboardSummaries', $this->dashboardSummariesEnabled);
 
             // Render the custom dashboard view
             $sender->render('dashboard', '', 'plugins/VanillaStats');
@@ -156,9 +161,8 @@ class VanillaStatsPlugin extends Gdn_Plugin {
     public function settingsController_dashboardSummaries_create($Sender) {
         $DiscussionData = [];
         $UserData = [];
-        $isVanillaAnalyticEnabled = Gdn::addonManager()->isEnabled('vanillaanalytics', Vanilla\Addon::TYPE_ADDON);
 
-        if (c('Garden.Analytics.DashboardSummaries', !$isVanillaAnalyticEnabled)) {
+        if ($this->dashboardSummariesEnabled) {
             $range = Gdn::request()->getValue('range');
             $range['to'] = date(MYSQL_DATE_FORMAT, strtotime($range['to']));
             $range['from'] = date(MYSQL_DATE_FORMAT, strtotime($range['from']));

--- a/plugins/VanillaStats/class.vanillastats.plugin.php
+++ b/plugins/VanillaStats/class.vanillastats.plugin.php
@@ -184,7 +184,7 @@ class VanillaStatsPlugin extends Gdn_Plugin {
             $toDateTime = new DateTime($range['to']);
             $dateDiff = date_diff($toDateTime, new DateTime($range['from']));
             if ($rowCountEstimate >= 10000000 && $dateDiff->format('%a') > 90) {
-                $range['from'] = ($toDateTime->sub(new DateInterval('P3M')))->format(MYSQL_DATE_FORMAT);
+                $range['from'] = $toDateTime->sub(new DateInterval('P3M'))->format(MYSQL_DATE_FORMAT);
                 $Sender->setData('UserDataRangeClamped', true);
             } else {
                 $Sender->setData('UserDataRangeClamped', false);

--- a/plugins/VanillaStats/js/vanillastats.js
+++ b/plugins/VanillaStats/js/vanillastats.js
@@ -753,7 +753,7 @@ var vanillaStats = (function() {
     };
 
     VanillaStats.prototype.getSummaries = function(container) {
-        if (gdn.definition('DashboardSummaries')) {
+        if (!gdn.getMeta('DashboardSummaries', true)) {
             return;
         }
 

--- a/plugins/VanillaStats/js/vanillastats.js
+++ b/plugins/VanillaStats/js/vanillastats.js
@@ -753,6 +753,10 @@ var vanillaStats = (function() {
     };
 
     VanillaStats.prototype.getSummaries = function(container) {
+        if (gdn.definition('DashboardSummaries')) {
+            return;
+        }
+
         var rangeFrom = this.getRange("from");
         var rangeTo = this.getRange("to");
         var dateRange = {

--- a/plugins/VanillaStats/views/dashboardsummaries.php
+++ b/plugins/VanillaStats/views/dashboardsummaries.php
@@ -1,10 +1,15 @@
 <?php if (!defined('APPLICATION')) exit();
 
-$userBoard = new TableSummaryModule(t('Active Users'));
+$titleSuffix = '';
+if ($this->data('UserDataRangeClamped')) {
+    $titleSuffix = '<span class="form-control-sm">*'.t('Summary clamped to 3 months due to the amount of data.').'</span>';
+}
+
+$userBoard = new TableSummaryModule(t('Active Users').$titleSuffix);
 $userBoard->addColumn('users', t('Name'), [], TableSummaryModule::MAIN_CSS_CLASS)
     ->addColumn('count-comments', t('Comments'), ['class' => 'column-xs']);
 
-foreach ($this->Data['UserData'] as $userdata) {
+foreach ($this->data('UserData') as $userdata) {
     $id = val('UserID', $userdata);
     $user = Gdn::userModel()->getID($id);
     $name = val('Name', $user);

--- a/plugins/VanillaStats/views/dashboardsummaries.php
+++ b/plugins/VanillaStats/views/dashboardsummaries.php
@@ -1,8 +1,8 @@
 <?php if (!defined('APPLICATION')) exit();
 
 $titleSuffix = '';
-if ($this->data('UserDataRangeClamped')) {
-    $titleSuffix = '<span class="form-control-sm">*'.t('Summary limited to 90 days.').'</span>';
+if ($this->data('UserRangeWarning')) {
+    $titleSuffix = '<span class="text-warning form-control-sm">'.$this->data('UserRangeWarning').'</span>';
 }
 
 $userBoard = new TableSummaryModule(t('Active Users').$titleSuffix);

--- a/plugins/VanillaStats/views/dashboardsummaries.php
+++ b/plugins/VanillaStats/views/dashboardsummaries.php
@@ -2,7 +2,7 @@
 
 $titleSuffix = '';
 if ($this->data('UserDataRangeClamped')) {
-    $titleSuffix = '<span class="form-control-sm">*'.t('Summary clamped to 3 months due to the amount of data.').'</span>';
+    $titleSuffix = '<span class="form-control-sm">*'.t('Summary clamped to 90 days.').'</span>';
 }
 
 $userBoard = new TableSummaryModule(t('Active Users').$titleSuffix);

--- a/plugins/VanillaStats/views/dashboardsummaries.php
+++ b/plugins/VanillaStats/views/dashboardsummaries.php
@@ -2,7 +2,7 @@
 
 $titleSuffix = '';
 if ($this->data('UserDataRangeClamped')) {
-    $titleSuffix = '<span class="form-control-sm">*'.t('Summary clamped to 90 days.').'</span>';
+    $titleSuffix = '<span class="form-control-sm">*'.t('Summary limited to 90 days.').'</span>';
 }
 
 $userBoard = new TableSummaryModule(t('Active Users').$titleSuffix);


### PR DESCRIPTION
On large sites the generation the dashboardsummaries should go from 15-30secs to under a second.
Fixes https://github.com/vanilla/vanillastatsapp/issues/8

`/utility/update` needs to be ran for the indexes to be created!

I was told to make the indexes approved by @tburry 