### PR TITLE
Fix notice in HtmLawedPlugin::spec

### DIFF
--- a/plugins/HtmLawed/class.htmlawed.plugin.php
+++ b/plugins/HtmLawed/class.htmlawed.plugin.php
@@ -224,7 +224,7 @@ class HtmLawedPlugin extends Gdn_Plugin {
             $spec = [];
             $allowedClasses = implode('|', $this->allowedClasses);
             foreach ($this->classedElements as $tag) {
-                if (!is_array($spec[$tag])) {
+                if (!array_key_exists($tag, $spec) || !is_array($spec[$tag])) {
                     $spec[$tag] = [];
                 }
                 if (!array_key_exists('class', $spec[$tag])) {


### PR DESCRIPTION
`HtmLawedPlugin::spec` wasn't verifying an array element existed under a specific key before attempting to determine if its value was an array. It still worked, but it had the potential for throwing PHP notices.

This update adds a call to `array_key_exists`, before attempting to verify the value under the key is an array. If either fails, an empty array is set under the specified key.