### PR TITLE
Add block exception for authenticate in Gdn_Dispatcher

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -31,19 +31,19 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
     /** @var array List of exceptions not to block */
     private $blockExceptions = [
-        '/^utility(\/.*)?$/' => self::BLOCK_NEVER,
-        '/^asset(\/.*)?$/' => self::BLOCK_NEVER,
-        '/^home\/error(\/.*)?/' => self::BLOCK_NEVER,
-        '/^home\/leave(\/.*)?/' => self::BLOCK_NEVER,
-        '/^plugin(\/.*)?$/' => self::BLOCK_NEVER,
-        '/^sso(\/.*)?$/' => self::BLOCK_NEVER,
-        '/^discussions\/getcommentcounts/' => self::BLOCK_NEVER,
-        '/^entry(\/.*)?$/' => self::BLOCK_PERMISSION,
-        '/^settings\/analyticstick.json$/' => self::BLOCK_PERMISSION,
-        '/^user\/usernameavailable(\/.*)?$/' => self::BLOCK_PERMISSION,
-        '/^user\/emailavailable(\/.*)?$/' => self::BLOCK_PERMISSION,
-        '/^home\/termsofservice(\/.*)?$/' => self::BLOCK_PERMISSION,
-        '/^api\/v\d+\/applications$/' => self::BLOCK_NEVER,
+        '#^api/v\d+/applications$#' => self::BLOCK_NEVER,
+        '#^asset(/|$)#' => self::BLOCK_NEVER,
+        '#^discussions/getcommentcounts(/|$)#' => self::BLOCK_NEVER,
+        '#^entry(/|$)#' => self::BLOCK_PERMISSION,
+        '#^home/error(/|$)#' => self::BLOCK_NEVER,
+        '#^home/leaving(/|$)#' => self::BLOCK_NEVER,
+        '#^home/termsofservice(/|$)#' => self::BLOCK_PERMISSION,
+        '#^plugin(/|$)#' => self::BLOCK_NEVER,
+        '#^settings/analyticstick.json$#' => self::BLOCK_PERMISSION,
+        '#^sso(/|$)#' => self::BLOCK_NEVER,
+        '#^user/emailavailable(/|$)#' => self::BLOCK_PERMISSION,
+        '#^user/usernameavailable(/|$)#' => self::BLOCK_PERMISSION,
+        '#^utility(/|$)#' => self::BLOCK_NEVER,
     ];
 
     /** @var string The name of the controller to be dispatched. */

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -33,6 +33,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
     private $blockExceptions = [
         '#^api/v\d+/applicants(/|$)#' => self::BLOCK_NEVER,
         '#^asset(/|$)#' => self::BLOCK_NEVER,
+        '#^authenticate(/|$)#' => self::BLOCK_NEVER,
         '#^discussions/getcommentcounts(/|$)#' => self::BLOCK_NEVER,
         '#^entry(/|$)#' => self::BLOCK_PERMISSION,
         '#^home/error(/|$)#' => self::BLOCK_NEVER,

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -31,7 +31,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
     /** @var array List of exceptions not to block */
     private $blockExceptions = [
-        '#^api/v\d+/applications$#' => self::BLOCK_NEVER,
+        '#^api/v\d+/applicants(/|$)#' => self::BLOCK_NEVER,
         '#^asset(/|$)#' => self::BLOCK_NEVER,
         '#^discussions/getcommentcounts(/|$)#' => self::BLOCK_NEVER,
         '#^entry(/|$)#' => self::BLOCK_PERMISSION,


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/6671

Add block exception for /authenticate.

Bonus commits in this PR:
- Improves regexes
  - Updated the delimiters so that we do not have to escape slashes
  - Replace `(\/.*)?$` by `(/|$)` which essentially does the same thing but is clearer
- Reorder the block exceptions alphabetically
- Update `api/v\d+/applications` to `api/v\d+/applicants(/|$)`
  - It was added here https://github.com/vanilla/vanilla/commit/e8cfd89825dbc830b6cd605dd66762e8ba625cf9 but we renamed applications to applicants  in https://github.com/vanilla/vanilla/pull/6140
- Fix "home/leave" to "home/leaving"