### PR TITLE
Remove call to nonexistant `cancel` view in OpenID

### DIFF
--- a/plugins/OpenID/class.openid.plugin.php
+++ b/plugins/OpenID/class.openid.plugin.php
@@ -192,7 +192,7 @@ class OpenIDPlugin extends Gdn_Plugin {
         $Mode = $Sender->Request->get('openid_mode');
         switch ($Mode) {
             case 'cancel':
-                $Sender->render('Cancel', '', 'plugins/OpenID');
+                redirectTo(Gdn::router()->getDestination('DefaultController'));
                 break;
             case 'id_res':
                 if ($OpenID->validate()) {


### PR DESCRIPTION
Closes #3743

Just redirect to the default page instead.