### PR TITLE
Use dependency injection in the search controller

### DIFF
--- a/applications/dashboard/controllers/class.searchcontroller.php
+++ b/applications/dashboard/controllers/class.searchcontroller.php
@@ -66,11 +66,10 @@ class SearchController extends Gdn_Controller {
     /**
      * Default search functionality.
      *
-     * @since 2.0.0
-     * @access public
-     * @param int $page Page number.
+     * @param string $search The search string.
+     * @param string $page Page number.
      */
-    public function index($page = '') {
+    public function index($search = '', $page = '') {
         $this->addJsFile('search.js');
         $this->title(t('Search'));
 
@@ -80,7 +79,6 @@ class SearchController extends Gdn_Controller {
         list($offset, $limit) = offsetLimit($page, c('Garden.Search.PerPage', 20));
         $this->setData('_Limit', $limit);
 
-        $search = $this->Form->getFormValue('Search');
         $mode = $this->Form->getFormValue('Mode');
         if ($mode) {
             $this->SearchModel->ForceSearchMode = $mode;

--- a/applications/dashboard/controllers/class.searchcontroller.php
+++ b/applications/dashboard/controllers/class.searchcontroller.php
@@ -25,11 +25,14 @@ class SearchController extends Gdn_Controller {
     /**
      * Object instantiation & form prep.
      */
-    public function __construct() {
+    public function __construct(SearchModel $searchModel = null) {
         parent::__construct();
 
-        // Object instantiation
-        $this->SearchModel = new SearchModel();
+        // Object instantiation.
+        if ($searchModel === null) {
+            $searchModel = new SearchModel();
+        }
+        $this->SearchModel = $searchModel;
         $form = Gdn::factory('Form');
 
         // Form prep


### PR DESCRIPTION
The search controller needs to use DI so that other search providers can override the model.