### PR TITLE
Phase out category muting in favor of category following

### DIFF
--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -21,7 +21,18 @@ class CategoryController extends VanillaController {
         $this->CategoryModel = new CategoryModel();
     }
 
+    /**
+     * Mute or unmute a category.
+     *
+     * @deprecated 2.6 Deprecated in favor of whitelist-style category following.
+     * @see CategoryController::followed
+     * @param $categoryID
+     * @param $value
+     * @param $tKey
+     */
     public function follow($categoryID, $value, $tKey) {
+        deprecated(__CLASS__.'::'.__FUNCTION__, __CLASS__.'::followed');
+
         if (Gdn::session()->validateTransientKey($tKey)) {
             $this->CategoryModel->saveUserTree($categoryID, ['Unfollow' => (int)(!(bool)$value)]);
         }

--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -31,7 +31,7 @@ class CategoryController extends VanillaController {
      * @param $tKey
      */
     public function follow($categoryID, $value, $tKey) {
-        deprecated(__CLASS__.'::'.__FUNCTION__, __CLASS__.'::followed');
+        deprecated(__METHOD__, __CLASS__.'::followed');
 
         if (Gdn::session()->validateTransientKey($tKey)) {
             $this->CategoryModel->saveUserTree($categoryID, ['Unfollow' => (int)(!(bool)$value)]);

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -276,7 +276,6 @@ class DiscussionsController extends VanillaController {
         $discussionModel->setFilters(Gdn::request()->get());
         $this->setData('Sort', $discussionModel->getSort());
         $this->setData('Filters', $discussionModel->getFilters());
-        $discussionModel->Watching = true;
 
         // Get Discussion Count
         $countDiscussions = $discussionModel->getUnreadCount();

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -152,8 +152,6 @@ class DiscussionsController extends VanillaController {
             $where['d.CategoryID'] = array_keys($categoryModel->getFollowed(Gdn::session()->UserID));
         } elseif ($categoryIDs) {
             $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
-        } else {
-            $DiscussionModel->Watching = true;
         }
 
         // Get Discussion Count

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -397,7 +397,7 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
-     *
+     * Get followed categories, taking into account view permissions and the category's HideAllDiscussions flag, optionally.
      *
      * @param bool $honorHideAllDiscussion Whether or not the HideAllDiscussions flag will be checked on categories.
      * @return array|bool Category IDs or true if all categories are watched.
@@ -413,7 +413,7 @@ class CategoryModel extends Gdn_Model {
                 continue;
             }
 
-            if ($category['PermsDiscussionsView'] && $category['Following']) {
+            if ($category['PermsDiscussionsView'] && $category['Followed']) {
                 $watch[] = $categoryID;
             }
         }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -443,6 +443,7 @@ class CategoryModel extends Gdn_Model {
      * Get a list of IDs of categories visible to the current user.
      *
      * @param array $options
+     *   - filterHideDiscussions (bool): Filter out categories with a truthy HideAllDiscussions column?
      * @return array|bool An array of filtered categories or true if no categories were filtered.
      */
     public function getVisibleCategories(array $options = []) {
@@ -480,10 +481,10 @@ class CategoryModel extends Gdn_Model {
      * Get a list of IDs of categories visible to the current user.
      *
      * @see CategoryModel::categoryWatch
-     * @param array $options
+     * @param array $options Options compatible with CategoryModel::getVisibleCategories
      * @return array|bool An array of filtered category IDs or true if no categories were filtered.
      */
-    public static function getVisibleCategoryIDs(array $options = []) {
+    public function getVisibleCategoryIDs(array $options = []) {
         $categoryModel = self::instance();
         $result = $categoryModel->getVisibleCategories($options);
         if (is_array($result)) {
@@ -2169,7 +2170,7 @@ class CategoryModel extends Gdn_Model {
         }
 
         if (!$categoryID) {
-            $categoryID = CategoryModel::getVisibleCategoryIDs();
+            $categoryID = CategoryModel::instance()->getVisibleCategoryIDs();
         }
 
         switch ($permissions) {
@@ -2228,7 +2229,7 @@ class CategoryModel extends Gdn_Model {
         if ($restrictIDs && !is_array($restrictIDs)) {
             $restrictIDs = [$restrictIDs];
         } else {
-            $restrictIDs = self::getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+            $restrictIDs = $this->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
         }
 
         switch ($permissions) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -413,7 +413,7 @@ class CategoryModel extends Gdn_Model {
      * @return array|bool Category IDs or true if all categories are watched.
      */
     public static function categoryWatch($honorHideAllDiscussion = true) {
-        deprecated(__CLASS__.'::'.__FUNCTION__, __CLASS__.'::getVisibleCategoryIDs');
+        deprecated(__METHOD__, __CLASS__.'::getVisibleCategoryIDs');
         $categories = self::categories();
         $allCount = count($categories);
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -397,8 +397,9 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
-     * Get followed categories, taking into account view permissions and the category's HideAllDiscussions flag, optionally.
+     * Get all categories, taking into account view permissions and, optionally, the category's HideAllDiscussions flag,.
      *
+     * @deprecated 2.6
      * @param bool $honorHideAllDiscussion Whether or not the HideAllDiscussions flag will be checked on categories.
      * @return array|bool Category IDs or true if all categories are watched.
      */
@@ -413,7 +414,7 @@ class CategoryModel extends Gdn_Model {
                 continue;
             }
 
-            if ($category['PermsDiscussionsView'] && $category['Followed']) {
+            if ($category['PermsDiscussionsView']) {
                 $watch[] = $categoryID;
             }
         }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -49,7 +49,10 @@ class CategoryModel extends Gdn_Model {
      */
     private $collection;
 
-    /** @var bool */
+    /**
+     * @deprecated 2.6
+     * @var bool
+     */
     public $Watching = false;
 
     /** @var array Merged Category data, including Pure + UserCategory. */

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -406,6 +406,7 @@ class CategoryModel extends Gdn_Model {
      * @return array|bool Category IDs or true if all categories are watched.
      */
     public static function categoryWatch($honorHideAllDiscussion = true) {
+        deprecated(__CLASS__.'::'.__FUNCTION__, __CLASS__.'::getVisibleCategoryIDs');
         $categories = self::categories();
         $allCount = count($categories);
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -49,6 +49,9 @@ class CategoryModel extends Gdn_Model {
      */
     private $collection;
 
+    /** @var EventManager */
+    private $eventManager;
+
     /**
      * @deprecated 2.6
      * @var bool
@@ -89,6 +92,7 @@ class CategoryModel extends Gdn_Model {
     public function __construct() {
         parent::__construct('Category');
         $this->collection = $this->createCollection();
+        $this->eventManager = Gdn::getContainer()->get(EventManager::class);
     }
 
     /**
@@ -442,7 +446,7 @@ class CategoryModel extends Gdn_Model {
      * @return array|bool An array of filtered categories or true if no categories were filtered.
      */
     public function getVisibleCategories(array $options = []) {
-        $categories = $this->categories();
+        $categories = self::categories();
         $unfiltered = true;
         $result = [];
 
@@ -466,6 +470,9 @@ class CategoryModel extends Gdn_Model {
             $result = true;
         }
 
+        // Allow addons to modify the visible categories.
+        $result = $this->eventManager->fireFilter('categoryModel_visibleCategories', $result);
+
         return $result;
     }
 
@@ -488,9 +495,6 @@ class CategoryModel extends Gdn_Model {
 
         // Backwards-compatible CategoryModel::categoryWatch event.
         $eventManager->fireDeprecated('categoryModel_categoryWatch', $categoryModel, ['CategoryIDs' => &$result]);
-
-        // Allow addons to modify the visible categories.
-        $result = $eventManager->fireFilter('categoryModel_visibleCategoryIDs', $result);
 
         return $result;
     }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -36,7 +36,10 @@ class DiscussionModel extends Gdn_Model {
     /** @var array */
     private static $discussionTypes = null;
 
-    /** @var bool */
+    /**
+     * @deprecated 2.6
+     * @var bool
+     */
     public $Watching = false;
 
     /** @var array Discussion Permissions */

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -664,7 +664,7 @@ class DiscussionModel extends Gdn_Model {
 
         // Determine category watching
         if (!isset($where['d.CategoryID'])) {
-            $categoryIDs = CategoryModel::getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+            $categoryIDs = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
             if ($categoryIDs !== true) {
                 $where['d.CategoryID'] = $categoryIDs;
             }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -331,11 +331,7 @@ class DiscussionModel extends Gdn_Model {
      */
     public function discussionSummaryQuery($additionalFields = [], $join = true) {
         // Verify permissions (restricting by category if necessary)
-        if ($this->Watching) {
-            $perms = CategoryModel::categoryWatch();
-        } else {
-            $perms = self::categoryPermissions();
-        }
+        $perms = self::categoryPermissions();
 
         if ($perms !== true) {
             $this->SQL->whereIn('d.CategoryID', $perms);
@@ -664,10 +660,10 @@ class DiscussionModel extends Gdn_Model {
         }
 
         // Determine category watching
-        if ($this->Watching && !isset($where['d.CategoryID'])) {
-            $watch = CategoryModel::categoryWatch();
-            if ($watch !== true) {
-                $where['d.CategoryID'] = $watch;
+        if (!isset($where['d.CategoryID'])) {
+            $categoryIDs = CategoryModel::getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+            if ($categoryIDs !== true) {
+                $where['d.CategoryID'] = $categoryIDs;
             }
         }
 
@@ -1518,11 +1514,7 @@ class DiscussionModel extends Gdn_Model {
      */
     public function getCount($wheres = [], $unused = null) {
         // Get permissions.
-        if ($this->Watching) {
-            $perms = CategoryModel::categoryWatch();
-        } else {
-            $perms = self::categoryPermissions();
-        }
+        $perms = self::categoryPermissions();
 
         // No permissions... That is sad :(
         if (!$perms) {
@@ -1608,11 +1600,7 @@ class DiscussionModel extends Gdn_Model {
         }
 
         // Check permission and limit to categories as necessary
-        if ($this->Watching) {
-            $perms = CategoryModel::categoryWatch();
-        } else {
-            $perms = self::categoryPermissions();
-        }
+        $perms = self::categoryPermissions();
 
         if (!$wheres || (count($wheres) == 1 && isset($wheres['d.CategoryID']))) {
             // Grab the counts from the faster category cache.

--- a/applications/vanilla/models/class.vanillasearchmodel.php
+++ b/applications/vanilla/models/class.vanillasearchmodel.php
@@ -48,7 +48,7 @@ class VanillaSearchModel extends Gdn_Model {
     public function discussionSql($searchModel, $addMatch = true) {
         // Get permission and limit search categories if necessary.
         if ($addMatch) {
-            $perms = CategoryModel::getVisibleCategoryIDs();
+            $perms = CategoryModel::instance()->getVisibleCategoryIDs();
 
             if ($perms !== true) {
                 $this->SQL->whereIn('d.CategoryID', $perms);
@@ -92,7 +92,7 @@ class VanillaSearchModel extends Gdn_Model {
     public function commentSql($searchModel, $addMatch = true) {
         if ($addMatch) {
             // Get permission and limit search categories if necessary.
-            $perms = CategoryModel::getVisibleCategoryIDs();
+            $perms = CategoryModel::instance()->getVisibleCategoryIDs();
             if ($perms !== true) {
                 $this->SQL->whereIn('d.CategoryID', $perms);
             }

--- a/applications/vanilla/models/class.vanillasearchmodel.php
+++ b/applications/vanilla/models/class.vanillasearchmodel.php
@@ -48,7 +48,7 @@ class VanillaSearchModel extends Gdn_Model {
     public function discussionSql($searchModel, $addMatch = true) {
         // Get permission and limit search categories if necessary.
         if ($addMatch) {
-            $perms = CategoryModel::categoryWatch(false);
+            $perms = CategoryModel::getVisibleCategoryIDs();
 
             if ($perms !== true) {
                 $this->SQL->whereIn('d.CategoryID', $perms);
@@ -92,7 +92,7 @@ class VanillaSearchModel extends Gdn_Model {
     public function commentSql($searchModel, $addMatch = true) {
         if ($addMatch) {
             // Get permission and limit search categories if necessary.
-            $perms = CategoryModel::categoryWatch(false);
+            $perms = CategoryModel::getVisibleCategoryIDs();
             if ($perms !== true) {
                 $this->SQL->whereIn('d.CategoryID', $perms);
             }

--- a/applications/vanilla/modules/class.discussionsmodule.php
+++ b/applications/vanilla/modules/class.discussionsmodule.php
@@ -69,8 +69,6 @@ class DiscussionsModule extends Gdn_Module {
 
         if ($categoryIDs) {
             $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
-        } else {
-            $discussionModel->Watching = true;
         }
 
         $this->setData('Discussions', $discussionModel->get(0, $limit, $where));


### PR DESCRIPTION
The UI for muting a category was phased out for category following with #6469. However, there still exists some functionality that needs to be walled off.

1. `CategoryController::follow` has been deprecated. This was formerly used to mute/unmute a category. Since we're shifting to following, this should no longer be used.
1. The recent discussions list no longer filters blacklisted (muted) categories.
1. Similar to the recent discussions page, `DiscussionsModule` no longer filters blacklisted (muted) categories.
1. `CategoryModel::categoryWatch` has been deprecated.
1. `CategoryModel::getVisibleCategories` has been added. The method gets categories a user has "view" access too, while allowing additional filtering (e.g. filtering by the `HideAllDiscussions` field).
1. `CategoryModel::getVisibleCategoryIDs` has been introduced as a drop-in replacement for `CategoryModel::categoryWatch`. It is essentially a wrapper for `CategoryModel::getVisibleCategories` that extracts category IDs. The event fired in `CategoryModel::categoryWatch`is now fired in this new method as a deprecated event. A new filter is fired to alter the return values of the method.
1. `CategoryModel::$Watching` has been deprecated.
1. `DiscussionModel::$Watching` has been deprecated.