### PR TITLE
Move session initiation in SiteTestTrait

### DIFF
--- a/tests/InternalClient.php
+++ b/tests/InternalClient.php
@@ -84,6 +84,10 @@ class InternalClient extends HttpClient {
     public function setUserID($userID) {
         $this->userID = $userID;
 
+        /* @var \Gdn_Session $session */
+        $session = $this->container->get(\Gdn_Session::class);
+        $session->start($userID, false, false);
+        
         return $this;
     }
 }

--- a/tests/InternalClient.php
+++ b/tests/InternalClient.php
@@ -87,7 +87,7 @@ class InternalClient extends HttpClient {
         /* @var \Gdn_Session $session */
         $session = $this->container->get(\Gdn_Session::class);
         $session->start($userID, false, false);
-        
+
         return $this;
     }
 }

--- a/tests/InternalClient.php
+++ b/tests/InternalClient.php
@@ -84,10 +84,6 @@ class InternalClient extends HttpClient {
     public function setUserID($userID) {
         $this->userID = $userID;
 
-        /* @var \Gdn_Session $session */
-        $session = $this->container->get(\Gdn_Session::class);
-        $session->start($userID, false, false);
-
         return $this;
     }
 }

--- a/tests/SiteTestTrait.php
+++ b/tests/SiteTestTrait.php
@@ -62,6 +62,10 @@ trait SiteTestTrait {
         ]);
 
         self::$siteInfo = $result;
+
+        /* @var \Gdn_Session $session */
+        $session = $dic->get(\Gdn_Session::class);
+        $session->start(self::$siteInfo['adminUserID'], false, false);
     }
 
     /**


### PR DESCRIPTION
This allows APIController calls in `setupBeforeClass` methods.
Otherwise you get permissions exceptions.

Example: https://github.com/vanilla/vanilla/blob/fa2b4ea8429b9c052f57edf087d784f0f8aa7939/tests/APIv2/MessagesTest.php#L31