### PR TITLE
Improve file upload support for API uploads

### DIFF
--- a/library/Vanilla/UploadedFile.php
+++ b/library/Vanilla/UploadedFile.php
@@ -1,0 +1,207 @@
+<?php
+namespace Vanilla;
+
+use Gdn;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Value object representing a file uploaded through an HTTP request.
+ */
+class UploadedFile {
+
+    /** @var string */
+    private $clientFileName;
+
+    /** @var string */
+    private $clientMediaType;
+
+    /** @var int */
+    private $error;
+
+    /** @var string */
+    private $file;
+
+    /** @var string */
+    private $moved = false;
+
+    /** @var int */
+    private $size;
+
+    /**
+     * UploadedFile constructor.
+     *
+     * @param string $file
+     * @param int $size
+     * @param int $error
+     * @param string|null $clientFileName
+     * @param string|null $clientMediaType
+     */
+    public function __construct($file, $size, $error, $clientFileName = null, $clientMediaType = null) {
+        $this->setSize($size);
+        $this->setError($error);
+        $this->setClientFileName($clientFileName);
+        $this->setClientMediaType($clientMediaType);
+
+        if ($this->getError() === UPLOAD_ERR_OK) {
+            $this->setFile($file);
+        }
+    }
+
+    /**
+     * Retrieve a stream representing the uploaded file.
+     *
+     * @throws RuntimeException
+     */
+    public function getStream() {
+        throw new RuntimeException(self::class.'::'.__FUNCTION__.' is not supported.');
+    }
+
+    /**
+     * Move the uploaded file to a new location.
+     *
+     * @param string $targetPath Path to which to move the uploaded file.
+     * @throws InvalidArgumentException if the $targetPath specified is invalid.
+     * @throws RuntimeException on any error during the move operation.
+     * @throws RuntimeException on the second or subsequent call to the method.
+     */
+    public function moveTo($targetPath) {
+        if ($this->moved) {
+            throw new RuntimeException('This upload has already been moved.');
+        }
+
+        $directory = dirname($targetPath);
+        if (!is_writable($directory)) {
+            throw new InvalidArgumentException('The specified path is not writable.');
+        }
+
+        if (!is_uploaded_file($this->file)) {
+            throw new RuntimeException("'{$this->file}' is not a valid upload.");
+        }
+
+        try {
+            Gdn::getContainer()->get('Gdn_Upload')->saveAs($this->file, $targetPath);
+        } catch (\Exception $e) {
+            throw new RuntimeException($e->getMessage(), $e->getCode());
+        }
+
+        $this->moved = true;
+    }
+
+    /**
+     * Retrieve the file size.
+     *
+     * @return int|null The file size in bytes or null if unknown.
+     */
+    public function getSize() {
+        return $this->size;
+    }
+
+    /**
+     * Retrieve the error associated with the uploaded file.
+     *
+     * @return int One of the UPLOAD_ERR_XXX constants.
+     */
+    public function getError() {
+        return $this->error;
+    }
+
+    /**
+     * Retrieve the filename sent by the client.
+     *
+     * @return string|null The filename sent by the client or null if none was provided.
+     */
+    public function getClientFilename() {
+        return $this->clientFileName;
+    }
+
+    /**
+     * Retrieve the media type sent by the client.
+     *
+     * @return string|null The media type sent by the client or null if none was provided.
+     */
+    public function getClientMediaType() {
+        return $this->clientMediaType;
+    }
+
+    /**
+     * Set the client-provided file name.
+     *
+     * @param string|null $clientFileName
+     * @throws InvalidArgumentException if the value is invalid.
+     */
+    private function setClientFileName($clientFileName) {
+        if ($clientFileName === null || is_string($clientFileName)) {
+            $this->clientFileName = $clientFileName;
+        } else {
+            throw new InvalidArgumentException('Client file name must be a string or null.');
+        }
+    }
+
+    /**
+     * Set the client-provided media type.
+     *
+     * @param string|null $clientMediaType
+     * @throws InvalidArgumentException if the value is invalid.
+     */
+    private function setClientMediaType($clientMediaType) {
+        if ($clientMediaType === null || is_string($clientMediaType)) {
+            $this->clientMediaType = $clientMediaType;
+        } else {
+            throw new InvalidArgumentException('Client media type must be a string or null.');
+        }
+    }
+
+    /**
+     * Set the error flag.
+     *
+     * @param int $error An error flag. Must be one of the UPLOAD_ERR_* constants.
+     * @throws InvalidArgumentException if the value is invalid.
+     */
+    private function setError($error) {
+        $validErrors = [
+            UPLOAD_ERR_OK,
+            UPLOAD_ERR_INI_SIZE,
+            UPLOAD_ERR_FORM_SIZE,
+            UPLOAD_ERR_PARTIAL,
+            UPLOAD_ERR_NO_FILE,
+            UPLOAD_ERR_NO_TMP_DIR,
+            UPLOAD_ERR_CANT_WRITE,
+            UPLOAD_ERR_EXTENSION
+        ];
+
+        if (is_integer($error) && in_array($error, $validErrors)) {
+            $this->error = $error;
+        } else {
+            throw new InvalidArgumentException('Error must be one of the UPLOAD_ERR_* constants.');
+        }
+    }
+
+    /**
+     * Set the temporary filename.
+     *
+     * @param string $file
+     * @throws InvalidArgumentException if the value is invalid.
+     */
+    private function setFile($file) {
+        if (is_string($file)) {
+            $this->file = $file;
+        } else {
+            throw new InvalidArgumentException('File name must be a string.');
+        }
+    }
+
+    /**
+     * Set the file size.
+     *
+     * @param int $size The size of the file, in bytes.
+     * @throws InvalidArgumentException if the value is invalid.
+     */
+    private function setSize($size) {
+        if (is_int($size)) {
+            $this->size = $size;
+        } else {
+            throw new InvalidArgumentException('Size must be an integer.');
+        }
+    }
+}

