### PR TITLE
Fix revealed token in profile not using row expiry

### DIFF
--- a/applications/dashboard/controllers/api/TokensApiController.php
+++ b/applications/dashboard/controllers/api/TokensApiController.php
@@ -259,7 +259,7 @@ class TokensApiController extends AbstractApiController {
         $dbRecord['Name'] = $name ?: t('Personal Access Token');
 
         if (array_key_exists('Token', $dbRecord) && is_string($dbRecord['Token'])) {
-            $dbRecord['AccessToken'] = $this->accessTokenModel->signToken($dbRecord['Token']);
+            $dbRecord['AccessToken'] = $this->accessTokenModel->signTokenRow($dbRecord);
         }
 
         $schemaRecord = ApiUtils::convertOutputKeys($dbRecord);


### PR DESCRIPTION
Signed tokens revealed in the "Access Tokens" area of a user's profile were not using the token's actual expiry, and instead using the current date/time. The signed tokens still work for API access, but could be confusing to users when seeing the last two dot-delimited portions (expiry and signature) changing after every reveal.

This update switches out the call to `AccessTokenModel::signToken` with `AccessTokenModel::signTokenRow` to use the token's true expiry when signing the token.