### PR TITLE
fixed mixed layout muted categories

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -539,7 +539,7 @@ class CategoriesController extends VanillaController {
         $CategoryFollowToggleModule = new CategoryFollowToggleModule($this);
         $CategoryFollowToggleModule->setToggle();
 
-        $this->CategoryModel->Watching = !Gdn::session()->getPreference('ShowAllCategories');
+        //$this->CategoryModel->Watching = !Gdn::session()->getPreference('ShowAllCategories');
 
         if ($Category) {
             $Subtree = CategoryModel::getSubtree($Category, false);


### PR DESCRIPTION
Muting a category while in a mixed layout, would hide that category from the side bar and users are not able to unmute