### PR TITLE
Add "none found" message to category pages with no categories

### DIFF
--- a/applications/vanilla/views/categories/discussions.php
+++ b/applications/vanilla/views/categories/discussions.php
@@ -6,36 +6,40 @@ if (!$this->data('Category') && c('Vanilla.EnableCategoryFollowing')) {
 $ViewLocation = $this->fetchViewLocation('discussions', 'discussions');
 ?>
 <div class="Categories">
-    <?php foreach ($this->CategoryData->result() as $Category) :
-        if ($Category->CategoryID <= 0)
-            continue;
+    <?php if ($this->CategoryData->numRows() > 0): ?>
+        <?php foreach ($this->CategoryData->result() as $Category) :
+            if ($Category->CategoryID <= 0)
+                continue;
 
-        $this->Category = $Category;
-        $this->DiscussionData = $this->CategoryDiscussionData[$Category->CategoryID];
+            $this->Category = $Category;
+            $this->DiscussionData = $this->CategoryDiscussionData[$Category->CategoryID];
 
-        if ($this->DiscussionData->numRows() > 0) : ?>
+            if ($this->DiscussionData->numRows() > 0) : ?>
 
-            <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">
-                <?php echo getOptions($Category); ?>
-                <h2 class="H"><?php
-                    echo anchor(htmlspecialchars($Category->Name), categoryUrl($Category));
-                    Gdn::controller()->EventArguments['Category'] = $Category;
-                    Gdn::controller()->fireEvent('AfterCategoryTitle');
-                    ?></h2>
+                <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">
+                    <?php echo getOptions($Category); ?>
+                    <h2 class="H"><?php
+                        echo anchor(htmlspecialchars($Category->Name), categoryUrl($Category));
+                        Gdn::controller()->EventArguments['Category'] = $Category;
+                        Gdn::controller()->fireEvent('AfterCategoryTitle');
+                        ?></h2>
 
-                <ul class="DataList Discussions">
-                    <?php include($this->fetchViewLocation('discussions', 'discussions')); ?>
-                </ul>
+                    <ul class="DataList Discussions">
+                        <?php include($this->fetchViewLocation('discussions', 'discussions')); ?>
+                    </ul>
 
-                <?php if ($this->DiscussionData->numRows() == $this->DiscussionsPerCategory) : ?>
-                    <div class="MorePager">
-                        <?php echo anchor(t('More Discussions'), '/categories/'.$Category->UrlCode); ?>
-                    </div>
-                <?php endif; ?>
+                    <?php if ($this->DiscussionData->numRows() == $this->DiscussionsPerCategory) : ?>
+                        <div class="MorePager">
+                            <?php echo anchor(t('More Discussions'), '/categories/'.$Category->UrlCode); ?>
+                        </div>
+                    <?php endif; ?>
 
-            </div>
+                </div>
 
-        <?php endif; ?>
+            <?php endif; ?>
 
-    <?php endforeach; ?>
+        <?php endforeach; ?>
+    <?php else: ?>
+        <div class="Empty"><?php echo t('No categories were found.'); ?></div>
+    <?php endif; ?>
 </div>

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -354,6 +354,11 @@ if (!function_exists('writeCategoryList')):
      * @param int $depth
      */
     function writeCategoryList($categories, $depth = 1) {
+        if (empty($categories)) {
+            echo '<div class="Empty">'.t('No categories were found.').'</div>';
+            return;
+        }
+
         ?>
         <div class="DataListWrap">
             <ul class="DataList CategoryList">
@@ -370,6 +375,11 @@ endif;
 
 if (!function_exists('writeCategoryTable')):
     function writeCategoryTable($categories, $depth = 1, $inTable = false) {
+        if (empty($categories)) {
+            echo '<div class="Empty">'.t('No categories were found.').'</div>';
+            return;
+        }
+
         foreach ($categories as $category) {
             $displayAs = val('DisplayAs', $category);
             $urlCode = $category['UrlCode'];


### PR DESCRIPTION
If a category page had no categories to show, the content area was empty. No feedback was given. This update adds a "No categories were found" message to the page, similar to the message seen on discussion pages, when no categories are able to be displayed. This is particularly apparent when you attempt to view followed categories, but aren't actually following any categories.

Closes #6500