### PR TITLE
Fix error caused by using editor in embedded site under iOS

### DIFF
--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1285,27 +1285,30 @@
             // iOS keyboard does not push content up initially,
             // thus blocking the actual content. Typing (spaces, newlines) also
             // jump the page up, so keep it in view.
-            if (window.parent.location != window.location
-                && (/ipad|iphone|ipod/i).test(navigator.userAgent)) {
+            if (window.parent.location != window.location && (/ipad|iphone|ipod/i).test(navigator.userAgent)) {
 
                 var contentEditable = $(editor.composer.iframe).contents().find('body');
                 contentEditable.attr('autocorrect', 'off');
                 contentEditable.attr('autocapitalize', 'off');
 
-                var iOSscrollFrame = $(window.parent.document).find('#vanilla-iframe').contents();
-                var iOSscrollTo = $(iOSscrollFrame).find('#' + editor.config.toolbar).closest('form').find('.Buttons');
+                try {
+                    var iOSscrollFrame = $(window.parent.document).find('#vanilla-iframe').contents();
+                    var iOSscrollTo = $(iOSscrollFrame).find('#' + editor.config.toolbar).closest('form').find('.Buttons');
 
-                contentEditable.on('keydown keyup', function(e) {
-                    Vanilla.scrollTo(iOSscrollTo);
-                    editor.focus();
-                });
-
-                editor.on('focus', function() {
-                    //var postButton = $('#'+editor.config.toolbar).parents('form').find('.CommentButton');
-                    setTimeout(function() {
+                    contentEditable.on('keydown keyup', function(e) {
                         Vanilla.scrollTo(iOSscrollTo);
-                    }, 1);
-                });
+                        editor.focus();
+                    });
+
+                    editor.on('focus', function() {
+                        //var postButton = $('#'+editor.config.toolbar).parents('form').find('.CommentButton');
+                        setTimeout(function() {
+                            Vanilla.scrollTo(iOSscrollTo);
+                        }, 1);
+                    });
+                } catch (e) {
+                    // "window.parent unsupported for iFrames in your browser"
+                }
             }
         }
 


### PR DESCRIPTION
iOS does not allow you to call window.parent in an iFrame. The JS error was causing errors for flyouts for the editor.  By surrounding the code with a try/catch, we prevent the bug. The only side effect is we lose scroll to functionality on certain version of iOS, but it was broken to begin with.

Fixes https://vanillaforums.teamwork.com/#/tasks/6317471