### PR TITLE
Add a default for $scanDirs in the addon manager constructor

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -84,7 +84,7 @@ class AddonManager {
      *
      * @param null|string $cacheDir The path to the cache.
      */
-    public function __construct(array $scanDirs, $cacheDir = null) {
+    public function __construct(array $scanDirs = [], $cacheDir = null) {
         $r = true;
         if ($cacheDir !== null) {
             $this->setCacheDir($cacheDir);


### PR DESCRIPTION
This is mainly to support easier testing because the AddonManager is a dependency of so many classes. Using all the defaults in the constructor basically means there are no addons to scan, but that is fine for testing.