### PR TITLE
Add ability to translate Activity HeadlineFormat on sub-communities

### DIFF
--- a/applications/conversations/models/class.conversationmessagemodel.php
+++ b/applications/conversations/models/class.conversationmessagemodel.php
@@ -361,6 +361,10 @@ class ConversationMessageModel extends ConversationsModel {
                 if ($session->UserID == $notifyUserID) {
                     continue; // don't notify self.
                 }
+                /**
+                 * Wherever we are saving the activity, add the raw code as HeadlineFormatCode in the data array
+                 * so that we can translate it in sub-communities that use other languages.
+                 */
                 // Notify the users of the new message.
                 $activity = [
                     'ActivityType' => 'ConversationMessage',
@@ -372,10 +376,15 @@ class ConversationMessageModel extends ConversationsModel {
                     'Story' => $body,
                     'Format' => val('Format', $fields, c('Garden.InputFormatter')),
                     'Route' => "/messages/{$conversationID}#{$messageID}",
+                    'Data' => [
+                        'HeadlineFormatCode' => 'HeadlineFormat.ConversationMessage'
+                    ]
                 ];
 
                 if (c('Conversations.Subjects.Visible') && $subject) {
                     $activity['HeadlineFormat'] = $subject;
+                    //Since particularly in conversations, users can overwrite the subject, don't user HeadlineFormatCode.
+                    unset($activity['HeadlineFormatCode']);
                 }
                 $activityModel->queue($activity, 'ConversationMessage');
             }

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -159,7 +159,16 @@ class ActivityModel extends Gdn_Model {
 
         $row['Url'] = externalUrl($row['Route']);
 
-        if ($row['HeadlineFormat']) {
+        /**
+         * Dealing with Headline formats in different languages
+         *
+         * If HeadlineFormatCode has been saved to the Data field of the activity translate it.
+         * If not send out the already translated HeadlineFormat saved in the row.
+         * And for backwards backwards compatibility, user the Headline from the ActivityType table
+         */
+        if (!empty($data['HeadlineFormatCode'])) {
+            $row['Headline'] = formatString(t($data['HeadlineFormatCode'], $row['HeadlineFormat']), $row);
+        } elseif ($row['HeadlineFormat']) {
             $row['Headline'] = formatString($row['HeadlineFormat'], $row);
         } else {
             $row['Headline'] = Gdn_Format::activityHeadline($row);


### PR DESCRIPTION
Save the raw, untranslated format of an activity headline in the data column of the activity table. If the activity is displayed in another language it can be translated from the original.