### PR TITLE
Add pagination information to API response headers

### DIFF
--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -211,7 +211,7 @@ class ConversationsApiController extends AbstractApiController {
      * @param int $id The ID of the conversation.
      * @param array $query The query string.
      * @throws NotFoundException if the conversation could not be found.
-     * @return array
+     * @return Data
      */
     public function get_participants($id, array $query) {
         $this->permission('Conversations.Conversations.Add');
@@ -268,14 +268,23 @@ class ConversationsApiController extends AbstractApiController {
         );
         $data = array_map([$this, 'normalizeParticipantOutput'], $data);
 
-        return $out->validate($data);
+        $result = $out->validate($data);
+
+        $paging = ApiUtils::numberedPagerInfo(
+            $this->conversationModel->getConversationMembersCount($id, $active),
+            "/api/v2/conversations/$id/participants",
+            $query,
+            $in
+        );
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**
      * List conversations of a user.
      *
      * @param array $query The query string.
-     * @return array
+     * @return Data
      */
     public function index(array $query) {
         $this->permission('Conversations.Conversations.Add');
@@ -337,7 +346,11 @@ class ConversationsApiController extends AbstractApiController {
         );
         $conversations = array_map([$this, 'normalizeOutput'], $conversations);
 
-        return $out->validate($conversations);
+        $result = $out->validate($conversations);
+
+        $paging = ApiUtils::morePagerInfo($result, '/api/v2/conversations', $query, $in);
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -162,7 +162,7 @@ class MessagesApiController extends AbstractApiController {
      * List messages of a user.
      *
      * @param array $query The query string.
-     * @return array
+     * @return Data
      */
     public function index(array $query) {
         $this->permission('Conversations.Conversations.Add');
@@ -236,7 +236,16 @@ class MessagesApiController extends AbstractApiController {
             $message = $this->normalizeOutput($message);
         });
 
-        return $out->validate($messages);
+        $result = $out->validate($messages);
+
+        $paging = ApiUtils::numberedPagerInfo(
+            $this->conversationMessageModel->getCountWhere($where),
+            '/api/v2/messages',
+            $query,
+            $in
+        );
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**

--- a/applications/conversations/models/class.conversationsmodel.php
+++ b/applications/conversations/models/class.conversationsmodel.php
@@ -99,6 +99,28 @@ abstract class ConversationsModel extends Gdn_Model {
     }
 
     /**
+     * Get the count of all the members of a conversation from the $conversationID.
+     *
+     * @param int $conversationID The conversation ID.
+     * @param bool|null $active **true** for active participants, **false** for users who have left the conversation and **null** for everyone.
+     *
+     * @return array Array of users or userIDs depending on $idsOnly's value.
+     */
+    public function getConversationMembersCount($conversationID, $active = null) {
+        $userConversation = new Gdn_Model('UserConversation');
+
+        $where = ['ConversationID' => $conversationID];
+
+        if ($active === true) {
+            $where['Deleted'] = 0;
+        } elseif ($active === false) {
+            $where['Deleted'] = 1;
+        }
+
+        return $userConversation->getCount($where);
+    }
+
+    /**
      * Check if user posting to the conversation is already a member.
      *
      * @param int $conversationID The conversation ID.

--- a/applications/dashboard/controllers/api/ApplicantsApiController.php
+++ b/applications/dashboard/controllers/api/ApplicantsApiController.php
@@ -123,7 +123,8 @@ class ApplicantsApiController extends AbstractApiController {
     /**
      * Get a list of current applicants.
      *
-     * @return array
+     * @param $query
+     * @return Data
      */
     public function index(array $query) {
         $this->permission('Garden.Users.Approve');
@@ -152,12 +153,13 @@ class ApplicantsApiController extends AbstractApiController {
         list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
         $rows = $this->userModel->getApplicants($limit, $offset)->resultArray();
 
-        foreach ($rows as &$row) {
-            $row = $this->normalizeOutput($row);
-        }
+        $rows = array_map([$this, 'normalizeOutput'], $rows);
 
         $result = $out->validate($rows);
-        return $result;
+
+        $paging = ApiUtils::numberedPagerInfo($this->userModel->getApplicantCount(), '/api/v2/applicants', $query, $in);
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**

--- a/applications/dashboard/controllers/api/InvitesApiController.php
+++ b/applications/dashboard/controllers/api/InvitesApiController.php
@@ -180,7 +180,7 @@ class InvitesApiController extends AbstractApiController {
 
         $result = $out->validate($rows);
 
-        $paging = ApiUtils::numberedPagerInfo($this->userModel->getInvitationCount($userID), '/api/v2/invites', $query, $in);
+        $paging = ApiUtils::numberedPagerInfo($this->invitationModel->getCount(['InsertUserID' => $userID]), '/api/v2/invites', $query, $in);
 
         return ApiUtils::setPageMeta($result, $paging);
     }

--- a/applications/dashboard/controllers/api/InvitesApiController.php
+++ b/applications/dashboard/controllers/api/InvitesApiController.php
@@ -133,7 +133,7 @@ class InvitesApiController extends AbstractApiController {
      * Get a list of invites for the current user.
      *
      * @param array $query The request query.
-     * @return array
+     * @return Data
      */
     public function index(array $query) {
         $this->permission('Garden.SignIn.Allow');
@@ -160,8 +160,10 @@ class InvitesApiController extends AbstractApiController {
         $query = $in->validate($query);
         list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
 
+        $userID = $this->getSession()->UserID;
+
         $rows = $this->invitationModel->getByUserID(
-            $this->getSession()->UserID,
+            $userID,
             '',
             $limit,
             $offset,
@@ -174,11 +176,13 @@ class InvitesApiController extends AbstractApiController {
             $this->resolveExpandFields($query, ['acceptedUser' => 'acceptedUserID'])
         );
 
-        foreach ($rows as &$row) {
-            $row = $this->normalizeOutput($row);
-        }
+        $rows = array_map([$this, 'normalizeOutput'], $rows);
+
         $result = $out->validate($rows);
-        return $result;
+
+        $paging = ApiUtils::numberedPagerInfo($this->userModel->getInvitationCount($userID), '/api/v2/invites', $query, $in);
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -5,6 +5,7 @@
  */
 
 use Garden\Schema\Schema;
+use Garden\Web\Data;
 use Garden\Web\Exception\ClientException;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -185,7 +185,7 @@ class CategoriesApiController extends AbstractApiController {
      * Search categories.
      *
      * @param array $query The query string.
-     * @return array
+     * @return Data
      */
     public function get_search(array $query) {
         $this->permission('Garden.SignIn.Allow');
@@ -226,7 +226,10 @@ class CategoriesApiController extends AbstractApiController {
         }
 
         $result = $out->validate($rows);
-        return $result;
+
+        $paging = ApiUtils::morePagerInfo($result, '/api/v2/comments', $query, $in);
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**
@@ -259,17 +262,23 @@ class CategoriesApiController extends AbstractApiController {
             'parentCategoryCode:s?' => 'Parent category URL code.',
             'followed:b' => [
                 'default' => false,
-                'description' => 'Only list categories followed by the current user.'
+                'description' => 'Only list categories followed by the current user.',
             ],
             'maxDepth:i?' => [
                 'description' => '',
-                'default' => 2
+                'default' => 2,
             ],
             'page:i?' => [
-                'description' => 'The page number for flat category displays.',
+                'description' => 'The page number. Works with flat and followed categories.',
                 'default' => 1,
                 'minimum' => 1,
-                'maximum' => $this->categoryModel->getMaxPages()
+                'maximum' => $this->categoryModel->getMaxPages(),
+            ],
+            'limit:i?' => [
+                'description' => 'The number of items per page.',
+                'default' => $this->categoryModel->getDefaultLimit(),
+                'minimum' => 1,
+                'maximum' => 100,
             ],
         ], 'in')->setDescription('List categories.');
         $out = $this->schema([':a' => $this->schemaWithChildren()], 'out');
@@ -286,7 +295,9 @@ class CategoriesApiController extends AbstractApiController {
 
         $joinUserCategory = $this->categoryModel->joinUserCategory();
         $this->categoryModel->setJoinUserCategory(true);
-        list($offset, $limit) = offsetLimit("p{$query['page']}", $this->categoryModel->getDefaultLimit());
+
+        list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
+
         if ($query['followed']) {
             $categories = $this->categoryModel
                 ->getWhere(['Followed' => true], '', 'asc', $limit, $offset)
@@ -297,12 +308,20 @@ class CategoriesApiController extends AbstractApiController {
             $categories = $this->categoryModel->flattenCategories($categories);
             // Reset indexes for proper output detection as an indexed array.
             $categories = array_values($categories);
+
+            $totalCountCallBack = function() {
+                return $this->categoryModel->getCount(['Followed' => true]);
+            };
         } elseif ($parent['DisplayAs'] === 'Flat') {
             $categories = $this->categoryModel->getTreeAsFlat(
                 $parent['CategoryID'],
                 $offset,
                 $limit
             );
+
+            $totalCountCallBack = function() use ($parent) {
+                return $parent['CountCategories'];
+            };
         } else {
             $categories = $this->categoryModel->getTree(
                 $parent['CategoryID'],
@@ -317,7 +336,15 @@ class CategoriesApiController extends AbstractApiController {
         $this->categoryModel->setJoinUserCategory($joinUserCategory);
         $categories = array_map([$this, 'normalizeOutput'], $categories);
 
-        return new Data($out->validate($categories));
+        $result = $out->validate($categories);
+
+        if (isset($totalCountCallBack)) {
+            $paging = ApiUtils::numberedPagerInfo($totalCountCallBack(), '/api/v2/categories', $query, $in);
+        } else {
+            $paging = [];
+        }
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -5,6 +5,7 @@
  */
 
 use Garden\Schema\Schema;
+use Garden\Web\Data;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\DateFilterSchema;
@@ -175,6 +176,7 @@ class CommentsApiController extends AbstractApiController {
 
         // Allow addons to modify the result.
         $result = $this->getEventManager()->fireFilter('commentsApiController_get_output', $result, $this, $in, $query, $comment);
+
         return $result;
     }
 
@@ -279,7 +281,14 @@ class CommentsApiController extends AbstractApiController {
 
         list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
 
-        $rows = $this->commentModel->lookup($where, true, $limit, $offset, 'asc')->resultArray();
+        $comments = $this->commentModel->lookup($where, true, $limit, $offset, 'asc');
+        $rows = $comments->resultArray();
+
+        if (isset($discussion) && count($where) === 1) {
+            $paging = ApiUtils::numberedPagerInfo($discussion['CountComments'], '/api/v2/comments', $query, $in);
+        } else {
+            $paging = ApiUtils::morePagerInfo(val('hasMore', $comments), '/api/v2/comments', $query, $in);
+        }
 
         // Expand associated rows.
         $this->userModel->expandUsers(
@@ -295,7 +304,7 @@ class CommentsApiController extends AbstractApiController {
 
         // Allow addons to modify the result.
         $result = $this->getEventManager()->fireFilter('commentsApiController_index_output', $result, $this, $in, $query, $rows);
-        return $result;
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -91,7 +91,10 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         $result = $out->validate($rows);
-        return new Data($result, ['paging' => ApiUtils::morePagerInfo($result, '/api/v2/discussions/bookmarked', $query, $in)]);
+
+        $paging = ApiUtils::morePagerInfo($result, '/api/v2/discussions/bookmarked', $query, $in);
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**
@@ -431,14 +434,6 @@ class DiscussionsApiController extends AbstractApiController {
             }
         }
 
-        if (empty($where) ||
-            (isset($where['d.CategoryID']) && (count($where) === 1 || (count($where) === 2 && isset($where['Announce']))))
-        ) {
-            $paging = ApiUtils::numberedPagerInfo($this->discussionModel->getCount($where), '/api/v2/discussions', $query, $in);
-        } else {
-            $paging = ApiUtils::morePagerInfo($rows, '/api/v2/discussions', $query, $in);
-        }
-
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
@@ -453,7 +448,16 @@ class DiscussionsApiController extends AbstractApiController {
 
         // Allow addons to modify the result.
         $result = $this->getEventManager()->fireFilter('discussionsApiController_index_output', $result, $this, $in, $query, $rows);
-        return new Data($result, ['paging' => $paging]);
+
+        $whereCount = count($where);
+        $isWhereOptimized = (isset($where['d.CategoryID']) && ($whereCount === 1 || ($whereCount === 2 && isset($where['Announce']))));
+        if ($whereCount === 0 || $isWhereOptimized) {
+            $paging = ApiUtils::numberedPagerInfo($this->discussionModel->getCount($where), '/api/v2/discussions', $query, $in);
+        } else {
+            $paging = ApiUtils::morePagerInfo($rows, '/api/v2/discussions', $query, $in);
+        }
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -6,6 +6,7 @@
  */
 
 use Garden\Schema\Schema;
+use Garden\Web\Data;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\DateFilterSchema;
@@ -49,7 +50,7 @@ class DiscussionsApiController extends AbstractApiController {
      * Get a list of the current user's bookmarked discussions.
      *
      * @param array $query The request query.
-     * @return array
+     * @return Data
      */
     public function get_bookmarked(array $query) {
         $this->permission('Garden.SignIn.Allow');
@@ -90,7 +91,7 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         $result = $out->validate($rows);
-        return $result;
+        return new Data($result, ['paging' => ApiUtils::morePagerInfo($result, '/api/v2/discussions/bookmarked', $query, $in)]);
     }
 
     /**
@@ -319,7 +320,7 @@ class DiscussionsApiController extends AbstractApiController {
      * List discussions.
      *
      * @param array $query The query string.
-     * @return array
+     * @return Data
      */
     public function index(array $query) {
         $this->permission();
@@ -405,6 +406,14 @@ class DiscussionsApiController extends AbstractApiController {
             }
         }
 
+        if (empty($where) ||
+            (isset($where['d.CategoryID']) && (count($where) === 1 || (count($where) === 2 && isset($where['Announce']))))
+        ) {
+            $paging = ApiUtils::numberedPagerInfo($this->discussionModel->getCount($where), '/api/v2/discussions', $query, $in);
+        } else {
+            $paging = ApiUtils::morePagerInfo($rows, '/api/v2/discussions', $query, $in);
+        }
+
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
@@ -419,7 +428,7 @@ class DiscussionsApiController extends AbstractApiController {
 
         // Allow addons to modify the result.
         $result = $this->getEventManager()->fireFilter('discussionsApiController_index_output', $result, $this, $in, $query, $rows);
-        return $result;
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/vanilla/controllers/api/DraftsApiController.php
+++ b/applications/vanilla/controllers/api/DraftsApiController.php
@@ -179,7 +179,7 @@ class DraftsApiController extends AbstractApiController {
      * List drafts created by the current user.
      *
      * @param array $query The query string.
-     * @return array
+     * @return Data
      */
     public function index(array $query) {
         $this->permission('Garden.SignIn.Allow');
@@ -236,7 +236,15 @@ class DraftsApiController extends AbstractApiController {
         }
 
         $result = $out->validate($rows);
-        return $result;
+
+        $paging = ApiUtils::numberedPagerInfo(
+            $this->draftModel->getCount($where),
+            '/api/v2/drafts',
+            $query,
+            $in
+        );
+
+        return ApiUtils::setPageMeta($result, $paging);
     }
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3503,7 +3503,7 @@ SQL;
         }
 
         $categories = $query->get()->resultArray();
-        L
+
         $result = [];
         foreach ($categories as $category) {
             self::calculate($category);

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2237,6 +2237,27 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getCount($wheres = '') {
+        if (array_key_exists('Followed', (array)$wheres)) {
+            if ($wheres['Followed']) {
+                $followed = $this->getFollowed(Gdn::session()->UserID);
+                $categoryIDs = array_column($followed, 'CategoryID');
+
+                if (isset($wheres['CategoryID'])) {
+                    $wheres['CategoryID'] = array_values(array_intersect((array)$wheres['CategoryID'], $categoryIDs));
+                } else {
+                    $wheres['CategoryID'] = $categoryIDs;
+                }
+            }
+            unset($wheres['Followed']);
+        }
+
+        return parent::getCount($wheres);
+    }
+
+    /**
      * A simplified version of GetWhere that polls the cache instead of the database.
      * @param array $where
      * @return array
@@ -3482,6 +3503,7 @@ SQL;
         }
 
         $categories = $query->get()->resultArray();
+        L
         $result = [];
         foreach ($categories as $category) {
             self::calculate($category);

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -490,6 +490,7 @@ class CommentModel extends Gdn_Model {
         }
         $result = $query->get();
         $data =& $result->result();
+        $this->LastCommentCount = $result->numRows();
 
         // Filter out any comments this user does not have access to.
         if ($permissionFilter && $perms !== true) {

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -89,12 +89,12 @@ class ApiUtils {
             'links' => []
         ];
 
-        $r['links']['first'] = sprintf($r['urlFormat'], 1);
+        $r['links']['first'] = str_replace('%s', 1, $r['urlFormat']);
         if ($r['page'] > 1) {
-            $r['links']['prev'] = $r['page'] > 2 ? sprintf($r['urlFormat'], $r['page'] - 1) : $r['links']['first'];
+            $r['links']['prev'] = $r['page'] > 2 ? str_replace('%s', $r['page'] - 1, $r['urlFormat']) : $r['links']['first'];
         }
         if ($r['more']) {
-            $r['links']['next'] = sprintf($r['urlFormat'], $r['page'] + 1);
+            $r['links']['next'] = str_replace('%s', $r['page'] + 1, $r['urlFormat']);
         }
 
         return $r;
@@ -118,13 +118,13 @@ class ApiUtils {
             'links' => []
         ];
 
-        $r['links']['first'] = sprintf($r['urlFormat'], 1);
-        $r['links']['last'] = sprintf($r['urlFormat'], $r['pageCount']);
+        $r['links']['first'] = str_replace('%s', 1, $r['urlFormat']);
+        $r['links']['last'] = str_replace('%s', $r['pageCount'], $r['urlFormat']);
         if ($r['page'] > 1) {
-            $r['links']['prev'] = $r['page'] > 2 ? sprintf($r['urlFormat'], $r['page'] - 1) : $r['links']['first'];
+            $r['links']['prev'] = $r['page'] > 2 ? str_replace('%s', $r['page'] - 1, $r['urlFormat']) : $r['links']['first'];
         }
         if ($r['page'] < $r['pageCount']) {
-            $r['links']['next'] = sprintf($r['urlFormat'], $r['page'] + 1);
+            $r['links']['next'] = str_replace('%s', $r['page'] + 1, $r['urlFormat']);
         }
 
         return $r;
@@ -145,6 +145,7 @@ class ApiUtils {
      * Calculate a pager URL format.
      *
      * This method passes through all of the non-default arguments from a query string to the resulting URL.
+     * Note that the returned URL is not compatible with printf due to URL encoding.
      *
      * @param string $url The basic URL format without querystring.
      * @param array $query The current query string.

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -145,7 +145,7 @@ class ApiUtils {
             $argsStr = 'page=%s'.(empty($argsStr) ? '' : '&'.$argsStr);
         }
         if (!empty($argsStr)) {
-            $url = (strpos($url, '?') === false ? '?' : '&').$argsStr;
+            $url .= (strpos($url, '?') === false ? '?' : '&').$argsStr;
         }
         return $url;
     }

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -112,4 +112,21 @@ abstract class AbstractAPIv2Test extends TestCase {
             }
         }
     }
+
+    /**
+     * Test paging on a resource. Must have at least 2 records.
+     *
+     * @param $resourceUrl
+     */
+    protected function pagingTest($resourceUrl) {
+        $pagingTestUrl = $resourceUrl.(strpos($resourceUrl, '?') === false ? '?' : '&').'limit=1';
+
+        $result = $this->api()->get($pagingTestUrl);
+        $this->assertNotEmpty($result->getHeader('Paging-First'));
+        $this->assertNotEmpty($result->getHeader('Paging-Next'));
+
+        $result = $this->api()->get(str_replace('/api/v2', '', $result->getHeader('Paging-Next')));
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertEquals(1, count($result->getBody()));
+    }
 }

--- a/tests/APIv2/AbstractResourceTest.php
+++ b/tests/APIv2/AbstractResourceTest.php
@@ -23,6 +23,9 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
     /** @var array Fields to be checked with get/<id>/edit */
     protected $editFields = ['name', 'body', 'format'];
 
+    /** @var bool Whether to check if paging works or not in the index. */
+    protected $testPagingOnIndex = true;
+
     /**
      * @var string The singular name of the resource.
      */
@@ -310,6 +313,10 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
         // The index should be a proper indexed array.
         for ($i = 0; $i < count($newRows); $i++) {
             $this->assertArrayHasKey($i, $newRows);
+        }
+
+        if ($this->testPagingOnIndex) {
+            $this->pagingTest($indexUrl);
         }
 
         // There's not much we can really test here so just return and let subclasses do some more assertions.

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -38,6 +38,9 @@ class CategoriesTest extends AbstractResourceTest {
     /** {@inheritdoc} */
     protected $singular = 'category';
 
+    /** {@inheritdoc} */
+    protected $testPagingOnIndex = false;
+
     /**
      * {@inheritdoc}
      */

--- a/tests/APIv2/RolesTest.php
+++ b/tests/APIv2/RolesTest.php
@@ -26,6 +26,7 @@ class RolesTest extends AbstractResourceTest {
             'canSession' => true,
             'personalInfo' => false
         ];
+        $this->testPagingOnIndex = false;
 
         parent::__construct($name, $data, $dataName);
     }


### PR DESCRIPTION
Addresses EOF problem of https://github.com/vanilla/vanilla/issues/6069

Add the ApiUtils::setPageMeta() function which update/create a data object with meta/header information about paging.

- [x] /discussions
- [x] /discussions/bookmarked
- [x] /comments
- [x] /conversations
- [x] /conversations/participants
- [x] /messages
- [x] /categories
- [x] /categories/search
- [x] /applicants
- [x] /invites
- [x] /users
- [x] /drafts