### PR TITLE
Fix registration invitations expire time 

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1563,15 +1563,14 @@ class SettingsController extends DashboardController {
             $this->ExistingRoleInvitations = arrayCombine($InvitationRoleIDs, $InvitationCounts);
             $ConfigurationModel->forceSetting('Garden.Registration.InviteRoles', $this->ExistingRoleInvitations);
 
-            // Define InviteExpiration based on the postback values
-            $this->InviteExpiration = $this->Form->getValue('Garden.Registration.InviteExpiration');
-
             // Event hook
             $this->EventArguments['ConfigurationModel'] = &$ConfigurationModel;
             $this->fireEvent('BeforeRegistrationUpdate');
 
             // Save!
             if ($this->Form->save() !== false) {
+                // Get the updated Expiration Length
+                $this->InviteExpiration = Gdn::config('Garden.Registration.InviteExpiration', '');
                 $this->informMessage(t("Your settings have been saved."));
                 if ($RedirectUrl != '') {
                     $this->RedirectUrl = $RedirectUrl;

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1563,6 +1563,9 @@ class SettingsController extends DashboardController {
             $this->ExistingRoleInvitations = arrayCombine($InvitationRoleIDs, $InvitationCounts);
             $ConfigurationModel->forceSetting('Garden.Registration.InviteRoles', $this->ExistingRoleInvitations);
 
+            // Define InviteExpiration based on the postback values
+            $this->InviteExpiration = $this->Form->getValue('Garden.Registration.InviteExpiration');
+
             // Event hook
             $this->EventArguments['ConfigurationModel'] = &$ConfigurationModel;
             $this->fireEvent('BeforeRegistrationUpdate');


### PR DESCRIPTION
Fixes problem where in dashboard/settings/registration upon changing the time when the invitation will expire and saving we get the "Your changes have been saved" message but the page still shows the previous value in the "Invitations will expire" select box until we refresh the page one more time manually.

We were fetching that value from the config before it was updated. Setting $this->InviteExpiration to the postback value will have the view build correctly after the form submission. 