### PR TITLE
Update redirectTo calls to use the $trustedOnly option where necessary

### DIFF
--- a/applications/conversations/controllers/class.conversationscontroller.php
+++ b/applications/conversations/controllers/class.conversationscontroller.php
@@ -41,7 +41,7 @@ class ConversationsController extends Gdn_Controller {
     public function initialize() {
         // You've got to be signed in to send private messages.
         if (!Gdn::session()->isValid()) {
-            redirectTo('/entry/signin?Target='.urlencode($this->SelfUrl), 302, false);
+            redirectTo('/entry/signin?Target='.urlencode($this->SelfUrl));
         }
 
         if ($this->deliveryType() == DELIVERY_TYPE_ALL) {

--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -194,7 +194,7 @@ class MessagesController extends ConversationsController {
 
             if ($NewMessageID) {
                 if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
-                    redirectTo('messages/'.$ConversationID.'/#'.$NewMessageID, 302, false);
+                    redirectTo('messages/'.$ConversationID.'/#'.$NewMessageID);
                 }
 
                 $this->setJson('MessageID', $NewMessageID);
@@ -584,7 +584,7 @@ class MessagesController extends ConversationsController {
 
         // Redirect back where the user came from if necessary
         if ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
-            redirectTo($_SERVER['HTTP_REFERER'], 302, false);
+            redirectTo($_SERVER['HTTP_REFERER']);
         } else {
             $this->render();
         }

--- a/applications/dashboard/controllers/class.activitycontroller.php
+++ b/applications/dashboard/controllers/class.activitycontroller.php
@@ -205,7 +205,7 @@ class ActivityController extends Gdn_Controller {
         }
         $this->ActivityModel->deleteComment($ID);
         if ($this->deliveryType() === DELIVERY_TYPE_ALL) {
-            redirectTo($Target, 302, false);
+            redirectTo($Target);
         }
 
         $this->render('Blank', 'Utility', 'Dashboard');
@@ -241,7 +241,7 @@ class ActivityController extends Gdn_Controller {
             $target = Gdn::request()->get('Target');
             if ($target) {
                 // Bail with a redirect if we got one.
-                redirectTo($target, 302, false);
+                redirectTo($target);
             } else {
                 // We got this as a full page somehow, so send them back to /activity.
                 $this->setRedirectTo('activity', false);
@@ -308,7 +308,7 @@ class ActivityController extends Gdn_Controller {
             if (!$Target) {
                 $Target = '/activity';
             }
-            redirectTo($Target, 302, false);
+            redirectTo($Target);
         } else {
             // Load the newly added comment.
             $this->setData('Comment', $this->ActivityModel->getComment($ID));
@@ -411,9 +411,9 @@ class ActivityController extends Gdn_Controller {
         if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
             $Target = $this->Request->get('Target', '/activity');
             if (isSafeUrl($Target)) {
-                redirectTo($Target, 302, false);
+                redirectTo($Target);
             } else {
-                redirectTo(url('/activity'), 302, false);
+                redirectTo('/activity');
             }
         }
 

--- a/applications/dashboard/controllers/class.embedcontroller.php
+++ b/applications/dashboard/controllers/class.embedcontroller.php
@@ -20,7 +20,7 @@ class EmbedController extends DashboardController {
      * Default method.
      */
     public function index() {
-        redirectTo('embed/comments', 302, false);
+        redirectTo('embed/comments');
     }
 
     /**
@@ -52,7 +52,7 @@ class EmbedController extends DashboardController {
 
         try {
             if ($this->toggle($Toggle, $TransientKey)) {
-                redirectTo('embed/forum', 302, false);
+                redirectTo('embed/forum');
             }
         } catch (Gdn_UserException $Ex) {
             $this->Form->addError($Ex);
@@ -78,7 +78,7 @@ class EmbedController extends DashboardController {
 
 //        try {
 //            if ($this->toggle($Toggle, $TransientKey)) {
-//                redirectTo('embed/advanced', 302, false);
+//                redirectTo('embed/advanced');
 //            }
 //        } catch (Gdn_UserException $Ex) {
 //            $this->Form->addError($Ex);

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -270,9 +270,9 @@ class EntryController extends Gdn_Controller {
                     $this->setRedirectTo($Route, false);
                 } else {
                     if ($Route !== false) {
-                        redirectTo($Route, 302, false);
+                        redirectTo($Route);
                     } else {
-                        redirectTo(Gdn::router()->getDestination('DefaultController'), 302, false);
+                        redirectTo(Gdn::router()->getDestination('DefaultController'));
                     }
                 }
                 break;
@@ -1191,9 +1191,9 @@ class EntryController extends Gdn_Controller {
                     /// ... and redirect them appropriately
                     $Route = $this->getTargetRoute();
                     if ($Route !== false) {
-                        redirectTo($Route, 302, false);
+                        redirectTo($Route);
                     } else {
-                        redirectTo('/', 302, false);
+                        redirectTo('/');
                     }
 
                 } else {
@@ -1319,7 +1319,7 @@ class EntryController extends Gdn_Controller {
                 /// ... and redirect them appropriately
                 $Route = $this->getTargetRoute();
                 if ($Route !== false) {
-                    redirectTo($Route, 302, false);
+                    redirectTo($Route);
                 }
             } else {
                 // Add the hidden inputs back into the form.
@@ -1333,7 +1333,7 @@ class EntryController extends Gdn_Controller {
             $Id = Gdn::authenticator()->getIdentity(true);
             if ($Id > 0) {
                 // The user is signed in so we can just go back to the homepage.
-                redirectTo($Target, 302, false);
+                redirectTo($Target);
             }
 
             $Name = $UserInfo['UserName'];
@@ -1856,7 +1856,7 @@ class EntryController extends Gdn_Controller {
                         '{username} has reset their password.'
                     );
                     Gdn::session()->start($User->UserID, true);
-                    redirectTo('/', 302, false);
+                    redirectTo('/');
                 }
             }
 
@@ -1995,9 +1995,9 @@ class EntryController extends Gdn_Controller {
                     $this->setRedirectTo($Route, false);
                 } else {
                     if ($Route !== false) {
-                        redirectTo($Route, 302, false);
+                        redirectTo($Route);
                     } else {
-                        redirectTo(Gdn::router()->getDestination('DefaultController'), 302, false);
+                        redirectTo(Gdn::router()->getDestination('DefaultController'));
                     }
                 }
                 break;

--- a/applications/dashboard/controllers/class.importcontroller.php
+++ b/applications/dashboard/controllers/class.importcontroller.php
@@ -44,7 +44,7 @@ class ImportController extends DashboardController {
             if ($Imp->ImportPath) {
                 $Imp->CurrentStep = 1;
             } else {
-                redirectTo(strtolower($this->Application).'/import', 302, false);
+                redirectTo(strtolower($this->Application).'/import');
             }
         }
 
@@ -230,6 +230,6 @@ class ImportController extends DashboardController {
         }
         $Imp->deleteState();
 
-        redirectTo(strtolower($this->Application).'/import', 302, false);
+        redirectTo(strtolower($this->Application).'/import');
     }
 }

--- a/applications/dashboard/controllers/class.messagecontroller.php
+++ b/applications/dashboard/controllers/class.messagecontroller.php
@@ -71,7 +71,7 @@ class MessageController extends DashboardController {
         }
 
         if ($this->_DeliveryType === DELIVERY_TYPE_ALL) {
-            redirectTo(getIncomingValue('Target', '/discussions'), 302, false);
+            redirectTo(getIncomingValue('Target', '/discussions'));
         }
 
         $this->render();

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -200,7 +200,7 @@ class ProfileController extends Gdn_Controller {
         }
 
         if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
-            redirectTo('/profile', 302, false);
+            redirectTo('/profile');
         } else {
             $this->jsonTarget('#Status', '', 'Remove');
             $this->render('Blank', 'Utility');
@@ -314,7 +314,7 @@ class ProfileController extends Gdn_Controller {
         Gdn::userModel()->saveAttribute($this->User->UserID, $Provider, null);
 
         if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
-            redirectTo(userUrl($this->User, '', 'connections'), 302, false);
+            redirectTo(userUrl($this->User, '', 'connections'));
         } else {
             // Grab all of the providers again.
             $PModel = new Gdn_AuthenticationProviderModel();
@@ -1149,7 +1149,7 @@ class ProfileController extends Gdn_Controller {
         } else {
             $redirectUrl = userUrl($this->User, '', 'picture');
         }
-        redirectTo($redirectUrl, 302, false);
+        redirectTo($redirectUrl);
     }
 
     /**
@@ -1532,7 +1532,7 @@ class ProfileController extends Gdn_Controller {
         if ($this->User === false) {
             throw notFoundException('User');
         } elseif ($this->User->Deleted == 1) {
-            redirectTo('dashboard/home/deleted', 302, false);
+            redirectTo('dashboard/home/deleted');
         } else {
             $this->RoleData = $this->UserModel->getRoles($this->User->UserID);
             if ($this->RoleData !== false && $this->RoleData->numRows(DATASET_TYPE_ARRAY) > 0) {

--- a/applications/dashboard/controllers/class.routescontroller.php
+++ b/applications/dashboard/controllers/class.routescontroller.php
@@ -128,7 +128,7 @@ class RoutesController extends DashboardController {
         }
 
         if ($this->_DeliveryType === DELIVERY_TYPE_ALL) {
-            redirectTo('dashboard/routes', 302, false);
+            redirectTo('dashboard/routes');
         }
 
         $this->render();

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -398,7 +398,7 @@ class SettingsController extends DashboardController {
 
                     // New uploads stay on the page to allow cropping. Otherwise, redirect to avatar settings page.
                     if (!$newUpload) {
-                        redirectTo('/dashboard/settings/avatars', 302, false);
+                        redirectTo('/dashboard/settings/avatars');
                     }
                 }
                 $this->informMessage(t("Your settings have been saved."));
@@ -796,7 +796,7 @@ class SettingsController extends DashboardController {
      * @deprecated 2.4 Legacy redirect. Use SettingsController::layout instead.
      */
     public function homepage() {
-        redirectTo('/settings/layout', 302, false);
+        redirectTo('/settings/layout');
     }
 
     /**
@@ -805,7 +805,7 @@ class SettingsController extends DashboardController {
      * @deprecated 2.4 Legacy redirect. Use SettingsController::branding instead.
      */
     public function banner() {
-        redirectTo('/settings/branding', 302, false);
+        redirectTo('/settings/branding');
     }
 
 
@@ -1162,7 +1162,7 @@ class SettingsController extends DashboardController {
             $sections = DashboardNavModule::getDashboardNav()->getSectionsInfo();
             $url = val('url', val($section, $sections));
             if ($url) {
-                redirectTo($url, 302, false);
+                redirectTo($url);
             }
         }
 
@@ -1173,11 +1173,11 @@ class SettingsController extends DashboardController {
                 'Garden.Community.Manage',
             ], false)) {
             // We don't have permission to see the dashboard/home.
-            redirectTo(DashboardNavModule::getDashboardNav()->getUrlForSection('Moderation'), 302, false);
+            redirectTo(DashboardNavModule::getDashboardNav()->getUrlForSection('Moderation'));
         }
 
         // Still here?
-        redirectTo('dashboard/settings/home', 302, false);
+        redirectTo('dashboard/settings/home');
     }
 
     public function home() {
@@ -1285,7 +1285,7 @@ class SettingsController extends DashboardController {
             $this->informMessage(t("Your changes have been saved."));
 
             Gdn::locale()->refresh();
-            redirectTo('/settings/locales', 302, false);
+            redirectTo('/settings/locales');
         } else {
             $this->Form->setValue('Locale', Gdn_Locale::canonicalize(c('Garden.Locale', 'en')));
         }
@@ -1884,7 +1884,7 @@ class SettingsController extends DashboardController {
             }
 
             if ($this->Form->errorCount() == 0) {
-                redirectTo('/settings/themes', 302, false);
+                redirectTo('/settings/themes');
             }
 
         }
@@ -2050,7 +2050,7 @@ class SettingsController extends DashboardController {
                     $this->render('Blank', 'Utility', 'Dashboard');
                     exit;
                 } else {
-                    redirectTo('/settings/mobilethemes', 302, false);
+                    redirectTo('/settings/mobilethemes');
                 }
             } else {
                 if ($AsyncRequest) {
@@ -2175,9 +2175,9 @@ class SettingsController extends DashboardController {
 
             $this->fireEvent('PreviewTheme', ['ThemeInfo' => $ThemeInfo]);
 
-            redirectTo('/', 302, false);
+            redirectTo('/');
         } else {
-            redirectTo('settings/themes', 302, false);
+            redirectTo('settings/themes');
         }
     }
 
@@ -2212,9 +2212,9 @@ class SettingsController extends DashboardController {
         }
 
         if ($isMobile) {
-            redirectTo('settings/mobilethemes', 302, false);
+            redirectTo('settings/mobilethemes');
         } else {
-            redirectTo('settings/themes', 302, false);
+            redirectTo('settings/themes');
         }
     }
 

--- a/applications/dashboard/controllers/class.setupcontroller.php
+++ b/applications/dashboard/controllers/class.setupcontroller.php
@@ -133,7 +133,7 @@ class SetupController extends DashboardController {
 
                     // Go to the dashboard.
                     if ($this->deliveryType() === DELIVERY_TYPE_ALL) {
-                        redirectTo('/settings/gettingstarted', 302, false);
+                        redirectTo('/settings/gettingstarted');
                     }
                 } elseif ($this->deliveryType() === DELIVERY_TYPE_DATA) {
                     $maxCode = 0;

--- a/applications/dashboard/controllers/class.socialcontroller.php
+++ b/applications/dashboard/controllers/class.socialcontroller.php
@@ -28,7 +28,7 @@ class SocialController extends DashboardController {
      * Default method.
      */
     public function index() {
-        redirectTo('social/manage', 302, false);
+        redirectTo('social/manage');
     }
 
     /**

--- a/applications/dashboard/controllers/class.utilitycontroller.php
+++ b/applications/dashboard/controllers/class.utilitycontroller.php
@@ -153,7 +153,7 @@ class UtilityController extends DashboardController {
 
         // Redirect back where the user came from if necessary
         if ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
-            redirectTo($_SERVER['HTTP_REFERER'], 302, false);
+            redirectTo($_SERVER['HTTP_REFERER']);
         } else {
             $this->render();
         }

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -648,7 +648,7 @@ class DashboardHooks extends Gdn_Plugin {
             $deliveryType = $Sender->getDeliveryType($deliveryMethod);
             if (!$IsApi && !Gdn::request()->isPostBack() && $deliveryType !== DELIVERY_TYPE_DATA) {
                 $url = trim(preg_replace('#(\?.*)sso=[^&]*&?(.*)$#', '$1$2', Gdn::request()->pathAndQuery()), '&');
-                redirectTo(url($url, true), 302, false);
+                redirectTo($url);
             }
         }
         $this->checkAccessToken();

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -619,7 +619,7 @@ class CategoriesController extends VanillaController {
     public function initialize() {
         parent::initialize();
         if (!c('Vanilla.Categories.Use')) {
-            redirectTo('/discussions', 302, false);
+            redirectTo('/discussions');
         }
         if ($this->Menu) {
             $this->Menu->highlightRoute('/categories');

--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -27,7 +27,7 @@ class CategoryController extends VanillaController {
         }
 
         if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
-            redirectTo('/categories', 302, false);
+            redirectTo('/categories');
         }
 
         $this->render();
@@ -51,7 +51,7 @@ class CategoryController extends VanillaController {
             $this->CategoryModel->SaveUserTree($CategoryID, array('DateMarkedRead' => Gdn_Format::toDateTime()));
         }
         if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
-            redirectTo('/categories', 302, false);
+            redirectTo('/categories');
         }
 
         $this->render();

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -203,7 +203,7 @@ class DiscussionsController extends VanillaController {
         deprecated(__METHOD__);
 
         if (!Gdn::session()->isValid()) {
-            redirectTo('/discussions/index', 302, false);
+            redirectTo('/discussions/index');
         }
 
         // Figure out which discussions layout to choose (Defined on "Homepage" settings page).
@@ -647,7 +647,7 @@ class DiscussionsController extends VanillaController {
         }
 
         if ($Target) {
-            redirectTo($Target, 302, false);
+            redirectTo($Target);
         }
 
         // Send sorted discussions.

--- a/applications/vanilla/controllers/class.draftscontroller.php
+++ b/applications/vanilla/controllers/class.draftscontroller.php
@@ -110,7 +110,7 @@ class DraftsController extends VanillaController {
         // Redirect
         if ($this->_DeliveryType === DELIVERY_TYPE_ALL) {
             $Target = GetIncomingValue('Target', '/drafts');
-            redirectTo($Target, 302, false);
+            redirectTo($Target);
         }
 
         // Return any errors

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -218,7 +218,7 @@ class ModerationController extends VanillaController {
             Gdn::userModel()->saveAttribute($Session->UserID, 'CheckedComments', $CheckedComments);
         }
 
-        redirectTo(GetIncomingValue('Target', '/discussions'), 302, false);
+        redirectTo(GetIncomingValue('Target', '/discussions'));
     }
 
     /**
@@ -230,7 +230,7 @@ class ModerationController extends VanillaController {
             Gdn::userModel()->saveAttribute($Session->UserID, 'CheckedDiscussions', false);
         }
 
-        redirectTo(GetIncomingValue('Target', '/discussions'), 302, false);
+        redirectTo(GetIncomingValue('Target', '/discussions'));
     }
 
     /**

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -351,7 +351,7 @@ class PostController extends VanillaController {
                         $this->fireEvent('AfterDiscussionSave');
 
                         if ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
-                            redirectTo(discussionUrl($Discussion, 1).'?new=1', 302, false);
+                            redirectTo(discussionUrl($Discussion, 1).'?new=1');
                         } else {
                             $this->setRedirectTo(discussionUrl($Discussion, 1, true).'?new=1', false);
                         }
@@ -620,7 +620,7 @@ class PostController extends VanillaController {
 
         // If closed, cancel & go to discussion
         if ($Discussion && $Discussion->Closed == 1 && !$Editing && !CategoryModel::checkPermission($Discussion->CategoryID, 'Vanilla.Discussions.Close')) {
-            redirectTo(DiscussionUrl($Discussion), 302, false);
+            redirectTo(DiscussionUrl($Discussion));
         }
 
         // Add hidden IDs to form
@@ -731,7 +731,7 @@ class PostController extends VanillaController {
                     if (!$Draft) {
                         // Redirect to the new comment.
                         if ($CommentID > 0) {
-                            redirectTo("discussion/comment/$CommentID/#Comment_$CommentID", 302, false);
+                            redirectTo("discussion/comment/$CommentID/#Comment_$CommentID");
                         } elseif ($CommentID == SPAM) {
                             $this->setData('DiscussionUrl', DiscussionUrl($Discussion));
                             $this->View = 'Spam';

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -101,7 +101,7 @@ class VanillaSettingsController extends Gdn_Controller {
      * @deprecated 2.4 Legacy redirect. Use VanillaSettingsController::posting instead.
      */
     public function advanced() {
-        redirectTo('/vanilla/settings/posting', 302, false);
+        redirectTo('/vanilla/settings/posting');
     }
 
     /**
@@ -161,7 +161,7 @@ class VanillaSettingsController extends Gdn_Controller {
      * @access public
      */
     public function index() {
-        redirectTo('/vanilla/settings/categories', 302, false);
+        redirectTo('/vanilla/settings/categories');
     }
 
     /**
@@ -390,7 +390,7 @@ class VanillaSettingsController extends Gdn_Controller {
                 $this->setData('Category', $Category);
 
                 if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
-                    redirectTo('vanilla/settings/categories', 302, false);
+                    redirectTo('vanilla/settings/categories');
                 } elseif ($this->deliveryType() === DELIVERY_TYPE_DATA && method_exists($this, 'getCategory')) {
                     $this->Data = [];
                     $this->getCategory($CategoryID);
@@ -700,7 +700,7 @@ class VanillaSettingsController extends Gdn_Controller {
 
                 if ($this->deliveryType() == DELIVERY_TYPE_ALL) {
                     $destination = $this->categoryPageByParent($parentCategory);
-                    redirectTo($destination, 302, false);
+                    redirectTo($destination);
                 } elseif ($this->deliveryType() === DELIVERY_TYPE_DATA && method_exists($this, 'getCategory')) {
                     $this->Data = [];
                     $this->getCategory($CategoryID);

--- a/applications/vanilla/modules/class.categoryfollowtogglemodule.php
+++ b/applications/vanilla/modules/class.categoryfollowtogglemodule.php
@@ -32,7 +32,7 @@ class CategoryFollowToggleModule extends Gdn_Module {
                 $Session->setPreference('ShowAllCategories', $ShowAllCategories);
             }
 
-            redirectTo('/'.ltrim(Gdn::request()->Path(), '/'), 302, false);
+            redirectTo('/'.ltrim(Gdn::request()->Path(), '/'));
         }
     }
 

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -1040,7 +1040,7 @@ class VanillaHooks implements Gdn_IPlugin {
      */
     public function pluginController_tagsearch_create() {
         $query = http_build_query(Gdn::request()->getQuery());
-        redirectTo(url('/tags/search'.($query ? '?'.$query : null)), 301, false);
+        redirectTo(url('/tags/search'.($query ? '?'.$query : null)), 301);
     }
 
     /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1144,7 +1144,7 @@ class Gdn_Controller extends Gdn_Pluggable {
             );
 
             if (!$Session->isValid() && $this->deliveryType() == DELIVERY_TYPE_ALL) {
-                redirectTo('/entry/signin?Target='.urlencode($this->Request->pathAndQuery()), 302, false);
+                redirectTo('/entry/signin?Target='.urlencode($this->Request->pathAndQuery()));
             } else {
                 Gdn::dispatcher()->dispatch('DefaultPermission');
                 exit();

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -231,7 +231,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
                 safeHeader('Content-Type: application/json; charset=utf-8', true);
                 echo json_encode(array('Code' => '401', 'Exception' => t('You must sign in.')));
             } else {
-                redirectTo('/entry/signin?Target='.urlencode($request->pathAndQuery()), 302, false);
+                redirectTo('/entry/signin?Target='.urlencode($request->pathAndQuery()));
             }
             exit();
         }

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -569,7 +569,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
                 $sender->EventArguments['User'] = $sender->User;
                 $sender->fireEvent('AfterConnection');
 
-                redirectTo(userUrl($user, '', 'connections'), 302, false);
+                redirectTo(userUrl($user, '', 'connections'));
                 break;
             case 'entry':
             default:
@@ -582,7 +582,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
                 if ($target = val('target', $state)) {
                     $url .= '?Target='.urlencode($target);
                 }
-                redirectTo($url, 302, false);
+                redirectTo($url);
                 break;
         }
     }

--- a/library/core/class.plugin.php
+++ b/library/core/class.plugin.php
@@ -328,9 +328,9 @@ abstract class Gdn_Plugin extends Gdn_Pluggable implements Gdn_IPlugin {
                 return $CurrentConfig;
             }
             if (is_null($Redirect)) {
-                redirectTo('plugin/'.strtolower($PluginName), 302, false);
+                redirectTo('plugin/'.strtolower($PluginName));
             } else {
-                redirectTo($Redirect, 302, false);
+                redirectTo($Redirect);
             }
         }
         return $CurrentConfig;

--- a/library/core/functions.deprecated.php
+++ b/library/core/functions.deprecated.php
@@ -227,7 +227,7 @@ if (!function_exists('forceSSL')) {
     function forceSSL() {
         if (c('Garden.AllowSSL')) {
             if (Gdn::Request()->Scheme() != 'https') {
-                redirectTo(Gdn::Request()->Url('', true, true), 302, false);
+                redirectTo(Gdn::Request()->Url('', true, true));
             }
         }
     }
@@ -244,7 +244,7 @@ if (!function_exists('forceNoSSL')) {
      */
     function forceNoSSL() {
         if (Gdn::Request()->Scheme() != 'http') {
-            redirectTo(Gdn::Request()->Url('', true, false), 302, false);
+            redirectTo(Gdn::Request()->Url('', true, false));
         }
     }
 }
@@ -731,7 +731,7 @@ if (!function_exists('safeRedirect')) {
                 'url' => $Destination
             ]);
 
-            redirectTo("/home/leaving?Target=".urlencode($Destination), 302, false);
+            redirectTo("/home/leaving?Target=".urlencode($Destination));
         }
     }
 }

