### PR TITLE
Add /media/scrape to API

### DIFF
--- a/applications/dashboard/controllers/api/MediaApiController.php
+++ b/applications/dashboard/controllers/api/MediaApiController.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @copyright 2009-2018 Vanilla Forums Inc.
- * @license GPLv2
+ * @license GPL-2.0
  */
 
 /**

--- a/applications/dashboard/controllers/api/MediaApiController.php
+++ b/applications/dashboard/controllers/api/MediaApiController.php
@@ -12,10 +12,25 @@ class MediaApiController extends AbstractApiController {
     /** @var WebScraper */
     private $webScraper;
 
+    /**
+     * MediaApiController constructor.
+     *
+     * @param WebScraper $webScraper
+     */
     public function __construct(WebScraper $webScraper) {
         $this->webScraper = $webScraper;
     }
 
+    /**
+     * Scrape information from a URL.
+     *
+     * @param array $body The request body.
+     * @return array
+     * @throws Exception
+     * @throws \Garden\Schema\ValidationException
+     * @throws \Garden\Web\Exception\HttpException
+     * @throws \Vanilla\Exception\PermissionException
+     */
     public function post_scrape(array $body) {
         $this->permission('Garden.SignIn.Allow');
 
@@ -25,7 +40,7 @@ class MediaApiController extends AbstractApiController {
                 'default' => false,
                 'description' => 'Force the scrape even if the result is cached.'
             ]
-        ]);
+        ], 'in');
         $out = $this->schema([
             'url:s'	=> 'The URL that was scraped.',
             'type:s' => [
@@ -39,7 +54,7 @@ class MediaApiController extends AbstractApiController {
             'height:i|n' => 'The height of the image/video/etc. if applicable. This may be the photoUrl, but might exist even when there is no photoUrl in the case of a video without preview image.',
             'width:i|n' => 'The width of the image/video/etc. if applicable.',
             'attributes:o|n' => 'Any additional attributes required by the the specific embed.',
-        ]);
+        ], 'out');
 
         $body = $in->validate($body);
 

