### PR TITLE
Add cookie validation to Vanillaconnect

### DIFF
--- a/applications/dashboard/controllers/class.authenticatecontroller.php
+++ b/applications/dashboard/controllers/class.authenticatecontroller.php
@@ -172,7 +172,7 @@ class AuthenticateController extends Gdn_Controller {
 
                 if ($connectUserID) {
                     // This will effectively sync the user info / roles if there is a need for it.
-                    $connectSuccess = (bool)$this->ssoModel->sso($ssoData);
+                    $connectSuccess = (bool)$this->ssoModel->sso($ssoData, []);
                 } else {
                     $this->form->addError(t('Unable to connect user.'));
                 }

--- a/plugins/vanillaconnect/VanillaConnectAuthenticator.php
+++ b/plugins/vanillaconnect/VanillaConnectAuthenticator.php
@@ -53,7 +53,7 @@ class VanillaConnectAuthenticator extends SSOAuthenticator {
      * @param string $providerID
      * @param Gdn_AuthenticationProviderModel $authProviderModel
      * @param Gdn_Configuration $config
-     * @paraVam Cookie $cookie
+     * @param Cookie $cookie
      * @param RequestInterface $request
      * @param UserAuthenticationNonceModel $nonceModel
      */


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/6801

Pretty simple, we store the nonce in a cookie to make sure that the same browser that initiated the process is trying to validate it. We also sign the nonce in a JWT to make sure that the cookie is not created from a leaked "sign in JWT".