### PR TITLE
Fix embed scrolling

### DIFF
--- a/js/embed.js
+++ b/js/embed.js
@@ -57,7 +57,10 @@ window.vanilla.embed = function(host) {
             if ((typeof e.data) === 'string') {
                 var message = e.data.split(':');
                 var frame = document.getElementById('vanilla' + id);
-                if (!frame || frame.contentWindow != e.source) {
+
+                // Unload event's source is undefined
+                var isUnload = message[0] == 'unload';
+                if (!frame || (!isUnload && frame.contentWindow != e.source)) {
                     return;
                 }
                 processMessage(message);
@@ -158,8 +161,9 @@ window.vanilla.embed = function(host) {
                 }
             }
         } else if (message[0] == 'unload') {
-            if (window.attachEvent || scrollPosition('vanilla' + id) < 0)
+            if (window.attachEvent || scrollPosition('vanilla' + id) < 0) {
                 document.getElementById('vanilla' + id).scrollIntoView(true);
+            }
 
             iframe.style.visibility = "hidden";
 

--- a/js/embed_local.js
+++ b/js/embed_local.js
@@ -137,12 +137,14 @@ jQuery(document).ready(function($) {
 
     if (inIframe) {
         // DO NOT set the parent location if this is a page of embedded comments!!
-        if (path != '~' && !isEmbeddedComments)
+        if (path != '~' && !isEmbeddedComments) {
             remotePostMessage('location:' + encodePath(path), '*');
+        }
 
         // Unembed if in the dashboard, in an iframe, and not forcing dashboard embed
-        if (inDashboard && !forceEmbedDashboard)
+        if (inDashboard && !forceEmbedDashboard) {
             remotePostMessage('unembed', '*');
+        }
 
         setHeight = function(explicitHeight) {
             // Offset height can be influenced by CSS styling, like height. A
@@ -164,6 +166,7 @@ jQuery(document).ready(function($) {
             remotePostMessage('scrollto:' + $('div.Popup').offset().top, '*');
         });
 
+        // Scroll to the top of the iframe when we change page.
         $(window).unload(function() {
             remotePostMessage('unload', '*');
         });
@@ -213,8 +216,6 @@ jQuery(document).ready(function($) {
                     }
                 }
                 return;
-            } else {
-                remotePostMessage('scrollto:0', '*');
             }
         });
     }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5600
Properly fix https://github.com/vanilla/vanilla/issues/4185

The scrolling behaviour was already coded to work properly.
As suggested in https://github.com/vanilla/vanilla/issues/5600 the proper solution is to scroll to the top the the frame if the parent window is lower than the top of the frame when the page unload (AKA we change pages inside the iframe). The existing solution even disregard scrolling if the parent window is higher than the frame's top which is even better.

The source of the problem was that the unload `event` was never parsed due to `event.source` being `undefined`. I fixed the code and now the scrolling behaviour works properly.

I also removed the scrollto on link click.