### PR TITLE
Mark a scrape test as @large

### DIFF
--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -666,6 +666,7 @@ class MediaTest extends AbstractAPIv2Test {
      * @param bool $enableFetch
      * @throws \Garden\Container\ContainerException
      * @throws \Garden\Container\NotFoundException
+     * @large
      */
     public function testScrape($url, $type, array $info, $enableFetch = false) {
         // Fetching is disabled by default in tests. Should it be enabled for this test?


### PR DESCRIPTION
This test calls out to the test server so should be marked in a way that it can be skipped like the APIv0 tests. This is necessary for other repos that pull in Vanilla and test against it.

Longer term the scraper should be subclassed/configured for testing and the URL should be replaced by a local fixture.