### PR TITLE
Properly disable caching for unit tests

### DIFF
--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -352,12 +352,14 @@ class CategoryCollection {
         }
         if (!empty($keys)) {
             $cacheCategories = $this->cache->get($keys);
-            foreach ($cacheCategories as $key => $category) {
-                $this->calculateDynamic($category);
-                $this->categories[(int)$category['CategoryID']] = $category;
-                $this->categorySlugs[strtolower($category['UrlCode'])] = (int)$category['CategoryID'];
+            if (!empty($cacheCategories)) {
+                foreach ($cacheCategories as $key => $category) {
+                    $this->calculateDynamic($category);
+                    $this->categories[(int)$category['CategoryID']] = $category;
+                    $this->categorySlugs[strtolower($category['UrlCode'])] = (int)$category['CategoryID'];
 
-                $categories[(int)$category['CategoryID']] = $category;
+                    $categories[(int)$category['CategoryID']] = $category;
+                }
             }
         }
 

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -17,6 +17,7 @@ use Psr\Log\LoggerInterface;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
 use Vanilla\InjectableInterface;
+use VanillaTests\Fixtures\NullCache;
 
 /**
  * Run bootstrap code for Vanilla tests.
@@ -72,9 +73,10 @@ class Bootstrap {
             ->addCall('setDependencies')
 
             // Cache
+            ->setInstance(NullCache::class, new NullCache())
+
             ->rule(\Gdn_Cache::class)
-            ->setShared(true)
-            ->setFactory(['Gdn_Cache', 'initialize'])
+            ->setAliasOf(NullCache::class)
             ->addAlias('Cache')
 
             // Configuration

--- a/tests/fixtures/src/NullCache.php
+++ b/tests/fixtures/src/NullCache.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+namespace VanillaTests\Fixtures;
+
+use \Gdn_Cache;
+
+/**
+ * Class NullCache.
+ *
+ * A real nullcache object. Gdn_DirtyCache needs to be kept as is for some weird reason.
+ * This class is what Gdn_DirtyCache should be.
+ */
+class NullCache extends Gdn_Cache {
+
+    /**
+     * NullCache constructor.
+     */
+    public function __construct() {
+        parent::__construct();
+        $this->cacheType = Gdn_Cache::CACHE_TYPE_NULL;
+    }
+
+    /**
+     * @param $options
+     * @return bool
+     */
+    public function addContainer($options) {
+        return Gdn_Cache::CACHEOP_SUCCESS;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @param array $options
+     * @return bool
+     */
+    public function add($key, $value, $options = []) {
+        return $this->store($key, $value, $options);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @param array $options
+     * @return bool
+     */
+    public function store($key, $value, $options = []) {
+        return Gdn_Cache::CACHEOP_SUCCESS;
+    }
+
+    /**
+     * @param $key
+     * @return bool
+     */
+    public function exists($key) {
+        return Gdn_Cache::CACHEOP_FAILURE;
+    }
+
+    /**
+     * @param $key
+     * @param array $options
+     * @return bool
+     */
+    public function get($key, $options = []) {
+        return Gdn_Cache::CACHEOP_FAILURE;
+    }
+
+    /**
+     * @param $key
+     * @param array $options
+     * @return bool
+     */
+    public function remove($key, $options = []) {
+        return Gdn_Cache::CACHEOP_SUCCESS;
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     * @param array $options
+     * @return bool
+     */
+    public function replace($key, $value, $options = []) {
+        return Gdn_Cache::CACHEOP_SUCCESS;
+    }
+
+    /**
+     * @param $key
+     * @param int $amount
+     * @param array $options
+     * @return bool
+     */
+    public function increment($key, $amount = 1, $options = []) {
+        return Gdn_Cache::CACHEOP_SUCCESS;
+    }
+
+    /**
+     * @param $key
+     * @param int $amount
+     * @param array $options
+     * @return bool
+     */
+    public function decrement($key, $amount = 1, $options = []) {
+        return Gdn_Cache::CACHEOP_SUCCESS;
+    }
+
+    /**
+     * @return bool
+     */
+    public function flush() {
+        return true;
+    }
+}


### PR DESCRIPTION
Edit: We fear that changing Gdn_Dirty cache may break something on our infrastructure. We are gonna fix the unit tests bootstrap instead. 

~~Five years ago we [changed the way that DirtyCache works](https://github.com/vanilla/vanilla/commit/553b0fe67f8f59701c86f66c467f8d273eae3dc2)~~

~~The problem with this is that we use this caching object when the cache is [DISABLED](https://github.com/vanilla/vanilla/blob/aec797045f14cafb38716b85f9063dbc80429ee9/library/core/class.cache.php#L156).~~

~~This ends up causing problem if the application lives longer than one request which happens to be the case in unit tests.
For example in the role model, when we get the roles, [we cache the results](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/models/class.rolemodel.php#L517). When we save we only [clear the cached results if the cache is active](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/models/class.rolemodel.php#L615) which ends up with the cache never being cleared.~~

~~DirtyCache should not be caching anything as per its description.~~