### PR TITLE
Add README for the Rich Editor

### DIFF
--- a/plugins/rich-editor/README.md
+++ b/plugins/rich-editor/README.md
@@ -24,13 +24,20 @@ This plugin conflicts with and aims to replace some existing plugins.
 
 There are two main types of formatting: inline and block. Inline formatting applies to text within a paragraph while block formatting applies to entire paragraphs.
 
+The MODIFIER-KEY varies by platform.
+
+**MacOS** - CMD (⌘)
+**Windows** - CTRL
+**LINUX** - CTRL
+
+
 | Format    | Type      | Applied With      | Notes
 | ------    | ----      | ------------      | -----
-| Bold      | Inline    | Button, cmd-b     |
-| Italic    | Inline    | Button, cmd-i     |    
+| Bold      | Inline    | Button, MODIFIER-KEY- + b     |
+| Italic    | Inline    | Button, MODIFIER-KEY- + i     |    
 | Code      | Inline    | Button            | Code has both inline and block versions.
 | Strike    | Inline    | Button            |
-| Link      | Inline    | Button, cmd-k     |
+| Link      | Inline    | Button, MODIFIER-KEY- + k     |
 | H1, H2    | Block     | Button            | Two levels of heading are supported.
 | Bullets   | Block     | Auto              | A bulleted list automatically starts when you start a paragraph with "-" or "*"
 | Numbers   | Block     | Auto              | A numbered list automatically starts when you start a paragraph with "1." or any number plus a ".".

--- a/plugins/rich-editor/README.md
+++ b/plugins/rich-editor/README.md
@@ -53,7 +53,7 @@ There are two main types of formatting: inline and block. Inline formatting appl
 
 This plugin is primarily javascript based. The main entrypoint for the application is [src/scripts/app/rich-editor.js](./src/scripts/app/rich-editor.js)
 
-The [`RichEditor` class](./src/scripts/RichEditor.js) is responsible for a single editor instance. It uses our extended [`Quill` class](./src/scripts/Quill.js) to which loads all of our custom Blots from [/blots](./src/scripts/blots) and [/formats](.src/scripts/formats).
+The [`RichEditor` class](./src/scripts/RichEditor.js) is responsible for a single editor instance. It uses our extended [`Quill` class](./src/scripts/Quill.js) which loads all of our custom Blots from [/blots](./src/scripts/blots) and [/formats](.src/scripts/formats).
 
 A custom [Quill theme](./src/scripts/QuillTheme.jsx) is responsible for mounting the various React components that make up the editor's UI. These components can be found in [/components](./src/scripts/components) and primarily consist of
 
@@ -64,7 +64,9 @@ A custom [Quill theme](./src/scripts/QuillTheme.jsx) is responsible for mounting
 
 ### What is a Blot?
 
-A Blot is javascript class used as part of Quill's (and it's underlying library Parchment's) in memory document format. Quill uses LinkedLists for it's data structure. Every Blot has reference to:
+A Blot is javascript class used as part of Quill's (and its underlying library Parchment's) in memory document format. Quill uses LinkedLists for its in-memory data structure. This is different from Quill's persistent [Delta JSON format](https://quilljs.com/guides/designing-the-delta-format/).
+
+Every Blot has reference to:
 
 - Its parent `.parent`
 - Its children `.children`
@@ -78,15 +80,15 @@ Existing Blots will generally be imported from Quill, but could also be imported
 
 **Block**
 
-Equivalent to a paragraph. A line break signifies the end of a Block unless `white-space: pre` is set, in which case line breaks will be preserved. This is already handled in the `CodeBlockBlot`.
+Equivalent to a paragraph. A line break signifies the end of a Block unless `white-space: pre` is set, in which case line breaks will be preserved. This is handled in the `CodeBlockBlot`.
 
 **Inline**
 
