### PR TITLE
Fix Category following filter displaying on QnA plugin

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -28,7 +28,7 @@ class CategoriesController extends VanillaController {
     /** @var object Category object. */
     public $Category;
 
-    /** @var boolean Value indicating if the category-following filter should be displayed when rendering a view */
+    /** @var bool Value indicating if the category-following filter should be displayed when rendering a view */
     public $enableFollowingFilter = false;
 
 

--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -28,6 +28,10 @@ class CategoriesController extends VanillaController {
     /** @var object Category object. */
     public $Category;
 
+    /** @var boolean Value indicating if the category-following filter should be displayed when rendering a view */
+    public $enableFollowingFilter = false;
+
+
     /**
      * @var \Closure $categoriesCompatibilityCallback A backwards-compatible callback to get `$this->data('Categories')`.
      */
@@ -261,10 +265,10 @@ class CategoriesController extends VanillaController {
 
         if ($this->CategoryModel->followingEnabled()) {
             // Only use the following filter on the root category level.
-            $enableFollowingFilter = $categoryIdentifier === '';
+            $this->enableFollowingFilter = $categoryIdentifier === '';
             $this->fireEvent('EnableFollowingFilter', [
                 'CategoryIdentifier' => $categoryIdentifier,
-                'EnableFollowingFilter' => &$enableFollowingFilter
+                'EnableFollowingFilter' => &$this->enableFollowingFilter
             ]);
 
             $followed = paramPreference(
@@ -275,9 +279,9 @@ class CategoriesController extends VanillaController {
                 Gdn::request()->get('save')
             );
         } else {
-            $enableFollowingFilter = $followed = false;
+            $this->enableFollowingFilter = $followed = false;
         }
-        $this->setData('EnableFollowingFilter', $enableFollowingFilter);
+        $this->setData('EnableFollowingFilter', $this->enableFollowingFilter);
         $this->setData('Followed', $followed);
 
         if ($categoryIdentifier == '') {

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -31,7 +31,7 @@ class DiscussionsController extends VanillaController {
     protected $categoryIDs;
 
     /** @var boolean Value indicating if the category-following filter should be displayed when rendering a view */
-    public $enableFollowingFilter;
+    public $enableFollowingFilter = false;
 
     /** @var array list of pages that opt in to the category following filter */
     private $categoryFilterList = ["discussions"];
@@ -351,7 +351,6 @@ class DiscussionsController extends VanillaController {
     public function initialize() {
         parent::initialize();
         $this->ShowOptions = true;
-        $this->enableFollowingFilter = false;
         $this->Menu->highlightRoute('/discussions');
         $this->addJsFile('discussions.js');
 
@@ -856,7 +855,7 @@ class DiscussionsController extends VanillaController {
      *
      * @param string $url
      */
-    public function setCategoryFollowingList(string $url = null) {
+    public function addCategoryFollowingUrl(string $url) {
         if ($url) {
             array_push($this->categoryFilterList, $url);
         }

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -33,6 +33,9 @@ class DiscussionsController extends VanillaController {
     /** @var boolean Value indicating if the category-following filter should be displayed when rendering a view */
     public $enableFollowingFilter;
 
+    /** @var array list of pages that opt in to the category following filter */
+    private $categoryFilterList = ["discussions"];
+
 
     /**
      * "Table" layout for discussions. Mimics more traditional forum discussion layout.
@@ -133,8 +136,7 @@ class DiscussionsController extends VanillaController {
                 null,
                 Gdn::request()->get('save')
             );
-            // If categories aren't set we display the category following view filter
-            if ((!$this->categoryIDs) && !is_array($this->categoryIDs)) {
+            if (in_array($this->SelfUrl, $this->categoryFilterList)) {
                 $this->enableFollowingFilter = true;
             }
         } else {
@@ -847,5 +849,16 @@ class DiscussionsController extends VanillaController {
 
         $this->View = c('Vanilla.Discussions.Layout') == 'table' && $this->SyndicationMethod == SYNDICATION_NONE ? 'table' : 'index';
         $this->render($this->View, 'discussions', 'vanilla');
+    }
+
+    /**
+     * Allows pages to opt-in to the category following filter.
+     *
+     * @param string $selfURL
+     */
+    public function setCategoryFollowingList(string $selfURL = null) {
+        if ($selfURL) {
+            array_push($this->categoryFilterList, $selfURL);
+        }
     }
 }

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -30,6 +30,9 @@ class DiscussionsController extends VanillaController {
     /** @var array Limit the discussions to just this list of categories, checked for view permission. */
     protected $categoryIDs;
 
+    /** @var boolean Value indicating if the category-following filter should be displayed when rendering a view */
+    public $enableFollowingFilter;
+
 
     /**
      * "Table" layout for discussions. Mimics more traditional forum discussion layout.
@@ -120,7 +123,6 @@ class DiscussionsController extends VanillaController {
 
         $this->setData('Breadcrumbs', [['Name' => t('Recent Discussions'), 'Url' => '/discussions']]);
 
-
         $categoryModel = new CategoryModel();
         $followingEnabled = $categoryModel->followingEnabled();
         if ($followingEnabled) {
@@ -131,10 +133,14 @@ class DiscussionsController extends VanillaController {
                 null,
                 Gdn::request()->get('save')
             );
+            // If categories aren't set we display the category following view filter
+            if ((!$this->categoryIDs) && !is_array($this->categoryIDs)) {
+                $this->enableFollowingFilter = true;
+            }
         } else {
             $followed = false;
         }
-        $this->setData('EnableFollowingFilter', $followingEnabled);
+        $this->setData('EnableFollowingFilter', $this->enableFollowingFilter);
         $this->setData('Followed', $followed);
 
         // Set criteria & get discussions data
@@ -343,6 +349,7 @@ class DiscussionsController extends VanillaController {
     public function initialize() {
         parent::initialize();
         $this->ShowOptions = true;
+        $this->enableFollowingFilter = false;
         $this->Menu->highlightRoute('/discussions');
         $this->addJsFile('discussions.js');
 

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -30,12 +30,8 @@ class DiscussionsController extends VanillaController {
     /** @var array Limit the discussions to just this list of categories, checked for view permission. */
     protected $categoryIDs;
 
-    /** @var boolean Value indicating if the category-following filter should be displayed when rendering a view */
+    /** @var boolean Value indicating whether to show the category following filter */
     public $enableFollowingFilter = false;
-
-    /** @var array list of pages that opt in to the category following filter */
-    private $categoryFilterList = ["discussions"];
-
 
     /**
      * "Table" layout for discussions. Mimics more traditional forum discussion layout.
@@ -136,7 +132,7 @@ class DiscussionsController extends VanillaController {
                 null,
                 Gdn::request()->get('save')
             );
-            if (in_array($this->SelfUrl, $this->categoryFilterList)) {
+            if ($this->SelfUrl === "discussions") {
                 $this->enableFollowingFilter = true;
             }
         } else {
@@ -848,16 +844,5 @@ class DiscussionsController extends VanillaController {
 
         $this->View = c('Vanilla.Discussions.Layout') == 'table' && $this->SyndicationMethod == SYNDICATION_NONE ? 'table' : 'index';
         $this->render($this->View, 'discussions', 'vanilla');
-    }
-
-    /**
-     * Allows pages to opt-in to the category following filter.
-     *
-     * @param string $url
-     */
-    public function addCategoryFollowingUrl(string $url) {
-        if ($url) {
-            array_push($this->categoryFilterList, $url);
-        }
     }
 }

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -854,11 +854,11 @@ class DiscussionsController extends VanillaController {
     /**
      * Allows pages to opt-in to the category following filter.
      *
-     * @param string $selfURL
+     * @param string $url
      */
-    public function setCategoryFollowingList(string $selfURL = null) {
-        if ($selfURL) {
-            array_push($this->categoryFilterList, $selfURL);
+    public function setCategoryFollowingList(string $url = null) {
+        if ($url) {
+            array_push($this->categoryFilterList, $url);
         }
     }
 }


### PR DESCRIPTION
fixes vanilla/addons#629

The category-following filter is currently by default true and with and  the option to opt-out.  This allows for the filter to be displayed on views that it shouldn't.  The filter should only be displayed on the category index and recent discussions pages.

This fix checks if category following is enabled and then allows the view to opt in or out accordingly.  In order to opt-in, the SelfUrl will have to be added to the $categoryFilterList.  The DiscussionsController::setCategoryFollowingList can be used to set any request to opt-in.

This approach was taken because some plugins call the DiscussionsController::index method (ie. QnA ) and there was no clear way to distinguish whether the filter should be displayed (opted into) besides the requested url to the controller.

I've tested this using the QnA, Resolved, Participated, Ideation and Reaction plugins.  Subcommunities were tested as well.

