### PR TITLE
Add followed category filtering to discussions and categories API endpoints

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -134,7 +134,7 @@ class CategoriesApiController extends AbstractApiController {
             'countComments:i' => 'Total comments in the category.',
             'countAllDiscussions:i' => 'Total of all discussions in a category and its children.',
             'countAllComments:i' => 'Total of all comments in a category and its children.',
-            'follow:b?' => 'Is the category being followed by the current user?'
+            'followed:b?' => 'Is the category being followed by the current user?'
         ]);
     }
 
@@ -389,7 +389,7 @@ class CategoriesApiController extends AbstractApiController {
     public function put_follow($id, array $body) {
         $this->permission('Garden.SignIn.Allow');
 
-        $schema = ['follow:b' => 'The category-follow status for the current user.'];
+        $schema = ['followed:b' => 'The category-follow status for the current user.'];
         $in = $this->schema($schema);
         $out = $this->schema($schema);
 
@@ -399,17 +399,17 @@ class CategoriesApiController extends AbstractApiController {
         $followed = $this->categoryModel->getFollowed($userID);
 
         // Is this a new follow?
-        if ($body['follow'] && !array_key_exists($id, $followed)) {
+        if ($body['followed'] && !array_key_exists($id, $followed)) {
             $this->permission('Vanilla.Discussions.View', $category['PermissionCategoryID']);
             if (count($followed) >= $this->categoryModel->getMaxFollowedCategories()) {
                 throw new ClientException('Already following the maximum number of categories.');
             }
         }
 
-        $this->categoryModel->follow($userID, $id, $body['follow']);
+        $this->categoryModel->follow($userID, $id, $body['followed']);
 
         $result = $out->validate([
-            'follow' => $this->categoryModel->isFollowed($userID, $id)
+            'followed' => $this->categoryModel->isFollowed($userID, $id)
         ]);
         return $result;
     }

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -289,8 +289,12 @@ class CategoriesApiController extends AbstractApiController {
             $categories = $this->categoryModel
                 ->getWhere(['Followed' => true], '', 'asc', $limit, $offset)
                 ->resultArray();
-            $categories = array_values($categories);
+
+            // Index by ID for category calculation functions.
+            $categories = array_column($categories, null, 'CategoryID');
             $categories = $this->categoryModel->flattenCategories($categories);
+            // Reset indexes for proper output detection as an indexed array.
+            $categories = array_values($categories);
         } elseif ($parent['DisplayAs'] === 'Flat') {
             $categories = $this->categoryModel->getTreeAsFlat(
                 $parent['CategoryID'],

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -345,6 +345,10 @@ class DiscussionsApiController extends AbstractApiController {
                     'processor' => [DateFilterSchema::class, 'dateFilterField'],
                 ],
             ]),
+            'followed:b' => [
+                'default' => false,
+                'description' => 'Only fetch discussions from followed categories. Pinned discussions are mixed in.'
+            ],
             'pinned:b?' => 'Whether or not to include pinned discussions. If true, only return pinned discussions. Cannot be used with the pinOrder parameter.',
             'pinOrder:s?' => [
                 'default' => 'first',
@@ -387,12 +391,15 @@ class DiscussionsApiController extends AbstractApiController {
         // Allow addons to update the where clause.
         $where = $this->getEventManager()->fireFilter('discussionsApiController_index_filters', $where, $this, $in, $query);
 
+        if ($query['followed']) {
+            $where['Followed'] = true;
+            $query['pinOrder'] = 'mixed';
+        }
+
         $pinned = array_key_exists('pinned', $query) ? $query['pinned'] : null;
         if ($pinned === true) {
             $announceWhere = array_merge($where, ['d.Announce >' => '0']);
             $rows = $this->discussionModel->getAnnouncements($announceWhere, $offset, $limit)->resultArray();
-        } elseif ($pinned === false) {
-            $rows = $this->discussionModel->getWhereRecent($where, $limit, $offset, false)->resultArray();
         } else {
             $pinOrder = array_key_exists('pinOrder', $query) ? $query['pinOrder'] : null;
             if ($pinOrder == 'first') {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -229,7 +229,7 @@ class CategoryModel extends Gdn_Model {
             $following = !((bool)val('Archived', $category) || (bool)val('Unfollow', $userData, false));
             $category['Following'] = $following;
 
-            $category['Follow'] = boolval($userData['Follow']);
+            $category['Followed'] = boolval($userData['Followed']);
 
             // Calculate the read field.
             if (strcasecmp($category['DisplayAs'], 'heading') === 0) {
@@ -310,7 +310,7 @@ class CategoryModel extends Gdn_Model {
 
             $userData = $sql->getWhere('UserCategory', [
                 'UserID' => $userID,
-                'Follow' => 1
+                'Followed' => 1
             ])->resultArray();
             $result = array_column($userData, null, 'CategoryID');
             Gdn::cache()->store($key, $result);
@@ -324,10 +324,10 @@ class CategoryModel extends Gdn_Model {
      *
      * @param int $userID The target user's ID.
      * @param int $categoryID The target category's ID.
-     * @param bool|null $follow True for following. False for not following. Null for toggle.
+     * @param bool|null $followed True for following. False for not following. Null for toggle.
      * @return bool A boolean value representing the user's resulting "follow" status for the category.
      */
-    public function follow($userID, $categoryID, $follow = null) {
+    public function follow($userID, $categoryID, $followed = null) {
         $validationOptions = ['options' => [
             'min_range' => 1
         ]];
@@ -339,10 +339,10 @@ class CategoryModel extends Gdn_Model {
         }
 
         $isFollowed = $this->isFollowed($userID, $categoryID);
-        if ($follow === null) {
-            $follow = !$isFollowed;
+        if ($followed === null) {
+            $followed = !$isFollowed;
         }
-        $follow = $follow ? 1 : 0;
+        $followed = $followed ? 1 : 0;
 
         $category = static::categories($categoryID);
         if (!is_array($category)) {
@@ -353,7 +353,7 @@ class CategoryModel extends Gdn_Model {
 
         $this->SQL->replace(
             'UserCategory',
-            ['Follow' => $follow],
+            ['Followed' => $followed],
             ['UserID' => $userID, 'CategoryID' => $categoryID]
         );
         static::clearUserCache();
@@ -1643,7 +1643,7 @@ class CategoryModel extends Gdn_Model {
                 $following = !((bool)val('Archived', $category) || (bool)val('Unfollow', $row, false));
                 $categories[$iD]['Following'] = $following;
 
-                $categories[$iD]['Follow'] = boolval($row['Follow']);
+                $categories[$iD]['Followed'] = boolval($row['Followed']);
 
                 // Calculate the read field.
                 if ($category['DisplayAs'] == 'Heading') {

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -718,6 +718,21 @@ class DiscussionModel extends Gdn_Model {
             $sql->orderBy($this->addFieldPrefix($field), $direction);
         }
 
+        if (array_key_exists('Followed', $where)) {
+            if ($where['Followed']) {
+                $categoryModel = new CategoryModel();
+                $followed = $categoryModel->getFollowed(Gdn::session()->UserID);
+                $categoryIDs = array_column($followed, 'CategoryID');
+
+                if (isset($where['d.CategoryID'])) {
+                    $where['d.CategoryID'] = array_values(array_intersect((array)$where['d.CategoryID'], $categoryIDs));
+                } else {
+                    $where['d.CategoryID'] = $categoryIDs;
+                }
+            }
+            unset($where['Followed']);
+        }
+
         if ($perms !== true) {
             if (isset($where['d.CategoryID'])) {
                 $where['d.CategoryID'] = array_values(array_intersect((array)$where['d.CategoryID'], $perms));
@@ -1174,6 +1189,21 @@ class DiscussionModel extends Gdn_Model {
         }
 
         $this->discussionSummaryQuery([], false);
+
+        if (array_key_exists('Followed', $wheres)) {
+            if ($wheres['Followed']) {
+                $categoryModel = new CategoryModel();
+                $followed = $categoryModel->getFollowed(Gdn::session()->UserID);
+                $categoryIDs = array_column($followed, 'CategoryID');
+
+                if (isset($wheres['d.CategoryID'])) {
+                    $wheres['d.CategoryID'] = array_values(array_intersect((array)$wheres['d.CategoryID'], $categoryIDs));
+                } else {
+                    $wheres['d.CategoryID'] = $categoryIDs;
+                }
+            }
+            unset($wheres['Followed']);
+        }
 
         if (!empty($wheres)) {
             $this->SQL->where($wheres);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1190,21 +1190,6 @@ class DiscussionModel extends Gdn_Model {
 
         $this->discussionSummaryQuery([], false);
 
-        if (array_key_exists('Followed', $wheres)) {
-            if ($wheres['Followed']) {
-                $categoryModel = new CategoryModel();
-                $followed = $categoryModel->getFollowed(Gdn::session()->UserID);
-                $categoryIDs = array_column($followed, 'CategoryID');
-
-                if (isset($wheres['d.CategoryID'])) {
-                    $wheres['d.CategoryID'] = array_values(array_intersect((array)$wheres['d.CategoryID'], $categoryIDs));
-                } else {
-                    $wheres['d.CategoryID'] = $categoryIDs;
-                }
-            }
-            unset($wheres['Followed']);
-        }
-
         if (!empty($wheres)) {
             $this->SQL->where($wheres);
         }

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -164,7 +164,7 @@ $Construct->table('UserCategory')
     ->column('UserID', 'int', false, 'primary')
     ->column('CategoryID', 'int', false, 'primary')
     ->column('DateMarkedRead', 'datetime', null)
-    ->column('Follow', 'tinyint(1)', 0);
+    ->column('Followed', 'tinyint(1)', 0);
 
 // This column should be removed when muting categories is dropped in favor of category following..
 $Construct->column('Unfollow', 'tinyint(1)', 0);

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -120,6 +120,22 @@ class CategoriesTest extends AbstractResourceTest {
     }
 
     /**
+     * Test getting a list of followed categories.
+     */
+    public function testIndexFollowed() {
+        // Make sure we're starting from scratch.
+        $preFollow = $this->api()->get($this->baseUrl, ['followed' => true])->getBody();
+        $this->assertEmpty($preFollow);
+
+        // Follow. Make sure we're following.
+        $testCategoryID = self::PARENT_CATEGORY_ID;
+        $this->api()->put("{$this->baseUrl}/{$testCategoryID}/follow", ['follow' => true]);
+        $postFollow = $this->api()->get($this->baseUrl, ['followed' => true])->getBody();
+        $this->assertCount(1, $postFollow);
+        $this->assertEquals($testCategoryID, $postFollow[0]['categoryID']);
+    }
+
+    /**
      * Ensure moving a category actually moves it and updates the new parent's category count.
      */
     public function testMove() {

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -90,24 +90,24 @@ class CategoriesTest extends AbstractResourceTest {
         $record['displayAs'] = 'discussions';
         $row = $this->testPost($record);
 
-        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['follow' => true]);
+        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['followed' => true]);
         $this->assertEquals(200, $follow->getStatusCode());
         $followBody = $follow->getBody();
-        $this->assertTrue($followBody['follow']);
+        $this->assertTrue($followBody['followed']);
 
         $index = $this->api()->get($this->baseUrl, ['parentCategoryID' => self::PARENT_CATEGORY_ID])->getBody();
         $categories = array_column($index, null, 'categoryID');
         $this->assertArrayHasKey($row['categoryID'], $categories);
-        $this->assertTrue($categories[$row['categoryID']]['follow']);
+        $this->assertTrue($categories[$row['categoryID']]['followed']);
 
-        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['follow' => false]);
+        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['followed' => false]);
         $this->assertEquals(200, $follow->getStatusCode());
         $followBody = $follow->getBody();
-        $this->assertFalse($followBody['follow']);
+        $this->assertFalse($followBody['followed']);
 
         $index = $this->api()->get($this->baseUrl, ['parentCategoryID' => self::PARENT_CATEGORY_ID])->getBody();
         $categories = array_column($index, null, 'categoryID');
-        $this->assertFalse($categories[$row['categoryID']]['follow']);
+        $this->assertFalse($categories[$row['categoryID']]['followed']);
     }
 
     /**
@@ -129,7 +129,7 @@ class CategoriesTest extends AbstractResourceTest {
 
         // Follow. Make sure we're following.
         $testCategoryID = self::PARENT_CATEGORY_ID;
-        $this->api()->put("{$this->baseUrl}/{$testCategoryID}/follow", ['follow' => true]);
+        $this->api()->put("{$this->baseUrl}/{$testCategoryID}/follow", ['followed' => true]);
         $postFollow = $this->api()->get($this->baseUrl, ['followed' => true])->getBody();
         $this->assertCount(1, $postFollow);
         $this->assertEquals($testCategoryID, $postFollow[0]['categoryID']);
@@ -248,25 +248,25 @@ class CategoriesTest extends AbstractResourceTest {
         $record['displayAs'] = 'discussions';
         $row = $this->testPost($record);
 
-        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['follow' => true]);
+        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['followed' => true]);
         $this->assertEquals(200, $follow->getStatusCode());
         $followBody = $follow->getBody();
-        $this->assertTrue($followBody['follow']);
+        $this->assertTrue($followBody['followed']);
 
         $index = $this->api()->get($this->baseUrl, ['parentCategoryID' => self::PARENT_CATEGORY_ID])->getBody();
         $categories = array_column($index, null, 'categoryID');
         $this->assertArrayHasKey($row['categoryID'], $categories);
-        $this->assertTrue($categories[$row['categoryID']]['follow']);
+        $this->assertTrue($categories[$row['categoryID']]['followed']);
 
         $this->api()->patch("{$this->baseUrl}/{$row[$this->pk]}", ['displayAs' => 'categories']);
 
-        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['follow' => false]);
+        $follow = $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/follow", ['followed' => false]);
         $this->assertEquals(200, $follow->getStatusCode());
         $followBody = $follow->getBody();
-        $this->assertFalse($followBody['follow']);
+        $this->assertFalse($followBody['followed']);
 
         $index = $this->api()->get($this->baseUrl, ['parentCategoryID' => self::PARENT_CATEGORY_ID])->getBody();
         $categories = array_column($index, null, 'categoryID');
-        $this->assertFalse($categories[$row['categoryID']]['follow']);
+        $this->assertFalse($categories[$row['categoryID']]['followed']);
     }
 }

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -114,7 +114,7 @@ class DiscussionsTest extends AbstractResourceTest {
             'urlcode' => __FUNCTION__
         ]);
         $testCategoryID = $category['categoryID'];
-        $this->api()->put("categories/{$testCategoryID}/follow", ['follow' => true]);
+        $this->api()->put("categories/{$testCategoryID}/follow", ['followed' => true]);
 
         // Add some discussions
         $totalDiscussions = 3;

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -101,6 +101,40 @@ class DiscussionsTest extends AbstractResourceTest {
     }
 
     /**
+     * Test getting a list of discussions from followed categories.
+     */
+    public function testIndexFollowed() {
+        // Make sure we're starting from scratch.
+        $preFollow = $this->api()->get($this->baseUrl, ['followed' => true])->getBody();
+        $this->assertEmpty($preFollow);
+
+        // Create a new category to follow.
+        $category = $this->api()->post("categories", [
+            'name' => __FUNCTION__,
+            'urlcode' => __FUNCTION__
+        ]);
+        $testCategoryID = $category['categoryID'];
+        $this->api()->put("categories/{$testCategoryID}/follow", ['follow' => true]);
+
+        // Add some discussions
+        $totalDiscussions = 3;
+        $record = $this->record();
+        $record['categoryID'] = $testCategoryID;
+        for ($i = 1; $i <= $totalDiscussions; $i++) {
+            $this->testPost($record);
+        }
+
+        // See if we have any discussions.
+        $postFollow = $this->api()->get($this->baseUrl, ['followed' => true])->getBody();
+        $this->assertCount($totalDiscussions, $postFollow);
+
+        // Make sure discussions are only from the followed category.
+        $categoryIDs = array_unique(array_column($postFollow, 'categoryID'));
+        $this->assertCount(1, $categoryIDs);
+        $this->assertEquals($testCategoryID, $categoryIDs[0]);
+    }
+
+    /**
      * Test PATCH /discussions/<id> with a a single field update.
      *
      * @param string $field The name of the field to patch.


### PR DESCRIPTION
This update adds filtering for followed categories to the discussions and categories API indexes. Here's an overview of the included changes:

1. The `UserCategory.Follow` field has been renamed to `UserCategory.Followed`. The original naming was done to be similar to the muting field, but this doesn't make sense with the rest of Vanilla's naming standards. Flags are almost always past-tense.
1. Added filtering for followed categories to the discussions API index.
1. Added tests for filtering in the discussions API index to followed categories.
1. Added filtering for followed categories to the categories API index.
1. Added tests for filtering in the categories API index to only those flagged as followed by the current user.
1. Updated `DiscussionModel::getWhere` to support a "Followed" flag in the `$where` parameter.
1. Updated `CategoryModel::getWhere` to support a "Followed" flag in the `$where` parameter.
1. Added `CategoryModel::flattenCategories` to interpret a category result set as a flat tree.

Closes #6398 
Closes #6399 