### PR TITLE
Fix admin permission not being reset between tests

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -425,6 +425,8 @@ class Gdn_Session {
             return;
         }
 
+        $this->permissions = new Permissions();
+
         // Retrieve the authenticated UserID from the Authenticator module.
         $userModel = Gdn::authenticator()->getUserModel();
         $this->UserID = $userID !== false ? $userID : Gdn::authenticator()->getIdentity();

--- a/tests/APIv2/Authenticate/AutoConnectTest.php
+++ b/tests/APIv2/Authenticate/AutoConnectTest.php
@@ -110,6 +110,9 @@ class AutoConnectTest extends AbstractAPIv2Test {
             $this->assertArrayHasKey('authSessionID', $body);
         }
 
+        // Start the session as the current user to do the verification.
+        $this->api()->setUserID($this->currentUser['userID']);
+
         $result = $this->api()->get(
             $this->baseUrl.'/'.$this->authenticator->getName().'/'.$this->authenticator->getID()
         );

--- a/tests/Models/CommentModelTest.php
+++ b/tests/Models/CommentModelTest.php
@@ -15,7 +15,19 @@ use VanillaTests\SiteTestTrait;
  * Test {@link CommentModel}.
  */
 class CommentModelTest extends TestCase {
-    use SiteTestTrait;
+    use SiteTestTrait {
+        setupBeforeClass as baseSetupBeforeClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setupBeforeClass() {
+        self::baseSetupBeforeClass();
+
+        // Test as an admin
+        self::container()->get('Session')->start(self::$siteInfo['adminUserID']);
+    }
 
     /**
      * Test the lookup method.


### PR DESCRIPTION
The following case (which can happen in unit tests) was causing a bug where permissions were bugged:

```php
Gdn::session()->start($adminUserID, false, false);
Gdn::session()->start(false, false);
Gdn::session()->getPermissions()->hasAny('Garden.Settings.Manage'); // Returns true
```

The problem is that the admin flag is set but not properly removed from the permission object on subsequent call to `Gdn::session()->start()` if the session if not started with a valid user.

I opted to overwrite the whole permission object on each call to `Gdn::session()->start()` so that if we had other properties to the Permission object they will be reset without needing to update this code.