### PR TITLE
Fix LogModel::deleteIDs() when $logIDs is a string containing multiple IDs

### DIFF
--- a/applications/dashboard/models/class.logmodel.php
+++ b/applications/dashboard/models/class.logmodel.php
@@ -162,6 +162,10 @@ class LogModel extends Gdn_Pluggable {
      * @param int[]|string $logIDs
      */
     public function deleteIDs($logIDs) {
+        if (is_string($logIDs)) {
+            $logIDs = explode(',', $logIDs);
+        }
+
         // Get the log entries.
         $logs = $this->getIDs($logIDs);
         $models = [];


### PR DESCRIPTION
Properly fix https://github.com/vanilla/vanilla/issues/6976

To test
- Set members permission for Approval -> Required
- Try to post 2 discussion as a member
- Go in the moderation logs with a moderator
- Delete the 2 posts