### PR TITLE
Add the core app js if it exists

### DIFF
--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -168,8 +168,14 @@ class AssetModel extends Gdn_Model {
             "/js/$basename/lib-core-$basename.js"
         ];
 
-        // Loop through the enabled addons and get their javascript.
         $addons = [];
+
+        $core = "/js/$basename/core-$basename.js";
+        if (file_exists(PATH_ROOT."/$core")) {
+            $addons[] = $core;
+        }
+
+        // Loop through the enabled addons and get their javascript.
         foreach ($this->addonManager->getEnabled() as $addon) {
             /* @var Addon $addon */
             if ($addon->getType() !== Addon::TYPE_ADDON) {


### PR DESCRIPTION
Since the core js isn’t a true addon the check needs to be done
separately. This fix doesn’t currently have an impact since there is no
core app, but it should when code needs to add core app functionality.

Closes #6807.