### PR TITLE
Fix generating user tokens from profile pages

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -1318,7 +1318,7 @@ class ProfileController extends Gdn_Controller {
                 $token = $tokenApi->post([
                     'name' => $this->Form->getFormValue('Name'),
                     'transientKey' => $this->Form->getFormValue('TransientKey')
-                ])->getData();
+                ]);
 
                 $this->jsonTarget(".DataList-Tokens", $this->revealTokenRow($token), 'Prepend');
 


### PR DESCRIPTION
#6000 moved POST requests in the API from returning `Data` objects as responses to arrays. Prior to this, e10c69a altered an internal API call to the tokens endpoint, expecting a `Data` object as the result.

This update removes the assumption the result will be an object and instead allows the response to be processed as an array.