### PR TITLE
Format emojis and mentions links with full URLs

### DIFF
--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -96,7 +96,7 @@ class Emoji {
      *
      */
     protected function __construct() {
-        $this->assetPath = asset('/resources/emoji', '//');
+        $this->assetPath = asset('/resources/emoji', true);
 
         // Initialize the canonical list. (emoji)
         $this->emoji = [
@@ -263,12 +263,12 @@ class Emoji {
             foreach ($emojis as $name => $data) {
                 $emoji[] = [
                     "name" => "".$name."",
-                    "url" => Asset($emojiAssetPath.'/'.$data)
+                    "url" => asset($emojiAssetPath.'/'.$data, true)
                 ];
             }
 
             $emoji = [
-                'assetPath' => Asset($this->getAssetPath()),
+                'assetPath' => asset($this->getAssetPath(), true),
                 'format' => $this->getFormat(),
                 'emoji' => $this->getEmoji()
             ];
@@ -482,7 +482,7 @@ class Emoji {
         $filename = basename($emoji_path);
         $ext = '.'.pathinfo($filename, PATHINFO_EXTENSION);
         $basename = basename($filename, $ext);
-        $src = asset($emoji_path);
+        $src = asset($emoji_path, true);
 
         $attributes = [$src, $emoji_name, $src, $emoji_name, $dir, $filename, $basename, $ext];
         $attributes = array_map('htmlspecialchars', $attributes);

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1871,7 +1871,7 @@ EOT;
             }
 
             if ($mention) {
-                $parts[$i] = anchor('@'.$mention, str_replace('{name}', rawurlencode($mention), self::$MentionsUrlFormat)).$suffix;
+                $parts[$i] = anchor('@'.$mention, url(str_replace('{name}', rawurlencode($mention), self::$MentionsUrlFormat), true)).$suffix;
             } else {
                 $parts[$i] = '@' . $parts[$i];
             }
@@ -1906,7 +1906,7 @@ EOT;
             if (c('Garden.Format.Hashtags')) {
                 $mixed = Gdn_Format::replaceButProtectCodeBlocks(
                     '/(^|[\s,\.>])\#([\w\-]+)(?=[\s,\.!?<]|$)/i',
-                    '\1'.anchor('#\2', '/search?Search=%23\2&Mode=like').'\3',
+                    '\1'.anchor('#\2', url('/search?Search=%23\2&Mode=like', true)).'\3',
                     $mixed
                 );
             }


### PR DESCRIPTION
When posts are presented via the API in external sites it’s important to format URLs as full URLs.