### PR TITLE
Backport: Fix invalid permission check when searching ban

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -2049,7 +2049,6 @@ class SettingsController extends DashboardController {
      * @param int|string $userIdentifier Either the username or user ID.
      */
     private function findBanRule($userIdentifier) {
-        $this->permission('Moderation.Bans.Manage');
 
         $userModel = new UserModel();
 


### PR DESCRIPTION
### Issue

Users with admin rights did not have access to /dashboard/settings/bans/find/["userid"]

Original PR [6112](https://github.com/vanilla/vanilla/pull/6112)