### PR TITLE
Improves dispatcher errors while unit testing

### DIFF
--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -139,6 +139,8 @@ class Dispatcher {
         } elseif ($raw instanceof \Exception) {
             $data = $raw instanceof \JsonSerializable ? $raw->jsonSerialize() : ['message' => $raw->getMessage(), 'status' => $raw->getCode()];
             $result = new Data($data, $raw->getCode());
+            // Provide stack trace as meta information.
+            $result->setMeta('error_trace', $raw->getTraceAsString());
         } elseif ($raw instanceof \JsonSerializable) {
             $result = new Data((array)$raw->jsonSerialize());
         } elseif (!empty($ob)) {

--- a/tests/InternalClient.php
+++ b/tests/InternalClient.php
@@ -62,6 +62,11 @@ class InternalClient extends HttpClient {
                 $message .= ' '.implode(' ', array_column($body['errors'], 'message'));
             }
 
+            $dataMeta = json_decode($response->getHeader('X-Data-Meta'), true);
+            if (!empty($dataMeta['error_trace'])) {
+                $message .= "\n".$dataMeta['error_trace'];
+            }
+
             throw new \Exception($message, $response->getStatusCode());
         }
     }

--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -100,7 +100,10 @@ class InternalRequest extends HttpRequest implements RequestInterface {
 
         $data = $this->dispatcher->dispatch($this);
 
-        $response = new HttpResponse($data->getStatus(), $data->getHeaders(), '');
+        $response = new HttpResponse(
+            $data->getStatus(),
+            array_merge($data->getHeaders(), ['X-Data-Meta', json_encode($data->getMetaArray())])
+        );
         $response->setBody($data->getData());
 
         return $response;


### PR DESCRIPTION
I had a really bad time trying to find out what was not working while unit testing the API v2.

This change add the stack trace to reported errors from the new Dispatcher.
With the source of the error the debugging is waaayyy faster.

~The stack trace is only added when we are in the UnitTest environment so that's a good thing!~

The stack is set as part of the Data meta informations which are never displayed on the client side. 
We extract that information in VanillaTests\InternalRequest and set it as a custom header on the `HttpResponse`.
We then check, in `VanillaTests\InternalClient` if the custom header contains an error stack trace.