--- a/library/Vanilla/UploadedFile.php
+++ b/library/Vanilla/UploadedFile.php
@@ -6,9 +6,9 @@
 
 namespace Vanilla;
 
-use Gdn;
 use InvalidArgumentException;
 use RuntimeException;
+use Gdn_Upload;
 
 /**
  * Value object representing a file uploaded through an HTTP request.
@@ -33,16 +33,22 @@ class UploadedFile {
     /** @var int */
     private $size;
 
+    /** @var  Gdn_Upload */
+    private $uploadModel;
+
     /**
      * UploadedFile constructor.
      *
+     * @param Gdn_Upload $uploadModel
      * @param string $file
      * @param int $size
      * @param int $error
      * @param string|null $clientFileName
      * @param string|null $clientMediaType
      */
-    public function __construct($file, $size, $error, $clientFileName = null, $clientMediaType = null) {
+    public function __construct(Gdn_Upload $uploadModel, $file, $size, $error, $clientFileName = null, $clientMediaType = null) {
+        $this->uploadModel = $uploadModel;
+
         $this->setSize($size);
         $this->setError($error);
         $this->setClientFileName($clientFileName);
@@ -85,7 +91,7 @@ class UploadedFile {
         }
 
         try {
-            Gdn::getContainer()->get('Gdn_Upload')->saveAs($this->file, $targetPath);
+            $this->uploadModel->saveAs($this->file, $targetPath);
         } catch (\Exception $e) {
             throw new RuntimeException($e->getMessage(), $e->getCode());
         }

--- a/library/Vanilla/UploadedFile.php
+++ b/library/Vanilla/UploadedFile.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GNU GPLv2
+ */
+
 namespace Vanilla;
 
 use Gdn;

--- a/library/Vanilla/UploadedFileSchema.php
+++ b/library/Vanilla/UploadedFileSchema.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GNU GPLv2
+ */
+
+namespace Vanilla;
+
+use Garden\Schema\Invalid;
+use Garden\Schema\Schema;
+use Garden\Schema\ValidationField;
+use Garden\Schema\ValidationException;
+
+class UploadedFileSchema extends Schema {
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(array $schema = []) {
+        if (!empty($schema)) {
+            throw new \InvalidArgumentException(self::class.' does not support custom schemas.');
+        }
+
+        parent::__construct([
+            'id' => 'UploadedFile',
+            'type' => 'string',
+            'format' => 'binary'
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($data, $sparse = false) {
+        $field = new ValidationField($this->createValidation(), $this->getSchemaArray(), '', $sparse);
+
+        $clean = $this->validateUploadedFile($data, $field);
+
+        if (Invalid::isInvalid($clean) && $field->isValid()) {
+            // This really shouldn't happen, but we want to protect against seeing the invalid object.
+            $field->addError('invalid', ['messageCode' => '{field} is invalid.', 'status' => 422]);
+        }
+
+        if (!$field->getValidation()->isValid()) {
+            throw new ValidationException($field->getValidation());
+        }
+
+        return $data;
+    }
+
+    /**
+     * Validate a file upload.
+     *
+     * @param mixed $value The value to validate.
+     * @param ValidationField $field The validation results to add.
+     * @return string|Invalid Returns the valid string or **null** if validation fails.
+     */
+    protected function validateUploadedFile($value, ValidationField $field) {
+        if (!($value instanceof UploadedFile)) {
+            $field->addError('invalid', ['messageCode' => '{field} is not a valid file upload.']);
+            return Invalid::value();
+        }
+
+        return $value;
+    }
+}

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1178,6 +1178,7 @@ class Gdn_Request implements RequestInterface {
                 $result = $normalizeArray($value);
             } else {
                 $result = new UploadedFile(
+                    Gdn::getContainer()->get(Gdn_Upload::class),
                     $value['tmp_name'],
                     $value['size'],
                     $value['error'],


### PR DESCRIPTION
In preparation for using file uploads with the API, this update does a few things:

1. Adds the new `Vanilla\UploadedFile` class, which attempts to be adherent to the `UploadedFileInterface` from [PSR-7](http://www.php-fig.org/psr/psr-7), with the exception that streams are not supported.
1. Merges entries from the `$_FILES` array into POST data in `Gdn_Request` as instances of `Vanilla\UploadedFile`. The structure of file attributes is normalized to something a little more sane in the process.
1. Adds a new `Vanilla\UploadedFileSchema` class, which extends `Garden\Schema\Schema`. This class will be used to verify a field in an API request is populated with a file (instance of `Vanilla\UploadedFile`).
1. Adds tests for `Vanilla\UploadedFile`.

To test out `Vanilla\UploadedFileSchema`, all you need to do is add it into an input schema.

```php
$in = $this->schema([
    'myFile' => new Vanilla\UploadedFileSchema()
]);
```

Closes #6084
Closes #6085