### PR TITLE
Add new beforeAddUser event to ConversationModel->addUserToConversation

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -785,6 +785,11 @@ class ConversationModel extends ConversationsModel {
             ->get()
             ->firstRow();
 
+        $this->EventArguments['ConversationID'] = $ConversationID;
+        $this->EventArguments['UserIDs'] = &$UserID;
+        $this->EventArguments['OldContributorData'] = $OldContributorData;
+        $this->fireEvent('beforeAddUser');
+
         // Add the user(s) if they are not already in the conversation
         foreach ($UserID as $NewUserID) {
             if (!array_key_exists($NewUserID, $OldContributorData)) {


### PR DESCRIPTION
That event allows taking influence on the users which should be added. Needful for plugins like "Ignore" which should disallow users to contact ignoring users.

That new event would be a requirement to handle https://github.com/vanilla/addons/issues/510

I have chosen the EventArguments name "UserID**s**" on purpose: although the addUserToConversation method takes an integer "UserID" based on its documentation, that integer is transformed to an array and this array is used in a foreach loop. Using "UserID" as a name would be misleading.
Maybe that variable name should be changed to UserIDs anyway.