### PR TITLE
Fix invalid plural "IDs" conversion in the CamelCaseScheme

### DIFF
--- a/library/Vanilla/Utility/CamelCaseScheme.php
+++ b/library/Vanilla/Utility/CamelCaseScheme.php
@@ -24,7 +24,7 @@ class CamelCaseScheme extends NameScheme {
 
         // Check for the final ID case.
         if (preg_match('`[a-z](I[Dd]|I[Pp])(s?)$`', $name, $m)) {
-            $sx = strtoupper($m[1].$m[2]);
+            $sx = strtoupper($m[1]).$m[2];
             $name = substr($name, 0, -strlen($sx));
         }
 

--- a/tests/Library/Vanilla/Utility/NameSchemeTest.php
+++ b/tests/Library/Vanilla/Utility/NameSchemeTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Vanilla\Utility;
+
+use PHPUnit\Framework\TestCase;
+use Vanilla\Utility\CamelCaseScheme;
+
+/**
+ * Tests for Vanilla\Utility\NameScheme classes.
+ */
+class NameSchemeTest extends TestCase {
+    /**
+     * Test some camel case scheme cases.
+     *
+     * @param string $name The name to convert.
+     * @param string $expected The expected result.
+     * @dataProvider provideCamelCaseNames
+     */
+    public function testCamelCaseScheme($name, $expected) {
+        $names = new CamelCaseScheme();
+        $actual = $names->convert($name);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Provide some basic camel case scheme tests.
+     *
+     * @return array Returns a data provider array.
+     */
+    public function provideCamelCaseNames() {
+        $r = [
+            ['RoleId', 'roleID'],
+            ['role_id', 'roleID'],
+            ['RoleIds', 'roleIDs'],
+        ];
+
+        return array_column($r, null, 1);
+    }
+}


### PR DESCRIPTION
I'm going to start adding tasks to fix some of our database column names to be consistent with a naming convention. This is PR is just a small test to make sure we have some testing on the actual naming scheme.