### PR TITLE
Fix ShimAuthenticators URL

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticatorsApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticatorsApiController.php
@@ -209,7 +209,7 @@ class AuthenticatorsApiController extends AbstractApiController  {
         $record['resourceUrl'] = strtolower(url('/api/v2/authenticators/'.$authenticator::getType().'/'.$authenticator->getID()));
 
         // Convert URLs from relative to absolute.
-        foreach (['signInUrl', 'registerUrl', 'signOutUrl', 'ui.photoUrl', 'resourceUrl'] as $field) {
+        foreach (['signInUrl', 'registerUrl', 'signOutUrl', 'ui.url', 'ui.photoUrl', 'resourceUrl'] as $field) {
             $value = valr($field, $record, null);
             if ($value !== null) {
                 setvalr($field, $record, url($value, true));

--- a/applications/dashboard/controllers/api/AuthenticatorsApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticatorsApiController.php
@@ -211,7 +211,7 @@ class AuthenticatorsApiController extends AbstractApiController  {
         // Convert URLs from relative to absolute.
         foreach (['signInUrl', 'registerUrl', 'signOutUrl', 'ui.url', 'ui.photoUrl', 'resourceUrl'] as $field) {
             $value = valr($field, $record, null);
-            if ($value !== null) {
+            if ($value !== null && !preg_match('#^(https?:)?//#i')) {
                 setvalr($field, $record, url($value, true));
             }
         }

--- a/applications/dashboard/controllers/api/AuthenticatorsApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticatorsApiController.php
@@ -209,16 +209,23 @@ class AuthenticatorsApiController extends AbstractApiController  {
         $record['resourceUrl'] = strtolower(url('/api/v2/authenticators/'.$authenticator::getType().'/'.$authenticator->getID()));
 
         // Convert URLs from relative to absolute.
-        foreach (['signInUrl', 'registerUrl', 'signOutUrl', 'ui.url', 'ui.photoUrl', 'resourceUrl'] as $field) {
+        foreach (['signInUrl', 'registerUrl', 'signOutUrl', 'ui.url', 'resourceUrl'] as $field) {
             $value = valr($field, $record, null);
-            if ($value !== null && !preg_match('#^(https?:)?//#i')) {
+            if ($value !== null && !preg_match('#^(https?:)?//#i', $value)) {
                 setvalr($field, $record, url($value, true));
+            }
+        }
+        // Convert asset URLs from relative to absolute.
+        foreach (['ui.photoUrl'] as $field) {
+            $value = valr($field, $record, null);
+            if ($value !== null && !preg_match('#^(https?:)?//#i', $value)) {
+                setvalr($field, $record, asset($value, true));
             }
         }
 
         // Pad some fields with default values.
         $fieldDefaults = [
-            'ui.photoUrl' => url('/applications/dashboard/design/images/authenticators/sign_in.svg', true),
+            'ui.photoUrl' => asset('/applications/dashboard/design/images/authenticators/sign_in.svg', true),
             'ui.backgroundColor' => '#0291db',
             'ui.foregroundColor' => '#fff',
         ];

--- a/library/Vanilla/Authenticator/Authenticator.php
+++ b/library/Vanilla/Authenticator/Authenticator.php
@@ -166,7 +166,7 @@ abstract class Authenticator {
         return Schema::parse([
             'url:s' => 'Local relative URL from which you can initiate the SignIn process with this authenticator',
             'buttonName:s' => 'The display text to put in the button. Ex: "Sign in with Facebook"',
-            'photoUrl:s|n' => 'The relative icon URL for the button.',
+            'photoUrl:s|n' => 'The icon URL for the button.',
             'backgroundColor:s|n' => 'A css color code for the background. (Hex color, rgb or rgba)',
             'foregroundColor:s|n' => 'A css color code for the foreground. (Hex color, rgb or rgba)',
         ]);

--- a/library/Vanilla/Authenticator/ShimAuthenticator.php
+++ b/library/Vanilla/Authenticator/ShimAuthenticator.php
@@ -54,7 +54,7 @@ abstract class ShimAuthenticator extends Authenticator {
         return [
             'ui' => [
                 'url' => '/entry/'.strtolower(self::getType()),
-                'buttonName' => 'Sign in with '.self::getType(),
+                'buttonName' => sprintft('Sign In with %s', self::getType()),
             ],
         ];
     }

--- a/library/Vanilla/Authenticator/ShimAuthenticator.php
+++ b/library/Vanilla/Authenticator/ShimAuthenticator.php
@@ -53,7 +53,7 @@ abstract class ShimAuthenticator extends Authenticator {
     protected function getAuthenticatorInfoImpl(): array {
         return [
             'ui' => [
-                'url' => '/entry/connect/'.strtolower(self::getType()),
+                'url' => '/entry/'.strtolower(self::getType()),
                 'buttonName' => 'Sign in with '.self::getType(),
             ],
         ];

--- a/plugins/GooglePlus/GooglePlusAuthenticator.php
+++ b/plugins/GooglePlus/GooglePlusAuthenticator.php
@@ -61,7 +61,7 @@ class GooglePlusAuthenticator extends ShimAuthenticator {
     protected function getAuthenticatorInfoImpl(): array {
         return [
             'ui' => [
-                'url' => '/entry/connect/googlePlusAuthRedirect',
+                'url' => '/entry/googlePlusAuthRedirect',
                 'buttonName' => 'Sign in with Google',
             ],
         ];

--- a/plugins/GooglePlus/GooglePlusAuthenticator.php
+++ b/plugins/GooglePlus/GooglePlusAuthenticator.php
@@ -62,7 +62,7 @@ class GooglePlusAuthenticator extends ShimAuthenticator {
         return [
             'ui' => [
                 'url' => '/entry/googlePlusAuthRedirect',
-                'buttonName' => 'Sign in with Google',
+                'buttonName' => sprintft('Sign In with %s', 'Google'),
             ],
         ];
     }

--- a/plugins/Twitter/TwitterAuthenticator.php
+++ b/plugins/Twitter/TwitterAuthenticator.php
@@ -62,7 +62,7 @@ class TwitterAuthenticator extends ShimAuthenticator {
         return [
             'ui' => [
                 'url' => '/entry/twauthorize',
-                'buttonName' => 'Sign in with Twitter',
+                'buttonName' => sprintft('Sign In with %s', self::getType()),
             ],
         ];
     }

--- a/plugins/Twitter/TwitterAuthenticator.php
+++ b/plugins/Twitter/TwitterAuthenticator.php
@@ -54,4 +54,16 @@ class TwitterAuthenticator extends ShimAuthenticator {
     public static function isUnique(): bool {
         return true;
     }
+
+    /**
+     * {@link Authenticator::getAuthenticatorInfoImpl()}
+     */
+    protected function getAuthenticatorInfoImpl(): array {
+        return [
+            'ui' => [
+                'url' => '/entry/twauthorize',
+                'buttonName' => 'Sign in with Twitter',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/7115

Should be /entry/{PluginName} but for twitter and googlePlus which have an exception.

Authentication will work with all plugins now.