### PR TITLE
Fix swagger documentation

### DIFF
--- a/applications/dashboard/controllers/api/TokensApiController.php
+++ b/applications/dashboard/controllers/api/TokensApiController.php
@@ -31,9 +31,6 @@ class TokensApiController extends AbstractApiController {
     private $fullSchema;
 
     /** @var Schema */
-    private $idSchema;
-
-    /** @var Schema */
     private $sensitiveSchema;
 
     /**
@@ -52,7 +49,7 @@ class TokensApiController extends AbstractApiController {
      * @throws ClientException if current user isn't authorized to delete the token.
      */
     public function delete($id) {
-        $this->schema($this->idSchema(),'in')->setDescription('Revoke an access token.');
+        $this->idParamSchema()->setDescription('Revoke an access token.');
         $out = $this->schema([], 'out');
 
         $row = $this->token($id);
@@ -141,10 +138,11 @@ class TokensApiController extends AbstractApiController {
     public function get($id, array $query) {
         $this->permission('Garden.Tokens.Add');
 
+        $this->idParamSchema();
         $in = $this->schema([
             'id',
             'transientKey:s' => 'A valid CSRF token for the current user.'
-        ], 'in')->add($this->idSchema())->setDescription('Reveal a usable access token.');
+        ], 'in')->setDescription('Reveal a usable access token.');
         $out = $this->schema($this->sensitiveSchema(), 'out');
 
         $query['id'] = $id;
@@ -169,14 +167,8 @@ class TokensApiController extends AbstractApiController {
      *
      * @return Schema
      */
-    public function idSchema() {
-        if (!isset($this->idSchema)) {
-            $this->idSchema = $this->schema(
-                ['id:i' => 'The numeric ID of a token.'],
-                'tokenID'
-            );
-        }
-        return $this->idSchema;
+    public function idParamSchema() {
+        return $this->schema(['id:i' => 'The numeric ID of a token.'], 'in');
     }
 
     /**
@@ -187,7 +179,7 @@ class TokensApiController extends AbstractApiController {
     public function index() {
         $this->permission('Garden.Tokens.Add');
 
-        $in = $this->schema([], 'in');
+        $in = $this->schema([], 'in')->setDescription('Get a list of access token IDs for the current user.');
         // Full access token details are not available in the index. Use GET on a single ID for sensitive information.
         $out = $this->schema([
             ':a' => $this->schema([
@@ -195,7 +187,7 @@ class TokensApiController extends AbstractApiController {
                 'name',
                 'dateInserted'
             ])->add($this->fullSchema())
-        ], 'out')->setDescription('Get a list of access token IDs for the current user.');
+        ], 'out');
 
         $rows = $this->accessTokenModel->getWhere([
             'UserID' => $this->getSession()->UserID,

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -206,7 +206,7 @@ class CategoriesApiController extends AbstractApiController {
                 'default' => false,
                 'description' => 'Expand with the parent record.'
             ]
-        ]);
+        ])->setDescription('Search categories.');
         $out = $this->schema([':a' => $this->schemaWithParent($query['expand'])], 'out');
 
         $query = $in->validate($query);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -74,7 +74,7 @@ class DiscussionsApiController extends AbstractApiController {
                 'maximum' => 100
             ],
             'expand?' => $this->getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
-        ], 'in');
+        ], 'in')->setDescription('Get a list of the current user\'s bookmarked discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
         $query = $in->validate($query);


### PR DESCRIPTION
Fixes #6190
Fixes #6187

I had to move `$this->roleByID($id);` after the schema definition in RoleApiController.
We need to remember that we must do: `PermissionCheck > Schemas definition > Anything else` in that particular order to be sure that the documentation will be properly generated.

I also changed `getPermissionsFragment()` to `getPermissionFragment()` because it was causing issues.
Long story short:
```
[
    something? => Schema::parse([
            ':a' => [
                'id:i?',
                'type:s' => [
                    'enum' => ['global', 'category'],
                ],
                'permissions:o',
            ],
    ]),
]
```
Does not work like
```
[
    something:a? => Schema::parse([
            'id:i?',
            'type:s' => [
                'enum' => ['global', 'category'],
            ],
            'permissions:o',
    ]),
]
```