### PR TITLE
Add filter event to discussions API index

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -289,8 +289,10 @@ class DiscussionsApiController extends AbstractApiController {
     public function get_edit($id) {
         $this->permission('Garden.SignIn.Allow');
 
-        $in = $this->idParamSchema()->setDescription('Get a discussion for editing.');
-        $out = $this->schema(Schema::parse(['discussionID', 'name', 'body', 'format', 'categoryID', 'sink', 'closed', 'pinned', 'pinLocation'])->add($this->fullSchema()), 'out');
+        $this->idParamSchema()->setDescription('Get a discussion for editing.');
+        $out = $this->schema(
+            Schema::parse(['discussionID', 'name', 'body', 'format', 'categoryID', 'sink', 'closed', 'pinned', 'pinLocation']
+        )->add($this->fullSchema()), ['DiscussionGetEdit', 'out']);
 
         $row = $this->discussionByID($id);
         $row['Url'] = discussionUrl($row);
@@ -380,7 +382,7 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         // Allow addons to update the where clause.
-        $this->getEventManager()->fireArray('discussionsApiController_filter', [$this, $in, $query, &$where]);
+        $where = $this->getEventManager()->fireFilter('discussionsApiController_index_filters', $where, $this, $in, $query);
 
         $pinned = array_key_exists('pinned', $query) ? $query['pinned'] : null;
         if ($pinned === true) {
@@ -468,8 +470,8 @@ class DiscussionsApiController extends AbstractApiController {
     public function post(array $body) {
         $this->permission('Garden.SignIn.Allow');
 
-        $in = $this->schema($this->discussionPostSchema(), 'in')->setDescription('Add a discussion.');
-        $out = $this->schema($this->discussionSchema(), 'out');
+        $in = $this->discussionPostSchema('in')->setDescription('Add a discussion.');
+        $out = $this->discussionSchema('out');
 
         $body = $in->validate($body);
         $categoryID = $body['categoryID'];

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -114,7 +114,7 @@ abstract class Controller implements InjectableInterface {
         if (is_array($schema)) {
             $schema = Schema::parse($schema);
         } elseif ($schema instanceof Schema) {
-            $schema = new Schema($schema->getSchemaArray());
+            $schema = clone $schema;
         }
 
         // Fire an event for schema modification.

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -155,7 +155,7 @@ abstract class Controller implements InjectableInterface {
     /**
      * Get the event manager.
      *
-     * @return mixed Returns the event manager.
+     * @return EventManager Returns the event manager.
      */
     public function getEventManager() {
         return $this->eventManager;
@@ -164,7 +164,7 @@ abstract class Controller implements InjectableInterface {
     /**
      * Set the event manager.
      *
-     * @param mixed $eventManager The new event manager.
+     * @param EventManager $eventManager The new event manager.
      * @return $this
      */
     public function setEventManager($eventManager) {


### PR DESCRIPTION
This will allow addons to update the `$where` array.
Combined with an update of the 'in' schema this allows plugins to add additional filters in `index()`

**We now clone schemas in \Vanilla\Controller to preserve filters and validators added by addons.
If we want to not clone schemas we are gonna have to refactor our code to name ALL schemas.**

Backport to 2.5