### PR TITLE
Feature/authenticate checkbox tweaks

### DIFF
--- a/applications/dashboard/src/scripts/Forms/Checkbox.tsx
+++ b/applications/dashboard/src/scripts/Forms/Checkbox.tsx
@@ -16,8 +16,7 @@ interface IState {
 }
 
 export default class Button extends React.Component<IProps, IState> {
-    private labelDom;
-
+    
     public static defaultProps = {
         disabled: false,
     };

--- a/applications/dashboard/src/scripts/Forms/Checkbox.tsx
+++ b/applications/dashboard/src/scripts/Forms/Checkbox.tsx
@@ -11,15 +11,26 @@ interface IProps extends IComponentID {
     label: string;
 }
 
-export default class Button extends React.Component<IProps> {
+interface IState {
+    ID: string;
+}
+
+export default class Button extends React.Component<IProps, IState> {
+    private labelDom;
+
     public static defaultProps = {
         disabled: false,
     };
-    public ID: string;
 
     constructor(props) {
         super(props);
-        this.ID = uniqueID(props, 'checkbox');
+        this.state = {
+            ID: uniqueID(props, "checkbox"),
+        };
+    }
+
+    get labelID():string {
+        return this.state.ID + "-label";
     }
 
     public render() {
@@ -28,8 +39,8 @@ export default class Button extends React.Component<IProps> {
             this.props.className
         );
 
-        return <label id={this.ID} className={componentClasses}>
-            <input className="checkbox-input" type="checkbox" onChange={this.props.onChange} checked={this.props.checked}/>
+        return <label id={this.state.ID} className={componentClasses}>
+            <input className="checkbox-input" aria-labelledby={this.labelID} type="checkbox" onChange={this.props.onChange} checked={this.props.checked}/>
             <span className="checkbox-box" aria-hidden="true">
                 <span className="checkbox-state">
                     <svg className="checkbox-icon checkbox-checkIcon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
@@ -38,7 +49,7 @@ export default class Button extends React.Component<IProps> {
                     </svg>
                 </span>
             </span>
-            <span className="checkbox-label">{this.props.label}</span>
+            <span id={this.labelID} className="checkbox-label">{this.props.label}</span>
         </label>;
     }
 }


### PR DESCRIPTION
Refactored ID generation to match pattern in InputText component. We want the IDs to be stored as state just in case they need to re-render. 

Added missing `aria-labelledby` on the input.

Closes: https://github.com/vanilla/vanilla/issues/6998