### PR TITLE
Use photoUrl in users API v2 endpoint

### DIFF
--- a/applications/dashboard/controllers/Api/UsersApiController.php
+++ b/applications/dashboard/controllers/Api/UsersApiController.php
@@ -71,12 +71,12 @@ class UsersApiController extends AbstractApiController {
             'photo:s' => [
                 'allowNull' => true,
                 'minLength' => 0,
-                'description' => 'Photo of the user.'
+                'description' => 'Raw photo field value from the user record.'
             ],
             'photoUrl:s' => [
                 'allowNull' => true,
                 'minLength' => 0,
-                'description' => 'Url to the user photo.'
+                'description' => 'URL to the user photo.'
             ],
             'confirmed:b' => 'Is the user confirmed?',
             'showEmail:b' => 'Is the email address visible to other users?',

--- a/applications/dashboard/controllers/Api/UsersApiController.php
+++ b/applications/dashboard/controllers/Api/UsersApiController.php
@@ -73,6 +73,11 @@ class UsersApiController extends AbstractApiController {
                 'minLength' => 0,
                 'description' => 'Photo of the user.'
             ],
+            'photoUrl:s' => [
+                'allowNull' => true,
+                'minLength' => 0,
+                'description' => 'Url to the user photo.'
+            ],
             'confirmed:b' => 'Is the user confirmed?',
             'showEmail:b' => 'Is the email address visible to other users?',
             'verified:b' => 'Has the user been verified?',
@@ -176,6 +181,9 @@ class UsersApiController extends AbstractApiController {
         $query = $in->validate($query);
         list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
         $rows = $this->userModel->search('', '', '', $limit, $offset)->resultArray();
+        foreach ($rows as &$row) {
+            $this->prepareRow($row);
+        }
 
         $result = $out->validate($rows);
         return $result;
@@ -193,7 +201,9 @@ class UsersApiController extends AbstractApiController {
             $row['roles'] = $roles;
         }
         if (array_key_exists('Photo', $row)) {
-            $row['Photo'] = userPhotoUrl($row);
+            $photo = userPhotoUrl($row);
+            $row['Photo'] = $photo;
+            $row['PhotoUrl'] = $photo;
         }
     }
 
@@ -218,6 +228,7 @@ class UsersApiController extends AbstractApiController {
         $userData['UserID'] = $id;
         $this->userModel->save($userData);
         $row = $this->userByID($id);
+        $this->prepareRow($row);
 
         $result = $out->validate($row);
         return $result;
@@ -353,7 +364,7 @@ class UsersApiController extends AbstractApiController {
      */
     public function userSchema($type = '') {
         if ($this->userSchema === null) {
-            $schema = Schema::parse(['userID', 'name', 'email', 'photo', 'confirmed',
+            $schema = Schema::parse(['userID', 'name', 'email', 'photoUrl', 'confirmed',
                 'showEmail', 'verified', 'banned', 'roles?']);
             $schema = $schema->add($this->fullSchema());
             $this->userSchema = $this->schema($schema, 'User');

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -90,6 +90,29 @@ class UsersTest extends AbstractResourceTest {
     }
 
     /**
+     * Test PATCH /users/<id> with a full record overwrite.
+     */
+    public function testPatchFull() {
+        $row = $this->testGetEdit();
+        $newRow = $this->modifyRow($row);
+
+        $r = $this->api()->patch(
+            "{$this->baseUrl}/{$row[$this->pk]}",
+            $newRow
+        );
+
+        $this->assertEquals(200, $r->getStatusCode());
+
+        // Setting a photo requires the "photo" field, but output schemas use "photoUrl" as a URL to the actual photo. Account for that.
+        $newRow['photoUrl'] = $newRow['photo'];
+        unset($newRow['photo']);
+
+        $this->assertRowsEqual($newRow, $r->getBody(), true);
+
+        return $r->getBody();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function testPost($record = null, array $extra = []) {


### PR DESCRIPTION
The standard for outputting a user's photo as part of a record in API endpoints is in the `photoUrl` field. The output schema used under the /users API v2 isn't adopting this standard and only uses the normal "photo" field.

This update alters the output schemas under the /users endpoint to put a URL to a user's photo under the `photoUrl` field.

"Photo" is going to remain a part of the full schema of the user record, because it is beneficial for setting a photo or reading a raw photo value (e.g. s3://path/to/file.jpg), whereas photoUrl should always be a client-consumable URL to the file.

Closes #5900