### PR TITLE
Fix undefined variable notice and refactoring error

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -608,13 +608,12 @@ class ConversationModel extends ConversationsModel {
 
                 $recipientData = [
                     'UserID' => $userID,
-                    'ConversationID' => $conversationID,
-                    'LastMessageID' => $messageID,
-                    'CountReadMessages' => $countReadMessages
+                    'ConversationID' => $conversationID
                 ];
 
-                if (!$createMessage) {
-                    unset($recipientData['LastMessageID'], $recipientData['CountReadMessages']);
+                if ($createMessage) {
+                    $recipientData['LastMessageID'] = $messageID;
+                    $recipientData['CountReadMessages'] = $countReadMessages;
                 }
 
                 $this->SQL->options('Ignore', true)->insert('UserConversation', $recipientData);

--- a/applications/conversations/models/class.conversationsmodel.php
+++ b/applications/conversations/models/class.conversationsmodel.php
@@ -132,7 +132,7 @@ abstract class ConversationsModel extends Gdn_Model {
 
         $activityModel = new ActivityModel();
         foreach ($notifyUserIDs as $userID) {
-            if ($message['InsertUserID'] == $notifyUserID) {
+            if ($message['InsertUserID'] == $userID) {
                 continue; // Don't notify self.
             }
 


### PR DESCRIPTION
Simple stuff really.

- `$messageID` can be undefined unless `$createMessage` is `true` which was not a problem but it raises a notice.
- Copy pasta errors on `$notifyUserID`

Fixes issues caused by https://github.com/vanilla/vanilla/pull/5908
