### PR TITLE
Add drafts API endpoint

### DIFF
--- a/applications/vanilla/controllers/api/DraftsApiController.php
+++ b/applications/vanilla/controllers/api/DraftsApiController.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+use Garden\Schema\Schema;
+use Garden\Web\Exception\NotFoundException;
+use Vanilla\Utility\CapitalCaseScheme;
+use Vanilla\Utility\CamelCaseScheme;
+
+/**
+ * API Controller for the `/drafts` resource.
+ */
+class DraftsApiController extends AbstractApiController {
+
+    /** @var CapitalCaseScheme */
+    private $caseScheme;
+
+    /** @var DraftModel */
+    private $draftModel;
+
+    /** @var Schema */
+    private $idParamSchema;
+
+    /** @var CamelCaseScheme */
+    private $translateCaseScheme;
+
+    /**
+     * DraftsApiController constructor.
+     *
+     * @param DraftModel $draftModel
+     */
+    public function __construct(DraftModel $draftModel) {
+        $this->draftModel = $draftModel;
+        $this->caseScheme = new CapitalCaseScheme();
+        $this->translateCaseScheme = new CamelCaseScheme();
+    }
+
+    /**
+     * Delete a draft.
+     *
+     * @param int $id The unique ID of the draft.
+     */
+    public function delete($id) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $in = $this->idParamSchema('in')->setDescription('Delete a draft.');
+        $out = $this->schema([], 'out');
+
+        $row = $this->draftByID($id);
+        if ($row['InsertUserID'] !== $this->getSession()->UserID) {
+            $this->permission('Garden.Moderation.Manage');
+        }
+        $this->draftModel->deleteID($id);
+    }
+
+    /**
+     * Get a draft by its unique ID.
+     *
+     * @param int $id
+     * @throws
+     * @return array
+     */
+    public function draftByID($id) {
+        $row = $this->draftModel->getID($id, DATASET_TYPE_ARRAY);
+        if (!$row || $row['Deleted'] > 0) {
+            throw new NotFoundException('Draft');
+        }
+        return $row;
+    }
+
+    /**
+     * Get a draft schema with minimal add/edit fields.
+     *
+     * @param string $type The type of schema.
+     * @return Schema Returns a schema object.
+     */
+    public function draftPostSchema($type) {
+        static $draftPostSchema;
+
+        if (!isset($draftPostSchema)) {
+            $draftPostSchema = $this->schema(
+                Schema::parse(
+                    ['recordType', 'parentRecordID?', 'attributes']
+                )->add($this->fullSchema()),
+                'DiscussionPost'
+            );
+        }
+
+        return $this->schema($draftPostSchema, $type);
+    }
+
+    /**
+     * Get a schema instance comprised of all available draft fields.
+     *
+     * @return Schema Returns a schema object.
+     */
+    protected function fullSchema() {
+        static $schema;
+
+        if (!isset($schema)) {
+            $schema = Schema::parse([
+                'draftID:i' => 'The unique ID of the draft.',
+                'recordType:s' => [
+                    'description' => 'The type of record associated with this draft.',
+                    'enum' => ['comment', 'discussion']
+                ],
+                'parentRecordID:i|n' => 'The unique ID of the intended parent to this record.',
+                'attributes:o' => [
+                    'description' => 'A free-form object containing all custom data for this draft.',
+                    'properties' => [
+                        'announce:b?' => 'If the record is a discussion, should it be announced when posted?',
+                        'body:s' => 'The body content of a post draft.',
+                        'closed:b?' => 'If the record is a discussion, should it be closed when posted?',
+                        'categoryID:i?' => 'The category ID of a discussion.',
+                        'name:s?' => 'The title of a discussion.',
+                        'sink:b?' => 'If the record is a discussion, should it be sunk when posted?',
+                        'tags:a?' => [
+                            'description' => 'Tags to apply to a discussion.',
+                            'items' => ['type' => 'string'],
+                            'style' => 'form'
+                        ],
+                        'format:s?' => 'The format of the post.'
+                    ]
+                ],
+                'insertUserID:i' => 'The unique ID of the user who created this draft.',
+                'dateInserted:dt' => 'When the draft was created.',
+                'updateUserID:i|n' => 'The unique ID of the user who updated this draft.',
+                'dateUpdated:dt|n' => 'When the draft was updated.'
+            ]);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Get a draft.
+     *
+     * @param int $id The unique ID of the draft.
+     * @return array
+     */
+    public function get($id) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $in = $this->idParamSchema('in')->setDescription('Get a draft.');
+        $out = $this->schema($this->fullSchema(), 'out');
+
+        $row = $this->draftByID($id);
+        if ($row['InsertUserID'] !== $this->getSession()->UserID) {
+            $this->permission('Garden.Moderation.Manage');
+        }
+        $this->prepareRow($row);
+
+        $result = $out->validate($row);
+        return $result;
+    }
+
+    /**
+     * Get an ID-only draft record schema.
+     *
+     * @param string $type The type of schema.
+     * @return Schema Returns a schema object.
+     */
+    public function idParamSchema($type = 'in') {
+        if ($this->idParamSchema === null) {
+            $this->idParamSchema = $this->schema(
+                Schema::parse(['id:i' => 'The draft ID.']),
+                $type
+            );
+        }
+        return $this->schema($this->idParamSchema, $type);
+    }
+
+    /**
+     * List drafts created by the current user.
+     *
+     * @param array $query The query string.
+     * @return array
+     */
+    public function index(array $query) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $in = $this->schema([
+            'recordType:s?' => [
+                'description' => 'Limit the drafts to this record type.',
+                'enum' => ['comment', 'discussion']
+            ],
+            'parentRecordID:i?' => 'Filter by the unique ID of the parent for a draft. Used with recordType.',
+            'page:i?' => [
+                'description' => 'Page number.',
+                'default' => 1,
+                'minimum' => 1
+            ],
+            'limit:i?' => [
+                'description' => 'The number of items per page.',
+                'default' => 30,
+                'minimum' => 1,
+                'maximum' => 100
+            ]
+        ], 'in')->setDescription('List drafts created by the current user.');
+        $out = $this->schema([':a' => $this->fullSchema()], 'out');
+
+        $query = $in->validate($query);
+
+        $where = ['InsertUserID' => $this->getSession()->UserID];
+        if (array_key_exists('recordType', $query)) {
+            switch ($query['recordType']) {
+                case 'comment':
+                    if (array_key_exists('parentRecordID', $query) && !empty($query['parentRecordID'])) {
+                        $where['DiscussionID'] = $query['parentRecordID'];
+                    } else {
+                        $where['DiscussionID >'] = 0;
+                    }
+                    break;
+                case 'discussion':
+                    $where['DiscussionID'] = null;
+                    break;
+            }
+        }
+
+        list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
+        $rows = $this->draftModel->getWhere($where, '', 'asc', $limit, $offset)->resultArray();
+
+        foreach ($rows as &$row) {
+            $this->prepareRow($row);
+        }
+
+        $result = $out->validate($rows);
+        return $result;
+    }
+
+    /**
+     * Update a draft.
+     *
+     * @param int $id The unique ID of the draft.
+     * @param array $body The request body.
+     * @return array
+     */
+    public function patch($id, array $body) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $in = $this->draftPostSchema('in')->setDescription('Update a draft.');
+        $out = $this->schema($this->fullSchema(), 'out');
+
+        $row = $this->draftByID($id);
+        if ($row['InsertUserID'] !== $this->getSession()->UserID) {
+            $this->permission('Garden.Moderation.Manage');
+        }
+
+        $body = $in->validate($body, true);
+        $draftData = $this->translateRequest($body);
+        $draftData['DraftID'] = $id;
+        $this->draftModel->save($draftData);
+        $this->validateModel($this->draftModel);
+
+        $row = $this->draftByID($id);
+        $this->prepareRow($row);
+
+        $result = $out->validate($row);
+        return $result;
+    }
+
+    /**
+     * Create a draft.
+     *
+     * @param array $body The request body.
+     * @return array
+     */
+    public function post(array $body) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $in = $this->draftPostSchema('in')->setDescription('Create a draft.');
+        $out = $this->schema($this->fullSchema(), 'out');
+
+        $body = $in->validate($body);
+        $draftData = $this->translateRequest($body);
+        $draftID = $this->draftModel->save($draftData);
+        $this->validateModel($this->draftModel);
+
+        $row = $this->draftByID($draftID);
+        $this->prepareRow($row);
+
+        $result = $out->validate($row);
+        return $result;
+    }
+
+    /**
+     * Prepare data for output.
+     *
+     * @param array $row
+     */
+    public function prepareRow(array &$row) {
+        $row = $this->translateRow($row);
+    }
+
+    /**
+     * Translate a request to this endpoint into a format compatible for saving with DraftModel.
+     *
+     * @param array $body
+     * @return array
+     */
+    private function translateRequest(array $body) {
+        if (array_key_exists('attributes', $body)) {
+            $columns = ['announce', 'body', 'categoryID', 'closed', 'format', 'name', 'sink', 'tags'];
+            $attributes = array_intersect_key($body['attributes'], array_flip($columns));
+            $body = array_merge($body, $attributes);
+            unset($body['attributes']);
+        }
+
+        if (array_key_exists('tags', $body)) {
+            if (empty($body['tags'])) {
+                $body['tags'] = null;
+            } elseif (is_array($body['tags'])) {
+                $body['tags'] = implode(',', $body['tags']);
+            }
+        }
+
+        if (array_key_exists('recordType', $body)) {
+            switch ($body['recordType']) {
+                case 'comment':
+                    if (array_key_exists('parentRecordID', $body)) {
+                        $body['DiscussionID'] = $body['parentRecordID'];
+                    }
+                    break;
+            }
+        }
+        unset($body['recordType'], $body['parentRecordID']);
+
+        $result = $this->caseScheme->convertArrayKeys($body);
+        return $result;
+    }
+
+    /**
+     * Translate the structure of a row from the drafts table into the format used by this endpoint.
+     *
+     * @param array $row
+     * @return array
+     */
+    private function translateRow(array $row) {
+        $parentRecordID = null;
+
+        $commentAttributes = ['Body', 'DiscussionID', 'Format'];
+        $discussionAttributes = ['Announce', 'Body', 'CategoryID', 'Closed', 'Format', 'Name', 'Sink', 'Tags'];
+        if (array_key_exists('DiscussionID', $row) && !empty($row['DiscussionID'])) {
+            $row['RecordType'] = 'comment';
+            $parentRecordID = $row['DiscussionID'];
+            $attributes = $commentAttributes;
+        } else {
+            $row['RecordType'] = 'discussion';
+            $attributes = $discussionAttributes;
+        }
+
+        $row['Attributes'] = array_intersect_key($row, array_flip($attributes));
+        $row['ParentRecordID'] = $parentRecordID;
+
+        // Remove redundant attribute columns on the row.
+        foreach (array_merge($commentAttributes, $discussionAttributes) as $col) {
+            unset($row[$col]);
+        }
+
+        $result = $this->translateCaseScheme->convertArrayKeys($row);
+        return $result;
+    }
+}

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -85,7 +85,7 @@ class DraftModel extends Gdn_Model {
      * @param int $draftID Unique ID of draft to get data for.
      * @param string|false $dataSetType The format of the data.
      * @param array $options Not used.
-     * @return object SQL results.
+     * @return array|object SQL results.
      */
     public function getID($draftID, $dataSetType = false, $options = []) {
         $dataSetType = $dataSetType ?: DATASET_TYPE_OBJECT;

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -138,12 +138,14 @@ class DraftModel extends Gdn_Model {
         // Define the primary key in this model's table.
         $this->defineSchema();
 
-        // Add & apply any extra validation rules:
-        $this->Validation->applyRule('Body', 'Required');
-        $maxCommentLength = Gdn::config('Vanilla.Comment.MaxLength');
-        if (is_numeric($maxCommentLength) && $maxCommentLength > 0) {
-            $this->Validation->setSchemaProperty('Body', 'Length', $maxCommentLength);
-            $this->Validation->applyRule('Body', 'Length');
+        if (array_key_exists('Body', $formPostValues)) {
+            // Add & apply any extra validation rules:
+            $this->Validation->applyRule('Body', 'Required');
+            $maxCommentLength = Gdn::config('Vanilla.Comment.MaxLength');
+            if (is_numeric($maxCommentLength) && $maxCommentLength > 0) {
+                $this->Validation->setSchemaProperty('Body', 'Length', $maxCommentLength);
+                $this->Validation->applyRule('Body', 'Length');
+            }
         }
 
         // Get the DraftID from the form so we know if we are inserting or updating.
@@ -155,7 +157,7 @@ class DraftModel extends Gdn_Model {
         }
 
         // Remove the discussionid from the form value collection if it's empty
-        if (array_key_exists('DiscussionID', $formPostValues) && $formPostValues['DiscussionID'] == '') {
+        if (array_key_exists('DiscussionID', $formPostValues) && $formPostValues['DiscussionID'] === '') {
             unset($formPostValues['DiscussionID']);
         }
 
@@ -253,7 +255,7 @@ class DraftModel extends Gdn_Model {
      */
     public function updateUser($userID) {
         // Retrieve a draft count
-        $countDrafts = $this->getCount($userID);
+        $countDrafts = $this->getCountByUser($userID);
 
         // Update CountDrafts column of user table fot this user
         Gdn::userModel()->setField($userID, 'CountDrafts', $countDrafts);

--- a/tests/APIv2/DraftsTest.php
+++ b/tests/APIv2/DraftsTest.php
@@ -64,17 +64,17 @@ class DraftsTest extends AbstractResourceTest {
     public function testPostDiscussion() {
         $data = [
             'recordType' => 'discussion',
+            'parentRecordID' => 1,
             'attributes' => [
-                'announce' => true,
+                'announce' => 1,
                 'body' => 'Hello world.',
-                'categoryID' => 1,
-                'closed' => true,
+                'closed' => 1,
                 'format' => 'Markdown',
                 'name' => 'Discussion Draft',
-                'sink' => false,
-                'tags' => ['interesting', 'helpful']
+                'sink' => 0,
+                'tags' => 'interesting,helpful'
             ]
         ];
-        $row = parent::testPost($data);
+        parent::testPost($data);
     }
 }

--- a/tests/APIv2/DraftsTest.php
+++ b/tests/APIv2/DraftsTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\APIv2;
+
+/**
+ * Test the /api/v2/drafts endpoints.
+ */
+class DraftsTest extends AbstractResourceTest {
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($name = null, array $data = [], $dataName = '') {
+        $this->baseUrl = '/drafts';
+        $this->record = [
+            'recordType' => 'comment',
+            'parentRecordID' => 1,
+            'attributes' => [
+                'body' => 'Hello world. I am a comment.',
+                'format' => 'Markdown'
+            ]
+        ];
+
+        $this->patchFields = ['parentRecordID', 'attributes'];
+
+        parent::__construct($name, $data, $dataName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function modifyRow(array $row) {
+        $row = parent::modifyRow($row);
+        $formats = ['BBCode', 'Html', 'Markdown', 'Text', 'TextEx', 'Wysiwyg'];
+        shuffle($formats);
+
+        if (array_key_exists('parentRecordID', $row)) {
+            $row['parentRecordID']++;
+        }
+        if (array_key_exists('attributes', $row) && is_array($row['attributes'])) {
+            foreach ($row['attributes'] as $key => &$val) {
+                if ($key == 'format') {
+                    $val = $formats[0];
+                } elseif (filter_var($val, FILTER_VALIDATE_BOOLEAN)) {
+                    $val = !(bool)$val;
+                } elseif (filter_var($val, FILTER_VALIDATE_INT)) {
+                    $val++;
+                } else {
+                    $val = strval($val).microtime();
+                }
+            }
+        }
+
+        return $row;
+    }
+
+    /**
+     * Verify the ability to create a discussion draft.
+     */
+    public function testPostDiscussion() {
+        $data = [
+            'recordType' => 'discussion',
+            'attributes' => [
+                'announce' => true,
+                'body' => 'Hello world.',
+                'categoryID' => 1,
+                'closed' => true,
+                'format' => 'Markdown',
+                'name' => 'Discussion Draft',
+                'sink' => false,
+                'tags' => ['interesting', 'helpful']
+            ]
+        ];
+        $row = parent::testPost($data);
+    }
+}


### PR DESCRIPTION
This update adds support for creating drafts with the API. The specifics of the actual implementation are detailed in the associated issue. The API implementation is what will become of drafts: all resource-specific fields going into the `Attributes` column. Right now, the API is serving as a translation layer. Once the necessary refactoring occurs to make drafts a more universally-usable resource, the translations can be dropped.

`DraftsModel` needed some help, so I've also performed the following updates:

1. Do not always require the `Body` field. This was blocking sparse updating with PATCH. The implemented fix mirrors similar `Body` requirement conditions from `DiscussionModel`.
1. Do not unset the `DiscussionID` if it is a `null` value. The condition appeared to be looking for an empty string, but `null` values were also tripping its loose comparison.
1. `DraftModel::updateUser` was using `DraftModel::getCount`, which is deprecated. It has been updated to use `DraftModel::getCountByUser`, instead.

Closes #5535