### PR TITLE
Update API data event parameters for comments and discussions

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -150,13 +150,17 @@ class CommentsApiController extends AbstractApiController {
      * Get a comment.
      *
      * @param int $id The ID of the comment.
+     * @param array $query The request query.
      * @return array
      */
-    public function get($id) {
+    public function get($id, array $query) {
         $this->permission();
 
-        $in = $this->idParamSchema()->setDescription('Get a comment.');
+        $this->idParamSchema()->setDescription('Get a comment.');
+        $in = $this->schema([], 'in');
         $out = $this->schema($this->commentSchema(), 'out');
+
+        $query = $in->validate($query);
 
         $comment = $this->commentByID($id);
         if ($comment['InsertUserID'] !== $this->getSession()->UserID) {
@@ -169,7 +173,7 @@ class CommentsApiController extends AbstractApiController {
         $result = $out->validate($comment);
 
         // Allow addons to modify the result.
-        $this->getEventManager()->fireArray('commentsApiController_get_data', [&$result]);
+        $this->getEventManager()->fireArray('commentsApiController_get_data', [$this, &$result, $query, $comment]);
         return $result;
     }
 
@@ -295,7 +299,7 @@ class CommentsApiController extends AbstractApiController {
         $result = $out->validate($rows);
 
         // Allow addons to modify the result.
-        $this->getEventManager()->fireArray('commentsApiController_index_data', [&$result, $query]);
+        $this->getEventManager()->fireArray('commentsApiController_index_data', [$this, &$result, $query, $rows]);
         return $result;
     }
 

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -156,8 +156,8 @@ class CommentsApiController extends AbstractApiController {
     public function get($id, array $query) {
         $this->permission();
 
-        $this->idParamSchema()->setDescription('Get a comment.');
-        $in = $this->schema([], 'in');
+        $this->idParamSchema();
+        $in = $this->schema([], 'in')->setDescription('Get a comment.');
         $out = $this->schema($this->commentSchema(), 'out');
 
         $query = $in->validate($query);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -200,8 +200,8 @@ class DiscussionsApiController extends AbstractApiController {
     public function get($id, array $query) {
         $this->permission();
 
-        $this->idParamSchema()->setDescription('Get a discussion.');
-        $in = $this->schema([], 'in');
+        $this->idParamSchema();
+        $in = $this->schema([], 'in')->setDescription('Get a discussion.');
         $out = $this->schema($this->discussionSchema(), 'out');
 
         $query = $in->validate($query);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -193,14 +193,18 @@ class DiscussionsApiController extends AbstractApiController {
      * Get a discussion.
      *
      * @param int $id The ID of the discussion.
+     * @param array $query The request query.
      * @throws NotFoundException if the discussion could not be found.
      * @return array
      */
-    public function get($id) {
+    public function get($id, array $query) {
         $this->permission();
 
-        $in = $this->idParamSchema()->setDescription('Get a discussion.');
+        $this->idParamSchema()->setDescription('Get a discussion.');
+        $in = $this->schema([], 'in');
         $out = $this->schema($this->discussionSchema(), 'out');
+
+        $query = $in->validate($query);
 
         $row = $this->discussionByID($id);
         if (!$row) {
@@ -215,7 +219,7 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $out->validate($row);
 
         // Allow addons to modify the result.
-        $this->getEventManager()->fireArray('discussionsApiController_get_data', [&$result]);
+        $this->getEventManager()->fireArray('discussionsApiController_get_data', [&$result, $query]);
         return $result;
     }
 

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -219,7 +219,7 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $out->validate($row);
 
         // Allow addons to modify the result.
-        $this->getEventManager()->fireArray('discussionsApiController_get_data', [&$result, $query]);
+        $this->getEventManager()->fireArray('discussionsApiController_get_data', [$this, &$result, $query, $row]);
         return $result;
     }
 
@@ -383,7 +383,7 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $out->validate($rows, true);
 
         // Allow addons to modify the result.
-        $this->getEventManager()->fireArray('discussionsApiController_index_data', [&$result, $query]);
+        $this->getEventManager()->fireArray('discussionsApiController_index_data', [$this, &$result, $query, $rows]);
         return $result;
     }
 


### PR DESCRIPTION
This update does a couple minor things:

1. Adds more parameters for the discussions and comments API data events.
1. Adds validating the query parameter to GETs for discussions and comments. The queries are validated with empty schemas by default, but addons will be able to modify these schemas.