### PR TITLE
Add bearer token in HTTP header for profile requests in OAuth2

### DIFF
--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -379,7 +379,8 @@ class Gdn_OAuth2 extends Gdn_Plugin {
             'AssociationSecret' =>  ['LabelCode' => 'Secret', 'Description' => 'Secret provided by the authentication provider.'],
             'AuthorizeUrl' =>  ['LabelCode' => 'Authorize Url', 'Description' => 'URL where users sign-in with the authentication provider.'],
             'TokenUrl' => ['LabelCode' => 'Token Url', 'Description' => 'Endpoint to retrieve the authorization token for a user.'],
-            'ProfileUrl' => ['LabelCode' => 'Profile Url', 'Description' => 'Endpoint to retrieve a user\'s profile.']
+            'ProfileUrl' => ['LabelCode' => 'Profile Url', 'Description' => 'Endpoint to retrieve a user\'s profile.'],
+            'BearerToken' => ['LabelCode' => 'Authorization Code in Header', 'Description' => 'When requesting the profile, pass the access token in the HTTP header. i.e Authorization: Bearer [accesstoken]', 'Control' => 'checkbox']
         ];
 
         $formFields = $formFields + $this->getSettingsFormFields();
@@ -728,11 +729,19 @@ class Gdn_OAuth2 extends Gdn_Plugin {
             'access_token' => $this->accessToken()
         ];
 
+        // Either send the Access Token in the GET request or as an Authorization header, depending on the client workflow.
+        if (val('BearerToken', $provider)) {
+            $defaultParams = [];
+            $profileRequestOptions = array_merge($this->getProfileRequestOptions(), ['Authorization-Header-Message' => 'Bearer '.$this->accessToken()]);
+        } else {
+            $profileRequestOptions = $this->getProfileRequestOptions();
+        }
+
         // Merge any inherited parameters and remove any empty parameters before sending them in the request.
         $requestParams = array_filter(array_merge($defaultParams, $this->requestProfileParams));
 
         // Request the profile from the Authentication Provider
-        $rawProfile = $this->api($uri, 'GET', $requestParams, $this->getProfileRequestOptions());
+        $rawProfile = $this->api($uri, 'GET', $requestParams, $profileRequestOptions);
 
         // Translate the keys of the profile sent to match the keys we are looking for.
         $profile = $this->translateProfileResults($rawProfile);


### PR DESCRIPTION
Vanilla's OAuth2 passes the access token in the body of the request for a user's protected resources from an authenticating server. According to [rfc6750](https://tools.ietf.org/html/rfc6750) this is acceptable, but the preferred way is by passing it in the "Authorization" http request header field, as in:
>    GET /oauth/me HTTP/1.1
     Host: server.example.com
     Authorization: Bearer mF_9.B5f-4.1JqM

This PR will:

- Add a checkbox to the Oauth2 settings in the dashboard to opt into this workflow.
- If the provider is set to BearerToken=true, it will send not send the access_token in the body but send it in the HTTP request headers.
- These changes are fully backwards compatible.

