### PR TITLE
Remove Database.CharacterEncoding from inf configs

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -892,7 +892,7 @@ if (c('Garden.Registration.CaptchaPublicKey')) {
 }
 
 // Remove Charset from inf.
-if (c('Database.CharacterEncoding')) {
+if (c('Database.CharacterEncoding') !== 'utf8mb4') {
     removeFromConfig('Database.CharacterEncoding');
     removeFromConfig('Database.ExtendedProperties.Collate');
 }

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -891,6 +891,11 @@ if (c('Garden.Registration.CaptchaPublicKey')) {
     removeFromConfig('Garden.Registration.CaptchaPublicKey');
 }
 
+// Remove Charset from inf.
+if (c('Database.CharacterEncoding')) {
+    removeFromConfig('Database.CharacterEncoding');
+}
+
 // Make sure the smarty folders exist.
 touchFolder(PATH_CACHE.'/Smarty/cache');
 touchFolder(PATH_CACHE.'/Smarty/compile');

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -894,6 +894,7 @@ if (c('Garden.Registration.CaptchaPublicKey')) {
 // Remove Charset from inf.
 if (c('Database.CharacterEncoding')) {
     removeFromConfig('Database.CharacterEncoding');
+    removeFromConfig('Database.ExtendedProperties.Collate');
 }
 
 // Make sure the smarty folders exist.


### PR DESCRIPTION
This is a pure infrastructure change, so it should never go to `master`.

When we added utf8mb4 compatibility as the default, we manually set every existing forum to use utf8 via the config so we wouldn't get an impromptu change. We're now ready to do that switchover, and ops has already made the necessary changes to the my.cnf. So now it's time to undo the manual setting of this config globally.

Because we've already deployed a change effecting the collation, we're currently blocked from further database changes until this is deployed and activated.