--- a/applications/dashboard/controllers/api/MediaApiController.php
+++ b/applications/dashboard/controllers/api/MediaApiController.php
@@ -45,7 +45,7 @@ class MediaApiController extends AbstractApiController {
             'url:s'	=> 'The URL that was scraped.',
             'type:s' => [
                 'description' => 'The type of site. This determines how the embed is rendered.',
-                'enum' => ['getty', 'hitbox', 'image', 'imgur', 'instagram', 'pinterest', 'site',
+                'enum' => ['getty', 'image', 'imgur', 'instagram', 'pinterest', 'site', 'smashcast',
                     'soundcloud', 'twitch', 'twitter', 'vimeo', 'vine', 'wistia', 'youtube']
             ],
             'name:s|n' => 'The title of the page/item/etc. if any.',

--- a/applications/dashboard/controllers/api/MediaApiController.php
+++ b/applications/dashboard/controllers/api/MediaApiController.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+/**
+ * API Controller for `/media`.
+ */
+class MediaApiController extends AbstractApiController {
+
+    /** @var WebScraper */
+    private $webScraper;
+
+    public function __construct(WebScraper $webScraper) {
+        $this->webScraper = $webScraper;
+    }
+
+    public function post_scrape(array $body) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $in = $this->schema([
+            'url:s' => 'The URL to scrape.',
+            'force:b?' => [
+                'default' => false,
+                'description' => 'Force the scrape even if the result is cached.'
+            ]
+        ]);
+        $out = $this->schema([
+            'url:s'	=> 'The URL that was scraped.',
+            'type:s' => [
+                'description' => 'The type of site. This determines how the embed is rendered.',
+                'enum' => ['getty', 'hitbox', 'image', 'imgur', 'instagram', 'pinterest', 'site',
+                    'soundcloud', 'twitch', 'twitter', 'vimeo', 'vine', 'wistia', 'youtube']
+            ],
+            'name:s|n' => 'The title of the page/item/etc. if any.',
+            'body:s|n' => 'A paragraph summarizing the content, if any. This is not what is what gets rendered to the page.',
+            'photoUrl:s|n' => 'A photo that goes with the content.',
+            'height:i|n' => 'The height of the image/video/etc. if applicable. This may be the photoUrl, but might exist even when there is no photoUrl in the case of a video without preview image.',
+            'width:i|n' => 'The width of the image/video/etc. if applicable.',
+            'attributes:o|n' => 'Any additional attributes required by the the specific embed.',
+        ]);
+
+        $body = $in->validate($body);
+
+        $pageInfo = $this->webScraper->getPageInfo($body['url'], $body['force']);
+
+        $result = $out->validate($pageInfo);
+        return $result;
+    }
+}

--- a/library/core/class.webscraper.php
+++ b/library/core/class.webscraper.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0
+ */
 
 class WebScraper {
 

--- a/library/core/class.webscraper.php
+++ b/library/core/class.webscraper.php
@@ -22,20 +22,26 @@ class WebScraper {
     private $disableFetch = false;
 
     /** @var array */
-    private $types = [
-        'getty' => ['domains' => ['embed.gettyimages.com']],
-        'hitbox' => ['domains' => ['hitbox.tv']],
-        'imgur' => ['domains' => ['i.imgur.com']],
-        'instagram' => ['domains' => ['instagram.com', 'instagr.am']],
-        'pinterest' => ['domains' => ['pinterest.com']],
-        'soundcloud' => ['domains' => ['soundcloud.com']],
-        'twitch' => ['domains' => ['twitch.tv']],
-        'twitter' => ['domains' => ['twitter.com']],
-        'vimeo' => ['domains' => ['vimeo.com']],
-        'vine' => ['domains' => ['vine.co']],
-        'wistia' => ['domains' => ['wistia.com', 'wi.st']],
-        'youtube' => ['domains' => ['youtube.com', 'youtu.be']]
-    ];
+    private $types = [];
+
+    /**
+     * WebScraper constructor.
+     */
+    public function __construct() {
+        // Add some default sites.
+        $this->registerType('getty', ['embed.gettyimages.com'], [$this, 'lookupGetty']);
+        $this->registerType('hitbox', ['hitbox.tv'], [$this, 'lookupHitbox']);
+        $this->registerType('imgur', ['i.imgur.com'], [$this, 'lookupImgur']);
+        $this->registerType('instagram', ['instagram.com', 'instagr.am'], [$this, 'lookupInstagram']);
+        $this->registerType('pinterest', ['pinterest.com'], [$this, 'lookupPinterest']);
+        $this->registerType('soundcloud', ['soundcloud.com'], [$this, 'lookupSoundcloud']);
+        $this->registerType('twitch', ['twitch.tv'], [$this, 'lookupTwitch']);
+        $this->registerType('twitter', ['twitter.com'], [$this, 'lookupTwitter']);
+        $this->registerType('vimeo', ['vimeo.com'], [$this, 'lookupVimeo']);
+        $this->registerType('vine', ['vine.co'], [$this, 'lookupVine']);
+        $this->registerType('wistia', ['wistia.com', 'wi.st'], [$this, 'lookupWistia']);
+        $this->registerType('youtube', ['youtube.com', 'youtu.be'], [$this, 'lookupYouTube']);
+    }
 
     /**
      * Fetch page info and normalize its keys.
@@ -241,13 +247,7 @@ class WebScraper {
             }
 
             $config = $types[$type];
-
-            $lookup = array_key_exists('function', $config) ? $config['function'] : [$this, "lookup{$type}"];
-            if (!is_callable($lookup)) {
-                throw new Exception("Unable to call info lookup function for type: {$type}");
-            }
-
-            $data = call_user_func($lookup, $url);
+            $data = call_user_func($config['callback'], $url);
         }
 
         $defaults = [
@@ -677,6 +677,23 @@ class WebScraper {
             'start' => $start
         ];
         return $data;
+    }
+
+    /**
+     * Register a site.
+     *
+     * @param string $type
+     * @param array $domains
+     * @param callable $callback
+     * @return self
+     */
+    public function registerType($type, array $domains, callable $callback) {
+        $this->types[$type] = [
+            'domains' => $domains,
+            'callback' => $callback
+        ];
+
+        return $this;
     }
 
     /**

--- a/library/core/class.webscraper.php
+++ b/library/core/class.webscraper.php
@@ -1,0 +1,525 @@
+<?php
+
+class WebScraper {
+
+    /** Page info caching expiry (24 hours). */
+    const CACHE_EXPIRY = 24 * 60 * 60;
+
+    /** Valid image extensions. */
+    const IMAGE_EXTENSIONS = ['bmp', 'gif', 'jpeg', 'jpg', 'png', 'svg', 'tif', 'tiff'];
+
+    /** Default scrape type. */
+    const TYPE_DEFAULT = 'site';
+
+    /** Type for generic image URLs. */
+    const TYPE_IMAGE = 'image';
+
+    /** @var array */
+    private $types = [
+        'getty' => ['domains' => ['embed.gettyimages.com']],
+        'hitbox' => ['domains' => ['hitbox.tv']],
+        'imgur' => ['domains' => ['i.imgur.com']],
+        'instagram' => ['domains' => ['instagram.com', 'instagr.am']],
+        'pinterest' => ['domains' => ['pinterest.com']],
+        'soundcloud' => ['domains' => ['soundcloud.com']],
+        'twitch' => ['domains' => ['twitch.tv']],
+        'twitter' => ['domains' => ['twitter.com']],
+        'vimeo' => ['domains' => ['vimeo.com']],
+        'vine' => ['domains' => ['vine.co']],
+        'wistia' => ['domains' => ['wistia.com', 'wi.st']],
+        'youtube' => ['domains' => ['youtube.com', 'youtu.be']]
+    ];
+
+    /**
+     * Fetch page info and normalize its keys.
+     *
+     * @param string $url Full target URL.
+     * @return array
+     * @throws Exception if there was an error encountered while getting the page's info.
+     */
+    private function fetchPageInfo($url) {
+        $pageInfo = fetchPageInfo($url);
+
+        if ($pageInfo['Exception']) {
+            throw new Exception($pageInfo['Exception']);
+        }
+
+        $name = $pageInfo['Title'] ?: null;
+        $body = $pageInfo['Description'] ?: null;
+        $photoUrl = !empty($pageInfo['Images']) ? reset($pageInfo['Images']) : null;
+
+        $result = [
+            'url' => $url,
+            'name' => $name,
+            'body' => $body,
+            'photoUrl' => $photoUrl
+        ];
+        return $result;
+    }
+
+    /**
+     * Get data about a page, including site-specific information, if available.
+     *
+     * @param string $url Full target URL.
+     * @param bool $forceRefresh Should loading from the cache be skipped?
+     * @return string|null
+     * @throws Exception if errors encountered during processing.
+     */
+    public function getPageInfo($url, $forceRefresh = false) {
+        $urlKey = md5($url);
+        $cacheKey = "WebScraper.{$urlKey}";
+        $result = null;
+
+        if (!$forceRefresh) {
+            $info = Gdn::cache()->get($cacheKey);
+
+            if ($info === Gdn_Cache::CACHEOP_FAILURE) {
+                unset($info);
+            }
+        }
+
+        if (!isset($info)) {
+            $type = $this->getTypeFromUrl($url);
+            $info = $this->getInfoByType($type, $url);
+        }
+
+        if ($info) {
+            Gdn::cache()->store($cacheKey, $info, [Gdn_Cache::FEATURE_EXPIRY => self::CACHE_EXPIRY]);
+        }
+
+        return $info;
+    }
+
+    /**
+     * Given a URL, return its type. Use default if no specific type can be determined..
+     *
+     * @param string $url
+     * @return string
+     * @throws InvalidArgumentException if the URL is invalid.
+     * @throws Exception if the type does not have a valid "domains" value.
+     */
+    private function getTypeFromUrl($url) {
+        $urlDomain = parse_url($url, PHP_URL_HOST);
+        if ($urlDomain === false) {
+            throw new InvalidArgumentException('Invalid URL.');
+        }
+
+        $types = $this->getTypes();
+        $result = null;
+        $testDomains = [];
+        $urlDomainParts = explode('.', $urlDomain);
+        while ($urlDomainParts) {
+            $testDomains[] = implode('.', $urlDomainParts);
+            array_shift($urlDomainParts);
+        }
+
+        foreach ($types as $type => $config) {
+            if (!array_key_exists('domains', $config) || !is_array($config['domains'])) {
+                throw new Exception('Invalid domains for type.');
+            }
+            foreach ($config['domains'] as $typeDomain) {
+                foreach ($testDomains as $testDomain) {
+                    if ($typeDomain == $testDomain) {
+                        $result = $type;
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        // No site-specific matches? Test if we're dealing with an image URL.
+        if ($result === null) {
+            $path = parse_url($url, PHP_URL_PATH);
+            if ($path !== false) {
+                $extension = pathinfo($path, PATHINFO_EXTENSION);
+                if ($extension && in_array(strtolower($extension), self::IMAGE_EXTENSIONS)) {
+                    $result = self::TYPE_IMAGE;
+                }
+            }
+        }
+
+        // Still nothing? Default type.
+        if ($result === null) {
+            $result = self::TYPE_DEFAULT;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get all supported sites and their configurations.
+     *
+     * @return array
+     */
+    private function getTypes() {
+        return $this->types;
+    }
+
+    /**
+     * Get site-specific data from a page.
+     *
+     * @param string $type A supported site type.
+     * @param string $url The full URL to the page.
+     * @return array
+     * @throws InvalidArgumentException if the type is invalid.
+     * @throws Exception if unable to find a lookup function for the type.
+     */
+    private function getInfoByType($type, $url) {
+        if ($type === self::TYPE_DEFAULT) {
+            $data = $this->lookupDefault($url);
+        } elseif ($type === self::TYPE_IMAGE) {
+            $data = $this->lookupImage($url);
+        } else {
+            $types = $this->getTypes();
+            if (!array_key_exists($type, $types)) {
+                throw new InvalidArgumentException("Invalid type: {$type}");
+            }
+
+            $config = $types[$type];
+
+            $lookup = array_key_exists('function', $config) ? $config['function'] : [$this, "lookup{$type}"];
+            if (!is_callable($lookup)) {
+                throw new Exception("Unable to call info lookup function for type: {$type}");
+            }
+
+            $data = call_user_func($lookup, $url);
+        }
+
+        $defaults = [
+            'url' => $url,
+            'type' => $type,
+            'name' => null,
+            'body' => null,
+            'photoUrl' => null,
+            'height' => null,
+            'width' => null,
+            'attributes' => null
+        ];
+
+        $result = array_merge($defaults, $data);
+        return $result;
+    }
+
+    /**
+     * Gather general information about a document..
+     *
+     * @param string $url
+     * @return array
+     */
+    private function lookupDefault($url) {
+        $result = $this->fetchPageInfo($url);
+        return $result;
+    }
+
+    /**
+     * Grab info from Getty Images.
+     *
+     * @param string $url
+     * @return array
+     */
+    private function lookupGetty($url) {
+        preg_match(
+            '/https?:\/\/embed.gettyimages\.com\/(?<mediaID>[\w=?&;+-_]*)\/(?<width>[\d]*)\/(?<height>[\d]*)/i',
+            $url,
+            $matches
+        );
+        $mediaID = $matches['mediaID'] ?: null;
+        $width = $matches['width'] ?: null;
+        $height = $matches['height'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+        $data['width'] = $width;
+        $data['height'] = $height;
+
+        $data['attributes'] = ['mediaID' => $mediaID];
+
+        return $data;
+    }
+
+    /**
+     * Grab info from Smashcast.tv (formerly Hitbox.tv).
+     *
+     * @param string $url
+     * @return array
+     */
+    private function lookupHitbox($url) {
+        preg_match(
+            '/https?:\/\/(?:www\.)?hitbox\.tv\/(?<channelID>[\w]+)/i',
+            $url,
+            $matches
+        );
+        $channelID = $matches['channelID'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = ['channelID' => $channelID];
+
+        return $data;
+    }
+
+    /**
+     * @param string $url
+     * @return array
+     */
+    private function lookupImage($url) {
+        $data = ['photoUrl' => $url];
+        return $data;
+    }
+
+    /**
+     * Grab info from an Imgur embed.
+     * @param $url
+     * @return array
+     */
+    private function lookupImgur($url) {
+        preg_match(
+            '/https?:\/\/i\.imgur\.com\/(?<mediaID>[a-z0-9]+)\.gifv/i',
+            $url,
+            $matches
+        );
+        $mediaID = $matches['mediaID'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = ['mediaID' => $mediaID];
+
+        return $data;
+    }
+
+    /**
+     * Grab info from Instagram.
+     * @param $url
+     * @return array
+     */
+    private function lookupInstagram($url) {
+        preg_match(
+            '/https?:\/\/(?:www\.)?instagr(?:\.am|am\.com)\/p\/(?<mediaID>[\w-]+)/i',
+            $url,
+            $matches
+        );
+        $mediaID = $matches['mediaID'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = ['mediaID' => $mediaID];
+
+        return $data;
+    }
+
+    /**
+     * Grab info from Pinterest.
+     *
+     * @param $url
+     * @return array
+     */
+    private function lookupPinterest($url) {
+        preg_match(
+            '/https?:\/\/(?:www\.)?pinterest\.com\/pin\/(?<pinID>[\d]+)/i',
+            $url,
+            $matches
+        );
+        $pinID = $matches['pinID'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = ['pinID' => $pinID];
+
+        return $data;
+    }
+
+    /**
+     * Grab info from SoundCloud.
+     *
+     * @param $url
+     * @return array
+     */
+    private function lookupSoundcloud($url) {
+        preg_match(
+            '/https?:(?:www\.)?\/\/soundcloud\.com\/(?<user>[\w=?&;+-_]*)\/(?<track>[\w=?&;+-_]*)/i',
+            $url,
+            $matches
+        );
+        $user = $matches['user'] ?: null;
+        $track = $matches['track'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = [
+            'user' => $user,
+            'track' => $track
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Grab info from Twitch.tv.
+     *
+     * @param $url
+     * @return array
+     */
+    private function lookupTwitch($url) {
+        preg_match(
+            '/https?:\/\/(?:www\.)?twitch\.tv\/(?<channel>[\w]+)/i',
+            $url,
+            $matches
+        );
+        $channel = $matches['channel'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = ['channel' => $channel];
+
+        return $data;
+    }
+
+
+    /**
+     * Grab info from Twitter.
+     *
+     * @param $url
+     * @return array
+     */
+    private function lookupTwitter($url) {
+        preg_match(
+            '/https?:\/\/(?:www\.)?twitter\.com\/(?:#!\/)?(?:[^\/]+)\/status(?:es)?\/(?<statusID>[\d]+)/i',
+            $url,
+            $matches
+        );
+
+        $statusID = $matches['statusID'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = ['statusID' => $statusID];
+
+        return $data;
+    }
+
+    /**
+     * Grab info from Vimeo.
+     *
+     * @param $url
+     * @return array
+     */
+    private function lookupVimeo($url) {
+        preg_match(
+            '/https?:\/\/(?:www\.)?vimeo\.com\/(?:channels\/[a-z0-9]+\/)?(?<videoID>\d+)/i',
+            $url,
+            $matches
+        );
+
+        $videoID = $matches['videoID'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = [
+            'videoID' => $videoID
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Grab info from Vine.
+     *
+     * @param $url
+     * @return array
+     */
+    private function lookupVine($url) {
+        preg_match(
+            '/https?:\/\/(?:www\.)?vine\.co\/(?:v\/)?(?<videoID>[\w]+)/i',
+            $url,
+            $matches
+        );
+
+        $videoID = $matches['videoID'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = ['videoID' => $videoID];
+
+        return $data;
+    }
+
+    /**
+     * Grab info from Wistia.
+     *
+     * @param $url
+     * @return array
+     */
+    private function lookupWistia($url) {
+        // Try the wvideo-style URL.
+        $wvideo = preg_match(
+            '/https?:\/\/(?:[A-za-z0-9\-]+\.)?(?:wistia\.com|wi\.st)\/.*?\?wvideo=(?<videoID>([A-za-z0-9]+))(\?wtime=(?<time>((\d)+m)?((\d)+s)?))?/i',
+            $url,
+            $matches
+        );
+        if (!$wvideo) {
+            // Fallback to the medias-style URL.
+            preg_match(
+                '/https?:\/\/([A-za-z0-9\-]+\.)?(wistia\.com|wi\.st)\/medias\/(?<videoID>[A-za-z0-9]+)(\?wtime=(?<time>((\d)+m)?((\d)+s)?))?/i',
+                $url,
+                $matches
+            );
+        }
+
+        $videoID = $matches['videoID'] ?: null;
+        $time = $matches['time'] ?: null;
+
+        // Get basic info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = [
+            'videoID' => $videoID,
+            'time' => $time
+        ];
+
+        return $data;
+    }
+
+    /**
+     * Grab info about a YouTube video.
+     *
+     * @param string $url
+     * @return array
+     */
+    private function lookupYouTube($url) {
+        // Get info from the URL.
+        preg_match(
+            '/https?:\/\/(?:(?:www.)|(?:m.))?(?:(?:youtube.com)|(?:youtu.be))\/(?:(?:playlist?)|(?:(?:watch\?v=)?(?P<videoId>[\w-]{11})))(?:\?|\&)?(?:list=(?P<listId>[\w-]*))?(?:t=(?:(?P<minutes>\d*)m)?(?P<seconds>\d*)s)?(?:#t=(?P<start>\d*))?/i',
+            $url,
+            $urlParts
+        );
+
+        // Figure out the start time.
+        $start = null;
+        if (array_key_exists('start', $urlParts)) {
+            $start = $urlParts['start'];
+        } elseif (array_key_exists('minutes', $urlParts) || array_key_exists('seconds', $urlParts)) {
+            $minutes = $urlParts['minutes'] ? intval($urlParts['minutes']) : 0;
+            $seconds = $urlParts['seconds'] ? intval($urlParts['seconds']) : 0;
+            $start = ($minutes * 60) + $seconds;
+        }
+
+        // Get info from the page markup.
+        $data = $this->fetchPageInfo($url);
+
+        $data['attributes'] = [
+            'videoID' => $urlParts['videoId'] ?: null,
+            'listID' => $urlParts['listId'] ?: null,
+            'start' => $start
+        ];
+        return $data;
+    }
+}

--- a/library/core/class.webscraper.php
+++ b/library/core/class.webscraper.php
@@ -406,6 +406,7 @@ class WebScraper {
             // Get basic info from the page markup.
             $data = $this->fetchPageInfo("https://imgur.com/{$mediaID}");
             list($width, $height) = $this->getMediaSize($data, 'image');
+            $data['url'] = $url;
             $data['width'] = $width;
             $data['height'] = $height;
         }

--- a/library/core/class.webscraper.php
+++ b/library/core/class.webscraper.php
@@ -87,7 +87,7 @@ class WebScraper {
     public function getPageInfo($url, $forceRefresh = false) {
         $urlKey = md5($url);
         $cacheKey = "WebScraper.{$urlKey}";
-        $result = null;
+        $info = null;
 
         if (!$forceRefresh) {
             $info = Gdn::cache()->get($cacheKey);

--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -6,48 +6,6 @@ use WebScraper;
 class MediaTest extends AbstractAPIv2Test {
 
     /**
-     * Called after each test is executed.
-     *
-     * @throws \Garden\Container\ContainerException
-     * @throws \Garden\Container\NotFoundException
-     */
-    public function tearDown() {
-        // Make sure fetching page info is re-disabled, after every test.
-        $this->setDisableFetch(true);
-    }
-
-    /**
-     * Test scraping pages with /media/scrape.
-     *
-     * @dataProvider provideScrapeUrls
-     * @param array $url
-     * @param string $type
-     * @param array $info
-     * @param bool $enableFetch
-     * @throws \Garden\Container\ContainerException
-     * @throws \Garden\Container\NotFoundException
-     */
-    public function testScrape($url, $type, array $info, $enableFetch = false) {
-        // Fetching is disabled by default in tests. Should it be enabled for this test?
-        if ($enableFetch) {
-            $this->setDisableFetch(false);
-        }
-        $result = $this->api()->post('media/scrape', ['url' => $url]);
-        $this->assertEquals(201, $result->getStatusCode());
-
-        $body = $result->getBody();
-        $this->assertEquals($url, $body['url']);
-        $this->assertEquals($type, $body['type']);
-
-        // Body and type have been validated. Validate the remaining fields.
-        unset($body['url'], $body['type']);
-        $this->assertCount(count($info), $body);
-        foreach ($body as $key => $value) {
-            $this->assertEquals($info[$key], $value);
-        }
-    }
-
-    /**
      * Provide scrape-able URLs in the testing environment and expected information to be returned by each.
      *
      * @return array
@@ -476,10 +434,10 @@ class MediaTest extends AbstractAPIv2Test {
                     'height' => null,
                     'width' => null,
                     'attributes' => [
-                            'videoID' => '9bZkp7q19f0',
-                            'listID' => null,
-                            'start' => null,
-                        ],
+                        'videoID' => '9bZkp7q19f0',
+                        'listID' => null,
+                        'start' => null,
+                    ],
                 ]
             ],
             [
@@ -533,6 +491,87 @@ class MediaTest extends AbstractAPIv2Test {
         ];
 
         return $urls;
+    }
+
+    /**
+     * Provide data to verify a parsed URL matches a type.
+     *
+     * @return array
+     */
+    public function provideTypeUrls() {
+        $urls = [
+            ['https://vine.co/v/abc123', 'vine'],
+            ['https://embed.gettyimages.com/embed/1234567890', 'getty'],
+            ['https://www.smashcast.tv/example', 'smashcast'],
+            ['https://imgur.com/example', 'imgur'],
+            ['https://imgur.com/example.jpg', 'imgur'],
+            ['https://i.imgur.com/example', 'imgur'],
+            ['https://m.imgur.com/example', 'imgur'],
+            ['https://www.pinterest.com/pin/1234567890', 'pinterest'],
+            ['https://vimeo.com/251083506', 'vimeo'],
+            ['https://youtube.com/watch?v=example', 'youtube'],
+            ['https://youtube.ca/watch?v=example', 'youtube']
+        ];
+
+        return $urls;
+    }
+
+    /**
+     * Called after each test is executed.
+     *
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
+     */
+    public function tearDown() {
+        // Make sure fetching page info is re-disabled, after every test.
+        $this->setDisableFetch(true);
+    }
+
+    /**
+     * Test scraping pages with /media/scrape.
+     *
+     * @dataProvider provideScrapeUrls
+     * @param array $url
+     * @param string $type
+     * @param array $info
+     * @param bool $enableFetch
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
+     */
+    public function testScrape($url, $type, array $info, $enableFetch = false) {
+        // Fetching is disabled by default in tests. Should it be enabled for this test?
+        if ($enableFetch) {
+            $this->setDisableFetch(false);
+        }
+        $result = $this->api()->post('media/scrape', ['url' => $url]);
+        $this->assertEquals(201, $result->getStatusCode());
+
+        $body = $result->getBody();
+        $this->assertEquals($url, $body['url']);
+        $this->assertEquals($type, $body['type']);
+
+        // Body and type have been validated. Validate the remaining fields.
+        unset($body['url'], $body['type']);
+        $this->assertCount(count($info), $body);
+        foreach ($body as $key => $value) {
+            $this->assertEquals($info[$key], $value);
+        }
+    }
+
+    /**
+     * Verify a URL matches a specific type.
+     *
+     * @param string $url
+     * @param string $type
+     * @dataProvider provideTypeUrls
+     */
+    public function testUrlType($url, $type) {
+        $result = $this->api()->post('media/scrape', ['url' => $url]);
+        $this->assertEquals(201, $result->getStatusCode());
+
+        $body = $result->getBody();
+        $this->assertEquals($url, $body['url']);
+        $this->assertEquals($type, $body['type']);
     }
 
     /**

--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -1,0 +1,54 @@
+<?php
+namespace VanillaTests\APIv2;
+
+class MediaTest extends AbstractAPIv2Test {
+
+    /**
+     * Test scraping pages with /media/scrape.
+     *
+     * @dataProvider provideScrapeUrls
+     * @param array $url
+     * @param string $type
+     * @param array $info
+     */
+    public function testScrape($url, $type, array $info) {
+        $result = $this->api()->post('media/scrape', ['url' => $url]);
+        $this->assertEquals(201, $result->getStatusCode());
+
+        $body = $result->getBody();
+        $this->assertEquals($url, $body['url']);
+        $this->assertEquals($type, $body['type']);
+
+        // Body and type have been validated. Validate the remaining fields.
+        unset($body['url'], $body['type']);
+        $this->assertCount(count($info), $body);
+        foreach ($body as $key => $value) {
+            $this->assertEquals($info[$key], $value);
+        }
+    }
+
+    /**
+     * Provide scrape-able URLs in the testing environment and expected information to be returned by each.
+     *
+     * @return array
+     */
+    public function provideScrapeUrls() {
+        $testBaseUrl = getenv('TEST_BASEURL');
+        $urls = [
+            [
+                "{$testBaseUrl}/tests/fixtures/html/og.htm",
+                'site',
+                [
+                    'name' => 'Online Community Software and Customer Forum Software by Vanilla Forums',
+                    'body' => 'Engage your customers with a vibrant and modern online customer community forum. A customer community helps to increases loyalty, reduce support costs and deliver feedback.',
+                    'photoUrl' => 'https://vanillaforums.com/images/metaIcons/vanillaForums.png',
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => null
+                ]
+            ]
+        ];
+
+        return $urls;
+    }
+}

--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -1,7 +1,20 @@
 <?php
 namespace VanillaTests\APIv2;
 
+use WebScraper;
+
 class MediaTest extends AbstractAPIv2Test {
+
+    /**
+     * Called after each test is executed.
+     *
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
+     */
+    public function tearDown() {
+        // Make sure fetching page info is re-disabled, after every test.
+        $this->setDisableFetch(true);
+    }
 
     /**
      * Test scraping pages with /media/scrape.
@@ -10,8 +23,15 @@ class MediaTest extends AbstractAPIv2Test {
      * @param array $url
      * @param string $type
      * @param array $info
+     * @param bool $enableFetch
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
      */
-    public function testScrape($url, $type, array $info) {
+    public function testScrape($url, $type, array $info, $enableFetch = false) {
+        // Fetching is disabled by default in tests. Should it be enabled for this test?
+        if ($enableFetch) {
+            $this->setDisableFetch(false);
+        }
         $result = $this->api()->post('media/scrape', ['url' => $url]);
         $this->assertEquals(201, $result->getStatusCode());
 
@@ -44,11 +64,487 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://vanillaforums.com/images/metaIcons/vanillaForums.png',
                     'height' => null,
                     'width' => null,
-                    'attributes' => null
+                    'attributes' => []
+                ],
+                true
+            ],
+            [
+                'https://embed.gettyimages.com/foo-bar/640/360',
+                'getty',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => 360,
+                    'width' => 640,
+                    'attributes' => [
+                        'mediaID' => 'foo-bar'
+                    ],
+                ]
+            ],
+            [
+                'https://hitbox.tv/foobar',
+                'hitbox',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'channelID' => 'foobar'
+                    ],
+                ]
+            ],
+            [
+                'https://www.hitbox.tv/foobar',
+                'hitbox',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'channelID' => 'foobar'
+                    ],
+                ]
+            ],
+            [
+                'https://example.com/image.bmp',
+                'image',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => 'https://example.com/image.bmp',
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [],
+                ]
+            ],
+            [
+                'https://example.com/image.gif',
+                'image',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => 'https://example.com/image.gif',
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [],
+                ]
+            ],
+            [
+                'https://example.com/image.jpg',
+                'image',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => 'https://example.com/image.jpg',
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [],
+                ]
+            ],
+            [
+                'https://example.com/image.jpeg',
+                'image',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => 'https://example.com/image.jpeg',
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [],
+                ]
+            ],
+            [
+                'https://example.com/image.png',
+                'image',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => 'https://example.com/image.png',
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [],
+                ]
+            ],
+            [
+                'https://example.com/image.svg',
+                'image',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => 'https://example.com/image.svg',
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [],
+                ]
+            ],
+            [
+                'https://example.com/image.tif',
+                'image',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => 'https://example.com/image.tif',
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [],
+                ]
+            ],
+            [
+                'https://example.com/image.tiff',
+                'image',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => 'https://example.com/image.tiff',
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [],
+                ]
+            ],
+            [
+                'https://i.imgur.com/foobar.gifv',
+                'imgur',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'mediaID' => 'foobar'
+                    ],
+                ]
+            ],
+            [
+                'https://www.instagram.com/p/foo-bar',
+                'instagram',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'mediaID' => 'foo-bar'
+                    ],
+                ]
+            ],
+            [
+                'https://instagram.com/p/foo-bar',
+                'instagram',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'mediaID' => 'foo-bar'
+                    ],
+                ]
+            ],
+            [
+                'https://instagr.am/p/foo-bar',
+                'instagram',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'mediaID' => 'foo-bar'
+                    ],
+                ]
+            ],
+            [
+                'https://www.pinterest.com/pin/1234567890',
+                'pinterest',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'pinID' => '1234567890'
+                    ],
+                ]
+            ],
+            [
+                'https://pinterest.com/pin/1234567890',
+                'pinterest',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'pinID' => '1234567890'
+                    ],
+                ]
+            ],
+            [
+                'https://soundcloud.com/example-user/foo-bar',
+                'soundcloud',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'user' => 'example-user',
+                        'track' => 'foo-bar'
+                    ],
+                ]
+            ],
+            [
+                'https://twitch.tv/foobar',
+                'twitch',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'channel' => 'foobar'
+                    ],
+                ]
+            ],
+            [
+                'https://twitter.com/example-user/status/1234567890',
+                'twitter',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'statusID' => '1234567890'
+                    ],
+                ]
+            ],
+            [
+                'https://vimeo.com/1234567890',
+                'vimeo',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => '1234567890'
+                    ],
+                ]
+            ],
+            [
+                'https://vine.co/v/hzxpjd6b9d9',
+                'vine',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => 'hzxpjd6b9d9'
+                    ],
+                ]
+            ],
+            [
+                'https://example.wistia.com/medias/foobar',
+                'wistia',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => 'foobar',
+                        'time' => null
+                    ],
+                ]
+            ],
+            [
+                'https://example.wistia.com/?wvideo=foobar',
+                'wistia',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => 'foobar',
+                        'time' => null
+                    ],
+                ]
+            ],
+            [
+                'https://example.wi.st/?wvideo=foobar',
+                'wistia',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => 'foobar',
+                        'time' => null
+                    ],
+                ]
+            ],
+            [
+                'https://example.wistia.com/medias/foobar',
+                'wistia',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => 'foobar',
+                        'time' => null
+                    ],
+                ]
+            ],
+            [
+                'https://example.wi.st/medias/foobar',
+                'wistia',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => 'foobar',
+                        'time' => null
+                    ],
+                ]
+            ],
+            [
+                'https://example.wistia.com/?wvideo=foobar&wtime=3m30s',
+                'wistia',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => 'foobar',
+                        'time' => '3m30s'
+                    ],
+                ]
+            ],
+            [
+                'https://example.wistia.com/medias/foobar?wtime=3m30s',
+                'wistia',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => 'foobar',
+                        'time' => '3m30s'
+                    ],
+                ]
+            ],
+            [
+                'https://www.youtube.com/watch?v=9bZkp7q19f0',
+                'youtube',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                            'videoID' => '9bZkp7q19f0',
+                            'listID' => null,
+                            'start' => null,
+                        ],
+                ]
+            ],
+            [
+                'https://youtu.be/9bZkp7q19f0',
+                'youtube',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => '9bZkp7q19f0',
+                        'listID' => null,
+                        'start' => null,
+                    ],
+                ]
+            ],
+            [
+                "https://www.youtube.com/watch?v=9bZkp7q19f0&t=3m2s",
+                'youtube',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => '9bZkp7q19f0',
+                        'listID' => null,
+                        'start' => 182,
+                    ],
+                ]
+            ],
+            [
+                "https://youtu.be/9bZkp7q19f0?t=3m2s",
+                'youtube',
+                [
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'videoID' => '9bZkp7q19f0',
+                        'listID' => null,
+                        'start' => 182,
+                    ],
                 ]
             ]
         ];
 
         return $urls;
