### PR TITLE
Improve README instructions for upgrades and installs for 2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Please consider using [maintenance mode](#using-maintenance-mode) before running
 
 1. Backup your database, `.htaccess` and `conf/config.php` file somewhere safe.
 1. Upload the new release's files so they overwrite the old ones.
-1. Delete all files in `/cache`.
+1. Delete all files in `/cache` (except `.htaccess` if you use Apache).
 1. Follow all version-specific instructions below. It is **critcal** you delete the listed files.
-1. Go to `example.com/utility/update` to run any database updates needed. (404? See next paragraph.) If it fails, try it a second times by refreshing the page.
+1. Go to `example.com/utility/update` to run any database updates needed. (404? See next paragraph.) If it fails, try it a second time by refreshing the page.
 
 If you run into a problem, see [Getting Help](#getting-help) below.
 
@@ -103,7 +103,7 @@ If you run into a problem, see [Getting Help](#getting-help) below.
 
 If your forum still uses URLs including `?p=`, support for this URL structure has ended. Follow these steps to switch to the simpler format:
 
-1. Confirm your server is setup to handle rewrites. On Apache, using the `.htaccess` file provided will accomplish this. Additional setup is required on nginx and other platforms. 
+1. Confirm your server is setup to handle rewrites. On Apache, using the `.htaccess` file provided will accomplish this. Additional setup is required on [nginx](https://docs.vanillaforums.com/developer/backend/server-nginx/) and other platforms. 
 2. Test whether it is working by visiting `/discussions` - if you see a discussions list (rather than a 404), it is likely setup correctly. 
 3. Open `/conf/config.php` and find the line with `$Configuration['Garden']['RewriteUrls'] = false;` and **delete the entire line**. 
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@ You cannot clone this repo right into a web directory - it requires a build step
 
 ![Vanilla](http://images.v-cdn.net/vanilla-black-logo-400.svg)
 
-[![Build Status](https://img.shields.io/travis/vanilla/vanilla/master.svg)](https://travis-ci.org/vanilla/vanilla)
-[![Contributors](https://img.shields.io/github/contributors/vanilla/vanilla.svg)](https://github.com/vanilla/vanilla/graphs/contributors)
-[![Last Commit](https://img.shields.io/github/last-commit/vanilla/vanilla/master.svg)](https://github.com/vanilla/vanilla/commits/master)
-[![Commit Activity](https://img.shields.io/github/commit-activity/y/vanilla/vanilla.svg)](https://github.com/vanilla/vanilla/graphs/commit-activity)
-
 ## Howdy, Stranger!
 
 Vanilla was born out of the desire to create flexible, customizable, and downright entertaining

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ You cannot clone this repo right into a web directory - it requires a build step
 
 ![Vanilla](http://images.v-cdn.net/vanilla-black-logo-400.svg)
 
+[![Build Status](https://img.shields.io/travis/vanilla/vanilla/master.svg)](https://travis-ci.org/vanilla/vanilla)
+[![Contributors](https://img.shields.io/github/contributors/vanilla/vanilla.svg)](https://github.com/vanilla/vanilla/graphs/contributors)
+[![Last Commit](https://img.shields.io/github/last-commit/vanilla/vanilla/master.svg)](https://github.com/vanilla/vanilla/commits/master)
+[![Commit Activity](https://img.shields.io/github/commit-activity/y/vanilla/vanilla.svg)](https://github.com/vanilla/vanilla/graphs/commit-activity)
+
 ## Howdy, Stranger!
 
 Vanilla was born out of the desire to create flexible, customizable, and downright entertaining
@@ -70,42 +75,75 @@ by default for all smartphones & tablets. Heck, it even works on the PlayStation
 
 Vanilla is built to be simple, and its installation is no exception.
 
-* Upload Vanilla's [pre-built version](https://open.vanillaforums.com/addon/vanilla-core) to your server.
-* Confirm the cache, conf, and uploads folders are writable by PHP.
-* Navigate to that folder in your web browser.
-* Follow the instructions on screen.
+1. Upload Vanilla's [pre-built version](https://open.vanillaforums.com/addon/vanilla-core) to your server.
+1. Using nginx? [See our nginx guide](https://docs.vanillaforums.com/developer/backend/server-nginx/).
+1. Confirm the `cache`, `conf`, and `uploads` folders are writable by PHP.
+1. Navigate to the folder where you uploaded Vanilla in your web browser.
+1. Follow the instructions on screen.
+
+If you run into a problem, see [Getting Help](#getting-help) below.
 
 ## Upgrading
 
-Follow these steps to upgrade Vanilla when a new stable release is announced.
+Follow these steps to upgrade Vanilla when a new stable release is announced. These instructions assume you're using SFTP to manually copy files to a server.
 
-Please consider using maintenance mode before running database updates if your database is very large (millions of users or discussions).
+Please consider using [maintenance mode](#using-maintenance-mode) before running database updates if your database is very large (millions of users or comments).
 
-* Backup your database, `.htaccess` and `conf/config.php` file somewhere safe.
-* Upload the new release's files so they overwrite the old ones.
-* Delete all files in `/cache`.
-* Go to `yourforum.com/utility/update` to run any database updates needed. (404? See next paragraph.) If it fails, try it a second times by refreshing the page.
-* If any "Deleted Files" are listed on the upgrade page, manually delete the listed files.
+1. Backup your database, `.htaccess` and `conf/config.php` file somewhere safe.
+1. Upload the new release's files so they overwrite the old ones.
+1. Delete all files in `/cache`.
+1. Follow all version-specific instructions below. It is **critcal** you delete the listed files.
+1. Go to `example.com/utility/update` to run any database updates needed. (404? See next paragraph.) If it fails, try it a second times by refreshing the page.
 
-If your forum still uses URLs including `?p=`:
+If you run into a problem, see [Getting Help](#getting-help) below.
 
-Support for this URL structure ended after 2.3 in favor of "pretty" URLs so it's time to make the switch. First, confirm your server is setup to handle rewrites. On Apache, using the `.htaccess` file provided will accomplish this. Additional setup is required on nginx and other platforms. Test whether it is working by visiting `/discussions` - if you see a discussions list (rather than a 404), it is likely setup correctly. Then, open `conf/config.php` and find the line with `$Configuration['Garden']['RewriteUrls'] = false;` and **delete the entire line**. Your site should immediately switch to "pretty" URL paths instead of using the 'p' parameter. If there is a problem, re-add the line to your config and do further troubleshooting.
+### From Vanilla 2.5 or earlier:
 
-To upgrade from **2.1 or earlier**:
+* Delete `plugins/HtmLawed`. (This is now in core.)
+* Delete `plugins/Tagging`. (This is now in core.)
 
-* Update any locales you have installed (their name format changed in 2.2). Verify they are working after upgrade.
+### From Vanilla 2.3 or earlier:
+
+* Delete `/applications/vanilla/controllers/class.settingscontroller.php`.
+
+If your forum still uses URLs including `?p=`, support for this URL structure has ended. Follow these steps to switch to the simpler format:
+
+1. Confirm your server is setup to handle rewrites. On Apache, using the `.htaccess` file provided will accomplish this. Additional setup is required on nginx and other platforms. 
+2. Test whether it is working by visiting `/discussions` - if you see a discussions list (rather than a 404), it is likely setup correctly. 
+3. Open `/conf/config.php` and find the line with `$Configuration['Garden']['RewriteUrls'] = false;` and **delete the entire line**. 
+
+Your site should immediately switch to "pretty" URL paths instead of using the 'p' parameter. If there is a problem, re-add the line to your config and do further troubleshooting.
+
+### From Vanilla 2.1 or earlier:
+
+* Update ALL locales you have installed (in `/locales`).
 * Apache users must update their `.htaccess` file.
-* Delete these files from your server if they exist: `/themes/mobile/views/discussions/helper_functions.php` and  `/applications/dashboard/views/default.master.php`
+* Delete `/themes/mobile/views/discussions/helper_functions.php`
+* Delete `/applications/dashboard/views/default.master.php`
 
-To upgrade from Vanilla **1.0** requires a full migration (see next section). Themes and plugins are not compatible. Backup your Vanilla 1 data and files completely, then delete them from your server before attempting to install Vanilla 2.
+### From Vanilla 1.0:
+
+Upgrading from 1.0 (any version) requires a full migration (see next section). Themes and plugins are not compatible. Backup your Vanilla 1 data and files completely, then delete them from your server before attempting to install Vanilla 2.
 
 ## Migrating to Vanilla
 
-* Get [Vanilla Porter](https://open.vanillaforums.com/addon/porter-core) and verify it supports your platform.
-* Read the Advanced Uses notes on that page.
-* Upload it to your current server.
-* Navigate to the file in your web browser & run it.
-* Take the file it produces and import it to Vanilla.
+1. Get [Vanilla Porter](https://open.vanillaforums.com/addon/porter-core) and verify it supports your platform.
+1. Read the Advanced Uses notes on that page.
+1. Upload it to your current server.
+1. Navigate to the file in your web browser & run it.
+1. Take the file it produces and import it to Vanilla via the Dashboard's "Import" option.
+
+If you run into a problem, see [Getting Help](#getting-help) below.
+
+## Using Maintenance Mode
+
+You can temporarily halt all access to your forum by putting it into maintenance mode. Users currently signed in with owner privileges (the user who created the forum) will still be able to use the site.
+
+To put your site in maintenance mode, add this to `/conf/config.php` and save it:
+
+`$Configuration['Garden']['UpdateMode'] = true;`
+
+To end maintenance mode, delete it and save.
 
 ## Getting Help
 


### PR DESCRIPTION
Update our installation and migration instructions to break out per-version instructions better and provide more obvious linking to other sections.

Addresses feedback from @cdepage and this open community discussion: https://open.vanillaforums.com/discussion/36260