### PR TITLE
Addon: Differentiate between unreadable file and invalid JSON format

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -146,7 +146,7 @@ class Addon {
 
             $info = json_decode($addonJSON, true);
             if (empty($info)) {
-                throw new \Exception("The addon at $subdir has non valid JSON in addon.json.");
+                throw new \Exception("The addon at $subdir has invalid JSON in addon.json.");
             }
 
             // Kludge that sets oldType until we unify applications and plugins into addon.

--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -139,10 +139,14 @@ class Addon {
 
         // Look for an addon.json file.
         if (file_exists("$dir/addon.json")) {
-            $info = json_decode(file_get_contents("$dir/addon.json"), true);
+            $addonJSON = file_get_contents("$dir/addon.json");
+            if (!$addonJSON) {
+                throw new \Exception("The addon at $subdir has an unreadable addon.json file.");
+            }
 
+            $info = json_decode($addonJSON, true);
             if (empty($info)) {
-                throw new \Exception("The addon at $subdir has an empty info array.");
+                throw new \Exception("The addon at $subdir has non valid JSON in addon.json.");
             }
 
             // Kludge that sets oldType until we unify applications and plugins into addon.


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5718

This report a more accurate error if you have a syntax error in the addon.json file.
Having an extra comma in the file would throw "The addon at $subdir doesn't have any info." which is not useful at all :)