### PR TITLE
Add score to post endpoint schemas

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -146,6 +146,7 @@ class CommentsApiController extends AbstractApiController {
             'dateInserted:dt' => 'When the comment was created.',
             'dateUpdated:dt|n' => 'When the comment was last updated.',
             'insertUserID:i' => 'The user that created the comment.',
+            'score:i|n' => 'Total points associated with this post.',
             'insertUser?' => $this->getUserFragmentSchema(),
             'url:s?' => 'The full URL to the comment.'
         ]);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -197,6 +197,7 @@ class DiscussionsApiController extends AbstractApiController {
             'sink:b' => 'Whether or not the discussion has been sunk.',
             'countComments:i' => 'The number of comments on the discussion.',
             'countViews:i' => 'The number of views on the discussion.',
+            'score:i|n' => 'Total points associated with this post.',
             'url:s?' => 'The full URL to the discussion.',
             'lastPost?' => $this->getPostFragmentSchema(),
             'bookmarked:b' => 'Whether or not the discussion is bookmarked by the current user.',


### PR DESCRIPTION
This update adds the "score" column to discussion and comment endpoint results.

Closes #6636