### PR TITLE
Backport: Fix invalid permission check when searching bans

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -2071,7 +2071,6 @@ class SettingsController extends DashboardController {
      * @param int|string $userIdentifier Either the username or user ID.
      */
     private function findBanRule($userIdentifier) {
-        $this->permission('Moderation.Bans.Manage');
 
         $userModel = new UserModel();
 


### PR DESCRIPTION
## Issue

Users with admin rights did not have access to /dashboard/settings/bans/find/["userid"]

_Already Backported to Branch Release/2.5a__

Original PR [https://github.com/vanilla/vanilla/pull/6153](https://github.com/vanilla/vanilla/pull/6153)