### PR TITLE
Remove HOST header support from Gdn_Request

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -18,7 +18,7 @@ use Garden\Web\RequestInterface;
  * @method string requestURI($uri = null) Get/Set the Request URI (REQUEST_URI).
  * @method string requestScript($scriptName = null) Get/Set the Request ScriptName (SCRIPT_NAME).
  * @method string requestMethod($method = null) Get/Set the Request Method (REQUEST_METHOD).
- * @method string requestHost($uri = null) Get/Set the Request Host (HTTP_HOST).
+ * @method string requestHost($uri = null) Get/Set the Request Host (SERVER_NAME).
  * @method string requestFolder($folder = null) Get/Set the Request script's Folder.
  * @method string requestAddress($ip = null) Get/Set the Request IP address (first existing of HTTP_X_ORIGINALLY_FORWARDED_FOR,
  *                HTTP_X_CLUSTER_CLIENT_IP, HTTP_CLIENT_IP, HTTP_X_FORWARDED_FOR, REMOTE_ADDR).
@@ -133,7 +133,7 @@ class Gdn_Request implements RequestInterface {
 
     /**
      * Accessor method for unparsed request environment data, such as the REQUEST_URI, SCRIPT_NAME,
-     * HTTP_HOST and REQUEST_METHOD keys in $_SERVER.
+     * SERVER_NAME and REQUEST_METHOD keys in $_SERVER.
      *
      * A second argument can be supplied, which causes the value of the specified key to be changed
      * to that of the second parameter itself.
@@ -141,7 +141,7 @@ class Gdn_Request implements RequestInterface {
      * Currently recognized keys (and their relation to $_SERVER) are:
      *  - URI      -> REQUEST_URI
      *  - SCRIPT   -> SCRIPT_NAME
-     *  - HOST     -> HTTP_HOST
+     *  - HOST     -> SERVER_NAME
      *  - METHOD   -> REQUEST_METHOD
      *  - FOLDER   -> none. this is extracted from SCRIPT_NAME and only available after _ParseRequest()
      *  - SCHEME   -> none. this is derived from 'HTTPS' and 'X-Forwarded-Proto'
@@ -654,13 +654,7 @@ class Gdn_Request implements RequestInterface {
         $this->_environmentElement('ConfigWebRoot', Gdn::config('Garden.WebRoot'));
         $this->_environmentElement('ConfigStripUrls', Gdn::config('Garden.StripWebRoot', false));
 
-        if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-            $host = $_SERVER['HTTP_X_FORWARDED_HOST'];
-        } elseif (isset($_SERVER['HTTP_HOST'])) {
-            $host = $_SERVER['HTTP_HOST'];
-        } else {
-            $host = val('SERVER_NAME', $_SERVER);
-        }
+        $host = val('SERVER_NAME', $_SERVER);
 
         // The host can have the port passed in, remove it here if it exists
         $hostParts = explode(':', $host, 2);


### PR DESCRIPTION
Support for the HOST header should only be utilized in advanced network setups that can properly vet the value. This update removes automatic handling of that header.