### PR TITLE
Add support for refresh tokens in OAuth2

### DIFF
--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -559,7 +559,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
                 // for future requests, if not, store the access_token.
                 $attributes = [
                     'RefreshToken' => val('refresh_token', $response),
-                    'AccessToken' => val('access_token', $response, val('access_token', $response)),
+                    'AccessToken' => val('access_token', $response, val('refresh_token', $response)),
                     'Profile' => $profile
                 ];
 

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -152,7 +152,19 @@ class Gdn_OAuth2 extends Gdn_Plugin {
 
         // If there is no token passed, try to retrieve one from the user's attributes.
         if ($this->accessToken === null && Gdn::session()->UserID) {
-            $this->accessToken = valr($this->getProviderKey().'.AccessToken', Gdn::session()->User->Attributes);
+            // If this workflow uses a RefreshToken, regenerate the access token using the RefreshToken, otherwise use the stored AccessToken.
+            $refreshToken = valr($this->getProviderKey().'.RefreshToken', Gdn::session()->User->Attributes);
+            if ($refreshToken) {
+                $response = $this->requestAccessToken($refreshToken, true);
+                // save the new refresh_token if there is one and it is different from the existing one.
+                if (val('refresh_token', $response) !== $refreshToken) {
+                    $userModel = New UserModel();
+                    $userModel->saveAttribute(Gdn::session()->UserID, [$this->getProviderKey() => ['RefreshToken' => val('refresh_token', $response)]]);
+                }
+                $this->accessToken = val('access_token', $response);
+            } else {
+                $this->accessToken = valr($this->getProviderKey().'.AccessToken', Gdn::session()->User->Attributes);
+            }
         }
 
         return $this->accessToken;
@@ -543,8 +555,11 @@ class Gdn_OAuth2 extends Gdn_Plugin {
                     'UniqueID' => $profile['id']]);
 
                 // Save the information as attributes.
+                // If a client has passed a refresh_token, store it as the access_token in the attributes
+                // for future requests, if not, store the access_token.
                 $attributes = [
-                    'AccessToken' => $response['access_token'],
+                    'RefreshToken' => val('refresh_token', $response),
+                    'AccessToken' => val('access_token', $response, val('access_token', $response)),
                     'Profile' => $profile
                 ];
 
@@ -560,7 +575,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
             default:
 
                 // This is an sso request, we need to redispatch to /entry/connect/[providerKey] which is Base_ConnectData_Handler() in this class.
-                Gdn::session()->stash($this->getProviderKey(), ['AccessToken' => $response['access_token'], 'Profile' => $profile]);
+                Gdn::session()->stash($this->getProviderKey(), ['AccessToken' => val('access_token', $response), 'RefreshToken' => val('refresh_token', $response), 'Profile' => $profile]);
                 $url = '/entry/connect/'.$this->getProviderKey();
 
                 //pass the target if there is one so that the user will be redirected to where the request originated.
@@ -591,9 +606,11 @@ class Gdn_OAuth2 extends Gdn_Plugin {
         }
         $profile = val('Profile', $savedProfile);
         $accessToken = val('AccessToken', $savedProfile);
+        $refreshToken = val('RefreshToken', $savedProfile);
 
         trace($profile, 'Profile');
         trace($accessToken, 'Access Token');
+        trace($refreshToken, 'Refresh Token');
 
         /* @var Gdn_Form $form */
         $form = $sender->Form; //new Gdn_Form();
@@ -608,6 +625,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
         $attributes = [];
         $attributes[$this->getProviderKey()] = [
             'AccessToken' => $accessToken,
+            'RefreshToken' => $refreshToken,
             'Profile' => $profile
         ];
         $form->setFormValue('Attributes', $attributes);
@@ -630,21 +648,29 @@ class Gdn_OAuth2 extends Gdn_Plugin {
      * Request access token from provider.
      *
      * @param string $code code returned from initial handshake with provider.
-     *
+     * @param bool $refresh if we are using the stored RefreshToken to request a new AccessToken
      * @return mixed Result of the API call to the provider, usually JSON.
      */
-    public function requestAccessToken($code) {
+    public function requestAccessToken($code, $refresh=false) {
         $provider = $this->provider();
         $uri = val('TokenUrl', $provider);
 
-        $defaultParams = [
-            'code' => $code,
-            'client_id' => val('AssociationKey', $provider),
-            'redirect_uri' => url('/entry/'. $this->getProviderKey(), true),
-            'client_secret' => val('AssociationSecret', $provider),
-            'grant_type' => 'authorization_code',
-            'scope' => val('AcceptedScope', $provider)
-        ];
+        //When requesting the AccessToken using the RefreshToken the params are different.
+        if ($refresh) {
+            $defaultParams = [
+                'refresh_token' => $code,
+                'grant_type' => 'refresh_token'
+            ];
+        } else {
+            $defaultParams = [
+                'code' => $code,
+                'client_id' => val('AssociationKey', $provider),
+                'redirect_uri' => url('/entry/'. $this->getProviderKey(), true),
+                'client_secret' => val('AssociationSecret', $provider),
+                'grant_type' => 'authorization_code',
+                'scope' => val('AcceptedScope', $provider)
+            ];
+        }
 
         $post = array_merge($defaultParams, $this->requestAccessTokenParams);
 


### PR DESCRIPTION
Some implementations of Oauth2 may want to issue a refresh token that can then be used to get a new access token when the access token is expired. In this PR the OAuth2 class has been changed to save a refresh token to the users attributes if one is passed and when getting the AccessToken OAuth2 will:

- check if the access token is present, if not
- if no refresh token is saved in Gdn_User Attributes it will use the access_token saved there.
- if there is a refresh token saved in Gdn_User Attributes it will request a new access_token from the provider and save the new a refresh token to Gdn_User Attributes.