### PR TITLE
Add the /api/v2/dashboard/menus endpoint

### DIFF
--- a/applications/dashboard/controllers/api/DashboardApiController.php
+++ b/applications/dashboard/controllers/api/DashboardApiController.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla\Dashboard\Api;
+
+use DashboardNavModule;
+use Vanilla\Web\Controller;
+
+/**
+ * Contains information useful for building the dashboard.
+ */
+class DashboardApiController extends Controller {
+    /**
+     * Get the menus in the dashboard.
+     *
+     * @return array Returns the menus.
+     */
+    public function index_menus() {
+        // This is the array of permissions from the module.
+        // We just want to make sure the user has at least one of the permissions although if they don't then the menus would be empty.
+        $this->permission([
+            'Garden.Settings.Manage',
+            'Garden.Community.Manage',
+            'Garden.Moderation.Manage',
+            'Garden.Settings.View',
+            'Moderation.ModerationQueue.Manage',
+            'Garden.Users.Add',
+            'Garden.Users.Edit',
+            'Garden.Users.Delete',
+            'Garden.Users.Approve',
+        ]);
+
+        $in = $this->schema([], 'in')->setDescription('List the dashboard menus.');
+        $out = $this->schema([
+            ':a' => [
+                'name:s' => 'The title of the menu.',
+                'key:s' => 'The ID of the menu.',
+                'description:s' => 'The menu description.',
+                'url:s?' =>  'The URL to the menu if it doesn\'t have a submenu.',
+                'groups:a' => [
+                    'name:s' => 'The title of the group.',
+                    'key:s' => 'The key of the group.',
+                    'links:a' => [
+                        'name:s' => 'The title of the link.',
+                        'key:s' => 'The key of the link.',
+                        'url:s' => 'The URL of the link.',
+                        'react:b' => 'Whether or not the link represents a React component.',
+                        'badge?' => [
+                            'type' => 'object',
+                            'description' => 'Information about a badge to display beside the link.',
+                            'properties' => [
+                                'type:s' => [
+                                    'description' => 'The type of badge.',
+                                    'enum' => ['view', 'text'],
+                                ],
+                                'url:s?' => 'The URL of a view.',
+                                'text:s' => 'Literal text for the badge.',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], 'out');
+
+        $module = new DashboardNavModule();
+        $result = $module->getMenus();
+
+        $result = $out->validate($result);
+
+        return $result;
+    }
+}

--- a/applications/dashboard/library/class.nestedcollection.php
+++ b/applications/dashboard/library/class.nestedcollection.php
@@ -539,29 +539,34 @@ trait NestedCollection {
     /**
      * Recursive function to sort the items in a given array.
      *
-     * @param array $items The items to sort.
+     * @param array &$items The items to sort.
      */
-    private function sortItems(&$items) {
-        foreach($items as &$item) {
+    protected function sortItems(&$items) {
+        $i = 0;
+        foreach ($items as &$item) {
+            $item += ['_sort' => $i++];
             if (val('items', $item)) {
                 $this->sortItems($item['items']);
             }
         }
-        uasort($items, function($a, $b) use ($items) {
+
+        uasort($items, function ($a, $b) use ($items) {
             $sort_a = $this->sortItemsOrder($a, $items);
             $sort_b = $this->sortItemsOrder($b, $items);
 
-            if ($sort_a > $sort_b)
+            if ($sort_a > $sort_b) {
                 return 1;
-            elseif ($sort_a < $sort_b)
+            } elseif ($sort_a < $sort_b) {
                 return -1;
-            else
+            } else {
                 return 0;
+            }
         });
     }
 
     /**
      * Get the sort order of an item in the items array.
+     *
      * This function looks at the following keys:
      * - **sort (numeric)**: A specific numeric sort was provided.
      * - **sort array('before|after', 'key')**: You can specify that the item is before or after another item.
@@ -580,7 +585,7 @@ trait NestedCollection {
             if (is_numeric($item['sort'])) {
                 // This is a numeric sort
                 return $item['sort'] * 10000 + $default_sort;
-            } elseif (is_array($item['sort']) && $depth < 10) {
+            } elseif (is_array($item['sort']) && !empty($item['sort']) && $depth < 10) {
                 // This sort is before or after another depth.
                 $op = array_keys($item['sort'])[0];
                 $key = $item['sort'][$op];

--- a/applications/dashboard/models/ReflectionAction.php
+++ b/applications/dashboard/models/ReflectionAction.php
@@ -140,7 +140,7 @@ class ReflectionAction {
         }
 
         // Check against the controller pattern.
-        if (preg_match("`(?:^|\\\\)$resourceRegex$`i", $controller, $m)) {
+        if (preg_match("`$resourceRegex$`i", $controller, $m)) {
             $resource = $m[1];
         } else {
             throw new \InvalidArgumentException("The controller is not an API controller.", 500);

--- a/applications/dashboard/views/modules/nav-dashboard.php
+++ b/applications/dashboard/views/modules/nav-dashboard.php
@@ -24,7 +24,10 @@ if (!function_exists('renderDashboardNav')) {
                             echo icon(val('icon', $item)).' ';
                         }
                         echo val('text', $item);
-                        if (val('popinRel', $item)) {
+
+                        if (!empty($item['badge'])) {
+                            echo ' <span class="badge">'.htmlspecialchars($item['badge']).'</span >';
+                        } elseif (val('popinRel', $item)) {
                             echo ' <span class="Popin badge" rel="'.val('popinRel', $item).'"></span >';
                         }
                         ?>

--- a/plugins/swagger-ui/SwaggerUIPlugin.php
+++ b/plugins/swagger-ui/SwaggerUIPlugin.php
@@ -17,13 +17,21 @@ use Vanilla\Addon;
  */
 class SwaggerUIPlugin extends Gdn_Plugin {
     /**
-     * Adds "API v2" menu option to the Forum menu on the dashboard.
+     * Add the APIv2 menu item.
      *
-     * @param \Gdn_Controller $sender The settings controller.
+     * @param \DashboardNavModule $nav The menu to add the module to.
      */
-    public function base_getAppSettingsMenuItems_handler($sender) {
-        $menu = $sender->EventArguments['SideMenu'];
-        $menu->addLink('Site Settings', t('API v2', 'API <span class="nav-pill">v2</span>'), '/settings/swagger', 'Garden.Settings.Manage', ['class' => 'nav-swagger']);
+    public function dashboardNavModule_init_handler(\DashboardNavModule $nav) {
+        $nav->addLinkToSectionIf(
+            \gdn::session()->checkPermission('Garden.Settings.Manage'),
+            'settings',
+            t('API'),
+            '/settings/swagger',
+            'site-settings.swagger-ui',
+            'nav-swagger-ui',
+            ['after' => 'security'],
+            ['badge' => 'v2']
+        );
     }
 
     /**

--- a/tests/APIv2/DashboardTest.php
+++ b/tests/APIv2/DashboardTest.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\APIv2;
+
+/**
+ * Tests for the /api/v2/dashboard endpoints.
+ */
+class DashboardTest extends AbstractAPIv2Test {
+
+    /**
+     * A basic smoke test of the dashboard menus.
+     */
+    public function testIndexMenusSmoke() {
+        $r = $this->api()->get('/dashboard/menus');
+        $data = $r->getBody();
+        $this->assertSame(3, count($data));
+    }
+}

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -194,7 +194,7 @@ class Bootstrap {
 
             ->rule('@api-v2-route')
             ->setClass(\Garden\Web\ResourceRoute::class)
-            ->setConstructorArgs(['/api/v2/', '%sApiController'])
+            ->setConstructorArgs(['/api/v2/', '*\\%sApiController'])
             ->addCall('setConstraint', ['locale', ['position' => 0]])
             ->addCall('setMeta', ['CONTENT_TYPE', 'application/json; charset=utf-8'])
 


### PR DESCRIPTION
This endpoint lists all of the menus in the dashboard. It is going to be necessary in order to add a client-side nav module and addon management page.

This is a bit of yack shaving, but to give a bit of context on where this PR is coming from:

- We've the /api/v2/addons resource for a while which is necessary for a client-side addons page.
- Since enabling/disabling an addon can affect the menu we need a way of refreshing it.
- We need to refactor the addons page in general to support the new feature in the API such as conflicts. And once we change the page we can remove a bunch of old code.