### PR TITLE
Remove "none" from discussion sort options

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -52,7 +52,6 @@ class DiscussionModel extends Gdn_Model {
      *   `['field1' => 'direction', 'field2' => 'direction']`
      */
     protected static $allowedSorts = [
-        'none' => ['key' => self::EMPTY_FILTER_KEY, 'name' => 'None'],
         'hot' => ['key' => 'hot', 'name' => 'Hot', 'orderBy' => ['DateLastComment' => 'desc']],
         'top' => ['key' => 'top', 'name' => 'Top', 'orderBy' => ['Score' => 'desc', 'DateInserted' => 'desc']],
         'new' => ['key' => 'new', 'name' => 'New', 'orderBy' => ['DateInserted' => 'desc']]


### PR DESCRIPTION
I thought "Hot" was separate from "None" as a sort option for ideation. I removed "None" as an option. 