### PR TITLE
Update version requirements message in dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ If you professionally run a large community or enterprise forum, our cloud solut
 
 We strongly recommend:
 
-*  **PHP 7.0** or higher.
+*  **PHP 7.1** or higher.
 *  MySQL 5.6 or higher (or Percona/MariaDB equivalent).
 
-If your server is not running PHP 7.0 or higher, **you should address this soon**. While PHP 5.6 will receive security patches thru 2018, Vanilla may end support for it prior to that.
+If your server is not running PHP 7.1 or higher, **you should address this soon**. While PHP 7.0 will receive security patches until December 2018, Vanilla may end support for it prior to that.
 
 Our _minimum_ requirements are now:
 
-* PHP 5.6 or newer.
+* PHP 7.0 or newer.
 * PHP extensions mbstring (`--enable-mbstring`), cURL (`--with-curl`), and PDO (on by default).
 * To [import into Vanilla](#migrating-to-vanilla) you need MySQLi (`--with-mysqli`).
 * To use our social plugins you need [OpenSSL](http://php.net/manual/en/openssl.installation.php).

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -341,8 +341,9 @@ class DashboardHooks extends Gdn_Plugin {
             return;
         }
 
-        if (version_compare(phpversion(), '7.0') < 0) {
-            $upgradeMessage = ['Content' => 'Upgrade to <b>PHP 7.1</b> or higher immediately. Version '.phpversion().' is no longer supported.', 'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'];
+        $phpVersion = phpversion();
+        if (version_compare($phpVersion, '7.1') < 0) {
+            $upgradeMessage = ['Content' => 'We recommend using at least PHP 7.1. Support for PHP '.htmlspecialchars($phpVersion).' may be dropped in upcoming releases.', 'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'];
             $messageModule = new MessageModule($sender, $upgradeMessage);
             $sender->addModule($messageModule);
         }

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -342,7 +342,7 @@ class DashboardHooks extends Gdn_Plugin {
         }
 
         if (version_compare(phpversion(), '7.0') < 0) {
-            $upgradeMessage = ['Content' => 'Upgrade to <b>PHP 7.1</b> or higher immediately. Version '.phpversion().' is not supported in the next version of Vanilla.', 'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'];
+            $upgradeMessage = ['Content' => 'Upgrade to <b>PHP 7.1</b> or higher immediately. Version '.phpversion().' is no longer supported.', 'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'];
             $messageModule = new MessageModule($sender, $upgradeMessage);
             $sender->addModule($messageModule);
         }


### PR DESCRIPTION
Vanilla 2.5 altered its version requirements warning in the dashboard to let users know PHP 5.6 support would be dropped with Vanilla 2.6. Now that Vanilla 2.6 is almost here, it's time to revert the warning message back to alerting users of the *current* version requirements.

This update alters the version requirements phrasing to state that anything less than PHP 7.0 is not current supported.

Closes #6365 