### PR TITLE
Add /users/name to API v2 for searching for users by name

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -180,7 +180,7 @@ class UsersApiController extends AbstractApiController {
      * @param array $query
      * @return array
      */
-    public function get_names(array $query) {
+    public function get_byNames(array $query) {
         $this->permission('Garden.SignIn.Allow');
 
         $in = $this->schema([

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -229,7 +229,6 @@ class UsersApiController extends AbstractApiController {
             ->resultArray();
 
         foreach ($rows as &$row) {
-            $this->userModel->setCalculatedFields($row);
             $row = $this->normalizeOutput($row);
         }
         $result = $out->validate($rows);

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2714,14 +2714,13 @@ class UserModel extends Gdn_Model {
      * @return Gdn_DataSet
      */
     public function searchByName($name, $sortField = 'name', $sortDirection = 'asc', $limit = false, $offset = false) {
-        $wildcardSearch = (strpos($name, '*') !== false);
+        $wildcardSearch = (substr($name, -1, 1) === '*');
 
         // Preserve existing % by escaping.
         $name = trim($name);
         $name = str_replace('%', '\%', $name);
         if ($wildcardSearch) {
-            // Convert * to new, unescaped %.
-            $name = str_replace('*', '%', $name);
+            $name = rtrim($name, '*');
         }
 
         // Avoid potential pollution by resetting.

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -127,13 +127,13 @@ class UsersTest extends AbstractResourceTest {
     }
 
     /**
-     * Test full-name filtering with GET /users/names.
+     * Test full-name filtering with GET /users/by-names.
      */
     public function testNamesFull() {
         $users = $this->api()->get($this->baseUrl)->getBody();
         $testUser = array_pop($users);
 
-        $request = $this->api()->get("{$this->baseUrl}/names", ['name' => $testUser['name']]);
+        $request = $this->api()->get("{$this->baseUrl}/by-names", ['name' => $testUser['name']]);
         $this->assertEquals(200, $request->getStatusCode());
         $searchFull = $request->getBody();
         $row = reset($searchFull);
@@ -141,14 +141,14 @@ class UsersTest extends AbstractResourceTest {
     }
 
     /**
-     * Test partial-name filtering with GET /users/names.
+     * Test partial-name filtering with GET /users/by-names.
      */
     public function testNamesWildcard() {
         $users = $this->api()->get($this->baseUrl)->getBody();
         $testUser = array_pop($users);
 
         $partialName = substr($testUser['name'], 0, -1);
-        $request = $this->api()->get("{$this->baseUrl}/names", ['name' => "{$partialName}*"]);
+        $request = $this->api()->get("{$this->baseUrl}/by-names", ['name' => "{$partialName}*"]);
         $this->assertEquals(200, $request->getStatusCode());
         $searchWildcard = $request->getBody();
         $this->assertNotEmpty($searchWildcard);


### PR DESCRIPTION
This update adds /users/by-names to API v2 for searching users by partial or full usernames. The primary intended functionality is to support \@mentions.

1. /users/by-names was chosen instead of attempting to add this functionality onto the index of /users, because the index was built for user management, similar to what is seen on the users dashboard page. Permissions are tightened down on the index and the data returned can contain potentially-sensitive information. Making the index accept different parameters or output different fields based on user permissions would likely be confusing to users and difficult to effectively document.
1. `UserModel::searchByName` (public method) has been added as a simple method for searching users by name, allowing wildcards in the search string.
1. `UserModel::getMentionsSort` (public method) has been added to return the proper sort field and direction based on the `Garden.MentionsOrder` config. This logic was pulled from `UserModel::tagSearch`, which now uses the new method.
1. Tests included for full- and wildcard-match searches using /users/by-names.

Closes #6514