### PR TITLE
Fix inaccurate toggle for embedding URLs in Posting Settings

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -65,6 +65,10 @@ class VanillaSettingsController extends Gdn_Controller {
             // Apply the config settings to the form.
             $this->Form->setData($ConfigurationModel->Data);
         } else {
+            // This is a "reverse" field on the form. Disabling URL embeds is associated with a toggle that enables them.
+            $disableUrlEmbeds = $this->Form->getFormValue('Garden.Format.DisableUrlEmbeds', true);
+            $this->Form->setFormValue('Garden.Format.DisableUrlEmbeds', !$disableUrlEmbeds);
+
             // Define some validation rules for the fields being saved
             $ConfigurationModel->Validation->applyRule('Vanilla.Categories.MaxDisplayDepth', 'Required');
             $ConfigurationModel->Validation->applyRule('Vanilla.Categories.MaxDisplayDepth', 'Integer');


### PR DESCRIPTION
The toggle for the `Garden.Format.DisableUrlEmbeds` config under Posting Settings in the dashboard is reversed. Instead of "disabling URL embedding", the toggle is for "Enable link embeds in discussions and comments". The UI handles this value inversion, but it's not accounted for during the form's saving routine. This means you can toggle the control on, thinking you're allowing URL embeds, but you're actually setting the `DisableUrlEmbeds` to true and disabling them. The next time you looked at the form, the value would be reversed in the UI, so it wouldn't look like your change had been saved.

This update leaves the UI the way it is, along with existing UI translations, and instead opts to instead introduce the minor correction of the data before it is saved.

Closes #5605 