### PR TITLE
Allow index_subresource to be listed in APIv2 documentation.

### DIFF
--- a/applications/dashboard/models/ReflectionAction.php
+++ b/applications/dashboard/models/ReflectionAction.php
@@ -137,7 +137,6 @@ class ReflectionAction {
 
         if (strcasecmp($httpMethod, 'index') === 0) {
             $httpMethod = 'GET';
-            $subpath = '';
         }
 
         // Check against the controller pattern.


### PR DESCRIPTION
Since #6755 the controllers can now define index_subresource but swagger was never updated to list them properly.

$subpath was removed as a "protection" i guess but since #6755 that's actually incorrect!