### PR TITLE
AuthenticateApiController part 1

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticatorsApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticatorsApiController.php
@@ -206,7 +206,7 @@ class AuthenticatorsApiController extends AbstractApiController  {
 
         $this->idParamSchema();
         $in = $this->schema(
-            Schema::parse(['active'])->add($this->fullSchema()),
+            Schema::parse(['isActive'])->add($this->fullSchema()),
             ['AuthenticatorPatch', 'in']
         )->setDescription('Update an authenticator.');
         $out = $this->schema($this->fullSchema(), 'out');

--- a/applications/dashboard/controllers/api/AuthenticatorsApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticatorsApiController.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+use Garden\Schema\Schema;
+use Garden\Web\Data;
+use Vanilla\Models\AuthenticatorModel;
+use Vanilla\Authenticator\Authenticator;
+use Vanilla\Authenticator\SSOAuthenticator;
+
+/**
+ * Class AuthenticatorsApiController
+ */
+class AuthenticatorsApiController extends AbstractApiController  {
+
+    /** @var AuthenticatorModel */
+    private $authenticatorModel;
+
+    /** @var Schema */
+    private $idParamSchema;
+
+    /** @var Schema */
+    private $fullSchema;
+
+    /**
+     * AuthenticatorsApiController constructor.
+     *
+     * @param AuthenticatorModel $authenticatorModel
+     */
+    public function __construct(AuthenticatorModel $authenticatorModel) {
+        $this->authenticatorModel = $authenticatorModel;
+    }
+
+    /**
+     * Get an authenticator.
+     *
+     * @param $type
+     * @param $id
+     * @return Authenticator
+     */
+    public function authenticator($type, $id) {
+        try {
+            $authenticator = $this->authenticatorModel->getAuthenticator($type, $id);
+        } catch (Exception $e) {
+            Logger::log(Logger::DEBUG, 'authenticator_not_found', [
+                'exception' => [
+                    'message' => $e->getMessage(),
+                    'code' => $e->getCode(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]
+            ]);
+
+            throw new NotFoundException('Authenticator');
+        }
+
+        return $authenticator;
+    }
+
+    /**
+     * Get an authenticator by its ID.
+     *
+     * @param $id
+     * @return Authenticator
+     */
+    public function authenticatorByID($id) {
+        try {
+            $authenticator = $this->authenticatorModel->getAuthenticatorByID($id);
+        } catch (Exception $e) {
+            Logger::log(Logger::DEBUG, 'authenticator_not_found', [
+                'exception' => [
+                    'message' => $e->getMessage(),
+                    'code' => $e->getCode(),
+                    'file' => $e->getFile(),
+                    'line' => $e->getLine(),
+                ]
+            ]);
+
+            throw new NotFoundException('Authenticator');
+        }
+
+        return $authenticator;
+    }
+
+    /**
+     * Get the full authenticator schema.
+     *
+     * @return Schema
+     */
+    public function fullSchema() {
+        if (!$this->fullSchema) {
+            $this->fullSchema = $this->schema(
+                // Use the SSOAuthenticator schema but make the sso attribute optional.
+                Schema::parse([
+                    'resourceUrl:s' => 'API URL to get the authenticator',
+                    'sso?',
+                ])->merge(SSOAuthenticator::getAuthenticatorSchema()),
+                'Authenticator'
+            );
+        }
+
+        return $this->fullSchema;
+    }
+
+    /**
+     * Get an ID-only authenticator record schema.
+     *
+     * @return Schema Returns a schema object.
+     */
+    public function idParamSchema() {
+        if ($this->idParamSchema === null) {
+            $this->idParamSchema = $this->schema(
+                Schema::parse(['id:s' => 'The authenticator ID.']),
+                $type
+            );
+        }
+        return $this->schema($this->idParamSchema, 'in');
+    }
+
+    /**
+     * Get a Type-only authenticator record schema.
+     *
+     * @return Schema Returns a schema object.
+     */
+    public function typeParamSchema() {
+        if ($this->typeParamSchema === null) {
+            $this->typeParamSchema = $this->schema(
+                Schema::parse(['type:s' => 'The authenticator type.']),
+                $type
+            );
+        }
+        return $this->schema($this->typeParamSchema, 'in');
+    }
+
+    /**
+     * GET an authenticator.
+     *
+     * @param string $type
+     * @param string $id
+     * @return array
+     */
+    public function get(string $type, string $id) {
+        $this->permission('Garden.Setting.Manage');
+
+        $this->typeParamSchema();
+        $this->idParamSchema();
+        $this->schema([], ['AuthenticatorGet', 'in'])->setDescription('Get an authenticator.');
+        $out = $this->schema($this->fullSchema(), 'out');
+
+        $authenticator = $this->authenticator($type, $id);
+
+        $result = $this->normalizeOutput($authenticator);
+
+        return $out->validate($result);
+    }
+
+    /**
+     * List authenticators.
+     *
+     * @return Data
+     */
+    public function index() {
+        $this->permission('Garden.Setting.Manage');
+
+        $this->schema([], ['AuthenticatorIndex', 'in'])->setDescription('List authenticators.');
+        $out = $this->schema([':a' => $this->fullSchema()], 'out');
+
+        $authenticators = $this->authenticatorModel->getAuthenticators();
+        $result = [];
+        foreach ($authenticators as $authenticator) {
+            $result[] = $this->normalizeOutput($authenticator);
+        }
+
+        $data = $out->validate($result);
+
+        return new Data($data);
+    }
+
+    /**
+     * Normalize an authenticator to match the Schema definition.
+     *
+     * @param Authenticator $authenticator
+     * @return array Return a Schema record.
+     */
+    protected function normalizeOutput(Authenticator $authenticator) {
+        $record = $authenticator->getAuthenticatorInfo();
+        $record['authenticatorID'] = strtolower($record['authenticatorID']);
+        $record['type'] = strtolower($record['type']);
+        $record['resourceUrl'] = strtolower(url('/api/v2/authenticators/'.$authenticator::getType().'/'.$authenticator->getID()));
+
+        return $record;
+    }
+
+    /**
+     * Update an authenticator.
+     *
+     * @param string $id
+     * @param array $body
+     * @return array
+     */
+    public function patch(string $id, array $body) {
+        $this->permission('Garden.Setting.Manage');
+
+        $this->idParamSchema();
+        $in = $this->schema(
+            Schema::parse(['active'])->add($this->fullSchema()),
+            ['AuthenticatorPatch', 'in']
+        )->setDescription('Update an authenticator.');
+        $out = $this->schema($this->fullSchema(), 'out');
+
+        $authenticator = $this->authenticatorByID($id);
+
+        $body = $in->validate($body);
+
+        $authenticator->setActive($body['active']);
+
+        $result = $this->normalizeOutput($authenticator);
+
+        return $out->validate($result);
+    }
+}

--- a/applications/dashboard/controllers/api/AuthenticatorsApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticatorsApiController.php
@@ -37,11 +37,11 @@ class AuthenticatorsApiController extends AbstractApiController  {
     /**
      * Get an authenticator.
      *
-     * @param $type
-     * @param $id
+     * @param string $type
+     * @param string $id
      * @return Authenticator
      */
-    public function authenticator($type, $id) {
+    public function authenticator(string $type, string $id): Authenticator {
         try {
             $authenticator = $this->authenticatorModel->getAuthenticator($type, $id);
         } catch (Exception $e) {
@@ -63,10 +63,10 @@ class AuthenticatorsApiController extends AbstractApiController  {
     /**
      * Get an authenticator by its ID.
      *
-     * @param $id
+     * @param string $id
      * @return Authenticator
      */
-    public function authenticatorByID($id) {
+    public function authenticatorByID(string $id): Authenticator {
         try {
             $authenticator = $this->authenticatorModel->getAuthenticatorByID($id);
         } catch (Exception $e) {
@@ -125,7 +125,7 @@ class AuthenticatorsApiController extends AbstractApiController  {
      *
      * @return Schema Returns a schema object.
      */
-    public function typeParamSchema() {
+    public function typeParamSchema(): Schema {
         if ($this->typeParamSchema === null) {
             $this->typeParamSchema = $this->schema(
                 Schema::parse(['type:s' => 'The authenticator type.']),
@@ -142,7 +142,7 @@ class AuthenticatorsApiController extends AbstractApiController  {
      * @param string $id
      * @return array
      */
-    public function get(string $type, string $id) {
+    public function get(string $type, string $id): array {
         $this->permission('Garden.Setting.Manage');
 
         $this->typeParamSchema();
@@ -162,7 +162,7 @@ class AuthenticatorsApiController extends AbstractApiController  {
      *
      * @return Data
      */
-    public function index() {
+    public function index(): Data {
         $this->permission('Garden.Setting.Manage');
 
         $this->schema([], ['AuthenticatorIndex', 'in'])->setDescription('List authenticators.');
@@ -185,7 +185,7 @@ class AuthenticatorsApiController extends AbstractApiController  {
      * @param Authenticator $authenticator
      * @return array Return a Schema record.
      */
-    protected function normalizeOutput(Authenticator $authenticator) {
+    protected function normalizeOutput(Authenticator $authenticator): array {
         $record = $authenticator->getAuthenticatorInfo();
         $record['authenticatorID'] = strtolower($record['authenticatorID']);
         $record['type'] = strtolower($record['type']);
@@ -201,7 +201,7 @@ class AuthenticatorsApiController extends AbstractApiController  {
      * @param array $body
      * @return array
      */
-    public function patch(string $id, array $body) {
+    public function patch(string $id, array $body): array {
         $this->permission('Garden.Setting.Manage');
 
         $this->idParamSchema();

--- a/library/Vanilla/Authenticator/Authenticator.php
+++ b/library/Vanilla/Authenticator/Authenticator.php
@@ -203,7 +203,7 @@ abstract class Authenticator {
             'getRegisterUrl' => $this->getRegisterUrl(),
             'getSignOutUrl' => $this->getSignOutUrl(),
             'ui' => [
-                'url' => url('/authenticate/signin/'.static::getType().'/'.$this->getID())
+                'url' => strtolower(url('/authenticate/signin/'.static::getType().'/'.$this->getID())),
             ],
             'isActive' => $this->isActive(),
             'attributes' => [],
@@ -275,5 +275,4 @@ abstract class Authenticator {
      * @return array The user's information.
      */
      abstract public function validateAuthentication(RequestInterface $request);
-
 }

--- a/library/Vanilla/Models/AuthenticatorModel.php
+++ b/library/Vanilla/Models/AuthenticatorModel.php
@@ -49,7 +49,7 @@ class AuthenticatorModel {
      * @throws NotFoundException
      * @throws ServerException
      */
-    public function getAuthenticator($authenticatorType, $authenticatorID) {
+    public function getAuthenticator(string $authenticatorType, string $authenticatorID) {
         if (empty($authenticatorType)) {
             throw new NotFoundException('Authenticator does not exist.');
         }
@@ -110,7 +110,7 @@ class AuthenticatorModel {
      * @param string $authenticatorID
      * @return Authenticator
      */
-    public function getAuthenticatorByID($authenticatorID) {
+    public function getAuthenticatorByID(string $authenticatorID) {
         $authenticatorData = $this->authenticationProviderModel->getID($authenticatorID, DATASET_TYPE_ARRAY);
 
         return $this->getAuthenticator($authenticatorData['AuthenticationSchemeAlias'] ?? null, $authenticatorID);
@@ -119,7 +119,7 @@ class AuthenticatorModel {
     /**
      * Get authenticator instances.
      *
-     * @return array
+     * @return Authenticator[]
      */
     public function getAuthenticators() {
         $authenticatorClasses = $this->getAuthenticatorClasses();

--- a/tests/APIv2/AuthenticatorsTest.php
+++ b/tests/APIv2/AuthenticatorsTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests\APIv2;
+
+
+use Vanilla\Authenticator\Authenticator;
+use Vanilla\Models\AuthenticatorModel;
+
+class AuthenticatorsTest extends AbstractAPIv2Test {
+
+    /** @var Authenticator[] */
+    private static $authenticators;
+
+    /** @var string */
+    private $baseUrl;
+
+    /**
+     * AuthenticatorsTest constructor.
+     *
+     * @param null $name
+     * @param array $data
+     * @param string $dataName
+     */
+    public function __construct($name = null, array $data = [], $dataName = '') {
+        $this->baseUrl = '/authenticators';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function setupBeforeClass() {
+        parent::setupBeforeClass();
+
+        /** @var AuthenticatorModel $authenticatorModel */
+        $authenticatorModel = self::container()->get('AuthenticatorModel');
+        self::$authenticators = $authenticatorModel->getAuthenticators();
+
+
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp() {
+        if (!self::$authenticators) {
+            $this->markTestSkipped('No Authenticator found.');
+        }
+    }
+
+    /**
+     * @param array $record
+     */
+    public function assertIsAuthenticator(array $record) {
+        $this->assertInternalType('array', $record);
+
+        $this->assertArrayHasKey('authenticatorID', $record);
+        $this->assertArrayHasKey('type', $record);
+        $this->assertArrayHasKey('resourceUrl', $record);
+        $this->assertArrayHasKey('ui', $record);
+        $this->assertInternalType('array', $record['ui']);
+        $this->assertArrayHasKey('isActive', $record);
+        $this->assertInternalType('bool', $record['isActive']);
+    }
+
+    /**
+     * Test GET /authenticators/:id
+     */
+    public function testGetAuthenticators() {
+        $id = self::$authenticators[0]->getID();
+
+        $response = $this->api()->get($this->baseUrl.'/'.$id);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = $response->getBody();
+        $this->assertIsAuthenticator($body);
+    }
+
+    /**
+     * Test GET /authenticators
+     */
+    public function testListAuthenticators() {
+        $response = $this->api()->get($this->baseUrl);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = $response->getBody();
+
+        $this->assertInternalType('array', $body);
+        $this->assertCount(count(self::$authenticators), $body);
+
+        foreach ($body as $record) {
+            $this->assertIsAuthenticator($record);
+        }
+    }
+
+    /**
+     * Test PATCH /authenticators/:id
+     */
+    public function testPatchAuthenticator() {
+        $id = self::$authenticators[0]->getID();
+
+        $response = $this->api()->patch($this->baseUrl.'/'.$id, [
+            'isActive' => !self::$authenticators[0]->isActive(),
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = $response->getBody();
+        $this->assertIsAuthenticator($body);
+    }
+}

--- a/tests/APIv2/AuthenticatorsTest.php
+++ b/tests/APIv2/AuthenticatorsTest.php
@@ -37,7 +37,7 @@ class AuthenticatorsTest extends AbstractAPIv2Test {
         parent::setupBeforeClass();
 
         /** @var AuthenticatorModel $authenticatorModel */
-        $authenticatorModel = self::container()->get('AuthenticatorModel');
+        $authenticatorModel = self::container()->get(AuthenticatorModel::class);
         self::$authenticators = $authenticatorModel->getAuthenticators();
 
 


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/6668

To test you can move MockAuthenticator and MockSSOAuthenticator from tests/fixtures/src into any plugins (dashboard application would do too) and add the following in our database:

```
INSERT INTO `GDN_UserAuthenticationProvider` (`AuthenticationKey`, `AuthenticationSchemeAlias`, `Name`, `URL`, `AssociationSecret`, `AssociationHashMethod`, `AuthenticateUrl`, `RegisterUrl`, `SignInUrl`, `SignOutUrl`, `PasswordUrl`, `ProfileUrl`, `Attributes`, `Active`, `IsDefault`)
VALUES
	('mock', 'Mock', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, 0),
	('mocksso', 'MockSSO', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, 0);
```

Unfortunately we have a problem with finding classes that are not in addons so the test authenticators are not found when the test runs. I added an issue about it  -> https://github.com/vanilla/vanilla/issues/6877