### PR TITLE
Fix addon installations when installed as part of the initial forum setup

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -292,7 +292,7 @@ $dic->call(function (
         /* @var Addon $addon */
         if ($bootstrapPath = $addon->getSpecial('bootstrap')) {
             $bootstrapPath = $addon->path($bootstrapPath);
-            include $bootstrapPath;
+            include_once $bootstrapPath;
         }
     }
 

--- a/library/Vanilla/Models/AddonModel.php
+++ b/library/Vanilla/Models/AddonModel.php
@@ -167,6 +167,12 @@ class AddonModel implements LoggerAwareInterface {
         $wasEnabled = $this->isEnabledConfig($addon, $options);
 
         $this->addonManager->startAddon($addon);
+
+        // Load bootstrap file.
+        if ($bootstrap = $addon->getSpecial('bootstrap')) {
+            include_once $addon->path($bootstrap, Addon::PATH_FULL);
+        }
+
         $this->runSetup($addon);
         $this->enableInConfig($addon, true, $options);
         if ($pluginClass = $addon->getPluginClass()) {

--- a/library/Vanilla/Models/InstallModel.php
+++ b/library/Vanilla/Models/InstallModel.php
@@ -17,13 +17,20 @@ use PDO;
  * Handles installing Vanilla.
  */
 class InstallModel {
+    /** @var array  */
     protected static $DEFAULT_ADDONS = ['vanilla', 'conversations', 'stubcontent'];
 
+    /** @var \Gdn_Configuration  */
     protected $config;
 
+    /** @var AddonModel  */
     protected $addonModel;
 
+    /** @var ContainerInterface  */
     protected $container;
+
+    /** @var \Gdn_Session  */
+    protected $session;
 
     /**
      * InstallModel constructor.
@@ -32,17 +39,25 @@ class InstallModel {
      * @param AddonModel $addonModel The addon model dependency used to enable installation addons.
      * @param ContainerInterface $container The container used to create additional dependencies once they are enabled.
      */
-    public function __construct(\Gdn_Configuration $config, AddonModel $addonModel, ContainerInterface $container) {
+    public function __construct(
+        \Gdn_Configuration $config,
+        AddonModel $addonModel,
+        ContainerInterface $container,
+        \Gdn_Session $session
+    ) {
         $this->config = $config;
         $this->addonModel = $addonModel;
         $this->container = $container;
+        $this->session = $session;
     }
 
     /**
      * Install Vanilla.
      *
-     * @param array $data Database installation information.
      * @see InstallModel::getSchema()
+     * @throws \Exception
+     * @param array $data Database installation information.
+     * @return array
      */
     public function install(array $data) {
         $data = $this->validate($data);
@@ -86,6 +101,14 @@ class InstallModel {
             'Email' => $data['admin']['email'],
             'Password' => $data['admin']['password']
         ]);
+
+        // Make sure that we install the addons as the admin user.
+        if (!$this->session->isValid()) {
+            $oldConfigValue = $this->config->get('Garden.Installed');
+            $this->config->set('Garden.Installed', true);
+            $this->session->start($adminUserID, false);
+            $this->config->set('Garden.Installed', $oldConfigValue);
+        }
 
         // Run through the addons.
         $data += ['addons' => static::$DEFAULT_ADDONS];

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -249,7 +249,7 @@ class Bootstrap {
                 /* @var Addon $addon */
                 if ($bootstrapPath = $addon->getSpecial('bootstrap')) {
                     $bootstrapPath = $addon->path($bootstrapPath);
-                    include $bootstrapPath;
+                    include_once $bootstrapPath;
                 }
             }
 

--- a/tests/TestInstallModel.php
+++ b/tests/TestInstallModel.php
@@ -28,8 +28,14 @@ class TestInstallModel extends InstallModel {
     /**
      * {@inheritdoc}
      */
-    public function __construct(\Gdn_Configuration $config, AddonModel $addonModel, ContainerInterface $container, \Gdn_Request $request) {
-        parent::__construct($config, $addonModel, $container);
+    public function __construct(
+        \Gdn_Configuration $config,
+        AddonModel $addonModel,
+        ContainerInterface $container,
+        \Gdn_Request $request,
+        \Gdn_Session $session
+    ) {
+        parent::__construct($config, $addonModel, $container, $session);
         $this->setBaseUrl($request->url('/'));
 
         $this->config->Data = [];


### PR DESCRIPTION
Make sure that addon's bootstrap file is loaded no matter how/when it was activated.
I also modified the bootstrap `include` to `include_once` to prevent any bugs if we start refactoring that code in the future.
Calling `AddonModel::enable()` will now load the bootstrap file properly.

We also start a non persistent session as System to make sure that everything is installed properly. Some addons needs a valid user to install themselves properly. Especially those that insert data and need to fill the InsertUserID column.