### PR TITLE
Fix find-ban URL on profile page when user has been banned by a rule

### DIFF
--- a/applications/dashboard/modules/class.userbanmodule.php
+++ b/applications/dashboard/modules/class.userbanmodule.php
@@ -51,7 +51,7 @@ class UserBanModule extends GDN_Module {
             // Add a link to identify the corresponding ban rule.
             if ($bit === 2) {
                 $text = sprintf(t('Find the corresponding ban rule for %s'), val('Name', $user));
-                $reasons[$bit] .= ' '.anchor($text, url('settings/bans/find/'.$userID));
+                $reasons[$bit] .= ' '.anchor($text, url('settings/bans/find/'.$userID, true));
             }
         }
 

--- a/applications/dashboard/modules/class.userbanmodule.php
+++ b/applications/dashboard/modules/class.userbanmodule.php
@@ -51,7 +51,7 @@ class UserBanModule extends GDN_Module {
             // Add a link to identify the corresponding ban rule.
             if ($bit === 2) {
                 $text = sprintf(t('Find the corresponding ban rule for %s'), val('Name', $user));
-                $reasons[$bit] .= ' '.anchor($text, url('settings/bans/find/'.$userID, true));
+                $reasons[$bit] .= ' '.anchor($text, 'settings/bans/find/'.$userID);
             }
         }
 


### PR DESCRIPTION
When subcommunities are turned on, the link to the banned reasons had the subcommunity uri twice in the address.