### PR TITLE
Enable turning off search optimization plugin adds custom filter criteria.

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2542,6 +2542,7 @@ class UserModel extends Gdn_Model {
 
         $this->EventArguments['Keywords'] =& $keywords;
         $this->EventArguments['RankID'] =& $rankID;
+        $this->EventArguments['Optimize'] =& $optimize;
         $this->fireEvent('BeforeUserQuery');
 
         $this->userQuery();


### PR DESCRIPTION
In the UserModel we have added hooks to allow plugins to filter users based on custom criteria (e.g. RankID). This requires that, just like we do when we filter by Role, we be able to turn off search optimization.

This PR passes the $optimize to the event handler so that any plugin hooking into 'BeforeUserQuery' or 'AfterUserQuery' can set it to false.