### PR TITLE
Add ability for addons to include tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,16 +25,20 @@
 
     <testsuites>
         <testsuite name="Library">
-            <directory suffix="Test.php">./tests/Library/</directory>
+            <directory suffix="Test.php">./tests/Library/</directory> for
         </testsuite>
         <testsuite name="Models">
             <directory suffix="Test.php">./tests/Models</directory>
+            <directory suffix="Test.php">./applications/*/tests/Models</directory>
+            <directory suffix="Test.php">./plugins/*/tests/Models</directory>
         </testsuite>
         <testsuite name="APIv0">
             <directory suffix="Test.php">./tests/APIv0</directory>
         </testsuite>
         <testsuite name="APIv2">
             <directory suffix="Test.php">./tests/APIv2</directory>
+            <directory suffix="Test.php">./applications/*/tests/APIv2</directory>
+            <directory suffix="Test.php">./plugins/*/tests/APIv2</directory>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,7 @@
 
     <testsuites>
         <testsuite name="Library">
-            <directory suffix="Test.php">./tests/Library/</directory> for
+            <directory suffix="Test.php">./tests/Library/</directory>
         </testsuite>
         <testsuite name="Models">
             <directory suffix="Test.php">./tests/Models</directory>

--- a/tests/SiteTestTrait.php
+++ b/tests/SiteTestTrait.php
@@ -26,7 +26,7 @@ trait SiteTestTrait {
     protected static $siteInfo;
 
     /**
-     * @var array The addons to install.
+     * @var array The addons to install. Restored on teardownAfterClass();
      */
     protected static $addons = ['vanilla', 'conversations', 'stubcontent'];
 
@@ -51,7 +51,6 @@ trait SiteTestTrait {
     public static function setupBeforeClass() {
         $dic = self::$container = static::createContainer();
 
-
         /* @var TestInstallModel $installer */
         $installer = $dic->get(TestInstallModel::class);
 
@@ -71,6 +70,7 @@ trait SiteTestTrait {
      * Cleanup the container after testing is done.
      */
     public static function teardownAfterClass() {
+        self::$addons = ['vanilla', 'conversations', 'stubcontent'];
         Bootstrap::cleanup(self::container());
     }
 


### PR DESCRIPTION
> Restore SiteTestTrait::$addon array to it's original value on teardown.
This prevents pollution between tests since the variable is static and set on the base class AbstractAPIv2Test

Addons can now provide unit tests by having a tests folder.