### PR TITLE
Fix username disappearing from the dashboard user edit form on failed submission  

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -746,7 +746,7 @@ class UserController extends DashboardController {
                     $this->informMessage(t('Your changes have been saved.'));
                 } else {
                     // We unset the form value on save when username is not edited or user can't edit this field.
-                    // On error we need to reset the field to the original value otherwise the field is empty.
+                    // On error we need to reset the field to the original value otherwise the field is empty
                     if (!is_null($restoreName)) {
                         $this->Form->setFormValue("Name", $restoreName);
                     }
@@ -1037,7 +1037,7 @@ class UserController extends DashboardController {
      *
      *
      * @param bool $UserID
-     * @throws Exceptio
+     * @throws Exception
      * @throws Gdn_UserException
      */
     public function sso($UserID = false) {

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -746,7 +746,7 @@ class UserController extends DashboardController {
                     $this->informMessage(t('Your changes have been saved.'));
                 } else {
                     // We unset the form value on save when username is not edited or user can't edit this field.
-                    // On error we need to reset the field to the original value otherwise the field is empty
+                    // On error we need to reset the field to the original value otherwise the field is empty.
                     if (!is_null($restoreName)) {
                         $this->Form->setFormValue("Name", $restoreName);
                     }

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -746,7 +746,7 @@ class UserController extends DashboardController {
                     $this->informMessage(t('Your changes have been saved.'));
                 } else {
                     // We unset the form value on save when username is not edited or user can't edit this field.
-                    // On error we need to reset the field to the original value otherwise the field is empty
+                    // On error we need to reset the field to the original value otherwise the field is empty.
                     if (!is_null($restoreName)) {
                         $this->Form->setFormValue("Name", $restoreName);
                     }
@@ -1037,7 +1037,7 @@ class UserController extends DashboardController {
      *
      *
      * @param bool $UserID
-     * @throws Exception
+     * @throws Exceptio
      * @throws Gdn_UserException
      */
     public function sso($UserID = false) {

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -674,8 +674,10 @@ class UserController extends DashboardController {
             if ($this->Form->authenticatedPostBack(true)) {
                 // Do not re-validate or change the username if disabled or exactly the same.
                 $nameUnchanged = ($User['Name'] === $this->Form->getValue('Name'));
+                $restoreName = null;
                 if (!$CanEditUsername || $nameUnchanged) {
-                    $this->Form->setFormValue('Name', $User['Name']);
+                    $this->Form->removeFormValue("Name");
+                    $restoreName = $User['Name'];
                 }
 
                 // Allow mods to confirm/unconfirm emails
@@ -742,6 +744,12 @@ class UserController extends DashboardController {
                     }
 
                     $this->informMessage(t('Your changes have been saved.'));
+                } else {
+                    // We unset the form value on save when username is not edited or user can't edit this field.
+                    // On error we need to reset the field to the original value otherwise the field is empty
+                    if (!is_null($restoreName)) {
+                        $this->Form->setFormValue("Name", $restoreName);
+                    }
                 }
 
                 $UserRoleData = $UserNewRoles;

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -675,7 +675,7 @@ class UserController extends DashboardController {
                 // Do not re-validate or change the username if disabled or exactly the same.
                 $nameUnchanged = ($User['Name'] === $this->Form->getValue('Name'));
                 if (!$CanEditUsername || $nameUnchanged) {
-                    $this->Form->removeFormValue("Name");
+                    $this->Form->setFormValue('Name', $User['Name']);
                 }
 
                 // Allow mods to confirm/unconfirm emails


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5270

When save fails, verifying if there is a username to restore because we unset the form value on different cases to prevent it from being validated and saved when there is no need to.