### PR TITLE
Fix category following filters being saved without explicitly opting in

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -248,14 +248,28 @@ class CategoriesController extends VanillaController {
         // Figure out which category layout to choose (Defined on "Homepage" settings page).
         $layout = c('Vanilla.Categories.Layout');
 
-        if ($categoryIdentifier == '') {
+        if ($this->CategoryModel->followingEnabled()) {
+            // Only use the following filter on the root category level.
+            $enableFollowingFilter = $categoryIdentifier === '';
+            $this->fireEvent('EnableFollowingFilter', [
+                'CategoryIdentifier' => $categoryIdentifier,
+                'EnableFollowingFilter' => &$enableFollowingFilter
+            ]);
+
             $followed = paramPreference(
                 'followed',
                 'FollowedCategories',
-                'Vanilla.SaveFollowingPreference'
+                'Vanilla.SaveFollowingPreference',
+                null,
+                Gdn::request()->get('save')
             );
-            $this->setData('Followed', $followed);
+        } else {
+            $enableFollowingFilter = $followed = false;
+        }
+        $this->setData('EnableFollowingFilter', $enableFollowingFilter);
+        $this->setData('Followed', $followed);
 
+        if ($categoryIdentifier == '') {
             switch ($layout) {
                 case 'mixed':
                     $this->View = 'discussions';

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -120,11 +120,21 @@ class DiscussionsController extends VanillaController {
 
         $this->setData('Breadcrumbs', [['Name' => t('Recent Discussions'), 'Url' => '/discussions']]);
 
-        $followed = paramPreference(
-            'followed',
-            'FollowedDiscussions',
-            'Vanilla.SaveFollowingPreference'
-        );
+
+        $categoryModel = new CategoryModel();
+        $followingEnabled = $categoryModel->followingEnabled();
+        if ($followingEnabled) {
+            $followed = paramPreference(
+                'followed',
+                'FollowedDiscussions',
+                'Vanilla.SaveFollowingPreference',
+                null,
+                Gdn::request()->get('save')
+            );
+        } else {
+            $followed = false;
+        }
+        $this->setData('EnableFollowingFilter', $followingEnabled);
         $this->setData('Followed', $followed);
 
         // Set criteria & get discussions data
@@ -139,7 +149,6 @@ class DiscussionsController extends VanillaController {
         $categoryIDs = $this->getCategoryIDs();
         $where = [];
         if ($this->data('Followed')) {
-            $categoryModel = new CategoryModel();
             $where['d.CategoryID'] = array_keys($categoryModel->getFollowed(Gdn::session()->UserID));
         } elseif ($categoryIDs) {
             $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -364,6 +364,16 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * Get the enabled status of category following, returned as a boolean value.
+     *
+     * @return bool
+     */
+    public function followingEnabled() {
+        $result = boolval(c('Vanilla.EnableCategoryFollowing'));
+        return $result;
+    }
+
+    /**
      * Get the maximum number of categories a user is allowed to follow.
      *
      * @return mixed

--- a/applications/vanilla/views/categories/all.php
+++ b/applications/vanilla/views/categories/all.php
@@ -9,7 +9,7 @@ if ($description = $this->description()) {
     echo wrap($description, 'div', ['class' => 'P PageDescription']);
 }
 $this->fireEvent('AfterPageTitle');
-if (!$this->data('Category') && c('Vanilla.EnableCategoryFollowing')) {
+if ($this->data('EnableFollowingFilter')) {
     echo '<div class="PageControls Top">'.categoryFilters().'</div>';
 }
 $categories = $this->data('CategoryTree');

--- a/applications/vanilla/views/categories/discussions.php
+++ b/applications/vanilla/views/categories/discussions.php
@@ -1,6 +1,6 @@
 <?php if (!defined('APPLICATION')) exit();
 echo '<h1 class="H HomepageTitle">'.$this->data('Title').'</h1>';
-if (!$this->data('Category') && c('Vanilla.EnableCategoryFollowing')) {
+if ($this->data('EnableFollowingFilter')) {
     echo '<div class="PageControls Top">'.categoryFilters().'</div>';
 }
 $ViewLocation = $this->fetchViewLocation('discussions', 'discussions');

--- a/applications/vanilla/views/categories/table.php
+++ b/applications/vanilla/views/categories/table.php
@@ -7,7 +7,7 @@ $categoryID = isset($this->Category) ? $this->Category->CategoryID : null;
 <?php
 $this->fireEvent('AfterDescription');
 $this->fireEvent('AfterPageTitle');
-if (!$this->data('Category') && c('Vanilla.EnableCategoryFollowing')) {
+if ($this->data('EnableFollowingFilter')) {
     echo '<div class="PageControls Top">'.categoryFilters().'</div>';
 }
 $categories = $this->data('CategoryTree');

--- a/applications/vanilla/views/discussions/index.php
+++ b/applications/vanilla/views/discussions/index.php
@@ -41,7 +41,7 @@ echo '<div class="PageControls Top">';
 PagerModule::write($PagerOptions);
 echo Gdn_Theme::module('NewDiscussionModule', $this->data('_NewDiscussionProperties', ['CssClass' => 'Button Action Primary']));
 // Avoid displaying in a category's list of discussions.
-if (!$this->data('Category.CategoryID')) {
+if ($this->data('EnableFollowingFilter')) {
     echo discussionFilters();
 }
 $this->fireEvent('PageControls');

--- a/applications/vanilla/views/discussions/table.php
+++ b/applications/vanilla/views/discussions/table.php
@@ -44,7 +44,7 @@ echo '<div class="PageControls Top">';
 PagerModule::write($PagerOptions);
 echo Gdn_Theme::module('NewDiscussionModule', $this->data('_NewDiscussionProperties', ['CssClass' => 'Button Action Primary']));
 // Avoid displaying in a category's list of discussions.
-if (!$this->data('Category.CategoryID')) {
+if ($this->data('EnableFollowingFilter')) {
     echo discussionFilters();
 }
 $this->fireEvent('PageControls');

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -4079,9 +4079,10 @@ if (!function_exists('paramPreference')) {
      * @param string $preference User preference name
      * @param string|null $config Config value, used as a conditional for performing this action
      * @param string null $configVal Look for a specific config value, instead of allowing truthy values.
+     * @param bool $save Save the parameter value to the user preference, if available.
      * @return mixed
      */
-    function paramPreference($param, $preference, $config = null, $configVal = null) {
+    function paramPreference($param, $preference, $config = null, $configVal = null, $save = false) {
         $value = Gdn::request()->get($param, null);
 
         if ($config === null || (($configVal === null && c($config)) || c($config) === $configVal)) {
@@ -4090,7 +4091,7 @@ if (!function_exists('paramPreference')) {
                 if ($value) {
                     Gdn::request()->setQueryItem($param, $value);
                 }
-            } else {
+            } elseif ($save) {
                 Gdn::session()->setPreference($preference, $value);
             }
         }

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -420,7 +420,7 @@ if (!function_exists('categoryFilters')) {
             return;
         }
 
-        $baseUrl = url('categories');
+        $baseUrl = 'categories';
         $filters = [['name' => 'Following', 'param' => 'followed']];
 
         $defaultParams = [];
@@ -715,7 +715,7 @@ if (!function_exists('discussionFilters')) {
             return;
         }
 
-        $baseUrl = url('discussions');
+        $baseUrl = 'discussions';
         $filters = [['name' => 'Following', 'param' => 'followed']];
 
         $defaultParams = [];

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -421,9 +421,15 @@ if (!function_exists('categoryFilters')) {
         }
 
         $baseUrl = 'categories';
-        $filters = [['name' => 'Following', 'param' => 'followed']];
+        $filters = [
+            [
+                'name' => 'Following',
+                'param' => 'followed',
+                'extra' => ['save' => 1]
+            ]
+        ];
 
-        $defaultParams = [];
+        $defaultParams = ['save' => 1];
         if (Gdn::request()->get('followed')) {
             $defaultParams['followed'] = 0;
         }
@@ -716,9 +722,15 @@ if (!function_exists('discussionFilters')) {
         }
 
         $baseUrl = 'discussions';
-        $filters = [['name' => 'Following', 'param' => 'followed']];
+        $filters = [
+            [
+                'name' => 'Following',
+                'param' => 'followed',
+                'extra' => ['save' => 1]
+            ]
+        ];
 
-        $defaultParams = [];
+        $defaultParams = ['save' => 1];
         if (Gdn::request()->get('followed')) {
             $defaultParams['followed'] = 0;
         }
@@ -823,7 +835,11 @@ if (!function_exists('filtersDropDown')) {
 
                 // Prepare for consumption by linkDropDown.
                 $value = val('value', $filter, 1);
-                $url = url($baseUrl.'?'.http_build_query([$filter['param'] => $value]));
+                $query = [$filter['param'] => $value];
+                if (array_key_exists('extra', $filter) && is_array($filter['extra'])) {
+                    $query += $filter['extra'];
+                }
+                $url = url($baseUrl.'?'.http_build_query($query));
                 $link = [
                     'name' => $filter['name'],
                     'url' => $url


### PR DESCRIPTION
This update alters the new "category following" feature in the following way:

1. Adds a new parameter to `paramPreference` function to control if the preference is saved.
1. Adds the ability to pass extra URL query string parameters to the `filtersDropDown` function.
1. Updates the root-category index and "recent discussions" page to require a "saved" query string parameter in the URL to save the current filter.
1. Adds "saved" parameter to filter dropdown menu URLs.
1. Adds `CategoryModel::followingEnabled` as a convenience method for checking the availability of the following feature.
1. Adds a new element to the controller data array (EnableFollowingFilter) to serve as a UI hint for displaying the "following" filter menu.
1. Adds an "EnableFollowingFilter" event to `CategoriesController`, which will allow addons to change the value of this element in the controller's data array.
1. Fixes an issue where URLs could potentially be doubly pre-pended with the web root.

Closes #6512 
Closes #6539