### PR TITLE
[Oauth2] Display an appropriate error message when the code parameter is missing

### DIFF
--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -520,6 +520,9 @@ class Gdn_OAuth2 extends Gdn_Plugin {
         if ($error = $sender->Request->get('error')) {
             throw new Gdn_UserException($error);
         }
+        if (empty($code)) {
+            throw new Gdn_UserException('The code parameter is either not set or empty.');
+        }
 
         Gdn::session()->stash($this->getProviderKey()); // remove any stashed provider data.
 

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -510,13 +510,13 @@ class Gdn_OAuth2 extends Gdn_Plugin {
      * Create a controller to handle entry request.
      *
      * @param Gdn_Controller $sender.
-     * @param $code string Retrieved from the response of the authentication provider, used to fetch an authentication token.
-     * @param $state string Values passed by us and returned in the response of the authentication provider.
+     * @param string $code Retrieved from the response of the authentication provider, used to fetch an authentication token.
+     * @param string $state Values passed by us and returned in the response of the authentication provider.
      *
      * @throws Exception.
      * @throws Gdn_UserException.
      */
-    public function entryEndpoint($sender, $code, $state) {
+    public function entryEndpoint($sender, $code, $state = '') {
         if ($error = $sender->Request->get('error')) {
             throw new Gdn_UserException($error);
         }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5766

Throw an exception if the code parameter is not set or empty.