### PR TITLE
Change default draft delete text

### DIFF
--- a/applications/vanilla/views/drafts/drafts.php
+++ b/applications/vanilla/views/drafts/drafts.php
@@ -21,7 +21,7 @@ foreach ($this->DraftData->resultArray() as $Draft) {
     <li class="Item Draft">
         <div
             class="Options"><?php
-                echo anchor(t('Draft.Delete', 'Delete'), $deleteUrl, 'Delete'); ?></div>
+                echo anchor(t('Draft.Delete', '&times;'), $deleteUrl, 'Delete'); ?></div>
         <div class="ItemContent">
             <?php echo anchor(Gdn_Format::text(val('Name', $Draft), false), $editUrl, 'Title DraftLink'); ?>
             <?php if ($excerpt) : ?>


### PR DESCRIPTION
This default text is what is set in the dashboard (It uses a symbol instead of a word) The text isn't currently in our locales at, but shouldn't need to be as a symbol. Using a times symbol would align other languages with the default english translation and the other pages with "delete"/"x" buttons.