### PR TITLE
Add IDs to some schemas in comment and discussion API controllers

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -164,7 +164,7 @@ class CommentsApiController extends AbstractApiController {
         $this->permission();
 
         $this->idParamSchema();
-        $in = $this->schema([], ['CommentsGet', 'in'])->setDescription('Get a comment.');
+        $in = $this->schema([], ['CommentGet', 'in'])->setDescription('Get a comment.');
         $out = $this->schema($this->commentSchema(), 'out');
 
         $query = $in->validate($query);
@@ -180,7 +180,7 @@ class CommentsApiController extends AbstractApiController {
         $result = $out->validate($comment);
 
         // Allow addons to modify the result.
-        $result = $this->getEventManager()->fireFilter('commentsApiController_get_data', $result, $this, $query, $comment, $in);
+        $result = $this->getEventManager()->fireFilter('commentsApiController_get_data', $result, $this, $in, $query, $comment);
         return $result;
     }
 
@@ -250,7 +250,7 @@ class CommentsApiController extends AbstractApiController {
             ],
             'insertUserID:i?' => 'Filter by author.',
             'expand?' => $this->getExpandDefinition(['insertUser'])
-        ], ['CommentsIndex', 'in'])->requireOneOf(['discussionID', 'insertUserID'])->setDescription('List comments.');
+        ], ['CommentIndex', 'in'])->requireOneOf(['discussionID', 'insertUserID'])->setDescription('List comments.');
         $out = $this->schema([':a' => $this->commentSchema()], 'out');
 
         $query = $in->validate($query);
@@ -289,7 +289,7 @@ class CommentsApiController extends AbstractApiController {
         $result = $out->validate($rows);
 
         // Allow addons to modify the result.
-        $result = $this->getEventManager()->fireFilter('commentsApiController_index_data', $result, $this, $query, $rows, $in);
+        $result = $this->getEventManager()->fireFilter('commentsApiController_index_data', $result, $this, $in, $query, $rows);
         return $result;
     }
 

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -164,7 +164,7 @@ class CommentsApiController extends AbstractApiController {
         $this->permission();
 
         $this->idParamSchema();
-        $in = $this->schema([], 'in')->setDescription('Get a comment.');
+        $in = $this->schema([], ['CommentsGet', 'in'])->setDescription('Get a comment.');
         $out = $this->schema($this->commentSchema(), 'out');
 
         $query = $in->validate($query);
@@ -180,7 +180,7 @@ class CommentsApiController extends AbstractApiController {
         $result = $out->validate($comment);
 
         // Allow addons to modify the result.
-        $this->getEventManager()->fireArray('commentsApiController_get_data', [$this, &$result, $query, $comment]);
+        $result = $this->getEventManager()->fireFilter('commentsApiController_get_data', $result, $this, $query, $comment, $in);
         return $result;
     }
 
@@ -250,7 +250,7 @@ class CommentsApiController extends AbstractApiController {
             ],
             'insertUserID:i?' => 'Filter by author.',
             'expand?' => $this->getExpandDefinition(['insertUser'])
-        ], 'in')->requireOneOf(['discussionID', 'insertUserID'])->setDescription('List comments.');
+        ], ['CommentsIndex', 'in'])->requireOneOf(['discussionID', 'insertUserID'])->setDescription('List comments.');
         $out = $this->schema([':a' => $this->commentSchema()], 'out');
 
         $query = $in->validate($query);
@@ -289,7 +289,7 @@ class CommentsApiController extends AbstractApiController {
         $result = $out->validate($rows);
 
         // Allow addons to modify the result.
-        $this->getEventManager()->fireArray('commentsApiController_index_data', [$this, &$result, $query, $rows]);
+        $result = $this->getEventManager()->fireFilter('commentsApiController_index_data', $result, $this, $query, $rows, $in);
         return $result;
     }
 

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -207,7 +207,7 @@ class DiscussionsApiController extends AbstractApiController {
         $this->permission();
 
         $this->idParamSchema();
-        $in = $this->schema([], ['discussionsGet', 'in'])->setDescription('Get a discussion.');
+        $in = $this->schema([], ['DiscussionGet', 'in'])->setDescription('Get a discussion.');
         $out = $this->schema($this->discussionSchema(), 'out');
 
         $query = $in->validate($query);
@@ -225,7 +225,7 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $out->validate($row);
 
         // Allow addons to modify the result.
-        $result = $this->getEventManager()->fireFilter('discussionsApiController_get_data', $result, $this, $query, $row, $in);
+        $result = $this->getEventManager()->fireFilter('discussionsApiController_get_data', $result, $this, $in, $query, $row);
         return $result;
     }
 
