### PR TITLE
Add options argument to conversations for group invite emails

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -508,10 +508,11 @@ class ConversationModel extends ConversationsModel {
      *
      * @param array $formPostValues Values submitted via form.
      * @param array $settings
+     * @param array $options
      *   - ConversationOnly If set, no message will be created.
      * @return int Unique ID of conversation created or updated.
      */
-    public function save($formPostValues, $settings = []) {
+    public function save($formPostValues, $settings = [], $options = []) {
         $deprecated = $settings instanceof ConversationMessageModel;
         $createMessage =  $deprecated || empty($settings['ConversationOnly']);
 
@@ -663,7 +664,7 @@ class ConversationModel extends ConversationsModel {
 
                 $notifyUserIDs = array_column($unreadData, 'UserID');
 
-                $this->notifyUsers($conversation, $message, $notifyUserIDs);
+                $this->notifyUsers($conversation, $message, $notifyUserIDs, $options);
             }
 
         } else if ($createMessage) {

--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -513,6 +513,9 @@ class ConversationModel extends ConversationsModel {
      * @return int Unique ID of conversation created or updated.
      */
     public function save($formPostValues, $settings = [], $options = []) {
+        if (!is_array($options)) {
+            $options = [];
+        }
         $deprecated = $settings instanceof ConversationMessageModel;
         $createMessage =  $deprecated || empty($settings['ConversationOnly']);
 
@@ -664,7 +667,7 @@ class ConversationModel extends ConversationsModel {
 
                 $notifyUserIDs = array_column($unreadData, 'UserID');
 
-                $this->notifyUsers($conversation, $message, $notifyUserIDs, $options);
+                $this->notifyUsers($conversation, $message, $notifyUserIDs, $options + ['FirstMessage' => true]);
             }
 
         } else if ($createMessage) {

--- a/applications/conversations/models/class.conversationsmodel.php
+++ b/applications/conversations/models/class.conversationsmodel.php
@@ -158,13 +158,12 @@ abstract class ConversationsModel extends Gdn_Model {
             'Route' => "/messages/{$conversation['ConversationID']}#Message_{$message['MessageID']}"
         ];
 
-        if (isset($options['Invite'])) {
-            $isInvite = val('Invite', $options);
-            if ($isInvite) {
-                $activity['ActionText'] = t('Join');
-                $activity['Route'] = $options['Url'];
-            }
+        if (isset($options['Url']) && !empty($options['Url'])) {
+            $activity['Route'] = $options['Url'];
+        }
 
+        if (isset($options['ActionText']) && !empty($options['ActionText'])) {
+            $activity['ActionText'] = t($options['ActionText']);
         }
 
         $subject = val('subject', $conversation);

--- a/applications/conversations/models/class.conversationsmodel.php
+++ b/applications/conversations/models/class.conversationsmodel.php
@@ -139,8 +139,10 @@ abstract class ConversationsModel extends Gdn_Model {
      * @param array|object $conversation
      * @param array|object $message
      * @param array $notifyUserIDs
+     * @param array $options
      */
-    protected function notifyUsers($conversation, $message, $notifyUserIDs) {
+    protected function notifyUsers($conversation, $message, $notifyUserIDs, $options = [])
+    {
         $conversation = (array)$conversation;
         $message = (array)$message;
 
@@ -155,6 +157,15 @@ abstract class ConversationsModel extends Gdn_Model {
             'Format' => val('Format', $message, c('Garden.InputFormatter')),
             'Route' => "/messages/{$conversation['ConversationID']}#Message_{$message['MessageID']}"
         ];
+
+        if (isset($options['Invite'])) {
+            $isInvite = val('Invite', $options);
+            if ($isInvite) {
+                $activity['ActionText'] = t('Join');
+                $activity['Route'] = $options['Url'];
+            }
+
+        }
 
         $subject = val('subject', $conversation);
         if ($subject) {

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -978,11 +978,24 @@ class ActivityModel extends Gdn_Model {
      *
      *
      * @param $activity
-     * @param bool $noDelete
+     * @param array $options Options to modify the behavior of the emailing.
+     *
+     * - **NoDelete**: Don't delete an email-only activity once the email is sent.
+     * - **EmailSubject**: A custom subject for the email.
      * @return bool
      * @throws Exception
      */
-    public function email(&$activity, $noDelete = false) {
+    public function email(&$activity, $options = []) {
+        // The $options parameter used to be $noDelete bool, this is the backwards compat.
+        if (is_bool($options)) {
+            $options = ['NoDelete' => $options];
+        }
+
+        $options += [
+            'NoDelete' => false,
+            'EmailSubject' => '',
+        ];
+
         if (is_numeric($activity)) {
             $activityID = $activity;
             $activity = $this->getID($activityID);
@@ -1022,16 +1035,22 @@ class ActivityModel extends Gdn_Model {
             $activity['Headline'] = Gdn_Format::activityHeadline($activity, '', $user['UserID']);
         }
 
+        $subject = $options['EmailSubject'] ?: Gdn_Format::plainText($activity['Headline']);
+
         // Build the email to send.
         $email = new Gdn_Email();
-        $email->subject(sprintf(t('[%1$s] %2$s'), c('Garden.Title'), Gdn_Format::plainText($activity['Headline'])));
+        $email->subject(sprintf(
+            t('[%1$s] %2$s'),
+            c('Garden.Title'),
+            $subject
+        ));
         $email->to($user);
 
         $url = externalUrl(val('Route', $activity) == '' ? '/' : val('Route', $activity));
 
         $emailTemplate = $email->getEmailTemplate()
             ->setButton($url, val('ActionText', $activity, t('Check it out')))
-            ->setTitle(Gdn_Format::plainText(val('Headline', $activity)));
+            ->setTitle($subject);
 
         if ($message = $this->getEmailMessage($activity)) {
             $emailTemplate->setMessage($message, true);
@@ -1055,7 +1074,7 @@ class ActivityModel extends Gdn_Model {
             }
 
             // Delete the activity now that it has been emailed.
-            if (!$noDelete && !$activity['Notified']) {
+            if (!$options['NoDelete'] && !$activity['Notified']) {
                 if (val('ActivityID', $activity)) {
                     $this->delete($activity['ActivityID']);
                 } else {
@@ -1502,7 +1521,7 @@ class ActivityModel extends Gdn_Model {
 
         $delete = false;
         if ($activity['Emailed'] == self::SENT_PENDING) {
-            $this->email($activity);
+            $this->email($activity, $options);
             $delete = val('_Delete', $activity);
         }
 


### PR DESCRIPTION
Currently group invites send and email with a link directly to the message instead of the group homepage. 
 
These changes will allow the conversation to  detect if the message being sent is a group invite and modify link sent in the email to direct the user to the group home page so they can join the group.  An options array is added to save method in the conversationmodel and notifyusers method in the conversationsmodel.  

[Issue#1533](https://github.com/vanilla/internal/issues/1533)

