### PR TITLE
Fix unit tests not always disabling email capabilities before execution

### DIFF
--- a/tests/APIv2/ApplicantsTest.php
+++ b/tests/APIv2/ApplicantsTest.php
@@ -46,6 +46,7 @@ class ApplicantsTest extends AbstractResourceTest {
         $configuration->set('Garden.Registration.Method', 'Approval');
         $configuration->set('Garden.Registration.ConfirmEmail', false);
         $configuration->set('Garden.Registration.SkipCaptcha', true);
+        $configuration->set('Garden.Email.Disabled', true);
     }
 
     /**

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -248,6 +248,7 @@ class UsersTest extends AbstractResourceTest {
         $configuration->set('Garden.Registration.Method', 'Basic');
         $configuration->set('Garden.Registration.ConfirmEmail', false);
         $configuration->set('Garden.Registration.SkipCaptcha', true);
+        $configuration->set('Garden.Email.Disabled', true);
 
         $fields = $this->registrationFields();
         $this->verifyRegistration($fields);
@@ -262,6 +263,7 @@ class UsersTest extends AbstractResourceTest {
         $configuration->set('Garden.Registration.Method', 'Invitation');
         $configuration->set('Garden.Registration.ConfirmEmail', false);
         $configuration->set('Garden.Registration.SkipCaptcha', true);
+        $configuration->set('Garden.Email.Disabled', true);
 
         $fields = $this->registrationFields();
         $invitation = $this->api()->post('/invites', ['email' => $fields['email']])->getBody();


### PR DESCRIPTION
Fix the tests on my local machine. They were hanging while sending emails. The addresses are invalid anyway.