### PR TITLE
Add aria-hidden="true" on photos on activity page

### DIFF
--- a/applications/dashboard/views/activity/helper_functions.php
+++ b/applications/dashboard/views/activity/helper_functions.php
@@ -10,7 +10,7 @@ function writeActivity($activity, $sender, $session) {
 
     if ($activity->Photo) {
         $photoAnchor = anchor(
-            img($activity->Photo, ['class' => 'ProfilePhoto ProfilePhotoMedium']),
+            img($activity->Photo, ['class' => 'ProfilePhoto ProfilePhotoMedium', 'aria-hidden' => 'true']),
             $activity->PhotoUrl, 'PhotoWrap');
     }
 


### PR DESCRIPTION
We don't have proper alt text on the activity photos, so for accessibility, we're adding aria-hidden="true" on the photos on the /activity page