### PR TITLE
Allow plugins to set a dependency on Gdn_Controller

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -44,6 +44,10 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->setShared(true)
     ->addAlias('Config')
 
+    // Controller
+    // Set in Gdn_Dispatcher
+    // $this->container->setInstance('Gdn_Controller', $controller);
+
     // AddonManager
     ->rule(Vanilla\AddonManager::class)
     ->setShared(true)

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -842,8 +842,12 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
     private function createController($controllerName, $request, &$routeArgs) {
         /* @var Gdn_Controller $controller */
         $controller = $this->container->get($controllerName);
+
         // Allow classes to have a dependency on Gdn_Controller.
-        $this->container->setInstance('Gdn_Controller', $controller);
+        // It is possible that the controller does not inherit Gdn_Controller :(
+        if (is_a($controller, Gdn_Controller::class)) {
+            $this->container->setInstance(Gdn_Controller::class, $controller);
+        }
         Gdn::controller($controller);
 
         $this->EventArguments['Controller'] =& $controller;

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -10,6 +10,7 @@
  * @package Core
  * @since 2.0
  */
+use Garden\Container\Container;
 use Garden\Web\Dispatcher;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
@@ -103,16 +104,26 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
      */
     private $addonManager;
 
+    /**
+     * @var Container
+     */
+    private $container;
+
     /** @var bool */
     private $isHomepage;
 
     /**
-     * Class constructor.
+     * Gdn_Dispatcher constructor.
+     *
+     * @param AddonManager $addonManager
+     * @param Container $container
+     * @param Dispatcher $dispatcher
      */
-    public function __construct(AddonManager $addonManager = null, Dispatcher $dispatcher = null) {
+    public function __construct(AddonManager $addonManager, Container $container, Dispatcher $dispatcher) {
         parent::__construct();
         $this->addonManager = $addonManager;
-        $this->dispatcher = $dispatcher ?: new Dispatcher();
+        $this->container = $container;
+        $this->dispatcher = $dispatcher;
         $this->reset();
     }
 
@@ -830,7 +841,9 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
      */
     private function createController($controllerName, $request, &$routeArgs) {
         /* @var Gdn_Controller $controller */
-        $controller = new $controllerName();
+        $controller = $this->container->get($controllerName);
+        // Allow classes to have a dependency on Gdn_Controller.
+        $this->container->setInstance('Gdn_Controller', $controller);
         Gdn::controller($controller);
 
         $this->EventArguments['Controller'] =& $controller;


### PR DESCRIPTION
Allows plugins, or any class really, to have a dependency on the current controller without calling Gdn::controller().

In the plugins it is useful if the event was not fire from a controller but you still need to reference it.

```php
    /**
     * @param Gdn_Controller $controller Current controller.
     */
    public function __construct(Gdn_Controller $controller) {
        $this->controller = $controller;
    }
   
    public function model_event_handler() {
        $this->controller->jsonTarget({TARGET}, {DATA}, {TYPE});
    }
```

I tried adding
```
    ->rule('Gdn_Controller')
    ->setInherit(true)
    ->setShared(true)
```
in `bootstrap.php` but the problem is that when you instantiate a new Controller you end up having a `Gdn_Controller` instance instead of a `SpecificController` instance in the container.

I was also playing with the idea of creating a `SharedInstanceInterface` in `Garden\Container` but wasn't sure it was the way to go.