### PR TITLE
Don’t unset records in joinRecords() if unset is false

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2103,7 +2103,13 @@ if (!function_exists('joinRecords')) {
                 // Check to see if the user has permission to view this record.
                 $categoryID = getValue('CategoryID', $record, -1);
                 if (!in_array($categoryID, $allowedCats)) {
-                    $unsets[] = $index;
+                    if ($unset) {
+                        $unsets[] = $index;
+                    } else {
+                        $row['RecordType'] = null;
+                        $row['RecordID'] = null;
+                        unset($row['RecordBody'], $row['RecordFormat']);
+                    }
                     continue;
                 }
             }


### PR DESCRIPTION
If the user does not have permission to the record then just don’t join the record and unset the link as if there is no join.