### PR TITLE
Add APIv2 smart ID support

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -151,6 +151,14 @@ $dic->setInstance('Garden\Container\Container', $dic)
         return new \Garden\Web\PreflightRoute('/api/v2', true);
     })])
     ->addCall('setAllowedOrigins', ['isTrustedDomain'])
+    ->addCall('addMiddleware', [new Reference('@smart-id-middleware')])
+
+    ->rule('@smart-id-middleware')
+    ->setClass(\Vanilla\Web\SmartIDMiddleware::class)
+    ->setConstructorArgs(['/api/v2/'])
+    ->addCall('addSmartID', ['CategoryID', 'categories', ['name', 'urlcode'], 'Category'])
+    ->addCall('addSmartID', ['RoleID', 'roles', ['name'], 'Role'])
+    ->addCall('addSmartID', ['UserID', 'users', '*', new Reference(\Vanilla\Web\UserSmartIDResolver::class)])
 
     ->rule('@api-v2-route')
     ->setClass(\Garden\Web\ResourceRoute::class)

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -158,7 +158,17 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->setConstructorArgs(['/api/v2/'])
     ->addCall('addSmartID', ['CategoryID', 'categories', ['name', 'urlcode'], 'Category'])
     ->addCall('addSmartID', ['RoleID', 'roles', ['name'], 'Role'])
-    ->addCall('addSmartID', ['UserID', 'users', '*', new Reference(\Vanilla\Web\UserSmartIDResolver::class)])
+    ->addCall('addSmartID', ['UserID', 'users', '*', new Reference('@user-smart-id-resolver')])
+
+    ->rule('@user-smart-id-resolver')
+    ->setFactory(function (Container $dic) {
+        /* @var \Vanilla\Web\UserSmartIDResolver $uid */
+        $uid = $dic->get(\Vanilla\Web\UserSmartIDResolver::class);
+        $uid->setEmailEnabled(!$dic->get(Gdn_Configuration::class)->get('Garden.Registration.NoEmail'))
+            ->setViewEmail($dic->get(\Gdn_Session::class)->checkPermission('Garden.PersonalInfo.View'));
+
+        return $uid;
+    })
 
     ->rule('@api-v2-route')
     ->setClass(\Garden\Web\ResourceRoute::class)

