### PR TITLE
Fix double encoding of BBCode code block contents

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -281,6 +281,7 @@ class Gdn_Format {
                 // Always filter after basic parsing.
                 // Add htmLawed-compatible specification updates.
                 $options = [
+                    'codeBlockEntities' => false,
                     'spec' => [
                         'span' => [
                             'style' => ['match' => '/^(color:(#[a-f\d]{3}[a-f\d]{3}?|[a-z]+))?;?$/i']


### PR DESCRIPTION
Using an HTML special character (e.g. <, &, >) in a code block with BBCode causes the characters to be doubly encoded: [once by NBBC](https://github.com/vanilla/nbbc/blob/2da62098363c3da5a653d611ce15c41fa6681092/src/BBCode.php#L2218) and [again by Gdn_Format::htmlFilter](https://github.com/vanilla/vanilla/blob/c049793290ad3e91508c8a9ce478a9fdcdb3da42/library/core/class.format.php#L933). This update removes one of these checks. NBBC's application of `htmlspecialchars` remains, while the `$options` parameter passed to `Gdn_Format::htmlFilter` has been altered, explicitly setting the `codeBlockEntities` value to `false`. This change will avoid encoding the HTML entities (the ampersand, in particular) a second time.

Closes #5720 

Please backport to [release/2017-Q2-6](https://github.com/vanilla/vanilla/tree/release/2017-Q2-6)