### PR TITLE
Restore backward compatibility on the entry/passwordReset endpoint.

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1826,6 +1826,13 @@ class EntryController extends Gdn_Controller {
             }
 
             if ($this->Form->isPostBack() === true) {
+                // Backward compatibility fix.
+                $confirm = $this->Form->getFormValue('Confirm');
+                $passwordMatch = $this->Form->getFormValue('PasswordMatch');
+                if ($confirm && !$passwordMatch) {
+                    $this->Form->setValue('PasswordMatch', $confirm);
+                }
+
                 $this->UserModel->Validation->applyRule('Password', 'Required');
                 $this->UserModel->Validation->applyRule('Password', 'Strength');
                 $this->UserModel->Validation->applyRule('Password', 'Match');


### PR DESCRIPTION
The Confirm form field was changed to PasswordMatch since existing validation functionalities required the field name to be PasswordMatch. While doing so we did not put in place some code to maintain backward compatibility. This PR fixes that by setting PasswordMatch to Confirm if the latter is set but the former is not.

Addresses https://github.com/vanilla/vanilla/pull/5091#issuecomment-340824430