### PR TITLE
Do not try to format the body if format does not exists

### DIFF
--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -67,7 +67,7 @@ abstract class AbstractAPIv2Test extends \PHPUnit_Framework_TestCase {
 
     public function assertRowsEqual(array $expected, array $actual, $format = false) {
         // Fix the body and format.
-        if ($format && array_key_exists('body', $expected)) {
+        if ($format && array_key_exists('body', $expected) && array_key_exists('format', $expected)) {
             $expected['body'] = \Gdn_Format::to($expected['body'], $expected['format']);
             unset($expected['format']);
         }


### PR DESCRIPTION
There is some case when there is not format (which means that it default to text).
When that's the case we should not attempt to format the "body" field.