### PR TITLE
Fix events not firing when using discussionID in /comments endpoint index

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -249,14 +249,14 @@ class CommentsApiController extends AbstractApiController {
             $after = $after->format(DateTime::ATOM);
         }
 
+        list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
+
         // Lookup by discussion or by user?
         if (array_key_exists('discussionID', $query)) {
             $discussion = $this->discussionByID($query['discussionID']);
-            list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
             $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $discussion['CategoryID']);
 
-            // Build up the where clause.
-            $where = ['DiscussionID' => $query['discussionID'], 'joinUsers' => false];
+            $where = [];
 
             if (isset($query['insertUserID'])) {
                 $where['InsertUserID'] = $query['insertUserID'];
@@ -266,18 +266,17 @@ class CommentsApiController extends AbstractApiController {
                 $where['DateInserted >'] = $after;
             }
 
-            $rows = $this->commentModel->getWhere(
-                $where,
-                'DateInserted',
-                'asc',
+            $rows = $this->commentModel->getByDiscussion(
+                $query['discussionID'],
                 $limit,
-                $offset
+                $offset,
+                $where
             )->resultArray();
         } else {
             $rows = $this->commentModel->getByUser2(
                 $query['insertUserID'],
-                $query['limit'],
-                $query['offset'],
+                $limit,
+                $offset,
                 false,
                 $after,
                 'asc'


### PR DESCRIPTION
The /comments endpoint index allow querying comments by discussion ID. Currently, this is done with `CommentModel::getWhere`. However, this method doesn't provide the hooks some addons use to modify comment content.

This update alters `CommentModel::getByDiscussion` to include a `$where` parameter. The contents of this parameter are passed along to the comment query, so additional filtering (InsertUserID, DateInserted, etc.) can be applied on top of filtering by the discussion ID.

There was a minor issue with paginating comments when querying by user, so I opted to solve that here, as well.

Closes #5854