### PR TITLE
Fixed erroneous usage of printf() instead of sprintf()

### DIFF
--- a/applications/dashboard/views/settings/helper_functions.php
+++ b/applications/dashboard/views/settings/helper_functions.php
@@ -254,7 +254,7 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
     $pluginUrl = val('PluginUrl', $addonInfo, '');
 
     if ($upgrade && $pluginUrl) {
-        $info[] = anchor(printf(t('%1$s version %2$s is available.'), $screenName, $newVersion),
+        $info[] = anchor(sprintf(t('%1$s version %2$s is available.'), $screenName, $newVersion),
             combinePaths([$pluginUrl, 'find', urlencode($screenName)], '/'));
     }
 


### PR DESCRIPTION
The addon.json key "newVersion" showed only a number as the link text instead of "PluginName version x.y is available." because the wrong function has been chosen.