### PR TITLE
Add DateAccepted to Invitation table

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2847,6 +2847,7 @@ class UserModel extends Gdn_Model {
             $this->SQL
                 ->update('Invitation')
                 ->set('AcceptedUserID', $userID)
+                ->set('DateAccepted', Gdn_Format::toDateTime())
                 ->where('InvitationID', $invitation->InvitationID)
                 ->put();
 

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -385,6 +385,7 @@ $Construct->table('Invitation')
     ->column('InsertUserID', 'int', true, 'index.userdate')
     ->column('DateInserted', 'datetime', false, 'index.userdate')
     ->column('AcceptedUserID', 'int', true)
+    ->column('DateAccepted', 'datetime', true)
     ->column('DateExpires', 'datetime', true)
     ->set($Explicit, $Drop);
 


### PR DESCRIPTION
This update adds the `DateAccepted` field to the `Invitation` table. When a user accepts an invitation and their user ID is recorded in the invitation row, the `DateAccepted` column will also be populated.