### PR TITLE
Fix Advanced Editor uploads failing if unable to determine MIME type

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -741,8 +741,10 @@ class EditorPlugin extends Gdn_Plugin {
 
         $mimeType = $fileData['type'];
         $allowedMimeTypes = $this->getAllowedMimeTypes();
+        // If mimetype is not in the allowedMimeTypes list, set it to application/octet-stream
+        // before saving it to the database.
         if (!in_array($mimeType, $allowedMimeTypes)) {
-            throw new Gdn_UserException('Invalid file type.');
+            $fileData['type'] = 'application/octet-stream';
         }
 
         $discussionID = ($sender->Request->post('DiscussionID')) ? $sender->Request->post('DiscussionID') : '';

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -741,8 +741,7 @@ class EditorPlugin extends Gdn_Plugin {
 
         $mimeType = $fileData['type'];
         $allowedMimeTypes = $this->getAllowedMimeTypes();
-        // If mimetype is not in the allowedMimeTypes list, set it to application/octet-stream
-        // before saving it to the database.
+        // When a MIME type fails validation, we set it to "application/octet-stream" to prevent a malicious type.
         if (!in_array($mimeType, $allowedMimeTypes)) {
             $fileData['type'] = 'application/octet-stream';
         }


### PR DESCRIPTION
Added a default MIME type of 'application/octet-stream' in case:

- Uploaded file is an allowed file extension
   &
- Extension has an unknown MIME

Closes #7270 
