### PR TITLE
Add a hookable filter to UserModel::expandUsers

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -8,6 +8,8 @@
  * @since 2.0
  */
 
+use Garden\EventManager;
+
 /**
  * Handles user data.
  */
@@ -49,6 +51,9 @@ class UserModel extends Gdn_Model {
     /** Timeout for SSO */
     const SSO_TIMEOUT = 1200;
 
+    /** @var EventManager */
+    private $eventManager;
+
     /** @var */
     public $SessionColumns;
 
@@ -63,6 +68,8 @@ class UserModel extends Gdn_Model {
      */
     public function __construct() {
         parent::__construct('User');
+
+        $this->eventManager = Gdn::getContainer()->get(EventManager::class);
 
         $this->addFilterField([
             'Admin', 'Deleted', 'CountVisits', 'CountInvitations', 'CountNotifications', 'Preferences', 'Permissions',
@@ -1057,8 +1064,9 @@ class UserModel extends Gdn_Model {
      *
      * @param array $rows Results we need to associate user data with.
      * @param array $columns Database columns containing UserIDs to get data for.
+     * @param array $options
      */
-    public function expandUsers(array &$rows, array $columns) {
+    public function expandUsers(array &$rows, array $columns, array $options = []) {
         // How are we supposed to lookup users by column if we don't have any columns?
         if (count($rows) === 0 || count($columns) === 0) {
             return;
@@ -1131,6 +1139,8 @@ class UserModel extends Gdn_Model {
                 $populate($row);
             }
         }
+
+        $rows = $this->eventManager->fireFilter('userModel_expandUsers', $rows, $single, $options);
     }
 
     /**

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -65,11 +65,17 @@ class UserModel extends Gdn_Model {
 
     /**
      * Class constructor. Defines the related database table name.
+     *
+     * @param EventManager $eventManager
      */
-    public function __construct() {
+    public function __construct(EventManager $eventManager = null) {
         parent::__construct('User');
 
-        $this->eventManager = Gdn::getContainer()->get(EventManager::class);
+        if ($eventManager === null) {
+            $this->eventManager = Gdn::getContainer()->get(EventManager::class);
+        } else {
+            $this->eventManager = $eventManager;
+        }
 
         $this->addFilterField([
             'Admin', 'Deleted', 'CountVisits', 'CountInvitations', 'CountNotifications', 'Preferences', 'Permissions',
@@ -1064,7 +1070,7 @@ class UserModel extends Gdn_Model {
      *
      * @param array $rows Results we need to associate user data with.
      * @param array $columns Database columns containing UserIDs to get data for.
-     * @param array $options
+     * @param array $options Additional options. Passed to filter event.
      */
     public function expandUsers(array &$rows, array $columns, array $options = []) {
         // How are we supposed to lookup users by column if we don't have any columns?

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -174,7 +174,7 @@ class CommentsApiController extends AbstractApiController {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $discussion['CategoryID']);
         }
 
-        $this->userModel->expandUsers($comment, ['InsertUserID']);
+        $this->userModel->expandUsers($comment, ['InsertUserID'], ['expand' => true]);
         $comment = $this->normalizeOutput($comment);
         $result = $out->validate($comment);
 
@@ -296,7 +296,8 @@ class CommentsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID'])
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID']),
+            ['expand' => $query['expand']]
         );
 
         foreach ($rows as &$currentRow) {
@@ -375,7 +376,7 @@ class CommentsApiController extends AbstractApiController {
         $this->commentModel->save($commentData);
         $this->validateModel($this->commentModel);
         $row = $this->commentByID($id);
-        $this->userModel->expandUsers($row, ['InsertUserID']);
+        $this->userModel->expandUsers($row, ['InsertUserID'], ['expand' => true]);
         $row = $this->normalizeOutput($row);
 
         $result = $out->validate($row);
@@ -405,7 +406,7 @@ class CommentsApiController extends AbstractApiController {
             throw new ServerException('Unable to insert comment.', 500);
         }
         $row = $this->commentByID($id);
-        $this->userModel->expandUsers($row, ['InsertUserID']);
+        $this->userModel->expandUsers($row, ['InsertUserID'], ['expand' => true]);
         $row = $this->normalizeOutput($row);
 
         $result = $out->validate($row);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -83,7 +83,8 @@ class DiscussionsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID'])
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID']),
+            ['expand' => $query['expand']]
         );
 
         foreach ($rows as &$currentRow) {
@@ -230,7 +231,7 @@ class DiscussionsApiController extends AbstractApiController {
 
         $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $row['CategoryID']);
 
-        $this->userModel->expandUsers($row, ['InsertUserID', 'LastUserID']);
+        $this->userModel->expandUsers($row, ['InsertUserID', 'LastUserID'], ['expand' => true]);
         $row = $this->normalizeOutput($row);
 
         $result = $out->validate($row);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -454,7 +454,8 @@ class DiscussionsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID'])
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID']),
+            ['expand' => $query['expand']]
         );
 
         foreach ($rows as &$currentRow) {


### PR DESCRIPTION
This update adds a way for addons to easily hook into `UserModel::expandUsers` to add additional fields without needing to hook into individual endpoint normalization methods.

`UserModel::expandUsers` now throws a filter event: userModel_expandUsers. This event passes along the row(s), an indicator of whether or not this is a single row or multiple and an array of arbitrary options the method does not use, itself. This is primarily used for passing through additional data, such as the "expand" parameter from an API request, without it being required for basic model usage.

Closes #6786