### PR TITLE
Index UserAuthenticationProvider Timestamp and purge nonce after 45 minutes

### DIFF
--- a/applications/dashboard/models/class.userauthenticationnoncemodel.php
+++ b/applications/dashboard/models/class.userauthenticationnoncemodel.php
@@ -19,6 +19,7 @@ class UserAuthenticationNonceModel extends Gdn_Model {
     public function __construct() {
         parent::__construct('UserAuthenticationNonce');
         $this->setPruneField('Timestamp');
+        $this->setPruneAfter('45 minutes');
     }
 
     /**

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -253,7 +253,7 @@ $Construct->table('UserAuthenticationProvider')
 $Construct->table('UserAuthenticationNonce')
     ->column('Nonce', 'varchar(100)', false, 'primary')
     ->column('Token', 'varchar(128)', false)
-    ->column('Timestamp', 'timestamp', false)
+    ->column('Timestamp', 'timestamp', false, 'index')
     ->set($Explicit, $Drop);
 
 $Construct->table('UserAuthenticationToken')


### PR DESCRIPTION
Every page load with jsConnect generate a nonce.
The table need an index since we prune the table on every insert.