### PR TITLE
Update API to use Web Linking

### DIFF
--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -6,6 +6,7 @@
  */
 
 use Garden\Schema\Schema;
+use Garden\Web\Data;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\Exception\ConfigurationException;

--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -277,7 +277,7 @@ class ConversationsApiController extends AbstractApiController {
             $in
         );
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**
@@ -350,7 +350,7 @@ class ConversationsApiController extends AbstractApiController {
 
         $paging = ApiUtils::morePagerInfo($result, '/api/v2/conversations', $query, $in);
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -245,7 +245,7 @@ class MessagesApiController extends AbstractApiController {
             $in
         );
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -6,6 +6,7 @@
  */
 
 use Garden\Schema\Schema;
+use Garden\Web\Data;
 use Garden\Web\Exception\ClientException;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;

--- a/applications/dashboard/controllers/api/ApplicantsApiController.php
+++ b/applications/dashboard/controllers/api/ApplicantsApiController.php
@@ -159,7 +159,7 @@ class ApplicantsApiController extends AbstractApiController {
 
         $paging = ApiUtils::numberedPagerInfo($this->userModel->getApplicantCount(), '/api/v2/applicants', $query, $in);
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/dashboard/controllers/api/InvitesApiController.php
+++ b/applications/dashboard/controllers/api/InvitesApiController.php
@@ -182,7 +182,7 @@ class InvitesApiController extends AbstractApiController {
 
         $paging = ApiUtils::numberedPagerInfo($this->invitationModel->getCount(['InsertUserID' => $userID]), '/api/v2/invites', $query, $in);
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -268,7 +268,7 @@ class UsersApiController extends AbstractApiController {
             $paging = ApiUtils::morePagerInfo($result, '/api/v2/users', $query, $in);
         }
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
 
     }
 

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -229,7 +229,7 @@ class CategoriesApiController extends AbstractApiController {
 
         $paging = ApiUtils::morePagerInfo($result, '/api/v2/comments', $query, $in);
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**
@@ -344,7 +344,7 @@ class CategoriesApiController extends AbstractApiController {
             $paging = [];
         }
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -314,7 +314,7 @@ class CommentsApiController extends AbstractApiController {
             $paging = ApiUtils::morePagerInfo($hasMore, '/api/v2/comments', $query, $in);
         }
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -94,7 +94,7 @@ class DiscussionsApiController extends AbstractApiController {
 
         $paging = ApiUtils::morePagerInfo($result, '/api/v2/discussions/bookmarked', $query, $in);
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**
@@ -457,7 +457,7 @@ class DiscussionsApiController extends AbstractApiController {
             $paging = ApiUtils::morePagerInfo($rows, '/api/v2/discussions', $query, $in);
         }
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/vanilla/controllers/api/DraftsApiController.php
+++ b/applications/vanilla/controllers/api/DraftsApiController.php
@@ -244,7 +244,7 @@ class DraftsApiController extends AbstractApiController {
             $in
         );
 
-        return ApiUtils::setPageMeta($result, $paging);
+        return new Data($result, ['paging' => $paging]);
     }
 
     /**

--- a/applications/vanilla/controllers/api/DraftsApiController.php
+++ b/applications/vanilla/controllers/api/DraftsApiController.php
@@ -5,6 +5,7 @@
  */
 
 use Garden\Schema\Schema;
+use Garden\Web\Data;
 use Garden\Web\Exception\NotFoundException;
 use Vanilla\ApiUtils;
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -150,6 +150,10 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->setConstructorArgs(['/api/v2/', '*\\%sApiController'])
     ->addCall('setMeta', ['CONTENT_TYPE', 'application/json; charset=utf-8'])
 
+    ->rule('@view-application/json')
+    ->setClass(\Vanilla\Web\JsonView::class)
+    ->setShared(true)
+
     ->rule(\Garden\ClassLocator::class)
     ->setClass(\Vanilla\VanillaClassLocator::class)
 
@@ -184,6 +188,10 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->setShared(true)
 
     ->rule('Smarty')
+    ->setShared(true)
+
+    ->rule('WebLinking')
+    ->setClass(\Vanilla\Web\WebLinking::class)
     ->setShared(true)
 
     ->rule('ViewHandler.tpl')

--- a/library/Garden/Web/Data.php
+++ b/library/Garden/Web/Data.php
@@ -240,12 +240,14 @@ class Data implements \JsonSerializable, \ArrayAccess, \Countable, \IteratorAggr
     public function render() {
         http_response_code($this->getStatus());
 
-        if (!$this->hasHeader('Content-Type')) {
-            header('Content-Type: application/json; charset=utf-8', true);
-        }
-        foreach ($this->getHeaders() as $name => $value) {
-            foreach ((array)$value as $line) {
-                header("$name: $line");
+        if (!headers_sent()) {
+            if (!$this->hasHeader('Content-Type')) {
+                header('Content-Type: application/json; charset=utf-8', true);
+            }
+            foreach ($this->getHeaders() as $name => $value) {
+                foreach ((array)$value as $line) {
+                    header("$name: $line");
+                }
             }
         }
 

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -82,22 +82,11 @@ class ApiUtils {
     public static function morePagerInfo($rows, $url, array $query, Schema $schema) {
         $count = is_array($rows) ? count($rows) : $rows;
 
-        $r = [
+        return [
             'page' => $query['page'] ?: 1,
             'more' => $count === true || $count >= $query['limit'],
             'urlFormat' => static::pagerUrlFormat($url, $query, $schema),
-            'links' => []
         ];
-
-        $r['links']['first'] = str_replace('%s', 1, $r['urlFormat']);
-        if ($r['page'] > 1) {
-            $r['links']['prev'] = $r['page'] > 2 ? str_replace('%s', $r['page'] - 1, $r['urlFormat']) : $r['links']['first'];
-        }
-        if ($r['more']) {
-            $r['links']['next'] = str_replace('%s', $r['page'] + 1, $r['urlFormat']);
-        }
-
-        return $r;
     }
 
     /**
@@ -110,24 +99,12 @@ class ApiUtils {
      * @return array Returns an array suitable to generate a pager.
      */
     public static function numberedPagerInfo($totalCount, $url, array $query, Schema $schema) {
-        $r = [
+        return [
             'page' => $query['page'] ?: 1,
             'pageCount' => static::pageCount($totalCount, $query['limit']),
             'urlFormat' => static::pagerUrlFormat($url, $query, $schema),
             'totalCount' => $totalCount, // For regenerating with different URL.
-            'links' => []
         ];
-
-        $r['links']['first'] = str_replace('%s', 1, $r['urlFormat']);
-        $r['links']['last'] = str_replace('%s', $r['pageCount'], $r['urlFormat']);
-        if ($r['page'] > 1) {
-            $r['links']['prev'] = $r['page'] > 2 ? str_replace('%s', $r['page'] - 1, $r['urlFormat']) : $r['links']['first'];
-        }
-        if ($r['page'] < $r['pageCount']) {
-            $r['links']['next'] = str_replace('%s', $r['page'] + 1, $r['urlFormat']);
-        }
-
-        return $r;
     }
 
     /**

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -150,27 +150,6 @@ class ApiUtils {
     }
 
     /**
-     * Add paging information to API results.
-     *
-     * @param array|Data $data The results returned by the API.
-     * @param array $pagingInfo Paging information.
-     * @return Data
-     */
-    public static function setPageMeta($data, $pagingInfo) {
-        if (!($data instanceof Data)) {
-            $data = new Data($data);
-        }
-
-        if (!$pagingInfo) {
-            return $data;
-        }
-
-        $data->setMeta('paging', $pagingInfo);
-
-        return $data;
-    }
-
-    /**
      * Convert query parameters to filters. Useful to fill a where clause ;)
      *
      * @throws \Exception If something goes wrong. Example, the field processor is not callable.

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -190,10 +190,6 @@ class ApiUtils {
 
         $data->setMeta('paging', $pagingInfo);
 
-        foreach($pagingInfo['links'] as $key => $value) {
-            $data->setHeader('Paging-'.ucfirst($key), $value);
-        }
-
         return $data;
     }
 

--- a/library/Vanilla/Web/JsonView.php
+++ b/library/Vanilla/Web/JsonView.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace Vanilla\Web;
+
+use Garden\Web\ViewInterface;
+use Garden\Web\Data;
+
+/**
+ * Class JsonView
+ */
+class JsonView implements ViewInterface {
+
+    /** @var WebLinking */
+    private $webLinking;
+
+    /**
+     * JsonView constructor.
+     *
+     * @param WebLinking $webLinking
+     */
+    public function __construct(WebLinking $webLinking) {
+        $this->webLinking = $webLinking;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render(Data $data) {
+
+        $paging = $data->getMeta('paging', []);
+
+        foreach(($paging['links'] ?? []) as $relType => $uri) {
+            $this->webLinking->addLink($relType, $uri);
+        }
+
+        $data->setHeader('Link', $this->webLinking->getLinkHeaderValue());
+
+        echo $data->render();
+    }
+}

--- a/library/Vanilla/Web/JsonView.php
+++ b/library/Vanilla/Web/JsonView.php
@@ -31,11 +31,24 @@ class JsonView implements ViewInterface {
      * {@inheritdoc}
      */
     public function render(Data $data) {
+        $paging = $data->getMeta('paging');
 
-        $paging = $data->getMeta('paging', []);
+        // Handle pagination.
+        if ($paging) {
+            $hasPageCount = isset($paging['pageCount']);
 
-        foreach(($paging['links'] ?? []) as $relType => $uri) {
-            $this->webLinking->addLink($relType, $uri);
+            $firstPageUrl = str_replace('%s', 1, $paging['urlFormat']);
+            $this->webLinking->addLink('first', $firstPageUrl);
+            if ($paging['page'] > 1) {
+                $prevPageUrl = $paging['page'] > 2 ? str_replace('%s', $paging['page'] - 1, $paging['urlFormat']) : $firstPageUrl;
+                $this->webLinking->addLink('prev', $prevPageUrl);
+            }
+            if (($paging['more'] ?? false) || ($hasPageCount && $paging['page'] < $paging['pageCount'])) {
+                $this->webLinking->addLink('next', str_replace('%s', $paging['page'] + 1, $paging['urlFormat']));
+            }
+            if ($hasPageCount) {
+                $this->webLinking->addLink('last', str_replace('%s', $paging['pageCount'], $paging['urlFormat']));
+            }
         }
 
         $data->setHeader('Link', $this->webLinking->getLinkHeaderValue());

--- a/library/Vanilla/Web/WebLinking.php
+++ b/library/Vanilla/Web/WebLinking.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace Vanilla\Web;
+
+/**
+ * Class WebLinking
+ */
+class WebLinking {
+
+    /** @var array */
+    private $links = [];
+
+    /**
+     * Add a link.
+     *
+     * @link http://tools.ietf.org/html/rfc5988
+     * @link http://www.iana.org/assignments/link-relations/link-relations.xml
+     *
+     * @param string $uri Target URI for the link.
+     * @param string $rel Link relation. Either an IANA registered type, or an absolute URL.
+     * @param array $attributes Link parameters.
+     * @return WebLinking
+     */
+    public function addLink($rel, $uri, $attributes = []) {
+        if (empty($this->links[$rel])) {
+            $this->links[$rel] = [];
+        }
+
+        $this->links[$rel][] = [
+            'uri' => $uri,
+            'attributes' => $attributes,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Remove a link.
+     *
+     * @param string $rel Link relation. Either an IANA registered type, or an absolute URL.
+     * @param string $uri Target URI for the link.
+     */
+    public function removeLink($rel, $uri = null) {
+        if (!isset($this->links[$rel])) {
+            return;
+        }
+
+        if ($uri !== null) {
+            $this->links[$rel] = array_filter($this->links[$rel], function($element) use ($uri) {
+                return $element['uri'] !== $uri;
+            });
+        } else {
+            $this->links[$rel] = [];
+        }
+
+        if (!$this->links[$rel]) {
+            unset($this->links[$rel]);
+        }
+    }
+
+    /**
+     * Return link header string.
+     *
+     * @return string|null
+     */
+    public function getLinkHeader() {
+        $headerValue = $this->getLinkHeaderValue();
+        return $headerValue ? 'Link: '.$headerValue : null;
+    }
+
+    /**
+     * return link header value.
+     */
+    public function getLinkHeaderValue() {
+        $results = [];
+
+        foreach ($this->links as $rel => $links) {
+            foreach ($links as $data) {
+                $parameters = '';
+                foreach ($data['attributes'] as $param => $value) {
+                    $parameters .= "; $param=\"$value\"";
+                }
+                $results[] = "<{$data['uri']}>; rel=\"$rel\"$parameters";
+            }
+        }
+
+        return implode(", ", $results);
+    }
+
+    /**
+     * Clear added links.
+     * @return WebLinking
+     */
+    public function clear() {
+        $this->links = [];
+        return $this;
+    }
+}

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -120,12 +120,15 @@ abstract class AbstractAPIv2Test extends TestCase {
      */
     protected function pagingTest($resourceUrl) {
         $pagingTestUrl = $resourceUrl.(strpos($resourceUrl, '?') === false ? '?' : '&').'limit=1';
+        $resourcePath = parse_url($resourceUrl, PHP_URL_PATH);
 
         $result = $this->api()->get($pagingTestUrl);
-        $this->assertNotEmpty($result->getHeader('Paging-First'));
-        $this->assertNotEmpty($result->getHeader('Paging-Next'));
+        $link = $result->getHeader('Link');
+        $this->assertNotEmpty($link);
+        $this->assertTrue(preg_match('/<([^;]*?'.preg_quote($resourcePath, '/').'[^>]+)>; rel="first"/', $link) === 1);
+        $this->assertTrue(preg_match('/<([^;]*?'.preg_quote($resourcePath, '/').'[^>]+)>; rel="next"/', $link, $matches) === 1);
 
-        $result = $this->api()->get(str_replace('/api/v2', '', $result->getHeader('Paging-Next')));
+        $result = $this->api()->get(str_replace('/api/v2', '', $matches[1]));
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertEquals(1, count($result->getBody()));
     }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -189,6 +189,11 @@ class Bootstrap {
             ->setClass(\Garden\Web\ResourceRoute::class)
             ->setConstructorArgs(['/api/v2/', '%sApiController'])
             ->addCall('setConstraint', ['locale', ['position' => 0]])
+            ->addCall('setMeta', ['CONTENT_TYPE', 'application/json; charset=utf-8'])
+
+            ->rule('@view-application/json')
+            ->setClass(\Vanilla\Web\JsonView::class)
+            ->setShared(true)
 
             ->rule(\Garden\ClassLocator::class)
             ->setClass(\Vanilla\VanillaClassLocator::class)
@@ -200,6 +205,10 @@ class Bootstrap {
             ->rule(\Vanilla\FileUtils::class)
             ->setAliasOf(\VanillaTests\Fixtures\FileUtils::class)
             ->addAlias('FileUtils')
+
+            ->rule('WebLinking')
+            ->setClass(\Vanilla\Web\WebLinking::class)
+            ->setShared(true)
         ;
     }
 

--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -131,8 +131,13 @@ class InternalRequest extends HttpRequest implements RequestInterface {
                 $cookies[$key] = rawurldecode($val);
             }
         }
+
         $_COOKIE = $cookies;
         $data = $this->dispatcher->dispatch($this);
+        // Render the view in case it updates the Data object.
+        ob_start();
+            $this->dispatcher->render($this->container->get(\Gdn_Request::class), $data);
+        ob_end_clean();
         $_COOKIE = $cookieStash;
 
         $response = new HttpResponse(

--- a/tests/Library/Vanilla/Web/WebLinkingTest.php
+++ b/tests/Library/Vanilla/Web/WebLinkingTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests\Library\Vanilla\Utility;
+
+use PHPUnit\Framework\TestCase;
+use Vanilla\Web\WebLinking;
+
+class WebLinkingTest extends TestCase {
+
+    /** @var WebLinking */
+    private $webLinking;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp() {
+        $this->webLinking = new WebLinking();
+    }
+
+    /**
+     * Test: Add a basic link.
+     */
+    public function testAddLink() {
+        $this->webLinking->addLink('next', '/nextPage');
+
+        $this->assertEquals('Link: </nextPage>; rel="next"', $this->webLinking->getLinkHeader());
+    }
+
+    /**
+     * Test: Add multiple basic link.
+     */
+    public function testAddLinks() {
+        $this->webLinking->addLink('next', '/nextPage');
+        $this->webLinking->addLink('prev', '/prevPage');
+
+        $this->assertEquals('Link: </nextPage>; rel="next", </prevPage>; rel="prev"', $this->webLinking->getLinkHeader());
+    }
+
+    /**
+     * Test: Add link with attributes.
+     */
+    public function testAddLinkWExtraAttributes() {
+        $this->webLinking->addLink('prev', 'http://example.com/TheBook/chapter2', ['title' => 'previous chapter']);
+
+        $this->assertEquals(
+            'Link: <http://example.com/TheBook/chapter2>; rel="prev"; title="previous chapter"',
+            $this->webLinking->getLinkHeader()
+        );
+    }
+
+    /**
+     * Test: Add an URI as a relation.
+     */
+    public function testAddURIRel() {
+        $this->webLinking->addLink('http://example.net/foo', '/');
+
+        $this->assertEquals(
+            'Link: </>; rel="http://example.net/foo"',
+            $this->webLinking->getLinkHeader()
+        );
+    }
+
+    /**
+     * Test: Remove a link.
+     */
+    public function testRemoveLink() {
+        $this->webLinking->addLink('next', '/nextPage');
+        $this->webLinking->addLink('prev', '/prevPage');
+        $this->webLinking->removeLink('prev', '/prevPage');
+
+        $this->assertEquals(
+            'Link: </nextPage>; rel="next"',
+            $this->webLinking->getLinkHeader()
+        );
+    }
+
+    /**
+     * Test: Remove all link specified by a relation.
+     */
+    public function testRemoveLinksByRel() {
+        $this->webLinking->addLink('next', '/nextPage');
+        $this->webLinking->addLink('next', '/nextPageToo');
+        $this->webLinking->removeLink('next');
+
+        $this->assertEmpty($this->webLinking->getLinkHeader());
+    }
+
+    /**
+     * Test: Clear all links from the object.
+     */
+    public function testClearLinks() {
+        $this->webLinking->addLink('next', '/nextPage');
+        $this->webLinking->addLink('next', '/nextPageToo');
+        $this->webLinking->clear();
+
+        $this->assertEmpty($this->webLinking->getLinkHeader());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/6480

- Add a basic class to handle Web Linking
   - This class can be used application wise to add links. The new JsonView uses it to add the relevant header to the Data object before rendering it. Our old Head module can do the same thing.
- Create a custom view that allow to transform Data->meta to headers
- Remove setPageMeta function from APIUtils since it does basically nothing now. (Do not forget to merge https://github.com/vanilla/internal/pull/1385 too)