### PR TITLE
Catch a wider variety of errors when generating OpenAPI docs

### DIFF
--- a/applications/dashboard/controllers/api/OpenApiApiController.php
+++ b/applications/dashboard/controllers/api/OpenApiApiController.php
@@ -5,7 +5,7 @@
  * @license GPLv2
  */
 
-namespace Vanilla\Dashboard\Controllers;
+namespace Vanilla\Dashboard\Controllers\API;
 
 use Garden\Schema\Schema;
 use Vanilla\Web\Controller;

--- a/applications/dashboard/models/ReflectionAction.php
+++ b/applications/dashboard/models/ReflectionAction.php
@@ -249,7 +249,7 @@ class ReflectionAction {
 
         } catch (ShortCircuitException $ex) {
             // We should have everything we need now.
-        } catch (\Exception $ex) {
+        } catch (\Throwable $ex) {
             $other['deprecated'] = true;
             // We shouldn't get here, but let's allow it.
             $summary = "Something happened before the output schema was found. The endpoint most likely didn't define its output properly.";


### PR DESCRIPTION
This prevents the page from crapping out when there is a lower-level error generating docs.

I also moved the OpenApiApiController to the api subdirectory because that is where it belongs.