### PR TITLE
Add param to comments index endpoint to allow lookup by author

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -252,14 +252,14 @@ class CommentsApiController extends AbstractApiController {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $discussion['CategoryID']);
 
             // Build up the where clause.
-            $where = ['discussionID' => $query['discussionID'], 'joinUsers' => false];
+            $where = ['DiscussionID' => $query['discussionID'], 'joinUsers' => false];
 
             if (isset($query['insertUserID'])) {
-                $where['insertUserID'] = $query['insertUserID'];
+                $where['InsertUserID'] = $query['insertUserID'];
             }
 
             if (isset($query['after'])) {
-                $where['dateInserted >'] = $query['after'];
+                $where['DateInserted >'] = $query['after'];
             }
 
             $rows = $this->commentModel->getWhere(

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -351,10 +351,12 @@ class CommentModel extends Gdn_Model {
      * @param int $userID Which user to get comments for.
      * @param int $limit Max number to get.
      * @param int $offset Number to skip.
-     * @param int $lastCommentID A hint for quicker paging.
+     * @param int|bool $lastCommentID A hint for quicker paging.
+     * @param string|null $after Only pull comments following this date.
+     * @param string $order Order comments ascending (asc) or descending (desc) by ID.
      * @return Gdn_DataSet SQL results.
      */
-    public function getByUser2($userID, $limit, $offset, $lastCommentID = false) {
+    public function getByUser2($userID, $limit, $offset, $lastCommentID = false, $after = null, $order = 'desc') {
         $perms = DiscussionModel::categoryPermissions();
 
         if (is_array($perms) && empty($perms)) {
@@ -371,7 +373,11 @@ class CommentModel extends Gdn_Model {
             ->join('Comment c2', 'c.CommentID = c2.CommentID')
             ->join('Discussion d', 'c2.DiscussionID = d.DiscussionID')
             ->where('c.InsertUserID', $userID)
-            ->orderBy('c.CommentID', 'desc');
+            ->orderBy('c.CommentID', $order);
+
+        if ($after) {
+            $this->SQL->where('c.DateInserted >', $after);
+        }
 
         if ($lastCommentID) {
             // The last comment id from the last page was given and can be used as a hint to speed up the query.


### PR DESCRIPTION
This update adds the insertUserID parameter to the comments index endpoint under API v2 (/api/v2/comments). Performing a GET request to this endpoint using this parameter will allow you to filter the results based on who authored the comment. This can be used on its own to retrieve all comments by a user, or it can be used with the discussionID parameter to filter comments on a particular discussion by a specific user. The index endpoint now requires insertUserID *or* discussionID.

This new functionality uses the `CommentModel::getByUser2` method. The ability to control record sorting and filtering by date has been added to this function.

Closes #5800 