### PR TITLE
Fix deprecated detection when receiving an object in conversation model

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -507,10 +507,11 @@ class ConversationModel extends ConversationsModel {
      * @return int Unique ID of conversation created or updated.
      */
     public function save($formPostValues, $settings = []) {
-        $createMessage = empty($settings['ConversationOnly']);
+        $deprecated = $settings instanceof ConversationMessageModel;
+        $createMessage =  $deprecated || empty($settings['ConversationOnly']);
 
         if ($createMessage) {
-            if ($settings instanceof ConversationMessageModel) {
+            if ($deprecated) {
                 deprecated('ConversationModel->save(array, ConversationMessageModel)');
                 $messageModel = $settings;
             } else {


### PR DESCRIPTION
Fixes https://github.com/vanilla/internal/issues/1164

Fixes an issue where we were using $settings as an array where it was an object.