### PR TITLE
Revise Travis build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,4 @@
-dist: precise
-
-language: php
-
-php:
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
-    - hhvm
-
-sudo: false
-
-matrix:
-  allow_failures:
-    - php: 7.2
-    - php: hhvm
-  fast_finish: true
-
-cache:
-  - apt
-
+# Add dependencies whitelisted by Travis and setup a loopback hostname for testing.
 addons:
   apt:
     packages:
@@ -28,23 +7,32 @@ addons:
   hosts:
     - vanilla.test
 
-install:
+# Steps to prepare for build script execution.
+before_script:
+  - phpenv config-rm xdebug.ini
   - composer self-update
-  - composer install -o
+  - composer install --optimize-autoloader
   - composer require phpunit/phpunit ~5
   - tests/travis/setup.sh
 
-script:
-  - tests/travis/php-lint.sh ./applications
-  - tests/travis/php-lint.sh ./conf
-  - tests/travis/php-lint.sh ./library
-  - tests/travis/php-lint.sh ./plugins
-  - tests/travis/php-lint.sh ./themes
-  - ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
-  - ls -lah ./conf
-  - cat /tmp/error.log
-  - cat /tmp/access.log
+# Cache Composer package files.
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
+# No additional system dependencies to install. Skip the install step.
+install: true
+
+# The project's primary programming language. This will affect default dependency availability.
+language: php
+
+# Configure the build.
+matrix:
+  allow_failures:
+    - php: 7.2
+  fast_finish: true
+
+# Send status update notifications to a HipChat room.
 notifications:
   hipchat:
     format: html
@@ -53,3 +41,20 @@ notifications:
       - secure: "SsKmSAZFynBz4ZKm5NPyuXvNjIMyxpNMXsgfXVImG8xjQHdXjEpZAiyckK8E2lXBBypv59Oex6wsS0RvyxpI/mwQ9dTQ9ayurQxwH3V5Q/+pRbtXJOkP+DSIsHhRb9D4xa5nPbh4N48+QZvUFiH2ety9/gev4mtMkLv3lC0vgpc="
     template:
       - '%{repository_slug} build <a href="%{build_url}">#%{build_number}</a> (%{branch} - <a href="%{compare_url}">%{commit}</a> by %{author}): %{message}'
+
+# The versions of PHP to test the project under.
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+
+# Steps of the build script.
+script:
+  - tests/travis/main.sh
+  - ls -lah ./conf
+  - cat /tmp/error.log
+  - cat /tmp/access.log
+
+# Run build in a Docker container.  Reduces time between commit and start of build.
+sudo: false

--- a/tests/travis/main.sh
+++ b/tests/travis/main.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $TRAVIS_BUILD_DIR
 

--- a/tests/travis/main.sh
+++ b/tests/travis/main.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cd $TRAVIS_BUILD_DIR
+
+DO_COVERAGE=false
+DO_LINT=false
+
+if [ "$TRAVIS_BRANCH" = "master" ]; then
+    DO_COVERAGE=true
+    DO_LINT=true
+fi
+
+if [ "$DO_LINT" = true ]; then
+    tests/travis/php-lint.sh ./applications
+    tests/travis/php-lint.sh ./conf
+    tests/travis/php-lint.sh ./library
+    tests/travis/php-lint.sh ./plugins
+    tests/travis/php-lint.sh ./themes
+else
+    echo "Skipping code linting..."
+fi
+
+if [ "$DO_LINT" = true ]; then
+    ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
+else
+    echo "Skipping code coverage..."
+    ./vendor/bin/phpunit -c phpunit.xml.dist
+fi


### PR DESCRIPTION
This update performs the following updates to the Travis build process:

1. Stop forcing Ubuntu Precise. This LTS release is no longer supported and Travis is phasing it out in favor of the next LTS release: Ubuntu Trusty.
1. Comment the build file.
1. Reorganize the build file (mainly alphabetizing).
1. Move Composer installation/updating from the install step to the before_script step. The install step is typically used for system dependencies and the before_script setup is used to prepare for the build script to be executed.
1. Cache Composer package files.
1. Stop caching apt (Debian) packages. [Travis's caching documentation](https://docs.travis-ci.com/user/caching/#Things-not-to-cache) recommends these types of files should be avoided, because there's no real benefit.
1. Move linting, code coverage generation and phpUnit into a separate script.
1. Do not perform linting and code coverage generation unless the current branch is "master".
1. Remove testing against HHVM.

Closes #5815