### PR TITLE
Fix tests for conversation and message API v2 endpoints

### DIFF
--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -49,14 +49,12 @@ class ConversationsApiController extends AbstractApiController {
     /**
      * Check that the user has moderation rights over conversations.
      *
-     * @throw Exception
+     * @throws ConfigurationException Throws an exception when the site is not configured for moderating conversations.
+     * @throws \Vanilla\Exception\PermissionException Throws an
      */
     private function checkModerationPermission() {
         if (!$this->config->get('Conversations.Moderation.Allow', false)) {
-            throw new ConfigurationException(
-                'Conversations.Moderation.Allow',
-                ['configurationValue' => true]
-            );
+            throw new ConfigurationException(t('The site is not configured for moderating conversations.'));
         }
         $this->permission('Conversations.Moderation.Manage');
     }

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -55,7 +55,7 @@ class ConversationsApiController extends AbstractApiController {
         if (!$this->config->get('Conversations.Moderation.Allow', false)) {
             throw new ConfigurationException(
                 'Conversations.Moderation.Allow',
-                ['requiredValues' => ['Conversations.Moderation.Allow' => true]]
+                ['configurationValue' => true]
             );
         }
         $this->permission('Conversations.Moderation.Manage');

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -53,7 +53,10 @@ class ConversationsApiController extends AbstractApiController {
      */
     private function checkModerationPermission() {
         if (!$this->config->get('Conversations.Moderation.Allow', false)) {
-            throw new ConfigurationException('Conversations.Moderation.Allow');
+            throw new ConfigurationException(
+                'Conversations.Moderation.Allow',
+                ['requiredValues' => ['Conversations.Moderation.Allow' => true]]
+            );
         }
         $this->permission('Conversations.Moderation.Manage');
     }

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -8,6 +8,7 @@
 use Garden\Schema\Schema;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
+use Vanilla\Exception\ConfigurationException;
 use Vanilla\Utility\CapitalCaseScheme;
 
 /**
@@ -52,7 +53,7 @@ class ConversationsApiController extends AbstractApiController {
      */
     private function checkModerationPermission() {
         if (!$this->config->get('Conversations.Moderation.Allow', false)) {
-            throw permissionException();
+            throw new ConfigurationException('Conversations.Moderation.Allow');
         }
         $this->permission('Conversations.Moderation.Manage');
     }

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -61,10 +61,7 @@ class MessagesApiController extends AbstractApiController {
      */
     private function checkModerationPermission() {
         if (!$this->config->get('Conversations.Moderation.Allow', false)) {
-            throw new ConfigurationException(
-                'Conversations.Moderation.Allow',
-                ['configurationValue' => true]
-            );
+            throw new ConfigurationException(t('The site is not configured for moderating conversations.'));
         }
         $this->permission('Conversations.Moderation.Manage');
     }

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -61,7 +61,10 @@ class MessagesApiController extends AbstractApiController {
      */
     private function checkModerationPermission() {
         if (!$this->config->get('Conversations.Moderation.Allow', false)) {
-            throw new ConfigurationException('Conversations.Moderation.Allow');
+            throw new ConfigurationException(
+                'Conversations.Moderation.Allow',
+                ['requiredValues' => ['Conversations.Moderation.Allow' => true]]
+            );
         }
         $this->permission('Conversations.Moderation.Manage');
     }

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -63,7 +63,7 @@ class MessagesApiController extends AbstractApiController {
         if (!$this->config->get('Conversations.Moderation.Allow', false)) {
             throw new ConfigurationException(
                 'Conversations.Moderation.Allow',
-                ['requiredValues' => ['Conversations.Moderation.Allow' => true]]
+                ['configurationValue' => true]
             );
         }
         $this->permission('Conversations.Moderation.Manage');

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -6,10 +6,10 @@
  */
 
 use Garden\Schema\Schema;
-use Garden\Web\Data;
 use Garden\Web\Exception\ClientException;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
+use Vanilla\Exception\ConfigurationException;
 use Vanilla\Utility\CapitalCaseScheme;
 
 
@@ -61,7 +61,7 @@ class MessagesApiController extends AbstractApiController {
      */
     private function checkModerationPermission() {
         if (!$this->config->get('Conversations.Moderation.Allow', false)) {
-            throw permissionException();
+            throw new ConfigurationException('Conversations.Moderation.Allow');
         }
         $this->permission('Conversations.Moderation.Manage');
     }

--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -393,7 +393,7 @@ class ConversationModel extends ConversationsModel {
         if (!$row) {
             return false;
         }
-        return !empty($Row['Deleted']);
+        return empty($row['Deleted']);
     }
 
     public function joinLastMessages(&$data) {

--- a/library/Vanilla/Exception/ConfigurationException.php
+++ b/library/Vanilla/Exception/ConfigurationException.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+namespace Vanilla\Exception;
+
+use Garden\Web\Exception\ForbiddenException;
+
+/**
+ * An exception tha represents a configuration test failing.
+ */
+class ConfigurationException extends ForbiddenException {
+    /**
+     * Construct a {@link ConfigurationException} object.
+     *
+     * @param string The configuration that failed the test.
+     * @param array $context Additional information for the error.
+     */
+    public function __construct($configuration, array $context = []) {
+        $context['configuration'] = $configuration;
+
+        $msg = sprintf('The %s configuration value disallow you to do that.', $configuration);
+
+        parent::__construct($msg, $context);
+    }
+}

--- a/library/Vanilla/Exception/ConfigurationException.php
+++ b/library/Vanilla/Exception/ConfigurationException.php
@@ -28,7 +28,6 @@ class ConfigurationException extends ForbiddenException {
         $context['configurations'] = $configurations;
 
         $messageParts = [];
-        $messageParts[] = t('The site is not configured to support the current action.');
 
         $or = t('or');
         foreach ($configurations as $configurationName) {
@@ -41,7 +40,7 @@ class ConfigurationException extends ForbiddenException {
 
                 $messageParts[] = sprintft("The $configurationName config must be set to %s to support the current action.", implode(" $or ", $requiredValues));
             } else {
-                $messageParts[] = t("The $configurationName config is required to access this.");
+                $messageParts[] = t("The $configurationName config is required to support the current action.");
             }
         }
 

--- a/library/Vanilla/Exception/ConfigurationException.php
+++ b/library/Vanilla/Exception/ConfigurationException.php
@@ -25,12 +25,12 @@ class ConfigurationException extends ForbiddenException {
 
         if (array_key_exists('configurationValue', $context)) {
             $message = sprintft(
-                "The %s config must be set to %s to support the current action.",
+                'The %s config must be set to %s to support the current action.',
                 $configuration,
                 json_encode($context['configurationValue'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
             );
         } else {
-            $message = sprintft("The %s config is required to support the current action.", $configurationName);
+            $message = sprintft('The %s config is required to support the current action.', $configurationName);
         }
 
         parent::__construct($message, $context);

--- a/library/Vanilla/Exception/ConfigurationException.php
+++ b/library/Vanilla/Exception/ConfigurationException.php
@@ -13,26 +13,4 @@ use Garden\Web\Exception\ForbiddenException;
  * An exception tha represents a configuration test failing.
  */
 class ConfigurationException extends ForbiddenException {
-    /**
-     * Construct a {@link ConfigurationException} object.
-     *
-     * @param string The configurations that failed the test.
-     * @param array $context Additional information for the error.
-     *   - You can set $context['configurationValue'] = value; to specify that the configuration requires a specific value to be set.
-     */
-    public function __construct($configuration, array $context = []) {
-        $context['configuration'] = $configuration;
-
-        if (array_key_exists('configurationValue', $context)) {
-            $message = sprintft(
-                'The %s config must be set to %s to support the current action.',
-                $configuration,
-                json_encode($context['configurationValue'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
-            );
-        } else {
-            $message = sprintft('The %s config is required to support the current action.', $configurationName);
-        }
-
-        parent::__construct($message, $context);
-    }
 }

--- a/tests/APIv2/ConversationsAllowModerationTest.php
+++ b/tests/APIv2/ConversationsAllowModerationTest.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+namespace VanillaTests\APIv2;
+
+/**
+ * Test the /api/v2/conversations endpoints.
+ */
+class ConversationsAllowModerationTest extends AbstractAPIv2Test {
+
+    private $baseUrl = '/conversations';
+
+    private static $userIDs = [];
+
+    private $originalConfigEmailValue;
+
+    private $pk = 'conversationID';
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setupBeforeClass() {
+        parent::setupBeforeClass();
+
+        /**
+         * @var \Gdn_Session $session
+         */
+        $session = self::container()->get(\Gdn_Session::class);
+        $session->start(self::$siteInfo['adminUserID'], false, false);
+
+        /** @var \UsersApiController $usersAPIController */
+        $usersAPIController = static::container()->get('UsersAPIController');
+
+        foreach ([1, 2, 3, 4] as $id) {
+            $user = $usersAPIController->post([
+                'name' => "ConversationsUser$id",
+                'email' => "ConversationsUser$id@example.com",
+                'password' => "$%#$&ADSFBNYI*&WBV$id",
+            ]);
+            self::$userIDs[] = $user['userID'];
+        }
+
+        // Disable email sending.
+        /** @var \Gdn_Configuration $config */
+        $config = static::container()->get('Config');
+        $config->set('Garden.Email.Disabled', true, true, false);
+
+        // Allow moderator/admins to moderate the conversations.
+        $config->set('Conversations.Moderation.Allow', true, true, false);
+
+        $session->end();
+    }
+
+    /**
+     * Test GET /conversations/<id>.
+     */
+    public function testGet() {
+        $conversation = $this->testPost();
+
+        $result = $this->api()->get(
+            "{$this->baseUrl}/{$conversation[$this->pk]}"
+        );
+
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertRowsEqual($conversation, $result->getBody());
+        $this->assertCamelCase($result->getBody());
+
+        return $result->getBody();
+    }
+
+
+    /**
+     * Test GET /conversations/<id>/participants.
+     */
+    public function testGetParticipants() {
+        $conversation = $this->testPostParticipants();
+
+        $result = $this->api()->get(
+            "{$this->baseUrl}/{$conversation[$this->pk]}/participants"
+        );
+
+        $expectedCountParticipant = count(self::$userIDs) + 1;
+        $expectedFirstParticipant = [
+            'userID' => $this->api()->getUserID(),
+            'deleted' => false,
+        ];
+
+        $this->assertEquals(200, $result->getStatusCode());
+
+        $participants = $result->getBody();
+
+        $this->assertTrue(is_array($participants));
+        $this->assertEquals($expectedCountParticipant, count($participants));
+        $this->assertRowsEqual($expectedFirstParticipant, $participants[0]);
+    }
+
+    /**
+     * Test GET /conversations.
+     *
+     * @return array Returns the fetched data.
+     */
+    public function testIndex() {
+        $nbsInsert = 3;
+
+        // Insert a few rows.
+        $rows = [];
+        for ($i = 0; $i < $nbsInsert; $i++) {
+            $rows[] = $this->testPost();
+        }
+
+        $result = $this->api()->get($this->baseUrl, ['insertUserID' => $this->api()->getUserID()]);
+        $this->assertEquals(200, $result->getStatusCode());
+
+        $rows = $result->getBody();
+        $this->assertGreaterThan($nbsInsert, count($rows));
+        // The index should be a proper indexed array.
+        for ($i = 0; $i < count($rows); $i++) {
+            $this->assertArrayHasKey($i, $rows);
+        }
+    }
+
+    /**
+     * @requires function ConversationAPIController::delete
+     */
+    public function testDelete() {
+        $this->fail(__METHOD__.' needs to be implemented');
+    }
+
+    /**
+     * Test DELETE /conversations/<id>/leave.
+     *
+     * @return array Returns the fetched data.
+     */
+    public function testDeleteLeave() {
+        $conversation = $this->testPost();
+
+        $result = $this->api()->delete(
+            "{$this->baseUrl}/{$conversation[$this->pk]}/leave"
+        );
+
+        $this->assertEquals(204, $result->getStatusCode());
+
+        $participantsResult = $this->api()->get(
+            "{$this->baseUrl}/{$conversation[$this->pk]}/participants"
+        );
+
+        $this->assertEquals(200, $participantsResult->getStatusCode());
+
+        $expectedFirstParticipant = [
+            'userID' => $this->api()->getUserID(),
+            'deleted' => true,
+        ];
+        $participants = $participantsResult->getBody();
+
+        $this->assertTrue(is_array($participants));
+        $this->assertRowsEqual($expectedFirstParticipant, $participants[0]);
+    }
+
+    /**
+     * Test POST /conversations.
+     *
+     * @return array The conversation.
+     */
+    public function testPost() {
+        $postData = [
+            'participantUserIDs' => array_slice(self::$userIDs, 0, 2)
+        ];
+        $expectedResult = [
+            'insertUserID' => $this->api()->getUserID(),
+            'countParticipants' => 3,
+            'countMessages' => 0,
+            'countReadMessages' => 0,
+            'dateLastViewed' => null,
+        ];
+
+        $result = $this->api()->post(
+            $this->baseUrl,
+            $postData
+        );
+
+        $this->assertEquals(201, $result->getStatusCode());
+
+        $body = $result->getBody();
+        $this->assertTrue(is_int($body[$this->pk]));
+        $this->assertTrue($body[$this->pk] > 0);
+
+        $this->assertRowsEqual($expectedResult, $body, true);
+
+        return $body;
+    }
+
+    /**
+     * Test POST /conversations/<id>/participants.
+     */
+    public function testPostParticipants() {
+        $conversation = $this->testPost();
+
+        $postData = [
+            'participantUserIDs' => array_slice(self::$userIDs, 2)
+        ];
+        $result = $this->api()->post(
+            "{$this->baseUrl}/{$conversation[$this->pk]}/participants",
+            $postData
+        );
+
+        $this->assertEquals(201, $result->getStatusCode());
+
+        $updatedConversation = $result->getBody();
+
+        $this->assertEquals($conversation['countParticipants'] + 2, $updatedConversation['countParticipants']);
+
+        return $conversation;
+    }
+}

--- a/tests/APIv2/ConversationsAllowModerationTest.php
+++ b/tests/APIv2/ConversationsAllowModerationTest.php
@@ -10,15 +10,7 @@ namespace VanillaTests\APIv2;
 /**
  * Test the /api/v2/conversations endpoints.
  */
-class ConversationsAllowModerationTest extends AbstractAPIv2Test {
-
-    private $baseUrl = '/conversations';
-
-    private static $userIDs = [];
-
-    private $originalConfigEmailValue;
-
-    private $pk = 'conversationID';
+class ConversationsAllowModerationTest extends ConversationsTest {
 
     /**
      * {@inheritdoc}
@@ -26,76 +18,26 @@ class ConversationsAllowModerationTest extends AbstractAPIv2Test {
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
 
-        /**
-         * @var \Gdn_Session $session
-         */
-        $session = self::container()->get(\Gdn_Session::class);
-        $session->start(self::$siteInfo['adminUserID'], false, false);
-
-        /** @var \UsersApiController $usersAPIController */
-        $usersAPIController = static::container()->get('UsersAPIController');
-
-        foreach ([1, 2, 3, 4] as $id) {
-            $user = $usersAPIController->post([
-                'name' => "ConversationsUser$id",
-                'email' => "ConversationsUser$id@example.com",
-                'password' => "$%#$&ADSFBNYI*&WBV$id",
-            ]);
-            self::$userIDs[] = $user['userID'];
-        }
-
-        // Disable email sending.
         /** @var \Gdn_Configuration $config */
         $config = static::container()->get('Config');
-        $config->set('Garden.Email.Disabled', true, true, false);
-
         // Allow moderator/admins to moderate the conversations.
         $config->set('Conversations.Moderation.Allow', true, true, false);
-
-        $session->end();
     }
 
     /**
      * Test GET /conversations/<id>.
+     *
+     * @return array
      */
     public function testGet() {
-        $conversation = $this->testPost();
-
-        $result = $this->api()->get(
-            "{$this->baseUrl}/{$conversation[$this->pk]}"
-        );
-
-        $this->assertEquals(200, $result->getStatusCode());
-        $this->assertRowsEqual($conversation, $result->getBody());
-        $this->assertCamelCase($result->getBody());
-
-        return $result->getBody();
+        return parent::testGet();
     }
-
 
     /**
      * Test GET /conversations/<id>/participants.
      */
     public function testGetParticipants() {
-        $conversation = $this->testPostParticipants();
-
-        $result = $this->api()->get(
-            "{$this->baseUrl}/{$conversation[$this->pk]}/participants"
-        );
-
-        $expectedCountParticipant = count(self::$userIDs) + 1;
-        $expectedFirstParticipant = [
-            'userID' => $this->api()->getUserID(),
-            'deleted' => false,
-        ];
-
-        $this->assertEquals(200, $result->getStatusCode());
-
-        $participants = $result->getBody();
-
-        $this->assertTrue(is_array($participants));
-        $this->assertEquals($expectedCountParticipant, count($participants));
-        $this->assertRowsEqual($expectedFirstParticipant, $participants[0]);
+        parent::testGetParticipants();
     }
 
     /**
@@ -104,115 +46,15 @@ class ConversationsAllowModerationTest extends AbstractAPIv2Test {
      * @return array Returns the fetched data.
      */
     public function testIndex() {
-        $nbsInsert = 3;
-
-        // Insert a few rows.
-        $rows = [];
-        for ($i = 0; $i < $nbsInsert; $i++) {
-            $rows[] = $this->testPost();
-        }
-
-        $result = $this->api()->get($this->baseUrl, ['insertUserID' => $this->api()->getUserID()]);
-        $this->assertEquals(200, $result->getStatusCode());
-
-        $rows = $result->getBody();
-        $this->assertGreaterThan($nbsInsert, count($rows));
-        // The index should be a proper indexed array.
-        for ($i = 0; $i < count($rows); $i++) {
-            $this->assertArrayHasKey($i, $rows);
-        }
-    }
-
-    /**
-     * @requires function ConversationAPIController::delete
-     */
-    public function testDelete() {
-        $this->fail(__METHOD__.' needs to be implemented');
-    }
-
-    /**
-     * Test DELETE /conversations/<id>/leave.
-     *
-     * @return array Returns the fetched data.
-     */
-    public function testDeleteLeave() {
-        $conversation = $this->testPost();
-
-        $result = $this->api()->delete(
-            "{$this->baseUrl}/{$conversation[$this->pk]}/leave"
-        );
-
-        $this->assertEquals(204, $result->getStatusCode());
-
-        $participantsResult = $this->api()->get(
-            "{$this->baseUrl}/{$conversation[$this->pk]}/participants"
-        );
-
-        $this->assertEquals(200, $participantsResult->getStatusCode());
-
-        $expectedFirstParticipant = [
-            'userID' => $this->api()->getUserID(),
-            'deleted' => true,
-        ];
-        $participants = $participantsResult->getBody();
-
-        $this->assertTrue(is_array($participants));
-        $this->assertRowsEqual($expectedFirstParticipant, $participants[0]);
-    }
-
-    /**
-     * Test POST /conversations.
-     *
-     * @return array The conversation.
-     */
-    public function testPost() {
-        $postData = [
-            'participantUserIDs' => array_slice(self::$userIDs, 0, 2)
-        ];
-        $expectedResult = [
-            'insertUserID' => $this->api()->getUserID(),
-            'countParticipants' => 3,
-            'countMessages' => 0,
-            'countReadMessages' => 0,
-            'dateLastViewed' => null,
-        ];
-
-        $result = $this->api()->post(
-            $this->baseUrl,
-            $postData
-        );
-
-        $this->assertEquals(201, $result->getStatusCode());
-
-        $body = $result->getBody();
-        $this->assertTrue(is_int($body[$this->pk]));
-        $this->assertTrue($body[$this->pk] > 0);
-
-        $this->assertRowsEqual($expectedResult, $body, true);
-
-        return $body;
+        parent::testIndex();
     }
 
     /**
      * Test POST /conversations/<id>/participants.
+     *
+     * @return array The conversation.
      */
     public function testPostParticipants() {
-        $conversation = $this->testPost();
-
-        $postData = [
-            'participantUserIDs' => array_slice(self::$userIDs, 2)
-        ];
-        $result = $this->api()->post(
-            "{$this->baseUrl}/{$conversation[$this->pk]}/participants",
-            $postData
-        );
-
-        $this->assertEquals(201, $result->getStatusCode());
-
-        $updatedConversation = $result->getBody();
-
-        $this->assertEquals($conversation['countParticipants'] + 2, $updatedConversation['countParticipants']);
-
-        return $conversation;
+        return parent::testPostParticipants();
     }
 }

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -12,19 +12,24 @@ namespace VanillaTests\APIv2;
  */
 class ConversationsTest extends AbstractAPIv2Test {
 
-    private $baseUrl = '/conversations';
+    protected static $userCounter = 0;
 
-    private static $userIDs = [];
+    protected static $userIDs = [];
 
-    private $originalConfigEmailValue;
+    protected $baseUrl = '/conversations';
 
-    private $pk = 'conversationID';
+    protected $pk = 'conversationID';
 
     /**
      * {@inheritdoc}
      */
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
+        self::$userIDs = [];
+
+        // Disable flood control checks on the model and make sure that the specific instance is injected into the controllers.
+        $conversationModel = self::container()->get(\ConversationModel::class)->setFloodControlEnabled(false);
+        self::container()->setInstance(\ConversationModel::class, $conversationModel);
 
         /**
          * @var \Gdn_Session $session
@@ -35,11 +40,11 @@ class ConversationsTest extends AbstractAPIv2Test {
         /** @var \UsersApiController $usersAPIController */
         $usersAPIController = static::container()->get('UsersAPIController');
 
-        foreach ([1, 2, 3, 4] as $id) {
+        for ($i = self::$userCounter; $i < self::$userCounter + 4; $i++) {
             $user = $usersAPIController->post([
-                'name' => "ConversationsUser$id",
-                'email' => "ConversationsUser$id@example.com",
-                'password' => "$%#$&ADSFBNYI*&WBV$id",
+                'name' => "ConversationsUser$i",
+                'email' => "ConversationsUser$i@example.com",
+                'password' => "$%#$&ADSFBNYI*&WBV$i",
             ]);
             self::$userIDs[] = $user['userID'];
         }
@@ -54,16 +59,26 @@ class ConversationsTest extends AbstractAPIv2Test {
 
     /**
      * Test GET /conversations/<id>.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     *
+     * @return array
      */
     public function testGet() {
-        $conversation = $this->testPost();
+        $postedConversation = $this->testPost();
 
         $result = $this->api()->get(
-            "{$this->baseUrl}/{$conversation[$this->pk]}"
+            "{$this->baseUrl}/{$postedConversation[$this->pk]}"
         );
 
         $this->assertEquals(200, $result->getStatusCode());
-        $this->assertRowsEqual($conversation, $result->getBody());
+
+        $conversation = $result->getBody();
+        // The current model assign dateUpdated as dateLastViewed which makes the test fail.
+        unset($postedConversation['dateLastViewed'], $conversation['dateLastViewed']);
+
+        $this->assertRowsEqual($postedConversation, $conversation);
         $this->assertCamelCase($result->getBody());
 
         return $result->getBody();
@@ -72,6 +87,9 @@ class ConversationsTest extends AbstractAPIv2Test {
 
     /**
      * Test GET /conversations/<id>/participants.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
      */
     public function testGetParticipants() {
         $conversation = $this->testPostParticipants();
@@ -80,9 +98,9 @@ class ConversationsTest extends AbstractAPIv2Test {
             "{$this->baseUrl}/{$conversation[$this->pk]}/participants"
         );
 
-        $expectedCountParticipant = count(self::$userIDs) + 1;
+        $expectedCountParticipant = count(self::$userIDs);
         $expectedFirstParticipant = [
-            'userID' => $this->api()->getUserID(),
+            'userID' => self::$userIDs[0],
             'deleted' => false,
         ];
 
@@ -98,7 +116,8 @@ class ConversationsTest extends AbstractAPIv2Test {
     /**
      * Test GET /conversations.
      *
-     * @return array Returns the fetched data.
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
      */
     public function testIndex() {
         $nbsInsert = 3;
@@ -109,7 +128,7 @@ class ConversationsTest extends AbstractAPIv2Test {
             $rows[] = $this->testPost();
         }
 
-        $result = $this->api()->get($this->baseUrl, ['insertUserID' => $this->api()->getUserID()]);
+        $result = $this->api()->get($this->baseUrl, ['insertUserID' => self::$userIDs[0]]);
         $this->assertEquals(200, $result->getStatusCode());
 
         $rows = $result->getBody();
@@ -129,17 +148,22 @@ class ConversationsTest extends AbstractAPIv2Test {
 
     /**
      * Test DELETE /conversations/<id>/leave.
-     *
-     * @return array Returns the fetched data.
      */
     public function testDeleteLeave() {
         $conversation = $this->testPost();
+
+        // Leave the conversation as the user that created it
+        $this->api()->getUserID();
+        $this->api()->setUserID(self::$userIDs[0]);
 
         $result = $this->api()->delete(
             "{$this->baseUrl}/{$conversation[$this->pk]}/leave"
         );
 
         $this->assertEquals(204, $result->getStatusCode());
+
+        // Get the participant count as another user that is part of the conversation.
+        $this->api()->setUserID(self::$userIDs[1]);
 
         $participantsResult = $this->api()->get(
             "{$this->baseUrl}/{$conversation[$this->pk]}/participants"
@@ -148,7 +172,7 @@ class ConversationsTest extends AbstractAPIv2Test {
         $this->assertEquals(200, $participantsResult->getStatusCode());
 
         $expectedFirstParticipant = [
-            'userID' => $this->api()->getUserID(),
+            'userID' => self::$userIDs[0],
             'deleted' => true,
         ];
         $participants = $participantsResult->getBody();
@@ -160,24 +184,32 @@ class ConversationsTest extends AbstractAPIv2Test {
     /**
      * Test POST /conversations.
      *
+     * @throws \Exception
+     *
      * @return array The conversation.
      */
     public function testPost() {
         $postData = [
-            'participantUserIDs' => array_slice(self::$userIDs, 0, 2)
+            'participantUserIDs' => array_slice(self::$userIDs, 1, 2)
         ];
         $expectedResult = [
-            'insertUserID' => $this->api()->getUserID(),
+            'insertUserID' => self::$userIDs[0],
             'countParticipants' => 3,
             'countMessages' => 0,
             'countReadMessages' => 0,
             'dateLastViewed' => null,
         ];
 
+        // Create the conversation as the first test user.
+        $currentUserID = $this->api()->getUserID();
+        $this->api()->setUserID(self::$userIDs[0]);
+
         $result = $this->api()->post(
             $this->baseUrl,
             $postData
         );
+
+        $this->api()->setUserID($currentUserID);
 
         $this->assertEquals(201, $result->getStatusCode());
 
@@ -192,12 +224,17 @@ class ConversationsTest extends AbstractAPIv2Test {
 
     /**
      * Test POST /conversations/<id>/participants.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     *
+     * @return array The conversation.
      */
     public function testPostParticipants() {
         $conversation = $this->testPost();
 
         $postData = [
-            'participantUserIDs' => array_slice(self::$userIDs, 2)
+            'participantUserIDs' => array_slice(self::$userIDs, 3)
         ];
         $result = $this->api()->post(
             "{$this->baseUrl}/{$conversation[$this->pk]}/participants",
@@ -208,8 +245,11 @@ class ConversationsTest extends AbstractAPIv2Test {
 
         $updatedConversation = $result->getBody();
 
-        $this->assertEquals($conversation['countParticipants'] + 2, $updatedConversation['countParticipants']);
+        $this->assertEquals(
+            $conversation['countParticipants'] + count($postData['participantUserIDs']),
+            $updatedConversation['countParticipants']
+        );
 
-        return $conversation;
+        return $updatedConversation;
     }
 }

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -6,6 +6,7 @@
  */
 
 namespace VanillaTests\APIv2;
+use Garden\Web\Exception\ForbiddenException;
 
 /**
  * Test the /api/v2/conversations endpoints.
@@ -61,7 +62,7 @@ class ConversationsTest extends AbstractAPIv2Test {
      * Test GET /conversations/<id>.
      *
      * @expectedException \Exception
-     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     * @expectedExceptionMessage The site is not configured for moderating conversations.
      *
      * @return array
      */
@@ -89,7 +90,8 @@ class ConversationsTest extends AbstractAPIv2Test {
      * Test GET /conversations/<id>/participants.
      *
      * @expectedException \Exception
-     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     * @expectedExceptionCode 403
+     * @expectedExceptionMessage The site is not configured for moderating conversations.
      */
     public function testGetParticipants() {
         $conversation = $this->testPostParticipants();
@@ -117,7 +119,8 @@ class ConversationsTest extends AbstractAPIv2Test {
      * Test GET /conversations.
      *
      * @expectedException \Exception
-     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     * @expectedExceptionCode 403
+     * @expectedExceptionMessage The site is not configured for moderating conversations.
      */
     public function testIndex() {
         $nbsInsert = 3;
@@ -226,7 +229,8 @@ class ConversationsTest extends AbstractAPIv2Test {
      * Test POST /conversations/<id>/participants.
      *
      * @expectedException \Exception
-     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     * @expectedExceptionCode 403
+     * @expectedExceptionMessage The site is not configured for moderating conversations.
      *
      * @return array The conversation.
      */

--- a/tests/APIv2/MessagesAllowModerationTest.php
+++ b/tests/APIv2/MessagesAllowModerationTest.php
@@ -10,20 +10,7 @@ namespace VanillaTests\APIv2;
 /**
  * Test the /api/v2/messages endpoints.
  */
-class MessagesAllowModerationTest extends AbstractResourceTest {
-
-    private static $userID;
-
-    private static $conversationID;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct($name = null, array $data = [], $dataName = '') {
-        $this->baseUrl = '/messages';
-
-        parent::__construct($name, $data, $dataName);
-    }
+class MessagesAllowModerationTest extends MessagesTest {
 
     /**
      * {@inheritdoc}
@@ -31,102 +18,22 @@ class MessagesAllowModerationTest extends AbstractResourceTest {
     public static function setUpBeforeClass() {
         parent::setupBeforeClass();
 
-        /**
-         * @var \Gdn_Session $session
-         */
-        $session = self::container()->get(\Gdn_Session::class);
-        $session->start(self::$siteInfo['adminUserID'], false, false);
-
-        /** @var \UsersApiController $usersAPIController */
-        $usersAPIController = static::container()->get('UsersAPIController');
-
-        $user = $usersAPIController->post([
-            'name' => "MessagesUser1",
-            'email' => "MessagesUser1@example.com",
-            'password' => "$%#$&ADSFBNYI*&WBV1",
-        ]);
-        self::$userID = $user['userID'];
-
-        /** @var \ConversationsApiController $conversationsAPiController */
-        $conversationsAPiController = static::container()->get('ConversationsAPiController');
-
-        $conversation = $conversationsAPiController->post([
-            'participantUserIDs' => [self::$userID]
-        ]);
-        self::$conversationID = $conversation['conversationID'];
-
-        // Disable email sending.
-        /** @var \Gdn_Configuration $config */
-        $config = static::container()->get('Config');
-        $config->set('Garden.Email.Disabled', true, true, false);
-
         // Allow moderator/admins to moderate the conversations.
+        $config = static::container()->get('Config');
         $config->set('Conversations.Moderation.Allow', true, true, false);
-
-        $session->end();
     }
 
     /**
-     * {@inheritdoc}
+     * Test GET /resource/<id>.
      */
-    public function record() {
-        return array_merge(parent::record(), ['conversationID' => self::$conversationID]);
+    public function testGet() {
+        parent::testGet();
     }
 
     /**
-     * {@inheritdoc}
+     * Test GET /messages.
      */
-    public function indexUrl() {
-        $indexUrl = $this->baseUrl;
-        $indexUrl .= '?'.http_build_query(['conversationID' => self::$conversationID]);
-        return $indexUrl;
-    }
-
-    /**
-     * {@inheritdoc}
-     * @requires function MessagesApiController::delete
-     */
-    public function testDelete() {
-        $this->fail(__METHOD__.' needs to be implemented');
-    }
-
-    /**
-     * {@inheritdoc}
-     * @requires function MessagesApiController::patch
-     */
-    public function testGetEdit($record = null) {
-        $this->fail(__METHOD__.' needs to be implemented');
-    }
-
-    /**
-     * {@inheritdoc}
-     * @requires function MessagesApiController::patch
-     */
-    public function testGetEditFields() {
-        $this->fail(__METHOD__.' needs to be implemented');
-    }
-
-    /**
-     * {@inheritdoc}
-     * @requires function MessagesApiController::patch
-     */
-    public function testPatch() {
-        $this->fail(__METHOD__.' needs to be implemented');
-    }
-
-    /**
-     * {@inheritdoc}
-     * @requires function MessagesApiController::patch
-     */
-    public function testPatchSparse($field = null) {
-        $this->fail(__METHOD__.' needs to be implemented');
-    }
-
-    /**
-     * {@inheritdoc}
-     * @requires function MessagesApiController::patch
-     */
-    public function testPatchFull() {
-        $this->fail(__METHOD__.' needs to be implemented');
+    public function testIndex() {
+        parent::testIndex();
     }
 }

--- a/tests/APIv2/MessagesAllowModerationTest.php
+++ b/tests/APIv2/MessagesAllowModerationTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+namespace VanillaTests\APIv2;
+
+/**
+ * Test the /api/v2/messages endpoints.
+ */
+class MessagesAllowModerationTest extends AbstractResourceTest {
+
+    private static $userID;
+
+    private static $conversationID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($name = null, array $data = [], $dataName = '') {
+        $this->baseUrl = '/messages';
+
+        parent::__construct($name, $data, $dataName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setUpBeforeClass() {
+        parent::setupBeforeClass();
+
+        /**
+         * @var \Gdn_Session $session
+         */
+        $session = self::container()->get(\Gdn_Session::class);
+        $session->start(self::$siteInfo['adminUserID'], false, false);
+
+        /** @var \UsersApiController $usersAPIController */
+        $usersAPIController = static::container()->get('UsersAPIController');
+
+        $user = $usersAPIController->post([
+            'name' => "MessagesUser1",
+            'email' => "MessagesUser1@example.com",
+            'password' => "$%#$&ADSFBNYI*&WBV1",
+        ]);
+        self::$userID = $user['userID'];
+
+        /** @var \ConversationsApiController $conversationsAPiController */
+        $conversationsAPiController = static::container()->get('ConversationsAPiController');
+
+        $conversation = $conversationsAPiController->post([
+            'participantUserIDs' => [self::$userID]
+        ]);
+        self::$conversationID = $conversation['conversationID'];
+
+        // Disable email sending.
+        /** @var \Gdn_Configuration $config */
+        $config = static::container()->get('Config');
+        $config->set('Garden.Email.Disabled', true, true, false);
+
+        // Allow moderator/admins to moderate the conversations.
+        $config->set('Conversations.Moderation.Allow', true, true, false);
+
+        $session->end();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function record() {
+        return array_merge(parent::record(), ['conversationID' => self::$conversationID]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function indexUrl() {
+        $indexUrl = $this->baseUrl;
+        $indexUrl .= '?'.http_build_query(['conversationID' => self::$conversationID]);
+        return $indexUrl;
+    }
+
+    /**
+     * {@inheritdoc}
+     * @requires function MessagesApiController::delete
+     */
+    public function testDelete() {
+        $this->fail(__METHOD__.' needs to be implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     * @requires function MessagesApiController::patch
+     */
+    public function testGetEdit($record = null) {
+        $this->fail(__METHOD__.' needs to be implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     * @requires function MessagesApiController::patch
+     */
+    public function testGetEditFields() {
+        $this->fail(__METHOD__.' needs to be implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     * @requires function MessagesApiController::patch
+     */
+    public function testPatch() {
+        $this->fail(__METHOD__.' needs to be implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     * @requires function MessagesApiController::patch
+     */
+    public function testPatchSparse($field = null) {
+        $this->fail(__METHOD__.' needs to be implemented');
+    }
+
+    /**
+     * {@inheritdoc}
+     * @requires function MessagesApiController::patch
+     */
+    public function testPatchFull() {
+        $this->fail(__METHOD__.' needs to be implemented');
+    }
+}

--- a/tests/APIv2/MessagesTest.php
+++ b/tests/APIv2/MessagesTest.php
@@ -99,8 +99,9 @@ class MessagesTest extends AbstractResourceTest {
     /**
      * Test GET /resource/<id>.
      *
-     * @expectedException Exception
-     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     * @expectedException \Exception
+     * @expectedExceptionCode 403
+     * @expectedExceptionMessage The site is not configured for moderating conversations.
      */
     public function testGet() {
         parent::testGet();
@@ -125,8 +126,9 @@ class MessagesTest extends AbstractResourceTest {
     /**
      * Test GET /messages.
      *
-     * @expectedException Exception
-     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     * @expectedException \Exception
+     * @expectedExceptionCode 403
+     * @expectedExceptionMessage The site is not configured for moderating conversations.
      */
     public function testIndex() {
         parent::testIndex();

--- a/tests/APIv2/MessagesTest.php
+++ b/tests/APIv2/MessagesTest.php
@@ -2,7 +2,7 @@
 /**
  * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
  * @copyright 2009-2017 Vanilla Forums Inc.
- * @license GPLv2
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
  */
 
 namespace VanillaTests\APIv2;
@@ -12,9 +12,9 @@ namespace VanillaTests\APIv2;
  */
 class MessagesTest extends AbstractResourceTest {
 
-    private static $userID;
+    protected static $userID;
 
-    private static $conversationID;
+    protected static $conversationID;
 
     /**
      * {@inheritdoc}
@@ -37,6 +37,12 @@ class MessagesTest extends AbstractResourceTest {
         $session = self::container()->get(\Gdn_Session::class);
         $session->start(self::$siteInfo['adminUserID'], false, false);
 
+        // Disable flood control checks on the models and make sure that those specific instances are injected into the controllers.
+        $conversationModel = self::container()->get(\ConversationModel::class)->setFloodControlEnabled(false);
+        self::container()->setInstance(\ConversationModel::class, $conversationModel);
+        $conversationMessageModel = self::container()->get(\ConversationMessageModel::class)->setFloodControlEnabled(false);
+        self::container()->setInstance(\ConversationMessageModel::class, $conversationMessageModel);
+
         /** @var \UsersApiController $usersAPIController */
         $usersAPIController = static::container()->get('UsersAPIController');
 
@@ -49,6 +55,9 @@ class MessagesTest extends AbstractResourceTest {
 
         /** @var \ConversationsApiController $conversationsAPiController */
         $conversationsAPiController = static::container()->get('ConversationsAPiController');
+
+        // Create the conversation as the newly created user.
+        $session->start(self::$userID, false, false);
 
         $conversation = $conversationsAPiController->post([
             'participantUserIDs' => [self::$userID]
@@ -88,6 +97,16 @@ class MessagesTest extends AbstractResourceTest {
     }
 
     /**
+     * Test GET /resource/<id>.
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     */
+    public function testGet() {
+        parent::testGet();
+    }
+
+    /**
      * {@inheritdoc}
      * @requires function MessagesApiController::patch
      */
@@ -101,6 +120,34 @@ class MessagesTest extends AbstractResourceTest {
      */
     public function testGetEditFields() {
         $this->fail(__METHOD__.' needs to be implemented');
+    }
+
+    /**
+     * Test GET /messages.
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessageRegExp /Conversations\.Moderation\.Allow/
+     */
+    public function testIndex() {
+        parent::testIndex();
+    }
+
+    /**
+     * Test POST /resource.
+     *
+     * @param array|null $record Fields for a new record.
+     * @param array $extra Additional fields to send along with the POST request.
+     * @return array Returns the new record.
+     */
+    public function testPost($record = null, array $extra = []) {
+        $currentUserID = $this->api()->getUserID();
+        $this->api()->setUserID(self::$userID);
+
+        $result = parent::testPost($record, $extra);
+
+        $this->api()->setUserID($currentUserID);
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Fixes #6061 

- Add the new ConfigurationException
   - `permissionException()` should not have been used in APIControllerr
- Fix ConversationModel::inConversation function.
  - This was a result of bad merges and the patch repo not being in sync with the master repo.
- Fix inability to disable floodControl check on ConversationMessageModel
  - If the user was not an administrator `setFloodControlEnabled()` was called which was overriding any prior call to it. This was preventing us from disabling the floodControl check on the model for API tests.
- Update the Conversation/Message test suites to test with and without AllowModeration enabled.

Backport to `release/2.5a`