### PR TITLE
Allow conversation to be created without message

### DIFF
--- a/applications/conversations/models/class.conversationsmodel.php
+++ b/applications/conversations/models/class.conversationsmodel.php
@@ -94,4 +94,44 @@ abstract class ConversationsModel extends Gdn_Model {
         $conversationMembers = $this->getConversationMembers($conversationID);
         return (in_array($userID, $conversationMembers));
     }
+
+    /**
+     * Notify users when a new message is created.
+     *
+     * @param array|object $conversation
+     * @param array|object $message
+     * @param array $notifyUserIDs
+     */
+    protected function notifyUsers($conversation, $message, $notifyUserIDs) {
+        $conversation = (array)$conversation;
+        $message = (array)$message;
+
+        $activity = [
+            'ActivityType' => 'ConversationMessage',
+            'ActivityUserID' => $conversation['InsertUserID'],
+            'HeadlineFormat' => t('HeadlineFormat.ConversationMessage', '{ActivityUserID,User} sent you a <a href="{Url,html}">message</a>'),
+            'RecordType' => 'Conversation',
+            'RecordID' => $conversation['ConversationID'],
+            'Story' => $message['Body'],
+            'ActionText' => t('Reply'),
+            'Format' => val('Format', $message, c('Garden.InputFormatter')),
+            'Route' => "/messages/{$conversation['ConversationID']}#Message_{$message['MessageID']}"
+        ];
+
+        $subject = val('subject', $conversation);
+        if ($subject) {
+            $activity['Story'] = sprintf(t('Re: %s'), $subject).'<br>'.$body;
+        }
+
+        $activityModel = new ActivityModel();
+        foreach ($notifyUserIDs as $userID) {
+            if ($message['InsertUserID'] == $notifyUserID) {
+                continue; // Don't notify self.
+            }
+
+            $activity['NotifyUserID'] = $userID;
+            $activityModel->queue($activity, 'ConversationMessage');
+        }
+        $activityModel->saveQueue();
+    }
 }

--- a/applications/conversations/models/class.conversationsmodel.php
+++ b/applications/conversations/models/class.conversationsmodel.php
@@ -108,7 +108,7 @@ abstract class ConversationsModel extends Gdn_Model {
 
         $activity = [
             'ActivityType' => 'ConversationMessage',
-            'ActivityUserID' => $conversation['InsertUserID'],
+            'ActivityUserID' => $message['InsertUserID'],
             'HeadlineFormat' => t('HeadlineFormat.ConversationMessage', '{ActivityUserID,User} sent you a <a href="{Url,html}">message</a>'),
             'RecordType' => 'Conversation',
             'RecordID' => $conversation['ConversationID'],


### PR DESCRIPTION
Add an option that allows to create a conversation without a message.
This is required by the ConversationAPIController.

Once we have time for it we can refactor both models to be separated instead of being mixed together.

What to check when testing:
- Users notifications (Activities)
- Users unread message count
- Conversation's message related fields (FirstMessageID, LastMessageID, CountMessages...)
- UserConversation message related fields (CountReadMessages, LastMessageID...)
- All the above when adding a user to a conversation that has no messages.

Easy way to clean your DB for testing purpose:
```sql
TRUNCATE GDN_Conversation;
TRUNCATE GDN_ConversationMessage;
TRUNCATE GDN_UserConversation;
UPDATE GDN_User SET CountUnreadConversations = NULL;
DELETE FROM GDN_Activity WHERE ActivityTypeID IN (20, 21);
```

To test the option really easily from the UI you can switch 
`$createMessage = empty($settings['ConversationOnly']);`
to
`$createMessage = !empty($settings['ConversationOnly']);`
in `ConversationModel::save()`

