### PR TITLE
Close editor's dropdowns on right click

### DIFF
--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -357,6 +357,10 @@
                 editorDropdownsClose();
             });
 
+            $(window).on('contextmenu closedropdowns', function() {
+                editorDropdownsClose();
+            });
+
             $(document).on('click touchstart', '.editor-dropdown', function(e) {
                 e.stopPropagation();
             });

--- a/plugins/editor/js/wysihtml5-0.4.0pre.js
+++ b/plugins/editor/js/wysihtml5-0.4.0pre.js
@@ -5583,8 +5583,15 @@ wysihtml5.dom.replaceWithChildNodes = function(node) {
                     this._unset(iframeDocument, "cookie", "", true);
                 }
 
-                this.loaded = true;
+                // Bubble up right click events to close dropdowns
+                iframeDocument.addEventListener("contextmenu", function(e) {
+                    var event = document.createEvent('HTMLEvents');
+                    event.initEvent('closedropdowns', true, false);
+                    parent.dispatchEvent(event);
+                });
 
+
+                this.loaded = true;
                 // Trigger the callback
                 setTimeout(function() {
                     that.callback(that);


### PR DESCRIPTION
Firefox was the only browser to close the editor's dropdowns on right click. I've added 2 events to fix this issue.

First, the "contextmenu" event (i.e. right click) for the main window. 

Second, since the editor's in an iframe, we need to send the event up to the main window, since the function to close the dropdown menus is private and exists in the main window. Note that the "closedropdowns" event is a custom event.

Tested in Chrome, FF, Safari, Edge and IE > 9.

Closes https://github.com/vanilla/vanilla/issues/5208