### PR TITLE
Do not rewrite URLs by default

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1418,7 +1418,8 @@ class Gdn_Request implements RequestInterface {
         }
         static $rewrite = null;
         if ($rewrite === null) {
-            $rewrite = val('X_REWRITE', $_SERVER, c('Garden.RewriteUrls', true));
+            // Garden.RewriteUrls is maintained for compatibility but X_REWRITE is what really need to be used.
+            $rewrite = val('X_REWRITE', $_SERVER, c('Garden.RewriteUrls', false));
         }
 
         if (!$allowSSL) {

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -258,6 +258,9 @@ class RequestTest extends \PHPUnit\Framework\TestCase {
     }
 
     public function testUrlEquivalence() {
+        // Simulate that rewrite is ON
+        $_SERVER['X_REWRITE'] = 1;
+
         $req = new Gdn_Request();
 
         $req->setScheme('http');


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5709

We did an update to improve the install experience in 2.3: https://github.com/vanilla/vanilla/pull/4622

We then [updated our install process](https://github.com/vanilla/vanilla/pull/4736) to avoid overwritting .htaccess which caused the installation process to fail since the urls are now rewritten and no rewrite are set by default.

To fix this issue this PR reverts the default of URL rewrites to false.
Our .htaccess.dist already contains REWRITE_X=1 which makes the forum use rewrites.
Our nginx installation process also specify that this flag must be there.

The config should not exist since rewriting capabilities should be specified by the X_REWRITE alone. We are only keeping it, here, for backward compatibility.