### PR TITLE
Change html tag "td" in "thead" to "th" in notifications settings page

### DIFF
--- a/applications/dashboard/views/profile/preferences.php
+++ b/applications/dashboard/views/profile/preferences.php
@@ -4,12 +4,13 @@
         width: 500px;
     }
 
-    thead td {
+    table.PreferenceGroup th {
         vertical-align: bottom;
         text-align: center;
     }
 
     table.PreferenceGroup thead .TopHeading {
+        text-align: center;
         border-bottom: none;
     }
 
@@ -17,7 +18,7 @@
         border-top: none;
     }
 
-    td.PrefCheckBox {
+    th.PrefCheckBox, td.PrefCheckBox {
         width: 50px;
         text-align: center;
     }
@@ -46,14 +47,14 @@
                 <thead>
                 <tr>
                     <?php
-                    echo wrap(t('Notification'), 'td', array('style' => 'text-align: left'));
+                    echo wrap(t('Notification'), 'th', array('style' => 'text-align: left'));
 
                     $PreferenceTypes = $this->data("PreferenceTypes.{$PreferenceGroup}");
                     foreach ($PreferenceTypes as $PreferenceType) {
                         if ($PreferenceType === 'Email' && c('Garden.Email.Disabled')) {
                             continue;
                         }
-                        echo wrap(t($PreferenceType), 'td', array('class' => 'PrefCheckBox'));
+                        echo wrap(t($PreferenceType), 'th', array('class' => 'PrefCheckBox'));
                     }
                     ?>
                 </tr>

--- a/applications/vanilla/views/vanillasettings/notificationpreferences.php
+++ b/applications/vanilla/views/vanillasettings/notificationpreferences.php
@@ -14,16 +14,16 @@ $span = (c('Garden.Email.Disabled')) ? '1' : '2';
 <table class="PreferenceGroup">
     <thead>
     <tr>
-        <td style="border: none;">&nbsp;</td>
-        <td class="TopHeading" colspan="<?php echo $span; ?>"><?php echo t('Discussions'); ?></td>
-        <td class="TopHeading" colspan="<?php echo $span; ?>"><?php echo t('Comments'); ?></td>
+        <th style="border: none;">&nbsp;</th>
+        <th class="TopHeading" colspan="<?php echo $span; ?>"><?php echo t('Discussions'); ?></th>
+        <th class="TopHeading" colspan="<?php echo $span; ?>"><?php echo t('Comments'); ?></th>
     </tr>
     <tr>
-        <td style="text-align: left;"><?php echo t('Category'); ?></td>
-        <td class="PrefCheckBox BottomHeading<?php echo $emailClass; ?>"><?php echo t('Email'); ?></td>
-        <td class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></td>
-        <td class="PrefCheckBox BottomHeading<?php echo $emailClass; ?>"><?php echo t('Email'); ?></td>
-        <td class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></td>
+        <th style="text-align: left;"><?php echo t('Category'); ?></th>
+        <th class="PrefCheckBox BottomHeading<?php echo $emailClass; ?>"><?php echo t('Email'); ?></th>
+        <th class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></th>
+        <th class="PrefCheckBox BottomHeading<?php echo $emailClass; ?>"><?php echo t('Email'); ?></th>
+        <th class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></th>
     </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
In a table header `<thead>`, you should use `<th>` instead of `<td>` for the header elements.

Small css adjustments were made to keep the formatting. The visible effect here is that `<th>` element has a heavier font weight and therefore the header is now printed bold. But if you ask me, that's an improvement, too.