### PR TITLE
Update expand API parameter to be a CSV of specific fields

### DIFF
--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -277,7 +277,7 @@ class ConversationsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $data,
-            $this->getExpandFields($query, ['user' => 'userID'])
+            $this->resolveExpandFields($query, ['user' => 'userID'])
         );
 
         return $out->validate($data);
@@ -340,7 +340,7 @@ class ConversationsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $conversations,
-            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID'])
         );
 
         return $out->validate($conversations);

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -225,14 +225,7 @@ class ConversationsApiController extends AbstractApiController {
                 'minimum' => 5,
                 'maximum' => 100
             ],
-            'expand:a?' => [
-                'description' => 'Expand associated records.',
-                'items' => [
-                    'enum' => ['user'],
-                    'type' => 'string'
-                ],
-                'style' => 'form'
-            ]
+            'expand?' => $this->getExpandFragment(['user'])
         ], 'in')->setDescription('Get participants of a conversation.');
         $out = $this->schema([
             ':a' => [
@@ -282,15 +275,10 @@ class ConversationsApiController extends AbstractApiController {
         }
 
         // Expand associated rows.
-        if (array_key_exists('expand', $query)) {
-            $expand = [];
-            if (in_array('user', $query['expand'])) {
-                $expand[] = 'UserID';
-            }
-            if (!empty($expand)) {
-                $this->userModel->expandUsers($data, $expand);
-            }
-        }
+        $this->userModel->expandUsers(
+            $data,
+            $this->getExpandFields($query, ['user' => 'userID'])
+        );
 
         return $out->validate($data);
     }
@@ -318,14 +306,7 @@ class ConversationsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand:a?' => [
-                'description' => 'Expand associated records.',
-                'items' => [
-                    'enum' => ['insertUser'],
-                    'type' => 'string'
-                ],
-                'style' => 'form'
-            ]
+            'expand?' => $this->getExpandFragment(['insertUser'])
         ], 'in')
             ->requireOneOf(['insertUserID', 'participantUserID'])
             ->setDescription('List user conversations.');
@@ -357,15 +338,10 @@ class ConversationsApiController extends AbstractApiController {
         }
 
         // Expand associated rows.
-        if (array_key_exists('expand', $query)) {
-            $expand = [];
-            if (in_array('insertUser', $query['expand'])) {
-                $expand[] = 'InsertUserID';
-            }
-            if (!empty($expand)) {
-                $this->userModel->expandUsers($conversations, $expand);
-            }
-        }
+        $this->userModel->expandUsers(
+            $conversations,
+            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+        );
 
         return $out->validate($conversations);
     }

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -186,7 +186,14 @@ class MessagesApiController extends AbstractApiController {
                     'minimum' => 1,
                     'maximum' => 100
                 ],
-                'expand:b?' => 'Expand associated records.'
+                'expand:a?' => [
+                    'description' => 'Expand associated records.',
+                    'items' => [
+                        'enum' => ['insertUser'],
+                        'type' => 'string'
+                    ],
+                    'style' => 'form'
+                ]
             ], 'in')
             ->requireOneOf(['conversationID', 'insertUserID'])
             ->setDescription('List user messages.');
@@ -231,8 +238,15 @@ class MessagesApiController extends AbstractApiController {
             $offset
         )->resultArray();
 
