### PR TITLE
Add ability to override theme per contoller

### DIFF
--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -79,7 +79,7 @@ class AssetModel extends Gdn_Model {
      * @return array
      * @throws Exception
      */
-    public function getCssFiles($themeType, $basename, $eTag, &$notFound = null, $dynamicCurrentTheme = null) {
+    public function getCssFiles($themeType, $basename, $eTag, &$notFound = null, $currentTheme = null) {
         $notFound = [];
         $basename = strtolower($basename);
 
@@ -138,7 +138,7 @@ class AssetModel extends Gdn_Model {
                 $paths[] = [false, $folder, $options];
 
             } else {
-                list($path, $urlPath) = self::cssPath($filename, $folder, $themeType, $dynamicCurrentTheme);
+                list($path, $urlPath) = self::cssPath($filename, $folder, $themeType, $currentTheme);
                 if ($path) {
                     $paths[] = [$path, $urlPath, $options];
                 } else {
@@ -258,7 +258,7 @@ class AssetModel extends Gdn_Model {
      * @param string $themeType mobile or desktop
      * @return array|bool
      */
-    public static function cssPath($filename, $folder = '', $themeType = '', $dynamicCurrentTheme = null) {
+    public static function cssPath($filename, $folder = '', $themeType = '', $currentTheme = null) {
         if (!$themeType) {
             $themeType = isMobile() ? 'mobile' : 'desktop';
         }
@@ -288,7 +288,9 @@ class AssetModel extends Gdn_Model {
         $theme = Gdn::themeManager()->themeFromType($themeType);
 
         // Let override theme dynamically
-        if (isset($dynamicCurrentTheme) && $dynamicCurrentTheme != $theme) $theme = $dynamicCurrentTheme;
+        if (isset($currentTheme) && $currentTheme != $theme) {
+            $theme = $currentTheme;
+        }
 
         if ($theme) {
             $path = "/$theme/design/$filename";

--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -79,7 +79,7 @@ class AssetModel extends Gdn_Model {
      * @return array
      * @throws Exception
      */
-    public function getCssFiles($themeType, $basename, $eTag, &$notFound = null) {
+    public function getCssFiles($themeType, $basename, $eTag, &$notFound = null, $dynamicCurrentTheme = null) {
         $notFound = [];
         $basename = strtolower($basename);
 
@@ -138,7 +138,7 @@ class AssetModel extends Gdn_Model {
                 $paths[] = [false, $folder, $options];
 
             } else {
-                list($path, $urlPath) = self::cssPath($filename, $folder, $themeType);
+                list($path, $urlPath) = self::cssPath($filename, $folder, $themeType, $dynamicCurrentTheme);
                 if ($path) {
                     $paths[] = [$path, $urlPath, $options];
                 } else {
@@ -258,7 +258,7 @@ class AssetModel extends Gdn_Model {
      * @param string $themeType mobile or desktop
      * @return array|bool
      */
-    public static function cssPath($filename, $folder = '', $themeType = '') {
+    public static function cssPath($filename, $folder = '', $themeType = '', $dynamicCurrentTheme = null) {
         if (!$themeType) {
             $themeType = isMobile() ? 'mobile' : 'desktop';
         }
@@ -286,6 +286,10 @@ class AssetModel extends Gdn_Model {
 
         // 3. Check the theme.
         $theme = Gdn::themeManager()->themeFromType($themeType);
+
+        // Let override theme dynamically
+        if (isset($dynamicCurrentTheme) && $dynamicCurrentTheme != $theme) $theme = $dynamicCurrentTheme;
+
         if ($theme) {
             $path = "/$theme/design/$filename";
             $paths[] = [PATH_THEMES.$path, "/themes{$path}"];

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1809,8 +1809,7 @@ class Gdn_Controller extends Gdn_Pluggable {
                     // style.css and admin.css deserve some custom processing.
                     if (in_array($CssFile, $CssAnchors)) {
                         // Grab all of the css files from the asset model.
-                        $dummy = null;
-                        $CssFiles = $AssetModel->getCssFiles($ThemeType, ucfirst(substr($CssFile, 0, -4)), $ETag, $dummy, $this->Theme);
+                        $CssFiles = $AssetModel->getCssFiles($ThemeType, ucfirst(substr($CssFile, 0, -4)), $ETag, $_, $this->Theme);
                         foreach ($CssFiles as $Info) {
                             $this->Head->addCss($Info[1], 'all', true, $CssInfo);
                         }

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1809,7 +1809,8 @@ class Gdn_Controller extends Gdn_Pluggable {
                     // style.css and admin.css deserve some custom processing.
                     if (in_array($CssFile, $CssAnchors)) {
                         // Grab all of the css files from the asset model.
-                        $CssFiles = $AssetModel->getCssFiles($ThemeType, ucfirst(substr($CssFile, 0, -4)), $ETag);
+                        $dummy = null;
+                        $CssFiles = $AssetModel->getCssFiles($ThemeType, ucfirst(substr($CssFile, 0, -4)), $ETag, $dummy, $this->Theme);
                         foreach ($CssFiles as $Info) {
                             $this->Head->addCss($Info[1], 'all', true, $CssInfo);
                         }


### PR DESCRIPTION
Although class.controller.php said it was possible the override theme from any controller, you couldn't do so, because the assetmodel would never know about it.

To test it:
1. Don't pull the code first, but add 
`$this->Theme = isMobile() ? 'mobile' : desktop';`
to any controller before 
`$this->Render();`

2. Change 'mobile' or 'desktop' to any theme of your kind, i.e. 'bittersweet' and see that the current theme won't change.

3. Pull and merge my code.

4. Repeat step 2 and see that the theme now changes.

