### PR TITLE
Disable the ability to verify users using the users API v2 endpoint

### DIFF
--- a/applications/dashboard/controllers/Api/UsersApiController.php
+++ b/applications/dashboard/controllers/Api/UsersApiController.php
@@ -292,22 +292,22 @@ class UsersApiController extends AbstractApiController {
      * @throws NotFoundException if unable to find the user.
      * @return array
      */
-    public function put_verify($id, array $body) {
-        $this->permission('Garden.Users.Edit');
-
-        $in = $this
-            ->schema(['verified:b' => 'Pass true to flag as verified or false for unverified.'], 'in')
-            ->setDescription('Verify a user.');
-        $out = $this->schema(['verified:b' => 'The current verified value.'], 'out');
-
-        $row = $this->userByID($id);
-        $body = $in->validate($body);
-        $verify = intval($body['verified']);
-        $this->userModel->setField($id, 'Verified', $verify);
-
-        $result = $this->userByID($id);
-        return $out->validate($result);
-    }
+//    public function put_verify($id, array $body) {
+//        $this->permission('Garden.Users.Edit');
+//
+//        $in = $this
+//            ->schema(['verified:b' => 'Pass true to flag as verified or false for unverified.'], 'in')
+//            ->setDescription('Verify a user.');
+//        $out = $this->schema(['verified:b' => 'The current verified value.'], 'out');
+//
+//        $row = $this->userByID($id);
+//        $body = $in->validate($body);
+//        $verify = intval($body['verified']);
+//        $this->userModel->setField($id, 'Verified', $verify);
+//
+//        $result = $this->userByID($id);
+//        return $out->validate($result);
+//    }
 
     /**
      * Get a user by its numeric ID.

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -311,7 +311,7 @@ class CategoriesApiController extends AbstractApiController {
         $this->permission('Garden.Settings.Manage');
 
         $in = $this->categoryPostSchema('in', ['description'])->setDescription('Update a category.');
-        $out = $this->schemaWithParent('out');
+        $out = $this->schemaWithParent(false, 'out');
 
         $body = $in->validate($body, true);
         // If a row associated with this ID cannot be found, a "not found" exception will be thrown.
@@ -376,7 +376,7 @@ class CategoriesApiController extends AbstractApiController {
      * @param bool $expand
      * @return Schema
      */
-    public function schemaWithParent($expand = false) {
+    public function schemaWithParent($expand = false, $type = '') {
         $attributes = ['parentCategoryID:i|n' => 'Parent category ID.'];
         if ($expand) {
             $attributes['parent:o?'] = Schema::parse(['categoryID', 'name', 'urlCode', 'url'])
@@ -384,6 +384,6 @@ class CategoriesApiController extends AbstractApiController {
         }
         $schema = $this->fullSchema();
         $result = $schema->merge(Schema::parse($attributes));
-        return $result;
+        return $this->schema($result, $type);
     }
 }

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -75,7 +75,7 @@ class UsersTest extends AbstractResourceTest {
     public function providePutFields() {
         $fields = [
             'ban' => ['ban', true, 'banned'],
-            'verify' => ['verify', true, 'verified'],
+//            'verify' => ['verify', true, 'verified'],
         ];
         return $fields;
     }


### PR DESCRIPTION
There was an issue with generating automated docs. I also removed an endpoint I don’t want to launch with right now.