### PR TITLE
Properly set addons info fields 'Index'(old info) and 'rawKey'(new info)

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -154,7 +154,7 @@ class Addon {
                 if ($info['oldType'] === 'application') {
                     $info['keyRaw'] = $info['name'];
                 } else {
-                    if ($addonFolder !== strtolower($info['key'])) {
+                    if ($addonFolder !== $info['key']) {
                         $info['keyRaw'] = $addonFolder;
                     }
                 }

--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -146,9 +146,14 @@ class Addon {
             }
 
             // Kludge that sets oldType until we unify applications and plugins into addon.
-            $baseDir = explode('/', ltrim($subdir, '/'))[0];
-            if (in_array($baseDir, ['applications', 'plugins'])) {
-                $info['oldType'] = substr($baseDir, 0, -1);
+            list($addonParentFolder, $addonFolder) = explode('/', ltrim($subdir, '/'));
+            if (in_array($addonParentFolder, ['applications', 'plugins'])) {
+                $info['oldType'] = substr($addonParentFolder, 0, -1);
+            }
+
+            // Kludge that sets keyRaw until we use key everywhere.
+            if ($addonFolder !== $info['key']) {
+                $info['keyRaw'] = $addonFolder;
             }
 
             return $info;

--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -149,11 +149,15 @@ class Addon {
             list($addonParentFolder, $addonFolder) = explode('/', ltrim($subdir, '/'));
             if (in_array($addonParentFolder, ['applications', 'plugins'])) {
                 $info['oldType'] = substr($addonParentFolder, 0, -1);
-            }
 
-            // Kludge that sets keyRaw until we use key everywhere.
-            if ($addonFolder !== $info['key']) {
-                $info['keyRaw'] = $addonFolder;
+                // Kludge that sets keyRaw until we use key everywhere.
+                if ($info['oldType'] === 'application') {
+                    $info['keyRaw'] = $info['name'];
+                } else {
+                    if ($addonFolder !== strtolower($info['key'])) {
+                        $info['keyRaw'] = $addonFolder;
+                    }
+                }
             }
 
             return $info;

--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -104,6 +104,9 @@ class Gdn_ApplicationManager {
         $directories = explode(DS, $addon->getSubdir());
         $info['Folder'] = $directories[count($directories) - 1];
 
+        // $ApplicationInfo[INDEX] is converted to $info['Name'] = 'Index'
+        $info['Index'] = $info['Name'];
+
         return $info;
     }
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5598

In PermissionModel->getAllowedPermissionNamespaces() we were stripping all applications permissions because the applications index were set to `key` (or `keyRaw`) which are all lowercased instead of `name` which looks like this: `Dashboard`