### PR TITLE
Add SessionModel and use it in Gdn_Session

### DIFF
--- a/applications/dashboard/models/class.sessionmodel.php
+++ b/applications/dashboard/models/class.sessionmodel.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+/**
+ * Class SessionModel
+ */
+class SessionModel extends Gdn_Model {
+    use \Vanilla\PrunableTrait;
+
+    /**
+     * Class constructor. Defines the related database table name.
+     */
+    public function __construct() {
+        parent::__construct('Session');
+        $this->setPruneField('DateExpire');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function insert($fields) {
+        $this->prune();
+
+        return parent::insert($fields);
+    }
+}

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -291,8 +291,8 @@ $Construct->table('Session')
     ->column('SessionID', 'char(32)', false, 'primary')
     ->column('UserID', 'int', 0)
     ->column('DateInserted', 'datetime', false)
-    ->column('DateUpdated', 'datetime', false)
-    ->column('TransientKey', 'varchar(12)', false)
+    ->column('DateUpdated', 'datetime', null)
+    ->column('DateExpire', 'datetime', null, 'index')
     ->column('Attributes', 'text', null)
     ->set($Explicit, $Drop);
 


### PR DESCRIPTION
- Remove transient key from GDN_Session table since it was not used.
- Add DateExpire to GDN_Session so that we can prune it.
- Update Gdn_Session object to use the SessionModel.