### PR TITLE
Move "category" back link definition into discusion controller

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -95,6 +95,7 @@ class DiscussionController extends VanillaController {
         }
 
         $this->setData('Category', $Category);
+        $this->setData('Editor.BackLink', anchor($Category['Name'], categoryUrl($Category)));
 
         if ($CategoryCssClass = val('CssClass', $Category)) {
             Gdn_Theme::section($CategoryCssClass);

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -95,7 +95,7 @@ class DiscussionController extends VanillaController {
         }
 
         $this->setData('Category', $Category);
-        $this->setData('Editor.BackLink', anchor($Category['Name'], categoryUrl($Category)));
+        $this->setData('Editor.BackLink', anchor(htmlspecialchars($Category['Name']), categoryUrl($Category)));
 
         if ($CategoryCssClass = val('CssClass', $Category)) {
             Gdn_Theme::section($CategoryCssClass);

--- a/applications/vanilla/views/post/comment.php
+++ b/applications/vanilla/views/post/comment.php
@@ -37,24 +37,19 @@ $this->fireEvent('BeforeCommentForm');
                     echo "<div class=\"Buttons\">\n";
                     $this->fireEvent('BeforeFormButtons');
 
-                    // Keep commented for now but if you stumble on this in a year you can just remove it :).
-//                    $CancelText = t('Home');
-//                    $CancelClass = 'Back';
-//                    if (!$NewOrDraft || $Editing) {
-//                        $CancelText = t('Cancel');
-//                        $CancelClass = 'Cancel';
-//                    }
-//
-//                    echo '<span class="'.$CancelClass.'">';
-//                    echo anchor($CancelText, '/');
-//                    $CategoryID = $this->data('Discussion.CategoryID');
-//                    if (c('Vanilla.Categories.Use', true) && $CategoryID) {
-//                        $Category = CategoryModel::categories($CategoryID);
-//                        if ($Category) {
-//                            echo ' <span class="Bullet">•</span> '.anchor(htmlspecialchars($Category['Name']), categoryUrl($Category));
-//                        }
-//                    }
-//                    echo '</span>';
+                    $CancelText = t('Home');
+                    $CancelClass = 'Back';
+                    if (!$NewOrDraft || $Editing) {
+                        $CancelText = t('Cancel');
+                        $CancelClass = 'Cancel';
+                    }
+
+                    echo '<span class="'.$CancelClass.'">';
+                    echo anchor($CancelText, '/');
+                    if ($this->data('Editor.BackLink')) {
+                        echo ' <span class="Bullet">•</span> '.$this->data('Editor.BackLink') ;
+                    }
+                    echo '</span>';
 
                     $ButtonOptions = ['class' => 'Button Primary CommentButton'];
                     $ButtonOptions['tabindex'] = 1;


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/7014

We added a new property that can be redefined using events.
Views that have been redefined won't reflect that change but nothing will break!