### PR TITLE
Fix outdated user data in UserModel's AfterSave event

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2341,8 +2341,8 @@ class UserModel extends Gdn_Model {
                     $this->sendEmailConfirmationEmail($user, true);
                 }
 
-                $this->EventArguments['UserID'] = $userID;
                 $this->clearCache($userID, ['user']);
+                $this->EventArguments['UserID'] = $userID;
                 $this->fireEvent('AfterSave');
             } else {
                 $userID = false;

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2342,17 +2342,13 @@ class UserModel extends Gdn_Model {
                 }
 
                 $this->EventArguments['UserID'] = $userID;
+                $this->clearCache($userID, ['user']);
                 $this->fireEvent('AfterSave');
             } else {
                 $userID = false;
             }
         } else {
             $userID = false;
-        }
-
-        // Clear cached user data
-        if (!$insert && $userID) {
-            $this->clearCache($userID, ['user']);
         }
 
         return $userID;


### PR DESCRIPTION
Moves the clearCache call to the only place where it is actually triggered.
Allows UserModel->getID() to returned fresh data when called from an handler of afterSave()