### PR TITLE
Disable hashtags by default

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -120,7 +120,7 @@ $Configuration['Garden']['Html']['AllowedElements'] = "a, abbr, acronym, address
 $Configuration['Garden']['Search']['Mode'] = 'boolean'; // matchboolean, match, boolean, like
 $Configuration['Garden']['EditContentTimeout'] = 3600; // -1 means no timeout. 0 means immediate timeout. > 0 is in seconds. 60 * 60 = 3600 (aka 1hr)
 $Configuration['Garden']['Format']['Mentions'] = true;
-$Configuration['Garden']['Format']['Hashtags'] = true;
+$Configuration['Garden']['Format']['Hashtags'] = false;
 $Configuration['Garden']['Format']['YouTube'] = true;
 $Configuration['Garden']['Format']['Vimeo'] = true;
 $Configuration['Garden']['Format']['EmbedSize'] = 'normal'; // tiny/small/normal/big/huge or WIDTHxHEIGHT


### PR DESCRIPTION
A recent internal poll revealed much of our own staff didn't know that Vanilla auto-links #hashtags to a search page. Conversely, we frequently see the results of accidental hashtags from writing numbers, e.g. #3, in the middle of a post. Since this appears to be 99% of all uses of this feature, let's start by disabling it in the config and folks who are super attached to it can tell us to re-enable it on their site.