### PR TITLE
Fix discussion summaries not always including all visible categories

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -334,7 +334,7 @@ class DiscussionModel extends Gdn_Model {
      */
     public function discussionSummaryQuery($additionalFields = [], $join = true) {
         // Verify permissions (restricting by category if necessary)
-        $perms = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+        $perms = CategoryModel::instance()->getVisibleCategoryIDs();
 
         if ($perms !== true) {
             $this->SQL->whereIn('d.CategoryID', $perms);


### PR DESCRIPTION
A copy-paste error in #7240 led to the discussion summary query only including discussions in categories that haven't opted out of displaying on the Recent Discussions page. This limitation doesn't exist in `DiscussionModel::categoryPermissions`, so it shouldn't exist in the method call that replaced it.