### PR TITLE
Add the Attributes class

### DIFF
--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -14,6 +14,11 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
     private $userFragmentSchema;
 
     /**
+     * @var Schema
+     */
+    private $postFragmentSchema;
+
+    /**
      * Filter unwanted values from an array (particularly empty values from request parameters).
      *
      * @param array $values
@@ -57,6 +62,28 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
             ], 'UserFragment');
         }
         return $this->userFragmentSchema;
+    }
+
+    /**
+     * Get the schema for posts joined to records.
+     *
+     * Posts are joined to categories and discussions, usually in the form of **firstPost** and **lastPost** fields.
+     *
+     * @return Schema Returns a schema.
+     */
+    public function getPostFragmentSchema() {
+        if ($this->postFragmentSchema === null) {
+            $this->postFragmentSchema = $this->schema([
+                'discussionID:i?' => 'The discussion ID of the post.',
+                'commentID:i?' => 'The comment ID of the post, if any.',
+                'name:s' => 'The title of the post.',
+                'url:s' => 'The URL of the post.',
+                'dateInserted:dt' => 'The date of the post.',
+                'insertUserID:i' => 'The author of the post.',
+                'insertUser?' => $this->getUserFragmentSchema(),
+            ], 'PostFragment');
+        }
+        return $this->postFragmentSchema;
     }
 
     public function options($path) {

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -179,7 +179,8 @@ class DiscussionsApiController extends AbstractApiController {
             'url:s?' => 'The full URL to the discussion.',
             'lastPost?' => $this->getPostFragmentSchema(),
             'bookmarked:b' => 'Whether or not the discussion is bookmarked by the current user.',
-            'unread:b' => 'Whether or not the discussion should have an unread indicator.'
+            'unread:b' => 'Whether or not the discussion should have an unread indicator.',
+            'countUnread:i?' => 'The number of unread comments.',
         ]);
     }
 
@@ -222,7 +223,11 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         if ($this->getSession()->User) {
-            $row['unread'] = $row['CountUnreadComments'] !== 0 && ($row['CountUnreadComments'] !== true || dateCompare(val('DateFirstVisit', $this->getSession()->User), $row['DateInserted']) <= 0);
+            $row['unread'] = $row['CountUnreadComments'] !== 0
+                && ($row['CountUnreadComments'] !== true || dateCompare(val('DateFirstVisit', $this->getSession()->User), $row['DateInserted']) <= 0);
+            if ($row['CountUnreadComments'] !== true && $row['CountUnreadComments'] > 0) {
+                $row['countUnread'] = $row['CountUnreadComments'];
+            }
         } else {
             $row['unread'] = false;
         }

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -216,11 +216,7 @@ class DiscussionsApiController extends AbstractApiController {
         $row['Bookmarked'] = (bool)$row['Bookmarked'];
         $row['Url'] = discussionUrl($row);
         $this->formatField($row, 'Body', $row['Format']);
-
-        if (!is_array($row['Attributes'])) {
-            $attributes = dbdecode($row['Attributes']);
-            $row['Attributes'] = is_array($attributes) ? $attributes : [];
-        }
+        $row['Attributes'] = new \Vanilla\Attributes($row['Attributes']);
 
         if ($this->getSession()->User) {
             $row['unread'] = $row['CountUnreadComments'] !== 0

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ff5dd33964dc9866f43676908ef522a",
+    "content-hash": "0ed823c7d48d43e195e9ae6db2147dfd",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -679,16 +679,16 @@
         },
         {
             "name": "vanilla/garden-schema",
-            "version": "v1.7",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vanilla/garden-schema.git",
-                "reference": "04669138bd0786a0b81355959e56ebb1d02ec468"
+                "reference": "0f27b859a31bb720f37c469c2184dbc591c293ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vanilla/garden-schema/zipball/04669138bd0786a0b81355959e56ebb1d02ec468",
-                "reference": "04669138bd0786a0b81355959e56ebb1d02ec468",
+                "url": "https://api.github.com/repos/vanilla/garden-schema/zipball/0f27b859a31bb720f37c469c2184dbc591c293ea",
+                "reference": "0f27b859a31bb720f37c469c2184dbc591c293ea",
                 "shasum": ""
             },
             "require": {
@@ -711,7 +711,7 @@
                 }
             ],
             "description": "A simple data validation and cleaning library based on JSON Schema.",
-            "time": "2017-10-15T23:51:14+00:00"
+            "time": "2017-11-07T17:30:23+00:00"
         },
         {
             "name": "vanilla/htmlawed",
@@ -885,6 +885,48 @@
             ],
             "description": "A composer-compatible fork of the NBBC BBCode parsing library.",
             "time": "2016-04-26T18:19:47+00:00"
