### PR TITLE
Fix filtering categories by allowed types in new post form

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -503,8 +503,8 @@ class Gdn_Form extends Gdn_Pluggable {
 
                 // Filter out categories that don't allow our discussion type, if specified
                 if ($discussionType) {
-                    $permissionCategory = CategoryModel::permissionCategory($Category);
-                    $allowedDiscussionTypes = CategoryModel::allowedDiscussionTypes($permissionCategory, $Category);
+                    $permissionCategory = CategoryModel::permissionCategory($category);
+                    $allowedDiscussionTypes = CategoryModel::allowedDiscussionTypes($permissionCategory, $category);
                     if (!array_key_exists($discussionType, $allowedDiscussionTypes)) {
                         continue;
                     }


### PR DESCRIPTION
#5785 was created before #5788, but it was merged after it. This seems to have introduced a casing issue where in the discussion type filtering no longer functions within `Gdn_Form::categoryDropDown`.

This update tweaks the casing to restore the aforementioned functionality.

Backport to [release/2.5a](https://github.com/vanilla/vanilla/tree/release/2.5a).