### PR TITLE
Don’t clean certain APIv0 data for users when it’s themselves

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1903,6 +1903,7 @@ class EntryController extends Gdn_Controller {
             Gdn::session()->start($userID);
         }
 
+        $this->setData('UserID', $userID);
         $this->setData('EmailConfirmed', $emailConfirmed);
         $this->setData('Email', $user->Email);
         $this->render();

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1511,14 +1511,10 @@ class Gdn_Controller extends Gdn_Pluggable {
                 $Remove[] = 'LastIPAddress';
                 $Remove[] = 'AllIPAddresses';
                 $Remove[] = 'Fingerprint';
-                if (c('Api.Clean.Email', true)) {
-                    $Remove[] = 'Email';
-                }
                 $Remove[] = 'DateOfBirth';
                 $Remove[] = 'Preferences';
                 $Remove[] = 'Banned';
                 $Remove[] = 'Admin';
-                $Remove[] = 'Confirmed';
                 $Remove[] = 'Verified';
                 $Remove[] = 'DiscoveryText';
                 $Remove[] = 'InviteUserID';
@@ -1527,10 +1523,18 @@ class Gdn_Controller extends Gdn_Pluggable {
                 $Remove[] = 'CountNotifications';
                 $Remove[] = 'CountBookmarks';
                 $Remove[] = 'CountDrafts';
-                $Remove[] = 'HourOffset';
-                $Remove[] = 'Gender';
                 $Remove[] = 'Punished';
                 $Remove[] = 'Troll';
+
+
+                if (empty($Data['UserID']) || $Data['UserID'] != Gdn::session()->UserID) {
+                    if (c('Api.Clean.Email', true)) {
+                        $Remove[] = 'Email';
+                    }
+                    $Remove[] = 'Confirmed';
+                    $Remove[] = 'HourOffset';
+                    $Remove[] = 'Gender';
+                }
             }
             $Data = removeKeysFromNestedArray($Data, $Remove);
         }


### PR DESCRIPTION
This is to fix a specific issue from ops, but is also a reasonable thing to do.