### PR TITLE
Add title to embedded videos created with VideoEmbed

### DIFF
--- a/library/Vanilla/Embeds/VideoEmbed.php
+++ b/library/Vanilla/Embeds/VideoEmbed.php
@@ -84,7 +84,7 @@ abstract class VideoEmbed extends Embed {
         $result = <<<HTML
 <div class="embed-video embed embedVideo">
     <div class="{$containerAttr['class']}" style="{$containerAttr['style']}">
-        <button type="button" data-url="{$attr['url']}" aria-label="{$attr['name']}" class="embedVideo-playButton iconButton js-playVideo" style="background-image: url({$attr['photoUrl']});">
+        <button type="button" data-url="{$attr['url']}" aria-label="{$attr['name']}" class="embedVideo-playButton iconButton js-playVideo" style="background-image: url({$attr['photoUrl']});" title="{$attr['name']}">
             <svg class="embedVideo-playIcon" xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 24 24">
                 <title>Play Video</title>
                 <path class="embedVideo-playIconPath embedVideo-playIconPath-circle" style="fill: currentColor; stroke-width: .3;" d="M11,0A11,11,0,1,0,22,11,11,11,0,0,0,11,0Zm0,20.308A9.308,9.308,0,1,1,20.308,11,9.308,9.308,0,0,1,11,20.308Z"></path>

--- a/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
+++ b/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
@@ -113,7 +113,7 @@ class EmbedManagerTest extends TestCase {
                 ],
                 '<div class="embed-video embed embedVideo">
     <div class="embedVideo-ratio is16by9" style="">
-        <button type="button" data-url="https://www.youtube.com/embed/9bZkp7q19f0?feature=oembed&amp;autoplay=1" aria-label="YouTube" class="embedVideo-playButton iconButton js-playVideo" style="background-image: url(https://img.youtube.com/vi/9bZkp7q19f0/0.jpg);">
+        <button type="button" data-url="https://www.youtube.com/embed/9bZkp7q19f0?feature=oembed&amp;autoplay=1" aria-label="YouTube" class="embedVideo-playButton iconButton js-playVideo" style="background-image: url(https://img.youtube.com/vi/9bZkp7q19f0/0.jpg);" title="YouTube">
             <svg class="embedVideo-playIcon" xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 24 24">
                 <title>Play Video</title>
                 <path class="embedVideo-playIconPath embedVideo-playIconPath-circle" style="fill: currentColor; stroke-width: .3;" d="M11,0A11,11,0,1,0,22,11,11,11,0,0,0,11,0Zm0,20.308A9.308,9.308,0,1,1,20.308,11,9.308,9.308,0,0,1,11,20.308Z"></path>
@@ -141,7 +141,7 @@ class EmbedManagerTest extends TestCase {
                 ],
                 '<div class="embed-video embed embedVideo">
     <div class="embedVideo-ratio" style="padding-top: 42.5%;">
-        <button type="button" data-url="https://player.vimeo.com/video/264197456?autoplay=1" aria-label="Vimeo" class="embedVideo-playButton iconButton js-playVideo" style="background-image: url(https://i.vimeocdn.com/video/694532899_640.jpg);">
+        <button type="button" data-url="https://player.vimeo.com/video/264197456?autoplay=1" aria-label="Vimeo" class="embedVideo-playButton iconButton js-playVideo" style="background-image: url(https://i.vimeocdn.com/video/694532899_640.jpg);" title="Vimeo">
             <svg class="embedVideo-playIcon" xmlns="http://www.w3.org/2000/svg" viewBox="-1 -1 24 24">
                 <title>Play Video</title>
                 <path class="embedVideo-playIconPath embedVideo-playIconPath-circle" style="fill: currentColor; stroke-width: .3;" d="M11,0A11,11,0,1,0,22,11,11,11,0,0,0,11,0Zm0,20.308A9.308,9.308,0,1,1,20.308,11,9.308,9.308,0,0,1,11,20.308Z"></path>


### PR DESCRIPTION
This update adds a title attribute to the video container markup generated by `VideoEmbed::videoCode`. Hovering over a video should now display its title.

Closes #7201