### PR TITLE
Fix external links with relative protocol not always receiving the leaving warning when expected

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1229,6 +1229,10 @@ class Gdn_Format {
             if (!isset($matches[4]) || $inTag || $inAnchor) {
                 return $matches[0];
             }
+            // We are not in a tag and what we matched starts with //
+            if (preg_match('#^//#', $matches[4])) {
+                return $matches[0];
+            }
 
             $url = $matches[4];
 
@@ -1278,9 +1282,9 @@ class Gdn_Format {
         };
 
         if (unicodeRegexSupport()) {
-            $regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:https?|ftp)://[@\p{L}\p{N}\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`iu";
+            $regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:(?:https?|ftp):)?//[@\p{L}\p{N}\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`iu";
         } else {
-            $regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:https?|ftp)://[@a-z0-9\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`i";
+            $regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:(?:https?|ftp):)?//[@a-z0-9\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`i";
         }
 
         $mixed = Gdn_Format::replaceButProtectCodeBlocks(


### PR DESCRIPTION
Links with no scheme were not matched which resulted in `Garden.Format.WarnLeaving = true` not working with `<a href="//google.com">google.com</a>`

Backport to `release/2017-Q1-6`, `release/2017-Q2-4`

You can do a test Before VS After with (Format Simple HTML)
```
<a href="http://google.com">google.com</a> Parsed
<a href="//google.com">google.com</a> Parsed
http://google.com Parsed
//google.com Not Parsed
//blablabla Not Parsed
http://blabla Parsed 
<img src="http://smalldata.io/startup/common-files/icons/sdl_logo.png" alt="" /> Parsed
<img src="//smalldata.io/startup/common-files/icons/sdl_logo.png" alt="" /> Parsed
http://smalldata.io/startup/common-files/icons/sdl_logo.png Parsed
//smalldata.io/startup/common-files/icons/sdl_logo.png Not Parsed
```