### PR TITLE
Fix strict standards warning in RoleModel

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -98,7 +98,8 @@ class RoleModel extends Gdn_Model {
      */
     public static function filterPersonalInfo($role) {
         if (is_string($role)) {
-            $role = array_shift(self::getByName($role));
+            $roles = self::getByName($role);
+            $role = array_shift($roles);
         }
 
         return (val('PersonalInfo', $role)) ? false : true;


### PR DESCRIPTION
PHP can throw a "strict standards" warning when calling `RoleModel::filterPersonalInfo`, because it uses `array_shift` directly on the result of `RoleModel::getByName`. The issue is the `array_shift` parameter is passed by reference and PHP only wants variables passed by reference. This update adds a simple intermediate variable. Functionality should remain unchanged.