### PR TITLE
Fix build randomly failing on CookieTest::testSetCookie

### DIFF
--- a/library/Garden/Web/Cookie.php
+++ b/library/Garden/Web/Cookie.php
@@ -65,11 +65,19 @@ class Cookie {
     /**
      * Calculate a cookie's expiration time.
      *
-     * @param int $expire
+     * @param int $expire Target expiration value.
+     * @param int|null $timestamp If calculating a relative expiry, use this timestamp as the offset.
      * @return int
      */
-    public function calculateExpiry($expire) {
-        $result = $expire > self::EXPIRE_THRESHOLD ? $expire : time() + $expire;
+    public function calculateExpiry($expire, $timestamp = null) {
+        if ($expire > self::EXPIRE_THRESHOLD) {
+            $result = $expire;
+        } else {
+            if ($timestamp === null || filter_var($timestamp, FILTER_VALIDATE_INT) === false) {
+                $timestamp = time();
+            }
+            $result = $timestamp + $expire;
+        }
         return $result;
     }
 


### PR DESCRIPTION
`CookieTest::testSetCookie` has a check to validate the cookie's expiry. However, there is an issue where relative dates can be off just enough between when they're set and when they're checked, causing intermittent test failures.

This update does a couple things:

1. It alters the signature of `Cookie::calculateExpiry` to introduce a new parameter: `$timestamp`. If a valid timestamp is specified, its used as the base when determining relative expiry values. If no valid timestamp is supplied, the current timestamp will be used, as is the current behavior.
1. It moves expiry checking out of `CookieTest::testSetCookie` and into its own dedicated batch of tests. Since all `Cookie::setCookie` does with the expiry is pass it along to `Cookie::calculateExpiry`, it will maintain the same code coverage. In addition, moving to directly testing the function allows us to call it with an explicit timestamp. This should avoid any further timing issues related to this test.

Closes #5643 