### PR TITLE
Add default parameters to Gdn_ErrorException and fix cleanErrorArguments()

### DIFF
--- a/applications/dashboard/views/deverror.master.php
+++ b/applications/dashboard/views/deverror.master.php
@@ -91,20 +91,26 @@
             }
         }
 
-        if (function_exists('CleanErrorArguments') && is_array($Arguments) && count($Arguments) > 0) {
+        if (function_exists('__cleanErrorArguments') && is_array($Arguments) && count($Arguments) > 0) {
             echo '<h3><strong>Variables in local scope:</strong></h3>
             <div class="PreContainer">';
             $Odd = FALSE;
-            cleanErrorArguments($Arguments);
-            foreach ($Arguments as $Key => $Value) {
-                // Don't echo the configuration array as it contains sensitive information
-                if (!in_array($Key, ['Config', 'Configuration'])) {
-                    echo '<pre'.($Odd === FALSE ? '' : ' class="Odd"').'><strong>['.$Key.']</strong> ';
-                    echo htmlentities(var_export($Value, true), ENT_COMPAT, 'UTF-8');
-                    echo "</pre>\r\n";
-                    $Odd = $Odd == TRUE ? FALSE : TRUE;
+            try {
+                $Arguments = __cleanErrorArguments($Arguments);
+
+                foreach ($Arguments as $Key => $Value) {
+                    // Don't echo the configuration array as it contains sensitive information
+                    if (!in_array($Key, ['Config', 'Configuration'])) {
+                        echo '<pre'.($Odd === FALSE ? '' : ' class="Odd"').'><strong>['.$Key.']</strong> ';
+                        echo htmlentities(var_export($Value, true), ENT_COMPAT, 'UTF-8');
+                        echo "</pre>\r\n";
+                        $Odd = $Odd == TRUE ? FALSE : TRUE;
+                    }
                 }
+            } catch (\Throwable $ex) {
+                echo "<pre>{$ex->getMessage()}</pre>";
             }
+
             echo "</div>\n";
         }
         ?>

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -9,7 +9,9 @@
  */
 
 /**
- * Class Gdn_ErrorException
+ * This class is for internal use within the global error handler only. Don't use this class elsewhere.
+ *
+ * An extension of the **ErrorException** that includes context variables.
  */
 class Gdn_ErrorException extends ErrorException {
 

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -13,20 +13,20 @@
  */
 class Gdn_ErrorException extends ErrorException {
 
-    /** @var string */
+    /** @var array */
     protected $_Context;
 
     /**
+     * Constructs the exception.
      *
-     *
-     * @param string $message
-     * @param int $errorNumber
-     * @param int $file
-     * @param string $line
-     * @param int $context
+     * @param string $message The Exception message to throw.
+     * @param int $code The Exception code.
+     * @param string $filename The filename where the exception is thrown.
+     * @param int $line The line number where the exception is thrown.
+     * @param array $context The currently defined variables.
      */
-    public function __construct($message, $errorNumber, $file, $line, $context) {
-        parent::__construct($message, $errorNumber, 0, $file, $line);
+    public function __construct($message = "", $code = 0, $filename = __FILE__, $line = __LINE__, $context = []) {
+        parent::__construct($message, $code, 0, $filename, $line);
         $this->_Context = $context;
     }
 
@@ -48,7 +48,7 @@ class Gdn_ErrorException extends ErrorException {
  * @param $file
  * @param $line
  * @param $arguments
- * @return bool|void
+ * @return bool|null
  * @throws Gdn_ErrorException
  */
 function gdn_ErrorHandler($errorNumber, $message, $file, $line, $arguments) {
@@ -56,7 +56,7 @@ function gdn_ErrorHandler($errorNumber, $message, $file, $line, $arguments) {
 
     // Don't do anything for @supressed errors.
     if ($errorReporting === 0) {
-        return;
+        return null;
     }
 
     if (($errorReporting & $errorNumber) !== $errorNumber) {
@@ -671,6 +671,7 @@ if (!function_exists('cleanErrorArguments')) {
      *
      * @param $var
      * @param array $blackList
+     * @deprecated
      */
     function cleanErrorArguments(&$var, $blackList = ['configuration', 'config', 'database', 'password']) {
         if (is_array($var)) {
@@ -689,6 +690,49 @@ if (!function_exists('cleanErrorArguments')) {
                 }
             }
         }
+    }
+}
+
+if (!function_exists('__cleanErrorArguments')) {
+    /**
+     * This is an internal function not to be used outside of error printing.
+     *
+     * @param $var
+     * @param array $blackList
+     */
+    function __cleanErrorArguments($var, $blackList = ['configuration', 'config', 'database', 'password']) {
+        $seen = [];
+
+        $fn = function ($var, int $nest = 0) use (&$fn, $blackList, &$seen) {
+            if (is_array($var)) {
+                $result = [];
+                foreach ($var as $key => $value) {
+                    if (in_array(strtolower($key), $blackList)) {
+                        $value = '**SECURITY**';
+                    } else {
+                        if (is_object($value) && !in_array($value, $seen, true)) {
+                            $seen[] = $value;
+                            $value = Gdn_Format::objectAsArray($value);
+                        }
+
+                        if (is_array($value)) {
+                            if ($nest < 10) {
+                                $value = $fn($value, $nest + 1);
+                            } else {
+                                $value = "**MAX NESTING**";
+                            }
+                        }
+                    }
+                    $result[$key] = $value;
+                }
+            } else {
+                $result = $var;
+            }
+            return $result;
+        };
+
+        $result = $fn($var);
+        return $result;
     }
 }
 


### PR DESCRIPTION
With PHP 7.1 functions can no longer be called with too few arguments. This was causing issues with the Gdn_ErrorException constructor. I copied the defaults of its base class to help with this.

While fixing this issue I uncovered an issue with the cleanErrorArguments() function. It has no protection for infinite recursion and also doesn’t clean the security blacklist on object properties. I fixed this, but decided to make another version because I wanted a no side-effects version of the function.