### PR TITLE
Add /users/:id/confirm-email to APIv2

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -597,15 +597,15 @@ class UsersApiController extends AbstractApiController {
         $this->userModel->passwordRequest($body['email']);
         $this->validateModel($this->userModel, true);
     }
-
     /**
-     * Confirm user email address after registration
+     * Confirm a user email address after registration.
      *
      * @param int $id The ID of the user.
      * @param array $body The POST body.
-     * @throws Exception
+     * @throws ClientException if email has been confirmed.
+     * @throws Exception if confirmationCode doesn't match.
      * @throws NotFoundException if unable to find the user.
-     * @return array
+     * @return array the response body.
      */
     public function post_confirmEmail($id, array $body) {
         $this->permission();

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -613,7 +613,7 @@ class UsersApiController extends AbstractApiController {
         $this->idParamSchema('in');
         $in = $this->schema( [
             'confirmationCode:s' => 'Email confirmation code'
-        ])->setDescription('Confirm a users current email address by using a confirmation code');
+        ], 'in')->setDescription('Confirm a users current email address by using a confirmation code');
         $out = $this->schema(['userID:i', 'email:s', 'emailConfirmed:b'], 'out');
 
         $row = $this->userByID($id);

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -608,7 +608,7 @@ class UsersApiController extends AbstractApiController {
     public function post_confirmEmail ($id, array $body) {
         $this->permission('Garden.Users.Edit');
 
-        $in = $this->schema( ['emailKey:s' => ''])->setDescription('Code sent via email');
+        $in = $this->schema( ['emailKey:s' => 'key generated on registration'])->setDescription('Confirm new user email upon registration');
         $out = $this->schema(['emailConfirmed:b' => 'The current email confirmed value.'], 'out');
 
         $row = $this->userByID($id);
@@ -616,14 +616,14 @@ class UsersApiController extends AbstractApiController {
 
         $emailKey = '';
         $userData = $this->normalizeInput($body);
-        if (array_key_exists('emailKey', $userData)) {
-            $emailKey = $userData['emailKey'];
+        if (array_key_exists('EmailKey', $userData)) {
+            $emailKey = $userData['EmailKey'];
         }
 
         $this->userModel->confirmEmail($row, $emailKey);
-        $this->validateModel($this->userModel, true);
+        $this->validateModel($this->userModel);
 
-        $result = $out->validate($row);
+        $result = $out->validate($this->userByID($id));
         return $result;
     }
 

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -608,8 +608,8 @@ class UsersApiController extends AbstractApiController {
      * @return array the response body.
      */
     public function post_confirmEmail($id, array $body) {
-        $this->permission();
-        
+        $this->permission(\Vanilla\Permissions::BAN_CSRF);
+
         $this->idParamSchema('in');
         $in = $this->schema( [
             'confirmationCode:s' => 'Email confirmation code'
@@ -617,7 +617,7 @@ class UsersApiController extends AbstractApiController {
         $out = $this->schema(['userID:i', 'email:s', 'emailConfirmed:b'], 'out');
 
         $row = $this->userByID($id);
-        if ($row['Confirmed'] == 1){
+        if ($row['Confirmed']) {
             throw new ClientException('This email has already been confirmed');
         }
 

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -611,9 +611,9 @@ class UsersApiController extends AbstractApiController {
         $this->permission(\Vanilla\Permissions::BAN_CSRF);
 
         $this->idParamSchema('in');
-        $in = $this->schema( [
+        $in = $this->schema([
             'confirmationCode:s' => 'Email confirmation code'
-        ],'in')->setDescription('Confirm a users current email address by using a confirmation code');
+        ], 'in')->setDescription('Confirm a users current email address by using a confirmation code');
         $out = $this->schema(['userID:i', 'email:s', 'emailConfirmed:b'], 'out');
 
         $row = $this->userByID($id);

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -599,6 +599,35 @@ class UsersApiController extends AbstractApiController {
     }
 
     /**
+     * @param $id
+     * @param array $body
+     * @return array
+     * @throws Exception
+     * @throws NotFoundException if unable to find the user.
+     */
+    public function post_confirmEmail ($id, array $body) {
+        $this->permission('Garden.Users.Edit');
+
+        $in = $this->schema( ['emailKey:s' => ''])->setDescription('Code sent via email');
+        $out = $this->schema(['emailConfirmed:b' => 'The current email confirmed value.'], 'out');
+
+        $row = $this->userByID($id);
+        $body = $in->validate($body);
+
+        $emailKey = '';
+        $userData = $this->normalizeInput($body);
+        if (array_key_exists('emailKey', $userData)) {
+            $emailKey = $userData['emailKey'];
+        }
+
+        $this->userModel->confirmEmail($row, $emailKey);
+        $this->validateModel($this->userModel, true);
+
+        $result = $out->validate($row);
+        return $result;
+    }
+
+    /**
      * Verify a user.
      *
      * @param int $id The ID of the user.

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -608,6 +608,8 @@ class UsersApiController extends AbstractApiController {
      * @return array the response body.
      */
     public function post_confirmEmail($id, array $body) {
+        $this->permission();
+        
         $this->idParamSchema('in');
         $in = $this->schema( [
             'confirmationCode:s' => 'Email confirmation code'

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -608,9 +608,6 @@ class UsersApiController extends AbstractApiController {
      * @return array the response body.
      */
     public function post_confirmEmail($id, array $body) {
-        $this->permission();
-        //$Configuration['Garden']['Registration']['ConfirmEmail'] = true;
-
         $this->idParamSchema('in');
         $in = $this->schema( [
             'confirmationCode:s' => 'Email confirmation code'

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -613,7 +613,7 @@ class UsersApiController extends AbstractApiController {
         $this->idParamSchema('in');
         $in = $this->schema( [
             'confirmationCode:s' => 'Email confirmation code'
-        ], 'in')->setDescription('Confirm a users current email address by using a confirmation code');
+        ],'in')->setDescription('Confirm a users current email address by using a confirmation code');
         $out = $this->schema(['userID:i', 'email:s', 'emailConfirmed:b'], 'out');
 
         $row = $this->userByID($id);

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -601,7 +601,7 @@ class UsersApiController extends AbstractApiController {
     /**
      * @param $id
      * @param array $body
-     * @return array
+     * @return array $result The response body
      * @throws Exception
      * @throws NotFoundException if unable to find the user.
      */

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -151,7 +151,8 @@ class UsersTest extends AbstractResourceTest {
      * Test confirm email fails.
      *
      * @expectedException \Exception
-     * @expectedExceptionMessage We couldn't confirm your email. Check the link in the email we sent you or try sending another confirmation email.
+     * @expectedExceptionMessage We couldn't confirm your email.
+     * Check the link in the email we sent you or try sending another confirmation email.
      */
     public function testConfirmEmailFail() {
         /** @var \UserModel $userModel */

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -130,6 +130,24 @@ class UsersTest extends AbstractResourceTest {
     }
 
     /**
+     * Test confirm email endpoint
+     */
+    public function testConfirmEmail() {
+        $emailKey = [
+            'test123'
+        ];
+        $user = $this->testPost();
+
+        /** @var \UserModel $userModel */
+        $userModel = self::container()->get('UserModel');
+        $userModel->saveAttribute($user['userID'], 'EmailKey', 'test123');
+
+        $response = $this->api()->post("{$this->baseUrl}/{$user['userID']}/confirmEmail", [$emailKey]);
+        $this->assertEquals($response->getBody(), $user['emailConfirm']);
+
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function testGetEdit($record = null) {

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -130,21 +130,34 @@ class UsersTest extends AbstractResourceTest {
     }
 
     /**
-     * Test confirm email endpoint
+     * Test confirm email is successful
      */
-    public function testConfirmEmail() {
-        $emailKey = [
-            'test123'
-        ];
+    public function testConfirmEmailSucceed() {
+        $emailKey = ['emailKey' => 'test123'];
         $user = $this->testPost();
 
         /** @var \UserModel $userModel */
         $userModel = self::container()->get('UserModel');
         $userModel->saveAttribute($user['userID'], 'EmailKey', 'test123');
 
-        $response = $this->api()->post("{$this->baseUrl}/{$user['userID']}/confirmEmail", [$emailKey]);
-        $this->assertEquals($response->getBody(), $user['emailConfirm']);
+        $response = $this->api()->post("{$this->baseUrl}/{$user['userID']}/confirmEmail", $emailKey);
+        $this->assertEquals($response->getBody(), ['emailConfirmed' => true]);
+    }
 
+    /**
+     * Test confirm email fails
+     *
+     * @expectedException \Exception
+     */
+    public function testConfirmEmailFail() {
+        $emailKey = ['emailKey' => '123test'];
+        $user = $this->testPost();
+
+        /** @var \UserModel $userModel */
+        $userModel = self::container()->get('UserModel');
+        $userModel->saveAttribute($user['userID'], 'EmailKey', 'test123');
+
+        $this->api()->post("{$this->baseUrl}/{$user['userID']}/confirmEmail", $emailKey);
     }
 
     /**

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -130,34 +130,38 @@ class UsersTest extends AbstractResourceTest {
     }
 
     /**
-     * Test confirm email is successful
+     * Test confirm email is successful.
      */
     public function testConfirmEmailSucceed() {
-        $emailKey = ['emailKey' => 'test123'];
-        $user = $this->testPost();
-
         /** @var \UserModel $userModel */
         $userModel = self::container()->get('UserModel');
-        $userModel->saveAttribute($user['userID'], 'EmailKey', 'test123');
 
-        $response = $this->api()->post("{$this->baseUrl}/{$user['userID']}/confirmEmail", $emailKey);
-        $this->assertEquals($response->getBody(), ['emailConfirmed' => true]);
+        $emailKey = ['confirmationCode' =>'test123'];
+
+        $user = $this->testPost();
+        $userModel->saveAttribute($user['userID'], 'EmailKey', $emailKey['confirmationCode']);
+
+        $response = $this->api()->post("{$this->baseUrl}/{$user['userID']}/confirm-email", $emailKey);
+
+        $user = $userModel->getID($user['userID']);
+        $this->assertEquals(1, $user->Confirmed);
     }
 
     /**
-     * Test confirm email fails
+     * Test confirm email fails.
      *
      * @expectedException \Exception
+     * @expectedExceptionMessage We couldn't confirm your email. Check the link in the email we sent you or try sending another confirmation email.
      */
     public function testConfirmEmailFail() {
-        $emailKey = ['emailKey' => '123test'];
-        $user = $this->testPost();
-
         /** @var \UserModel $userModel */
         $userModel = self::container()->get('UserModel');
-        $userModel->saveAttribute($user['userID'], 'EmailKey', 'test123');
 
-        $this->api()->post("{$this->baseUrl}/{$user['userID']}/confirmEmail", $emailKey);
+        $emailKey = ['confirmationCode' =>'test123'];;
+        $user = $this->testPost();
+        $userModel->saveAttribute($user['userID'], 'EmailKey', '123Test');
+
+        $this->api()->post("{$this->baseUrl}/{$user['userID']}/confirm-email", $emailKey);
     }
 
     /**


### PR DESCRIPTION
This update adds /users/:id/confirmEmail to API v2 to confirm new users email address after registration.  Currently functionality signs the user in after confirmation, this will return true or throw an exception on failure

Closes #7170 