### PR TITLE
Allow table-related HTML elements to have classes in posts

### DIFF
--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -123,7 +123,10 @@ class VanillaHtmlFormatter {
         'pre',
         'span',
         'strong',
-        'ul'
+        'ul',
+        'table',
+        'tr',
+        'td'
     ];
 
     /** @var array Extra allowed classes. */

--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -126,6 +126,7 @@ class VanillaHtmlFormatter {
         'ul',
         'table',
         'thead',
+        'tbody',
         'tr',
         'th',
         'td',

--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -125,8 +125,11 @@ class VanillaHtmlFormatter {
         'strong',
         'ul',
         'table',
+        'thead',
         'tr',
-        'td'
+        'th',
+        'td',
+        'tfoot'
     ];
 
     /** @var array Extra allowed classes. */

--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -129,7 +129,10 @@ class VanillaHtmlFormatter {
         'tr',
         'th',
         'td',
-        'tfoot'
+        'tfoot',
+        'caption',
+        'col',
+        'colgroup'
     ];
 
     /** @var array Extra allowed classes. */


### PR DESCRIPTION
Presently the VanillaHtmlFormatter will allow certain css classes to be added to certain DOM elements. This PR will allow table, tr and td elements to have css classes added to them. 