### PR TITLE
Include .htaccess.dist in phing build

### DIFF
--- a/build/package-exclude.txt
+++ b/build/package-exclude.txt
@@ -9,10 +9,10 @@
 **/node_modules/**
 **/npm-shrinkwrap.json
 **/package.json
-**/*.dist
 **/*.scss
 **/*.map
 **/.yo-rc.json
+*/**/*.dist
 */**/*.md
 */**/*.txt
 */**/.travis.yml


### PR DESCRIPTION
The Phing build has an exception rule for files ending in "dist". This is primarily meant to keep unwanted files from dependencies or sub-builds from finding their way into the core Vanilla build. However, it has the additional effect of excluding .htaccess.dist from the build.

Phing's pattern matching rules are pretty rudimentary, so this update alters the "dist" exclusion rule to avoid applying it to root-level files. Since .htaccess.dist resides in the root directory of Vanilla, it is once again included in the build. Files ending in "dist" in subdirectories are still excluded.

Closes #6277