### PR TITLE
Add nofollow to profile links behind @mentions

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1915,7 +1915,7 @@ EOT;
             }
 
             if ($mention) {
-                $parts[$i] = anchor('@'.$mention, url(str_replace('{name}', rawurlencode($mention), self::$MentionsUrlFormat), true)).$suffix;
+                $parts[$i] = anchor('@'.$mention, url(str_replace('{name}', rawurlencode($mention), self::$MentionsUrlFormat), true), '', ['rel' => 'nofollow']).$suffix;
             } else {
                 $parts[$i] = '@' . $parts[$i];
             }


### PR DESCRIPTION
This update adds the `rel="nofollow"` attribute to profile links behind \@mentions in Vanilla. This mirrors the behavior seen in the Quotes addon for [linking to an author's profile from a quote](https://github.com/vanilla/vanilla/blob/073651a7e7b1707f39eef167d2fd207d96c1f4c2/plugins/Quotes/class.quotes.plugin.php#L344).

If you want to read up on nofollow, you can checkout it's Wikipedia page: [nofollow](https://en.wikipedia.org/wiki/Nofollow). It primarily functions as a hint for SEO crawlers to avoid "following" the content of links and associating them with the current site. This can also be good for guiding crawlers away from "page not found" (404) errors, when the generated \@mention profile link references a user that doesn't exist (since Vanilla doesn't check for an existing user when generating these anchors).