### PR TITLE
Add simplified permissions roles API output

### DIFF
--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -121,9 +121,8 @@ class RolesApiController extends AbstractApiController {
             }
 
             $result[$name] = $val;
-            unset($currentPerm, $pass, $fail);
+            unset($currentPerm, $pass);
         }
-        unset($perms);
 
         return $result;
     }

--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -60,7 +60,7 @@ class RolesApiController extends AbstractApiController {
         'Vanilla.Tagging.Add' => 'tags.add'
     ];
 
-    /** @var array Permissions with a fixed name. Do not change them. */
+    /** @var array These permissions should not be renamed. */
     private $fixedPermissions = [
         'Reactions.Negative.Add',
         'Reactions.Positive.Add'
@@ -394,8 +394,6 @@ class RolesApiController extends AbstractApiController {
      * @return string
      */
     private function renamePermission($permission) {
-        $result = $permission;
-
         if (array_key_exists($permission, $this->renamedPermissions)) {
             // Already got a mapping for this permission? Go ahead and use it.
             $result = $this->renamedPermissions[$permission];
@@ -414,7 +412,7 @@ class RolesApiController extends AbstractApiController {
 
             // Cache the renamed permission for this request.
             $result = implode('.', $segments);
-            $rename[$permission] = $result;
+            $this->renamedPermissions[$permission] = $result;
         }
 
         return $result;

--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -78,6 +78,7 @@ class RolesApiController extends AbstractApiController {
      * RolesApiController constructor.
      *
      * @param RoleModel $roleModel
+     * @param PermissionModel $permissionModel
      */
     public function __construct(RoleModel $roleModel, PermissionModel $permissionModel) {
         $this->roleModel = $roleModel;


### PR DESCRIPTION
An overhaul of the structure of permissions was proposed in #5539. This update implements that permission structure in roles API responses.

Closes #6062 