### PR TITLE
Add the POST /users/request-password endpoint

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -590,13 +590,12 @@ class UsersApiController extends AbstractApiController {
         $in = $this->schema([
             'email:s' => 'The email/username of the user.',
         ]);
+        $out = $this->schema([], 'out');
 
         $body = $in->validate($body);
 
         $this->userModel->passwordRequest($body['email']);
         $this->validateModel($this->userModel, true);
-
-        return '';
     }
 
     /**

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -579,6 +579,27 @@ class UsersApiController extends AbstractApiController {
     }
 
     /**
+     * Send a password reset email.
+     *
+     * @param array $body The POST body.
+     * @throws Exception Throws all exceptions to the dispatcher.
+     */
+    public function post_requestPassword(array $body) {
+        $this->permission();
+
+        $in = $this->schema([
+            'email:s' => 'The email/username of the user.',
+        ]);
+
+        $body = $in->validate($body);
+
+        $this->userModel->passwordRequest($body['email']);
+        $this->validateModel($this->userModel, true);
+
+        return '';
+    }
+
+    /**
      * Verify a user.
      *
      * @param int $id The ID of the user.

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -64,6 +64,16 @@ class UserModel extends Gdn_Model {
     public $UserMegaThreshold = 1000000;
 
     /**
+     * @var bool
+     */
+    private $nameUnique;
+
+    /**
+     * @var bool
+     */
+    private $emailUnique;
+
+    /**
      * Class constructor. Defines the related database table name.
      *
      * @param EventManager $eventManager
@@ -82,6 +92,10 @@ class UserModel extends Gdn_Model {
             'LastIPAddress', 'AllIPAddresses', 'DateFirstVisit', 'DateLastActive', 'CountDiscussions', 'CountComments',
             'Score'
         ]);
+
+
+        $this->nameUnique = (bool)c('Garden.Registration.NameUnique', true);
+        $this->emailUnique = (bool)c('Garden.Registration.EmailUnique', true);
     }
 
     /**
@@ -4454,26 +4468,43 @@ class UserModel extends Gdn_Model {
     /**
      * Send forgot password email.
      *
-     * @param string $email
+     * @param string $input
+     * @param array $options
      * @return bool
      */
