### PR TITLE
Fix scrolling to top of embed iframe if not in the viewport

### DIFF
--- a/js/embed.js
+++ b/js/embed.js
@@ -163,7 +163,7 @@ window.vanilla.embed = function(host) {
         } else if (message[0] == 'unload') {
             // Scroll to the top of the IFRAME if the top position is not in the view.
             var currentScrollAmount = (window.pageYOffset || document.documentElement.scrollTop);
-            if (scrollPosition('vanilla' + id) - currentScrollAmount < 0) {
+            if (offsetFromTop('vanilla' + id) - currentScrollAmount < 0) {
                 document.getElementById('vanilla' + id).scrollIntoView(true);
             }
 
@@ -178,7 +178,7 @@ window.vanilla.embed = function(host) {
         }
     }
 
-    scrollPosition = function(id) {
+    offsetFromTop = function(id) {
         var node = document.getElementById(id),
             top = 0,
             topScroll = 0;

--- a/js/embed.js
+++ b/js/embed.js
@@ -161,7 +161,9 @@ window.vanilla.embed = function(host) {
                 }
             }
         } else if (message[0] == 'unload') {
-            if (window.attachEvent || scrollPosition('vanilla' + id) < 0) {
+            // Scroll to the top of the IFRAME if the top position is not in the view.
+            var currentScrollAmount = (window.pageYOffset || document.documentElement.scrollTop);
+            if (scrollPosition('vanilla' + id) - currentScrollAmount < 0) {
                 document.getElementById('vanilla' + id).scrollIntoView(true);
             }
 

--- a/js/embed.js
+++ b/js/embed.js
@@ -163,8 +163,9 @@ window.vanilla.embed = function(host) {
         } else if (message[0] == 'unload') {
             // Scroll to the top of the IFRAME if the top position is not in the view.
             var currentScrollAmount = (window.pageYOffset || document.documentElement.scrollTop);
-            if (offsetFromTop('vanilla' + id) - currentScrollAmount < 0) {
-                document.getElementById('vanilla' + id).scrollIntoView(true);
+            var offsetTop = offsetFromTop('vanilla' + id);
+            if (offsetTop - currentScrollAmount < 0) {
+                window.scrollTo(0, offsetTop);
             }
 
             iframe.style.visibility = "hidden";


### PR DESCRIPTION
- window.attachEvent is an IE only feature so I removed the call.
- scrollPosition() actually returns the offsetFromTop where top is the top of the document.

The intended behaviour is that when you click a link you on a link and the top of the iframe is not in the viewport of the browser there should be a "Scroll" top action so that the iframe top position is a the top of the viewport.
If the top of the iframe is in (or below since you shouldn't be able to click on something then) the viewport nothing should happen. 