### PR TITLE
Add filtering by archived status to categories API v2 endpoint

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -123,7 +123,7 @@ class CategoriesApiController extends AbstractApiController {
             ],
             'parentCategoryID:i|n' => 'Parent category ID.',
             'customPermissions:b' => 'Are custom permissions set for this category?',
-            'archived:b' => 'The archived state of this category.',
+            'isArchived:b' => 'The archived state of this category.',
             'urlcode:s' => 'The URL code of the category.',
             'url:s' => 'The URL to the category.',
             'displayAs:s' => [
@@ -520,6 +520,8 @@ class CategoriesApiController extends AbstractApiController {
         if (!empty($dbRecord['Children']) && is_array($dbRecord['Children'])) {
             $dbRecord['Children'] = array_map([$this, 'normalizeOutput'], $dbRecord['Children']);
         }
+
+        $dbRecord['isArchived'] = $dbRecord['Archived'];
 
         $schemaRecord = ApiUtils::convertOutputKeys($dbRecord);
         return $schemaRecord;

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -112,7 +112,7 @@ class CategoriesTest extends AbstractResourceTest {
         // Iterate through the results, detecting the archived status.
         $notArchived = 0;
         foreach ($categories as $category) {
-            if ($category['archived'] !== true) {
+            if ($category['isArchived'] !== true) {
                 $notArchived++;
             }
         }
@@ -138,7 +138,7 @@ class CategoriesTest extends AbstractResourceTest {
         // Iterate through the results, detecting the archived status.
         $archived = 0;
         foreach ($categories as $category) {
-            if ($category['archived'] === true) {
+            if ($category['isArchived'] === true) {
                 $archived++;
             }
         }

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -20,14 +20,14 @@ class CategoriesTest extends AbstractResourceTest {
     /** The standard parent category ID. */
     const PARENT_CATEGORY_ID = 1;
 
+    /** @var CategoryModel */
+    private static $categoryModel;
+
     /** @var int A value to ensure new records are unique. */
     protected static $recordCounter = 1;
 
     /** {@inheritdoc} */
     protected $baseUrl = '/categories';
-
-    /** @var CategoryModel */
-    protected $categoryModel;
 
     /** {@inheritdoc} */
     protected $editFields = ['description', 'name', 'parentCategoryID', 'urlcode', 'displayAs'];
@@ -64,18 +64,6 @@ class CategoriesTest extends AbstractResourceTest {
     }
 
     /**
-     * Get an instance of CategoryModel.
-     *
-     * @return CategoryModel
-     */
-    protected function getCategoryModel() {
-        if (!isset($this->categoryModel)) {
-            $this->categoryModel = $this->container()->get(CategoryModel::class);
-        }
-        return $this->categoryModel;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function indexUrl() {
@@ -101,14 +89,20 @@ class CategoriesTest extends AbstractResourceTest {
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public static function setupBeforeClass() {
+        parent::setupBeforeClass();
+        self::$categoryModel = self::container()->get(CategoryModel::class);
+    }
+
+    /**
      * Test getting only archived categories.
      */
     public function testFilterArchived() {
-        $categoryModel = $this->getCategoryModel();
-
         // Make sure there'es at least one archived category.
         $archived = $this->testPost();
-        $categoryModel->setField($archived['categoryID'], 'Archived', 1);
+        self::$categoryModel->setField($archived['categoryID'], 'Archived', 1);
 
         $categories = $this->api()->get($this->baseUrl, [
             'archived' => true,
@@ -131,11 +125,9 @@ class CategoriesTest extends AbstractResourceTest {
      * Test getting only categories that are not archived.
      */
     public function testFilterNotArchived() {
-        $categoryModel = $this->getCategoryModel();
-
         // Make sure there's at least one archived category.
         $archived = $this->testPost();
-        $categoryModel->setField($archived['categoryID'], 'Archived', 1);
+        self::$categoryModel->setField($archived['categoryID'], 'Archived', 1);
 
         // Get only non-archived categories.
         $categories = $this->api()->get($this->baseUrl, [
@@ -317,11 +309,9 @@ class CategoriesTest extends AbstractResourceTest {
      * Test getting both archived and non-archived categories.
      */
     public function testNoFilterArchived() {
-        $categoryModel = $this->getCategoryModel();
-
         // Make sure there's at least one archived category.
         $archived = $this->testPost();
-        $categoryModel->setField($archived['categoryID'], 'Archived', 1);
+        self::$categoryModel->setField($archived['categoryID'], 'Archived', 1);
 
         // ...and one non-archived category.
         $notArchived = $this->testPost();


### PR DESCRIPTION
This update adds the ability to filter results from the index of the categories endpoint by their archived status. Per the original issue:

1. If `archived` is false (default), only return non-archived categories from the current tree.
1. If `archived` is true, only return archived categories from the current tree.
1. If `archived` is null (an empty value), don't filter by the archived status. Return both archived and non-archived categories.

Closes #6255