### PR TITLE
Add explicit category following

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -28,7 +28,7 @@ class CategoriesApiController extends AbstractApiController {
     private $idParamSchema;
 
     /**
-     * CategoriessApiController constructor.
+     * CategoriesApiController constructor.
      *
      * @param CategoryModel $categoryModel
      */
@@ -133,7 +133,8 @@ class CategoriesApiController extends AbstractApiController {
             'countDiscussions:i' => 'Total discussions in the category.',
             'countComments:i' => 'Total comments in the category.',
             'countAllDiscussions:i' => 'Total of all discussions in a category and its children.',
-            'countAllComments:i' => 'Total of all comments in a category and its children.'
+            'countAllComments:i' => 'Total of all comments in a category and its children.',
+            'follow:b?' => 'Is the category being followed by the current user?'
         ]);
     }
 
@@ -277,6 +278,8 @@ class CategoriesApiController extends AbstractApiController {
             $parent = $this->category(-1);
         }
 
+        $joinUserCategory = $this->categoryModel->joinUserCategory();
+        $this->categoryModel->setJoinUserCategory(true);
         if ($parent['DisplayAs'] === 'Flat') {
             list($offset, $limit) = offsetLimit("p{$query['page']}", $this->categoryModel->getDefaultLimit());
             $categories = $this->categoryModel->getTreeAsFlat(
@@ -287,6 +290,7 @@ class CategoriesApiController extends AbstractApiController {
         } else {
             $categories = $this->categoryModel->getTree($parent['CategoryID'], ['maxdepth' => $query['maxDepth']]);
         }
+        $this->categoryModel->setJoinUserCategory($joinUserCategory);
         $categories = array_map([$this, 'normalizeOutput'], $categories);
 
         return $out->validate($categories);

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -338,17 +338,18 @@ class CategoryModel extends Gdn_Model {
             throw new InvalidArgumentException('Invalid $categoryID');
         }
 
+        $isFollowed = $this->isFollowed($userID, $categoryID);
+        if ($follow === null) {
+            $follow = !$isFollowed;
+        }
+        $follow = $follow ? 1 : 0;
+
         $category = static::categories($categoryID);
         if (!is_array($category)) {
             throw new InvalidArgumentException('Category not found.');
-        } elseif ($category['DisplayAs'] !== 'Discussions') {
+        } elseif ($category['DisplayAs'] !== 'Discussions' && !$isFollowed) {
             throw new InvalidArgumentException('Category not configured to display as discussions.');
         }
-
-        if ($follow === null) {
-            $follow = !$this->isFollowed($userID, $categoryID);
-        }
-        $follow = $follow ? 1 : 0;
 
         $this->SQL->replace(
             'UserCategory',

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -229,6 +229,8 @@ class CategoryModel extends Gdn_Model {
             $following = !((bool)val('Archived', $category) || (bool)val('Unfollow', $userData, false));
             $category['Following'] = $following;
 
+            $category['Follow'] = boolval($userData['Follow']);
+
             // Calculate the read field.
             if (strcasecmp($category['DisplayAs'], 'heading') === 0) {
                 $category['Read'] = false;
@@ -1627,6 +1629,8 @@ class CategoryModel extends Gdn_Model {
                 // Calculate the following field.
                 $following = !((bool)val('Archived', $category) || (bool)val('Unfollow', $row, false));
                 $categories[$iD]['Following'] = $following;
+
+                $categories[$iD]['Follow'] = boolval($row['Follow']);
 
                 // Calculate the read field.
                 if ($category['DisplayAs'] == 'Heading') {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -25,6 +25,9 @@ class CategoryModel extends Gdn_Model {
     /** Cache key. */
     const MASTER_VOTE_KEY = 'Categories.Rebuild.Vote';
 
+    /** The default maximum number of categories a user can follow. */
+    const MAX_FOLLOWED_CATEGORIES_DEFAULT = 100;
+
     /** Flag for aggregating comment counts. */
     const AGGREGATE_COMMENT = 'comment';
 
@@ -242,19 +245,24 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
-     * Get the per-category information for the current user.
+     * Get the per-category information for a user.
      *
+     * @param int $userID
      * @return array|mixed
      */
-    private function getUserCategories() {
-        if (Gdn::session()->UserID) {
-            $key = 'UserCategory_'.Gdn::session()->UserID;
+    private function getUserCategories($userID = null) {
+        if ($userID === null) {
+            $userID = Gdn::session()->UserID;
+        }
+
+        if ($userID) {
+            $key = 'UserCategory_'.$userID;
             $userData = Gdn::cache()->get($key);
             if ($userData === Gdn_Cache::CACHEOP_FAILURE) {
                 $sql = clone $this->SQL;
                 $sql->reset();
 
-                $userData = $sql->getWhere('UserCategory', ['UserID' => Gdn::session()->UserID])->resultArray();
+                $userData = $sql->getWhere('UserCategory', ['UserID' => $userID])->resultArray();
                 $userData = array_column($userData, null, 'CategoryID');
                 Gdn::cache()->store($key, $userData);
                 return $userData;
@@ -283,6 +291,96 @@ class CategoryModel extends Gdn_Model {
      */
     public static function getRootDisplayAs() {
         return c('Vanilla.RootCategory.DisplayAs', 'Categories');
+    }
+
+    /**
+     * Get a list of a user's followed categories.
+     *
+     * @param int $userID The target user's ID.
+     * @return array
+     */
+    public function getFollowed($userID) {
+        $key = "Follow_{$userID}";
+        $result = Gdn::cache()->get($key);
+        if ($result === Gdn_Cache::CACHEOP_FAILURE) {
+            $sql = clone $this->SQL;
+            $sql->reset();
+
+            $userData = $sql->getWhere('UserCategory', [
+                'UserID' => $userID,
+                'Follow' => 1
+            ])->resultArray();
+            $result = array_column($userData, null, 'CategoryID');
+            Gdn::cache()->store($key, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Set whether a user is following a category.
+     *
+     * @param int $userID The target user's ID.
+     * @param int $categoryID The target category's ID.
+     * @param bool|null $follow True for following. False for not following. Null for toggle.
+     * @return bool A boolean value representing the user's resulting "follow" status for the category.
+     */
+    public function follow($userID, $categoryID, $follow = null) {
+        $validationOptions = ['options' => [
+            'min_range' => 1
+        ]];
+        if (!($userID = filter_var($userID, FILTER_VALIDATE_INT, $validationOptions))) {
+            throw new InvalidArgumentException('Invalid $userID');
+        }
+        if (!($categoryID = filter_var($categoryID, FILTER_VALIDATE_INT, $validationOptions))) {
+            throw new InvalidArgumentException('Invalid $categoryID');
+        }
+
+        $category = static::categories($categoryID);
+        if (!is_array($category)) {
+            throw new InvalidArgumentException('Category not found.');
+        } elseif ($category['DisplayAs'] !== 'Discussions') {
+            throw new InvalidArgumentException('Category not configured to display as discussions.');
+        }
+
+        if ($follow === null) {
+            $follow = !$this->isFollowed($userID, $categoryID);
+        }
+        $follow = $follow ? 1 : 0;
+
+        $this->SQL->replace(
+            'UserCategory',
+            ['Follow' => $follow],
+            ['UserID' => $userID, 'CategoryID' => $categoryID]
+        );
+        static::clearUserCache();
+        Gdn::cache()->remove("Follow_{$userID}");
+
+        $result = $this->isFollowed($userID, $categoryID);
+        return $result;
+    }
+
+    /**
+     * Get the maximum number of categories a user is allowed to follow.
+     *
+     * @return mixed
+     */
+    public function getMaxFollowedCategories() {
+        $result = c('Vanilla.MaxFollowedCategories', self::MAX_FOLLOWED_CATEGORIES_DEFAULT);
+        return $result;
+    }
+    /**
+     * Is the specified user following the specified category?
+     *
+     * @param int $userID The target user's ID.
+     * @param int $categoryID The target category's ID.
+     * @return bool
+     */
+    public function isFollowed($userID, $categoryID) {
+        $followed = $this->getFollowed($userID);
+        $result = array_key_exists($categoryID, $followed);
+
+        return $result;
     }
 
     /**
@@ -514,10 +612,16 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * Clear the cached UserCategory data for a specific user.
      *
+     * @param int|null $userID The user to clear. Use `null` for the current user.
      */
-    public static function clearUserCache() {
-        $key = 'UserCategory_'.Gdn::session()->UserID;
+    public static function clearUserCache($userID = null) {
+        if ($userID === null) {
+            $userID = Gdn::session()->UserID;
+        }
+
+        $key = 'UserCategory_'.$userID;
         Gdn::cache()->remove($key);
     }
 

--- a/applications/vanilla/settings/configuration.php
+++ b/applications/vanilla/settings/configuration.php
@@ -50,3 +50,6 @@ $Configuration['Vanilla']['Modules']['ShowBookmarkedModule'] = false;
 
 // Allow users to delete their own comments if are still allowed to edit (per timeout).
 $Configuration['Vanilla']['Comments']['AllowSelfDelete'] = false;
+
+// Allow users to follow categories. Users will be able to see a feed of discussions of only their followed categories.
+$Configuration['Vanilla']['EnableCategoryFollowing'] = false;

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -164,8 +164,12 @@ $Construct->table('UserCategory')
     ->column('UserID', 'int', false, 'primary')
     ->column('CategoryID', 'int', false, 'primary')
     ->column('DateMarkedRead', 'datetime', null)
-    ->column('Unfollow', 'tinyint(1)', 0)
-    ->set($Explicit, $Drop);
+    ->column('Follow', 'tinyint(1)', 0);
+
+// This column should be removed when muting categories is dropped in favor of category following..
+$Construct->column('Unfollow', 'tinyint(1)', 0);
+
+$Construct->set($Explicit, $Drop);
 
 // Allows the tracking of relationships between discussions and users (bookmarks, dismissed announcements, # of read comments in a discussion, etc)
 // column($Name, $Type, $Length = '', $Null = FALSE, $Default = null, $KeyType = FALSE, $AutoIncrement = FALSE)

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -7,6 +7,8 @@
 
 namespace VanillaTests\APIv2;
 
+use CategoryModel;
+
 /**
  * Test the /api/v2/categories endpoints.
  */
@@ -78,6 +80,35 @@ class CategoriesTest extends AbstractResourceTest {
         ];
         static::$recordCounter++;
         return $record;
+    }
+
+
+    /**
+     * Test flagging (and unflagging) a category as followed by the current user.
+     */
+    public function testFollow() {
+        $record = $this->record();
+        $record['displayAs'] = 'discussions';
+        $row = $this->testPost($record);
+
+        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['follow' => true]);
+        $this->assertEquals(200, $follow->getStatusCode());
+        $followBody = $follow->getBody();
+        $this->assertTrue($followBody['follow']);
+
+        $index = $this->api()->get($this->baseUrl, ['parentCategoryID' => self::PARENT_CATEGORY_ID])->getBody();
+        $categories = array_column($index, null, 'categoryID');
+        $this->assertArrayHasKey($row['categoryID'], $categories);
+        $this->assertTrue($categories[$row['categoryID']]['follow']);
+
+        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['follow' => false]);
+        $this->assertEquals(200, $follow->getStatusCode());
+        $followBody = $follow->getBody();
+        $this->assertFalse($followBody['follow']);
+
+        $index = $this->api()->get($this->baseUrl, ['parentCategoryID' => self::PARENT_CATEGORY_ID])->getBody();
+        $categories = array_column($index, null, 'categoryID');
+        $this->assertFalse($categories[$row['categoryID']]['follow']);
     }
 
     /**


### PR DESCRIPTION
Vanilla currently has a version of category following that has all categories being "followed" by default. A user has to "mute" a category to unfollow it.

Vanilla will be moving away from its blacklist-style following and towards a whitelist-style. This update introduces selective category following, so a users choose what categories to follow, instead of which categories to unfollow. The specifics of the overall feature are outlined in #6026. The subset of functionality introduced here is only the core components for toggling a category followed or not by a user, getting a list of followed categories and determining if a category is followed by a user. Details can be found in the associated issue, #6397.

The `Vanilla.EnableCategoryFollowing` config is introduced here, defaulting to `false`, but not used. Subsequent UI portions of this feature will rely on this config.

*Note: The "mute" feature of Vanilla has already claimed fields with "follow" in the name (e.g. `Unfollow`, `Following`). Since we can't just rip out these fields, I've had to use fields that are relevant and but different. They might seem redundant (e.g. `Follow`, `Followed`).*

Closes #6397