### PR TITLE
Add unit test for comments API and custom category permissions

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1421,10 +1421,11 @@ class DiscussionModel extends Gdn_Model {
      * @access public
      *
      * @param bool $escape Prepends category IDs with @
+     * @param bool $forceRefresh Reset the cache and pull fresh permission values.
      * @return array Protected local _CategoryPermissions
      */
-    public static function categoryPermissions($escape = false) {
-        if (is_null(self::$categoryPermissions)) {
+    public static function categoryPermissions($escape = false, $forceRefresh = false) {
+        if (is_null(self::$categoryPermissions) || $forceRefresh) {
             $session = Gdn::session();
 
             if ((is_object($session->User) && $session->User->Admin)) {

--- a/tests/APIv2/CommentsTest.php
+++ b/tests/APIv2/CommentsTest.php
@@ -7,6 +7,8 @@
 
 namespace VanillaTests\APIv2;
 
+use DiscussionModel;
+
 /**
  * Test the /api/v2/discussions endpoints.
  */
@@ -29,5 +31,65 @@ class CommentsTest extends AbstractResourceTest {
         $indexUrl = $this->baseUrl;
         $indexUrl .= '?'.http_build_query(['discussionID' => 1]);
         return $indexUrl;
+    }
+
+    /**
+     * Verify that custom category permissions don't wipe out access to all comments.
+     */
+    public function testCustomCategoryPermissions() {
+        // Default discussion ID. This is created during install.
+        $discussionID = 1;
+
+        // Create a new user for this test. It will receive the default member role.
+        $username = substr(__FUNCTION__, 0, 20);
+        $user = $this->api()->post('users', [
+            'name' => $username,
+            'email' => $username.'@example.com',
+            'password' => 'vanilla'
+        ])->getBody();
+        $this->assertCount(1, $user['roles'], 'User has too many default roles.');
+        $roleID = $user['roles'][0]['roleID'];
+
+        // Switch to the user we just created and comment on the default discussion.
+        $this->api()->setUserID($user['userID']);
+        $this->api()->post('comments', [
+            'body' => 'Hello world.',
+            'format' => 'text',
+            'discussionID' => $discussionID
+        ]);
+        $comments = $this->api()->get('comments', [
+            'discussionID' => $discussionID
+        ])->getBody();
+
+        // Switch back to the admin user and add a new category.
+        $this->api()->setUserID(self::$siteInfo['adminUserID']);
+        $category = $this->api()->post('categories', [
+            'name' => __FUNCTION__,
+            'urlcode' => strtolower(__FUNCTION__)
+        ])->getBody();
+
+        // Update the permissions of the default member role to revoke permissions to the new category.
+        $this->api()->patch("roles/{$roleID}/permissions", [[
+            'id' => $category['categoryID'],
+            'type' => 'category',
+            'permissions' => [
+                'comments.add' => false,
+                'comments.delete' => false,
+                'comments.edit' => false,
+                'discussions.add' => false,
+                'discussions.manage' => false,
+                'discussions.moderate' => false,
+                'discussions.view' => false
+            ]
+        ]]);
+
+        // Switch back to the user we created and make sure they can still see the same comments as before.
+        $this->api()->setUserID($user['userID']);
+        DiscussionModel::categoryPermissions(false, true);
+        $updatedComments = $this->api()->get('comments', [
+            'discussionID' => $discussionID
+        ])->getBody();
+
+        $this->assertEquals($comments, $updatedComments);
     }
 }

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -8,6 +8,7 @@
 namespace VanillaTests\APIv2;
 
 use CategoryModel;
+use DiscussionModel;
 
 /**
  * Test the /api/v2/discussions endpoints.
@@ -88,6 +89,10 @@ class DiscussionsTest extends AbstractResourceTest {
         }
     }
 
+    public function setUp() {
+        parent::setUp();
+        DiscussionModel::categoryPermissions(false, true);
+    }
     /**
      * Verify a bookmarked discussion shows up under /discussions/bookmarked.
      */


### PR DESCRIPTION
#6446 added a fix for a permission issue related to the comments API index. This update adds some regression testing.

For testing purposes, I also added a parameter to `DiscussionModel::categoryPermissions` that will force a refresh of category permissions. Prior to this, once permissions were cached during a test, they were cached, indefinitely.

Closes #6484 