### PR TITLE
Allow admins to not set "Remember Me" by default over SSO

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -548,7 +548,7 @@ class EntryController extends Gdn_Controller {
             }
 
             // Sign the user in.
-            Gdn::session()->start($UserID, true, (bool)$this->Form->getFormValue('RememberMe', true));
+            Gdn::session()->start($UserID, true, (bool)$this->Form->getFormValue('RememberMe', c('Garden.SSO.RememberMe', true)));
             Gdn::userModel()->fireEvent('AfterSignIn');
 
             // Send them on their way.
@@ -635,7 +635,7 @@ class EntryController extends Gdn_Controller {
                             ]);
 
                             // Sign the user in.
-                            Gdn::session()->start($UserID, true, (bool)$this->Form->getFormValue('RememberMe', true));
+                            Gdn::session()->start($UserID, true, (bool)$this->Form->getFormValue('RememberMe', c('Garden.SSO.RememberMe', true)));
                             Gdn::userModel()->fireEvent('AfterSignIn');
                             $this->_setRedirect(Gdn::request()->get('display') === 'popup');
                             $this->render();
@@ -765,7 +765,7 @@ class EntryController extends Gdn_Controller {
                     $this->Form->setFormValue('UserSelect', false);
 
                     // Sign in as the new user.
-                    Gdn::session()->start($UserID, true, (bool)$this->Form->getFormValue('RememberMe', true));
+                    Gdn::session()->start($UserID, true, (bool)$this->Form->getFormValue('RememberMe', c('Garden.SSO.RememberMe', true)));
                     Gdn::userModel()->fireEvent('AfterSignIn');
 
                     // Send the welcome email.
@@ -877,7 +877,7 @@ class EntryController extends Gdn_Controller {
                 }
 
                 // Sign the user in.
-                Gdn::session()->start($this->Form->getFormValue('UserID'), true, (bool)$this->Form->getFormValue('RememberMe', true));
+                Gdn::session()->start($this->Form->getFormValue('UserID'), true, (bool)$this->Form->getFormValue('RememberMe', c('Garden.SSO.RememberMe', true)));
                 Gdn::userModel()->fireEvent('AfterSignIn');
 
                 // Move along.


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/5586

Backport 5586 to release/2017-Q2-2

Currently when you connect over SSO we hard code the user's session as if he had signed in and clicked "Remember Me" giving him a cookie with an expiration date. This PR will allow us to configure a site so that when users connect they are given a cookie that expires with the browser session.