### PR TITLE
Refactor SsoUtils

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -63,10 +63,18 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->setShared(true)
     ->addAlias('ApplicationManager')
 
+    ->rule(Garden\Web\Cookie::class)
+    ->setShared(true)
+    ->addAlias('Cookie')
+
     // PluginManager
     ->rule('Gdn_PluginManager')
     ->setShared(true)
     ->addAlias('PluginManager')
+
+    ->rule(SsoUtils::class)
+    ->setShared(true)
+    ->addAlias('SsoUtils')
 
     // ThemeManager
     ->rule('Gdn_ThemeManager')
@@ -314,6 +322,13 @@ $dic->call(function (
 
     // Now that all of the events have been bound, fire an event that allows plugins to modify the container.
     $eventManager->fire('container_init', $dic);
+});
+
+// Send out cookie headers.
+register_shutdown_function(function() use ($dic) {
+    $dic->call(function(Garden\Web\Cookie $cookie) {
+        $cookie->flush();
+    });
 });
 
 /**

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -22,11 +22,6 @@ class Gdn_Session {
      */
     const CSRF_NAME = 'TransientKey';
 
-    /**
-     * CSRF tokens time to live.
-     */
-    const CSRF_TOKEN_TTL = 1200; // 20 minutes.
-
     /** @var int Unique user identifier. */
     public $UserID;
 
@@ -823,87 +818,5 @@ class Gdn_Session {
         }
 
         return $session;
