### PR TITLE
Fix InternalRequest header merge

### DIFF
--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -137,7 +137,7 @@ class InternalRequest extends HttpRequest implements RequestInterface {
 
         $response = new HttpResponse(
             $data->getStatus(),
-            array_merge($data->getHeaders(), ['X-Data-Meta', json_encode($data->getMetaArray())])
+            array_merge($data->getHeaders(), ['X-Data-Meta' => json_encode($data->getMetaArray())])
         );
         $response->setBody($data->getData());
 


### PR DESCRIPTION
The array should be an associative array with X-Data-Meta as its key.