### PR TITLE
Add pagination link tags to page when using pager

### DIFF
--- a/applications/dashboard/modules/class.pagermodule.php
+++ b/applications/dashboard/modules/class.pagermodule.php
@@ -112,11 +112,11 @@ class PagerModule extends Gdn_Module {
     }
 
     /**
-     * Add prev/next rel meta pagination tags to the document head. Also, add Link header to the response.
+     * Add prev/next relationship links to document and the response headers.
      *
      * @param Gdn_Controller $controller
      */
-    private function addPageMeta(Gdn_Controller $controller) {
+    private function addRelLinks(Gdn_Controller $controller) {
         static $pending = true;
 
         // Make sure this only happens once.
@@ -127,7 +127,7 @@ class PagerModule extends Gdn_Module {
 
             if ($currentPage > 1) {
                 $prevHref = $this->pageUrl($currentPage - 1);
-                $head->addTag('meta', [
+                $head->addTag('link', [
                     'rel' => 'prev',
                     'href' => $prevHref
                 ]);
@@ -136,7 +136,7 @@ class PagerModule extends Gdn_Module {
 
             if ($this->hasMorePages()) {
                 $nextHref = $this->pageUrl($currentPage + 1);
-                $head->addTag('meta', [
+                $head->addTag('link', [
                     'rel' => 'next',
                     'href' => $nextHref
                 ]);
@@ -193,7 +193,7 @@ class PagerModule extends Gdn_Module {
             }
 
             $this->_PropertiesDefined = true;
-            $this->addPageMeta(Gdn::controller());
+            $this->addRelLinks(Gdn::controller());
 
             Gdn::controller()->EventArguments['Pager'] = $this;
             Gdn::controller()->fireEvent('PagerInit');

--- a/applications/dashboard/modules/class.pagermodule.php
+++ b/applications/dashboard/modules/class.pagermodule.php
@@ -129,7 +129,7 @@ class PagerModule extends Gdn_Module {
                 $prevHref = $this->pageUrl($currentPage - 1);
                 $head->addTag('link', [
                     'rel' => 'prev',
-                    'href' => $prevHref
+                    'href' => url($prevHref)
                 ]);
                 $this->webLinking->addLink('prev', $prevHref);
             }
@@ -138,7 +138,7 @@ class PagerModule extends Gdn_Module {
                 $nextHref = $this->pageUrl($currentPage + 1);
                 $head->addTag('link', [
                     'rel' => 'next',
-                    'href' => $nextHref
+                    'href' => url($nextHref)
                 ]);
                 $this->webLinking->addLink('next', $nextHref);
             }


### PR DESCRIPTION
`PagerModule` has been updated to add rel=prev/next link tags to the page head, as necessary, when the pager module is used.

1. `PagerModule::addRelLinks`, a private method, has been added. This method is responsible for updating the page head and setting the link response header. It is currently only called in `PagerModule::configure`.
1. Adding the link tags should only occur once. It doesn't matter if you write the pager once or ten times.
1. The first page of the pager has been normalized to have no page number. This is done for search engines, to avoid seemingly duplicating content (e.g. /discussions and /discussions/p1 being identical).

Closes #6522 