### PR TITLE
Fix RSS feeds on PHP 7.1

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1231,7 +1231,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
         // Make sure to clear out the content asset collection if this is a syndication request
         if ($this->SyndicationMethod !== SYNDICATION_NONE) {
-            $this->Assets['Content'] = '';
+            $this->Assets['Content'] = [];
         }
 
         // Define the view


### PR DESCRIPTION
A change in string to array "conversion" breaks RSS feeds on PHP 7.1.

See this comment:
http://php.net/manual/en/migration71.other-changes.php#120336

The error happens in Gdn_Controller::addAsset which assumes an asset container to be an array.
When RSS feeds are served, the container is cleared by setting it to an empty string.
Before PHP 7.1 it would be silently converted to an array, but on PHP 7.1 that conversion is not being made, leading to an empty content asset.
