### PR TITLE
Properly set where condition if all categories are visible

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -150,17 +150,20 @@ class DiscussionsController extends VanillaController {
         $where = [];
         if ($this->data('Followed')) {
             $followedCategories = array_keys($categoryModel->getFollowed(Gdn::session()->UserID));
-            $visibleCategories = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
-            if ($visibleCategories === true) {
+            $visibleCategoriesResult = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+            if ($visibleCategoriesResult === true) {
                 $visibleFollowedCategories = $followedCategories;
             } else {
-                $visibleFollowedCategories = array_intersect($followedCategories, $visibleCategories);
+                $visibleFollowedCategories = array_intersect($followedCategories, $visibleCategoriesResult);
             }
             $where['d.CategoryID'] = $visibleFollowedCategories;
         } elseif ($categoryIDs) {
             $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
         } else {
-            $where['d.CategoryID'] = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+            $visibleCategoriesResult = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+            if ($visibleCategoriesResult !== true) {
+                $where['d.CategoryID'] = $visibleCategoriesResult;
+            }
         }
 
         // Get Discussion Count

--- a/applications/vanilla/modules/class.discussionsmodule.php
+++ b/applications/vanilla/modules/class.discussionsmodule.php
@@ -70,7 +70,10 @@ class DiscussionsModule extends Gdn_Module {
         if ($categoryIDs) {
             $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
         } else {
-            $where['d.CategoryID'] = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+            $visibleCategoriesResult = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+            if ($visibleCategoriesResult !== true) {
+                $where['d.CategoryID'] = $visibleCategoriesResult;
+            }
         }
 
         $this->setData('Discussions', $discussionModel->get(0, $limit, $where));


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/6949

If all categories are visible we were setting the following condition: `$where['d.CategoryID'] = true`
This is obviously incorrect since there should be no condition set at all.

I assume this was translated to `$where['d.CategoryID'] = 1` down the line.