-        if (!empty($query['expand'])) {
-            $this->userModel->expandUsers($messages, ['InsertUserID']);
+        // Expand associated rows.
+        if (array_key_exists('expand', $query)) {
+            $expand = [];
+            if (in_array('insertUser', $query['expand'])) {
+                $expand[] = 'InsertUserID';
+            }
+            if (!empty($expand)) {
+                $this->userModel->expandUsers($messages, $expand);
+            }
         }
 
         array_walk($messages, function(&$message) {

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -186,14 +186,7 @@ class MessagesApiController extends AbstractApiController {
                     'minimum' => 1,
                     'maximum' => 100
                 ],
-                'expand:a?' => [
-                    'description' => 'Expand associated records.',
-                    'items' => [
-                        'enum' => ['insertUser'],
-                        'type' => 'string'
-                    ],
-                    'style' => 'form'
-                ]
+                'expand?' => $this->getExpandFragment(['insertUser'])
             ], 'in')
             ->requireOneOf(['conversationID', 'insertUserID'])
             ->setDescription('List user messages.');
@@ -239,15 +232,10 @@ class MessagesApiController extends AbstractApiController {
         )->resultArray();
 
         // Expand associated rows.
-        if (array_key_exists('expand', $query)) {
-            $expand = [];
-            if (in_array('insertUser', $query['expand'])) {
-                $expand[] = 'InsertUserID';
-            }
-            if (!empty($expand)) {
-                $this->userModel->expandUsers($messages, $expand);
-            }
-        }
+        $this->userModel->expandUsers(
+            $messages,
+            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+        );
 
         array_walk($messages, function(&$message) {
             $this->prepareRow($message);

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -234,7 +234,7 @@ class MessagesApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $messages,
-            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID'])
         );
 
         array_walk($messages, function(&$message) {

--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -44,6 +44,47 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
     }
 
     /**
+     * Determine which fields should be expanded, using a request and a field map.
+     *
+     * @param array $data An array representing request data.
+     * @param array $map An array of short-to-full field names (e.g. insertUser => InsertUserID).
+     * @param string $field The name of the field where the expand fields can be found.
+     * @return array
+     */
+    protected function getExpandFields(array $data, array $map, $field = 'expand') {
+        $result = [];
+        if (array_key_exists($field, $data)) {
+            $expand = $data[$field];
+            foreach ($map as $short => $full) {
+                if (in_array($short, $expand)) {
+                    $result[] = $full;
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Get a simple schema for nesting as an "expand" parameter.
+     *
+     * @param array $fields Valid values for the expand parameter.
+     * @return Schema
+     */
+    protected function getExpandFragment(array $fields) {
+        $result = $this->schema([
+            'description' => 'Expand associated records.',
+            'items' => [
+                'enum' => $fields,
+                'type' => 'string'
+            ],
+            'style' => 'form',
+            'type' => 'array'
+        ], 'ExpandFragment');
+
+        return $result;
+    }
+
+    /**
      * Get the schema for users joined to records.
      *
      * @return Schema Returns a schema.

--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -44,17 +44,17 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
     }
 
     /**
-     * Determine which fields should be expanded, using a request and a field map.
+     * Resolve values from an expand parameter, based on the provided map.
      *
-     * @param array $data An array representing request data.
+     * @param array $request An array representing request data.
      * @param array $map An array of short-to-full field names (e.g. insertUser => InsertUserID).
      * @param string $field The name of the field where the expand fields can be found.
      * @return array
      */
-    protected function getExpandFields(array $data, array $map, $field = 'expand') {
+    protected function resolveExpandFields(array $request, array $map, $field = 'expand') {
         $result = [];
-        if (array_key_exists($field, $data)) {
-            $expand = $data[$field];
+        if (array_key_exists($field, $request)) {
+            $expand = $request[$field];
             foreach ($map as $short => $full) {
                 if (in_array($short, $expand)) {
                     $result[] = $full;
@@ -71,7 +71,8 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
      * @return Schema
      */
     protected function getExpandFragment(array $fields) {
-        $result = $this->schema([
+        // Avoid using Controller::schema, because API document generators likely can't handle this dynamic schema.
+        $result = Schema::parse([
             'description' => 'Expand associated records.',
             'items' => [
                 'enum' => $fields,
@@ -79,7 +80,7 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
             ],
             'style' => 'form',
             'type' => 'array'
-        ], 'ExpandFragment');
+        ]);
 
         return $result;
     }

--- a/applications/dashboard/controllers/api/InvitationsApiController.php
+++ b/applications/dashboard/controllers/api/InvitationsApiController.php
@@ -176,7 +176,7 @@ class InvitationsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->getExpandFields($query, ['acceptedUser' => 'acceptedUserID'])
+            $this->resolveExpandFields($query, ['acceptedUser' => 'acceptedUserID'])
         );
 
         foreach ($rows as &$row) {

--- a/applications/dashboard/controllers/api/InvitationsApiController.php
+++ b/applications/dashboard/controllers/api/InvitationsApiController.php
@@ -156,14 +156,7 @@ class InvitationsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand:a?' => [
-                'description' => 'Expand associated records.',
-                'items' => [
-                    'enum' => ['acceptedUser'],
-                    'type' => 'string'
-                ],
-                'style' => 'form'
-            ]
+            'expand?' => $this->getExpandFragment(['acceptedUser'])
         ], 'in')->setDescription('Get a list of invitations sent by the current user.');
         $out = $this->schema([
             ':a' => $this->fullSchema()
@@ -181,15 +174,10 @@ class InvitationsApiController extends AbstractApiController {
         )->resultArray();
 
         // Expand associated rows.
-        if (array_key_exists('expand', $query)) {
-            $expand = [];
-            if (in_array('acceptedUser', $query['expand'])) {
-                $expand[] = 'AcceptedUserID';
-            }
-            if (!empty($expand)) {
-                $this->userModel->expandUsers($rows, $expand);
-            }
-        }
+        $this->userModel->expandUsers(
+            $rows,
+            $this->getExpandFields($query, ['acceptedUser' => 'acceptedUserID'])
+        );
 
         foreach ($rows as &$row) {
             $this->prepareRow($row);

--- a/applications/dashboard/controllers/api/InvitationsApiController.php
+++ b/applications/dashboard/controllers/api/InvitationsApiController.php
@@ -156,7 +156,14 @@ class InvitationsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand:b?' => 'Expand associated records.'
+            'expand:a?' => [
+                'description' => 'Expand associated records.',
+                'items' => [
+                    'enum' => ['acceptedUser'],
+                    'type' => 'string'
+                ],
+                'style' => 'form'
+            ]
         ], 'in')->setDescription('Get a list of invitations sent by the current user.');
         $out = $this->schema([
             ':a' => $this->fullSchema()
@@ -173,8 +180,15 @@ class InvitationsApiController extends AbstractApiController {
             false
         )->resultArray();
 
-        if (!empty($query['expand'])) {
-            $this->userModel->expandUsers($rows, ['AcceptedUserID']);
+        // Expand associated rows.
+        if (array_key_exists('expand', $query)) {
+            $expand = [];
+            if (in_array('acceptedUser', $query['expand'])) {
+                $expand[] = 'AcceptedUserID';
+            }
+            if (!empty($expand)) {
+                $this->userModel->expandUsers($rows, $expand);
+            }
         }
 
         foreach ($rows as &$row) {

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -237,14 +237,7 @@ class CommentsApiController extends AbstractApiController {
             ],
             'insertUserID:i?' => 'Filter by author.',
             'after:dt?' => 'Limit to comments after this date.',
-            'expand:a?' => [
-                'description' => 'Expand associated records.',
-                'items' => [
-                    'enum' => ['insertUser'],
-                    'type' => 'string'
-                ],
-                'style' => 'form'
-            ]
+            'expand?' => $this->getExpandFragment(['insertUser'])
         ], 'in')->requireOneOf(['discussionID', 'insertUserID'])->setDescription('List comments.');
         $out = $this->schema([':a' => $this->commentSchema()], 'out');
 
@@ -290,15 +283,10 @@ class CommentsApiController extends AbstractApiController {
         }
 
         // Expand associated rows.
-        if (array_key_exists('expand', $query)) {
-            $expand = [];
-            if (in_array('insertUser', $query['expand'])) {
-                $expand[] = 'InsertUserID';
-            }
-            if (!empty($expand)) {
-                $this->userModel->expandUsers($rows, $expand);
-            }
-        }
+        $this->userModel->expandUsers(
+            $rows,
+            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+        );
 
         foreach ($rows as &$currentRow) {
             $this->prepareRow($currentRow);

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -237,9 +237,13 @@ class CommentsApiController extends AbstractApiController {
             ],
             'insertUserID:i?' => 'Filter by author.',
             'after:dt?' => 'Limit to comments after this date.',
-            'expand:b?' => [
+            'expand:a?' => [
                 'description' => 'Expand associated records.',
-                'default' => false
+                'items' => [
+                    'enum' => ['insertUser'],
+                    'type' => 'string'
+                ],
+                'style' => 'form'
             ]
         ], 'in')->requireOneOf(['discussionID', 'insertUserID'])->setDescription('List comments.');
         $out = $this->schema([':a' => $this->commentSchema()], 'out');
@@ -285,9 +289,17 @@ class CommentsApiController extends AbstractApiController {
             )->resultArray();
         }
 
-        if ($query['expand']) {
-            $this->userModel->expandUsers($rows, ['InsertUserID']);
+        // Expand associated rows.
+        if (array_key_exists('expand', $query)) {
+            $expand = [];
+            if (in_array('insertUser', $query['expand'])) {
+                $expand[] = 'InsertUserID';
+            }
+            if (!empty($expand)) {
+                $this->userModel->expandUsers($rows, $expand);
+            }
         }
+
         foreach ($rows as &$currentRow) {
             $this->prepareRow($currentRow);
         }

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -285,7 +285,7 @@ class CommentsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID'])
         );
 
         foreach ($rows as &$currentRow) {

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -83,7 +83,7 @@ class DiscussionsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID'])
         );
 
         foreach ($rows as &$currentRow) {
@@ -335,7 +335,7 @@ class DiscussionsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID'])
         );
 
         foreach ($rows as &$currentRow) {

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -68,14 +68,7 @@ class DiscussionsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand:a?' => [
-                'description' => 'Expand associated records.',
-                'items' => [
-                    'enum' => ['insertUser'],
-                    'type' => 'string'
-                ],
-                'style' => 'form'
-            ]
+            'expand?' => $this->getExpandFragment(['insertUser'])
         ], 'in');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
@@ -88,15 +81,10 @@ class DiscussionsApiController extends AbstractApiController {
         ])->resultArray();
 
         // Expand associated rows.
-        if (array_key_exists('expand', $query)) {
-            $expand = [];
-            if (in_array('insertUser', $query['expand'])) {
-                $expand[] = 'InsertUserID';
-            }
-            if (!empty($expand)) {
-                $this->userModel->expandUsers($rows, $expand);
-            }
-        }
+        $this->userModel->expandUsers(
+            $rows,
+            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+        );
 
         foreach ($rows as &$currentRow) {
             $this->prepareRow($currentRow);
@@ -308,14 +296,7 @@ class DiscussionsApiController extends AbstractApiController {
                 'maximum' => 100
             ],
             'insertUserID:i?' => 'Filter by author.',
-            'expand:a?' => [
-                'description' => 'Expand associated records.',
-                'items' => [
-                    'enum' => ['insertUser'],
-                    'type' => 'string'
-                ],
-                'style' => 'form'
-            ]
+            'expand?' => $this->getExpandFragment(['insertUser'])
         ], 'in')->setDescription('List discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
@@ -352,15 +333,10 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         // Expand associated rows.
-        if (array_key_exists('expand', $query)) {
-            $expand = [];
-            if (in_array('insertUser', $query['expand'])) {
-                $expand[] = 'InsertUserID';
-            }
-            if (!empty($expand)) {
-                $this->userModel->expandUsers($rows, $expand);
-            }
-        }
+        $this->userModel->expandUsers(
+            $rows,
+            $this->getExpandFields($query, ['insertUser' => 'InsertUserID'])
+        );
 
         foreach ($rows as &$currentRow) {
             $this->prepareRow($currentRow);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -68,7 +68,14 @@ class DiscussionsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand:b?' => 'Expand associated records.'
+            'expand:a?' => [
+                'description' => 'Expand associated records.',
+                'items' => [
+                    'enum' => ['insertUser'],
+                    'type' => 'string'
+                ],
+                'style' => 'form'
+            ]
         ], 'in');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
@@ -79,9 +86,18 @@ class DiscussionsApiController extends AbstractApiController {
             'w.Bookmarked' => 1,
             'w.UserID' => $this->getSession()->UserID
         ])->resultArray();
-        if (!empty($query['expand'])) {
-            $this->userModel->expandUsers($rows, ['InsertUserID']);
+
+        // Expand associated rows.
+        if (array_key_exists('expand', $query)) {
+            $expand = [];
+            if (in_array('insertUser', $query['expand'])) {
+                $expand[] = 'InsertUserID';
+            }
+            if (!empty($expand)) {
+                $this->userModel->expandUsers($rows, $expand);
+            }
         }
+
         foreach ($rows as &$currentRow) {
             $this->prepareRow($currentRow);
         }
@@ -292,7 +308,14 @@ class DiscussionsApiController extends AbstractApiController {
                 'maximum' => 100
             ],
             'insertUserID:i?' => 'Filter by author.',
-            'expand:b?' => 'Expand associated records.'
+            'expand:a?' => [
+                'description' => 'Expand associated records.',
+                'items' => [
+                    'enum' => ['insertUser'],
+                    'type' => 'string'
+                ],
+                'style' => 'form'
+            ]
         ], 'in')->setDescription('List discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
@@ -328,9 +351,17 @@ class DiscussionsApiController extends AbstractApiController {
             }
         }
 
-        if (!empty($query['expand'])) {
-            $this->userModel->expandUsers($rows, ['InsertUserID']);
+        // Expand associated rows.
+        if (array_key_exists('expand', $query)) {
+            $expand = [];
+            if (in_array('insertUser', $query['expand'])) {
+                $expand[] = 'InsertUserID';
+            }
+            if (!empty($expand)) {
+                $this->userModel->expandUsers($rows, $expand);
+            }
         }
+
         foreach ($rows as &$currentRow) {
             $this->prepareRow($currentRow);
         }


### PR DESCRIPTION
This update alters the "expand" parameter on several API endpoints, changing it from a boolean to a CSV of field names. The intended effect is to allow more control over what data is expanded.

Addons should be able to modify the allowed "expand" values in these schemas by hooking into relevant events (e.g. `controller_schema`).

Closes #6106