### PR TITLE
Move setting of announce, closed and sink fields to PATCH and POST under discussions endpoint

### DIFF
--- a/applications/dashboard/controllers/Api/AbstractApiController.php
+++ b/applications/dashboard/controllers/Api/AbstractApiController.php
@@ -62,4 +62,18 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
     public function options($path) {
         return '';
     }
+
+    /**
+     * Verify current user permission, if a particular field is in a data array.
+     *
+     * @param array $data The data array (e.g. request body fields).
+     * @param string $field The protected field name.
+     * @param string|array $permission A required permissions.
+     * @param int|null $id The ID of the record we are checking the permission of (e.g. category ID).
+     */
+    public function fieldPermission(array $data, $field, $permission, $id = null) {
+        if (array_key_exists($field, $data)) {
+            $this->permission($permission, $id);
+        }
+    }
 }

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -133,7 +133,8 @@ class DiscussionsApiController extends AbstractApiController {
     public function discussionPostSchema($type = '') {
         if ($this->discussionPostSchema === null) {
             $this->discussionPostSchema = $this->schema(
-                Schema::parse(['name', 'body', 'format', 'categoryID', 'closed?', 'sink?'])->add($this->fullSchema()),
+                Schema::parse(
+                    ['name', 'body', 'format', 'categoryID', 'closed?', 'sink?', 'pinned?', 'pinLocation?'])->add($this->fullSchema()),
                 'DiscussionPost'
             );
         }
@@ -168,7 +169,6 @@ class DiscussionsApiController extends AbstractApiController {
             'insertUserID:i' => 'The user that created the discussion.',
             'insertUser?' => $this->getUserFragmentSchema(),
             'bookmarked:b' => 'Whether or no the discussion is bookmarked by the current user.',
-            'announce:b' => 'Whether or not the discussion has been announced (pinned).',
             'pinned:b?' => 'Whether or not the discussion has been pinned.',
             'pinLocation:s|n' => [
                 'enum' => ['category', 'recent'],
@@ -231,7 +231,7 @@ class DiscussionsApiController extends AbstractApiController {
         $this->permission('Garden.SignIn.Allow');
 
         $in = $this->idParamSchema()->setDescription('Get a discussion for editing.');
-        $out = $this->schema(Schema::parse(['discussionID', 'name', 'body', 'format', 'categoryID'])->add($this->fullSchema()), 'out');
+        $out = $this->schema(Schema::parse(['discussionID', 'name', 'body', 'format', 'categoryID', 'sink', 'closed', 'pinned', 'pinLocation'])->add($this->fullSchema()), 'out');
 
         $row = $this->discussionByID($id);
         $row['Url'] = discussionUrl($row);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -366,6 +366,7 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $categoryID);
+        $this->fieldPermission($body, 'pinned', 'Vanilla.Discussions.Announce', $categoryID);
         $this->fieldPermission($body, 'sink', 'Vanilla.Discussions.Sink', $categoryID);
 
         $this->discussionModel->save($discussionData);
@@ -392,6 +393,7 @@ class DiscussionsApiController extends AbstractApiController {
         $categoryID = $body['categoryID'];
         $this->discussionModel->categoryPermission('Vanilla.Discussions.Add', $categoryID);
         $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $categoryID);
+        $this->fieldPermission($body, 'pinned', 'Vanilla.Discussions.Announce', $categoryID);
         $this->fieldPermission($body, 'sink', 'Vanilla.Discussions.Sink', $categoryID);
 
         $discussionData = $this->caseScheme->convertArrayKeys($body);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -133,7 +133,7 @@ class DiscussionsApiController extends AbstractApiController {
     public function discussionPostSchema($type = '') {
         if ($this->discussionPostSchema === null) {
             $this->discussionPostSchema = $this->schema(
-                Schema::parse(['name', 'body', 'format', 'categoryID'])->add($this->fullSchema()),
+                Schema::parse(['name', 'body', 'format', 'categoryID', 'closed?', 'sink?'])->add($this->fullSchema()),
                 'DiscussionPost'
             );
         }
@@ -356,12 +356,17 @@ class DiscussionsApiController extends AbstractApiController {
         $row = $this->discussionByID($id);
         $discussionData = $this->caseScheme->convertArrayKeys($body);
         $discussionData['DiscussionID'] = $id;
+        $categoryID = $row['CategoryID'];
         if ($row['InsertUserID'] !== $this->getSession()->UserID) {
-            $this->discussionModel->categoryPermission('Vanilla.Discussions.Edit', $row['CategoryID']);
+            $this->discussionModel->categoryPermission('Vanilla.Discussions.Edit', $categoryID);
         }
-        if (array_key_exists('CategoryID', $discussionData) && $row['CategoryID'] !== $discussionData['CategoryID']) {
+        if (array_key_exists('CategoryID', $discussionData) && $categoryID !== $discussionData['CategoryID']) {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.Add', $discussionData['CategoryID']);
+            $categoryID = $discussionData['CategoryID'];
         }
+
+        $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $categoryID);
+        $this->fieldPermission($body, 'sink', 'Vanilla.Discussions.Sink', $categoryID);
 
         $this->discussionModel->save($discussionData);
 
@@ -384,7 +389,10 @@ class DiscussionsApiController extends AbstractApiController {
         $out = $this->schema($this->discussionSchema(), 'out');
 
         $body = $in->validate($body);
-        $this->discussionModel->categoryPermission('Vanilla.Discussions.Add', $body['categoryID']);
+        $categoryID = $body['categoryID'];
+        $this->discussionModel->categoryPermission('Vanilla.Discussions.Add', $categoryID);
+        $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $categoryID);
+        $this->fieldPermission($body, 'sink', 'Vanilla.Discussions.Sink', $categoryID);
 
         $discussionData = $this->caseScheme->convertArrayKeys($body);
         $id = $this->discussionModel->save($discussionData);
@@ -398,33 +406,6 @@ class DiscussionsApiController extends AbstractApiController {
         $this->prepareRow($row);
         $result = $out->validate($row);
         return new Data($result, 201);
-    }
-
-    /**
-     * Announce a discussion.
-     *
-     * @param int $id The ID of the discussion.
-     * @param array $body The request body.
-     * @throws NotFoundException if unable to find the discussion.
-     * @return array
-     */
-    public function put_announce($id, array $body) {
-        $this->permission('Garden.SignIn.Allow');
-
-        $in = $this
-            ->schema(['announce:b' => 'Pass true to announce or false to unannounce.'], 'in')
-            ->setDescription('Announce a discussion.');
-        $out = $this->schema(['announce:b' => 'The current announce value.'], 'out');
-
-        $row = $this->discussionByID($id);
-        $this->discussionModel->categoryPermission('Vanilla.Discussions.Announce', $row['CategoryID']);
-
-        $body = $in->validate($body);
-        $announce = intval($body['announce']);
-        $this->discussionModel->setField($row['DiscussionID'], 'Announce', $announce);
-
-        $result = $this->discussionByID($id);
-        return $out->validate($result);
     }
 
     /**
@@ -449,57 +430,6 @@ class DiscussionsApiController extends AbstractApiController {
         $this->discussionModel->bookmark($id, $this->getSession()->UserID, $bookmarked);
 
         $result = $this->discussionByID($id);
-        return $out->validate($result);
-    }
-
-    /**
-     * Close a discussion.
-     *
-     * @param int $id The ID of the discussion.
-     * @param array $body The request body.
-     * @return array
-     */
-    public function put_close($id, array $body) {
-        $this->permission('Garden.SignIn.Allow');
-
-        $in = $this
-            ->schema(['closed:b' => 'Pass true to close or false to open.'], 'in')->setDescription('Close a discussion.');
-        $out = $this->schema(['closed:b' => 'The current close value.'], 'out');
-
-        $row = $this->discussionByID($id);
-        $this->discussionModel->categoryPermission('Vanilla.Discussions.Close', $row['CategoryID']);
-
-        $body = $in->validate($body);
-        $closed = intval($body['closed']);
-        $this->discussionModel->setField($row['DiscussionID'], 'Closed', $closed);
-
-        $result = $this->discussionByID($id);
-        return $out->validate($result);
-    }
-
-    /**
-     * Sink a discussion.
-     *
-     * @param int $id The ID of the discussion.
-     * @param array $body The request body.
-     * @return array
-     */
-    public function put_sink($id, array $body) {
-        $this->permission('Garden.SignIn.Allow');
-
-        $in = $this
-            ->schema(['sink:b' => 'Pass true to sink or false to unsink.'], 'in')->setDescription('Sink a discussion.');
-        $out = $this->schema(['sink:b' => 'The current sink value.'], 'out');
-
-        $row = $this->discussionByID($id);
-        $this->discussionModel->categoryPermission('Vanilla.Discussions.Sink', $row['CategoryID']);
-
-        $body = $in->validate($body);
-        $sink = intval($body['sink']);
-        $this->discussionModel->setField($row['DiscussionID'], 'Sink', $sink);
-
-        $result = $this->discussionByID($id);
-        $this->userModel->expandUsers($result, ['InsertUserID']);
         return $out->validate($result);
     }
 }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1977,6 +1977,26 @@ class DiscussionModel extends Gdn_Model {
             $this->addUpdateFields($formPostValues);
         }
 
+        // Pinned-to-Announce translation
+        $isPinned = val('Pinned', $formPostValues, null);
+        if ($isPinned !== null) {
+            $announce = 0;
+            $isPinned = filter_var($isPinned, FILTER_VALIDATE_BOOLEAN);
+            if ($isPinned) {
+                $pinLocation = strtolower(val('PinLocation', $formPostValues, 'category'));
+                switch ($pinLocation) {
+                    case 'recent':
+                        $announce = 1;
+                        break;
+                    default:
+                        $announce = 2;
+                }
+
+            }
+            $formPostValues['Announce'] = $announce;
+            unset($announce);
+        }
+
         // Set checkbox values to zero if they were unchecked
         if (val('Announce', $formPostValues, '') === false) {
             $formPostValues['Announce'] = 0;

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -19,7 +19,27 @@ class DiscussionsTest extends AbstractResourceTest {
         $this->baseUrl = '/discussions';
         $this->record += ['categoryID' => 1, 'name' => __CLASS__];
 
+        $this->patchFields = ['body', 'categoryID', 'closed', 'format', 'name', 'pinLocation', 'pinned', 'sink'];
+
         parent::__construct($name, $data, $dataName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function modifyRow(array $row) {
+        $row = parent::modifyRow($row);
+
+        $row['closed'] = !$row['closed'];
+        $row['pinned'] = !$row['pinned'];
+        if ($row['pinned']) {
+            $row['pinLocation'] = $row['pinLocation'] == 'category' ? 'recent' : 'category';
+        } else {
+            $row['pinLocation'] = null;
+        }
+        $row['sink'] = !$row['sink'];
+
+        return $row;
     }
 
     /**
@@ -27,10 +47,7 @@ class DiscussionsTest extends AbstractResourceTest {
      */
     public function providePutFields() {
         $fields = [
-            'announce' => ['announce', true],
             'bookmark' => ['bookmark', true, 'bookmarked'],
-            'close' => ['close', true, 'closed'],
-            'sink' => ['sink', true]
         ];
         return $fields;
     }
@@ -45,5 +62,20 @@ class DiscussionsTest extends AbstractResourceTest {
         $bookmarked = $this->api()->get("{$this->baseUrl}/bookmarked")->getBody();
         $discussionIDs = array_column($bookmarked, 'discussionID');
         $this->assertContains($rowID, $discussionIDs);
+    }
+
+    /**
+     * Test PATCH /discussions/<id> with a a single field update.
+     *
+     * @param string $field The name of the field to patch.
+     * @dataProvider providePatchFields
+     */
+    public function testPatchSparse($field) {
+        // pinLocation doesn't do anything on its own, it requires pinned. It's not a good candidate for a single-field sparse PATCH.
+        if ($field == 'pinLocation') {
+            $this->markTestSkipped('pinLocation cannot be used alone in PATCH.');
+        }
+
+        parent::testPatchSparse($field);
     }
 }


### PR DESCRIPTION
This update does a few things:

1. Moves setting the sink, closed and "announce" fields from PUT into POST and PATCH.
1. Updates setting "announce" to splitting it into two fields: pinned and pinLocation.
1. Adds `AbstractApiController::fieldPermission` to verify the current user has the specified permission, if a field is included in an array. This is used on the discussions endpoint, where you want to restrict access to the sink, closed, pinned and pinLocation fields, while still allowing fairly open access to the other fields.
1. Updates `DiscussionModel::save` to translate "pinned" and "pinLocation" into an appropriate value for "Announce".
1. Updates discussions endpoint tests to test the new method of setting the aforementioned fields.

Closes #5937