### PR TITLE
Forward client Xdebug cookies in ProxyRequest requests if in debug mode

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -393,7 +393,7 @@ class ProxyRequest {
         $cookie = '';
         $encodeCookies = true;
         foreach ($_COOKIE as $key => $value) {
-            if (strncasecmp($key, 'XDEBUG', 6) == 0) {
+            if (!debug() && strncasecmp($key, 'XDEBUG', 6) == 0) {
                 continue;
             }
 


### PR DESCRIPTION
`ProxyRequest::request` can send along cookies from the user's browser, but will always strip out [Xdebug cookies](https://xdebug.org/docs/remote#browser_session). This update allows the browser's Xdebug cookies to be sent, if the site is in debug mode. Useful when you want to debug server to server calls and both run in your environment.