### PR TITLE
Add AddonManager->isCacheEnabled()

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -296,7 +296,7 @@ class AddonManager {
             if ($this->isCacheEnabled() && is_readable($cachePath)) {
                 $this->multiCache = require $cachePath;
             } else {
-                $this->multiCache = $this->scan(Addon::TYPE_ADDON, true);
+                $this->multiCache = $this->scan(Addon::TYPE_ADDON, $this->isCacheEnabled());
             }
         }
     }

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -99,7 +99,7 @@ class AddonManager {
         $scanDirs += array_fill_keys($types, []);
 
         foreach ($types as $type) {
-            if ($this->cacheDir !== null && !$this->typeUsesMultiCaching($type)) {
+            if ($this->isCacheEnabled() && !$this->typeUsesMultiCaching($type)) {
                 $dir = "$cacheDir/$type";
                 if (!file_exists($dir)) {
                     $r = $r && mkdir($dir, 0755);
@@ -292,11 +292,8 @@ class AddonManager {
      */
     private function ensureMultiCache() {
         if (!isset($this->multiCache)) {
-            $cachePath = null;
-            if ($this->cacheDir) {
-                $cachePath = $this->cacheDir.'/'.Addon::TYPE_ADDON.'.php';
-            }
-            if ($cachePath !== null && is_readable($cachePath)) {
+            $cachePath = $this->cacheDir.'/'.Addon::TYPE_ADDON.'.php';
+            if ($this->isCacheEnabled() && is_readable($cachePath)) {
                 $this->multiCache = require $cachePath;
             } else {
                 $this->multiCache = $this->scan(Addon::TYPE_ADDON, true);
@@ -312,7 +309,7 @@ class AddonManager {
      * @return array Returns an array of {@link Addon} objects.
      */
     public function scan($type, $saveCache = false) {
-        if ($saveCache && empty($this->cacheDir)) {
+        if ($saveCache && !$this->isCacheEnabled()) {
             throw new \InvalidArgumentException("Cannot save the addon cache when the cache directory is empty.", 500);
         }
 
@@ -387,13 +384,13 @@ class AddonManager {
     }
 
     /**
-     * Cache an array.
+     * Cache an array if the cache is enabled.
      *
      * @param string $path Relative path path to save the array to.
      * @param string $array The array to save.
      */
     private function saveArrayCache($path, $array) {
-        if ($this->cacheDir !== null) {
+        if ($this->isCacheEnabled()) {
             $varString = '<?php return '.var_export($array, true).";\n";
             $this->filePutContents($this->cacheDir.'/'.$path, $varString);
         }
@@ -452,7 +449,7 @@ class AddonManager {
         if (!isset($this->singleIndex[$type])) {
             $cachePath = "$type-index.php";
 
-            if ($this->cacheDir !== null && is_readable("$this->cacheDir/$cachePath")) {
+            if ($this->isCacheEnabled() && is_readable("$this->cacheDir/$cachePath")) {
                 $this->singleIndex[$type] = require "$this->cacheDir/$cachePath";
             } else {
                 $addonDirs = $this->scanAddonDirs($type);
@@ -477,13 +474,7 @@ class AddonManager {
         if (isset($index[$key])) {
             unset($index[$key]);
 
-            $cachePath = null;
-            if ($this->cacheDir !== null) {
-                $cachePath = $this->cacheDir."/$type-index.php";
-            }
-            if ($cachePath !== null) {
-                $this->saveArrayCache($cachePath, $index);
-            }
+            $this->saveArrayCache($this->cacheDir."/$type-index.php", $index);
 
             $this->singleIndex[$type] = $index;
             return true;
@@ -505,7 +496,7 @@ class AddonManager {
             return $result === false ? null : $result;
         }
         // Look at the file cache.
-        if (!empty($this->cacheDir)) {
+        if ($this->isCacheEnabled()) {
             $cachePath = "{$this->cacheDir}/$type/$key.php";
             if (is_readable($cachePath)) {
                 $addon = require $cachePath;
@@ -523,9 +514,7 @@ class AddonManager {
             }
         }
         // Cache the addon's information.
-        if (!empty($this->cacheDir)) {
-            $this->saveArrayCache("$type/$key.php", $addon);
-        }
+        $this->saveArrayCache("$type/$key.php", $addon);
         $this->singleCache[$type][$key] = $addon;
         return $addon === false ? null : $addon;
     }
@@ -1037,7 +1026,7 @@ class AddonManager {
      * @return bool Returns **true** if the files were removed or **false** otherwise.
      */
     public function clearCache() {
-        if ($this->cacheDir === null) {
+        if (!$this->isCacheEnabled()) {
             return true;
         }
 
@@ -1137,5 +1126,14 @@ class AddonManager {
         } else {
             trigger_error("$pluginClass does not implement Gdn_IPlugin", E_USER_DEPRECATED);
         }
+    }
+
+    /**
+     * Tells whether the AddonManager's cache is enabled or not.
+     *
+     * @return bool
+     */
+    public function isCacheEnabled() {
+        return $this->cacheDir !== null;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5544

Improve AddonManager's readability by encapsulating `$this->cacheDir` comparisons (!empty, !== null, ...) in a function.