### PR TITLE
Improve error reporting in API v2 endpoints

### DIFF
--- a/applications/dashboard/controllers/Api/RolesApiController.php
+++ b/applications/dashboard/controllers/Api/RolesApiController.php
@@ -204,6 +204,7 @@ class RolesApiController extends AbstractApiController {
         $roleData = $this->caseScheme->convertArrayKeys($body);
         $roleData['RoleID'] = $id;
         $this->roleModel->save($roleData);
+        $this->validateModel($this->roleModel);
         $row = $this->roleByID($id);
 
         $result = $out->validate($row);
@@ -227,6 +228,7 @@ class RolesApiController extends AbstractApiController {
 
         $roleData = $this->caseScheme->convertArrayKeys($body);
         $id = $this->roleModel->save($roleData);
+        $this->validateModel($this->roleModel);
 
         if (!$id) {
             throw new ServerException('Unable to add role.', 500);

--- a/applications/dashboard/controllers/Api/UsersApiController.php
+++ b/applications/dashboard/controllers/Api/UsersApiController.php
@@ -227,6 +227,7 @@ class UsersApiController extends AbstractApiController {
         $userData = $this->caseScheme->convertArrayKeys($body);
         $userData['UserID'] = $id;
         $this->userModel->save($userData);
+        $this->validateModel($this->userModel);
         $row = $this->userByID($id);
         $this->prepareRow($row);
 
@@ -258,6 +259,7 @@ class UsersApiController extends AbstractApiController {
             'SaveRoles' => true
         ];
         $id = $this->userModel->save($userData, $settings);
+        $this->validateModel($this->userModel);
 
         if (!$id) {
             throw new ServerException('Unable to add user.', 500);

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -341,6 +341,7 @@ class CategoriesApiController extends AbstractApiController {
 
         $categoryData = $this->caseScheme->convertArrayKeys($body);
         $id = $this->categoryModel->save($categoryData);
+        $this->validateModel($this->categoryModel);
 
         if (!$id) {
             throw new ServerException('Unable to add category.', 500);

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -340,6 +340,7 @@ class CommentsApiController extends AbstractApiController {
             $commentData['Body'] = $row['Body'];
         }
         $this->commentModel->save($commentData);
+        $this->validateModel($this->commentModel);
         $row = $this->commentByID($id);
         $this->userModel->expandUsers($row, ['InsertUserID']);
         $this->prepareRow($row);
@@ -366,6 +367,7 @@ class CommentsApiController extends AbstractApiController {
         $discussion = $this->discussionByID($commentData['DiscussionID']);
         $this->discussionModel->categoryPermission('Vanilla.Comments.Add', $discussion['CategoryID']);
         $id = $this->commentModel->save($commentData);
+        $this->validateModel($this->commentModel);
         if (!$id) {
             throw new ServerException('Unable to insert comment.', 500);
         }

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -370,6 +370,7 @@ class DiscussionsApiController extends AbstractApiController {
         $this->fieldPermission($body, 'sink', 'Vanilla.Discussions.Sink', $categoryID);
 
         $this->discussionModel->save($discussionData);
+        $this->validateModel($this->discussionModel);
 
         $result = $this->discussionByID($id);
         $this->prepareRow($result);
@@ -398,6 +399,7 @@ class DiscussionsApiController extends AbstractApiController {
 
         $discussionData = $this->caseScheme->convertArrayKeys($body);
         $id = $this->discussionModel->save($discussionData);
+        $this->validateModel($this->discussionModel);
 
         if (!$id) {
             throw new ServerException('Unable to insert discussion.', 500);


### PR DESCRIPTION
This update alters existing endpoints to ensure `validateModel` is called after records are added or updated using a model's `save` method. [`validateModel` will analyze the `Validation` property of an object and throw specific `ValidationException` exceptions, if necessary.](https://github.com/vanilla/vanilla/blob/eae0d14e82c550bde08ab32d44f2195d79834102/library/Vanilla/Web/Controller.php#L203) This is done to ensure error messages returned by the API are as clear and specific as possible for these write operations.

Closes #5909 