### PR TITLE
Restore redirectTo on entryController and deprecated it.

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -2007,6 +2007,17 @@ class EntryController extends Gdn_Controller {
     }
 
     /**
+     * Get the the redirect URL.
+     *
+     * @deprecated 2017-06-29
+     * @return string
+     */
+    public function redirectTo() {
+        deprecated(__FUNCTION__, 'target');
+        return $this->getTargetRoute();
+    }
+
+    /**
      * Go to requested target() or the default controller if none was set.
      *
      * @access public


### PR DESCRIPTION
We obviously need to deprecate a method before removing it!