### PR TITLE
Remove recommended version message from v2.6

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -341,13 +341,6 @@ class DashboardHooks extends Gdn_Plugin {
             return;
         }
 
-        $phpVersion = phpversion();
-        if (version_compare($phpVersion, '7.1') < 0) {
-            $upgradeMessage = ['Content' => 'We recommend using at least PHP 7.1. Support for PHP '.htmlspecialchars($phpVersion).' may be dropped in upcoming releases.', 'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'];
-            $messageModule = new MessageModule($sender, $upgradeMessage);
-            $sender->addModule($messageModule);
-        }
-
         $mysqlVersion = gdn::sql()->version();
         if (version_compare($mysqlVersion, '5.6') < 0) {
             $upgradeMessage = ['Content' => 'We recommend using at least <b>MySQL 5.7</b> or <b>MariaDB 10.2</b>. Version '.htmlspecialchars($mysqlVersion).' will not support all upcoming Vanilla features.', 'AssetTarget' => 'Content', 'CssClass' => 'InfoMessage'];


### PR DESCRIPTION
PHP 7.0 reaches EOL at the end of this year. Vanilla currently supports PHP 7+, but recommends PHP 7.1+.

This update yanks the PHP 7.1+ nagging message from the dashboard (for inf as much as users) on the 2.6 release. There's already a [hard PHP 7 requirement](https://github.com/vanilla/vanilla/blob/e0476d536c22ad83abe8987c3798fb999ae461ba/environment.php#L10), so downgrading the version requirements in the messsage for PHP 7+ doesn't make much sense.