### PR TITLE
Allow Connect to blank a photo it previously set

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -532,7 +532,7 @@ class EntryController extends Gdn_Controller {
 
                 // Don't overwrite the user photo if the user uploaded a new one.
                 $photo = val('Photo', $user);
-                if (!val('Photo', $data) || ($photo && !isUrl($photo))) {
+                if ($photo && !isUrl($photo)) {
                     unset($data['Photo']);
                 }
 


### PR DESCRIPTION
Closes #2772

If an SSO connection sets an avatar, it should then be allowed to blank said avatar on a later connection. Currently, or logic does not allow for that. This change fixes that, while preserving the commented functionality of "don't override an avatar we uploaded via Vanilla".