### PR TITLE
Fix error message on profile post lists when all page content is filtered

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -853,6 +853,7 @@ class VanillaHooks implements Gdn_IPlugin {
             $sender->View = 'profilecomments';
         }
         $sender->setData('Comments', $comments);
+        $sender->setData('UnfilteredCommentsCount', $commentModel->LastCommentCount);
 
         // Set the HandlerType back to normal on the profilecontroller so that it fetches it's own views
         $sender->HandlerType = HANDLER_TYPE_NORMAL;
@@ -890,6 +891,8 @@ class VanillaHooks implements Gdn_IPlugin {
         $discussionModel = new DiscussionModel();
         $discussions = $discussionModel->getByUser($sender->User->UserID, $limit, $offset, false, Gdn::session()->UserID);
         $countDiscussions = $offset + $discussionModel->LastDiscussionCount + 1;
+
+        $sender->setData('UnfilteredDiscussionsCount', $discussionModel->LastDiscussionCount);
         $sender->DiscussionData = $sender->setData('Discussions', $discussions);
 
         // Build a pager

--- a/applications/vanilla/views/discussion/profile.php
+++ b/applications/vanilla/views/discussion/profile.php
@@ -8,7 +8,7 @@ if (sizeof($this->data('Comments'))) {
     echo $this->fetchView('profilecomments', 'Discussion', 'Vanilla');
     echo $this->Pager->toString('more');
 } elseif ($this->data('UnfilteredCommentsCount', 0) > 0) {
-    echo '<li class="Item Empty">'.t('Every comments on this page have been filtered out because you do not have the permission to see them.').'</li>';
+    echo '<li class="Item Empty">'.t('You do not have access to any comments on this page.').'</li>';
     echo $this->Pager->toString('more');
 } else {
     echo '<li class="Item Empty">'.t('This user has not commented yet.').'</li>';

--- a/applications/vanilla/views/discussion/profile.php
+++ b/applications/vanilla/views/discussion/profile.php
@@ -7,8 +7,12 @@ echo '<ul class="DataList SearchResults">';
 if (sizeof($this->data('Comments'))) {
     echo $this->fetchView('profilecomments', 'Discussion', 'Vanilla');
     echo $this->Pager->toString('more');
+} elseif ($this->data('UnfilteredCommentsCount', 0) > 0) {
+    echo '<li class="Item Empty">'.t('Every comments on this page have been filtered out because you do not have the permission to see them.').'</li>';
+    echo $this->Pager->toString('more');
 } else {
     echo '<li class="Item Empty">'.t('This user has not commented yet.').'</li>';
 }
+
 echo '</ul>';
 echo '</div>';

--- a/applications/vanilla/views/discussions/profile.php
+++ b/applications/vanilla/views/discussions/profile.php
@@ -11,7 +11,7 @@ if (is_object($this->DiscussionData) && $this->DiscussionData->numRows() > 0) {
     include($ViewLocation);
     echo $this->Pager->toString('more');
 } elseif ($this->data('UnfilteredDiscussionsCount', 0) > 0) {
-    echo '<li class="Item Empty">'.t('Every discussions on this page have been filtered out because you do not have the permission to see them.').'</li>';
+    echo '<li class="Item Empty">'.t('You do not have access to any discussions on this page.').'</li>';
     echo $this->Pager->toString('more');
 } else {
     echo wrap(t("This user has not made any discussions yet."), 'li', ['Class' => 'Item Empty']);

--- a/applications/vanilla/views/discussions/profile.php
+++ b/applications/vanilla/views/discussions/profile.php
@@ -7,11 +7,14 @@ echo '<ul class="DataList Discussions">';
 // Create some variables so that they aren't defined in every loop.
 $ViewLocation = $this->fetchViewLocation('discussions', 'discussions', 'vanilla');
 
-if (!is_object($this->DiscussionData) || $this->DiscussionData->numRows() <= 0) {
-    echo wrap(t("This user has not made any discussions yet."), 'li', ['Class' => 'Item Empty']);
-} else {
+if (is_object($this->DiscussionData) && $this->DiscussionData->numRows() > 0) {
     include($ViewLocation);
     echo $this->Pager->toString('more');
+} elseif ($this->data('UnfilteredDiscussionsCount', 0) > 0) {
+    echo '<li class="Item Empty">'.t('Every discussions on this page have been filtered out because you do not have the permission to see them.').'</li>';
+    echo $this->Pager->toString('more');
+} else {
+    echo wrap(t("This user has not made any discussions yet."), 'li', ['Class' => 'Item Empty']);
 }
 echo '</ul>';
 echo '</div>';


### PR DESCRIPTION
Fixes #6107

First of, let's start by saying that the basic pager uses "more" which does not let you access "pages".
Since `/profile/discussions/{DISCUSISON_ID}/{USER_NAME}/p{NUMBER}` works, I added a detection that checks if the page had data before the permission filtering. If that's the case we display a more relevant message and let the "more" page active.

This solves the issue.