### PR TITLE
Improve customizability of the PHPUnit testing environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ npm-debug.log
 !/build/package-exclude.txt
 /tests/cache/
 /cgi-bin/
+phpunit.xml

--- a/tests/APIv0/APIv0.php
+++ b/tests/APIv0/APIv0.php
@@ -47,6 +47,16 @@ class APIv0 extends HttpClient {
     }
 
     /**
+     * Get the host of the database.
+     *
+     * @return string
+     */
+    public function getDbHost() {
+        $host = isset($_ENV['dbhost']) ? $_ENV['dbhost'] : 'localhost';
+        return $host;
+    }
+
+    /**
      * Get the name of the database for direct access.
      *
      * @return string Returns the name of the database.
@@ -116,7 +126,8 @@ class APIv0 extends HttpClient {
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 PDO::MYSQL_ATTR_INIT_COMMAND  => "set names 'utf8mb4'"
             ];
-            $pdo = new PDO("mysql:host=localhost", $this->getDbUser(), $this->getDbPassword(), $options);
+            $host = $this->getDbHost();
+            $pdo = new PDO("mysql:host={$host}", $this->getDbUser(), $this->getDbPassword(), $options);
 
             $dbname = $this->getDbName();
             $r = $pdo->query("show databases like '$dbname'", PDO::FETCH_COLUMN, 0);
@@ -190,7 +201,7 @@ class APIv0 extends HttpClient {
 
         // Install Vanilla via cURL.
         $post = [
-            'Database-dot-Host' => 'localhost',
+            'Database-dot-Host' => $this->getDbHost(),
             'Database-dot-Name' => $this->getDbName(),
             'Database-dot-User' => $this->getDbUser(),
             'Database-dot-Password' => $this->getDbPassword(),

--- a/tests/APIv0/AltTest.php
+++ b/tests/APIv0/AltTest.php
@@ -51,7 +51,7 @@ class AltTest extends \PHPUnit_Framework_TestCase {
 
         $config = [
             'Database' => [
-                'Host' => 'localhost',
+                'Host' => $api->getDbHost(),
                 'Name' => $api->getDbName(),
                 'User' => $api->getDbUser(),
                 'Password' => $api->getDbPassword(),

--- a/tests/TestInstallModel.php
+++ b/tests/TestInstallModel.php
@@ -30,12 +30,11 @@ class TestInstallModel extends InstallModel {
      */
     public function __construct(\Gdn_Configuration $config, AddonModel $addonModel, ContainerInterface $container) {
         parent::__construct($config, $addonModel, $container);
+        $this->setBaseUrl($_ENV['baseurl']);
 
         $this->config->Data = [];
         $this->config->load(PATH_ROOT.'/conf/config-defaults.php');
         $this->config->load($this->getConfigPath(), 'Configuration', true);
-
-        $this->setBaseUrl($_ENV['baseurl']);
     }
 
     /**
@@ -98,11 +97,21 @@ class TestInstallModel extends InstallModel {
      */
     private function getDbInfo() {
         return [
-            'host' => 'localhost',
+            'host' => $this->getDbHost(),
             'name' => $this->getDbName(),
             'user' => $this->getDbUser(),
             'password' => $this->getDbPassword()
         ];
+    }
+
+    /**
+     * Get the database host.
+     *
+     * @return string
+     */
+    public function getDbHost() {
+        $host = isset($_ENV['dbhost']) ? $_ENV['dbhost'] : 'localhost';
+        return $host;
     }
 
     /**


### PR DESCRIPTION
This update primarily does two things:

1. Adds the ability to define a database host. Currently, the database is hardcoded to "localhost". The value still defaults to "localhost", but can be overridden with a "dbhost" environment variable.
1. Adds "phpunit.xml" to the repo's `.gitignore` file. Without explicitly defining a config with the `--configuration` parameter, PHPUnit will attempt to use one of two files: phpunit.xml or phpunit.xml.dist, in that order. Vanilla already comes with a phpunit.xml.dist, so now developers can use their own phpunit.xml.

@DaazKu pointed out an issue in `TestInstallModel::__construct` wherein the `baseUrl` property could be set too early and lead to a config with an invalid name being created (".php"). This was due to `getConfigPath` being called before `baseUrl` had been set. Since `getConfigPath` uses `baseUrl` to determine its file name, this caused empty filenames. To fix this, I made sure `baseUrl` was one of the first things set in `TestInstallModel::__construct`