### PR TITLE
Fix dba/counts overwriting Category.LastDiscussionID with older discussion

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -689,19 +689,17 @@ class CategoryModel extends Gdn_Model {
                     $discussionID = valr("$commentID.DiscussionID", $discussions, null);
 
                     $dateLastComment = Gdn_Format::toTimestamp($row['DateLastComment']);
-                    $dateLastDiscussion = Gdn_Format::toTimestamp($row['DateLastDiscussion']);
+
+                    $discussionModel = new DiscussionModel();
+                    $latestDiscussion = $discussionModel->getID($category['LastDiscussionID']);
+                    $dateLastDiscussion = Gdn_Format::toTimestamp(val('DateInserted', $latestDiscussion));
 
                     $set = ['LastCommentID' => $commentID];
 
                     if ($discussionID) {
-                        $lastDiscussionID = val('LastDiscussionID', $category);
-
                         if ($dateLastComment >= $dateLastDiscussion) {
                             // The most recent discussion is from this comment.
                             $set['LastDiscussionID'] = $discussionID;
-                        } else {
-                            // The most recent discussion has no comments.
-                            $set['LastCommentID'] = null;
                         }
                     } else {
                         // Something went wrong.

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -699,6 +699,9 @@ class CategoryModel extends Gdn_Model {
                         if ($dateLastComment >= $dateLastDiscussion) {
                             // The most recent discussion is from this comment.
                             $set['LastDiscussionID'] = $discussionID;
+                        } else {
+                            // The most recent discussion has no comments.
+                            $set['LastCommentID'] = null;
                         }
                     } else {
                         // Something went wrong.

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -664,7 +664,6 @@ class CategoryModel extends Gdn_Model {
                     ->select('c.CommentID', 'max', 'LastCommentID')
                     ->select('d.DiscussionID', 'max', 'LastDiscussionID')
                     ->select('c.DateInserted', 'max', 'DateLastComment')
-                    ->select('d.DateInserted', 'max', 'DateLastDiscussion')
                     ->from('Comment c')
                     ->join('Discussion d', 'd.DiscussionID = c.DiscussionID')
                     ->groupBy('d.CategoryID')


### PR DESCRIPTION
3 "steps" of dba/counts are important here.
* Recalculate Category.LastDiscussionID
* Recalculate Category.LastCommentID
* Recalculate Category.LastDateInserted 

Previously we were updating the LastDiscussionID when the LastCommentID had a later date, but, our data set to compare the DateInserted from the Comment wasn't including discussions with no comments causing the wrong latest discussion to be used to update the category record (also to show up in the category page in certain themes).

This will in turn enable the 3rd step listed above to update the category records properly.

I also removed in this a few unnecessary lines.

`$lastDiscussionID` was never used.

We don't want to set LastCommentID to null when a discussion is the latest content inserted but instead returning the correct latest inserted comment.

Removed the LastDiscussionID field from the query as we now don't use it.