### PR TITLE
Add followed category filtering to mixed category layout

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -587,6 +587,10 @@ class CategoriesController extends VanillaController {
             $Subtree = CategoryModel::getSubtree($Category, false);
             $CategoryIDs = array_column($Subtree, 'CategoryID');
             $Categories = $this->CategoryModel->getFull($CategoryIDs)->resultArray();
+        } elseif ($this->data('Followed')) {
+            $Categories = $this->CategoryModel->getWhere(['Followed' => true])->resultArray();
+            $Categories = array_column($Categories, null, 'CategoryID');
+            $Categories = $this->CategoryModel->flattenCategories($Categories);
         } else {
             $Categories = $this->CategoryModel->getFull()->resultArray();
         }

--- a/applications/vanilla/views/categories/discussions.php
+++ b/applications/vanilla/views/categories/discussions.php
@@ -1,5 +1,8 @@
 <?php if (!defined('APPLICATION')) exit();
 echo '<h1 class="H HomepageTitle">'.$this->data('Title').'</h1>';
+if (!$this->data('Category') && c('Vanilla.EnableCategoryFollowing')) {
+    echo '<div class="PageControls Top">'.categoryFilters().'</div>';
+}
 $ViewLocation = $this->fetchViewLocation('discussions', 'discussions');
 ?>
 <div class="Categories">


### PR DESCRIPTION
This update adds the "Following" filter menu to the mixed category layout for filtering to followed categories.