### PR TITLE
Filter out <link> tags from user posts

### DIFF
--- a/plugins/HtmLawed/class.htmlawed.plugin.php
+++ b/plugins/HtmLawed/class.htmlawed.plugin.php
@@ -152,7 +152,7 @@ class HtmLawedPlugin extends Gdn_Plugin {
             'css_expression' => 1,
             'deny_attribute' => $attributes,
             'direct_list_nest' => 1,
-            'elements' => '*-applet-form-input-textarea-iframe-script-style-embed-object-select-option-button-fieldset-optgroup-legend',
+            'elements' => '*-applet-button-embed-fieldset-form-iframe-input-legend-link-object-optgroup-option-script-select-style-textarea',
             'keep_bad' => 0,
             'schemes' => 'classid:clsid; href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, sftp, ssh, telnet; style: nil; *:file, http, https', // clsid allowed in class
             'unique_ids' => 1,


### PR DESCRIPTION
Backport to 2.3, 2.4, release/2017-Q1-6, release/2017-Q2-4

I reordered the tags. The only thing I added was `-link`

This affects any formatter that allow some html (WYSIWYG, Markdown, Simple HTML...)