### PR TITLE
Add support for second-only time parameter to YouTubeEmbed::matchUrl

### DIFF
--- a/library/Vanilla/Embeds/YouTubeEmbed.php
+++ b/library/Vanilla/Embeds/YouTubeEmbed.php
@@ -46,10 +46,14 @@ class YouTubeEmbed extends VideoEmbed {
         $start = null;
         if (preg_match('/t=(?P<start>\d+)/', $fragment, $timeParts)) {
             $start = $timeParts['start'];
-        } elseif (array_key_exists('t', $query) && preg_match('/((?P<minutes>\d*)m)?((?P<seconds>\d*)s)?/', $query['t'], $timeParts)) {
-            $minutes = $timeParts['minutes'] ? (int)$timeParts['minutes'] : 0;
-            $seconds = $timeParts['seconds'] ? (int)$timeParts['seconds'] : 0;
-            $start = ($minutes * 60) + $seconds;
+        } elseif (array_key_exists('t', $query) && preg_match('/^(?:(?P<ticks>\d+)|(?:(?P<minutes>\d*)m)?(?:(?P<seconds>\d*)s)?)$/', $query['t'], $timeParts)) {
+            if (array_key_exists('ticks', $timeParts) && $timeParts['ticks'] !== '') {
+                $start = $timeParts['ticks'];
+            } else {
+                $minutes = $timeParts['minutes'] ? (int)$timeParts['minutes'] : 0;
+                $seconds = $timeParts['seconds'] ? (int)$timeParts['seconds'] : 0;
+                $start = ($minutes * 60) + $seconds;
+            }
         }
 
         if ($this->isNetworkEnabled()) {


### PR DESCRIPTION
`YouTubeEmbed::matchUrl` only supports extracting the start time if it is in the minute-second format (e.g. 1m30s) format and does not currently support extracting the start time when in the second-only format (e.g. 90).

The method has been updated to support a second-only time value in a YouTube URL (e.g. https://youtu.be/QljRe99OMCU?t=110).

Closes #7202