### PR TITLE
Fix username validation when signing in with SSO

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -477,6 +477,16 @@ class EntryController extends Gdn_Controller {
             }
         }
 
+        // Validate username fields, in order of relevancy.
+        foreach (['ConnectName', 'Name'] as $usernameField) {
+            if ($this->Form->getFormValue($usernameField, null) !== null) {
+                $this->Form->validateRule($usernameField, 'function:validateAgainstUsernameBlacklist');
+                $this->Form->validateRule($usernameField, 'ValidateUsername');
+                // Only validate the most relevant field.
+                break;
+            }
+        }
+
         // Make sure the minimum required data has been provided by the connection.
         if (!$this->Form->getFormValue('Provider')) {
             $this->Form->addError('ValidateRequired', t('Provider'));
@@ -806,11 +816,6 @@ class EntryController extends Gdn_Controller {
                     if (c('Garden.Registration.NameUnique')) {
                         // Check to see if there is already a user with the given name.
                         $user = $userModel->getWhere(['Name' => $connectName])->firstRow(DATASET_TYPE_ARRAY);
-                    }
-
-                    if (!$user) {
-                        // Using a new username, so validate it.
-                        $this->Form->validateRule('ConnectName', 'ValidateUsername');
                     }
                 }
             } else {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2173,6 +2173,9 @@ class UserModel extends Gdn_Model {
         if (array_key_exists('Email', $formPostValues) && val('ValidateEmail', $settings, true)) {
             $this->Validation->applyRule('Email', 'Email');
         }
+        if (val('ValidateName', $settings, true)) {
+            $this->Validation->applyRule('Name', 'Username');
+        }
 
         if ($this->validate($formPostValues, $insert) && $uniqueValid) {
             // All fields on the form that need to be validated (including non-schema field rules defined above)
@@ -3038,8 +3041,13 @@ class UserModel extends Gdn_Model {
         $this->defineSchema();
 
         // Add & apply any extra validation rules.
+        $this->Validation->addRule('UsernameBlacklist', 'function:validateAgainstUsernameBlacklist');
+        $this->Validation->applyRule('Name', 'UsernameBlacklist');
         if (val('ValidateEmail', $options, true)) {
             $this->Validation->applyRule('Email', 'Email');
+        }
+        if (val('ValidateName', $options, true)) {
+            $this->Validation->applyRule('Name', 'Username');
         }
 
         // TODO: DO I NEED THIS?!

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -25,6 +25,9 @@ if (!$hasUserID) {
     $firstTimeHere = !($this->Form->isPostBack() && $this->Form->getFormValue('Connect', null) !== null);
     $connectNameProvided = (bool)$this->Form->getFormValue('ConnectName');
 
+    $validationResults = $this->Form->validationResults();
+    $usernameNotValid = array_key_exists('Name', $validationResults) || array_key_exists('ConnectName', $validationResults);
+
     // Buckle up, deciding whether to show this field is intense.
     // Any of these 3 scenarios will do it:
     $displayConnectName =
@@ -34,7 +37,9 @@ if (!$hasUserID) {
         // 2) If you clicked submit and we found matches (but validation failed and you need to try again).
         || (!$firstTimeHere && count($ExistingUsers))
         // 3) We're forcing a manual username selection.
-        || !$allowConnect;
+        || !$allowConnect
+        // 4) There was an error with the submitted name.
+        || $usernameNotValid;
 }
 ?>
 <div class="Connect">

--- a/plugins/stubcontent/class.stubcontent.plugin.php
+++ b/plugins/stubcontent/class.stubcontent.plugin.php
@@ -236,7 +236,8 @@ class StubContentPlugin extends Gdn_Plugin {
                     ], [
                         'ValidateEmail' => false,
                         'NoConfirmEmail' => true,
-                        'SaveRoles' => true
+                        'SaveRoles' => true,
+                        'ValidateName' => false
                     ]);
 
                     if ($rowID) {

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -152,4 +152,16 @@ abstract class AbstractAPIv2Test extends TestCase {
         $item = $this->logger->search($filter);
         $this->assertNotNull($item, "Could not find expected log: ".json_encode($filter));
     }
+
+    /**
+     * Generate a random valid username.
+     *
+     * @param string $prefix
+     * @return string
+     */
+    protected static function randomUsername(string $prefix = ''): string {
+        $uniqueID = preg_replace('/[^0-9A-Z_]/i', '_', uniqid($prefix, true));
+        $result = substr($uniqueID, 0, 20);
+        return $result;
+    }
 }

--- a/tests/APIv2/Authenticate/AutoConnectTest.php
+++ b/tests/APIv2/Authenticate/AutoConnectTest.php
@@ -51,10 +51,10 @@ class AutoConnectTest extends AbstractAPIv2Test {
     public function setUp() {
         parent::setUp();
 
-        $uniqueID = uniqid('ac_');
+        $uniqueID = self::randomUsername('ac');
         $userData = [
-            'name' => 'Authenticate_'.$uniqueID,
-            'email' => 'authenticate_'.$uniqueID.'@example.com',
+            'name' => $uniqueID,
+            'email' => $uniqueID.'@example.com',
             'password' => 'pwd_'.$uniqueID,
         ];
 

--- a/tests/APIv2/Authenticate/LinkUserTest.php
+++ b/tests/APIv2/Authenticate/LinkUserTest.php
@@ -43,10 +43,10 @@ class LinkUserTest extends AbstractAPIv2Test {
     public function setUp() {
         parent::setUp();
 
-        $uniqueID = uniqid('lu_');
+        $uniqueID = self::randomUsername('lu');
         $userData = [
-            'name' => 'Authenticate_'.$uniqueID,
-            'email' => 'authenticate_'.$uniqueID.'@example.com',
+            'name' => $uniqueID,
+            'email' => $uniqueID.'@example.com',
             'password' => 'pwd_'.$uniqueID,
         ];
 

--- a/tests/APIv2/Authenticate/NoEmailTest.php
+++ b/tests/APIv2/Authenticate/NoEmailTest.php
@@ -52,9 +52,9 @@ class NoEmailTest extends AbstractAPIv2Test {
         parent::setUp();
 
 
-        $uniqueID = uniqid('ne_');
+        $uniqueID = self::randomUsername('ne');
         $this->currentUser = [
-            'name' => 'Authenticate_'.$uniqueID,
+            'name' => $uniqueID,
         ];
 
         $this->authenticator = new MockSSOAuthenticator($uniqueID, $this->currentUser);

--- a/tests/APIv2/Authenticate/PasswordAuthenticatorTest.php
+++ b/tests/APIv2/Authenticate/PasswordAuthenticatorTest.php
@@ -21,10 +21,10 @@ class PasswordAuthenticatorTest extends AbstractAPIv2Test {
     public function setUp() {
         parent::setUp();
 
-        $uniqueID = uniqid('ac_');
+        $uniqueID = self::randomUsername('pa');
         $userData = [
-            'name' => 'pa_'.$uniqueID,
-            'email' => 'pa_'.$uniqueID.'@example.com',
+            'name' => $uniqueID,
+            'email' => $uniqueID.'@example.com',
             'password' => 'pwd_'.$uniqueID,
         ];
 

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -70,7 +70,7 @@ class UsersTest extends AbstractResourceTest {
     private function registrationFields(array $extra = []) {
         static $inc = 0;
 
-        $name = 'vanilla-'.$inc++;
+        $name = 'vanilla_'.$inc++;
         $fields = [
             'email' => "{$name}@example.com",
             'name' => $name,
@@ -87,6 +87,9 @@ class UsersTest extends AbstractResourceTest {
      */
     protected function modifyRow(array $row) {
         $row = parent::modifyRow($row);
+        if (array_key_exists('name', $row)) {
+            $row['name'] = substr(md5($row['name']), 0, 20);
+        }
         foreach ($this->patchFields as $key) {
             $value = $row[$key];
             switch ($key) {


### PR DESCRIPTION
SSO has been updated to utilize `UserModel` updates introduced in #7163.

1. If the username comes from a trusted authentication provider, it must not be a blacklisted name.
1. If the username comes from an untrusted authentication provider, or if the username comes from a user during connection, it must not be blacklisted __*and*__ it must match the regex validation pattern.

Tests and some addons have been updated, as necessary, to generate default valid usernames.

*Warning: At 500 lines, `EntryController::connect` is a complex, delicate beast. It's not something to be taken lightly. Please take your time in carefully reviewing the code.*

### Testing

This can have a significant impact on SSO. Please test, throughly. I've primarily tested with social connect addons and jsConnect. I recommend testing with as many configurations as you can think of.

Here's a few scenarios to test with trusted __*and*__ untrusted providers:

1. Connecting with no username from the authentication provider.
1. Connecting with an existing username, providing a new name.
1. Connecting with an existing username, connecting to that user with its password.
1. Connecting with a blacklisted username.
1. Connecting with an invalid username (e.g. one that does not match the username validation regex)

Closes #5866