### PR TITLE
Fix path detection in environment setup to work with symlinks again

### DIFF
--- a/environment.php
+++ b/environment.php
@@ -22,7 +22,7 @@ if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
 }
 if (!defined('PATH_ROOT')) {
-    define('PATH_ROOT', __DIR__);
+    define('PATH_ROOT', getcwd());
 }
 
 /**


### PR DESCRIPTION
Reverts use of `__DIR__` to `getcwd()` in setting our `PATH_ROOT`. 

Using `__DIR__` adds the benefit of caching its value, but removes the ability to use symlinks for much of Vanilla. Since we currently have no plan or strategy to accommodate complex localhost setups (e.g. "How do you then symlink 50 plugins into 50 localhost sites?"), this tradeoff was very bad. It also creates a bunch of communication overhead for the open source release that we had no plan for.

Relevant discussion was previously here: https://github.com/vanilla/vanilla/pull/5492#pullrequestreview-36433978