### PR TITLE
Fix notice when calling HeadModule::setMobileAddressBarColor

### DIFF
--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -310,7 +310,7 @@ if (!class_exists('HeadModule', false)) {
          *
          * @param string meta tags for various browsers
          */
-        public function setMobileAddressBarColor($mobileAddressBarColor, $iosAddressBarColor) {
+        public function setMobileAddressBarColor($mobileAddressBarColor) {
             if (!$this->_MobileAddressBarColorSet && $mobileAddressBarColor) {
                 $this->_MobileAddressBarColorSet = true;
                 $this->addTag(


### PR DESCRIPTION
`HeadModule::setMobileAddressBarColor` has an unused parameter: `$iosAddressBarColor`. This update removes it.