### PR TITLE
Add ID field to input schema of some API endpoints

### DIFF
--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -195,6 +195,7 @@ class RolesApiController extends AbstractApiController {
     public function patch($id, array $body) {
         $this->permission('Garden.Settings.Manage');
 
+        $this->idParamSchema('in');
         $in = $this->rolePostSchema('in')->setDescription('Update a role.');
         $out = $this->roleSchema('out');
 

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -237,6 +237,7 @@ class UsersApiController extends AbstractApiController {
     public function patch($id, array $body) {
         $this->permission('Garden.Users.Edit');
 
+        $this->idParamSchema('in');
         $in = $this->userPostSchema('in')->setDescription('Update a user.');
         $out = $this->userSchema('out');
 
@@ -367,6 +368,7 @@ class UsersApiController extends AbstractApiController {
     public function put_ban($id, array $body) {
         $this->permission('Garden.Users.Edit');
 
+        $this->idParamSchema('in');
         $in = $this
             ->schema(['banned:b' => 'Pass true to ban or false to unban.'], 'in')
             ->setDescription('Ban a user.');

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -300,6 +300,7 @@ class CategoriesApiController extends AbstractApiController {
     public function patch($id, array $body) {
         $this->permission('Garden.Settings.Manage');
 
+        $this->idParamSchema('in');
         $in = $this->categoryPostSchema('in', [
             'description',
             'parentCategoryID' => 'Parent category ID. Changing a category\'s parent will rebuild the category tree.'

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -318,6 +318,7 @@ class CommentsApiController extends AbstractApiController {
     public function patch($id, array $body) {
         $this->permission('Garden.SignIn.Allow');
 
+        $this->idParamSchema('in');
         $in = $this->commentPostSchema('in')->setDescription('Update a comment.');
         $out = $this->commentSchema('out');
 

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -347,6 +347,7 @@ class DiscussionsApiController extends AbstractApiController {
     public function patch($id, array $body) {
         $this->permission('Garden.SignIn.Allow');
 
+        $this->idParamSchema('in');
         $in = $this->discussionPostSchema('in')->setDescription('Update a discussion.');
         $out = $this->schema($this->discussionSchema(), 'out');
 
@@ -421,6 +422,7 @@ class DiscussionsApiController extends AbstractApiController {
     public function put_bookmark($id, array $body) {
         $this->permission('Garden.SignIn.Allow');
 
+        $this->idParamSchema('in');
         $in = $this
             ->schema(['bookmarked:b' => 'Pass true to bookmark or false to remove bookmark.'], 'in')
             ->setDescription('Bookmark a discussion.');


### PR DESCRIPTION
This update adds the URL parameter "ID" into all core endpoints that use it. Examples:

1. GET /api/v2/users/1/edit
1. PATCH /api/v2/comments/10

The schemas for some endpoints previously did not include the "id" URL path parameter, so it was not contained in auto-generated documentation. This should no longer be the case.

Closes #5911