### PR TITLE
Add noopener to all of the things

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -378,7 +378,7 @@ jQuery(document).ready(function($) {
      */
     $("a[target='_blank']")
         .filter(":not([rel*='noopener']):not([data-allow-opener='true'])")
-            .each(function() {
+        .each(function() {
             var $this = $(this);
             var rel = $this.attr("rel");
 

--- a/js/global.js
+++ b/js/global.js
@@ -371,18 +371,6 @@ jQuery(document).ready(function($) {
         return false;
     });
 
-    // Add noopener to any user content with target="_blank"
-    $(".Message a[target='_blank']").filter(":not([rel*='noopener'])").each(function() {
-        var $this = $(this);
-        var rel = $this.attr("rel");
-
-        if (rel) {
-            $this.attr("rel", rel + " noopener");
-        } else {
-            $this.attr("rel", "noopener");
-        }
-    });
-
     // This turns any anchor with the "Popup" class into an in-page pop-up (the
     // view of the requested in-garden link will be displayed in a popup on the
     // current screen).

--- a/js/global.js
+++ b/js/global.js
@@ -371,6 +371,20 @@ jQuery(document).ready(function($) {
         return false;
     });
 
+    // Add noopener to any user content with target="_blank"
+    $("a[target='_blank']")
+        .filter(":not([rel*='noopener']):not([data-allow-opener='true'])")
+            .each(function() {
+            var $this = $(this);
+            var rel = $this.attr("rel");
+
+            if (rel) {
+                $this.attr("rel", rel + " noopener");
+            } else {
+                $this.attr("rel", "noopener");
+            }
+        });
+
     // This turns any anchor with the "Popup" class into an in-page pop-up (the
     // view of the requested in-garden link will be displayed in a popup on the
     // current screen).

--- a/js/global.js
+++ b/js/global.js
@@ -371,6 +371,18 @@ jQuery(document).ready(function($) {
         return false;
     });
 
+    // Add noopener to any user content with target="_blank"
+    $(".Message a[target='_blank']").filter(":not([rel*='noopener'])").each(function() {
+        var $this = $(this);
+        var rel = $this.attr("rel");
+
+        if (rel) {
+            $this.attr("rel", rel + " noopener");
+        } else {
+            $this.attr("rel", "noopener");
+        }
+    });
+
     // This turns any anchor with the "Popup" class into an in-page pop-up (the
     // view of the requested in-garden link will be displayed in a popup on the
     // current screen).

--- a/js/global.js
+++ b/js/global.js
@@ -371,7 +371,11 @@ jQuery(document).ready(function($) {
         return false;
     });
 
-    // Add noopener to any user content with target="_blank"
+    /**
+     * Add `rel='noopener'` to everything on the page.
+     *
+     * If you really need the linked page to have window.opener, set the `data-allow-opener='true'` on your link.
+     */
     $("a[target='_blank']")
         .filter(":not([rel*='noopener']):not([data-allow-opener='true'])")
             .each(function() {

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -916,6 +916,7 @@ class Gdn_Format {
 
                 // Do HTML filtering before our special changes.
                 $result = $formatter->format($mixed, $options);
+                $result = self::sanitizeLinks($result);
             } else {
                 // The text does not contain HTML and does not have to be purified.
                 // This is an optimization because purifying is very slow and memory intense.
@@ -982,6 +983,32 @@ class Gdn_Format {
 
         return $html;
     }
+
+    /**
+     * Add noopener to any link that has target="_blank"
+     *
+     * @param string $html An HTML-formatted string.
+     *
+     * @return string Returns the html with noopener added to any links with target="_blank".
+     */
+    protected static function sanitizeLinks($html) {
+        if (preg_match('/target="_blank"/i', $html)) {
+            $htmlDom = pQuery::parseStr($html);
+
+            foreach($htmlDom->query('a[target="_blank"]') as $targetBlankLink) {
+                $rel = $targetBlankLink->attr("rel");
+                if ($rel) {
+                    $targetBlankLink->attr("rel", $rel . " noopener");
+                } else {
+                    $targetBlankLink->attr("rel", "noopener");
+                }
+            }
+            $html = (string)$htmlDom;
+        }
+
+        return $html;
+    }
+
 
     /**
      * Check to see if a string has quotes and replace with them with a placeholder.

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -995,7 +995,7 @@ class Gdn_Format {
         if (preg_match('/target="_blank"/i', $html)) {
             $htmlDom = pQuery::parseStr($html);
 
-            foreach($htmlDom->query('a[target="_blank"]') as $targetBlankLink) {
+            foreach($htmlDom->query('a[target="_blank"]:not([rel*="noopener"])') as $targetBlankLink) {
                 $rel = $targetBlankLink->attr("rel");
                 if ($rel) {
                     $targetBlankLink->attr("rel", $rel . " noopener");


### PR DESCRIPTION
Closes #6205 

Adds a function to Gdn_Format that adds `rel="noopener"` to and links with `target="_blank"`. This processing will only be run on formats containing html.

I initially looked into doing this in htmlawed but that seems unmaintainable and doing this with regex seems like it would be a mess.

@tburry Had proposed doing it client side with a javascript solution, but since I couldn't put together a good whitelist or blacklist of places to run/not run the sanitization I feel that a server side solution is necessary to properly implement this.