### PR TITLE
Fix inability to validate OpenID authentications with nonce

### DIFF
--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -92,10 +92,11 @@ if (!$hasUserID) {
                 </li>
                 <?php endif; ?>
 
-                <?php if ($displayConnectName) : ?>
+                <?php
+                    $PasswordMessage = t('ConnectLeaveBlank', 'Leave blank unless connecting to an existing account.');
+                    if ($displayConnectName) : ?>
                 <li>
                     <?php
-                    $PasswordMessage = t('ConnectLeaveBlank', 'Leave blank unless connecting to an existing account.');
 
                     if (count($ExistingUsers) == 1 && $NoConnectName) {
                         $PasswordMessage = t('ConnectExistingPassword', 'Enter your existing account password.');

--- a/plugins/OpenID/class.lightopenid.php
+++ b/plugins/OpenID/class.lightopenid.php
@@ -299,13 +299,13 @@ class LightOpenID {
     }
 
     protected function request($url, $method = 'GET', $params = []) {
-        $timeStart = microtime();
+        $timeStart = microtime(true);
         if (function_exists('curl_init') && !ini_get('safe_mode')) {
             $result = $this->request_curl($url, $method, $params);
         } else {
             $result = $this->request_streams($url, $method, $params);
         }
-        $timeDiff = microtime() - $timeStart;
+        $timeDiff = microtime(true) - $timeStart;
 
         // Make sure every request takes at least .5 second.
         // This nullify brute forcing
@@ -773,5 +773,25 @@ class LightOpenID {
             return $this->getAxAttributes() + $this->getSregAttributes();
         }
         return $this->getSregAttributes();
+    }
+
+    /**
+     * Get data for the OpenID authentication attempt.
+     *
+     * @return array
+     */
+    public function getData() {
+        return $this->data;
+    }
+
+    /**
+     * Set OpenID authentication data.
+     *
+     * @param array $data
+     * @return array
+     */
+    public function setData(array $data) {
+        $this->data = $data;
+        return $this->data;
     }
 }


### PR DESCRIPTION
OpenID authentication attempts can contain a nonce. If a user is connecting to Vanilla via OpenID and the registration requires more information (e.g. an email address), validation is attempted twice: once during the initial connection and again after the required information has been provided by the user. If a nonce is part of the OpenID authentication, the first validation will succeed and the second will fail.

This update stashes a successful validation in a session, so subsequent validations aren't necessary.

A couple of bonus fixes are included:

1. `microtime` was being called without using the `$get_as_float` parameter, which meant it returned a string. The result was used in a subtraction statement, which are meant for numerical values. This was causing a warning. The fix was using `$get_as_float` to ensure a numerical value is returned.
1. `$PasswordMessage` was initialized in a place where it might not be accessible to all subsequent code that utilized it. This caused "undefined" warnings. It has been moved slightly higher in the view.