### PR TITLE
Fix option name when fetching tree with CategoryModel::getSubtree

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1939,7 +1939,7 @@ class CategoryModel extends Gdn_Model {
         if (val('DisplayAs', $parent) === 'Flat') {
             $categories = self::instance()->getTreeAsFlat($parent['CategoryID']);
         } else {
-            $categories = self::instance()->collection->getTree($parent['CategoryID'], ['depth' => 10]);
+            $categories = self::instance()->collection->getTree($parent['CategoryID'], ['maxdepth' => 10]);
             $categories = self::instance()->flattenTree($categories);
         }
 


### PR DESCRIPTION
5232ad7 updated a call to `CategoryCollection::getTree` in `CategoryModel::getSubTree` to properly use the `$options` parameter, but it used the wrong option name. There is no "depth" option recognized by `CategoryCollection::getTree`. [The proper option is "maxdepth".](https://github.com/vanilla/vanilla/blob/942ecd5b00ba53d548cf5266eb35642d7ded9ab8/applications/vanilla/library/class.categorycollection.php#L410) Failure to use the proper option can cause the tree to be prematurely truncated. An addon could be expecting the tree to go at least ten levels deep. However, the current code would only allow a result that went three levels deep.

This update alters the option name in the cited call to `CategoryCollection::getTree` from "depth" to "maxdepth". Calls to `CategoryModel::getSubTree` should now be able to return the full ten-deep category subtree, where available.