### PR TITLE
Add a way to defined extra allowed classes in VanillaHTMLFormatter

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -179,6 +179,7 @@ $dic->setInstance('Garden\Container\Container', $dic)
 
     ->rule('HtmlFormatter')
     ->setClass(VanillaHtmlFormatter::class)
+    ->addAlias(VanillaHtmlFormatter::class)
     ->setShared(true)
 
     ->rule('Smarty')

--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -4,6 +4,8 @@
  * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
  */
 
+use \Garden\EventManager;
+
 /**
  * Class VanillaHtmlFormatter
  */
@@ -124,6 +126,18 @@ class VanillaHtmlFormatter {
         'ul'
     ];
 
+    /** @var array Extra allowed classes. */
+    protected $extraAllowedClasses = [];
+
+    /**
+     * VanillaHtmlFormatter constructor.
+     *
+     * @param EventManager $eventManager
+     */
+    public function __construct(EventManager $eventManager) {
+        $eventManager->fire(__CLASS__.'_init', $this);
+    }
+
     /**
      * Filter provided HTML through htmlLawed and return the result.
      *
@@ -211,6 +225,24 @@ class VanillaHtmlFormatter {
     }
 
     /**
+     * Add extra allowed classes.
+     *
+     * @param array $extraAllowedClasses
+     */
+    public function addExtraAllowedClasses($extraAllowedClasses) {
+        $this->extraAllowedClasses = array_unique(array_merge($this->extraAllowedClasses, $extraAllowedClasses));
+    }
+
+    /**
+     * Get the currently defined extra allowed classes.
+     *
+     * @return array Extra allowed classes
+     */
+    public function getExtraAllowedClasses() {
+        return $this->extraAllowedClasses;
+    }
+
+    /**
      * Grab the default htmLawed spec.
      *
      * @return array
@@ -219,7 +251,7 @@ class VanillaHtmlFormatter {
         static $spec;
         if ($spec === null) {
             $spec = [];
-            $allowedClasses = implode('|', $this->allowedClasses);
+            $allowedClasses = implode('|', array_merge($this->allowedClasses, $this->extraAllowedClasses));
             foreach ($this->classedElements as $tag) {
                 if (!array_key_exists($tag, $spec) || !is_array($spec[$tag])) {
                     $spec[$tag] = [];

--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -130,15 +130,6 @@ class VanillaHtmlFormatter {
     protected $extraAllowedClasses = [];
 
     /**
-     * VanillaHtmlFormatter constructor.
-     *
-     * @param EventManager $eventManager
-     */
-    public function __construct(EventManager $eventManager) {
-        $eventManager->fire(__CLASS__.'_init', $this);
-    }
-
-    /**
      * Filter provided HTML through htmlLawed and return the result.
      *
      * @param string $html String of HTML to filter.


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/5725

~~Fire 'VanillaHtmlFormatter_init' event when an instance is created.~~
This allows addons to add extra allowed classes through `addExtraAllowedClasses()`

Edit:

To test you can add this to a plugin:
```
    /**
     * @param Container $container
     */
    public function container_init_handler($container) {
        $container->get(VanillaHtmlFormatter::class)->addExtraAllowedClasses(['test']);
    }
```