### PR TITLE
Force SSL when Garden.AllowSSL or Garden.ForceSSL are true

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -235,7 +235,7 @@ class ProfileController extends Gdn_Controller {
             touchValue('Connected', $Row, !is_null(val('UniqueID', $Provider, null)));
         }
 
-        $this->canonicalUrl(userUrl($this->User, '', 'connections'));
+        $this->canonicalUrl(url(userUrl($this->User, '', 'connections'), true));
         $this->title(t('Social'));
         require_once $this->fetchViewLocation('connection_functions');
         $this->render();

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -414,7 +414,7 @@ class CategoriesController extends VanillaController {
             $this->fireEvent('AfterBuildPager');
 
             // Set the canonical Url.
-            $this->canonicalUrl(categoryUrl($Category, pageNumber($Offset, $Limit)));
+            $this->canonicalUrl(url(categoryUrl($Category, pageNumber($Offset, $Limit)), true));
 
             // Change the controller name so that it knows to grab the discussion views
             $this->ControllerName = 'DiscussionsController';

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -153,7 +153,7 @@ class DiscussionController extends VanillaController {
         $this->setData('_LatestItem', $LatestItem);
 
         // Set the canonical url to have the proper page title.
-        $this->canonicalUrl(discussionUrl($this->Discussion, pageNumber($this->Offset, $Limit, 0, false)));
+        $this->canonicalUrl(url(discussionUrl($this->Discussion, pageNumber($this->Offset, $Limit, 0, false)), true));
 
 //      url(ConcatSep('/', 'discussion/'.$this->Discussion->DiscussionID.'/'. Gdn_Format::url($this->Discussion->Name), PageNumber($this->Offset, $Limit, TRUE, Gdn::session()->UserID != 0)), true), Gdn::session()->UserID == 0);
 

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -875,7 +875,7 @@ body { background: transparent !important; }
             }
 
             // Set the canonical url to have the proper page title.
-            $this->canonicalUrl(discussionUrl($Discussion, pageNumber($this->Offset, $Limit)));
+            $this->canonicalUrl(url(discussionUrl($Discussion, pageNumber($this->Offset, $Limit)), true));
 
             // Load the comments.
             $CurrentOrderBy = $this->CommentModel->orderBy();

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -469,7 +469,7 @@ class Gdn_Controller extends Gdn_Pluggable {
             $Return = $Value;
         }
 
-        if (c('Garden.AllowSSL', c('Garden.ForceSSL', 'false'))) {
+        if (!c('Garden.AllowSSL') && c('Garden.ForceSSL')) {
             $Return = preg_replace("/^http:/i", "https:", $Return);
         }
 

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1464,7 +1464,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         }
 
         // Add schemes to to urls.
-        if (!c('Garden.AllowSSL') || c('Garden.ForceSSL')) {
+        if (!c('Garden.AllowSSL') && c('Garden.ForceSSL')) {
             $r = array_walk_recursive($Data, array('Gdn_Controller', '_FixUrlScheme'), Gdn::request()->scheme());
         }
 

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -434,8 +434,9 @@ class Gdn_Controller extends Gdn_Pluggable {
      */
     public function canonicalUrl($Value = null) {
         if ($Value === null) {
+            $Return = null;
             if ($this->_CanonicalUrl) {
-                return $this->_CanonicalUrl;
+                $Return =  $this->_CanonicalUrl;
             } else {
                 $Parts = array();
 
@@ -461,12 +462,18 @@ class Gdn_Controller extends Gdn_Pluggable {
 
                 $Path = implode('/', $Parts);
                 $Result = Url($Path, true);
-                return $Result;
+                $Return = $Result;
             }
         } else {
             $this->_CanonicalUrl = $Value;
-            return $Value;
+            $Return = $Value;
         }
+
+        if (c('Garden.AllowSSL') || c('Garden.ForceSSL')) {
+            $Return = preg_replace("/^http:/i", "https:", $Return);
+        }
+
+        return $Return;
     }
 
     /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -469,7 +469,7 @@ class Gdn_Controller extends Gdn_Pluggable {
             $Return = $Value;
         }
 
-        if (c('Garden.AllowSSL') || c('Garden.ForceSSL')) {
+        if (c('Garden.AllowSSL', c('Garden.ForceSSL', 'false'))) {
             $Return = preg_replace("/^http:/i", "https:", $Return);
         }
 

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -469,7 +469,7 @@ class Gdn_Controller extends Gdn_Pluggable {
             $Return = $Value;
         }
 
-        if (!c('Garden.AllowSSL') && c('Garden.ForceSSL')) {
+        if (c('Garden.AllowSSL', true) && c('Garden.ForceSSL')) {
             $Return = preg_replace("/^http:/i", "https:", $Return);
         }
 
@@ -1464,7 +1464,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         }
 
         // Add schemes to to urls.
-        if (!c('Garden.AllowSSL') && c('Garden.ForceSSL')) {
+        if (c('Garden.AllowSSL', true) && c('Garden.ForceSSL')) {
             $r = array_walk_recursive($Data, array('Gdn_Controller', '_FixUrlScheme'), Gdn::request()->scheme());
         }
 

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1415,7 +1415,7 @@ class Gdn_Request implements RequestInterface {
     public function url($path = '', $withDomain = false, $ssl = null) {
         static $allowSSL = null;
         if ($allowSSL === null) {
-            $allowSSL = c('Garden.AllowSSL', c('Garden.ForceSSL'));
+            $allowSSL = c('Garden.AllowSSL', true) && c('Garden.ForceSSL');
         }
 
         static $rewrite = null;

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1415,8 +1415,9 @@ class Gdn_Request implements RequestInterface {
     public function url($path = '', $withDomain = false, $ssl = null) {
         static $allowSSL = null;
         if ($allowSSL === null) {
-            $allowSSL = c('Garden.AllowSSL', false);
+            $allowSSL = c('Garden.AllowSSL', c('Garden.ForceSSL'));
         }
+
         static $rewrite = null;
         if ($rewrite === null) {
             $rewrite = val('X_REWRITE', $_SERVER, c('Garden.RewriteUrls', true));
@@ -1424,7 +1425,7 @@ class Gdn_Request implements RequestInterface {
 
         if (!$allowSSL) {
             $ssl = null;
-        } elseif ($withDomain === 'https') {
+        } elseif ($withDomain === 'https' || c('Garden.ForceSSL')) {
             $ssl = true;
             $withDomain = true;
         }

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1415,7 +1415,7 @@ class Gdn_Request implements RequestInterface {
     public function url($path = '', $withDomain = false, $ssl = null) {
         static $allowSSL = null;
         if ($allowSSL === null) {
-            $allowSSL = c('Garden.AllowSSL', true) && c('Garden.ForceSSL');
+            $allowSSL = c('Garden.AllowSSL', true);
         }
 
         static $rewrite = null;

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -168,6 +168,10 @@ class Gdn_Upload extends Gdn_Pluggable {
         $Name = str_replace('\\', '/', $Name);
         $PathUploads = str_replace('\\', '/', PATH_UPLOADS);
 
+        if (c('Garden.AllowSSL') || c('Garden.ForceSSL')) {
+            $Name = preg_replace("/^http:/i", "https:", $Name);
+        }
+
         if (preg_match('`^https?://`', $Name)) {
             $Result = array('Name' => $Name, 'Type' => 'external', 'SaveName' => $Name, 'SaveFormat' => '%s', 'Url' => $Name,);
             return $Result;
@@ -334,9 +338,15 @@ class Gdn_Upload extends Gdn_Pluggable {
      * @param $Name
      * @return mixed
      */
-    public static function url($Name) {
-        $Parsed = self::parse($Name);
-        return $Parsed['Url'];
+    public static function url($name) {
+        $parsed = self::parse($name);
+        $url = $parsed['Url'];
+
+        if (c('Garden.AllowSSL') || c('Garden.ForceSSL')) {
+            $url = preg_replace("/^http:/i", "https:", $url);
+        }
+
+        return $url;
     }
 
     /**

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -168,7 +168,7 @@ class Gdn_Upload extends Gdn_Pluggable {
         $Name = str_replace('\\', '/', $Name);
         $PathUploads = str_replace('\\', '/', PATH_UPLOADS);
 
-        if (c('Garden.AllowSSL') || c('Garden.ForceSSL')) {
+        if (c('Garden.AllowSSL', c('Garden.ForceSSL', 'false'))) {
             $Name = preg_replace("/^http:/i", "https:", $Name);
         }
 
@@ -342,7 +342,7 @@ class Gdn_Upload extends Gdn_Pluggable {
         $parsed = self::parse($name);
         $url = $parsed['Url'];
 
-        if (c('Garden.AllowSSL') || c('Garden.ForceSSL')) {
+        if (c('Garden.AllowSSL', c('Garden.ForceSSL', 'false'))) {
             $url = preg_replace("/^http:/i", "https:", $url);
         }
 

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -168,7 +168,7 @@ class Gdn_Upload extends Gdn_Pluggable {
         $Name = str_replace('\\', '/', $Name);
         $PathUploads = str_replace('\\', '/', PATH_UPLOADS);
 
-        if (!c('Garden.AllowSSL') && c('Garden.ForceSSL')) {
+        if (c('Garden.AllowSSL', true) && c('Garden.ForceSSL')) {
             $Name = preg_replace("/^http:/i", "https:", $Name);
         }
 

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -168,7 +168,7 @@ class Gdn_Upload extends Gdn_Pluggable {
         $Name = str_replace('\\', '/', $Name);
         $PathUploads = str_replace('\\', '/', PATH_UPLOADS);
 
-        if (c('Garden.AllowSSL', c('Garden.ForceSSL', 'false'))) {
+        if (!c('Garden.AllowSSL') && c('Garden.ForceSSL')) {
             $Name = preg_replace("/^http:/i", "https:", $Name);
         }
 

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -340,13 +340,7 @@ class Gdn_Upload extends Gdn_Pluggable {
      */
     public static function url($name) {
         $parsed = self::parse($name);
-        $url = $parsed['Url'];
-
-        if (c('Garden.AllowSSL', c('Garden.ForceSSL', 'false'))) {
-            $url = preg_replace("/^http:/i", "https:", $url);
-        }
-
-        return $url;
+        return $parsed['Url'];
     }
 
     /**


### PR DESCRIPTION
Updated canonicalUrl(), parse(), and url() to force SSL if Garden.AllowSSL or Garden.ForceSSL are true.