+        },
+        {
+            "name": "vanilla/vanilla-connect",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vanilla/vanilla-connect-php.git",
+                "reference": "838657be3c04fd1dae2fb0cca333b2b0ac6319e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vanilla/vanilla-connect-php/zipball/838657be3c04fd1dae2fb0cca333b2b0ac6319e6",
+                "reference": "838657be3c04fd1dae2fb0cca333b2b0ac6319e6",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "~5.0",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.0"
+            },
+            "type": "project",
+            "autoload": {
+                "exclude-from-classmap": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Vanilla\\": "src/Vanilla"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Alexandre (DaazKu) Chouinard",
+                    "email": "alexandre.c@vanillaforums.com"
+                }
+            ],
+            "time": "2017-10-05T21:51:35+00:00"
         }
     ],
     "packages-dev": [

--- a/library/Vanilla/Attributes.php
+++ b/library/Vanilla/Attributes.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla;
+
+
+class Attributes extends \ArrayObject implements \JsonSerializable {
+    public function __construct($input = null) {
+        if (is_string($input)) {
+            $input = dbdecode($input);
+        } elseif (empty($input)) {
+            $input = [];
+        }
+
+        parent::__construct($input, \ArrayObject::ARRAY_AS_PROPS);
+    }
+
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    function jsonSerialize() {
+        $r = (object)$this->getArrayCopy();
+        return $r;
+    }
+}

--- a/library/Vanilla/InternalRequest.php
+++ b/library/Vanilla/InternalRequest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla;
+
+use Garden\Web\RequestInterface;
+
+class InternalRequest implements RequestInterface {
+    private $path;
+    private $query;
+    private $body;
+    private $headers;
+    private $method;
+
+    public function __construct($method = 'GET', $path = '', array $body = [], array $headers = []) {
+        $this->method = strtoupper($method);
+        $this->path = '/'.ltrim($path, '/');
+
+        if ($this->method === 'GET') {
+            $this->query = $body;
+        } else {
+            $this->body = $body;
+        }
+        $this->headers = $headers;
+    }
+
+    /**
+     * Get the hostname of the request.
+     *
+     * @return string
+     */
+    public function getHost() {
+        return 'internal';
+    }
+
+    /**
+     * Get the method used to do the request.
+     *
+     * @return string
+     */
+    public function getMethod() {
+        return $this->method;
+    }
+
+    public function getRoot() {
+        return '';
+    }
+
+    /**
+     * Get the path of the request.
+     *
+     * @return string
+     */
+    public function getPath() {
+        return $this->path;
+    }
+
+    /**
+     * Get the query of the request.
+     *
+     * @return mixed
+     */
+    public function getQuery() {
+        return $this->query;
+    }
+
+    /**
+     * Get the body of the request.
+     *
+     * @return mixed
+     */
+    public function getBody() {
+        return $this->body;
+    }
+
+    /**
+     * Get the scheme of the request.
+     *
+     * @return string Either http or https.
+     */
+    public function getScheme() {
+        return 'https';
+    }
+
+    /**
+     * Get all headers from the request.
+     *
+     * @return array
+     */
+    public function getHeaders() {
+        return $this->headers;
+    }
+
+    /**
+     * Get a header value.
+     *
+     * @param string $header The name of the header.
+     * @return string Returns the header value or an empty string.
+     */
+    public function getHeader($header) {
+        return isset($this->headers[$header]) ? $this->headers[$header] : '';
+    }
+
+    public function setHeader($header, $value) {
+        $this->headers[$header] = $value;
+        return $this;
+    }
+
+    /**
+     * Get a header's value(s) as a string.
+     *
+     * @param string $name The name of the header.
+     * @return string A header's value(s). Multiple values are returned as a CSV string.
+     */
+    public function getHeaderLine($name) {
+        $header = $this->getHeader($name);
+        if (is_array($header)) {
+            $header = implode(',', $header);
+        }
+        return $header;
+    }
+
+    /**
+     * Checks if a header exists by the given case-insensitive name.
+     *
+     * @param string $header Case-insensitive header name.
+     * @return bool Returns **true** if the header exists or **false** otherwise.
+     */
+    public function hasHeader($header) {
+        return !empty($this->headers[$header]);
+    }
+
+    /**
+     * Set the body.
+     *
+     * @param mixed $body
+     * @return $this
+     */
+    public function setBody($body) {
+        $this->body = $body;
+        return $this;
+    }
+}


### PR DESCRIPTION
This class is an array wrapper for the "attributes" style columns of API call results. We need this class because attributes can be empty which then JSON encode to `[]` instead of `{}` which can throw non-PHP clients off.