### PR TITLE
Extend notification preference table with accessibility attributes

### DIFF
--- a/applications/dashboard/views/profile/preferences.php
+++ b/applications/dashboard/views/profile/preferences.php
@@ -4,12 +4,13 @@
         width: 500px;
     }
 
-    thead td {
+    table.PreferenceGroup th {
         vertical-align: bottom;
         text-align: center;
     }
 
     table.PreferenceGroup thead .TopHeading {
+        text-align: center;
         border-bottom: none;
     }
 
@@ -17,7 +18,7 @@
         border-top: none;
     }
 
-    td.PrefCheckBox {
+    th.PrefCheckBox, td.PrefCheckBox {
         width: 50px;
         text-align: center;
     }
@@ -40,20 +41,34 @@
         $this->fireEvent("BeforePreferencesRender");
 
         foreach ($this->data('PreferenceGroups') as $PreferenceGroup => $Preferences) {
-            echo wrap(t($PreferenceGroup == 'Notifications' ? 'General' : $PreferenceGroup), 'h2');
+            if ($PreferenceGroup == 'Notifications') {
+                $Header = t('General');
+            } else {
+                $Header = t($PreferenceGroup);
+            }
             ?>
+            <h2><?php echo $Header; ?></h2>
             <table class="PreferenceGroup">
                 <thead>
                 <tr>
+                    <th id="<?php echo $Header; ?>NotificationHeader" scope="col" style="text-align:left">
+                        <?php echo t('Notification'); ?>
+                    </th>
                     <?php
-                    echo wrap(t('Notification'), 'td', array('style' => 'text-align: left'));
-
                     $PreferenceTypes = $this->data("PreferenceTypes.{$PreferenceGroup}");
                     foreach ($PreferenceTypes as $PreferenceType) {
                         if ($PreferenceType === 'Email' && c('Garden.Email.Disabled')) {
                             continue;
                         }
-                        echo wrap(t($PreferenceType), 'td', array('class' => 'PrefCheckBox'));
+                        echo wrap(
+                            t($PreferenceType),
+                            'th',
+                            [
+                                'id' => "{$Header}{$PreferenceType}Header",
+                                'class' => 'PrefCheckBox',
+                                'scope' => 'col'
+                            ]
+                        );
                     }
                     ?>
                 </tr>
@@ -81,7 +96,14 @@
                         } else {
                             // Everything's fine, show checkbox.
                             $checkbox = $this->Form->checkBox($NotificationType.'.'.$Event, '', ['value' => '1']);
-                            $ColumnsMarkup .= wrap($checkbox, 'td', ['class' => 'PrefCheckBox']);
+                            $ColumnsMarkup .= wrap(
+                                $checkbox,
+                                'td',
+                                [
+                                    'class' => 'PrefCheckBox',
+                                    'headers' => "{$Header}{$NotificationType}Header"
+                                ]
+                            );
                             // Set flag so that line is printed.
                             $RowHasConfigValues = true;
                         }
@@ -95,7 +117,14 @@
                             $Description = $Description[0];
                         }
                         echo '<tr>';
-                        echo wrap($Description, 'td', ['class' => 'Description']);
+                        echo wrap(
+                            $Description,
+                            'td',
+                            [
+                                'class' => 'Description',
+                                'headers' => "{$Header}NotificationHeader"
+                            ]
+                        );
                         echo $ColumnsMarkup;
                         echo '</tr>';
                     }

--- a/applications/vanilla/views/vanillasettings/notificationpreferences.php
+++ b/applications/vanilla/views/vanillasettings/notificationpreferences.php
@@ -12,6 +12,9 @@ $span = (c('Garden.Email.Disabled')) ? '1' : '2';
     ?>
 </div>
 <table class="PreferenceGroup">
+    <colgroup></colgroup>
+    <colgroup span="2"></colgroup>
+    <colgroup span="2"></colgroup>
     <thead>
     <tr>
         <th scope="col" style="border: none;">&nbsp;</th>

--- a/applications/vanilla/views/vanillasettings/notificationpreferences.php
+++ b/applications/vanilla/views/vanillasettings/notificationpreferences.php
@@ -14,16 +14,28 @@ $span = (c('Garden.Email.Disabled')) ? '1' : '2';
 <table class="PreferenceGroup">
     <thead>
     <tr>
-        <td style="border: none;">&nbsp;</td>
-        <td class="TopHeading" colspan="<?php echo $span; ?>"><?php echo t('Discussions'); ?></td>
-        <td class="TopHeading" colspan="<?php echo $span; ?>"><?php echo t('Comments'); ?></td>
+        <th scope="col" style="border: none;">&nbsp;</th>
+        <th id="DiscussionsNotificationHeader" class="TopHeading" colspan="<?php echo $span; ?>" scope="col">
+            <?php echo t('Discussions'); ?>
+        </th>
+        <th id="CommentsNotificationHeader" class="TopHeading" colspan="<?php echo $span; ?>" scope="col">
+            <?php echo t('Comments'); ?>
+        </th>
     </tr>
     <tr>