--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -97,7 +97,11 @@ class Dispatcher {
      * @return Data Returns the response as a data object.
      */
     public function dispatch(RequestInterface $request) {
-        $result = $this->callMiddleware($request);
+        try {
+            $result = $this->callMiddleware($request);
+        } catch (\Exception $ex) {
+            $result = $this->makeResponse($ex);
+        }
         return $result;
     }
 

--- a/library/Vanilla/Web/SmartIDMiddleware.php
+++ b/library/Vanilla/Web/SmartIDMiddleware.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla\Web;
+
+use Garden\Web\Exception\ClientException;
+use Garden\Web\RequestInterface;
+
+/**
+ * Lookup smart IDs in requests.
+ *
+ * This middleware replaces smart ID expressions in the request with their IDs and passes on the middleware.
+ */
+class SmartIDMiddleware {
+    const SMART = '$';
+
+    /**
+     * @var string The base path to match in order to apply smart IDs.
+     */
+    private $basePath = '/';
+
+    /**
+     * @var \Gdn_SQLDriver
+     */
+    private $sql;
+
+    /**
+     * @var array An array of resource directories that apply to a smart ID.
+     */
+    private $resources = [];
+
+    /**
+     * @var array An array of PK columns that are fetched as the result of a smart ID.
+     */
+    private $pks = [];
+
+    /**
+     * @var string a cached regular expression to match a field against the known smart ID PK columns.
+     */
+    private $pksRegex;
+
+    /**
+     * SmartIDMiddleware constructor.
+     *
+     * @param string $basePath The base path to match in order to apply the middleware.
+     * @param \Gdn_SQLDriver $sql Used to look up smart IDs.
+     */
+    public function __construct(string $basePath = '/', \Gdn_SQLDriver $sql) {
+        $this->basePath = $basePath;
+        $this->sql = clone $sql;
+    }
+
+    /**
+     * Add a smart ID.
+     *
+     * Smart IDs can have a basic implementation where you supply a table name or a custom implementation where you provide a resolver callback.
+     *
+     * The resolver callback must have the following signature:
+     *
+     * ```php
+     * function resolver(SmartIDMiddleware $sender, string $pk, string $column, string $value)
+     * ```
+     *
+     * The function must return the result of the smart ID lookup.
+     *
+     * @param string $pk The name of the primary key field of the resource.
+     * @param string $resource The directory name of the resource the smart ID applies to (ex. users for /users resource).
+     * @param string|array $columns Either an array of valid lookup columns or "*" for any column.
+     * @param string|callable $resolver Either a table name or a callback that will resolve the smart ID.
+     */
+    public function addSmartID(string $pk, string $resource, $columns, $resolver) {
+        if ($columns !== '*' && !is_array($columns)) {
+            throw new \InvalidArgumentException('The $columns argument must be an array or "*".', 500);
+        }
+        if (!is_string($resolver) && !is_callable($resolver)) {
+            throw new \InvalidArgumentException('The $resolver argument must be an string or callable.', 500);
+        }
+
+        if (is_array($columns)) {
+            $columns = array_map('strtolower', $columns);
+        }
+
+        $this->pks[strtolower($pk)] = [$pk, $columns, $resolver];
+        $this->resources[strtolower($resource)] = strtolower($pk);
+
+        $this->pksRegex = null;
+    }
+
+    /**
+     * Fetch the smart ID value from the database.
+     *
+     * @param string $table The name of the table to search.
+     * @param string $pk The name primary key.
+     * @param array $where An array of where statements.
+     * @return mixed Returns the value of the smart ID or **0** if it was not found.
+     */
+    public function fetchValue(string $table, string $pk, array $where) {
+        $result = $this->sql->select($pk)->getWhere($table, $where)->value($pk, 0);
+        return $result;
+    }
+
+    /**
+     * Invoke the smart ID middleware on a request.
+     *
+     * @param RequestInterface $request The incoming request.
+     * @param callable $next The next middleware.
+     * @return mixed Returns the response of the inner middleware.
+     */
+    public function __invoke(RequestInterface $request, callable $next) {
+        if (strcasecmp(substr($request->getPath(), 0, strlen($this->basePath)), $this->basePath) === 0) {
+            $this->replaceQuery($request);
+            $this->replaceBody($request);
+            $this->replacePath($request);
+        }
+
+        $response = $next($request);
+        return $response;
+    }
+
+    /**
+     * Replace the smart IDs in a request path.
+     *
+     * @param RequestInterface $request The request to process.
+     */
+    private function replacePath(RequestInterface $request) {
+        $parts = explode('/', $request->getPath());
+        $prev = '';
+        foreach ($parts as &$part) {
+            if ($part && $part[0] === static::SMART) {
+                if (empty($prev)) {
+                    throw new ClientException("No resource specified for smart ID: $part.", 400);
+                } elseif (!isset($this->resources[$prev])) {
+                    throw new ClientException("Invalid resource for smart ID: $prev/$part.", 400);
+                }
+                $replaced = $this->replaceSmartID($this->resources[$prev], $part);
+                $part = $replaced;
+            }
+
+            $prev = strtolower($part);
+        }
+        $request->setPath(implode('/', $parts));
+    }
+
+    /**
+     * Replace the smart IDs in a request querystring.
+     *
+     * @param RequestInterface $request The request to process.
+     */
+    private function replaceQuery(RequestInterface $request) {
+        $query = $this->replaceArray($request->getQuery());
+        if ($query !== false) {
+            $request->setQuery($query);
+        }
+    }
+
+    /**
+     * Replace the smart IDs in a request body.
+     *
+     * @param RequestInterface $request The request to process.
+     */
+    private function replaceBody(RequestInterface $request) {
+        if (in_array($request->getMethod(), ['GET', 'OPTIONS'])) {
+            return;
+        }
+
+        $body = $this->replaceArray($request->getBody());
+        if ($body !== false) {
+            $request->setBody($body);
+        }
+    }
+
+    /**
+     * Get the regular expression that finds a smart ID primary key field in a field name.
+     *
+     * @return string Returns a regular expression string.
+     */
+    private function getPKsRegex() {
+        if (!$this->pksRegex) {
+            $this->pksRegex = '`('.implode('|', array_keys($this->pks)).')$`i';
+        }
+        return $this->pksRegex;
+    }
+
+    /**
+     * Replace the smart IDs in a deeply nested array.
+     *
+     * @param array $arr The array to replace.
+     * @return array|false Returns the replaced array of **false** if no replacements were made.
+     */
+    private function replaceArray($arr) {
+        if (empty($arr)) {
+            return false;
+        }
+
+        $regex = $this->getPKsRegex();
+
+        array_walk_recursive($arr, function (&$value, $key) use ($regex, &$changed) {
+            if ($value && is_string($value) && $value[0] === static::SMART && preg_match($regex, $key, $m)) {
+                $value = $this->replaceSmartID($m[1], $value);
+                $changed = true;
+            }
+        });
+
+        if ($changed) {
+            return $arr;
+        }
+    }
+
+    /**
+     * Replace a smart ID with it PK value.
+     *
+     * @param string $pk The name of the PK column for the smart ID.
+     * @param string $smartID The smart ID to lookup.
+     * @return mixed Returns the resulting value of the smart ID.
+     */
+    private function replaceSmartID(string $pk, string $smartID) {
+        list($column, $value) = explode(':', ltrim($smartID, static::SMART)) + ['', ''];
+        list($pk, $columns, $resolver) = $this->pks[strtolower($pk)];
+
+        if ($columns !== '*' && !in_array(strtolower($column), $columns)) {
+            throw new ClientException("Unknown column in smart ID expression: $column.", 400);
+        }
+        if (is_string($resolver)) {
+            // The resolver is a table and is fetched itself.
+            $result = $this->fetchValue($resolver, $pk, [strtolower($column) => $value]);
+        } else {
+            // The resolver is a callback that performs a custom action.
+            $result = $resolver($this, $pk, strtolower($column), $value);
+        }
+        return $result;
+    }
+
+    /**
+     * Get the base path.
+     *
+     * @return string Returns the basePath.
+     */
+    public function getBasePath(): string {
+        return $this->basePath;
+    }
+
+    /**
+     * Set the base path.
+     *
+     * @param string $basePath The new value.
+     * @return $this
+     */
+    public function setBasePath(string $basePath) {
+        $this->basePath = $basePath;
+        return $this;
+    }
+}

--- a/library/Vanilla/Web/SmartIDMiddleware.php
+++ b/library/Vanilla/Web/SmartIDMiddleware.php
@@ -8,6 +8,7 @@
 namespace Vanilla\Web;
 
 use Garden\Web\Exception\ClientException;
+use Garden\Web\Exception\NotFoundException;
 use Garden\Web\RequestInterface;
 
 /**
@@ -101,7 +102,9 @@ class SmartIDMiddleware {
     public function fetchValue(string $table, string $pk, array $where) {
         $data = $this->sql->select($pk)->getWhere($table, $where);
 
-        if ($data->count() > 1) {
+        if ((int)$data->count() === 0) {
+            throw new NotFoundException("Smart ID not found.");
+        } elseif ($data->count() > 1) {
             throw new ClientException('More than one record matches smart ID: '.implodeAssoc(': ', ', ', $where), 409);
         }
 

--- a/library/Vanilla/Web/SmartIDMiddleware.php
+++ b/library/Vanilla/Web/SmartIDMiddleware.php
@@ -223,6 +223,8 @@ class SmartIDMiddleware {
 
         if ($changed) {
             return $arr;
+        } else {
+            return false;
         }
     }
 

--- a/library/Vanilla/Web/SmartIDMiddleware.php
+++ b/library/Vanilla/Web/SmartIDMiddleware.php
@@ -99,8 +99,13 @@ class SmartIDMiddleware {
      * @return mixed Returns the value of the smart ID or **0** if it was not found.
      */
     public function fetchValue(string $table, string $pk, array $where) {
-        $result = $this->sql->select($pk)->getWhere($table, $where)->value($pk, 0);
-        return $result;
+        $data = $this->sql->select($pk)->getWhere($table, $where);
+
+        if ($data->count() > 1) {
+            throw new ClientException('More than one record matches smart ID: '.implodeAssoc(': ', ', ', $where), 409);
+        }
+
+        return $data->value($pk, 0);
     }
 
     /**

--- a/tests/Library/Vanilla/Web/SmartIDMiddlewareTest.php
+++ b/tests/Library/Vanilla/Web/SmartIDMiddlewareTest.php
@@ -8,7 +8,6 @@
 namespace VanillaTests\Library\Vanilla\Web;
 
 use Garden\Web\Data;
-use Garden\Web\Exception\ForbiddenException;
 use Garden\Web\RequestInterface;
 use PHPUnit\Framework\TestCase;
 use Vanilla\Web\SmartIDMiddleware;
@@ -81,6 +80,7 @@ class SmartIDMiddlewareTest extends TestCase {
             ['/categories/$urlCode:foo', '/categories/(Category.CategoryID.urlcode:foo)'],
             ['/users/$name:baz', '/users/(User.UserID.name:baz)'],
             ['/users/$foozbook:123', '/users/(UserAuthentication.UserID.providerKey:foozbook.foreignUserKey:123)'],
+            ['/users/$query:userID?userID=$name:baz', '/users/(User.UserID.name:baz)'],
         ];
 
         return array_column($r, null, 0);
@@ -208,6 +208,15 @@ class SmartIDMiddlewareTest extends TestCase {
      */
     public function testNoResource() {
         $this->callMiddleware(new Request('/$foo:bar'));
+    }
+
+    /**
+     * Query substitution smart IDs must be in the querystring.
+     *
+     * @expectedException \Garden\Web\Exception\ClientException
+     */
+    public function testInvalidQueryField() {
+        $this->callMiddleware(new Request('/$query:bar'));
     }
 
     /**

--- a/tests/Library/Vanilla/Web/SmartIDMiddlewareTest.php
+++ b/tests/Library/Vanilla/Web/SmartIDMiddlewareTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Vanilla\Web;
+
+
+use Garden\Web\Data;
+use Garden\Web\RequestInterface;
+use PHPUnit\Framework\TestCase;
+use Vanilla\Web\UserSmartIDResolver;
+use VanillaTests\Fixtures\Request;
+
+/**
+ * Test the **SmartIDMiddleware** class.
+ */
+class SmartIDMiddlewareTest extends TestCase {
+    protected $middleware;
+
+    /**
+     * Create a configured test middleware for each test.
+     */
+    public function setUp() {
+        $this->middleware =  new TestSmartIDMiddleware();
+        $this->middleware->addSmartID('CategoryID', 'categories', ['name', 'urlcode'], 'Category');
+
+        $usr = new UserSmartIDResolver();
+        $usr->setEmailEnabled(true)
+            ->setViewEmail(true);
+        $this->middleware->addSmartID('UserID', 'users', '*', $usr);
+    }
+
+    /**
+     * Call the test middleware and return the augmented request.
+     *
+     * @param RequestInterface $request The request being called.
+     * @return RequestInterface Returns the augmented request.
+     */
+    protected function callMiddleware(RequestInterface $request): RequestInterface {
+        /* @var Data $data */
+        $data = call_user_func($this->middleware, $request, function ($request) {
+            return new Data([], ['request' => $request]);
+        });
+
+        return $data->getMeta('request');
+    }
+
+    /**
+     * Some basic tests for smart IDs in paths.
+     *
+     * @param string $path The path to replace.
+     * @param string $expected The expected path replacement.
+     * @dataProvider providePathTests
+     */
+    public function testReplacePath(string $path, string $expected) {
+        $request = new Request($path);
+        $r = $this->callMiddleware($request);
+        $this->assertEquals($expected, $r->getPath());
+    }
+
+    /**
+     * Provide some basic path tests.
+     *
+     * @return array Returns a data provider.
+     */
+    public function providePathTests(): array {
+        $r = [
+            ['/categories/$name:foo', '/categories/(Category.CategoryID.name:foo)'],
+            ['/categories/$urlCode:foo', '/categories/(Category.CategoryID.urlcode:foo)'],
+            ['/users/$name:baz', '/users/(User.UserID.name:baz)'],
+            ['/users/$foozbook:123', '/users/(UserAuthentication.UserID.providerKey:foozbook.foreignUserKey:123)'],
+        ];
+
+        return array_column($r, null, 0);
+    }
+
+    /**
+     * Test smart ID lookup in the querystring.
+     *
+     * @param array $query The request querystring.
+     * @param array $expected The expected processed querystring.
+     * @dataProvider provideQueryTests
+     */
+    public function testReplaceQuery(array $query, array $expected) {
+        $request = new Request('/', 'GET', $query);
+        $r = $this->callMiddleware($request);
+        $this->assertEquals($expected, $r->getQuery());
+    }
+
+    /**
+     * Provide some basic querystring replacement tests.
+     *
+     * @return array Returns a data provider.
+     */
+    public function provideQueryTests(): array {
+        $r = [
+            'basic' => [['categoryID' => '$name:foo'], ['categoryID' => '(Category.CategoryID.name:foo)']],
+            'suffix' => [['parentCategoryID' => '$urlcode:foo'], ['parentCategoryID' => '(Category.CategoryID.urlcode:foo)']],
+            'callback' => [['insertUserID' => '$name:baz'], ['insertUserID' => '(User.UserID.name:baz)']],
+        ];
+
+        return $r;
+    }
+
+    /**
+     * Test smart ID lookup in the request body.
+     *
+     * @param array $body The request body.
+     * @param array $expected The expected processed body.
+     * @dataProvider provideBodyTests
+     */
+    public function testReplaceBody(array $body, array $expected) {
+        $request = new Request('/', 'POST', $body);
+        $r = $this->callMiddleware($request);
+        $this->assertEquals($expected, $r->getBody());
+    }
+
+    /**
+     * Provide test request bodies with smart IDs.
+     *
+     * @return array Returns a data provider.
+     */
+    public function provideBodyTests(): array {
+        $r = [
+            'basic' => [['categoryID' => '$name:foo'], ['categoryID' => '(Category.CategoryID.name:foo)']],
+            'nested' => [['r' => ['categoryID' => '$urlcode:foo']], ['r' => ['categoryID' => '(Category.CategoryID.urlcode:foo)']]],
+            'callback' => [['insertUserID' => '$name:baz'], ['insertUserID' => '(User.UserID.name:baz)']],
+        ];
+
+        return $r;
+    }
+}

--- a/tests/Library/Vanilla/Web/TestSmartIDMiddleware.php
+++ b/tests/Library/Vanilla/Web/TestSmartIDMiddleware.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Vanilla\Web;
+
+use Vanilla\Web\SmartIDMiddleware;
+
+/**
+ * A test version of the **SmartIDMiddleware** that doesn't make database calls.
+ */
+class TestSmartIDMiddleware extends SmartIDMiddleware {
+    /**
+     * TestSmartIDMiddleware constructor.
+     */
+    public function __construct() {
+    }
+
+    /**
+     * Return a dummy value that represents the query parameters.
+     *
+     * @param string $table The name of the table being fetched.
+     * @param string $pk The PK column of the table.
+     * @param array $where The where clause of the query.
+     * @return string Returns a dummy smart ID value.
+     */
+    public function fetchValue(string $table, string $pk, array $where) {
+        return "($table.$pk.".implodeAssoc(':', '.', $where).')';
+    }
+}


### PR DESCRIPTION
Add smart ID support to the API v2. Go to the blocking roadmap issue for a description of how it works.

- I tried to make the middleware extensible without exploding the number of classes we have to have. To this end I allow basic smart ID resolvers that do simple DB lookup and callback resolvers that can do whatever they want.

- I opted not to inject models into the middleware because I don't want every model hanging around for every request. In the future we may want to explore some sort of model factory that allows us to map record types to models since we have many kludges throughout our app for this.

- User ID smart IDs do some basic security checking on email addresses. I opted not to do an extra check on whether authenticators exist or are enabled. If an authenticator does not exist then there is a generic not found error so the single query is functionally equivalent. In terms of an authenticator being enabled/disabled I'm not actually sure we should be looking at this for smart IDs. In any case I want to wait for the new authentication to be complete before doing something more sophisticated.

Closes #7108.
