### PR TITLE
Change "All X" strings to accommodate gendered translations

### DIFF
--- a/applications/dashboard/views/activity/popin.php
+++ b/applications/dashboard/views/activity/popin.php
@@ -32,7 +32,7 @@
     <?php endforeach; ?>
         <li class="Item Center">
             <?php
-            echo anchor(sprintf(t('All %s'), t('Notifications')), '/profile/notifications');
+            echo anchor(t('All Notifications'), '/profile/notifications');
             ?>
         </li>
     <?php else: ?>

--- a/applications/vanilla/views/discussions/popin.php
+++ b/applications/vanilla/views/discussions/popin.php
@@ -32,7 +32,7 @@
         <?php endforeach; ?>
         <li class="Item Center">
             <?php
-            echo anchor(sprintf(t('All %s'), t('Bookmarks')), '/discussions/bookmarked');
+            echo anchor(t('All Bookmarks'), '/discussions/bookmarked');
             ?>
         </li>
     <?php else: ?>


### PR DESCRIPTION
We have recently made changes in the code and created translation strings in order to accommodate differences in gender and pluralizations of certain strings. Instead of composing two unrelated strings (eg. t('All') . t('Bookmarks')) which doesn't translate easily in some languages we have created composed strings: "All Bookmarks". 

This PR replaces two places in the code where we were still putting the string together by composition.