### PR TITLE
Improve pruning of UserAuthenticationToken table

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -263,7 +263,7 @@ $Construct->table('UserAuthenticationToken')
     ->column('TokenSecret', 'varchar(64)', false)
     ->column('TokenType', ['request', 'access'], false)
     ->column('Authorized', 'tinyint(1)', false)
-    ->column('Timestamp', 'timestamp', false)
+    ->column('Timestamp', 'timestamp', false ,'index')
     ->column('Lifetime', 'int', false)
     ->set($Explicit, $Drop);
 


### PR DESCRIPTION
The index was missing on `Timestamp` which is the `PruneField` in the UserAuthenticationTokenModel.
https://github.com/vanilla/vanilla/blob/master/applications/dashboard/models/class.userauthenticationtokenmodel.php#L17

This was causing the prune requests to stack up when the table reaches above 100K entries.

Would need to be backported to 2.5a