### PR TITLE
Fix ban filter including admins and mods

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -2087,7 +2087,7 @@ class SettingsController extends DashboardController {
             $this->setData('EmptyMessageTitle', $emptyMessageTitle);
             $emptyMessageBody = sprintf(t('Cannot find the user identified by %s.'), htmlspecialchars($userIdentifier));
             $this->setData('EmptyMessageBody', $emptyMessageBody);
-            $this->render('bans', 'settings', 'dashboard');
+            return;
         }
 
         $matchingBans = [];
@@ -2132,7 +2132,6 @@ class SettingsController extends DashboardController {
         $this->setData('Bans', $matchingBans);
         $emptyMessage = sprintf(t('There are no existing ban rules affecting user %s.'), val('Name', $user));
         $this->setData('EmptyMessageBody', $emptyMessage);
-        $this->render('bans', 'settings', 'dashboard');
     }
 
 

--- a/applications/dashboard/views/settings/banstable.php
+++ b/applications/dashboard/views/settings/banstable.php
@@ -8,10 +8,10 @@ PagerModule::write(array('Sender' => $this, 'Limit' => 20, 'CurrentRecords' => c
     <table id="Log" class="table-data js-tj">
         <thead>
         <tr>
-            <th class="column-lg"><?php echo t('Ban Item', 'Item'); ?></th>
+            <th class="column-lg"><?php echo t('Ban Item', 'Rule'); ?></th>
             <th><?php echo t('Ban Type', 'Type'); ?></th>
-            <th class="column-sm"><?php echo t('User Count', 'Users'); ?></th>
-            <th class="column-sm"><?php echo '<span title="'.t('Number of blocked registrations').'">', t('Blocked'), '</span>'; ?></th>
+            <th class="column-sm"><?php echo '<span title="'.t('Number of affected users').'">'.t('User Count', 'Users').'</span>'; ?></th>
+            <th class="column-sm"><?php echo '<span title="'.t('Number of blocked registrations').'">'.t('Blocked').'</span>'; ?></th>
             <th class="UsernameCell"><?php echo t('Added By'); ?></th>
             <th class="column-lg"><?php echo t('Notes'); ?></th>
             <th class="options"></th>
@@ -26,7 +26,7 @@ PagerModule::write(array('Sender' => $this, 'Limit' => 20, 'CurrentRecords' => c
                 <td><?php echo t($Row['BanType']); ?></td>
                 <td>
                     <?php
-                    echo anchor($Row['CountUsers'], '/dashboard/user?Filter='.urlencode($this->_BanFilter($Row)));
+                    echo anchor($Row['CountUsers'], '/dashboard/user/banned?Filter='.urlencode($this->_BanFilter($Row)));
                     ?>
                 </td>
                 <td>


### PR DESCRIPTION
The ban filters were including admin and mods when we were clicking on the Users' count.

The add Ban Rule button was opening 3 modals dialog because SettingsController->findBanRule was calling render without calling `Gdn_Theme::section('Moderation')` which made the master template render the admin template.
The calling function `bans` is already rendering the correct view so I removed the calls to render in findBanRule.
You have to go on /en/settings/bans/find/ to reproduce this issue.