### PR TITLE
Fix category permission check when using the comments API endpoint

### DIFF
--- a/tests/Models/CommentModelTest.php
+++ b/tests/Models/CommentModelTest.php
@@ -8,6 +8,7 @@ namespace VanillaTests\Models;
 
 use PHPUnit\Framework\TestCase;
 use CommentModel;
+use DiscussionModel;
 use VanillaTests\SiteTestTrait;
 
 /**
@@ -20,20 +21,31 @@ class CommentModelTest extends TestCase {
      * Test the lookup method.
      */
     public function testLookup() {
-        $model = new CommentModel();
-        $fields = [
-            'DiscussionID' => 9999,
+        $commentModel = new CommentModel();
+        $discussionModel = new DiscussionModel();
+
+        $discussion = [
+            'CategoryID' => 1,
+            'Name' => 'Comment Lookup Test',
+            'Body' => 'foo foo foo',
+            'Format' => 'Text',
+            'InsertUserID' => 1
+        ];
+        $discussionID = $discussionModel->save($discussion);
+
+        $comment = [
+            'DiscussionID' => $discussionID,
             'Body' => 'Hello world.',
             'Format' => 'Text'
         ];
-        $id = $model->save($fields);
-        $this->assertNotFalse($id);
+        $commentID = $commentModel->save($comment);
+        $this->assertNotFalse($commentID);
 
-        $result = $model->lookup(['CommentID' => $id] + $fields);
+        $result = $commentModel->lookup(['CommentID' => $commentID] + $comment);
         $this->assertInstanceOf('Gdn_DataSet', $result);
         $this->assertEquals(1, $result->count());
 
         $row = $result->firstRow(DATASET_TYPE_ARRAY);
-        $this->assertEquals($id, $row['CommentID']);
+        $this->assertEquals($commentID, $row['CommentID']);
     }
 }


### PR DESCRIPTION
`CommentModel::lookup` has a routine to filter out comments the user doesn't have access to. It does this by looking at the category the comment is in and comparing it against the result of `DiscussionModel::categoryPermissions`. The problem is, in its current state, the category ID isn't available. `CommentModel::lookup` is referencing an undefined property. Because of this, custom category permissions on a site can filter out *all* comments on the comments API endpoint for some users/roles (e.g. ["if `null` isn't in my list of allowed categories, remove this comment](https://github.com/vanilla/vanilla/blob/9491a2dca2f527ebc22c615ef02526afdd403e7b/applications/vanilla/models/class.commentmodel.php#L476)).

This update joins in the Discussion table when querying comments. Since category ID is now brought over from the discussions table as part of the row, comments can be properly filtered.