### PR TITLE
Fix category cache being polluted between tests

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -300,6 +300,8 @@ class Bootstrap {
      * @param Container $container The container to clean up.
      */
     public static function cleanup(Container $container) {
+        \CategoryModel::$Categories = null;
+
         if ($container->hasInstance(AddonManager::class)) {
             /* @var AddonManager $addonManager */
 


### PR DESCRIPTION
Can cause problems when running the full test suite with some other plugins.