### PR TITLE
Add ability to update permissions to RolesAPIController

### DIFF
--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -89,6 +89,7 @@ class RolesApiController extends AbstractApiController {
      *
      * @param RoleModel $roleModel
      * @param PermissionModel $permissionModel
+     * @param CategoryModel $categoryModel
      */
     public function __construct(RoleModel $roleModel, PermissionModel $permissionModel, CategoryModel $categoryModel) {
         $this->roleModel = $roleModel;
@@ -242,6 +243,7 @@ class RolesApiController extends AbstractApiController {
      * Get a single role.
      *
      * @param int $id The ID of the role.
+     * @param array $query
      * @throws NotFoundException if unable to find the role.
      * @return array
      */
@@ -313,6 +315,11 @@ class RolesApiController extends AbstractApiController {
         return $result;
     }
 
+    /**
+     * Return a schema to represent a collection of permission rows.
+     *
+     * @return static
+     */
     private function getPermissionsFragment() {
         static $permissionsFragment;
 
@@ -348,6 +355,7 @@ class RolesApiController extends AbstractApiController {
     /**
      * List roles.
      *
+     * @param array $query
      * @return array
      */
     public function index(array $query) {

--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -248,7 +248,7 @@ class RolesApiController extends AbstractApiController {
     public function get($id, array $query) {
         $this->permission('Garden.Settings.Manage');
 
-        //$this->idParamSchema()->setDescription('Get a role.');
+        $this->idParamSchema()->setDescription('Get a role.');
         $in = $this->schema([
             'expand?' => $this->getExpandFragment(['permissions'])
         ], 'in');

--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -566,6 +566,7 @@ class RolesApiController extends AbstractApiController {
                 Schema::parse($fields)->add($this->fullSchema()),
                 'RolePost'
             );
+            // garden-schema has an issue with merging nested schemas using Schema::add. This is a way around that for now.
             $this->rolePostSchema->merge(Schema::parse(['permissions?' => $this->getPermissionsFragment()]));
         }
         return $this->schema($this->rolePostSchema, $type);

--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -440,15 +440,17 @@ class RolesApiController extends AbstractApiController {
         $body = $in->validate($body, true);
         // If a row associated with this ID cannot be found, a "not found" exception will be thrown.
         $this->roleByID($id);
-        $roleData = $this->caseScheme->convertArrayKeys($body);
-        $roleData['RoleID'] = $id;
-        $this->roleModel->save($roleData);
-        $this->validateModel($this->roleModel);
-        $row = $this->roleByID($id);
 
         if (array_key_exists('permissions', $body)) {
             $this->savePermissions($id, $body['permissions']);
+            unset($body['permissions']);
         }
+
+        $roleData = $this->caseScheme->convertArrayKeys($body);
+        $roleData['RoleID'] = $id;
+        $this->roleModel->save($roleData, ['DoPermissions' => false]);
+        $this->validateModel($this->roleModel);
+        $row = $this->roleByID($id);
 
         $result = $out->validate($row);
         return $result;

--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -425,6 +425,10 @@ class RolesApiController extends AbstractApiController {
         $this->validateModel($this->roleModel);
         $row = $this->roleByID($id);
 
+        if (array_key_exists('permissions', $body)) {
+            $this->savePermissions($id, $body['permissions']);
+        }
+
         $result = $out->validate($row);
         return $result;
     }
@@ -471,6 +475,10 @@ class RolesApiController extends AbstractApiController {
 
         if (!$id) {
             throw new ServerException('Unable to add role.', 500);
+        }
+
+        if (array_key_exists('permissions', $body)) {
+            $this->savePermissions($id, $body['permissions']);
         }
 
         $row = $this->roleByID($id);
@@ -558,6 +566,7 @@ class RolesApiController extends AbstractApiController {
                 Schema::parse($fields)->add($this->fullSchema()),
                 'RolePost'
             );
+            $this->rolePostSchema->merge(Schema::parse(['permissions?' => $this->getPermissionsFragment()]));
         }
         return $this->schema($this->rolePostSchema, $type);
     }
@@ -665,7 +674,7 @@ class RolesApiController extends AbstractApiController {
             }
 
             if ($type === 'category') {
-                if (filter_var($id, FILTER_VALIDATE_INT) && $id < 0 && $id !== -1) {
+                if (filter_var($id, FILTER_VALIDATE_INT) === false || ($id < 0 && $id !== -1)) {
                     throw new InvalidArgumentException('Category permissions must have a valid ID.');
                 }
                 $dbRow['JunctionTable'] = 'Category';

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -801,7 +801,7 @@ class PermissionModel extends Gdn_Model {
      *
      * @param int|array $roleID The role(s) to get the permissions for.
      * @param string $limitToSuffix Whether or not to limit the permissions to a suffix.
-     * @return Returns an
+     * @return array
      */
     public function getGlobalPermissions($roleID, $limitToSuffix = '') {
         $roleIDs = (array)$roleID;

--- a/tests/APIv2/RolesTest.php
+++ b/tests/APIv2/RolesTest.php
@@ -29,4 +29,194 @@ class RolesTest extends AbstractResourceTest {
 
         parent::__construct($name, $data, $dataName);
     }
+
+    /**
+     * Given a role ID, get its full list of permissions.
+     *
+     * @param $roleID
+     * @return array
+     */
+    private function getPermissions($roleID) {
+        $role = $this->api()->get("{$this->baseUrl}/{$roleID}",['expand' => 'permissions'])->getBody();
+        return $role['permissions'];
+    }
+
+    /**
+     * Create and return a new role for testing permission setting.
+     *
+     * @param array $permissions
+     * @return array
+     */
+    private function getPermissionsRole(array $permissions = []) {
+        if (empty($permissions)) {
+            $permissions = [
+                [
+                    'type' => 'global',
+                    'permissions' => [
+                        'tokens.add' => true
+                    ]
+                ],
+                [
+                    'type' => 'category',
+                    'id' => 1,
+                    'permissions' => [
+                        'comments.add' => true,
+                        'discussions.view' => true
+                    ]
+                ],
+            ];
+        }
+
+        $result = $this->testPost(null, ['permissions' => $permissions]);
+        return $result;
+    }
+
+    /**
+     * Check if a particular permission exists in the permissions array.
+     *
+     * @param string $name The name of the permission.
+     * @param string $type Permission type (e.g. global, category)
+     * @param array $permissions An array of permission rows.
+     * @param int|bool $id A resource ID (e.g. a category ID)
+     * @return bool
+     */
+    private function hasPermission($name, $type, array $permissions, $id = false) {
+        $result = false;
+        foreach ($permissions as $perm) {
+            if ($type !== $perm['type']) {
+                continue;
+            } elseif ($id !== false && (!array_key_exists('id', $perm) || $perm['id'] != $id)) {
+                continue;
+            } else {
+                $result = array_key_exists($name, $perm['permissions']) && $perm['permissions'][$name];
+                break;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Test setting permissions with POST /roles
+     */
+    public function testPostPermission() {
+        $role = $this->getPermissionsRole();
+        $permissions = $this->getPermissions($role['roleID']);
+
+        $this->assertTrue($this->hasPermission('tokens.add', 'global', $permissions));
+        $this->assertTrue($this->hasPermission('comments.add', 'category', $permissions, 1));
+        $this->assertTrue($this->hasPermission('discussions.view', 'category', $permissions, 1));
+
+        $this->assertFalse($this->hasPermission('site.manage', 'global', $permissions));
+        $this->assertFalse($this->hasPermission('discussions.add', 'category', $permissions, 1));
+    }
+
+    /**
+     * Test updating permissions with PATCH /roles
+     */
+    public function testPatchPermission() {
+        $role = $this->getPermissionsRole();
+
+        $this->api()->patch(
+            "{$this->baseUrl}/{$role[$this->pk]}",
+            [
+                'permissions' => [
+                    [
+                        'type' => 'global',
+                        'permissions' => [
+                            'email.view' => true
+                        ]
+                    ],
+                    [
+                        'type' => 'category',
+                        'id' => 1,
+                        'permissions' => [
+                            'discussions.add' => true,
+                            'comments.add' => false
+                        ]
+                    ]
+                ]
+            ]
+        );
+
+        $permissions = $this->getPermissions($role['roleID']);
+
+        $this->assertTrue($this->hasPermission('tokens.add', 'global', $permissions));
+        $this->assertTrue($this->hasPermission('email.view', 'global', $permissions));
+        $this->assertTrue($this->hasPermission('discussions.add', 'category', $permissions, 1));
+        $this->assertTrue($this->hasPermission('discussions.view', 'category', $permissions, 1));
+
+        $this->assertFalse($this->hasPermission('site.manage', 'global', $permissions));
+        $this->assertFalse($this->hasPermission('comments.add', 'category', $permissions, 1));
+
+    }
+
+    /**
+     * Test updating permissions with PATCH /roles/:id/permissions
+     */
+    public function testPatchPermissionEndpoint() {
+        $role = $this->getPermissionsRole();
+
+        $this->api()->patch(
+            "{$this->baseUrl}/{$role[$this->pk]}/permissions",
+            [
+                [
+                    'type' => 'global',
+                    'permissions' => [
+                        'email.view' => true
+                    ]
+                ],
+                [
+                    'type' => 'category',
+                    'id' => 1,
+                    'permissions' => [
+                        'discussions.add' => true,
+                        'comments.add' => false
+                    ]
+                ]
+            ]
+        );
+
+        $permissions = $this->getPermissions($role['roleID']);
+
+        $this->assertTrue($this->hasPermission('tokens.add', 'global', $permissions));
+        $this->assertTrue($this->hasPermission('email.view', 'global', $permissions));
+        $this->assertTrue($this->hasPermission('discussions.add', 'category', $permissions, 1));
+        $this->assertTrue($this->hasPermission('discussions.view', 'category', $permissions, 1));
+
+        $this->assertFalse($this->hasPermission('site.manage', 'global', $permissions));
+        $this->assertFalse($this->hasPermission('comments.add', 'category', $permissions, 1));
+    }
+
+    public function testPutPermissionsEndpoint() {
+        $role = $this->getPermissionsRole();
+
+        $this->api()->put(
+            "{$this->baseUrl}/{$role[$this->pk]}/permissions",
+            [
+                [
+                    'type' => 'global',
+                    'permissions' => [
+                        'email.view' => true
+                    ]
+                ],
+                [
+                    'type' => 'category',
+                    'id' => 1,
+                    'permissions' => [
+                        'discussions.add' => true,
+                    ]
+                ]
+            ]
+        );
+
+        $permissions = $this->getPermissions($role['roleID']);
+
+        $this->assertTrue($this->hasPermission('email.view', 'global', $permissions));
+        $this->assertTrue($this->hasPermission('discussions.add', 'category', $permissions, 1));
+
+        // Make sure all the original permissions have been removed.
+        $this->assertFalse($this->hasPermission('comments.add', 'category', $permissions, 1));
+        $this->assertFalse($this->hasPermission('discussions.view', 'category', $permissions, 1));
+        $this->assertFalse($this->hasPermission('tokens.add', 'global', $permissions));
+    }
 }


### PR DESCRIPTION
This update allows setting permissions on a role with the /roles endpoint. Specifics are in the associated issue, including the permission structure, but here's a rundown:

- [x] Update (not overwrite) global permissions with PATCH /roles/:id/permissions
- [x] Overwrite global permissions with PUT /roles/:id/permissions
- [x] Update (not overwrite) per-category permissions with PATCH /roles/:id/permissions
- [x] Overwrite per-category permissions with PUT /roles/:id/permissions
- [x] Add `expand` parameter to /roles GET and index, allow users to expand permission rows
- [x] Add limitation of 100 permission rows when expanded. Exceeding this limit throws an [HTTP 416](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/416)
- [x] Add `permissions` parameter to POST /roles
- [x] Add `permissions` parameter to  PATCH /roles/:id
- [x] Add `customPermissions` field to /categories to indicate if custom permissions are set on this category and allow toggling them off with the same parameter.

Closes #5775