### PR TITLE
Fix timestamp column comparison when altering the database structure

### DIFF
--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -796,8 +796,8 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
             if ($column->Type !== 'timestamp') {
                 $return .= " default ".self::_quoteValue($column->Default);
             } else {
-                if (in_array(strtolower($column->Default), ['current_timestamp', 'current_timestamp()'])) {
-                    $return .= " default ".$column->Default;
+                if (in_array(strtolower($column->Default), ['current_timestamp', 'current_timestamp()', true])) {
+                    $return .= " default current_timestamp";
                 }
             }
         }


### PR DESCRIPTION
Columns of type “timestamp” always have a default of “current_timestamp”, however the database comes back with “CURRENT_TIMESTAMP” which would always show as a database alter. This change makes the current default always “current_timestamp” so it can be shown as not a change.