### PR TITLE
Increment duplicate form element IDs when multiple are added

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -117,6 +117,11 @@ class Gdn_Form extends Gdn_Pluggable {
     private $_IDCollection = [];
 
     /**
+     * @var array An array of ID counters so that we don't have ID clashes.
+     */
+    private static $idCounters = [];
+
+    /**
      * Constructor
      *
      * @param string $tableName
@@ -576,7 +581,7 @@ class Gdn_Form extends Gdn_Pluggable {
                 } elseif ($selected) {
                     $return .= ' selected="selected"'; // only allow selection if NOT disabled
                 }
-              
+
                 $name = htmlspecialchars(val('Name', $category, 'Blank Category Name'));
                 if ($depth > 1) {
                     $name = str_repeat('&#160;', 4 * ($depth - 1)).$name;
@@ -3156,12 +3161,18 @@ PASSWORDMETER;
      */
     protected function _idAttribute($fieldName, $attributes) {
         // ID from attributes overrides the default.
-        $iD = arrayValueI('id', $attributes, false);
-        if (!$iD) {
-            $iD = $this->escapeID($fieldName);
+        $id = arrayValueI('id', $attributes, false);
+        if (!$id) {
+            $id = $this->escapeID($fieldName);
         }
 
-        return ' id="'.htmlspecialchars($iD).'"';
+        if (isset(self::$idCounters[$id])) {
+            $id .= self::$idCounters[$id]++;
+        } else {
+            self::$idCounters[$id] = 1;
+        }
+
+        return ' id="'.htmlspecialchars($id).'"';
     }
 
     /**


### PR DESCRIPTION
It is invalid HTML to have duplicate IDs. Although we should consider getting rid of default element IDs altogether that would be too much of a change so this change at least increments the IDs if they are re-used.

A few points:

* The first use of an ID should not add any prefix. This means that unique IDs will behave the same way they did before.
* If you view the source on a page that has duplicate IDs you’ll notice that some of the IDs seem out of sync. Look at the Form_hpt in particular. I decided that this is acceptable since we aren’t looking for an aesthetic solution to a dirty problem. Again, the ultimate solution should be to remove form element IDs altogether.
- There is a lot of javascript targeting form IDs. This seems risky and some testing should be done. However, according to the [jQuery docs on the ID selector](http://api.jquery.com/id-selector/) only the first element with a given ID is queried no matter what so the behavior should not change.