### PR TITLE
Backport #5734 to release/2017-Q2-6

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -976,7 +976,7 @@ class PostController extends VanillaController {
             'HeadlineFormat' => $HeadlineFormat,
             'RecordType' => 'Discussion',
             'RecordID' => $DiscussionID,
-            'Route' => DiscussionUrl($Discussion),
+            'Route' => DiscussionUrl($Discussion, '', false),
             'Data' => array(
                 'Name' => $Discussion->Name,
                 'Category' => val('Name', $Category)

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2116,7 +2116,7 @@ class DiscussionModel extends Gdn_Model {
                         'HeadlineFormat' => $HeadlineFormat,
                         'RecordType' => 'Discussion',
                         'RecordID' => $DiscussionID,
-                        'Route' => DiscussionUrl($Fields),
+                        'Route' => DiscussionUrl($Fields, '', false),
                         'Data' => [
                             'Name' => $DiscussionName,
                             'Category' => val('Name', $Category)


### PR DESCRIPTION
Backporting https://github.com/vanilla/vanilla/pull/5734 to [release/2017-Q2-6](https://github.com/vanilla/vanilla/tree/release/2017-Q2-6).