### PR TITLE
Give more control over the category tree in the categories module

### DIFF
--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -397,8 +397,8 @@ class CategoryCollection {
      * @param int $parentID The ID of the parent category.
      * @param array $options An array of options to affect the fetching.
      *
-     * - maxdepth: The maximum depth of the tree.
-     * - collapsed: Stop when looking at a category of a certain type.
+     * - maxDepth: The maximum depth of the tree.
+     * - collapseCategories: Stop when looking at a categories that contain categories.
      * - permission: The permission to use when looking at the tree.
      * @return array
      */

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -700,8 +700,11 @@ class CategoryModel extends Gdn_Model {
     public function getChildTree($id, $options = []) {
         $category = $this->getOne($id);
 
+        $options = array_change_key_case($options ?: []) + [
+            'collapsecategories' => true
+        ];
+
         $tree = $this->collection->getTree((int)val('CategoryID', $category), $options);
-        self::filterChildren($tree);
         return $tree;
     }
 


### PR DESCRIPTION
- Allow the categories module to provide a collapseCategories property
that specifies whether category categories are displayed.
- All the categories module to provide a root category.
- Use the CategoryCollection to filter category categories rather than
the redundant filterChildren() method.

Fixes #5585.