### PR TITLE
Add new addon type

### DIFF
--- a/conf/constants.php
+++ b/conf/constants.php
@@ -80,6 +80,7 @@ define('ADDON_TYPE_PLUGIN', 1);
 define('ADDON_TYPE_THEME', 2);
 define('ADDON_TYPE_LOCALE', 4);
 define('ADDON_TYPE_APPLICATION', 5);
+define('ADDON_TYPE_GENERAL', 6);
 define('ADDON_TYPE_CORE', 10);
 
 // Use this constant if you are sick of looking up how to format dates to go into the database.


### PR DESCRIPTION
In new addon.json files no distinction between plugins/themes/applications is made anymore, everything only has "type":"addon" defined.

This causes trouble in updatemodel::buildAddon when the Addon application tries to parse an addon.json file of a new plugin.
To be able to fix that, a new addon type constant is necessary.