### PR TITLE
[Backport] Remove hacky contextmenu handler in wysiwyg editor 

### DIFF
--- a/plugins/editor/js/wysihtml5-0.4.0pre.js
+++ b/plugins/editor/js/wysihtml5-0.4.0pre.js
@@ -7745,51 +7745,6 @@ wysihtml5.commands.undo = {
                     }
                 });
 
-                // Now this is very hacky:
-                // These days browsers don't offer a undo/redo event which we could hook into
-                // to be notified when the user hits undo/redo in the contextmenu.
-                // Therefore we simply insert two elements as soon as the contextmenu gets opened.
-                // The last element being inserted will be immediately be removed again by a exexCommand("undo")
-                //  => When the second element appears in the dom tree then we know the user clicked "redo" in the context menu
-                //  => When the first element disappears from the dom tree then we know the user clicked "undo" in the context menu
-                if (wysihtml5.browser.hasUndoInContextMenu()) {
-                    var interval, observed, cleanUp = function() {
-                        cleanTempElements(doc);
-                        clearInterval(interval);
-                    };
-
-                    dom.observe(this.element, "contextmenu", function() {
-                        cleanUp();
-                        that.composer.selection.executeAndRestoreSimple(function() {
-                            if (that.element.lastChild) {
-                                that.composer.selection.setAfter(that.element.lastChild);
-                            }
-
-                            // enable undo button in context menu
-                            doc.execCommand("insertHTML", false, UNDO_HTML);
-                            // enable redo button in context menu
-                            doc.execCommand("insertHTML", false, REDO_HTML);
-                            doc.execCommand("undo", false, null);
-                        });
-
-                        interval = setInterval(function() {
-                            if (doc.getElementById("_wysihtml5-redo")) {
-                                cleanUp();
-                                that.redo();
-                            } else if (!doc.getElementById("_wysihtml5-undo")) {
-                                cleanUp();
-                                that.undo();
-                            }
-                        }, 400);
-
-                        if (!observed) {
-                            observed = true;
-                            dom.observe(document, "mousedown", cleanUp);
-                            dom.observe(doc, ["mousedown", "paste", "cut", "copy"], cleanUp);
-                        }
-                    });
-                }
-
                 this.editor
                     .on("newword:composer", function() {
                         that.transact();


### PR DESCRIPTION
Backport of #6752 
Reference #6621

> This removes the libraries janky context-menu handling to use native browser undo/redo handling in the context menu. As a result the context-menu undo/redo items with not work editor created events such as formatting. This the case with our new rich editor at least for the time being.
>
> For a little more context, before the library was attempting to detect the context-menu's undo/redo in the same way you would detect cmd-z/cmd-shift-z. This is broken in the latest versions of chrome in a pretty significant way and wasn't really a solid solution in the first place. Maybe we'll investigate other solutions in the future (such as if the browser adds a proper event handler, or using custom context-menu), but for now this will work.