### PR TITLE
Allow URL functions in smarty

### DIFF
--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -126,8 +126,12 @@ class Gdn_Smarty {
             'multiCheckPermission',
             'getValue',
             'setValue',
+            'useragenttype',
             'url',
-            'useragenttype'
+            'userUrl',
+            'commentUrl',
+            'discussionUrl',
+            'categoryUrl'
         ]));
 
         $security->php_modifiers = array_merge(

--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -119,19 +119,19 @@ class Gdn_Smarty {
         $security->setPhpFunctions(array_merge($security->php_functions, [
             'array', // Yes, Smarty really blocks this.
             'category',
+            'categoryUrl',
             'checkPermission',
+            'commentUrl',
+            'discussionUrl',
             'inSection',
             'inCategory',
             'ismobile',
             'multiCheckPermission',
             'getValue',
             'setValue',
-            'useragenttype',
             'url',
+            'useragenttype',
             'userUrl',
-            'commentUrl',
-            'discussionUrl',
-            'categoryUrl'
         ]));
 
         $security->php_modifiers = array_merge(


### PR DESCRIPTION
`categoryUrl`, `discussionUrl`, `userUrl`, and `commentUrl` should all be allowed for use in Smarty. This PR adds them to list of allowed functions.

Needs backport to `release/2017-Q2-6`