### PR TITLE
Fix drafts being assigned to the Root category by default

### DIFF
--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -159,13 +159,10 @@ class DraftModel extends Gdn_Model {
             unset($formPostValues['DiscussionID']);
         }
 
-        if ($Insert) {
-            // If no categoryid is defined, grab the first available.
-            if (!is_numeric(val('CategoryID', $formPostValues, false))) {
-                $formPostValues['CategoryID'] = $this->SQL->get('Category', '', '', 1)->firstRow()->CategoryID;
-            }
-
+        if (array_key_exists('CategoryID', $formPostValues) && filter_var($formPostValues['CategoryID'], FILTER_VALIDATE_INT) === false) {
+            unset($formPostValues['CategoryID']);
         }
+
         // Add the update fields because this table's default sort is by DateUpdated (see $this->get()).
         $this->addInsertFields($formPostValues);
         $this->addUpdateFields($formPostValues);


### PR DESCRIPTION
The `Draft` table's `CategoryID` column is optional. It is a nullable integer field. The current behavior when saving a draft without a category is to grab the first category in the `Category` table and use that for the draft. It's seemingly been like that since Vanilla has been under version control. When you edit such a draft, the Root category (and all its children) can appear in the dropdown.

This update stops guessing at the category ID for a draft. It also removes non-integer values for `CategoryID` during `DraftModel::save`. If an empty string is passed through to this method (as can happen when drafts are auto-saved), it's removed from the `$formPostValues` array.

Please backport to [release/2017-Q1-6](https://github.com/vanilla/vanilla/tree/release/2017-Q1-6) and [release/2017-Q2-4](https://github.com/vanilla/vanilla/tree/release/2017-Q2-4).