### PR TITLE
Add PageInfo class

### DIFF
--- a/library/Vanilla/Embeds/LinkEmbed.php
+++ b/library/Vanilla/Embeds/LinkEmbed.php
@@ -7,16 +7,23 @@
 namespace Vanilla\Embeds;
 
 use Exception;
+use Vanilla\PageInfo;
 
 /**
  * Generic link embed.
  */
 class LinkEmbed extends Embed {
 
+    /** @var PageInfo */
+    private $pageInfo;
+
     /**
      * LinkEmbed constructor.
+     *
+     * @param PageInfo $pageInfo
      */
-    public function __construct() {
+    public function __construct(PageInfo $pageInfo) {
+        $this->pageInfo = $pageInfo;
         parent::__construct('link', 'link');
     }
 
@@ -33,11 +40,7 @@ class LinkEmbed extends Embed {
         ];
 
         if ($this->isNetworkEnabled()) {
-            $pageInfo = fetchPageInfo($url, 3, false, true);
-
-            if ($pageInfo['Exception']) {
-                throw new Exception($pageInfo['Exception']);
-            }
+            $pageInfo = $this->pageInfo->fetch($url);
 
             $result['name'] = $pageInfo['Title'] ?: null;
             $result['body'] = $pageInfo['Description'] ?: null;

--- a/library/Vanilla/Embeds/LinkEmbed.php
+++ b/library/Vanilla/Embeds/LinkEmbed.php
@@ -41,11 +41,12 @@ class LinkEmbed extends Embed {
 
         if ($this->isNetworkEnabled()) {
             $pageInfo = $this->pageInfo->fetch($url);
+            $images = $pageInfo['Images'] ?? [];
 
             $result['name'] = $pageInfo['Title'] ?: null;
             $result['body'] = $pageInfo['Description'] ?: null;
-            $result['photoUrl'] = !empty($pageInfo['Images']) ? reset($pageInfo['Images']) : null;
-            $result['media'] = $pageInfo['Media'];
+            $result['photoUrl'] = !empty($images) ? reset($images) : null;
+            $result['media'] = !empty($images) ? ['image' => $images] : [];
         }
 
         return $result;

--- a/library/Vanilla/PageInfo.php
+++ b/library/Vanilla/PageInfo.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0
+ */
+
+namespace Vanilla;
+
+use DOMDocument;
+use DOMElement;
+use DOMNodeList;
+use Exception;
+use Garden\Http\HttpRequest;
+use Garden\Http\HttpResponse;
+use InvalidArgumentException;
+
+class PageInfo {
+
+    /** @var HttpRequest */
+    private $httpRequest;
+
+    /** @var array Valid URL schemes. */
+    protected $validSchemes = ['http', 'https'];
+
+    /**
+     * PageInfo constructor.
+     *
+     * @param HttpRequest $httpRequest
+     */
+    public function __construct(HttpRequest $httpRequest) {
+        $this->httpRequest = $httpRequest;
+    }
+
+    /**
+     * Fetch page info from a URL.
+     *
+     * @param string $url Target URL.
+     * @return array Structured page information.
+     * @throws Exception
+     */
+    public function fetch(string $url): array {
+        $info = [
+            'Title' => '',
+            'Description' => '',
+            'Images' => []
+        ];
+
+        $response = $this->getUrl($url);
+
+        if ($response->isResponseClass('2xx') === false) {
+            throw new Exception('Unable to get URL contents.');
+        }
+
+        $document = new DOMDocument();
+        $rawBody = $response->getRawBody();
+        $loadResult = $document->loadHTML($rawBody);
+        if ($loadResult === false) {
+            throw new Exception('Failed to load document for parsing.');
+        }
+        $meta = $document->getElementsByTagName('meta');
+
+        $openGraph = $this->parseOpengraphMeta($meta);
+        if ($openGraph) {
+            $info = array_merge($info, $openGraph);
+        }
+
+        if (empty($info['Title'])) {
+            $titleTags = $document->getElementsByTagName('title');
+            $titleTag = $titleTags->item(0);
+            if ($titleTag) {
+                $info['Title'] = $titleTag->textContent;
+            }
+        }
+
+        if (empty($info['Description'])) {
+            $description = $this->parseDescription($document, $meta);
+            if ($description) {
+                $info['Description'] = $description;
+            }
+        }
+
+        $info['Url'] = $url;
+        $info['Title'] = htmlEntityDecode($info['Title']);
+        $info['Description'] = htmlEntityDecode($info['Description']);
+
+        return $info;
+    }
+
+    /**
+     * Send an HTTP GET request.
+     *
+     * @param string $url The URL where the request will be sent.
+     * @return HttpResponse
+     */
+    private function getUrl(string $url): HttpResponse {
+        $urlParts = parse_url($url);
+        if ($urlParts === false) {
+            throw new InvalidArgumentException('Invalid URL.');
+        } elseif (!in_array(val('scheme', $urlParts), $this->validSchemes)) {
+            throw new InvalidArgumentException('Unsupported URL scheme.');
+        }
+
+        $this->httpRequest->setMethod(HttpRequest::METHOD_GET);
+        $this->httpRequest->setUrl($url);
+        $result = $this->httpRequest->send();
+        return $result;
+    }
+
+    /**
+     * Parse the document to find a suitable description.
+     *
+     * @param DOMDocument $document
+     * @param DOMNodeList $meta
+     * @return string|null
+     */
+    private function parseDescription(DOMDocument $document, DomNodeList $meta) {
+        $result = null;
+
+        // Try to get it from the meta.
+        /** @var DOMElement $tag */
+        foreach ($meta as $tag) {
+            if ($tag->hasAttribute('name') === false) {
+                continue;
+            } elseif ($tag->getAttribute('name') === 'description') {
+                $result = $tag->getAttribute('content');
+            }
+        }
+
+        // Try looking in paragraph tags.
+        if ($result === null) {
+            $paragraphs = $document->getElementsByTagName('p');
+            foreach ($paragraphs as $tag) {
+                if (strlen($tag->textContent) > 150) {
+                    $result = $tag->textContent;
+                    break;
+                }
+            }
+            if ($result && strlen($result) > 400) {
+                $result = sliceParagraph($result, 400);
+            }
+        }
+
+        if ($result === null) {
+            $paragraphs = $paragraphs ?? $document->getElementsByTagName('p');
+            foreach ($paragraphs as $tag) {
+                if (trim($tag->textContent) !== '') {
+                    $result = $tag->textContent;
+                    break;
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Parse meta tags for OpenGraph info.
+     *
+     * @param DOMNodeList $meta A list of meta tags in the document.
+     * @return array
+     */
+    private function parseOpenGraphMeta(DOMNodeList $meta): array {
+        $result = [];
+        $ogTags = [];
+
+        /** @var DOMElement $tag */
+        foreach ($meta as $tag) {
+            if ($tag->hasAttribute('property') === false) {
+                continue;
+            } elseif (substr($tag->getAttribute('property'), 0, 3) !== 'og:') {
+                continue;
+            }
+
+            $property = $tag->getAttribute('property');
+            $content = $tag->getAttribute('content');
+            $ogTags[] = [
+                'property' => $property,
+                'content' => $content
+            ];
+
+            if ($property === 'og:title') {
+                $result['Title'] = $content;
+            } elseif ($property === 'og:description') {
+                $result['Description'] = $content;
+            }
+        }
+
+        // Harvest those OpenGraph images.
+        foreach ($ogTags as $node) {
+            $property = $node['property'];
+            $content = $node['content'];
+            if ($property == 'og:image') {
+                // Only allow valid URLs.
+                if (filter_var($content, FILTER_VALIDATE_URL) === false) {
+                    continue;
+                }
+                if (!array_key_exists('Images', $result)) {
+                    $result['Images'] = [];
+                }
+                $result['Images'][] = $content;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
+++ b/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
@@ -7,12 +7,14 @@
 namespace VanillaTests\Library\Vanilla\Embeds;
 
 use Exception;
+use Garden\Http\HttpRequest;
 use PHPUnit\Framework\TestCase;
 use Vanilla\Embeds\EmbedManager;
 use Vanilla\Embeds\LinkEmbed;
 use Vanilla\Embeds\ImageEmbed;
 use Vanilla\Embeds\YouTubeEmbed;
 use Vanilla\Embeds\VimeoEmbed;
+use VanillaTests\Fixtures\PageInfo;
 use VanillaTests\Fixtures\NullCache;
 
 class EmbedManagerTest extends TestCase {
@@ -24,7 +26,7 @@ class EmbedManagerTest extends TestCase {
      */
     private function createEmbedManager(): EmbedManager {
         $embedManager = new EmbedManager(new NullCache(), new ImageEmbed);
-        $embedManager->setDefaultEmbed(new LinkEmbed())
+        $embedManager->setDefaultEmbed(new LinkEmbed(new PageInfo(new HttpRequest())))
             ->addEmbed(new YouTubeEmbed())
             ->addEmbed(new VimeoEmbed())
             ->addEmbed(new ImageEmbed(), EmbedManager::PRIORITY_LOW)

--- a/tests/Library/Vanilla/PageInfoTest.php
+++ b/tests/Library/Vanilla/PageInfoTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Vanilla;
+
+use Exception;
+use Garden\Http\HttpRequest;
+use PHPUnit\Framework\TestCase;
+use VanillaTests\Fixtures\PageInfo;
+
+class PageInfoTest extends TestCase {
+
+    /** @var string Directory of test HTML files. */
+    const HTML_DIR = PATH_ROOT.'/tests/fixtures/html';
+
+    /**
+     * Provide data for testing the PageInfo::fetch method.
+     *
+     * @return array
+     */
+    public function provideFetchData(): array {
+        $data = [
+            [
+                'og.htm',
+                [
+                    'Title' => 'Online Community Software and Customer Forum Software by Vanilla Forums',
+                    'Description' => 'Engage your customers with a vibrant and modern online customer community forum. A customer community helps to increases loyalty, reduce support costs and deliver feedback.',
+                    'Images' => ['https://vanillaforums.com/images/metaIcons/vanillaForums.png']
+                ]
+            ],
+            [
+                'plain.htm',
+                [
+                    'Title' => 'I am a standard title.',
+                    'Description' => 'I am a standard description.',
+                    'Images' => []
+                ]
+            ],
+            [
+                'no-description.htm',
+                [
+                    'Title' => 'I am a standard title.',
+                    'Description' => 'I am a description. Instead of being part of the document head, I am inside the page contents. This is not ideal and is only a fallback for pages without proper meta descriptors.',
+                    'Images' => []
+                ]
+            ]
+        ];
+        return $data;
+    }
+
+    /**
+     * Test the PageInfo::fetch method.
+     *
+     * @param string $file
+     * @param array $expected
+     * @throws Exception if there was an error loading the file.
+     * @dataProvider provideFetchData
+     */
+    public function testFetch(string $file, array $expected) {
+        $pageInfo = new PageInfo(new HttpRequest());
+        $url = 'file://'.self::HTML_DIR."/{$file}";
+        $expected['Url'] = $url;
+        $result = $pageInfo->fetch($url);
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/fixtures/html/no-description.htm
+++ b/tests/fixtures/html/no-description.htm
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>I am a standard title.</title>
+    </head>
+    <body>
+        <p>I am a description. Instead of being part of the document head, I am inside the page contents. This is not ideal and is only a fallback for pages without proper meta descriptors.</p>
+        <img src="file://invalid/file/path" />
+    </body>
+</html>

--- a/tests/fixtures/html/og.htm
+++ b/tests/fixtures/html/og.htm
@@ -1,13 +1,12 @@
 <html prefix="og: http://ogp.me/ns#">
-<head>
-    <title>Online Community Software and Customer Forum Software by Vanilla Forums</title>
-    <meta property="og:title" content="Online Community Software and Customer Forum Software by Vanilla Forums">
-    <meta property="og:type" content="Website">
-    <meta property="og:url" content="https://vanillaforums.com/en/">
-    <meta property="og:image" content="https://vanillaforums.com/images/metaIcons/vanillaForums.png">
-    <meta property="og:description" content="Engage your customers with a vibrant and modern online customer community forum. A customer community helps to increases loyalty, reduce support costs and deliver feedback.">
-    <meta property="og:site_name" content="Vanilla Forums">
-</head>
-<body>
-</body>
+    <head>
+        <title>Online Community Software and Customer Forum Software by Vanilla Forums</title>
+        <meta property="og:title" content="Online Community Software and Customer Forum Software by Vanilla Forums">
+        <meta property="og:type" content="Website">
+        <meta property="og:url" content="https://vanillaforums.com/en/">
+        <meta property="og:image" content="https://vanillaforums.com/images/metaIcons/vanillaForums.png">
+        <meta property="og:description" content="Engage your customers with a vibrant and modern online customer community forum. A customer community helps to increases loyalty, reduce support costs and deliver feedback.">
+        <meta property="og:site_name" content="Vanilla Forums">
+    </head>
+    <body></body>
 </html>

--- a/tests/fixtures/html/plain.htm
+++ b/tests/fixtures/html/plain.htm
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>I am a standard title.</title>
+        <meta name="description" content="I am a standard description." />
+    </head>
+    <body>
+        <img src="file://invalid/file/path" />
+    </body>
+</html>

--- a/tests/fixtures/src/PageInfo.php
+++ b/tests/fixtures/src/PageInfo.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace VanillaTests\Fixtures;
+
+/**
+ * A PageInfo class, limited to local files.
+ */
+class PageInfo extends \Vanilla\PageInfo {
+    /** @inheritDoc */
+    protected $validSchemes = ['file'];
+}


### PR DESCRIPTION
This update adds the `PageInfo` class, which more or less is intended to replace the `fetchPageInfo` function.

1. The `HttpRequest` class from Garden HTTP is used for the requests.
1. `pQuery` has been dropped in favor of DOMDocument.
1. The class only looks for images in OpenGraph tags. No more scouring a page for every random image.
1. The default embed class now uses `PageInfo`, which means the media endpoint is also using it.
1. Tests have been added to verify document processing yields desired results.

Closes #7004
Closes #7030