### PR TITLE
[Backport] Fix permission column name escaping

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -466,7 +466,7 @@ class RoleModel extends Gdn_Model {
         $this->SQL->beginWhereGroup();
         $permissionCount = count($permission);
         for ($i = 0; $i < $permissionCount; ++$i) {
-            $this->SQL->where('per.`'.$permission[$i].'`', 1);
+            $this->SQL->where('per.'.$permission[$i], 1);
         }
         $this->SQL->endWhereGroup();
         return $this->SQL->get();


### PR DESCRIPTION
Backport https://github.com/vanilla/vanilla/pull/7310

> re: https://github.com/vanilla/vanilla-patches/pull/249
>
> We no longer need this manual escaping, and in fact it breaks the world.
