### PR TITLE
Fix some error exception responses having an HTTP code in the 2xx (successful) range

### DIFF
--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -9,6 +9,7 @@ namespace Garden\Web;
 
 use Gdn;
 use Gdn_Locale;
+use Garden\Schema\ValidationException;
 use Garden\Web\Exception\HttpException;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\Pass;
@@ -236,8 +237,9 @@ class Dispatcher {
 
             // Make sure that there's a "proper" conversion from non-HTTP to HTTP exceptions since
             // errors in the 2xx ranges are treated as success.
+            // ValidationException status code are compatible with HTTP codes.
             $errorCode = $raw->getCode();
-            if (!$raw instanceof HttpException) {
+            if (!$raw instanceof HttpException && !$raw instanceof ValidationException) {
                 $errorCode = 500;
             }
 

--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -9,6 +9,7 @@ namespace Garden\Web;
 
 use Gdn;
 use Gdn_Locale;
+use Garden\Web\Exception\HttpException;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\Pass;
 use Interop\Container\ContainerInterface;
@@ -232,8 +233,16 @@ class Dispatcher {
             // This is an array of response data.
             $result = new Data($raw);
         } elseif ($raw instanceof \Exception || $raw instanceof \Error) {
-            $data = $raw instanceof \JsonSerializable ? $raw->jsonSerialize() : ['message' => $raw->getMessage(), 'status' => $raw->getCode()];
-            $result = new Data($data, $raw->getCode());
+
+            // Make sure that there's a "proper" conversion from non-HTTP to HTTP exceptions since
+            // errors in the 2xx ranges are treated as success.
+            $errorCode = $raw->getCode();
+            if (!$raw instanceof HttpException) {
+                $errorCode = 500;
+            }
+
+            $data = $raw instanceof \JsonSerializable ? $raw->jsonSerialize() : ['message' => $raw->getMessage()];
+            $result = new Data($data, $errorCode);
             // Provide stack trace as meta information.
             $result->setMeta('errorTrace', $raw->getTraceAsString());
 


### PR DESCRIPTION
This fixes a problem where "php" exception would be treated as successful response instead of errors because the error code could be in the 2xx range.
This was happening for E_USER_ERROR which has a value of 256. These kind of errors should be treated as internal errors when returned.
The problem was worse for unit test since we didn't get to see the error message because the response was a "success".