### PR TITLE
Backport: Fix failing discussion API tests

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1923,7 +1923,7 @@ class DiscussionModel extends Gdn_Model {
         $this->defineSchema();
 
         // If the site isn't configured to use categories, don't allow one to be set.
-        if (!c('Vanilla.Categories.Use')) {
+        if (!c('Vanilla.Categories.Use', true)) {
             unset($formPostValues['CategoryID']);
         }
 


### PR DESCRIPTION
This update backports #6203 to [release/2.5](https://github.com/vanilla/vanilla/tree/release/2.5)