### PR TITLE
Fix magic Vanilla formatting in BBCode code tags

### DIFF
--- a/library/core/class.bbcode.php
+++ b/library/core/class.bbcode.php
@@ -386,7 +386,7 @@ class BBCode extends Gdn_Pluggable {
                 'mode' => Nbbc::BBCODE_MODE_ENHANCED,
                 'plain_end' => "\n",
                 'plain_start' => "\n<b>Code:</b>\n",
-                'template' => "\n<pre>{\$_content/v}\n</pre>\n"
+                'template' => "\n<pre><code>{\$_content/v}\n</code></pre>\n"
             ]);
 
             $nbbc->addRule('hr', [


### PR DESCRIPTION
Current BBCode formatting [only uses `pre` tags](https://github.com/vanilla/vanilla/blob/b7a6fafdd821dee3bcab14f0de404856a9897d72/library/core/class.bbcode.php#L389) for code blocks. However, Vanilla's magic parsing only dodges formatting [based on the `code` tag](https://github.com/vanilla/vanilla/blob/b7a6fafdd821dee3bcab14f0de404856a9897d72/library/core/class.format.php#L1869). This causes Vanilla's magic parsing to happen in BBCode's code blocks, where it shouldn't be.

This update alters the BBCode code block template to use `code` tags, in addition to `pre` tags. This is similar to [the structure used by Vanilla's Markdown library](https://github.com/michelf/php-markdown/blob/1f51cc520948f66cd2af8cbc45a5ee175e774220/Michelf/Markdown.php#L1223).

Please backport to [release/2017-Q1-6](https://github.com/vanilla/vanilla/tree/release/2017-Q1-6) and [release/2017-Q2-4](https://github.com/vanilla/vanilla/tree/release/2017-Q2-4)