### PR TITLE
Don’t add exception stack traces to every exception just for tests

### DIFF
--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -251,7 +251,7 @@ class Dispatcher {
             $data = $raw instanceof \JsonSerializable ? $raw->jsonSerialize() : ['message' => $raw->getMessage()];
             $result = new Data($data, $errorCode);
             // Provide stack trace as meta information.
-            $result->setMeta('errorTrace', $raw->getTraceAsString());
+            $result->setMeta('exception', $raw);
 
             $this->mergeMeta($result, ['template' => 'error-page']);
         } elseif ($raw instanceof \JsonSerializable) {

--- a/tests/InternalClient.php
+++ b/tests/InternalClient.php
@@ -91,6 +91,13 @@ class InternalClient extends HttpClient {
         return $result;
     }
 
+    /**
+     * Handle a non 200 series response from the API.
+     *
+     * @param HttpResponse $response The response to process.
+     * @param array $options Options from the request invocation.
+     * @throws \Exception Throws an exception representing the error.
+     */
     public function handleErrorResponse(HttpResponse $response, $options = []) {
         if ($this->val('throw', $options, $this->throwExceptions)) {
             $body = $response->getBody();

--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -140,6 +140,11 @@ class InternalRequest extends HttpRequest implements RequestInterface {
         ob_end_clean();
         $_COOKIE = $cookieStash;
 
+        if ($ex = $data->getMeta('exception')) {
+            /* @var \Throwable $ex */
+            $data->setMeta('errorTrace', $ex->getTraceAsString());
+        }
+
         $response = new HttpResponse(
             $data->getStatus(),
             array_merge($data->getHeaders(), ['X-Data-Meta' => json_encode($data->getMetaArray())])


### PR DESCRIPTION
This change stores the exception object in the response rather than the stack trace. The test suite then expands the exception.