### PR TITLE
Improve accessibility of MeBox

### DIFF
--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -5230,7 +5230,7 @@ input + .ReactSprite {
   border: 0;
 }
 
-.sr-only-important {
+.u-srcOnly {
   position: absolute !important;
   width: 1px !important;
   height: 1px !important;

--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -5230,6 +5230,17 @@ input + .ReactSprite {
   border: 0;
 }
 
+.sr-only-important {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  margin: -1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  border: 0 !important;
+}
+
 /* Token input */
 ul.token-input-list {
   -webkit-box-sizing: border-box;

--- a/applications/dashboard/design/style.css
+++ b/applications/dashboard/design/style.css
@@ -5230,17 +5230,6 @@ input + .ReactSprite {
   border: 0;
 }
 
-.u-srcOnly {
-  position: absolute !important;
-  width: 1px !important;
-  height: 1px !important;
-  margin: -1px !important;
-  padding: 0 !important;
-  overflow: hidden !important;
-  clip: rect(0, 0, 0, 0) !important;
-  border: 0 !important;
-}
-
 /* Token input */
 ul.token-input-list {
   -webkit-box-sizing: border-box;

--- a/applications/dashboard/views/modules/dropdown.php
+++ b/applications/dashboard/views/modules/dropdown.php
@@ -3,7 +3,6 @@
 $dropdown = $this;
 $trigger = $dropdown->getTrigger();
 ?>
-
 <span class="ToggleFlyout <?php echo $dropdown->getCssClass(); ?>">
     <?php if (val('type', $trigger) === 'button') : ?>
     <span class="Button-Options">

--- a/applications/dashboard/views/modules/dropdown.php
+++ b/applications/dashboard/views/modules/dropdown.php
@@ -2,10 +2,9 @@
 /** @var DropdownModule $dropdown */
 $dropdown = $this;
 $trigger = $dropdown->getTrigger();
-?>
-<span class="ToggleFlyout <?php echo $dropdown->getCssClass(); ?>">
-    <?php if (val('type', $trigger) === 'button') : ?>
-    <span class="Button-Options">
+?><span class="ToggleFlyout <?php echo $dropdown->getCssClass(); ?>"><?php
+    if (val('type', $trigger) === 'button') :
+    ?><span class="Button-Options">
         <span class="OptionsTitle" title="<?php echo t('Options'); ?>">
             <?php echo val('text', $trigger); ?>
         </span>

--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -37,7 +37,7 @@ if ($Session->isValid()):
     $CNotifications = is_numeric($CountNotifications) && $CountNotifications > 0 ? '<span class="Alert NotificationsAlert">'.$CountNotifications.'</span>' : '';
 
     echo '<span class="ToggleFlyout" rel="/profile/notificationspopin">';
-    echo anchor(sprite('SpNotifications', 'Sprite Sprite16', t('Globe')).$CNotifications, userUrl($User), 'MeButton FlyoutButton js-clear-notifications', ['title' => t('Notifications'), 'tabindex' => '0']);
+    echo anchor(sprite('SpNotifications', 'Sprite Sprite16', t('Notifications')).$CNotifications, userUrl($User), 'MeButton FlyoutButton js-clear-notifications', ['title' => t('Notifications'), 'tabindex' => '0', "role" => "button", "aria-haspopup" => true]);
     echo sprite('SpFlyoutHandle', 'Arrow');
     echo '<div class="Flyout FlyoutMenu"></div></span>';
 
@@ -46,7 +46,7 @@ if ($Session->isValid()):
         $CountInbox = val('CountUnreadConversations', Gdn::session()->User);
         $CInbox = is_numeric($CountInbox) && $CountInbox > 0 ? ' <span class="Alert">'.$CountInbox.'</span>' : '';
         echo '<span class="ToggleFlyout" rel="/messages/popin">';
-        echo anchor(sprite('SpInbox', 'Sprite Sprite16', t('Envelope')).wrap(t('Inbox'), 'em').$CInbox, '/messages/all', 'MeButton FlyoutButton', ['title' => t('Inbox'), 'tabindex' => '0']);
+        echo anchor(sprite('SpInbox', 'Sprite Sprite16', t('Inbox')).$CInbox, '/messages/all', 'MeButton FlyoutButton', ['title' => t('Inbox'), 'tabindex' => '0', "role" => "button", "aria-haspopup" => true]);
         echo sprite('SpFlyoutHandle', 'Arrow');
         echo '<div class="Flyout FlyoutMenu"></div></span>';
     }
@@ -54,7 +54,7 @@ if ($Session->isValid()):
     // Bookmarks
     if (Gdn::addonManager()->lookupAddon('Vanilla')) {
         echo '<span class="ToggleFlyout" rel="/discussions/bookmarkedpopin">';
-        echo anchor(sprite('SpBookmarks', 'Sprite Sprite16', t('Star')), '/discussions/bookmarked', 'MeButton FlyoutButton', ['title' => t('Bookmarks'), 'tabindex' => '0']);
+        echo anchor(sprite('SpBookmarks', 'Sprite Sprite16', t('Bookmarks')), '/discussions/bookmarked', 'MeButton FlyoutButton', ['title' => t('Bookmarks'), 'tabindex' => '0', "role" => "button", "aria-haspopup" => true]);
         echo sprite('SpFlyoutHandle', 'Arrow');
         echo '<div class="Flyout FlyoutMenu"></div></span>';
     }
@@ -62,9 +62,9 @@ if ($Session->isValid()):
     // Profile Settings & Logout
     $dropdown = new DropdownModule();
     $dropdown->setData('DashboardCount', $DashboardCount);
-    $triggerIcon = sprite('SpOptions', 'Sprite Sprite16', t('Cog Wheel'));
     $triggerTitle = t('Account Options');
-    $dropdown->setTrigger('', 'anchor', 'MeButton FlyoutButton', $triggerIcon, '/profile/edit', ['title' => $triggerTitle, 'tabindex' => '0']);
+    $triggerIcon = sprite('SpOptions', 'Sprite Sprite16', $triggerTitle);
+    $dropdown->setTrigger('', 'anchor', 'MeButton FlyoutButton', $triggerIcon, '/profile/edit', ['title' => $triggerTitle, 'tabindex' => '0', "role" => "button", "aria-haspopup" => true]);
     $editModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-editprofile'];
     $preferencesModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-preferences'];
 

--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -37,7 +37,7 @@ if ($Session->isValid()):
     $CNotifications = is_numeric($CountNotifications) && $CountNotifications > 0 ? '<span class="Alert NotificationsAlert">'.$CountNotifications.'</span>' : '';
 
     echo '<span class="ToggleFlyout" rel="/profile/notificationspopin">';
-    echo anchor(sprite('SpNotifications', 'Sprite Sprite16').wrap(t('Notifications'), 'em').$CNotifications, userUrl($User), 'MeButton FlyoutButton js-clear-notifications', ['title' => t('Notifications')]);
+    echo anchor(sprite('SpNotifications', 'Sprite Sprite16', t('Globe')).$CNotifications, userUrl($User), 'MeButton FlyoutButton js-clear-notifications', ['title' => t('Notifications'), 'tabindex' => 0]);
     echo sprite('SpFlyoutHandle', 'Arrow');
     echo '<div class="Flyout FlyoutMenu"></div></span>';
 
@@ -46,7 +46,7 @@ if ($Session->isValid()):
         $CountInbox = val('CountUnreadConversations', Gdn::session()->User);
         $CInbox = is_numeric($CountInbox) && $CountInbox > 0 ? ' <span class="Alert">'.$CountInbox.'</span>' : '';
         echo '<span class="ToggleFlyout" rel="/messages/popin">';
-        echo anchor(sprite('SpInbox', 'Sprite Sprite16').wrap(t('Inbox'), 'em').$CInbox, '/messages/all', 'MeButton FlyoutButton', ['title' => t('Inbox')]);
+        echo anchor(sprite('SpInbox', 'Sprite Sprite16', t('Envelope')).wrap(t('Inbox'), 'em').$CInbox, '/messages/all', 'MeButton FlyoutButton', ['title' => t('Inbox'), 'tabindex' => 0]);
         echo sprite('SpFlyoutHandle', 'Arrow');
         echo '<div class="Flyout FlyoutMenu"></div></span>';
     }
@@ -54,7 +54,7 @@ if ($Session->isValid()):
     // Bookmarks
     if (Gdn::addonManager()->lookupAddon('Vanilla')) {
         echo '<span class="ToggleFlyout" rel="/discussions/bookmarkedpopin">';
-        echo anchor(sprite('SpBookmarks', 'Sprite Sprite16').wrap(t('Bookmarks'), 'em'), '/discussions/bookmarked', 'MeButton FlyoutButton', ['title' => t('Bookmarks')]);
+        echo anchor(sprite('SpBookmarks', 'Sprite Sprite16', t('Star')), '/discussions/bookmarked', 'MeButton FlyoutButton', ['title' => t('Bookmarks'), 'tabindex' => 0]);
         echo sprite('SpFlyoutHandle', 'Arrow');
         echo '<div class="Flyout FlyoutMenu"></div></span>';
     }
@@ -62,9 +62,9 @@ if ($Session->isValid()):
     // Profile Settings & Logout
     $dropdown = new DropdownModule();
     $dropdown->setData('DashboardCount', $DashboardCount);
-    $triggerIcon = '<span class="Sprite Sprite16 SpOptions"></span>';
+    $triggerIcon = sprite('SpOptions', 'Sprite Sprite16', t('Cog Wheel'));
     $triggerTitle = t('Account Options');
-    $dropdown->setTrigger(wrap($triggerTitle, 'em'), 'anchor', 'MeButton FlyoutButton', $triggerIcon, '/profile/edit', ['title' => $triggerTitle]);
+    $dropdown->setTrigger('', 'anchor', 'MeButton FlyoutButton', $triggerIcon, '/profile/edit', ['title' => $triggerTitle, 'tabindex' => '0']);
     $editModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-editprofile'];
     $preferencesModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-preferences'];
 

--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -37,7 +37,7 @@ if ($Session->isValid()):
     $CNotifications = is_numeric($CountNotifications) && $CountNotifications > 0 ? '<span class="Alert NotificationsAlert">'.$CountNotifications.'</span>' : '';
 
     echo '<span class="ToggleFlyout" rel="/profile/notificationspopin">';
-    echo anchor(sprite('SpNotifications', 'Sprite Sprite16', t('Globe')).$CNotifications, userUrl($User), 'MeButton FlyoutButton js-clear-notifications', ['title' => t('Notifications'), 'tabindex' => 0]);
+    echo anchor(sprite('SpNotifications', 'Sprite Sprite16', t('Globe')).$CNotifications, userUrl($User), 'MeButton FlyoutButton js-clear-notifications', ['title' => t('Notifications'), 'tabindex' => '0']);
     echo sprite('SpFlyoutHandle', 'Arrow');
     echo '<div class="Flyout FlyoutMenu"></div></span>';
 
@@ -46,7 +46,7 @@ if ($Session->isValid()):
         $CountInbox = val('CountUnreadConversations', Gdn::session()->User);
         $CInbox = is_numeric($CountInbox) && $CountInbox > 0 ? ' <span class="Alert">'.$CountInbox.'</span>' : '';
         echo '<span class="ToggleFlyout" rel="/messages/popin">';
-        echo anchor(sprite('SpInbox', 'Sprite Sprite16', t('Envelope')).wrap(t('Inbox'), 'em').$CInbox, '/messages/all', 'MeButton FlyoutButton', ['title' => t('Inbox'), 'tabindex' => 0]);
+        echo anchor(sprite('SpInbox', 'Sprite Sprite16', t('Envelope')).wrap(t('Inbox'), 'em').$CInbox, '/messages/all', 'MeButton FlyoutButton', ['title' => t('Inbox'), 'tabindex' => '0']);
         echo sprite('SpFlyoutHandle', 'Arrow');
         echo '<div class="Flyout FlyoutMenu"></div></span>';
     }
@@ -54,7 +54,7 @@ if ($Session->isValid()):
     // Bookmarks
     if (Gdn::addonManager()->lookupAddon('Vanilla')) {
         echo '<span class="ToggleFlyout" rel="/discussions/bookmarkedpopin">';
-        echo anchor(sprite('SpBookmarks', 'Sprite Sprite16', t('Star')), '/discussions/bookmarked', 'MeButton FlyoutButton', ['title' => t('Bookmarks'), 'tabindex' => 0]);
+        echo anchor(sprite('SpBookmarks', 'Sprite Sprite16', t('Star')), '/discussions/bookmarked', 'MeButton FlyoutButton', ['title' => t('Bookmarks'), 'tabindex' => '0']);
         echo sprite('SpFlyoutHandle', 'Arrow');
         echo '<div class="Flyout FlyoutMenu"></div></span>';
     }

--- a/applications/dashboard/views/modules/me.php
+++ b/applications/dashboard/views/modules/me.php
@@ -37,7 +37,7 @@ if ($Session->isValid()):
     $CNotifications = is_numeric($CountNotifications) && $CountNotifications > 0 ? '<span class="Alert NotificationsAlert">'.$CountNotifications.'</span>' : '';
 
     echo '<span class="ToggleFlyout" rel="/profile/notificationspopin">';
-    echo anchor(sprite('SpNotifications', 'Sprite Sprite16', t('Notifications')).$CNotifications, userUrl($User), 'MeButton FlyoutButton js-clear-notifications', ['title' => t('Notifications'), 'tabindex' => '0', "role" => "button", "aria-haspopup" => true]);
+    echo anchor(sprite('SpNotifications', 'Sprite Sprite16', t('Notifications')).$CNotifications, userUrl($User), 'MeButton FlyoutButton js-clear-notifications', ['title' => t('Notifications'), 'tabindex' => '0', "role" => "button", "aria-haspopup" => "true"]);
     echo sprite('SpFlyoutHandle', 'Arrow');
     echo '<div class="Flyout FlyoutMenu"></div></span>';
 
@@ -46,7 +46,7 @@ if ($Session->isValid()):
         $CountInbox = val('CountUnreadConversations', Gdn::session()->User);
         $CInbox = is_numeric($CountInbox) && $CountInbox > 0 ? ' <span class="Alert">'.$CountInbox.'</span>' : '';
         echo '<span class="ToggleFlyout" rel="/messages/popin">';
-        echo anchor(sprite('SpInbox', 'Sprite Sprite16', t('Inbox')).$CInbox, '/messages/all', 'MeButton FlyoutButton', ['title' => t('Inbox'), 'tabindex' => '0', "role" => "button", "aria-haspopup" => true]);
+        echo anchor(sprite('SpInbox', 'Sprite Sprite16', t('Inbox')).$CInbox, '/messages/all', 'MeButton FlyoutButton', ['title' => t('Inbox'), 'tabindex' => '0', "role" => "button", "aria-haspopup" => "true"]);
         echo sprite('SpFlyoutHandle', 'Arrow');
         echo '<div class="Flyout FlyoutMenu"></div></span>';
     }
