### PR TITLE
Default nonce timestamp to the current time if not provided

### DIFF
--- a/applications/dashboard/models/class.userauthenticationnoncemodel.php
+++ b/applications/dashboard/models/class.userauthenticationnoncemodel.php
@@ -27,6 +27,11 @@ class UserAuthenticationNonceModel extends Gdn_Model {
      */
     public function insert($fields) {
         $this->prune();
+
+        if (!isset($fields['Timestamp'])) {
+            $fields['Timestamp'] = date(MYSQL_DATE_FORMAT);
+        }
+
         return parent::insert($fields);
     }
 }


### PR DESCRIPTION
Partially addresses https://github.com/vanilla/vanilla/issues/5763 until we fix the issue for good.

One some MySQL setup insert will throw an exception when trying to do an insert with no Timestamp field.