### PR TITLE
Add the addon’s proper path to deprecated locale notice

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -647,7 +647,7 @@ class Addon {
                 $locale = self::canonicalizeLocale(basename(dirname($localePath)));
                 $result[$locale][] = $localePath;
 
-                $properPath = "/locale/$locale.php";
+                $properPath = $this->path("/locale/$locale.php", self::PATH_ADDON);
                 trigger_error("Locales in $localePath is deprecated. Use $properPath instead.", E_USER_DEPRECATED);
             }
         }


### PR DESCRIPTION
This is to help developers find addons that need fixing.