### PR TITLE
Rename urlCode to urlcode in categories API responses

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -45,7 +45,7 @@ class CategoriesApiController extends AbstractApiController {
      */
     public function categoryPostSchema($type = '', array $extra = []) {
         if ($this->categoryPostSchema === null) {
-            $fields = ['name', 'parentCategoryID?', 'urlCode', 'displayAs?', 'customPermissions?'];
+            $fields = ['name', 'parentCategoryID?', 'urlcode', 'displayAs?', 'customPermissions?'];
             $this->categoryPostSchema = $this->schema(
                 Schema::parse(array_merge($fields, $extra))->add($this->schemaWithParent()),
                 'CategoryPost'
@@ -122,7 +122,7 @@ class CategoriesApiController extends AbstractApiController {
             ],
             'parentCategoryID:i|n' => 'Parent category ID.',
             'customPermissions:b' => 'Are custom permissions set for this category?',
-            'urlCode:s' => 'The URL code of the category.',
+            'urlcode:s' => 'The URL code of the category.',
             'url:s' => 'The URL to the category.',
             'displayAs:s' => [
                 'description' => 'The display style of the category.',
@@ -169,7 +169,7 @@ class CategoriesApiController extends AbstractApiController {
 
         $in = $this->idParamSchema()->setDescription('Get a category for editing.');
         $out = $this->schema(Schema::parse([
-            'categoryID', 'name', 'parentCategoryID', 'urlCode', 'description', 'displayAs'
+            'categoryID', 'name', 'parentCategoryID', 'urlcode', 'description', 'displayAs'
         ])->add($this->fullSchema()), 'out');
 
         $row = $this->category($id);
@@ -327,7 +327,7 @@ class CategoriesApiController extends AbstractApiController {
                 ]);
                 unset($body['customPermissions']);
             }
-            $categoryData = ApiUtils::convertInputKeys($body);
+            $categoryData = $this->normalizeInput($body);
             $this->categoryModel->setField($id, $categoryData);
         }
 
@@ -352,7 +352,7 @@ class CategoriesApiController extends AbstractApiController {
 
         $body = $in->validate($body);
 
-        $categoryData = ApiUtils::convertInputKeys($body);
+        $categoryData = $this->normalizeInput($body);
         $id = $this->categoryModel->save($categoryData);
         $this->validateModel($this->categoryModel);
 
@@ -364,6 +364,23 @@ class CategoriesApiController extends AbstractApiController {
         $row = $this->normalizeOutput($row);
         $result = $out->validate($row);
         return $result;
+    }
+
+    /**
+     * Normalize request data to be passed to a model.
+     *
+     * @param array $request
+     * @return array
+     */
+    public function normalizeInput(array $request) {
+        $request = ApiUtils::convertInputKeys($request);
+
+        if (array_key_exists('Urlcode', $request)) {
+            $request['UrlCode'] = $request['Urlcode'];
+            unset($request['Urlcode']);
+        }
+
+        return $request;
     }
 
     /**
@@ -465,7 +482,7 @@ class CategoriesApiController extends AbstractApiController {
     public function schemaWithParent($expand = false, $type = '') {
         $attributes = ['parentCategoryID:i|n' => 'Parent category ID.'];
         if ($expand) {
-            $attributes['parent:o?'] = Schema::parse(['categoryID', 'name', 'urlCode', 'url'])
+            $attributes['parent:o?'] = Schema::parse(['categoryID', 'name', 'urlcode', 'url'])
                 ->add($this->fullSchema());
         }
         $schema = $this->fullSchema();

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -25,10 +25,10 @@ class CategoriesTest extends AbstractResourceTest {
     protected $baseUrl = '/categories';
 
     /** {@inheritdoc} */
-    protected $editFields = ['description', 'name', 'parentCategoryID', 'urlCode', 'displayAs'];
+    protected $editFields = ['description', 'name', 'parentCategoryID', 'urlcode', 'displayAs'];
 
     /** {@inheritdoc} */
-    protected $patchFields = ['description', 'name', 'parentCategoryID', 'urlCode', 'displayAs'];
+    protected $patchFields = ['description', 'name', 'parentCategoryID', 'urlcode', 'displayAs'];
 
     /** {@inheritdoc} */
     protected $pk = 'categoryID';
@@ -45,7 +45,7 @@ class CategoriesTest extends AbstractResourceTest {
         foreach ($this->patchFields as $key) {
             $value = $row[$key];
             switch ($key) {
-                case 'urlCode':
+                case 'urlcode':
                     $value = md5($value);
                 case 'displayAs':
                     $value = $value === 'flat' ? 'categories' : 'flat';
@@ -69,10 +69,10 @@ class CategoriesTest extends AbstractResourceTest {
     public function record() {
         $count = static::$recordCounter;
         $name = "Test Category {$count}";
-        $urlCode = strtolower(preg_replace('/[^A-Z0-9]/i', '-', $name));
+        $urlcode = strtolower(preg_replace('/[^A-Z0-9]/i', '-', $name));
         $record = [
             'name' => $name,
-            'urlCode' => $urlCode,
+            'urlcode' => $urlcode,
             'parentCategoryID' => self::PARENT_CATEGORY_ID,
             'displayAs' => 'flat'
         ];
@@ -97,7 +97,7 @@ class CategoriesTest extends AbstractResourceTest {
             $this->baseUrl,
             [
                 'name' => 'Test Parent Category',
-                'urlCode' => 'test-parent-category',
+                'urlcode' => 'test-parent-category',
                 'parentCategoryID' => -1
             ]
         )->getBody();
@@ -105,7 +105,7 @@ class CategoriesTest extends AbstractResourceTest {
             $this->baseUrl,
             [
                 'name' => 'Test Child Category',
-                'urlCode' => 'test-child-category',
+                'urlcode' => 'test-child-category',
                 'parentCategoryID' => self::PARENT_CATEGORY_ID
             ]
         )->getBody();
@@ -133,7 +133,7 @@ class CategoriesTest extends AbstractResourceTest {
             $this->baseUrl,
             [
                 'name' => 'Test Bad Parent',
-                'urlCode' => 'test-bad-parent',
+                'urlcode' => 'test-bad-parent',
                 'parentCategoryID' => self::PARENT_CATEGORY_ID
             ]
         )->getBody();
@@ -154,7 +154,7 @@ class CategoriesTest extends AbstractResourceTest {
             $this->baseUrl,
             [
                 'name' => 'Test Child Parent',
-                'urlCode' => 'test-child-parent',
+                'urlcode' => 'test-child-parent',
                 'parentCategoryID' => self::PARENT_CATEGORY_ID
             ]
         )->getBody();
@@ -175,7 +175,7 @@ class CategoriesTest extends AbstractResourceTest {
             $this->baseUrl,
             [
                 'name' => 'Test Parent as Child',
-                'urlCode' => 'test-parent-as-child',
+                'urlcode' => 'test-parent-as-child',
                 'parentCategoryID' => self::PARENT_CATEGORY_ID
             ]
         )->getBody();
@@ -183,7 +183,7 @@ class CategoriesTest extends AbstractResourceTest {
             $this->baseUrl,
             [
                 'name' => 'Test Child as Parent',
-                'urlCode' => 'test-child-as-parent',
+                'urlcode' => 'test-child-as-parent',
                 'parentCategoryID' => $row[$this->pk]
             ]
         )->getBody();


### PR DESCRIPTION
This update alters the re-casing of the `UrlCode` field in categories endpoints to "urlcode", instead of the current "urlCode".

1. `CategoriesApiController::normalizeInput` has been implemented to handle the proper case adjustment for "urlcode", since `CategoryModel` expects "UrlCode".
1. Tests have been updated, accordingly.