### PR TITLE
Do not validate usernames when managing users

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -394,7 +394,7 @@ class UsersApiController extends AbstractApiController {
         $this->userByID($id);
         $userData = $this->normalizeInput($body);
         $userData['UserID'] = $id;
-        $settings = [];
+        $settings = ['ValidateName' => false];
         if (!empty($userData['RoleID'])) {
             $settings['SaveRoles'] = true;
         }
@@ -426,6 +426,7 @@ class UsersApiController extends AbstractApiController {
         $settings = [
             'NoConfirmEmail' => true,
             'SaveRoles' => array_key_exists('RoleID', $userData),
+            'ValidateName' => false
         ];
         $id = $this->userModel->save($userData, $settings);
         $this->validateModel($this->userModel);

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -194,7 +194,7 @@ class UserController extends DashboardController {
                     $this->Form->setFormValue('HashMethod', 'Random');
                 }
 
-                $newUserID = $this->Form->save(['SaveRoles' => true, 'NoConfirmEmail' => true]);
+                $newUserID = $this->Form->save(['SaveRoles' => true, 'NoConfirmEmail' => true, 'ValidateName' => false]);
                 if ($newUserID !== false) {
                     $this->setData('UserID', $newUserID);
                     if ($noPassword) {
@@ -737,7 +737,7 @@ class UserController extends DashboardController {
                     $this->Form->setFormValue('Banned', $user['Banned'] | BanModel::BAN_MANUAL);
                 }
 
-                if ($this->Form->save(['SaveRoles' => true]) !== false) {
+                if ($this->Form->save(['SaveRoles' => true, 'ValidateName' => false]) !== false) {
                     if ($this->Form->getValue('ResetPassword', '') == 'Auto') {
                         $userModel->passwordRequest($user['Email']);
                         $userModel->setField($userID, 'HashMethod', 'Reset');


### PR DESCRIPTION
This update opts out of username validation when managing users in the dashboard or using the API.

Closes #7154