### PR TITLE
Define schema types in PUT /categories/follow

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -431,8 +431,8 @@ class CategoriesApiController extends AbstractApiController {
         $this->permission('Garden.SignIn.Allow');
 
         $schema = ['followed:b' => 'The category-follow status for the current user.'];
-        $in = $this->schema($schema);
-        $out = $this->schema($schema);
+        $in = $this->schema($schema, 'in');
+        $out = $this->schema($schema, 'out');
 
         $category = $this->category($id);
         $body = $in->validate($body);


### PR DESCRIPTION
The schemas in `CategoriesApiController::put_follow` were using the default type ("in"). This causes an issue for API documentation generation, because no output schema was detected.

This update explicitly defines a type for both schemas.

Closes #6593 