### PR TITLE
Fix "Active" class on edit profile link not appearing under specific circumstances

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -1543,11 +1543,14 @@ EOT;
         } else {
             if (hasEditProfile($this->User->UserID)) {
                 $editLinkUrl = '/profile/edit';
+
+                // Kludge for if we're on /profile/edit/username for the current user.
                 $requestUrl = Gdn_Url::request();
                 $editUrl = "profile/edit/{$this->User->Name}";
                 if ($requestUrl === $editUrl) {
                     $editLinkUrl = $editUrl;
                 }
+
                 $module->addLink('Options', sprite('SpEdit').' '.t('Edit Profile'), $editLinkUrl, false, ['class' => 'Popup EditAccountLink']);
             }
 

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -1542,7 +1542,13 @@ EOT;
             }
         } else {
             if (hasEditProfile($this->User->UserID)) {
-                $module->addLink('Options', sprite('SpEdit').' '.t('Edit Profile'), '/profile/edit', false, ['class' => 'Popup EditAccountLink']);
+                $editLinkUrl = '/profile/edit';
+                $requestUrl = Gdn_Url::request();
+                $editUrl = "profile/edit/{$this->User->Name}";
+                if ($requestUrl === $editUrl) {
+                    $editLinkUrl = $editUrl;
+                }
+                $module->addLink('Options', sprite('SpEdit').' '.t('Edit Profile'), $editLinkUrl, false, ['class' => 'Popup EditAccountLink']);
             }
 
             // Add profile options for the profile owner

--- a/applications/dashboard/modules/class.sidemenumodule.php
+++ b/applications/dashboard/modules/class.sidemenumodule.php
@@ -309,7 +309,7 @@ if (!class_exists('SideMenuModule', false)) {
 
                 // Hightlight the correct item in the group.
                 foreach ($item['Links'] as &$link) {
-                    if (val('Url', $link) && url($link['Url']) == $highlightUrl) {
+                    if (val('Url', $link) && (strpos($highlightUrl, url($link['Url'])) === 0)) {
                         $link['Attributes']['class'] = concatSep(' ', val('class', $link['Attributes']), 'Active');
                         $item['Attributes']['class'] = concatSep(' ', val('class', $item['Attributes']), 'Active');
                     }

--- a/applications/dashboard/modules/class.sidemenumodule.php
+++ b/applications/dashboard/modules/class.sidemenumodule.php
@@ -309,7 +309,7 @@ if (!class_exists('SideMenuModule', false)) {
 
                 // Hightlight the correct item in the group.
                 foreach ($item['Links'] as &$link) {
-                    if (val('Url', $link) && (strpos($highlightUrl, url($link['Url'])) === 0)) {
+                    if (val('Url', $link) && url($link['Url']) == $highlightUrl) {
                         $link['Attributes']['class'] = concatSep(' ', val('class', $link['Attributes']), 'Active');
                         $item['Attributes']['class'] = concatSep(' ', val('class', $item['Attributes']), 'Active');
                     }


### PR DESCRIPTION
In the panel on the edit profile page, we didn't set an "Active" class on the "Edit Profile" link when we were on `/profile/edit/[user id]` urls. I've updated the check to work for both `/profile/edit` and `/profile/edit[user id]`.

Closes: https://github.com/vanilla/vanilla/issues/6868