### PR TITLE
Update SSOAuthenticator properties

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticateApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticateApiController.php
@@ -431,7 +431,6 @@ class AuthenticateApiController extends AbstractApiController {
             $ssoDataSchema = $this->schema([
                 'authenticatorName:s' => 'Name of the authenticator that was used to create this object.',
                 'authenticatorID:s' => 'ID of the authenticator instance that was used to create this object.',
-                'authenticatorIsTrusted:b' => 'If the authenticator is trusted to sync user\'s information.',
                 'uniqueID:s' => 'Unique ID of the user supplied by the provider.',
                 'user:o' => [
                     'email:s?' => 'Email of the user.',

--- a/library/Vanilla/Authenticator/SSOAuthenticator.php
+++ b/library/Vanilla/Authenticator/SSOAuthenticator.php
@@ -20,6 +20,13 @@ abstract class SSOAuthenticator extends Authenticator {
     private $isTrusted = false;
 
     /**
+     * Determine whether the authenticator can automatically link users by email.
+     *
+     * @var bool
+     */
+    private $autoLinkUser = false;
+
+    /**
      * Authenticator constructor.
      *
      * @param string $authenticatorID Currently maps to "UserAuthenticationProvider.AuthenticationKey".
@@ -31,17 +38,25 @@ abstract class SSOAuthenticator extends Authenticator {
     /**
      * Getter of isTrusted.
      */
-    public final function isTrusted() {
+    public final function isTrusted(): bool {
         return $this->isTrusted;
     }
 
     /**
-     * Setter of isTrusted.
-     *
-     * @param bool $isTrusted
+     * @return bool
      */
-    protected function setTrusted($isTrusted) {
-        $this->isTrusted = $isTrusted;
+    public function isAutoLinkUser(): bool {
+        return $this->autoLinkUser;
+    }
+
+    /**
+     * @param bool $autoLinkUser
+     * @return SSOAuthenticator
+     */
+    public function setAutoLinkUser(bool $autoLinkUser): SSOAuthenticator {
+        $this->autoLinkUser = $autoLinkUser;
+
+        return $this;
     }
 
     /**
@@ -66,6 +81,20 @@ abstract class SSOAuthenticator extends Authenticator {
     public abstract function signOutURL();
 
     /**
+     * Validate an authentication by using the request's data.
+     *
+     * @throws Exception Reason why the authentication failed.
+     * @param RequestInterface $request
+     * @return SSOData The user's information.
+     */
+    public final function validateAuthentication(RequestInterface $request) {
+        $ssoData = $this->sso($request);
+        $ssoData->validate();
+
+        return $ssoData;
+    }
+
+    /**
      * Core implementation of the validateAuthentication() function.
      *
      * @throws Exception Reason why the authentication failed.
@@ -76,15 +105,14 @@ abstract class SSOAuthenticator extends Authenticator {
     protected abstract function sso(RequestInterface $request);
 
     /**
-     * Validate an authentication by using the request's data.
+     * Setter of isTrusted.
      *
-     * @throws Exception Reason why the authentication failed.
-     * @param RequestInterface $request
-     * @return SSOData The user's information.
+     * @param bool $isTrusted
+     * @return SSOAuthenticator
      */
-    public final function validateAuthentication(RequestInterface $request) {
-        $ssoData = $this->sso($request);
-        $ssoData->validate();
-        return $ssoData;
+    protected function setTrusted(bool $isTrusted): SSOAuthenticator {
+        $this->isTrusted = $isTrusted;
+
+        return $this;
     }
 }

--- a/library/Vanilla/Authenticator/SSOAuthenticator.php
+++ b/library/Vanilla/Authenticator/SSOAuthenticator.php
@@ -43,6 +43,8 @@ abstract class SSOAuthenticator extends Authenticator {
     }
 
     /**
+     * Getter of autoLinkUser.
+     *
      * @return bool
      */
     public function canAutoLinkUser(): bool {
@@ -50,6 +52,8 @@ abstract class SSOAuthenticator extends Authenticator {
     }
 
     /**
+     * Setter of autoLinkUser.
+     * 
      * @param bool $autoLinkUser
      * @return SSOAuthenticator
      */

--- a/library/Vanilla/Authenticator/SSOAuthenticator.php
+++ b/library/Vanilla/Authenticator/SSOAuthenticator.php
@@ -45,7 +45,7 @@ abstract class SSOAuthenticator extends Authenticator {
     /**
      * @return bool
      */
-    public function isAutoLinkUser(): bool {
+    public function canAutoLinkUser(): bool {
         return $this->autoLinkUser;
     }
 

--- a/library/Vanilla/Models/AuthenticatorModel.php
+++ b/library/Vanilla/Models/AuthenticatorModel.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace Vanilla\Models;
+
+
+use \Exception;
+use Garden\Container\Container;
+use Garden\Web\Exception\ServerException;
+use Garden\Web\Exception\NotFoundException;
+use Vanilla\AddonManager;
+use Vanilla\Authenticator\Authenticator;
+
+class AuthenticatorModel {
+
+    /** @var Container */
+    private $container;
+
+    /** @var AddonManager */
+    private $addonManager;
+
+    /**
+     * AuthenticatorModel constructor.
+     *
+     * @param Container $container
+     * @param AddonManager $addonManager
+     */
+    public function __construct(Container $container, AddonManager $addonManager) {
+        $this->container = $container;
+        $this->addonManager = $addonManager;
+    }
+
+    /**
+     * Get an authenticator.
+     *
+     * @param string $authenticatorType
+     * @param string $authenticatorID
+     * @return Authenticator
+     * @throws NotFoundException
+     * @throws ServerException
+     */
+    public function getAuthenticator($authenticatorType, $authenticatorID) {
+        if (empty($authenticatorType)) {
+            throw new NotFoundException();
+        }
+
+        $authenticatorClassName = $authenticatorType.'Authenticator';
+
+        /** @var Authenticator $authenticatorInstance */
+        $authenticatorInstance = null;
+
+        // Check if the container can find the authenticator.
+        try {
+            $authenticatorInstance = $this->container->getArgs($authenticatorClassName, [$authenticatorID]);
+            return $authenticatorInstance;
+        } catch (Exception $e) {}
+
+        // Use the addonManager to find the class.
+        $authenticatorClasses = $this->addonManager->findClasses("*\\$authenticatorClassName");
+
+        if (empty($authenticatorClasses)) {
+            throw new NotFoundException($authenticatorClassName);
+        }
+
+        // Throw an exception if there are multiple authenticators with that type.
+        // We are not handling authenticators with the same name in different namespaces for now.
+        if (count($authenticatorClasses) > 1) {
+            throw new ServerException(
+                "Multiple class named \"$authenticatorClasses\" have been found.",
+                500,
+                ['classes' => $authenticatorClasses]
+            );
+        }
+
+        $fqnAuthenticationClass = $authenticatorClasses[0];
+
+        if (!is_a($fqnAuthenticationClass, Authenticator::class, true)) {
+            throw new ServerException(
+                "\"$fqnAuthenticationClass\" is not an ".Authenticator::class,
+                500
+            );
+        }
+
+        $authenticatorInstance = $this->container->getArgs($fqnAuthenticationClass, [$authenticatorID]);
+
+        return $authenticatorInstance;
+    }
+}

--- a/library/Vanilla/Models/SSOData.php
+++ b/library/Vanilla/Models/SSOData.php
@@ -21,9 +21,6 @@ class SSOData implements \JsonSerializable {
     /** @var string Maps to "GDN_UserAuthenticationProvider.ProviderKey" */
     private $authenticatorID;
 
-    /** @var bool Whether the authenticator can sync Roles or User info. */
-    private $authenticatorIsTrusted;
-
     /** @var string Maps to "GDN_UserAuthentication.ForeignUserKey" */
     private $uniqueID;
 
@@ -54,7 +51,6 @@ class SSOData implements \JsonSerializable {
     ) {
         $this->authenticatorName = $authenticatorName;
         $this->authenticatorID = $authenticatorID;
-        $this->authenticatorIsTrusted = $authenticatorIsTrusted;
         $this->uniqueID = $uniqueID;
         $this->extra = $extra;
 
@@ -92,22 +88,6 @@ class SSOData implements \JsonSerializable {
      */
     public function setAuthenticatorID($authenticatorID) {
         $this->authenticatorID = $authenticatorID;
-        return $this;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getAuthenticatorIsTrusted() {
-        return $this->authenticatorIsTrusted;
-    }
-
-    /**
-     * @param $authenticatorIsTrusted
-     * @return $this
-     */
-    public function setAuthenticatorIsTrusted($authenticatorIsTrusted) {
-        $this->authenticatorIsTrusted = $authenticatorIsTrusted;
         return $this;
     }
 
@@ -198,7 +178,7 @@ class SSOData implements \JsonSerializable {
      * @throws \Exception If the validation fails.
      */
     public function validate() {
-        $required = ['authenticatorName', 'authenticatorID', 'authenticatorIsTrusted', 'uniqueID'];
+        $required = ['authenticatorName', 'authenticatorID', 'uniqueID'];
 
         $invalidProperties = [];
         foreach ($required as $name) {
@@ -223,7 +203,6 @@ class SSOData implements \JsonSerializable {
         $ssoData = new SSOData(
             array_key_exists('authenticatorName', $array) ? $array['authenticatorName'] : null,
             array_key_exists('authenticatorID', $array) ? $array['authenticatorID'] : null,
-            array_key_exists('authenticatorIsTrusted', $array) ? $array['authenticatorIsTrusted'] : null,
             array_key_exists('uniqueID', $array) ? $array['uniqueID'] : null,
             array_key_exists('user', $array) ? $array['user'] : [],
             array_key_exists('extra', $array) ? $array['extra'] : []

--- a/library/Vanilla/Models/SSOModel.php
+++ b/library/Vanilla/Models/SSOModel.php
@@ -7,11 +7,11 @@
 namespace Vanilla\Models;
 
 use Garden\EventManager;
+use Garden\Web\Exception\ServerException;
 use Gdn_Configuration;
 use Gdn_Session;
-use Garden\Web\Exception\ServerException;
 use UserModel;
-use Vanilla\AddonManager;
+use Vanilla\Authenticator\SSOAuthenticator;
 use Vanilla\Utility\CapitalCaseScheme;
 
 /**
@@ -19,8 +19,8 @@ use Vanilla\Utility\CapitalCaseScheme;
  */
 class SSOModel {
 
-    /** @var AddonManager */
-    private $addonManager;
+    /** @var AuthenticatorModel */
+    private $authenticatorModel;
 
     /** @var Gdn_Configuration */
     private $config;
@@ -40,20 +40,20 @@ class SSOModel {
     /**
      * SSOModel constructor.
      *
-     * @param AddonManager $addonManager
+     * @param AuthenticatorModel $authenticatorModel
      * @param Gdn_Configuration $config
      * @param EventManager $eventManager
      * @param Gdn_Session $session
      * @param UserModel $userModel
      */
     public function __construct(
-        AddonManager $addonManager,
+        AuthenticatorModel $authenticatorModel,
         Gdn_Configuration $config,
         EventManager $eventManager,
         Gdn_Session $session,
         UserModel $userModel
     ) {
-        $this->addonManager = $addonManager;
+        $this->authenticatorModel = $authenticatorModel;
         $this->capitalCaseScheme = new CapitalCaseScheme();
         $this->config = $config;
         $this->eventManager = $eventManager;
@@ -188,6 +188,12 @@ class SSOModel {
     public function sso(SSOData $ssoData) {
         $user = $this->getUser($ssoData);
 
+        /** @var SSOAuthenticator $ssoAuthenticator */
+        $ssoAuthenticator = $this->authenticatorModel->getAuthenticator($ssoData->getAuthenticatorName(), $ssoData->getAuthenticatorID());
+        if (!is_a($ssoAuthenticator, SSOAuthenticator::class)) {
+            throw new ServerException('Expected an SSOAuthenticator');
+        }
+
         if (!$user) {
             // Allows registration without an email address.
             $noEmail = $this->config->get('Garden.Registration.NoEmail', false);
@@ -196,16 +202,10 @@ class SSOModel {
             $emailUnique = !$noEmail && $this->config->get('Garden.Registration.EmailUnique', true);
 
             // Allows SSO connections to link a VanillaUser to a ForeignUser.
-            $allowConnect = $this->config->get('Garden.Registration.AllowConnect', true);
+            $allowConnect = $emailUnique && $this->config->get('Garden.Registration.AllowConnect', true);
 
             // Will automatically try to link users using the provided Email address if the Provider is "Trusted".
-            $autoConnect =
-                $emailUnique &&
-                (
-                    $ssoData->getAuthenticatorIsTrusted()
-                    || ($allowConnect && $this->config->get('Garden.Registration.AutoConnect', false))
-                )
-            ;
+            $autoConnect = $allowConnect && $ssoAuthenticator->canAutoLinkUser();
 
             // Let's try to find a matching user.
             if ($autoConnect) {
@@ -248,7 +248,7 @@ class SSOModel {
                 $syncRoles = $this->config->get('Garden.SSO.SyncRoles', false);
 
                 // Override $syncRoles if the authenticator is trusted.
-                if ($ssoData->getAuthenticatorIsTrusted()) {
+                if ($ssoAuthenticator->isTrusted()) {
                     // Synchronize user's roles only on registration.
                     $syncRolesOnlyRegistration = $this->config->get('Garden.SSO.SyncRolesOnRegistrationOnly', false);
 

--- a/tests/fixtures/src/TestSSOAuthenticator.php
+++ b/tests/fixtures/src/TestSSOAuthenticator.php
@@ -83,7 +83,7 @@ class TestSSOAuthenticator extends SSOAuthenticator {
     /**
      * @inheritDoc
      */
-    public function setTrusted($isTrusted) {
+    public function setTrusted(bool $isTrusted): bool {
         parent::setTrusted($isTrusted);
     }
 

--- a/tests/fixtures/src/TestSSOAuthenticator.php
+++ b/tests/fixtures/src/TestSSOAuthenticator.php
@@ -83,8 +83,8 @@ class TestSSOAuthenticator extends SSOAuthenticator {
     /**
      * @inheritDoc
      */
-    public function setTrusted(bool $isTrusted): bool {
-        parent::setTrusted($isTrusted);
+    public function setTrusted(bool $isTrusted): SSOAuthenticator {
+        return parent::setTrusted($isTrusted);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vanilla/internal/issues/1381
Closes https://github.com/vanilla/vanilla/issues/6665

This PR does multiple things that kind of go together:

- Fix a bug where AutoConnect was ON if an authenticator was trusted. This should not happen.
- Create the AuthenticatorModel since there is a need for `getAuthenthicator(Type, ID)` from multiple places.
- Move isTrusted out of SSOData since we now have access to the authenticator instance by using AuthenticatorModel.
- Add the autoLinkUser property on SSOAuthenticator. This replaces the old global `Garden.Registration.AutoConnect` config.
- Update the unit tests to account for the fact that the autoConnect feature has been moved to the authenticators as autoLinkUser.