### PR TITLE
Fix addons inability to affect permissions checks before a notification is sent

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -235,7 +235,7 @@ class UserModel extends Gdn_Model {
      *
      * @param mixed $user The user to check.
      * @param mixed $permission The permission (or array of permissions) to check.
-     * @param array $options Not used.
+     * @param array $options
      * @return boolean
      */
     public function checkPermission($user, $permission, $options = []) {
@@ -261,7 +261,9 @@ class UserModel extends Gdn_Model {
             $permissions = $this->getPermissions($user->UserID);
         }
 
-        return $permissions->has($permission);
+        $id = val('ForeignID', $options, null);
+
+        return $permissions->has($permission, $id);
     }
 
     /**

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -567,16 +567,10 @@ class VanillaHooks implements Gdn_IPlugin {
      * @return bool Whether user has permission.
      */
     public function userModel_getCategoryViewPermission_create($sender) {
-        static $permissionModel = null;
-
         $userID = val(0, $sender->EventArguments, '');
         $categoryID = val(1, $sender->EventArguments, '');
         $permission = val(2, $sender->EventArguments, 'Vanilla.Discussions.View');
         if ($userID && $categoryID) {
-            if ($permissionModel === null) {
-                $permissionModel = new PermissionModel();
-            }
-
             $category = CategoryModel::categories($categoryID);
             if ($category) {
                 $permissionCategoryID = $category['PermissionCategoryID'];
@@ -584,12 +578,12 @@ class VanillaHooks implements Gdn_IPlugin {
                 $permissionCategoryID = -1;
             }
 
-            $result = $permissionModel->getUserPermissions($userID, $permission, 'Category', 'PermissionCategoryID', 'CategoryID', $permissionCategoryID);
-            return (val($permission, val(0, $result), false)) ? true : false;
+            $options = ['ForeignID' => $permissionCategoryID];
+            $result = Gdn::userModel()->checkPermission($userID, $permission, $options);
+            return $result;
         }
         return false;
     }
-
 
     /**
      * Add CSS assets to front end.


### PR DESCRIPTION
`UserModel::getCategoryViewPermissions` is a virtual method, overridden by Vanilla in its hooks, to check if a user has view permissions on a category. It's been in Vanilla forever. To lookup permissions, it uses the `PermissionModel::getUserPermissions`. This method queries the database for permission values and has no caching.

This update swaps out the aforementioned permission lookup from `PermissionModel::getUserPermissions` to `UserModel::checkPermission`. This new method utilizes `UserModel::getPermissions`, which implements caching and includes the "loadPermissions" event for addons to hook into. Since `UserModel::checkPermission` didn't previously have the ability to check permissions against a specific foreign ID, I've implemented the ability to pass an ID with the existing `$options` parameter.

Addons, like the Category Roles plugin, could not properly modify user permissions under certain circumstances before this update. This affected users' ability to receive notifications in categories they had special permissions in. Since this update includes the presence of the "loadPermissions" event, these types of addons should have better control over these types of permission checks.

As always, please be especially thorough when reviewing a PR dealing with user permissions.