### PR TITLE
Camel case AuthenticateApiController::post_linkUser()

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticateApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticateApiController.php
@@ -403,7 +403,7 @@ class AuthenticateApiController extends AbstractApiController {
      * @param array $body
      * @return array
      */
-    public function post_linkuser(array $body) {
+    public function post_linkUser(array $body) {
         $this->permission();
 
         if (!$this->config->get('Garden.Registration.AllowConnect', true)) {

--- a/tests/APIv2/Authenticate/LinkUserTest.php
+++ b/tests/APIv2/Authenticate/LinkUserTest.php
@@ -67,7 +67,7 @@ class LinkUserTest extends AbstractAPIv2Test {
     }
 
     /**
-     * Test POST /authenticate/linkuser by sending userid + password.
+     * Test POST /authenticate/link-user by sending userid + password.
      */
     public function testLinkUserWithUserID() {
         $authSessionID = $this->createAuthSessionID();
@@ -79,7 +79,7 @@ class LinkUserTest extends AbstractAPIv2Test {
         ];
 
         $result = $this->api()->post(
-            $this->baseUrl.'/linkuser',
+            $this->baseUrl.'/link-user',
             $postData
         );
 
@@ -93,7 +93,7 @@ class LinkUserTest extends AbstractAPIv2Test {
     }
 
     /**
-     * Test POST /authenticate/linkuser by sending name + email + password.
+     * Test POST /authenticate/link-user by sending name + email + password.
      */
     public function testLinkUserWithNameEmail() {
         $authSessionID = $this->createAuthSessionID();
@@ -106,7 +106,7 @@ class LinkUserTest extends AbstractAPIv2Test {
         ];
 
         $result = $this->api()->post(
-            $this->baseUrl.'/linkuser',
+            $this->baseUrl.'/link-user',
             $postData
         );
 
@@ -120,7 +120,7 @@ class LinkUserTest extends AbstractAPIv2Test {
     }
 
     /**
-     * Test POST /authenticate/linkuser with a wrong password.
+     * Test POST /authenticate/link-user with a wrong password.
      *
      * @expectedException \Exception
      * @expectedExceptionMessage The password verification failed.
@@ -135,7 +135,7 @@ class LinkUserTest extends AbstractAPIv2Test {
         ];
 
         $result = $this->api()->post(
-            $this->baseUrl.'/linkuser',
+            $this->baseUrl.'/link-user',
             $postData
         );
 


### PR DESCRIPTION
This allows POST `/api/v2/authenticate/link-user` and `/api/v2/authenticate/linkUser` to be called instead of `/api/v2/authenticate/linkuser`