### PR TITLE
Validate SSO timestamp

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -46,6 +46,9 @@ class UserModel extends Gdn_Model {
     /** Seconds between login attempts. */
     const LOGIN_RATE = 1;
 
+    /** Timeout for SSO */
+    const SSO_TIMEOUT = 1200;
+    
     /** @var */
     public $SessionColumns;
 
@@ -657,7 +660,7 @@ class UserModel extends Gdn_Model {
 
         $Provider = Gdn_AuthenticationProviderModel::getProviderByKey($ClientID);
 
-        if (!filter_var($Timestamp, FILTER_VALIDATE_INT) || abs($Timestamp - time()) > 20 * 60) {
+        if (!filter_var($Timestamp, FILTER_VALIDATE_INT) || abs($Timestamp - time()) > self::SSO_TIMEOUT) {
             $this->Validation->addValidationResult('sso', 'The timestamp is invalid.');
             return false;
         }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -657,6 +657,11 @@ class UserModel extends Gdn_Model {
 
         $Provider = Gdn_AuthenticationProviderModel::getProviderByKey($ClientID);
 
+        if (!filter_var($Timestamp, FILTER_VALIDATE_INT) || abs($Timestamp - time()) > 20 * 60) {
+            $this->Validation->addValidationResult('sso', 'The timestamp is invalid.');
+            return false;
+        }
+
         if (!$Provider) {
             $this->Validation->addValidationResult('sso', "Unknown SSO Provider: $ClientID");
             return false;


### PR DESCRIPTION
We were not validating the timestamp.

Refer to http://docs.vanillaforums.com/help/sso/jsconnect/embed/ for testing.
`jsSSOString()` from functions.jsconnect.php

Backport to 2.3, 2.4, 2017-Q1-6, 2017-Q2-4