### PR TITLE
Do not request publish_actions in facebook plugin

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -532,7 +532,7 @@ class FacebookPlugin extends Gdn_Plugin {
      */
     public function authorizeUri($Query = false, $RedirectUri = false) {
         $AppID = c('Plugins.Facebook.ApplicationID');
-        $FBScope = c('Plugins.Facebook.Scope', 'email,publish_actions');
+        $FBScope = c('Plugins.Facebook.Scope', 'email');
 
         if (is_array($FBScope)) {
             $Scopes = implode(',', $FBScope);


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/5458 and closes https://github.com/vanilla/docs/issues/49

We [removed the automatic sharing feature](https://github.com/vanilla/vanilla/pull/5371) and the publish_actions is not needed by the Share Dialog.

To make sure that everything work, I created an app, made it public, made a coworker login in my forum with their facebook account and share something on their facebook feed.