### PR TITLE
Fix inserting images on mobile

### DIFF
--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1106,8 +1106,10 @@
                         if (!result.error) {
                             var payload = result.payload;
 
-                            // If photo, insert directly into editor area.
-                            if (payload.upload_type === 'image') {
+                            var imgTag = buildImgTag(payload.original_url, format);
+
+                            // If we uploaded an image and we have an image tag, insert directly into editor area.
+                            if (payload.upload_type === 'image' && imgTag) {
                                 // Determine max height for sample. They can resize it
                                 // afterwards.
                                 var maxHeight = (payload.original_height >= 400)
@@ -1122,8 +1124,6 @@
                                 if (editorWidth < payloadWidth) {
                                     payloadHeight = (editorWidth * payload.original_height) / payload.original_width;
                                 }
-
-                                var imgTag = buildImgTag(payload.original_url, format);
 
                                 if (handleIframe) {
                                     editor.focus();


### PR DESCRIPTION
Fixes  https://github.com/vanilla/vanilla/issues/5660

Text and TextEx do not support html tags so we need to revert back to display a file preview under the editor when we are on mobile.