### PR TITLE
Refactor CategoryModeratorsModule

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2116,7 +2116,7 @@ class CategoryModel extends Gdn_Model {
      * @param string $Permission
      * @param string $Column
      */
-    public static function joinModerators($Data, $Permission = 'Vanilla.Comments.Edit', $Column = 'Moderators') {
+    public static function joinModerators(&$Data, $Permission = 'Vanilla.Comments.Edit', $Column = 'Moderators') {
         $Moderators = Gdn::sql()
             ->select('u.UserID, u.Name, u.Photo, u.Email')
             ->select('p.JunctionID as CategoryID')

--- a/applications/vanilla/modules/class.categorymoderatorsmodule.php
+++ b/applications/vanilla/modules/class.categorymoderatorsmodule.php
@@ -13,29 +13,70 @@
  */
 class CategoryModeratorsModule extends Gdn_Module {
 
-    public function __construct($Sender = '') {
-        parent::__construct($Sender);
-        $this->ModeratorData = false;
+    /**
+     * CategoryModeratorsModule constructor.
+     *
+     * @param object|string $sender
+     * @param bool $applicationFolder
+     */
+    public function __construct($sender = '', $applicationFolder = false) {
+        parent::__construct($sender, $applicationFolder);
     }
 
-    public function getData($Category) {
-        $this->ModeratorData = array($Category);
-        CategoryModel::JoinModerators($this->ModeratorData);
+    /**
+     * Load the data for this module.
+     *
+     * @param array|null $category
+     */
+    protected function getData($category = null) {
+        $moderators = $this->data('Moderators', null);
+
+        // Only attempt to fetch data if we do not already have it.
+        if ($moderators === null) {
+            $moderators = false;
+
+            // If we received a category, try to use it. If not, try to pull one from the current controller.
+            if ($category === null) {
+                $controller = Gdn::controller();
+                $category = $controller->data('Category');
+            } elseif (!is_array($category)) {
+                $category = (array)$category;
+            }
+
+            // Moderators are fetched via the PermissionCategoryID property. Make sure we have it.
+            if (is_array($category) && array_key_exists('PermissionCategoryID', $category)) {
+                // CategoryModel::joinModerators expects an array of category records.
+                $category = [$category];
+                CategoryModel::joinModerators($category);
+                if (array_key_exists('Moderators', $category[0]) && count($category[0]['Moderators']) > 0) {
+                    // Success. Stash the moderators.
+                    $moderators = $category[0]['Moderators'];
+                }
+            }
+
+            $this->setData('Moderators', $moderators);
+        }
     }
 
+    /**
+     * @inheritdoc
+     */
     public function assetTarget() {
         return 'Panel';
     }
 
+    /**
+     * @inheritdoc
+     */
     public function toString() {
-        if (is_array($this->ModeratorData)
-            && count($this->ModeratorData) > 0
-            && is_array($this->ModeratorData[0]->Moderators)
-            && count($this->ModeratorData[0]->Moderators) > 0
-        ) {
-            return parent::ToString();
+        $result = '';
+        $this->getData();
+
+        $moderators = $this->data('Moderators');
+        if (is_array($moderators)) {
+            $result = parent::toString();
         }
 
-        return '';
+        return $result;
     }
 }

--- a/applications/vanilla/modules/class.categorymoderatorsmodule.php
+++ b/applications/vanilla/modules/class.categorymoderatorsmodule.php
@@ -26,14 +26,14 @@ class CategoryModeratorsModule extends Gdn_Module {
     /**
      * Load the data for this module.
      *
-     * @param array|null $category
+     * @param array|object|null $category
      */
     protected function getData($category = null) {
-        $moderators = $this->data('Moderators', null);
+        $data = $this->data('Moderators', null);
 
         // Only attempt to fetch data if we do not already have it.
-        if ($moderators === null) {
-            $moderators = false;
+        if ($data === null) {
+            $data = false;
 
             // If we received a category, try to use it. If not, try to pull one from the current controller.
             if ($category === null) {
@@ -44,17 +44,19 @@ class CategoryModeratorsModule extends Gdn_Module {
             }
 
             // Moderators are fetched via the PermissionCategoryID property. Make sure we have it.
-            if (is_array($category) && array_key_exists('PermissionCategoryID', $category)) {
+            $hasPermissionCategoryID = val('PermissionCategoryID', $category) !== false;
+            if ($hasPermissionCategoryID) {
                 // CategoryModel::joinModerators expects an array of category records.
                 $category = [$category];
                 CategoryModel::joinModerators($category);
-                if (array_key_exists('Moderators', $category[0]) && count($category[0]['Moderators']) > 0) {
+                $moderators = val('Moderators', $category[0]);
+                if (is_array($moderators) && count($moderators) > 0) {
                     // Success. Stash the moderators.
-                    $moderators = $category[0]['Moderators'];
+                    $data = $moderators;
                 }
             }
 
-            $this->setData('Moderators', $moderators);
+            $this->setData('Moderators', $data);
         }
     }
 

--- a/applications/vanilla/views/modules/categorymoderators.php
+++ b/applications/vanilla/views/modules/categorymoderators.php
@@ -3,9 +3,11 @@
     <?php echo panelHeading(t('Moderators')); ?>
     <ul class="PanelInfo">
         <?php
-        foreach ($this->ModeratorData[0]->Moderators as $Mod) {
-            $Mod = UserBuilder($Mod);
-            echo '<li>'.UserPhoto($Mod, 'Small').' '.UserAnchor($Mod).'</li>';
+        $moderators = $this->data('Moderators', []);
+        foreach ($moderators as $user) {
+            $photo = userPhoto($user, 'Small');
+            $anchor = userAnchor($user);
+            echo "<li>{$photo} {$anchor}</li>";
         }
         ?>
     </ul>


### PR DESCRIPTION
This update refactors the `CategoryModeratorsModule` in the following ways:

1. Add code documentation
1. Update coding standards
1. Use the `Data` array in the module, instead of a dynamically-declared property
1. Update the constructor signature to match the parent class
1. Add a auto-fetching of moderator data for the current category

In addition, the signature of`CategoryModel::joinModerators` has been updated to properly pass its `$Data` parameter by reference.