### PR TITLE
Set participant's email to empty if permission check fails

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -368,6 +368,14 @@ class MessagesController extends ConversationsController {
 
         $this->Conversation = $this->ConversationModel->getID($conversationID);
         $this->Conversation->Participants = $this->ConversationModel->getRecipients($conversationID);
+
+        //Verify if participant email should be visible
+        foreach ($this->Conversation->Participants as $participant) {
+            if (!Gdn::session()->checkPermission('Garden.PersonalInfo.View')) {
+                $participant->Email = '';
+            }
+        }
+
         $this->setData('Conversation', $this->Conversation);
 
         // Bad conversation? Redirect


### PR DESCRIPTION
fixes#208

The participants email was being exposed to members without permission

To ensure the the participants email is exposed, we loop through the participants and verify if they have permission to view the personal information, if not the email is sent to an empty string
