### PR TITLE
Use a ban instead of an exception for bans

### DIFF
--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -9,6 +9,7 @@ namespace Garden\Web;
 
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\Pass;
+use Vanilla\Permissions;
 
 class Dispatcher {
 
@@ -82,7 +83,14 @@ class Dispatcher {
                     // Once we can test properly then a route can be added that checks for CSRF on all requests.
                     if ($request->getMethod() === 'POST' && $request instanceof \Gdn_Request) {
                         /* @var \Gdn_Request $request */
-                        $request->isAuthenticatedPostBack(true);
+                        try {
+                            $request->isAuthenticatedPostBack(true);
+                        } catch (\Exception $ex) {
+                            \Gdn::session()->getPermissions()->addBan(
+                                Permissions::BAN_CSRF,
+                                ['msg' => t('Invalid CSRF token.', 'Invalid CSRF token. Please try again.'), 'code' => 403]
+                            );
+                        }
                     }
 
                     try {


### PR DESCRIPTION
Some endpoints will need to opt out of CSRF protection (such as SSO
endpoints). So instead of throwing an exception we ban the user within
the request. This will make permission checks fail unless an endpoint
specifically bypasses it.