### PR TITLE
Fix latest comment link to point directly to the comment

### DIFF
--- a/applications/vanilla/views/discussions/table_functions.php
+++ b/applications/vanilla/views/discussions/table_functions.php
@@ -74,7 +74,8 @@ if (!function_exists('writeDiscussionRow')) :
         $discussion->CountPages = ceil($discussion->CountComments / $sender->CountCommentsPerPage);
 
         $firstPageUrl = discussionUrl($discussion, 1);
-        $lastPageUrl = discussionUrl($discussion, val('CountPages', $discussion)).'#latest';
+        $lastComment = CommentModel::instance()->getID($discussion->LastCommentID);
+        $lastPageUrl = $lastComment ? commentUrl($lastComment) : $firstPageUrl;
         ?>
         <tr id="Discussion_<?php echo $discussion->DiscussionID; ?>" class="<?php echo $cssClass; ?>">
             <?php $sender->fireEvent('BeforeDiscussionContent'); ?>


### PR DESCRIPTION
Closes https://github.com/vanilla/internal/issues/1280

The actual issue is pretty well detailed. ~~I didn't use commentUrl() because that requires passing the actual comment. It seemed wasteful to lookup the comment only to strip it right back down to it's ID.~~