### PR TITLE
Improve feedback when a duplicate addon key is encountered

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -328,6 +328,10 @@ class AddonManager {
                 if (!array_key_exists($key, $addons)) {
                     $addons[$key] = $addon;
                 } else {
+                    \Logger::error('Duplicate addon: {key}', [
+                        'key' => $key,
+                        'event' => 'duplicate_addon'
+                    ]);
                     throw new \Exception("Duplicate addon: {$key}");
                 }
             } catch (\Exception $ex) {

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -373,7 +373,7 @@ class AddonManager {
             foreach ($paths as $path) {
                 $basename = basename($path);
                 if (!array_key_exists($basename, $result)) {
-                    $result[basename($path)] = substr($path, $strlen);
+                    $result[$basename] = substr($path, $strlen);
                 } else {
                     \Logger::error('Duplicate addon: {basename}', [
                         'basename' => $basename,

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -20,6 +20,7 @@ use Garden\EventManager;
  * - Any translations the addon has declared will be loaded for the currently enabled locale.
  */
 class AddonManager {
+
     /// Constants ///
 
     const REQ_ENABLED = 0x01; // addon enabled, yay!
@@ -323,9 +324,15 @@ class AddonManager {
         foreach ($addonDirs as $subdir) {
             try {
                 $addon = new Addon($subdir);
-                $addons[$addon->getKey()] = $addon;
+                $key = $addon->getKey();
+                if (!array_key_exists($key, $addons)) {
+                    $addons[$key] = $addon;
+                } else {
+                    throw new \Exception("Duplicate addon: {$key}");
+                }
             } catch (\Exception $ex) {
-                trigger_error("The $type in $subdir is invalid.", E_USER_WARNING);
+                $exceptionMessage = $ex->getMessage();
+                trigger_error("The $type in $subdir is invalid. $exceptionMessage", E_USER_WARNING);
             }
         }
         $this->multiCache = $addons;
@@ -351,6 +358,7 @@ class AddonManager {
      *
      * @param string $type One of the **Addon::TYPE_*** constants.
      * @return array Returns an array of root-relative addon directories.
+     * @throws \Exception if a duplicate addon is detected.
      */
     private function scanAddonDirs($type) {
         $strlen = strlen(PATH_ROOT);
@@ -359,7 +367,16 @@ class AddonManager {
         foreach ($this->scanDirs[$type] as $subdir) {
             $paths = glob(PATH_ROOT."$subdir/*", GLOB_ONLYDIR | GLOB_NOSORT);
             foreach ($paths as $path) {
-                $result[basename($path)] = substr($path, $strlen);
+                $basename = basename($path);
+                if (!array_key_exists($basename, $result)) {
+                    $result[basename($path)] = substr($path, $strlen);
+                } else {
+                    \Logger::error('Duplicate addon: {basename}', [
+                        'basename' => $basename,
+                        'event' => 'duplicate_addon'
+                    ]);
+                    throw new \Exception("Duplicate addon: {$basename}");
+                }
             }
         }
 

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -375,7 +375,6 @@ class AddonManager {
                         'basename' => $basename,
                         'event' => 'duplicate_addon'
                     ]);
-                    throw new \Exception("Duplicate addon: {$basename}");
                 }
             }
         }


### PR DESCRIPTION
When addons use duplicate directories or keys, there's currently not a lot of feedback to go on for the errors that arise.

This update adds some exception throwing to two key areas when addons are scanned. If a duplicately-named addon directory is encountered, an exception is thrown indicating which addon is causing the issue. If a duplicate addon key is encountered, a similar exception is thrown and the error is logged to the database. The directory scan doesn't include logging, because it's done before addons are loaded and hence we cannot count on a logger being available. The addon key scanning is run on addon pages during cache checks, so there's an increased likeliness a logger will be available.

We're moving in a directory where an addon is an addon is an addon. Themes, plugins and applications should have globally unique keys and their keys should match their directory names.

Closes #5053