### PR TITLE
Remove last references to Garden.Charset

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -28,7 +28,6 @@ $Configuration['Cache']['Filecache']['Store']  = PATH_CACHE.'/Filecache';
 
 // Technical content stuff.
 $Configuration['Garden']['ContentType'] = 'text/html';
-$Configuration['Garden']['Charset'] = 'utf-8';
 $Configuration['Garden']['Locale'] = 'en';
 $Configuration['Garden']['LocaleCodeset'] = 'UTF8';
 

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -3187,7 +3187,7 @@ PASSWORDMETER;
     protected function _nameAttribute($fieldName, $attributes) {
         // Name from attributes overrides the default.
         $name = $this->escapeFieldName(arrayValueI('name', $attributes, $fieldName));
-        return ' name="'.htmlspecialchars($name, ENT_COMPAT, c('Garden.Charset', 'UTF-8')).'"';
+        return ' name="'.htmlspecialchars($name).'"';
     }
 
     /**


### PR DESCRIPTION
This was a needless use of parameters - those are already the defaults for `htmlspecialchars()` and we long ago decided this config wasn't necessary. This should be the end of it.

Closes #3047