### PR TITLE
Fix attempting to set value on file field in Gdn_Form

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -1843,12 +1843,12 @@ class Gdn_Form extends Gdn_Pluggable {
             );
         } else {
             $return .= $this->_nameAttribute($fieldName, $attributes);
+            if ($strength) {
+                $return .= ' data-strength="true"';
+            }
+            $return .= $this->_valueAttribute($fieldName, $attributes);
         }
 
-        if ($strength) {
-            $return .= ' data-strength="true"';
-        }
-        $return .= $this->_valueAttribute($fieldName, $attributes);
         $return .= $this->_attributesToString($attributes);
         $return .= ' />';
 

--- a/tests/Library/Core/FormTest.php
+++ b/tests/Library/Core/FormTest.php
@@ -38,6 +38,6 @@ class FormTest extends \PHPUnit\Framework\TestCase {
         $frm = new Gdn_Form('', 'bootstrap');
 
         $input = $frm->input('DefaultAvatar', 'file', ['class' => 'js-new-avatar-upload Hidden']);
-        $this->assertSame('<input type="file" id="Form_DefaultAvatar" name="DefaultAvatar" value="" class="js-new-avatar-upload Hidden form-control-file" />', $input);
+        $this->assertSame('<input type="file" id="Form_DefaultAvatar" name="DefaultAvatar" class="js-new-avatar-upload Hidden form-control-file" />', $input);
     }
 }


### PR DESCRIPTION
`Gdn_Form::input` is used to generate markup for form inputs. One part of this method analyzes the requests and attempts to [set the value attribute on the input markup its generating](https://github.com/vanilla/vanilla/blob/cbb18ce9e5be5eb85126d723ba0fd2d3a98dacff/library/core/class.form.php#L1851), based on values form a form submission. This functionality more or less checks postback data for a field with the same name and, if found, inserts that value as the "value" attribute on the input element.

There's been a longstanding issue where an empty "value" attribute is being applied to field fields. This was caused by the method not checking what the input type was, before attempting to assign its value attribute. Since files weren't in the postback data (`$_POST`), the value defaulted to an empty string.

Since Vanilla has started normalizing file uploads to postback data in the `Gdn_Request` object as of #6101, files are represented as objects in the data array. Trying to convert those objects into a string for the value attribute is causing a fatal error.

This update moves some of the special attribute handling into an existing input type conditional to prevent this issue. It also updates a test that was using static markup of previous output, which included the empty value attribute, for comparison.