### PR TITLE
Add header methods to GDN_Request and RequestInterface

### DIFF
--- a/library/Garden/Web/RequestInterface.php
+++ b/library/Garden/Web/RequestInterface.php
@@ -45,10 +45,9 @@ interface RequestInterface {
      * Get a header's value(s) as a string.
      *
      * @param string $name The name of the header.
-     * @param string $default
      * @return string A header's value(s). Multiple values are returned as a CSV string.
      */
-    public function getHeaderLine($name, $default = '');
+    public function getHeaderLine($name);
 
     /**
      * Checks if a header exists by the given case-insensitive name.

--- a/library/Garden/Web/RequestInterface.php
+++ b/library/Garden/Web/RequestInterface.php
@@ -27,13 +27,28 @@ interface RequestInterface {
     public function getBody();
 
     /**
+     * Get all headers from the request.
+     *
+     * @return array
+     */
+    public function getHeaders();
+
+    /**
      * Get a header value.
      *
      * @param string $header The name of the header.
-     * @param mixed $default The default value if the header does not exist.
      * @return string Returns the header value or an empty string.
      */
     public function getHeader($header);
+
+    /**
+     * Get a header's value(s) as a string.
+     *
+     * @param string $name The name of the header.
+     * @param string $default
+     * @return string A header's value(s). Multiple values are returned as a CSV string.
+     */
+    public function getHeaderLine($name, $default = '');
 
     /**
      * Checks if a header exists by the given case-insensitive name.

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -67,6 +67,9 @@ class Gdn_Request implements RequestInterface {
     /** HTTP request method. */
     const METHOD_OPTIONS = 'OPTIONS';
 
+    /** Special cases in $_SERVER that are also considered headers. */
+    const SPECIAL_HEADERS = ['CONTENT_TYPE', 'CONTENT_LENGTH', 'PHP_AUTH_USER', 'PHP_AUTH_PW', 'PHP_AUTH_DIGEST', 'AUTH_TYPE'];
+
     /** @var bool Whether or not _ParseRequest has been called yet. */
     protected $_HaveParsedRequest = false;
 
@@ -240,6 +243,25 @@ class Gdn_Request implements RequestInterface {
     }
 
     /**
+     * Convert a header key from HTTP_HEADER_NAME format to Header-Name.
+     *
+     * @param string $key A header key.
+     * @return string The formatted header key.
+     */
+    private function formatHeaderKey($key) {
+        $key = $this->headerKey($key);
+        if (substr($key, 0, 5) == 'HTTP_') {
+            $key = substr($key, 5);
+        }
+        $key = strtolower($key);
+        $key = str_replace('_', '-', $key);
+        $key = preg_replace_callback('/(?<=^|\-)[a-z]/', function ($m) {
+            return strtoupper($m[0]);
+        }, $key);
+        return $key;
+    }
+
+    /**
      * Chainable lazy Environment Bootstrap
      *
      * Convenience method allowing quick setup of the default request state... from the current environment.
@@ -326,20 +348,45 @@ class Gdn_Request implements RequestInterface {
     }
 
     /**
-     * Get a header value.
-     *
-     * @param string $header The name of the header.
-     * @return string Returns the header value or an empty string.
+     * {@inheritdoc}
      */
     public function getHeader($header) {
         return $this->getValueFrom(self::INPUT_SERVER, $this->headerKey($header), '');
     }
 
     /**
-     * Checks if a header exists by the given case-insensitive name.
-     *
-     * @param string $header Case-insensitive header name.
-     * @return bool Returns **true** if the header exists or **false** otherwise.
+     * {@inheritdoc}
+     */
+    public function getHeaderLine($name, $default = '') {
+        $value = $this->getHeader($name);
+        if (empty($value)) {
+            $value = $default;
+        } elseif (is_array($value)) {
+            $value = implode(',', $value);
+        }
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHeaders() {
+        $server = $this->getRequestArguments(self::INPUT_SERVER);
+
+        $headers = [];
+        foreach ($server as $name => $val) {
+            if (substr($name, 0, 5) != 'HTTP_' && !in_array($name, self::SPECIAL_HEADERS)) {
+                continue;
+            }
+
+            $name = $this->formatHeaderKey($name);
+            $headers[$name] = $val;
+        }
+        return $headers;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function hasHeader($header) {
         return !empty($this->getHeader($header));
@@ -353,7 +400,7 @@ class Gdn_Request implements RequestInterface {
      */
     private function headerKey($name) {
         $key = strtoupper(str_replace('-', '_', $name));
-        if ($key !== 'CONTENT_TYPE') {
+        if (substr($key, 0, 5) != 'HTTP_' && !in_array($key, self::SPECIAL_HEADERS)) {
             $key = 'HTTP_'.$key;
         }
         return $key;

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -357,10 +357,10 @@ class Gdn_Request implements RequestInterface {
     /**
      * {@inheritdoc}
      */
-    public function getHeaderLine($name, $default = '') {
+    public function getHeaderLine($name) {
         $value = $this->getHeader($name);
         if (empty($value)) {
-            $value = $default;
+            $value = '';
         } elseif (is_array($value)) {
             $value = implode(',', $value);
         }

--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -36,10 +36,10 @@ class InternalRequest extends HttpRequest implements RequestInterface {
     /**
      * {@inheritdoc}
      */
-    public function getHeaderLine($name, $default = '') {
+    public function getHeaderLine($name) {
         $value = $this->getHeaderLines($name);
         if (empty($value)) {
-            $value = $default;
+            $value = '';
         } else {
             $value = implode(',', $value);
         }

--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -36,6 +36,19 @@ class InternalRequest extends HttpRequest implements RequestInterface {
     /**
      * {@inheritdoc}
      */
+    public function getHeaderLine($name, $default = '') {
+        $value = $this->getHeaderLines($name);
+        if (empty($value)) {
+            $value = $default;
+        } else {
+            $value = implode(',', $value);
+        }
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getHost() {
         return parse_url($this->getUrl(), PHP_URL_HOST);
     }

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -74,6 +74,79 @@ class RequestTest extends \PHPUnit\Framework\TestCase {
         $this->assertSame('http://localhost:8080/root-dir/path/to/resource.json?foo=bar', $request->getUrl());
     }
 
+    public function testGetHeaders() {
+        $server = [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_HOST' => 'localhost',
+            'HTTP_CACHE_CONTROL' => 'no-cache'
+        ];
+        $expectedHeaders = [
+            'Content-Type' => 'application/json',
+            'Host' => 'localhost',
+            'Cache-Control' => 'no-cache'
+        ];
+
+        $request = new Gdn_Request();
+        $request->setRequestArguments(Gdn_Request::INPUT_SERVER, $server);
+
+        $this->assertEquals($expectedHeaders, $request->getHeaders());
+    }
+
+    public function testGetHeader() {
+        $server = [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_CACHE_CONTROL' => 'no-cache',
+        ];
+
+        $request = new Gdn_Request();
+        $request->setRequestArguments(Gdn_Request::INPUT_SERVER, $server);
+
+        $this->assertEquals('application/json', $request->getHeader('CONTENT_TYPE'));
+        $this->assertEquals('application/json', $request->getHeader('Content-Type'));
+        $this->assertEquals('application/json', $request->getHeader('content-type'));
+
+        $this->assertEquals('no-cache', $request->getHeader('HTTP_CACHE_CONTROL'));
+        $this->assertEquals('no-cache', $request->getHeader('CACHE_CONTROL'));
+        $this->assertEquals('no-cache', $request->getHeader('Cache-Control'));
+        $this->assertEquals('no-cache', $request->getHeader('cache-control'));
+    }
+
+    public function testGetHeaderLine() {
+        $server = [
+            'CONTENT_LENGTH' => '',
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => ['application/json', 'application/xml']
+        ];
+
+        $request = new Gdn_Request();
+        $request->setRequestArguments(Gdn_Request::INPUT_SERVER, $server);
+
+        $this->assertEquals('', $request->getHeaderLine('Content-Length'));
+        $this->assertEquals('application/json', $request->getHeaderLine('Content-Type'));
+        $this->assertEquals('application/json,application/xml', $request->getHeaderLine('Accept'));
+    }
+
+    public function testHasHeader() {
+        $server = [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_CACHE_CONTROL' => 'no-cache',
+        ];
+
+        $request = new Gdn_Request();
+        $request->setRequestArguments(Gdn_Request::INPUT_SERVER, $server);
+
+        $this->assertTrue($request->hasHeader('CONTENT_TYPE'));
+        $this->assertTrue($request->hasHeader('Content-Type'));
+        $this->assertTrue($request->hasHeader('content-type'));
+
+        $this->assertTrue($request->hasHeader('HTTP_CACHE_CONTROL'));
+        $this->assertTrue($request->hasHeader('CACHE_CONTROL'));
+        $this->assertTrue($request->hasHeader('Cache-Control'));
+        $this->assertTrue($request->hasHeader('cache-control'));
+
+        $this->assertFalse($request->hasHeader('Auth'));
+    }
+
     public function testHostEquivalence() {
         $req = new Gdn_Request();
 

--- a/tests/fixtures/src/Request.php
+++ b/tests/fixtures/src/Request.php
@@ -84,10 +84,10 @@ class Request implements RequestInterface {
     /**
      * {@inheritdoc}
      */
-    public function getHeaderLine($name, $default = '') {
+    public function getHeaderLine($name) {
         $value = $this->getHeader($name);
         if (empty($value)) {
-            $value = $default;
+            $value = '';
         } elseif (is_array($value)) {
             $value = implode(',', $value);
         }

--- a/tests/fixtures/src/Request.php
+++ b/tests/fixtures/src/Request.php
@@ -82,6 +82,26 @@ class Request implements RequestInterface {
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getHeaderLine($name, $default = '') {
+        $value = $this->getHeader($name);
+        if (empty($value)) {
+            $value = $default;
+        } elseif (is_array($value)) {
+            $value = implode(',', $value);
+        }
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHeaders() {
+        return $this->headers;
+    }
+
+    /**
      * Checks if a header exists by the given case-insensitive name.
      *
      * @param string $header Case-insensitive header name.


### PR DESCRIPTION
This update adds some new members to request classes and tweaks some existing methods. Vanilla needs stronger header support, implemented similar to [PSR-7](http://www.php-fig.org/psr/psr-7). A couple header methods were added in #5349 and refined in #5519. The two remaining functions, `getHeaders` and `getHeaderLine` are implemented here. In addition, tests are included for these two functions, as well as `getHeader` and `hasHeader`.

Closes #5240