### PR TITLE
Fix a category's latest post not being updated when moving or deleting a discussion

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2804,6 +2804,33 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * Get the most recent post info for a group of categories.
+     *
+     * @param array $categoryIDs
+     * @return array
+     */
+    public function getAggregateRecentPost(array $categoryIDs) {
+        $result = [
+            'LastCommentID' => null,
+            'LastDiscussionID' => null
+        ];
+
+        $discussion = $this->SQL->getWhere(
+            'Discussion',
+            ['CategoryID' => $categoryIDs],
+            'DateLastComment',
+            'desc',
+        1)->firstRow(DATASET_TYPE_ARRAY);
+
+        if (is_array($discussion)) {
+            $result['LastCommentID'] = $discussion['LastCommentID'];
+            $result['LastDiscussionID'] = $discussion['DiscussionID'];
+        }
+
+        return $result;
+    }
+
+    /**
      *
      *
      * @param $CategoryID

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2890,7 +2890,11 @@ class CategoryModel extends Gdn_Model {
             foreach ($ancestors as $row) {
                 // If this ancestor already has a newer discussion, stop.
                 if ($lastInserted < strtotime($row['LastDateInserted'])) {
-                    break;
+                    // Make sure this latest discussion is even valid.
+                    $lastDiscussion = DiscussionModel::instance()->getID($row['LastDiscussionID']);
+                    if ($lastDiscussion) {
+                        break;
+                    }
                 }
                 $currentCategoryID = val('CategoryID', $row);
                 self::instance()->setField($currentCategoryID, $db);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2692,6 +2692,9 @@ class DiscussionModel extends Gdn_Model {
         $this->SQL->delete('UserDiscussion', ['DiscussionID' => $discussionID]);
         $this->updateDiscussionCount($CategoryID);
 
+        // Update the last post info for the category and its parents.
+        CategoryModel::instance()->refreshAggregateRecentPost($CategoryID, true);
+
         // Decrement CountAllDiscussions for category and its parents.
         CategoryModel::decrementAggregateCount($CategoryID, CategoryModel::AGGREGATE_DISCUSSION);
 


### PR DESCRIPTION
This update adds some additional checks and updates to the routines involved in moving and deleting discussions to ensure the last post/category fields on a category are updated, in addition to their parent aggregate counts.

Closes #5236 