### PR TITLE
Wysiwyg IE bug fixes

### DIFF
--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1690,6 +1690,13 @@
                                                 code.appendChild(selectedNodes);
                                                 range.insertNode(pre);
                                                 composer.selection.selectNode(code);
+
+                                                if ($(composer.element.lastChild).hasClass('CodeBlock')) {
+                                                    var bookmark = composer.selection.getBookmark();
+                                                    composer.selection.setAfter(composer.element.lastChild);
+                                                    composer.commands.exec("insertHTML", "<p><br></p>");
+                                                    composer.selection.setBookmark(bookmark);
+                                                }
                                             }
                                         },
                                         state: function(composer) {

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1608,8 +1608,10 @@
                                             // after the insertion, and insert a break, because that will set the
                                             // caret to after the latest insertion.
                                             if ($(composer.element.lastChild).hasClass('Spoiler')) {
+                                                var bookmark = composer.selection.getBookmark();
                                                 composer.selection.setAfter(composer.element.lastChild);
                                                 composer.commands.exec("insertHTML", "<p><br></p>");
+                                                composer.selection.setBookmark(bookmark);
                                             }
                                         },
 

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -365,7 +365,7 @@
             $('.editor-dropdown .editor-action')
                 .off('click.dd')
                 .on('click.dd', function(e) {
-                    var parentEl = $(e.target).parent();
+                    var parentEl = $(e.target).closest('.editor-dropdown');
 
                     // Again, tackling with clash from multiple codebases.
                     $('.editor-insert-dialog').each(function(i, el) {

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1634,8 +1634,10 @@
                                         exec: function(composer, command) {
                                             wysihtml5.commands.formatBlock.exec(composer, "formatBlock", "div", "Quote", REG_EXP);
                                             if ($(composer.element.lastChild).hasClass('Quote')) {
+                                                var bookmark = composer.selection.getBookmark();
                                                 composer.selection.setAfter(composer.element.lastChild);
                                                 composer.commands.exec("insertHTML", "<p><br></p>");
+                                                composer.selection.setBookmark(bookmark);
                                             }
                                         },
 


### PR DESCRIPTION
In IE, when adding a "block' element such as a quote, code block or spoiler, we added an empty paragraph at the bottom so you could continue writing under it. However, in IE, the focus went to the new paragraph, not the block we created. Luckily there's a "bookmark" feature in the wysiwyg plugin to save the cursor position. 

I've also noticed that in IE, if you click on the caret of a dropdown menu, it did not open. I've made the JS a bit more robust by using a ".closest()" call, instead of a ".parent()" to get the button.

Fixes: https://github.com/vanilla/vanilla/issues/5214