### PR TITLE
Remove unnecessary tests

### DIFF
--- a/tests/APIv2/AbstractResourceTest.php
+++ b/tests/APIv2/AbstractResourceTest.php
@@ -133,33 +133,6 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
     }
 
     /**
-     * Test updating a field with PUT.
-     *
-     * @param string $action
-     * @param mixed $val
-     * @param string|null $col
-     * @throws \Exception if the new record already has its field set to the target value.
-     * @dataProvider providePutFields
-     */
-    public function testPutField($action, $val, $col = null) {
-        if ($col === null) {
-            $col = $action;
-        }
-        $row = $this->testPost();
-
-        $before = $this->api()->get("{$this->baseUrl}/{$row[$this->pk]}");
-        if ($before[$col] === $val) {
-            $printVal = var_export($val, true);
-            throw new \Exception("Unable to test PUT for {$this->singular} field: {$col} is already {$printVal}");
-        }
-        $urlAction = urlencode($action);
-        $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/{$urlAction}", [$col => $val]);
-        $after = $this->api()->get("{$this->baseUrl}/{$row[$this->pk]}");
-
-        $this->assertEquals($val, $after[$col]);
-    }
-
-    /**
      * Test GET /resource/<id>/edit.
      *
      * @param array|null $record A record to use for comparison.
@@ -355,14 +328,5 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
             $r[$field] = [$field];
         }
         return $r;
-    }
-
-    /**
-     * Provide fields for PUT operations in a format that is compatible with a data provider.
-     *
-     * @return array
-     */
-    public function providePutFields() {
-        return [];
     }
 }

--- a/tests/APIv2/ApplicantsTest.php
+++ b/tests/APIv2/ApplicantsTest.php
@@ -105,7 +105,8 @@ class ApplicantsTest extends AbstractResourceTest {
 
     /**
      * {@inheritdoc}
-     * @requires function ApplicationsApiController::get_edit
+     * @requires function ApplicantsApiController::get_edit
+     * @group ignore
      */
     public function testGetEdit($record = null) {
         $this->fail(__METHOD__.' needs to be implemented.');
@@ -113,7 +114,8 @@ class ApplicantsTest extends AbstractResourceTest {
 
     /**
      * {@inheritdoc}
-     * @requires function ApplicationsApiController::get_edit
+     * @requires function ApplicantsApiController::get_edit
+     * @group ignore
      */
     public function testGetEditFields() {
         $this->fail(__METHOD__.' needs to be implemented.');
@@ -121,6 +123,7 @@ class ApplicantsTest extends AbstractResourceTest {
 
     /**
      * {@inheritdoc}
+     * @group ignore
      */
     public function testPatchFull() {
         $this->markTestSkipped();
@@ -129,6 +132,7 @@ class ApplicantsTest extends AbstractResourceTest {
     /**
      * {@inheritdoc}
      * @dataProvider providePatchFields
+     * @group ignore
      */
     public function testPatchSparse($field) {
         $this->markTestSkipped();

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -14,6 +14,7 @@ use DiscussionModel;
  * Test the /api/v2/discussions endpoints.
  */
 class DiscussionsTest extends AbstractResourceTest {
+    use TestPutFieldTrait;
 
     /** @var array */
     private static $categoryIDs = [];
@@ -148,7 +149,8 @@ class DiscussionsTest extends AbstractResourceTest {
     public function testPatchSparse($field) {
         // pinLocation doesn't do anything on its own, it requires pinned. It's not a good candidate for a single-field sparse PATCH.
         if ($field == 'pinLocation') {
-            $this->markTestSkipped('pinLocation cannot be used alone in PATCH.');
+            $this->assertTrue(true);
+            return;
         }
 
         parent::testPatchSparse($field);

--- a/tests/APIv2/InvitesTest.php
+++ b/tests/APIv2/InvitesTest.php
@@ -52,6 +52,7 @@ class InvitesTest extends AbstractResourceTest {
     /**
      * {@inheritdoc}
      * @requires function InvitationsApiController::get_edit
+     * @group ignore
      */
     public function testGetEdit($record = null) {
         $this->fail(__METHOD__.' needs to be implemented.');
@@ -60,6 +61,7 @@ class InvitesTest extends AbstractResourceTest {
     /**
      * {@inheritdoc}
      * @requires function InvitationsApiController::get_edit
+     * @group ignore
      */
     public function testGetEditFields() {
         $this->fail(__METHOD__.' needs to be implemented.');

--- a/tests/APIv2/TestPutFieldTrait.php
+++ b/tests/APIv2/TestPutFieldTrait.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\APIv2;
+
+use VanillaTests\InternalClient;
+
+trait TestPutFieldTrait {
+    /**
+     * Test updating a field with PUT.
+     *
+     * @param string $action
+     * @param mixed $val
+     * @param string|null $col
+     * @throws \Exception if the new record already has its field set to the target value.
+     * @dataProvider providePutFields
+     */
+    public function testPutField($action, $val, $col = null) {
+        if ($col === null) {
+            $col = $action;
+        }
+        $row = $this->testPost();
+
+        $before = $this->api()->get("{$this->baseUrl}/{$row[$this->pk]}");
+        if ($before[$col] === $val) {
+            $printVal = var_export($val, true);
+            throw new \Exception("Unable to test PUT for {$this->singular} field: {$col} is already {$printVal}");
+        }
+        $urlAction = urlencode($action);
+        $this->api()->put("{$this->baseUrl}/{$row[$this->pk]}/{$urlAction}", [$col => $val]);
+        $after = $this->api()->get("{$this->baseUrl}/{$row[$this->pk]}");
+
+        $this->assertEquals($val, $after[$col]);
+    }
+
+    abstract function providePutFields();
+    abstract function testPost();
+
+    /**
+     * Get the API client for internal requests.
+     *
+     * @return InternalClient Returns the API client.
+     */
+    abstract function api();
+
+    abstract function assertEquals($expected, $actual, $message = '');
+}

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -12,6 +12,7 @@ use VanillaTests\Fixtures\Uploader;
  * Test the /api/v2/users endpoints.
  */
 class UsersTest extends AbstractResourceTest {
+    use TestPutFieldTrait;
 
     /** @var int A value to ensure new records are unique. */
     protected static $recordCounter = 1;

--- a/tests/travis/main.sh
+++ b/tests/travis/main.sh
@@ -21,8 +21,8 @@ else
 fi
 
 if [ "$DO_LINT" = true ]; then
-    ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover
+    ./vendor/bin/phpunit -c phpunit.xml.dist --coverage-clover=coverage.clover --exclude-group=ignore
 else
     echo "Skipping code coverage..."
-    ./vendor/bin/phpunit -c phpunit.xml.dist
+    ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore
 fi


### PR DESCRIPTION
We are currently skipping or ignoring tests that will never be implemented or are not applicable. I want to put an end to this practice as it means that we don’t have a way of knowing which tests really do need to implement. Since there are a lot of boiler plate tests in base classes we have a lot of test methods that can’t be removed.

This PR accomplishes test removal in two ways:

1. Add the “ignore” group to exclude tests marked as such.
2. I noticed the “testPutField” method was only being used on a handful of resources so I moved that to a trait to be included on-demand.