### PR TITLE
Accessibility - Add placeholder/title for text areas

### DIFF
--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -28,7 +28,7 @@ $this->fireEvent('BeforeCommentForm');
                     echo $this->Form->errors();
                     $this->fireEvent('BeforeBodyField');
 
-                    echo $this->Form->bodyBox('Body', ['Table' => 'Comment', 'FileUpload' => true]);
+                    echo $this->Form->bodyBox('Body', ['Table' => 'Comment', 'FileUpload' => true, 'placeholder' => t('Type your comment here'), 'title' => t('Type your comment here')]);
 
                     echo '<div class="CommentOptions List Inline">';
                     $this->fireEvent('AfterBodyField');

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -28,7 +28,7 @@ $this->fireEvent('BeforeCommentForm');
                     echo $this->Form->errors();
                     $this->fireEvent('BeforeBodyField');
 
-                    echo $this->Form->bodyBox('Body', ['Table' => 'Comment', 'FileUpload' => true, 'placeholder' => t('Type your comment here'), 'title' => t('Type your comment here')]);
+                    echo $this->Form->bodyBox('Body', ['Table' => 'Comment', 'FileUpload' => true, 'placeholder' => t('Type your comment'), 'title' => t('Type your comment')]);
 
                     echo '<div class="CommentOptions List Inline">';
                     $this->fireEvent('AfterBodyField');

--- a/applications/vanilla/views/post/discussion.php
+++ b/applications/vanilla/views/post/discussion.php
@@ -44,7 +44,7 @@ if (!$CancelUrl) {
     $this->fireEvent('BeforeBodyInput');
 
     echo '<div class="P">';
-    echo $this->Form->bodyBox('Body', ['Table' => 'Discussion', 'FileUpload' => true]);
+    echo $this->Form->bodyBox('Body', ['Table' => 'Discussion', 'FileUpload' => true, 'placeholder' => t('Type your message here'), 'title' => t('Type your message here')]);
     echo '</div>';
 
     $Options = '';

--- a/applications/vanilla/views/post/discussion.php
+++ b/applications/vanilla/views/post/discussion.php
@@ -44,7 +44,7 @@ if (!$CancelUrl) {
     $this->fireEvent('BeforeBodyInput');
 
     echo '<div class="P">';
-    echo $this->Form->bodyBox('Body', ['Table' => 'Discussion', 'FileUpload' => true, 'placeholder' => t('Type your message here'), 'title' => t('Type your message here')]);
+    echo $this->Form->bodyBox('Body', ['Table' => 'Discussion', 'FileUpload' => true, 'placeholder' => t('Type your message'), 'title' => t('Type your message')]);
     echo '</div>';
 
     $Options = '';

--- a/applications/vanilla/views/post/editcomment.php
+++ b/applications/vanilla/views/post/editcomment.php
@@ -10,7 +10,7 @@ $this->fireEvent('BeforeCommentForm');
                 echo $this->Form->open();
                 echo $this->Form->errors();
                 $this->fireEvent('BeforeBodyField');
-                echo $this->Form->bodyBox('Body', ['Table' => 'Comment', 'FileUpload' => true]);
+                echo $this->Form->bodyBox('Body', ['Table' => 'Comment', 'FileUpload' => true, 'placeholder' => t('Type your comment here'), 'title' => t('Type your comment here')]);
                 $this->fireEvent('AfterBodyField');
                 echo "<div class=\"Buttons\">\n";
                 $this->fireEvent('BeforeFormButtons');

--- a/applications/vanilla/views/post/editcomment.php
+++ b/applications/vanilla/views/post/editcomment.php
@@ -10,7 +10,7 @@ $this->fireEvent('BeforeCommentForm');
                 echo $this->Form->open();
                 echo $this->Form->errors();
                 $this->fireEvent('BeforeBodyField');
-                echo $this->Form->bodyBox('Body', ['Table' => 'Comment', 'FileUpload' => true, 'placeholder' => t('Type your comment here'), 'title' => t('Type your comment here')]);
+                echo $this->Form->bodyBox('Body', ['Table' => 'Comment', 'FileUpload' => true, 'placeholder' => t('Type your comment'), 'title' => t('Type your comment')]);
                 $this->fireEvent('AfterBodyField');
                 echo "<div class=\"Buttons\">\n";
                 $this->fireEvent('BeforeFormButtons');


### PR DESCRIPTION
The textareas in Vanilla don't have a label. I've added a title and placeholder to help screen readers to announce what the text area is for for new posts. 

Closes: https://github.com/vanilla/vanilla/issues/6380