### PR TITLE
Remove format field from output in non-edit GET API requests

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -74,7 +74,11 @@ class CommentsApiController extends AbstractApiController {
     public function commentPostSchema($type = '') {
         if ($this->commentPostSchema === null) {
             $this->commentPostSchema = $this->schema(
-                Schema::parse(['body', 'format', 'discussionID'])->add($this->fullSchema()),
+                Schema::parse([
+                    'body',
+                    'format:s' => 'The input format of the comment.',
+                    'discussionID'
+                ])->add($this->fullSchema()),
                 'CommentPost'
             );
         }
@@ -138,7 +142,6 @@ class CommentsApiController extends AbstractApiController {
             'commentID:i' => 'The ID of the comment.',
             'discussionID:i' => 'The ID of the discussion.',
             'body:s' => 'The body of the comment.',
-            'format:s' => 'The input format of the comment.',
             'dateInserted:dt' => 'When the comment was created.',
             'dateUpdated:dt|n' => 'When the comment was last updated.',
             'insertUserID:i' => 'The user that created the comment.',
@@ -188,7 +191,12 @@ class CommentsApiController extends AbstractApiController {
         $this->permission('Garden.SignIn.Allow');
 
         $in = $this->idParamSchema()->setDescription('Get a comment for editing.');
-        $out = $this->schema(Schema::parse(['commentID', 'discussionID', 'body', 'format'])->add($this->fullSchema()), 'out');
+        $out = $this->schema(Schema::parse([
+            'commentID',
+            'discussionID',
+            'body',
+            'format:s' => 'The input format of the comment.',
+        ])->add($this->fullSchema()), 'out');
 
         $comment = $this->commentByID($id);
         $comment['Url'] = commentUrl($comment);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -135,8 +135,16 @@ class DiscussionsApiController extends AbstractApiController {
     public function discussionPostSchema($type = '') {
         if ($this->discussionPostSchema === null) {
             $this->discussionPostSchema = $this->schema(
-                Schema::parse(
-                    ['name', 'body', 'format', 'categoryID', 'closed?', 'sink?', 'pinned?', 'pinLocation?'])->add($this->fullSchema()),
+                Schema::parse([
+                    'name',
+                    'body',
+                    'format:s' => 'The input format of the discussion.',
+                    'categoryID',
+                    'closed?',
+                    'sink?',
+                    'pinned?',
+                    'pinLocation?',
+                ])->add($this->fullSchema()),
                 'DiscussionPost'
             );
         }
@@ -285,8 +293,18 @@ class DiscussionsApiController extends AbstractApiController {
 
         $this->idParamSchema()->setDescription('Get a discussion for editing.');
         $out = $this->schema(
-            Schema::parse(['discussionID', 'name', 'body', 'format', 'categoryID', 'sink', 'closed', 'pinned', 'pinLocation']
-        )->add($this->fullSchema()), ['DiscussionGetEdit', 'out']);
+            Schema::parse([
+                'discussionID',
+                'name',
+                'body',
+                'format:s' => 'The input format of the discussion.',
+                'categoryID',
+                'sink',
+                'closed',
+                'pinned',
+                'pinLocation',
+            ])->add($this->fullSchema()
+        ), ['DiscussionGetEdit', 'out']);
 
         $row = $this->discussionByID($id);
         $row['Url'] = discussionUrl($row);

--- a/applications/vanilla/controllers/api/DraftsApiController.php
+++ b/applications/vanilla/controllers/api/DraftsApiController.php
@@ -69,9 +69,11 @@ class DraftsApiController extends AbstractApiController {
 
         if (!isset($draftPostSchema)) {
             $draftPostSchema = $this->schema(
-                Schema::parse(
-                    ['recordType', 'parentRecordID?', 'attributes']
-                )->add($this->fullSchema()),
+                Schema::parse([
+                    'recordType',
+                    'parentRecordID?',
+                    'attributes'
+                ])->add($this->fullSchema()),
                 'DraftPost'
             );
         }
@@ -138,7 +140,11 @@ class DraftsApiController extends AbstractApiController {
         $this->permission('Garden.SignIn.Allow');
 
         $in = $this->idParamSchema('in')->setDescription('Get a draft for editing.');
-        $out = $this->schema(['draftID', 'parentRecordID', 'attributes'], 'out')->add($this->fullSchema());
+        $out = $this->schema([
+            'draftID',
+            'parentRecordID',
+            'attributes',
+        ], 'out')->add($this->fullSchema());
 
         $row = $this->draftByID($id);
         if ($row['InsertUserID'] !== $this->getSession()->UserID) {

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -26,6 +26,11 @@ abstract class AbstractAPIv2Test extends TestCase {
     private $startSessionOnSetup = true;
 
     /**
+     * @var array Fields that are getting formatted using the format column.
+     */
+    protected $formattedFields = ['body'];
+
+    /**
      * Whether to start a session on setUp() or not.
      *
      * @param bool $enabled
@@ -66,11 +71,17 @@ abstract class AbstractAPIv2Test extends TestCase {
         return $this->api;
     }
 
-    public function assertRowsEqual(array $expected, array $actual, $format = false) {
-        // Fix the body and format.
-        if ($format && array_key_exists('body', $expected) && array_key_exists('format', $expected)) {
-            $expected['body'] = \Gdn_Format::to($expected['body'], $expected['format']);
-            unset($expected['format']);
+    public function assertRowsEqual(array $expected, array $actual) {
+        // Fix formatted fields.
+        foreach([&$expected, &$actual] as &$row) {
+            if (array_intersect(array_keys($row), $this->formattedFields) && array_key_exists('format', $row)) {
+                foreach ($this->formattedFields as $field) {
+                    if (array_key_exists($field, $row)) {
+                        $row[$field] = \Gdn_Format::to($row[$field], $row['format']);
+                    }
+                }
+                unset($row['format']);
+            }
         }
 
         $actualSparse = [];

--- a/tests/APIv2/AbstractResourceTest.php
+++ b/tests/APIv2/AbstractResourceTest.php
@@ -105,7 +105,7 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
         $this->assertTrue(is_int($body[$this->pk]));
         $this->assertTrue($body[$this->pk] > 0);
 
-        $this->assertRowsEqual($record, $body, true);
+        $this->assertRowsEqual($record, $body);
 
         return $body;
     }
@@ -124,7 +124,7 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
 
         $this->assertEquals(200, $r->getStatusCode());
 
-        $this->assertRowsEqual($newRow, $r->getBody(), true);
+        $this->assertRowsEqual($newRow, $r->getBody());
 
         return $r->getBody();
     }

--- a/tests/APIv2/ConversationsTest.php
+++ b/tests/APIv2/ConversationsTest.php
@@ -234,7 +234,7 @@ class ConversationsTest extends AbstractAPIv2Test {
         $this->assertTrue(is_int($body[$this->pk]));
         $this->assertTrue($body[$this->pk] > 0);
 
-        $this->assertRowsEqual($expectedResult, $body, true);
+        $this->assertRowsEqual($expectedResult, $body);
 
         return $body;
     }

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -144,7 +144,7 @@ class UsersTest extends AbstractResourceTest {
         $newRow['photoUrl'] = $newRow['photo'];
         unset($newRow['photo']);
 
-        $this->assertRowsEqual($newRow, $r->getBody(), true);
+        $this->assertRowsEqual($newRow, $r->getBody());
 
         return $r->getBody();
     }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/6191

- Remove format for all record but get_edit()
- Allow the format to be applied to any records (not just body)