### PR TITLE
Add ability for addons to modify followed recent discussions

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -149,7 +149,14 @@ class DiscussionsController extends VanillaController {
         $categoryIDs = $this->getCategoryIDs();
         $where = [];
         if ($this->data('Followed')) {
-            $where['d.CategoryID'] = array_keys($categoryModel->getFollowed(Gdn::session()->UserID));
+            $followedCategories = array_keys($categoryModel->getFollowed(Gdn::session()->UserID));
+            $visibleCategories = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+            if ($visibleCategories === true) {
+                $visibleFollowedCategories = $followedCategories;
+            } else {
+                $visibleFollowedCategories = array_intersect($followedCategories, $visibleCategories);
+            }
+            $where['d.CategoryID'] = $visibleFollowedCategories;
         } elseif ($categoryIDs) {
             $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
         }


### PR DESCRIPTION
There's currently no way for addons to hook in and modify the discussions displayed on the Recent Discussions page when the "following" filter is applied. This update adds usage of `CategoryModel::getVisibleCategoryIDs` to limit discussions by category. This method is hook-able, so addons can modify the result.