### PR TITLE
Fix Gdn_Format::formatMentionsCallback not respecting Gdn_Format::$DisplayNoFollow

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1931,7 +1931,11 @@ EOT;
             }
 
             if ($mention) {
-                $parts[$i] = anchor('@'.$mention, url(str_replace('{name}', rawurlencode($mention), self::$MentionsUrlFormat), true), '', ['rel' => 'nofollow']).$suffix;
+                $attributes = [];
+                if (self::$DisplayNoFollow) {
+                    $attributes['rel'] = 'nofollow';
+                }
+                $parts[$i] = anchor('@'.$mention, url(str_replace('{name}', rawurlencode($mention), self::$MentionsUrlFormat), true), '', $attributes).$suffix;
             } else {
                 $parts[$i] = '@' . $parts[$i];
             }


### PR DESCRIPTION
This update conditionally adds `rel="nofollow"` to \@mention links, based on the value of `Gdn_Format::$DisplayNoFollow`.