### PR TITLE
Fix cached announcements on Recent Discussions sometimes being filtered out

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -148,7 +148,7 @@ class DiscussionsController extends VanillaController {
 
         // Check for individual categories.
         $categoryIDs = $this->getCategoryIDs();
-        $where = [];
+        $where = $announcementsWhere = [];
         if ($this->data('Followed')) {
             $followedCategories = array_keys($categoryModel->getFollowed(Gdn::session()->UserID));
             $visibleCategoriesResult = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
@@ -159,7 +159,7 @@ class DiscussionsController extends VanillaController {
             }
             $where['d.CategoryID'] = $visibleFollowedCategories;
         } elseif ($categoryIDs) {
-            $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
+            $where['d.CategoryID'] = $announcementsWhere['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
         } else {
             $visibleCategoriesResult = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
             if ($visibleCategoriesResult !== true) {
@@ -179,7 +179,7 @@ class DiscussionsController extends VanillaController {
         $this->setData('CountDiscussions', $CountDiscussions);
 
         // Get Announcements
-        $this->AnnounceData = $Offset == 0 ? $DiscussionModel->getAnnouncements($where) : false;
+        $this->AnnounceData = $Offset == 0 ? $DiscussionModel->getAnnouncements($announcementsWhere) : false;
         $this->setData('Announcements', $this->AnnounceData !== false ? $this->AnnounceData : [], true);
 
         // Get Discussions

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -148,6 +148,8 @@ class DiscussionsController extends VanillaController {
 
         // Check for individual categories.
         $categoryIDs = $this->getCategoryIDs();
+        // Fix to segregate announcement conditions until announcement caching has been reworked.
+        // See https://github.com/vanilla/vanilla/issues/7241
         $where = $announcementsWhere = [];
         if ($this->data('Followed')) {
             $followedCategories = array_keys($categoryModel->getFollowed(Gdn::session()->UserID));

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -334,7 +334,7 @@ class DiscussionModel extends Gdn_Model {
      */
     public function discussionSummaryQuery($additionalFields = [], $join = true) {
         // Verify permissions (restricting by category if necessary)
-        $perms = self::categoryPermissions();
+        $perms = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
 
         if ($perms !== true) {
             $this->SQL->whereIn('d.CategoryID', $perms);


### PR DESCRIPTION
`DiscussionModel::getAnnouncements` is a very delicate method. It performs some unusual caching practices (namely using a fixed cache key, even for dynamic criteria) that didn't play well with the move from category watching to category following. The result is announced discussions might not be properly pinned when caching is enabled and something is filtering categories, like the Subcommunities addon. The announced discussion IDs are cached in one area, then retrieved and filtered out in another area.

This update makes a couple of minor tweaks to make Recent Discussions function a bit like it did in 2.5, while still utilizing the methods introduced with category following.

1. The call to `DiscussionModel::getAnnouncements` gets its own conditions array. This array only gets the conditions the method would've received in 2.5. This prevents caching of only a limited subset of announcements.
1. `DiscussionModel::discussionSummaryQuery` (used by `DiscussionModel::getAnnouncements`) now uses `CategoryModel::getVisibleCategoryIDs`, instead of `DiscussionModel::categoryPermissions`. This is the newer method for performing this action and is hook-able by addons.

Closes #7121