### PR TITLE
Fire event before displaying per-category notification preferences

### DIFF
--- a/applications/vanilla/views/vanillasettings/notificationpreferences.php
+++ b/applications/vanilla/views/vanillasettings/notificationpreferences.php
@@ -1,8 +1,11 @@
 <?php if (!defined('APPLICATION')) return;
 
+$Sender->EventArguments['DisableEmail'] = false;
+$Sender->fireAs('ProfileController')->fireEvent('BeforeCategoryNotificationPreferences');
+
 // If email is disabled, do not show those options.
-$emailClass = (c('Garden.Email.Disabled')) ? ' Hidden' : '';
-$span = (c('Garden.Email.Disabled')) ? '1' : '2';
+$emailClass = (c('Garden.Email.Disabled', $Sender->EventArguments['DisableEmail'])) ? ' Hidden' : '';
+$span = (c('Garden.Email.Disabled', $Sender->EventArguments['DisableEmail'])) ? '1' : '2';
 
 ?>
 <h2><?php echo t('Category Notifications'); ?></h2>


### PR DESCRIPTION
I'm trying to fulfill a service that requires hiding the email preferences for particular users with criteria to be determined in a separate plugin. The email preferences could just be hidden with CSS except that their is a double header with column spans set. This is not changeable through a stylesheet. So I've fired an event that allows a Plugin to set its own criteria for if these email preferences show up or not. This is a fallback and will not change any existing behaviour.

Needs backport to `release/2017-Q2-6` and `release/2.5a`.