### PR TITLE
Always load the transient key

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -433,8 +433,9 @@ class Gdn_Session {
         $userModel = Gdn::authenticator()->getUserModel();
         $this->UserID = $userID !== false ? $userID : Gdn::authenticator()->getIdentity();
         $this->User = false;
+        $this->loadTransientKey();
 
-        // Now retrieve user information
+        // Now retrieve user information.
         if ($this->UserID > 0) {
             // Instantiate a UserModel to get session info
             $this->User = $userModel->getSession($this->UserID);
@@ -604,6 +605,8 @@ class Gdn_Session {
                 $currentTKInvalid = $this->transientKey() != $cookie['TransientKey'];
                 if ($userValid && $signatureValid && $currentTKInvalid) {
                     $result = $this->transientKey($cookie['TransientKey'], false);
+                } else {
+                    $result = $this->transientKey();
                 }
             }
         }


### PR DESCRIPTION
The session was only loading the transient key when there is a valid user even though the TK cookie was submitted.

We need the TK for login pages where there is no session so the TK is important. As it turns out the entry controller always ensured the TK itself, but this really should be handled in the session.

The fix in Gdn_Session::start() caused a nasty redirect loop when signing a user out because Gdn_Session::loadTransientKey() had a bug. This shouldn’t be an issue now, but shows that this seemingly simple fix can cause some bad regressions because of the state of Gdn_Session.