### PR TITLE
Fix undefined $timeLeft variable notices

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -742,7 +742,7 @@ class DiscussionController extends VanillaController {
                 }
 
                 // Make sure that content can (still) be edited.
-                if (!$this->CommentModel->canEdit($comment)) {
+                if (!CommentModel::canEdit($comment)) {
                     $this->categoryPermission($discussion->CategoryID, 'Vanilla.Comments.Delete');
                 }
 

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -635,7 +635,7 @@ class PostController extends VanillaController {
         // Check permissions
         if ($Discussion && $Editing) {
             // Make sure that content can (still) be edited.
-            if (!$this->CommentModel::canEdit($this->Comment)) {
+            if (!CommentModel::canEdit($this->Comment)) {
                 throw permissionException('Vanilla.Comments.Edit');
             }
 

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -211,6 +211,7 @@ if (!function_exists('getDiscussionOptions')) :
      */
     function getDiscussionOptions($discussion = null) {
         $options = [];
+        $timeLeft = Gdn_Model::editContentTimeout($discussion, $timeLeft);
 
         $sender = Gdn::controller();
         $session = Gdn::session();
@@ -426,6 +427,7 @@ if (!function_exists('getCommentOptions')) :
      */
     function getCommentOptions($comment) {
         $options = [];
+        $timeLeft = Gdn_Model::editContentTimeout($comment, $timeLeft);
 
         if (!is_numeric(val('CommentID', $comment))) {
             return $options;

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -211,7 +211,6 @@ if (!function_exists('getDiscussionOptions')) :
      */
     function getDiscussionOptions($discussion = null) {
         $options = [];
-        $timeLeft = Gdn_Model::editContentTimeout($discussion, $timeLeft);
 
         $sender = Gdn::controller();
         $session = Gdn::session();
@@ -427,7 +426,6 @@ if (!function_exists('getCommentOptions')) :
      */
     function getCommentOptions($comment) {
         $options = [];
-        $timeLeft = Gdn_Model::editContentTimeout($comment, $timeLeft);
 
         if (!is_numeric(val('CommentID', $comment))) {
             return $options;
@@ -440,9 +438,11 @@ if (!function_exists('getCommentOptions')) :
         $categoryID = val('CategoryID', $discussion);
 
         // Can the user edit the comment?
-        $commentModel = new CommentModel();
-        $canEdit = $commentModel->canEdit($comment);
+        $canEdit = CommentModel::canEdit($comment, $timeLeft);
         if ($canEdit) {
+            if ($timeLeft) {
+                $timeLeft = ' ('.Gdn_Format::seconds($timeLeft).')';
+            }
             $options['EditComment'] = [
                 'Label' => t('Edit').$timeLeft,
                 'Url' => '/post/editcomment/'.$comment->CommentID,


### PR DESCRIPTION
I just started seeing a lot of notices crop up with a missing variable. I’m not sure when the change was done, but the underlying function in Gdn_Model was added in ccae291fffc03636884b26d51475f57dbc0e4d4e.