### PR TITLE
Refactor unit tests

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2106,48 +2106,33 @@ if (!function_exists('jsonEncodeChecked')) {
      * @throws Exception
      */
     function jsonEncodeChecked($value, $options = null) {
-        $advanced = (PHP_VERSION_ID >= 50500);
-
-        if ($options === null) {
-            if ($advanced) {
-                $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
-            } else {
-                $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
-            }
+         if ($options === null) {
+            $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
         }
-
         $encoded = json_encode($value, $options);
         $errorMessage = null;
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            if ($advanced) {
-                if ($encoded === false) {
-                    switch (json_last_error()) {
-                        case JSON_ERROR_UTF8:
-                            $errorMessage = 'Malformed UTF-8 characters, possibly incorrectly encoded';
-                            break;
-                        case JSON_ERROR_RECURSION:
-                            $errorMessage = 'One or more recursive references in the value to be encoded.';
-                            break;
-                        case JSON_ERROR_INF_OR_NAN:
-                            $errorMessage = 'One or more NAN or INF values in the value to be encoded';
-                            break;
-                        case JSON_ERROR_UNSUPPORTED_TYPE:
-                            $errorMessage = 'A value of a type that cannot be encoded was given.';
-                            break;
-                        default:
-                            $errorMessage = 'An unknown error has occurred.';
-                    }
-                }
-            } else {
+        switch (json_last_error()) {
+            case JSON_ERROR_NONE:
+                // Do absolutely nothing since all went well!
+                break;
+            case JSON_ERROR_UTF8:
+                $errorMessage = 'Malformed UTF-8 characters, possibly incorrectly encoded';
+                break;
+            case JSON_ERROR_RECURSION:
+                $errorMessage = 'One or more recursive references in the value to be encoded.';
+                break;
+            case JSON_ERROR_INF_OR_NAN:
+                $errorMessage = 'One or more NAN or INF values in the value to be encoded';
+                break;
+            case JSON_ERROR_UNSUPPORTED_TYPE:
+                $errorMessage = 'A value of a type that cannot be encoded was given.';
+                break;
+            default:
                 $errorMessage = 'An unknown error has occurred.';
-            }
         }
-
         if ($errorMessage !== null) {
             throw new Exception("JSON encoding error: {$errorMessage}", 500);
         }
-
         return $encoded;
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,10 +17,10 @@
         <ini name="memory_limit" value="-1"/>
         <ini name="date.timezone" value="America/Montreal"/>
 
-        <env name="baseurl" value="http://vanilla.test:8080" />
-        <env name="dbname" value="vanilla_test"/>
-        <env name="dbuser" value="travis" />
-        <env name="dbpass" value="" />
+        <env name="TEST_BASEURL" value="http://vanilla.test:8080" />
+        <env name="TEST_DB_NAME" value="vanilla_test"/>
+        <env name="TEST_DB_USER" value="travis" />
+        <env name="TEST_DB_PASSWORD" value="" />
     </php>
 
     <testsuites>

--- a/tests/APIv0/APIv0.php
+++ b/tests/APIv0/APIv0.php
@@ -42,7 +42,7 @@ class APIv0 extends HttpClient {
     public function __construct() {
         parent::__construct();
         $this
-            ->setBaseUrl($_ENV['baseurl'])
+            ->setBaseUrl(getenv('TEST_BASEURL'))
             ->setThrowExceptions(true);
     }
 
@@ -52,8 +52,12 @@ class APIv0 extends HttpClient {
      * @return string
      */
     public function getDbHost() {
-        $host = isset($_ENV['dbhost']) ? $_ENV['dbhost'] : 'localhost';
-        return $host;
+        if (getenv('TEST_DB_HOST')) {
+            $dbHost = getenv('TEST_DB_HOST');
+        } else {
+            $dbHost = 'localhost';
+        }
+        return $dbHost;
     }
 
     /**
@@ -64,8 +68,8 @@ class APIv0 extends HttpClient {
     public function getDbName() {
         $host = parse_url($this->getBaseUrl(), PHP_URL_HOST);
 
-        if (isset($_ENV['dbname'])) {
-            $dbname = $_ENV['dbname'];
+        if (getenv('TEST_DB_NAME')) {
+            $dbname = getenv('TEST_DB_NAME');
         } else {
             $dbname = preg_replace('`[^a-z]`i', '_', $host);
         }
@@ -78,7 +82,7 @@ class APIv0 extends HttpClient {
      * @return string Returns a username.
      */
     public function getDbUser() {
-        return $_ENV['dbuser'];
+        return getenv('TEST_DB_USER');
     }
 
     /**
@@ -87,7 +91,7 @@ class APIv0 extends HttpClient {
      * @return string Returns a password.
      */
     public function getDbPassword() {
-        return $_ENV['dbpass'];
+        return getenv('TEST_DB_PASSWORD');
     }
 
     /**
@@ -126,8 +130,7 @@ class APIv0 extends HttpClient {
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
                 PDO::MYSQL_ATTR_INIT_COMMAND  => "set names 'utf8mb4'"
             ];
-            $host = $this->getDbHost();
-            $pdo = new PDO("mysql:host={$host}", $this->getDbUser(), $this->getDbPassword(), $options);
+            $pdo = new PDO('mysql:host='.$this->getDbHost(), $this->getDbUser(), $this->getDbPassword(), $options);
 
             $dbname = $this->getDbName();
             $r = $pdo->query("show databases like '$dbname'", PDO::FETCH_COLUMN, 0);

--- a/tests/APIv0/AltTest.php
+++ b/tests/APIv0/AltTest.php
@@ -14,7 +14,7 @@ use PDO;
 /**
  * Tests an alternate install method.
  */
-class AltTest extends \PHPUnit_Framework_TestCase {
+class AltTest extends \PHPUnit\Framework\TestCase {
     /** @var APIv0  $api */
     protected static $api;
 

--- a/tests/APIv0/BaseTest.php
+++ b/tests/APIv0/BaseTest.php
@@ -10,7 +10,7 @@ namespace VanillaTests\APIv0;
 
 use Garden\Http\HttpResponse;
 
-abstract class BaseTest extends \PHPUnit_Framework_TestCase {
+abstract class BaseTest extends \PHPUnit\Framework\TestCase {
     /** @var APIv0  $api */
     protected static $api;
 

--- a/tests/APIv2/InstallTest.php
+++ b/tests/APIv2/InstallTest.php
@@ -13,7 +13,7 @@ use VanillaTests\TestInstallModel;
 /**
  * Test basic Vanilla installation.
  */
-class InstallTest extends \PHPUnit_Framework_TestCase {
+class InstallTest extends \PHPUnit\Framework\TestCase {
     /**
      * Test installing Vanilla with the {@link \Vanilla\Models\InstallModel}.
      */

--- a/tests/Library/Core/ArrayFunctionsTest.php
+++ b/tests/Library/Core/ArrayFunctionsTest.php
@@ -10,7 +10,7 @@ namespace VanillaTests\Library\Core;
 /**
  * Test array functions.
  */
-class ArrayFunctionsTest extends \PHPUnit_Framework_TestCase {
+class ArrayFunctionsTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * Test {@link flattenArray()}.

--- a/tests/Library/Core/ControllerTest.php
+++ b/tests/Library/Core/ControllerTest.php
@@ -8,11 +8,11 @@
 namespace VanillaTests\Library\Core;
 
 use Gdn_Controller;
-use PHPUnit_Framework_TestCase;
+use \PHPUnit\Framework\TestCase;
 use stdClass;
 
 
-class ControllerTest extends PHPUnit_Framework_TestCase {
+class ControllerTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * Testing that the same key will be used to set data and to get it back.

--- a/tests/Library/Core/DataSetTest.php
+++ b/tests/Library/Core/DataSetTest.php
@@ -12,7 +12,7 @@ use Gdn_DataSet;
 /**
  * Test the {@link Gdn_DataSet} class.
  */
-class DataSetTest extends \PHPUnit_Framework_TestCase {
+class DataSetTest extends \PHPUnit\Framework\TestCase {
     /**
      * A basic test of newing up a dataset.
      */

--- a/tests/Library/Core/DateTimeTest.php
+++ b/tests/Library/Core/DateTimeTest.php
@@ -11,7 +11,7 @@ use DateTime;
 use DateTimeZone;
 
 
-class DateTimeTest extends \PHPUnit_Framework_TestCase{
+class DateTimeTest extends \PHPUnit\Framework\TestCase{
 
     /**
      * Test that different named timezones in the same place produce equivalent dates.

--- a/tests/Library/Core/DbEncodeDecodeTest.php
+++ b/tests/Library/Core/DbEncodeDecodeTest.php
@@ -10,7 +10,7 @@ namespace VanillaTests\Library\Core;
 /**
  * Test some of the global functions that operate (or mostly operate) on arrays.
  */
-class DbEncodeDecodeTest extends \PHPUnit_Framework_TestCase {
+class DbEncodeDecodeTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * Test encoding/decoding an array.

--- a/tests/Library/Core/FactoryTest.php
+++ b/tests/Library/Core/FactoryTest.php
@@ -12,7 +12,7 @@ use VanillaTests\Fixtures\Tuple;
 /**
  * Tests for the {@link Gdn_Factory}.
  */
-class FactoryTest extends \PHPUnit_Framework_TestCase {
+class FactoryTest extends \PHPUnit\Framework\TestCase {
     const TUPLE = 'VanillaTests\Fixtures\Tuple';
 
     /**

--- a/tests/Library/Core/FormTest.php
+++ b/tests/Library/Core/FormTest.php
@@ -10,7 +10,7 @@ namespace VanillaTests\Library\Core;
 use Gdn;
 use Gdn_Form;
 
-class FormTest extends \PHPUnit_Framework_TestCase {
+class FormTest extends \PHPUnit\Framework\TestCase {
     /**
      * Setup a dummy request because {@link Gdn_Form} needs it.
      */

--- a/tests/Library/Core/GeneralFunctionsTest.php
+++ b/tests/Library/Core/GeneralFunctionsTest.php
@@ -8,7 +8,7 @@
 namespace VanillaTests\Library\Core;
 
 
-class GeneralFunctionsTest extends \PHPUnit_Framework_TestCase {
+class GeneralFunctionsTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * Test {@link urlMatch()}.
@@ -30,15 +30,13 @@ class GeneralFunctionsTest extends \PHPUnit_Framework_TestCase {
      * @dataProvider provideJsonEncodeCheckedTests
      */
     public function testJsonEncodeChecked($data, $expectException) {
-        if ($expectException && PHP_VERSION_ID < 50500) {
-            if (version_compare(\PHPUnit_Runner_Version::id(), '5.0', '<')) {
-                $this->setExpectedException('Exception');
-            } else {
-                $this->expectException('Exception');
-            }
+        if ($expectException) {
+            $this->expectException('Exception');
         }
 
-        jsonEncodeChecked($data);
+        $encodedData = jsonEncodeChecked($data);
+
+        $this->assertNotFalse($encodedData);
     }
 
     /**

--- a/tests/Library/Core/JsonFilterTest.php
+++ b/tests/Library/Core/JsonFilterTest.php
@@ -11,7 +11,7 @@ use DateTime;
 /**
  * Test the jsonFilter function.
  */
-class JsonFilterTest extends \PHPUnit_Framework_TestCase {
+class JsonFilterTest extends \PHPUnit\Framework\TestCase {
 
     public function testJsonFilterDateTime() {
         $date = new DateTime('now', new \DateTimeZone('UTC'));

--- a/tests/Library/Core/PasswordTest.php
+++ b/tests/Library/Core/PasswordTest.php
@@ -12,7 +12,7 @@ use Gdn_PasswordHash;
 /**
  * Test the the {@link Gdn_PasswordHash} class.
  */
-class PasswordTest extends \PHPUnit_Framework_TestCase {
+class PasswordTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * Make sure an empty password fails.

--- a/tests/Library/Core/PluginManagerTest.php
+++ b/tests/Library/Core/PluginManagerTest.php
@@ -13,7 +13,7 @@ use Gdn_PluginManager;
 /**
  * Test the {@link Gdn_PluginManager} class.
  */
-class PluginManagerTest extends \PHPUnit_Framework_Testcase {
+class PluginManagerTest extends \PHPUnit\Framework\TestCase {
     /**
      * Test a basic usage of {@link Gdn_PluginManager::registerCallback}.
      */

--- a/tests/Library/Core/RenderFunctionsTest.php
+++ b/tests/Library/Core/RenderFunctionsTest.php
@@ -10,7 +10,7 @@ namespace VanillaTests\Library\Core;
 /**
  * Test some of the functions in functions.render.php.
  */
-class RenderFunctionsTest extends \PHPUnit_Framework_TestCase {
+class RenderFunctionsTest extends \PHPUnit\Framework\TestCase {
     /**
      * Make sure the render functions are included.
      */
@@ -45,7 +45,7 @@ class RenderFunctionsTest extends \PHPUnit_Framework_TestCase {
             'FirstUserID' => 234,
             'FirstName' => 'Barry'
         ];
-        
+
         $user = userBuilder($userRow, ['First', 'Insert']);
         $this->assertSame(234, $user->UserID);
         $this->assertSame('Barry', $user->Name);

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -11,7 +11,7 @@ use Gdn_Request;
 /**
  * Test the {@link Gdn_Request} class.
  */
-class RequestTest extends \PHPUnit_Framework_TestCase {
+class RequestTest extends \PHPUnit\Framework\TestCase {
 
     public function provideUrls() {
         return [

--- a/tests/Library/Garden/ClassLocatorTest.php
+++ b/tests/Library/Garden/ClassLocatorTest.php
@@ -8,7 +8,7 @@ namespace VanillaTests\Library\Garden;
 
 use Garden\ClassLocator;
 
-class ClassLocatorTest extends \PHPUnit_Framework_TestCase {
+class ClassLocatorTest extends \PHPUnit\Framework\TestCase {
 
     public function testFindClass() {
         $classLocator = new ClassLocator();

--- a/tests/Library/Garden/EventManagerTest.php
+++ b/tests/Library/Garden/EventManagerTest.php
@@ -16,7 +16,7 @@ use VanillaTests\Fixtures\Container;
 /**
  * Tests for the {@link EventManager} class.
  */
-class EventManagerTest extends \PHPUnit_Framework_TestCase {
+class EventManagerTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * Creates an {@link AddonManager} against Vanilla.
@@ -72,6 +72,9 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase {
                 continue;
             }
         }
+
+        // No exception so we are cool!
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/Library/Garden/Web/CookieTest.php
+++ b/tests/Library/Garden/Web/CookieTest.php
@@ -12,7 +12,7 @@ use Garden\Web\Cookie;
 /**
  * Test the {@link ResourceRoute} class.
  */
-class CookieTest extends \PHPUnit_Framework_TestCase {
+class CookieTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * Parse a Cookie header into its individual cookie key-value pairs.

--- a/tests/Library/Garden/Web/ResourceRouteTest.php
+++ b/tests/Library/Garden/Web/ResourceRouteTest.php
@@ -16,7 +16,7 @@ use VanillaTests\Fixtures\Request;
 /**
  * Test the {@link ResourceRoute} class.
  */
-class ResourceRouteTest extends \PHPUnit_Framework_TestCase {
+class ResourceRouteTest extends \PHPUnit\Framework\TestCase {
     /**
      * Create a new {@link ResourceRoute} initialized for testing with fixtures.
      */

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -16,7 +16,7 @@ use Vanilla\Addon;
 use VanillaTests\Fixtures\TestAddonManager;
 
 
-class AddonManagerTest extends \PHPUnit_Framework_TestCase {
+class AddonManagerTest extends \PHPUnit\Framework\TestCase {
 
     private static $types = [Addon::TYPE_ADDON, Addon::TYPE_THEME, Addon::TYPE_LOCALE];
 
@@ -34,8 +34,11 @@ class AddonManagerTest extends \PHPUnit_Framework_TestCase {
         $manager = $this->createTestManager();
 
         foreach (static::$types as $type) {
-            $addons = $manager->scan($type, true);
+            $manager->scan($type, true);
         }
+
+        // No exception so we are cool!
+        $this->assertTrue(true);
     }
 
     /**
@@ -66,6 +69,9 @@ class AddonManagerTest extends \PHPUnit_Framework_TestCase {
         foreach (static::$types as $type) {
             $addons = $manager->scan($type, true);
         }
+
+        // No exception so we are cool!
+        $this->assertTrue(true);
     }
 
     /**
@@ -175,6 +181,7 @@ class AddonManagerTest extends \PHPUnit_Framework_TestCase {
 
         // Themes do not have a class
         if (empty($class)) {
+            $this->assertTrue(true);
             return;
         }
 

--- a/tests/Library/Vanilla/CheckVersionTest.php
+++ b/tests/Library/Vanilla/CheckVersionTest.php
@@ -13,7 +13,7 @@ use Vanilla\Addon;
 /**
  * Tests of the {@link Addon::checkVersion()} method.
  */
-class CheckVersionTest extends \PHPUnit_Framework_TestCase {
+class CheckVersionTest extends \PHPUnit\Framework\TestCase {
     /**
      * Check exact version matching.
      */

--- a/tests/Library/Vanilla/PermissionsTest.php
+++ b/tests/Library/Vanilla/PermissionsTest.php
@@ -8,7 +8,7 @@ namespace VanillaTests\Library\Vanilla;
 
 use Vanilla\Permissions;
 
-class PermissionsTest extends \PHPUnit_Framework_TestCase {
+class PermissionsTest extends \PHPUnit\Framework\TestCase {
 
     public function testAdd() {
         $permissions = new Permissions();

--- a/tests/TestInstallModel.php
+++ b/tests/TestInstallModel.php
@@ -111,11 +111,7 @@ class TestInstallModel extends InstallModel {
      */
     public function getDbHost() {
         if (empty($this->dbHost)) {
-            if ($dbHost = getenv('TEST_DB_HOST')) {
-                $this->dbHost = $dbHost;
-            } else {
-                $this->dbHost = 'localhost';
-            }
+            $this->dbHost = getenv('TEST_DB_HOST') ?: 'localhost';
         }
         return $this->dbHost;
     }

--- a/tests/TestInstallModel.php
+++ b/tests/TestInstallModel.php
@@ -30,7 +30,7 @@ class TestInstallModel extends InstallModel {
      */
     public function __construct(\Gdn_Configuration $config, AddonModel $addonModel, ContainerInterface $container) {
         parent::__construct($config, $addonModel, $container);
-        $this->setBaseUrl($_ENV['baseurl']);
+        $this->setBaseUrl(getenv('TEST_BASEURL'));
 
         $this->config->Data = [];
         $this->config->load(PATH_ROOT.'/conf/config-defaults.php');
@@ -110,8 +110,14 @@ class TestInstallModel extends InstallModel {
      * @return string
      */
     public function getDbHost() {
-        $host = isset($_ENV['dbhost']) ? $_ENV['dbhost'] : 'localhost';
-        return $host;
+        if (empty($this->dbHost)) {
+            if ($dbHost = getenv('TEST_DB_HOST')) {
+                $this->dbHost = $dbHost;
+            } else {
+                $this->dbHost = 'localhost';
+            }
+        }
+        return $this->dbHost;
     }
 
     /**
@@ -123,8 +129,8 @@ class TestInstallModel extends InstallModel {
         if (empty($this->dbName)) {
             $host = parse_url($this->getBaseUrl(), PHP_URL_HOST);
 
-            if (isset($_ENV['dbname'])) {
-                $dbname = $_ENV['dbname'];
+            if (getenv('TEST_DB_NAME')) {
+                $dbname = getenv('TEST_DB_NAME');
             } else {
                 $dbname = preg_replace('`[^a-z]`i', '_', $host);
             }
@@ -151,7 +157,7 @@ class TestInstallModel extends InstallModel {
      * @return string Returns a username.
      */
     public function getDbUser() {
-        return $_ENV['dbuser'];
+        return getenv('TEST_DB_USER');
     }
 
     /**
@@ -160,7 +166,7 @@ class TestInstallModel extends InstallModel {
      * @return string Returns a password.
      */
     public function getDbPassword() {
-        return $_ENV['dbpass'];
+        return getenv('TEST_DB_PASSWORD');
     }
 
     /**


### PR DESCRIPTION
- Update environment variables to respect naming convention
- Use PHPUnit namespace
- Fix some unit tests that did not have any assertions
- Update jsonEncodeChecked so that it fails properly when needed

Better version of https://github.com/vanilla/vanilla/pull/5495