### PR TITLE
Don't assume we get an array in convo save

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -507,7 +507,7 @@ class ConversationModel extends ConversationsModel {
      * @return int Unique ID of conversation created or updated.
      */
     public function save($formPostValues, $settings = []) {
-        $createMessage = empty($settings['ConversationOnly']);
+        $createMessage = (bool) val('ConversationOnly', $settings);
 
         if ($createMessage) {
             if ($settings instanceof ConversationMessageModel) {


### PR DESCRIPTION
A few lines we account for the deprecated condition of `$settings` being an object. Unfortunately, that fatals this first line.

Closes https://github.com/vanilla/internal/issues/1164