### PR TITLE
Fix failing discussion API tests

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1923,7 +1923,7 @@ class DiscussionModel extends Gdn_Model {
         $this->defineSchema();
 
         // If the site isn't configured to use categories, don't allow one to be set.
-        if (!c('Vanilla.Categories.Use')) {
+        if (!c('Vanilla.Categories.Use', true)) {
             unset($formPostValues['CategoryID']);
         }
 


### PR DESCRIPTION
Vanilla's abstract API resource tests do some general modification of data during testing. One such test increments the value of any field ending in "ID". A recent patch requires a valid category ID, so blindly incrementing the `CategoryID` column no longer works.

This update fixes discussions API tests. Three test categories are created before the tests are run and tests are limited to those categories. In addition, a small tweak to `DiscussioModel::save` has been added to default its use-categories config check to `true`.

Closes #6202 