### PR TITLE
Don’t show canonical links in the home controller

### DIFF
--- a/applications/dashboard/controllers/class.homecontroller.php
+++ b/applications/dashboard/controllers/class.homecontroller.php
@@ -28,6 +28,7 @@ class HomeController extends Gdn_Controller {
         $this->addJsFile('global.js');
         $this->addCssFile('admin.css');
         $this->MasterView = 'empty';
+        $this->canonicalUrl('');
         parent::initialize();
     }
 

--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -423,15 +423,13 @@ if (!class_exists('HeadModule', false)) {
             if (method_exists($this->_Sender, 'CanonicalUrl') && !c('Garden.Modules.NoCanonicalUrl', false)) {
                 $canonicalUrl = $this->_Sender->canonicalUrl();
 
-                if (!isUrl($canonicalUrl)) {
+                if (!empty($canonicalUrl) && !isUrl($canonicalUrl)) {
                     $canonicalUrl = Gdn::router()->reverseRoute($canonicalUrl);
+                    $this->_Sender->canonicalUrl($canonicalUrl);
                 }
-
-                $this->_Sender->canonicalUrl($canonicalUrl);
-//            $CurrentUrl = url('', true);
-//            if ($CurrentUrl != $CanonicalUrl) {
-                $this->addTag('link', ['rel' => 'canonical', 'href' => $canonicalUrl]);
-//            }
+                if ($canonicalUrl) {
+                    $this->addTag('link', ['rel' => 'canonical', 'href' => $canonicalUrl]);
+                }
             }
 
             // Include facebook open-graph meta information.

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -446,7 +446,7 @@ class Gdn_Controller extends Gdn_Pluggable {
      */
     public function canonicalUrl($value = null) {
         if ($value === null) {
-            if ($this->_CanonicalUrl) {
+            if ($this->_CanonicalUrl || $this->_CanonicalUrl === '') {
                 return $this->_CanonicalUrl;
             } else {
                 $parts = [];


### PR DESCRIPTION
- Allow the canonical URL to be blank by specifying an empty string.
- Don’t show any canonical URLs on the home controller.

Closes #7089.