### PR TITLE
Added class to back to profile button

### DIFF
--- a/applications/dashboard/views/modules/profileoptions.php
+++ b/applications/dashboard/views/modules/profileoptions.php
@@ -4,7 +4,7 @@
 <div class="ProfileOptions">
     <?php
     if (Gdn::controller()->EditMode)  {
-        echo anchor(t('Back to Profile'), userUrl(Gdn::controller()->User), ['class' => 'ProfileButtons']);
+        echo anchor(t('Back to Profile'), userUrl(Gdn::controller()->User), ['class' => 'ProfileButtons ProfileButtons-BackToProfile']);
     } else {
         echo buttonGroup($this->data('MemberOptions'), 'NavButton MemberButtons').' ';
         echo $this->data('ProfileOptionsDropdown');


### PR DESCRIPTION
We use the same class for buttons and links in the edit profile pages. I've added a class to help theming the "back to profile" link and differentiate it from the dropdown button.

Note, I didn't use `.BackToProfile` as the class name because I found it commented out in a css file... which leads me to believe it may exists or have existed at some point... The class I picked is longer and less likely to clash with anything.

Closes https://github.com/vanilla/vanilla/issues/6868