### PR TITLE
Add back category URL kludge in calculateUser

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -180,9 +180,8 @@ class CategoryModel extends Gdn_Model {
      * @param bool|null $addUserCategory
      */
     private function calculateUser(&$category, $addUserCategory = null) {
-        if (!isset($category['Url'])) {
-            $category['Url'] = self::categoryUrl($category, false, '/');
-        }
+        // Kludge to make sure that the url is absolute when reaching the user's screen.
+        $category['Url'] = self::categoryUrl($category, '', true);
 
         if (!isset($category['PhotoUrl'])) {
             if ($Photo = val('Photo', $category)) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -180,7 +180,7 @@ class CategoryModel extends Gdn_Model {
      * @param bool|null $addUserCategory
      */
     private function calculateUser(&$category, $addUserCategory = null) {
-        // Kludge to make sure that the url is absolute when reaching the user's screen.
+        // Kludge to make sure that the url is absolute when reaching the user's screen (or API).
         $category['Url'] = self::categoryUrl($category, '', true);
 
         if (!isset($category['PhotoUrl'])) {


### PR DESCRIPTION
We undid an undocumented kludge in https://github.com/vanilla/vanilla/pull/5701
Reverting the kludge does not break https://github.com/vanilla/multisite/pull/133

Changing the URL from being absolute to relative causes some problem since that value is accessible from the API.

Edit:
calculate() sets the URL as relative because the routing process needs the value to be.
calculateUser() then rewrites the URL as absolute to fix that. These kind of kludge should be explained in the code. The comment I made should at least help understand the why a bit more.