### PR TITLE
Fix broken user menu links on profile pages

### DIFF
--- a/applications/dashboard/modules/class.navmodule.php
+++ b/applications/dashboard/modules/class.navmodule.php
@@ -158,6 +158,7 @@ class NavModule extends Gdn_Module {
      * @return string
      */
 	public static function textToKey($text) {
+	    $text = strip_tags($text);
 	    $text = strtolower(trim($text));
 	    $text = str_replace(' ', '-', $text);
 	    $text = preg_replace('/-+/', '-', $text);


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/5574 introduced some slug/key/grouping improvements. However, its updated method of translating text to keys doesn't work well on its own in areas where markup may be used as part of the text. An example of this is the profile menu options. If a plug-in adds a menu link to the profile page's user menu and it passes markup as part of the title text of that link, it mangles the link. This update adds a `strip_tags` call to the text in `NavModule::textToKey`.

Please backport to [release/2017-Q2-4](https://github.com/vanilla/vanilla/tree/release/2017-Q2-4)