### PR TITLE
Add emailConfirmed and bypassSpam as fields in users endpoint

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2051,10 +2051,14 @@ class UserModel extends Gdn_Model {
 
         if (array_key_exists('Confirmed', $formPostValues)) {
             $formPostValues['Confirmed'] = forceBool($formPostValues['Confirmed'], '0', '1', '0');
+        } elseif (array_key_exists('EmailConfirmed', $formPostValues)) {
+            $formPostValues['Confirmed'] = forceBool($formPostValues['EmailConfirmed'], '1', '1', '0');
         }
 
         if (array_key_exists('Verified', $formPostValues)) {
             $formPostValues['Verified'] = forceBool($formPostValues['Verified'], '0', '1', '0');
+        } elseif (array_key_exists('BypassSpam', $formPostValues)) {
+            $formPostValues['Verified'] = forceBool($formPostValues['BypassSpam'], '0', '1', '0');
         }
 
         // Do not allowing setting this via general save.
@@ -3964,6 +3968,15 @@ class UserModel extends Gdn_Model {
             }
 
             setValue('PhotoUrl', $user, $photoUrl);
+        }
+
+        $confirmed = val('Confirmed', $user, null);
+        if ($confirmed !== null) {
+            setValue('EmailConfirmed', $user, $confirmed);
+        }
+        $verified = val('Verified', $user, null);
+        if ($verified !== null) {
+            setValue('BypassSpam', $user, $verified);
         }
 
         // We store IPs in the UserIP table. To avoid unnecessary queries, the full list is not built here. Shim for BC.

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -20,7 +20,7 @@ class UsersTest extends AbstractResourceTest {
     protected $editFields = ['email', 'name'];
 
     /** {@inheritdoc} */
-    protected $patchFields = ['name', 'email', 'photo'];
+    protected $patchFields = ['name', 'email', 'photo', 'emailConfirmed', 'bypassSpam'];
 
     /**
      * {@inheritdoc}
@@ -63,6 +63,10 @@ class UsersTest extends AbstractResourceTest {
                 case 'photo':
                     $hash = md5(microtime());
                     $value = "https://vanillicon.com/v2/{$hash}.svg";
+                    break;
+                case 'emailConfirmed':
+                case 'bypassSpam':
+                    $value = !$value;
             }
             $row[$key] = $value;
         }
@@ -117,7 +121,12 @@ class UsersTest extends AbstractResourceTest {
      */
     public function testPost($record = null, array $extra = []) {
         $record = $this->record();
-        $result = parent::testPost($record, ['password' => 'vanilla']);
+        $fields = [
+            'bypassSpam' => true,
+            'emailConfirmed' => false,
+            'password' => 'vanilla'
+        ];
+        $result = parent::testPost($record, $fields);
         return $result;
     }
 }


### PR DESCRIPTION
This update adds support for using emailConfirmed and bypassSpam in the users API v2 endpoint, instead of confirmed and verified, respectively. `UserModel` has been updated to support these fields. Tests have been updated to use these fields.

Closes #5920