### PR TITLE
Cleanup where category condition.

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -724,6 +724,11 @@ class DiscussionModel extends Gdn_Model {
                 $where['d.CategoryID'] = $perms;
             }
         }
+        
+        // Remove empty CategoryID condition - that could have resulted due to above merge
+        if (isset($where['d.CategoryID']) && empty($where['d.CategoryID'])) {
+            unset($where['d.CategoryID']);
+        }
 
         // Check to see whether or not we are removing announcements.
         if (strtolower(val('Announce', $where)) == 'all') {


### PR DESCRIPTION
When there is not category to filter - drop the where condition.

This was happening when (type=guest) was not set a default to any role and site was visited without any signin.