### PR TITLE
Replace escapeString with escapeFieldName

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1689,7 +1689,7 @@ class SettingsController extends DashboardController {
                 // Save the text to the locale.
                 $translations = [];
                 foreach ($this->data('ThemeInfo.Options.Text', []) as $key => $default) {
-                    $value = $this->Form->getFormValue($this->Form->escapeString('Text_'.$key));
+                    $value = $this->Form->getFormValue($this->Form->escapeFieldName('Text_'.$key));
                     $configSaveData["ThemeOption.{$key}"] = $value;
                     //$this->Form->setFormValue('Text_'.$Key, $Value);
                 }
@@ -1709,7 +1709,7 @@ class SettingsController extends DashboardController {
                         $value = $default;
                     }
 
-                    $this->Form->setValue($this->Form->escapeString('Text_'.$key), $value);
+                    $this->Form->setValue($this->Form->escapeFieldName('Text_'.$key), $value);
                 }
             }
 
@@ -1754,7 +1754,7 @@ class SettingsController extends DashboardController {
                 // Save the text to the locale.
                 $translations = [];
                 foreach ($this->data('ThemeInfo.Options.Text', []) as $key => $default) {
-                    $value = $this->Form->getFormValue($this->Form->escapeString('Text_'.$key));
+                    $value = $this->Form->getFormValue($this->Form->escapeFieldName('Text_'.$key));
                     $configSaveData["ThemeOption.{$key}"] = $value;
                     //$this->Form->setFormValue('Text_'.$Key, $Value);
                 }
@@ -1776,7 +1776,7 @@ class SettingsController extends DashboardController {
                         $value = $default;
                     }
 
-                    $this->Form->setFormValue($this->Form->escapeString('Text_'.$key), $value);
+                    $this->Form->setFormValue($this->Form->escapeFieldName('Text_'.$key), $value);
                 }
             }
 

--- a/applications/dashboard/views/settings/themeoptions.php
+++ b/applications/dashboard/views/settings/themeoptions.php
@@ -84,11 +84,11 @@ echo $this->Form->errors();
             <div class="input-wrap">
             <?php switch (strtolower(val('Type', $Options, 'textarea'))) {
                 case 'textbox':
-                    echo $this->Form->textBox($this->Form->escapeString('Text_'.$Code));
+                    echo $this->Form->textBox($this->Form->escapeFieldName('Text_'.$Code));
                     break;
                 case 'textarea':
                 default:
-                    echo $this->Form->textBox($this->Form->escapeString('Text_'.$Code), ['MultiLine' => TRUE]);
+                    echo $this->Form->textBox($this->Form->escapeFieldName('Text_'.$Code), ['MultiLine' => TRUE]);
                     break;
             } ?>
             </div>


### PR DESCRIPTION
`Gdn_Form::escapeString()` is deprecated. Internally it just calls `Gdn_Form::escapeFieldName()`. I've replace the all the usages I could find.

See the escapeString declaration here:

https://github.com/vanilla/vanilla/blob/809ac0d730345270164348eda06f7b22b70f0bb9/library/core/class.form.php#L1614-L1617