### PR TITLE
Allow addon bootstrap files to return closures

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -320,7 +320,10 @@ $dic->call(function (
         /* @var Addon $addon */
         if ($bootstrapPath = $addon->getSpecial('bootstrap')) {
             $bootstrapPath = $addon->path($bootstrapPath);
-            include_once $bootstrapPath;
+            $fn = include_once $bootstrapPath;
+            if (is_callable($fn)) {
+                $dic->call($fn);
+            }
         }
     }
 

--- a/library/Vanilla/Models/AddonModel.php
+++ b/library/Vanilla/Models/AddonModel.php
@@ -187,7 +187,10 @@ class AddonModel implements LoggerAwareInterface {
 
         // Load bootstrap file.
         if ($bootstrap = $addon->getSpecial('bootstrap')) {
-            include_once $addon->path($bootstrap, Addon::PATH_FULL);
+            $fn = include_once $addon->path($bootstrap, Addon::PATH_FULL);
+            if (is_callable($fn)) {
+                $this->container->call($fn);
+            }
         }
 
         $this->runSetup($addon);


### PR DESCRIPTION
If an addon bootstrap file returns a callable then it will be called through the container. This allows bootstrap files to declare dependencies in a cleaner way.