### PR TITLE
Replace quotes in the promoted content module.

### DIFF
--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -93,7 +93,11 @@ if (!function_exists('WritePromotedContent')):
                 class="Title"><?php echo anchor(Gdn_Format::text(sliceString($content['Name'], $sender->TitleLimit), false), $contentURL, 'DiscussionLink'); ?></div>
             <div class="Body">
                 <?php
-                echo anchor(htmlspecialchars(sliceString(Gdn_Format::plainText($content['Body'], $content['Format']), $sender->BodyLimit)), $contentURL, 'BodyLink');
+                $linkContent = Gdn_Format::excerpt($content['Body'], $content['Format']);
+                $trimmedLinkContent = sliceString($linkContent, $sender->BodyLimit);
+
+                echo anchor(htmlspecialchars($trimmedLinkContent), $contentURL, 'BodyLink');
+
                 $sender->fireEvent('AfterPromotedBody'); // separate event to account for less space.
                 ?>
             </div>

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1063,7 +1063,7 @@ class Gdn_Format {
      *
      * @return string An HTML-formatted strings with common tags replaced with plainText
      */
-    protected static function convertBasicHTMLTagsToPlainText($html, $format = 'Html', $collapse = false) {
+    protected static function convertCommonHTMLTagsToPlainText($html, $format = 'Html', $collapse = false) {
         if ($format != 'Text') {
             // Remove returns and then replace html return tags with returns.
             $result = str_replace(["\n", "\r"], ' ', $html);
@@ -1098,7 +1098,7 @@ class Gdn_Format {
     public static function plainText($body, $format = 'Html', $collapse = false) {
         $result = Gdn_Format::to($body, $format);
         $result = Gdn_Format::replaceSpoilers($result);
-        $result = Gdn_Format::convertBasicHTMLTagsToPlainText($result, $format, $collapse);
+        $result = Gdn_Format::convertCommonHTMLTagsToPlainText($result, $format, $collapse);
         $result = trim(html_entity_decode($result, ENT_QUOTES, 'UTF-8'));
 
         // Always filter after basic parsing.
@@ -1128,7 +1128,7 @@ class Gdn_Format {
         $result = Gdn_Format::to($body, $format);
         $result = Gdn_Format::replaceSpoilers($result);
         $result = Gdn_Format::replaceQuotes($result);
-        $result = Gdn_Format::convertBasicHTMLTagsToPlainText($result, $format, $collapse);
+        $result = Gdn_Format::convertCommonHTMLTagsToPlainText($result, $format, $collapse);
         $result = trim(html_entity_decode($result, ENT_QUOTES, 'UTF-8'));
 
         // Always filter after basic parsing.


### PR DESCRIPTION
## The Issue
The Promoted content module was showing quotes in the text, and since it only provides a small excerpt, having a quote at the beginning of a post would present the quote as the actual content. 

## The Fix
- Refactor the converting of common tags into plain text into it's own protected function `Gdn_Format::convertCommonHTMLTagsToPlainText()`.
- Create a new function `Gdn_Format::replaceQuotes()` that works like replaceSpoilers. It uses pQuery to strip replace any of our quote elements with a translatable string `(Quote)`.
- Create a new function `Gdn_Format::excerpt()` that that uses the same logic of `Gdn_Format::plainText()`, but strips additional items. Currently the only extra thing it replaces is the quotes, but I could see this replacing additional items in the future such as code blocks.

I've tested this with all the text editors, but put most of my time into testing the ones that can actually use quotes. pQuery seems to be really robust and generally replaces all of the quotes correctly. The worst that will happen is that it will be fed malformed html in which case it will not display any worse than the current plainText formatter.

I tried every feature of our editor nested inside of itself in a few different ways in all of the editors that support quotes.