### PR TITLE
Use inline display for bittersweet top menu

### DIFF
--- a/themes/bittersweet/design/custom.css
+++ b/themes/bittersweet/design/custom.css
@@ -38,6 +38,10 @@ a:hover {
     background: #333;
 }
 
+.TopMenu li {
+    display: inline;
+}
+
 .Banner {
     position: relative;
     min-height: 98px;


### PR DESCRIPTION
By default, the top-menu links in the bittersweet theme will be displayed in block instead of inline.
This change is intended to fix that.