### PR TITLE
Add setCookie and persist parameters to authenticate endpoint

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticateApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticateApiController.php
@@ -314,6 +314,14 @@ class AuthenticateApiController extends AbstractApiController {
         $in = $this->schema([
             'authenticator:s' => 'The authenticator that will be used.',
             'authenticatorID:s?' => 'Authenticator instance\'s identifier.',
+            'setCookie:b' => [
+                'default' => true,
+                'description' => 'Set session cookie on success.',
+            ],
+            'persist:b' => [
+                'default' => false,
+                'description' => 'Set the persist option on the cookie when it is set.'
+            ],
         ])->setDescription('Authenticate a user using a specific authenticator.');
         $out = $this->schema(Schema::parse([
             'authenticationStep:s' => [
@@ -324,7 +332,7 @@ class AuthenticateApiController extends AbstractApiController {
             'authSessionID:s?' => 'Identifier of the authentication session. Returned if more steps are required to complete the authentication.',
         ]), 'out');
 
-        $in->validate($body);
+        $body = $in->validate($body);
 
         $authenticator = $body['authenticator'];
         $authenticatorID = isset($body['authenticatorID']) ? $body['authenticatorID'] : null;
@@ -344,7 +352,10 @@ class AuthenticateApiController extends AbstractApiController {
                 throw new ServerException("Unknown error while authenticating with $authenticatorType.", 500);
             }
 
-            $user = $this->ssoModel->sso($ssoData, false);
+            $user = $this->ssoModel->sso($ssoData, [
+                'setCookie' => $body['setCookie'],
+                'persist' => $body['persist'],
+            ]);
         } else {
             throw new ServerException(get_class($authenticatorInstance).' is not a supported authenticator yet.', 500);
         }

--- a/library/Vanilla/Models/SSOModel.php
+++ b/library/Vanilla/Models/SSOModel.php
@@ -183,9 +183,12 @@ class SSOModel {
      *
      * @throws ServerException
      * @param SSOData $ssoData
+     * @param array $options
+     *   - setCookie:b Set session cookie on success. Default: true
+     *   - persist:b Set the persist option on the cookie when it is set. Default: false
      * @return array|false The authenticated user info or false.
      */
-    public function sso(SSOData $ssoData) {
+    public function sso(SSOData $ssoData, $options) {
         $user = $this->getUser($ssoData);
 
         if (!$user) {
@@ -237,7 +240,7 @@ class SSOModel {
         }
 
         if ($user) {
-            $this->session->start($user['UserID']);
+            $this->session->start($user['UserID'], $options['setCookie'] ?? true, $options['persistCookie'] ?? false);
             $this->userModel->fireEvent('AfterSignIn');
 
             // Allow user's synchronization


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/6711

Allows to "authenticate" a user without a session being set.
This can be used to verify that everything works properly or sync users informations.