### PR TITLE
Generate htmLawed spec array in plug-in

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -279,7 +279,15 @@ class Gdn_Format {
                 $Mixed = $BBCodeFormatter->format($Mixed);
 
                 // Always filter after basic parsing.
-                $Sanitized = Gdn_Format::htmlFilter($Mixed);
+                // Add htmLawed-compatible specification updates.
+                $options = [
+                    'spec' => [
+                        'span' => [
+                            'style' => ['match' => '/^(color:(#[a-f\d]{3}[a-f\d]{3}?|[a-z]+))?;?$/i']
+                        ]
+                    ]
+                ];
+                $Sanitized = Gdn_Format::htmlFilter($Mixed, $options);
 
                 // Vanilla magic parsing.
                 $Sanitized = Gdn_Format::processHTML($Sanitized);
@@ -901,9 +909,10 @@ class Gdn_Format {
      * Use this instead of Gdn_Format::Html() when you do not want magic formatting.
      *
      * @param mixed $Mixed An object, array, or string to be formatted.
+     * @param array $options An array of options to pass to the formatter.
      * @return string Sanitized HTML.
      */
-    public static function htmlFilter($Mixed) {
+    public static function htmlFilter($Mixed, $options = []) {
         if (!is_string($Mixed)) {
             return self::to($Mixed, 'HtmlFilter');
         } else {
@@ -924,7 +933,7 @@ class Gdn_Format {
                 }, $Mixed);
 
                 // Do HTML filtering before our special changes.
-                $Result = $Formatter->format($Mixed);
+                $Result = $Formatter->format($Mixed, $options);
             } else {
                 // The text does not contain HTML and does not have to be purified.
                 // This is an optimization because purifying is very slow and memory intense.

--- a/plugins/HtmLawed/class.htmlawed.plugin.php
+++ b/plugins/HtmLawed/class.htmlawed.plugin.php
@@ -133,10 +133,16 @@ class HtmLawedPlugin extends Gdn_Plugin {
      * Filter provided HTML through htmlLawed and return the result.
      *
      * @param string $html String of HTML to filter.
+     * @param array $options An array of options. The "spec" key is used for extra HTML specifications.
      * @return string Returns the filtered HTML.
      */
-    public function format($html) {
+    public function format($html, $options = []) {
         $attributes = c('Garden.Html.BlockedAttributes', 'on*, target');
+
+        $specOverrides = val('spec', $options, []);
+        if (!is_array($specOverrides)) {
+            $specOverrides = [];
+        }
 
         $config = [
             'anti_link_spam' => ['`.`', ''],
@@ -193,13 +199,10 @@ class HtmLawedPlugin extends Gdn_Plugin {
             'Status' => 1
         ];
 
-        $spec = 'object=-classid-type, -codebase; embed=type(oneof=application/x-shockwave-flash); ';
-
-        // Define elements allowed to have a `class`.
-        $spec .= implode(',', $this->classedElements);
-
-        // Whitelist classes we allow.
-        $spec .= '=class(oneof='.implode('|', $this->allowedClasses).'); ';
+        $spec = $this->spec();
+        if (is_array($specOverrides) && !empty($specOverrides)) {
+            $spec = array_merge_recursive($spec, $specOverrides);
+        }
 
         return Htmlawed::filter($html, $config, $spec);
     }
@@ -208,6 +211,29 @@ class HtmLawedPlugin extends Gdn_Plugin {
      * No setup.
      */
     public function setup() {
+    }
+
+    /**
+     * Grab the default htmLawed spec.
+     *
+     * @return array
+     */
+    private function spec() {
+        static $spec;
+        if ($spec === null) {
+            $spec = [];
+            $allowedClasses = implode('|', $this->allowedClasses);
+            foreach ($this->classedElements as $tag) {
+                if (!is_array($spec[$tag])) {
+                    $spec[$tag] = [];
+                }
+                if (!array_key_exists('class', $spec[$tag])) {
+                    $spec[$tag]['class'] = [];
+                }
+                $spec[$tag]['class']['oneof'] = $allowedClasses;
+            }
+        }
+        return $spec;
     }
 
     /**


### PR DESCRIPTION
This update moves to generate the htmLawed `$spec` param as an array. Currently, this parameter is a single giant string. In htmLawed, it's eventually passed through to `hl_spec`, which transforms it into an array. This workflow presents two issues:

1. It makes it difficult for anything to modify the standard htmLawed spec.
1. `hl_spec` does its job, but can lead to unexpected results. For instance, if you specify the same element in more than one rule, only the first is kept. A dev would most likely expect these items to be merged into multiple rules for the element.

An `$options` parameter has been introduced to `Gdn_Format::htmlFilter` that will be passed through to the `format` method of the site's HtmlFormatter (this is probably always going to be the htmLawed plug-in). The htmLawed plug-in will look for a "spec" key in this array of options and, if found, will merge it into the default array.

As an example, I've restored the ability to use color tags in the BBCode format by passing a special rule that allows spans to set their color in the style attribute.

I've also yanked the object and embed rules from the spec, because these two tags are seemingly [altogether forbidden by the config](https://github.com/vanilla/vanilla/blob/4d068ba095b06a3c15e13d710c912730c50fe55f/plugins/HtmLawed/class.htmlawed.plugin.php#L149).