### PR TITLE
Move getExpandDefinition into ApiUtils

### DIFF
--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -221,7 +221,7 @@ class ConversationsApiController extends AbstractApiController {
                 'minimum' => 5,
                 'maximum' => 100
             ],
-            'expand?' => $this->getExpandDefinition(['user'])
+            'expand?' => ApiUtils::getExpandDefinition(['user'])
         ], 'in')->setDescription('Get participants of a conversation.');
         $out = $this->schema([
             ':a' => [
@@ -302,7 +302,7 @@ class ConversationsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand?' => $this->getExpandDefinition(['insertUser'])
+            'expand?' => ApiUtils::getExpandDefinition(['insertUser'])
         ], 'in')
             ->requireOneOf(['insertUserID', 'participantUserID'])
             ->setDescription('List user conversations.');

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -181,7 +181,7 @@ class MessagesApiController extends AbstractApiController {
                     'minimum' => 1,
                     'maximum' => 100
                 ],
-                'expand?' => $this->getExpandDefinition(['insertUser'])
+                'expand?' => ApiUtils::getExpandDefinition(['insertUser'])
             ], 'in')
             ->requireOneOf(['conversationID', 'insertUserID'])
             ->setDescription('List user messages.');

--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -46,27 +46,6 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
     }
 
     /**
-     * Get an "expand" parameter definition with specific fields.
-     *
-     * @param array $fields Valid values for the expand parameter.
-     * @param bool|string $default The default value of expand.
-     * @return array
-     */
-    public function getExpandDefinition(array $fields, $default = false) {
-        $result = [
-            'description' => 'Expand associated records using one or more valid field names. A boolean true expands all expandable fields.',
-            'default' => $default,
-            'items' => [
-                'enum' => $fields,
-                'type' => 'string'
-            ],
-            'style' => 'form',
-            'type' => ['boolean', 'array'],
-        ];
-        return $result;
-    }
-
-    /**
      * Get the schema for users joined to records.
      *
      * @return Schema Returns a schema.

--- a/applications/dashboard/controllers/api/InvitesApiController.php
+++ b/applications/dashboard/controllers/api/InvitesApiController.php
@@ -151,7 +151,7 @@ class InvitesApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand?' => $this->getExpandDefinition(['acceptedUser'])
+            'expand?' => ApiUtils::getExpandDefinition(['acceptedUser'])
         ], 'in')->setDescription('Get a list of invites sent by the current user.');
         $out = $this->schema([
             ':a' => $this->fullSchema()

--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -241,7 +241,7 @@ class RolesApiController extends AbstractApiController {
 
         $this->idParamSchema();
         $in = $this->schema([
-            'expand?' => $this->getExpandDefinition(['permissions'])
+            'expand?' => ApiUtils::getExpandDefinition(['permissions'])
         ], 'in')->setDescription('Get a role.');
         $out = $this->schema($this->roleSchema(), 'out');
 
@@ -343,7 +343,7 @@ class RolesApiController extends AbstractApiController {
         $this->permission('Garden.Settings.Manage');
 
         $in = $this->schema([
-            'expand?' => $this->getExpandDefinition(['permissions'])
+            'expand?' => ApiUtils::getExpandDefinition(['permissions'])
         ], 'in')->setDescription('List roles.');
         $out = $this->schema([':a' => $this->roleSchema()], 'out');
 

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -270,7 +270,7 @@ class CommentsApiController extends AbstractApiController {
                     'field' => 'InsertUserID',
                 ],
             ],
-            'expand?' => $this->getExpandDefinition(['insertUser'])
+            'expand?' => ApiUtils::getExpandDefinition(['insertUser'])
         ], ['CommentIndex', 'in'])->requireOneOf(['discussionID', 'insertUserID'])->setDescription('List comments.');
         $out = $this->schema([':a' => $this->commentSchema()], 'out');
 

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -67,7 +67,7 @@ class DiscussionsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand?' => $this->getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
+            'expand?' => ApiUtils::getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
         ], 'in')->setDescription('Get a list of the current user\'s bookmarked discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
@@ -369,7 +369,7 @@ class DiscussionsApiController extends AbstractApiController {
                     'field' => 'd.InsertUserID',
                 ],
             ],
-            'expand?' => $this->getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
+            'expand?' => ApiUtils::getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
         ], ['DiscussionIndex', 'in'])->setDescription('List discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -48,6 +48,27 @@ class ApiUtils {
     }
 
     /**
+     * Get an "expand" parameter definition with specific fields.
+     *
+     * @param array $fields Valid values for the expand parameter.
+     * @param bool|string $default The default value of expand.
+     * @return array
+     */
+    public static function getExpandDefinition(array $fields, $default = false) {
+        $result = [
+            'description' => 'Expand associated records using one or more valid field names. A boolean true expands all expandable fields.',
+            'default' => $default,
+            'items' => [
+                'enum' => $fields,
+                'type' => 'string'
+            ],
+            'style' => 'form',
+            'type' => ['boolean', 'array'],
+        ];
+        return $result;
+    }
+
+    /**
      * Generate pager info when the total number of records is not known.
      *
      * @param int|array|bool $rows The count of rows from the current query or an array of rows from a result.

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -122,7 +122,7 @@ abstract class Controller implements InjectableInterface {
             // The type is a specific type of schema.
             $schema->setID($id);
 
-            $this->eventManager->fire("{$id}Schema_init", $this, $schema);
+            $this->eventManager->fire("{$id}Schema_init", $schema);
         }
 
         // Fire a generic schema event for documentation.


### PR DESCRIPTION
This update does a couple things:

1. Moves `getExpandDefinition` from `AbstractApiController` to `ApiUtils`. Usage updates in code made, accordingly.
1. Reverts "{$id}Schema_init" events to just passing the schema, instead of also passing the controller. Passing the controller was originally introduced in #6219.