### PR TITLE
Fix image upload button not always appearing in Advanced Editor

### DIFF
--- a/applications/dashboard/views/profile/activity.php
+++ b/applications/dashboard/views/profile/activity.php
@@ -12,7 +12,7 @@ if ($Session->isValid() && checkPermission('Garden.Profiles.Edit')) {
     echo '<div class="FormWrapper FormWrapper-Condensed">';
     echo $this->Form->open(['action' => url("/activity/post/{$this->User->UserID}?Target=".urlencode(userUrl($this->User))), 'class' => 'Activity']);
     echo $this->Form->errors();
-    echo $this->Form->bodyBox('Comment', ['Wrap' => TRUE]);
+    echo $this->Form->bodyBox('Comment', ['Wrap' => true, 'ImageUpload' => true]);
     echo '<div class="Buttons">';
     echo $this->Form->button($ButtonText, ['class' => 'Button Primary']);
     echo '</div>';

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -325,10 +325,12 @@ class EditorPlugin extends Gdn_Plugin {
         $editorToolbarAll = [];
         $allowedEditorActions = $this->getAllowedEditorActions();
         $allowedEditorActions['emoji'] = Emoji::instance()->hasEditorList();
-        if (val('FileUpload', $attributes) && $this->canUpload()) {
-            $allowedEditorActions['fileuploads'] = true;
-            $allowedEditorActions['imageuploads'] = true;
-            $allowedEditorActions['images'] = false;
+        $fileUpload = val('FileUpload', $attributes);
+        $imageUpload = $fileUpload || val('ImageUpload', $attributes);
+        if (($fileUpload || $imageUpload) && $this->canUpload()) {
+            $allowedEditorActions['fileuploads'] = $fileUpload;
+            $allowedEditorActions['imageuploads'] = $imageUpload;
+            $allowedEditorActions['images'] = !$imageUpload;
         }
         $fontColorList = $this->getFontColorList();
         $fontFormatOptions = $this->getFontFormatOptions();


### PR DESCRIPTION
Update the advanced editor so that image uploads can be activated without file upload.
Fixes https://github.com/vanilla/vanilla/issues/6374

Specifying FileUpload allows both file and image upload.
Specifying ImageUpload only allows image upload.