### PR TITLE
Fix multiple bugs with VanillaConnect redirects

### DIFF
--- a/plugins/vanillaconnect/VanillaConnectPlugin.php
+++ b/plugins/vanillaconnect/VanillaConnectPlugin.php
@@ -232,8 +232,8 @@ class VanillaConnectPlugin extends Gdn_Plugin {
         }
 
         // Redirect to /authenticate/vanillaconnect which will redirect to the proper URL with the JWT.
-        $signInUrl = url('/entry/vanillaconnect/signin/'.rawurlencode($provider['AuthenticationKey'])).'?target='.rawurlencode($this->request->getPath());
-        $registerUrl = url('/entry/vanillaconnect/register/'.rawurlencode($provider['AuthenticationKey'])).'?target='.rawurlencode($this->request->getPath());
+        $signInUrl = '/entry/vanillaconnect/signin/'.rawurlencode($provider['AuthenticationKey']).'?target='.rawurlencode($this->request->getPath());
+        $registerUrl = '/entry/vanillaconnect/register/'.rawurlencode($provider['AuthenticationKey']).'?target='.rawurlencode($this->request->getPath());
 
         $result = '<div class="vanilla-connect">';
         $result .= anchor(sprintf(t('Sign In with %s'), $provider['Name']), $signInUrl, 'Button Primary SignInLink');
@@ -360,7 +360,7 @@ class VanillaConnectPlugin extends Gdn_Plugin {
             ],
             'SignInUrl' => [
                 'LabelCode' => 'Sign In URL',
-                'Description' => t('The url that users use to sign in.').' '.t('Use {target} to specify a redirect.')
+                'Description' => t('The url that users use to sign in.').' '.t('Use target={target} to redirect users to the page they where on or target=WhateverYouWant to redirect to a specific url.')
             ],
             'RegisterUrl' => [
                 'LabelCode' => 'Registration URL',

--- a/plugins/vanillaconnect/VanillaConnectPlugin.php
+++ b/plugins/vanillaconnect/VanillaConnectPlugin.php
@@ -360,7 +360,7 @@ class VanillaConnectPlugin extends Gdn_Plugin {
             ],
             'SignInUrl' => [
                 'LabelCode' => 'Sign In URL',
-                'Description' => t('The url that users use to sign in.').' '.t('Use target={target} to redirect users to the page they where on or target=WhateverYouWant to redirect to a specific url.')
+                'Description' => t('The url that users use to sign in.').' '.t('Use target={target} to redirect users to the page they were on or target=WhateverYouWant to redirect to a specific url.')
             ],
             'RegisterUrl' => [
                 'LabelCode' => 'Registration URL',


### PR DESCRIPTION
This fixes 2 bugs 

1- If Gdn_Request::$webroot was set the signin and register url of VanillaConnect would contain 2 times the webroot because created the URLs with `url()` and they were wrapped in `url()` again in the `anchor()` function.

2- This is not a bug per say but since we moved the redirect parameter INTO the jwt token it was a bit messy. `provider.com/sigin?target=something` would become `provider.com/sigin?target=something&jwt={JWT}` which is counter intuitive since the redirect is done with the value of "redirect" which is located IN the jwt. So to clear things up the target parameter is now removed from the query string.