### PR TITLE
Disable autoscroll on an embedded signin page

### DIFF
--- a/applications/dashboard/views/entry/signin.php
+++ b/applications/dashboard/views/entry/signin.php
@@ -23,7 +23,7 @@ echo '<div class="MainForm">';
         <li>
             <?php
             echo $this->Form->label('Email/Username', 'Email');
-            echo $this->Form->textBox('Email', array('autofocus' => true, 'autocorrect' => 'off', 'autocapitalize' => 'off', 'Wrap' => TRUE));
+            echo $this->Form->textBox('Email', array('id' => 'Form_Email', 'autocorrect' => 'off', 'autocapitalize' => 'off', 'Wrap' => TRUE));
             ?>
         </li>
         <li>

--- a/js/global.js
+++ b/js/global.js
@@ -1308,6 +1308,11 @@ jQuery(document).ready(function($) {
         }
     });
 
+    // If we are not inside an iframe, focus the email input on the signin page.
+    if ($('#Form_User_SignIn').length && window.top.location === window.location) {
+        $('#Form_Email').focus();
+    }
+
     // Convert date fields to datepickers
     if ($.fn.datepicker) {
         $('input.DatePicker').datepicker({


### PR DESCRIPTION
This fixes an issue with embedding where the iframe would be down the page and the page would scroll down to the embed's email field.

Fixes https://github.com/vanilla/vanilla/issues/5597