### PR TITLE
Fix permission check when quoting a post

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -420,7 +420,12 @@ BLOCKQUOTE;
 
         if ($discussion) {
             // Check permission.
-            Gdn::controller()->permission('Vanilla.Discussions.View', true, 'Category', val('PermissionCategoryID', $discussion));
+            Gdn::controller()->permission(
+                ['Vanilla.Discussions.Add', 'Vanilla.Discussions.View'],
+                false,
+                'Category',
+                val('PermissionCategoryID', $discussion)
+            );
 
             $newFormat = $format;
             if ($newFormat == 'Wysiwyg') {


### PR DESCRIPTION
It is possible, with some plugins, to view a discussion without the "view" permission.
Checking for either add or view to allow quoting solves that problem.