### PR TITLE
Backport: Fix username display when sending a message to unknown users

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -123,7 +123,7 @@ class MessagesController extends ConversationsController {
                             'RecipientUserID' => [
                                 sprintf(
                                     '"%s" is an unknown username.',
-                                    $Recipient
+                                    htmlspecialchars($Recipient)
                                 )
                             ]
                         ]


### PR DESCRIPTION
Backporting #5868 