### PR TITLE
Fix deprecated call to Gdn::factory()->exists causing tests to fail

### DIFF
--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -460,7 +460,7 @@ class AssetModel extends Gdn_Model {
         $result = ['php'];
         foreach ($knownExts as $ext) {
             $handler = "ViewHandler.$ext";
-            if (Gdn::factory()->exists($handler)) {
+            if (Gdn::factoryExists($handler)) {
                 $result[] = $ext;
             }
         }


### PR DESCRIPTION
This was raising a deprecated notice which would make unit tests fails.