### PR TITLE
Fix discussion URLs in advanced notification emails

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -976,7 +976,7 @@ class PostController extends VanillaController {
             'HeadlineFormat' => $HeadlineFormat,
             'RecordType' => 'Discussion',
             'RecordID' => $DiscussionID,
-            'Route' => DiscussionUrl($Discussion, '', false),
+            'Route' => discussionUrl($Discussion, '', '/'),
             'Data' => [
                 'Name' => $Discussion->Name,
                 'Category' => val('Name', $Category)

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2128,7 +2128,7 @@ class DiscussionModel extends Gdn_Model {
                         'HeadlineFormat' => $HeadlineFormat,
                         'RecordType' => 'Discussion',
                         'RecordID' => $DiscussionID,
-                        'Route' => DiscussionUrl($Fields, '', false),
+                        'Route' => discussionUrl($Fields, '', '/'),
                         'Data' => [
                             'Name' => $DiscussionName,
                             'Category' => val('Name', $Category)


### PR DESCRIPTION
This fix updates how URLs are generated for new discussion alerts with advanced notifications. Currently, the URL is generated with `discussionUrl`, setting its `$withDomain` to `false`, then it is parsed again with `externalUrl` to generate a full URL for use in emails. Both of these function calls use the `url` function and both of them add the site's web root. It is currently possible for a site's web root to be doubly added to discussion URLs.

This update sets the `$withDomain` parameter to "/" during the call to `$discussionUrl`. This returns the Vanilla path, only. The web root is not included. When the string reaches `externalUrl`, the site's web root is only added the single time, so the URLs should be valid under normal usage.