### PR TITLE
Update syntax for allowing nulls in API schemas

### DIFF
--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -205,13 +205,11 @@ class RolesApiController extends AbstractApiController {
         $schema = Schema::parse([
             'roleID:i' => 'ID of the role.',
             'name:s' => 'Name of the role.',
-            'description:s' => [
-                'allowNull' => true,
+            'description:s|n' => [
                 'description' => 'Description of the role.',
                 'minLength' => 0
             ],
-            'type:s' => [
-                'allowNull' => true,
+            'type:s|n' => [
                 'description' => 'Default type of this role.',
                 'minLength' => 0
             ],

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -75,13 +75,11 @@ class UsersApiController extends AbstractApiController {
             'password:s' => 'Password of the user.',
             'hashMethod:s' => 'Hash method for the password.',
             'email:s' => 'Email address of the user.',
-            'photo:s' => [
-                'allowNull' => true,
+            'photo:s|n' => [
                 'minLength' => 0,
                 'description' => 'Raw photo field value from the user record.'
             ],
-            'photoUrl:s' => [
-                'allowNull' => true,
+            'photoUrl:s|n' => [
                 'minLength' => 0,
                 'description' => 'URL to the user photo.'
             ],

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -121,10 +121,9 @@ class CategoriesApiController extends AbstractApiController {
         return Schema::parse([
             'categoryID:i' => 'The ID of the category.',
             'name:s' => 'The name of the category.',
-            'description:s' => [
+            'description:s|n' => [
                 'description' => 'The description of the category.',
                 'minLength' => 0,
-                'allowNull' => true
             ],
             'parentCategoryID:i|n' => 'Parent category ID.',
             'urlCode:s' => 'The URL code of the category.',


### PR DESCRIPTION
This update alters how nullable parameters are defined in API schemas. Adding the "allowNull" attribute to a field is dropped in favor of specifying null as a valid type for that field.

Closes #6126