### PR TITLE
Add missing throws to Controller::permission()

### DIFF
--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -61,7 +61,9 @@ abstract class Controller implements InjectableInterface {
      * When passing several permissions to check the user can have any of the permissions. If you want to force several
      * permissions then make several calls to this method.
      *
-     * @throws \Exception
+     * @throws \Exception if no session is available.
+     * @throws HttpException if a ban has been applied on the permission(s) for this session.
+     * @throws PermissionException if the user does not have the specified permission(s).
      *
      * @param string|array $permission The permissions you are requiring.
      * @param int|null $id The ID of the record we are checking the permission of.

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -61,6 +61,8 @@ abstract class Controller implements InjectableInterface {
      * When passing several permissions to check the user can have any of the permissions. If you want to force several
      * permissions then make several calls to this method.
      *
+     * @throws \Exception
+     *
      * @param string|array $permission The permissions you are requiring.
      * @param int|null $id The ID of the record we are checking the permission of.
      */


### PR DESCRIPTION
Seems like we failed to properly do the Controller::permission() docblock.

