### PR TITLE
Fix broken sign-out URL in embed comment form

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -613,7 +613,7 @@ if (!function_exists('writeEmbedCommentForm')) :
                 $returnUrl = $controller->data('ForeignSource.vanilla_url', Gdn::request()->pathAndQuery());
 
                 if ($session->isValid()) {
-                    $authenticationUrl = Gdn::authenticator()->signOutUrl($returnUrl);
+                    $authenticationUrl = url(signOutUrl($returnUrl), true);
                     echo wrap(
                         sprintf(
                             t('Commenting as %1$s (%2$s)', 'Commenting as %1$s <span class="SignOutWrap">(%2$s)</span>'),


### PR DESCRIPTION
Current master breaks embedded comment forms when the user is logged in.

     The "Gdn_Auth" object does not have a "xgetAuthenticator" method. 

This PR makes the signout URL creation similar to the signin URL:

https://github.com/bleistivt/vanilla/blob/cee99aa4c0e4440da139f9a498c7481fe64667cf/applications/vanilla/views/discussion/helper_functions.php#L628