### PR TITLE
Allow Gdn_Dispatcher to dispatch to dash-cased controllers

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -205,7 +205,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
      * @return string Returns the filtered name.
      */
     private function filterName($name) {
-        if (empty($name) || $name[0] === '-' || substr($name, -1) === '-') {
+        if (empty($name) || $name[0] === '-' || substr($name, -1) === '-' || preg_match('`--`', $name)) {
             return $name;
         }
 

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -205,6 +205,10 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
      * @return string Returns the filtered name.
      */
     private function filterName($name) {
+        if (empty($name) || $name[0] === '-' || substr($name, -1) === '-') {
+            return $name;
+        }
+
         $result = implode('', array_map('ucfirst', explode('-', $name)));
         return $result;
     }
@@ -505,12 +509,15 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
      * If the method is not found then an empty string is returned for the method name.
      */
     private function findControllerMethod($controller, $pathArgs) {
-        if ($this->methodExists($controller, reset($pathArgs))) {
-            return [array_shift($pathArgs), $pathArgs];
-        } elseif ($this->methodExists($controller, 'x'.reset($pathArgs))) {
-            $method = array_shift($pathArgs);
-            deprecated(get_class($controller)."->x$method", get_class($controller)."->$method");
-            return ['x'.$method, $pathArgs];
+        $first = $this->filterName(reset($pathArgs));
+
+        if ($this->methodExists($controller, $first)) {
+            array_shift($pathArgs);
+            return [$first, $pathArgs];
+        } elseif ($this->methodExists($controller, "x$first")) {
+            array_shift($pathArgs);
+            deprecated(get_class($controller)."->x$first", get_class($controller)."->$first");
+            return ["x$first", $pathArgs];
         } elseif ($this->methodExists($controller, 'index')) {
             // "index" is the default controller method if an explicit method cannot be found.
             $this->EventArguments['PathArgs'] = $pathArgs;
@@ -830,12 +837,21 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             // Augment the arguments to the plugin with the sender and these arguments.
             // The named sender and args keys are an old legacy format before plugins could override controller methods properly.
             $inputArgs = array_merge([$controller], $pathArgs, ['sender' => $controller, 'args' => $pathArgs]);
-            $args = reflectArgs($callback, $inputArgs, $reflectionArguments);
         } else {
             $callback = [$controller, $controllerMethod];
-            $args = reflectArgs($callback, $pathArgs, $reflectionArguments);
+            $inputArgs = $pathArgs;
         }
+        $method = is_array($callback) ? new ReflectionMethod($callback[0], $callback[1]) : new ReflectionFunction($callback);
+        $args = reflectArgs($method, $inputArgs, $reflectionArguments);
         $controller->ReflectArgs = $args;
+
+
+        $canonicalUrl = $this->makeCanonicalUrl($controller, $method, $args);
+        $canonicalUrlOld = $this->makeCanonicalUrlOld($controller);
+        if ($canonicalUrl !== $canonicalUrlOld) {
+            trigger_error("Canonical URL $canonicalUrl !== $canonicalUrlOld.", E_USER_NOTICE);
+        }
+        $controller->canonicalUrl($canonicalUrl);
 
         // Now that we have everything its time to call the callback for the controller.
         try {
@@ -843,10 +859,137 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
             Gdn::pluginManager()->callEventHandlers($controller, $controllerName, $controllerMethod, 'before');
 
             call_user_func_array($callback, $args);
-        } catch (Exception $ex) {
+        } catch (\Throwable $ex) {
             $controller->renderException($ex);
             exit();
         }
+    }
+
+    /**
+     * This is the old default implementation of canonical URL calculation from `Gdn_Controller`.
+     *
+     * This method is here for debugging purposes and will be removed eventually.
+     *
+     * @param object $sender The controller about to be dispatched.
+     * @return string Returns a URL.
+     * @deprecated
+     */
+    private function makeCanonicalUrlOld($sender): string {
+        $controller = strtolower(stringEndsWith($sender->ControllerName, 'Controller', true, true));
+
+        if ($controller == 'settings') {
+            $parts[] = strtolower($sender->ApplicationFolder);
+        }
+
+        if ($controller != 'root') {
+            $parts[] = $controller;
+        }
+
+        if (strcasecmp($sender->RequestMethod, 'index') != 0) {
+            $parts[] = strtolower($sender->RequestMethod);
+        }
+
+        // The default canonical url is the fully-qualified url.
+        if (is_array($sender->RequestArgs)) {
+            $parts = array_merge($parts, $sender->RequestArgs);
+        } elseif (is_string($sender->RequestArgs)) {
+            $parts = trim($sender->RequestArgs, '/');
+        }
+
+        $path = implode('/', $parts);
+        $result = url($path, true);
+
+        return $result;
+    }
+
+    /**
+     * Make the default canonical URL.
+     *
+     * @param object $controller The controller to use for the canonical URL.
+     * @param ReflectionFunctionAbstract $method The method being dispatched.
+     * @param $array $args The reflected arguments.
+     * @return string Returns a URL.
+     */
+    private function makeCanonicalUrl($controller, \ReflectionFunctionAbstract $method, $args): string {
+        $parts = [];
+
+        $controllerName = stringEndsWith(\Garden\EventManager::classBasename(get_class($controller)), 'Controller', true, true);
+        $controllerName = $this->dashCase($controllerName);
+
+        if ($controllerName !== 'root') {
+            $parts[] = $controllerName;
+        }
+
+        $methodName = $method->getName();
+        if (preg_match('`^[^_]+_([^_]+)`', $methodName, $m)) {
+            $methodName = $m[1];
+        }
+        $methodName = $this->dashCase($methodName);
+        if ($methodName !== 'index') {
+            $parts[] = $methodName;
+        }
+
+        $args = array_change_key_case($args);
+
+        // Add args after known names to the querystring.
+        $query = [];
+        $split = false;
+        foreach ($args as $key => $value) {
+            if (is_object($value)) {
+                continue;
+            } elseif (in_array($key, ['search', 'query']) || $split) {
+                $query[$key] = $value;
+                $split = true;
+            } elseif (is_numeric($key)) {
+                break;
+            } else {
+                $parts[$key] = $value;
+            }
+        }
+        $query = array_filter($query);
+
+        // Remove empty parameters from the parts.
+        $defaults = [];
+        foreach ($method->getParameters() as $param) {
+            if ($param->isDefaultValueAvailable()) {
+                $defaults[strtolower($param->getName())] = $param->getDefaultValue();
+            }
+        }
+
+        // Remove empty or default path parameters from the end.
+        $keys = array_reverse(array_keys($parts));
+        foreach ($keys as $key) {
+            $value = $parts[$key];
+            if (empty($value) || $value == ($defaults[$key] ?? '')) {
+                unset($parts[$key]);
+            } else {
+                break;
+            }
+        }
+
+        $path = implode('/', array_map('rawurlencode', $parts));
+        if (!empty($query)) {
+            ksort($query);
+            $path .= '?'.http_build_query($query);
+        }
+        $result = url($path, true);
+
+        return $result;
+    }
+
+    /**
+     * Convert a string to dash-case.
+     *
+     * @param string $str The string to convert.
+     * @return string Returns a dash-case string.
+     */
+    private function dashCase(string $str): string {
+        if (preg_match_all('`((?:[A-Z]|^)[A-Z]*[a-z0-9]*)`', $str, $m)) {
+            $result = implode('-', array_map('strtolower', $m[1]));
+        } else {
+            $result = strtolower($str);
+        }
+        return $result;
     }
 
     /**

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3004,7 +3004,7 @@ if (!function_exists('reflectArgs')) {
     /**
      * Reflect the arguments on a callback and returns them as an associative array.
      *
-     * @param callback $callback A callback to the function.
+     * @param callback|ReflectionFunctionAbstract $callback A callback to the function.
      * @param array $args1 An array of arguments.
      * @param array $args2 An optional other array of arguments.
      * @return array The arguments in an associative array, in order ready to be passed to call_user_func_array().
@@ -3025,14 +3025,16 @@ if (!function_exists('reflectArgs')) {
 
         if (is_string($callback)) {
             $meth = new ReflectionFunction($callback);
-            $methName = $meth;
+        } elseif ($callback instanceof ReflectionFunctionAbstract) {
+            $meth = $callback;
         } else {
             $meth = new ReflectionMethod($callback[0], $callback[1]);
-            if (is_string($callback[0])) {
-                $methName = $callback[0].'::'.$meth->getName();
-            } else {
-                $methName = get_class($callback[0]).'->'.$meth->getName();
-            }
+        }
+
+        if ($meth instanceof ReflectionMethod) {
+            $methName = $meth->getDeclaringClass()->getName().'::'.$meth->getName();
+        } else {
+            $methName = $meth->getName();
         }
 
         $methArgs = $meth->getParameters();

--- a/tests/Library/Core/DispatcherTest.php
+++ b/tests/Library/Core/DispatcherTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Core;
+
+use PHPUnit\Framework\TestCase;
+use VanillaTests\Fixtures\FooBarController;
+use VanillaTests\Fixtures\UnitTestGdnDispatcher;
+
+class DispatcherTest extends TestCase {
+
+    /**
+     * Test **Gdn_Dispatcher::filterName()**.
+     *
+     * @param string $name The name to filter.
+     * @param string $expected The expected name.
+     * @dataProvider provideFilterNameTests
+     */
+    public function testFilterName(string $name, string $expected) {
+        $dis = new UnitTestGdnDispatcher();
+        $filtered = $dis->filterName($name);
+        $this->assertEquals($expected, $filtered);
+    }
+
+    /**
+     * Test **Gdn_Dispatcher::dashCase().
+     *
+     * @param string $name The name to convert.
+     * @param string $expected The expected dash case.
+     * @dataProvider provideDashCaseTests
+     */
+    public function testDashCase(string $name, string $expected) {
+        $dis = new UnitTestGdnDispatcher();
+        $dashed = $dis->dashCase($name);
+        $this->assertEquals($expected, $dashed);
+    }
+
+    /**
+     * Test **Gdn_Dispatcher::makeCanonicalUrl()**.
+     *
+     * @param object $controller The controller being dispatched.
+     * @param string $method The controller method being dispatched.
+     * @param array $args The args.
+     * @param string $expected The expected canonical URL.
+     * @dataProvider provideMakeCanonicalUrlTests
+     */
+    public function testMakeCanonicalUrl($controller, string $method, array $args, string $expected) {
+        $reflectedMethod = new \ReflectionMethod($controller, $method);
+        $reflectedArgs = reflectArgs($reflectedMethod, $args);
+
+        $dis = new UnitTestGdnDispatcher();
+        $url = $dis->makeCanonicalUrl($controller, $reflectedMethod, $reflectedArgs);
+        $this->assertEquals($expected, $url);
+    }
+
+    /**
+     * Provide test data for **testMakeCanonicalUrl**.
+     *
+     * @return array Returns a data provider array.
+     */
+    public function provideMakeCanonicalUrlTests(): array {
+        $foo = new FooBarController();
+
+        $r = [
+            [$foo, 'index', ['page' => 'p1'], '/foo-bar'],
+            [$foo, 'index', ['page' => 'p2'], '/foo-bar/p2'],
+            [$foo, 'index', ['p2', 'baz', 'bam'], '/foo-bar/p2'],
+
+            [$foo, 'search', ['foo', 'p1'], '/foo-bar/search?search=foo'],
+            [$foo, 'search', ['search' => 'foo', 'page' => 'p2'], '/foo-bar/search?page=p2&search=foo'],
+
+            [$foo, 'doit', ['9'], '/foo-bar/do-it'],
+
+            [$foo, 'foobarcontroller_foobar_create', ['sender' => $foo], '/foo-bar/foo-bar'],
+        ];
+
+        $result = [];
+        foreach ($r as $v) {
+            $key = $v[3];
+            $k2 = $key;
+            $i = 1;
+            while (isset($result[$k2])) {
+                $k2 = "$key-$i";
+                $i++;
+            }
+            $result[$k2] = $v;
+        }
+
+        return $result;
+    }
+
+    /***
+     * Provide data for **testDashCase()**.
+     *
+     * @return array Returns a data provider array.
+     */
+    public function provideDashCaseTests(): array {
+        $r = [
+            ['DashCase', 'dash-case'],
+            ['dashCase', 'dash-case'],
+            ['OneTwoThree', 'one-two-three'],
+            ['FooAPI', 'foo-api'],
+            ['FooBar2', 'foo-bar2'],
+        ];
+
+        return array_column($r, null, 0);
+    }
+
+    /**
+     * Provide test data for **testFilterName()**.
+     *
+     * @return array Returns a data provider array.
+     */
+    public function provideFilterNameTests(): array {
+        $r = [
+            ['discussions', 'Discussions'],
+            ['addon-cache', 'AddonCache'],
+            ['addoncache', 'Addoncache'],
+        ];
+
+        return array_column($r, null, 0);
+    }
+}

--- a/tests/fixtures/src/FooBarController.php
+++ b/tests/fixtures/src/FooBarController.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace VanillaTests\Fixtures;
+
+
+class FooBarController {
+    public function index($page = '') {
+
+    }
+
+    public function search($search = '', $page = 'p1') {
+
+    }
+
+    public function doIt($limit = 9) {
+
+    }
+
+    public function fooBarController_fooBar_create($sender, $a = '') {
+
+    }
+}

--- a/tests/fixtures/src/UnitTestGdnDispatcher.php
+++ b/tests/fixtures/src/UnitTestGdnDispatcher.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Fixtures;
+
+/**
+ * Make some **Gdn_Dispatcher** methods public for unit testing.
+ */
+class UnitTestGdnDispatcher extends \Gdn_Dispatcher {
+    /**
+     * UnitTestGdnDispatcher constructor.
+     */
+    public function __construct() {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filterName($name) {
+        return parent::filterName($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dashCase(string $str): string {
+        return parent::dashCase($str);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function makeCanonicalUrl($controller, \ReflectionFunctionAbstract $method, $args): string {
+        return parent::makeCanonicalUrl($controller, $method, $args);
+    }
+}


### PR DESCRIPTION
This PR allows us to dispatch to controllers/methods that contain dashes in their URL. That change itself is fairly trivial, but there is a bit of work handling canonical URLs when the dashes are not properly added.

This breaks backwards compatibility with some canonical URLs, but I think the new ones are more robust. This is just for default canonical URLs, not ones that are explicitly set.

I've grabbed the old default canonical URL code for comparison. You can browse around with the debug on and look for notices where the old and new canonical URLs differ. We want to ensure that our "main" canonical URLs are the same while other pages are fine.

Closes #7109.