### PR TITLE
Add dateLastActive to the UserFragmentSchema and UserSchema

### DIFF
--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -55,7 +55,8 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
             $this->userFragmentSchema = $this->schema([
                 'userID:i' => 'The ID of the user.',
                 'name:s' => 'The username of the user.',
-                'photoUrl:s' => 'The URL of the user\'s avatar picture.'
+                'photoUrl:s' => 'The URL of the user\'s avatar picture.',
+                'dateLastActive:dt|n' => 'Time the user was last active.',
             ], 'UserFragment');
         }
         return $this->userFragmentSchema;

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -187,7 +187,7 @@ class UsersApiController extends AbstractApiController {
      * @param array $query
      * @return array
      */
-    public function get_byNames(array $query) {
+    public function index_byNames(array $query) {
         $this->permission('Garden.SignIn.Allow');
 
         $in = $this->schema([
@@ -210,7 +210,7 @@ class UsersApiController extends AbstractApiController {
             ]
         ], 'in')->setDescription('Search for users by full or partial name matching.');
         $out = $this->schema([
-            ':a' => Schema::parse(['userID', 'name', 'photoUrl'])->add($this->userSchema())
+            ':a' => $this->getUserFragmentSchema(),
         ], 'out');
 
         $query = $in->validate($query);

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -122,11 +122,12 @@ class UsersApiController extends AbstractApiController {
             'bypassSpam:b' => 'Should submissions from this user bypass SPAM checks?',
             'banned:i' => 'Is the user banned?',
             'dateInserted:dt' => 'When the user was created.',
+            'dateLastActive:dt|n' => 'Time the user was last active.',
             'dateUpdated:dt|n' => 'When the user was last updated.',
             'roles:a?' => $this->schema([
                 'roleID:i' => 'ID of the role.',
                 'name:s' => 'Name of the role.'
-            ], 'RoleFragment')
+            ], 'RoleFragment'),
         ]);
         return $schema;
     }
@@ -760,7 +761,7 @@ class UsersApiController extends AbstractApiController {
     public function userSchema($type = '') {
         if ($this->userSchema === null) {
             $schema = Schema::parse(['userID', 'name', 'email', 'photoUrl', 'emailConfirmed',
-                'showEmail', 'bypassSpam', 'banned', 'dateInserted', 'dateUpdated', 'roles?']);
+                'showEmail', 'bypassSpam', 'banned', 'dateInserted', 'dateLastActive', 'dateUpdated', 'roles?']);
             $schema = $schema->add($this->fullSchema());
             $this->userSchema = $this->schema($schema, 'User');
         }


### PR DESCRIPTION
Also make GET /users/by-names return an array of UserFragments. The reason for these changes are the following:

- We think that dateLastActive is a useful field for a variety of purposes such as client-side sorting or showing if a user is online.
- We want to standardize on the UserFragmentModel as a means of displaying user information beside posts or whatever. If we can maintain as useful user fragment schema in one place this will be easier. We just need to take care that it does not become bloated. Perhaps it can be extensible in the future.