### PR TITLE
Revert "Fix initial logic for having a “fixed” panel"

### DIFF
--- a/applications/dashboard/js/jquery.fluidfixed.js
+++ b/applications/dashboard/js/jquery.fluidfixed.js
@@ -97,7 +97,7 @@
              */
 
             var containerOuterHeight = vars.containerHeight + vars.offsetTop + vars.offsetBottom;
-            var fixObject = containerOuterHeight < vars.documentHeight && containerOuterHeight < vars.windowHeight;
+            var fixObject = containerOuterHeight < vars.documentHeight;
 
             var handleScroll = fixObject
                 && containerOuterHeight > vars.windowHeight // Element height is higher than the window height


### PR DESCRIPTION
This reverts commit 56b380f31c6f9cd12e9367aac64d3e5e24777ee3.

Due to that commit we now never handle scrolling with the side panel. 

For `handleScroll` to be true both `containerOuterHeight < vars.windowHeight` and `containerOuterHeight > vars.windowHeight` would be true.

The initial PR was here: https://github.com/vanilla/vanilla/pull/5506.

Fulfils: https://github.com/vanilla/vanilla/issues/6021