### PR TITLE
Fix stripping of custom tag attributes when using BBCode

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -278,13 +278,10 @@ class Gdn_Format {
                 // Standard BBCode parsing.
                 $Mixed = $BBCodeFormatter->format($Mixed);
 
-                // Always filter after basic parsing.
-                $Sanitized = Gdn_Format::htmlFilter($Mixed);
-
                 // Vanilla magic parsing.
-                $Sanitized = Gdn_Format::processHTML($Sanitized);
+                $Mixed = Gdn_Format::processHTML($Mixed);
 
-                return $Sanitized;
+                return $Mixed;
             }
 
             // Fallback to minimalist BBCode parsing.


### PR DESCRIPTION
BBCode allows for certain styling, like `color`. The current processing pipeline runs the output from NBBC, Vanilla's BBCode parser, through htmLawed. Vanilla's stricter htmLawed config for other formats strips the custom formatting. BBCode, unlike other formats like Markdown, does not allow for HTML to be used alongside it. This means HTML entities are escaped or encoded, making them unusable. NBBC should be handling cleaning up the post format.

To that end, this update removes htmLawed from the BBCode formatting chain and entrusts NBBC with ensuring the output is properly sanitized.

Please backport to [release/2017-Q1-6](https://github.com/vanilla/vanilla/tree/release/2017-Q1-6).