### PR TITLE
Add validation filters and the BodyFormatValidator class

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -61,9 +61,11 @@ class ActivityModel extends Gdn_Model {
 
     /**
      * Defines the related database table name.
+     *
+     * @param Gdn_Validation $validation The validation dependency.
      */
-    public function __construct() {
-        parent::__construct('Activity');
+    public function __construct(Gdn_Validation $validation = null) {
+        parent::__construct('Activity', $validation);
         try {
             $this->setPruneAfter(c('Garden.PruneActivityAfter', '2 months'));
         } catch (Exception $ex) {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -76,10 +76,11 @@ class UserModel extends Gdn_Model {
     /**
      * Class constructor. Defines the related database table name.
      *
-     * @param EventManager $eventManager
+     * @param EventManager $eventManager The event manager dependency.
+     * @param Gdn_Validation $validation The validation dependency.
      */
-    public function __construct(EventManager $eventManager = null) {
-        parent::__construct('User');
+    public function __construct(EventManager $eventManager = null, Gdn_Validation $validation = null) {
+        parent::__construct('User', $validation);
 
         if ($eventManager === null) {
             $this->eventManager = Gdn::getContainer()->get(EventManager::class);

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -46,11 +46,10 @@ class CommentModel extends Gdn_Model {
     /**
      * Class constructor. Defines the related database table name.
      *
-     * @since 2.0.0
-     * @access public
+     * @param Gdn_Validation $validation The validation dependency.
      */
-    public function __construct() {
-        parent::__construct('Comment');
+    public function __construct(Gdn_Validation $validation = null) {
+        parent::__construct('Comment', $validation);
         $this->floodGate = FloodControlHelper::configure($this, 'Vanilla', 'Comment');
         $this->pageCache = Gdn::cache()->activeEnabled() && c('Properties.CommentModel.pageCache', false);
         $this->fireEvent('AfterConstruct');

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -101,11 +101,10 @@ class DiscussionModel extends Gdn_Model {
     /**
      * Class constructor. Defines the related database table name.
      *
-     * @since 2.0.0
-     * @access public
+     * @param Gdn_Validation $validation The validation dependency.
      */
-    public function __construct() {
-        parent::__construct('Discussion');
+    public function __construct(Gdn_Validation $validation = null) {
+        parent::__construct('Discussion', $validation);
         $this->floodGate = FloodControlHelper::configure($this, 'Vanilla', 'Discussion');
     }
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -185,6 +185,9 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->rule('Gdn_Model')
     ->setShared(true)
 
+    ->rule(Gdn_Validation::class)
+    ->addCall('addRule', ['BodyFormat', new Reference(\Vanilla\BodyFormatValidator::class)])
+
     ->rule(\Vanilla\Models\AuthenticatorModel::class)
     ->setShared(true)
     ->addCall('registerAuthenticatorClass', [\Vanilla\Authenticator\PasswordAuthenticator::class])

--- a/library/Vanilla/BodyFormatValidator.php
+++ b/library/Vanilla/BodyFormatValidator.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace Vanilla;
+
+
+class BodyFormatValidator {
+    public function __invoke() {
+        // TODO: Implement __invoke() method.
+    }
+}

--- a/library/Vanilla/BodyFormatValidator.php
+++ b/library/Vanilla/BodyFormatValidator.php
@@ -2,14 +2,85 @@
 /**
  * @author Todd Burry <todd@vanillaforums.com>
  * @copyright 2009-2018 Vanilla Forums Inc.
- * @license Proprietary
+ * @license GPLv2
  */
 
 namespace Vanilla;
 
-
+/**
+ * Validates body fields to make sure it complies with its format.
+ */
 class BodyFormatValidator {
-    public function __invoke() {
-        // TODO: Implement __invoke() method.
+    private $validators = [];
+
+    /**
+     * BodyFormatValidator constructor.
+     */
+    public function __construct() {
+        $this->validators = [
+            'rich' => [$this, 'validateRich'],
+        ];
+    }
+
+    /**
+     * Add a validator for a specific format.
+     *
+     * The validator must be a callable with the following signature:
+     *
+     * ```
+     * function validate($value, $field, $row = []): mixed|Invalid
+     * ```
+     *
+     * The validator will return value, optionally filtered on success or an instance of `Vanilla\Invalid` on failure.
+     *
+     * Adding a validator to a format that already exists will replace the existing validator.
+     *
+     * @param string $format The format to validate.
+     * @param callable|null $validator The validation function.
+     * @return $this
+     */
+    public function addFormatValidator(string $format, callable $validator = null) {
+        $this->validators[strtolower($format)] = $validator;
+        return $this;
+    }
+
+    /**
+     * Validate richly formatted text.
+     *
+     * @param string $value The value to validate.
+     * @param object $field The field meta data of the value.
+     * @param array $row The entire row where the field is.
+     * @return string|Invalid Returns the re-encoded string on success or `Invalid` on failure.
+     */
+    private function validateRich($value, $field, $row = []) {
+        $value = json_decode($value, true);
+        if ($value === null) {
+            $value = new Invalid("%s is not valid rich text.");
+        } else {
+            // Re-encode the value to escape unicode values.
+            $value = json_encode($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Validate a body field against its format.
+     *
+     * @param string $value The value to validate.
+     * @param object $field The field meta data of the value.
+     * @param array $row The entire row where the field is.
+     * @return string|Invalid Returns the valid string on success or `Invalid` on failure.
+     */
+    public function __invoke($value, $field, $row = []) {
+        $format = strtolower($row['Format'] ?? 'raw');
+
+        if (isset($this->validators[$format])) {
+            $valid = call_user_func($this->validators[$format], $value, $field, $row);
+        } else {
+            $valid = $value;
+        }
+
+        return $valid;
     }
 }

--- a/library/Vanilla/Invalid.php
+++ b/library/Vanilla/Invalid.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla;
+
+
+/**
+ * Represents an invalid validation result.
+ */
+class Invalid {
+    /**
+     * @var string
+     */
+    private $messageCode;
+
+    /**
+     * Invalid constructor.
+     *
+     * @param string $messageCode The message translation code.
+     */
+    public function __construct(string $messageCode) {
+        $this->messageCode = $messageCode;
+    }
+
+    /**
+     * Get the error message translation code.
+     *
+     * @return string Returns the message code.
+     */
+    public function getMessageCode(): string {
+        return $this->messageCode;
+    }
+
+    /**
+     * A default instance with no error message.
+     *
+     * Use this instance like a singleton if you don't need a custom error message.
+     *
+     * @return Invalid Returns an invalid value.
+     */
+    public static function emptyMessage() {
+        static $value;
+        if ($value === null) {
+            $value = new Invalid('');
+        }
+
+        return $value;
+    }
+}

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -88,17 +88,22 @@ class Gdn_Model extends Gdn_Pluggable {
     /**
      * Class constructor. Defines the related database table name.
      *
-     * @param string $name An optional parameter that allows you to explicitly define the name of
-     * the table that this model represents. You can also explicitly set this value with $this->Name.
+     * @param string $name Optionally define the name of the table that this model represents.
+     * You can also explicitly set this value with $this->Name.
+     * @param Gdn_Validation $validation The validation dependency.
+     * If a validation object is not passed in the constructor then one will be created.
      */
-    public function __construct($name = '') {
+    public function __construct($name = '', Gdn_Validation $validation = null) {
         if ($name == '') {
             $name = get_class($this);
         }
 
         $this->Database = Gdn::database();
         $this->SQL = $this->Database->sql();
-        $this->Validation = new Gdn_Validation();
+        if ($validation === null) {
+            $validation = new Gdn_Validation();
+        }
+        $this->Validation = $validation;
         $this->Name = $name;
         $this->PrimaryKey = $name.'ID';
         $this->filterFields = [
@@ -139,6 +144,26 @@ class Gdn_Model extends Gdn_Pluggable {
      * A overridable function called before the various get queries.
      */
     protected function _beforeGet() {
+    }
+
+    /**
+     * Get the validation object used to validate data upon saving.
+     *
+     * @return Gdn_Validation Returns the validation object.
+     */
+    public function getValidation(): Gdn_Validation {
+        return $this->Validation;
+    }
+
+    /**
+     * Set the validation object used to validate data upon saving.
+     *
+     * @param Gdn_Validation $Validation The new validation object.
+     * @return $this
+     */
+    public function setValidation(Gdn_Validation $Validation) {
+        $this->Validation = $Validation;
+        return $this;
     }
 
     /**

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -225,6 +225,10 @@ class Gdn_Validation {
                 $ruleNames[] = 'Format';
             }
 
+            if ($field === 'Body' && isset($this->_Schema['Format']) && $this->ruleExists('BodyFormat')) {
+                $ruleNames[] = 'BodyFormat';
+            }
+
             // Assign the rules to the field.
             // echo '<div>Field: '.$Field.'</div>';
             // print_r($RuleNames);
@@ -428,7 +432,7 @@ class Gdn_Validation {
      * When adding a callback it must have the following signature:
      *
      * ```
-     * function validator(mixed $value, ArrayObject $fieldInfo, array $row): mixed|Invalid
+     * function validator(mixed $value, object $fieldInfo, array $row): mixed|Invalid
      * ```
      *
      * Predefined rule names are:
@@ -450,7 +454,7 @@ class Gdn_Validation {
      * @param string|callable $rule The rule to be added.
      * @param bool $filter Whether or not the rule filters the value. This is ignored when the rule is a callback.
      */
-    public function addRule(string $name, $rule, bool $filter = false) {
+    public function addRule(string $name, $rule, bool $filter = null) {
         // Callback rules are always filtered.
         if (!is_string($rule) && is_callable($rule)) {
             $filter = true;
@@ -458,7 +462,17 @@ class Gdn_Validation {
 
         $this->_Rules[$name] = $rule;
 
-        $this->rules[$name] = [$rule, $filter];
+        $this->rules[$name] = [$rule, (bool)$filter];
+    }
+
+    /**
+     * Determine whether or not a rule exists.
+     *
+     * @param string $name The name of the rule.
+     * @return bool Returns **true** if the rule exists or **false** otherwise.
+     */
+    public function ruleExists(string $name) {
+        return !empty($this->rules[$name]);
     }
 
     /**

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -10,17 +10,26 @@
  * @since 2.0
  */
 
+use Vanilla\Invalid;
+
 /**
- * Manages data integrity validation rules. Can automatically define a set of
- * validation rules based on a @@Schema with $this->generateBySchema($Schema);
+ * Manages data integrity validation rules.
+ *
+ * Can automatically define a set of validation rules based on a schema with `$this->generateBySchema($Schema)`.
  */
 class Gdn_Validation {
 
     /**
-     * @var array The collection of validation rules in the format of $RuleName => $Rule.
-     * This list can be added to with $this->addRule($RuleName, $Rule).
+     * @var array The old collection of rules.
+     * @deprecated
      */
-    protected $_Rules;
+    protected $_Rules = [];
+
+    /**
+     * @var array The collection of validation rules in the format of `$ruleName => [$rule, $filter]`.
+     * This list can be added to with $this->addRule($name, $rule, $filter).
+     */
+    private $rules = [];
 
     /**
      * @var array An associative array of fieldname => value pairs that are being validated.
@@ -54,22 +63,21 @@ class Gdn_Validation {
     protected $_ResetOnValidate = false;
 
     /** @var array An array of FieldName.RuleName => "Custom Error Message"s. See $this->ApplyRule. */
-    private $_CustomErrors = [];
+    private $customErrors = [];
 
     /**
      * Class constructor. Optionally takes a schema definition to generate validation rules for.
      *
      * @param Gdn_Schema|array $schema A schema object to generate validation rules for.
-     * @param bool Whether or not to reset the validation results on {@link validate()}.
+     * @param bool $resetOnValidate Whether or not to reset the validation results on {@link validate()}.
      */
-    public function __construct($schema = false, $resetOnValidate = false) {
+    public function __construct($schema = null, $resetOnValidate = false) {
         if (is_object($schema) || is_array($schema)) {
             $this->setSchema($schema);
         }
         $this->setResetOnValidate($resetOnValidate);
 
-        // Define the default validation functions
-        $this->_Rules = [];
+        // Define the default validation functions.
         $this->addRule('Required', 'function:ValidateRequired');
         $this->addRule('RequiredArray', 'function:ValidateRequiredArray');
         $this->addRule('Email', 'function:ValidateEmail');
@@ -177,6 +185,7 @@ class Gdn_Validation {
 
                 case 'date':
                 case 'datetime':
+                case 'timestamp':
                     $ruleNames[] = 'Date';
                     break;
                 case 'time':
@@ -184,9 +193,6 @@ class Gdn_Validation {
                     break;
                 case 'year':
                     $ruleNames[] = 'Year';
-                    break;
-                case 'timestamp':
-                    $ruleNames[] = 'Timestamp';
                     break;
 
                 case 'char':
@@ -204,7 +210,7 @@ class Gdn_Validation {
                     if (!in_array($field, ['Attributes', 'Data', 'Preferences', 'Permissions'])) {
                         $ruleNames[] = 'String';
                     }
-                    if ($properties->Length != '') {
+                    if (!empty($properties->Length)) {
                         $ruleNames[] = 'Length';
                     }
                     break;
@@ -215,7 +221,7 @@ class Gdn_Validation {
                     break;
             }
 
-            if ($field == 'Format') {
+            if ($field === 'Format') {
                 $ruleNames[] = 'Format';
             }
 
@@ -248,24 +254,24 @@ class Gdn_Validation {
     /**
      * Apply a rule to the given rules array.
      *
-     * @param array $array The rules array to apply the rule to.
+     * @param array &$array The rules array to apply the rule to.
      * This should be either `$this->_FieldRules` or `$this->_SchemaRules`.
      * @param string $fieldName The name of the field that the rule applies to.
-     * @param string $ruleName The name of the rule.
+     * @param string|array $ruleName The name of the rule.
      * @param string $customError A custom error string when the rule is broken.
      */
     protected function applyRuleTo(&$array, $fieldName, $ruleName, $customError = '') {
         $array = (array)$array;
 
         if (!is_array($ruleName)) {
-            if ($customError != '') {
-                $this->_CustomErrors[$fieldName.'.'.$ruleName] = $customError;
+            if (!empty($customError)) {
+                $this->customErrors[$fieldName.'.'.$ruleName] = $customError;
             }
 
             $ruleName = [$ruleName];
         }
 
-        $existingRules = val($fieldName, $array, []);
+        $existingRules = $array[$fieldName] ?? [];
 
         // Merge the new rules with the existing ones (array_merge) and make
         // sure there is only one of each rule applied (array_unique).
@@ -405,41 +411,49 @@ class Gdn_Validation {
     /**
      * Adds to the rules collection ($this->_Rules).
      *
-     * If $ruleName already
-     * exists, this method will overwrite the existing rule. There are some
-     * special cases:
-     *  1. If the $rule begins with "function:", when the rule is evaluated
-     * on a field, it will strip the "function:" from the $rule and execute
-     * the remaining string name as a function with the field value passed as
-     * the first parameter and the related field properties as the second
-     * parameter. ie. "function:MySpecialValidation" will evaluate as
-     * mySpecialValidation($FieldValue, $FieldProperties). Any function defined
-     * in this way is expected to return boolean TRUE or FALSE.
-     *  2. If $rule begins with "regex:", when the rule is evaluated on a
-     * field, it will strip the "regex:" from $rule and use the remaining
-     * string as a regular expression rule. If a match between the regex rule
-     * and the field value is made, it will validate as TRUE.
-     *  3. Predefined $ruleNames are:
-     *  RuleName   Rule
-     *  ========================================================================
-     *  Required   Will not accept a null or empty value.
-     *  Email      Will validate against an email regex.
-     *  Date       Will only accept valid date values in a variety of formats.
-     *  Integer    Will only accept an integer.
-     *  Boolean    Will only accept 1 or 0.
-     *  Decimal    Will only accept a decimal.
-     *  Time       Will only accept a time in HH:MM:SS or HH:MM format.
-     *  Timestamp  Will only accept a valid timestamp.
-     *  Length     Will not accept a value longer than $Schema[$Field]->Length.
-     *  Enum       Will only accept one of the values in the $Schema[$Field]->Enum array.
+     * If $ruleName already exists, this method will overwrite the existing rule. There are some special cases:
      *
-     * @param string $ruleName The name of the rule to be added.
-     * @param string $rule The rule to be added. These are in the format of "function:FunctionName"
-     * or "regex:/regex/". Any function defined here must be included before
-     * the rule is enforced or the application will cause a fatal error.
+     * 1. If the $rule begins with "function:", when the rule is evaluated on a field, it will strip the "function:"
+     * from the $rule and execute the remaining string name as a function with the field value passed as the first
+     * parameter and the related field properties as the second parameter. ie. "function:MySpecialValidation" will
+     * evaluate as mySpecialValidation($FieldValue, $FieldProperties). Any function defined in this way is expected to
+     * return boolean **true** or **flase**.
+     *
+     * 2. If $rule begins with "regex:", when the rule is evaluated on a field, it will strip the "regex:" from $rule
+     * and use the remaining string as a regular expression rule. If a match between the regex rule and the field value
+     * is made, it will validate as **true**.
+     *
+     * 3. If the rule is callable then it will be invoked to validate the value.
+     *
+     * When adding a callback it must have the following signature:
+     *
+     * ```
+     * function validator(mixed $value, ArrayObject $fieldInfo, array $row): mixed|Invalid
+     * ```
+     *
+     * Predefined rule names are:
+     *
+     * RuleName     | Rule
+     * ------------ | ----
+     *  Required    | Will not accept a null or empty value.
+     *  Email       | Will validate against an email regex.
+     *  Date        | Will only accept valid date values in a variety of formats.
+     *  Integer     | Will only accept an integer.
+     *  Boolean     | Will only accept 1 or 0, true or false.
+     *  Decimal     | Will only accept a decimal.
+     *  Time        | Will only accept a time in HH:MM:SS or HH:MM format.
+     *  Timestamp   | Will only accept a valid timestamp.
+     *  Length      | Will not accept a value longer than $Schema[$Field]->Length.
+     *  Enum        | Will only accept one of the values in the $Schema[$Field]->Enum array.
+     *
+     * @param string $name The name of the rule to be added.
+     * @param string|callable $rule The rule to be added.
+     * @param bool $filter Whether or not the rule filters the value.
      */
-    public function addRule($ruleName, $rule) {
-        $this->_Rules[$ruleName] = $rule;
+    public function addRule(string $name, $rule, bool $filter = false) {
+        $this->_Rules[$name] = $rule;
+
+        $this->rules[$name] = [$rule, $filter];
     }
 
     /**
@@ -466,8 +480,7 @@ class Gdn_Validation {
      * Adds a fieldname to the $this->_ValidationFields collection.
      *
      * @param string $fieldName The name of the field to add to the $this->_ValidationFields collection.
-     * @param array $postedFields The associative array collection of field names to examine for the value
-     *  of $fieldName.
+     * @param array $postedFields The associative array collection of field names to examine for the value of $fieldName.
      */
     protected function addValidationField($fieldName, $postedFields) {
         if (!is_array($this->_ValidationFields)) {
@@ -519,9 +532,11 @@ class Gdn_Validation {
      *    - Name: The name of the function used to validate.
      *    - Args: An argument to pass to the function after the value.
      * @param string $customError A custom error message.
-     * @return bool|string One of the following
-     *  - TRUE: The value passed validation.
+     * @return bool|string One of the following:
+     *
+     *  - **true**: The value passed validation.
      *  - string: The error message associated with the error.
+     * @deprecated
      */
     public static function validateRule($value, $fieldName, $rule, $customError = false) {
         // Figure out the type of rule.
@@ -610,7 +625,9 @@ class Gdn_Validation {
         $honeypotName = c('Garden.Forms.HoneypotName', '');
         $honeypotContents = getPostValue($honeypotName, '');
         if ($honeypotContents != '') {
-            $this->addValidationResult($honeypotName, "You've filled our honeypot! We use honeypots to help prevent spam. If you're not a spammer or a bot, you should contact the application administrator for help.");
+            $this->addValidationResult(
+                $honeypotName,
+                "You've filled our honeypot! We use honeypots to help prevent spam. If you're not a spammer or a bot, you should contact the application administrator for help.");
         }
 
         $fieldRules = $this->defineValidationRules($postedFields, $insert);
@@ -618,51 +635,7 @@ class Gdn_Validation {
 
         // Loop through the fields that should be validated
         foreach ($fields as $fieldName => $fieldValue) {
-            // If this field has rules to be enforced...
-            if (array_key_exists($fieldName, $fieldRules) && is_array($fieldRules[$fieldName])) {
-                // Enforce them.
-                $rules = $fieldRules[$fieldName];
-
-                // Get the field info for the field.
-                $fieldInfo = ['Name' => $fieldName];
-                if (is_array($this->_Schema) && array_key_exists($fieldName, $this->_Schema)) {
-                    $fieldInfo = array_merge($fieldInfo, (array)$this->_Schema[$fieldName]);
-                }
-                $fieldInfo = (object)$fieldInfo;
-
-                foreach ($rules as $ruleName) {
-                    if (array_key_exists($ruleName, $this->_Rules)) {
-                        $rule = $this->_Rules[$ruleName];
-                        // echo '<div>FieldName: '.$FieldName.'; Rule: '.$Rule.'</div>';
-                        if (substr($rule, 0, 9) == 'function:') {
-                            $function = substr($rule, 9);
-                            if (!function_exists($function)) {
-                                trigger_error(errorMessage('Specified validation function could not be found.', 'Validation', 'Validate', $function), E_USER_ERROR);
-                            }
-
-                            $validationResult = $function($fieldValue, $fieldInfo, $postedFields);
-                            if ($validationResult !== true) {
-                                // If $ValidationResult is not FALSE, assume it is an error message
-                                $errorCode = $validationResult === false ? $function : $validationResult;
-                                // If there is a custom error, use it above all else
-                                $errorCode = val($fieldName.'.'.$ruleName, $this->_CustomErrors, $errorCode);
-                                // Add the result
-                                $this->addValidationResult($fieldName, $errorCode);
-                                // Only add one error per field
-                            }
-                        } elseif (substr($rule, 0, 6) == 'regex:') {
-                            $regex = substr($rule, 6);
-                            if (validateRegex($fieldValue, $regex) !== true) {
-                                $errorCode = 'Regex';
-                                // If there is a custom error, use it above all else
-                                $errorCode = val($fieldName.'.'.$ruleName, $this->_CustomErrors, $errorCode);
-                                // Add the result
-                                $this->addValidationResult($fieldName, $errorCode);
-                            }
-                        }
-                    }
-                }
-            }
+            $this->validateField($fieldValue, $fieldName, $postedFields, $fieldRules);
         }
         $this->_ValidationFields = $fields;
         return count($this->_ValidationResults) === 0;
@@ -700,8 +673,9 @@ class Gdn_Validation {
     }
 
     /**
-     * Returns the $this->_ValidationResults array. You must use this method
-     * because the array is read-only outside this object.
+     * Returns the $this->_ValidationResults array.
+     *
+     * You must use this method because the array is read-only outside this object.
      *
      * @param bool $reset Whether or not to clear the validation results.
      * @return array Returns an array of validation results (errors).
@@ -743,5 +717,77 @@ class Gdn_Validation {
 
         $result = implode(' ', $errors);
         return $result;
+    }
+
+    /**
+     * Validate a single field value.
+     *
+     * @param mixed $fieldValue The value of the field.
+     * @param string $fieldName The name of the field.
+     * @param array $row The entire row of data.
+     * @param array $fieldRules The full array of rules.
+     * @return mixed|Invalid Returns the valid value, piossibly filtered or an instance of **Invalid** if validation fails.
+     */
+    private function validateField($fieldValue, string $fieldName, $row, array $fieldRules) {
+        if (!isset($fieldRules[$fieldName]) || !is_array($fieldRules[$fieldName])) {
+            return $fieldValue;
+        }
+
+        $rules = $fieldRules[$fieldName];
+
+        // Get the field info for the field.
+        $fieldInfo = ['Name' => $fieldName];
+        if (is_array($this->_Schema) && array_key_exists($fieldName, $this->_Schema)) {
+            $fieldInfo = array_replace($fieldInfo, (array)$this->_Schema[$fieldName]);
+        }
+        $fieldInfo = new ArrayObject($fieldInfo, ArrayObject::ARRAY_AS_PROPS);
+
+        foreach ($rules as $ruleName) {
+            if (!array_key_exists($ruleName, $this->rules)) {
+                continue;
+            }
+            list($rule, $filter) = $this->rules[$ruleName];
+
+            if (is_string($rule)) {
+                list($ruleType, $ruleValue) = explode(':', $rule, 2) + ['', ''];
+
+                switch ($ruleType) {
+                    case 'function':
+                        $function = $ruleValue;
+                        if (!function_exists($function)) {
+                            throw new \Exception("Specified validation function could not be found: $function", 500);
+                        }
+
+                        $validationResult = call_user_func($function, $fieldValue, $fieldInfo, $row);
+                        if ($validationResult !== true) {
+                            $errorCode = $this->customErrors["$fieldName.$ruleName"] ?? ($validationResult === false ? $function : $validationResult);
+                            $this->addValidationResult($fieldName, $errorCode);
+
+                            if ($ruleName === 'Required') {
+                                // If a required validation failed then skip other rules.
+                                break 2;
+                            }
+                        }
+                        break;
+                    case 'regex':
+                        $regex = $ruleValue;
+                        if (validateRegex($fieldValue, $regex) !== true) {
+                            $errorCode = $this->customErrors["$fieldName.$ruleName"] ?? 'Regex';
+                            $this->addValidationResult($fieldName, $errorCode);
+                        }
+                        break;
+                    default:
+                        trigger_error("Unknown rule type: $ruleType.", E_USER_NOTICE);
+                }
+            } elseif (is_callable($rule)) {
+                $validValue = call_user_func($rule, $fieldValue, $fieldInfo, $row);
+                if ($validValue instanceof Invalid) {
+                    $errorCode = $this->customErrors["$fieldName.$ruleName"] ?? ($validValue->getMessageCode() ?: $ruleName);
+                    $this->addValidationResult($fieldName, $errorCode);
+                }
+            } else {
+                trigger_error("Unknown validator format for rule: $ruleName.", E_USER_NOTICE);
+            }
+        }
     }
 }

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -466,7 +466,7 @@ if (!function_exists('validateTime')) {
                 return sprintf('%d:%02d:%02d', $h, $m, $s);
             }
         }
-            return \Vanilla\Invalid::emptyMessage();
+        return \Vanilla\Invalid::emptyMessage();
     }
 }
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -454,11 +454,19 @@ if (!function_exists('validateTime')) {
      * Validate that a value can be converted into a time string.
      *
      * @param mixed $value The value to validate.
-     * @return bool Returns true if the value validates or false otherwise.
+     * @return string|\Vanilla\Invalid Returns a filtered value on success or **Invalid** on failure.
      */
     function validateTime($value) {
-        // TODO: VALIDATE AS HH:MM:SS OR HH:MM
-        return false;
+        if (preg_match('`^(\d\d?):(\d\d)(?::(\d\d))?$`', $value, $match)) {
+            $h = (int)$match[1];
+            $m = (int)$match[2];
+            $s = (int)($match[3] ?? 0);
+
+            if (0 <= $h && $h < 24 && 0 <= $m && $m < 60 && 0 <= $s && $s < 60) {
+                return sprintf('%d:%02d:%02d', $h, $m, $s);
+            }
+        }
+            return \Vanilla\Invalid::emptyMessage();
     }
 }
 

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -186,6 +186,9 @@ class Bootstrap {
             ->setShared(true)
             ->addAlias(Gdn::AliasDispatcher)
 
+            ->rule(\Gdn_Validation::class)
+            ->addCall('addRule', ['BodyFormat', new Reference(\Vanilla\BodyFormatValidator::class)])
+
             ->rule(AuthenticatorModel::class)
             ->setShared(true)
             ->addCall('registerAuthenticatorClass', [PasswordAuthenticator::class])

--- a/tests/Library/Core/ValidationFunctionsTest.php
+++ b/tests/Library/Core/ValidationFunctionsTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Core;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for validation functions.
+ */
+class ValidationFunctionsTest extends TestCase {
+
+    /**
+     * Assert a value is an instance of the Invalid class.
+     *
+     * @param mixed $value
+     */
+    protected function assertInvalid($value) {
+        $this->assertInstanceOf(\Vanilla\Invalid::class, $value);
+    }
+
+    /**
+     * Test validating a time-only string.
+     *
+     * @param mixed $value The time to validate.
+     * @param bool $isValid Is this expected to be a valid time?
+     * @dataProvider provideTimes
+     */
+    public function testValidateTime($value, $isValid) {
+        $result = validateTime($value);
+        if ($isValid) {
+            $this->assertInternalType('string', $value);
+        } else {
+            $this->assertInvalid($result);
+        }
+    }
+
+    /**
+     * Provides test time strings and whether or not they are valid.
+     *
+     * @return array
+     */
+    public function provideTimes() {
+        return [
+            ['12:00:00', true],
+            ['12:00', true],
+            ['12', false],
+            ['24:00:00', true],
+            ['60:00:00', false],
+            ['24:60:00', false],
+            ['24:00:60', false],
+            ['24:00:59', true],
+            ['24:59:00', true],
+            ['00:59:59', true],
+            ['1:00', true],
+            [1, false],
+            [true, false],
+            [false, false],
+            [null, false],
+        ];
+    }
+}

--- a/tests/Library/Core/ValidationTest.php
+++ b/tests/Library/Core/ValidationTest.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Core;
+
+use Gdn_Validation;
+use PHPUnit\Framework\TestCase;
+use Vanilla\Invalid;
+
+/**
+ * Tests for the **Gdn_Validation** object.
+ */
+class ValidationTest extends TestCase {
+    /**
+     * Test some basic valid types.
+     *
+     * @param string $type The dbtype to validate.
+     * @param mixed $value A valid example of that type.
+     * @dataProvider provideValidTypes
+     */
+    public function testValidType($type, $value) {
+        if (in_array($type, ['time'], true)) {
+            $this->markTestIncomplete("The $type type has not been implemented.");
+        }
+
+        $val = new Gdn_Validation(['v' => (object)['Type' => $type, 'AllowNull' => true, 'Enum' => ['foo', 'bar']]], true);
+        $r = $val->validate(['v' => $value]);
+        $this->assertTrue($r);
+    }
+
+    /**
+     * A failed required validation should be the only error.
+     *
+     * @param string $type The type to test.
+     * @param mixed $_ Not used.
+     * @dataProvider provideValidTypes
+     */
+    public function testRequiredMissing($type, $_) {
+        $val = new Gdn_Validation(['v' => (object)['Type' => $type, 'AllowNull' => false, 'Default' => null]], true);
+
+        $r = $val->validate([], true);
+        $this->assertFalse($r);
+        $results = $val->results()['v'];
+        $this->assertContains('ValidateRequired', $results);
+        $this->assertCount(1, $results);
+    }
+
+    public function testCallbackValidator() {
+
+
+    }
+
+    protected function testBasicCallback($value, $valid) {
+        $val = new Gdn_Validation(null, true);
+        $val->addRule('test', function ($value) {
+            $filtered = filter_var($value, FILTER_VALIDATE_INT);
+
+            if ($filtered === false) {
+                return Invalid::emptyMessage();
+            } else {
+                return $filtered;
+            }
+        }, true);
+        $val->applyRule('v', 'test');
+
+        $validated = $val->validate(['v' => $value]);
+
+        if ($valid instanceof Invalid) {
+            $this->assertFalse($validated);
+        } else {
+            $this->assertTrue($validated);
+            $this->assertSame($valid, $val->validationFields()['v']);
+        }
+    }
+
+    /**
+     * Provide types and valid values for them.
+     *
+     * @return array Returns a data provider array.
+     */
+    public function provideValidTypes() {
+        $r = [
+            ['bool', true],
+            ['boolean', false],
+
+            ['tinyint', 123],
+            ['smallint', -123],
+            ['mediumint', 123],
+            ['int', '123'],
+            ['integer', 123],
+            ['bigint', 0],
+
+            ['double', 1.2],
+            ['float', 33],
+            ['real', 44.4],
+            ['decimal', '12.3'],
+            ['dec', 44.4],
+            ['numeric', 44.4],
+            ['fixed', 44.4],
+
+            ['date', '2018-01-01'],
+            ['datetime', '2018-02-01 13:44'],
+
+            ['time', '13:14'],
+            ['timestamp', '2018-10-01'],
+
+            ['year', 2018],
+
+            ['char', 'foo'],
+            ['varchar', 'foo'],
+            ['tinyblob', 'foo'],
+            ['blob', 'foo'],
+            ['mediumblob', 'foo'],
+            ['longblob', 'foo'],
+            ['tinytext', 'foo'],
+            ['mediumtext', 'foo'],
+            ['text', 'foo'],
+            ['longtext', 'foo'],
+            ['binary', 'foo'],
+            ['varbinary', 'foo'],
+
+            ['enum', 'foo'],
+            ['set', 'bar'],
+        ];
+
+        return array_column($r, null, 0);
+    }
+}

--- a/tests/Library/Core/ValidationTest.php
+++ b/tests/Library/Core/ValidationTest.php
@@ -155,7 +155,9 @@ class ValidationTest extends TestCase {
             ['date', '2018-01-01'],
             ['datetime', '2018-02-01 13:44'],
 
+            ['time', '9:00'],
             ['time', '13:14'],
+            ['time', '23:59:59'],
             ['timestamp', '2018-10-01'],
 
             ['year', 2018],

--- a/tests/Library/Core/ValidationTest.php
+++ b/tests/Library/Core/ValidationTest.php
@@ -15,6 +15,43 @@ use Vanilla\Invalid;
  * Tests for the **Gdn_Validation** object.
  */
 class ValidationTest extends TestCase {
+
+    /**
+     * Test the ability to validate a post body's formatting.
+     *
+     * @param array $row Post row.
+     * @param bool $isValid Does this post row have a valid body?
+     * @dataProvider provideBodyFormatRows
+     */
+    public function testBodyFormat(array $row, bool $isValid) {
+        $validation = new Gdn_Validation([
+            'Body' => (object)['AllowNull' => false, 'Default' => '', 'Type' => 'string'],
+            'Format' => (object)['AllowNull' => false, 'Default' => '', 'Type' => 'string'],
+        ], true);
+        $validation->addRule('BodyFormat', new \Vanilla\BodyFormatValidator());
+
+        $result = $validation->validate($row);
+        $this->assertSame($isValid, $result);
+    }
+
+    /**
+     * Provide post rows for validating formatting.
+     *
+     * @return array
+     */
+    public function provideBodyFormatRows() {
+        return [
+            [
+                ['Body' => '{"insert":"This is a valid rich post."}', 'Format' => 'Rich'],
+                true
+            ],
+            [
+                ['Body' => 'This is not a valid rich post.', 'Format' => 'Rich'],
+                false
+            ],
+        ];
+    }
+
     /**
      * Test some basic valid types.
      *

--- a/tests/Library/Core/ValidationTest.php
+++ b/tests/Library/Core/ValidationTest.php
@@ -49,12 +49,14 @@ class ValidationTest extends TestCase {
         $this->assertCount(1, $results);
     }
 
-    public function testCallbackValidator() {
-
-
-    }
-
-    protected function testBasicCallback($value, $valid) {
+    /**
+     * Test a basic callback validator.
+     *
+     * @param mixed $value The value to test.
+     * @param int|Invalid $valid The expected result of the callback.
+     * @dataProvider provideBasicCallbackTests
+     */
+    public function testBasicCallback($value, $valid) {
         $val = new Gdn_Validation(null, true);
         $val->addRule('test', function ($value) {
             $filtered = filter_var($value, FILTER_VALIDATE_INT);
@@ -75,6 +77,21 @@ class ValidationTest extends TestCase {
             $this->assertTrue($validated);
             $this->assertSame($valid, $val->validationFields()['v']);
         }
+    }
+
+    /**
+     * Provide test data for **testBasicCallback()**.
+     *
+     * @return array Returns a data provider.
+     */
+    public function provideBasicCallbackTests() {
+        $r = [
+            [123, 123],
+            ['456', 456],
+            ['foo', Invalid::emptyMessage()],
+        ];
+
+        return array_column($r, null, 0);
     }
 
     /**

--- a/tests/Library/Core/ValidationTest.php
+++ b/tests/Library/Core/ValidationTest.php
@@ -23,10 +23,6 @@ class ValidationTest extends TestCase {
      * @dataProvider provideValidTypes
      */
     public function testValidType($type, $value) {
-        if (in_array($type, ['time'], true)) {
-            $this->markTestIncomplete("The $type type has not been implemented.");
-        }
-
         $val = new Gdn_Validation(['v' => (object)['Type' => $type, 'AllowNull' => true, 'Enum' => ['foo', 'bar']]], true);
         $r = $val->validate(['v' => $value]);
         $this->assertTrue($r);
@@ -66,7 +62,7 @@ class ValidationTest extends TestCase {
             } else {
                 return $filtered;
             }
-        }, true);
+        });
         $val->applyRule('v', 'test');
 
         $validated = $val->validate(['v' => $value]);


### PR DESCRIPTION
Several improvements to data validation are included. These include:

1. Refactor the `Gdn_Validation` class. One of the key improvements is allowing validation rule callbacks to update the value being validated. This can be done to improve formatting, alter the value's type and more.
1. Add the `BodyFormatValidator` class, which is used to validate a specific format. Currently, only rudimentary support for validating the "rich" format is provided. Instances of this class may be called as a function.
1. Add support for automatically using `BodyFormatValidator` from `Gdn_Validation`, if configured as an available rule.
1. Add `Gdn_Validation` to the container, configuring it to use `BodyFormatValidator`.
1. Add `Gdn_Validation` parameters to the constructors of several models for the sake of dependency injection with an instance preconfigured to use the `BodyFormatValidator` class.
1. Add the `Vanilla\Invalid` class to allow for more explicit "invalid" validation results.
1. Add code to make `validateTime` a useful function. Prior to this, the function had only been a placeholder in Vanilla. Now, it is a function that can validate a time string.
1. Add tests for verifying validation.