### PR TITLE
Prevent the twitter provider update to keep showing up in /utility/structure

### DIFF
--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -936,7 +936,8 @@ class TwitterPlugin extends Gdn_Plugin {
         Gdn::sql()->replace(
             'UserAuthenticationProvider',
             array('AuthenticationSchemeAlias' => 'twitter', 'URL' => '...', 'AssociationSecret' => '...', 'AssociationHashMethod' => '...'),
-            array('AuthenticationKey' => self::ProviderKey)
+            array('AuthenticationKey' => self::ProviderKey),
+            true
         );
     }
 }


### PR DESCRIPTION
Fixing this issue by checking if provider already exists, this is done simply by adding the true parameter to the replace structure function of the plugin.