### PR TITLE
Fix username display when sending a message to unknown users

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -123,7 +123,7 @@ class MessagesController extends ConversationsController {
                             'RecipientUserID' => [
                                 sprintf(
                                     '"%s" is an unknown username.',
-                                    $recipient
+                                    htmlspecialchars($recipient)
                                 )
                             ]
                         ]


### PR DESCRIPTION
This update makes sure names of unknown users are properly formatted when attempting to send a conversation message.