### PR TITLE
Backport: Fix installing Vanilla on Apache before .htaccess is available

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1540,7 +1540,7 @@ class Gdn_Request implements RequestInterface {
         static $rewrite = null;
         if ($rewrite === null) {
             // Garden.RewriteUrls is maintained for compatibility but X_REWRITE is what really need to be used.
-            $rewrite = val('X_REWRITE', $_SERVER, c('Garden.RewriteUrls', true));
+            $rewrite = val('X_REWRITE', $_SERVER, c('Garden.RewriteUrls', false));
         }
 
         if (!$allowSSL) {


### PR DESCRIPTION
This reverts commit 9bf81855b3bf33c73c51680bc41a6ab64d94837f which fixes https://github.com/vanilla/vanilla/issues/7258.

All the details here: https://github.com/vanilla/vanilla/issues/7258#issuecomment-393958487