### PR TITLE
Allow the API dispatcher to handle PHP 7 style errors

### DIFF
--- a/tests/InternalClient.php
+++ b/tests/InternalClient.php
@@ -105,8 +105,8 @@ class InternalClient extends HttpClient {
             }
 
             $dataMeta = json_decode($response->getHeader('X-Data-Meta'), true);
-            if (!empty($dataMeta['error_trace'])) {
-                $message .= "\n".$dataMeta['error_trace'];
+            if (!empty($dataMeta['errorTrace'])) {
+                $message .= "\n".$dataMeta['errorTrace'];
             }
 
             throw new \Exception($message, $response->getStatusCode());


### PR DESCRIPTION
This prevents full HTML error pages during low level errors. Also, fix
the naming convention on errorTrace (previously error_trace).