### PR TITLE
Fix issue with namespacing classes during lookup in AddonManager::lookupByClassname

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -1182,12 +1182,12 @@ class Addon {
      *
      * This is a case insensitive lookup.
      *
-     * @param string $fqClassName Fully qualified class name.
+     * @param string $fullClassName Fully qualified class name.
      * @param string $relative One of the **Addon::PATH*** constants.
      * @return string Returns the path or an empty string of the class isn't found.
      */
-    public function getClassPath($fqClassName, $relative = self::PATH_FULL) {
-        $classInfo = self::parseFullyQualifiedClass($fqClassName);
+    public function getClassPath($fullClassName, $relative = self::PATH_FULL) {
+        $classInfo = self::parseFullyQualifiedClass($fullClassName);
         $key = strtolower($classInfo['className']);
         if (array_key_exists($key, $this->classes)) {
             foreach($this->classes[$key] as $classData) {
@@ -1223,17 +1223,17 @@ class Addon {
     /**
      * Parse a fully qualified class name and return the namespace and className of it.
      *
-     * @param string $fqClassName Fully qualified class name.
+     * @param string $fullClassName Fully qualified class name.
      * @return array ['namespace' => $namespace, 'className' => $className]
      */
-    public static function parseFullyQualifiedClass($fqClassName) {
-        $lastNamespaceSeparatorPos = strrpos($fqClassName, '\\');
+    public static function parseFullyQualifiedClass($fullClassName) {
+        $lastNamespaceSeparatorPos = strrpos($fullClassName, '\\');
         if ($lastNamespaceSeparatorPos === false) {
             $namespace = '';
-            $className = $fqClassName;
+            $className = $fullClassName;
         } else {
-            $namespace = substr($fqClassName, 0, $lastNamespaceSeparatorPos+1);
-            $className = substr($fqClassName, $lastNamespaceSeparatorPos+1);
+            $namespace = substr($fullClassName, 0, $lastNamespaceSeparatorPos+1);
+            $className = substr($fullClassName, $lastNamespaceSeparatorPos+1);
         }
 
         return [

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -127,10 +127,10 @@ class AddonManager {
     /**
      *  Attempt to load undefined class based on the addons that are enabled.
      *
-     * @param string $fqClassName Fully qualified class name to load.
+     * @param string $fullClassName Fully qualified class name to load.
      */
-    public function autoload($fqClassName) {
-        $suppliedClassInfo = Addon::parseFullyQualifiedClass($fqClassName);
+    public function autoload($fullClassName) {
+        $suppliedClassInfo = Addon::parseFullyQualifiedClass($fullClassName);
         $classKey = strtolower($suppliedClassInfo['className']);
 
         if (isset($this->autoloadClasses[$classKey])) {
@@ -176,16 +176,17 @@ class AddonManager {
      *
      * This method should only be used with enabled addons as searching through all addons takes a performance hit.
      *
-     * @param string $fqClassName Fully qualified class name.
+     * @param string $fullClassName Fully qualified class name.
      * @param bool $searchAll Whether or not to search all addons or just the enabled ones.
      * @return Addon|null Returns an {@link Addon} object or **null** if one isn't found.
      */
-    public function lookupByClassname($fqClassName, $searchAll = false) {
-        $lookupClassInfo = Addon::parseFullyQualifiedClass($fqClassName);
+    public function lookupByClassName($fullClassName, $searchAll = false) {
+        $lookupClassInfo = Addon::parseFullyQualifiedClass($fullClassName);
         $classKey = strtolower($lookupClassInfo['className']);
+        $nameSpace = $lookupClassInfo['namespace'];
 
-        if (isset($this->autoloadClasses[$classKey])) {
-            return reset($this->autoloadClasses[$classKey])['addon'];
+        if ($addon = valr("$classKey.$nameSpace.addon", $this->autoloadClasses)) {
+            return $addon;
         } elseif ($searchAll) {
             foreach ($this->lookupAllByType(Addon::TYPE_ADDON) as $addon) {
                 /* @var Addon $addon */

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -957,7 +957,7 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
         if (is_array($var)) {
             reset($var);
             $name = key($var);
-            $var = current($var);
+            $var = (array)current($var);
 
             $var['Index'] = $name;
             $var['ClassName'] = $ClassName;

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -598,4 +598,19 @@ class AddonManagerTest extends \PHPUnit\Framework\TestCase {
         $classes = $am->findClasses('TestOldPluginPlugin');
         $this->assertSame(\TestOldPluginPlugin::class, $classes[0]);
     }
+
+    /**
+     * Looking up an addon by class name should give the right addon, even if there is another addon that has a class with the same basename.
+     */
+    public function testSameBasenameEdgeCase() {
+        $am = new TestAddonManager();
+
+        $am->startAddonsByKey(['multiclass-namespaced-plugin', 'namespaced-plugin'], Addon::TYPE_ADDON);
+
+        $addon1 = $am->lookupByClassname(\Deeply\TestClass::class);
+        $this->assertEquals('multiclass-namespaced-plugin', $addon1->getKey());
+
+        $addon2 = $am->lookupByClassname(\Deeply\Nested\Namespaced\Fixture\TestClass::class);
+        $this->assertEquals('namespaced-plugin', $addon2->getKey());
+    }
 }

--- a/tests/fixtures/plugins/multiclass-namespaced-plugin/class.multiclass-namespaced-plugin.plugin.php
+++ b/tests/fixtures/plugins/multiclass-namespaced-plugin/class.multiclass-namespaced-plugin.plugin.php
@@ -30,4 +30,5 @@ namespace Deeply\Nested {
 
 namespace Deeply {
     class MultiClassPluginHelper {}
+    class TestClass {}
 }

--- a/tests/fixtures/plugins/namespaced-plugin/class.namespaced-plugin.plugin.php
+++ b/tests/fixtures/plugins/namespaced-plugin/class.namespaced-plugin.plugin.php
@@ -16,4 +16,6 @@ namespace Deeply\Nested\Namespaced\Fixture {
             echo __CLASS__.' is loaded!';
         }
     }
+
+    class TestClass {}
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/6065

Return the correct Addon if multiple addons have the same name in different namespaces.