### PR TITLE
Switch jquery-ui for the minified version

### DIFF
--- a/applications/dashboard/controllers/class.logcontroller.php
+++ b/applications/dashboard/controllers/class.logcontroller.php
@@ -302,7 +302,7 @@ class LogController extends DashboardController {
         Gdn_Theme::section('Dashboard');
         $this->addJsFile('log.js');
         $this->addJsFile('jquery.expander.js');
-        $this->addJsFile('jquery-ui.js');
+        $this->addJsFile('jquery-ui.min.js');
         $this->addJsFile('jquery.popup.js');
     }
 


### PR DESCRIPTION
We currently have both the minified and non-minified version of jquery-ui in the core js folder [here](https://github.com/vanilla/vanilla/blob/master/js/library/jquery-ui.min.js), but for some reason we are using the the non-minified one. This PR changes that to use the minified version.

This saves ~150kb of every page load that includes these files, in some cases reducing page weight by more than 10%.