### PR TITLE
Fix 'getnew' endpoint

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -295,7 +295,7 @@ class DiscussionController extends VanillaController {
         $this->setData('CategoryID', $this->CategoryID = $this->Discussion->CategoryID, true);
 
         // Get the comments.
-        $Comments = $this->CommentModel->getNew($DiscussionID, $LastCommentID)->result();
+        $Comments = $this->CommentModel->getNew($DiscussionID, $LastCommentID);
         $this->setData('Comments', $Comments, true);
 
         // Set the data.

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -297,6 +297,7 @@ class DiscussionController extends VanillaController {
         // Get the comments.
         $Comments = $this->CommentModel->getNew($DiscussionID, $LastCommentID);
         $this->setData('Comments', $Comments, true);
+        $Comments = $Comments->result();
 
         // Set the data.
         if (count($Comments) > 0) {


### PR DESCRIPTION
Fixes getnew() to work with the newer comments.php view, which doesn't expect data's `Comments` to be an array. Pretty sure I'm the only person in existence using this endpoint.