### PR TITLE
Add checking for new visit without updating cookie

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -22,6 +22,9 @@ class Gdn_Session {
      */
     const CSRF_NAME = 'TransientKey';
 
+    /** Maximum length of inactivity, in seconds, before a visit is considered new. */
+    const VISIT_LENGTH = 1200; // 20 minutes
+
     /** @var int Unique user identifier. */
     public $UserID;
 
@@ -280,36 +283,44 @@ class Gdn_Session {
     }
 
     /**
-     *
+     * Determine if this is a new visit for this user.
      *
      * @return bool
      */
+    public function isNewVisit() {
+        static $result = null;
+
+        if ($result === null) {
+            if ($this->User) {
+                $cookie = $this->getCookie('-Vv', false);
+                $userVisitExpiry = Gdn_Format::toTimeStamp($this->User->DateLastActive) + self::VISIT_LENGTH;
+
+                if ($cookie) {
+                    $result = false; // User has cookie, not a new visit.
+                } elseif ($userVisitExpiry > time())
+                    $result = false; // User was last active less than 20 minutes ago, not a new visit.
+                else {
+                    $result = true; // No cookie and not active in the last 20 minutes? New visit.
+                }
+            } else {
+                return false;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Update the visit cookie.
+     *
+     * @return bool Is this a new visit?
+     */
     public function newVisit() {
-        static $newVisit = null;
+        $newVisit = $this->isNewVisit();
 
-        if ($newVisit !== null) {
-            return $newVisit;
-        }
-
-        if (!$this->User) {
-            return false;
-        }
-
-        $current = $this->getCookie('-Vv');
         $now = time();
-        $timeToExpire = 1200; // 20 minutes
-        $expires = $now + $timeToExpire;
-
-        // Figure out if this is a new visit.
-        if ($current) {
-            $newVisit = false; // user has cookie, not a new visit.
-        } elseif (Gdn_Format::toTimeStamp($this->User->DateLastActive) + $timeToExpire > $now)
-            $newVisit = false; // user was last active less than 20 minutes ago, not a new visit.
-        else {
-            $newVisit = true;
-        }
-
-        $this->setCookie('-Vv', $now, $expires);
+        $expiry = $now + self::VISIT_LENGTH;
+        $this->setCookie('-Vv', $now, $expiry);
 
         return $newVisit;
     }

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -288,23 +288,19 @@ class Gdn_Session {
      * @return bool
      */
     public function isNewVisit() {
-        static $result = null;
+        if ($this->User) {
+            $cookie = $this->getCookie('-Vv', false);
+            $userVisitExpiry = Gdn_Format::toTimeStamp($this->User->DateLastActive) + self::VISIT_LENGTH;
 
-        if ($result === null) {
-            if ($this->User) {
-                $cookie = $this->getCookie('-Vv', false);
-                $userVisitExpiry = Gdn_Format::toTimeStamp($this->User->DateLastActive) + self::VISIT_LENGTH;
-
-                if ($cookie) {
-                    $result = false; // User has cookie, not a new visit.
-                } elseif ($userVisitExpiry > time())
-                    $result = false; // User was last active less than 20 minutes ago, not a new visit.
-                else {
-                    $result = true; // No cookie and not active in the last 20 minutes? New visit.
-                }
-            } else {
-                return false;
+            if ($cookie) {
+                $result = false; // User has cookie, not a new visit.
+            } elseif ($userVisitExpiry > time())
+                $result = false; // User was last active less than 20 minutes ago, not a new visit.
+            else {
+                $result = true; // No cookie and not active in the last 20 minutes? New visit.
             }
+        } else {
+            $result = false;
         }
 
         return $result;


### PR DESCRIPTION
The current method of checking for a new visit (`Gdn_Session::newVisit`) also updates the "visit" cookie. This update adds `Gdn_Session::isNewVisit`, a way to check for a new visit without updating the cookie. The logic for checking for a new session has been moved into the new method and reworked a bit. There should be no functional changes to the original method and it now uses `Gdn_Session::isNewVisit`.