### PR TITLE
Update getExpandFragment() to getExpandDefinition()

### DIFF
--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -225,7 +225,7 @@ class ConversationsApiController extends AbstractApiController {
                 'minimum' => 5,
                 'maximum' => 100
             ],
-            'expand?' => $this->getExpandFragment(['user'])
+            'expand?' => $this->getExpandDefinition(['user'])
         ], 'in')->setDescription('Get participants of a conversation.');
         $out = $this->schema([
             ':a' => [
@@ -306,7 +306,7 @@ class ConversationsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand?' => $this->getExpandFragment(['insertUser'])
+            'expand?' => $this->getExpandDefinition(['insertUser'])
         ], 'in')
             ->requireOneOf(['insertUserID', 'participantUserID'])
             ->setDescription('List user conversations.');

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -186,7 +186,7 @@ class MessagesApiController extends AbstractApiController {
                     'minimum' => 1,
                     'maximum' => 100
                 ],
-                'expand?' => $this->getExpandFragment(['insertUser'])
+                'expand?' => $this->getExpandDefinition(['insertUser'])
             ], 'in')
             ->requireOneOf(['conversationID', 'insertUserID'])
             ->setDescription('List user messages.');

--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -100,24 +100,23 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
     }
 
     /**
-     * Get a simple schema for nesting as an "expand" parameter.
+     * Get an "expand" parameter definition with specific fields.
      *
      * @param array $fields Valid values for the expand parameter.
+     * @param bool|string $default The default value of expand.
      * @return Schema
      */
-    public function getExpandFragment(array $fields) {
-        // Avoid using Controller::schema, because API document generators likely can't handle this dynamic schema.
-        $result = Schema::parse([
+    public function getExpandDefinition(array $fields, $default = false) {
+        return [
             'description' => 'Expand associated records.',
+            'default' => $default,
             'items' => [
                 'enum' => $fields,
                 'type' => 'string'
             ],
             'style' => 'form',
-            'type' => ['boolean', 'array']
-        ]);
-
-        return $result;
+            'type' => ['boolean', 'array'],
+        ];
     }
 
     /**

--- a/applications/dashboard/controllers/api/InvitesApiController.php
+++ b/applications/dashboard/controllers/api/InvitesApiController.php
@@ -156,7 +156,7 @@ class InvitesApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand?' => $this->getExpandFragment(['acceptedUser'])
+            'expand?' => $this->getExpandDefinition(['acceptedUser'])
         ], 'in')->setDescription('Get a list of invites sent by the current user.');
         $out = $this->schema([
             ':a' => $this->fullSchema()

--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -252,12 +252,11 @@ class RolesApiController extends AbstractApiController {
 
         $this->idParamSchema()->setDescription('Get a role.');
         $in = $this->schema([
-            'expand?' => $this->getExpandFragment(['permissions'])
+            'expand?' => $this->getExpandDefinition(['permissions'])
         ], 'in');
         $out = $this->schema($this->roleSchema(), 'out');
 
         $query = $in->validate($query);
-        $query += ['expand' => false];
 
         $row = $this->roleByID($id);
         $this->prepareRow($row, $query['expand']);
@@ -365,12 +364,11 @@ class RolesApiController extends AbstractApiController {
         $this->permission('Garden.Settings.Manage');
 
         $in = $this->schema([
-            'expand?' => $this->getExpandFragment(['permissions'])
+            'expand?' => $this->getExpandDefinition(['permissions'])
         ], 'in')->setDescription('List roles.');
         $out = $this->schema([':a' => $this->roleSchema()], 'out');
 
         $query = $in->validate($query);
-        $query += ['expand' => false];
 
         $rows = $this->roleModel->getWithRankPermissions()->resultArray();
         foreach ($rows as &$row) {

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -249,7 +249,7 @@ class CommentsApiController extends AbstractApiController {
                 'maximum' => 100
             ],
             'insertUserID:i?' => 'Filter by author.',
-            'expand?' => $this->getExpandFragment(['insertUser'])
+            'expand?' => $this->getExpandDefinition(['insertUser'])
         ], 'in')->requireOneOf(['discussionID', 'insertUserID'])->setDescription('List comments.');
         $out = $this->schema([':a' => $this->commentSchema()], 'out');
 

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -74,7 +74,7 @@ class DiscussionsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand?' => $this->getExpandFragment(['insertUser', 'lastUser', 'lastPost'])
+            'expand?' => $this->getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
         ], 'in');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
@@ -342,13 +342,12 @@ class DiscussionsApiController extends AbstractApiController {
                 'maximum' => 100
             ],
             'insertUserID:i?' => 'Filter by author.',
-            'expand?' => $this->getExpandFragment(['insertUser', 'lastUser', 'lastPost'])
+            'expand?' => $this->getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
         ], 'in')->setDescription('List discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
         $query = $this->filterValues($query);
         $query = $in->validate($query);
-        $query += ['expand' => false];
 
         $where = array_intersect_key($query, array_flip(['categoryID', 'insertUserID']));
         if (array_key_exists('categoryID', $where)) {


### PR DESCRIPTION
Since is it currently not possible to set a default value in a sub-schemas (See https://github.com/vanilla/garden-schema/issues/27), this PR changes `getExpandFragment()` to `getExpandDefinition()` and allows us to set a default value to the expand definition.

This saves us from "padding" the `$query` parameter and remove unnecessary parsing.