### PR TITLE
Fix mention triggering in the editor

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -1900,17 +1900,32 @@ jQuery(document).ready(function($) {
                     // string as well as spaces. Spaces make things more
                     // complicated.
                     matcher: function(flag, subtext, should_start_with_space) {
-                        var regexStr = '(@(?=(")?)(\\w+|\\1(?:[^\\u0000-\\u001f\\u007f-\\u009f\\u2028]+?)\\1))(?:\\s|$)';
+
+                        // Split the string at the lines to allow for a simpler regex.
+                        var lines = subtext.split("\n");
+                        var lastLine = lines[lines.length - 1];
+
+                        var regexStr =
+                            '@' + // @ Symbol triggers the match
+                            '(?:(\\w+)' + // Any ASCII based letter characters
+                            '|' + // Or
+                            '"([^"\\u0000-\\u001f\\u007f-\\u009f\\u2028]+?)"?)' + // Almost any character if quoted. With or without the last quote.
+                            '(?:\\n|$)'; // Newline terminates.
+
+                        // Determined by at.who library
                         if (should_start_with_space) {
                             regexStr = '(?:^|\\s)' + regexStr;
                         }
                         var regex = new RegExp(regexStr, 'gi');
-                        var match = regex.exec(subtext);
-                        console.log(regexStr, match);
+                        var match = regex.exec(lastLine);
                         if (match) {
-                            this.raw_at_match = match[2];
-                            return match[3];
+                            this.raw_at_match = match[0];
+
+                            // Return either of the matching groups (quoted or unquoted).
+                            return match[2] ||  match[1];
                         } else {
+
+                            // No match
                             return null;
                         }
                     }

--- a/js/global.js
+++ b/js/global.js
@@ -1905,6 +1905,7 @@ jQuery(document).ready(function($) {
                         var lines = subtext.split("\n");
                         var lastLine = lines[lines.length - 1];
 
+                        // If you change this you MUST change the regex in src/scripts/__tests__/legacy.test.js !!!
                         var regexStr =
                             '@' + // @ Symbol triggers the match
                             '(?:(\\w+)' + // Any ASCII based letter characters

--- a/js/global.js
+++ b/js/global.js
@@ -1915,9 +1915,9 @@ jQuery(document).ready(function($) {
                          */
                         function nonExcludedCharacters(excludeWhiteSpace) {
                             var excluded = '[^' +
-                                '\\u2028' + // Line terminator
+                                '"' + // Quote character
                                 '\\u0000-\\u001f\\u007f-\\u009f' + // Control characters
-                                '"'; // Quote character
+                                '\\u2028';// Line terminator
 
                             if (excludeWhiteSpace) {
                                 excluded += '\\s';
@@ -1928,14 +1928,15 @@ jQuery(document).ready(function($) {
                         }
 
                         var regexStr =
-                            '(?:^|\\s)' + // Space before
                             '@' + // @ Symbol triggers the match
                             '(' +
-                                // One or more non-greedy characters that aren't exluded. Whitespace is excluded.
-                                '(' + nonExcludedCharacters(true) + '+?)"?' +
+                            // One or more non-greedy characters that aren't excluded. White is allowed, but a starting quote is required.
+                            '"(' + nonExcludedCharacters(false) + '+?)"?' +
+
                                 '|' + // Or
-                                // One or more non-greedy characters that aren't excluded. White is allowed, but a starting quote is required.
-                                '"(' + nonExcludedCharacters(false) + '+?)"?' +
+                            // One or more non-greedy characters that aren't exluded. Whitespace is excluded.
+                            '(' + nonExcludedCharacters(true) + '+?)"?' +
+
                             ')' +
                             '(?:\\n|$)'; // Newline terminates.
 

--- a/js/global.js
+++ b/js/global.js
@@ -1923,6 +1923,10 @@ jQuery(document).ready(function($) {
 
                         match = regexp.exec(subtext);
                         if (match) {
+                            console.log("flag: ", flag);
+                            console.log("subtext: ", subtext);
+                            console.log("regexp: ", regexp);
+                            console.log();
                             // Store the original matching string to check against
                             // quotation marks after the at symbol, to prevent
                             // double insertions of the at symbol. This will be

--- a/js/global.js
+++ b/js/global.js
@@ -1900,40 +1900,16 @@ jQuery(document).ready(function($) {
                     // string as well as spaces. Spaces make things more
                     // complicated.
                     matcher: function(flag, subtext, should_start_with_space) {
-                        var match, regexp;
-                        flag = flag.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
-
+                        var regexStr = '(@(?=(")?)(\\w+|\\1(?:[^\\u0000-\\u001f\\u007f-\\u009f\\u2028]+?)\\1))(?:\\s|$)';
                         if (should_start_with_space) {
-                            flag = '(?:^|\\s)' + flag;
+                            regexStr = '(?:^|\\s)' + regexStr;
                         }
-
-                        // Note: adding whitespace to regex makes the query in
-                        // remote_filter and before_insert callbacks throw
-                        // undefined when not accounted for, so optional
-                        // assigments added to each.
-                        //regexp = new RegExp(flag + '([A-Za-z0-9_\+\-]*)$|' + flag + '([^\\x00-\\xff]*)$', 'gi');
-                        // Note: this does make the searching a bit more loose,
-                        // but it's the only way, as spaces make searching
-                        // more ambiguous.
-                        // \xA0 non-breaking space
-                        // Skip \n which is \x0A and threat is as EOL
-                        //https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/RegExp#character-classes
-                        var whiteSpaceNoLineFeed = '\\f\\r\\t\\v\​\u00a0\\u1680​\\u180e'; //\u2000​-\u200a​\u2028\u2029\u202f\u205f​\u3000\ufeff  <- was throwing error.
-                        regexp = new RegExp(flag + '\"?(['+whiteSpaceNoLineFeed+'A-Za-z0-9_\+\-]*)\"?(?:\\n|$)|' + flag + '\"?([^\\x00-\\x09\\x0B-\\xff]*)\"?(?:\\n|$)', 'gi');
-
-                        match = regexp.exec(subtext);
+                        var regex = new RegExp(regexStr, 'gi');
+                        var match = regex.exec(subtext);
+                        console.log(regexStr, match);
                         if (match) {
-                            console.log("flag: ", flag);
-                            console.log("subtext: ", subtext);
-                            console.log("regexp: ", regexp);
-                            console.log();
-                            // Store the original matching string to check against
-                            // quotation marks after the at symbol, to prevent
-                            // double insertions of the at symbol. This will be
-                            // used in the before_insert callback.
-                            this.raw_at_match = match[0];
-
-                            return match[2] || match[1];
+                            this.raw_at_match = match[2];
+                            return match[3];
                         } else {
                             return null;
                         }

--- a/js/global.js
+++ b/js/global.js
@@ -1906,11 +1906,37 @@ jQuery(document).ready(function($) {
                         var lastLine = lines[lines.length - 1];
 
                         // If you change this you MUST change the regex in src/scripts/__tests__/legacy.test.js !!!
+                        /**
+                         * Put together the non-excluded characters.
+                         *
+                         * @param {boolean} excludeWhiteSpace - Whether or not to exclude whitespace characters.
+                         *
+                         * @returns {string} A Regex string.
+                         */
+                        function nonExcludedCharacters(excludeWhiteSpace) {
+                            var excluded = '[^' +
+                                '\\u2028' + // Line terminator
+                                '\\u0000-\\u001f\\u007f-\\u009f' + // Control characters
+                                '"'; // Quote character
+
+                            if (excludeWhiteSpace) {
+                                excluded += '\\s';
+                            }
+
+                            excluded += "]";
+                            return excluded;
+                        }
+
                         var regexStr =
+                            '(?:^|\\s)' + // Space before
                             '@' + // @ Symbol triggers the match
-                            '(?:(\\w+)' + // Any ASCII based letter characters
-                            '|' + // Or
-                            '"([^"\\u0000-\\u001f\\u007f-\\u009f\\u2028]+?)"?)' + // Almost any character if quoted. With or without the last quote.
+                            '(' +
+                                // One or more non-greedy characters that aren't exluded. Whitespace is excluded.
+                                '(' + nonExcludedCharacters(true) + '+?)"?' +
+                                '|' + // Or
+                                // One or more non-greedy characters that aren't excluded. White is allowed, but a starting quote is required.
+                                '"(' + nonExcludedCharacters(false) + '+?)"?' +
+                            ')' +
                             '(?:\\n|$)'; // Newline terminates.
 
                         // Determined by at.who library

--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -76,7 +76,23 @@
           clonedRange = range.cloneRange();
           clonedRange.selectNodeContents(this.domInputor);
           clonedRange.setEnd(range.endContainer, range.endOffset);
-          pos = clonedRange.toString().length;
+
+          var breaksBefore = 0;
+          var cont = true;
+          var currentElement = clonedRange.endContainer;
+          while (currentElement && cont) {
+            if (currentElement.nodeName === "BR") {
+                breaksBefore++;
+            }
+
+            if (currentElement.previousSibling) {
+                currentElement = currentElement.previousSibling;
+            } else {
+                cont = false;
+            }
+          }
+
+          pos = clonedRange.toString().length + breaksBefore;
           clonedRange.detach();
           return pos;
         } else if (document.selection) {
@@ -582,7 +598,8 @@
         var caret_pos, contents, end, query, start, subtext;
         contents = this.content();
         ////caret_pos = this.$inputor.caret('pos');
-        caret_pos = this.$inputor.caret('pos', this.setting.cWindow) + contents.offset;
+          console.log("Offset", contents.offset);
+        caret_pos = this.$inputor.caret('pos', this.setting.cWindow);
         subtext = contents.content.slice(0, caret_pos);
         query = this.callbacks("matcher").call(this, this.at, subtext, this.get_opt('start_with_space'));
         if (typeof query === "string" && query.length <= this.get_opt('max_len', 20)) {

--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -441,6 +441,8 @@
         var _this = this;
         return this.$inputor.on('keyup.atwho', function(e) {
           return _this.on_keyup(e);
+        }).on('input.atwho', function() {
+            _this.dispatch();
         }).on('keydown.atwho', function(e) {
           return _this.on_keydown(e);
         }).on('scroll.atwho', function(e) {
@@ -474,12 +476,10 @@
               _ref.view.hide();
             }
             break;
-          case KEY_CODE.DOWN:
-          case KEY_CODE.UP:
-            $.noop();
-            break;
           default:
-            this.dispatch();
+            $.noop();
+            // This used to dispatch here, but there was an issue with accented characters on mac. Dispatch now happens
+            // On input.
         }
       };
 

--- a/js/library/jquery.atwho.js
+++ b/js/library/jquery.atwho.js
@@ -78,20 +78,23 @@
           clonedRange.setEnd(range.endContainer, range.endOffset);
 
           var breaksBefore = 0;
-          var cont = true;
+          var shouldContinue = true;
           var currentElement = clonedRange.endContainer;
-          while (currentElement && cont) {
+
+          // Check the elements backwards from the final one in our selection for breaks.
+          while (currentElement && shouldContinue) {
             if (currentElement.nodeName === "BR") {
-                breaksBefore++;
+              breaksBefore++;
             }
 
             if (currentElement.previousSibling) {
-                currentElement = currentElement.previousSibling;
+              currentElement = currentElement.previousSibling;
             } else {
-                cont = false;
+              shouldContinue = false;
             }
           }
 
+          // The string representation of a Range does not contain breaks or newlines. We have to count them ourselves.
           pos = clonedRange.toString().length + breaksBefore;
           clonedRange.detach();
           return pos;
@@ -577,7 +580,6 @@
       Controller.prototype.content = function() {
         var result = {
           content: null,
-          offset: 0
         };
 
         if (this.$inputor.is('textarea, input')) {
@@ -586,7 +588,6 @@
           var textNode = $(document.createElement('div'));
           var html = this.$inputor.html();
           var breaks = /<br(\s+)?(\/)?>/g;
-          result.offset = html.match(breaks) ? html.match(breaks).length : 0;
           textNode.html(html.replace(breaks, "\n"));
           result.content = textNode.text();
         }
@@ -597,8 +598,6 @@
       Controller.prototype.catch_query = function() {
         var caret_pos, contents, end, query, start, subtext;
         contents = this.content();
-        ////caret_pos = this.$inputor.caret('pos');
-          console.log("Offset", contents.offset);
         caret_pos = this.$inputor.caret('pos', this.setting.cWindow);
         subtext = contents.content.slice(0, caret_pos);
         query = this.callbacks("matcher").call(this, this.at, subtext, this.get_opt('start_with_space'));

--- a/src/scripts/__tests__/legacy.test.js
+++ b/src/scripts/__tests__/legacy.test.js
@@ -11,13 +11,14 @@
 /*eslint-disable no-control-regex*/
 
 // Regex tests for at.who. See global.js `matcher()` at line 1902
-var regexStr =
+const regexStr =
     '(?:^|\\s)' + // Space before
     '@' + // @ Symbol triggers the match
     '(?:(\\w+)' + // Any ASCII based letter characters
     '|' + // Or
     '"([^"\\u0000-\\u001f\\u007f-\\u009f\\u2028]+?)"?)' + // Almost any character if quoted. With or without the last quote.
     '(?:\\n|$)'; // Newline terminates.
+const regex = new RegExp(regexStr, 'gi');
 
 function testMatchingSubject(subject) {
     test(subject, () => {

--- a/src/scripts/__tests__/legacy.test.js
+++ b/src/scripts/__tests__/legacy.test.js
@@ -69,7 +69,7 @@ describe("matching @mentions", () => {
         badSubjects.forEach(testFailingSubject);
     });
 
-    describe.only("Closing characters", () => {
+    describe("Closing characters", () => {
         const subjects = [
             `@Other Mention at end after linebreak   
                 @System`,

--- a/src/scripts/__tests__/legacy.test.js
+++ b/src/scripts/__tests__/legacy.test.js
@@ -20,10 +20,10 @@
  * @returns {string} A Regex string.
  */
 function nonExcludedCharacters(excludeWhiteSpace) {
-    let excluded = '[^' +
-        '\\u2028' + // Line terminator
+    var excluded = '[^' +
+        '"' + // Quote character
         '\\u0000-\\u001f\\u007f-\\u009f' + // Control characters
-        '"'; // Quote character
+        '\\u2028';// Line terminator
 
     if (excludeWhiteSpace) {
         excluded += '\\s';
@@ -33,15 +33,17 @@ function nonExcludedCharacters(excludeWhiteSpace) {
     return excluded;
 }
 
-const regexStr =
+var regexStr =
     '(?:^|\\s)' + // Space before
     '@' + // @ Symbol triggers the match
     '(' +
-        // One or more non-greedy characters that aren't exluded. Whitespace is excluded.
-        '(' + nonExcludedCharacters(true) + '+?)"?' +
-        '|' + // Or
-        // One or more non-greedy characters that aren't excluded. White is allowed, but a starting quote is required.
-        '"(' + nonExcludedCharacters(false) + '+?)"?' +
+    // One or more non-greedy characters that aren't excluded. White is allowed, but a starting quote is required.
+    '"(' + nonExcludedCharacters(false) + '+?)"?' +
+
+    '|' + // Or
+    // One or more non-greedy characters that aren't exluded. Whitespace is excluded.
+    '(' + nonExcludedCharacters(true) + '+?)"?' +
+
     ')' +
     '(?:\\n|$)'; // Newline terminates.
 const regex = new RegExp(regexStr, 'gi');
@@ -59,10 +61,12 @@ function testFailingSubject(subject) {
 }
 
 describe("matching @mentions", () => {
+    console.log(regex);
     describe("simple mentions", () => {
         const subjects = [
             `@System`,
             `Sometext @System`,
+            `asdfasdf @joe`,
         ];
 
         const badSubjects = [

--- a/src/scripts/__tests__/legacy.test.js
+++ b/src/scripts/__tests__/legacy.test.js
@@ -11,7 +11,7 @@
 /*eslint-disable no-control-regex*/
 
 // Regex tests for at.who
-const regex = /(?:^|\s)@"?([\f\r\t\v​ \u1680​\u180eA-Za-z0-9_+-]*)"?(?:\n|$)|(?:^|\s)@"?([^\x00-\x09\x0B-\xff]*)"?(?:\n|$)/gi;
+const regex = /(?:^|\s)(@(?=(")?)(\w+|\1(?:[^\u0000-\u001f\u007f-\u009f\u2028]+?)\1))(?:\s|$)/gi;
 
 function testMatchingSubject(subject) {
     test(subject, () => {
@@ -30,12 +30,10 @@ describe("matching @mentions", () => {
         const subjects = [
             `@System`,
             `Sometext @System`,
-            `Sometext with linebreak   
-                @System`,
         ];
 
         const badSubjects = [
-            "@a", // 2 letters required for matching.
+            // "@a", // 2 letters required for matching.
         ];
 
         subjects.forEach(testMatchingSubject);
@@ -48,8 +46,6 @@ describe("matching @mentions", () => {
             `@Séche`,
             `Something @Séche`,
             `@Umuüûū`,
-            `Newline with special char
-                           @Umuüûū,`,
         ];
 
         subjects.forEach(testMatchingSubject);
@@ -66,14 +62,33 @@ describe("matching @mentions", () => {
         const badSubjects = [
             `@someone with non-wrapped spaces`,
             `@"someone with a closed space"`,
-            `@"Do we close on a newline?
-                other text`,
             `@"What about multiple spaces?      `,
         ];
 
         subjects.forEach(testMatchingSubject);
-
         badSubjects.forEach(testFailingSubject);
     });
 
+    describe.only("Closing characters", () => {
+        const subjects = [
+            `@Other Mention at end after linebreak   
+                @System`,
+            `Newline with special char
+                           @Umuüûū`,
+        ];
+
+        const badSubjects = [
+            `@close on newline
+                other text`,
+            `@"Close on quote" other thing`,
+            `@"Do we close on a newline with quotes?
+                other text`,
+            `@Other Mention on other line
+                @"Someone with spaces"  
+                @System more text`,
+        ];
+
+        subjects.forEach(testMatchingSubject);
+        badSubjects.forEach(testFailingSubject);
+    });
 });

--- a/src/scripts/__tests__/legacy.test.js
+++ b/src/scripts/__tests__/legacy.test.js
@@ -11,7 +11,13 @@
 /*eslint-disable no-control-regex*/
 
 // Regex tests for at.who. See global.js `matcher()` at line 1902
-const regex = /(?:^|\s)@(?:(\w+)|"([^"\u0000-\u001f\u007f-\u009f\u2028]+?)"?)(?:\n|$)/gi;
+var regexStr =
+    '(?:^|\\s)' + // Space before
+    '@' + // @ Symbol triggers the match
+    '(?:(\\w+)' + // Any ASCII based letter characters
+    '|' + // Or
+    '"([^"\\u0000-\\u001f\\u007f-\\u009f\\u2028]+?)"?)' + // Almost any character if quoted. With or without the last quote.
+    '(?:\\n|$)'; // Newline terminates.
 
 function testMatchingSubject(subject) {
     test(subject, () => {

--- a/src/scripts/__tests__/legacy.test.js
+++ b/src/scripts/__tests__/legacy.test.js
@@ -10,8 +10,8 @@
  */
 /*eslint-disable no-control-regex*/
 
-// Regex tests for at.who
-const regex = /(?:^|\s)(@(?=(")?)(\w+|\1(?:[^\u0000-\u001f\u007f-\u009f\u2028]+?)\1))(?:\s|$)/gi;
+// Regex tests for at.who. See global.js `matcher()` at line 1902
+const regex = /(?:^|\s)@(?:(\w+)|"([^"\u0000-\u001f\u007f-\u009f\u2028]+?)"?)(?:\n|$)/gi;
 
 function testMatchingSubject(subject) {
     test(subject, () => {
@@ -37,32 +37,34 @@ describe("matching @mentions", () => {
         ];
 
         subjects.forEach(testMatchingSubject);
-
         badSubjects.forEach(testFailingSubject);
     });
 
     describe("special characters", () => {
         const subjects = [
-            `@Séche`,
-            `Something @Séche`,
-            `@Umuüûū`,
+            `@"Séche"`,
+            `Something @"Séche"`,
+            `@"Umuüûū"`,
+        ];
+
+        const badSubjects = [
+            `@Séche`, // Unquoted accent character
         ];
 
         subjects.forEach(testMatchingSubject);
-
-        // badSubjects.forEach(testFailingSubject);
+        badSubjects.forEach(testFailingSubject);
     });
 
     describe("names with spaces", () => {
         const subjects = [
             `@"Someon asdf `,
-            `@Some `, // Single space but no closing braces?
+            `@"someone with a closed space"`,
+            `@"What about multiple spaces?      `,
         ];
 
         const badSubjects = [
             `@someone with non-wrapped spaces`,
-            `@"someone with a closed space"`,
-            `@"What about multiple spaces?      `,
+            `@Some `,
         ];
 
         subjects.forEach(testMatchingSubject);
@@ -74,18 +76,11 @@ describe("matching @mentions", () => {
             `@Other Mention at end after linebreak   
                 @System`,
             `Newline with special char
-                           @Umuüûū`,
+                           @"Umuüûū"`,
         ];
 
         const badSubjects = [
-            `@close on newline
-                other text`,
             `@"Close on quote" other thing`,
-            `@"Do we close on a newline with quotes?
-                other text`,
-            `@Other Mention on other line
-                @"Someone with spaces"  
-                @System more text`,
         ];
 
         subjects.forEach(testMatchingSubject);

--- a/src/scripts/__tests__/legacy.test.js
+++ b/src/scripts/__tests__/legacy.test.js
@@ -1,0 +1,79 @@
+/**
+ * Tests for code that in our legacy javascript that we haven't necessarily been able
+ * move into modules yet.
+ *
+ * Everything here should be linked to the piece of code it connects to and vice-versa.
+ *
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+/*eslint-disable no-control-regex*/
+
+// Regex tests for at.who
+const regex = /(?:^|\s)@"?([\f\r\t\v​ \u1680​\u180eA-Za-z0-9_+-]*)"?(?:\n|$)|(?:^|\s)@"?([^\x00-\x09\x0B-\xff]*)"?(?:\n|$)/gi;
+
+function testMatchingSubject(subject) {
+    test(subject, () => {
+        expect(subject).toEqual(expect.stringMatching(regex));
+    });
+}
+
+function testFailingSubject(subject) {
+    test(subject, () => {
+        expect(subject).not.toEqual(expect.stringMatching(regex));
+    });
+}
+
+describe("matching @mentions", () => {
+    describe("simple mentions", () => {
+        const subjects = [
+            `@System`,
+            `Sometext @System`,
+            `Sometext with linebreak   
+                @System`,
+        ];
+
+        const badSubjects = [
+            "@a", // 2 letters required for matching.
+        ];
+
+        subjects.forEach(testMatchingSubject);
+
+        badSubjects.forEach(testFailingSubject);
+    });
+
+    describe("special characters", () => {
+        const subjects = [
+            `@Séche`,
+            `Something @Séche`,
+            `@Umuüûū`,
+            `Newline with special char
+                           @Umuüûū,`,
+        ];
+
+        subjects.forEach(testMatchingSubject);
+
+        // badSubjects.forEach(testFailingSubject);
+    });
+
+    describe("names with spaces", () => {
+        const subjects = [
+            `@"Someon asdf `,
+            `@Some `, // Single space but no closing braces?
+        ];
+
+        const badSubjects = [
+            `@someone with non-wrapped spaces`,
+            `@"someone with a closed space"`,
+            `@"Do we close on a newline?
+                other text`,
+            `@"What about multiple spaces?      `,
+        ];
+
+        subjects.forEach(testMatchingSubject);
+
+        badSubjects.forEach(testFailingSubject);
+    });
+
+});


### PR DESCRIPTION
Closes #6783
Closes #6165

Fixes the broken @mention behaviour.

## Matching unicode characters

Unicode characters can now be matched, just like punctuation. Like punctuation they must be quoted. Suggestions will be offered containing unicode characters if the first few characters are valid even without the quotes (this is just the current behaviour).

## Moving mention dropdown

This was fixed both through a updated regex that now only looks at the current line of text. In order to fix the current line I had to fix the content-editable line detection that was broken. The issue was that a native `Range` when converted to a string, does not contain line breaks. At.who was trying to compensate by counting line breaks elements, but was counting line breaks in the entire editor, not up to the current cursor position. I got rid of the offset and now account for the line breaks in the `getPos` function by walking the editor's DOM tree backwards from the ending Node.

## Tests

JS tests have been added for the regex as well in legacy.test.js. Until we move the stuff in global.js into our build system, I can't fully test the function or use the same exact regex instance in the test and in the function itself.

I've manually tested this extensively as well, using our different editor types and browser stack.