### PR TITLE
Improve feedback when required addons are enabled

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -1058,7 +1058,7 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
      * @param $pluginName
      * @param Gdn_Validation $validation
      * @param array|bool $options
-     * @return bool
+     * @return array|bool
      * @throws Exception
      * @throws Gdn_UserException
      */
@@ -1091,9 +1091,11 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
 
         // Enable this addon's requirements.
         $requirements = $this->addonManager->lookupRequirements($addon, AddonManager::REQ_DISABLED);
+        $enabledRequirements = [];
         foreach ($requirements as $addonKey => $row) {
             $requiredAddon = $this->addonManager->lookupAddon($addonKey);
             $this->enableAddon($requiredAddon, $setup);
+            $enabledRequirements[] = $requiredAddon;
         }
 
         // Enable the addon.
@@ -1105,7 +1107,11 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
         $this->EventArguments['AddonName'] = $addon->getRawKey();
         $this->fireEvent('AddonEnabled');
 
-        return true;
+        $result = [
+            'AddonEnabled' => true,
+            'RequirementsEnabled' => $enabledRequirements
+        ];
+        return $result;
     }
 
     /**


### PR DESCRIPTION
When you enable a plugin with dependencies, they're silently enabled. The user doesn't see any feedback in the UI: no toaster message, no "enabled" indicator. You have to refresh the page to see they're enabled.

This update does a couple things:
1. Alters the return type of `Gdn_PluginManager::enabledPlugin` from strictly a boolean to either a boolean or an array. The addition of the array type allows us to include additional information to the result of when a plug-in is enabled, such as including what requirements may've also been enabled.
1. Indicates via a toaster popup and UI element updates when a required addon has been auto-enabled.

Closes #5087 

Please backport to [release/2017-Q1-6](https://github.com/vanilla/vanilla/tree/release/2017-Q1-6) and [release/2017-Q2-4](https://github.com/vanilla/vanilla/tree/release/2017-Q2-4)