### PR TITLE
Update setRedirectTo calls to use the $trustedOnly option where necessary

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -103,7 +103,7 @@ class MessagesController extends ConversationsController {
             $ConversationID = $this->Form->save();
             if ($ConversationID !== false) {
                 $Target = $this->Form->getFormValue('Target', 'messages/'.$ConversationID);
-                $this->setRedirectTo($Target, false);
+                $this->setRedirectTo($Target);
 
                 $Conversation = $this->ConversationModel->getID(
                     $ConversationID,
@@ -296,7 +296,7 @@ class MessagesController extends ConversationsController {
             // Clear it
             $this->ConversationModel->clear($ConversationID, $Session->UserID);
             $this->informMessage(t('The conversation has been cleared.'));
-            $this->setRedirectTo('/messages/all', false);
+            $this->setRedirectTo('/messages/all');
         }
 
         $this->render();
@@ -324,7 +324,7 @@ class MessagesController extends ConversationsController {
 
         if ($this->Form->authenticatedPostBack(true)) {
             $this->ConversationModel->clear($conversationID, Gdn::session()->UserID);
-            $this->setRedirectTo('/messages/all', false);
+            $this->setRedirectTo('/messages/all');
         }
 
         $this->title(t('Leave Conversation'));

--- a/applications/conversations/modules/class.addpeoplemodule.php
+++ b/applications/conversations/modules/class.addpeoplemodule.php
@@ -57,7 +57,7 @@ class AddPeopleModule extends Gdn_Module {
             $Sender->ConversationModel->addUserToConversation($this->Conversation->ConversationID, $NewRecipientUserIDs);
 
             $Sender->informMessage(t('Your changes were saved.'));
-            $Sender->setRedirectTo('/messages/'.$this->Conversation->ConversationID, false);
+            $Sender->setRedirectTo('/messages/'.$this->Conversation->ConversationID);
         }
         $this->_ApplicationFolder = $Sender->Application;
         $this->_ThemeFolder = $Sender->Theme;

--- a/applications/dashboard/controllers/class.activitycontroller.php
+++ b/applications/dashboard/controllers/class.activitycontroller.php
@@ -244,7 +244,7 @@ class ActivityController extends Gdn_Controller {
                 redirectTo($target, 302, false);
             } else {
                 // We got this as a full page somehow, so send them back to /activity.
-                $this->setRedirectTo('activity', false);
+                $this->setRedirectTo('activity');
             }
         }
 

--- a/applications/dashboard/controllers/class.addoncachecontroller.php
+++ b/applications/dashboard/controllers/class.addoncachecontroller.php
@@ -49,7 +49,7 @@ class AddonCacheController extends DashboardController {
         }
 
         if (!empty($target)) {
-            $this->setRedirectTo($target, false);
+            $this->setRedirectTo($target);
         }
 
         $this->deliveryMethod(DELIVERY_METHOD_JSON);

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -267,7 +267,7 @@ class EntryController extends Gdn_Controller {
                 }
 
                 if ($this->_RealDeliveryType != DELIVERY_TYPE_ALL && $this->_DeliveryType != DELIVERY_TYPE_ALL) {
-                    $this->setRedirectTo($Route, false);
+                    $this->setRedirectTo($Route);
                 } else {
                     if ($Route !== false) {
                         redirectTo($Route, 302, false);
@@ -899,7 +899,7 @@ class EntryController extends Gdn_Controller {
     protected function _setRedirect($CheckPopup = false) {
         $Url = url($this->getTargetRoute(), true);
 
-        $this->setRedirectTo($Url, false);
+        $this->setRedirectTo($Url);
         $this->MasterView = 'popup';
         $this->View = 'redirect';
 
@@ -1491,7 +1491,7 @@ class EntryController extends Gdn_Controller {
                     }
 
                     if ($this->deliveryType() !== DELIVERY_TYPE_ALL) {
-                        $this->setRedirectTo('/entry/registerthanks', false);
+                        $this->setRedirectTo('/entry/registerthanks');
                     }
                 }
             } catch (Exception $Ex) {
@@ -1560,7 +1560,7 @@ class EntryController extends Gdn_Controller {
                     // ... and redirect them appropriately
                     $Route = $this->getTargetRoute();
                     if ($this->_DeliveryType != DELIVERY_TYPE_ALL) {
-                        $this->setRedirectTo($Route, false);
+                        $this->setRedirectTo($Route);
                     } else {
                         if ($Route !== false) {
                             redirectTo($Route);
@@ -1687,7 +1687,7 @@ class EntryController extends Gdn_Controller {
                     // ... and redirect them appropriately
                     $Route = $this->getTargetRoute();
                     if ($this->_DeliveryType != DELIVERY_TYPE_ALL) {
-                        $this->setRedirectTo($Route, false);
+                        $this->setRedirectTo($Route);
                     } else {
                         if ($Route !== false) {
                             redirectTo($Route);
@@ -1992,7 +1992,7 @@ class EntryController extends Gdn_Controller {
                 }
 
                 if ($this->_DeliveryType != DELIVERY_TYPE_ALL) {
-                    $this->setRedirectTo($Route, false);
+                    $this->setRedirectTo($Route);
                 } else {
                     if ($Route !== false) {
                         redirectTo($Route, 302, false);

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -563,7 +563,7 @@ class ProfileController extends Gdn_Controller {
             safeCookie('X-UA-Device-Force', $type, $Expiration, $Path, $Domain);
         }
 
-        $this->setRedirectTo('/', false);
+        $this->setRedirectTo('/');
         $this->render('Blank', 'Utility', 'Dashboard');
     }
 
@@ -811,7 +811,7 @@ class ProfileController extends Gdn_Controller {
             if ($this->deliveryType() === DELIVERY_TYPE_VIEW) {
                 $this->jsonTarget('', '', 'Refresh');
 
-                $this->setRedirectTo(userUrl($this->User), false);
+                $this->setRedirectTo(userUrl($this->User));
             }
             $this->informMessage(t("Your settings have been saved."));
         }

--- a/applications/dashboard/controllers/class.rolecontroller.php
+++ b/applications/dashboard/controllers/class.rolecontroller.php
@@ -104,7 +104,7 @@ class RoleController extends DashboardController {
             if ($this->Form->errorCount() == 0) {
                 // Go ahead and delete the Role
                 $this->RoleModel->deleteAndReplace($RoleID, $this->Form->getValue('ReplacementRoleID'));
-                $this->setRedirectTo('dashboard/role', false);
+                $this->setRedirectTo('dashboard/role');
                 $this->informMessage(t('Deleting role...'));
             }
         }
@@ -186,7 +186,7 @@ class RoleController extends DashboardController {
                 }
 
                 $this->informMessage(t('Your changes have been saved.'));
-                $this->setRedirectTo('dashboard/role', false);
+                $this->setRedirectTo('dashboard/role');
                 // Reload the permission data.
                 $this->setData('PermissionData', $PermissionModel->getPermissionsEdit(
                     $RoleID,

--- a/applications/dashboard/controllers/class.routescontroller.php
+++ b/applications/dashboard/controllers/class.routescontroller.php
@@ -100,7 +100,7 @@ class RoutesController extends DashboardController {
                 );
 
                 $this->informMessage(t("The route was saved successfully."));
-                $this->setRedirectTo('dashboard/routes', false);
+                $this->setRedirectTo('dashboard/routes');
             } else {
                 $this->Form->setValidationResults($ConfigurationModel->validationResults());
             }

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -205,7 +205,7 @@ class UserController extends DashboardController {
 
                     $UserModel->sendWelcomeEmail($NewUserID, $password, 'Add');
                     $this->informMessage(t('The user has been created successfully'));
-                    $this->setRedirectTo('dashboard/user', false);
+                    $this->setRedirectTo('dashboard/user');
                 } elseif ($noPassword) {
                     $this->Form->setFormValue('Password', '');
                     $this->Form->setFormValue('HashMethod', '');
@@ -405,9 +405,9 @@ class UserController extends DashboardController {
             if ($this->Form->errorCount() == 0) {
                 // Redirect after a successful save.
                 if ($this->Request->get('Target')) {
-                    $this->setRedirectTo($this->Request->get('Target'), false);
+                    $this->setRedirectTo($this->Request->get('Target'));
                 } elseif ($this->deliveryType() == DELIVERY_TYPE_ALL) {
-                    $this->setRedirectTo(userUrl($User), false);
+                    $this->setRedirectTo(userUrl($User));
                 } else {
                     $this->jsonTarget('', '', 'Refresh');
                 }
@@ -512,7 +512,7 @@ class UserController extends DashboardController {
             $this->Method = $Method;
             if ($Method != '') {
                 $this->View = 'deleteconfirm';
-                $this->setRedirectTo('/dashboard/user', false);
+                $this->setRedirectTo('/dashboard/user');
             }
 
             if ($this->Form->authenticatedPostBack(true) && $Method != '') {
@@ -578,9 +578,9 @@ class UserController extends DashboardController {
             Gdn::userModel()->deleteContent($UserID, array('Log' => true));
 
             if ($this->Request->get('Target')) {
-                $this->setRedirectTo($this->Request->get('Target'), false);
+                $this->setRedirectTo($this->Request->get('Target'));
             } else {
-                $this->setRedirectTo(userUrl($User), false);
+                $this->setRedirectTo(userUrl($User));
             }
         } else {
             $this->setData('Title', t('Are you sure you want to do this?'));

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -502,7 +502,7 @@ class DashboardHooks extends Gdn_Plugin {
 
                     if ($Sender->Form->Save()) {
                         $Sender->informMessage(t('Your changes have been saved.'));
-                        $Sender->setRedirectTo('/settings/tagging', false);
+                        $Sender->setRedirectTo('/settings/tagging');
                     }
                 }
 
@@ -544,7 +544,7 @@ class DashboardHooks extends Gdn_Plugin {
                     $Saved = $Sender->Form->save();
                     if ($Saved) {
                         $Sender->informMessage(t('Your changes have been saved.'));
-                        $Sender->setRedirectTo('/settings/tagging', false);
+                        $Sender->setRedirectTo('/settings/tagging');
                     }
                 }
 

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -531,7 +531,7 @@ class DiscussionController extends VanillaController {
             $this->DiscussionModel->SetProperty($DiscussionID, 'Announce', (int)$this->Form->getFormValue('Announce', 0));
 
             if ($Target) {
-                $this->setRedirectTo($Target, false);
+                $this->setRedirectTo($Target);
             }
 
             $this->jsonTarget('', '', 'Refresh');
@@ -692,7 +692,7 @@ class DiscussionController extends VanillaController {
                 }
 
                 if ($Target) {
-                    $this->setRedirectTo($Target, false);
+                    $this->setRedirectTo($Target);
                 }
 
                 $this->jsonTarget(".Section-DiscussionList #Discussion_$DiscussionID", null, 'SlideUp');

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -280,7 +280,7 @@ class ModerationController extends VanillaController {
             unset($CheckedComments[$DiscussionID]);
             Gdn::userModel()->saveAttribute($Session->UserID, 'CheckedComments', $CheckedComments);
             ModerationController::InformCheckedComments($this);
-            $this->setRedirectTo('discussions', false);
+            $this->setRedirectTo('discussions');
         }
 
         $this->render();

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -353,7 +353,7 @@ class PostController extends VanillaController {
                         if ($this->_DeliveryType == DELIVERY_TYPE_ALL) {
                             redirectTo(discussionUrl($Discussion, 1).'?new=1', 302, false);
                         } else {
-                            $this->setRedirectTo(discussionUrl($Discussion, 1, true).'?new=1', false);
+                            $this->setRedirectTo(discussionUrl($Discussion, 1, true).'?new=1');
                         }
                     } else {
                         // If this was a draft save, notify the user about the save

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -546,7 +546,7 @@ class VanillaSettingsController extends Gdn_Controller {
                     }
 
                     if ($this->Form->errorCount() == 0) {
-                        $this->setRedirectTo('vanilla/settings/categories', false);
+                        $this->setRedirectTo('vanilla/settings/categories');
                         $this->informMessage(t('Deleting category...'));
                     }
                 }
@@ -958,7 +958,7 @@ class VanillaSettingsController extends Gdn_Controller {
             $this->setData('Enabled', $enabled);
 
             if ($this->deliveryType() !== DELIVERY_TYPE_DATA) {
-                $this->setRedirectTo('/vanilla/settings/categories', false);
+                $this->setRedirectTo('/vanilla/settings/categories');
             }
         } else {
             throw forbiddenException('GET');

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -334,7 +334,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
                 $Data = c('ProfileExtender.Fields.'.$Name, array());
                 $Data = array_merge((array)$Data, (array)$FormPostValues);
                 saveToConfig('ProfileExtender.Fields.'.$Name, $Data);
-                $Sender->setRedirectTo('/settings/profileextender', false);
+                $Sender->setRedirectTo('/settings/profileextender');
             }
         } elseif (isset($Args[0])) {
             // Editing
@@ -376,7 +376,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         if (isset($Args[0])) {
             if ($Sender->Form->authenticatedPostBack()) {
                 removeFromConfig('ProfileExtender.Fields.'.$Args[0]);
-                $Sender->setRedirectTo('/settings/profileextender', false);
+                $Sender->setRedirectTo('/settings/profileextender');
             } else {
                 $Sender->setData('Field', $this->getProfileField($Args[0]));
             }

--- a/plugins/SplitMerge/class.splitmerge.plugin.php
+++ b/plugins/SplitMerge/class.splitmerge.plugin.php
@@ -126,7 +126,7 @@ class SplitMergePlugin extends Gdn_Plugin {
                 unset($CheckedComments[$DiscussionID]);
                 Gdn::userModel()->saveAttribute($Session->UserID, 'CheckedComments', $CheckedComments);
                 ModerationController::informCheckedComments($Sender);
-                $Sender->setRedirectTo('discussion/'.$NewDiscussionID.'/'.Gdn_Format::url($Data['Name']), false);
+                $Sender->setRedirectTo('discussion/'.$NewDiscussionID.'/'.Gdn_Format::url($Data['Name']));
             }
         } else {
             $Sender->Form->setValue('CategoryID', val('CategoryID', $Discussion));


### PR DESCRIPTION
Partially addresses https://github.com/vanilla/vanilla/issues/5218

We [consolidated all redirect functions into redirectTo](https://github.com/vanilla/vanilla/issues/5218#issuecomment-310513372) in order to have a "safe by default" redirect function.
This PR removes `$trustedOnly = false` to all redirections where it should be safe to do so.

Redirects updated to have `$trustedOnly = true`:
- Any relative `$destination`.
- Any `$destination` coming from Target that are not part of SSO redirects.

Backport to 2.4 (all pr depending on this one too)