### PR TITLE
Backport: Fix filtering followed categories on deep branch

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -550,7 +550,8 @@ class CategoriesController extends VanillaController {
                 if (empty($ancestor)) {
                     throw new Gdn_UserException("Invalid category ID: {$Category}");
                 }
-                $flatTree = $this->CategoryModel->getTreeAsFlat($ancestor['CategoryID']);
+                $tree = $this->CategoryModel->getTree($ancestor['CategoryID']);
+                $flatTree = CategoryModel::flattenTree($tree);
                 $filterIDs = array_column($flatTree, 'CategoryID');
             } else {
                 $filterIDs = null;


### PR DESCRIPTION
This is a backport of #7080.

> If filtering followed categories by an ancestor (like in subcommunities), not all followed categories in that branch of the tree might be displayed if they're too far down. This is due to `CategoryModel::getTreeAsFlat`, which is currently used by the filtering, not going very deep into the tree.
>
> This update replaces the previous tree filter with a call to `CategoryModel::getTree`, followed by a call to `CategoryModel::flattenTree` (which is actually significantly different from just calling `CategoryModel::getTreeAsFlat`).
>
> No functionality should be affected beyond getting followed categories further into a category branch.