### PR TITLE
Make /categories/archive and /discussions/tagged noindex, follow

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -97,7 +97,10 @@ class CategoriesController extends VanillaController {
         $this->title(htmlspecialchars(val('Name', $category, '')));
         $this->description(sprintf(t("Archives for %s"), gmdate('F Y', strtotime($from))), true);
         $this->addJsFile('discussions.js');
-        $this->Head->addTag('meta', ['name' => 'robots', 'content' => 'noindex']);
+
+        if ($this->Head) {
+            $this->Head->addTag('meta', ['name' => 'robots', 'content' => 'noindex, follow']);
+        }
 
         $this->ControllerName = 'DiscussionsController';
         $this->CssClass = 'Discussions';

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -764,6 +764,10 @@ class DiscussionsController extends VanillaController {
             $this->setData('Tags', $tags);
             $this->setData('Tag', $tagRow);
 
+            if ($this->Head) {
+                $this->Head->addTag('meta', ['name' => 'robots', 'content' => 'noindex, follow']);
+            }
+
             $childTags = $tagModel->getChildTags($tagRow['TagID']);
             $this->setData('ChildTags', $childTags);
         }


### PR DESCRIPTION
The category archives were already noindex, but I’m adding follow just
to be explicit.

Closes #6490.