### PR TITLE
Fix advanced embed scrolling to top of the page instead of top of the iframe

### DIFF
--- a/js/vanilla.embed.js
+++ b/js/vanilla.embed.js
@@ -396,9 +396,26 @@
         var result = func.apply(this, data.args);
     };
 
+    embed.getOffsetFromDocument = embed.fn.getOffsetFromDocument = function(elem) { // crossbrowser version
+        var box = elem.getBoundingClientRect();
+
+        var body = document.body;
+        var docEl = document.documentElement;
+
+        var scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop;
+        var scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft;
+
+        var clientTop = docEl.clientTop || body.clientTop || 0;
+        var clientLeft = docEl.clientLeft || body.clientLeft || 0;
+
+        var top  = box.top +  scrollTop - clientTop;
+        var left = box.left + scrollLeft - clientLeft;
+
+        return { top: Math.round(top), left: Math.round(left) };
+    };
+
     embed.scrollTo = embed.fn.scrollTo = function(top) {
-        console.log('scrollTo: ' + top);
-        window.scrollTo(0, this.iframe.offsetTop + top);
+        window.scrollTo(0, this.getOffsetFromDocument(this.iframe).top + top);
     };
 
     embed.setLocation = embed.fn.setLocation = function(path) {


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5634
I added a function that calculate the correct offset from the document.

Backport to 2.3, 2.4, 2017-Q1-6, 2017-Q2-4