### PR TITLE
Require PHPUnit ~5.0 as a dev install to allow unit testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,9 @@
         "vanilla/nbbc": "~2.1",
         "vanilla/garden-schema": "^1.4.2"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~5.0"
+    },
     "provide": {
         "ext-gd": "*"
     },


### PR DESCRIPTION
Install PHPUnit as a development dependency.
This allows for unit testing locally without installing phpunit elsewhere.

Especially useful for https://github.com/vanilla/vanilla-docker