### PR TITLE
Backport: Fix comment count not considered when deleting post from log

### DIFF
--- a/applications/dashboard/models/class.spammodel.php
+++ b/applications/dashboard/models/class.spammodel.php
@@ -166,10 +166,10 @@ class SpamModel extends Gdn_Pluggable {
                 $row = $model->getID($id, DATASET_TYPE_ARRAY);
 
                 /**
-                 * If our discussion has more than three comments, it might be worth saving.  Hold off on deleting and
-                 * just flag it.  If we have between 0 and 3 comments, save them along with the discussion.
+                 * If our discussion meets or exceeds our comment threshold, just flag it for review. Otherwise, save
+                 * it and its comments in the log for review and delete the original record.
                  */
-                if ($row['CountComments'] > 3) {
+                if ($row['CountComments'] >= DiscussionModel::DELETE_COMMENT_THRESHOLD) {
                     $deleteRow = false;
                 } elseif ($row['CountComments'] > 0) {
                     $comments = Gdn::database()->sql()->getWhere(

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -27,6 +27,9 @@ class DiscussionModel extends Gdn_Model {
     /** @var string The filter key for clearing-type filters. */
     const EMPTY_FILTER_KEY = 'none';
 
+    /** Max comments on a discussion before it cannot be auto-deleted by SPAM or moderation actions. */
+    const DELETE_COMMENT_THRESHOLD = 10;
+
     /** @var array|bool */
     private static $categoryPermissions = null;
 


### PR DESCRIPTION
This update is backporting [Fix deleting a revision on a popular discussion also deleting the original record](https://github.com/vanilla/vanilla/pull/5953) to [release/2017-Q2-6](https://github.com/vanilla/vanilla/tree/release/2017-Q2-6).