@@ -352,7 +352,7 @@ class DiscussionsApiController extends AbstractApiController {
             ],
             'insertUserID:i?' => 'Filter by author.',
             'expand?' => $this->getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
-        ], ['discussionsIndex', 'in'])->setDescription('List discussions.');
+        ], ['DiscussionIndex', 'in'])->setDescription('List discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
         $query = $this->filterValues($query);
@@ -407,7 +407,7 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $out->validate($rows, true);
 
         // Allow addons to modify the result.
-        $result = $this->getEventManager()->fireFilter('discussionsApiController_index_data', $result, $this, $query, $rows, $in);
+        $result = $this->getEventManager()->fireFilter('discussionsApiController_index_data', $result, $this, $in, $query, $rows);
         return $result;
     }
 

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -207,7 +207,7 @@ class DiscussionsApiController extends AbstractApiController {
         $this->permission();
 
         $this->idParamSchema();
-        $in = $this->schema([], 'in')->setDescription('Get a discussion.');
+        $in = $this->schema([], ['discussionsGet', 'in'])->setDescription('Get a discussion.');
         $out = $this->schema($this->discussionSchema(), 'out');
 
         $query = $in->validate($query);
@@ -225,7 +225,7 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $out->validate($row);
 
         // Allow addons to modify the result.
-        $this->getEventManager()->fireArray('discussionsApiController_get_data', [$this, &$result, $query, $row]);
+        $result = $this->getEventManager()->fireFilter('discussionsApiController_get_data', $result, $this, $query, $row, $in);
         return $result;
     }
 
@@ -352,7 +352,7 @@ class DiscussionsApiController extends AbstractApiController {
             ],
             'insertUserID:i?' => 'Filter by author.',
             'expand?' => $this->getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
-        ], 'in')->setDescription('List discussions.');
+        ], ['discussionsIndex', 'in'])->setDescription('List discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
         $query = $this->filterValues($query);
@@ -407,7 +407,7 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $out->validate($rows, true);
 
         // Allow addons to modify the result.
-        $this->getEventManager()->fireArray('discussionsApiController_index_data', [$this, &$result, $query, $rows]);
+        $result = $this->getEventManager()->fireFilter('discussionsApiController_index_data', $result, $this, $query, $rows, $in);
         return $result;
     }
 

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -103,7 +103,8 @@ abstract class Controller implements InjectableInterface {
     public function schema($schema, $type = 'in') {
         $id = '';
         if (is_array($type)) {
-            list($id, $type) = $type;
+            $origType = $type;
+            list($id, $type) = $origType;
         } elseif (!in_array($type, ['in', 'out'], true)) {
             $id = $type;
             $type = '';
@@ -121,7 +122,7 @@ abstract class Controller implements InjectableInterface {
             // The type is a specific type of schema.
             $schema->setID($id);
 
-            $this->eventManager->fire("{$id}Schema_init", $schema);
+            $this->eventManager->fire("{$id}Schema_init", $this, $schema);
         }
 
         // Fire a generic schema event for documentation.


### PR DESCRIPTION
This update adds schema IDs, not just types, to some actions in comment and discussion API endpoints.

Bonus fixes:

1. Use `fireFilter` instead of `fireArray` in comments and discussion API events, where the result is being modified, to avoid passing values by reference
1. Fixes a bug in `Vanilla\Web\Controller::schema`, where providing an array of ID and type would not properly translate to `$type` and `$id`.
1. Adds `$this` as a "sender"-style parameter to the schema init event, similar to the "controller_schema" event.