### PR TITLE
Fix on ready handler

### DIFF
--- a/src/scripts/application.js
+++ b/src/scripts/application.js
@@ -196,7 +196,7 @@ export function onReady(callback) {
 export function _executeReady() {
     return new Promise(resolve => {
         const exec = () => {
-            Promise.all(_readyHandlers).then(resolve);
+            Promise.all(_readyHandlers.map(handler => handler())).then(resolve);
         };
 
         if (document.readyState !== "loading") {


### PR DESCRIPTION
The on ready handler wasn't actually calling its callbacks. This fix ensures they are called to either return a value (gets implicitly wrapped in promise.all) or a promise.