### PR TITLE
Allow the index_ prefix as an alternative to get_ prefixes

### DIFF
--- a/library/Garden/Web/ResourceRoute.php
+++ b/library/Garden/Web/ResourceRoute.php
@@ -203,7 +203,7 @@ class ResourceRoute extends Route {
      * @return callable|null Returns the method callback or null if it doesn't.
      */
     private function findMethod($controller, $methodName) {
-        $regex = '`^(get|post|patch|put|options|delete)(_|$)`i';
+        $regex = '`^(get|index|post|patch|put|options|delete)(_|$)`i';
 
         // Getters and setters aren't found.
         if (!(preg_match($regex, $methodName) || strcasecmp($methodName, 'index') === 0)) {
@@ -381,10 +381,18 @@ class ResourceRoute extends Route {
         if (isset($pathArgs[0])) {
             $name = lcfirst($this->filterName($pathArgs[0]));
             $result[] = ["{$method}_{$name}", 0];
+
+            if ($method === 'get') {
+                $result[] = ["index_{$name}", 0];
+            }
         }
         if (isset($pathArgs[1])) {
             $name = lcfirst($this->filterName($pathArgs[1]));
             $result[] = ["{$method}_{$name}", 1];
+
+            if ($method === 'get') {
+                $result[] = ["index_{$name}", 1];
+            }
         }
 
         $result[] = [$method, null];

--- a/tests/Library/Garden/Web/ResourceRouteTest.php
+++ b/tests/Library/Garden/Web/ResourceRouteTest.php
@@ -79,6 +79,12 @@ class ResourceRouteTest extends TestCase {
 
             'no mapping' => ['POST', '/discussions/no-map/a/b/c?f=b', [$dc, 'post_noMap'], ['query' => 'a', 'body' => 'b', 'data' => 'c']],
 
+            // Nested get and index
+            'index /sub' => ['GET', '/discussions/sub', [$dc, 'index_sub'], []],
+            'get /sub/:arg' => ['GET', '/discussions/sub/abc', [$dc, 'get_sub'], ['arg' => 'abc']],
+            'index /:id/idsub' => ['GET', '/discussions/123/idsub', [$dc, 'index_idsub'], ['id' => '123']],
+            'get /:id/idsub/:id2' => ['GET', '/discussions/123/idsub/abc', [$dc, 'get_idsub'], ['id' => '123', 'id2' => 'abc']],
+
             // Special routes are special.
             'bad index' => ['GET', '/discussions/index', null],
             'bad get' => ['GET', '/discussions/get/123', null],

--- a/tests/fixtures/src/DiscussionsController.php
+++ b/tests/fixtures/src/DiscussionsController.php
@@ -106,4 +106,20 @@ class DiscussionsController {
 
     public function get_article($path, $page = '') {
     }
+
+    public function index_sub() {
+
+    }
+
+    public function get_sub($arg) {
+
+    }
+
+    public function get_idsub($id, $id2) {
+
+    }
+
+    public function index_idsub($id) {
+
+    }
 }


### PR DESCRIPTION
Consider the following endpoints we’d want to create:

```http
GET /conversations/123/participants
GET /conversations/123/participants/1
```

Previously we would be unable to create these routes because they would
both have to be called `get_participants`.

This change allows you to also prefix GET methods with `index_`. The
prefix works the same way as `get_` but is a lower priority. They are
differentiated by different parameter counts.

The above example can be done with the following methods:

```php
public function index_participants($id) {
}

public function get_participants($id, $userID) {
}
```