### PR TITLE
Fix test compatibility with PHPUnit 6

### DIFF
--- a/tests/APIv0/AltTest.php
+++ b/tests/APIv0/AltTest.php
@@ -7,14 +7,12 @@
 
 namespace VanillaTests\APIv0;
 
-use Garden\Http\HttpClient;
-use Garden\Http\HttpResponse;
-use PDO;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests an alternate install method.
  */
-class AltTest extends \PHPUnit\Framework\TestCase {
+class AltTest extends TestCase {
     /** @var APIv0  $api */
     protected static $api;
 

--- a/tests/APIv0/BaseTest.php
+++ b/tests/APIv0/BaseTest.php
@@ -9,8 +9,9 @@ namespace VanillaTests\APIv0;
 
 
 use Garden\Http\HttpResponse;
+use PHPUnit\Framework\TestCase;
 
-abstract class BaseTest extends \PHPUnit\Framework\TestCase {
+abstract class BaseTest extends TestCase {
     /** @var APIv0  $api */
     protected static $api;
 

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -7,11 +7,12 @@
 
 namespace VanillaTests\APIv2;
 
+use PHPUnit\Framework\TestCase;
 use Vanilla\Utility\CamelCaseScheme;
 use VanillaTests\InternalClient;
 use VanillaTests\SiteTestTrait;
 
-abstract class AbstractAPIv2Test extends \PHPUnit_Framework_TestCase {
+abstract class AbstractAPIv2Test extends TestCase {
     use SiteTestTrait;
 
     /**

--- a/tests/APIv2/AbstractApiControllerTest.php
+++ b/tests/APIv2/AbstractApiControllerTest.php
@@ -6,6 +6,7 @@
 
 namespace VanillaTests\APIv2;
 
+use PHPUnit\Framework\TestCase;
 use VanillaTests\SiteTestTrait;
 use Vanilla\DateFilterSchema;
 use DateTimeImmutable;
@@ -15,7 +16,7 @@ use DateTimeImmutable;
  *
  * @package VanillaTests\APIv2
  */
-class AbstractApiControllerTest extends \PHPUnit_Framework_TestCase {
+class AbstractApiControllerTest extends TestCase {
 
     use SiteTestTrait;
 

--- a/tests/Library/Core/ArrayFunctionsTest.php
+++ b/tests/Library/Core/ArrayFunctionsTest.php
@@ -7,10 +7,12 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test array functions.
  */
-class ArrayFunctionsTest extends \PHPUnit\Framework\TestCase {
+class ArrayFunctionsTest extends TestCase {
 
     /**
      * Test {@link flattenArray()}.

--- a/tests/Library/Core/ControllerTest.php
+++ b/tests/Library/Core/ControllerTest.php
@@ -7,12 +7,11 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 use Gdn_Controller;
-use \PHPUnit\Framework\TestCase;
 use stdClass;
 
-
-class ControllerTest extends \PHPUnit\Framework\TestCase {
+class ControllerTest extends TestCase {
 
     /**
      * Testing that the same key will be used to set data and to get it back.

--- a/tests/Library/Core/DataSetTest.php
+++ b/tests/Library/Core/DataSetTest.php
@@ -7,12 +7,13 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 use Gdn_DataSet;
 
 /**
  * Test the {@link Gdn_DataSet} class.
  */
-class DataSetTest extends \PHPUnit\Framework\TestCase {
+class DataSetTest extends TestCase {
     /**
      * A basic test of newing up a dataset.
      */

--- a/tests/Library/Core/DateTimeTest.php
+++ b/tests/Library/Core/DateTimeTest.php
@@ -7,11 +7,12 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 use DateTime;
 use DateTimeZone;
 
 
-class DateTimeTest extends \PHPUnit\Framework\TestCase{
+class DateTimeTest extends TestCase {
 
     /**
      * Test that different named timezones in the same place produce equivalent dates.

--- a/tests/Library/Core/DbEncodeDecodeTest.php
+++ b/tests/Library/Core/DbEncodeDecodeTest.php
@@ -7,10 +7,12 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test some of the global functions that operate (or mostly operate) on arrays.
  */
-class DbEncodeDecodeTest extends \PHPUnit\Framework\TestCase {
+class DbEncodeDecodeTest extends TestCase {
 
     /**
      * Test encoding/decoding an array.
@@ -89,7 +91,7 @@ class DbEncodeDecodeTest extends \PHPUnit\Framework\TestCase {
      * Make sure we have a bad string for {@link dbdecode()}.
      *
      * @param string $str The bad string to decode.
-     * @expectedException \PHPUnit_Framework_Error
+     * @expectedException \PHPUnit\Framework\Error\Notice
      * @dataProvider provideBadDbDecodeStrings
      */
     public function testBadDbDecodeString($str) {

--- a/tests/Library/Core/FactoryTest.php
+++ b/tests/Library/Core/FactoryTest.php
@@ -6,13 +6,15 @@
  */
 
 namespace Library\Core;
+
+use PHPUnit\Framework\TestCase;
 use Gdn;
 use VanillaTests\Fixtures\Tuple;
 
 /**
  * Tests for the {@link Gdn_Factory}.
  */
-class FactoryTest extends \PHPUnit\Framework\TestCase {
+class FactoryTest extends TestCase {
     const TUPLE = 'VanillaTests\Fixtures\Tuple';
 
     /**

--- a/tests/Library/Core/FormTest.php
+++ b/tests/Library/Core/FormTest.php
@@ -7,10 +7,11 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 use Gdn;
 use Gdn_Form;
 
-class FormTest extends \PHPUnit\Framework\TestCase {
+class FormTest extends TestCase {
     /**
      * Setup a dummy request because {@link Gdn_Form} needs it.
      */

--- a/tests/Library/Core/GeneralFunctionsTest.php
+++ b/tests/Library/Core/GeneralFunctionsTest.php
@@ -7,8 +7,9 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 
-class GeneralFunctionsTest extends \PHPUnit\Framework\TestCase {
+class GeneralFunctionsTest extends TestCase {
 
     /**
      * Test {@link urlMatch()}.

--- a/tests/Library/Core/JsonFilterTest.php
+++ b/tests/Library/Core/JsonFilterTest.php
@@ -6,12 +6,13 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 use DateTime;
 
 /**
  * Test the jsonFilter function.
  */
-class JsonFilterTest extends \PHPUnit\Framework\TestCase {
+class JsonFilterTest extends TestCase {
 
     public function testJsonFilterDateTime() {
         $date = new DateTime('now', new \DateTimeZone('UTC'));

--- a/tests/Library/Core/PasswordTest.php
+++ b/tests/Library/Core/PasswordTest.php
@@ -7,12 +7,13 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 use Gdn_PasswordHash;
 
 /**
  * Test the the {@link Gdn_PasswordHash} class.
  */
-class PasswordTest extends \PHPUnit\Framework\TestCase {
+class PasswordTest extends TestCase {
 
     /**
      * Make sure an empty password fails.

--- a/tests/Library/Core/PluginManagerTest.php
+++ b/tests/Library/Core/PluginManagerTest.php
@@ -8,12 +8,13 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 use Gdn_PluginManager;
 
 /**
  * Test the {@link Gdn_PluginManager} class.
  */
-class PluginManagerTest extends \PHPUnit\Framework\TestCase {
+class PluginManagerTest extends TestCase {
     /**
      * Test a basic usage of {@link Gdn_PluginManager::registerCallback}.
      */

--- a/tests/Library/Core/RenderFunctionsTest.php
+++ b/tests/Library/Core/RenderFunctionsTest.php
@@ -7,10 +7,12 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test some of the functions in functions.render.php.
  */
-class RenderFunctionsTest extends \PHPUnit\Framework\TestCase {
+class RenderFunctionsTest extends TestCase {
     /**
      * Make sure the render functions are included.
      */

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -6,12 +6,13 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 use Gdn_Request;
 
 /**
  * Test the {@link Gdn_Request} class.
  */
-class RequestTest extends \PHPUnit\Framework\TestCase {
+class RequestTest extends TestCase {
 
     public function provideUrls() {
         return [

--- a/tests/Library/Garden/ClassLocatorTest.php
+++ b/tests/Library/Garden/ClassLocatorTest.php
@@ -6,9 +6,10 @@
 
 namespace VanillaTests\Library\Garden;
 
+use PHPUnit\Framework\TestCase;
 use Garden\ClassLocator;
 
-class ClassLocatorTest extends \PHPUnit\Framework\TestCase {
+class ClassLocatorTest extends TestCase {
 
     public function testFindClass() {
         $classLocator = new ClassLocator();

--- a/tests/Library/Garden/EventManagerTest.php
+++ b/tests/Library/Garden/EventManagerTest.php
@@ -7,6 +7,7 @@
 
 namespace VanillaTests\Library\Core;
 
+use PHPUnit\Framework\TestCase;
 use Garden\EventManager;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
@@ -16,7 +17,7 @@ use VanillaTests\Fixtures\Container;
 /**
  * Tests for the {@link EventManager} class.
  */
-class EventManagerTest extends \PHPUnit\Framework\TestCase {
+class EventManagerTest extends TestCase {
 
     /**
      * Creates an {@link AddonManager} against Vanilla.
@@ -67,7 +68,7 @@ class EventManagerTest extends \PHPUnit\Framework\TestCase {
 
             try {
                 $pm->registerPlugin($class);
-            } catch (\PHPUnit_Framework_Error_Notice $ex) {
+            } catch (\PHPUnit\Framework\Error\Notice $ex) {
                 // This is okay.
                 continue;
             }
@@ -336,7 +337,7 @@ class EventManagerTest extends \PHPUnit\Framework\TestCase {
     /**
      * Make sure an event with higher than max priority just goes down to max priority.
      *
-     * @expectedException \PHPUnit_Framework_Error_Notice
+     * @expectedException \PHPUnit\Framework\Error\Notice
      */
     public function testMaxPriority() {
         $em = new EventManager();

--- a/tests/Library/Garden/Web/CookieTest.php
+++ b/tests/Library/Garden/Web/CookieTest.php
@@ -7,12 +7,13 @@
 
 namespace VanillaTests\Library\Garden\Web;
 
+use PHPUnit\Framework\TestCase;
 use Garden\Web\Cookie;
 
 /**
  * Test the {@link ResourceRoute} class.
  */
-class CookieTest extends \PHPUnit\Framework\TestCase {
+class CookieTest extends TestCase {
 
     /**
      * Parse a Cookie header into its individual cookie key-value pairs.

--- a/tests/Library/Garden/Web/ResourceRouteTest.php
+++ b/tests/Library/Garden/Web/ResourceRouteTest.php
@@ -7,6 +7,7 @@
 
 namespace VanillaTests\Library\Garden\Web;
 
+use PHPUnit\Framework\TestCase;
 use Garden\Web\Action;
 use Garden\Web\ResourceRoute;
 use Garden\Web\Route;
@@ -16,7 +17,7 @@ use VanillaTests\Fixtures\Request;
 /**
  * Test the {@link ResourceRoute} class.
  */
-class ResourceRouteTest extends \PHPUnit\Framework\TestCase {
+class ResourceRouteTest extends TestCase {
     /**
      * Create a new {@link ResourceRoute} initialized for testing with fixtures.
      */
@@ -226,7 +227,7 @@ class ResourceRouteTest extends \PHPUnit\Framework\TestCase {
     /**
      * Test that correct casing on method names is enforced.
      *
-     * @expectedException \PHPUnit_Framework_Error_Notice
+     * @expectedException \PHPUnit\Framework\Error\Notice
      */
     public function testMethodCaseSensitivity() {
 //        post_noMap($query, $body, $data)

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -7,6 +7,7 @@
 
 namespace VanillaTests\Library\Vanilla;
 
+use PHPUnit\Framework\TestCase;
 use Test\OldApplication\Controllers\Api\NewApiController;
 use Test\OldApplication\Controllers\ArchiveController;
 use Test\OldApplication\Controllers\HiddenController;
@@ -16,7 +17,7 @@ use Vanilla\Addon;
 use VanillaTests\Fixtures\TestAddonManager;
 
 
-class AddonManagerTest extends \PHPUnit\Framework\TestCase {
+class AddonManagerTest extends TestCase {
 
     private static $types = [Addon::TYPE_ADDON, Addon::TYPE_THEME, Addon::TYPE_LOCALE];
 

--- a/tests/Library/Vanilla/CheckVersionTest.php
+++ b/tests/Library/Vanilla/CheckVersionTest.php
@@ -7,13 +7,14 @@
 
 namespace VanillaTests\Library\Vanilla;
 
+use PHPUnit\Framework\TestCase;
 use Vanilla\Addon;
 
 
 /**
  * Tests of the {@link Addon::checkVersion()} method.
  */
-class CheckVersionTest extends \PHPUnit\Framework\TestCase {
+class CheckVersionTest extends TestCase {
     /**
      * Check exact version matching.
      */

--- a/tests/Library/Vanilla/DateFilterSchemaTest.php
+++ b/tests/Library/Vanilla/DateFilterSchemaTest.php
@@ -6,9 +6,9 @@
 
 namespace VanillaTests\Library\Vanilla;
 
+use PHPUnit\Framework\TestCase;
 use DateTimeImmutable;
 use Garden\Schema\Schema;
-use PHPUnit\Framework\TestCase;
 use Vanilla\DateFilterSchema;
 
 class DateFilterSchemaTest extends TestCase {

--- a/tests/Library/Vanilla/LoggerTest.php
+++ b/tests/Library/Vanilla/LoggerTest.php
@@ -7,8 +7,6 @@
 
 namespace VanillaTests\Library\Vanilla;
 
-use Psr\Log\LoggerInterface;
-use Psr\Log\LoggerTrait;
 use Psr\Log\Test\LoggerInterfaceTest;
 use Vanilla\Logger;
 

--- a/tests/Library/Vanilla/PermissionsTest.php
+++ b/tests/Library/Vanilla/PermissionsTest.php
@@ -6,9 +6,10 @@
 
 namespace VanillaTests\Library\Vanilla;
 
+use PHPUnit\Framework\TestCase;
 use Vanilla\Permissions;
 
-class PermissionsTest extends \PHPUnit\Framework\TestCase {
+class PermissionsTest extends TestCase {
 
     public function testAdd() {
         $permissions = new Permissions();

--- a/tests/Models/AccessTokenModelTest.php
+++ b/tests/Models/AccessTokenModelTest.php
@@ -7,13 +7,14 @@
 
 namespace VanillaTests\Models;
 
+use PHPUnit\Framework\TestCase;
 use AccessTokenModel;
 use VanillaTests\SiteTestTrait;
 
 /**
  * Test the {@link AccessTokenModel}.
  */
-class AccessTokenModelTest extends \PHPUnit_Framework_TestCase {
+class AccessTokenModelTest extends TestCase {
     use SiteTestTrait;
 
     /**

--- a/tests/Models/CommentModelTest.php
+++ b/tests/Models/CommentModelTest.php
@@ -6,13 +6,14 @@
 
 namespace VanillaTests\Models;
 
+use PHPUnit\Framework\TestCase;
 use CommentModel;
 use VanillaTests\SiteTestTrait;
 
 /**
  * Test {@link CommentModel}.
  */
-class CommentModelTest extends \PHPUnit_Framework_TestCase {
+class CommentModelTest extends TestCase {
     use SiteTestTrait;
 
     /**

--- a/tests/Models/InstallModelTest.php
+++ b/tests/Models/InstallModelTest.php
@@ -7,15 +7,15 @@
 
 namespace VanillaTests\Model;
 
+use PHPUnit\Framework\TestCase;
 use Garden\Container\Container;
-use Vanilla\AddonManager;
 use VanillaTests\Bootstrap;
 use VanillaTests\TestInstallModel;
 
 /**
  * Test basic Vanilla installation.
  */
-class InstallTest extends \PHPUnit\Framework\TestCase {
+class InstallTest extends TestCase {
     /**
      * Test installing Vanilla with the {@link \Vanilla\Models\InstallModel}.
      */

--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -1,8 +1,16 @@
 <?php
 
 use Garden\Container\Container;
-use Vanilla\Addon;
-use Vanilla\InjectableInterface;
+
+// Alias classes for some limited PHPUnit v6 compatibility with v5. To be removed when PHPUnit v5 support is dropped.
+$classCompatibility = [
+    'PHPUnit_Framework_Error_Notice' => 'PHPUnit\\Framework\\Error\\Notice',
+];
+foreach ($classCompatibility as $legacyClass => $class) {
+    if (class_exists($legacyClass) && !class_exists($class)) {
+        class_alias($legacyClass, $class);
+    }
+}
 
 // Define some constants to help with testing.
 define('APPLICATION', 'Vanilla Tests');


### PR DESCRIPTION
Vanilla's tests aren't compatible with PHPUnit v6. This update tweaks several items to make the tests compatible with PHPUnit v6, while maintaining compatibility with PHPUnit v5.

1. Replaced all references to `PHPUnit_Framework_TestCase` with the namespaced equivalent (`PHPUnit\Framework\TestCase`). This forward-compatible class name is compatible with PHP v5.
1. Added error class aliases, mapping relevant PHPUnit v6 namespaced classes (e.g. `PHPUnit\Framework\Error\Notice`) to their PHPUnit v5 counterparts (e.g. `PHPUnit_Framework_Error_Notice`).

The full suite of Vanilla tests should run under both PHPUnit v5 and v6.