-    public function passwordRequest($email) {
-        if (!$email) {
+    public function passwordRequest($input, $options = []) {
+        $this->Validation->reset();
+        if (!$input) {
             return false;
         }
+        $log = $options['log'] ?? true;
 
-        $users = $this->getWhere(['Email' => $email])->resultObject();
-        if (count($users) == 0) {
+        $users = $this->getWhere(['Email' => $input])->resultObject();
+        if (empty($users)) {
+            // Don't allow username reset unless usernames are unique.
+            if (($this->isEmailUnique() || !$this->isNameUnique()) && filter_var($input, FILTER_VALIDATE_EMAIL) === false) {
+                $this->Validation->addValidationResult('Email', 'You must enter a valid email address.');
+                return false;
+            }
+
             // Check for the username.
-            $users = $this->getWhere(['Name' => $email])->resultObject();
+            $users = $this->getWhere(['Name' => $input])->resultObject();
         }
 
         $this->EventArguments['Users'] =& $users;
-        $this->EventArguments['Email'] = $email;
+        $this->EventArguments['Email'] = $input;
         $this->fireEvent('BeforePasswordRequest');
 
         if (count($users) == 0) {
-            $this->Validation->addValidationResult('Name', "Couldn't find an account associated with that email/username.");
+            $this->Validation->addValidationResult('', "Couldn't find an account associated with that email/username.");
+            if ($log) {
+                Logger::event(
+                    'password_reset_failure',
+                    Logger::INFO,
+                    'Can\'t find account associated with email/username {input}.',
+                    ['input' => $input]
+                );
+            }
             return false;
         }
 
@@ -4500,9 +4531,34 @@ class UserModel extends Gdn_Model {
 
             try {
                 $email->send();
-            } catch (Exception $e) {
+                if ($log) {
+                    Logger::event(
+                        'password_reset_request',
+                        Logger::INFO,
+                        '{email} has been sent a password reset email.',
+                        ['input' => $input, 'email' => $user->Email, 'forUserID' => $user->UserID]
+                    );
+                }
+            } catch (Exception $ex) {
+                if ($log) {
+                    if ($ex->getCode() === Gdn_Email::ERR_SKIPPED) {
+                        Logger::event(
+                            'password_reset_skipped',
+                            Logger::INFO,
+                            $ex->getMessage(),
+                            ['input' => $input, 'email' => $user->Email]
+                        );
+                    } else {
+                        Logger::event(
+                            'password_reset_failure',
+                            Logger::ERROR,
+                            'The password reset email to {email} failed to send.',
+                            ['input' => $input, 'email' => $user->Email]
+                        );
+                    }
+                }
                 if (debug()) {
-                    throw $e;
+                    throw $ex;
                 }
             }
 
@@ -4511,6 +4567,14 @@ class UserModel extends Gdn_Model {
 
         if ($noEmail) {
             $this->Validation->addValidationResult('Name', 'There is no email address associated with that account.');
+            if ($log) {
+                Logger::event(
+                    'password_reset_failure',
+                    Logger::INFO,
+                    'Can\'t find account associated with email/username {input}.',
+                    ['input' => $input]
+                );
+            }
             return false;
         }
         return true;
@@ -5049,5 +5113,45 @@ class UserModel extends Gdn_Model {
 
         $result = [$column, $direction];
         return $result;
+    }
+
+    /**
+     * Whether or not usernames have to be unique.
+     *
+     * @return bool Returns the setting.
+     */
+    public function isNameUnique() {
+        return $this->nameUnique;
+    }
+
+    /**
+     * Whether or not usernames have to be unique.
+     *
+     * @param bool $nameUnique The new setting.
+     * @return $this
+     */
+    public function setNameUnique(bool $nameUnique) {
+        $this->nameUnique = $nameUnique;
+        return $this;
+    }
+
+    /**
+     * Whether or not email addresses have to be unique.
+     *
+     * @return bool Returns the setting.
+     */
+    public function isEmailUnique() {
+        return $this->emailUnique;
+    }
+
+    /**
+     * Whether or not email addresses have to be unique.
+     *
+     * @param bool $emailUnique The new setting.
+     * @return $this
+     */
+    public function setEmailUnique(bool $emailUnique) {
+        $this->emailUnique = $emailUnique;
+        return $this;
     }
 }

--- a/applications/dashboard/views/entry/passwordrequest.php
+++ b/applications/dashboard/views/entry/passwordrequest.php
@@ -1,5 +1,5 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
-<h1><?php echo t("Reset my password") ?></h1>
+<h1><?php echo t("Recover Password") ?></h1>
 <div class="">
     <?php
     // Make sure to force this form to post to the correct place in case the view is
@@ -9,7 +9,7 @@
     <ul>
         <li>
             <?php
-            echo $this->Form->label('Enter your Email address or username', 'Email');
+            echo $this->Form->label($this->data('RecoverPasswordLabelCode', 'Enter your email to continue.'), 'Email');
             echo $this->Form->textBox('Email', ['autofocus' => 'autofocus']);
             ?>
         </li>

--- a/applications/dashboard/views/entry/signin.php
+++ b/applications/dashboard/views/entry/signin.php
@@ -89,7 +89,7 @@ echo $this->Form->open(['Action' => url('/entry/passwordrequest'), 'id' => 'Form
     <ul>
         <li>
             <?php
-            echo $this->Form->label('Enter your Email address or username', 'Email');
+            echo $this->Form->label($this->data('RecoverPasswordLabelCode', 'Enter your email to continue.'), 'Email');
             echo $this->Form->textBox('Email');
             ?>
         </li>

--- a/tests/TestLogger.php
+++ b/tests/TestLogger.php
@@ -70,6 +70,9 @@ class TestLogger implements LoggerInterface {
         return null;
     }
 
+    /**
+     * Clear the log.
+     */
     public function clear() {
         $this->log = [];
     }

--- a/tests/TestLogger.php
+++ b/tests/TestLogger.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+
+/**
+ * A test logger that collects all messages in an array.
+ */
+class TestLogger implements LoggerInterface {
+    use LoggerTrait;
+
+    /**
+     * @var array
+     */
+    private $log;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = array()) {
+        $this->log[] = ['level' => $level, 'message' => $message] + $context;
+    }
+
+    /**
+     * Get the log.
+     *
+     * @return array Returns the log.
+     */
+    public function getLog(): array {
+        return $this->log;
+    }
+
+    /**
+     * Set the log.
+     *
+     * @param array $log The new log array.
+     * @return $this
+     */
+    public function setLog(array $log) {
+        $this->log = $log;
+        return $this;
+    }
+
+    /**
+     * Search the log for a filter.
+     *
+     * @param array $filter The log filter.
+     * @return array|null Returns the first found log entry or **null** if an entry isn't found.
+     */
+    public function search($filter = []) {
+        foreach ($this->log as $item) {
+            $found = true;
+            foreach ($filter as $key => $value) {
+                if (!array_key_exists($key, $item) || $item[$key] != $value) {
+                    $found = false;
+                    break;
+                }
+            }
+            if ($found) {
+                return $item;
+            }
+        }
+        return null;
+    }
+
+    public function clear() {
+        $this->log = [];
+    }
+}


### PR DESCRIPTION
This adds the endpoint with the following changes:

- Some of the code in /entry/password request has been refactored into
the UserModel so that both endpoints can use it.
- You can now only request a password for a username if email address
is not unique and username is unique. This is to crack down on some
attack vectors.
- Labelling on the forms have been changed to reflect the new
restrictions.
- A new TestLogger is now registered for APIv2 tests so that logging
can be checked during testing.