### PR TITLE
Changing file_get_contents in getProfile() to cURL

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -516,7 +516,11 @@ class FacebookPlugin extends Gdn_Plugin {
      */
     public function getProfile($accessToken) {
         $url = "https://graph.facebook.com/me?access_token=$accessToken&fields=name,id,email";
-        $contents = file_get_contents($url);
+        $c = curl_init();
+        curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($c, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($c, CURLOPT_URL, $url);
+        $contents = curl_exec($c);
         $profile = json_decode($contents, true);
         return $profile;
     }

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -92,7 +92,8 @@ class FacebookPlugin extends Gdn_Plugin {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
         curl_setopt($ch, CURLOPT_URL, $url);
 
         if ($post !== false) {
@@ -487,7 +488,8 @@ class FacebookPlugin extends Gdn_Plugin {
         // Get the redirect URI.
         $c = curl_init();
         curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($c, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($c, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($c, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
         curl_setopt($c, CURLOPT_URL, $url);
         $contents = curl_exec($c);
 
@@ -518,7 +520,8 @@ class FacebookPlugin extends Gdn_Plugin {
         $url = "https://graph.facebook.com/me?access_token=$accessToken&fields=name,id,email";
         $c = curl_init();
         curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($c, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($c, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($c, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
         curl_setopt($c, CURLOPT_URL, $url);
         $contents = curl_exec($c);
         $profile = json_decode($contents, true);


### PR DESCRIPTION
As cURL is required by Vanilla and it's used in this plugin, good idea is to change file_get_contents to cURL as some servers have allow_url_fopen set to false due security reasons. 