### PR TITLE
Refactor CommentModel->setWatch

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -752,14 +752,11 @@ class CommentModel extends Gdn_Model {
             return;
         }
 
-        // Loop over these discussions and see if any are still unread.
-        $markAsRead = true;
+        // Loop over these discussions and exit if there are any unread discussions
         while ($discussion = $discussions->nextRow(DATASET_TYPE_ARRAY)) {
-            if ($discussion['Read']) {
-                continue;
+            if (!$discussion['Read']) {
+                return;
             }
-            $markAsRead = false;
-            break;
         }
 
         // Mark this category read if all the new content is read.

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -752,9 +752,14 @@ class CommentModel extends Gdn_Model {
             return;
         }
 
-        // Search through all of these and exit if any are still unread.
-        if (in_array(false, array_column($discussions->resultArray(), 'Read'), true)) {
-            return;
+        // Loop over these discussions and see if any are still unread.
+        $markAsRead = true;
+        while ($discussion = $discussions->nextRow(DATASET_TYPE_ARRAY)) {
+            if ($discussion['Read']) {
+                continue;
+            }
+            $markAsRead = false;
+            break;
         }
 
         // Mark this category read if all the new content is read.

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -733,7 +733,7 @@ class CommentModel extends Gdn_Model {
 
                         // Find all discussions with content from after DateMarkedRead
                         $discussionModel = new DiscussionModel();
-                        $discussions = $discussionModel->get(0, 101, [
+                        $discussions = $discussionModel->get(0, $lookBackCount, [
                             'CategoryID' => $categoryID,
                             'DateLastComment>' => $dateMarkedRead
                         ]);

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -716,7 +716,7 @@ class CommentModel extends Gdn_Model {
             }
 
             /**
-             * Fuzzy way of trying to automatically mark a cateogyr read again
+             * Fuzzy way of trying to automatically mark a category read again
              * if the user reads all the comments on the first few pages.
              */
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -752,8 +752,8 @@ class CommentModel extends Gdn_Model {
             return;
         }
 
-        // Search through all of these and see if any are still unread.
-        if (in_array(true, array_column($discussions->resultArray(), 'Read'), true) {
+        // Search through all of these and exit if any are still unread.
+        if (in_array(false, array_column($discussions->resultArray(), 'Read'), true) {
             return;
         }
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -753,7 +753,7 @@ class CommentModel extends Gdn_Model {
         }
 
         // Search through all of these and exit if any are still unread.
-        if (in_array(false, array_column($discussions->resultArray(), 'Read'), true) {
+        if (in_array(false, array_column($discussions->resultArray(), 'Read'), true)) {
             return;
         }
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -723,48 +723,48 @@ class CommentModel extends Gdn_Model {
             // If this discussion is in a category that has been marked read,
             // check if reading this thread causes it to be completely read again
             $categoryID = val('CategoryID', $discussion);
-            if ($categoryID) {
-                $category = CategoryModel::categories($categoryID);
-                if ($category) {
-                    $dateMarkedRead = val('DateMarkedRead', $category);
-                    if ($dateMarkedRead) {
-                        // Fuzzy way of looking back about 2 pages into the past
-                        $lookBackCount = c('Vanilla.Discussions.PerPage', 50) * 2;
+            if (!$categoryID) {
+                return;
+            }
+            $category = CategoryModel::categories($categoryID);
+            if (!$category) {
+                return;
+            }
+            $dateMarkedRead = val('DateMarkedRead', $category);
+            if ($dateMarkedRead) {
+                // Fuzzy way of looking back about 2 pages into the past
+                $lookBackCount = c('Vanilla.Discussions.PerPage', 50) * 2;
 
-                        // Find all discussions with content from after DateMarkedRead
-                        $discussionModel = new DiscussionModel();
-                        $discussions = $discussionModel->get(0, $lookBackCount, [
-                            'CategoryID' => $categoryID,
-                            'DateLastComment>' => $dateMarkedRead
-                        ]);
-                        unset($discussionModel);
+                // Find all discussions with content from after DateMarkedRead
+                $discussionModel = new DiscussionModel();
+                $discussions = $discussionModel->get(0, $lookBackCount + 1, [
+                    'CategoryID' => $categoryID,
+                    'DateLastComment>' => $dateMarkedRead
+                ]);
+                unset($discussionModel);
 
-                        // Abort if we get back as many as we asked for, meaning a
-                        // lot has happened.
-                        $numDiscussions = $discussions->numRows();
-                        if ($numDiscussions <= $lookBackCount) {
-                            // Loop over these and see if any are still unread
-                            $markAsRead = true;
-                            while ($discussion = $discussions->nextRow(DATASET_TYPE_ARRAY)) {
-                                if ($discussion['Read']) {
-                                    continue;
-                                }
-                                $markAsRead = false;
-                                break;
-                            }
-
-                            // Mark this category read if all the new content is read
-                            if ($markAsRead) {
-                                $categoryModel = new CategoryModel();
-                                $categoryModel->saveUserTree($categoryID, ['DateMarkedRead' => Gdn_Format::toDateTime()]);
-                                unset($categoryModel);
-                            }
-
+                // Abort if we get back as many as we asked for, meaning a
+                // lot has happened.
+                $numDiscussions = $discussions->numRows();
+                if ($numDiscussions <= $lookBackCount) {
+                    // Loop over these and see if any are still unread
+                    $markAsRead = true;
+                    while ($discussion = $discussions->nextRow(DATASET_TYPE_ARRAY)) {
+                        if ($discussion['Read']) {
+                            continue;
                         }
+                        $markAsRead = false;
+                        break;
+                    }
+
+                    // Mark this category read if all the new content is read
+                    if ($markAsRead) {
+                        $categoryModel = new CategoryModel();
+                        $categoryModel->saveUserTree($categoryID, ['DateMarkedRead' => Gdn_Format::toDateTime()]);
+                        unset($categoryModel);
                     }
                 }
             }
-
         }
     }
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -751,22 +751,16 @@ class CommentModel extends Gdn_Model {
         if ($discussions->numRows() > $lookBackCount) {
             return;
         }
-        // Loop over these and see if any are still unread.
-        $markAsRead = true;
-        while ($discussion = $discussions->nextRow(DATASET_TYPE_ARRAY)) {
-            if ($discussion['Read']) {
-                continue;
-            }
-            $markAsRead = false;
-            break;
+
+        // Search through all of these and see if any are still unread.
+        if (in_array(true, array_column($discussions->resultArray(), 'Read'), true) {
+            return;
         }
 
         // Mark this category read if all the new content is read.
-        if ($markAsRead) {
-            $categoryModel = new CategoryModel();
-            $categoryModel->saveUserTree($categoryID, ['DateMarkedRead' => Gdn_Format::toDateTime()]);
-            unset($categoryModel);
-        }
+        $categoryModel = new CategoryModel();
+        $categoryModel->saveUserTree($categoryID, ['DateMarkedRead' => Gdn_Format::toDateTime()]);
+        unset($categoryModel);
     }
 
     /**

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -657,8 +657,8 @@ class CommentModel extends Gdn_Model {
 
         $newComments = false;
 
-        $session = Gdn::session();
-        if ($session->UserID > 0) {
+        $userID = Gdn::session()->UserID;
+        if ($userID > 0) {
             // Max comments we could have seen
             $countWatch = $limit + $offset;
             if ($countWatch > $totalComments) {
@@ -689,7 +689,7 @@ class CommentModel extends Gdn_Model {
                             'DateLastViewed' => Gdn_Format::toDateTime()
                         ],
                         [
-                            'UserID' => $session->UserID,
+                            'UserID' => $userID,
                             'DiscussionID' => $discussion->DiscussionID
                         ]
                     );
@@ -706,7 +706,7 @@ class CommentModel extends Gdn_Model {
                     $this->SQL->insert(
                         'UserDiscussion',
                         [
-                            'UserID' => $session->UserID,
+                            'UserID' => $userID,
                             'DiscussionID' => $discussion->DiscussionID,
                             'CountComments' => $countWatch,
                             'DateLastViewed' => Gdn_Format::toDateTime()


### PR DESCRIPTION
That method has a lot of nested if-clauses. I replaced them by `if (!condition) { return; }`

The other "bigger" change in this PR is that the following while block:
~~~
$markAsRead = true;
while ($discussion = $discussions->nextRow(DATASET_TYPE_ARRAY)) {
    if ($discussion['Read']) {
        continue;
    }
    $markAsRead = false;
    break;
}
~~~
with array functions:
~~~
if (in_array(false, array_column($discussions->resultArray(), 'Read'), true) {
    return;
}
~~~
