### PR TITLE
Addon Key for Toggle

### DIFF
--- a/applications/dashboard/views/settings/helper_functions.php
+++ b/applications/dashboard/views/settings/helper_functions.php
@@ -180,7 +180,7 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
         $label = sprintf(t('Enable %s'), $screenName);
     }
 
-    $url = '/settings/'.$addonType.'/'.$action.'/'.$addonName;
+    $url = '/settings/'.$addonType.'/'.$action.'/'.val('Key', $addonInfo, $addonInfo['KeyRaw']);
 
     $media->setToggle(slugify($addonName), $isEnabled, $url, $label);
 

--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -157,7 +157,7 @@ class Addon {
                 // Kludge that sets keyRaw until we use key everywhere.
                 if ($info['oldType'] === 'application') {
                     if (!isset($info['keyRaw'])) {
-                        $info['keyRaw'] = $info['name'];
+                        $info['keyRaw'] = str_replace(' ', '', $info['name']);
                     }
                 } else {
                     if ($addonFolder !== $info['key']) {


### PR DESCRIPTION
Fixes issue #6559.

1. For addons that have spaces in their names such as "Basic Pages", the toggle link would contain "Basic%20Pages". With this, Gdn::addonManager()->lookupAddon() wouldn't be able to find the addon because the multiCache array contains each addon's real key or raw key, not their name. The fix is to use Key or KeyRaw for the toggle link.
2. Vanilla's "kludge that sets keyRaw until we use key everywhere" sets $info['keyRaw'] to the addon's name that may contain spaces. It should set it to the name without a space as versions of Vanilla before 2.5 (without addon.json) had their key being their names without spaces like "BasicPages". The fix is to remove spaces in the name. This allows the application to properly be enabled or disabled as the config property had been "EnabledApplications.BasicPages" without any spaces.

Successfully tested my changes for compatibility with old style addons without addon.json and also new style addons with only addon.json. Lookup and toggling working good.