### PR TITLE
Allow configurable hot reload IP

### DIFF
--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -157,8 +157,9 @@ class AssetModel extends Gdn_Model {
         $basename = $basename === 'style' ? 'app' : $basename;
 
         if (c("HotReload.Enabled", false)) {
+            $ip = c("HotReload.IP", "127.0.0.1");
             return [
-                "http://127.0.0.1:3030/$basename-hot-bundle.js"
+                "http://$ip:3030/$basename-hot-bundle.js"
             ];
         }
 


### PR DESCRIPTION
Goes with https://github.com/vanilla/vanilla-cli/pull/109.

Allows the hot reload IP address to be read from a configuration value.