### PR TITLE
Fix init event in IE

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -254,7 +254,7 @@
             }
 
             var event = document.createEvent('CustomEvent');
-            event.initCustomEvent('X-DOMContentReady', true, false);
+            event.initCustomEvent('X-DOMContentReady', true, false, {});
             e.target.dispatchEvent(event);
         });
 


### PR DESCRIPTION
Closes #6960 

Apparently IE (and related require the 4th param to initEvent).