### PR TITLE
Rename WebScraper to PageScraper

### DIFF
--- a/library/Vanilla/Embeds/LinkEmbed.php
+++ b/library/Vanilla/Embeds/LinkEmbed.php
@@ -7,23 +7,23 @@
 namespace Vanilla\Embeds;
 
 use Exception;
-use Vanilla\WebScraper;
+use Vanilla\PageScraper;
 
 /**
  * Generic link embed.
  */
 class LinkEmbed extends Embed {
 
-    /** @var WebScraper */
-    private $webScraper;
+    /** @var PageScraper */
+    private $pageScraper;
 
     /**
      * LinkEmbed constructor.
      *
-     * @param WebScraper $webScraper
+     * @param PageScraper $pageScraper
      */
-    public function __construct(WebScraper $webScraper) {
-        $this->webScraper = $webScraper;
+    public function __construct(PageScraper $pageScraper) {
+        $this->pageScraper = $pageScraper;
         parent::__construct('link', 'link');
     }
 
@@ -40,7 +40,7 @@ class LinkEmbed extends Embed {
         ];
 
         if ($this->isNetworkEnabled()) {
-            $pageInfo = $this->webScraper->pageInfo($url);
+            $pageInfo = $this->pageScraper->pageInfo($url);
             $images = $pageInfo['Images'] ?? [];
 
             $result['name'] = $pageInfo['Title'] ?: null;

--- a/library/Vanilla/PageScraper.php
+++ b/library/Vanilla/PageScraper.php
@@ -14,7 +14,7 @@ use Garden\Http\HttpRequest;
 use Garden\Http\HttpResponse;
 use InvalidArgumentException;
 
-class WebScraper {
+class PageScraper {
 
     /** @var HttpRequest */
     private $httpRequest;

--- a/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
+++ b/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
@@ -14,7 +14,7 @@ use Vanilla\Embeds\LinkEmbed;
 use Vanilla\Embeds\ImageEmbed;
 use Vanilla\Embeds\YouTubeEmbed;
 use Vanilla\Embeds\VimeoEmbed;
-use VanillaTests\Fixtures\WebScraper;
+use VanillaTests\Fixtures\PageScraper;
 use VanillaTests\Fixtures\NullCache;
 
 class EmbedManagerTest extends TestCase {
@@ -26,7 +26,7 @@ class EmbedManagerTest extends TestCase {
      */
     private function createEmbedManager(): EmbedManager {
         $embedManager = new EmbedManager(new NullCache(), new ImageEmbed);
-        $embedManager->setDefaultEmbed(new LinkEmbed(new WebScraper(new HttpRequest())))
+        $embedManager->setDefaultEmbed(new LinkEmbed(new PageScraper(new HttpRequest())))
             ->addEmbed(new YouTubeEmbed())
             ->addEmbed(new VimeoEmbed())
             ->addEmbed(new ImageEmbed(), EmbedManager::PRIORITY_LOW)

--- a/tests/Library/Vanilla/PageScraperTest.php
+++ b/tests/Library/Vanilla/PageScraperTest.php
@@ -9,19 +9,19 @@ namespace VanillaTests\Library\Vanilla;
 use Exception;
 use Garden\Http\HttpRequest;
 use PHPUnit\Framework\TestCase;
-use VanillaTests\Fixtures\WebScraper;
+use VanillaTests\Fixtures\PageScraper;
 
-class PageInfoTest extends TestCase {
+class PageScraperTest extends TestCase {
 
     /** @var string Directory of test HTML files. */
     const HTML_DIR = PATH_ROOT.'/tests/fixtures/html';
 
     /**
-     * Provide data for testing the PageInfo::fetch method.
+     * Provide data for testing the PageScraper::pageInfo method.
      *
      * @return array
      */
-    public function provideFetchData(): array {
+    public function provideInfoData(): array {
         $data = [
             [
                 'og.htm',
@@ -52,18 +52,18 @@ class PageInfoTest extends TestCase {
     }
 
     /**
-     * Test the PageInfo::fetch method.
+     * Test the PageInfo::pageInfo method.
      *
      * @param string $file
      * @param array $expected
      * @throws Exception if there was an error loading the file.
-     * @dataProvider provideFetchData
+     * @dataProvider provideInfoData
      */
     public function testFetch(string $file, array $expected) {
-        $pageInfo = new WebScraper(new HttpRequest());
+        $pageScraper = new PageScraper(new HttpRequest());
         $url = 'file://'.self::HTML_DIR."/{$file}";
         $expected['Url'] = $url;
-        $result = $pageInfo->pageInfo($url);
+        $result = $pageScraper->pageInfo($url);
         $this->assertEquals($expected, $result);
     }
 }

--- a/tests/fixtures/src/PageScraper.php
+++ b/tests/fixtures/src/PageScraper.php
@@ -7,9 +7,9 @@
 namespace VanillaTests\Fixtures;
 
 /**
- * A PageInfo class, limited to local files.
+ * A PageScraper class, limited to local files.
  */
-class WebScraper extends \Vanilla\WebScraper {
+class PageScraper extends \Vanilla\PageScraper {
     /** @inheritDoc */
     protected $validSchemes = ['file'];
 }


### PR DESCRIPTION
This update renames `WebScraper` to `PageScraper`. The class is meant to scrape information from pages. It isn't the general-purpose scraper of all-things-web the original class was intended to be.