### PR TITLE
Inject extended profile fields into controller data

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -405,6 +405,8 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
             // Get the custom fields
             $ProfileFields = Gdn::userModel()->getMeta($Sender->User->UserID, 'Profile.%', 'Profile.');
 
+            Gdn::controller()->setData('ExtendedFields', $ProfileFields);
+
             // Get allowed GDN_User fields.
             $Blacklist = array_combine($this->ReservedNames, $this->ReservedNames);
             $NativeFields = array_diff_key((array)$Sender->User, $Blacklist);


### PR DESCRIPTION
Closes #6232

Injects profile extender fields into the controller so they can be used in theme templates.

Output is just `"key" => "value"`.
  