### PR TITLE
Fix recipient being added a second time to the same conversation

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -329,7 +329,7 @@ class ConversationModel extends ConversationsModel {
      * @param int $Limit The number of recipients to grab.
      * @return Gdn_DataSet SQL results.
      */
-    public function getRecipients($ConversationID, $Limit = 20) {
+    public function getRecipients($ConversationID, $Limit = 1000) {
         $Data = $this->SQL
             ->select('uc.*')
             ->from('UserConversation uc')
@@ -771,7 +771,7 @@ class ConversationModel extends ConversationsModel {
         }
 
         // First define the current users in the conversation
-        $OldContributorData = $this->getRecipients($ConversationID, 1000);
+        $OldContributorData = $this->getRecipients($ConversationID);
         $OldContributorData = Gdn_DataSet::index($OldContributorData, 'UserID');
         $AddedUserIDs = array();
 

--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -771,7 +771,7 @@ class ConversationModel extends ConversationsModel {
         }
 
         // First define the current users in the conversation
-        $OldContributorData = $this->getRecipients($ConversationID);
+        $OldContributorData = $this->getRecipients($ConversationID, 1000);
         $OldContributorData = Gdn_DataSet::index($OldContributorData, 'UserID');
         $AddedUserIDs = array();
 


### PR DESCRIPTION
There is a bug where if you have over 20 recipient and you try to add the 21st again on the conversation it will throw an exception due to the database rejecting the insert query because of the unique constraint on (ConversationID, UserID).

The default limit of getRecipients is 20 so I'm upping the query to 1000 since conversation are not meant to be thread of discussion.
