### PR TITLE
Add translation support for "All" and "Following" in category following filter menus

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -811,7 +811,7 @@ if (!function_exists('filtersDropDown')) {
      *     ** 'param': URL parameter associated with the filter.
      *     ** 'value': A value for the URL parameter.
      * @param string $extraClasses any extra classes you add to the drop down
-     * @param string $default The default label for when no filter is active.
+     * @param string|null $default The default label for when no filter is active. If `null`, the default label is "All".
      * @param string|null $defaultURL URL override to return to the default, unfiltered state.
      * @param string $label Text for the label to attach to the cont
      * @return string

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -423,7 +423,7 @@ if (!function_exists('categoryFilters')) {
         $baseUrl = 'categories';
         $filters = [
             [
-                'name' => 'Following',
+                'name' => t('Following'),
                 'param' => 'followed',
                 'extra' => ['save' => 1]
             ]
@@ -724,7 +724,7 @@ if (!function_exists('discussionFilters')) {
         $baseUrl = 'discussions';
         $filters = [
             [
-                'name' => 'Following',
+                'name' => t('Following'),
                 'param' => 'followed',
                 'extra' => ['save' => 1]
             ]
@@ -858,7 +858,7 @@ if (!function_exists('filtersDropDown')) {
             // Add the default link to the top of the list.
             array_unshift($links, [
                 'active' => $active === null,
-                'name' => $default,
+                'name' => t($default),
                 'url' => $defaultUrl ?: $baseUrl
             ]);
 
@@ -1132,7 +1132,7 @@ if (!function_exists('linkDropDown')) {
         }
         $selectedLink = val($selectedKey, $links);
         $extraClasses = trim($extraClasses);
-        $linkName = t(val('name', $selectedLink));
+        $linkName = val('name', $selectedLink);
 
         $output .= <<<EOT
         <span class="ToggleFlyout selectBox {$extraClasses}">
@@ -1158,14 +1158,14 @@ EOT;
                         $output .= '      <polygon fill="currentColor" points="1.938,8.7 0.538,10.1 5.938,15.5 17.337,3.9 15.938,2.5 5.938,12.8"></polygon>';
                         $output .= '    </svg>';
                         $output .= '    <span class="selectBox-selectedText">';
-                        $output .=        t(val('name', $link));
+                        $output .=        val('name', $link);
                         $output .= '    </span>';
                         $output .= '  </a>';
                         $output .= '</li>';
                     } else {
                         $output .= '<li class="selectBox-item" role="presentation">';
                         $output .= '  <a href="'.val('url', $link).'" role="menuitem" class="dropdown-menu-link selectBox-link" tabindex="0" href="#">';
-                        $output .=      t(val('name', $link));
+                        $output .=      val('name', $link);
                         $output .= '  </a>';
                         $output .= '</li>';
                     }

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -816,7 +816,10 @@ if (!function_exists('filtersDropDown')) {
      * @param string $label Text for the label to attach to the cont
      * @return string
      */
-    function filtersDropDown($baseUrl, array $filters = [], $extraClasses = '', $default = 'All', $defaultUrl = null, $label = 'View') {
+    function filtersDropDown($baseUrl, array $filters = [], $extraClasses = '', $default = null, $defaultUrl = null, $label = 'View') {
+        if ($default === null) {
+            $default = t('All');
+        }
         $output = '';
 
         if (c('Vanilla.EnableCategoryFollowing')) {
@@ -858,7 +861,7 @@ if (!function_exists('filtersDropDown')) {
             // Add the default link to the top of the list.
             array_unshift($links, [
                 'active' => $active === null,
-                'name' => t($default),
+                'name' => $default,
                 'url' => $defaultUrl ?: $baseUrl
             ]);
 

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1132,7 +1132,7 @@ if (!function_exists('linkDropDown')) {
         }
         $selectedLink = val($selectedKey, $links);
         $extraClasses = trim($extraClasses);
-        $linkName = val('name', $selectedLink);
+        $linkName = t(val('name', $selectedLink));
 
         $output .= <<<EOT
         <span class="ToggleFlyout selectBox {$extraClasses}">
@@ -1158,14 +1158,14 @@ EOT;
                         $output .= '      <polygon fill="currentColor" points="1.938,8.7 0.538,10.1 5.938,15.5 17.337,3.9 15.938,2.5 5.938,12.8"></polygon>';
                         $output .= '    </svg>';
                         $output .= '    <span class="selectBox-selectedText">';
-                        $output .=        val('name', $link);
+                        $output .=        t(val('name', $link));
                         $output .= '    </span>';
                         $output .= '  </a>';
                         $output .= '</li>';
                     } else {
                         $output .= '<li class="selectBox-item" role="presentation">';
                         $output .= '  <a href="'.val('url', $link).'" role="menuitem" class="dropdown-menu-link selectBox-link" tabindex="0" href="#">';
-                        $output .=      val('name', $link);
+                        $output .=      t(val('name', $link));
                         $output .= '  </a>';
                         $output .= '</li>';
                     }


### PR DESCRIPTION
Category-Following drop down filter and Label of "All" & "Following" was not translated, I added the key for 'Following' in [#62](https://github.com/vanilla/locales/pull/62/files), 'All' key is already added.
![cat_follow](https://user-images.githubusercontent.com/31856281/39311235-63f1167c-493a-11e8-904b-505a08186ef4.png)



