### PR TITLE
Add default response codes per HTTP verb to API requests

### DIFF
--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -6,7 +6,6 @@
  */
 
 use Garden\Schema\Schema;
-use Garden\Web\Data;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\Utility\CapitalCaseScheme;
@@ -334,7 +333,7 @@ class ConversationsApiController extends AbstractApiController {
      *
      * @param array $body The request body.
      * @throws ServerException If the conversation could not be created.
-     * @return Data
+     * @return array
      */
     public function post(array $body) {
         $this->permission('Conversations.Conversations.Add');
@@ -353,10 +352,7 @@ class ConversationsApiController extends AbstractApiController {
         }
 
         $conversation = $this->conversationByID($conversationID, $this->getSession()->UserID);
-        return new Data(
-            $out->validate($conversation),
-            201
-        );
+        return $out->validate($conversation);
     }
 
     /**
@@ -366,7 +362,7 @@ class ConversationsApiController extends AbstractApiController {
      * @param array $body The request body.
      * @throws NotFoundException if the conversation could not be found.
      * @throws ServerException If the participants could not be added.
-     * @return Data
+     * @return array
      */
     public function post_participants($id, array $body) {
         $this->permission('Conversations.Conversations.Add');
@@ -389,10 +385,7 @@ class ConversationsApiController extends AbstractApiController {
         // Fetch up to date conversation.
         $conversation = $this->conversationByID($id);
 
-        return new Data(
-            $out->validate($conversation),
-            201
-        );
+        return $out->validate($conversation);
     }
 
     /**

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -307,7 +307,7 @@ class MessagesApiController extends AbstractApiController {
      * @throws NotFoundException If the conversation was not found.
      * @throws ClientException If trying to add message to conversation you are not a participant of.
      * @throws ServerException If the message could not be created.
-     * @return Data
+     * @return array
      */
     public function post(array $body) {
         $this->permission('Conversations.Conversations.Add');
@@ -331,10 +331,7 @@ class MessagesApiController extends AbstractApiController {
 
         $message = $this->messageByID($messageID);
         $this->prepareRow($message);
-        return new Data(
-            $out->validate($message),
-            201
-        );
+        return $out->validate($message);
     }
 
     /**

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -5,7 +5,6 @@
  */
 
 use Garden\Schema\Schema;
-use Garden\Web\Data;
 use Garden\Web\Exception\ClientException;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
@@ -331,7 +330,7 @@ class CategoriesApiController extends AbstractApiController {
      *
      * @param array $body The request body.
      * @throws ServerException if the category could not be created.
-     * @return Data
+     * @return array
      */
     public function post(array $body) {
         $this->permission('Garden.Settings.Manage');
@@ -352,7 +351,7 @@ class CategoriesApiController extends AbstractApiController {
         $row = $this->category($id);
         $this->prepareRow($row);
         $result = $out->validate($row);
-        return new Data($result, 201);
+        return $result;
     }
 
     /**

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -5,7 +5,6 @@
  */
 
 use Garden\Schema\Schema;
-use Garden\Web\Data;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\Utility\CapitalCaseScheme;
@@ -353,7 +352,7 @@ class CommentsApiController extends AbstractApiController {
      *
      * @param array $body The request body.
      * @throws ServerException if the comment could not be created.
-     * @return Data
+     * @return array
      */
     public function post(array $body) {
         $this->permission('Garden.SignIn.Allow');
@@ -375,6 +374,6 @@ class CommentsApiController extends AbstractApiController {
         $this->userModel->expandUsers($row, ['InsertUserID']);
 
         $result = $out->validate($row);
-        return new Data($result, 201);
+        return $result;
     }
 }

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -6,7 +6,6 @@
  */
 
 use Garden\Schema\Schema;
-use Garden\Web\Data;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\Utility\CapitalCaseScheme;
@@ -382,7 +381,7 @@ class DiscussionsApiController extends AbstractApiController {
      *
      * @param array $body The request body.
      * @throws ServerException if the discussion could not be created.
-     * @return Data
+     * @return array
      */
     public function post(array $body) {
         $this->permission('Garden.SignIn.Allow');
@@ -409,7 +408,7 @@ class DiscussionsApiController extends AbstractApiController {
         $this->userModel->expandUsers($row, ['InsertUserID']);
         $this->prepareRow($row);
         $result = $out->validate($row);
-        return new Data($result, 201);
+        return $result;
     }
 
     /**

--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -14,7 +14,7 @@ use Vanilla\Permissions;
 class Dispatcher {
 
     /**
-     * @var Route[]
+     * @var array
      */
     private $routes;
 
@@ -118,6 +118,22 @@ class Dispatcher {
                 $response = $this->makeResponse(new NotFoundException($request->getPath()));
                 // This is temporary. Only use internally.
                 $response->setMeta('noMatch', true);
+            }
+        } else {
+            if ($response->getMeta('status', null) === null) {
+                switch ($request->getMethod()) {
+                    case 'GET':
+                    case 'PATCH':
+                    case 'PUT':
+                        $response->setStatus(200);
+                        break;
+                    case 'POST':
+                        $response->setStatus(201);
+                        break;
+                    case 'DELETE':
+                        $response->setStatus(204);
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5941

Also update the APIControllers POST functions to return an array instead of a Data object.