### PR TITLE
Use fallback for translations of approval messages

### DIFF
--- a/applications/dashboard/controllers/class.activitycontroller.php
+++ b/applications/dashboard/controllers/class.activitycontroller.php
@@ -288,7 +288,7 @@ class ActivityController extends Gdn_Controller {
                 $iD = $this->ActivityModel->comment($activityComment);
 
                 if ($iD == SPAM || $iD == UNAPPROVED) {
-                    $this->StatusMessage = t('ActivityCommentRequiresApproval', 'Your comment will appear after it is approved.');
+                    $this->StatusMessage = t('Your comment will appear after it is approved.');
                     $this->render('Blank', 'Utility');
                     return;
                 }

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -301,7 +301,7 @@ class PostController extends VanillaController {
                             }
                         }
                         if ($discussionID == SPAM || $discussionID == UNAPPROVED) {
-                            $this->StatusMessage = t('DiscussionRequiresApprovalStatus', 'Your discussion will appear after it is approved.');
+                            $this->StatusMessage = t("Your discussion will appear after it is approved.");
 
                             // Clear out the form so that a draft won't save.
                             $this->Form->formValues([]);
@@ -710,7 +710,7 @@ class PostController extends VanillaController {
                     $this->EventArguments['Comment'] = $Comment;
                     $this->fireEvent('AfterCommentSave');
                 } elseif ($CommentID === SPAM || $CommentID === UNAPPROVED) {
-                    $this->StatusMessage = t('CommentRequiresApprovalStatus', 'Your comment will appear after it is approved.');
+                    $this->StatusMessage = t('Your comment will appear after it is approved.');
                 }
 
                 $this->Form->setValidationResults($this->CommentModel->validationResults());

--- a/applications/vanilla/views/post/spam.php
+++ b/applications/vanilla/views/post/spam.php
@@ -6,9 +6,9 @@ echo $this->Form->close();
 <div class="Info">
     <?php
     if ($this->RequestMethod == 'discussion' || $this->RequestMethod == 'editdiscussion') {
-        $Message = t('DiscussionRequiresApproval', "Your discussion will appear after it is approved.");
+        $Message = t("Your discussion will appear after it is approved.");
     } else {
-        $Message = t('CommentRequiresApproval', "Your comment will appear after it is approved.");
+        $Message = t("Your comment will appear after it is approved.");
     }
     echo '<div>', $Message, '</div>';
 


### PR DESCRIPTION
Add fallback translations for approval messages. The existing definitions are the same and we need to order translations for them, so instead of ordering multiple of the same translation, we fall back to the default, but still allow it to be overridden on a granular level in the future.

Goes with https://github.com/vanilla/locales/pull/47