### PR TITLE
[Backport] Allow search to opt out of SQL table escaping (fix database error from added escaping)

### DIFF
--- a/applications/dashboard/models/class.searchmodel.php
+++ b/applications/dashboard/models/class.searchmodel.php
@@ -151,7 +151,7 @@ class SearchModel extends Gdn_Model {
         // Perform the search by unioning all of the sql together.
         $sql = $this->SQL
             ->select()
-            ->from('_TBL_ s')
+            ->from('_TBL_ s', false)
             ->orderBy('s.DateInserted', 'desc')
             ->limit($limit, $offset)
             ->getSelect();

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -592,16 +592,17 @@ abstract class Gdn_SQLDriver {
      *    user
      *    user, user u2, role
      *    array("user u", "user u2", "role")
+     * @param boolean $escape Whether or not the from query should be escaped.
      *
      * @return Gdn_SQLDriver $this
      **/
-    public function from($from) {
+    public function from($from, $escape = true) {
         if (!is_array($from)) {
             $from = [$from];
         }
 
         foreach ($from as $part) {
-            $this->_Froms[] = $this->mapAliases($part);
+            $this->_Froms[] = $this->mapAliases($part, $escape);
         }
 
         return $this;
@@ -1313,14 +1314,19 @@ abstract class Gdn_SQLDriver {
      * specification with any table prefix prepended.
      *
      * @param string $tableString The string specification of the table. ie. "tbl_User as u" or "user u".
+     * @param boolean $escape Whether or not to escape the tables and aliases.
      * @return string
      */
-    public function mapAliases($tableString) {
+    public function mapAliases($tableString, $escape = true) {
         if (preg_match('`^([^\s]+?)(?:\s+(?:as\s+)?([a-z_][a-z0-9_]*))?$`i', trim($tableString), $m)) {
             $tableName = $m[1];
             $alias = isset($m[2]) ? $m[2] : $tableName;
 
-            return $this->escapeIdentifier($this->Database->DatabasePrefix.$tableName).' '.$this->escapeIdentifier($alias);
+            $fullTableName = $this->Database->DatabasePrefix.$tableName;
+            $escapedTableName = $escape ? $this->escapeIdentifier($fullTableName) : $fullTableName;
+            $escapedAlias = $escape ? $this->escapeIdentifier($alias) : $alias;
+
+            return $escapedTableName.' '.$escapedAlias;
         } else {
             throw new \InvalidArgumentException("Unknown table expression: $tableString", 500);
         }


### PR DESCRIPTION
Backport https://github.com/vanilla/vanilla/pull/7315
> This PR fixes the the normal search's plaintext SQL search.
> 
> Because we don't have a `fromRaw` or `from(SqlObject)` or `fromSql` type function, we are doing a search and replace that broke because of the additional escaping. 
>
> https://github.com/vanilla/vanilla/blob/master/applications/dashboard/models/class.searchmodel.php#L152-L159
>
> @tburry's preferred fix was allowing to opt out of escaping on the `from()` method.
>
> Other solutions that were initially considered:
> - Changed the find/replace query
> - Allowing from to take a SQLObject that presumably already be escaped to the correct amount.