### PR TITLE
Fix not being logged in after installing

### DIFF
--- a/applications/dashboard/controllers/class.setupcontroller.php
+++ b/applications/dashboard/controllers/class.setupcontroller.php
@@ -229,6 +229,8 @@ class SetupController extends DashboardController {
                 $ConfigurationFormValues['Garden.Email.SupportName'] = $ConfigurationFormValues['Garden.Title'];
 
                 $ConfigurationModel->save($ConfigurationFormValues, true);
+                // Reload Gdn_CookieIdentity with the new configuration.
+                Gdn::getContainer()->get('Identity')->init();
 
                 // If changing locale, redefine locale sources:
                 $NewLocale = 'en-CA'; // $this->Form->getFormValue('Garden.Locale', false);

--- a/library/core/class.cookieidentity.php
+++ b/library/core/class.cookieidentity.php
@@ -216,12 +216,17 @@ class Gdn_CookieIdentity {
     /**
      * Generates the user's session cookie.
      *
+     * @throws Gdn_ErrorException If cookie salt is empty.
      * @param int $userID The unique id assigned to the user in the database.
      * @param boolean $persist Should the user's session remain persistent across visits?
      * @param array $data Additional data to include in the token.
      * @return array|bool
      */
     public function setIdentity($userID, $persist = false) {
+        if (empty($this->CookieSalt)) {
+            throw new Gdn_ErrorException('Cookie salt is empty.');
+        }
+
         if (is_null($userID)) {
             $this->_clearIdentity();
             return true;
@@ -293,6 +298,7 @@ class Gdn_CookieIdentity {
     /**
      * Set a cookie, using specified path, domain, salt and hash method
      *
+     * @throws Gdn_ErrorException If cookie salt is empty.
      * @param string $cookieName Name of the cookie
      * @param string $keyData
      * @param mixed $cookieContents
@@ -304,7 +310,6 @@ class Gdn_CookieIdentity {
      * @return void
      */
     public static function setCookie($cookieName, $keyData, $cookieContents, $cookieExpires, $path = null, $domain = null, $cookieHashMethod = null, $cookieSalt = null) {
-
         if (is_null($path)) {
             $path = Gdn::config('Garden.Cookie.Path', '/');
         }
@@ -325,6 +330,10 @@ class Gdn_CookieIdentity {
 
         if (!$cookieSalt) {
             $cookieSalt = Gdn::config('Garden.Cookie.Salt');
+        }
+
+        if (empty($cookieSalt)) {
+            throw new Gdn_ErrorException('Cookie salt is empty.');
         }
 
         // Create the cookie signature
@@ -362,6 +371,7 @@ class Gdn_CookieIdentity {
     /**
      * Validate security of our cookie.
      *
+     * @throws Gdn_ErrorException If cookie salt is empty.
      * @param $cookieName
      * @param null $cookieHashMethod
      * @param null $cookieSalt
@@ -378,6 +388,10 @@ class Gdn_CookieIdentity {
 
         if (is_null($cookieSalt)) {
             $cookieSalt = Gdn::config('Garden.Cookie.Salt');
+        }
+
+        if (empty($cookieSalt)) {
+            throw new Gdn_ErrorException('Cookie salt is empty.');
         }
 
         $cookieData = explode('|', $_COOKIE[$cookieName]);
@@ -423,10 +437,15 @@ class Gdn_CookieIdentity {
     /**
      * Attempt to decode a JWT payload from a cookie value.
      *
+     * @throws Gdn_ErrorException If cookie salt is empty.
      * @param string $name Name of the cookie holding a JWT token.
      * @return array|null
      */
     public function getJWTPayload($name) {
+        if (empty($this->CookieSalt)) {
+            throw new Gdn_ErrorException('Cookie salt is empty.');
+        }
+
         $result = null;
 
         if (array_key_exists($name, $_COOKIE)) {


### PR DESCRIPTION
Fixes #6035

SetupController starts the admin session but it is invalidated on the next page load.

In https://github.com/vanilla/vanilla/commit/e7a80d4305d88aca6a26802245478c56e427aecd#diff-b2652d1a4ab0d73c2d31b0affccddc06 we moved from using `_setCookie()` which get the cookie salt by calling `Gdn::config('Garden.Cookie.Salt')` (so we would always have the latest value of the configuration) to using 
```
$jwt = JWT::encode($payload, $this->CookieSalt, self::JWT_ALGORITHM);
// Save the cookie.
safeCookie($this->CookieName, $jwt, $expiry, $this->CookiePath, $this->CookieDomain, null, true);
```
which uses the values that were existing on initialization. 
The problem with this is that when we are installing vanilla `$this->CookieSalt` is empty before we initialize the configuration properly.

This PR reloads Gdn_CookieIdentity after the config has been updated to make sure that `$this->CookieSalt` has a proper value.
On top of that we now also throw an exception if CookieSalt is empty which should prevent issues like this from happening.