### PR TITLE
Ignore .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ composer-local.json
 .settings
 .buildpath
 .idea/*
+.vscode
 /nbproject/
 /vendor/
 node_modules/


### PR DESCRIPTION
This makes it easier for people that use VSCode to make commits without accidently commiting their editor's project specific configuration (Such as XDebug config)