### PR TITLE
Notification + embed: Store the route as a relative path for discussions' notifications

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -976,7 +976,7 @@ class PostController extends VanillaController {
             'HeadlineFormat' => $HeadlineFormat,
             'RecordType' => 'Discussion',
             'RecordID' => $DiscussionID,
-            'Route' => DiscussionUrl($Discussion),
+            'Route' => DiscussionUrl($Discussion, '', false),
             'Data' => array(
                 'Name' => $Discussion->Name,
                 'Category' => val('Name', $Category)

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2128,7 +2128,7 @@ class DiscussionModel extends Gdn_Model {
                         'HeadlineFormat' => $HeadlineFormat,
                         'RecordType' => 'Discussion',
                         'RecordID' => $DiscussionID,
-                        'Route' => DiscussionUrl($Fields),
+                        'Route' => DiscussionUrl($Fields, '', false),
                         'Data' => [
                             'Name' => $DiscussionName,
                             'Category' => val('Name', $Category)


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5421

The problem was that `discussionUrl()` was used with `$withDomain = true` to generate the route.
On embeded site that meant that `sendNotification()` could not [transform the route](https://github.com/vanilla/vanilla/blob/a4375c0f666a2f4a610657f2c6d9769e9bfa4cc0/applications/dashboard/models/class.activitymodel.php#L874) properly using `externalUrl()` since it was an absolute URL instead of a relative path.