### PR TITLE
Remove 2011 compat theme from addon test

### DIFF
--- a/tests/APIv2/AddonsTest.php
+++ b/tests/APIv2/AddonsTest.php
@@ -20,7 +20,7 @@ class AddonsTest extends AbstractAPIv2Test {
     ];
 
     private $coreThemes = [
-        '2011Compatibility', 'EmbedFriendly', 'bittersweet', 'default', 'mobile', // themes
+        'EmbedFriendly', 'bittersweet', 'default', 'mobile', // themes
     ];
 
     private $hiddenAddons = [


### PR DESCRIPTION
I missed the travis notification on #6660. This PR removes the theme from the test because it's now hidden.