### PR TITLE
Fix stuck category permission checks after enabling caching

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -255,7 +255,8 @@ class UserModel extends Gdn_Model {
         // Grab the permissions for the user.
         if ($user->UserID == 0) {
             $permissions = $this->getPermissions(0);
-        } elseif (is_array($user->Permissions)) {
+        } elseif (!Gdn::cache()->activeEnabled() && is_array($user->Permissions)) {
+            // Only attempt to use the DB field value if permissions aren't being cached elsewhere.
             $permissions = new Vanilla\Permissions($user->Permissions);
         } else {
             $permissions = $this->getPermissions($user->UserID);


### PR DESCRIPTION
When caching is disabled, Vanilla stores a copy of the user's current permissions in the `User.Permissions` column. When caching is enabled, permissions are read and stored in the caching system. If you enable caching after the site has been running for a bit, there's a good chance the `User.Permissions` column will be populated with old permissions. In most cases this doesn't matter, because the field is not used for any authorization. The exception to this rule seems to be `UserModel::checkPermission`, which [uses the `Permissions` column of a user row to validate permissions, if it is a valid array](https://github.com/vanilla/vanilla/blob/7213c8ed8fcbc8598173b30fc1baf0e8358620db/applications/dashboard/models/class.usermodel.php#L258).

This update is a minimal fix: only use the `User.Permissions` column if caching is disabled.

As always, since this is a change to permission checks (even though it's a small one), please test thoroughly.

Closes #6359