### PR TITLE
Add ability to move categories between parents with API v2

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -129,6 +129,7 @@ class CategoriesApiController extends AbstractApiController {
             'parentCategoryID:i' => 'Parent category ID.',
             'urlCode:s' => 'The URL code of the category.',
             'url:s' => 'The URL to the category.',
+            'countCategories:i' => 'Total number of child categories.',
             'countDiscussions:i' => 'Total discussions in the category.',
             'countComments:i' => 'Total comments in the category.',
             'countAllDiscussions:i' => 'Total of all discussions in a category and its children.',
@@ -408,6 +409,7 @@ class CategoriesApiController extends AbstractApiController {
 
         if ($rebuildTree) {
             $this->categoryModel->rebuildTree();
+            $this->categoryModel->recalculateTree();
         }
 
         $result = $this->category($categoryID);

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -126,6 +126,7 @@ class CategoriesApiController extends AbstractApiController {
                 'minLength' => 0,
                 'allowNull' => true
             ],
+            'parentCategoryID:i' => 'Parent category ID.',
             'urlCode:s' => 'The URL code of the category.',
             'url:s' => 'The URL to the category.',
             'countDiscussions:i' => 'Total discussions in the category.',
@@ -299,7 +300,10 @@ class CategoriesApiController extends AbstractApiController {
     public function patch($id, array $body) {
         $this->permission('Garden.Settings.Manage');
 
-        $in = $this->categoryPostSchema('in', ['description'])->setDescription('Update a category.');
+        $in = $this->categoryPostSchema('in', [
+            'description',
+            'parentCategoryID' => 'Parent category ID. Changing a category\'s parent will rebuild the category tree.'
+        ])->setDescription('Update a category.');
         $out = $this->schemaWithParent(false, 'out');
 
         $body = $in->validate($body, true);

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -12,6 +12,9 @@ namespace VanillaTests\APIv2;
  */
 class CategoriesTest extends AbstractResourceTest {
 
+    /** This category should never exist. */
+    const BAD_CATEGORY_ID = 999;
+
     /** The standard parent category ID. */
     const PARENT_CATEGORY_ID = 1;
 
@@ -81,5 +84,110 @@ class CategoriesTest extends AbstractResourceTest {
         $row = $this->testPost();
         $result = parent::testGetEdit($row);
         return $result;
+    }
+
+    /**
+     * Ensure moving a category actually moves it and updates the new parent's category count.
+     */
+    public function testMove() {
+        $parent = $this->api()->post(
+            $this->baseUrl,
+            [
+                'name' => 'Test Parent Category',
+                'urlCode' => 'test-parent-category',
+                'parentCategoryID' => -1
+            ]
+        )->getBody();
+        $row = $this->api()->post(
+            $this->baseUrl,
+            [
+                'name' => 'Test Child Category',
+                'urlCode' => 'test-child-category',
+                'parentCategoryID' => self::PARENT_CATEGORY_ID
+            ]
+        )->getBody();
+
+        $this->api()->patch(
+            "{$this->baseUrl}/{$row[$this->pk]}",
+            ['parentCategoryID' => $parent[$this->pk]]
+        );
+
+        $updatedRow = $this->api()->get("{$this->baseUrl}/{$row[$this->pk]}")->getBody();
+        $updatedParent = $this->api()->get("{$this->baseUrl}/{$parent[$this->pk]}")->getBody();
+
+        $this->assertEquals($parent['categoryID'], $updatedRow['parentCategoryID']);
+        $this->assertEquals($parent['countCategories']+1, $updatedParent['countCategories']);
+    }
+
+    /**
+     * Verify the proper exception is thrown when moving to a category that doesn't exist.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage The new parent category could not be found.
+     */
+    public function testMoveParentDoesNotExist() {
+        $row = $this->api()->post(
+            $this->baseUrl,
+            [
+                'name' => 'Test Bad Parent',
+                'urlCode' => 'test-bad-parent',
+                'parentCategoryID' => self::PARENT_CATEGORY_ID
+            ]
+        )->getBody();
+        $this->api()->patch(
+            "{$this->baseUrl}/{$row[$this->pk]}",
+            ['parentCategoryID' => self::BAD_CATEGORY_ID]
+        );
+    }
+
+    /**
+     * Verify the proper exception is thrown when trying to make a category the parent of itself.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage A category cannot be the parent of itself.
+     */
+    public function testMoveSelfParent() {
+        $row = $this->api()->post(
+            $this->baseUrl,
+            [
+                'name' => 'Test Child Parent',
+                'urlCode' => 'test-child-parent',
+                'parentCategoryID' => self::PARENT_CATEGORY_ID
+            ]
+        )->getBody();
+        $this->api()->patch(
+            "{$this->baseUrl}/{$row[$this->pk]}",
+            ['parentCategoryID' => $row[$this->pk]]
+        );
+    }
+
+    /**
+     * Verify the proper exception is thrown when trying to move a parent under one of its own children.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage Cannot move a category under one of its own children.
+     */
+    public function testMoveUnderChild() {
+        $row = $this->api()->post(
+            $this->baseUrl,
+            [
+                'name' => 'Test Parent as Child',
+                'urlCode' => 'test-parent-as-child',
+                'parentCategoryID' => self::PARENT_CATEGORY_ID
+            ]
+        )->getBody();
+        $child = $this->api()->post(
+            $this->baseUrl,
+            [
+                'name' => 'Test Child as Parent',
+                'urlCode' => 'test-child-as-parent',
+                'parentCategoryID' => $row[$this->pk]
+            ]
+        )->getBody();
+
+        $this->api()->patch(
+            "{$this->baseUrl}/{$row[$this->pk]}",
+            ['parentCategoryID' => $child[$this->pk]]
+        );
     }
 }


### PR DESCRIPTION
This update adds a PUT action on the /categories API v2 endpoint for moving categories between parents.

To use, perform a PUT request to /api/v2/categories/[categoryID]/parentCategoryID where the body is a JSON of the new value:

```json
{ "parentCategoryID": 123 }
```

Closes #5799 