### PR TITLE
Fix bitwise math to validate if an addon exists or is disabled

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -784,7 +784,7 @@ class Addon {
         if ($count = count($issues)) {
             $subdir = $this->getSubdir();
 
-            trigger_error("The addon in $subdir has $count issues.", E_USER_NOTICE);
+            trigger_error("The addon in $subdir has $count issue(s).", E_USER_NOTICE);
             foreach ($issues as $issue) {
                 trigger_error($issue, E_USER_NOTICE);
             }

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -601,7 +601,7 @@ class AddonManager {
         // Filter the list.
         if ($filter) {
             $array = array_filter($array, function ($row) use ($filter) {
-                return ($row['status'] & $filter) === $filter;
+                return ($row['status'] | $filter) === $filter;
             });
         }
 

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -592,7 +592,9 @@ class AddonManager {
      * @param Addon $addon The addon to check.
      * @param int $filter One or more of the **AddonManager::REQ_*** constants concatenated by `|`.
      *
-     * @return Returns the requirements array. An empty array represents an addon with no requirements.
+     * When using this filter, any requirement statuses that meet at least one of the filters will be returned.
+     *
+     * @return array Returns the requirements array. An empty array represents an addon with no requirements.
      */
     public function lookupRequirements(Addon $addon, $filter = null) {
         $array = [];
@@ -601,7 +603,7 @@ class AddonManager {
         // Filter the list.
         if ($filter) {
             $array = array_filter($array, function ($row) use ($filter) {
-                return ($row['status'] | $filter) === $filter;
+                return ($row['status'] & $filter) > 0;
             });
         }
 

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -644,4 +644,22 @@ class AddonManagerTest extends \PHPUnit\Framework\TestCase {
         $addon2 = $am->lookupByClassname(\Deeply\Nested\Namespaced\Fixture\TestClass::class);
         $this->assertEquals('namespaced-plugin', $addon2->getKey());
     }
+
+    /**
+     * Test looking up requirements that are not met.
+     *
+     * This test mimics the test from **AddonManager::checkRequirements()**.
+     */
+    public function testBadRequire() {
+        $am = new TestAddonManager();
+
+        $addon = $am->lookupAddon('bad-require');
+        $r = $am->lookupRequirements($addon, AddonManager::REQ_MISSING | AddonManager::REQ_VERSION);
+
+        $this->assertArrayHasKey('asd!', $r);
+        $this->assertArrayHasKey('namespaced-plugin', $r);
+
+        $this->assertSame(AddonManager::REQ_MISSING, $r['asd!']['status']);
+        $this->assertSame(AddonManager::REQ_VERSION, $r['namespaced-plugin']['status']);
+    }
 }

--- a/tests/fixtures/plugins/bad-require/addon.json
+++ b/tests/fixtures/plugins/bad-require/addon.json
@@ -1,0 +1,9 @@
+{
+    "key": "bad-require",
+    "name": "Requirements can't be met",
+    "type": "addon",
+    "require": {
+        "asd!": ">1.0",
+        "namespaced-plugin": ">= 4320"
+    }
+}


### PR DESCRIPTION
Closes #6146 

This bitwise operator was incorrect causing #6146. 

## The math
```php
const REQ_ENABLED = 0x01; // addon enabled, yay!
const REQ_DISABLED = 0x02; // addon disabled
const REQ_MISSING = 0x04; // addon missing from the manager
const REQ_VERSION = 0x08; // addon isn't the correct version
```

We pass `self::REQ_MISSING | self::REQ_VERSION` to `lookupRequirements`  or 
4 | 8 = 12

## Current behaviour with the given filter
For `$row['status'] = REQ_MISSING`
(4 & 12) === 12 -> _false 4 & 12 === 4_ 

For `$row['status'] = REQ_VERSION`
(8 & 12) === 12 -> _false 8 & 12 === 8_

## After with the given filter
For `$row['status'] = REQ_MISSING`
(4 | 12) === 12 -> _true_

For `$row['status'] = REQ_VERSION`
(8 | 12) === 12 -> _true_

With this change addons will correctly check their requirements versions and existance.