### PR TITLE
Fix deleting a revision on a popular discussion also deleting the original record

### DIFF
--- a/applications/dashboard/models/class.spammodel.php
+++ b/applications/dashboard/models/class.spammodel.php
@@ -166,10 +166,10 @@ class SpamModel extends Gdn_Pluggable {
                 $row = $model->getID($id, DATASET_TYPE_ARRAY);
 
                 /**
-                 * If our discussion has more than three comments, it might be worth saving.  Hold off on deleting and
-                 * just flag it.  If we have between 0 and 3 comments, save them along with the discussion.
+                 * If our discussion meets or exceeds our comment threshold, just flag it for review. Otherwise, save
+                 * it and its comments in the log for review and delete the original record.
                  */
-                if ($row['CountComments'] > 3) {
+                if ($row['CountComments'] >= DiscussionModel::DELETE_COMMENT_THRESHOLD) {
                     $deleteRow = false;
                 } elseif ($row['CountComments'] > 0) {
                     $comments = Gdn::database()->sql()->getWhere(

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -27,6 +27,9 @@ class DiscussionModel extends Gdn_Model {
     /** @var string The filter key for clearing-type filters. */
     const EMPTY_FILTER_KEY = 'none';
 
+    /** Max comments on a discussion before it cannot be auto-deleted by SPAM or moderation actions. */
+    const DELETE_COMMENT_THRESHOLD = 10;
+
     /** @var array|bool */
     private static $categoryPermissions = null;
 


### PR DESCRIPTION
When a discussion is flagged as SPAM and it has more than X comments, it's "flagged for review". This means the original post remains, but the revision is sent to the SPAM queue for approval. If the revision is confirmed *not to be* SPAM, the revision takes the place of the original post. If the revision is confirmed *to be* SPAM, the revision is deleted, along with the original discussion and its comments.

This update alters the SPAM removal process to be consistent with flagging. If a revision is confirmed as SPAM, but the discussion is still on the site and has more than X comments, it is not deleted. The revision will still be purged.

The number of comments before this behavior was triggered is currently three (3), however, that seems a little low. I'm bumping it up to 10 and moving it into a class constant that can be used in both `SpamModel` and `LogModel`.

Closes #5952