### PR TITLE
Make image upload on the by default for bodybox

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -270,9 +270,6 @@ class Gdn_Form extends Gdn_Pluggable {
         touchValue('Wrap', $attributes, true);
         touchValue('class', $attributes, '');
         $attributes['class'] .= ' '.$this->getStyle('bodybox');
-        if (!array_key_exists("ImageUpload", $attributes) && !array_key_exists("FileUpload", $attributes)) {
-            $attributes["ImageUpload"] = true;
-        }
 
         $this->setValue('Format', val('Format', $attributes, $this->getValue('Format', Gdn_Format::defaultFormat())));
 

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -270,6 +270,9 @@ class Gdn_Form extends Gdn_Pluggable {
         touchValue('Wrap', $attributes, true);
         touchValue('class', $attributes, '');
         $attributes['class'] .= ' '.$this->getStyle('bodybox');
+        if (!array_key_exists("ImageUpload", $attributes) && !array_key_exists("FileUpload", $attributes)) {
+            $attributes["ImageUpload"] = true;
+        }
 
         $this->setValue('Format', val('Format', $attributes, $this->getValue('Format', Gdn_Format::defaultFormat())));
 

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -326,7 +326,7 @@ class EditorPlugin extends Gdn_Plugin {
         $allowedEditorActions = $this->getAllowedEditorActions();
         $allowedEditorActions['emoji'] = Emoji::instance()->hasEditorList();
         $fileUpload = val('FileUpload', $attributes);
-        $imageUpload = $fileUpload || val('ImageUpload', $attributes);
+        $imageUpload = $fileUpload || val('ImageUpload', $attributes, true);
         if (($fileUpload || $imageUpload) && $this->canUpload()) {
             $allowedEditorActions['fileuploads'] = $fileUpload;
             $allowedEditorActions['imageuploads'] = $imageUpload;


### PR DESCRIPTION
Closes #6374

This PR allows uploading images on every bodyBox (unless it explicitly opts out by setting the `FileUpload` or `ImageUpload` itself).

I've tested this on every page I can think of (conversation, activity, profile activity, groups, comments, etc).

Just for clarification there were 3 different permutations of the bodyBox and image uploads before.

**Before**
1. User does not have `Plugins.AttachmentsUpload.Allow` permission. Only external image embedding is allowed.
2. User has `Plugins.AttachmentsUpload.Allow` permission. The`FileUpload` and `ImageUpload` options are **not** passed to the bodyBox. Only external image embedding is allowed.
3. User has `Plugins.AttachmentsUpload.Allow` permission. `FileUpload` option is passed to the bodyBox. File uploads, image uploads, and external image embedding is allowed.
4. User has `Plugins.AttachmentsUpload.Allow` permission. `ImageUpload` option is passed to the bodyBox. Image uploads, and external image embedding is allowed.

Essentially **2** was the default unless a call to the bodyBox passed in an option. Now **4** is the default unless some other option is passed in or the user does not have permission.