-    }
-
-    /**
-     * Generate a CSRF token that ca be used externally.
-     * ie. oauth2 state parameter validation.
-     *
-     * @param bool $forceNew The CSRF token is generated on a per request basis. Use forceNew to regenerate it.
-     * @return The CSRF token.
-     */
-    public function generateCSRFToken($forceNew = false) {
-        static $csrfToken;
-
-        if ($csrfToken === null || $forceNew) {
-            $expiration = time() + self::CSRF_TOKEN_TTL;
-            $csrfToken = betterRandomString(32);
-
-            /** @var Gdn_CookieIdentity $identity */
-            $identity = Gdn::getContainer()->get('Identity');
-            $identity->setJWTPayload(
-                c('Garden.Cookie.Name', 'Vanilla').'-csrf',
-                [
-                    'csrfToken' => $csrfToken,
-                    'expiration' => $expiration,
-                ],
-                $expiration
-            );
-        }
-
-        return $csrfToken;
-    }
-
-    /**
-     * Consume the CSRF token. Will prevent it from being used a subsequent time.
-     *
-     * @param string $csrfToken
-     * @return array|null the CSRF data.
-     * @throws Exception If the token doesn't match or have expired.
-     */
-    public function consumeCSRFToken($csrfToken) {
-        $cookieName = c('Garden.Cookie.Name', 'Vanilla').'-csrf';
-        /** @var Gdn_CookieIdentity $identity */
-        $identity = Gdn::getContainer()->get('Identity');
-
-        // This checks the expiration.
-        $data = $identity->getJWTPayload($cookieName);
-
-        if (!$data || empty($data['csrfToken'])) {
-            throw new Exception(t('The session is missing or contain an expired CSRF token.'));
-        }
-        if (!$this->isCSRFDataValid($csrfToken, $data)) {
-            throw new Exception('Invalid CSRF token.');
-        }
-
-        $identity::deleteCookie($cookieName);
-
-        return $data;
-    }
-
-    /**
-     * Utility function used to validate CSRF data.
-     *
-     * @param string $csrfToken
-     * @param array $csrfTokenData
-     * @return bool true if the data is valid and false otherwise.
-     */
-    public function isCSRFDataValid($csrfToken, $csrfTokenData) {
-        // Validate expected data.
-        if (!is_array($csrfTokenData) || empty($csrfTokenData['csrfToken']) || empty($csrfTokenData['expiration'])) {
-            return false;
-        }
-
-        // Check for expiration.
-        if ($csrfTokenData['expiration'] < time()) {
-            return false;
-        }
-
-        // Check the token.
-        if ($csrfToken !== $csrfTokenData['csrfToken']) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/library/core/helpers/class.ssoutils.php
+++ b/library/core/helpers/class.ssoutils.php
@@ -5,48 +5,161 @@
  * @license GPLv2
  */
 
+use Firebase\JWT\JWT;
+use Garden\Web\Cookie;
+
 /**
  * Class SsoUtils
  */
 class SsoUtils {
+
     /**
-     * Create a CSRF token to verify on a subsequent request.
-     *
-     * @return A CSRF token.
+     * State token time to live.
      */
-    public static function createCSRFToken() {
-        return Gdn::session()->generateCSRFToken();
+    const STATE_TOKEN_TTL = 1200; // 20 minutes.
+
+    /** Signing algorithm for JWT tokens. */
+    const JWT_ALGORITHM = 'HS256';
+
+    /** @var Cookie */
+    private $cookie;
+
+    /** @var string */
+    private $cookieName;
+
+    /** @var Gdn_Session */
+    private $session;
+
+    /** @var string */
+    private $stateToken;
+
+    /**
+     * SsoUtils constructor.
+     */
+    public function __construct(Gdn_Configuration $config, Cookie $cookie, Gdn_Session $session) {
+        $this->cookie = $cookie;
+        $this->cookieName = $config->get('Garden.Cookie.Name', 'Vanilla').'-ssostatetoken';
+        $this->cookieSalt = $config->get('Garden.Cookie.Salt');
+        $this->session = $session;
+
+        if (!$this->cookieSalt) {
+            throw new Gdn_ErrorException('Cookie salt is empty.');
+        }
     }
 
     /**
-     * Verify a CSRF token.
-     * This function will stash the token (using the context) so that it works with postbacks.
+     * Get a state token to verify on a subsequent request.
      *
-     * @param string $context Context defining where this function is used.
-     * @param $suppliedCSRFToken
-     * @throws Gdn_UserException If the CSRF token is invalid/expired.
+     * @param bool $forceNew Force a new token to be generated.
+     * @return A state token.
      */
-    public static function verifyCSRFToken($context, $suppliedCSRFToken) {
-        if (empty($suppliedCSRFToken)) {
-            throw new Gdn_UserException(t('Invalid CSRF token supplied.'), 403);
+    public function getStateToken($forceNew = false) {
+        if ($this->stateToken === null || $forceNew) {
+            $expiration = time() + self::STATE_TOKEN_TTL;
+            $this->stateToken = betterRandomString(32);
+
+            $payload = [
+                'stateToken' => $this->stateToken,
+                'exp' => $expiration,
+            ];
+
+            $jwt = JWT::encode($payload, $this->cookieSalt, self::JWT_ALGORITHM);
+
+            $this->cookie->set($this->cookieName, $jwt, $expiration);
         }
 
-        $storedCSRFData = null;
-        $isCSRFDataValid = false;
+        return $this->stateToken;
+    }
+
+    /**
+     * Verify a state token.
+     * This function will stash the token (using the context) so that it works with postbacks.
+     * From there, trying to validate the token in a different context will fail.
+     *
+     * To explain this simply, if multiple sso plugins are in a page they will have all the same state token.
+     * When trying to verify the state from an sso plugin the token becomes invalid for every other plugins but that one.
+     * Furthermore, for plugins that offer multiple authentication actions (SignIn, Social Connect, ...), each separate
+     * action should use a different context name.
+     *
+     * @param string $context Context defining where the verification happens.
+     * @param $stateToken
+     * @throws Gdn_UserException If the state token is invalid/expired.
+     */
+    public function verifyStateToken($context, $stateToken) {
+        if (empty($stateToken)) {
+            throw new Gdn_UserException(t('Invalid state token supplied.'), 403);
+        }
+
+        $storedStateTokenData = null;
+        $isStateTokenValid = false;
         try {
-            $storedCSRFData = Gdn::session()->consumeCSRFToken($suppliedCSRFToken);
+            $storedStateTokenData = $this->consumeStateToken($stateToken);
             // Stash the token in case we post back!
-            Gdn::session()->stash("{$context}CSRF", $storedCSRFData);
-            $isCSRFDataValid = true;
+            $this->session->stash("{$context}StateToken", $storedStateTokenData);
+            $isStateTokenValid = true;
         } catch (Exception $e){}
 
-        if (!$storedCSRFData) {
-            $storedCSRFData = Gdn::session()->stash("{$context}CSRF", '', false);
-            $isCSRFDataValid = Gdn::session()->isCSRFDataValid($suppliedCSRFToken, $storedCSRFData);
+        if (!$storedStateTokenData) {
+            $storedStateTokenData = $this->session->stash("{$context}StateToken", '', false);
+            $isStateTokenValid = $this->isStateTokenValid($storedStateTokenData, $stateToken);
         }
 
-        if (!$isCSRFDataValid) {
-            throw new Gdn_UserException(t('Invalid/Expired CSRF token.'), 400);
+        if (!$isStateTokenValid) {
+            throw new Gdn_UserException(t('Invalid/Expired state token.'), 400);
         }
+    }
+
+    /**
+     * Consume a state token and return its data.
+     *
+     * @throws Exception
+     * @param $stateToken
+     * @return array The state token data.
+     */
+    protected function consumeStateToken($stateToken) {
+        $stateTokenData = null;
+        $jwt = $this->cookie->get($this->cookieName);
+        if ($jwt) {
+            try {
+                $stateTokenData = (array)JWT::decode($jwt, $this->cookieSalt, [self::JWT_ALGORITHM]);
+            } catch (Exception $e) {}
+        }
+
+        if (!$stateTokenData || empty($stateTokenData['stateToken'])) {
+            throw new Exception(t('The state token could not be validated or is expired.'));
+        }
+        if (!$this->isStateTokenValid($stateTokenData, $stateToken)) {
+            throw new Exception('The state token is invalid.');
+        }
+
+        $this->cookie->delete($this->cookieName);
+
+        return $stateTokenData;
+    }
+
+    /**
+     * Check if a state token against some state token data.
+     *
+     * @param array $stateTokenData
+     * @param string $stateToken
+     * @return bool true if the data is valid and false otherwise.
+     */
+    protected function isStateTokenValid($stateTokenData, $stateToken) {
+        // Validate expected data.
+        if (!is_array($stateTokenData) || empty($stateTokenData['stateToken']) || empty($stateTokenData['exp'])) {
+            return false;
+        }
+
+        // Check for expiration.
+        if ($stateTokenData['exp'] < time()) {
+            return false;
+        }
+
+        // Check the token.
+        if ($stateToken !== $stateTokenData['stateToken']) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/library/core/helpers/class.ssoutils.php
+++ b/library/core/helpers/class.ssoutils.php
@@ -43,7 +43,7 @@ class SsoUtils {
         $this->session = $session;
 
         if (!$this->cookieSalt) {
-            throw new Gdn_ErrorException('Cookie salt is empty.');
+            throw new Gdn_UserException('Cookie salt is empty.');
         }
     }
 

--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -21,6 +21,19 @@ class GooglePlusPlugin extends Gdn_Plugin {
     /** @var string */
     protected $_AccessToken = null;
 
+    /** @var SsoUtils */
+    private $ssoUtils;
+
+    /**
+     * Constructor.
+     *
+     * @param SsoUtils $ssoUtils
+     */
+    public function __construct(SsoUtils $ssoUtils) {
+        parent::__construct();
+        $this->ssoUtils = $ssoUtils;
+    }
+
     /**
      * Get current access token.
      *
@@ -81,9 +94,12 @@ class GooglePlusPlugin extends Gdn_Plugin {
             'scope' => 'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email'
         ];
 
+        // Get a state token.
+        $stateToken = $this->ssoUtils->getStateToken();
+
         $state = array_merge(
             [
-                'csrf' => SsoUtils::createCSRFToken(),
+                'token' => $stateToken,
             ],
             (array)$extraState
         );
@@ -299,8 +315,8 @@ class GooglePlusPlugin extends Gdn_Plugin {
         }
 
         $state = json_decode(Gdn::request()->get('state', ''), true);
-        $suppliedCSRFToken = val('csrf', $state);
-        SsoUtils::verifyCSRFToken(self::PROVIDER_KEY, $suppliedCSRFToken);
+        $suppliedStateToken = val('token', $state);
+        $this->ssoUtils->verifyStateToken(self::PROVIDER_KEY, $suppliedStateToken);
 
         $code = Gdn::request()->get('code');
         $accessToken = $sender->Form->getFormValue('AccessToken');

--- a/tests/APIv0/AltTest.php
+++ b/tests/APIv0/AltTest.php
@@ -72,7 +72,7 @@ class AltTest extends TestCase {
                 'Title' => get_called_class(),
                 'Domain' => parse_url($api->getBaseUrl(), PHP_URL_HOST),
                 'Cookie' => [
-                    'Salt' => '',
+                    'Salt' => 'salt',
                     'Name' => 'vf_'.strtolower(get_called_class()).'_ENDTX',
                     'Domain' => '',
                 ],


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/6513

- Move everything related to state token into SsoUtils
- Update SsoUtils to be an object instead of a class providing static methods
- Inject SsoUtils where needed
- Use \Garden\Web\Cookie
    - I've added a shutdown handler function that calls Cookie::flush() so that cookies set through Cookie are sent to the browser