### PR TITLE
Simulate that the data was passed over HTTP for unit tests

### DIFF
--- a/tests/APIv2/TokensTest.php
+++ b/tests/APIv2/TokensTest.php
@@ -132,7 +132,8 @@ class TokensTest extends AbstractAPIv2Test {
         $this->assertTrue(is_int($body[$this->pk]));
         $this->assertTrue($body[$this->pk] > 0);
         $this->assertEquals($row['name'], $body['name']);
-        $this->assertInstanceOf('DateTimeImmutable', $body['dateInserted']);
+        $this->assertArrayHasKey('dateInserted', $body);
+        $this->assertInternalType('int', strtotime($body['dateInserted']));
 
         $this->accessTokenModel->verify($body['accessToken'], true);
 

--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -139,7 +139,9 @@ class InternalRequest extends HttpRequest implements RequestInterface {
             $data->getStatus(),
             array_merge($data->getHeaders(), ['X-Data-Meta' => json_encode($data->getMetaArray())])
         );
-        $response->setBody($data->getData());
+        // Simulate that the data was sent over HTTP and thus was serialized.
+        $body = $data->jsonSerialize();
+        $response->setBody($body);
 
         return $response;
     }


### PR DESCRIPTION
There is a date comparison problems in unit tests.
Sometimes the dates are strings and something they are `DateTimeImmutable` objects.

This PR calls `Data::jsonSerialize()` on the returned data to make sure that it is compatible with what would be returned by the API called over HTTP.

This will ensure that IPs and Dates are formatted as strings.