### PR TITLE
Move AbstractResourceTest index's row generation in a separate function

### DIFF
--- a/tests/APIv2/AbstractResourceTest.php
+++ b/tests/APIv2/AbstractResourceTest.php
@@ -299,17 +299,13 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
         $originalIndex = $this->api()->get($indexUrl);
         $this->assertEquals(200, $originalIndex->getStatusCode());
 
-        // Insert a few rows.
-        $rows = [];
-        for ($i = 0; $i < static::INDEX_ROWS; $i++) {
-            $rows[] = $this->testPost();
-        }
+        $rows = $this->generateIndexRows();
 
         $newIndex = $this->api()->get($indexUrl);
 
         $originalRows = $originalIndex->getBody();
         $newRows = $newIndex->getBody();
-        $this->assertEquals(count($originalRows)+self::INDEX_ROWS, count($newRows));
+        $this->assertEquals(count($originalRows)+count($rows), count($newRows));
         // The index should be a proper indexed array.
         for ($i = 0; $i < count($newRows); $i++) {
             $this->assertArrayHasKey($i, $newRows);
@@ -321,6 +317,22 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
 
         // There's not much we can really test here so just return and let subclasses do some more assertions.
         return [$rows, $newRows];
+    }
+
+    /**
+     * Generate rows for the index test.
+     *
+     * @return array
+     */
+    protected function generateIndexRows() {
+        $rows = [];
+
+        // Insert a few rows.
+        for ($i = 0; $i < static::INDEX_ROWS; $i++) {
+            $rows[] = $this->testPost();
+        }
+
+        return $rows;
     }
 
     /**


### PR DESCRIPTION
This allow tests to change the way rows are generated which is useful when created resources can't have the same name or need their own parent resource to be created.

This update would let us redefine the generator function and increment the $recordCounter instead of [having to enable/disable a flag as a workaround](https://github.com/vanilla/internal/blob/3e1094b267b754c7c7a88f497a15741fb52470b4/applications/groups/tests/APIv2/GroupsTest.php#L83).