### PR TITLE
Send spam registration to the applicants queue on approval when registration method is set to "Approval"

### DIFF
--- a/applications/dashboard/models/class.logmodel.php
+++ b/applications/dashboard/models/class.logmodel.php
@@ -784,7 +784,11 @@ class LogModel extends Gdn_Pluggable {
                     if (isset($data['Username'])) {
                         $set['Name'] = $data['Username'];
                     }
-                    $iD = Gdn::userModel()->insertForBasic($set, false, ['ValidateSpam' => false]);
+                    if (c('Garden.Registration.Method') === 'Approval') {
+                        $iD = Gdn::userModel()->insertForApproval($set, ['ValidateSpam' => false, 'CheckCaptcha' => false]);
+                    } else {
+                        $iD = Gdn::userModel()->insertForBasic($set, false, ['ValidateSpam' => false]);
+                    }
                     if (!$iD) {
                         throw new Exception(Gdn::userModel()->Validation->resultsText());
                     } else {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -48,7 +48,7 @@ class UserModel extends Gdn_Model {
 
     /** Timeout for SSO */
     const SSO_TIMEOUT = 1200;
-    
+
     /** @var */
     public $SessionColumns;
 
@@ -2858,6 +2858,8 @@ class UserModel extends Gdn_Model {
      *
      * @param array $formPostValues
      * @param array $options
+     *  - ValidateSpam
+     *  - CheckCaptcha
      * @return int UserID.
      */
     public function insertForApproval($formPostValues, $options = []) {
@@ -2884,11 +2886,14 @@ class UserModel extends Gdn_Model {
         $this->addInsertFields($formPostValues);
 
         if ($this->validate($formPostValues, true)) {
-            // Check for spam.
-            $spam = SpamModel::isSpam('Registration', $formPostValues);
-            if ($spam) {
-                $this->Validation->addValidationResult('Spam', 'You are not allowed to register at this time.');
-                return;
+
+            if (val('ValidateSpam', $options, true)) {
+                // Check for spam.
+                $spam = SpamModel::isSpam('Registration', $formPostValues);
+                if ($spam) {
+                    $this->Validation->addValidationResult('Spam', 'You are not allowed to register at this time.');
+                    return;
+                }
             }
 
             $fields = $this->Validation->validationFields(); // All fields on the form that need to be validated (including non-schema field rules defined above)


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/4951

- Update UserModel::insertForApproval() in order to be able to skip spam check.
- Use insertForApproval instead of insertForBasic when registration method is set to approval.