### PR TITLE
Fix category follow elements displaying where they should not

### DIFF
--- a/applications/vanilla/views/categories/all.php
+++ b/applications/vanilla/views/categories/all.php
@@ -9,10 +9,8 @@ if ($description = $this->description()) {
     echo wrap($description, 'div', ['class' => 'P PageDescription']);
 }
 $this->fireEvent('AfterPageTitle');
-if (c('Vanilla.EnableCategoryFollowing')) {
-    echo '<div class="PageControls Top">';
-    echo categoryFilters();
-    echo '</div>';
+if (!$this->data('Category') && c('Vanilla.EnableCategoryFollowing')) {
+    echo '<div class="PageControls Top">'.categoryFilters().'</div>';
 }
 $categories = $this->data('CategoryTree');
 writeCategoryList($categories, 1);

--- a/applications/vanilla/views/categories/flat_all.php
+++ b/applications/vanilla/views/categories/flat_all.php
@@ -6,7 +6,7 @@
     $categoryID = $this->Category->CategoryID;
 ?>
 
-<h1 class="H HomepageTitle"><?php echo $this->data('Title').followButton($categoryID); ?></h1>
+<h1 class="H HomepageTitle"><?php echo $this->data('Title'); ?></h1>
 
 <?php
     if ($description = $this->description()) {

--- a/applications/vanilla/views/categories/flat_table.php
+++ b/applications/vanilla/views/categories/flat_table.php
@@ -2,7 +2,7 @@
 $userID = Gdn::session()->UserID;
 $categoryID = $this->Category->CategoryID;
 ?>
-    <h1 class="H HomepageTitle"><?php echo $this->data('Title').followButton($categoryID); ?></h1>
+    <h1 class="H HomepageTitle"><?php echo $this->data('Title'); ?></h1>
     <div class="P PageDescription"><?php echo $this->description(); ?></div>
 <?php
 $this->fireEvent('AfterDescription');

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -75,7 +75,7 @@ if (!function_exists('getOptions')):
 
         $dropdown->addLink(t('Mark Read'), "/category/markread?categoryid={$categoryID}&tkey={$tk}", 'mark-read');
 
-        if (c('Vanilla.EnableCategoryFollowing')) {
+        if (c('Vanilla.EnableCategoryFollowing') && val('DisplayAs', $category) == 'Discussions') {
             $dropdown->addLink(
                 t($followed ? 'Unfollow' : 'Follow'),
                 "/category/followed?tkey={$tk}&categoryid={$categoryID}&value=" . ($followed ? 0 : 1),
@@ -446,7 +446,7 @@ if (!function_exists('followButton')) :
         $userID = Gdn::session()->UserID;
         $category = CategoryModel::categories($categoryID);
 
-        if (c('Vanilla.EnableCategoryFollowing') && $userID && $category && strtolower($category['DisplayAs']) == 'discussions') {
+        if (c('Vanilla.EnableCategoryFollowing') && $userID && $category && $category['DisplayAs'] == 'Discussions') {
             $categoryModel = new CategoryModel();
             $following = $categoryModel->isFollowed($userID, $categoryID);
 

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -444,8 +444,9 @@ if (!function_exists('followButton')) :
     function followButton($categoryID) {
         $output = ' ';
         $userID = Gdn::session()->UserID;
+        $category = CategoryModel::categories($categoryID);
 
-        if ($categoryID && c('Vanilla.EnableCategoryFollowing') && $userID) {
+        if (c('Vanilla.EnableCategoryFollowing') && $userID && $category && strtolower($category['DisplayAs']) == 'discussions') {
             $categoryModel = new CategoryModel();
             $following = $categoryModel->isFollowed($userID, $categoryID);
 

--- a/applications/vanilla/views/categories/table.php
+++ b/applications/vanilla/views/categories/table.php
@@ -7,10 +7,8 @@ $categoryID = isset($this->Category) ? $this->Category->CategoryID : null;
 <?php
 $this->fireEvent('AfterDescription');
 $this->fireEvent('AfterPageTitle');
-if (c('Vanilla.EnableCategoryFollowing')) {
-    echo '<div class="PageControls Top">';
-    echo categoryFilters();
-    echo '</div>';
+if (!$this->data('Category') && c('Vanilla.EnableCategoryFollowing')) {
+    echo '<div class="PageControls Top">'.categoryFilters().'</div>';
 }
 $categories = $this->data('CategoryTree');
 writeCategoryTable($categories);


### PR DESCRIPTION
The category follow buttons and filter menus were displaying in a couple areas where they shouldn't have been. The follow button was appearing on category rows and in category page titles where the category was not setup to display as "Discussions". The filter menu was sometimes appearing on non-root category index pages.