### PR TITLE
Respect scalar type hints in endpoint parameters

### DIFF
--- a/applications/dashboard/models/ReflectionAction.php
+++ b/applications/dashboard/models/ReflectionAction.php
@@ -162,7 +162,35 @@ class ReflectionAction {
             }
 
             // Default the call args.
-            $this->args[$param->getName()] = $param->isDefaultValueAvailable() ? $param->getDefaultValue() : ($param->isArray() ? [] : null);
+            if ($param->isDefaultValueAvailable()) {
+                $arg = $param->getDefaultValue();
+            } elseif ($param->isArray()) {
+                $arg = [];
+            } elseif ($param->hasType()) {
+                $type = $param->getType();
+                switch (strtolower($type->getName())) {
+                    case 'bool':
+                        $arg = false;
+                        $schemaType = 'boolean';
+                        break;
+                    case 'int':
+                        $arg = 0;
+                        $schemaType = 'integer';
+                        break;
+                    case 'float':
+                        $arg = 0.0;
+                        $schemaType = 'float';
+                        break;
+                    case 'string':
+                        $arg = '';
+                        break;
+                    default:
+                        $arg = null;
+                }
+            } else {
+                $arg = null;
+            }
+            $this->args[$param->getName()] = $arg;
 
             $p = null;
             if ($this->route->isMapped($param, Route::MAP_BODY)) {
@@ -170,6 +198,9 @@ class ReflectionAction {
                 $p = ['name' => $param->getName(), 'in' => 'body', 'required' => true];
             } elseif (!$param->getClass() && !$this->route->isMapped($param)) {
                 $p = ['name' => $param->getName(), 'in' => 'path', 'required' => true];
+                if (isset($schemaType)) {
+                    $p['type'] = $schemaType;
+                }
 
                 $constraint = (array)$this->route->getConstraint($param->getName()) + ['position' => '*'];
 
@@ -297,7 +328,7 @@ class ReflectionAction {
 
                     if (isset($allInArr['required']) && in_array($name, $allInArr['required'])) {
                         $param['required'] = true;
-                    } else if (isset($param['required'])) {
+                    } elseif (isset($param['required'])) {
                         unset($param['required']);
                     }
                 }

--- a/library/Garden/Web/ResourceRoute.php
+++ b/library/Garden/Web/ResourceRoute.php
@@ -67,7 +67,7 @@ class ResourceRoute extends Route {
 
 
         $this
-            ->setConstraint('id', ['regex' => '`^\d+$`', 'position' => 0])
+            ->setConstraint('id', ['position' => 0, 'notype' => ['regex' => '`^\d+$`']])
             ->setConstraint('page', '`^p\d+$`');
     }
 

--- a/tests/Library/Garden/Web/ResourceRouteTest.php
+++ b/tests/Library/Garden/Web/ResourceRouteTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Garden\Web\Action;
 use Garden\Web\ResourceRoute;
 use Garden\Web\Route;
+use VanillaTests\Fixtures\CommentsController;
 use VanillaTests\Fixtures\DiscussionsController;
 use VanillaTests\Fixtures\Request;
 
@@ -61,6 +62,7 @@ class ResourceRouteTest extends TestCase {
      */
     public function provideKnownRoutes() {
         $dc = DiscussionsController::class;
+        $cc = CommentsController::class;
 
         $r = [
             'index' => ['GET', '/discussions', [$dc, 'index'], ['page' => '']],
@@ -85,10 +87,16 @@ class ResourceRouteTest extends TestCase {
             'index /:id/idsub' => ['GET', '/discussions/123/idsub', [$dc, 'index_idsub'], ['id' => '123']],
             'get /:id/idsub/:id2' => ['GET', '/discussions/123/idsub/abc', [$dc, 'get_idsub'], ['id' => '123', 'id2' => 'abc']],
 
+            // Integer type hints.
+            'index comments' => ['GET', '/comments/p1', [$cc, 'index'], ['param' => 'p1']],
+            'get comments/:id' => ['GET', '/comments/1', [$cc, 'get'], ['id' => '1']],
+            'get comments/archives' => ['GET', '/comments/archives', [$cc, 'index_archives']],
+            'get comments/:id/archives' => ['GET', '/comments/1/archives', [$cc, 'get_archives'], ['id' => '1']],
+
             // Special routes are special.
             'bad index' => ['GET', '/discussions/index', null],
             'bad get' => ['GET', '/discussions/get/123', null],
-            'bad post' => ['PATCH', '/discussions/post', null]
+            'bad post' => ['PATCH', '/discussions/post', null],
         ];
 
         return $r;

--- a/tests/fixtures/CommentsController.php
+++ b/tests/fixtures/CommentsController.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Fixtures;
+
+class CommentsController {
+    public function index(string $param = '') {
+
+    }
+
+    public function get(int $id) {
+
+    }
+
+    public function index_archives() {
+
+    }
+
+    public function get_archives(int $id) {
+
+    }
+}


### PR DESCRIPTION
PHP 7’s scalar type hints can tell us what type a path parameter
expects. This provides much of the functionality that route constraints
required.

- Check for scalar type hints when testing parameter constraints.
- Change the default id constraint against its regex only when there is
no type hint.
- Set an appropriate type-hinted argument value when generating the
swagger documentation (this fixes documentation for the /authenticators
endpoint if you care to un-exclude that one in the SwaggerModel for
testing).
- Use the scalar type hint for default documentation parameters.