### PR TITLE
Add conversations and messages API controllers

### DIFF
--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -104,8 +104,6 @@ class ConversationsApiController extends AbstractApiController {
 //
 //        $this->conversationByID($id);
 //        $this->conversationModel->deleteID($id);
-//
-//        return new Data([], 204);
 //    }
 
 
@@ -114,7 +112,6 @@ class ConversationsApiController extends AbstractApiController {
      *
      * @param int $id The ID of the conversation.
      * @throws NotFoundException if the conversation could not be found.
-     * @return Data
      */
     public function delete_leave($id) {
         $this->permission('Garden.SignIn.Allow');
@@ -125,8 +122,6 @@ class ConversationsApiController extends AbstractApiController {
         $this->conversationByID($id);
 
         $this->conversationModel->clear($id, $this->getSession()->UserID);
-
-        return new Data([], 204);
     }
 
     /**
@@ -168,7 +163,7 @@ class ConversationsApiController extends AbstractApiController {
      *
      * @param int $id The ID of the conversation.
      * @throws NotFoundException if the conversation could not be found.
-     * @return Data
+     * @return array
      */
     public function get($id) {
         $this->permission('Conversations.Conversations.Add');
@@ -205,7 +200,7 @@ class ConversationsApiController extends AbstractApiController {
      * @param int $id The ID of the conversation.
      * @param array $query The query string.
      * @throws NotFoundException if the conversation could not be found.
-     * @return Data
+     * @return array
      */
     public function get_participants($id, array $query) {
         $this->permission('Conversations.Conversations.Add');
@@ -313,7 +308,7 @@ class ConversationsApiController extends AbstractApiController {
             $this->userModel->expandUsers($conversations, ['InsertUserID']);
         }
 
-        return $out->validate($conversations, true);
+        return $out->validate($conversations);
     }
 
     /**

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -135,32 +135,32 @@ class ConversationsApiController extends AbstractApiController {
      * @return Schema
      */
     private function fullSchema() {
-        $schemaDefinition = [
-            'conversationID:i' => 'The ID of the conversation.',
-            'name:s?' => 'The name of the conversation.',
-            'dateInserted:dt' => 'When the conversation was created.',
-            'insertUserID:i' => 'The user that created the conversation.',
-            'insertUser:o?' => $this->getUserFragmentSchema(),
-            'countParticipants:i' => 'The number of participants on the conversation.',
-            'countMessages:i' => 'The number of messages on the conversation.',
-            'countReadMessages:n|i?' => 'The number of unread messages by the current user on the conversation.',
-            'dateLastViewed:n|dt?' => 'When the conversation was last viewed by the current user.',
-        ];
+        /** @var Schema $schema */
+        static $schema;
 
-        // We unset to preserve the order of the parameters.
-        if (!$this->config->get('Conversations.Subjects.Visible', false)) {
-            unset($schemaDefinition['name:s?']);
+        if ($schema === null) {
+            $schemaDefinition = [
+                'conversationID:i' => 'The ID of the conversation.',
+                'name:s?' => 'The name of the conversation.',
+                'dateInserted:dt' => 'When the conversation was created.',
+                'insertUserID:i' => 'The user that created the conversation.',
+                'insertUser:o?' => $this->getUserFragmentSchema(),
+                'countParticipants:i' => 'The number of participants on the conversation.',
+                'countMessages:i' => 'The number of messages on the conversation.',
+                'countReadMessages:n|i?' => 'The number of unread messages by the current user on the conversation.',
+                'dateLastViewed:n|dt?' => 'When the conversation was last viewed by the current user.',
+            ];
+
+            // We unset to preserve the order of the parameters.
+            if (!$this->config->get('Conversations.Subjects.Visible', false)) {
+                unset($schemaDefinition['name:s?']);
+            }
+
+            // Name this schema so that it can be read by swagger.
+            $schema = $this->schema($schemaDefinition, 'Conversation');
         }
 
-        static $fullSchema;
-        if ($fullSchema === null) {
-            $fullSchema = Schema::parse($schemaDefinition);
-
-            // Trigger schema event for swagger.
-            $this->schema($fullSchema, 'Conversations');
-        }
-
-        return $fullSchema;
+        return $schema;
     }
 
     /**

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -378,6 +378,7 @@ class ConversationsApiController extends AbstractApiController {
         $in = $this->postSchema('in')->setDescription('Add participants to a conversation.');
         $this->schema([], 'out');
 
+        // Not found exception thrown if the conversation does not exist.
         $this->conversationByID($id);
 
         $body = $in->validate($body);
@@ -387,7 +388,10 @@ class ConversationsApiController extends AbstractApiController {
             throw new ServerException('Unable to add participants.', 500);
         }
 
-        return new Data([], 201);
+        // Fetch up to date conversation.
+        $conversation = $this->conversationByID($id);
+
+        return new Data($conversation, 201);
     }
 
     /**

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -104,6 +104,8 @@ class ConversationsApiController extends AbstractApiController {
 //
 //        $this->conversationByID($id);
 //        $this->conversationModel->deleteID($id);
+//
+//        return new Data([], 204);
 //    }
 
 

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -1,0 +1,440 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+use Garden\Schema\Schema;
+use Garden\Web\Data;
+use Garden\Web\Exception\NotFoundException;
+use Garden\Web\Exception\ServerException;
+use Vanilla\Utility\CapitalCaseScheme;
+
+/**
+ * API Controller for the `/conversations` resource.
+ */
+class ConversationsApiController extends AbstractApiController {
+
+    /** @var CapitalCaseScheme */
+    private $caseScheme;
+
+    /** @var ConversationModel */
+    private $conversationModel;
+
+    /** @var UserModel */
+    private $userModel;
+
+    /**
+     * ConversationsApiController constructor.
+     *
+     * @param ConversationModel $conversationModel
+     * @param UserModel $userModel
+     */
+    public function __construct(ConversationModel $conversationModel, UserModel $userModel) {
+        $this->caseScheme = new CapitalCaseScheme();
+        $this->conversationModel = $conversationModel;
+        $this->userModel = $userModel;
+    }
+
+    /**
+     * Check that the user has moderation rights over conversations.
+     *
+     * @throw Exception
+     */
+    private function checkModerationPermission() {
+        if (!c('ConversationMessages.Moderation.Allow', false)) {
+            throw permissionException();
+        }
+        $this->permission('ConversationMessages.Moderation.Manage');
+    }
+
+    /**
+     * Get a conversation by its numeric ID.
+     *
+     * @param int $id The conversation ID.
+     * @param int|null $viewingUserID The user viewing the conversation. Should only be set if user is part of the conversation.
+     * @throws NotFoundException if the conversation could not be found.
+     * @return array
+     */
+    private function conversationByID($id, $viewingUserID = null) {
+        if ($viewingUserID) {
+            $options = ['viewingUserID' => $viewingUserID];
+        } else {
+            $options = [];
+        }
+
+        $conversation = $this->conversationModel->getID($id, DATASET_TYPE_ARRAY, $options);
+        if (!$conversation) {
+            throw new NotFoundException('Conversation');
+        }
+
+        return $conversation;
+    }
+
+//
+//    Uncomment and test once ConversationModel::delete() is properly implemented.
+//    See https://github.com/vanilla/vanilla/issues/5897 for details.
+//
+//    /**
+//     * Delete a conversation.
+//     *
+//     * @param int $id The ID of the conversation.
+//     * @≠=throws NotFoundException if the conversation could not be found.
+//     * @throws MethodNotAllowedException if Conversations.Moderation.Allow !== true.
+//     */
+//    public function delete($id) {
+//        if (!c('Conversations.Moderation.Allow', false)) {
+//            throw new MethodNotAllowedException();
+//        }
+//
+//        $this->permission('Conversations.Moderation.Manage');
+//
+//        $this->schema(['id:i' => 'The conversation ID'])->setDescription('Delete a conversation.');
+//        $this->schema([], 'out');
+//
+//        $this->conversationByID($id);
+//        $this->conversationModel->deleteID($id);
+//    }
+
+
+    /**
+     * Leave a conversation.
+     *
+     * @param int $id The ID of the conversation.
+     * @throws NotFoundException if the conversation could not be found.
+     * @return Data
+     */
+    public function delete_leave($id) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $this->idParamSchema()->setDescription('Leave a conversation.');
+        $this->schema([], 'out');
+
+        $this->conversationByID($id);
+
+        $this->conversationModel->clear($id, $this->getSession()->UserID);
+
+        return new Data([], 204);
+    }
+
+    /**
+     * Get the schema definition comprised of all available conversation fields.
+     *
+     * @return Schema
+     */
+    private function fullSchema() {
+        $schemaDefinition = [
+            'conversationID:i' => 'The ID of the conversation.',
+            'name:s?' => 'The name of the conversation.',
+            'dateInserted:dt' => 'When the conversation was created.',
+            'insertUserID:i' => 'The user that created the conversation.',
+            'insertUser:o?' => $this->getUserFragmentSchema(),
+            'countParticipants:i' => 'The number of participants on the conversation.',
+            'countMessages:i' => 'The number of messages on the conversation.',
+            'countReadMessages:n|i?' => 'The number of unread messages by the current user on the conversation.',
+            'dateLastViewed:n|dt?' => 'When the conversation was last viewed by the current user.',
+        ];
+
+        // We unset to preserve the order of the parameters.
+        if (!c('Conversations.Subjects.Visible', false)) {
+            unset($schemaDefinition['name:s?']);
+        }
+
+        static $schemaInitialized = false;
+        if (!$schemaInitialized) {
+            $schemaInitialized = true;
+            $schema = $this->schema($schemaDefinition, 'Conversations');
+        } else {
+            $schema = Schema::parse($schemaDefinition);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Get a conversation.
+     *
+     * @param int $id The ID of the conversation.
+     * @throws NotFoundException if the conversation could not be found.
+     * @return Data
+     */
+    public function get($id) {
+        $this->permission('Conversations.Conversations.Add');
+
+        $this->idParamSchema()->setDescription('Get a conversation.');
+        $out = $this->schema($this->fullSchema(), 'out');
+
+        $isInConversation = $this->conversationModel->inConversation($id, $this->getSession()->UserID);
+        if ($isInConversation) {
+            $viewingUserID = $this->getSession()->UserID;
+        } else {
+            $viewingUserID = null;
+        }
+
+        $conversation = $this->conversationByID($id, $viewingUserID);
+        $data = [&$conversation];
+        $this->conversationModel->joinParticipants($data, 1000);
+
+        // We check for the moderation permission after we get the conversation to make sure that it actually exists.
+        if (!$isInConversation) {
+            $this->checkModerationPermission();
+        }
+
+        $this->userModel->expandUsers($conversation, ['InsertUserID']);
+
+        $conversation = $this->normalizeConversation($conversation);
+
+        return $out->validate($conversation);
+    }
+
+    /**
+     * Get the conversation participants.
+     *
+     * @param int $id The ID of the conversation.
+     * @param array $query The query string.
+     * @throws NotFoundException if the conversation could not be found.
+     * @return Data
+     */
+    public function get_participants($id, array $query) {
+        $this->permission('Conversations.Conversations.Add');
+
+        $this->idParamSchema();
+
+        $in = $this->schema([
+            'page:i?' => [
+                'description' => 'Page number.',
+                'default' => 1,
+                'minimum' => 1,
+            ],
+            'limit:i?' => [
+                'description' => 'The number of items per page.',
+                'default' => 5,
+                'minimum' => 5,
+                'maximum' => 100
+            ],
+            'expand:b?' => 'Expand associated records.',
+        ], 'in')->setDescription('Get participants of a conversation.');
+        $out = $this->schema([
+            'participants:a' => [
+                'items' => [
+                    'type'  => 'object',
+                    'properties' => [
+                        'userID' => [
+                            'type' => 'integer',
+                            'description' => 'The ID of the participant.',
+                        ],
+                        'user' => $this->getUserFragmentSchema(),
+                        'deleted' => [
+                            'type' => 'boolean',
+                            'description' => 'True if the user left the conversation.',
+                        ],
+                    ],
+                ],
+                'description' => 'List of participants.',
+            ]
+        ], 'out');
+
+        $query = $in->validate($query, true);
+
+        $this->conversationByID($id);
+
+        list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
+
+        $conversationMembers = $this->conversationModel->getConversationMembers($id, false, $limit, $offset);
+
+        $data = [
+            'participants' => array_values($conversationMembers),
+        ];
+
+        if (!empty($query['expand'])) {
+            $this->userModel->expandUsers($data['participants'], ['UserID']);
+        }
+
+        return $out->validate($data);
+    }
+
+    /**
+     * List conversations of a user.
+     *
+     * @param array $query The query string.
+     * @return array
+     */
+    public function index(array $query) {
+        $this->permission('Conversations.Conversations.Add');
+
+        $in = $this->schema([
+                'participantID:i?' => 'Filter by specified participating user instead of by current user.',
+                'page:i?' => [
+                    'description' => 'Page number.',
+                    'default' => 1,
+                    'minimum' => 1,
+                ],
+                'limit:i?' => [
+                    'description' => 'The number of items per page.',
+                    'default' => c('Conversations.Conversations.PerPage', 50),
+                    'minimum' => 1,
+                    'maximum' => 100
+                ],
+                'expand:b?' => 'Expand associated records.'
+            ], 'in')
+            ->setDescription('List user conversations.');
+        $out = $this->schema([':a' => $this->fullSchema()], 'out');
+
+        $query = $this->filterValues($query);
+        $query = $in->validate($query);
+
+        if (!empty($query['participantID'])) {
+            if ($query['participantID'] !== $this->getSession()->UserID) {
+                $this->checkModerationPermission();
+            }
+            $userID = $query['participantID'];
+        } else {
+            $userID = $this->getSession()->UserID;
+        }
+
+        list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
+
+        $conversations = $this->conversationModel->get2($userID, $offset, $limit)->resultArray();
+
+        if (!empty($query['expand'])) {
+            $this->userModel->expandUsers($conversations, ['InsertUserID']);
+        }
+
+        return $out->validate($conversations, true);
+    }
+
+    /**
+     * Get an ID-only conversation record schema.
+     *
+     * @return Schema Returns a schema object.
+     */
+    private function idParamSchema() {
+        return $this->schema(['id:i' => 'The conversation ID.'], 'in');
+    }
+
+    /**
+     * Add a conversation.
+     *
+     * @param array $body The request body.
+     * @throws ServerException If the conversation could not be created.
+     * @return Data
+     */
+    public function post(array $body) {
+        $this->permission('Conversations.Conversations.Add');
+
+        $in = $this->postSchema('in')->setDescription('Add a conversation.');
+        $out = $this->schema($this->fullSchema(), 'out');
+
+        $body = $in->validate($body);
+        $conversationData = $this->normalizeInput($body);
+        $conversationData = $this->caseScheme->convertArrayKeys($conversationData);
+
+        $conversationID = $this->conversationModel->save($conversationData, ['ConversationOnly' => true]);
+        $this->validateModel($this->conversationModel, true);
+        if (!$conversationID) {
+            throw new ServerException('Unable to insert conversation.', 500);
+        }
+
+        $conversation = $this->conversationByID($conversationID, $this->getSession()->UserID);
+        return new Data(
+            $out->validate($conversation),
+            201
+        );
+    }
+
+    /**
+     * Add participants to a conversation.
+     *
+     * @param int $id The ID of the conversation.
+     * @param array $body The request body.
+     * @throws NotFoundException if the conversation could not be found.
+     * @throws ServerException If the participants could not be added.
+     * @return Data
+     */
+    public function post_participants($id, array $body) {
+        $this->permission('Conversations.Conversations.Add');
+
+        $this->idParamSchema();
+
+        $in = $this->postSchema('in')->setDescription('Add participants to a conversation.');
+        $this->schema([], 'out');
+
+        $this->conversationByID($id);
+
+        $body = $in->validate($body);
+
+        $success = $this->conversationModel->addUserToConversation($id, $body['participantIDs']);
+        if (!$success) {
+            throw new ServerException('Unable to add participants.', 500);
+        }
+
+        return new Data([], 201);
+    }
+
+    /**
+     * Get a post schema with minimal add/edit fields.
+     *
+     * @param string $type The type of schema.
+     * @return Schema Returns a schema object.
+     */
+    public function postSchema($type) {
+        static $postSchema;
+
+        if ($postSchema === null) {
+            $inSchema = [
+                'participantIDs:a' => [
+                    'items' => [
+                        'type'  => 'integer',
+                    ],
+                    'description' => 'List of userID of the participants.',
+                ],
+                'name' => null,
+            ];
+            if (!c('Conversations.Subjects.Visible', false)) {
+                unset($inSchema['name']);
+            }
+
+            $postSchema = $this->schema(
+                Schema::parse($inSchema)->add($this->fullSchema()),
+                'ConversationPost'
+            );
+        }
+
+        return $this->schema($postSchema, $type);
+    }
+
+    /**
+     * Normalize input parameters.
+     *
+     * @param array $input
+     * @return array The normalized input.
+     */
+    private function normalizeInput(array $input) {
+        if (array_key_exists('name', $input)) {
+            $input['subject'] = $input['name'];
+            unset($input['name']);
+        }
+        if (array_key_exists('participantIDs', $input)) {
+            $input['recipientUserID'] = $input['participantIDs'];
+            unset($input['participantIDs']);
+        }
+
+        return $input;
+    }
+
+    /**
+     * Normalize conversation for output.
+     *
+     * @param array $conversation
+     * @return array The normalized conversation.
+     */
+    private function normalizeConversation(array $conversation) {
+        if (array_key_exists('subject', $conversation)) {
+            $conversation['name'] = $conversation['subject'];
+            unset($conversation['subject']);
+        }
+
+        return $conversation;
+    }
+}

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -428,7 +428,7 @@ class ConversationsApiController extends AbstractApiController {
      * @param array $input
      * @return array The normalized input.
      */
-    private function normalizeInput(array $input) {
+    public function normalizeInput(array $input) {
         if (array_key_exists('name', $input)) {
             $input['subject'] = $input['name'];
             unset($input['name']);
@@ -446,7 +446,7 @@ class ConversationsApiController extends AbstractApiController {
      *
      * @param array $conversation
      */
-    private function prepareRow(array &$conversation) {
+    public function prepareRow(array &$conversation) {
         if (array_key_exists('subject', $conversation)) {
             $conversation['name'] = $conversation['subject'];
             unset($conversation['subject']);

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -194,7 +194,7 @@ class ConversationsApiController extends AbstractApiController {
 
         $this->userModel->expandUsers($conversation, ['InsertUserID']);
 
-        $conversation = $this->normalizeConversation($conversation);
+        $this->prepareRow($conversation);
 
         return $out->validate($conversation);
     }
@@ -436,17 +436,14 @@ class ConversationsApiController extends AbstractApiController {
     }
 
     /**
-     * Normalize conversation for output.
+     * Prepare conversation for output.
      *
      * @param array $conversation
-     * @return array The normalized conversation.
      */
-    private function normalizeConversation(array $conversation) {
+    private function prepareRow(array &$conversation) {
         if (array_key_exists('subject', $conversation)) {
             $conversation['name'] = $conversation['subject'];
             unset($conversation['subject']);
         }
-
-        return $conversation;
     }
 }

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -376,7 +376,7 @@ class ConversationsApiController extends AbstractApiController {
         $this->idParamSchema();
 
         $in = $this->postSchema('in')->setDescription('Add participants to a conversation.');
-        $this->schema([], 'out');
+        $out = $this->schema($this->fullSchema(), 'out');
 
         // Not found exception thrown if the conversation does not exist.
         $this->conversationByID($id);
@@ -391,7 +391,10 @@ class ConversationsApiController extends AbstractApiController {
         // Fetch up to date conversation.
         $conversation = $this->conversationByID($id);
 
-        return new Data($conversation, 201);
+        return new Data(
+            $out->validate($conversation),
+            201
+        );
     }
 
     /**

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -246,7 +246,8 @@ class ConversationsApiController extends AbstractApiController {
             ]
         ], 'out');
 
-        $query = $in->validate($query, true);
+        $query = $this->filterValues($query);
+        $query = $in->validate($query);
 
         $this->conversationByID($id);
 

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -239,7 +239,7 @@ class MessagesApiController extends AbstractApiController {
             $this->prepareRow($message);
         });
 
-        return $out->validate($messages, true);
+        return $out->validate($messages);
     }
 
     /**

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -1,0 +1,364 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+use Garden\Schema\Schema;
+use Garden\Web\Data;
+use Garden\Web\Exception\ClientException;
+use Garden\Web\Exception\NotFoundException;
+use Garden\Web\Exception\ServerException;
+use Vanilla\Utility\CapitalCaseScheme;
+
+
+/**
+ * API Controller for the `/messages` resource.
+ */
+class MessagesApiController extends AbstractApiController {
+
+    /** @var CapitalCaseScheme */
+    private $caseScheme;
+
+    /** @var ConversationMessageModel */
+    private $conversationMessageModel;
+
+    /** @var ConversationModel */
+    private $conversationModel;
+
+    /** @var UserModel */
+    private $userModel;
+
+    /**
+     * MessagesApiController constructor.
+     *
+     * @param ConversationMessageModel $conversationMessageModel
+     * @param ConversationModel $conversationModel
+     * @param UserModel $userModel
+     */
+    public function __construct(
+        ConversationModel $conversationModel,
+        ConversationMessageModel $conversationMessageModel,
+        UserModel $userModel
+    ) {
+        $this->caseScheme = new CapitalCaseScheme();
+        $this->conversationMessageModel = $conversationMessageModel;
+        $this->conversationModel = $conversationModel;
+        $this->userModel = $userModel;
+    }
+
+    /**
+     * Check that the user has moderation rights over conversations.
+     *
+     * @throw Exception
+     */
+    private function checkModerationPermission() {
+        if (!c('Conversations.Moderation.Allow', false)) {
+            throw permissionException();
+        }
+        $this->permission('Conversations.Moderation.Manage');
+    }
+
+    /**
+     * Get a conversation by its numeric ID.
+     *
+     * @param int $id The conversation ID.
+     * @throws NotFoundException if the conversation could not be found.
+     * @return array
+     */
+    private function conversationByID($id) {
+        $row = $this->conversationModel->getID($id, DATASET_TYPE_ARRAY);
+        if (!$row) {
+            throw new NotFoundException('Conversation');
+        }
+
+        return $row;
+    }
+
+//
+//    Uncomment once ConversationMessagesModel::delete() is properly implemented.
+//    See https://github.com/vanilla/vanilla/issues/5897 for details.
+//
+//    /**
+//     * Delete a message.
+//     *
+//     * @param int $id The ID of the message.
+//     * @throws NotFoundException if the message could not be found.
+//     * @throws MethodNotAllowedException if Conversations.Moderation.Allow !== true.
+//     */
+//    public function delete($id) {
+//        if (!c('Conversations.Moderation.Allow', false)) {
+//            throw new MethodNotAllowedException();
+//        }
+//
+//        $this->permission('Conversations.Moderation.Manage');
+//
+//        $this->schema(['id:i' => 'The message ID'])->setDescription('Delete a message.');
+//        $this->schema([], 'out');
+//
+//        $this->messageByID($id);
+//        $this->conversationMessagesModel->deleteID($id);
+//    }
+
+    /**
+     * Get the schema definition comprised of all available message fields.
+     *
+     * @return Schema
+     */
+    private function fullSchema() {
+        $schemaDefinition = [
+            'messageID:i' => 'The ID of the message.',
+            'conversationID:i' => 'The ID of the conversation.',
+            'body:s' => 'The body of the message.',
+            'insertUserID:i' => 'The user that created the message.',
+            'insertUser?' => $this->getUserFragmentSchema(),
+            'dateInserted:dt' => 'When the message was created.',
+        ];
+
+        static $schemaInitialized = false;
+        if (!$schemaInitialized) {
+            $schemaInitialized = true;
+            $schema = $this->schema($schemaDefinition, 'Messages');
+        } else {
+            $schema = Schema::parse($schemaDefinition);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Get a message.
+     *
+     * @param int $id The ID of the message.
+     * @throws NotFoundException if the message could not be found.
+     * @return array
+     */
+    public function get($id) {
+        $this->permission('Conversations.Conversations.Add');
+
+        $this->schema([
+            'id:i' => 'The message ID.'
+        ], 'in')->setDescription('Get a message.');
+        $out = $this->schema($this->fullSchema(), 'out');
+
+        $message = $this->messageByID($id);
+
+        $isInConversation = $this->conversationModel->inConversation($message['ConversationID'], $this->getSession()->UserID);
+
+        if (!$isInConversation) {
+            $this->checkModerationPermission();
+        }
+
+        $this->userModel->expandUsers($message, ['InsertUserID']);
+
+        $message = $this->normalizeMessage($message);
+        return $out->validate($message);
+    }
+
+    /**
+     * List messages of a user.
+     *
+     * @param array $query The query string.
+     * @return array
+     */
+    public function index(array $query) {
+        $this->permission('Conversations.Conversations.Add');
+
+        $in = $this->schema([
+                'conversationID:i?'=> 'Filter messages by conversation.',
+                'insertUserID:i?' => 'Filter messages by specified user. '.
+                    'Use in conjunction with conversationID to have all messages of a conversation that were created by a specific user.',
+                'page:i?' => [
+                    'description' => 'Page number.',
+                    'default' => 1,
+                    'minimum' => 1,
+                ],
+                'limit:i?' => [
+                    'description' => 'The number of items per page.',
+                    'default' => c('Conversations.Messages.PerPage', 50),
+                    'minimum' => 1,
+                    'maximum' => 100
+                ],
+                'expand:b?' => 'Expand associated records.'
+            ], 'in')
+            ->setDescription('List user messages. By default, get the messages list of the current users.');
+        $out = $this->schema([':a' => $this->fullSchema()], 'out');
+
+        $query = $this->filterValues($query);
+        $query = $in->validate($query);
+
+        $where = [];
+
+        $filterByInsertUserID = !empty($query['insertUserID']);
+        if ($filterByInsertUserID) {
+            $missMatchUser = $query['insertUserID'] !== $this->getSession()->UserID;
+            $userID = $query['insertUserID'];
+            $where['InsertUserID'] = $userID;
+        } else {
+            $userID = $this->getSession()->UserID;
+        }
+
+        $filterByConversation = !empty($query['conversationID']);
+        if ($filterByConversation) {
+            $this->conversationByID($query['conversationID']);
+
+            $isInConversation = $this->conversationModel->inConversation($query['conversationID'], $userID);
+
+            $where['ConversationID'] = $query['conversationID'];
+        }
+
+        if (($filterByInsertUserID && $missMatchUser) || ($filterByConversation && !$isInConversation)) {
+            $this->checkModerationPermission();
+        }
+
+        list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
+
+        // Make sure that we filter at least by the current user.
+        // If we are to add other filtering options make sure that his still make sense.
+        if (empty($where)) {
+            $where['InsertUserID'] = $userID;
+        }
+
+        $messages = $this->conversationMessageModel->getWhere(
+            $where,
+            'DateInserted',
+            'desc',
+            $limit,
+            $offset
+        )->resultArray();
+
+        if (!empty($query['expand'])) {
+            $this->userModel->expandUsers($messages, ['InsertUserID']);
+        }
+
+        array_walk($messages, function(&$message) {
+            $message = $this->normalizeMessage($message);
+        });
+
+        return $out->validate($messages, true);
+    }
+
+    /**
+     * Get a message by its numeric ID.
+     *
+     * @param int $id The message ID.
+     * @throws NotFoundException if the message could not be found.
+     * @return array
+     */
+    private function messageByID($id) {
+        $message = $this->conversationMessageModel->getID($id, DATASET_TYPE_ARRAY);
+        if (!$message) {
+            throw new NotFoundException('Message');
+        }
+
+        return $message;
+    }
+
+    /**
+     * Normalize message for output.
+     *
+     * @param array $message
+     * @return array The normalized message.
+     */
+    private function normalizeMessage(array $message) {
+        $formattedMessage = $message;
+        $this->formatField($formattedMessage, 'Body', $message['Format']);
+        return $formattedMessage;
+    }
+
+//
+//    Uncomment and test once ConversationMessagesModel handles messages update.
+//    See https://github.com/vanilla/vanilla/issues/5913 for details.
+//
+//    /**
+//     * Update a message.
+//     *
+//     * @param int $id The ID of the message.
+//     * @param array $body The request body.
+//     * @throws NotFoundException If the message was not found.
+//     * @throws ServerException If the message could not be updated.
+//     * @return Data
+//     */
+//    public function patch($id, array $body) {
+//        $this->permission('Conversations.Conversations.Add');
+//
+//        $in = $this->schema(['format', 'body'],'in')
+//            ->add($this->fullSchema())
+//            ->setDescription('Update a message.');
+//        $out = $this->schema($this->fullSchema(), 'out');
+//
+//        $body = $in->validate($body);
+//
+//        $message = $this->messageByID($id);
+//
+//        if ($message['InsertUserID'] !== $this->getSession()->UserID) {
+//            $this->checkModerationPermission();
+//        }
+//
+//        $conversation = $this->conversationByID($message['ConversationID']);
+//
+//        $this->conversationMessageModel->save($body, $conversation);
+//    }
+
+    /**
+     * Add a message.
+     *
+     * @param array $body The request body.
+     * @throws NotFoundException If the conversation was not found.
+     * @throws ClientException If trying to add message to conversation you are not a participant of.
+     * @throws ServerException If the message could not be created.
+     * @return Data
+     */
+    public function post(array $body) {
+        $this->permission('Conversations.Conversations.Add');
+
+        $in = $this->postSchema('in')->setDescription('Add a message.');
+        $out = $this->schema($this->fullSchema(), 'out');
+
+        $body = $in->validate($body);
+
+        $conversation = $this->conversationByID($body['conversationID']);
+        if (!$this->conversationModel->inConversation($conversation['ConversationID'], $this->getSession()->UserID)) {
+            throw new ClientException('You can not add a message to a conversation that you are not a participant of.');
+        }
+
+        $messageData = $this->caseScheme->convertArrayKeys($body);
+        $messageID = $this->conversationMessageModel->save($messageData, $conversation);
+        $this->validateModel($this->conversationMessageModel, true);
+        if (!$messageID) {
+            throw new ServerException('Unable to insert message.', 500);
+        }
+
+        $message = $this->messageByID($messageID);
+        $message = $this->normalizeMessage($message);
+        return new Data(
+            $out->validate($message),
+            201
+        );
+    }
+
+    /**
+     * Get a post schema with minimal add/edit fields.
+     *
+     * @param string $type The type of schema.
+     * @return Schema Returns a schema object.
+     */
+    public function postSchema($type) {
+        static $postSchema;
+
+        if ($postSchema === null) {
+            $postSchema = $this->schema(
+                Schema::parse([
+                    'conversationID',
+                    'body',
+                    'format:s?' => 'The input format of the record.',
+                ])->add($this->fullSchema()),
+                'MessagePost'
+            );
+        }
+
+        return $this->schema($postSchema, $type);
+    }
+
+}

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -270,7 +270,7 @@ class MessagesApiController extends AbstractApiController {
      * @param array $message
      */
     private function prepareRow(array &$message) {
-        $this->formatField($formattedMessage, 'Body', $message['Format']);
+        $this->formatField($message, 'Body', $message['Format']);
     }
 
 //

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -263,7 +263,7 @@ class MessagesApiController extends AbstractApiController {
      *
      * @param array $message
      */
-    private function prepareRow(array &$message) {
+    public function prepareRow(array &$message) {
         $this->formatField($message, 'Body', $message['Format']);
     }
 

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -161,7 +161,7 @@ class MessagesApiController extends AbstractApiController {
 
         $this->userModel->expandUsers($message, ['InsertUserID']);
 
-        $message = $this->normalizeMessage($message);
+        $message = $this->prepareRow($message);
         return $out->validate($message);
     }
 
@@ -242,7 +242,7 @@ class MessagesApiController extends AbstractApiController {
         }
 
         array_walk($messages, function(&$message) {
-            $message = $this->normalizeMessage($message);
+            $this->prepareRow($message);
         });
 
         return $out->validate($messages, true);
@@ -265,15 +265,12 @@ class MessagesApiController extends AbstractApiController {
     }
 
     /**
-     * Normalize message for output.
+     * Prepare message for output.
      *
      * @param array $message
-     * @return array The normalized message.
      */
-    private function normalizeMessage(array $message) {
-        $formattedMessage = $message;
+    private function prepareRow(array &$message) {
         $this->formatField($formattedMessage, 'Body', $message['Format']);
-        return $formattedMessage;
     }
 
 //
@@ -340,7 +337,7 @@ class MessagesApiController extends AbstractApiController {
         }
 
         $message = $this->messageByID($messageID);
-        $message = $this->normalizeMessage($message);
+        $this->prepareRow($message);
         return new Data(
             $out->validate($message),
             201

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -123,7 +123,10 @@ class MessagesApiController extends AbstractApiController {
             $schema = $this->schema([
                 'messageID:i' => 'The ID of the message.',
                 'conversationID:i' => 'The ID of the conversation.',
-                'body:s' => 'The body of the message.',
+                'body:s' => [
+                    'maxLength' => $this->config->get('MaxLength', 2000),
+                    'description' => 'The body of the message.',
+                ],
                 'insertUserID:i' => 'The user that created the message.',
                 'insertUser?' => $this->getUserFragmentSchema(),
                 'dateInserted:dt' => 'When the message was created.',

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -105,8 +105,6 @@ class MessagesApiController extends AbstractApiController {
 //
 //        $this->messageByID($id);
 //        $this->conversationMessagesModel->deleteID($id);
-//
-//        return new Data([], 204);
 //    }
 
     /**
@@ -284,7 +282,6 @@ class MessagesApiController extends AbstractApiController {
 //     * @param array $body The request body.
 //     * @throws NotFoundException If the message was not found.
 //     * @throws ServerException If the message could not be updated.
-//     * @return Data
 //     */
 //    public function patch($id, array $body) {
 //        $this->permission('Conversations.Conversations.Add');

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -115,21 +115,19 @@ class MessagesApiController extends AbstractApiController {
      * @return Schema
      */
     private function fullSchema() {
-        $schemaDefinition = [
-            'messageID:i' => 'The ID of the message.',
-            'conversationID:i' => 'The ID of the conversation.',
-            'body:s' => 'The body of the message.',
-            'insertUserID:i' => 'The user that created the message.',
-            'insertUser?' => $this->getUserFragmentSchema(),
-            'dateInserted:dt' => 'When the message was created.',
-        ];
+        /** @var Schema $schema */
+        static $schema;
 
-        static $schemaInitialized = false;
-        if (!$schemaInitialized) {
-            $schemaInitialized = true;
-            $schema = $this->schema($schemaDefinition, 'Messages');
-        } else {
-            $schema = Schema::parse($schemaDefinition);
+        if ($schema === null) {
+            // Name this schema so that it can be read by swagger.
+            $schema = $this->schema([
+                'messageID:i' => 'The ID of the message.',
+                'conversationID:i' => 'The ID of the conversation.',
+                'body:s' => 'The body of the message.',
+                'insertUserID:i' => 'The user that created the message.',
+                'insertUser?' => $this->getUserFragmentSchema(),
+                'dateInserted:dt' => 'When the message was created.',
+            ], 'Message');
         }
 
         return $schema;

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -105,6 +105,8 @@ class MessagesApiController extends AbstractApiController {
 //
 //        $this->messageByID($id);
 //        $this->conversationMessagesModel->deleteID($id);
+//
+//        return new Data([], 204);
 //    }
 
     /**

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -21,6 +21,9 @@ class MessagesApiController extends AbstractApiController {
     /** @var CapitalCaseScheme */
     private $caseScheme;
 
+    /** @var Gdn_Configuration */
+    private $config;
+
     /** @var ConversationMessageModel */
     private $conversationMessageModel;
 
@@ -33,16 +36,19 @@ class MessagesApiController extends AbstractApiController {
     /**
      * MessagesApiController constructor.
      *
+     * @param Gdn_Configuration $config
      * @param ConversationMessageModel $conversationMessageModel
      * @param ConversationModel $conversationModel
      * @param UserModel $userModel
      */
     public function __construct(
+        Gdn_Configuration $config,
         ConversationModel $conversationModel,
         ConversationMessageModel $conversationMessageModel,
         UserModel $userModel
     ) {
         $this->caseScheme = new CapitalCaseScheme();
+        $this->config = $config;
         $this->conversationMessageModel = $conversationMessageModel;
         $this->conversationModel = $conversationModel;
         $this->userModel = $userModel;
@@ -54,7 +60,7 @@ class MessagesApiController extends AbstractApiController {
      * @throw Exception
      */
     private function checkModerationPermission() {
-        if (!c('Conversations.Moderation.Allow', false)) {
+        if (!$this->config->get('Conversations.Moderation.Allow', false)) {
             throw permissionException();
         }
         $this->permission('Conversations.Moderation.Manage');
@@ -88,7 +94,7 @@ class MessagesApiController extends AbstractApiController {
 //     * @throws MethodNotAllowedException if Conversations.Moderation.Allow !== true.
 //     */
 //    public function delete($id) {
-//        if (!c('Conversations.Moderation.Allow', false)) {
+//        if (!$this->config->get('Conversations.Moderation.Allow', false)) {
 //            throw new MethodNotAllowedException();
 //        }
 //
@@ -176,7 +182,7 @@ class MessagesApiController extends AbstractApiController {
                 ],
                 'limit:i?' => [
                     'description' => 'The number of items per page.',
-                    'default' => c('Conversations.Messages.PerPage', 50),
+                    'default' => $this->config->get('Conversations.Messages.PerPage', 50),
                     'minimum' => 1,
                     'maximum' => 100
                 ],

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -159,7 +159,7 @@ class MessagesApiController extends AbstractApiController {
 
         $this->userModel->expandUsers($message, ['InsertUserID']);
 
-        $message = $this->prepareRow($message);
+        $this->prepareRow($message);
         return $out->validate($message);
     }
 

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\APIv2;
+
+/**
+ * Test the /api/v2/conversations endpoints.
+ */
+class ConversationsTest extends AbstractAPIv2Test {
+
+    private $baseUrl = '/conversations';
+
+    private static $userIDs = [];
+
+    private $originalConfigEmailValue;
+
+    private $pk = 'conversationID';
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setupBeforeClass() {
+        parent::setupBeforeClass();
+
+        /** @var \UsersApiController $usersAPIController */
+        $usersAPIController = static::container()->get('UsersAPIController');
+
+        foreach ([1, 2, 3, 4] as $id) {
+            $user = $usersAPIController->post([
+                'name' => "ConversationsUser$id",
+                'email' => "ConversationsUser$id@example.com",
+                'password' => "$%#$&ADSFBNYI*&WBV$id",
+            ]);
+            self::$userIDs[] = $user['userID'];
+        }
+
+        // Disable email sending.
+        /** @var \Gdn_Configuration $config */
+        $config = static::container()->get('Config');
+        $config->set('Garden.Email.Disabled', true, true, false);
+    }
+
+    /**
+     * Test GET /conversations/<id>.
+     */
+    public function testGet() {
+        $conversation = $this->testPost();
+
+        $result = $this->api()->get(
+            "{$this->baseUrl}/{$conversation[$this->pk]}"
+        );
+
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertRowsEqual($conversation, $result->getBody());
+        $this->assertCamelCase($result->getBody());
+
+        return $result->getBody();
+    }
+
+
+    /**
+     * Test GET /conversations/<id>/participants.
+     */
+    public function testGetParticipants() {
+        $conversation = $this->testPostParticipants();
+
+        $result = $this->api()->get(
+            "{$this->baseUrl}/{$conversation[$this->pk]}/participants"
+        );
+
+        $expectedCountParticipant = count(self::$userIDs) + 1;
+        $expectedFirstParticipant = [
+            'userID' => $this->api()->getUserID(),
+            'deleted' => false,
+        ];
+
+        $this->assertEquals(200, $result->getStatusCode());
+
+        $participants = $result->getBody()['participants'];
+
+        $this->assertTrue(is_array($participants));
+        $this->assertEquals($expectedCountParticipant, count($participants));
+        $this->assertRowsEqual($expectedFirstParticipant, $participants[0]);
+    }
+
+    /**
+     * Test GET /conversations.
+     *
+     * @return array Returns the fetched data.
+     */
+    public function testIndex() {
+        $nbsInsert = 3;
+
+        // Insert a few rows.
+        $rows = [];
+        for ($i = 0; $i < $nbsInsert; $i++) {
+            $rows[] = $this->testPost();
+        }
+
+        $result = $this->api()->get($this->baseUrl);
+        $this->assertEquals(200, $result->getStatusCode());
+
+        $rows = $result->getBody();
+        $this->assertGreaterThan($nbsInsert, count($rows));
+        // The index should be a proper indexed array.
+        for ($i = 0; $i < count($dbRows); $i++) {
+            $this->assertArrayHasKey($i, $dbRows);
+        }
+    }
+
+
+    /**
+     * Test DELETE /conversations/<id>/leave.
+     *
+     * @return array Returns the fetched data.
+     */
+    public function testDeleteLeave() {
+        $conversation = $this->testPost();
+
+        $result = $this->api()->delete(
+            "{$this->baseUrl}/{$conversation[$this->pk]}/leave"
+        );
+
+        $this->assertEquals(204, $result->getStatusCode());
+
+        $participantsResult = $this->api()->get(
+            "{$this->baseUrl}/{$conversation[$this->pk]}/participants"
+        );
+
+        $this->assertEquals(200, $participantsResult->getStatusCode());
+
+        $expectedFirstParticipant = [
+            'userID' => $this->api()->getUserID(),
+            'deleted' => true,
+        ];
+        $participants = $participantsResult->getBody()['participants'];
+
+        $this->assertTrue(is_array($participants));
+        $this->assertRowsEqual($expectedFirstParticipant, $participants[0]);
+    }
+
+    /**
+     * Test POST /conversations.
+     *
+     * @return array The conversation.
+     */
+    public function testPost() {
+        $postData = [
+            'participantIDs' => array_slice(self::$userIDs, 0, 2)
+        ];
+        $expectedResult = [
+            'insertUserID' => $this->api()->getUserID(),
+            'countParticipants' => 3,
+            'countMessages' => 0,
+            'countReadMessages' => 0,
+            'dateLastViewed' => null,
+        ];
+
+        $result = $this->api()->post(
+            $this->baseUrl,
+            $postData
+        );
+
+        $this->assertEquals(201, $result->getStatusCode());
+
+        $body = $result->getBody();
+        $this->assertTrue(is_int($body[$this->pk]));
+        $this->assertTrue($body[$this->pk] > 0);
+
+        $this->assertRowsEqual($expectedResult, $body, true);
+
+        return $body;
+    }
+
+    /**
+     * Test POST /conversations/<id>/participants.
+     */
+    public function testPostParticipants() {
+        $conversation = $this->testPost();
+
+        $postData = [
+            'participantIDs' => array_slice(self::$userIDs, 2)
+        ];
+        $result = $this->api()->post(
+            "{$this->baseUrl}/{$conversation[$this->pk]}/participants",
+            $postData
+        );
+
+        $this->assertEquals(201, $result->getStatusCode());
+
+        $conversation['countParticipants'] += 2;
+
+        return $conversation;
+    }
+}

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -198,7 +198,9 @@ class ConversationsTest extends AbstractAPIv2Test {
 
         $this->assertEquals(201, $result->getStatusCode());
 
-        $conversation['countParticipants'] += 2;
+        $updatedConversation = $result->getBody();
+
+        $this->assertEquals($conversation['countParticipants'] + 2, $updatedConversation['countParticipants']);
 
         return $conversation;
     }

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -101,7 +101,7 @@ class ConversationsTest extends AbstractAPIv2Test {
             $rows[] = $this->testPost();
         }
 
-        $result = $this->api()->get($this->baseUrl);
+        $result = $this->api()->get($this->baseUrl, ['insertUserID' => $this->api()->getUserID()]);
         $this->assertEquals(200, $result->getStatusCode());
 
         $rows = $result->getBody();

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -107,8 +107,8 @@ class ConversationsTest extends AbstractAPIv2Test {
         $rows = $result->getBody();
         $this->assertGreaterThan($nbsInsert, count($rows));
         // The index should be a proper indexed array.
-        for ($i = 0; $i < count($dbRows); $i++) {
-            $this->assertArrayHasKey($i, $dbRows);
+        for ($i = 0; $i < count($rows); $i++) {
+            $this->assertArrayHasKey($i, $rows);
         }
     }
 

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -80,7 +80,7 @@ class ConversationsTest extends AbstractAPIv2Test {
 
         $this->assertEquals(200, $result->getStatusCode());
 
-        $participants = $result->getBody()['participants'];
+        $participants = $result->getBody();
 
         $this->assertTrue(is_array($participants));
         $this->assertEquals($expectedCountParticipant, count($participants));
@@ -143,7 +143,7 @@ class ConversationsTest extends AbstractAPIv2Test {
             'userID' => $this->api()->getUserID(),
             'deleted' => true,
         ];
-        $participants = $participantsResult->getBody()['participants'];
+        $participants = $participantsResult->getBody();
 
         $this->assertTrue(is_array($participants));
         $this->assertRowsEqual($expectedFirstParticipant, $participants[0]);
@@ -156,7 +156,7 @@ class ConversationsTest extends AbstractAPIv2Test {
      */
     public function testPost() {
         $postData = [
-            'participantIDs' => array_slice(self::$userIDs, 0, 2)
+            'participantUserIDs' => array_slice(self::$userIDs, 0, 2)
         ];
         $expectedResult = [
             'insertUserID' => $this->api()->getUserID(),
@@ -189,7 +189,7 @@ class ConversationsTest extends AbstractAPIv2Test {
         $conversation = $this->testPost();
 
         $postData = [
-            'participantIDs' => array_slice(self::$userIDs, 2)
+            'participantUserIDs' => array_slice(self::$userIDs, 2)
         ];
         $result = $this->api()->post(
             "{$this->baseUrl}/{$conversation[$this->pk]}/participants",

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -112,6 +112,12 @@ class ConversationsTest extends AbstractAPIv2Test {
         }
     }
 
+    /**
+     * @requires function ConversationAPIController::delete
+     */
+    public function testDelete() {
+        $this->fail(__METHOD__.' needs to be implemented');
+    }
 
     /**
      * Test DELETE /conversations/<id>/leave.

--- a/tests/APIv2/MessagesTest.php
+++ b/tests/APIv2/MessagesTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\APIv2;
+
+/**
+ * Test the /api/v2/messages endpoints.
+ */
+class MessagesTest extends AbstractResourceTest {
+
+    private static $userID;
+
+    private static $conversationID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($name = null, array $data = [], $dataName = '') {
+        $this->baseUrl = '/messages';
+
+        parent::__construct($name, $data, $dataName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setUpBeforeClass() {
+        parent::setupBeforeClass();
+
+        /** @var \UsersApiController $usersAPIController */
+        $usersAPIController = static::container()->get('UsersAPIController');
+
+        $user = $usersAPIController->post([
+            'name' => "MessagesUser$id",
+            'email' => "MessagesUser$id@example.com",
+            'password' => "$%#$&ADSFBNYI*&WBV$id",
+        ]);
+        self::$userID = $user['userID'];
+
+        /** @var \ConversationsApiController $conversationsAPiController */
+        $conversationsAPiController = static::container()->get('ConversationsAPiController');
+
+        $conversation = $conversationsAPiController->post([
+            'participantIDs' => [self::$userID]
+        ]);
+        self::$conversationID = $conversation['conversationID'];
+
+        // Disable email sending.
+        /** @var \Gdn_Configuration $config */
+        $config = static::container()->get('Config');
+        $config->set('Garden.Email.Disabled', true, true, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function record() {
+        return array_merge(parent::record(), ['conversationID' => self::$conversationID]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function indexUrl() {
+        $indexUrl = $this->baseUrl;
+        $indexUrl .= '?'.http_build_query(['conversationID' => self::$conversationID]);
+        return $indexUrl;
+    }
+
+ /**
+     * {@inheritdoc}
+     */
+    public function testDelete() {
+        $this->markTestSkipped('MessageAPIController does not support delete yet.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testGetEdit($record = null) {
+        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testGetEditFields() {
+        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testPatch() {
+        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testPatchSparse($field = null) {
+        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function testPatchFull() {
+        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+    }
+}

--- a/tests/APIv2/MessagesTest.php
+++ b/tests/APIv2/MessagesTest.php
@@ -35,9 +35,9 @@ class MessagesTest extends AbstractResourceTest {
         $usersAPIController = static::container()->get('UsersAPIController');
 
         $user = $usersAPIController->post([
-            'name' => "MessagesUser$id",
-            'email' => "MessagesUser$id@example.com",
-            'password' => "$%#$&ADSFBNYI*&WBV$id",
+            'name' => "MessagesUser1",
+            'email' => "MessagesUser1@example.com",
+            'password' => "$%#$&ADSFBNYI*&WBV1",
         ]);
         self::$userID = $user['userID'];
 

--- a/tests/APIv2/MessagesTest.php
+++ b/tests/APIv2/MessagesTest.php
@@ -45,7 +45,7 @@ class MessagesTest extends AbstractResourceTest {
         $conversationsAPiController = static::container()->get('ConversationsAPiController');
 
         $conversation = $conversationsAPiController->post([
-            'participantIDs' => [self::$userID]
+            'participantUserIDs' => [self::$userID]
         ]);
         self::$conversationID = $conversation['conversationID'];
 

--- a/tests/APIv2/MessagesTest.php
+++ b/tests/APIv2/MessagesTest.php
@@ -71,45 +71,51 @@ class MessagesTest extends AbstractResourceTest {
         return $indexUrl;
     }
 
- /**
+    /**
      * {@inheritdoc}
+     * @requires function MessagesApiController::delete
      */
     public function testDelete() {
-        $this->markTestSkipped('MessageAPIController does not support delete yet.');
+        $this->fail(__METHOD__.' needs to be implemented');
     }
 
     /**
      * {@inheritdoc}
+     * @requires function MessagesApiController::patch
      */
     public function testGetEdit($record = null) {
-        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+        $this->fail(__METHOD__.' needs to be implemented');
     }
 
     /**
      * {@inheritdoc}
+     * @requires function MessagesApiController::patch
      */
     public function testGetEditFields() {
-        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+        $this->fail(__METHOD__.' needs to be implemented');
     }
 
     /**
      * {@inheritdoc}
+     * @requires function MessagesApiController::patch
      */
     public function testPatch() {
-        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+        $this->fail(__METHOD__.' needs to be implemented');
     }
 
     /**
      * {@inheritdoc}
+     * @requires function MessagesApiController::patch
      */
     public function testPatchSparse($field = null) {
-        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+        $this->fail(__METHOD__.' needs to be implemented');
     }
 
     /**
      * {@inheritdoc}
+     * @requires function MessagesApiController::patch
      */
     public function testPatchFull() {
-        $this->markTestSkipped('MessageAPIController does not support patch yet.');
+        $this->fail(__METHOD__.' needs to be implemented');
     }
 }


### PR DESCRIPTION
**The blockers need to be merged before this can be fully reviewed.**

Creates 2 new API Controllers and their unit tests.

You can see that we used Message instead of ConversationMessage. We want the API to be simple for the user and ConversationMessage was a bad name. We know that we have a "message" feature in Vanilla but that will called something else. (alert, info, sitemessage...)
This was requested by Todd.

I could not use the `AbstractApiController` class for the Conversation message because it was assuming too many things about the controller. A refactoring of the base class will be likely needed if we want to accommodate controllers.

Note that the unit tests are using other controllers to setup themselves. That was a first and I had to make it work properly! See #5926

Unit tests were also hanging out for no apparent reason. I thought it was because of a recursion with that could have happen with this fix #5928 while being in the unit test environment but it turned out to be because of the `$email->send()` function that was waiting for a timeout.

Speaking of unit tests I [made an improvement](https://github.com/vanilla/vanilla/pull/5931) on error reporting because debugging them while testing the API v2 was laborious.

There are missing methods on the controllers because the model does not handle them properly.

At first I made the controller work as the model did. That means that we had to supply a message with the first conversation. We decided that it was not good for the API and I had to refactor the models (see #5908) to allow conversations to be created without a message without breaking anything else.

I also had to [refactor the ConversationsModel](https://github.com/vanilla/vanilla/pull/5932) to fetch members properly.

Last thing, I decided that `prepareRow()` was a bad name in the other models. I decided to go with `normalizeInput()` and `normalize{NameOfTheRecord}()` which I think is more appropriate. The second one could be named `normalizeRecord`() and both could be added to a base class some day. Open to criticisms on this.