### PR TITLE
Remove the comment query tight loop

### DIFF
--- a/applications/vanilla/views/discussions/table_functions.php
+++ b/applications/vanilla/views/discussions/table_functions.php
@@ -74,8 +74,18 @@ if (!function_exists('writeDiscussionRow')) :
         $discussion->CountPages = ceil($discussion->CountComments / $sender->CountCommentsPerPage);
 
         $firstPageUrl = discussionUrl($discussion, 1);
-        $lastComment = CommentModel::instance()->getID($discussion->LastCommentID);
-        $lastPageUrl = $lastComment ? commentUrl($lastComment) : $firstPageUrl;
+
+        if (isset($discussion->LastCommentID)) {
+            $lastComment = [
+                'CommentID' => $discussion->LastCommentID,
+                'DiscussionID' => $discussion->DiscussionID,
+                'CategoryID' => $discussion->CategoryID,
+            ];
+
+            $lastPageUrl = commentUrl($lastComment);
+        } else {
+            $lastPageUrl = $firstPageUrl;
+        }
         ?>
         <tr id="Discussion_<?php echo $discussion->DiscussionID; ?>" class="<?php echo $cssClass; ?>">
             <?php $sender->fireEvent('BeforeDiscussionContent'); ?>


### PR DESCRIPTION
The code in #7046 added a very inefficient comment query inside of the discussion table. Since the information we need is already in the result set this is unnecessary.

This change will need to be back-ported as right now a lot of servers are suffering.