### PR TITLE
Add ability to retrieve bookmarked discussions with API v2

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -69,7 +69,6 @@ class DiscussionsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'insertUserID:i?' => 'Filter by author.',
             'expand:b?' => 'Expand associated records.'
         ], 'in');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -83,6 +83,9 @@ class DiscussionsApiController extends AbstractApiController {
         if (!empty($query['expand'])) {
             $this->userModel->expandUsers($rows, ['InsertUserID']);
         }
+        foreach ($rows as &$currentRow) {
+            $this->prepareRow($currentRow);
+        }
 
         $result = $out->validate($rows);
         return $result;

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -34,4 +34,17 @@ class DiscussionsTest extends AbstractResourceTest {
         ];
         return $fields;
     }
+
+    /**
+     * Verify a bookmarked discussion shows up under /discussions/bookmarked.
+     */
+    public function testBookmarked() {
+        $row = $this->testPost();
+        $rowID = $row['discussionID'];
+        $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/bookmark", ['bookmarked' => 1]);
+        $bookmarked = $this->api()->get("{$this->baseUrl}/bookmarked")->getBody();
+        $discussionIDs = array_column($bookmarked, 'discussionID');
+        print_r($discussionIDs);
+        $this->assertContains($rowID, $discussionIDs);
+    }
 }

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -44,7 +44,6 @@ class DiscussionsTest extends AbstractResourceTest {
         $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/bookmark", ['bookmarked' => 1]);
         $bookmarked = $this->api()->get("{$this->baseUrl}/bookmarked")->getBody();
         $discussionIDs = array_column($bookmarked, 'discussionID');
-        print_r($discussionIDs);
         $this->assertContains($rowID, $discussionIDs);
     }
 }


### PR DESCRIPTION
This update adds the ability to pull the current user's bookmarked discussions with the API, using a GET request to /discussions/bookmarked. Available query parameters are:

1. `page` - The current page (defaults to 1).
1. `limit` - The maximum number of records to return, per page (defaults to the value of the Vanilla.Discussions.PerPage config or 50).
1. `expand` - Whether or not to insert a user record fragment for discussion authors.

A simple test is included to verify a bookmarked discussion shows up beneath /discussions/bookmarked.

Closes #5532 