### PR TITLE
Clear password reset info when updating password or email

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -692,7 +692,9 @@ class ProfileController extends Gdn_Controller {
 
             if ($this->Form->save()) {
                 $this->informMessage(sprite('Check', 'InformSprite').t('Your password has been changed.'), 'Dismissable AutoDismiss HasSprite');
+
                 $this->Form->clearInputs();
+
                 Logger::event(
                     'password_change',
                     Logger::INFO,


### PR DESCRIPTION
This update alters the `UserModel::save` routine to clear any outstanding password reset information when the user row's password or email is modified. Since this operation is performed at the model level, the cited attributes will be reset under the stated conditions, regardless of what is invoking the save routine.

Closes #2903