### PR TITLE
Allow applications to use DI (Dependency Injection)

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -1275,6 +1275,28 @@ class AddonManager {
     }
 
     /**
+     * Unbind the events of an addon's plugin class (if any).
+     *
+     * If the addon doesn't have a plugin then nothing will happen.
+     *
+     * @param Addon $addon The addon to unbind.
+     * @param EventManager $eventManager The event manager to bind the plugin classes to.
+     */
+    public function unbindAddonEvents(Addon $addon, EventManager $eventManager) {
+        // Check that the addon has a plugin.
+        if (!($pluginClass = $addon->getPluginClass())) {
+            return;
+        }
+
+        // Only register the plugin if it implements the Gdn_IPlugin interface.
+        if (is_a($pluginClass, 'Gdn_IPlugin', true)) {
+            $eventManager->unbindClass($pluginClass);
+        } else {
+            trigger_error("$pluginClass does not implement Gdn_IPlugin", E_USER_DEPRECATED);
+        }
+    }
+
+    /**
      * Tells whether the AddonManager's cache is enabled or not.
      *
      * @return bool

--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -267,7 +267,7 @@ class Gdn_ApplicationManager {
         }
         if (class_exists($hooks)) {
             /* @var Gdn_IPlugin $hooks The hooks object should be a plugin. */
-            $hooks = new $hooks();
+            $hooks = Gdn::getContainer()->get($hooks);
 
             if (method_exists($hooks, 'setup')) {
                 $hooks->setup();
@@ -315,6 +315,10 @@ class Gdn_ApplicationManager {
 
         // Clear the object caches.
         $this->addonManager->stopAddonsByKey([$applicationName], \Vanilla\Addon::TYPE_ADDON);
+
+        /** @var \Garden\EventManager $eventManager */
+        $eventManager = Gdn::getContainer()->get(\Garden\EventManager::class);
+        $this->addonManager->unbindAddonEvents($addon, $eventManager);
     }
 
     /**


### PR DESCRIPTION
There were issues with application.

1. The testApplication method was instanciating object itself and since which caused problem for hook class that have arguments in their constructor.
1. Events were not properly removed from the event manager once an application was disabled which caused an error to show on screen if the application had hooks on the `settingsController_render_before()` since `render()` is called in `disableApplication()`.