### PR TITLE
Fixed Rich Editor Paste

### DIFF
--- a/plugins/rich-editor/src/scripts/RichEditor.js
+++ b/plugins/rich-editor/src/scripts/RichEditor.js
@@ -107,11 +107,4 @@ export default class RichEditor {
     synchronizeDelta() {
         this.bodybox.value = JSON.stringify(this.editor.getContents()["ops"]);
     }
-
-    initializeOtherFormat() {
-
-        // TODO: check if we can convert from a format
-
-        return;
-    }
 }


### PR DESCRIPTION
Since we've added the "blots" to the Rich Editor MVP branch, the paste isn't behaving properly. It was broken because of the function `initializeOtherFormat` returning nothing.