### PR TITLE
Fixed click on close buttons iOS Safari

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1009,7 +1009,7 @@ jQuery(document).ready(function($) {
 
                 // If the message is dismissable, add a close button
                 if (css.indexOf('Dismissable') > 0)
-                    message = '<a class="Close"><span>&times;</span></a>' + message;
+                    message = '<a href="#" onclick="return false;" tabindex="0" class="Close"><span>&times;</span></a>' + message;
 
                 message = '<div class="InformMessage">' + message + '</div>';
                 // Insert any transient keys into the message (prevents csrf attacks in follow-on action urls).


### PR DESCRIPTION
The close buttons for inform messages were broken on iOS safari. 

* I've added an href, since links are supposed to have them. I'd prefer to use a button, but we're likely to break some styling if we do. 
* I've added the tabindex for keyboard accessibility
* The onclick false is to prevent the link to "navigate" 