### PR TITLE
Improve validation in file upload schemas

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1155,13 +1155,17 @@ class Gdn_Request implements RequestInterface {
             $result = [];
             foreach ($files['tmp_name'] as $key => $val) {
                 // Consolidate the attributes and push them down the tree.
-                $result[$key] = $getUpload([
+                $upload = $getUpload([
                     'error' => $files['error'][$key],
                     'name' => $files['name'][$key],
                     'size' => $files['size'][$key],
                     'tmp_name' => $files['tmp_name'][$key],
                     'type' => $files['type'][$key]
                 ]);
+                if ($upload instanceof UploadedFile && $upload->getError() === UPLOAD_ERR_NO_FILE) {
+                    continue;
+                }
+                $result[$key] = $upload;
             }
             return $result;
         };
@@ -1192,7 +1196,11 @@ class Gdn_Request implements RequestInterface {
 
         $result = [];
         foreach ($files as $key => $value) {
-            $result[$key] = $getUpload($value);
+            $upload = $getUpload($value);
+            if ($upload instanceof UploadedFile && $upload->getError() === UPLOAD_ERR_NO_FILE) {
+                continue;
+            }
+            $result[$key] = $upload;
         }
         return $result;
     }

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -234,6 +234,40 @@ class RequestTest extends TestCase {
     }
 
     /**
+     * Verify files with the UPLOAD_ERR_NO_FILE error are not added to the translated files array.
+     */
+    public function testNoFileRemoval() {
+        $post = $_POST;
+        $files = $_FILES;
+
+        $_FILES = [
+            'MyFile' => [
+                'error' => UPLOAD_ERR_OK,
+                'name' => 'MyFile.txt',
+                'size' => 10,
+                'tmp_name' => '/tmp/php/php123',
+                'type' => 'text/plain'
+            ],
+            'NoFile' => [
+                'error' => UPLOAD_ERR_NO_FILE,
+                'name' => 'bar.jpg',
+                'size' => 1024,
+                'tmp_name' => '/tmp/php/php456',
+                'type' => 'image/jpeg'
+            ]
+        ];
+
+        $request = Gdn_Request::create()->fromEnvironment();
+
+        // Put everything back like we found it.
+        $_POST = $post;
+        $_FILES = $files;
+
+        $this->assertInstanceOf(\Vanilla\UploadedFile::class, $request->post('MyFile'));
+        $this->assertFalse($request->post('NoFile', false), 'Nonexistent file was not removed.');
+    }
+
+    /**
      * The {@link Gdn_Request::path()} and {@link Gdn_Request::getPath()} methods should be compatible.
      */
     public function testPathEquivalence() {

--- a/tests/Library/Vanilla/UploadedFileSchemaTest.php
+++ b/tests/Library/Vanilla/UploadedFileSchemaTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Vanilla;
+
+use PHPUnit\Framework\TestCase;
+use Gdn_Upload;
+use Vanilla\UploadedFile;
+use Vanilla\UploadedFileSchema;
+
+/**
+ * Tests for the **UploadedFileSchema** class.
+ */
+class UploadedFileSchemaTest extends TestCase {
+
+    /**
+     * Test an upload possessing an invalid file extension.
+     *
+     * @throws \Garden\Schema\ValidationException
+     * @expectedException \Garden\Schema\ValidationException
+     */
+    public function testBadExtension() {
+        $schema = new UploadedFileSchema();
+        $schema->setAllowedExtensions(['jpg']);
+
+        $schema->validate(new UploadedFile(
+            new Gdn_Upload(),
+            '/tmp/php123',
+            40,
+            UPLOAD_ERR_OK,
+            'image.gif',
+            'image/gif'
+        ));
+        $this->fail('Unable to detect invalid upload extension.');
+    }
+
+    /**
+     * Test an upload that exceeds the file size restrictions.
+     *
+     * @throws \Garden\Schema\ValidationException
+     * @expectedException \Garden\Schema\ValidationException
+     */
+    public function testBadSize() {
+        $schema = new UploadedFileSchema();
+        $schema->setMaxSize(100);
+
+        $schema->validate(new UploadedFile(
+            new Gdn_Upload(),
+            '/tmp/php123',
+            200,
+            UPLOAD_ERR_OK,
+            'image.jpg',
+            'image/jpeg'
+        ));
+        $this->fail('Unable to detect large file.');
+    }
+
+    /**
+     * Test an upload possessing no extension.
+     *
+     * @throws \Garden\Schema\ValidationException
+     * @expectedException \Garden\Schema\ValidationException
+     */
+    public function testNoExtension() {
+        $schema = new UploadedFileSchema();
+
+        $schema->validate(new UploadedFile(
+            new Gdn_Upload(),
+            '/tmp/php123',
+            40,
+            UPLOAD_ERR_OK,
+            'image',
+            'image/gif'
+        ));
+        $this->fail('Unable to detect upload with no extension to validate.');
+    }
+
+    /**
+     * Test an upload possessing a valid file extension.
+     *
+     * @throws \Garden\Schema\ValidationException
+     */
+    public function testGoodExtension() {
+        $schema = new UploadedFileSchema();
+        $schema->setAllowedExtensions(['jpg']);
+
+        $schema->validate(new UploadedFile(
+            new Gdn_Upload(),
+            '/tmp/php123',
+            80,
+            UPLOAD_ERR_OK,
+            'image.JPG',
+            'image/jpeg'
+        ));
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Test an upload that falls within the allowed file size restrictions.
+     *
+     * @throws \Garden\Schema\ValidationException
+     */
+    public function testGoodSize() {
+        $schema = new UploadedFileSchema();
+        $schema->setMaxSize(100);
+
+        $schema->validate(new UploadedFile(
+            new Gdn_Upload(),
+            '/tmp/php123',
+            80,
+            UPLOAD_ERR_OK,
+            'image.jpg',
+            'image/jpeg'
+        ));
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This update performs a few improvements to file upload validation, particularly in regard to `UploadedFile` and `UploadedFileSchema`.

1. Adds configurable size restrictions to `UploadedFileSchema`.
1. Adds extension restrictions to `UploadedFileSchema`.
1. Adds removal of empty (no file) uploads to request parsing.
1. Tests for all of the above are included.