### PR TITLE
Optimize category sorting in the dashboard

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -786,6 +786,7 @@ class VanillaSettingsController extends Gdn_Controller {
         $this->setData('UsePagination', $usePagination);
 
         $this->addDefinition('AllowSorting', $allowSorting);
+        $this->addDefinition('SavePending', t('Saving. Please wait.'));
 
         $this->addJsFile('category-settings.js');
         $this->addJsFile('manage-categories.js');

--- a/applications/vanilla/js/category-settings.js
+++ b/applications/vanilla/js/category-settings.js
@@ -38,6 +38,22 @@
                 var tree = $(source).nestable('serialize');
                 var postTree = massageTree(tree);
 
+                /**
+                 * Time, in miliseconds, before displaying the "please wait" message.
+                 * @type {number}
+                 */
+                var saveWarningDelay = 1000;
+                $(".main").trigger("foggyOn");
+                setTimeout(function() {
+                    // Don't display unless the content area is disabled.
+                    var savePending = $(".main").first().hasClass("foggy");
+                    if (savePending) {
+                        gdn.informMessage(gdn.definition("SavePending"), {
+                            CssClass: "CategorySortMessage"
+                        });
+                    }
+                }, saveWarningDelay);
+
                 $.ajax({
                     type: "POST",
                     url: gdn.url('/vanilla/settings/categoriestree.json'),
@@ -49,11 +65,14 @@
                     dataType: 'json',
                     error: function (xhr) {
                         gdn.informError(xhr);
+                    },
+                    complete: function(jqXHR, textStatus) {
+                        // Remove overlay from tree controls and the "please wait" message, if present.
+                        $(".main").trigger("foggyOff");
+                        $(".InformWrapper.CategorySortMessage").remove();
                     }
                 });
             });
-
-            // console.log($('.dd', e.target).nestable('serialize'));
         })
         .on('click', '.js-displayas', function(e) {
             e.preventDefault();

--- a/applications/vanilla/js/category-settings.js
+++ b/applications/vanilla/js/category-settings.js
@@ -3,7 +3,7 @@
         var result = [];
 
         subtree.forEach(function (row) {
-            var resultRow = { CategoryID: row.id };
+            var resultRow = { CategoryID: row.categoryId };
 
             if (row.children) {
                 resultRow.Children = massageTree(row.children);
@@ -34,9 +34,31 @@
                 expandBtnHTML   : '<button class="nestable-collapse" data-action="expand"><svg class="icon icon-16 icon-chevron-closed" viewBox="0 0 16 16"><use xlink:href="#chevron-closed" /></svg></button>',
                 collapseBtnHTML : '<button class="nestable-collapse" data-action="collapse"><svg class="icon icon-16 icon-chevron-open" viewBox="0 0 16 16"><use xlink:href="#chevron-open" /></svg></button>'
             })
-            .on('dragEnd', function(event, item, source, destination, position) {
-                var tree = $(source).nestable('serialize');
-                var postTree = massageTree(tree);
+            .on('dragEnd', function(event, items, source, destination, position) {
+                // We're going to get this list item and all its children. Reduce it down to just this list item.
+                var item = $(items).first();
+                var parent = $(item).parents(".js-nestable-item").first();
+                var parentCategoryID = $(parent).data("categoryId");
+                var parentID = parentCategoryID ? parentCategoryID : $(source).data('parentId');
+
+                var getTreeData = function(elements) {
+                    var data = [];
+
+                    $(elements).each(function(index, element) {
+                        var category = $.extend({}, $(element).data());
+
+                        var children = $(element).children(".js-nestable-list").children(".js-nestable-item");
+                        if (children.length) {
+                            category.children = getTreeData(children);
+                        }
+
+                        data.push(category);
+                    });
+
+                    return data;
+                };
+                var subtree = $(item).parent().children(".js-nestable-item");
+                var tree = getTreeData(subtree);
 
                 /**
                  * Time, in miliseconds, before displaying the "please wait" message.
@@ -54,13 +76,15 @@
                     }
                 }, saveWarningDelay);
 
+                var postTree = massageTree(tree);
+                console.log(postTree);
                 $.ajax({
                     type: "POST",
                     url: gdn.url('/vanilla/settings/categoriestree.json'),
                     data: {
                         TransientKey: gdn.getMeta('TransientKey'),
                         Subtree: JSON.stringify(postTree),
-                        ParentID: $(source).data('parentId')
+                        ParentID: parentID
                     },
                     dataType: 'json',
                     error: function (xhr) {

--- a/applications/vanilla/views/vanillasettings/category-settings-functions.php
+++ b/applications/vanilla/views/vanillasettings/category-settings-functions.php
@@ -61,6 +61,7 @@ function categoryFilterBox(array $options = []) {
  */
 function writeCategoryItem($category, $allowSorting = true) {
     $categoryID = $category['CategoryID'];
+    $parentCategoryID = $category['ParentCategoryID'];
     $handle = $allowSorting ? '<div class="js-nestable-handle nestable-handle"></div>' : '';
     $icon = $allowSorting ? '<div class="btn btn-icon plank-icon">'.symbol('handle', t('Drag')).'</div>' : '';
     $categoryName = htmlspecialchars($category['Name']);
@@ -70,7 +71,7 @@ function writeCategoryItem($category, $allowSorting = true) {
         $categoryName = anchor($categoryName, $url);
     }
     ?>
-    <li class="js-nestable-item js-category-item nestable-item" data-id="<?php echo $categoryID; ?>">
+    <li class="js-nestable-item js-category-item nestable-item" data-category-id="<?php echo $categoryID; ?>" data-parent-category-id="<?php echo $parentCategoryID; ?>">
         <?php echo $handle; ?>
         <div class="nestable-content plank">
             <?php echo $icon; ?>


### PR DESCRIPTION
This update adds some improvements to the category management screen to improve the experience when managing a large number of categories (200+).

Highlights:

1. Once a user moves a category, they aren't allowed to move another one until the current request has completed. The content area is "fogged" over and a small "Please wait" message is displayed until the save has completed.
1. The data sent to the server for each reordering request is limited to the current category's branch level and below. Moving a root-level category still sends the whole tree, but moving a child category will only send the subtree of it and its siblings.

Modifying this process obviously has the potential to inflict some catastrophic effects on category structures, so please test thoroughly.

Closes #5415