### PR TITLE
Do not lock current encoding anymore

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -917,11 +917,6 @@ if (c('Garden.Registration.CaptchaPublicKey')) {
 touchFolder(PATH_CACHE.'/Smarty/cache');
 touchFolder(PATH_CACHE.'/Smarty/compile');
 
-// Lock the current database character Encoding
-saveToConfig('Database.CharacterEncoding', c('Database.CharacterEncoding'));
-saveToConfig('Database.ExtendedProperties.Collate', c('Database.ExtendedProperties.Collate'));
-
-
 // For Touch Icon
 if (c('Plugins.TouchIcon.Uploaded')) {
     saveToConfig('Garden.TouchIcon', 'TouchIcon/apple-touch-icon.png');


### PR DESCRIPTION
Since #5923 it no longer makes sense to lock the current encoding, and in fact it derives & saves as `false` now on inf.