### PR TITLE
Fix filter menus showing for guests on Recent Discussions and categories root

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -416,6 +416,10 @@ if (!function_exists('categoryFilters')) {
      * @return string
      */
     function categoryFilters($extraClasses = '') {
+        if (!Gdn::session()->isValid()) {
+            return;
+        }
+
         $baseUrl = url('categories');
         $filters = [['name' => 'Following', 'param' => 'followed']];
 
@@ -707,6 +711,10 @@ if (!function_exists('discussionFilters')) {
      * @return string
      */
     function discussionFilters($extraClasses = '') {
+        if (!Gdn::session()->isValid()) {
+            return;
+        }
+
         $baseUrl = url('discussions');
         $filters = [['name' => 'Following', 'param' => 'followed']];
 


### PR DESCRIPTION
This update adds a condition to `categoryFilters` and `discussionFilters` to avoid displaying these menus if there is no valid session for the user (i.e. the user is not signed in).

Closes #6492