### PR TITLE
Change redirect behaviour for users logging in through Facebook.

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -581,19 +581,6 @@ class FacebookPlugin extends Gdn_Plugin {
                 $p = urlencode(ltrim($p, '='));
                 $redirectUri = $uri.'='.$p;
             }
-
-            $path = Gdn::request()->path();
-
-            $target = val('Target', $_GET, $path ? $path : '/'); // TODO rm global
-
-            if (ltrim($target, '/') == 'entry/signin' || ltrim($target, '/') == 'entry/facebook' || empty($target)) {
-                $target = '/';
-            }
-
-            $args = ['Target' => $target];
-
-            $redirectUri .= strpos($redirectUri, '?') === false ? '?' : '&';
-            $redirectUri .= http_build_query($args);
             $this->_RedirectUri = $redirectUri;
         }
 

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -565,7 +565,7 @@ class FacebookPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Figure out where to send user after auth step.
+     * Send the Facebook entry page to Facebook as the redirectURI.
      *
      * @param null $newValue
      *
@@ -585,15 +585,17 @@ class FacebookPlugin extends Gdn_Plugin {
             $this->_RedirectUri = $redirectUri;
         }
 
-        $target = $this->getTargetUri();
-
         return $this->_RedirectUri;
     }
 
+    /**
+     * Get the target URL to pass to the state when making requests.
+     *
+     * @return mixed|string
+     */
     public function getTargetUri() {
-        $path = Gdn::request()->path();
-        $target = val('Target', $_GET, $path ? $path : '/'); // TODO rm global
-        if (ltrim($target, '/') == 'entry/signin' || ltrim($target, '/') == 'entry/facebook' || empty($target)) {
+        $target = Gdn::request()->getValueFrom(Gdn_Request::INPUT_GET, 'Target', '/');
+        if (ltrim($target, '/') == 'entry/signin' || ltrim($target, '/') == 'entry/facebook') {
             $target = '/';
         }
         return $target;
@@ -678,18 +680,5 @@ class FacebookPlugin extends Gdn_Plugin {
             ['AuthenticationKey' => self::PROVIDER_KEY],
             true
         );
-    }
-
-    /**
-     * @param $redirectUri
-     * @param $redirectUriQuery
-     * @return array
-     */
-    public function extractTargetFromUri($redirectUri) {
-        $redirectUriParts = parse_url($redirectUri);
-        $redirectUri = (val('scheme', $redirectUriParts) && val('host', $redirectUriParts)) ? val('scheme', $redirectUriParts).'://'.val('host', $redirectUriParts).val('path', $redirectUriParts) : null;
-        parse_str(val('query', $redirectUriParts), $redirectUriQuery);
-        $target = val('Target', $redirectUriQuery, '/');
-        return ['redirectUri' => $redirectUri, 'target' => $target];
     }
 }

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -431,7 +431,7 @@ class FacebookPlugin extends Gdn_Plugin {
         }
 
         // This isn't a trusted connection. Don't allow it to automatically connect a user account.
-//        saveToConfig('Garden.Registration.AutoConnect', false, false);
+        saveToConfig('Garden.Registration.AutoConnect', false, false);
 
         $form = $sender->Form; //new gdn_Form();
         $iD = val('id', $profile);
@@ -441,7 +441,7 @@ class FacebookPlugin extends Gdn_Plugin {
         $form->setFormValue('FullName', val('name', $profile));
         $form->setFormValue('Email', val('email', $profile));
         $form->setFormValue('Photo', "//graph.facebook.com/{$iD}/picture?width=200&height=200");
-        $form->setFormValue('Target', val('Target', $state, '/'));
+        $form->setFormValue('Target', val('target', $state, '/'));
         $form->addHidden('AccessToken', $accessToken);
 
         if (c('Plugins.Facebook.UseFacebookNames')) {
@@ -543,7 +543,7 @@ class FacebookPlugin extends Gdn_Plugin {
         }
 
         if ($query) {
-            $redirectUri .= '?'.$query;
+            $redirectUri .= (stripos($redirectUri, '?') === false) ? '?' : '&' .$query;
         }
 
         // Get a state token.
@@ -553,7 +553,7 @@ class FacebookPlugin extends Gdn_Plugin {
             'client_id' => $appID,
             'redirect_uri' => $redirectUri,
             'scope' => $scopes,
-            'state' => json_encode(['token' => $stateToken, 'Target' => $this->getTargetUri()]),
+            'state' => json_encode(['token' => $stateToken, 'target' => $this->getTargetUri()]),
         ]);
         $signinHref = "https://graph.facebook.com/oauth/authorize?{$authQuery}";
 


### PR DESCRIPTION
Facebook has recently changed their Redirect_Uri policy for Facebook Login. In the past and in grandfathered Facebook Login Apps you can have the "Use Strict Mode for Redirect URIs" set to "No" in an app allowing your app to accept Redirec_Uri's with variable query strings attached to them (e.g. https://myforum.com/entry/connect/facebook?Target=%2Fdiscussion%2Fsome-discussion). Now when you create a new Facebook Login app the "Use Strict Mode for Redirect URIs" is toggled to "Yes" and you cannot set it to "No". And if you switch a grandfathered account to "Yes" you cannot set it back to "No". This breaks the log in process entirely.

This PR removes adding "?Target" strings to Redirect_Uri sent to Facebook Login when a user is logging in. 

The affect for clients means that where ever a user is in the forum when he clicks on Facebook Login he will be redirected back to the home page of the forum when his log in is complete. 