### PR TITLE
Replace deleted users mail placeholder

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3487,7 +3487,7 @@ class UserModel extends Gdn_Model {
                 'Photo' => null,
                 'Password' => randomString('10'),
                 'About' => '',
-                'Email' => 'user_'.$userID.'@deleted.email',
+                'Email' => 'user_'.$userID.'@deleted.invalid',
                 'ShowEmail' => '0',
                 'Gender' => 'u',
                 'CountVisits' => 0,


### PR DESCRIPTION
Vanilla replaces deleted users mail address with a placeholder: `user_XY@deleted.email`. Since ".email" became a valid TLD, that isn't an invalid mail address any more.
[RFC 2606](https://tools.ietf.org/html/rfc2606) specifies a better TLD for that: ".invalid". Using this TLD leaves no doubt that the mail address itself is invalid although the format isvalid.