### PR TITLE
Fix issue where anchor text that are URL were altered

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1262,7 +1262,7 @@ class Gdn_Format {
                 $inTag--;
             }
 
-            if (c('Garden.Format.WarnLeaving', false) && isset($matches[4]) && $inAnchor) {
+            if (c('Garden.Format.WarnLeaving', false) && isset($matches[4]) && $inTag && $inAnchor) {
                 // This is a the href url value in an anchor tag.
                 $url = $matches[4];
                 $domain = parse_url($url, PHP_URL_HOST);


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/5961

The problem was that we were checking if the URL was in the anchor tag instead of checking that the URL was actually in the opening part of the anchor tag.