### PR TITLE
Change authenticator bootstrapping to container config

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -169,6 +169,7 @@ $dic->setInstance('Garden\Container\Container', $dic)
 
     ->rule(\Vanilla\Models\AuthenticatorModel::class)
     ->setShared(true)
+    ->addCall('registerAuthenticatorClass', [\Vanilla\Authenticator\PasswordAuthenticator::class])
 
     ->rule('Gdn_IPlugin')
     ->setShared(true)
@@ -210,10 +211,6 @@ $dic->setInstance('Garden\Container\Container', $dic)
 
     ->rule('Gdn_Form')
     ->addAlias('Form')
-
-    ->rule(\Vanilla\Models\AuthenticatorModel::class)
-    ->setShared(true)
-    ->addCall('registerAuthenticatorClass', [\Vanilla\Authenticator\PasswordAuthenticator::class])
 ;
 
 // Run through the bootstrap with dependencies.

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -210,6 +210,10 @@ $dic->setInstance('Garden\Container\Container', $dic)
 
     ->rule('Gdn_Form')
     ->addAlias('Form')
+
+    ->rule(\Vanilla\Models\AuthenticatorModel::class)
+    ->setShared(true)
+    ->addCall('registerAuthenticatorClass', [\Vanilla\Authenticator\PasswordAuthenticator::class])
 ;
 
 // Run through the bootstrap with dependencies.
@@ -253,11 +257,6 @@ $dic->call(function (
         safeHeader('Location: '.$request->url('dashboard/setup', true));
         exit();
     }
-
-    /** Authenticators */
-    /** @var \Vanilla\Models\AuthenticatorModel $authenticatorModel */
-    $authenticatorModel = $dic->get(\Vanilla\Models\AuthenticatorModel::class);
-    $authenticatorModel->registerAuthenticatorClass(\Vanilla\Authenticator\PasswordAuthenticator::class);
 
     /**
      * Extension Managers

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -187,6 +187,9 @@ class Bootstrap {
 
             ->rule(AuthenticatorModel::class)
             ->setShared(true)
+            ->addCall('registerAuthenticatorClass', [PasswordAuthenticator::class])
+            ->addCall('registerAuthenticatorClass', [MockAuthenticator::class])
+            ->addCall('registerAuthenticatorClass', [MockSSOAuthenticator::class])
 
             ->rule(\Garden\Web\Dispatcher::class)
             ->setShared(true)
@@ -220,14 +223,6 @@ class Bootstrap {
             ->rule(\WebScraper::class)
             ->setShared(true)
             ->addCall('setDisableFetch', [true]);
-        ;
-
-        /** @var AuthenticatorModel $authenticatorModel */
-        $authenticatorModel = $container->get(AuthenticatorModel::class);
-        $authenticatorModel
-            ->registerAuthenticatorClass(PasswordAuthenticator::class)
-            ->registerAuthenticatorClass(MockAuthenticator::class)
-            ->registerAuthenticatorClass(MockSSOAuthenticator::class)
         ;
     }
 


### PR DESCRIPTION
We should always be configuring dependencies in the container rather than instantiating them in the bootstrap. This ensures that they are instantiated as late as possible which can also mean that they aren’t instantiated at all if they aren’t needed.