### PR TITLE
Fix timestamp default values on AccessToken table

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -284,10 +284,10 @@ $Construct
     ->column('UserID', 'int', false, 'index')
     ->column('Type', 'varchar(20)', false, 'index')
     ->column('Scope', 'text', true)
-    ->column('DateInserted', 'timestamp', false)
+    ->column('DateInserted', 'timestamp', ['Null' => false, 'Default' => 'current_timestamp'])
     ->column('InsertUserID', 'int', true)
     ->column('InsertIPAddress', 'ipaddress', false)
-    ->column('DateExpires', 'timestamp', false)
+    ->column('DateExpires', 'timestamp', ['Null' => false, 'Default' => 'current_timestamp'])
     ->column('Attributes', 'text', true)
     ->set($Explicit, $Drop);
 

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -792,8 +792,14 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
             $return .= ' null';
         }
 
-        if (!is_null($column->Default) && $column->Type !== 'timestamp') {
-            $return .= " default ".self::_quoteValue($column->Default);
+        if (!is_null($column->Default)) {
+            if ($column->Type !== 'timestamp') {
+                $return .= " default ".self::_quoteValue($column->Default);
+            } else {
+                if (in_array(strtolower($column->Default), ['current_timestamp', 'current_timestamp()'])) {
+                    $return .= " default ".$column->Default;
+                }
+            }
         }
 
         if ($column->AutoIncrement) {


### PR DESCRIPTION
Fixes: https://github.com/vanilla/vanilla/issues/5832

This update allow to set the default value of a timestamp to 'current_timestamp' or 'current_timestamp()' and refactor the AccessToken table to use that new feature.