### PR TITLE
Fix losing query parameters on homepage

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -722,7 +722,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             $defaultController = Gdn::router()->getRoute('DefaultController');
             $originalGet = $request->get();
             $request->pathAndQuery($defaultController['Destination']);
-            if (is_array($originalGet) && !empty($originalGet)) {
+            if (is_array($originalGet) && count($originalGet) > 0) {
                 $request->setQuery(array_merge($request->get(), $originalGet));
             }
         }

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -720,7 +720,11 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         } elseif (in_array($request->path(), ['', '/'])) {
             $this->isHomepage = true;
             $defaultController = Gdn::router()->getRoute('DefaultController');
+            $originalGet = $request->get();
             $request->pathAndQuery($defaultController['Destination']);
+            if (is_array($originalGet) && !empty($originalGet)) {
+                $request->setQuery(array_merge($request->get(), $originalGet));
+            }
         }
 
         return $request;


### PR DESCRIPTION
[The dispatcher rewrites the full request to the default controller when visiting the homepage.](https://github.com/vanilla/vanilla/blob/8799b3ae7c468649afbf6e28c2dfa392aa0678af/library/core/class.dispatcher.php#L723) This means query parameters used by some addons (e.g. Multilingual's "locale" parameter) can be inaccessible on the homepage.

This update takes a snapshot of the query before the homepage rewrite, then merges in the original query parameters, if there were any.