### PR TITLE
Make Gdn_Pluggable calls more robust

### DIFF
--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -703,6 +703,8 @@ class UpdateModel extends Gdn_Model {
 
                     try {
                         call_user_func([$plugin, 'structure']);
+                    } catch (BadMethodCallException $ex) {
+                        // The structure method could not be called, probably because it wasn't public.
                     } catch (\Exception $ex) {
                         if (debug()) {
                             throw $ex;

--- a/library/core/class.pluggable.php
+++ b/library/core/class.pluggable.php
@@ -183,9 +183,11 @@ abstract class Gdn_Pluggable {
 
         // Make sure that $ActualMethodName exists before continuing:
         if (!method_exists($this, $actualMethodName)) {
+            $className = get_called_class();
+
             // Make sure that a plugin is not handling the call
-            if (!Gdn::pluginManager()->hasNewMethod($this->ClassName, $referenceMethodName)) {
-                trigger_error(errorMessage('The "'.$this->ClassName.'" object does not have a "'.$actualMethodName.'" method.', $this->ClassName, $actualMethodName), E_USER_ERROR);
+            if (!Gdn::pluginManager()->hasNewMethod($className, $referenceMethodName)) {
+                trigger_error(errorMessage('The "'.$className.'" object does not have a "'.$actualMethodName.'" method.', $this->ClassName, $actualMethodName), E_USER_ERROR);
             }
         }
 


### PR DESCRIPTION
This issue was discovered when a plugin declared its `structure()` method private. The `method_exists()` function returns true if a method exists, regardless of its visibility. Trying to call a private method then invokes `__call()` which throws an exception. This PR addresses the issue the following way:

- Make `Gdn_Pluggable` throw a `BadMethodCall` exception instead of triggering an error when it can't find a new method.
- Handle the `BadMethodCall` exception explicitly in `UpdateModel`.
- A pluggable class that does not set its own `ClassName` property will use `get_called_class()` instead to try and find new methods.

There was also an old "optimization" in `Gdn_Pluggable` that was removed in favor of a single call to `call_user_funct_array()`.