### PR TITLE
Simplify tsconfig includes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "jsx": "react",
+        "allowJs": true,
         "lib": [
             "es2017",
             "dom",
@@ -27,9 +28,7 @@
         "skipLibCheck": true
     },
     "include": [
-        "**/src/scripts/**/*.ts",
-        "**/@types/**/*.ts",
-        "global.ts"
+        "**/*.ts"
     ],
     "exclude": [
         "**/*.js"


### PR DESCRIPTION
Fixes the tsconfig file to allow js again, and simplifies the includes. Includes and excludes are used for typechecking and linting.