@@ -54,7 +54,7 @@ if ($Session->isValid()):
     // Bookmarks
     if (Gdn::addonManager()->lookupAddon('Vanilla')) {
         echo '<span class="ToggleFlyout" rel="/discussions/bookmarkedpopin">';
-        echo anchor(sprite('SpBookmarks', 'Sprite Sprite16', t('Bookmarks')), '/discussions/bookmarked', 'MeButton FlyoutButton', ['title' => t('Bookmarks'), 'tabindex' => '0', "role" => "button", "aria-haspopup" => true]);
+        echo anchor(sprite('SpBookmarks', 'Sprite Sprite16', t('Bookmarks')), '/discussions/bookmarked', 'MeButton FlyoutButton', ['title' => t('Bookmarks'), 'tabindex' => '0', "role" => "button", "aria-haspopup" => "true"]);
         echo sprite('SpFlyoutHandle', 'Arrow');
         echo '<div class="Flyout FlyoutMenu"></div></span>';
     }
@@ -64,7 +64,7 @@ if ($Session->isValid()):
     $dropdown->setData('DashboardCount', $DashboardCount);
     $triggerTitle = t('Account Options');
     $triggerIcon = sprite('SpOptions', 'Sprite Sprite16', $triggerTitle);
-    $dropdown->setTrigger('', 'anchor', 'MeButton FlyoutButton', $triggerIcon, '/profile/edit', ['title' => $triggerTitle, 'tabindex' => '0', "role" => "button", "aria-haspopup" => true]);
+    $dropdown->setTrigger('', 'anchor', 'MeButton FlyoutButton', $triggerIcon, '/profile/edit', ['title' => $triggerTitle, 'tabindex' => '0', "role" => "button", "aria-haspopup" => "true"]);
     $editModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-editprofile'];
     $preferencesModifiers['listItemCssClasses'] = ['EditProfileWrap', 'link-preferences'];
 

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -309,8 +309,10 @@ if (!function_exists('attribute')) {
             $exclude = $valueOrExclude;
         }
         foreach ($name as $attribute => $val) {
-            if (empty($val) || ($exclude && stringBeginsWith($attribute, $exclude))) {
-                continue;
+            if($attribute != "tabindex") {
+                if ((empty($val)) || ($exclude && stringBeginsWith($attribute, $exclude))) {
+                    continue;
+                }
             }
             if (is_array($val) && strpos($attribute, 'data-') === 0) {
                 $val = json_encode($val);

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1513,7 +1513,7 @@ if (!function_exists('sprite')) {
     function sprite($name, $type = 'Sprite', $text = false) {
         $sprite = '<span aria-hidden="true" class="'.$type.' '.$name.'"></span>';
         if ($text) {
-            $sprite .= '<span class="sr-only-important">'.$text.'</span>';
+            $sprite .= '<span class="sr-only">'.$text.'</span>';
         }
 
         return $sprite;

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1513,7 +1513,7 @@ if (!function_exists('sprite')) {
     function sprite($name, $type = 'Sprite', $text = false) {
         $sprite = '<span class="'.$type.' '.$name.'"></span>';
         if ($text) {
-            $sprite .= '<span class="sr-only">'.$text.'</span>';
+            $sprite .= '<span class="sr-only-important">'.$text.'</span>';
         }
 
         return $sprite;

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1511,7 +1511,7 @@ if (!function_exists('sprite')) {
      * @return string
      */
     function sprite($name, $type = 'Sprite', $text = false) {
-        $sprite = '<span class="'.$type.' '.$name.'"></span>';
+        $sprite = '<span aria-hidden="true" class="'.$type.' '.$name.'"></span>';
         if ($text) {
             $sprite .= '<span class="sr-only-important">'.$text.'</span>';
         }


### PR DESCRIPTION
The Accessibility of the icons use a technique recommended by fontawesome. http://fontawesome.io/accessibility/

Note that the `.sr-only` is defined inside `styles.css`. Some themes overwrite that file, but luckily, BS3 has that class as well. I've tested multiple themes and I haven't found any issues with that class not being defined. 

Removed the "em" which doesn't really make sense from a semantic point of view. 

Removed training white space at start of last flyout, creating an extra unwanted space in mebox.

Set "tabindex", "role" and "aria-haspopup" attributes on mebox.

___

*Note that there will also be JS to improve accessibility of flyouts in general in Vanilla. This is a first step for the MeBox.*


