### PR TITLE
Multiple fixes and improvements about Authenticators

### DIFF
--- a/library/Vanilla/Authenticator/Authenticator.php
+++ b/library/Vanilla/Authenticator/Authenticator.php
@@ -90,6 +90,7 @@ abstract class Authenticator {
 
     /**
      * Return authenticator type default information.
+     *
      * This method is intended to fill information so that child classes won't have to do it.
      * Use {@link getAuthenticatorTypeInfoImpl()} to fill the "final" information.
      *
@@ -106,7 +107,7 @@ abstract class Authenticator {
     }
 
     /**
-     * Return essential non-default authenticator type information.
+     * {@link getAuthenticatorTypeInfo} implementation.
      *
      * Must be returned by this method:
      * - ui.photoUrl
@@ -147,7 +148,7 @@ abstract class Authenticator {
     }
 
     /**
-     * Default getName implementation.
+     * Default {@link getType} implementation.
      *
      * @return string
      */
@@ -192,9 +193,9 @@ abstract class Authenticator {
      * Setter of active.
      *
      * @param bool $active
-     * @return self
+     * @return $this
      */
-    public function setActive(bool $active): self {
+    public function setActive(bool $active) {
         $this->active = $active;
 
         return $this;
@@ -238,7 +239,7 @@ abstract class Authenticator {
     }
 
     /**
-     * Return essential non-default authenticator information.
+     * {@link getAuthenticatorInfo} implementation.
      *
      * Must be returned by this method:
      * - ui.buttonName
@@ -286,5 +287,20 @@ abstract class Authenticator {
      * @param RequestInterface $request
      * @return array The user's information.
      */
-     abstract public function validateAuthentication(RequestInterface $request);
+    final public function validateAuthentication(RequestInterface $request) {
+         if (!$this->isActive()) {
+             throw new Exception('Cannot authenticate with an inactive authenticator.');
+         }
+
+         return $this->validateAuthenticationImpl($request);
+     }
+
+    /**
+     * {@link ValidateAuthentication} implementation.
+     *
+     * @throws Exception Reason why the authentication failed.
+     * @param RequestInterface $request
+     * @return array The user's information.
+     */
+     abstract public function validateAuthenticationImpl(RequestInterface $request);
 }

--- a/library/Vanilla/Authenticator/SSOAuthenticator.php
+++ b/library/Vanilla/Authenticator/SSOAuthenticator.php
@@ -102,9 +102,9 @@ abstract class SSOAuthenticator extends Authenticator {
      * Setter of autoLinkUser.
      *
      * @param bool $autoLinkUser
-     * @return self
+     * @return $this
      */
-    public function setAutoLinkUser(bool $autoLinkUser): self {
+    public function setAutoLinkUser(bool $autoLinkUser) {
         $this->autoLinkUser = $autoLinkUser;
 
         return $this;
@@ -131,9 +131,9 @@ abstract class SSOAuthenticator extends Authenticator {
      * Setter of linkSession.
      *
      * @param bool $linkSession
-     * @return self
+     * @return $this
      */
-    public function setLinkSession(bool $linkSession): self {
+    public function setLinkSession(bool $linkSession) {
         $this->linkSession = $linkSession;
 
         return $this;
@@ -152,9 +152,9 @@ abstract class SSOAuthenticator extends Authenticator {
      * Setter of signIn.
      *
      * @param bool $signIn
-     * @return self
+     * @return $this
      */
-    public function setSignIn(bool $signIn): self {
+    public function setSignIn(bool $signIn) {
         $this->signIn = $signIn;
 
         return $this;
@@ -171,9 +171,9 @@ abstract class SSOAuthenticator extends Authenticator {
      * Setter of trusted.
      *
      * @param bool $trusted
-     * @return self
+     * @return $this
      */
-    protected function setTrusted(bool $trusted): self {
+    protected function setTrusted(bool $trusted) {
         $this->trusted = $trusted;
 
         return $this;
@@ -186,7 +186,7 @@ abstract class SSOAuthenticator extends Authenticator {
      * @param RequestInterface $request
      * @return SSOData The user's information.
      */
-    final public function validateAuthentication(RequestInterface $request) {
+    final public function validateAuthenticationImpl(RequestInterface $request) {
         $ssoData = $this->sso($request);
         $ssoData->validate();
 

--- a/library/Vanilla/Authenticator/ShimAuthenticator.php
+++ b/library/Vanilla/Authenticator/ShimAuthenticator.php
@@ -43,7 +43,7 @@ abstract class ShimAuthenticator extends Authenticator {
     /**
      * {@link Authenticator::validateAuthentication()}
      */
-    public function validateAuthentication(\Garden\Web\RequestInterface $request) {
+    public function validateAuthenticationImpl(\Garden\Web\RequestInterface $request) {
         throw new ServerException('Method not implemented', 501);
     }
 

--- a/library/Vanilla/Models/AuthenticatorModel.php
+++ b/library/Vanilla/Models/AuthenticatorModel.php
@@ -52,10 +52,15 @@ class AuthenticatorModel {
      * Register an authenticator class.
      * Necessary only for authenticators that are not in an addon.
      *
+     * @throws Exception
      * @param string $authenticatorClass
      * @return self
      */
     public function registerAuthenticatorClass(string $authenticatorClass): self {
+        if (!is_a($authenticatorClass, Authenticator::class, true)) {
+            throw new Exception($authenticatorClass.' is not an Authenticator.');
+        }
+
         $this->authenticatorClasses[$authenticatorClass] = true;
 
         return $this;
@@ -142,7 +147,7 @@ class AuthenticatorModel {
      * @throws \Garden\Container\NotFoundException
      */
     public function getAuthenticatorByID(string $authenticatorID) {
-        $uniqueAuthenticators = $this->getUniqueAuthenticatorIDs();
+        $uniqueAuthenticators = $this->getUniqueAuthenticatorIDs(true);
 
         // Unique authenticators have type === id
         if (in_array($authenticatorID, $uniqueAuthenticators)) {
@@ -196,11 +201,12 @@ class AuthenticatorModel {
     /**
      * Get the list of ID of unique authenticators.
      *
+     * @param bool $includeShims
      * @return array
      */
-    public function getUniqueAuthenticatorIDs(): array {
+    public function getUniqueAuthenticatorIDs($includeShims = false): array {
         $ids = [];
-        foreach ($this->getAuthenticatorClasses() as $class) {
+        foreach ($this->getAuthenticatorClasses($includeShims) as $class) {
             /** @var Authenticator $class */
             if ($class::isUnique()) {
                 $ids[] = $class::getType();

--- a/tests/APIv2/Authenticate/InactiveAuthenticatorTest.php
+++ b/tests/APIv2/Authenticate/InactiveAuthenticatorTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests\APIv2\Authenticate;
+
+use Exception;
+use VanillaTests\APIv2\AbstractAPIv2Test;
+use VanillaTests\Fixtures\MockSSOAuthenticator;
+
+/**
+ * Class InactiveAuthenticatorTest
+ */
+class InactiveAuthenticatorTest extends AbstractAPIv2Test {
+
+    /** @var MockSSOAuthenticator */
+    private $authenticator;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setupBeforeClass() {
+        parent::setupBeforeClass();
+        self::container()
+            ->rule(MockSSOAuthenticator::class)
+            ->setAliasOf('MockSSOAuthenticator');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp() {
+        parent::setUp();
+
+        $uniqueID = uniqid('inactv_auth_');
+        $this->authenticator = new MockSSOAuthenticator($uniqueID);
+        $this->authenticator->setActive(false);
+
+        $this->container()->setInstance('MockSSOAuthenticator', $this->authenticator);
+
+        $session = $this->container()->get(\Gdn_Session::class);
+        $session->end();
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Cannot authenticate with an inactive authenticator.
+     */
+    public function testInactiveAuth() {
+        $postData = [
+            'authenticate' => [
+                'authenticatorType' => $this->authenticator::getType(),
+                'authenticatorID' => $this->authenticator->getID(),
+            ],
+        ];
+
+        $this->api()->post('/authenticate', $postData);
+    }
+}

--- a/tests/APIv2/Authenticate/PasswordAuthenticatorTest.php
+++ b/tests/APIv2/Authenticate/PasswordAuthenticatorTest.php
@@ -125,6 +125,32 @@ class PasswordAuthenticatorTest extends AbstractAPIv2Test {
         ]);
     }
 
+   /**
+     * /authenticate with password/password should not work if the PasswordAuthenticator is inactive.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage Cannot authenticate with an inactive authenticator.
+     */
+    public function testPostPasswordInactive() {
+        $this->assertNoSession();
+
+        /** @var \Gdn_Configuration $config */
+        $config = $this->container()->get(\Gdn_Configuration::class);
+        $config->set('Garden.SignIn.DisablePassword', true, true, false);
+        try {
+            $this->api()->post("{$this->baseUrl}", [
+                'authenticate' => [
+                    'authenticatorType' => 'password',
+                    'authenticatorID' => 'password',
+                ],
+                'username' => $this->currentUser['email'],
+                'password' => $this->currentUser['password']
+            ]);
+        } finally {
+            $config->set('Garden.SignIn.DisablePassword', false, true, false);
+        }
+    }
+
     /**
      * An incorrect password should return 401.
      *

--- a/tests/fixtures/src/MockAuthenticator.php
+++ b/tests/fixtures/src/MockAuthenticator.php
@@ -87,7 +87,7 @@ class MockAuthenticator extends Authenticator {
     /**
      * @inheritDoc
      */
-    public function validateAuthentication(RequestInterface $request) {
+    public function validateAuthenticationImpl(RequestInterface $request) {
         return $this->data;
     }
 }

--- a/tests/fixtures/src/MockSSOAuthenticator.php
+++ b/tests/fixtures/src/MockSSOAuthenticator.php
@@ -67,9 +67,9 @@ class MockSSOAuthenticator extends SSOAuthenticator {
      * Setter of data.
      *
      * @param SSOData $data
-     * @return self
+     * @return $this
      */
-    public function setData(SSOData $data): self {
+    public function setData(SSOData $data) {
         $this->data = $data;
 
         return $this;


### PR DESCRIPTION
Depends on https://github.com/vanilla/vanilla/pull/7166

- Ensure authentication failure if authenticator is inactive.
    - This is done by making `validateAuthentication()` final, putting a check on `isActive()` in there and moving the implementation part into `validateAuthenticationImpl()`
- Unit tests on inactive authenticators
- Type hinting updates
- AuthenticatorModel fixes related to ShimAuthenticators.