### PR TITLE
Permission problem with Quotes-2.5

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -420,7 +420,7 @@ BLOCKQUOTE;
 
         if ($discussion) {
             // Check permission.
-            Gdn::controller()->permission('Vanilla.Discussions.View', true, 'Category', val('CategoryID', $discussion));
+            Gdn::controller()->permission('Vanilla.Discussions.View', true, 'Category', val('PermissionCategoryID', $discussion));
 
             $newFormat = $format;
             if ($newFormat == 'Wysiwyg') {


### PR DESCRIPTION
Users logged in with "Members" are getting a permission error when trying to Quote.

Backporting to 2.5