### PR TITLE
Fix edge case crawl errors

### DIFF
--- a/applications/dashboard/modules/class.pagermodule.php
+++ b/applications/dashboard/modules/class.pagermodule.php
@@ -199,7 +199,6 @@ class PagerModule extends Gdn_Module {
             }
 
             $this->_PropertiesDefined = true;
-            $this->addRelLinks(Gdn::controller());
 
             Gdn::controller()->EventArguments['Pager'] = $this;
             Gdn::controller()->fireEvent('PagerInit');
@@ -334,6 +333,8 @@ class PagerModule extends Gdn_Module {
 
         // Urls with url-encoded characters will break sprintf, so we need to convert them for backwards compatibility.
         $this->Url = str_replace(['%1$s', '%2$s', '%s'], '{Page}', $this->Url);
+
+        $this->addRelLinks(Gdn::controller());
 
         if ($this->TotalRecords === false) {
             return $this->toStringPrevNext($type);

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -427,6 +427,8 @@ class CategoriesController extends VanillaController {
             }
 
             $countDiscussions = $discussionModel->getCount($wheres);
+            $this->checkPageRange($offset, $countDiscussions);
+
             if ($maxPages && $maxPages * $limit < $countDiscussions) {
                 $countDiscussions = $maxPages * $limit;
             }

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -121,13 +121,13 @@ class DiscussionController extends VanillaController {
 
                 // (((67 comments / 10 perpage) = 6.7) rounded down = 6) * 10 perpage = offset 60;
                 $this->Offset = floor($CountCommentWatch / $Limit) * $Limit;
-            }
-            if ($ActualResponses <= $Limit) {
-                $this->Offset = 0;
-            }
 
-            if ($this->Offset == $ActualResponses) {
-                $this->Offset -= $Limit;
+                if ($this->Offset >= $ActualResponses) {
+                    $this->Offset = $ActualResponses - $Limit;
+                }
+                if ($ActualResponses <= $Limit) {
+                    $this->Offset = 0;
+                }
             }
         } else {
             if ($this->Offset == '') {
@@ -155,7 +155,7 @@ class DiscussionController extends VanillaController {
         // Set the canonical url to have the proper page title.
         $this->canonicalUrl(discussionUrl($this->Discussion, pageNumber($this->Offset, $Limit, 0, false)));
 
-//      url(concatSep('/', 'discussion/'.$this->Discussion->DiscussionID.'/'. Gdn_Format::url($this->Discussion->Name), pageNumber($this->Offset, $Limit, TRUE, Gdn::session()->UserID != 0)), true), Gdn::session()->UserID == 0);
+        $this->checkPageRange($this->Offset, $ActualResponses);
 
         // Load the comments
         $this->setData('Comments', $this->CommentModel->getByDiscussion($DiscussionID, $Limit, $this->Offset));

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -169,6 +169,8 @@ class DiscussionsController extends VanillaController {
         // Get Discussion Count
         $CountDiscussions = $DiscussionModel->getCount($where);
 
+        $this->checkPageRange($Offset, $CountDiscussions);
+
         if ($MaxPages) {
             $CountDiscussions = min($MaxPages * $Limit, $CountDiscussions);
         }

--- a/applications/vanilla/controllers/class.vanillacontroller.php
+++ b/applications/vanilla/controllers/class.vanillacontroller.php
@@ -56,4 +56,17 @@ class VanillaController extends Gdn_Controller {
             $this->permission($permission, $fullMatch, 'Category', $categoryID);
         }
     }
+
+    /**
+     * Check to see if we've gone off the end of the page.
+     *
+     * @param int $offset The offset requested.
+     * @param int $totalCount The total count of records.
+     * @throws Exception Throws an exception if the offset is past the last page.
+     */
+    protected function checkPageRange(int $offset, int $totalCount) {
+        if ($offset > 0 && $offset >= $totalCount) {
+            throw notFoundException();
+        }
+    }
 }


### PR DESCRIPTION
There are several edge cases where crawlers may start crawling non-existent pages of discussions, categories, etc. See the individual commits for more information.

There are two main components to this PR:

1. Render a single previous link for numbered pagers when the specified page is greater than the number of pages.
2. Throw not found errors on select pages when the specified page is greater than the number of pages.

The not found errors provide some edge cases that should be taken into consideration:

1. When there are no records the first page should not throw an error.
2. Auto offset into discussions can throw things for a loop.
3. Off-by-one errors.

Closes #6796