### PR TITLE
Add data events to comments and discussions API controllers

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -167,6 +167,9 @@ class CommentsApiController extends AbstractApiController {
         $this->prepareRow($comment);
         $this->userModel->expandUsers($comment, ['InsertUserID']);
         $result = $out->validate($comment);
+
+        // Allow addons to modify the result.
+        $this->getEventManager()->fireArray('commentsApiController_get_data', [&$result]);
         return $result;
     }
 
@@ -290,6 +293,9 @@ class CommentsApiController extends AbstractApiController {
         }
 
         $result = $out->validate($rows);
+
+        // Allow addons to modify the result.
+        $this->getEventManager()->fireArray('commentsApiController_index_data', [&$result, $query]);
         return $result;
     }
 

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -204,6 +204,9 @@ class DiscussionsApiController extends AbstractApiController {
         $this->userModel->expandUsers($row, ['InsertUserID']);
 
         $result = $out->validate($row);
+
+        // Allow addons to modify the result.
+        $this->getEventManager()->fireArray('discussionsApiController_get_data', [&$result]);
         return $result;
     }
 
@@ -333,6 +336,9 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         $result = $out->validate($rows, true);
+
+        // Allow addons to modify the result.
+        $this->getEventManager()->fireArray('discussionsApiController_index_data', [&$result, $query]);
         return $result;
     }
 


### PR DESCRIPTION
This update adds a couple events to the comments and discussions API controllers, allowing addons to modify the results of GET and index requests.

To test, an addon can have a hook method with one of the following signatures:

```php
//Modify a single comment from a successful GET request.
public function commentsApiController_get_data(&$data);

//Modify an array of comments from a successful index request.
public function commentsApiController_index_data(&$data, $query);

//Modify a single discussion from a successful GET request.
public function discussionsApiController_get_data(&$data);

//Modify an array of discussions from a successful index request.
public function discussionsApiController_index_data(&$data, $query);
```



Closes #6105