### PR TITLE
Allow POST requests to dispatch to Controller::patch() in some circumstances

### DIFF
--- a/library/Garden/Web/ResourceRoute.php
+++ b/library/Garden/Web/ResourceRoute.php
@@ -380,6 +380,10 @@ class ResourceRoute extends Route {
 
         if ($method === 'get') {
             $result[] = ['index', null];
+        } elseif ($method === 'post' && !empty($pathArgs)) {
+            // This is a bit of a kludge to allow POST to be used against the usual PATCH method to allow for
+            // multipart/form-data on PATCH (edit) endpoints.
+            $result[] = ['patch', null];
         }
 
         return $result;

--- a/tests/Library/Garden/Web/ResourceRouteTest.php
+++ b/tests/Library/Garden/Web/ResourceRouteTest.php
@@ -74,6 +74,7 @@ class ResourceRouteTest extends \PHPUnit\Framework\TestCase {
 
             'map body' => ['POST', '/discussions', [$dc, 'post'], ['body' => ['!']]],
             'map data' => ['PATCH', '/discussions/1', [$dc, 'patch'], ['id' => '1', 'data' => ['id' => '1', 0 => '!']]],
+            'post and patch' => ['POST', '/discussions/1', [$dc, 'patch'], ['id' => '1', 'data' => ['id' => '1', 0 => '!']]],
 
             'no mapping' => ['POST', '/discussions/no-map/a/b/c?f=b', [$dc, 'post_noMap'], ['query' => 'a', 'body' => 'b', 'data' => 'c']],
 


### PR DESCRIPTION
This is a bit of a kludge to allow POST to be used against the usual PATCH method to allow for multipart/form-data on PATCH (edit) endpoints.

The initial implementation of this is narrow so POST cannot dispatch to `patch_action` style methods, just the default `patch` method.