-        <td style="text-align: left;"><?php echo t('Category'); ?></td>
-        <td class="PrefCheckBox BottomHeading<?php echo $emailClass; ?>"><?php echo t('Email'); ?></td>
-        <td class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></td>
-        <td class="PrefCheckBox BottomHeading<?php echo $emailClass; ?>"><?php echo t('Email'); ?></td>
-        <td class="PrefCheckBox BottomHeading"><?php echo t('Popup'); ?></td>
+        <th id="CategoryNotificationHeader" scope="col" style="text-align: left;"><?php echo t('Category'); ?></th>
+        <th id="EmailDiscussionsHeader" class="PrefCheckBox BottomHeading<?php echo $emailClass; ?>" scope="col">
+            <?php echo t('Email'); ?>
+        </th>
+        <th id="PopupDiscussionsHeader" class="PrefCheckBox BottomHeading" scope="col">
+            <?php echo t('Popup'); ?>
+        </th>
+        <th id="EmailCommentsHeader" class="PrefCheckBox BottomHeading<?php echo $emailClass; ?>" scope="col">
+            <?php echo t('Email'); ?>
+        </th>
+        <th id="PopupCommentsHeader" class="PrefCheckBox BottomHeading" scope="col">
+            <?php echo t('Popup'); ?>
+        </th>
     </tr>
     </thead>
     <tbody>
@@ -43,11 +55,21 @@ $span = (c('Garden.Email.Disabled')) ? '1' : '2';
             </tr>
         <?php else: ?>
             <tr>
-                <td class="<?php echo "Depth_{$Category['Depth']}"; ?>"><?php echo $Category['Name']; ?></td>
-                <td class="PrefCheckBox<?php echo $emailClass; ?>"><?php echo Gdn::controller()->Form->checkBox("Email.NewDiscussion.{$CategoryID}", '', array('value' => 1)); ?></td>
-                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->checkBox("Popup.NewDiscussion.{$CategoryID}", '', array('value' => 1)); ?></td>
-                <td class="PrefCheckBox<?php echo $emailClass; ?>"><?php echo Gdn::controller()->Form->checkBox("Email.NewComment.{$CategoryID}", '', array('value' => 1)); ?></td>
-                <td class="PrefCheckBox"><?php echo Gdn::controller()->Form->checkBox("Popup.NewComment.{$CategoryID}", '', array('value' => 1)); ?></td>
+                <td class="<?php echo "Depth_{$Category['Depth']}"; ?>" headers="CategoryNotificationHeader">
+                    <?php echo $Category['Name']; ?>
+                </td>
+                <td class="PrefCheckBox<?php echo $emailClass; ?>" headers="DiscussionsNotificationHeader EmailDiscussionsHeader">
+                    <?php echo Gdn::controller()->Form->checkBox("Email.NewDiscussion.{$CategoryID}", '', ['value' => 1]); ?>
+                </td>
+                <td class="PrefCheckBox" headers="DiscussionsNotificationHeader PopupDiscussionsHeader">
+                    <?php echo Gdn::controller()->Form->checkBox("Popup.NewDiscussion.{$CategoryID}", '', ['value' => 1]); ?>
+                </td>
+                <td class="PrefCheckBox<?php echo $emailClass; ?>" headers="CommentsNotificationHeader EmailCommentsHeader">
+                    <?php echo Gdn::controller()->Form->checkBox("Email.NewComment.{$CategoryID}", '', ['value' => 1]); ?>
+                </td>
+                <td class="PrefCheckBox" headers="CommentsNotificationHeader EmailCommentsHeader">
+                    <?php echo Gdn::controller()->Form->checkBox("Popup.NewComment.{$CategoryID}", '', ['value' => 1]); ?>
+                </td>
             </tr>
         <?php
         endif;


### PR DESCRIPTION
First I've changed some `<td>` elements to semantically correct `<th>` elements.

Furthermore I have added `scope` and `headers` attributes to the `th` and `td` elements like @chrisvanpatten suggested [here](https://github.com/vanilla/vanilla/pull/5654). 

If someone has the possibility to test it, I've pasted the table to [codepen](https://codepen.io/anon/pen/qjbMeP)

I'm not sure if the scope in line 25 and 27 of the codepen must be col or colgroup. See [here](https://www.w3schools.com/tags/att_th_scope.asp) for some more info