### PR TITLE
Fix localhost unit testing for some external addons

### DIFF
--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -214,6 +214,7 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
             }
 
             $pluginPath = combinePaths([$searchPath, $pluginFolderName]);
+
             $pluginFile = $this->findPluginFileOld($pluginPath);
 
             if ($pluginFile === false) {
@@ -946,15 +947,13 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
         // Return early!
         if (empty($PluginInfoString)) {
             return null;
-        } else {
-            eval($PluginInfoString);
         }
 
         eval($PluginInfoString);
 
         // Define the folder name and assign the class name for the newly added item.
         $var = !empty(${$VariableName}) ? ${$VariableName} : null;
-        if (is_array($var)) {
+        if (is_array($var) && !array_key_exists('Name', $var)) {
             reset($var);
             $name = key($var);
             $var = current($var);

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -193,9 +193,10 @@ class AddonManagerTest extends \PHPUnit\Framework\TestCase {
 
         $subpath = reset($classes[$classKey])['path'];
         // Kludge: Check for the userPhoto() function.
-        $fileContents = file_get_contents($addon->path($subpath));
+        $path = $addon->path($subpath);
+        $fileContents = file_get_contents($path);
         if (preg_match('`function userPhoto`i', $fileContents)) {
-            $this->markTestSkipped("We can't test classes that redeclare userPhoto().");
+            $this->markTestSkipped("We can't test classes that redeclare userPhoto(). $path");
             return;
         }
 


### PR DESCRIPTION
We have unit tests that make sure that old $PluginInfo arrays and
addon.json arrays are compatible. Some of these tests broke when we
removed the $PluginInfo arrays due to underlying bugs in
Gdn_PluginManager::scanPluginFile().

I’m interesting in really fixing a deprecating function that shouldn’t
get called in production much, but our unit tests should not be
failing. This little kludge helps at least one of our addons.

FYI: The offending addon executes the [following
line](https://github.com/vanilla/internal/blob/master/plugins/SimpleAPI/
class.simpleapi.plugin.php#L387) as its addon.