### PR TITLE
Normalize the cache buster into the asset model

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1857,7 +1857,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
                 $this->Head->addScript('', 'text/javascript', false, ['content' => $this->definitionList(false)]);
 
-                $busta = trim(assetVersion('', ''), '.');
+                $busta = $AssetModel->cacheBuster();
 
                 // Add the client-side translations.
                 // This is done in the controller rather than the asset model because the translations are not linked to compiled code.


### PR DESCRIPTION
The new js code still needs a deploy hash and it has not shown off in different places. I’m guessing we’ll need to make the buster more robust in the future for OSS, but this solution should get us through a release or two.