### PR TITLE
Add the style-compat.scss file

### DIFF
--- a/applications/dashboard/design/style-compat.css
+++ b/applications/dashboard/design/style-compat.css
@@ -1,0 +1,2 @@
+
+/*# sourceMappingURL=style-compat.css.map */

--- a/applications/dashboard/design/style-compat.css.map
+++ b/applications/dashboard/design/style-compat.css.map
@@ -1,0 +1,9 @@
+{
+	"version": 3,
+	"file": "style-compat.css",
+	"sources": [
+		"../scss/style-compat.scss"
+	],
+	"mappings": "",
+	"names": []
+}

--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -103,6 +103,7 @@ class AssetModel extends Gdn_Model {
         // Include theme customizations last so that they override everything else.
         switch ($basename) {
             case 'style':
+                $this->addCssFile(asset('/applications/dashboard/design/style-compat.css', true), false, ['Sort' => -9.999]);
                 $this->addCssFile('custom.css', false, ['Sort' => 1000]);
 
                 if (Gdn::controller()->Theme && Gdn::controller()->ThemeOptions) {

--- a/applications/dashboard/scss/style-compat.scss
+++ b/applications/dashboard/scss/style-compat.scss
@@ -1,0 +1,2 @@
+// A style sheet for compatibility with new features.
+// This should always be added after style.css and not be overridden.


### PR DESCRIPTION
The purpose of this file is to allow us to add new design elements even for themes that have overridden style.css.

Closes #6392.