### PR TITLE
Prevent discussions from being truncated when inserted in the log table

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2729,7 +2729,7 @@ class DiscussionModel extends Gdn_Model {
         $Comments = $this->SQL->getWhere('Comment', ['DiscussionID' => $discussionID])->resultArray();
         $totalComments = count($Comments);
 
-        if ($totalComments > 0 && $totalComments < 50) {
+        if ($totalComments > 0 && $totalComments <= 25) {
             // A smaller number of comments should just be stored with the record.
             $Data['_Data']['Comment'] = $Comments;
             LogModel::insert($Log, 'Discussion', $Data, $LogOptions);


### PR DESCRIPTION
GDN_Log: `Data mediumtext COLLATE utf8mb4_unicode_ci,`
GDN_Comment: `Body text COLLATE utf8mb4_unicode_ci NOT NULL,`

mediumtext can contain ~256 text fields.
If you add all the other fields + the overhead of the serialization it may be possible to bust the mediumtext field. To ensure that this can't happen this PR lower the number of comments that can be embedded into a discussion to 25.

Fixes https://github.com/vanilla/vanilla/issues/2946 and https://github.com/vanilla/vanilla/issues/5197