### PR TITLE
Fix user search by IP never returning results

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2657,19 +2657,13 @@ class UserModel extends Gdn_Model {
         $sql->reset();
 
         // Get all users that matches the IP address.
-        $userIDs = [];
-
         $sql
             ->select('UserID')
             ->from('UserIP')
             ->where('IPAddress', inet_pton($ip));
 
         $matchingUserIDs = $sql->get()->resultArray();
-        if(!empty($matchingUserIDs)) {
-            foreach ($matchingUserIDs as $matchingUserID) {
-                $userIDs[] = valr('UserID', $matchingUserID);
-            }
-        }
+        $userIDs = array_column($matchingUserIDs, 'UserID');
 
         // Add these users to search query.
         $this->SQL

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2563,7 +2563,6 @@ class UserModel extends Gdn_Model {
         // Check for an IP address.
         if (preg_match('`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`', $keywords)) {
             $ipAddress = $keywords;
-            $optimize = false;
             $this->addIpFilters($ipAddress, ['LastIPAddress']);
         } elseif (strtolower($keywords) == 'banned') {
             $this->SQL->where('u.Banned >', 0);

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2563,6 +2563,7 @@ class UserModel extends Gdn_Model {
         // Check for an IP address.
         if (preg_match('`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`', $keywords)) {
             $ipAddress = $keywords;
+            $optimize = false;
             $this->addIpFilters($ipAddress, ['LastIPAddress']);
         } elseif (strtolower($keywords) == 'banned') {
             $this->SQL->where('u.Banned >', 0);
@@ -2656,16 +2657,23 @@ class UserModel extends Gdn_Model {
         $sql->reset();
 
         // Get all users that matches the IP address.
+        $userIDs = [];
+
         $sql
             ->select('UserID')
             ->from('UserIP')
             ->where('IPAddress', inet_pton($ip));
 
         $matchingUserIDs = $sql->get()->resultArray();
+        if(!empty($matchingUserIDs)) {
+            foreach ($matchingUserIDs as $matchingUserID) {
+                $userIDs[] = valr('UserID', $matchingUserID);
+            }
+        }
 
         // Add these users to search query.
         $this->SQL
-            ->orWhereIn('u.UserID', $matchingUserIDs);
+            ->orWhereIn('u.UserID', $userIDs);
 
         // Check the user table ip fields.
         $allowedFields = ['LastIPAddress', 'InsertIPAddress', 'UpdateIPAddress'];


### PR DESCRIPTION
User search by IP would return no results when the user count was past the threshold (the query was in "optimized" mode).

The user search IP query was searching for user IDs in a `null` list. This would give no results. User IDs now populate the list, when available, so matches can be properly made.

Related #6381

Fixes #6989