+    }
+
+    /**
+     * Set the "disable fetch" flag of the web scraper to avoid attempting to download documents.
+     *
+     * @param bool $disableFetch
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
+     */
+    private function setDisableFetch($disableFetch) {
+        /** @var WebScraper $webScraper */
+        $webScraper = static::container()->get(WebScraper::class);
+        $webScraper->setDisableFetch($disableFetch);
     }
 }

--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -69,22 +69,22 @@ class MediaTest extends AbstractAPIv2Test {
                 true
             ],
             [
-                'https://embed.gettyimages.com/foo-bar/640/360',
+                'https://embed.gettyimages.com/embed/1234567890',
                 'getty',
                 [
                     'name' => null,
                     'body' => null,
                     'photoUrl' => null,
-                    'height' => 360,
-                    'width' => 640,
+                    'height' => null,
+                    'width' => null,
                     'attributes' => [
-                        'mediaID' => 'foo-bar'
+                        'mediaID' => '1234567890'
                     ],
                 ]
             ],
             [
-                'https://hitbox.tv/foobar',
-                'hitbox',
+                'https://smashcast.tv/foobar',
+                'smashcast',
                 [
                     'name' => null,
                     'body' => null,
@@ -97,8 +97,8 @@ class MediaTest extends AbstractAPIv2Test {
                 ]
             ],
             [
-                'https://www.hitbox.tv/foobar',
-                'hitbox',
+                'https://www.smashcast.tv/foobar',
+                'smashcast',
                 [
                     'name' => null,
                     'body' => null,

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -209,6 +209,10 @@ class Bootstrap {
             ->rule('WebLinking')
             ->setClass(\Vanilla\Web\WebLinking::class)
             ->setShared(true)
+
+            ->rule(\WebScraper::class)
+            ->setShared(true)
+            ->addCall('setDisableFetch', [true]);
         ;
     }
 

--- a/tests/fixtures/html/og.htm
+++ b/tests/fixtures/html/og.htm
@@ -1,0 +1,13 @@
+<html prefix="og: http://ogp.me/ns#">
+<head>
+    <title>Online Community Software and Customer Forum Software by Vanilla Forums</title>
+    <meta property="og:title" content="Online Community Software and Customer Forum Software by Vanilla Forums">
+    <meta property="og:type" content="Website">
+    <meta property="og:url" content="https://vanillaforums.com/en/">
+    <meta property="og:image" content="https://vanillaforums.com/images/metaIcons/vanillaForums.png">
+    <meta property="og:description" content="Engage your customers with a vibrant and modern online customer community forum. A customer community helps to increases loyalty, reduce support costs and deliver feedback.">
+    <meta property="og:site_name" content="Vanilla Forums">
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
This update adds the /media/scrape action to API v2.

The spec is outlined in the associated issue. Tests are included.

### Notes
1. This is taking a lot of existing functionality from [`fetchPageInfo`](https://github.com/vanilla/vanilla/blob/36faa6b09a6f8c95dee8ed888d9c240cbba0cc2a/library/core/functions.general.php#L904) and [`Gdn_Format::embedReplacement`](https://github.com/vanilla/vanilla/blob/36faa6b09a6f8c95dee8ed888d9c240cbba0cc2a/library/core/class.format.php#L1388) and marrying it under the media endpoint for the purpose of assisting with embeds. The code is built to return very similar (identical, if possible) values to what we see when performing embeds with the aforementioned functions.
1. Tests are primarily split between gathering data via parsing a page and extracting information from a URL. Pulling data from a page is limited to a single test loading a static HTML page in the tests directory. Otherwise, fetching page data is disabled in tests and only the URLs are used. If you want to see additional information gathered via scraping (e.g. title, description) added to a response, manually call the API with a URL (e.g. https://youtu.be/QljRe99OMCU)

Closes #6439