### PR TITLE
Add conflict support to addons

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -767,6 +767,14 @@ class Addon {
             $issues['multiple-plugins'] = "The addon should have at most one plugin class ($plugins).";
         }
 
+        if (isset($this->info['require']) && !is_array($this->info['require'])) {
+            $issues['invalid-require'] = "The require key must be an array.";
+        }
+
+        if (isset($this->info['conflict']) && !is_array($this->info['conflict'])) {
+            $issues['invalid-conflict'] = "The conflict key must be an array.";
+        }
+
         if ($trigger) {
             $this->triggerIssues();
         }
@@ -1076,6 +1084,19 @@ class Addon {
      */
     public function getRequirements() {
         $result = $this->getInfoValue('require', []);
+        if (!is_array($result)) {
+            return [];
+        }
+        return $result;
+    }
+
+    /**
+     * Get addons that conflict with this addon.
+     *
+     * @return array Returns an array in the form addonKey => version.
+     */
+    public function getConflicts() {
+        $result = $this->getInfoValue('conflict', []);
         if (!is_array($result)) {
             return [];
         }

--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -1013,7 +1013,9 @@ class Addon {
             $req += ['op' => '==', 'v' => '0.0', 'logic' => ',', 'v2' => '999999'];
             $op = $req['op'];
 
-            if ($op === '-') {
+            if ($req['v'] === '*') {
+                $valid = true;
+            } elseif ($op === '-') {
                 $valid = version_compare($version, $req['v'], '>=') && version_compare($version, $req['v2'], '<=');
             } else {
                 $valid = version_compare($version, $req['v'], $op);

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -605,7 +605,7 @@ class AddonManager {
                     $addon->getName(),
                     implode(', ', $conflicts)
                 );
-                throw new \Exception($msg, 400);
+                throw new \Exception($msg, 409);
             }
             return false;
         }

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -584,6 +584,35 @@ class AddonManager {
     }
 
     /**
+     * Check to see if an addon has any conflicts with another addon(s).
+     *
+     * @param Addon $addon The addon to check.
+     * @param bool $throw Whether or not to throw an exception if there are conflicts.
+     * @return bool Returns **true** if there are no conflicts or **false** otherwise.
+     * @throws \Exception Throws an exception if there are conflicts and **$throw** is **true**.
+     */
+    public function checkConflicts(Addon $addon, $throw = false) {
+        $addons = $this->lookupConflicts($addon);
+        $conflicts = [];
+        foreach ($addons as $key => $_) {
+            $conflicts[] = $this->lookupAddon($key)->getName();
+        }
+
+        if (!empty($conflicts)) {
+            if ($throw) {
+                $msg = sprintf(
+                    '%1$s conflicts with: %2$s.',
+                    $addon->getName(),
+                    implode(', ', $conflicts)
+                );
+                throw new \Exception($msg, 400);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Get all of the requirements for an addon.
      *
      * This method returns an array of all of the addon requirements for a given addon. The return is an array of
@@ -612,6 +641,60 @@ class AddonManager {
         }
 
         return $array;
+    }
+
+    /**
+     * Lookup the addons that conflict with an addon.
+     *
+     * This method returns an array of all of the conflicting addons in the following format:
+     *
+     * ```
+     * 'addonKey' => ['from' => ['addonKey', ...]]
+     * ```
+     *
+     * @param Addon $addon The addon to lookup the conflicts for.
+     * @return array Returns an array of conflicts.
+     */
+    public function lookupConflicts(Addon $addon) {
+        // Get a list of requirements to check their conflicts too.
+        $addons = [$addon->getKey() => $addon];
+        $reqs = $this->lookupRequirements($addon, self::REQ_DISABLED | self::REQ_ENABLED);
+        foreach ($reqs as $key => $_) {
+            $addons[$key] = $this->lookupAddon($key);
+        }
+
+        $enabled = $this->getEnabled();
+        $conflicts = [];
+        foreach ($addons as $a) {
+            /* @var Addon $a */
+            foreach ($a->getConflicts() as $key => $req) {
+                $conflict = null;
+                if (isset($addons[$key])) {
+                    $conflict = $addons[$key];
+                } elseif ($this->isEnabled($key, Addon::TYPE_ADDON)) {
+                    $conflict = $this->lookupAddon($key);
+                }
+
+                if ($conflict && Addon::checkVersion($conflict->getVersion(), $req)) {
+                    $conflicts[$conflict->getKey()]['from'][] = $a->getKey();
+                }
+            }
+
+            // Check against enabled addons.
+            foreach ($enabled as $a2) {
+                /* @var Addon $a2 */
+                if (isset($conflicts[$a2->getKey()])) {
+                    continue;
+                }
+
+                $a2Conflicts = $a2->getConflicts();
+                if (isset($a2Conflicts[$a->getKey()]) && Addon::checkVersion($a->getVersion(), $a2Conflicts[$a->getKey()])) {
+                    $conflicts[$a2->getKey()]['from'][] = $a->getKey();
+                }
+            }
+        }
+
+        return $conflicts;
     }
 
     /**

--- a/library/Vanilla/Models/AddonModel.php
+++ b/library/Vanilla/Models/AddonModel.php
@@ -111,14 +111,27 @@ class AddonModel implements LoggerAwareInterface {
         $validation = new Validation();
 
         if (!$options['force'] && $this->isEnabledConfig($addon, $options)) {
-            $validation->addError('enabled', 'The {addonName} {addonType} is already enabled.', ['addonName' => $addon->getName(), 'addonType' => $addon->getType()]);
+            $validation->addError(
+                'enabled',
+                'The {addonName} {addonType} is already enabled.',
+                ['addonName' => $addon->getName(), 'addonType' => $addon->getType()]
+            );
             throw new ValidationException($validation);
         }
 
         try {
             $this->addonManager->checkRequirements($addon, true);
         } catch (\Exception $ex) {
-            $validation->addError('requirements', $ex->getMessage());
+            $validation->addError('requirements', $ex->getMessage(), $ex->getCode());
+        }
+
+        try {
+            $this->addonManager->checkConflicts($addon, true);
+        } catch (\Exception $ex) {
+            $validation->addError('conflicts', $ex->getMessage(), $ex->getCode());
+        }
+
+        if (!$validation->isValid()) {
             throw new ValidationException($validation);
         }
 

--- a/plugins/ButtonBar/addon.json
+++ b/plugins/ButtonBar/addon.json
@@ -16,5 +16,8 @@
     ],
     "require": {
         "vanilla": ">=2.1"
+    },
+    "conflict": {
+        "editor": "*"
     }
 }

--- a/plugins/editor/addon.json
+++ b/plugins/editor/addon.json
@@ -19,5 +19,8 @@
     ],
     "require": {
         "vanilla": ">=2.2"
+    },
+    "conflict": {
+        "buttonbar": "*"
     }
 }

--- a/tests/APIv2/AddonsTest.php
+++ b/tests/APIv2/AddonsTest.php
@@ -160,6 +160,18 @@ class AddonsTest extends AbstractAPIv2Test {
     }
 
     /**
+     * You shouldn't be able to enable two conflicting plugins at the same time.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionCode 409
+     * @expectedExceptionMessage Advanced Editor conflicts with: Button Bar.
+     */
+    public function testConflictingAddons() {
+        $this->api()->patch('/addons/buttonbar', ['enabled' => true]);
+        $this->api()->patch('/addons/editor', ['enabled' => true]);
+    }
+
+    /**
      * Provide a list of hidden addons.
      *
      * @return array Returns a data provider.

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -693,4 +693,85 @@ class AddonManagerTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertEquals([], $addon->getConflicts());
     }
+
+    /**
+     * Test **AddonManager::lookupConflicts()**.
+     */
+    public function testLookupConflicts() {
+        $am = $this->makeConflictedAddonManager();
+        $am->startAddon($am->lookupAddon('grand-parent'));
+
+        $parent = $am->lookupAddon('parent');
+        $parentConflicts = $am->lookupConflicts($parent);
+        $this->assertArrayHasKey('grand-parent', $parentConflicts);
+
+        $child = $am->lookupAddon('child');
+        $childConflicts = $am->lookupConflicts($child);
+        $this->assertArrayHasKey('grand-parent', $childConflicts);
+    }
+
+    /**
+     * An addon should list enabled addons that conflict with it even if it doesn't list the conflict itself.
+     */
+    public function testLookupConflicts2() {
+        $am = $this->makeConflictedAddonManager();
+        $am->startAddon($am->lookupAddon('child'));
+
+        $gp = $am->lookupAddon('grand-parent');
+        $gpConflicts = $am->lookupConflicts($gp);
+        $this->assertArrayHasKey('child', $gpConflicts);
+    }
+
+    /**
+     * Test **AddonManager::checkConflicts()**.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionCode 400
+     * @expectedExceptionMessage Parent conflicts with: Grandparent.
+     */
+    public function testCheckConflicts() {
+        $am = $this->makeConflictedAddonManager();
+        $am->startAddon($am->lookupAddon('grand-parent'));
+
+        $parent = $am->lookupAddon('parent');
+        $this->assertFalse($am->checkConflicts($parent, false));
+
+        $am->checkConflicts($parent, true);
+    }
+
+    /**
+     * Make an addon manager that has conflicting addons..
+     *
+     * @return AddonManager
+     */
+    private function makeConflictedAddonManager() {
+        $am = new AddonManager([], PATH_ROOT.'/tests/cache/cam');
+
+        $am->add(Addon::__set_state(['info' => [
+            'key' => 'grand-parent',
+            'name' => 'Grandparent',
+            'type' => Addon::TYPE_ADDON
+        ]]), false);
+
+        $am->add(Addon::__set_state(['info' => [
+            'key' => 'parent',
+            'name' => 'Parent',
+            'type' => Addon::TYPE_ADDON,
+            'require' => [
+                'child' => '1'
+            ]
+        ]]), false);
+
+        $am->add(Addon::__set_state(['info' => [
+            'key' => 'child',
+            'name' => 'Child',
+            'type' => Addon::TYPE_ADDON,
+            'version' => '1',
+            'conflict' => [
+                'grand-parent' => '*'
+            ]
+        ]]), false);
+
+        return $am;
+    }
 }

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -726,7 +726,7 @@ class AddonManagerTest extends \PHPUnit\Framework\TestCase {
      * Test **AddonManager::checkConflicts()**.
      *
      * @expectedException \Exception
-     * @expectedExceptionCode 400
+     * @expectedExceptionCode 409
      * @expectedExceptionMessage Parent conflicts with: Grandparent.
      */
     public function testCheckConflicts() {

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -662,4 +662,35 @@ class AddonManagerTest extends \PHPUnit\Framework\TestCase {
         $this->assertSame(AddonManager::REQ_MISSING, $r['asd!']['status']);
         $this->assertSame(AddonManager::REQ_VERSION, $r['namespaced-plugin']['status']);
     }
+
+
+    /**
+     * Test an addon with an invalid require key.
+     */
+    public function testInvalidRequire() {
+        $addon = Addon::__set_state(['info' => ['require' => []]]);
+        $issues = $addon->check();
+        $this->assertArrayNotHasKey('invalid-require', $issues);
+
+        $addon = Addon::__set_state(['info' => ['require' => 'foo']]);
+        $issues = $addon->check();
+        $this->assertArrayHasKey('invalid-require', $issues);
+
+        $this->assertEquals([], $addon->getRequirements());
+    }
+
+    /**
+     * Test an addon with an invalid conflict key.
+     */
+    public function testInvalidConflict() {
+        $addon = Addon::__set_state(['info' => ['conflict' => []]]);
+        $issues = $addon->check();
+        $this->assertArrayNotHasKey('invalid-conflict', $issues);
+
+        $addon = Addon::__set_state(['info' => ['conflict' => 'foo']]);
+        $issues = $addon->check();
+        $this->assertArrayHasKey('invalid-conflict', $issues);
+
+        $this->assertEquals([], $addon->getConflicts());
+    }
 }


### PR DESCRIPTION
Addons can add a **conflict** key in their addon.json to specify other addons that conflict with them. The key is in the same format at the **require** key. A few points:

- This is a change to the AddonModel which isn't currently hooked up to the various old managers so it won't have an immediate impact on the UI. This is part of a larger change to move to addon management via API.
- I modified the **require** and **conflict** array outputs from the /api/v2/addons endpoints. This isn't specifically necessary for this PR, but I didn't want to make yet another PR for this.
- Addons can now specify "*" as a version requirement like composer. This is useful for specifying conflicts.

*This PR was rebased. Make sure you do a force pull if you have already checked the branch out!*