### PR TITLE
Fix 403 error requiring Community.Manage when trying to post a new discussion draft

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -242,7 +242,7 @@ class PostController extends VanillaController {
                     $draftObject = $this->DraftModel->getID($draftID, DATASET_TYPE_ARRAY);
                     if (!$draftObject) {
                         throw notFoundException('Draft');
-                    } elseif ((val('InsertUserID', $draftObject) != $Session->UserID) && !checkPermission('Garden.Community.Manage')) {
+                    } elseif ((val('InsertUserID', $draftObject) != Gdn::session()->UserID) && !checkPermission('Garden.Community.Manage')) {
                         throw permissionException('Garden.Community.Manage');
                     }
                 }


### PR DESCRIPTION
Problem originates in https://github.com/vanilla/vanilla-patches/pull/224/files

Copy/pasting variable casing and lack of testing caused an error.