### PR TITLE
Add ability to CRUD SSOAuthenticators

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticateApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticateApiController.php
@@ -415,7 +415,7 @@ class AuthenticateApiController extends AbstractApiController {
         $this->permission();
 
         $in = $this->schema([
-            'authenticate' => [
+            'authenticate:o' => [
                 'authenticatorType:s' => 'The authenticator type that will be used.',
                 'authenticatorID:s' => 'Authenticator instance\'s identifier.',
             ],

--- a/applications/dashboard/models/SwaggerModel.php
+++ b/applications/dashboard/models/SwaggerModel.php
@@ -58,8 +58,6 @@ class SwaggerModel {
 
     private $exclude = [
         OpenApiApiController::class,
-//        \AuthenticateApiController::class,
-        \AuthenticatorsApiController::class,
     ];
 
     /**

--- a/library/Vanilla/Authenticator/Authenticator.php
+++ b/library/Vanilla/Authenticator/Authenticator.php
@@ -13,6 +13,13 @@ use Garden\Schema\ValidationException;
 use Garden\Schema\ValidationField;
 use Garden\Web\RequestInterface;
 
+/**
+ * Class Authenticator
+ *
+ * Authenticators should be fetching their data on instanciation.
+ * Thus, extending classes will most likely require to have a dependency on some other classes like Gdn_Configuration
+ * or something that gives them access to the Database.
+ */
 abstract class Authenticator {
 
     /**
@@ -20,21 +27,19 @@ abstract class Authenticator {
      *
      * If the authenticator {@link isUnique()} the ID should match the {@link getType}.
      *
-     * Extending classes will most likely require to have a dependency on RequestInterface so that they can
-     * fetch the ID from the URL and throw an exception if it is not found or invalid.
-     *
      * @var string
      */
     private $authenticatorID;
 
-    /** @var bool Determine if this authenticator is active or not. */
-    private $active = true;
+    /** @var array Any extra attributes */
+    protected $attributes = [];
 
     /**
      * Authenticator constructor.
      *
      * @throws Exception
      * @throws ValidationException
+     *
      * @param string $authenticatorID
      */
     public function __construct($authenticatorID) {
@@ -70,7 +75,7 @@ abstract class Authenticator {
                 'ui:o' => static::getUiSchema(),
                 'isActive:b' => 'Whether or not the Authenticator can be used.',
                 'isUnique' => null,
-                'attributes:o' => 'Provider specific attributes',
+                'attributes:o' => 'Authenticator specific attributes',
             ])
         );
     }
@@ -98,7 +103,8 @@ abstract class Authenticator {
      * @return array
      */
     protected static function getAuthenticatorTypeDefaultInfo(): array {
-        $type =  static::getType();
+        $type = static::getType();
+
         return [
             'type' => $type,
             'name' => ucfirst($type),
@@ -131,10 +137,10 @@ abstract class Authenticator {
             'type:s' => 'Authenticator instance\'s type.',
             'name:s' => 'User friendly name of the authenticator.',
             'ui:o' => Schema::parse([
-                    'photoUrl' => null,
-                    'backgroundColor' => null,
-                    'foregroundColor' => null,
-                ])
+                'photoUrl' => null,
+                'backgroundColor' => null,
+                'foregroundColor' => null,
+            ])
                 ->addValidator('backgroundColor', self::getCSSColorValidator())
                 ->addValidator('foregroundColor', self::getCSSColorValidator())
                 ->add(static::getUiSchema())
@@ -160,6 +166,7 @@ abstract class Authenticator {
     private static function getTypeImpl() {
         // return Type from "{Type}Authenticator"
         $classParts = explode('\\', static::class);
+
         return (string)substr(array_pop($classParts), 0, -strlen('Authenticator'));
     }
 
@@ -168,17 +175,16 @@ abstract class Authenticator {
      *
      * @return Schema
      */
-     public static function getUiSchema(): Schema {
+    public static function getUiSchema(): Schema {
         return Schema::parse([
-                'url:s' => 'Local relative URL from which you can initiate the SignIn process with this authenticator',
-                'buttonName:s' => 'The display text to put in the button. Ex: "Sign in with Facebook"',
-                'photoUrl:s|n' => 'The icon URL for the button.',
-                'backgroundColor:s|n' => 'A css color code for the background. (Hex color, rgb or rgba)',
-                'foregroundColor:s|n' => 'A css color code for the foreground. (Hex color, rgb or rgba)',
-            ])
+            'url:s' => 'Local relative URL from which you can initiate the SignIn process with this authenticator',
+            'buttonName:s' => 'The display text to put in the button. Ex: "Sign in with Facebook"',
+            'photoUrl:s|n' => 'The icon URL for the button.',
+            'backgroundColor:s|n' => 'A css color code for the background. (Hex color, rgb or rgba)',
+            'foregroundColor:s|n' => 'A css color code for the foreground. (Hex color, rgb or rgba)',
+        ])
             ->addValidator('backgroundColor', self::getCSSColorValidator())
-            ->addValidator('foregroundColor', self::getCSSColorValidator())
-        ;
+            ->addValidator('foregroundColor', self::getCSSColorValidator());
     }
 
     /**
@@ -187,7 +193,7 @@ abstract class Authenticator {
      * @return \Closure
      */
     protected static function getCSSColorValidator() {
-        return function($data, ValidationField $field) {
+        return function ($data, ValidationField $field) {
             if ($data === null) {
                 return true;
             }
@@ -242,21 +248,16 @@ abstract class Authenticator {
      *
      * @return bool
      */
-    public function isActive(): bool {
-        return $this->active;
-    }
+    abstract public function isActive(): bool;
 
     /**
      * Setter of active.
      *
      * @param bool $active
+     *
      * @return $this
      */
-    public function setActive(bool $active) {
-        $this->active = $active;
-
-        return $this;
-    }
+    abstract public function setActive(bool $active);
 
     /**
      * Return authenticator default information.
@@ -276,7 +277,7 @@ abstract class Authenticator {
                 'url' => strtolower(url('/authenticate/signin/'.static::getType().'/'.$this->getID())),
             ],
             'isActive' => $this->isActive(),
-            'attributes' => [],
+            'attributes' => $this->attributes,
         ];
     }
 
@@ -341,23 +342,27 @@ abstract class Authenticator {
      * Validate an authentication by using the request's data.
      *
      * @throws Exception Reason why the authentication failed.
+     *
      * @param RequestInterface $request
+     *
      * @return mixed The user's information.
      */
     final public function validateAuthentication(RequestInterface $request) {
-         if (!$this->isActive()) {
-             throw new Exception('Cannot authenticate with an inactive authenticator.');
-         }
+        if (!$this->isActive()) {
+            throw new Exception('Cannot authenticate with an inactive authenticator.');
+        }
 
-         return $this->validateAuthenticationImpl($request);
-     }
+        return $this->validateAuthenticationImpl($request);
+    }
 
     /**
      * {@link ValidateAuthentication} implementation.
      *
      * @throws Exception Reason why the authentication failed.
+     *
      * @param RequestInterface $request
+     *
      * @return array The user's information.
      */
-     abstract public function validateAuthenticationImpl(RequestInterface $request);
+    abstract public function validateAuthenticationImpl(RequestInterface $request);
 }

--- a/library/Vanilla/Authenticator/SSOAuthenticator.php
+++ b/library/Vanilla/Authenticator/SSOAuthenticator.php
@@ -10,9 +10,16 @@ namespace Vanilla\Authenticator;
 use Exception;
 use Garden\Schema\Schema;
 use Garden\Web\RequestInterface;
+use Vanilla\Models\AuthenticatorModel;
 use Vanilla\Models\SSOData;
 
+/**
+ * Class SSOAuthenticator
+ */
 abstract class SSOAuthenticator extends Authenticator {
+
+    /** @var bool */
+    private $active = true;
 
     /**
      * Determine whether the authenticator can automatically link users by email.
@@ -44,14 +51,97 @@ abstract class SSOAuthenticator extends Authenticator {
      */
     private $trusted = false;
 
+    /** @var string */
+    private $signInUrl;
+
+    /** @var string */
+    private $signOutUrl;
+
+    /** @var string */
+    private $registerUrl;
+
+    /** @var AuthenticatorModel */
+    protected $authenticatorModel;
+
+    /** @var bool Prevent this object from saving itself in the DB when using set{$propery}() when constructing the object. */
+    protected $saveState = false;
+
     /**
      * Authenticator constructor.
      *
-     * @throws Exception
      * @param string $authenticatorID Currently maps to "UserAuthenticationProvider.AuthenticationKey".
+     * @param \Vanilla\Models\AuthenticatorModel $authenticatorModel
+     *
+     * @throws \Garden\Schema\ValidationException
+     * @throws \Garden\Web\Exception\NotFoundException
      */
-    public function __construct($authenticatorID) {
+    public function __construct($authenticatorID, AuthenticatorModel $authenticatorModel) {
+        $this->authenticatorModel = $authenticatorModel;
+        $data = $this->loadData($authenticatorID);
+        if (!$data) {
+            throw new \Exception('Could not load authenticator data.');
+        }
+
+        $this->setAuthenticatorInfo($data);
+
         parent::__construct($authenticatorID);
+        $this->saveState = true;
+    }
+
+    /**
+     * Load this authenticator instance's data.
+     *
+     * Highly coupled to AuthenticatorModel.
+     *
+     * Calling {@link AuthenticatorModel::createSSOAuthenticatorInstance($data)} put $data in memory and that data is
+     * then passed back to this function from {@link AuthenticatorModel::getSSOAuthenticatorData()}.
+     *
+     * Calling {@link AuthenticatorModel::getSSOAuthenticatorData()} will return data from the database.
+     *
+     * @param string $authenticatorID
+     * @return bool|mixed
+     * @throws \Garden\Schema\ValidationException
+     * @throws \Garden\Web\Exception\NotFoundException
+     */
+    protected function loadData(string $authenticatorID) {
+        return $this->authenticatorModel->getSSOAuthenticatorData(self::getType(), $authenticatorID);
+    }
+
+    /**
+     *
+     *
+     * @param array $data
+     *
+     * @throws \Garden\Schema\ValidationException
+     */
+    protected function setAuthenticatorInfo(array $data) {
+        // SSO Stuff
+        if ($data['sso']['canSignIn'] ?? false) {
+            $this->setSignIn(true);
+        }
+        if ($data['sso']['canLinkSession'] ?? false) {
+            $this->setLinkSession(true);
+        }
+        if ($data['sso']['isTrusted'] ?? false) {
+            $this->setTrusted(true);
+        }
+        if ($data['sso']['canAutoLinkUser'] ?? false) {
+            $this->setAutoLinkUser(true);
+        }
+
+        // Set data to appropriate target.
+        foreach($data as $key => $value) {
+            // Set directly to variable.
+            if (property_exists($this, $key)) {
+                $this->{$key} = $value;
+            // Set through method name can{Something}.
+            } else if (substr($key, 0, 3) === 'can' && method_exists($this, $key)) {
+                $this->{$key}($value);
+            // Set through method name set{Something}. Note that the property should be named is{Something}.
+            } else if (preg_match('/^is([A-Z].+)/', $key, $matches) && method_exists($this, 'set'.$matches[1])) {
+                $this->{'set'.$matches[1]}($value);
+            }
+        }
     }
 
     /**
@@ -83,10 +173,27 @@ abstract class SSOAuthenticator extends Authenticator {
                     'canSignIn:b' => 'Whether or not the authenticator can be used to sign in.',
                     'canLinkSession:b' => 'Whether or not, using the authenticator, the user can link his account from the profile page.',
                     'isTrusted:b' => 'Whether or not the authenticator is trusted to synchronize user information.',
-                    'canAutoLinkUser:b' => 'Whether or not the authenticator can automatically link the incoming user information to an existing user account.',
+                    'canAutoLinkUser:b' => 'Whether or not the authenticator can automatically link the incoming user information to an existing user account by using email address.',
                 ])
             ])
         );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setActive(bool $active) {
+        $this->active = $active;
+
+        if ($this->saveState) {
+            $this->authenticatorModel->saveSSOAuthenticatorData($this);
+        }
+
+        return $this;
+    }
+
+    public function isActive(): bool {
+        return $this->active;
     }
 
     /**
@@ -102,10 +209,16 @@ abstract class SSOAuthenticator extends Authenticator {
      * Setter of autoLinkUser.
      *
      * @param bool $autoLinkUser
+     *
      * @return $this
+     * @throws \Garden\Schema\ValidationException
      */
     public function setAutoLinkUser(bool $autoLinkUser) {
         $this->autoLinkUser = $autoLinkUser;
+
+        if ($this->saveState) {
+            $this->authenticatorModel->saveSSOAuthenticatorData($this);
+        }
 
         return $this;
     }
@@ -131,10 +244,16 @@ abstract class SSOAuthenticator extends Authenticator {
      * Setter of linkSession.
      *
      * @param bool $linkSession
+     *
      * @return $this
+     * @throws \Garden\Schema\ValidationException
      */
     public function setLinkSession(bool $linkSession) {
         $this->linkSession = $linkSession;
+
+        if ($this->saveState) {
+            $this->authenticatorModel->saveSSOAuthenticatorData($this);
+        }
 
         return $this;
     }
@@ -152,10 +271,16 @@ abstract class SSOAuthenticator extends Authenticator {
      * Setter of signIn.
      *
      * @param bool $signIn
+     *
      * @return $this
+     * @throws \Garden\Schema\ValidationException
      */
     public function setSignIn(bool $signIn) {
         $this->signIn = $signIn;
+
+        if ($this->saveState) {
+            $this->authenticatorModel->saveSSOAuthenticatorData($this);
+        }
 
         return $this;
     }
@@ -171,12 +296,39 @@ abstract class SSOAuthenticator extends Authenticator {
      * Setter of trusted.
      *
      * @param bool $trusted
+     *
      * @return $this
+     * @throws \Garden\Schema\ValidationException
      */
     protected function setTrusted(bool $trusted) {
         $this->trusted = $trusted;
 
+        if ($this->saveState) {
+            $this->authenticatorModel->saveSSOAuthenticatorData($this);
+        }
+
         return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRegisterUrl() {
+        return $this->registerUrl;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSignInUrl() {
+        return $this->signInUrl;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSignOutUrl() {
+        return $this->signOutUrl;
     }
 
     /**

--- a/library/Vanilla/Authenticator/SSOAuthenticator.php
+++ b/library/Vanilla/Authenticator/SSOAuthenticator.php
@@ -108,7 +108,8 @@ abstract class SSOAuthenticator extends Authenticator {
     }
 
     /**
-     *
+     * Take an array of data matching {@link AuthenticatorModel::getAuthenticatorInfo()} and assign the values to this
+     * authenticator's property. Extending classes might want to redefine this function to add extra functionalities to it.
      *
      * @param array $data
      *

--- a/library/Vanilla/Authenticator/ShimAuthenticator.php
+++ b/library/Vanilla/Authenticator/ShimAuthenticator.php
@@ -8,6 +8,7 @@
 namespace Vanilla\Authenticator;
 
 use Garden\Web\Exception\ServerException;
+use \Garden\Web\RequestInterface;
 
 
 /**
@@ -15,40 +16,51 @@ use Garden\Web\Exception\ServerException;
  */
 abstract class ShimAuthenticator extends Authenticator {
 
+    /**
+     * ShimAuthenticator constructor.
+     *
+     * @param string $authenticatorID
+     *
+     * @throws \Garden\Schema\ValidationException
+     */
     public function __construct(string $authenticatorID) {
         parent::__construct($authenticatorID);
     }
 
     /**
-     * {@link Authenticator::getRegisterUrl()}
+     * @inheritdoc
      */
     public function getRegisterUrl() {
         return null;
     }
 
     /**
-     * {@link Authenticator::getSignInUrl()}
+     * @inheritdoc
      */
     public function getSignInUrl() {
         return null;
     }
 
     /**
-     * {@link Authenticator::getSignOutUrl()}
+     * @inheritdoc
      */
     public function getSignOutUrl() {
         return null;
     }
 
-    /**
-     * {@link Authenticator::validateAuthentication()}
-     */
-    public function validateAuthenticationImpl(\Garden\Web\RequestInterface $request) {
-        throw new ServerException('Method not implemented', 501);
+    public function setActive(bool $active) {
+        throw new ServerException('Method not implemented.', 501);
     }
 
     /**
-     * {@link Authenticator::getAuthenticatorInfoImpl()}
+     * @inheritdoc
+     */
+    public function validateAuthenticationImpl(RequestInterface $request) {
+        throw new ServerException('Method not implemented.', 501);
+    }
+
+    /**
+     * @inheritdoc
      */
     protected function getAuthenticatorInfoImpl(): array {
         return [

--- a/library/Vanilla/Models/SSOData.php
+++ b/library/Vanilla/Models/SSOData.php
@@ -200,7 +200,7 @@ class SSOData implements \JsonSerializable {
 
         $invalidProperties = [];
         foreach ($required as $name) {
-            if ($this->$name === null) {
+            if ($this->$name === '') {
                 $invalidProperties[] = $name;
             }
         }
@@ -220,9 +220,9 @@ class SSOData implements \JsonSerializable {
      */
     public static function fromArray(array $array): SSOData {
         $ssoData = new SSOData(
-            array_key_exists('authenticatorType', $array) ? $array['authenticatorType'] : null,
-            array_key_exists('authenticatorID', $array) ? $array['authenticatorID'] : null,
-            array_key_exists('uniqueID', $array) ? $array['uniqueID'] : null,
+            array_key_exists('authenticatorType', $array) ? $array['authenticatorType'] : '',
+            array_key_exists('authenticatorID', $array) ? $array['authenticatorID'] : '',
+            array_key_exists('uniqueID', $array) ? $array['uniqueID'] : '',
             array_key_exists('user', $array) ? $array['user'] : [],
             array_key_exists('extra', $array) ? $array['extra'] : []
         );

--- a/library/Vanilla/Models/SSOModel.php
+++ b/library/Vanilla/Models/SSOModel.php
@@ -436,7 +436,7 @@ class SSOModel {
             $allowConnect = $this->config->get('Garden.Registration.AllowConnect', true);
 
             // We want to link to the currently logged user.
-            if ($body['linkToSession'] ?? false) {
+            if ($options['linkToSession'] ?? false) {
                 if (!$this->session->isValid()) {
                     throw new ClientException('Cannot link user to session while not signed in.', 401);
                 }

--- a/library/Vanilla/Utility/ModelUtils.php
+++ b/library/Vanilla/Utility/ModelUtils.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace Vanilla\Utility;
+
+use Garden\Schema\Validation;
+use Garden\Schema\ValidationException;
+use Gdn_Locale as LocaleInterface;
+use Gdn_Validation;
+
+/**
+ * Class ModelUtils.
+ */
+class ModelUtils {
+    /**
+     * Given a model (old Gdn_Model mainly), analyze its validation property and return failures.
+     *
+     * @param object $model The model to analyze the Validation property of.
+     * @param LocaleInterface $locale
+     * @param bool $throw If errors are found, should an exception be thrown?
+     *
+     * @return Validation
+     * @throws \Garden\Schema\ValidationException
+     */
+    public static function validationResultToValidationException($model, LocaleInterface $locale, $throw = true) {
+        $validation = new Validation();
+        $caseScheme = new CamelCaseScheme();
+
+        if (property_exists($model, 'Validation') && $model->Validation instanceof Gdn_Validation) {
+            $results = $model->Validation->results();
+            $results = $caseScheme->convertArrayKeys($results);
+            foreach ($results as $field => $errors) {
+                foreach ($errors as $error) {
+                    $message = trim(sprintf(
+                        $locale->translate($error),
+                        $locale->translate($field)
+                    ), '.').'.';
+                    $validation->addError(
+                        $field,
+                        $error,
+                        ['message' => $message]
+                    );
+                }
+            }
+        }
+
+        if ($throw && $validation->getErrorCount() > 0 ) {
+            throw new ValidationException($validation);
+        }
+
+        return $validation;
+    }
+}

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -12,14 +12,13 @@ use Garden\Schema\Schema;
 use Garden\Schema\Validation;
 use Garden\Schema\ValidationException;
 use Garden\Web\Exception\HttpException;
-use Gdn_Session as SessionInterface;
 use Gdn_Locale as LocaleInterface;
+use Gdn_Session as SessionInterface;
 use Gdn_Upload as Upload;
-use Gdn_Validation as DataValidation;
 use Vanilla\Exception\PermissionException;
 use Vanilla\InjectableInterface;
 use Vanilla\UploadedFile;
-use Vanilla\Utility\CamelCaseScheme;
+use Vanilla\Utility\ModelUtils;
 
 /**
  * The controller base class.
@@ -258,31 +257,6 @@ abstract class Controller implements InjectableInterface {
      * @return Validation
      */
     public function validateModel($model, $throw = true) {
-        $validation = new Validation();
-        $caseScheme = new CamelCaseScheme();
-
-        if (property_exists($model, 'Validation') && $model->Validation instanceof DataValidation) {
-            $results = $model->Validation->results();
-            $results = $caseScheme->convertArrayKeys($results);
-            foreach ($results as $field => $errors) {
-                foreach ($errors as $error) {
-                    $message = trim(sprintf(
-                        $this->locale->translate($error),
-                        $this->locale->translate($field)
-                    ), '.').'.';
-                    $validation->addError(
-                        $field,
-                        $error,
-                        ['message' => $message]
-                    );
-                }
-            }
-        }
-
-        if ($throw && $validation->getErrorCount() > 0 ) {
-            throw new ValidationException($validation);
-        }
-
-        return $validation;
+        return ModelUtils::validationResultToValidationException($model, $this->locale, $throw);
     }
 }

--- a/tests/APIv2/Authenticate/AuthenticatorsTest.php
+++ b/tests/APIv2/Authenticate/AuthenticatorsTest.php
@@ -7,8 +7,10 @@
 
 namespace VanillaTests\APIv2\Authenticate;
 
+use Vanilla\Models\AuthenticatorModel;
+use Vanilla\Models\SSOData;
 use VanillaTests\APIv2\AbstractAPIv2Test;
-use VanillaTests\Fixtures\MockSSOAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 
 /**
  * Class AuthenticatorsTest
@@ -26,9 +28,7 @@ class AuthenticatorsTest extends AbstractAPIv2Test {
      */
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
-        self::container()
-            ->rule(MockSSOAuthenticator::class)
-            ->setAliasOf('MockSSOAuthenticator');
+        self::container()->rule(MockSSOAuthenticator::class);
     }
 
     /**
@@ -37,13 +37,31 @@ class AuthenticatorsTest extends AbstractAPIv2Test {
     public function setUp() {
         parent::setUp();
 
-        $uniqueID = uniqid('inactv_auth_');
-        $this->authenticator = new MockSSOAuthenticator($uniqueID);
+        /** @var \Vanilla\Models\AuthenticatorModel $authenticatorModel */
+        $authenticatorModel = $this->container()->get(AuthenticatorModel::class);
 
-        $this->container()->setInstance('MockSSOAuthenticator', $this->authenticator);
+        $uniqueID = uniqid('inactv_auth_');
+        $authType = MockSSOAuthenticator::getType();
+        $this->authenticator = $authenticatorModel->createSSOAuthenticatorInstance([
+            'authenticatorID' => $authType,
+            'type' => $authType,
+            'SSOData' => json_decode(json_encode(new SSOData($authType, $authType, $uniqueID)), true),
+        ]);
+
+//        $this->container()->setInstance('MockSSOAuthenticator', $this->authenticator);
 
         $session = $this->container()->get(\Gdn_Session::class);
         $session->end();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function tearDown() {
+        /** @var \Vanilla\Models\AuthenticatorModel $authenticatorModel */
+        $authenticatorModel = $this->container()->get(AuthenticatorModel::class);
+
+        $authenticatorModel->deleteSSOAuthenticatorInstance($this->authenticator);
     }
 
     /**

--- a/tests/APIv2/Authenticate/AutoConnectTest.php
+++ b/tests/APIv2/Authenticate/AutoConnectTest.php
@@ -7,9 +7,10 @@
 
 namespace VanillaTests\APIv2\Authenticate;
 
+use Vanilla\Models\AuthenticatorModel;
 use Vanilla\Models\SSOData;
 use VanillaTests\APIv2\AbstractAPIv2Test;
-use VanillaTests\Fixtures\MockSSOAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 
 /**
  * Test the /api/v2/authenticate endpoints.
@@ -38,9 +39,7 @@ class AutoConnectTest extends AbstractAPIv2Test {
      */
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
-        self::container()
-            ->rule(MockSSOAuthenticator::class)
-            ->setAliasOf('MockSSOAuthenticator');
+        self::container()->rule(MockSSOAuthenticator::class);
 
         self::$config = self::container()->get('Config');
     }
@@ -63,12 +62,30 @@ class AutoConnectTest extends AbstractAPIv2Test {
         $userFragment = $usersAPIController->post($userData)->getData();
         $this->currentUser = array_merge($userFragment, $userData);
 
-        $this->authenticator = new MockSSOAuthenticator($uniqueID, $userData);
+        /** @var \Vanilla\Models\AuthenticatorModel $authenticatorModel */
+        $authenticatorModel = $this->container()->get(AuthenticatorModel::class);
+
+        $authType = MockSSOAuthenticator::getType();
+        $this->authenticator = $authenticatorModel->createSSOAuthenticatorInstance([
+            'authenticatorID' => $authType,
+            'type' => $authType,
+            'SSOData' => json_decode(json_encode(new SSOData($authType, $authType, $uniqueID, $userData)), true),
+        ]);
 
         $this->container()->setInstance('MockSSOAuthenticator', $this->authenticator);
 
         $session = $this->container()->get(\Gdn_Session::class);
         $session->end();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function tearDown() {
+        /** @var \Vanilla\Models\AuthenticatorModel $authenticatorModel */
+        $authenticatorModel = $this->container()->get(AuthenticatorModel::class);
+
+        $authenticatorModel->deleteSSOAuthenticatorInstance($this->authenticator);
     }
 
     /**

--- a/tests/APIv2/Authenticate/InactiveAuthenticatorTest.php
+++ b/tests/APIv2/Authenticate/InactiveAuthenticatorTest.php
@@ -8,8 +8,10 @@
 namespace VanillaTests\APIv2\Authenticate;
 
 use Exception;
+use Vanilla\Models\AuthenticatorModel;
+use Vanilla\Models\SSOData;
 use VanillaTests\APIv2\AbstractAPIv2Test;
-use VanillaTests\Fixtures\MockSSOAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 
 /**
  * Class InactiveAuthenticatorTest
@@ -24,9 +26,7 @@ class InactiveAuthenticatorTest extends AbstractAPIv2Test {
      */
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
-        self::container()
-            ->rule(MockSSOAuthenticator::class)
-            ->setAliasOf('MockSSOAuthenticator');
+        self::container()->rule(MockSSOAuthenticator::class);
     }
 
     /**
@@ -35,8 +35,17 @@ class InactiveAuthenticatorTest extends AbstractAPIv2Test {
     public function setUp() {
         parent::setUp();
 
+
+        /** @var \Vanilla\Models\AuthenticatorModel $authenticatorModel */
+        $authenticatorModel = $this->container()->get(AuthenticatorModel::class);
+
         $uniqueID = uniqid('inactv_auth_');
-        $this->authenticator = new MockSSOAuthenticator($uniqueID);
+        $authType = MockSSOAuthenticator::getType();
+        $this->authenticator = $authenticatorModel->createSSOAuthenticatorInstance([
+            'authenticatorID' => $authType,
+            'type' => $authType,
+            'SSOData' => json_decode(json_encode(new SSOData($authType, $authType, $uniqueID)), true),
+        ]);
         $this->authenticator->setActive(false);
 
         $this->container()->setInstance('MockSSOAuthenticator', $this->authenticator);

--- a/tests/APIv2/Authenticate/NoEmailTest.php
+++ b/tests/APIv2/Authenticate/NoEmailTest.php
@@ -7,8 +7,10 @@
 
 namespace VanillaTests\APIv2\Authenticate;
 
+use Vanilla\Models\AuthenticatorModel;
+use Vanilla\Models\SSOData;
 use VanillaTests\APIv2\AbstractAPIv2Test;
-use VanillaTests\Fixtures\MockSSOAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 
 /**
  * Test the /api/v2/authenticate endpoints.
@@ -37,9 +39,7 @@ class NoEmailTest extends AbstractAPIv2Test {
      */
     public static function setupBeforeClass() {
         parent::setupBeforeClass();
-        self::container()
-            ->rule(MockSSOAuthenticator::class)
-            ->setAliasOf('MockSSOAuthenticator');
+        self::container()->rule(MockSSOAuthenticator::class);
 
         self::$config = self::container()->get('Config');
     }
@@ -57,7 +57,15 @@ class NoEmailTest extends AbstractAPIv2Test {
             'name' => $uniqueID,
         ];
 
-        $this->authenticator = new MockSSOAuthenticator($uniqueID, $this->currentUser);
+        /** @var \Vanilla\Models\AuthenticatorModel $authenticatorModel */
+        $authenticatorModel = $this->container()->get(AuthenticatorModel::class);
+
+        $authType = MockSSOAuthenticator::getType();
+        $this->authenticator = $authenticatorModel->createSSOAuthenticatorInstance([
+            'authenticatorID' => $authType,
+            'type' => $authType,
+            'SSOData' => json_decode(json_encode(new SSOData($authType, $authType, $uniqueID, $this->currentUser)), true),
+        ]);
 
         $this->container()->setInstance('MockSSOAuthenticator', $this->authenticator);
 

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -20,9 +20,8 @@ use Vanilla\Authenticator\PasswordAuthenticator;
 use Vanilla\InjectableInterface;
 use Vanilla\Models\AuthenticatorModel;
 use Vanilla\Models\SSOModel;
-use Vanilla\Quill\Renderer;
-use VanillaTests\Fixtures\MockAuthenticator;
-use VanillaTests\Fixtures\MockSSOAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 use VanillaTests\Fixtures\NullCache;
 
 /**

--- a/tests/Library/Vanilla/Authenticator/AuthenticatorCssColorValidation.php
+++ b/tests/Library/Vanilla/Authenticator/AuthenticatorCssColorValidation.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use Vanilla\Authenticator\Authenticator;
 use Vanilla\Models\AuthenticatorModel;
 use VanillaTests\Bootstrap;
-use VanillaTests\Fixtures\CssColorAuthenticator;
+use VanillaTests\Fixtures\Authenticator\CssColorAuthenticator;
 
 /**
  * Class AuthenticatorCssColorValidation.

--- a/tests/Library/Vanilla/Authenticator/AuthenticatorTest.php
+++ b/tests/Library/Vanilla/Authenticator/AuthenticatorTest.php
@@ -8,7 +8,7 @@
 namespace VanillaTests\Library\Vanilla;
 
 use PHPUnit\Framework\TestCase;
-use VanillaTests\Fixtures\MockAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockAuthenticator;
 
 
 class AuthenticatorTest extends TestCase {

--- a/tests/Library/Vanilla/Authenticator/SSOAuthenticatorTest.php
+++ b/tests/Library/Vanilla/Authenticator/SSOAuthenticatorTest.php
@@ -8,16 +8,48 @@
 namespace VanillaTests\Library\Vanilla;
 
 use PHPUnit\Framework\TestCase;
-use VanillaTests\Fixtures\MockSSOAuthenticator;
-
+use Vanilla\Models\AuthenticatorModel;
+use Vanilla\Models\SSOData;
+use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
+use VanillaTests\SiteTestTrait;
 
 class SSOAuthenticatorTest extends TestCase {
+    use SiteTestTrait;
+
+    /** @var AuthenticatorModel */
+    private $authenticatorModel;
+
+    /**
+     * @inheritdoc
+     */
+    public function setUp() {
+        parent::setUp();
+
+        /** @var AuthenticatorModel $authenticatorModel */
+        $this->authenticatorModel = self::container()->get(AuthenticatorModel::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function tearDown() {
+        /** @var \Gdn_SQLDriver $driver */
+        $driver = self::container()->get('SqlDriver');
+        $driver->truncate('UserAuthenticationProvider');
+
+        parent::tearDown();
+    }
 
     /**
      * Test that an authenticator with minimal/properly implemented methods will instantiate.
      */
     public function testInstantiateAuthenticator() {
-        new MockSSOAuthenticator(uniqid());
+        $authType = MockSSOAuthenticator::getType();
+        $this->authenticatorModel->createSSOAuthenticatorInstance([
+            'authenticatorID' => $authType,
+            'type' => $authType,
+            'SSOData' => json_decode(json_encode(new SSOData($authType, $authType, uniqid())), true),
+        ]);
         $this->assertTrue(true);
     }
 }

--- a/tests/Models/SSOModel/CreateUserTest.php
+++ b/tests/Models/SSOModel/CreateUserTest.php
@@ -9,6 +9,7 @@ namespace VanillaTests\Models\SSOModel;
 
 use Garden\Schema\ValidationException;
 use PHPUnit\Framework\TestCase;
+use Vanilla\Models\AuthenticatorModel;
 use Vanilla\Models\SSOData;
 use Vanilla\Models\SSOModel;
 use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
@@ -69,9 +70,12 @@ class CreateUserTest extends TestCase {
      * @param $options
      * @param $expectedResult
      *
-     * @throws \ErrorException
      * @throws \Garden\Container\ContainerException
      * @throws \Garden\Container\NotFoundException
+     * @throws \Garden\Schema\ValidationException
+     * @throws \Garden\Web\Exception\ClientException
+     * @throws \Garden\Web\Exception\NotFoundException
+     * @throws \Garden\Web\Exception\ServerException
      */
     public function testCreateUser($configurations, $ssoDataArray, $options, $expectedResult) {
         /** @var \Gdn_Configuration $config */
@@ -81,13 +85,27 @@ class CreateUserTest extends TestCase {
             $config->set($name, $value);
         }
 
+        $ssoData = SSOData::fromArray($ssoDataArray);
+
+        /** @var \Vanilla\Models\AuthenticatorModel $authenticatorModel */
+        $authenticatorModel = $this->container()->get(AuthenticatorModel::class);
+        $authenticator = $authenticatorModel->createSSOAuthenticatorInstance([
+            'authenticatorID' => $ssoData->getAuthenticatorID(),
+            'type' => $ssoData->getAuthenticatorType(),
+            'SSOData' => json_decode(json_encode($ssoData), true),
+        ]);
+
         if (isset($expectedResult['exception'])) {
             $this->expectException($expectedResult['exception']);
         }
 
-        $result = self::$ssoModel->createUser(SSOData::fromArray($ssoDataArray), $options);
+        try {
+            $result = self::$ssoModel->createUser($ssoData, $options);
+            $expectedResult['dataCallback']($result);
+        } finally {
+            $authenticatorModel->deleteSSOAuthenticatorInstance($authenticator);
+        }
 
-        $expectedResult['dataCallback']($result);
     }
 
 

--- a/tests/Models/SSOModel/CreateUserTest.php
+++ b/tests/Models/SSOModel/CreateUserTest.php
@@ -11,7 +11,7 @@ use Garden\Schema\ValidationException;
 use PHPUnit\Framework\TestCase;
 use Vanilla\Models\SSOData;
 use Vanilla\Models\SSOModel;
-use VanillaTests\Fixtures\MockSSOAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 use VanillaTests\SetsGeneratorTrait;
 use VanillaTests\SiteTestTrait;
 

--- a/tests/Models/SSOModel/LinkUserFromCredentialsTest.php
+++ b/tests/Models/SSOModel/LinkUserFromCredentialsTest.php
@@ -10,7 +10,7 @@ namespace VanillaTests\Models\SSOModel;
 use PHPUnit\Framework\TestCase;
 use Vanilla\Models\SSOData;
 use Vanilla\Models\SSOModel;
-use VanillaTests\Fixtures\MockSSOAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 use VanillaTests\SiteTestTrait;
 
 /**

--- a/tests/Models/SSOModel/LinkUserFromSessionTest.php
+++ b/tests/Models/SSOModel/LinkUserFromSessionTest.php
@@ -10,7 +10,7 @@ namespace VanillaTests\Models\SSOModel;
 use PHPUnit\Framework\TestCase;
 use Vanilla\Models\SSOData;
 use Vanilla\Models\SSOModel;
-use VanillaTests\Fixtures\MockSSOAuthenticator;
+use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 use VanillaTests\SiteTestTrait;
 
 /**

--- a/tests/fixtures/src/Authenticator/CssColorAuthenticator.php
+++ b/tests/fixtures/src/Authenticator/CssColorAuthenticator.php
@@ -5,7 +5,7 @@
  * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
  */
 
-namespace VanillaTests\Fixtures;
+namespace VanillaTests\Fixtures\Authenticator;
 
 use Garden\Web\RequestInterface;
 use Vanilla\Authenticator\Authenticator;
@@ -17,6 +17,9 @@ use Vanilla\Authenticator\Exception;
 class CssColorAuthenticator extends Authenticator {
 
     const DEFAULT_CSS_COLOR = '#FFFFFF';
+
+    /** @var bool */
+    protected $active = true;
 
     /** @var array */
     protected $data = [];
@@ -32,6 +35,22 @@ class CssColorAuthenticator extends Authenticator {
     }
 
     /**
+     * @inheritDoc
+     */
+    public function isActive(): bool {
+        return $this->active;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setActive(bool $active) {
+        $this->active = $active;
+
+        return $this;
+    }
+
+    /**
      * Set the current cssColor
      *
      * @param $color
@@ -44,7 +63,7 @@ class CssColorAuthenticator extends Authenticator {
      * Reset the current cssColor.
      */
     public static function resetColor() {
-        self::$cssColor = self::DEFAULT_CSS_COLOR
+        self::$cssColor = self::DEFAULT_CSS_COLOR;
     }
 
     /**

--- a/tests/fixtures/src/Authenticator/MockAuthenticator.php
+++ b/tests/fixtures/src/Authenticator/MockAuthenticator.php
@@ -1,12 +1,20 @@
 <?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
 
-namespace VanillaTests\Fixtures;
+namespace VanillaTests\Fixtures\Authenticator;
 
 use Garden\Web\RequestInterface;
 use Vanilla\Authenticator\Authenticator;
 use Vanilla\Authenticator\Exception;
 
 class MockAuthenticator extends Authenticator {
+
+    /** @var bool */
+    protected $active = true;
 
     /** @var array */
     protected $data = [];
@@ -17,6 +25,23 @@ class MockAuthenticator extends Authenticator {
     public function __construct() {
         parent::__construct('Mock');
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function isActive(): bool {
+        return $this->active;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setActive(bool $active) {
+        $this->active = $active;
+
+        return $this;
+    }
+
 
     /**
      * @return array

--- a/tests/fixtures/src/Authenticator/MockSSOAuthenticator.php
+++ b/tests/fixtures/src/Authenticator/MockSSOAuthenticator.php
@@ -5,46 +5,43 @@
  * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
  */
 
-namespace VanillaTests\Fixtures;
+namespace VanillaTests\Fixtures\Authenticator;
 
 use Garden\Web\RequestInterface;
 use Vanilla\Authenticator\SSOAuthenticator;
 use Vanilla\Models\SSOData;
+use Vanilla\Models\AuthenticatorModel;
 
 /**
  * Class MockSSOAuthenticator
  */
 class MockSSOAuthenticator extends SSOAuthenticator {
 
-    /** @var SSOData */
-    protected $data;
-
     /**
      * MockSSOAuthenticator constructor.
      *
-     * @throws \Exception
-     * @param $uniqueID
-     * @param $userData
-     * @param $extraData
+     * @param \Vanilla\Models\AuthenticatorModel $authenticatorModel
+     *
+     * @throws \Garden\Schema\ValidationException
+     * @throws \Garden\Web\Exception\NotFoundException
      */
-    public function __construct($uniqueID = null, $userData = [], $extraData = []) {
-        parent::__construct('MockSSO');
+    public function __construct(AuthenticatorModel $authenticatorModel) {
+        parent::__construct('MockSSO', $authenticatorModel);
+    }
 
-        if ($uniqueID === null) {
-            $uniqueID = uniqid('MockSSOUserID_');
-        }
+    protected function setAuthenticatorInfo(array $data) {
+        $data['attributes'] = $data['attributes'] ?? [];
+        $data['attributes']['SSOData'] = $data['attributes']['SSOData'] ?? [];
+        $data['attributes']['SSOData']['uniqueID'] = $data['attributes']['SSOData']['uniqueID'] ?? uniqid('MockSSOUserID_');
 
-        $this
-            ->setData(new SSOData(
-                self::getType(),
-                $this->getID(),
-                $uniqueID,
-                $userData,
-                $extraData
-            ))
-            ->setTrusted(true)
-            ->setSignIn(true)
-        ;
+        // Defaults to canSignIn
+        $data['sso']['canSignIn'] = $data['sso']['canSignIn'] ?? true;
+        // Defaults to isTrusted
+        $data['sso']['isTrusted'] = $data['sso']['isTrusted'] ?? true;
+
+        parent::setAuthenticatorInfo($data);
+
+        $this->attributes['SSOData'] = SSOData::fromArray($this->attributes['SSOData'] ?? []);
     }
 
     /**
@@ -55,24 +52,10 @@ class MockSSOAuthenticator extends SSOAuthenticator {
     }
 
     /**
-     * Getter of data.
-     *
-     * @return SSOData
+     * @return \Vanilla\Models\SSOData
      */
-    public function getData() {
-        return $this->data;
-    }
-
-    /**
-     * Setter of data.
-     *
-     * @param SSOData $data
-     * @return $this
-     */
-    public function setData(SSOData $data) {
-        $this->data = $data;
-
-        return $this;
+    protected function getData() {
+        return $this->attributes['SSOData'];
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/6898
Fixes https://github.com/vanilla/vanilla/issues/7023

Fluff:
- Added authentication stuff back in Swagger
- Fixed some bug related to Swagger (Incorrect schema definitions)
- Fixed type hinting problems in SSOData
- Moved Authenticators to their own folder in test/fixtures

Main:
- Moved `$active` property out of Authenticator since some authenticators might want to use a config of whatever.
- Update SSOAuthenticator
    - Couple the class with AuthenticatorModel so that an SSOAuthenticator save any change to itself directly in the database and can load its data itself when initialized. This makes SSOAuthenticator like little model objects.
    - Add `setAuthenticatorInfo()` which "unpacks and assign" the authenticator data to its properties.
- Add CRUD functions to AuthenticatorModel for SSOAuthenticators.
- Update MockSSOAuthenticator to work as a proper SSOAuthenticator and update related unit tests.

