### PR TITLE
Fix core version check to read environment.php

### DIFF
--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -117,7 +117,7 @@ class UpdateModel extends Gdn_Model {
             '/class.*.plugin.php', // plugin
             '/about.php', // theme
             '/definitions.php', // locale
-            '/index.php', // vanilla core
+            '/environment.php', // vanilla core
             'vanilla2export.php' // porter
         ];
 
@@ -148,7 +148,7 @@ class UpdateModel extends Gdn_Model {
             }
 
             foreach ($entries as $entry) {
-                if ($entry['Name'] == '/index.php') {
+                if ($entry['Name'] == '/environment.php') {
                     // This could be the core vanilla package.
                     $version = self::parseCoreVersion($entry['Path']);
 


### PR DESCRIPTION
We use core's `parseCoreVersion()` to evaluate uploads to the Addon directory on open.vanillaforums.com. Moving our basic app & version info out of index.php to environment.php broke backwards compatibility with ourselves.