### PR TITLE
Miscellaneous improvements to testing

### DIFF
--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -20,14 +20,32 @@ abstract class AbstractAPIv2Test extends \PHPUnit_Framework_TestCase {
     private $api;
 
     /**
+     * @var bool Set to false before setUp() to skip the session->start();
+     */
+    private $startSessionOnSetup = true;
+
+    /**
+     * Whether to start a session on setUp() or not.
+     *
+     * @param $enabled
+     */
+    protected function startSessionOnSetup($enabled) {
+        $this->startSessionOnSetup = $enabled;
+    }
+
+    /**
      * Create a fresh API client for the test.
      */
     public function setUp() {
         parent::setUp();
 
         $this->api = static::container()->getArgs(InternalClient::class, [static::container()->get('@baseUrl').'/api/v2']);
-        $this->api->setUserID(self::$siteInfo['adminUserID']);
-        $this->api->setTransientKey(md5(now()));
+
+        if ($this->startSessionOnSetup) {
+            $this->api->setUserID(self::$siteInfo['adminUserID']);
+            $this->api->setTransientKey(md5(now()));
+        }
+
     }
 
     /**

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -27,7 +27,7 @@ abstract class AbstractAPIv2Test extends \PHPUnit_Framework_TestCase {
     /**
      * Whether to start a session on setUp() or not.
      *
-     * @param $enabled
+     * @param bool $enabled
      */
     protected function startSessionOnSetup($enabled) {
         $this->startSessionOnSetup = $enabled;

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -26,6 +26,12 @@ class ConversationsTest extends AbstractAPIv2Test {
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
 
+        /**
+         * @var \Gdn_Session $session
+         */
+        $session = self::container()->get(\Gdn_Session::class);
+        $session->start(self::$siteInfo['adminUserID'], false, false);
+
         /** @var \UsersApiController $usersAPIController */
         $usersAPIController = static::container()->get('UsersAPIController');
 
@@ -42,6 +48,8 @@ class ConversationsTest extends AbstractAPIv2Test {
         /** @var \Gdn_Configuration $config */
         $config = static::container()->get('Config');
         $config->set('Garden.Email.Disabled', true, true, false);
+
+        $session->end();
     }
 
     /**

--- a/tests/APIv2/MessagesTest.php
+++ b/tests/APIv2/MessagesTest.php
@@ -31,6 +31,12 @@ class MessagesTest extends AbstractResourceTest {
     public static function setUpBeforeClass() {
         parent::setupBeforeClass();
 
+        /**
+         * @var \Gdn_Session $session
+         */
+        $session = self::container()->get(\Gdn_Session::class);
+        $session->start(self::$siteInfo['adminUserID'], false, false);
+
         /** @var \UsersApiController $usersAPIController */
         $usersAPIController = static::container()->get('UsersAPIController');
 
@@ -53,6 +59,8 @@ class MessagesTest extends AbstractResourceTest {
         /** @var \Gdn_Configuration $config */
         $config = static::container()->get('Config');
         $config->set('Garden.Email.Disabled', true, true, false);
+
+        $session->end();
     }
 
     /**

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -9,7 +9,7 @@ namespace VanillaTests;
 
 use Garden\Container\Container;
 use Garden\Container\Reference;
-use \Garden\Web\RequestInterface;
+use Garden\Web\RequestInterface;
 use Gdn;
 use Interop\Container\ContainerInterface;
 use Psr\Log\LoggerAwareInterface;

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -9,6 +9,7 @@ namespace VanillaTests;
 
 use Garden\Container\Container;
 use Garden\Container\Reference;
+use \Garden\Web\RequestInterface;
 use Gdn;
 use Interop\Container\ContainerInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -131,6 +132,7 @@ class Bootstrap {
             ->rule(\Gdn_Request::class)
             ->setShared(true)
             ->addAlias('Request')
+            ->addAlias(RequestInterface::class)
 
             // Database.
             ->rule('Gdn_Database')

--- a/tests/SiteTestTrait.php
+++ b/tests/SiteTestTrait.php
@@ -23,7 +23,7 @@ trait SiteTestTrait {
     /**
      * @var array
      */
-    private static $siteInfo;
+    protected static $siteInfo;
 
     /**
      * @var array The addons to install.
@@ -61,11 +61,10 @@ trait SiteTestTrait {
             'addons' => static::$addons
         ]);
 
-        self::$siteInfo = $result;
+        // Start Authenticators
+        $dic->get('Authenticator')->startAuthenticator();
 
-        /* @var \Gdn_Session $session */
-        $session = $dic->get(\Gdn_Session::class);
-        $session->start(self::$siteInfo['adminUserID'], false, false);
+        self::$siteInfo = $result;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/6015

- Allows to unit tests without a session being started.
- Add missing alias "RequestInterface" for Gdn_Request.
- Call `startAuthenticator()` after the site was installed (otherwise you get an error when calling `$session->end()` because the password authenticator is not loaded.