### PR TITLE
Backport: Avoid using null coalescing operator in Gdn_Format

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1397,7 +1397,7 @@ class Gdn_Format {
 
         $urlParts = parse_url($url);
 
-        parse_str($urlParts['query'] ?? '', $query);
+        parse_str(val('query', $urlParts,  ''), $query);
         // There's the possibility the query string could be encoded, resulting in parameters that begin with "amp;"
         foreach ($query as $key => $val) {
             $newKey = stringBeginsWith($key, 'amp;', false, true);


### PR DESCRIPTION
Backport of #6526

> For the sake of being able to backport a recent fix, this update removes usage of the null coalescing operator from Gdn_Format.