### PR TITLE
Add breadcrumb meta

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -344,7 +344,13 @@ class CategoriesApiController extends AbstractApiController {
             $paging = [];
         }
 
-        return ApiUtils::setPageMeta($result, $paging);
+        $data = ApiUtils::setPageMeta($result, $paging);
+
+        if (!empty($query['parentCategoryID'])) {
+            $data->setMeta('breadcrumbs', $this->categoryModel->getApiBreadcrumbs($query['parentCategoryID']));
+        }
+
+        return $data;
     }
 
     /**

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -458,7 +458,10 @@ class DiscussionsApiController extends AbstractApiController {
         $isWhereOptimized = (isset($where['d.CategoryID']) && ($whereCount === 1 || ($whereCount === 2 && isset($where['Announce']))));
         if ($whereCount === 0 || $isWhereOptimized) {
             $paging = ApiUtils::numberedPagerInfo($this->discussionModel->getCount($where), '/api/v2/discussions', $query, $in);
-            $breadcrumbs = $this->categoryModel->getApiBreadcrumbs($where['d.CategoryID']);
+
+            if (!empty($query['categoryID'])) {
+                $breadcrumbs = $this->categoryModel->getApiBreadcrumbs($query['categoryID']);
+            }
         } else {
             $paging = ApiUtils::morePagerInfo($rows, '/api/v2/discussions', $query, $in);
         }

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -260,7 +260,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             // Now that the controller has been found, dispatch to a method on it.
             $this->dispatchController($request, $routeArgs);
         } else {
-            $response->render();
+            $this->dispatcher->render($request, $response);
         }
     }
 


### PR DESCRIPTION
The breadcrumb meta is meant to be used in the API and controllers when data-driven breadcrumbs are desired.