### PR TITLE
Fix Tag.Tag and Discussion.DateLastComment errors on DBA count jobs

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -272,12 +272,24 @@ class DiscussionModel extends Gdn_Model {
                 $this->Database->query(DBAModel::getCountSQL('max', 'Discussion', 'Comment', $Column));
                 break;
             case 'DateLastComment':
-                $this->Database->query(DBAModel::getCountSQL('max', 'Discussion', 'Comment', $Column, 'DateInserted'));
+                $defaultDate = '0000-00-00 00:00:00';
+                $countSql = DBAModel::getCountSQL(
+                    'max',
+                    'Discussion',
+                    'Comment',
+                    $Column,
+                    'DateInserted',
+                    '',
+                    '',
+                    [],
+                    $defaultDate
+                );
+                $this->Database->query($countSql);
                 $this->SQL
                     ->update('Discussion')
                     ->set('DateLastComment', 'DateInserted', false, false)
                     ->where('DateLastComment', null)
-                    ->orWhere('DateLastComment','0000-00-00 00:00:00')
+                    ->orWhere('DateLastComment',$defaultDate)
                     ->put();
                 break;
             case 'LastCommentUserID':

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -22,7 +22,7 @@ class VanillaHooks implements Gdn_IPlugin {
         $Counts = [
             'Discussion' => ['CountComments', 'FirstCommentID', 'LastCommentID', 'DateLastComment', 'LastCommentUserID'],
             'Category' => ['CountDiscussions', 'CountAllDiscussions', 'CountComments', 'CountAllComments', 'LastDiscussionID', 'LastCommentID', 'LastDateInserted'],
-            'Tag' => ['table' => 'Tag', 'column' => 'CountDiscussions'],
+            'Tag' => ['CountDiscussions'],
         ];
 
         foreach ($Counts as $Table => $Columns) {


### PR DESCRIPTION
The DBA counts page has a couple issues:

1. There is a "Tag.Tag" job. This job tries to update the counts in the "Tag" column of the "Tag" table. This column doesn't exist, so the job errors out. It's due to a misconfigured count job in Vanilla's countJobs hook.
1. The "Discussion.DateLastComment" job can throw an error stating 0 is an invalid value for a `DATETIME` field. This is caused by its usage of `DBAModel::getCountSQL`, which has a hardcoded default of zero. While the function is named `getCountSQL`, [it actually serves as a way to get several aggregate values (min, max and sum)](https://github.com/vanilla/vanilla/commit/9d23700975984b8ce2844beb09199ab35fefd708#diff-7f22adbbfe67749b245f5ac0a5acc443R62), in addition to counts. Forcing zero as the default may not be compatible with an otherwise supported field (e.g. getting the max value of a `DATETIME` field).

This update fixes the formatting for the Tag table job. It also adds a `$default` parameter to `DBAModel::getCountSQL`, which allows an override to be passed to MySQL's `coalesce` function.