### PR TITLE
Globally map space and enter keypress on fake buttons to a click

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -194,6 +194,20 @@
         });
     });
 
+    function accessibleButtonsInit() {
+        $(document).delegate("[role=button]", 'keydown', function(event) {
+            var $button = $(this);
+            var ENTER_KEY = 13;
+            var SPACE_KEY = 32;
+            var isActiveElement = document.activeElement === $button[0];
+            var isSpaceOrEnter = event.keyCode === ENTER_KEY || event.keyCode === SPACE_KEY;
+            if (isActiveElement && isSpaceOrEnter) {
+                event.preventDefault();
+                $button.click();
+            }
+        });
+    }
+
     $(document).on("contentLoad", function(e) {
         // Setup AJAX filtering for flat category module.
         // Find each flat category module container, if any.
@@ -246,6 +260,7 @@
 
         // Set up accessible flyouts
         $('.ToggleFlyout, .editor-dropdown, .ButtonGroup').accessibleFlyoutsInit();
+        accessibleButtonsInit();
     });
 })(window, jQuery);
 
@@ -2240,7 +2255,7 @@ $.fn.extend({
 
     setFlyoutAttributes: function () {
         $(this).each(function(){
-            var $handle = $(this).find('.FlyoutButton, .Handle, .editor-action:not(.editor-action-separator)');
+            var $handle = $(this).find('.FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)');
             var $flyout = $(this).find('.Flyout, .Dropdown');
             var isOpen = $flyout.is(':visible');
 
@@ -2254,7 +2269,7 @@ $.fn.extend({
 
         $context.each(function(){
 
-            $context.find('.FlyoutButton, .Handle, .editor-action:not(.editor-action-separator)').each(function (){
+            $context.find('.FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)').each(function (){
                 $(this)
                     .attr('tabindex', '0')
                     .attr('role', 'button')
@@ -2271,7 +2286,7 @@ $.fn.extend({
                 });
             });
         });
-    }
+    },
 });
 
 })(jQuery);


### PR DESCRIPTION
Fixes #6455

- Adds the additional `.Button-Options` class to go through our accessible flyout treatment.
- Pressing enter to open these didn't work because they weren't links. So I've added a global click handler for everything we add `[role=button]` to, so that space and enter keys trigger a click on the element, just like a real button. This handler prevents default so there are no clashes with default focus + link enter key behaviour.

Other existing accessibility issues with the flyouts still remain and are outside of the scope of this issue. Thi