### PR TITLE
Backport: Fix unnecessary discussion querying when verifying comment edit abilities

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -743,7 +743,8 @@ class DiscussionController extends VanillaController {
                 }
 
                 // Make sure that content can (still) be edited.
-                if (!$this->CommentModel->canEdit($comment)) {
+                $editTimeout = 0;
+                if (!CommentModel::canEdit($comment, $editTimeout, $discussion)) {
                     $this->categoryPermission($discussion->CategoryID, 'Vanilla.Comments.Delete');
                 }
 

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -643,6 +643,7 @@ class PostController extends VanillaController {
         // Check permissions
         if ($Discussion && $Editing) {
             // Make sure that content can (still) be edited.
+            $editTimeout = 0;
             if (!CommentModel::canEdit($this->Comment, $editTimeout, $Discussion)) {
                 throw permissionException('Vanilla.Comments.Edit');
             }

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -643,7 +643,7 @@ class PostController extends VanillaController {
         // Check permissions
         if ($Discussion && $Editing) {
             // Make sure that content can (still) be edited.
-            if (!$this->CommentModel::canEdit($this->Comment)) {
+            if (!CommentModel::canEdit($this->Comment, $editTimeout, $Discussion)) {
                 throw permissionException('Vanilla.Comments.Edit');
             }
 

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -438,8 +438,7 @@ if (!function_exists('getCommentOptions')) :
         $categoryID = val('CategoryID', $discussion);
 
         // Can the user edit the comment?
-        $commentModel = new CommentModel();
-        $canEdit = $commentModel->canEdit($comment);
+        $canEdit = CommentModel::canEdit($comment, $timeLeft, $discussion);
         if ($canEdit) {
             $options['EditComment'] = [
                 'Label' => t('Edit').$timeLeft,


### PR DESCRIPTION
Backporting #7062 

> `CommentModel::canEdit` (introduced in #6782) grabs the discussion it's associated with, every time it's called. For functions that use it, like `getCommentOptions`, this can mean the same discussion is queried dozens of times on the same page.
>
> This update alters `CommentModel::canEdit` to allow passing in a discussion row. If none is detected, the lookup will occur. Existing calls to `CommentModel::canEdit` have been updated to pass in a discussion row. A simple shortcut has also been added to always return `false` for guests.