### PR TITLE
Fix session state during sign-in attempts when a user is banned

### DIFF
--- a/applications/dashboard/controllers/class.authenticatecontroller.php
+++ b/applications/dashboard/controllers/class.authenticatecontroller.php
@@ -111,18 +111,10 @@ class AuthenticateController extends Gdn_Controller {
      * @throws Exception
      */
     public function index($authenticator = '', $authenticatorID = '') {
-        try {
-            $response = $this->authenticateApiController->post([
-                'authenticator' => $authenticator,
-                'authenticatorID' => $authenticatorID,
-            ]);
-        } catch(Exception $e) {
-            if (debug()) {
-                throw $e;
-            }
-            throw notFoundException();
-        }
-
+        $response = $this->authenticateApiController->post([
+            'authenticator' => $authenticator,
+            'authenticatorID' => $authenticatorID,
+        ]);
 
         if ($response['authenticationStep'] === 'authenticated') {
             $redirectURL = (val('target', $this->request->getQuery(), '/'));

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -665,7 +665,7 @@ class DashboardHooks extends Gdn_Plugin {
      */
     public function base_afterSignIn_handler() {
         if (!Gdn::session()->isValid()) {
-            if ($ban = Gdn::session()->getPermissions()->getBan([])) {
+            if ($ban = Gdn::session()->getPermissions()->getBan()) {
                 throw new ClientException($ban['msg'], 401, $ban);
             } else {
                 if (!Gdn::session()->getPermissions()->has('Garden.SignIn.Allow')) {

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -10,6 +10,8 @@
 
 use Garden\Container\Container;
 use Garden\Container\Reference;
+use Garden\Web\Exception\ClientException;
+use Vanilla\Exception\PermissionException;
 
 /**
  * Event handlers for the Dashboard application.
@@ -654,6 +656,23 @@ class DashboardHooks extends Gdn_Plugin {
             }
         }
         $this->checkAccessToken();
+    }
+
+    /**
+     * Check to see if a user is banned.
+     *
+     * @throws Exception if the user is banned.
+     */
+    public function base_afterSignIn_handler() {
+        if ($ban = Gdn::session()->getPermissions()->getBan([])) {
+            throw new ClientException($ban['msg'], 401, $ban);
+        } else if (!Gdn::session()->isValid()) {
+            if (!Gdn::session()->getPermissions()->has('Garden.SignIn.Allow')) {
+                throw new PermissionException('Garden.SignIn.Allow');
+            } else {
+                throw new ClientException('The session could not be started', 401);
+            }
+        }
     }
 
     /**

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -664,13 +664,15 @@ class DashboardHooks extends Gdn_Plugin {
      * @throws Exception if the user is banned.
      */
     public function base_afterSignIn_handler() {
-        if ($ban = Gdn::session()->getPermissions()->getBan([])) {
-            throw new ClientException($ban['msg'], 401, $ban);
-        } else if (!Gdn::session()->isValid()) {
-            if (!Gdn::session()->getPermissions()->has('Garden.SignIn.Allow')) {
-                throw new PermissionException('Garden.SignIn.Allow');
+        if (!Gdn::session()->isValid()) {
+            if ($ban = Gdn::session()->getPermissions()->getBan([])) {
+                throw new ClientException($ban['msg'], 401, $ban);
             } else {
-                throw new ClientException('The session could not be started', 401);
+                if (!Gdn::session()->getPermissions()->has('Garden.SignIn.Allow')) {
+                    throw new PermissionException('Garden.SignIn.Allow');
+                } else {
+                    throw new ClientException('The session could not be started', 401);
+                }
             }
         }
     }

--- a/library/Vanilla/Models/SSOModel.php
+++ b/library/Vanilla/Models/SSOModel.php
@@ -238,6 +238,7 @@ class SSOModel {
 
         if ($user) {
             $this->session->start($user['UserID']);
+            $this->userModel->fireEvent('AfterSignIn');
 
             // Allow user's synchronization
             $syncInfo = $this->config->get('Garden.Registration.ConnectSynchronize', true);

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1614,6 +1614,7 @@ class Gdn_Controller extends Gdn_Pluggable {
                 // Pick our route.
                 switch ($ex->getCode()) {
                     case 401:
+                    case 403:
                         $route = 'DefaultPermission';
                         break;
                     case 404:
@@ -1634,7 +1635,7 @@ class Gdn_Controller extends Gdn_Pluggable {
                         ->passData('Url', url())
                         ->passData('Breadcrumbs', $this->data('Breadcrumbs', []))
                         ->dispatch($route);
-                } elseif (in_array($ex->getCode(), [401, 404])) {
+                } elseif (in_array($ex->getCode(), [401, 403, 404])) {
                     // Default forbidden & not found codes.
                     Gdn::dispatcher()
                         ->passData('Message', $ex->getMessage())

--- a/plugins/vanillaconnect/VanillaConnectPlugin.php
+++ b/plugins/vanillaconnect/VanillaConnectPlugin.php
@@ -122,11 +122,7 @@ class VanillaConnectPlugin extends Gdn_Plugin {
 
             saveToConfig('Garden.Registration.SendConnectEmail', false, false);
 
-            if ($this->ssoModel->sso($ssoData)) {
-                if ($this->session->UserID != $currentUserID) {
-                    $this->userModel->fireEvent('AfterSignIn');
-                }
-            } else {
+            if (!$this->ssoModel->sso($ssoData)) {
                 throw new \Exception('Unable to push connect the user.');
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
Fixes #5988

- Session is now "invalid" if the user is banned or deleted.
- Throw the AfterSignIn event everywhere.
- Throw an exception on AfterSignIn if the user is banned.
    - This take care of #5988 
    - It is done that way (instead of in Session::start() to preserve backward compatibility). I'm also unsure as to why we are filling a ban array instead of throwing an exception but that tells me that we are probably checking the bad array later in the code.

How to test:
- Use entry/signin via PopUp
- Use entry/signin with no popup.
- Use VanillaConnect (which uses the /authenticate endpoint)
- Use any other SSO plugin (which uses the /entry/connect endpoint)