### PR TITLE
Update expandUsers filter event to avoid the need for the "single" parameter

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1146,7 +1146,14 @@ class UserModel extends Gdn_Model {
             }
         }
 
-        $rows = $this->eventManager->fireFilter('userModel_expandUsers', $rows, $single, $options);
+        // Don't bother addons with whether or not this is a single row. Pack and unpack it here, as necessary.
+        if ($single) {
+            $rows = [$rows];
+        }
+        $rows = $this->eventManager->fireFilter('userModel_expandUsers', $rows, $options);
+        if ($single) {
+            $rows = reset($rows);
+        }
     }
 
     /**


### PR DESCRIPTION
`UserModel::expandUsers` contains a filter event for addons to hook in and modify the result. The event currently passes a `$single` parameter, which indicates whether or not the value being passed is a single row or multiple rows. This update removes that parameter, instead packing and unpacking a single row, as necessary. This way, the addons can always act on the input as though it were a multi-row array.