### PR TITLE
Force Precise dist on Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: precise
+
 language: php
 
 php:


### PR DESCRIPTION
Until #5815 can be addressed, this update will force usage of the Precise distro on Travis builds.