### PR TITLE
Add filtering by type to discussions API v2 endpoint

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -371,6 +371,12 @@ class DiscussionsApiController extends AbstractApiController {
                     'processor' => [DateFilterSchema::class, 'dateFilterField'],
                 ],
             ]),
+            'type:s?' => [
+                'description' => 'Filter by discussion type.',
+                'x-filter' => [
+                    'field' => 'd.Type'
+                ],
+            ],
             'followed:b' => [
                 'default' => false,
                 'description' => 'Only fetch discussions from followed categories. Pinned discussions are mixed in.'


### PR DESCRIPTION
This update adds filtering by type to the discussions API v2 endpoint.

### Usage

```
GET http://vanilla.localhost/api/v2/discussions?type=idea
```

### Expected Result

Only discussions with the type "Idea" should be returned.