### PR TITLE
Stop function heading() from nesting h1 tags

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -139,7 +139,7 @@ if (!function_exists('heading')) {
                 <a class="btn btn-icon btn-return" aria-label="Return" href="'.url($returnUrl).'">'.
                     dashboardSymbol('chevron-left').'
                 </a>
-                <h1>'.$title.'</h1>
+                '.$title.'
             </div>';
         }
 


### PR DESCRIPTION
The heading() function wraps the $title variable in h1 tags. The code in the if $returnUrl !== '' statement wraps the (now already altered) $title again in h1 tags, resulting in `<h1><h1>$title</h1></h1>`
I simply removed the second wrapping.