### PR TITLE
Backport: Fix addons inability to affect permissions checks before a notification is sent

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -225,7 +225,7 @@ class UserModel extends Gdn_Model {
      *
      * @param mixed $User The user to check.
      * @param mixed $Permission The permission (or array of permissions) to check.
-     * @param array $Options Not used.
+     * @param array $Options
      * @return boolean
      */
     public function checkPermission($User, $Permission, $Options = []) {
@@ -251,7 +251,9 @@ class UserModel extends Gdn_Model {
             $permissions = $this->getPermissions($User->UserID);
         }
 
-        return $permissions->has($Permission);
+        $id = val('ForeignID', $Options, null);
+
+        return $permissions->has($Permission, $id);
     }
 
     /**

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -567,16 +567,10 @@ class VanillaHooks implements Gdn_IPlugin {
      * @return bool Whether user has permission.
      */
     public function userModel_getCategoryViewPermission_create($Sender) {
-        static $PermissionModel = null;
-
         $UserID = val(0, $Sender->EventArguments, '');
         $CategoryID = val(1, $Sender->EventArguments, '');
         $Permission = val(2, $Sender->EventArguments, 'Vanilla.Discussions.View');
         if ($UserID && $CategoryID) {
-            if ($PermissionModel === null) {
-                $PermissionModel = new PermissionModel();
-            }
-
             $Category = CategoryModel::categories($CategoryID);
             if ($Category) {
                 $PermissionCategoryID = $Category['PermissionCategoryID'];
@@ -584,12 +578,12 @@ class VanillaHooks implements Gdn_IPlugin {
                 $PermissionCategoryID = -1;
             }
 
-            $Result = $PermissionModel->getUserPermissions($UserID, $Permission, 'Category', 'PermissionCategoryID', 'CategoryID', $PermissionCategoryID);
-            return (val($Permission, val(0, $Result), false)) ? true : false;
+            $options = ['ForeignID' => $PermissionCategoryID];
+            $result = Gdn::userModel()->checkPermission($UserID, $Permission, $options);
+            return $result;
         }
         return false;
     }
-
 
     /**
      * Add CSS assets to front end.


### PR DESCRIPTION
This update backports #6003 to [release/2017-Q2-6](https://github.com/vanilla/vanilla/tree/release/2017-Q2-6).