### PR TITLE
Fix flat category views failing in PHP 7.1

### DIFF
--- a/applications/vanilla/views/categories/flat_all.php
+++ b/applications/vanilla/views/categories/flat_all.php
@@ -23,7 +23,7 @@
         $this->EventArguments['Category'] = &$category;
         $this->fireEvent('BeforeCategoryItem');
 
-        writeListItem($category);
+        writeListItem($category, 1);
     }
 ?>
 </ul>

--- a/applications/vanilla/views/modules/flatcategory.php
+++ b/applications/vanilla/views/modules/flatcategory.php
@@ -16,7 +16,7 @@
         <ul class="DataList CategoryList">
             <?php
             foreach ($this->data('Categories') as $category) {
-                writeListItem($category);
+                writeListItem($category, 1);
             }
             ?>
         </ul>


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/4953 removed the default value ("1") for the `$depth` parameter of `writeListItem` in category helper functions. The flat category views count on this default. They only call `writeListItem` with one parameter. Up until PHP 7.1, this only generated a warning. As of PHP 7.1, "too few arguments" is a fatal error.

This update makes the calls to `writeListItem` in flat category views explicitly use the previous default: 1. This addresses the fatal error.

Closes #5787 