### PR TITLE
Remove html from translation keys in quotes plugin

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -138,8 +138,8 @@ class QuotesPlugin extends Gdn_Plugin {
 
         $QuoteFolding = val('Quotes.Folding', $UserPrefs, '1');
         $Sender->addDefinition('QuotesFolding', $QuoteFolding);
-        $Sender->addDefinition('hide previous quotes', t('hide previous quotes', '&laquo; hide previous quote'));
-        $Sender->addDefinition('show previous quotes', t('show previous quotes', '&raquo; show previous quote'));
+        $Sender->addDefinition('hide previous quotes', t('hide previous quotes', '&laquo; hide previous quotes'));
+        $Sender->addDefinition('show previous quotes', t('show previous quotes', '&raquo; show previous quotes'));
     }
 
     /**

--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -138,8 +138,8 @@ class QuotesPlugin extends Gdn_Plugin {
 
         $QuoteFolding = val('Quotes.Folding', $UserPrefs, '1');
         $Sender->addDefinition('QuotesFolding', $QuoteFolding);
-        $Sender->addDefinition('&laquo; hide previous quotes', t('&laquo; hide previous quotes'));
-        $Sender->addDefinition('&raquo; show previous quotes', t('&raquo; show previous quotes'));
+        $Sender->addDefinition('hide previous quotes', t('hide previous quotes', 'hide previous quote'));
+        $Sender->addDefinition('show previous quotes', t('show previous quotes', 'show previous quote'));
     }
 
     /**

--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -138,8 +138,8 @@ class QuotesPlugin extends Gdn_Plugin {
 
         $QuoteFolding = val('Quotes.Folding', $UserPrefs, '1');
         $Sender->addDefinition('QuotesFolding', $QuoteFolding);
-        $Sender->addDefinition('hide previous quotes', t('hide previous quotes', 'hide previous quote'));
-        $Sender->addDefinition('show previous quotes', t('show previous quotes', 'show previous quote'));
+        $Sender->addDefinition('hide previous quotes', t('hide previous quotes', '&laquo; hide previous quote'));
+        $Sender->addDefinition('show previous quotes', t('show previous quotes', '&raquo; show previous quote'));
     }
 
     /**

--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -32,9 +32,9 @@ Gdn_Quotes.prototype.Prepare = function () {
                 .toggle();
 
         if (QuoteTarget.css('display') != 'none') {
-            Anchor.html(gdn.definition('&laquo; hide previous quotes'));
+            Anchor.html(gdn.definition('hide previous quotes'));
         } else {
-            Anchor.html(gdn.definition('&raquo; show previous quotes'));
+            Anchor.html(gdn.definition('show previous quotes'));
         }
 
         return false;
@@ -84,7 +84,7 @@ Gdn_Quotes.prototype.ExploreFold = function(QuoteTree, FoldingLevel, MaxLevel, T
                 .hide()
                 .before(
                     '<div class="QuoteFoldingWrapper"><a href="" class="QuoteFolding">' +
-                    gdn.definition('&raquo; show previous quotes') +
+                    gdn.definition('show previous quotes') +
                     '</a></div>'
                 );
             return;


### PR DESCRIPTION
We had untranslated translation strings that we recently added to locales. When adding them we decided that that we should remove some html special chars that were in them to keep the keys clean. This PR removes `&raquo;` and `&laquo;` from strings in locales and in gdn.meta as well.