### PR TITLE
Change .editorconfig to only 4 spaces.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,10 +12,3 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.{yml,css,scss}]
-indent_size = 2
-
-[*.json]
-indent_size = 4
-indent_style = tab


### PR DESCRIPTION
We've been moving towards 4 spaces only for a while.
This updates the `.editorconfig` to reflect that.


