### PR TITLE
Remove addCssFile calls referencing non existent or superfluous files

### DIFF
--- a/plugins/Flagging/class.flagging.plugin.php
+++ b/plugins/Flagging/class.flagging.plugin.php
@@ -80,9 +80,6 @@ class FlaggingPlugin extends Gdn_Plugin {
      * Default method of virtual Flagging controller.
      */
     public function controller_index($Sender) {
-        $Sender->addCssFile('admin.css');
-        $Sender->addCssFile($this->getResource('design/flagging.css', false, false));
-
         $Validation = new Gdn_Validation();
         $ConfigurationModel = new Gdn_ConfigurationModel($Validation);
         $ConfigurationModel->setField(array(
@@ -148,13 +145,6 @@ class FlaggingPlugin extends Gdn_Plugin {
             $Sender->informMessage(sprintf(t('%s dismissed.'), t('Flag')));
         }
         $Sender->render('blank', 'utility', 'dashboard');
-    }
-
-    /**
-     * Add Flagging styling to Discussion.
-     */
-    public function discussionController_beforeCommentsRender_handler($Sender) {
-        $Sender->addCssFile($this->getResource('design/flagging.css', false, false));
     }
 
     /**


### PR DESCRIPTION
The plugin tries to a) add admin.css which is included anyway in the dashboard and b) add flagging.css which has been removed since it wasn't used.
The way that this plugin was add css files wasn't working since release 2.2

This closes https://github.com/vanilla/vanilla/issues/3015