### PR TITLE
Fix/categories discussions tag information

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -572,7 +572,7 @@ class CategoriesController extends VanillaController {
                 );
             }
         }
-        // $this->setData('Discussions', $Discussions); 
+        $this->setData('Discussions', $Discussions); 
         
         // Add modules
         $this->addModule('NewDiscussionModule');

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -559,14 +559,21 @@ class CategoriesController extends VanillaController {
         $this->setData('Sort', $DiscussionModel->getSort());
         $this->setData('Filters', $DiscussionModel->getFilters());
 
-        $this->CategoryDiscussionData = array();
+        $this->CategoryDiscussionData = [];
+        $Discussions = [];
 
         foreach ($this->CategoryData->result() as $Category) {
             if ($Category->CategoryID > 0) {
-                $this->CategoryDiscussionData[$Category->CategoryID] = $DiscussionModel->get(0, $this->DiscussionsPerCategory, array('d.CategoryID' => $Category->CategoryID, 'Announce' => 'all'));
+                $this->CategoryDiscussionData[$Category->CategoryID] = $DiscussionModel->get(0, $this->DiscussionsPerCategory, ['d.CategoryID' => $Category->CategoryID, 'Announce' => 'all']);
+
+                $Discussions = array_merge(
+                    $Discussions,
+                    $this->CategoryDiscussionData[$Category->CategoryID]->resultObject()
+                );
             }
         }
-
+        // $this->setData('Discussions', $Discussions); 
+        
         // Add modules
         $this->addModule('NewDiscussionModule');
         $this->addModule('DiscussionFilterModule');


### PR DESCRIPTION
CategoriesController's and DiscussionController's index method fill their $Data['Discussions'] array with a list of discussions. That is needed in the base_render_before() method in applications/vanilla/settings/class.hooks.php. If there is  Discussions info available, tagging information is joined to the discussion:
~~~
if (null !== $sender->data('Discussions', null)) {
    TagModel::instance()->joinTags($sender->Data['Discussions']);
}
~~~

I do not see a need for that in Vanilla, but I wrote a plugin which shows tag information in discussion overviews and I was surprised to find that it worked in /discussions, /categories/something, but not in /categories/discussions

For the sake of consistency, that info should also be available in that method.