### PR TITLE
Add getScheme() to RequestInterface

### DIFF
--- a/library/Garden/Web/RequestInterface.php
+++ b/library/Garden/Web/RequestInterface.php
@@ -16,15 +16,42 @@ interface RequestInterface {
      */
     public function getHost();
 
+    /**
+     * Get the method used to do the request.
+     *
+     * @return string
+     */
     public function getMethod();
 
     public function getRoot();
 
+    /**
+     * Get the path of the request.
+     *
+     * @return string
+     */
     public function getPath();
 
+    /**
+     * Get the query of the request.
+     *
+     * @return mixed
+     */
     public function getQuery();
 
+    /**
+     * Get the body of the request.
+     *
+     * @return mixed
+     */
     public function getBody();
+
+    /**
+     * Get the scheme of the request.
+     *
+     * @return string Either http or https.
+     */
+    public function getScheme();
 
     /**
      * Get all headers from the request.

--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -56,6 +56,13 @@ class InternalRequest extends HttpRequest implements RequestInterface {
     /**
      * {@inheritdoc}
      */
+    public function getScheme() {
+        return parse_url($this->url, PHP_URL_SCHEME);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getRoot() {
         $root = trim(parse_url($this->container->get('@baseUrl'), PHP_URL_PATH), '/');
         $root = $root ? "/$root" : '';

--- a/tests/fixtures/src/Request.php
+++ b/tests/fixtures/src/Request.php
@@ -57,6 +57,10 @@ class Request implements RequestInterface {
         return $this->body;
     }
 
+    public function getScheme() {
+        return 'http';
+    }
+
     /**
      * Get the hostname of the request.
      *


### PR DESCRIPTION
There was no way to get the scheme from a RequestInterface.

The method was already implemented on Gdn_Request.