### PR TITLE
Do not block Vanilla install for stub or swagger addons

### DIFF
--- a/applications/dashboard/controllers/class.setupcontroller.php
+++ b/applications/dashboard/controllers/class.setupcontroller.php
@@ -118,7 +118,7 @@ class SetupController extends DashboardController {
                             ]);
                         }
                     } catch (Exception $ex) {
-                        $this->Form->addError($ex);
+                        // Do nothing so we don't block install for a non-critical addon.
                     }
                 }
 


### PR DESCRIPTION
We currently auto-enable two addons on install:
* `swagger-ui` (API v2 convenience docs in the Dashboard)
* `stubcontent` (prepopulates some dummy content)

If either of these is missing, a generic "Plugin not found." error is returned on install, blocking further progress and not giving sufficient info to remedy it. Further, adding the missing addon doesn't fix the problem until you manually clear the addon cache (`cache/addon.php`). 

Neither of these addons is critical (hence... addons), there are legitimate reasons they might be removed from a package, and we don't have sufficient handling around the error condition if they fail. Therefore, this pull request removes the error being added to the form data so that install will proceed uninterrupted.