### PR TITLE
Backport: Fix undefined $timeLeft variable notices

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -211,6 +211,7 @@ if (!function_exists('getDiscussionOptions')) :
      */
     function getDiscussionOptions($discussion = null) {
         $options = [];
+        $timeLeft = Gdn_Model::editContentTimeout($discussion, $timeLeft);
 
         $sender = Gdn::controller();
         $session = Gdn::session();
@@ -426,6 +427,7 @@ if (!function_exists('getCommentOptions')) :
      */
     function getCommentOptions($comment) {
         $options = [];
+        $timeLeft = Gdn_Model::editContentTimeout($comment, $timeLeft);
 
         if (!is_numeric(val('CommentID', $comment))) {
             return $options;

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -211,7 +211,6 @@ if (!function_exists('getDiscussionOptions')) :
      */
     function getDiscussionOptions($discussion = null) {
         $options = [];
-        $timeLeft = Gdn_Model::editContentTimeout($discussion, $timeLeft);
 
         $sender = Gdn::controller();
         $session = Gdn::session();
@@ -427,7 +426,6 @@ if (!function_exists('getCommentOptions')) :
      */
     function getCommentOptions($comment) {
         $options = [];
-        $timeLeft = Gdn_Model::editContentTimeout($comment, $timeLeft);
 
         if (!is_numeric(val('CommentID', $comment))) {
             return $options;
@@ -442,6 +440,9 @@ if (!function_exists('getCommentOptions')) :
         // Can the user edit the comment?
         $canEdit = CommentModel::canEdit($comment, $timeLeft, $discussion);
         if ($canEdit) {
+            if ($timeLeft) {
+                $timeLeft = ' ('.Gdn_Format::seconds($timeLeft).')';
+            }
             $options['EditComment'] = [
                 'Label' => t('Edit').$timeLeft,
                 'Url' => '/post/editcomment/'.$comment->CommentID,


### PR DESCRIPTION
Backporting #6970

> I just started seeing a lot of notices crop up with a missing variable. I’m not sure when the change was done, but the underlying function in Gdn_Model was added in ccae291fffc03636884b26d51475f57dbc0e4d4e.