### PR TITLE
Fix deprecation notice in the Vanilla Stats plugin

### DIFF
--- a/plugins/VanillaStats/class.vanillastats.plugin.php
+++ b/plugins/VanillaStats/class.vanillastats.plugin.php
@@ -50,19 +50,6 @@ class VanillaStatsPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Override the default dashboard page with the new stats one.
-     *
-     * @param Gdn_Dispatcher $sender
-     */
-    public function gdn_dispatcher_beforeDispatch_handler($sender) {
-        $enabled = c('Garden.Analytics.Enabled', true);
-
-        if ($enabled) {
-            Gdn::pluginManager()->registerNewMethod('VanillaStatsPlugin', 'StatsDashboard', 'SettingsController', 'home');
-        }
-    }
-
-    /**
      *
      *
      * @param $jsonResponse


### PR DESCRIPTION
The notice was caused by a call to a deprecated plugin manager method. However, it seems to be old code from the previous dashboard and removing it didn’t cause a problem.