### PR TITLE
Compare namespaces in a case insentive manner in the AddonManager

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -1191,7 +1191,7 @@ class Addon {
         $key = strtolower($classInfo['className']);
         if (array_key_exists($key, $this->classes)) {
             foreach($this->classes[$key] as $classData) {
-                if ($classInfo['namespace'] === $classData['namespace']) {
+                if (strtolower($classInfo['namespace']) === strtolower($classData['namespace'])) {
                     $path = $this->path($classData['path'], $relative);
                     return $path;
                 }

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -541,6 +541,12 @@ class AddonManagerTest extends \PHPUnit\Framework\TestCase {
                 'Vanilla\API\DiscussionsController' => true,
                 'API\DiscussionsController' => false
             ],
+            'vanilla\*\DiscussionsController' => [
+                'DiscussionsController' => false,
+                'Vanilla\DiscussionsController' => true,
+                'Vanilla\API\DiscussionsController' => true,
+                'API\DiscussionsController' => false
+            ],
             '*\*Controller' => [
                 'DiscussionsController' => true,
                 'Vanilla\DiscussionsController' => true,
@@ -592,12 +598,36 @@ class AddonManagerTest extends \PHPUnit\Framework\TestCase {
     /**
      * Test finding classes on a started addon.
      */
-    public function testFindClassesStarted() {
+    public function testFindClassesNamespaceCaseMismatch() {
         $am = new TestAddonManager();
 
-        $am->startAddonsByKey(['test-old-plugin'], Addon::TYPE_ADDON);
-        $classes = $am->findClasses('TestOldPluginPlugin');
-        $this->assertSame(\TestOldPluginPlugin::class, $classes[0]);
+        $am->startAddonsByKey(['namespaced-plugin'], Addon::TYPE_ADDON);
+        $classes = $am->findClasses('deeply\\NESTed\\NamesPaced\\Fixture\\TestClass');
+        $this->assertSame(\Deeply\Nested\Namespaced\Fixture\TestClass::class, $classes[0]);
+    }
+
+    /**
+     * Test a findClass with a namespace case mismatch
+     */
+    public function testFindClassNamespaceCaseMismatch() {
+        $am = new TestAddonManager();
+
+        $am->startAddonsByKey(['namespaced-plugin'], Addon::TYPE_ADDON);
+
+        $addon = $am->lookupByClassname('deeply\\NESTed\\NamesPaced\\Fixture\\TestClass');
+        $this->assertEquals('namespaced-plugin', $addon->getKey());
+    }
+
+    /**
+     * Test a lookup with a namespace case mismatch
+     */
+    public function testLookupNamespaceCaseMismatch() {
+        $am = new TestAddonManager();
+
+        $am->startAddonsByKey(['namespaced-plugin'], Addon::TYPE_ADDON);
+
+        $addon = $am->lookupByClassname('deeply\\NESTed\\NamesPaced\\Fixture\\TestClass');
+        $this->assertEquals('namespaced-plugin', $addon->getKey());
     }
 
     /**


### PR DESCRIPTION
Closes #6066

PHP namespaces are case insensitive so we are now storing the LC version of the namespace as the autoloadClasses index.
All comparison have been updated to make sure that we compare namespaces using LC.