### PR TITLE
Add a checkExisting option for saving authentication providers

### DIFF
--- a/library/core/class.authenticationprovidermodel.php
+++ b/library/core/class.authenticationprovidermodel.php
@@ -254,9 +254,14 @@ class Gdn_AuthenticationProviderModel extends Gdn_Model {
 
             $fields = $this->Validation->validationFields();
             if ($insert === false) {
-                $primaryKeyVal = $row[$this->PrimaryKey];
-                $this->update($fields, [$this->PrimaryKey => $primaryKeyVal]);
+                if ($settings['checkExisting'] ?? false) {
+                    $fields = array_diff_assoc($fields, $row);
+                }
 
+                if (!empty($fields)) {
+                    $primaryKeyVal = $row[$this->PrimaryKey];
+                    $this->update($fields, [$this->PrimaryKey => $primaryKeyVal]);
+                }
             } else {
                 $primaryKeyVal = $this->insert($fields);
             }


### PR DESCRIPTION
Allow authentication providers that are hard-coded in the database structure to be saved with a `“checkExisting” => true` option so that they don’t show up in the database structure every single time.