### PR TITLE
Add displayAs to /api/v2/categories

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -49,7 +49,7 @@ class CategoriesApiController extends AbstractApiController {
      */
     public function categoryPostSchema($type = '', array $extra = []) {
         if ($this->categoryPostSchema === null) {
-            $fields = ['name', 'parentCategoryID', 'urlCode'];
+            $fields = ['name', 'parentCategoryID?', 'urlCode', 'displayAs?'];
             $this->categoryPostSchema = $this->schema(
                 Schema::parse(array_merge($fields, $extra))->add($this->schemaWithParent()),
                 'CategoryPost'
@@ -131,7 +131,8 @@ class CategoriesApiController extends AbstractApiController {
             'url:s' => 'The URL to the category.',
             'displayAs:s' => [
                 'description' => 'The display style of the category.',
-                'enum' => ['categories', 'discussions', 'flat', 'heading']
+                'enum' => ['categories', 'discussions', 'flat', 'heading'],
+                'default' => 'discussions'
             ],
             'countCategories:i' => 'Total number of child categories.',
             'countDiscussions:i' => 'Total discussions in the category.',
@@ -173,7 +174,7 @@ class CategoriesApiController extends AbstractApiController {
 
         $in = $this->idParamSchema()->setDescription('Get a category for editing.');
         $out = $this->schema(Schema::parse([
-            'categoryID', 'name', 'parentCategoryID', 'urlCode', 'description'
+            'categoryID', 'name', 'parentCategoryID', 'urlCode', 'description', 'displayAs'
         ])->add($this->fullSchema()), 'out');
 
         $row = $this->category($id);

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -125,9 +125,13 @@ class CategoriesApiController extends AbstractApiController {
                 'minLength' => 0,
                 'allowNull' => true
             ],
-            'parentCategoryID:i' => 'Parent category ID.',
+            'parentCategoryID:i|n' => 'Parent category ID.',
             'urlCode:s' => 'The URL code of the category.',
             'url:s' => 'The URL to the category.',
+            'displayAs:s' => [
+                'description' => 'The display style of the category.',
+//                'enum' => ['categories', 'discussions', 'flat', 'heading']
+            ],
             'countCategories:i' => 'Total number of child categories.',
             'countDiscussions:i' => 'Total discussions in the category.',
             'countComments:i' => 'Total comments in the category.',
@@ -285,6 +289,8 @@ class CategoriesApiController extends AbstractApiController {
         } else {
             $categories = $this->categoryModel->getTree($parent['CategoryID'], ['maxdepth' => $query['maxDepth']]);
         }
+        array_walk($categories, [$this, 'prepareRow']);
+
 
         return $out->validate($categories);
     }
@@ -365,6 +371,11 @@ class CategoriesApiController extends AbstractApiController {
             $row['ParentCategoryID'] = null;
         }
         $row['Description'] = $row['Description'] ?: '';
+        $row['DisplayAs'] = strtolower($row['DisplayAs']);
+
+        if (!empty($row['Children']) && is_array($row['Children'])) {
+            array_walk($row['Children'], [$this, 'prepareRow']);
+        }
     }
 
     /**

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -83,6 +83,7 @@ class CategoriesApiController extends AbstractApiController {
         if (empty($category)) {
             throw new NotFoundException('Category');
         }
+        $this->prepareRow($category);
         return $category;
     }
 
@@ -130,7 +131,7 @@ class CategoriesApiController extends AbstractApiController {
             'url:s' => 'The URL to the category.',
             'displayAs:s' => [
                 'description' => 'The display style of the category.',
-//                'enum' => ['categories', 'discussions', 'flat', 'heading']
+                'enum' => ['categories', 'discussions', 'flat', 'heading']
             ],
             'countCategories:i' => 'Total number of child categories.',
             'countDiscussions:i' => 'Total discussions in the category.',

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -508,7 +508,7 @@ if (!function_exists('validateEnum')) {
      * @return bool Returns true of the value is valid or false otherwise.
      */
     function validateEnum($value, $field) {
-        return (in_array($value, $field->Enum) || ($field->AllowNull && !validateRequired($value)));
+        return (inArrayI($value, $field->Enum) || ($field->AllowNull && !validateRequired($value)));
     }
 }
 

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -25,10 +25,10 @@ class CategoriesTest extends AbstractResourceTest {
     protected $baseUrl = '/categories';
 
     /** {@inheritdoc} */
-    protected $editFields = ['description', 'name', 'parentCategoryID', 'urlCode'];
+    protected $editFields = ['description', 'name', 'parentCategoryID', 'urlCode', 'displayAs'];
 
     /** {@inheritdoc} */
-    protected $patchFields = ['description', 'name', 'parentCategoryID', 'urlCode'];
+    protected $patchFields = ['description', 'name', 'parentCategoryID', 'urlCode', 'displayAs'];
 
     /** {@inheritdoc} */
     protected $pk = 'categoryID';
@@ -47,6 +47,8 @@ class CategoriesTest extends AbstractResourceTest {
             switch ($key) {
                 case 'urlCode':
                     $value = md5($value);
+                case 'displayAs':
+                    $value = $value === 'flat' ? 'categories' : 'flat';
             }
             $row[$key] = $value;
         }
@@ -71,7 +73,8 @@ class CategoriesTest extends AbstractResourceTest {
         $record = [
             'name' => $name,
             'urlCode' => $urlCode,
-            'parentCategoryID' => self::PARENT_CATEGORY_ID
+            'parentCategoryID' => self::PARENT_CATEGORY_ID,
+            'displayAs' => 'flat'
         ];
         static::$recordCounter++;
         return $record;


### PR DESCRIPTION
- Add displayAs to categories endpoints.
- Run prepareRow() in more cases.
- Core enum validation is now case-insensitive.
- Mark some category fields as not required for POST. 