### PR TITLE
Fix “All messages” string for translations

### DIFF
--- a/applications/conversations/views/messages/popin.php
+++ b/applications/conversations/views/messages/popin.php
@@ -45,7 +45,7 @@
         <?php endforeach; ?>
         <li class="Item Center">
             <?php
-            echo anchor(sprintf(t('All %s'), t('Messages')), '/messages/inbox');
+            echo anchor(t('All Messages'), '/messages/inbox');
             ?>
         </li>
     <?php else: ?>


### PR DESCRIPTION
This is to un-couple "All" and "messages" for more accurate translations in certain languages.