### PR TITLE
Fix querying discussions always filtering out categories hidden from Recent Discussions

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -159,6 +159,8 @@ class DiscussionsController extends VanillaController {
             $where['d.CategoryID'] = $visibleFollowedCategories;
         } elseif ($categoryIDs) {
             $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
+        } else {
+            $where['d.CategoryID'] = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
         }
 
         // Get Discussion Count
@@ -289,7 +291,9 @@ class DiscussionsController extends VanillaController {
         $this->setData('CountDiscussions', $countDiscussions);
 
         // Get Discussions
-        $this->DiscussionData = $discussionModel->getUnread($page, $limit);
+        $this->DiscussionData = $discussionModel->getUnread($page, $limit, [
+            'd.CategoryID' => CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true])
+        ]);
 
         $this->setData('Discussions', $this->DiscussionData, true);
         $this->setJson('Loading', $page.' to '.$limit);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -662,14 +662,6 @@ class DiscussionModel extends Gdn_Model {
             unset($where['CategoryID']);
         }
 
-        // Determine category watching
-        if (!isset($where['d.CategoryID'])) {
-            $categoryIDs = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
-            if ($categoryIDs !== true) {
-                $where['d.CategoryID'] = $categoryIDs;
-            }
-        }
-
         $where = $this->combineWheres($this->getWheres(), $where);
 
         $orderBy = [];

--- a/applications/vanilla/modules/class.discussionsmodule.php
+++ b/applications/vanilla/modules/class.discussionsmodule.php
@@ -69,6 +69,8 @@ class DiscussionsModule extends Gdn_Module {
 
         if ($categoryIDs) {
             $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
+        } else {
+            $where['d.CategoryID'] = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
         }
 
         $this->setData('Discussions', $discussionModel->get(0, $limit, $where));


### PR DESCRIPTION
Remnants of Category Watching were removed with #6840. Altering some of the conditions that used Category Watching made them less flexible, specifically when it came to filtering categories with a truthy `HideAllDiscussions` flag. `DiscussionsModel::getWhere` now always filters out these categories.

This update removes the hard condition from `DiscussionsModel::getWhere` and adds it to calls, as needed.

Needs to be backported to [release/2.6](https://github.com/vanilla/vanilla/tree/release/2.6)