### PR TITLE
Properly set keyRaw for applications if not defined

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -152,7 +152,9 @@ class Addon {
 
                 // Kludge that sets keyRaw until we use key everywhere.
                 if ($info['oldType'] === 'application') {
-                    $info['keyRaw'] = $info['name'];
+                    if (!isset($info['keyRaw'])) {
+                        $info['keyRaw'] = $info['name'];
+                    }
                 } else {
                     if ($addonFolder !== $info['key']) {
                         $info['keyRaw'] = $addonFolder;

--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -104,9 +104,6 @@ class Gdn_ApplicationManager {
         $directories = explode(DS, $addon->getSubdir());
         $info['Folder'] = $directories[count($directories) - 1];
 
-        // $ApplicationInfo[INDEX] is converted to $info['Name'] = 'Index'
-        $info['Index'] = $info['Name'];
-
         return $info;
     }
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5642
Depends on https://github.com/vanilla/vanilla-cli/pull/6

While converting from $ApplicationInfo to addon.json I tried to [get rid of some kludges](https://github.com/vanilla/vanilla-cli/pull/1/files#diff-96b428404a3aef197827541a95fb71c9R61).

The problem with this is that by getting rid of keyRaw (which is used to set the 'Index' field in calcOldInfoArray which is in turn used in the ApplicationManager) in addon.json and putting the kludge in the codebase we made the wrong assumption that $ApplicationInfo[INDEX] was === to $addon['name].

As you can see from the old Conversation [about.php](https://github.com/vanilla/vanilla/blob/6ed8a7bbd9fb31ea174271a61a3d71394d8a23bb/applications/conversations/settings/about.php) the index is the name (and every other application we converted where that way) but there are some applications, which we did not have access to, that had a name field and it was different than their index.
This caused issue https://github.com/vanilla/vanilla/issues/5642

To correct this problem I removed the kludge in class.applicationmanager.php and defined keyRaw in addon.php only if not present in addon.json.

I updated Vanilla CLI to generate keyRaw by default. 