### PR TITLE
Fix permissions fragment schema definition

### DIFF
--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -318,17 +318,20 @@ class RolesApiController extends AbstractApiController {
     /**
      * Return a schema to represent a collection of permission rows.
      *
-     * @return static
+     * @return Schema
      */
-    private function getPermissionsFragment() {
+    public function getPermissionsFragment() {
         static $permissionsFragment;
 
         if ($permissionsFragment === null) {
             $permissionsFragment = Schema::parse([
                 ':a' => [
-                    'id:i?',
-                    'type:s' => ['enum' => ['global', 'category']],
-                    'permissions:o'
+                    'items' => 'object',
+                    'properties' => [
+                        'id:i?',
+                        'type:s' => ['enum' => ['global', 'category']],
+                        'permissions:o'
+                    ]
                 ]
             ]);
         }


### PR DESCRIPTION
The schema generated with `RolesApiController::getPermissionsFragment` used "type" as a property at the root of the schema definition. This is a special property in `garden-schema`.

This update reformats the schema definition to retain the same properties, but avoids defining the "type" property at the root schema level.

Also included:
1. Fixed the return type documented on `RolesApiController::getPermissionsFragment`.
1. Increased the visibility of `RolesApiController::getPermissionsFragment` to public.