### PR TITLE
Fix HTML 5 media embeds being allowed when URL embeds are disabled

### DIFF
--- a/plugins/HtmLawed/class.htmlawed.plugin.php
+++ b/plugins/HtmLawed/class.htmlawed.plugin.php
@@ -159,6 +159,14 @@ class HtmLawedPlugin extends Gdn_Plugin {
             'valid_xhtml' => 0
         ];
 
+        // If we don't allow URL embeds, don't allow HTML media embeds, either.
+        if (c('Garden.Format.DisableUrlEmbeds')) {
+            if (!array_key_exists('elements', $config) || !is_string($config['elements'])) {
+                $config['elements'] = '';
+            }
+            $config['elements'] .= '-audio-video';
+        }
+
         // Turn embedded videos into simple links (legacy workaround)
         $html = Gdn_Format::unembedContent($html);
 


### PR DESCRIPTION
If "Enable link embeds in discussions and comments" is toggled off under "Posting Settings" in the dashboard, users can still use `audio` and `video` tags in HTML-format posts to embed media content. This update adds support for excluding these tags via htmLawed if `Garden.Format.DisableUrlEmbeds` is enabled.

Example post (make sure its `Format` is set to "Html" or another HTML-compatible format):

```html
<em>Hello</em> <b>world</b>. <u>This is an HTML test</u>.

<video width="400" controls>
  <source src="https://www.w3schools.com/html/mov_bbb.mp4" type="video/mp4">
  <source src="https://www.w3schools.com/html/mov_bbb.ogg" type="video/ogg">
</video>

<audio controls>
  <source src="https://www.w3schools.com/html/horse.ogg" type="audio/ogg">
  <source src="https://www.w3schools.com/html/horse.mp3" type="audio/mpeg">
</audio>
```

Closes #5611