### PR TITLE
Backport: Fix default condition in ActivityModel::canView

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -122,14 +122,14 @@ class ActivityModel extends Gdn_Model {
                     $result = true;
                 }
                 break;
-            case ActivityModel::NOTIFY_ADMIN:
+            case ActivityModel::NOTIFY_ADMINS:
                 if (checkPermission('Garden.Settings.Manage')) {
                     $result = true;
                 }
                 break;
             default:
                 // Actual userid.
-                if (checkPermission('Garden.Community.Manage') && Gdn::session()->UserID === $userid) {
+                if (Gdn::session()->UserID === $userid || checkPermission('Garden.Community.Manage')) {
                     $result = true;
                 }
                 break;


### PR DESCRIPTION
Backports #7090 

> `ActivityModel::canView` has a couple issues that are addressed here.
>
> 1. There's a typo in `ActivityModel::NOTIFY_ADMINS` ([that's apparently been there for almost three years](https://github.com/vanilla/vanilla/commit/5250b1cc36f0d2726bf22c77a88cdb37a180e6f9#diff-987a5acb3eb9035837eb3a5a705b500fR104)).
> 1. The fallback permission check attempts to determine if the user has the community management permission, first, *and* that they are the target user for the action. It should be checking if they are the target user, first, *or* if they have the community management permission.