### PR TITLE
Removed back links from comment form

### DIFF
--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -43,16 +43,16 @@ $this->fireEvent('BeforeCommentForm');
                         $CancelClass = 'Cancel';
                     }
 
-                    echo '<span class="'.$CancelClass.'">';
-                    echo anchor($CancelText, '/');
-                    $CategoryID = $this->data('Discussion.CategoryID');
-                    if (c('Vanilla.Categories.Use', true) && $CategoryID) {
-                        $Category = CategoryModel::categories($CategoryID);
-                        if ($Category) {
-                            echo ' <span class="Bullet">•</span> '.anchor(htmlspecialchars($Category['Name']), categoryUrl($Category));
-                        }
-                    }
-                    echo '</span>';
+//                    echo '<span class="'.$CancelClass.'">';
+//                    echo anchor($CancelText, '/');
+//                    $CategoryID = $this->data('Discussion.CategoryID');
+//                    if (c('Vanilla.Categories.Use', true) && $CategoryID) {
+//                        $Category = CategoryModel::categories($CategoryID);
+//                        if ($Category) {
+//                            echo ' <span class="Bullet">•</span> '.anchor(htmlspecialchars($Category['Name']), categoryUrl($Category));
+//                        }
+//                    }
+//                    echo '</span>';
 
                     $ButtonOptions = ['class' => 'Button Primary CommentButton'];
                     $ButtonOptions['tabindex'] = 1;


### PR DESCRIPTION
The back links for comments are sometimes broken and are often hidden by themes. We've just removed them from Vanilla.

Closes https://github.com/vanilla/vanilla/pull/6516