### PR TITLE
Add uploading user photos with the API

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -366,7 +366,7 @@ class UsersApiController extends AbstractApiController {
     public function post_photo($id = null, array $body) {
         $this->permission('Garden.SignIn.Allow');
 
-        $photoUploadSchema = UploadedFileSchema::parse([]);
+        $photoUploadSchema = new UploadedFileSchema();
         $photoUploadSchema->setAllowedExtensions(array_values(ImageResizer::getTypeExt()));
 
         $in = $this->schema([

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -366,8 +366,9 @@ class UsersApiController extends AbstractApiController {
     public function post_photo($id = null, array $body) {
         $this->permission('Garden.SignIn.Allow');
 
-        $photoUploadSchema = new UploadedFileSchema();
-        $photoUploadSchema->setAllowedExtensions(array_values(ImageResizer::getTypeExt()));
+        $photoUploadSchema = new UploadedFileSchema([
+            'allowedExtensions' => array_values(ImageResizer::getTypeExt())
+        ]);
 
         $in = $this->schema([
             'photo' => $photoUploadSchema

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -373,7 +373,7 @@ class UsersApiController extends AbstractApiController {
         $in = $this->schema([
             'photo' => $photoUploadSchema
         ], 'in');
-        $out = $this->schema(Schema::parse(['photo'])->add($this->fullSchema()), 'out');
+        $out = $this->schema(Schema::parse(['photoUrl'])->add($this->fullSchema()), 'out');
 
         if ($id === null) {
             $id = $this->getSession()->UserID;

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -5,13 +5,16 @@
  */
 
 use Garden\Schema\Schema;
-use \Garden\Schema\ValidationException;
+use Garden\Schema\ValidationException;
 use Garden\Web\Data;
 use Garden\Web\Exception\ClientException;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
-use Vanilla\DateFilterSchema;
 use Vanilla\ApiUtils;
+use Vanilla\DateFilterSchema;
+use Vanilla\ImageResizer;
+use Vanilla\UploadedFile;
+use Vanilla\UploadedFileSchema;
 
 /**
  * API Controller for the `/users` resource.
@@ -24,6 +27,9 @@ class UsersApiController extends AbstractApiController {
     /** @var Schema */
     private $idParamSchema;
 
+    /** @var ImageResizer */
+    private $imageResizer;
+
     /** @var UserModel */
     private $userModel;
 
@@ -35,13 +41,16 @@ class UsersApiController extends AbstractApiController {
      *
      * @param UserModel $userModel
      * @param Gdn_Configuration $configuration
+     * @param ImageResizer $imageResizer
      */
     public function __construct(
         UserModel $userModel,
-        Gdn_Configuration $configuration
+        Gdn_Configuration $configuration,
+        ImageResizer $imageResizer
     ) {
         $this->configuration = $configuration;
         $this->userModel = $userModel;
+        $this->imageResizer = $imageResizer;
     }
 
     /**
@@ -60,6 +69,34 @@ class UsersApiController extends AbstractApiController {
         $this->userModel->deleteID($id);
     }
 
+    /**
+     * Delete a user photo.
+     *
+     * @param int|null $id The ID of the user.
+     * @throws ClientException if the user does not have a photo.
+     */
+    public function delete_photo($id = null) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $in = $this->idParamSchema()->setDescription('Delete a user photo.');
+        $out = $this->schema([], 'out');
+
+        if ($id === null) {
+            $id = $this->getSession()->UserID;
+        }
+
+        $user = $this->userByID($id);
+
+        if ($id !== $this->getSession()->UserID) {
+            $this->permission('Garden.Users.Edit');
+        }
+
+        if (empty($user['Photo'])) {
+            throw new ClientException('The user does not have a photo.');
+        }
+
+        $this->userModel->removePicture($id);
+    }
     /**
      * Get a schema instance comprised of all available user fields.
      *
@@ -319,6 +356,48 @@ class UsersApiController extends AbstractApiController {
     }
 
     /**
+     * Set a new photo on a user.
+     *
+     * @param $id A valid user ID.
+     * @param array $body The request body.
+     * @throws ClientException if the image provided is not supported.
+     * @return array
+     */
+    public function post_photo($id = null, array $body) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $photoUploadSchema = UploadedFileSchema::parse([]);
+        $photoUploadSchema->setAllowedExtensions(array_values(ImageResizer::getTypeExt()));
+
+        $in = $this->schema([
+            'photo' => $photoUploadSchema
+        ], 'in');
+        $out = $this->schema(Schema::parse(['photo'])->add($this->fullSchema()), 'out');
+
+        if ($id === null) {
+            $id = $this->getSession()->UserID;
+        }
+
+        $this->userByID($id);
+
+        if ($id !== $this->getSession()->UserID) {
+            $this->permission('Garden.Users.Edit');
+        }
+
+        $body = $in->validate($body);
+
+        $photo = $this->processPhoto($body['photo']);
+        $this->userModel->removePicture($id);
+        $this->userModel->save(['UserID' => $id, 'Photo' => $photo]);
+
+        $user = $this->userByID($id);
+        $user = $this->normalizeOutput($user);
+
+        $result = $out->validate($user);
+        return $result;
+    }
+
+    /**
      * Submit a new user registration.
      *
      * @param array $body The request body.
@@ -450,6 +529,58 @@ class UsersApiController extends AbstractApiController {
 
         $dbRecord = ApiUtils::convertInputKeys($schemaRecord);
         return $dbRecord;
+    }
+
+    /**
+     * Process a user photo upload.
+     *
+     * @param UploadedFile $photo
+     * @throws Exception if there was an error encountered when saving the upload.
+     * @return string
+     */
+    private function processPhoto(UploadedFile $photo) {
+        // Make sure this upload extension is associated with an allowed image type, then grab the extension.
+        $this->imageResizer->imageTypeFromExt($photo->getClientFilename());
+        $ext = pathinfo(strtolower($photo->getClientFilename()), PATHINFO_EXTENSION);
+
+        $height = $this->configuration->get('Garden.Profile.MaxHeight');
+        $width = $this->configuration->get('Garden.Profile.MaxWidth');
+        $thumbSize = $this->configuration->get('Garden.Thumbnail.Size');
+
+        // The image is going to be squared off. Go with the larger dimension.
+        $size = $height >= $width ? $height : $width;
+
+        $destination = ProfileController::AVATAR_FOLDER.'/'.$this->generateUploadPath($ext, true);
+
+        // Resize/crop the photo, then save it. Save by copying so upload can be used again for the thumbnail.
+        $this->savePhoto($photo, $destination, $size, 'p', true);
+
+        // Resize and save the thumbnail.
+        $this->savePhoto($photo, $destination, $thumbSize, 'n');
+
+        return $destination;
+    }
+
+    /**
+     * Save a photo upload.
+     *
+     * @param UploadedFile $upload An instance of an uploaded file.
+     * @param string $destination The path, relative to the uploads directory, to save the images into.
+     * @param int $size Maximum size, in pixels, for the photo.
+     * @param string $prefix An optional prefix (e.g. p for full-size or n for thumbnail).
+     * @param bool $copy Should the upload be saved by copying, instead of moving?
+     * @throws Exception if there was an error encountered when saving the upload.
+     * @return array|bool
+     */
+    private function savePhoto(UploadedFile $upload, $destination, $size, $prefix = '', $copy = false) {
+        $this->imageResizer->resize(
+            $upload->getFile(),
+            null,
+            ['crop' => true, 'height' => $size, 'width' => $size]
+        );
+
+        $result = $this->saveUpload($upload, $destination, "{$prefix}%s", $copy);
+        return $result;
     }
 
     /**

--- a/library/Vanilla/FileUtils.php
+++ b/library/Vanilla/FileUtils.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla;
+
+class FileUtils {
+
+    /**
+     * Check if a file was uploaded in the current request.
+     *
+     * @param $filename
+     * @return bool
+     */
+    function isUploadedFile($filename) {
+        $result = is_uploaded_file($filename);
+        return $result;
+    }
+
+    /**
+     * Move an upload to a new location.
+     *
+     * @param $filename
+     * @param $destination
+     * @return bool
+     */
+    function moveUploadedFile($filename, $destination) {
+        $result = move_uploaded_file($filename, $destination);
+        return $result;
+    }
+}

--- a/library/Vanilla/ImageResizer.php
+++ b/library/Vanilla/ImageResizer.php
@@ -27,7 +27,7 @@ class ImageResizer {
      * Resize an image.
      *
      * @param string $source The path of the source image.
-     * @param string $destination The path of the destination image.
+     * @param string|null $destination The path of the destination image. Use `null` for an in-place resize.
      * @param array $options An array of options constraining the image crop.
      *
      * - width: The max width of the destination image.
@@ -46,8 +46,14 @@ class ImageResizer {
             throw new \InvalidArgumentException("Cannot resize images of this type ($ext).");
         }
 
-        if (pathinfo($destination, PATHINFO_EXTENSION) === '*') {
-            $destination = substr($destination, 0, -1).self::$typeExt[$srcType];
+        if ($destination === null) {
+            $destType = $srcType;
+            $destination = $source;
+        } else {
+            if (pathinfo($destination, PATHINFO_EXTENSION) === '*') {
+                $destination = substr($destination, 0, -1) . self::$typeExt[$srcType];
+            }
+            $destType = $this->imageTypeFromExt($destination);
         }
 
         // Check for EXIF rotation tag, and rotate the image if present
@@ -68,7 +74,6 @@ class ImageResizer {
         }
 
         $resize = $this->calculateResize(['height' => $height, 'width' => $width], $options);
-        $destType = $this->imageTypeFromExt($destination);
 
         try {
             $srcImage = $this->createImage($source, $srcType);
@@ -230,6 +235,15 @@ class ImageResizer {
             'sourceX' => $sx,
             'sourceY' => $sy
         ];
+    }
+
+    /**
+     * Return the type-to-extension map.
+     *
+     * @return array
+     */
+    public static function getTypeExt() {
+        return static::$typeExt;
     }
 
     /**

--- a/library/Vanilla/UploadedFile.php
+++ b/library/Vanilla/UploadedFile.php
@@ -118,6 +118,15 @@ class UploadedFile {
     }
 
     /**
+     * Get the temporary filename associated with this uploaded file.
+     *
+     * @return string
+     */
+    public function getFile() {
+        return $this->file;
+    }
+
+    /**
      * Retrieve the filename sent by the client.
      *
      * @return string|null The filename sent by the client or null if none was provided.

--- a/library/Vanilla/UploadedFileSchema.php
+++ b/library/Vanilla/UploadedFileSchema.php
@@ -27,10 +27,20 @@ class UploadedFileSchema extends Schema {
     /**
      * Initialize an instance of a new UploadedFileSchema class.
      */
-    public function __construct() {
+    public function __construct(array $options = []) {
         $this->config = Gdn::getContainer()->get('Config');
-        $maxSize = Gdn_Upload::unformatFileSize($this->config->get('Garden.Upload.MaxFileSize', ini_get('upload_max_filesize')));
-        $allowedExtensions = $this->config->get('Garden.Upload.AllowedFileExtensions', []);
+
+        if (array_key_exists('allowedExtensions', $options)) {
+            $allowedExtensions = $options['allowedExtensions'];
+        } else {
+            $allowedExtensions = $this->config->get('Garden.Upload.AllowedFileExtensions', []);
+        }
+
+        if (array_key_exists('maxSize', $options)) {
+            $maxSize = $options['maxSize'];
+        } else {
+            $maxSize = Gdn_Upload::unformatFileSize($this->config->get('Garden.Upload.MaxFileSize', ini_get('upload_max_filesize')));
+        }
 
         $this->setMaxSize($maxSize);
         $this->setAllowedExtensions(array_map('strtolower', $allowedExtensions));

--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -24,6 +24,9 @@ class Gdn_Upload extends Gdn_Pluggable {
     /** @var string */
     protected $_UploadedFile;
 
+    /** @var \Vanilla\FileUtils */
+    protected $fileUtils;
+
     /**
      * Class constructor.
      */
@@ -31,6 +34,8 @@ class Gdn_Upload extends Gdn_Pluggable {
         $this->clear();
         parent::__construct();
         $this->ClassName = 'Gdn_Upload';
+
+        $this->fileUtils = Gdn::getContainer()->get(\Vanilla\FileUtils::class);
     }
 
     /**
@@ -318,13 +323,14 @@ class Gdn_Upload extends Gdn_Pluggable {
         if (!$handled) {
             $target = PATH_UPLOADS.'/'.$parsed['Name'];
             if (!file_exists(dirname($target))) {
-                mkdir(dirname($target));
+                mkdir(dirname($target), 0777, true);
             }
 
             if (stringBeginsWith($source, PATH_UPLOADS)) {
                 rename($source, $target);
             } else {
-                $result = ($copy && is_uploaded_file($source)) ? copy($source, $target) : move_uploaded_file($source, $target);
+                $isUpload = $this->fileUtils->isUploadedFile($source);
+                $result = ($copy && $isUpload) ? copy($source, $target) : $this->fileUtils->moveUploadedFile($source, $target);
                 if (!$result) {
                     throw new Exception(sprintf(t('Failed to save uploaded file to target destination (%s).'), $target));
                 }
@@ -396,7 +402,7 @@ class Gdn_Upload extends Gdn_Pluggable {
     public function validateUpload($inputName, $throwException = true) {
         $ex = false;
 
-        if (!array_key_exists($inputName, $_FILES) || (!is_uploaded_file($_FILES[$inputName]['tmp_name']) && getValue('error', $_FILES[$inputName], 0) == 0)) {
+        if (!array_key_exists($inputName, $_FILES) || (!$this->fileUtils->isUploadedFile($_FILES[$inputName]['tmp_name']) && getValue('error', $_FILES[$inputName], 0) == 0)) {
             // Check the content length to see if we exceeded the max post size.
             $contentLength = Gdn::request()->getValueFrom('server', 'CONTENT_LENGTH');
             $maxPostSize = self::unformatFileSize(ini_get('post_max_size'));

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -195,6 +195,10 @@ class Bootstrap {
             ->rule(\Gdn_Plugin::class)
             ->setShared(true)
             ->addCall('setAddonFromManager')
+
+            ->rule(\Vanilla\FileUtils::class)
+            ->setAliasOf(\VanillaTests\Fixtures\FileUtils::class)
+            ->addAlias('FileUtils')
         ;
     }
 

--- a/tests/fixtures/src/FileUtils.php
+++ b/tests/fixtures/src/FileUtils.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Fixtures;
+
+class FileUtils extends \Vanilla\FileUtils {
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isUploadedFile($filename) {
+        $uploadedFiles = array_column($_FILES, 'tmp_name');
+        $result = in_array($filename, $uploadedFiles);
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function moveUploadedFile($filename, $destination) {
+        $result = rename($filename, $destination);
+        return $result;
+    }
+}

--- a/tests/fixtures/src/Uploader.php
+++ b/tests/fixtures/src/Uploader.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+namespace VanillaTests\Fixtures;
+
+use Exception;
+use Vanilla\UploadedFile;
+use Gdn_Upload;
+
+class Uploader {
+
+    protected static $uploadsPath = PATH_ROOT.'/tests/cache/uploads';
+
+    /**
+     * Verify the uploads directory exists. Attempt to create it, if not.
+     *
+     * @throws Exception
+     */
+    protected static function ensureDirectory() {
+        if (!file_exists(static::$uploadsPath)) {
+            $result = mkdir (static::$uploadsPath , 0777, true);
+            if (!$result) {
+                throw new Exception('Unable to create uploads directory: '.self::$uploadsPath);
+            }
+        }
+    }
+
+    /**
+     * Generate a valid, random filename for an upload.
+     *
+     * @return string
+     */
+    protected static function generateFilename() {
+        do {
+            $name = randomString(12);
+            $path = static::$uploadsPath."/{$name}";
+        } while (file_exists($path));
+        return $path;
+    }
+
+    /**
+     * Clear the uploads directory and reset the $_FILES global..
+     */
+    public static function resetUploads() {
+        if (file_exists(self::$uploadsPath)) {
+            $files = glob(self::$uploadsPath.'/*.*');
+            array_walk($files, 'unlink');
+        }
+
+        $_FILES = [];
+    }
+
+    /**
+     * Copy a file into the uploads directory and add its details to the current $_FILES superglobal.
+     *
+     * @param string $name A field name associated with this file upload.
+     * @param string $file Path to the file.
+     * @throws Exception if the file does not exist.
+     * @throws Exception if the file is not actually a file (i.e. is a directory).
+     * @throws Exception if the file is not readable.
+     * @return UploadedFile
+     */
+    public static function uploadFile($name, $file) {
+        if (!file_exists($file)) {
+            throw new Exception("{$file} does not exist.");
+        }
+        if (!is_file($file)) {
+            throw new Exception("{$file} is not a file.");
+        }
+        if (!is_readable($file)) {
+            throw new Exception("{$file} could not be read.");
+        }
+
+        static::ensureDirectory();
+        $destination = static::generateFilename();
+
+        if (!copy($file, $destination)) {
+            throw new Exception('Unable to copy file to destination: '.$destination);
+        }
+
+        $info = [
+            'name' => basename($file),
+            'type' => mime_content_type($file),
+            'size' => filesize($file),
+            'tmp_name' => $destination,
+            'error' => UPLOAD_ERR_OK
+        ];
+
+        $_FILES[$name] = $info;
+
+        $result = new UploadedFile(
+            new Gdn_Upload(),
+            $info['tmp_name'],
+            $info['size'],
+            $info['error'],
+            $info['name'],
+            $info['type']
+        );
+        return $result;
+    }
+}


### PR DESCRIPTION
This update adds the ability to set and remove a user's photo with the API.

### Additional
1. Added the ability to perform an in-place save of images with `ImageResizer`.
1. Added a method to retrieve the protected `ImageResizer::$typeExt` property.
1. Added the ability to get an upload's temporary filename to `UploadedFile`.
1. Added `$copy` parameter to `Gdn_Upload::saveAs` for allowing copying an upload a destination, instead of moving it.
1. Added `Controller::generateUploadPath` method for generating a valid, randomized upload path/filename, relative to the uploads directory.
1. Added `Controller::saveUpload` for saving uploads represented as instances of `UploadedFile`.
    * Allows for easy manipulation of the file's base name, which is handy for the full-size (p) and thumbnail (n) prefixes used by Vanilla for image uploads.
1. Added `UsersApiController::processPhoto` to prepare a photo (and its thumbnail) for saving.
1. Added `UsersApiController::savePhoto` to resize and save uploaded images.
1. Added the ability to set options (e.g. allowed extensions, maximum file size) to `UploadedFileSchema` constructor.
1. Added `Upload` upload class for tests to simulate user uploads.
1. Added `Vanilla\FileUtils` to abstract `is_uploaded_file` and `move_uploaded_file`.
1. Added `VanillaTests\Fixtures\FileUtils` to handle simulated uploads during testing.
1. Added tests for uploading and deleting user photos using the API.
1. Updated the directory creation in `Gdn_Upload::saveAs` to allow recursively creating directories, similar to what is currently used in [`Gdn_UploadImage::saveImageAs`](https://github.com/vanilla/vanilla/blob/bdf4b2b18364263ace7accbfaa620d3ae040f4be/library/core/class.uploadimage.php#L179).