### PR TITLE
Backport: Fix bookmarking a discussion

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -442,7 +442,8 @@ class DiscussionController extends VanillaController {
         }
 
         // Make sure that the user has access to the discussion.
-        $this->DiscussionModel->categoryPermission('Vanilla.Discussions.View', $Discussion['CategoryID']);
+        $categoryID = val('CategoryID', $Discussion);
+        $this->DiscussionModel->categoryPermission('Vanilla.Discussions.View', $categoryID);
 
         $Bookmark = $this->DiscussionModel->bookmark($DiscussionID, $UserID, $Bookmark);
 


### PR DESCRIPTION
Backporting #6935 

> The permission check in `DiscussionController::bookmark` expects an associative array, but gets an object. This update resolves a fatal error of trying to access an object's properties as an array when bookmarking a discussion.