### PR TITLE
Improve ZIP file handling in UpdateModel::analyzeAddon

### DIFF
--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -265,6 +265,7 @@ class UpdateModel extends Gdn_Model {
         $variable = $info['Variable'];
         $info = $info[$key];
 
+        // If there wasn't a "Variable" in the original $info, try the updated $info.
         if (empty($variable) && array_key_exists('Variable', $info)) {
             $variable = $info['Variable'];
         }


### PR DESCRIPTION
Vanilla made a semi-recent update to using "addon.json" for addon info. Support for this method was implemented in `UpdateModel::analyzeAddon`, a deprecated method. However, the support didn't accommodate ZIP files. Addons, like Community, use this method to analyze such archives. If you had an addon in an archive with only addon.json for info (e.g. no fallback about.php), the analyzation would fail ("Could not parse addon info array.").

This update hopefully makes ZIP file handling more robust.

See https://github.com/vanilla/community/issues/135