-Represents and Inline text containing element. See [quill/formats](https://github.com/quilljs/quill/tree/master/formats) for examples of these. Bold, Italic, and Strike through blots are examples of these.
+Represents an text containing element. See [quill/formats](https://github.com/quilljs/quill/tree/master/formats) for examples of these (Bold, Italic, Strike).
 
 **BlockEmbed** and **Embed**
 
-Represents an element which is __not__ contenteditable. Quill by default has no control or knowledge of the contents of these Blots. Embeds have a length of 1 and get deleted all at once unless special handling is introduced. Embeds can store arbitrary data in their `insert` by implementing the `static value()` function.
+Represents an element which is __not__ contenteditable. Quill by default has no control or knowledge of the contents of these Blots. Embeds have a length of 1 and get deleted all at once unless special handling is introduced. Embeds can store arbitrary data in their delta/persistent data-structure by implementing the `static value()` function.
  
 The BlockEmbed behaves like a Block element and generally cannot have siblings within its container and it's top level DOM element __must__ have `display: block`. Look at the LinkEmbedBlot or the ImageBlot for an example.
 

--- a/plugins/rich-editor/README.md
+++ b/plugins/rich-editor/README.md
@@ -1,6 +1,6 @@
 # Rich Editor (WIP)
 
-A highly-functional WYSIWYG editor for Vanilla built on top of [contenteditable](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content) using [Quill.js](https://quilljs.com/), [Quill's document model parchment](https://github.com/quilljs/parchment) and [React](https://reactjs.org/).
+A highly-functional Rich Text editor for Vanilla built on top of [contenteditable](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content) using [Quill.js](https://quilljs.com/), [Quill's document model parchment](https://github.com/quilljs/parchment) and [React](https://reactjs.org/).
 
 This plugin conflicts with and aims to replace some existing plugins.
 
@@ -9,7 +9,7 @@ This plugin conflicts with and aims to replace some existing plugins.
 
 ## Core features
 
-- Consistent WYSIWYG experience.
+- Rich editing experience (similar to Medium editor).
 - Rich text embeds of external and internal content.
 - Improved video and image embedding.
 - Intuitive minimal design.
@@ -17,8 +17,6 @@ This plugin conflicts with and aims to replace some existing plugins.
 - Consistent serialized format that can be easily parsed on the server and client (JSON).
 - Convert all existing Advanced Editor formats (HTML/Wysiwyg, Markdown, BBCode, Text, TextEx).
 - Extendable to support future embeddable objects.
-
-## Formatting Options
 
 ## Formatting
 

--- a/plugins/rich-editor/README.md
+++ b/plugins/rich-editor/README.md
@@ -1,6 +1,6 @@
 # Rich Editor (WIP)
 
-A highly-functional WYSIWYG editor for Vanilla built on top of [contenteditable](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content) using [Quill.js](https://quilljs.com/) and [React](https://reactjs.org/).
+A highly-functional WYSIWYG editor for Vanilla built on top of [contenteditable](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content) using [Quill.js](https://quilljs.com/), [Quill's document model parchment](https://github.com/quilljs/parchment) and [React](https://reactjs.org/).
 
 This plugin conflicts with and aims to replace some existing plugins.
 
@@ -76,7 +76,7 @@ Every Blot has reference to:
 
 ### Existing Blots
 
-Existing Blots will generally be imported from Quill, but could also be imported from Parchment or the rich editor. The most common Blots to extend `Block`, `Inline`, `Embed`, `BlockEmbed`, and `Container`. Some custom Blots provided are `WrapperBlot`, `ContentBlot`, and `LineBlot`,
+Existing Blots will generally be imported from Quill, but could also be imported from Parchment or the rich editor. The most common Blots to extend are `Block`, `Inline`, `Embed`, `BlockEmbed`, and `Container`. Some custom Blots provided are `WrapperBlot`, `ContentBlot`, and `LineBlot`,
 
 **Block**
 

--- a/plugins/rich-editor/README.md
+++ b/plugins/rich-editor/README.md
@@ -1,0 +1,216 @@
+# Rich Editor (WIP)
+
+A highly-functional WYSIWYG editor for Vanilla built on top of [contenteditable](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content) using [Quill.js](https://quilljs.com/) and [React](https://reactjs.org/).
+
+This plugin conflicts with and aims to replace some existing plugins.
+
+- [Advanced Editor](../editor)
+- [Quotes](../Quotes)
+
+## Core features
+
+- Consistent WYSIWYG experience.
+- Rich text embeds of external and internal content.
+- Improved video and image embedding.
+- Intuitive minimal design.
+- Opinionated restrictions on functionality.
+- Consistent serialized format that can be easily parsed on the server and client (JSON).
+- Convert all existing Advanced Editor formats (HTML/Wysiwyg, Markdown, BBCode, Text, TextEx).
+- Extendable to support future embeddable objects.
+
+## Formatting Options
+
+## Formatting
+
+There are two main types of formatting: inline and block. Inline formatting applies to text within a paragraph while block formatting applies to entire paragraphs.
+
+| Format    | Type      | Applied With      | Notes
+| ------    | ----      | ------------      | -----
+| Bold      | Inline    | Button, cmd-b     |
+| Italic    | Inline    | Button, cmd-i     |    
+| Code      | Inline    | Button            | Code has both inline and block versions.
+| Strike    | Inline    | Button            |
+| Link      | Inline    | Button, cmd-k     |
+| H1, H2    | Block     | Button            | Two levels of heading are supported.
+| Bullets   | Block     | Auto              | A bulleted list automatically starts when you start a paragraph with "-" or "*"
+| Numbers   | Block     | Auto              | A numbered list automatically starts when you start a paragraph with "1." or any number plus a ".".
+| Quote     | Block     | Button            |
+| Code      | Block     | Button            | Code has both inline and block versions.
+| Spoiler   | Block     | Button            |
+
+### Intentionally omitted formats
+
+- Underline
+- Font family
+- Text color
+- Text alignment
+
+### Future supported formats
+
+- Tables
+
+## Project Structure
+
+This plugin is primarily javascript based. The main entrypoint for the application is [src/scripts/app/rich-editor.js](./src/scripts/app/rich-editor.js)
+
+The [`RichEditor` class](./src/scripts/RichEditor.js) is responsible for a single editor instance. It uses our extended [`Quill` class](./src/scripts/Quill.js) to which loads all of our custom Blots from [/blots](./src/scripts/blots) and [/formats](.src/scripts/formats).
+
+A custom [Quill theme](./src/scripts/QuillTheme.jsx) is responsible for mounting the various React components that make up the editor's UI. These components can be found in [/components](./src/scripts/components) and primarily consist of
+
+- An emoji picker.
+- Block and inline formatting toolbars.
+
+## Custom Quill Blots
+
+### What is a Blot?
+
+A Blot is javascript class used as part of Quill's (and it's underlying library Parchment's) in memory document format. Quill uses LinkedLists for it's data structure. Every Blot has reference to:
+
+- Its parent `.parent`
+- Its children `.children`
+- Its direct siblings `.prev`, `.next`
+- Its domNode `domNode`
+- The top level parent (a `ScrollBlot`) `.scroll`.
+
+### Existing Blots
+
+Existing Blots will generally be imported from Quill, but could also be imported from Parchment or the rich editor. The most common Blots to extend `Block`, `Inline`, `Embed`, `BlockEmbed`, and `Container`. Some custom Blots provided are `WrapperBlot`, `ContentBlot`, and `LineBlot`,
+
+**Block**
+
+Equivalent to a paragraph. A line break signifies the end of a Block unless `white-space: pre` is set, in which case line breaks will be preserved. This is already handled in the `CodeBlockBlot`.
+
+**Inline**
+
+Represents and Inline text containing element. See [quill/formats](https://github.com/quilljs/quill/tree/master/formats) for examples of these. Bold, Italic, and Strike through blots are examples of these.
+
+**BlockEmbed** and **Embed**
+
+Represents an element which is __not__ contenteditable. Quill by default has no control or knowledge of the contents of these Blots. Embeds have a length of 1 and get deleted all at once unless special handling is introduced. Embeds can store arbitrary data in their `insert` by implementing the `static value()` function.
+ 
+The BlockEmbed behaves like a Block element and generally cannot have siblings within its container and it's top level DOM element __must__ have `display: block`. Look at the LinkEmbedBlot or the ImageBlot for an example.
+
+The normal Embed is meant to represent an inline embed. The contents you assign in the `create()` method are get wrapped in a `span` and some guard text (0-width whitespace). Look at the EmojiBlot for an example.
+
+**Container**
+
+A container has the length of its children. Think of it like a DIV DOM Element. It is meant to wrap other elements. Extra work is required to get these to work because the are not representable in the final JSON data-structure. They must be created by their children. See the WrapperBlot for an example.
+
+### Custom multi-line Blots with containers
+
+Quill encourages a flattened HTML structure but this is not always possible. To implement structures like the following:
+
+```html
+<blockquote>
+    <div class="blockquote-content">
+        <p>Line 1</p>
+        <p>Line 2</p>
+    </div>
+</blockquote>
+```
+
+Use the `Wrapperblot`, `ContentBlot`, and `LineBlot`. See the Blockquote for an example. You will need to implement and register all 3 blots. The whole is actually created form the `LineBlot` upwards. The `LineBlot` then creates it's parents. This does not work in the other direction.
+
+Both the LineBlot and the ContentBlot must implement a `static ParentName` in addition to their `blotName` and `className`.
+
+See the Blockquote or Spoiler for an example.
+
+### How to define a new Blot
+
+1. Extend an existing Blot.
+
+```js
+import Block, { BlockEmbed } from "quill/blots/block";
+import Inline from "quill/blots/inline";
+import Embed from "quill/blots/embed";
+
+// Custom Blots
+import WrapperBlot, { ContentBlot, LineBlot } from "@rich-editor/blots/WrapperBlot";
+
+export default class MyCustomBlot extends OneOfTheImportedClasses {
+    static blotName = "my-custom-blot";
+    static tagName = "div";
+    static className = "this-blots-css-class";
+}
+```
+
+See [differentiating blots]("#differentiating-blots) for more information about these properties.
+
+2. Register the Blot in our [Quill instance]("./src/scripts/Quill.js") with a unique id. This is ID is only used for Quill's registration and overriding existing Blots, and is not used for instantiating the Blot.
+
+3. Instantiate the Blot using it's `blotName`.
+
+```js
+import parchment from "parchment";
+
+// Using parchment and the blotName
+const newBlot = parchment.create(MyCustomBlot.blotName);
+
+// Insert the blot somewhere
+newBlot.insertInto(parentBlot, referenceBlot);
+parentBlot.insertBefore(newBlot, referenceBlot);
+parentBlot.appendChild(newBlot);
+someOtherBlot.replaceWith(newBlot)
+newBlot.replace(someOtherBlot);
+```
+
+### Differentiating Blots
+
+There are a few requirements for custom Blots so that everything works properly.
+
+- Blots must have a unique `static blotName`.
+- Blots must have a unique `static tagName` or a unique `static className` or implement a unique `formats(): Object` and `static formats(): boolean`.
+
+### Lifecycle of a Blot.
+
+1. `static create(): Node`
+
+This static function generates a DOM Node for the Blot. It will generate a DOM Node with the provided `tagName` and `className`. This is not a good place to set listeners because you can't save a reference to them anywhere to remove them. _Don't call this function directly. Use `parchment.create(blotName): Blot` instead_.
+
+```js
+class CustomBlot extends Block {
+    static create() {
+        const node = super.create();
+        
+        // Do things with the DOM Node in a static context
+        
+        return node;
+    }
+}
+```
+
+2. `constructor(domNode)`
+
+The constructor gets passed the DOM Node created by the create() function. The Blot still has not been connected to it's parent and siblings at the time of construction and it (as well its DOM Node) have not actually been attached anywhere.
+
+```js
+class CustomBlot extends Block {
+    constructor(node) {
+        super(node);
+
+        // Do things with the DOM Node in a class context. Save anything you need a reference to.
+    }
+}
+```
+
+3. `attach(): void`
+
+Attaches the Blot to it's parent and siblings. Inserts the Blot's DOM Node into the document under it's parent. _Don't call this function directly. Use `parchment.create(blotName): Blot` and one of the various insert functions instead_.
+
+```js
+class CustomBlot extends Block {
+    attach() {
+        super.attach();
+        
+        // Do something that requires the parent or sibling Blots, or for the Blot to actually be in the document.
+    }
+}
+```
+
+4. `detach(): void`
+
+The opposite of attach. Do any cleanup from that here.
+
+5. `remove(): void`
+
+Deletes the Blot and it's DOM Node. Put any cleanup from `static create()` or the constructor here.

--- a/plugins/rich-editor/addon.json
+++ b/plugins/rich-editor/addon.json
@@ -1,5 +1,5 @@
 {
-    "name": "Rich Editor",
+    "name": "Rich Editor (WIP)",
     "description": "The new WYSIWYG editor for Vanilla. Easy to use, with support for rich content embedding. Also supports a more minimal text mode, Markdown, and BBCode.",
     "version": "0.1",
     "mobileFriendly": true,


### PR DESCRIPTION
Closes #6686 
Closes #6733

This PR adds a README for the rich editor, with some details on the project structure and a bit of information on getting started with Quill for use case. It's not 100% comprehensive, but it's a good start.