### PR TITLE
Fix shim authenticators active property

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticateApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticateApiController.php
@@ -232,6 +232,9 @@ class AuthenticateApiController extends AbstractApiController {
 
         $result = array_map([$this->authenticatorApiController, 'normalizeOutput'], $authenticators);
 
+        // Reset keys otherwise the array could be interpreted as an associative array (read object) by $out->validate.
+        $result = array_values($result);
+
         return $out->validate($result);
     }
 

--- a/plugins/Facebook/FacebookAuthenticator.php
+++ b/plugins/Facebook/FacebookAuthenticator.php
@@ -12,19 +12,24 @@ use \Vanilla\Authenticator\ShimAuthenticator;
  */
 class FacebookAuthenticator extends ShimAuthenticator {
 
+    /** @var FacebookPlugin */
+    private $facebookPlugin;
+
     /**
      * FacebookAuthenticator constructor.
      *
-     * @param string $authenticatorID
+     * @param FacebookPlugin $facebookPlugin
      *
      * @throws \Garden\Schema\ValidationException
      */
-    public function __construct(string $authenticatorID) {
+    public function __construct(FacebookPlugin $facebookPlugin) {
+        $this->facebookPlugin = $facebookPlugin;
+
         parent::__construct('Facebook');
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
     protected static function getAuthenticatorTypeInfoImpl(): array {
         return [
@@ -37,7 +42,14 @@ class FacebookAuthenticator extends ShimAuthenticator {
     }
 
     /**
-     * @inheritDoc
+     * @inheritdoc
+     */
+    public function isActive(): bool {
+        return $this->facebookPlugin->socialSignIn();
+    }
+
+    /**
+     * @inheritdoc
      */
     public static function isUnique(): bool {
         return true;

--- a/plugins/GooglePlus/GooglePlusAuthenticator.php
+++ b/plugins/GooglePlus/GooglePlusAuthenticator.php
@@ -12,14 +12,19 @@ use \Vanilla\Authenticator\ShimAuthenticator;
  */
 class GooglePlusAuthenticator extends ShimAuthenticator {
 
+    /** @var GooglePlusPlugin */
+    private $googlePlusPlugin;
+
     /**
      * GoogleAuthenticator constructor.
      *
-     * @param string $authenticatorID
+     * @param GooglePlusPlugin $googlePlusPlugin
      *
      * @throws \Garden\Schema\ValidationException
      */
-    public function __construct(string $authenticatorID) {
+    public function __construct(GooglePlusPlugin $googlePlusPlugin) {
+        $this->googlePlusPlugin = $googlePlusPlugin;
+
         parent::__construct('GooglePlus');
     }
 
@@ -34,6 +39,13 @@ class GooglePlusAuthenticator extends ShimAuthenticator {
                 'foregroundColor' => '#000',
             ]
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isActive(): bool {
+        return $this->googlePlusPlugin->isConfigured();
     }
 
     /**

--- a/plugins/Twitter/TwitterAuthenticator.php
+++ b/plugins/Twitter/TwitterAuthenticator.php
@@ -12,15 +12,19 @@ use \Vanilla\Authenticator\ShimAuthenticator;
  */
 class TwitterAuthenticator extends ShimAuthenticator {
 
+    /** @var TwitterPlugin */
+    private $twitterPlugin;
 
     /**
      * TwitterAuthenticator constructor.
      *
-     * @param string $authenticatorID
+     * @param TwitterPlugin $twitterPlugin
      *
      * @throws \Garden\Schema\ValidationException
      */
-    public function __construct(string $authenticatorID) {
+    public function __construct(TwitterPlugin $twitterPlugin) {
+        $this->twitterPlugin = $twitterPlugin;
+
         parent::__construct('Twitter');
     }
 
@@ -35,6 +39,13 @@ class TwitterAuthenticator extends ShimAuthenticator {
                 'foregroundColor' => '#fff',
             ]
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isActive(): bool {
+        return $this->twitterPlugin->socialSignIn();
     }
 
     /**

--- a/plugins/oauth2/OAuth2Authenticator.php
+++ b/plugins/oauth2/OAuth2Authenticator.php
@@ -13,14 +13,19 @@ use \Vanilla\Authenticator\ShimAuthenticator;
  */
 class OAuth2Authenticator extends ShimAuthenticator {
 
+    /** @var OAuth2Plugin */
+    private $oAuth2Plugin;
+
     /**
      * OAuth2Authenticator constructor.
      *
-     * @param string $authenticatorID
+     * @param OAuth2Plugin $oAuth2Plugin
      *
      * @throws \Garden\Schema\ValidationException
      */
-    public function __construct(string $authenticatorID) {
+    public function __construct(OAuth2Plugin $oAuth2Plugin) {
+        $this->oAuth2Plugin = $oAuth2Plugin;
+
         parent::__construct('OAuth2');
     }
 
@@ -35,6 +40,13 @@ class OAuth2Authenticator extends ShimAuthenticator {
                 'foregroundColor' => null,
             ]
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isActive(): bool {
+        return $this->oAuth2Plugin->isConfigured();
     }
 
     /**


### PR DESCRIPTION
Use what most plugins use in `entryController_signIn_handler` to know if a plugin is allowed to be used to sign in.

With this update authenticators won't show up until they are properly configured!