### PR TITLE
Remove exceptions from DateFilter and UploadedFile schemas

### DIFF
--- a/library/Vanilla/DateFilterSchema.php
+++ b/library/Vanilla/DateFilterSchema.php
@@ -30,14 +30,10 @@ class DateFilterSchema extends Schema {
     private $simpleOperators = ['=', '>', '<', '>=', '<='];
 
     /**
-     * {@inheritdoc}
+     * Initialize an instance of a new DateFilterSchema class.
      */
-    public function __construct(array $schema = []) {
-        if (!empty($schema)) {
-            throw new \InvalidArgumentException(self::class.' does not support custom schemas.');
-        }
-
-        parent::__construct($schema);
+    public function __construct() {
+        parent::__construct();
     }
 
     /**

--- a/library/Vanilla/UploadedFileSchema.php
+++ b/library/Vanilla/UploadedFileSchema.php
@@ -14,13 +14,9 @@ use Garden\Schema\ValidationException;
 class UploadedFileSchema extends Schema {
 
     /**
-     * {@inheritdoc}
+     * Initialize an instance of a new UploadedFileSchema class.
      */
-    public function __construct(array $schema = []) {
-        if (!empty($schema)) {
-            throw new \InvalidArgumentException(self::class.' does not support custom schemas.');
-        }
-
+    public function __construct() {
         parent::__construct([
             'id' => 'UploadedFile',
             'type' => 'string',


### PR DESCRIPTION
This update removes parameters and `InvalidArgumentException` from `DateFilterSchema ` and `UploadedFileSchema` constructors. The exceptions give notice that custom schema specs aren't usable with these child classes, but the parameter causes the constructor signature to give the false impression they are.