### PR TITLE
Add /tokens API v2 endpoint and UI

### DIFF
--- a/applications/dashboard/controllers/Api/TokensApiController.php
+++ b/applications/dashboard/controllers/Api/TokensApiController.php
@@ -138,12 +138,13 @@ class TokensApiController extends AbstractApiController {
         $this->permission('Garden.Tokens.Add');
 
         $in = $this->schema([], 'in');
+        // Full access token details are not available in the index. Use GET on a single ID for sensitive information.
         $out = $this->schema([
             ':a' => $this->schema([
                 'accessTokenID',
                 'name',
                 'dateInserted'
-            ])->add($this->sensitiveSchema())
+            ])->add($this->fullSchema())
         ], 'out')->setDescription('Get a list of authentication token IDs for the current user.');
 
         $rows = $this->accessTokenModel->getWhere(['UserID' => $this->session->UserID])->resultArray();

--- a/applications/dashboard/controllers/Api/TokensApiController.php
+++ b/applications/dashboard/controllers/Api/TokensApiController.php
@@ -95,7 +95,7 @@ class TokensApiController extends AbstractApiController {
      * @param array $query
      * @return array
      */
-    public function get_reveal($id, array $query) {
+    public function get($id, array $query) {
         $this->permission('Garden.Tokens.Add');
 
         $in = $this->schema([

--- a/applications/dashboard/controllers/Api/TokensApiController.php
+++ b/applications/dashboard/controllers/Api/TokensApiController.php
@@ -197,11 +197,8 @@ class TokensApiController extends AbstractApiController {
 
         $rows = $this->accessTokenModel->getWhere([
             'UserID' => $this->session->UserID,
-            'Type' => self::TOKEN_TYPE,
-            '',
-            'asc',
-            self::RESPONSE_LIMIT
-        ])->resultArray();
+            'Type' => self::TOKEN_TYPE
+        ], '', 'asc', self::RESPONSE_LIMIT)->resultArray();
         $activeTokens = [];
         foreach ($rows as $token) {
             if ($this->isActiveToken($token) === false) {

--- a/applications/dashboard/controllers/Api/TokensApiController.php
+++ b/applications/dashboard/controllers/Api/TokensApiController.php
@@ -120,6 +120,7 @@ class TokensApiController extends AbstractApiController {
      *
      * @param int $id
      * @param array $query
+     * @throws NotFoundException if this is not an active token.
      * @return array
      */
     public function get($id, array $query) {

--- a/applications/dashboard/controllers/Api/TokensApiController.php
+++ b/applications/dashboard/controllers/Api/TokensApiController.php
@@ -14,7 +14,13 @@ use Garden\Web\Exception\NotFoundException;
 class TokensApiController extends AbstractApiController {
 
     /** Default expiry for issued tokens. */
-    const DEFAULT_EXPIRY = '1 month';
+    const DEFAULT_EXPIRY = '10 years';
+
+    /** The maximum number of tokens in a response. */
+    const RESPONSE_LIMIT = 200;
+
+    /** Default token type. */
+    const TOKEN_TYPE = 'personal';
 
     /** @var AccessTokenModel */
     private $accessTokenModel;
@@ -189,7 +195,13 @@ class TokensApiController extends AbstractApiController {
             ])->add($this->fullSchema())
         ], 'out')->setDescription('Get a list of authentication token IDs for the current user.');
 
-        $rows = $this->accessTokenModel->getWhere(['UserID' => $this->session->UserID])->resultArray();
+        $rows = $this->accessTokenModel->getWhere([
+            'UserID' => $this->session->UserID,
+            'Type' => self::TOKEN_TYPE,
+            '',
+            'asc',
+            self::RESPONSE_LIMIT
+        ])->resultArray();
         $activeTokens = [];
         foreach ($rows as $token) {
             if ($this->isActiveToken($token) === false) {
@@ -226,7 +238,7 @@ class TokensApiController extends AbstractApiController {
         $accessToken = $this->accessTokenModel->issue(
             $this->session->UserID,
             self::DEFAULT_EXPIRY,
-            'personal'
+            self::TOKEN_TYPE
         );
         $this->validateModel($this->accessTokenModel);
         $token = $this->accessTokenModel->trim($accessToken);

--- a/applications/dashboard/controllers/Api/TokensApiController.php
+++ b/applications/dashboard/controllers/Api/TokensApiController.php
@@ -257,7 +257,7 @@ class TokensApiController extends AbstractApiController {
      */
     public function prepareRow(array &$row) {
         $name = null;
-        if (array_key_exists('Attributes', $row)) {
+        if (array_key_exists('Attributes', $row) && is_array($row['Attributes'])) {
             if (array_key_exists('name', $row['Attributes']) && is_string($row['Attributes']['name'])) {
                 $name = $row['Attributes']['name'];
             }

--- a/applications/dashboard/controllers/Api/TokensApiController.php
+++ b/applications/dashboard/controllers/Api/TokensApiController.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+use Garden\Schema\Schema;
+use Garden\Web\Data;
+use Garden\Web\Exception\ClientException;
+use Garden\Web\Exception\ServerException;
+use Vanilla\Utility\CapitalCaseScheme;
+
+/**
+ * API Controller for the `/tokens` resource.
+ */
+class TokensApiController extends AbstractApiController {
+
+    /** Default expiry for issued tokens. */
+    const DEFAULT_EXPIRY = '1 month';
+
+    /** @var AccessTokenModel */
+    private $accessTokenModel;
+
+    /** @var Gdn_Session */
+    private $session;
+
+    /**
+     * TokensApiController constructor.
+     *
+     * @param AccessTokenModel $accessTokenModel
+     * @param Gdn_Session $session
+     */
+    public function __construct(AccessTokenModel $accessTokenModel, Gdn_Session $session) {
+        $this->accessTokenModel = $accessTokenModel;
+        $this->session = $session;
+    }
+
+    /**
+     * Issue a new transient key for the current user.
+     *
+     * @param array $body
+     * @return mixed
+     */
+    public function post(array $body) {
+        $this->permission();
+
+        $in = $this->schema([
+            'name:s' => 'A name indicating what the access token will be used for.',
+            'transientKey:s' => 'A valid CSRF token for the current user.'
+        ], 'in');
+        $out = $this->schema([
+            'accessTokenID:i',
+            'name:s',
+            'accessToken:s',
+            'dateInserted:dt'
+        ], 'out');
+
+        $body = $in->validate($body);
+        $this->validateTK($body['transientKey']);
+
+        // Issue the new token.
+        $accessToken = $this->accessTokenModel->issue(
+            $this->session->UserID,
+            self::DEFAULT_EXPIRY,
+            'personal'
+        );
+        $this->validateModel($this->accessTokenModel);
+        $token = $this->accessTokenModel->trim($accessToken);
+        $row = $this->accessTokenModel->getToken($token);
+        $accessTokenID = $row['AccessTokenID'];
+        $row = $this->accessTokenModel->setAttribute($accessTokenID, 'Name', $body['name']);
+
+        // Serve up the result.
+        $this->prepareRow($row);
+        $result = $out->validate($row);
+        return $result;
+    }
+
+    /**
+     * Prepare the current row for output.
+     *
+     * @param array $row
+     */
+    public function prepareRow(&$row) {
+        if (array_key_exists('Attributes', $row)) {
+            if (array_key_exists('Name', $row['Attributes']) && is_string($row['Attributes']['Name'])) {
+                $row['Name'] = $row['Attributes']['Name'];
+            }
+        }
+        if (array_key_exists('Token', $row) && is_string($row['Token'])) {
+            $row['AccessToken'] = $this->accessTokenModel->signToken($row['Token']);
+        }
+    }
+
+    /**
+     * Validate the transient key for the current request.
+     *
+     * @param $transientKey
+     * @throws ClientException
+     */
+    public function validateTK($transientKey) {
+        if ($this->session->transientKey() === false) {
+            $this->session->loadTransientKey();
+        }
+
+        if ($this->session->transientKey() != $transientKey) {
+            throw new ClientException('Invalid transient key.', 401);
+        }
+    }
+}

--- a/applications/dashboard/controllers/Api/TokensApiController.php
+++ b/applications/dashboard/controllers/Api/TokensApiController.php
@@ -52,10 +52,8 @@ class TokensApiController extends AbstractApiController {
         $out = $this->schema([], 'out');
 
         $row = $this->token($id);
-        $isOwnToken = $row['UserID'] == $this->session->UserID;
-        $isAdmin = $this->session->checkPermission('Garden.Settings.Manage');
-        if (!$isOwnToken && !$isAdmin) {
-            throw new ClientException('You do not have permission to revoke this token.', 401);
+        if ($row['UserID'] != $this->session->UserID) {
+            $this->permission('Garden.Settings.Manage');
         }
 
         $this->accessTokenModel->revoke($id);

--- a/applications/dashboard/controllers/Api/TokensApiController.php
+++ b/applications/dashboard/controllers/Api/TokensApiController.php
@@ -46,8 +46,6 @@ class TokensApiController extends AbstractApiController {
      * @throws ClientException if current user isn't authorized to delete the token.
      */
     public function delete($id) {
-        $this->permission('');
-
         $this->schema($this->idSchema(),'in')->setDescription('Revoke an authentication token.');
         $out = $this->schema([], 'out');
 
@@ -98,7 +96,7 @@ class TokensApiController extends AbstractApiController {
      * @return array
      */
     public function get_reveal($id, array $query) {
-        $this->permission('');
+        $this->permission('Garden.Tokens.Add');
 
         $in = $this->schema([
             'id',
@@ -137,7 +135,7 @@ class TokensApiController extends AbstractApiController {
      * @return array
      */
     public function index() {
-        $this->permission('');
+        $this->permission('Garden.Tokens.Add');
 
         $in = $this->schema([], 'in');
         $out = $this->schema([
@@ -179,7 +177,7 @@ class TokensApiController extends AbstractApiController {
      * @return mixed
      */
     public function post(array $body) {
-        $this->permission();
+        $this->permission('Garden.Tokens.Add');
 
         $in = $this->schema([
             'name:s' => 'A name indicating what the access token will be used for.',

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -1262,7 +1262,7 @@ class ProfileController extends Gdn_Controller {
                 $token = $tokenApi->post([
                     'name' => $this->Form->getFormValue('Name'),
                     'transientKey' => $this->Form->getFormValue('TransientKey')
-                ]);
+                ])->getData();
 
                 $this->jsonTarget(".DataList-Tokens", $this->revealTokenRow($token), 'Prepend');
 

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -267,8 +267,10 @@ $Construct->table('UserAuthenticationToken')
     ->column('Lifetime', 'int', false)
     ->set($Explicit, $Drop);
 
-$Construct->table('AccessToken')
-    ->column('Token', 'varchar(100)', false, 'primary')
+$Construct
+    ->table('AccessToken')
+    ->primaryKey('AccessTokenID')
+    ->column('Token', 'varchar(100)', false, 'index')
     ->column('UserID', 'int', false, 'index')
     ->column('Type', 'varchar(20)', false, 'index')
     ->column('Scope', 'text', true)

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -285,6 +285,7 @@ $Construct
     ->column('Type', 'varchar(20)', false, 'index')
     ->column('Scope', 'text', true)
     ->column('DateInserted', 'timestamp', false)
+    ->column('InsertUserID', 'int', true)
     ->column('InsertIPAddress', 'ipaddress', false)
     ->column('DateExpires', 'timestamp', false)
     ->column('Attributes', 'text', true)

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -267,10 +267,20 @@ $Construct->table('UserAuthenticationToken')
     ->column('Lifetime', 'int', false)
     ->set($Explicit, $Drop);
 
+if ($captureOnly === false && $Construct->table('AccessToken')->columnExists('AccessTokenID') === false) {
+    $accessTokenTable = $SQL->prefixTable('AccessToken');
+    try {
+        $SQL->query("alter table {$accessTokenTable} drop primary key");
+    } catch (Exception $e) {
+        // Primary key doesn't exist. Nothing to do here.
+    }
+    $SQL->query("alter table {$accessTokenTable} add AccessTokenID int not null auto_increment primary key first");
+}
+
 $Construct
     ->table('AccessToken')
     ->primaryKey('AccessTokenID')
-    ->column('Token', 'varchar(100)', false, 'index')
+    ->column('Token', 'varchar(100)', false, 'unique')
     ->column('UserID', 'int', false, 'index')
     ->column('Type', 'varchar(20)', false, 'index')
     ->column('Scope', 'text', true)

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -352,7 +352,8 @@ $PermissionModel->define([
     'Garden.Moderation.Manage',
     'Garden.PersonalInfo.View' => 'Garden.Moderation.Manage',
     'Garden.AdvancedNotifications.Allow',
-    'Garden.Community.Manage' => 'Garden.Settings.Manage'
+    'Garden.Community.Manage' => 'Garden.Settings.Manage',
+    'Garden.Tokens.Add' => 'Garden.Settings.Manage'
 ]);
 
 $PermissionModel->undefine([

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -267,7 +267,7 @@ $Construct->table('UserAuthenticationToken')
     ->column('Lifetime', 'int', false)
     ->set($Explicit, $Drop);
 
-if ($captureOnly === false && $Construct->table('AccessToken')->columnExists('AccessTokenID') === false) {
+if ($captureOnly === false && $Construct->tableExists('AccessToken') && $Construct->table('AccessToken')->columnExists('AccessTokenID') === false) {
     $accessTokenTable = $SQL->prefixTable('AccessToken');
     try {
         $SQL->query("alter table {$accessTokenTable} drop primary key");

--- a/applications/dashboard/views/profile/token-delete.php
+++ b/applications/dashboard/views/profile/token-delete.php
@@ -1,0 +1,16 @@
+<?php if (!defined('APPLICATION')) exit(); ?>
+
+<h1><?php echo $this->data('Title'); ?></h1>
+
+<?php
+echo $this->Form->open();
+echo $this->Form->errors();
+
+echo '<div class="P">'.sprintf(t('Are you sure you want to delete this %s?'), t('access token')).'</div>';
+
+echo '<div class="Buttons Buttons-Confirm">';
+echo $this->Form->button('OK', ['class' => 'Button Primary']);
+echo $this->Form->button('Cancel', ['type' => 'button', 'class' => 'Button Close']);
+echo '</div>';
+echo $this->Form->close();
+?>

--- a/applications/dashboard/views/profile/token.php
+++ b/applications/dashboard/views/profile/token.php
@@ -1,0 +1,17 @@
+<?php if (!defined('APPLICATION')) exit(); ?>
+<div class="FormTitleWrapper">
+    <h1 class="H"><?php echo $this->data('Title'); ?></h1>
+    <?php
+    echo $this->Form->open();
+    echo $this->Form->errors();
+    ?>
+    <ul>
+        <li>
+            <?php
+            echo $this->Form->label('Token Name', 'Name');
+            echo $this->Form->textBox('Name');
+            ?>
+        </li>
+    </ul>
+    <?php echo $this->Form->close('Generate', '', ['class' => 'Button Primary']); ?>
+</div>

--- a/applications/dashboard/views/profile/tokens.php
+++ b/applications/dashboard/views/profile/tokens.php
@@ -1,0 +1,22 @@
+<?php if (!defined('APPLICATION')) exit(); ?>
+<h1 class="H"><?=t('Personal Access Tokens')?></h1>
+
+<div class="PageControls Top">
+    <a href="<?=userUrl($this->User, '', 'token')?>" class="Button Action Popup Primary"><?=t('Generate New Token')?></a>
+</div>
+<div class="DataListWrap">
+    <ul class="DataList DataList-Tokens">
+    <?php
+    foreach ($this->data('Tokens') as $token) {
+        ?><li id="Token_<?=$token['accessTokenID']?>" class="Item Item-Token">
+            <b><?=htmlspecialchars($token['name'])?></b>&nbsp;
+            <div class="Meta Options">
+                <a href="<?=url('/profile/tokenReveal?accessTokenID='.$token['accessTokenID'])?>" class="OptionsLink Hijack"><?=t('Reveal')?></a>
+                <span class="Bullet">·</span>
+                <a href="<?=url('/profile/tokenDelete?accessTokenID='.$token['accessTokenID'])?>" class="OptionsLink Popup"><?=t('Delete')?></a>
+            </div>
+        </li><?php
+    }
+    ?>
+    </ul>
+</div>

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -27,7 +27,7 @@ abstract class Controller implements InjectableInterface {
     /**
      * @var SessionInterface
      */
-    private $session;
+    protected $session;
 
     /**
      * @var EventManager

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -27,7 +27,7 @@ abstract class Controller implements InjectableInterface {
     /**
      * @var SessionInterface
      */
-    protected $session;
+    private $session;
 
     /**
      * @var EventManager

--- a/library/core/class.accesstokenmodel.php
+++ b/library/core/class.accesstokenmodel.php
@@ -64,13 +64,22 @@ class AccessTokenModel extends Gdn_Model {
     /**
      * Revoke an already issued token.
      *
-     * @param string $token The token or access token to revoke.
+     * @param string|int $token The token, access or numeric ID token to revoke.
      * @return bool Returns true if the token was revoked or false otherwise.
      */
     public function revoke($token) {
-        $token = $this->trim($token);
+        $id = false;
+        if (filter_var($token, FILTER_VALIDATE_INT)) {
+            $id = $token;
+        } else {
+            $token = $this->trim($token);
+            $row = $this->getToken($token);
+            if ($row) {
+                $id = $row['AccessTokenID'];
+            }
+        }
 
-        $this->setField($token, [
+        $this->setField($id, [
             'DateExpires' => Gdn_Format::toDateTime(strtotime('-1 hour')),
             'Attributes' => ['revoked' => true]
         ]);

--- a/library/core/class.accesstokenmodel.php
+++ b/library/core/class.accesstokenmodel.php
@@ -80,9 +80,9 @@ class AccessTokenModel extends Gdn_Model {
         }
 
         $this->setField($id, [
-            'DateExpires' => Gdn_Format::toDateTime(strtotime('-1 hour')),
-            'Attributes' => ['revoked' => true]
+            'DateExpires' => Gdn_Format::toDateTime(strtotime('-1 hour'))
         ]);
+        $this->setAttribute($id, 'revoked', true);
         return $this->Database->LastInfo['RowCount'] > 0;
     }
 

--- a/library/core/class.accesstokenmodel.php
+++ b/library/core/class.accesstokenmodel.php
@@ -24,7 +24,7 @@ class AccessTokenModel extends Gdn_Model {
      */
     public function __construct($secret = '') {
         parent::__construct('AccessToken');
-        $this->PrimaryKey = 'Token';
+        $this->PrimaryKey = 'AccessTokenID';
         $this->secret = $secret ?: c('Garden.Cookie.Salt');
 
         $this->setPruneAfter('1 day')
@@ -92,6 +92,30 @@ class AccessTokenModel extends Gdn_Model {
                 $row[$field] = empty($row[$field]) ? null : json_encode($row[$field], JSON_UNESCAPED_SLASHES);
             }
         }
+    }
+
+    /**
+     * Get an access token by its numeric ID.
+     *
+     * @param int $accessTokenID
+     * @param string $datasetType
+     * @param array $options
+     * @return array|bool
+     */
+    public function getID($accessTokenID, $datasetType = DATASET_TYPE_ARRAY, $options = []) {
+        $row = $this->getWhere(['AccessTokenID' => $accessTokenID])->firstRow($datasetType);
+        return $row;
+    }
+
+    /**
+     * Fetch an access token row using the token.
+     *
+     * @param mixed $token
+     * @return array|bool
+     */
+    public function getToken($token) {
+        $row = $this->getWhere(['Token' => $token])->firstRow(DATASET_TYPE_ARRAY);
+        return $row;
     }
 
     /**
@@ -251,7 +275,7 @@ class AccessTokenModel extends Gdn_Model {
 
         $token = $this->trim($accessToken);
 
-        $row = $this->getID($token, DATASET_TYPE_ARRAY);
+        $row = $this->getToken($token);
 
         if (!$row) {
             return $this->tokenError('Access token not found.', 401, $throw);
@@ -406,5 +430,28 @@ class AccessTokenModel extends Gdn_Model {
      */
     private static function base64urlDecode($str) {
         return base64_decode(strtr($str, '-_', '+/'));
+    }
+
+    /**
+     * Save an attribute on an access token row.
+     *
+     * @param int $accessTokenID
+     * @param string $key
+     * @param mixed $value
+     * @return array|bool
+     */
+    public function setAttribute($accessTokenID, $key, $value) {
+        $row = $this->getID($accessTokenID, DATASET_TYPE_ARRAY);
+        $result = false;
+        if ($row) {
+            $attributes = array_key_exists('Attributes', $row) ? $row['Attributes'] : [];
+            $attributes[$key] = $value;
+            $this->update(
+                ['Attributes' => $attributes],
+                ['AccessTokenID' => $accessTokenID],
+            1);
+            $result = $this->getID($accessTokenID);
+        }
+        return $result;
     }
 }

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -604,7 +604,7 @@ class Gdn_Session {
      * @param int|null $timestamp
      * @return string
      */
-    protected function generateTKPayload($tk, $userID = null, $timestamp = null) {
+    public function generateTKPayload($tk, $userID = null, $timestamp = null) {
         $userID = $userID ?: $this->UserID;
 
         $timestamp = $timestamp ?: time();
@@ -618,7 +618,7 @@ class Gdn_Session {
      * @param string $payload
      * @return string
      */
-    protected function generateTKSignature($payload) {
+    public function generateTKSignature($payload) {
         return hash_hmac(c('Garden.Cookie.HashMethod'), $payload, c('Garden.Cookie.Salt'));
     }
 

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -532,37 +532,13 @@ class Gdn_Session {
      * @return string
      */
     public function ensureTransientKey() {
-        $cookieString = getAppCookie('tk');
-        $reset = false;
+        $transientKey = $this->loadTransientKey();
 
-        if ($cookieString === null) {
-            $reset = true;
-        } else {
-            $cookie = $this->decodeTKCookie($cookieString);
-            if ($cookie === false) {
-                $reset = true;
-            } else {
-                $payload = $this->generateTKPayload(
-                    $cookie['TransientKey'],
-                    $cookie['UserID'],
-                    $cookie['Timestamp']
-                );
-
-                $userInvalid = ($cookie['UserID'] != $this->UserID);
-                $signatureInvalid = $this->generateTKSignature($payload) !== $cookie['Signature'];
-                if ($userInvalid || $signatureInvalid) {
-                    $reset = true;
-                } elseif ($this->transientKey() !== $cookie['TransientKey']) {
-                    $this->transientKey($cookie['TransientKey'], false);
-                }
-            }
+        if ($transientKey === false) {
+            $transientKey = $this->transientKey(betterRandomString(16, 'Aa0'));
         }
 
-        if ($reset) {
-            return $this->transientKey(betterRandomString(16, 'Aa0'));
-        } else {
-            return $this->transientKey();
-        }
+        return $transientKey;
     }
 
     /**
@@ -588,6 +564,36 @@ class Gdn_Session {
             'Timestamp' => $elements[2],
             'Signature' => $elements[3]
         ];
+    }
+
+    /**
+     * Load the transient key from the user's cookie into the TK property.
+     *
+     * @return bool|string
+     */
+    public function loadTransientKey() {
+        $cookieString = getAppCookie('tk');
+        $result = false;
+
+        if ($cookieString !== null) {
+            $cookie = $this->decodeTKCookie($cookieString);
+            if ($cookie !== false) {
+                $payload = $this->generateTKPayload(
+                    $cookie['TransientKey'],
+                    $cookie['UserID'],
+                    $cookie['Timestamp']
+                );
+
+                $userValid = ($cookie['UserID'] == $this->UserID);
+                $signatureValid = $this->generateTKSignature($payload) == $cookie['Signature'];
+                $currentTKInvalid = $this->transientKey() != $cookie['TransientKey'];
+                if ($userValid && $signatureValid && $currentTKInvalid) {
+                    $result = $this->transientKey($cookie['TransientKey'], false);
+                }
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -27,6 +27,7 @@ abstract class AbstractAPIv2Test extends \PHPUnit_Framework_TestCase {
 
         $this->api = static::container()->getArgs(InternalClient::class, [static::container()->get('@baseUrl').'/api/v2']);
         $this->api->setUserID(self::$siteInfo['adminUserID']);
+        $this->api->setTransientKey(md5(now()));
     }
 
     /**

--- a/tests/APIv2/TokensTest.php
+++ b/tests/APIv2/TokensTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\APIv2;
+
+use AccessTokenModel;
+
+/**
+ * Test the /api/v2/tokens endpoints.
+ */
+class TokensTest extends AbstractAPIv2Test {
+
+    /**
+     * The number of rows create when testing index endpoints.
+     */
+    const INDEX_ROWS = 4;
+
+    /** @var AccessTokenModel */
+    private $accessTokenModel;
+
+    /** {@inheritdoc} */
+    protected $baseUrl = '/tokens';
+
+    /** {@inheritdoc} */
+    protected $pk = 'accessTokenID';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp() {
+        parent::setUp();
+        $this->accessTokenModel = static::container()->get(AccessTokenModel::class);
+    }
+
+    /**
+     * Test DELETE /tokens/<id>.
+     */
+    public function testDelete() {
+        $row = $this->testPost();
+
+        $r = $this->api()->delete(
+            "{$this->baseUrl}/{$row[$this->pk]}"
+        );
+
+        $this->assertEquals(204, $r->getStatusCode());
+
+        try {
+            $this->api()->getWithTransientKey("{$this->baseUrl}/{$row[$this->pk]}");
+            $this->fail('The token was not deleted.');
+        } catch (\Exception $ex) {
+            // A revoked (deleted) token should return a 410 (gone).
+            $this->assertEquals(410, $ex->getCode());
+            return;
+        }
+        $this->fail('Something odd happened while deleting a token');
+    }
+
+    /**
+     * Test GET /tokens/<id>.
+     *
+     * @return array
+     */
+    public function testGet() {
+        $row = $this->testPost();
+
+        $r = $this->api()->getWithTransientKey(
+            "{$this->baseUrl}/{$row[$this->pk]}"
+        );
+
+        $this->assertEquals(200, $r->getStatusCode());
+
+        $body = $r->getBody();
+        $this->assertCamelCase($body);
+        $accessToken = $body['accessToken'];
+        $this->assertEquals(
+            $this->accessTokenModel->trim($row['accessToken']),
+            $this->accessTokenModel->trim($body['accessToken'])
+        );
+        unset($row['accessToken'], $body['accessToken']);
+        $this->assertRowsEqual($row, $r->getBody());
+
+        $this->accessTokenModel->verify($accessToken, true);
+
+        return $body;
+    }
+
+    /**
+     * Test GET /tokens.
+     *
+     * @return array Returns the fetched data.
+     */
+    public function testIndex() {
+        // Insert a few rows.
+        $rows = [];
+        for ($i = 0; $i < static::INDEX_ROWS; $i++) {
+            $rows[] = $this->testPost();
+        }
+
+        $r = $this->api()->get($this->baseUrl);
+        $this->assertEquals(200, $r->getStatusCode());
+
+        $dbRows = $r->getBody();
+        $this->assertGreaterThan(self::INDEX_ROWS, count($dbRows));
+
+        // The index should be a proper indexed array.
+        for ($i = 0; $i < count($dbRows); $i++) {
+            $this->assertArrayHasKey($i, $dbRows);
+        }
+
+        return [$rows, $dbRows];
+    }
+
+    /**
+     * Test POST /tokens.
+     *
+     * @return array
+     */
+    public function testPost() {
+        $row = ['name' => 'phpUnit'];
+        $result = $this->api()->postWithTransientKey(
+            $this->baseUrl,
+            $row
+        );
+
+        $this->assertEquals(201, $result->getStatusCode());
+
+        $body = $result->getBody();
+        $this->assertCamelCase($body);
+        $this->assertTrue(is_int($body[$this->pk]));
+        $this->assertTrue($body[$this->pk] > 0);
+        $this->assertEquals($row['name'], $body['name']);
+        $this->assertInstanceOf('DateTimeImmutable', $body['dateInserted']);
+
+        $this->accessTokenModel->verify($body['accessToken'], true);
+
+        return $body;
+    }
+}

--- a/tests/InternalClient.php
+++ b/tests/InternalClient.php
@@ -12,6 +12,7 @@ use Garden\Http\HttpClient;
 use Garden\Http\HttpResponse;
 
 class InternalClient extends HttpClient {
+
     /**
      * @var Container The container used to construct request objects.
      */
@@ -23,6 +24,16 @@ class InternalClient extends HttpClient {
     private $userID;
 
     /**
+     * @var string
+     */
+    private $transientKey;
+
+    /**
+     * @var string
+     */
+    private $transientKeySigned;
+
+    /**
      * InternalClient constructor.
      *
      * @param Container $container The container used to create requests.
@@ -32,6 +43,21 @@ class InternalClient extends HttpClient {
         parent::__construct($baseUrl);
         $this->throwExceptions = true;
         $this->container = $container;
+    }
+
+    /**
+     * Add the transient key cookie header to an array of headers.
+     *
+     * @param array $headers
+     */
+    public function addTransientKeyHeader(array &$headers) {
+        /** @var \Gdn_Configuration $config */
+        $config = $session = $this->container->get(\Gdn_Configuration::class);
+        $name = $config->get('Garden.Cookie.Name').'-tk';
+        $value = rawurlencode($this->transientKeySigned);
+        $cookies = array_key_exists('Cookie', $headers) ? rtrim($headers['Cookie'], '; ').'; ' : '';
+        $cookies .= "$name=$value;";
+        $headers['Cookie'] = $cookies;
     }
 
     /**
@@ -47,6 +73,22 @@ class InternalClient extends HttpClient {
 
         $request = $this->container->getArgs(InternalRequest::class, [$method, $uri, $body, $headers, $options]);
         return $request;
+    }
+
+    /**
+     * Send a GET request to the API and include the transient key.
+     *
+     * @param string $uri The URL or path of the request.
+     * @param array $query The querystring to add to the URL.
+     * @param array $headers The HTTP headers to add to the request.
+     * @param array $options An array of additional options for the request.
+     * @return HttpResponse Returns the {@link HttpResponse} object from the call.
+     */
+    public function getWithTransientKey($uri, array $query = [], array $headers = [], $options = []) {
+        $this->addTransientKeyHeader($headers);
+        $query['TransientKey'] = $this->getTransientKey();
+        $result = $this->get($uri, $query, $headers, $options);
+        return $result;
     }
 
     public function handleErrorResponse(HttpResponse $response, $options = []) {
@@ -67,12 +109,61 @@ class InternalClient extends HttpClient {
     }
 
     /**
+     * Get the configured transient key.
+     *
+     * @return string
+     */
+    public function getTransientKey() {
+        return $this->transientKey;
+    }
+
+    /**
      * Get the user ID that will be used to make requests.
      *
      * @return int Returns the userID.
      */
     public function getUserID() {
         return $this->userID;
+    }
+
+    /**
+     * Send a POST request to the API and include the transient key.
+     *
+     * @param string $uri The URL or path of the request.
+     * @param array $body The HTTP body to send to the request.
+     * @param array $headers The HTTP headers to add to the request.
+     * @param array $options An array of additional options for the request.
+     * @return HttpResponse Returns the {@link HttpResponse} object from the call.
+     */
+    public function postWithTransientKey($uri, array $body = [], array $headers = [], $options = []) {
+        $this->addTransientKeyHeader($headers);
+        $body['TransientKey'] = $this->getTransientKey();
+        $result = $this->post($uri, $body, $headers, $options);
+        return $result;
+    }
+
+    /**
+     * Configure the transient key to be used for requests.
+     *
+     * @param string $transientKey
+     * @throws \Exception if no active user session is available.
+     * @return $this
+     */
+    public function setTransientKey($transientKey) {
+        $this->transientKey = $transientKey;
+
+        /** @var \Gdn_Session $session */
+        $session = $this->container->get(\Gdn_Session::class);
+        if ($session->UserID) {
+            $session->transientKey($transientKey);
+            $payload = $session->generateTKPayload($transientKey);
+            $signature = $session->generateTKSignature($payload);
+            $this->transientKeySigned = "$payload:$signature";
+        } else {
+            throw new \Exception('Cannot build transient key payload without an active session.');
+        }
+
+        return $this;
     }
 
     /**

--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -98,7 +98,22 @@ class InternalRequest extends HttpRequest implements RequestInterface {
     public function send() {
         $this->container->setInstance(\Gdn_Request::class, $this->convertToLegacyRequest());
 
+        $cookieStash = $_COOKIE;
+        $cookies = [];
+        if ($rawCookies = $this->getHeader('Cookie')) {
+            $rawCookies = explode(';', $rawCookies);
+            array_walk($rawCookies, 'trim');
+            foreach ($rawCookies as $cookie) {
+                if (strpos($cookie, '=') === false) {
+                    continue;
+                }
+                list($key, $val) = explode('=', $cookie);
+                $cookies[$key] = rawurldecode($val);
+            }
+        }
+        $_COOKIE = $cookies;
         $data = $this->dispatcher->dispatch($this);
+        $_COOKIE = $cookieStash;
 
         $response = new HttpResponse($data->getStatus(), $data->getHeaders(), '');
         $response->setBody($data->getData());

--- a/tests/Models/AccessTokenModelTest.php
+++ b/tests/Models/AccessTokenModelTest.php
@@ -103,7 +103,9 @@ class AccessTokenModelTest extends \PHPUnit_Framework_TestCase {
         $model = new AccessTokenModel('sss');
         $token = $model->issue(1);
         $model->verify($token, true);
-        $model->deleteID($model->trim($token));
+        $row = $model->getToken($model->trim($token));
+        $id = $row['AccessTokenID'];
+        $model->deleteID($id);
         $model->verify($token, true);
     }
 }


### PR DESCRIPTION
First and foremost, this update adds the /tokens endpoint for API v2. To that end, it does several things:

1. Adds index, GET id and DELETE methods to the endpoint. The index will list all of a user's active tokens. Getting a specific token by its AccessTokenID will return a usable `accessToken`. Deleting a token retains the record, but revokes and expires it.
1. To limit the usage of this endpoint to UI operations, some actions require a transient key. By design, API calls dodge transient key checks, so more direct checks have been added to `TokensApiController`. This has necessitated modifications to `Gdn_Session` to allow better access to its transient key generation/verification methods.
1. The AccessToken table now has an auto-increment primary key: AccessTokenID. InsertUserID has also been added to this table.
1. A new permission, Garden.Tokens.Add, has been added. Users with this permission have access to managing their own access tokens for a site.
1. `AccessTokenModel` has been updated alongside the AccessToken table. `AccessTokenModel::getID` looks up an access token by the AccessTokenID field. `AccessTokenModel::getToken` looks up an access token by the Token field.
1. `InternalClient`, used in automated testing, has been updated to allow GET and POST calls with a transient key field.
1. `InternalRequest`, also used in automated testing, has been updated to support cookies.
1. Unit tests have been added for the /tokens endpoint.

Closes #5876