### PR TITLE
Fix non-ascii items not being added to menus

### DIFF
--- a/applications/dashboard/library/class.nestedcollectionadapter.php
+++ b/applications/dashboard/library/class.nestedcollectionadapter.php
@@ -36,7 +36,7 @@ class NestedCollectionAdapter {
         if ($permission === false) {
             $permission = true;
         }
-        $key = slugify($group) . '.' . slugify($text);
+        $key = strtolower($group.'.'.$text);
         $cssClass = val('class', $attributes, '');
         $this->siteNavModule->addLinkIf($permission, $text, $url, $key, $cssClass, [], $attributes);
         return $this;
@@ -55,7 +55,7 @@ class NestedCollectionAdapter {
         if ($permission === false) {
             $permission = true;
         }
-        $this->siteNavModule->addGroupIf($permission, $text, slugify($group), val('class', $attributes), '', $attributes);
+        $this->siteNavModule->addGroupIf($permission, $text, strtolower($group), val('class', $attributes), '', $attributes);
         return $this;
     }
 

--- a/applications/dashboard/library/class.nestedcollectionadapter.php
+++ b/applications/dashboard/library/class.nestedcollectionadapter.php
@@ -36,7 +36,7 @@ class NestedCollectionAdapter {
         if ($permission === false) {
             $permission = true;
         }
-        $key = strtolower($group.'.'.$text);
+        $key = NavModule::textToKey($group.'.'.$text);
         $cssClass = val('class', $attributes, '');
         $this->siteNavModule->addLinkIf($permission, $text, $url, $key, $cssClass, [], $attributes);
         return $this;
@@ -55,7 +55,7 @@ class NestedCollectionAdapter {
         if ($permission === false) {
             $permission = true;
         }
-        $this->siteNavModule->addGroupIf($permission, $text, strtolower($group), val('class', $attributes), '', $attributes);
+        $this->siteNavModule->addGroupIf($permission, $text, NavModule::textToKey($group), val('class', $attributes), '', $attributes);
         return $this;
     }
 

--- a/applications/dashboard/modules/class.navmodule.php
+++ b/applications/dashboard/modules/class.navmodule.php
@@ -150,4 +150,17 @@ class NavModule extends Gdn_Module {
 		$this->fireAs(get_called_class())->fireEvent('render');
 		return parent::toString();
 	}
+
+    /**
+     * Convert some text to a key.
+     *
+     * @param $text
+     * @return string
+     */
+	public static function textToKey($text) {
+	    $text = strtolower(trim($text));
+	    $text = str_replace(' ', '-', $text);
+	    $text = preg_replace('/-+/', '-', $text);
+	    return $text;
+    }
 }

--- a/applications/dashboard/modules/class.profileoptionsmodule.php
+++ b/applications/dashboard/modules/class.profileoptionsmodule.php
@@ -58,7 +58,7 @@ class ProfileOptionsModule extends Gdn_Module {
 
         foreach($profileOptions as $option) {
             if (val('Text', $option) && val('Url', $option)) {
-                $this->profileOptionsDropdown->addLink(val('Text', $option), val('Url', $option), slugify(val('Text', $option)), val('CssClass', $option, ''));
+                $this->profileOptionsDropdown->addLink(val('Text', $option), val('Url', $option), strtolower(val('Text', $option)), val('CssClass', $option, ''));
             }
         }
 

--- a/applications/dashboard/modules/class.profileoptionsmodule.php
+++ b/applications/dashboard/modules/class.profileoptionsmodule.php
@@ -58,7 +58,7 @@ class ProfileOptionsModule extends Gdn_Module {
 
         foreach($profileOptions as $option) {
             if (val('Text', $option) && val('Url', $option)) {
-                $this->profileOptionsDropdown->addLink(val('Text', $option), val('Url', $option), strtolower(val('Text', $option)), val('CssClass', $option, ''));
+                $this->profileOptionsDropdown->addLink(val('Text', $option), val('Url', $option), NavModule::textToKey(val('Text', $option)), val('CssClass', $option, ''));
             }
         }
 

--- a/applications/dashboard/views/settings/helper_functions.php
+++ b/applications/dashboard/views/settings/helper_functions.php
@@ -179,7 +179,7 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
 
     $url = '/settings/'.$addonType.'/'.$action.'/'.$addonName;
 
-    $media->setToggle(strtolower($addonName), $isEnabled, $url, $label);
+    $media->setToggle(slugify($addonName), $isEnabled, $url, $label);
 
     // Meta
 

--- a/applications/dashboard/views/settings/helper_functions.php
+++ b/applications/dashboard/views/settings/helper_functions.php
@@ -179,7 +179,7 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
 
     $url = '/settings/'.$addonType.'/'.$action.'/'.$addonName;
 
-    $media->setToggle(slugify($addonName), $isEnabled, $url, $label);
+    $media->setToggle(strtolower($addonName), $isEnabled, $url, $label);
 
     // Meta
 

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -193,7 +193,7 @@ if (!function_exists('discussionOptionsToDropdown')):
 
         if (!empty($options)) {
             foreach ($options as $option) {
-                $dropdown->addLink(val('Label', $option), val('Url', $option), slugify(val('Label', $option)), val('Class', $option));
+                $dropdown->addLink(val('Label', $option), val('Url', $option), strtolower(val('Label', $option)), val('Class', $option));
             }
         }
 

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -193,7 +193,7 @@ if (!function_exists('discussionOptionsToDropdown')):
 
         if (!empty($options)) {
             foreach ($options as $option) {
-                $dropdown->addLink(val('Label', $option), val('Url', $option), strtolower(val('Label', $option)), val('Class', $option));
+                $dropdown->addLink(val('Label', $option), val('Url', $option), NavModule::textToKey(val('Label', $option)), val('Class', $option));
             }
         }
 


### PR DESCRIPTION
`slugify()` does not work with non ascii characters.
Also... keys are used as index in php arrays there is no need to `slugify()` them.

Fixes https://github.com/vanilla/vanilla/issues/5212