### PR TITLE
Backport: Fix losing query parameters on homepage

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -722,7 +722,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             $defaultController = Gdn::router()->getRoute('DefaultController');
             $originalGet = $request->get();
             $request->pathAndQuery($defaultController['Destination']);
-            if (is_array($originalGet) && !empty($originalGet)) {
+            if (is_array($originalGet) && count($originalGet) > 0) {
                 $request->setQuery(array_merge($request->get(), $originalGet));
             }
         }

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -720,7 +720,11 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         } elseif (in_array($request->path(), ['', '/'])) {
             $this->isHomepage = true;
             $defaultController = Gdn::router()->getRoute('DefaultController');
+            $originalGet = $request->get();
             $request->pathAndQuery($defaultController['Destination']);
+            if (is_array($originalGet) && !empty($originalGet)) {
+                $request->setQuery(array_merge($request->get(), $originalGet));
+            }
         }
 
         return $request;


### PR DESCRIPTION
This update backports #6004 to the [release/2.5a](https://github.com/vanilla/vanilla/tree/release/2.5a) branch.