### PR TITLE
Allow to get the list of current handlers from the event manager

### DIFF
--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -305,6 +305,15 @@ class EventManager {
     }
 
     /**
+     * Get all of handlers.
+     *
+     * @return array Returns all the handlers.
+     */
+    public function getAllHandlers() {
+        return $this->handlers;
+    }
+
+    /**
      * Get all of the handlers bound to an event.
      *
      * @param string $name The name of the event.


### PR DESCRIPTION
Pretty simple.

The function is named getAllHandlers because `getHandlers($name)` already exists.

I will also need that for https://github.com/vanilla/internal/issues/1416