### PR TITLE
Throw relevant error when the session could not be started

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticateApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticateApiController.php
@@ -9,6 +9,7 @@ use Garden\Schema\Schema;
 use Garden\Schema\ValidationField;
 use Garden\Web\Data;
 use Garden\Web\Exception\ClientException;
+use Garden\Web\Exception\HttpException;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Garden\Web\RequestInterface;
@@ -149,6 +150,20 @@ class AuthenticateApiController extends AbstractApiController {
     }
 
     /**
+     * Make sure that the session is started and throw a relevant error message if that's not the case.
+     *
+     * @throws \Garden\Web\Exception\HttpException
+     * @throws \Vanilla\Exception\PermissionException
+     */
+    private function ensureSessionIsValid() {
+        if (!$this->getSession()->isValid()) {
+            $this->permission(); // This will throw if there's a ban reason.
+
+            throw HttpException::createFromStatus(401, 'The session could not be started.');
+        }
+    }
+
+    /**
      * Fill authenticator information into a response.
      *
      * @param array $response
@@ -283,8 +298,11 @@ class AuthenticateApiController extends AbstractApiController {
         if (!$authenticator->isActive()) {
             throw new ClientException('Authenticator is not active.');
         }
-        if (is_a($authenticator, SSOAuthenticator::class) && !$authenticator->canSignIn()) {
-            throw new ClientException('Authenticator does not allow authentication.');
+        if (is_a($authenticator, SSOAuthenticator::class)) {
+            /** @var SSOAuthenticator $authenticator */
+            if (!$authenticator->canSignIn()) {
+                throw new ClientException('Authenticator does not allow authentication.');
+            }
         }
 
         $result = $this->authenticatorApiController->normalizeOutput($authenticator);
@@ -365,7 +383,7 @@ class AuthenticateApiController extends AbstractApiController {
                     return false;
                 }
 
-                if (isset($isUserLinked) && !$authenticator->isUserLinked($this->getSession()->UserID)) {
+                if (isset($isUserLinked) && !$ssoAuthenticator->isUserLinked($this->getSession()->UserID)) {
                     return false;
                 }
             }
@@ -427,6 +445,8 @@ class AuthenticateApiController extends AbstractApiController {
 
         $authenticatorInstance = $this->authenticatorApiController->getAuthenticator($authenticatorType, $authenticatorID);
 
+        $user = null;
+        $ssoData = null;
         $sso = is_a($authenticatorInstance, SSOAuthenticator::class);
         if ($sso) {
             /** @var SSOAuthenticator $authenticatorInstance */
@@ -436,15 +456,22 @@ class AuthenticateApiController extends AbstractApiController {
                 throw new ServerException("Unknown error while authenticating with $authenticatorType.", 500);
             }
 
-            $user = $this->ssoModel->sso($ssoData, [
-                'linkToSession' => $body['method'] === 'session',
-                'setCookie' => $body['method'] !== 'linkUser',
-                'persist' => $body['persist'],
-            ]);
+            try {
+                 $user = $this->ssoModel->sso($ssoData, [
+                    'linkToSession' => $body['method'] === 'session',
+                    'setCookie' => $body['method'] !== 'linkUser',
+                    'persist' => $body['persist'],
+                ]);
+            } catch(ClientException $e) {
+                if ($e->getCode() === 401) {
+                    $this->ensureSessionIsValid(); // This will throw a more relevant error message.
+                    throw $e; // Fallback to the original error if the session is valid. Should not happen tho.
+                }
+            }
         } else {
             $user = $authenticatorInstance->validateAuthentication($this->request);
             if ($user) {
-                $this->getSession()->start($user['UserID'], true, $body['persist']);
+                $this->startSession($user['UserID'], $body['persist']);
             }
         }
 
@@ -542,6 +569,8 @@ class AuthenticateApiController extends AbstractApiController {
             } else {
                 throw new Exception('Undefined method.');
             }
+
+            return count($field->getValidation()->getErrors()) === 0;
         };
 
         $in = $this
