### PR TITLE
Discussion/Comment API normalization event

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -333,7 +333,12 @@ class CommentsApiController extends AbstractApiController {
         }
 
         $schemaRecord = ApiUtils::convertOutputKeys($dbRecord);
-        return $schemaRecord;
+
+        // Allow addons to hook into the normalization process.
+        $options = [];
+        $result = $this->getEventManager()->fireFilter('commentsApiController_normalizeOutput', $schemaRecord, $this, $options);
+
+        return $result;
     }
 
     /**

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -286,7 +286,12 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         $schemaRecord = ApiUtils::convertOutputKeys($dbRecord);
-        return $schemaRecord;
+
+        // Allow addons to hook into the normalization process.
+        $options = ['expand' => $expand];
+        $result = $this->getEventManager()->fireFilter('discussionsApiController_normalizeOutput', $schemaRecord, $this, $options);
+
+        return $result;
     }
 
     /**

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -286,6 +286,7 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         $schemaRecord = ApiUtils::convertOutputKeys($dbRecord);
+        $schemaRecord['type'] = isset($schemaRecord['type']) ? lcfirst($schemaRecord['type']) : null;
 
         // Allow addons to hook into the normalization process.
         $options = ['expand' => $expand];


### PR DESCRIPTION
These events allow plugins to normalize records if needed.
Useful for the "attributes" field. (Ideation, QnA..)

This ensure that every output record are properly updated.