### PR TITLE
Require PHP 7.2 to pass on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ language: php
 
 # Configure the build.
 matrix:
-  allow_failures:
-    - php: 7.2
   fast_finish: true
 
 # Send status update notifications to a HipChat room.


### PR DESCRIPTION
PHP 7.2 is live. Time to start requiring a passing build.