@@ -647,7 +676,7 @@ class AuthenticateApiController extends AbstractApiController {
             $response['user'] = $user['User'];
 
             if ($body['method'] !== 'session') {
-                $this->getSession()->start($user['UserID'], true, $body['persist']);
+                $this->startSession($user['UserID'], $body['persist']);
             }
         } else {
             $response = $this->fillSSOUser($response, $ssoData);
@@ -699,5 +728,20 @@ class AuthenticateApiController extends AbstractApiController {
         $this->config->set('Garden.SignIn.DisablePassword', $oldConfig, true, false);
 
         return $out->validate($result['user']);
+    }
+
+    /**
+     * Start a session an throw an error if there's a problem.
+     *
+     * @param $userID
+     * @param $persist
+     *
+     * @throws \Garden\Web\Exception\HttpException
+     */
+    private function startSession($userID, $persist) {
+        $this->getSession()->start($userID, true, $persist);
+        $this->userModel->fireEvent('AfterSignIn');
+
+        $this->ensureSessionIsValid();
     }
 }

--- a/library/Vanilla/Authenticator/Authenticator.php
+++ b/library/Vanilla/Authenticator/Authenticator.php
@@ -285,7 +285,7 @@ abstract class Authenticator {
      *
      * @throws Exception Reason why the authentication failed.
      * @param RequestInterface $request
-     * @return array The user's information.
+     * @return mixed The user's information.
      */
     final public function validateAuthentication(RequestInterface $request) {
          if (!$this->isActive()) {

--- a/library/Vanilla/Models/SSOModel.php
+++ b/library/Vanilla/Models/SSOModel.php
@@ -438,7 +438,7 @@ class SSOModel {
             // We want to link to the currently logged user.
             if ($body['linkToSession'] ?? false) {
                 if (!$this->session->isValid()) {
-                    throw new ForbiddenException('Cannot link user to session while not signed in.');
+                    throw new ClientException('Cannot link user to session while not signed in.', 401);
                 }
                 if (!$allowConnect) {
                     throw new ForbiddenException('This site is not configured to allow user linking.');
@@ -488,6 +488,10 @@ class SSOModel {
         if ($user) {
             $this->session->start($user['UserID'], $options['setCookie'] ?? true, $options['persistCookie'] ?? false);
             $this->userModel->fireEvent('AfterSignIn');
+
+            if (!$this->session->isValid()) {
+                throw new ClientException('The session could not be started.', 401);
+            }
 
             // Allow user's synchronization
             $syncInfo = $this->config->get('Garden.Registration.ConnectSynchronize', true);

--- a/tests/APIv2/Authenticate/PasswordAuthenticatorTest.php
+++ b/tests/APIv2/Authenticate/PasswordAuthenticatorTest.php
@@ -16,159 +16,6 @@ class PasswordAuthenticatorTest extends AbstractAPIv2Test {
     private $baseUrl = '/authenticate';
 
     /**
-     * @inheritdoc
-     */
-    public function setUp() {
-        parent::setUp();
-
-        $uniqueID = self::randomUsername('pa');
-        $userData = [
-            'name' => $uniqueID,
-            'email' => $uniqueID.'@example.com',
-            'password' => 'pwd_'.$uniqueID,
-        ];
-
-        /** @var \UsersApiController $usersAPIController */
-        $usersAPIController = $this->container()->get('UsersAPIController');
-        $userFragment = $usersAPIController->post($userData)->getData();
-        $this->currentUser = array_merge($userFragment, $userData);
-
-        $session = $this->container()->get(\Gdn_Session::class);
-        $session->end();
-    }
-
-    /**
-     * A user should be able to sign in through /authenticate/password
-     */
-    public function testPostPasswordShortcut() {
-        $this->assertNoSession();
-
-        $this->api()->post("{$this->baseUrl}/password", [
-            'username' => $this->currentUser['email'],
-            'password' => $this->currentUser['password']
-        ]);
-
-        $this->assertSessionUserID();
-    }
-
-    /**
-     * /authenticate/password should work even if the PasswordAuthenticator is inactive.
-     */
-    public function testPostPasswordShortcutAlwaysOn() {
-        $this->assertNoSession();
-
-        /** @var \Gdn_Configuration $config */
-        $config = $this->container()->get(\Gdn_Configuration::class);
-        $config->set('Garden.SignIn.DisablePassword', true, true, false);
-        try {
-            $this->api()->post("{$this->baseUrl}/password", [
-                'username' => $this->currentUser['email'],
-                'password' => $this->currentUser['password']
-            ]);
-        } finally {
-            $config->set('Garden.SignIn.DisablePassword', false, true, false);
-        }
-
-        $this->assertSessionUserID();
-    }
-
-    /**
-     * A user should be able to sign in with their username and password.
-     */
-    public function testPostPasswordName() {
-        $this->assertNoSession();
-
-        $this->api()->post("{$this->baseUrl}", [
-            'authenticate' => [
-                'authenticatorType' => 'password',
-                'authenticatorID' => 'password',
-            ],
-            'username' => $this->currentUser['name'],
-            'password' => $this->currentUser['password']
-        ]);
-
-        $this->assertSessionUserID();
-    }
-
-    /**
-     * A user should be able to sign in with their email and password.
-     */
-    public function testPostPasswordEmail() {
-        $this->assertNoSession();
-
-        $this->api()->post("{$this->baseUrl}", [
-            'authenticate' => [
-                'authenticatorType' => 'password',
-                'authenticatorID' => 'password',
-            ],
-            'username' => $this->currentUser['email'],
-            'password' => $this->currentUser['password']
-        ]);
-
-        $this->assertSessionUserID();
-    }
-
-    /**
-     * An incorrect username should return 404.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionCode 404
-     */
-    public function testPostPasswordNotFound() {
-        $this->api()->post("{$this->baseUrl}", [
-            'authenticate' => [
-                'authenticatorType' => 'password',
-                'authenticatorID' => 'password',
-            ],
-            'username' => $this->currentUser['email'].'!!!!',
-            'password' => $this->currentUser['password']
-        ]);
-    }
-
-   /**
-     * /authenticate with password/password should not work if the PasswordAuthenticator is inactive.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionMessage Cannot authenticate with an inactive authenticator.
-     */
-    public function testPostPasswordInactive() {
-        $this->assertNoSession();
-
-        /** @var \Gdn_Configuration $config */
-        $config = $this->container()->get(\Gdn_Configuration::class);
-        $config->set('Garden.SignIn.DisablePassword', true, true, false);
-        try {
-            $this->api()->post("{$this->baseUrl}", [
-                'authenticate' => [
-                    'authenticatorType' => 'password',
-                    'authenticatorID' => 'password',
-                ],
-                'username' => $this->currentUser['email'],
-                'password' => $this->currentUser['password']
-            ]);
-        } finally {
-            $config->set('Garden.SignIn.DisablePassword', false, true, false);
-        }
-    }
-
-    /**
-     * An incorrect password should return 401.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionCode 401
-     */
-    public function testPostPasswordIncorrect() {
-        $this->api()->post("{$this->baseUrl}", [
-            'authenticate' => [
-                'authenticatorType' => 'password',
-                'authenticatorID' => 'password',
-            ],
-            'username' => $this->currentUser['email'],
-            'password' => $this->currentUser['password'].'!!!'
-        ]);
-    }
-
-    /**
      * Assert that there is not currently a user in the session.
      *
      * @throws \Garden\Container\ContainerException
@@ -196,5 +43,159 @@ class PasswordAuthenticatorTest extends AbstractAPIv2Test {
         /* @var \Gdn_Session $session */
         $session = $this->container()->get(\Gdn_Session::class);
         $this->assertEquals($expected, $session->UserID);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp() {
+        parent::setUp();
+
+        $uniqueID = self::randomUsername('pa');
+        $userData = [
+            'name' => $uniqueID,
+            'email' => $uniqueID.'@example.com',
+            'password' => 'pwd_'.$uniqueID,
+        ];
+
+        /** @var \UsersApiController $usersAPIController */
+        $usersAPIController = $this->container()->get('UsersAPIController');
+        $userFragment = $usersAPIController->post($userData)->getData();
+        $this->currentUser = array_merge($userFragment, $userData);
+
+        /** @var \Gdn_Session $session */
+        $session = $this->container()->get(\Gdn_Session::class);
+        $session->end();
+    }
+
+    /**
+     * A user should be able to sign in through /authenticate/password
+     */
+    public function testEndpointPasswordShortcut() {
+        $this->assertNoSession();
+
+        $this->api()->post("{$this->baseUrl}/password", [
+            'username' => $this->currentUser['email'],
+            'password' => $this->currentUser['password']
+        ]);
+
+        $this->assertSessionUserID();
+    }
+
+    /**
+     * /authenticate/password should work even if the PasswordAuthenticator is inactive.
+     */
+    public function testEndpointPasswordShortcutAlwaysOn() {
+        $this->assertNoSession();
+
+        /** @var \Gdn_Configuration $config */
+        $config = $this->container()->get(\Gdn_Configuration::class);
+        $config->set('Garden.SignIn.DisablePassword', true, true, false);
+        try {
+            $this->api()->post("{$this->baseUrl}/password", [
+                'username' => $this->currentUser['email'],
+                'password' => $this->currentUser['password']
+            ]);
+        } finally {
+            $config->set('Garden.SignIn.DisablePassword', false, true, false);
+        }
+
+        $this->assertSessionUserID();
+    }
+
+    /**
+     * An incorrect username should return 404.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionCode 404
+     */
+    public function testInvalidEmail() {
+        $this->api()->post("{$this->baseUrl}", [
+            'authenticate' => [
+                'authenticatorType' => 'password',
+                'authenticatorID' => 'password',
+            ],
+            'username' => $this->currentUser['email'].'!!!!',
+            'password' => $this->currentUser['password']
+        ]);
+    }
+
+    /**
+     * An incorrect password should return 401.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionCode 401
+     */
+    public function testInvalidPassword() {
+        $this->api()->post("{$this->baseUrl}", [
+            'authenticate' => [
+                'authenticatorType' => 'password',
+                'authenticatorID' => 'password',
+            ],
+            'username' => $this->currentUser['email'],
+            'password' => $this->currentUser['password'].'!!!'
+        ]);
+    }
+
+    /**
+     * /authenticate with password/password should not work if the PasswordAuthenticator is inactive.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage Cannot authenticate with an inactive authenticator.
+     */
+    public function testPasswordAuthenticatorInactive() {
+        $this->assertNoSession();
+
+        /** @var \Gdn_Configuration $config */
+        $config = $this->container()->get(\Gdn_Configuration::class);
+        $config->set('Garden.SignIn.DisablePassword', true, true, false);
+        try {
+            $this->api()->post("{$this->baseUrl}", [
+                'authenticate' => [
+                    'authenticatorType' => 'password',
+                    'authenticatorID' => 'password',
+                ],
+                'username' => $this->currentUser['email'],
+                'password' => $this->currentUser['password']
+            ]);
+        } finally {
+            $config->set('Garden.SignIn.DisablePassword', false, true, false);
+        }
+    }
+
+    /**
+     * A user should be able to sign in with their email and password.
+     */
+    public function testValidEmailPassword() {
+        $this->assertNoSession();
+
+        $this->api()->post("{$this->baseUrl}", [
+            'authenticate' => [
+                'authenticatorType' => 'password',
+                'authenticatorID' => 'password',
+            ],
+            'username' => $this->currentUser['email'],
+            'password' => $this->currentUser['password']
+        ]);
+
+        $this->assertSessionUserID();
+    }
+
+    /**
+     * A user should be able to sign in with their username and password.
+     */
+    public function testValidNamePassword() {
+        $this->assertNoSession();
+
+        $this->api()->post("{$this->baseUrl}", [
+            'authenticate' => [
+                'authenticatorType' => 'password',
+                'authenticatorID' => 'password',
+            ],
+            'username' => $this->currentUser['name'],
+            'password' => $this->currentUser['password']
+        ]);
+
+        $this->assertSessionUserID();
     }
 }

--- a/tests/APIv2/Authenticate/PasswordAuthenticatorTest.php
+++ b/tests/APIv2/Authenticate/PasswordAuthenticatorTest.php
@@ -164,6 +164,27 @@ class PasswordAuthenticatorTest extends AbstractAPIv2Test {
     }
 
     /**
+     * A banned user should not be able to log in.
+     *
+     * @expectedException \Exception
+     * @expectedExceptionCode 401
+     */
+    public function testUserBanned() {
+        /** @var \UserModel $userModel */
+        $userModel = $this->container()->get(\UserModel::class);
+        $userModel->ban($this->currentUser['userID'], ['AddActivity' => false]);
+
+        $this->api()->post("{$this->baseUrl}", [
+            'authenticate' => [
+                'authenticatorType' => 'password',
+                'authenticatorID' => 'password',
+            ],
+            'username' => $this->currentUser['email'],
+            'password' => $this->currentUser['password'],
+        ]);
+    }
+
+    /**
      * A user should be able to sign in with their email and password.
      */
     public function testValidEmailPassword() {


### PR DESCRIPTION
Fixes #7119

Throw relevant error when the session could not be started when using the AuthenticateApiController/SSOModel.

Before this fix the session would not be started but the API was returning code 200 with the user's information because `Gdn_Session->start()` doesn't do anything when the session could not be started.