### PR TITLE
Fix the URL when signing in through Facebook.

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -137,7 +137,8 @@ class FacebookPlugin extends Gdn_Plugin {
         }
 
         if (isset($sender->Data['Methods'])) {
-            $url = 'entry/facebook';
+            // pass the relative path, socialSigninButton handles the URL.
+            $url = '/entry/facebook';
 
             // Add the facebook method to the controller.
             $fbMethod = [
@@ -335,7 +336,7 @@ class FacebookPlugin extends Gdn_Plugin {
      */
     private function _getButton() {
         // pass the relative path, socialSigninButton handles the URL.
-        $url = 'entry/facebook';
+        $url = '/entry/facebook';
         return socialSigninButton('Facebook', $url, 'icon', ['rel' => 'nofollow']);
     }
 


### PR DESCRIPTION
Changes to the way we pass the URL to the Facebook Connect button meant that we were running it through the url() function twice causing the subcommunity folder to be added twice to the URL. 

This PR fixes that.

Closes #6965 