--- a/plugins/AllViewed/class.allviewed.plugin.php
+++ b/plugins/AllViewed/class.allviewed.plugin.php
@@ -168,7 +168,7 @@ class AllViewedPlugin extends Gdn_Plugin {
 
             // Didn't use the default async option and landed here directly.
             if ($sender->deliveryType() == DELIVERY_TYPE_ALL) {
-                redirectTo('/', 302, false);
+                redirectTo('/');
             }
 
             $sender->render('blank', 'utility', 'dashboard');

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -313,7 +313,7 @@ class FacebookPlugin extends Gdn_Plugin {
         $this->EventArguments['User'] = $Sender->User;
         $this->fireEvent('AfterConnection');
 
-        redirectTo(userUrl($Sender->User, '', 'connections'), 302, false);
+        redirectTo(userUrl($Sender->User, '', 'connections'));
     }
 
     /**

--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -419,7 +419,7 @@ class GooglePlusPlugin extends Gdn_Plugin {
                 $this->EventArguments['User'] = $Sender->User;
                 $this->fireEvent('AfterConnection');
 
-                redirectTo(userUrl($User, '', 'connections'), 302, false);
+                redirectTo(userUrl($User, '', 'connections'));
                 break;
             case 'entry':
             default:
@@ -430,7 +430,7 @@ class GooglePlusPlugin extends Gdn_Plugin {
                 if ($target = val('target', $State)) {
                     $url .= '?Target='.urlencode($target);
                 }
-                redirectTo($url, 302, false);
+                redirectTo($url);
                 break;
         }
     }

--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -439,7 +439,7 @@ class TwitterPlugin extends Gdn_Plugin {
         $this->EventArguments['User'] = $Sender->User;
         $this->fireEvent('AfterConnection');
 
-        redirectTo(userUrl($Sender->User, '', 'connections'), 302, false);
+        redirectTo(userUrl($Sender->User, '', 'connections'));
     }
 
     /**

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1514,7 +1514,7 @@ class EditorPlugin extends Gdn_Plugin {
             $url = asset('/plugins/FileUpload/images/file.png');
         }
 
-        redirectTo($url, 301, false);
+        redirectTo($url, 301);
     }
 
     /**


### PR DESCRIPTION
Partially addresses https://github.com/vanilla/vanilla/issues/5218

We [consolidated all redirect functions into redirectTo](https://github.com/vanilla/vanilla/issues/5695) in order to have a "safe by default" redirect function.
This PR removes `$trustedOnly = false` to all redirections where it should be safe to do so.

Redirects updated to have `$trustedOnly = true`:
- Any relative `$destination`.
- Any `$destination` coming from Target that are not part of SSO redirects.

Backport to 2.4 (all pr depending on this one too)