### PR TITLE
Deprecate & null the API configuration endpoint

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -697,44 +697,11 @@ class SettingsController extends DashboardController {
 
     /**
      *
-     *
+     * @deprecated
      * @throws Exception
      */
     public function configuration() {
-        $this->permission('Garden.Settings.Manage');
-        $this->deliveryMethod(DELIVERY_METHOD_JSON);
-        $this->deliveryType(DELIVERY_TYPE_DATA);
-
-        $transientKey = Gdn::request()->get('TransientKey');
-        if (Gdn::session()->validateTransientKey($transientKey) === false) {
-            throw new Gdn_UserException(t('Invalid CSRF token.', 'Invalid CSRF token. Please try again.'), 403);
-        }
-
-        $ConfigData = [
-            'Title' => c('Garden.Title'),
-            'Domain' => c('Garden.Domain'),
-            'Cookie' => c('Garden.Cookie'),
-            'Theme' => c('Garden.Theme'),
-            'Analytics' => [
-                'InstallationID' => c('Garden.InstallationID'),
-                'InstallationSecret' => c('Garden.InstallationSecret')
-            ]
-        ];
-
-        $Config = Gdn_Configuration::format($ConfigData, [
-            'FormatStyle' => 'Dotted',
-            'WrapPHP' => false,
-            'SafePHP' => false,
-            'Headings' => false,
-            'ByLine' => false,
-        ]);
-
-        $Configuration = [];
-        eval($Config);
-
-        $this->setData('Configuration', $Configuration);
-
-        $this->render();
+        deprecated('settingsController->configuration()');
     }
 
     /**


### PR DESCRIPTION
`/configuration` under API v1, which sits at /settings/configuration in the Dashboard.

* I cannot figure out what this was ever for.
* It's a bad security idea to leave anything like this laying around.
* It's been broken for a long time due to manually requiring a `transientkey` in a `GET`.

I've elected to leave a deprecated stub despite it consistently returning a 403 to all API request as-is, meaning it's extremely likely no one's using it.