### PR TITLE
Add ability to filter and sort discussions endpoint index by pinned status

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -261,13 +261,20 @@ class DiscussionsApiController extends AbstractApiController {
 
         $pinned = array_key_exists('pinned', $query) ? $query['pinned'] : null;
         if ($pinned === true) {
+            if (array_key_exists('categoryID', $where)) {
+                $where['d.CategoryID'] = $where['categoryID'];
+            }
             $rows = $this->discussionModel->getAnnouncements($where, $offset, $limit)->resultArray();
         } elseif ($pinned === false) {
             $rows = $this->discussionModel->getWhereRecent($where, $limit, $offset)->resultArray();
         } else {
             $pinOrder = array_key_exists('pinOrder', $query) ? $query['pinOrder'] : null;
             if ($pinOrder == 'first') {
+                if (array_key_exists('categoryID', $where)) {
+                    $where['d.CategoryID'] = $where['categoryID'];
+                }
                 $announcements = $this->discussionModel->getAnnouncements($where, $offset, $limit)->resultArray();
+                unset($where['d.CategoryID']);
                 $discussions = $this->discussionModel->getWhereRecent($where, $limit, $offset)->resultArray();
                 $rows = array_merge($announcements, $discussions);
             } else {

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -125,7 +125,7 @@ class DiscussionsApiController extends AbstractApiController {
             'insertUser?' => $this->getUserFragmentSchema(),
             'bookmarked:b' => 'Whether or no the discussion is bookmarked by the current user.',
             'announce:b' => 'Whether or not the discussion has been announced (pinned).',
-            'pinned:b|n' => 'Whether or not the discussion has been pinned.',
+            'pinned:b?' => 'Whether or not the discussion has been pinned.',
             'pinLocation:s|n' => [
                 'enum' => ['category', 'discussions'],
                 'description' => 'The location for the discussion, if pinned.'
@@ -227,10 +227,7 @@ class DiscussionsApiController extends AbstractApiController {
 
         $in = $this->schema([
             'categoryID:i?' => 'Filter by a category.',
-            'pinned:b|n' => [
-                'default' => null,
-                'description' => 'Whether or not to include pinned discussions. If true, only return pinned discussions.'
-            ],
+            'pinned:b?' => 'Whether or not to include pinned discussions. If true, only return pinned discussions.',
             'pinOrder:s?' => [
                 'enum' => ['first', 'mixed'],
                 'description' => 'If including pinned posts, in what order should they be integrated?'
@@ -262,7 +259,7 @@ class DiscussionsApiController extends AbstractApiController {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $where['categoryID']);
         }
 
-        $pinned = $query['pinned'];
+        $pinned = array_key_exists('pinned', $query) ? $query['pinned'] : null;
         if ($pinned === true) {
             $rows = $this->discussionModel->getAnnouncements($where, $offset, $limit)->resultArray();
         } elseif ($pinned === false) {

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -227,10 +227,10 @@ class DiscussionsApiController extends AbstractApiController {
 
         $in = $this->schema([
             'categoryID:i?' => 'Filter by a category.',
-            'pinned:b?' => 'Whether or not to include pinned discussions. If true, only return pinned discussions.',
+            'pinned:b?' => 'Whether or not to include pinned discussions. If true, only return pinned discussions. Discussions pinned in specific categories are not included unless the categoryID parameter is used.',
             'pinOrder:s?' => [
                 'enum' => ['first', 'mixed'],
-                'description' => 'If including pinned posts, in what order should they be integrated?'
+                'description' => 'If including pinned posts, in what order should they be integrated? Not compatible with the pinned parameter.'
             ],
             'page:i?' => [
                 'description' => 'Page number.',

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -128,7 +128,7 @@ class DiscussionsApiController extends AbstractApiController {
             'pinned:b?' => 'Whether or not the discussion has been pinned.',
             'pinLocation:s|n' => [
                 'enum' => ['category', 'recent'],
-                'description' => 'The location for the discussion, if pinned.'
+                'description' => 'The location for the discussion, if pinned. "category" are pinned to their own category. "recent" are pinned to the recent discussions list, as well as their own category.'
             ],
             'closed:b' => 'Whether the discussion is closed or open.',
             'sink:b' => 'Whether or not the discussion has been sunk.',

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1062,6 +1062,22 @@ class DiscussionModel extends Gdn_Model {
             $discussion->LastDate = $discussion->DateInserted;
         }
 
+        // Translate Announce to Pinned.
+        $pinned = false;
+        $pinLocation = null;
+        if (property_exists($discussion, 'Announce') && $discussion->Announce > 0) {
+            $pinned = true;
+            switch (intval($discussion->Announce)) {
+                case 1:
+                    $pinLocation = 'discussions';
+                    break;
+                case 2:
+                    $pinLocation = 'category';
+            }
+        }
+        $discussion->pinned = $pinned;
+        $discussion->pinLocation = $pinLocation;
+
         $this->EventArguments['Discussion'] = &$discussion;
         $this->fireEvent('SetCalculatedFields');
     }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1069,7 +1069,7 @@ class DiscussionModel extends Gdn_Model {
             $pinned = true;
             switch (intval($discussion->Announce)) {
                 case 1:
-                    $pinLocation = 'discussions';
+                    $pinLocation = 'recent';
                     break;
                 case 2:
                     $pinLocation = 'category';
@@ -1133,11 +1133,22 @@ class DiscussionModel extends Gdn_Model {
         $this->SQL->select('d.DiscussionID')
             ->from('Discussion d');
 
-        if (!is_array($categoryID) && ($categoryID > 0 || $groupID > 0)) {
-            $this->SQL->where('d.Announce >', '0');
-        } else {
-            $this->SQL->where('d.Announce', 1);
+        $announceOverride = false;
+        $whereFields = array_keys($wheres);
+        foreach ($whereFields as $field) {
+            if (stringBeginsWith($field, 'd.Announce')) {
+                $announceOverride = true;
+                break;
+            }
         }
+        if (!$announceOverride) {
+            if (!is_array($categoryID) && ($categoryID > 0 || $groupID > 0)) {
+                $this->SQL->where('d.Announce >', '0');
+            } else {
+                $this->SQL->where('d.Announce', 1);
+            }
+        }
+
         if ($groupID > 0) {
             $this->SQL->where('d.GroupID', $groupID);
         } elseif (is_array($categoryID)) {


### PR DESCRIPTION
This update adds the ability to sort and filter the discussions endpoint index by pinned/announced status. The implementation follows what is seen on Vanilla's frontend. If you have 30 normal discussions in a result and there are two pinned discussions, your result is going to be 32 total discussions.

Specifics on usage of the new parameters can be found in the associated issue.

Closes #5534