### PR TITLE
Check discussion view permission on a category before rendering its link

### DIFF
--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -211,7 +211,7 @@ if (!function_exists('WriteDiscussion')) :
                     }
 
                     if ($sender->data('_ShowCategoryLink', true) && $category && c('Vanilla.Categories.Use') &&
-                        CategoryModel::checkPermission(val('CategoryID', $discussion), 'Vanilla.Discussions.View')) {
+                        CategoryModel::checkPermission($category, 'Vanilla.Discussions.View')) {
 
                         echo wrap(
                             anchor(htmlspecialchars($discussion->Category),

--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -210,7 +210,9 @@ if (!function_exists('WriteDiscussion')) :
                         echo '</span> ';
                     }
 
-                    if ($sender->data('_ShowCategoryLink', true) && c('Vanilla.Categories.Use') && $category) {
+                    if ($sender->data('_ShowCategoryLink', true) && $category && c('Vanilla.Categories.Use') &&
+                        CategoryModel::checkPermission(val('CategoryID', $discussion), 'Vanilla.Discussions.View')) {
+
                         echo wrap(
                             anchor(htmlspecialchars($discussion->Category),
                             categoryUrl($discussion->CategoryUrlCode)),

--- a/applications/vanilla/views/discussions/table_functions.php
+++ b/applications/vanilla/views/discussions/table_functions.php
@@ -31,6 +31,10 @@ endif;
 if (!function_exists('writeDiscussionRow')) :
     /**
      * Writes a discussion in table row format.
+     *
+     * @param object $discussion The discussion to write.
+     * @param DiscussionsController $sender The controller rendering the view.
+     * @param Gdn_Session $sender The sender
      */
     function writeDiscussionRow($discussion, $sender, $session) {
         if (!property_exists($sender, 'CanEditDiscussions')) {
@@ -105,7 +109,7 @@ if (!function_exists('writeDiscussionRow')) :
 
                     writeMiniPager($discussion);
                     echo newComments($discussion);
-                    if ($sender->data('_ShowCategoryLink', true)) {
+                    if ($sender->data('_ShowCategoryLink', true) && CategoryModel::checkPermission(val('CategoryID', $discussion), 'Vanilla.Discussions.View')) {
                         echo categoryLink($discussion, ' '.t('in').' ');
                     }
                     // Other stuff that was in the standard view that you may want to display:


### PR DESCRIPTION
This issue doesn’t really surface at the moment, but will once [this issue](https://github.com/vanilla/internal/issues/1565) is fixed.

We should only be showing links to categories the user has the ability to view and this extra permission check does just that. Since this is mostly a duplicate check I’m a little concerned about the overhead, but since the `optionsList()` call a few lines above makes many of the exact same call I don’t think it will cause a performance impact that we haven’t already seen.