### PR TITLE
Fix editing drafts in sub catergories with do headings enabled

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -553,6 +553,18 @@ class Gdn_Form extends Gdn_Pluggable {
         // Show root categories as headings (ie. you can't post in them)?
         $doHeadings = val('Headings', $options, c('Vanilla.Categories.DoHeadings'));
 
+        // If DoHeadings is enabled check if post is a draft so that children,
+        // so that children categories won't be considered a top-level
+        // category and disabled.
+        $isDraft = false;
+        if ($doHeadings) {
+            $draftID = $this->HiddenInputs['DraftID'];
+            $discussionID = $this->HiddenInputs['DiscussionID'];
+            if ($draftID && $discussionID == "") {
+                $isDraft = true;
+            }
+        }
+
         // If making headings disabled and there was no default value for
         // selection, make sure to select the first non-disabled value, or the
         // browser will auto-select the first disabled option.
@@ -562,11 +574,6 @@ class Gdn_Form extends Gdn_Pluggable {
         if (is_array($safeCategoryData)) {
             foreach ($safeCategoryData as $categoryID => $category) {
                 $depth = val('Depth', $category, 0);
-                $isDraft = false;
-                $draftID = $this->HiddenInputs['DraftID'];
-                if (isset($draftID) && $draftID > 0) {
-                    $isDraft = true;
-                }
                 $disabled = (($depth == 1 && $doHeadings && !$isDraft) || !$category['AllowDiscussions'] || val('DisplayAs', $category) != 'Discussions');
                 $selected = in_array($categoryID, $value) && $hasValue;
                 if ($forceCleanSelection && $depth > 1) {

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -562,7 +562,12 @@ class Gdn_Form extends Gdn_Pluggable {
         if (is_array($safeCategoryData)) {
             foreach ($safeCategoryData as $categoryID => $category) {
                 $depth = val('Depth', $category, 0);
-                $disabled = (($depth == 1 && $doHeadings) || !$category['AllowDiscussions'] || val('DisplayAs', $category) != 'Discussions');
+                $isDraft = false;
+                $draftID = $this->HiddenInputs['DraftID'];
+                if (isset($draftID) && $draftID > 0) {
+                    $isDraft = true;
+                }
+                $disabled = (($depth == 1 && $doHeadings && !$isDraft) || !$category['AllowDiscussions'] || val('DisplayAs', $category) != 'Discussions');
                 $selected = in_array($categoryID, $value) && $hasValue;
                 if ($forceCleanSelection && $depth > 1) {
                     $selected = true;


### PR DESCRIPTION
fix vanilla/vanilla#5641

When Vanilla.Categories.DoHeadings is enabled, editing a draft created in sub categories is disabled and doesn't allow for the draft to be edited.  The category the draft was created is now considered a top-level category and is therefore disabled.

This update verifies if a post is a draft and doesn't disable the category from the dropdown list in the form.