### PR TITLE
Fix Generate New Token URL link in profile pages

### DIFF
--- a/applications/dashboard/views/profile/tokens.php
+++ b/applications/dashboard/views/profile/tokens.php
@@ -2,7 +2,7 @@
 <h1 class="H"><?=t('Personal Access Tokens')?></h1>
 
 <div class="PageControls Top">
-    <a href="<?=userUrl($this->User, '', 'token')?>" class="Button Action Popup Primary"><?=t('Generate New Token')?></a>
+    <a href="<?=url(userUrl($this->User, '', 'token'))?>" class="Button Action Popup Primary"><?=t('Generate New Token')?></a>
 </div>
 <div class="DataListWrap">
     <ul class="DataList DataList-Tokens">


### PR DESCRIPTION
The "Generate New Token" button in a user's profile uses the `userUrl` function to generate the URL. The URLs generated by this function are relative to the configured web root and do not contain the web root, itself.

This update passes the `userUrl` result through `url`, which other links on the page use, and should handle properly prepending a configured web root.