### PR TITLE
Fix unit tests bootstrapping problems

### DIFF
--- a/tests/APIv0/APIv0.php
+++ b/tests/APIv0/APIv0.php
@@ -559,7 +559,7 @@ class APIv0 extends HttpClient {
      * Bootstrap some of the internal objects with this connection.
      */
     public function bootstrap() {
-        $bootstrap = new \VanillaTests\Bootstrap();
+        $bootstrap = new \VanillaTests\Bootstrap('http://vanilla.test');
         $dic = new Container();
         $bootstrap->run($dic);
 

--- a/tests/APIv0/AltTest.php
+++ b/tests/APIv0/AltTest.php
@@ -7,12 +7,12 @@
 
 namespace VanillaTests\APIv0;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 
 /**
  * Tests an alternate install method.
  */
-class AltTest extends TestCase {
+class AltTest extends SharedBootstrapTestCase {
     /** @var APIv0  $api */
     protected static $api;
 
@@ -20,6 +20,7 @@ class AltTest extends TestCase {
      * Make sure there is a fresh copy of Vanilla for the class' tests.
      */
     public static function setUpBeforeClass() {
+        parent::setUpBeforeClass();
         $api = new APIv0();
         self::$api = $api;
     }

--- a/tests/APIv0/BaseTest.php
+++ b/tests/APIv0/BaseTest.php
@@ -9,9 +9,9 @@ namespace VanillaTests\APIv0;
 
 
 use Garden\Http\HttpResponse;
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 
-abstract class BaseTest extends TestCase {
+abstract class BaseTest extends SharedBootstrapTestCase {
     /** @var APIv0  $api */
     protected static $api;
 
@@ -19,6 +19,7 @@ abstract class BaseTest extends TestCase {
      * Make sure there is a fresh copy of Vanilla for the class' tests.
      */
     public static function setUpBeforeClass() {
+        parent::setUpBeforeClass();
         $api = new APIv0();
 
         $api->uninstall();
@@ -35,6 +36,7 @@ abstract class BaseTest extends TestCase {
     public static function tearDownAfterClass() {
         self::$api->uninstall();
         self::$api->terminate();
+        parent::tearDownAfterClass();
     }
 
     /**

--- a/tests/BootstrapTrait.php
+++ b/tests/BootstrapTrait.php
@@ -11,16 +11,18 @@ use Garden\Container\Container;
 use Garden\EventManager;
 
 trait BootstrapTrait {
-    /**
-     * @var Container
-     */
-    protected static $container;
+
+    /** @var Bootstrap */
+    private static $bootstrap;
+
+    /** @var Container */
+    private static $container;
 
     /**
      * Bootstrap the site.
      */
-    public static function setupBeforeClass() {
-        self::$container = static::createContainer();
+    public static function setUpBeforeClass() {
+        self::createContainer();
     }
 
     /**
@@ -29,20 +31,29 @@ trait BootstrapTrait {
      * @return Container Returns a container.
      */
     protected static function createContainer() {
-        $folder = strtolower(EventManager::classBasename(get_called_class()));
-        $bootstrap = new Bootstrap("http://vanilla.test/$folder");
+        $folder = static::getBootstrapFolderName();
+        self::$bootstrap = new Bootstrap("http://vanilla.test/$folder");
 
-        $container = new Container();
-        $bootstrap->run($container);
+        self::$container = new Container();
+        self::$bootstrap->run(self::$container);
 
-        return $container;
+        return self::$container;
+    }
+
+    /**
+     * Get the folder name to construct Bootstrap.
+     *
+     * @return string
+     */
+    protected static function getBootstrapFolderName() {
+        return strtolower(EventManager::classBasename(get_called_class()));
     }
 
     /**
      * Cleanup the container after testing is done.
      */
-    public static function teardownAfterClass() {
-        Bootstrap::cleanup(self::container());
+    public static function tearDownAfterClass() {
+        Bootstrap::cleanup(self::$container);
     }
 
     /**
@@ -52,5 +63,14 @@ trait BootstrapTrait {
      */
     protected static function container() {
         return self::$container;
+    }
+
+    /**
+     * Get the Bootstrap.
+     *
+     * @return Bootstrap
+     */
+    protected static function bootstrap() {
+        return self::$bootstrap;
     }
 }

--- a/tests/Library/Core/ArrayFunctionsTest.php
+++ b/tests/Library/Core/ArrayFunctionsTest.php
@@ -7,12 +7,12 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 
 /**
  * Test array functions.
  */
-class ArrayFunctionsTest extends TestCase {
+class ArrayFunctionsTest extends SharedBootstrapTestCase {
 
     /**
      * Test {@link flattenArray()}.

--- a/tests/Library/Core/ArrayReplaceConfigTest.php
+++ b/tests/Library/Core/ArrayReplaceConfigTest.php
@@ -7,12 +7,12 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 
 /**
  * Tests for the **arrayReplaceConfig** function.
  */
-class ArrayReplaceConfigTest extends TestCase {
+class ArrayReplaceConfigTest extends SharedBootstrapTestCase {
 
     /**
      * An empty default should return the override.

--- a/tests/Library/Core/ControllerTest.php
+++ b/tests/Library/Core/ControllerTest.php
@@ -7,11 +7,11 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Gdn_Controller;
 use stdClass;
 
-class ControllerTest extends TestCase {
+class ControllerTest extends SharedBootstrapTestCase {
 
     /**
      * Testing that the same key will be used to set data and to get it back.

--- a/tests/Library/Core/DataSetTest.php
+++ b/tests/Library/Core/DataSetTest.php
@@ -7,13 +7,13 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Gdn_DataSet;
 
 /**
  * Test the {@link Gdn_DataSet} class.
  */
-class DataSetTest extends TestCase {
+class DataSetTest extends SharedBootstrapTestCase {
     /**
      * A basic test of newing up a dataset.
      */

--- a/tests/Library/Core/DateTimeTest.php
+++ b/tests/Library/Core/DateTimeTest.php
@@ -7,12 +7,12 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use DateTime;
 use DateTimeZone;
 
 
-class DateTimeTest extends TestCase {
+class DateTimeTest extends SharedBootstrapTestCase {
 
     /**
      * Test that different named timezones in the same place produce equivalent dates.

--- a/tests/Library/Core/DbEncodeDecodeTest.php
+++ b/tests/Library/Core/DbEncodeDecodeTest.php
@@ -7,12 +7,12 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 
 /**
  * Test some of the global functions that operate (or mostly operate) on arrays.
  */
-class DbEncodeDecodeTest extends TestCase {
+class DbEncodeDecodeTest extends SharedBootstrapTestCase {
 
     /**
      * Test encoding/decoding an array.

--- a/tests/Library/Core/DispatcherTest.php
+++ b/tests/Library/Core/DispatcherTest.php
@@ -7,11 +7,11 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use VanillaTests\Fixtures\FooBarController;
 use VanillaTests\Fixtures\UnitTestGdnDispatcher;
 
-class DispatcherTest extends TestCase {
+class DispatcherTest extends SharedBootstrapTestCase {
 
     /**
      * Test **Gdn_Dispatcher::filterName()**.

--- a/tests/Library/Core/FactoryTest.php
+++ b/tests/Library/Core/FactoryTest.php
@@ -7,14 +7,14 @@
 
 namespace Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Gdn;
 use VanillaTests\Fixtures\Tuple;
 
 /**
  * Tests for the {@link Gdn_Factory}.
  */
-class FactoryTest extends TestCase {
+class FactoryTest extends SharedBootstrapTestCase {
     const TUPLE = 'VanillaTests\Fixtures\Tuple';
 
     /**

--- a/tests/Library/Core/FormTest.php
+++ b/tests/Library/Core/FormTest.php
@@ -7,11 +7,11 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Gdn;
 use Gdn_Form;
 
-class FormTest extends TestCase {
+class FormTest extends SharedBootstrapTestCase {
     /**
      * Setup a dummy request because {@link Gdn_Form} needs it.
      */

--- a/tests/Library/Core/GeneralFunctionsTest.php
+++ b/tests/Library/Core/GeneralFunctionsTest.php
@@ -7,9 +7,9 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 
-class GeneralFunctionsTest extends TestCase {
+class GeneralFunctionsTest extends SharedBootstrapTestCase {
 
     /**
      * Test {@link urlMatch()}.

--- a/tests/Library/Core/JsonFilterTest.php
+++ b/tests/Library/Core/JsonFilterTest.php
@@ -6,13 +6,13 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use DateTime;
 
 /**
  * Test the jsonFilter function.
  */
-class JsonFilterTest extends TestCase {
+class JsonFilterTest extends SharedBootstrapTestCase {
 
     public function testJsonFilterDateTime() {
         $date = new DateTime('now', new \DateTimeZone('UTC'));

--- a/tests/Library/Core/PasswordTest.php
+++ b/tests/Library/Core/PasswordTest.php
@@ -7,13 +7,13 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Gdn_PasswordHash;
 
 /**
  * Test the the {@link Gdn_PasswordHash} class.
  */
-class PasswordTest extends TestCase {
+class PasswordTest extends SharedBootstrapTestCase {
 
     /**
      * Make sure an empty password fails.

--- a/tests/Library/Core/PluginManagerTest.php
+++ b/tests/Library/Core/PluginManagerTest.php
@@ -8,13 +8,13 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Gdn_PluginManager;
 
 /**
  * Test the {@link Gdn_PluginManager} class.
  */
-class PluginManagerTest extends TestCase {
+class PluginManagerTest extends SharedBootstrapTestCase {
     /**
      * Test a basic usage of {@link Gdn_PluginManager::registerCallback}.
      */

--- a/tests/Library/Core/RenderFunctionsTest.php
+++ b/tests/Library/Core/RenderFunctionsTest.php
@@ -7,12 +7,12 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 
 /**
  * Test some of the functions in functions.render.php.
  */
-class RenderFunctionsTest extends TestCase {
+class RenderFunctionsTest extends SharedBootstrapTestCase {
     /**
      * Make sure the render functions are included.
      */

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -6,13 +6,13 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Gdn_Request;
 
 /**
  * Test the {@link Gdn_Request} class.
  */
-class RequestTest extends TestCase {
+class RequestTest extends SharedBootstrapTestCase {
 
     public function provideUrls() {
         return [

--- a/tests/Library/Garden/ClassLocatorTest.php
+++ b/tests/Library/Garden/ClassLocatorTest.php
@@ -6,10 +6,10 @@
 
 namespace VanillaTests\Library\Garden;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Garden\ClassLocator;
 
-class ClassLocatorTest extends TestCase {
+class ClassLocatorTest extends SharedBootstrapTestCase {
 
     public function testFindClass() {
         $classLocator = new ClassLocator();

--- a/tests/Library/Garden/EventManagerTest.php
+++ b/tests/Library/Garden/EventManagerTest.php
@@ -7,7 +7,7 @@
 
 namespace VanillaTests\Library\Core;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Garden\EventManager;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
@@ -17,7 +17,7 @@ use VanillaTests\Fixtures\Container;
 /**
  * Tests for the {@link EventManager} class.
  */
-class EventManagerTest extends TestCase {
+class EventManagerTest extends SharedBootstrapTestCase {
 
     /**
      * Creates an {@link AddonManager} against Vanilla.

--- a/tests/Library/Garden/Web/CookieTest.php
+++ b/tests/Library/Garden/Web/CookieTest.php
@@ -7,13 +7,13 @@
 
 namespace VanillaTests\Library\Garden\Web;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Garden\Web\Cookie;
 
 /**
  * Test the {@link ResourceRoute} class.
  */
-class CookieTest extends TestCase {
+class CookieTest extends SharedBootstrapTestCase {
 
     /**
      * Parse a Cookie header into its individual cookie key-value pairs.

--- a/tests/Library/Garden/Web/DispatcherTest.php
+++ b/tests/Library/Garden/Web/DispatcherTest.php
@@ -10,14 +10,14 @@ namespace VanillaTests\Library\Garden\Web;
 use Garden\Web\Data;
 use Garden\Web\Dispatcher;
 use Garden\Web\RequestInterface;
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use VanillaTests\Fixtures\Request;
 use VanillaTests\Fixtures\ExactRoute;
 
 /**
  * Test methods on the Dispatcher class.
  */
-class DispatcherTest extends TestCase {
+class DispatcherTest extends SharedBootstrapTestCase {
     /**
      * Test Dispatcher::callMiddlewares().
      */

--- a/tests/Library/Garden/Web/ResourceRouteTest.php
+++ b/tests/Library/Garden/Web/ResourceRouteTest.php
@@ -7,7 +7,7 @@
 
 namespace VanillaTests\Library\Garden\Web;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Garden\Web\Action;
 use Garden\Web\ResourceRoute;
 use Garden\Web\Route;
@@ -19,7 +19,7 @@ use VanillaTests\Fixtures\Request;
 /**
  * Test the {@link ResourceRoute} class.
  */
-class ResourceRouteTest extends TestCase {
+class ResourceRouteTest extends SharedBootstrapTestCase {
     /**
      * Create a new {@link ResourceRoute} initialized for testing with fixtures.
      */

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -7,7 +7,7 @@
 
 namespace VanillaTests\Library\Vanilla;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Test\OldApplication\Controllers\Api\NewApiController;
 use Test\OldApplication\Controllers\ArchiveController;
 use Test\OldApplication\Controllers\HiddenController;
@@ -17,7 +17,7 @@ use Vanilla\Addon;
 use VanillaTests\Fixtures\TestAddonManager;
 
 
-class AddonManagerTest extends TestCase {
+class AddonManagerTest extends SharedBootstrapTestCase {
 
     private static $types = [Addon::TYPE_ADDON, Addon::TYPE_THEME, Addon::TYPE_LOCALE];
 

--- a/tests/Library/Vanilla/ApiUtilsTest.php
+++ b/tests/Library/Vanilla/ApiUtilsTest.php
@@ -8,13 +8,13 @@
 namespace VanillaTests\Library\Vanilla;
 
 use Garden\Schema\Schema;
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\ApiUtils;
 
 /**
  * Class ApiUtilsTest
  */
-class ApiUtilsTest extends TestCase {
+class ApiUtilsTest extends SharedBootstrapTestCase {
 
     /**
      * @param Schema $schema

--- a/tests/Library/Vanilla/AttributesTest.php
+++ b/tests/Library/Vanilla/AttributesTest.php
@@ -7,13 +7,13 @@
 
 namespace VanillaTests\Library\Vanilla;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Attributes;
 
 /**
  * Tests for the **Attributes** class.
  */
-class AttributesTest extends TestCase {
+class AttributesTest extends SharedBootstrapTestCase {
     /**
      * Empty attributes should encode as a JSON object.
      */

--- a/tests/Library/Vanilla/Authenticator/AuthenticatorCssColorValidation.php
+++ b/tests/Library/Vanilla/Authenticator/AuthenticatorCssColorValidation.php
@@ -8,7 +8,7 @@
 namespace VanillaTests\Library\Vanilla;
 
 use Garden\Container\Container;
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Authenticator\Authenticator;
 use Vanilla\Models\AuthenticatorModel;
 use VanillaTests\Bootstrap;
@@ -17,7 +17,7 @@ use VanillaTests\Fixtures\CssColorAuthenticator;
 /**
  * Class AuthenticatorCssColorValidation.
  */
-class AuthenticatorCssColorValidation extends TestCase {
+class AuthenticatorCssColorValidation extends SharedBootstrapTestCase {
 
     /** @var Bootstrap */
     private static $bootstrap;

--- a/tests/Library/Vanilla/CheckVersionTest.php
+++ b/tests/Library/Vanilla/CheckVersionTest.php
@@ -7,14 +7,14 @@
 
 namespace VanillaTests\Library\Vanilla;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Addon;
 
 
 /**
  * Tests of the {@link Addon::checkVersion()} method.
  */
-class CheckVersionTest extends TestCase {
+class CheckVersionTest extends SharedBootstrapTestCase {
     /**
      * Check exact version matching.
      */

--- a/tests/Library/Vanilla/DateFilterSchemaTest.php
+++ b/tests/Library/Vanilla/DateFilterSchemaTest.php
@@ -6,12 +6,12 @@
 
 namespace VanillaTests\Library\Vanilla;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use DateTimeImmutable;
 use Garden\Schema\Schema;
 use Vanilla\DateFilterSchema;
 
-class DateFilterSchemaTest extends TestCase {
+class DateFilterSchemaTest extends SharedBootstrapTestCase {
 
     /**
      * Provide invalid date filter strings to test error conditions.

--- a/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
+++ b/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
@@ -8,7 +8,7 @@ namespace VanillaTests\Library\Vanilla\Embeds;
 
 use Exception;
 use Garden\Http\HttpRequest;
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Embeds\EmbedManager;
 use Vanilla\Embeds\LinkEmbed;
 use Vanilla\Embeds\ImageEmbed;
@@ -18,7 +18,7 @@ use Vanilla\Embeds\VimeoEmbed;
 use VanillaTests\Fixtures\PageScraper;
 use VanillaTests\Fixtures\NullCache;
 
-class EmbedManagerTest extends TestCase {
+class EmbedManagerTest extends SharedBootstrapTestCase {
 
     /**
      * Create a new EmbedManager instance.

--- a/tests/Library/Vanilla/ImageResizerTest.php
+++ b/tests/Library/Vanilla/ImageResizerTest.php
@@ -7,13 +7,13 @@
 
 namespace VanillaTests\Library\Vanilla;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\ImageResizer;
 
 /**
  * Tests for the **ImageResizer** class.
  */
-class ImageResizerTest extends TestCase {
+class ImageResizerTest extends SharedBootstrapTestCase {
     protected static $cachePath = PATH_ROOT.'/tests/cache/image-resizer';
 
     /**

--- a/tests/Library/Vanilla/PageScraperTest.php
+++ b/tests/Library/Vanilla/PageScraperTest.php
@@ -8,12 +8,12 @@ namespace VanillaTests\Library\Vanilla;
 
 use Exception;
 use Garden\Http\HttpRequest;
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use VanillaTests\Fixtures\PageScraper;
 use Vanilla\Metadata\Parser\OpenGraphParser;
 use Vanilla\Metadata\Parser\JsonLDParser;
 
-class PageScraperTest extends TestCase {
+class PageScraperTest extends SharedBootstrapTestCase {
 
     /** @var string Directory of test HTML files. */
     const HTML_DIR = PATH_ROOT.'/tests/fixtures/html';

--- a/tests/Library/Vanilla/PermissionsTest.php
+++ b/tests/Library/Vanilla/PermissionsTest.php
@@ -6,10 +6,10 @@
 
 namespace VanillaTests\Library\Vanilla;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Permissions;
 
-class PermissionsTest extends TestCase {
+class PermissionsTest extends SharedBootstrapTestCase {
 
     public function testAdd() {
         $permissions = new Permissions();

--- a/tests/Library/Vanilla/Quill/BlockTest.php
+++ b/tests/Library/Vanilla/Quill/BlockTest.php
@@ -7,12 +7,12 @@
 
 namespace VanillaTests\Library\Vanilla\Quill;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Quill\BlotGroup;
 use Vanilla\Quill\Blots\HeadingBlot;
 use Vanilla\Quill\Blots\TextBlot;
 
-class BlockTest extends TestCase {
+class BlockTest extends SharedBootstrapTestCase {
     public function testMakeEmptyBlock() {
         $block = BlotGroup::makeEmptyGroup();
 

--- a/tests/Library/Vanilla/Quill/FormatTest.php
+++ b/tests/Library/Vanilla/Quill/FormatTest.php
@@ -7,12 +7,12 @@
 
 namespace VanillaTests\Library\Vanilla\Quill;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Quill\Formats\Bold;
 use Vanilla\Quill\Formats\Italic;
 use Vanilla\Quill\Formats\Link;
 
-class FormatTest extends TestCase {
+class FormatTest extends SharedBootstrapTestCase {
 
     private $boldOperation = [
         "insert" => "bold",

--- a/tests/Library/Vanilla/Quill/RendererTest.php
+++ b/tests/Library/Vanilla/Quill/RendererTest.php
@@ -7,13 +7,13 @@
 
 namespace VanillaTests\Library\Vanilla\Quill;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Quill\Parser;
 use Vanilla\Quill\Renderer;
 use Vanilla\Quill\Blots;
 
 
-class RendererTest extends TestCase {
+class RendererTest extends SharedBootstrapTestCase {
 
     /**
      * Replace all zero-width whitespace in a string.

--- a/tests/Library/Vanilla/Utility/NameSchemeTest.php
+++ b/tests/Library/Vanilla/Utility/NameSchemeTest.php
@@ -7,14 +7,14 @@
 
 namespace VanillaTests\Library\Vanilla\Utility;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Utility\CamelCaseScheme;
 use Vanilla\Utility\DelimitedScheme;
 
 /**
  * Tests for Vanilla\Utility\NameScheme classes.
  */
-class NameSchemeTest extends TestCase {
+class NameSchemeTest extends SharedBootstrapTestCase {
     /**
      * Test some camel case scheme cases.
      *

--- a/tests/Library/Vanilla/Web/WebLinkingTest.php
+++ b/tests/Library/Vanilla/Web/WebLinkingTest.php
@@ -7,10 +7,10 @@
 
 namespace VanillaTests\Library\Vanilla\Utility;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Web\WebLinking;
 
-class WebLinkingTest extends TestCase {
+class WebLinkingTest extends SharedBootstrapTestCase {
 
     /** @var WebLinking */
     private $webLinking;

--- a/tests/Models/AccessTokenModelTest.php
+++ b/tests/Models/AccessTokenModelTest.php
@@ -7,14 +7,14 @@
 
 namespace VanillaTests\Models;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use AccessTokenModel;
 use VanillaTests\SiteTestTrait;
 
 /**
  * Test the {@link AccessTokenModel}.
  */
-class AccessTokenModelTest extends TestCase {
+class AccessTokenModelTest extends SharedBootstrapTestCase {
     use SiteTestTrait;
 
     /**

--- a/tests/Models/CommentModelTest.php
+++ b/tests/Models/CommentModelTest.php
@@ -6,7 +6,7 @@
 
 namespace VanillaTests\Models;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use CommentModel;
 use DiscussionModel;
 use VanillaTests\SiteTestTrait;
@@ -14,7 +14,7 @@ use VanillaTests\SiteTestTrait;
 /**
  * Test {@link CommentModel}.
  */
-class CommentModelTest extends TestCase {
+class CommentModelTest extends SharedBootstrapTestCase {
     use SiteTestTrait {
         setupBeforeClass as baseSetupBeforeClass;
     }

--- a/tests/Models/InstallModelTest.php
+++ b/tests/Models/InstallModelTest.php
@@ -8,27 +8,33 @@
 namespace VanillaTests\Model;
 
 use PHPUnit\Framework\TestCase;
-use Garden\Container\Container;
-use VanillaTests\Bootstrap;
+use VanillaTests\BootstrapTrait;
 use VanillaTests\TestInstallModel;
 
 /**
  * Test basic Vanilla installation.
  */
 class InstallTest extends TestCase {
+    use BootstrapTrait;
+
+    /**
+     * @inheritdoc
+     */
+    public static function tearDownAfterClass() {
+        /* @var TestInstallModel $installer */
+        $installer = self::container()->get(TestInstallModel::class);
+        $installer->uninstall();
+
+        BootstrapTrait::tearDownAfterClass();
+    }
+
     /**
      * Test installing Vanilla with the {@link \Vanilla\Models\InstallModel}.
      */
     public function testInstall() {
-        $bootstrap = new Bootstrap();
-        $dic = new Container();
-        $bootstrap->run($dic);
-
-
         /* @var TestInstallModel $installer */
-        $installer = $dic->get(TestInstallModel::class);
+        $installer = self::container()->get(TestInstallModel::class);
 
-        $installer->uninstall();
         $result = $installer->install([
             'site' => ['title' => __METHOD__]
         ]);

--- a/tests/Models/SSOModel/CreateUserTest.php
+++ b/tests/Models/SSOModel/CreateUserTest.php
@@ -8,7 +8,7 @@
 namespace VanillaTests\Models\SSOModel;
 
 use Garden\Schema\ValidationException;
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Models\SSOData;
 use Vanilla\Models\SSOModel;
 use VanillaTests\Fixtures\MockSSOAuthenticator;
@@ -18,7 +18,7 @@ use VanillaTests\SiteTestTrait;
 /**
  * Class CreateUserTest.
  */
-class CreateUserTest extends TestCase {
+class CreateUserTest extends SharedBootstrapTestCase {
     use SiteTestTrait;
     use SetsGeneratorTrait;
 

--- a/tests/Models/SSOModel/GetUserByTest.php
+++ b/tests/Models/SSOModel/GetUserByTest.php
@@ -7,7 +7,7 @@
 
 namespace VanillaTests\Models\SSOModel;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Models\SSOModel;
 use VanillaTests\SiteTestTrait;
 use VanillaTests\InvokeMethodTrait;
@@ -15,7 +15,7 @@ use VanillaTests\InvokeMethodTrait;
 /**
  * Class SSOModelLinkUserFromCredentials.
  */
-class GetUserByTest extends TestCase {
+class GetUserByTest extends SharedBootstrapTestCase {
     use SiteTestTrait {
         SiteTestTrait::setUpBeforeClass as siteSetUpBeforeClass;
     }

--- a/tests/Models/SSOModel/LinkUserFromCredentialsTest.php
+++ b/tests/Models/SSOModel/LinkUserFromCredentialsTest.php
@@ -7,7 +7,7 @@
 
 namespace VanillaTests\Models\SSOModel;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Models\SSOData;
 use Vanilla\Models\SSOModel;
 use VanillaTests\Fixtures\MockSSOAuthenticator;
@@ -16,7 +16,7 @@ use VanillaTests\SiteTestTrait;
 /**
  * Class LinkUserFromCredentialsTest.
  */
-class LinkUserFromCredentialsTest extends TestCase {
+class LinkUserFromCredentialsTest extends SharedBootstrapTestCase {
     use SiteTestTrait {
         SiteTestTrait::setUpBeforeClass as siteSetUpBeforeClass;
     }

--- a/tests/Models/SSOModel/LinkUserFromSessionTest.php
+++ b/tests/Models/SSOModel/LinkUserFromSessionTest.php
@@ -7,7 +7,7 @@
 
 namespace VanillaTests\Models\SSOModel;
 
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Models\SSOData;
 use Vanilla\Models\SSOModel;
 use VanillaTests\Fixtures\MockSSOAuthenticator;
@@ -16,7 +16,7 @@ use VanillaTests\SiteTestTrait;
 /**
  * Class LinkUserFromSessionTest.
  */
-class LinkUserFromSessionTest extends TestCase {
+class LinkUserFromSessionTest extends SharedBootstrapTestCase {
     use SiteTestTrait {
         SiteTestTrait::setUpBeforeClass as siteSetUpBeforeClass;
     }

--- a/tests/NullContainer.php
+++ b/tests/NullContainer.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests;
+
+class NullContainer extends \Garden\Container\Container {
+    /**
+     * NullContainer constructor.
+     */
+    public function __construct() {}
+
+    /**
+     * Make sure that we fail!
+     */
+    public function rule($id) {
+        throw new \Exception('NullContainer is being called which means that the bootstrapping process failed somewhere.');
+    }
+
+    /**
+     * Make sure that we fail!
+     */
+    public function getArgs($id, array $args = []) {
+        throw new \Exception('NullContainer is being called which means that the bootstrapping process failed somewhere.');
+    }
+}

--- a/tests/SharedBootstrapTestCase.php
+++ b/tests/SharedBootstrapTestCase.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests;
+
+use Gdn;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Exception;
+use Garden\Container\Container;
+
+
+/**
+ * Class SharedBootstrapTestCase.
+ */
+class SharedBootstrapTestCase extends TestCase {
+    use BootstrapTrait;
+
+    /**
+     * Bootstrap the first test cases and reuse the same container/bootstrap for subsequent test cases.
+     */
+    public static function setUpBeforeClass() {
+        /** @var Container $currentContainer */
+        $currentContainer = Gdn::getContainer();
+
+        $containerCorruption = false;
+
+        if (self::$container === null) {
+            if (!self::containerIsNull($currentContainer)) {
+                $containerCorruption = true;
+            } else {
+                BootstrapTrait::setUpBeforeClass();
+            }
+
+        } else {
+            if (!self::containerIsNull($currentContainer) && $currentContainer !== self::$container) {
+                $containerCorruption = true;
+            } else {
+                self::bootstrap()->setGlobals(self::$container);
+            }
+        }
+
+        if ($containerCorruption) {
+            throw new Exception('A container has not been properly cleaned by a previous test!');
+        }
+    }
+
+    /**
+     * Whether or not the container is "null".
+     *
+     * @param $container
+     *
+     * @return bool
+     */
+    private static function containerIsNull($container) {
+        return $container === null || is_a($container, NullContainer::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected static function getBootstrapFolderName() {
+        return 'sharedbootstrap';
+    }
+
+    /**
+     * Cleanup the container after testing is done.
+     */
+    public static function tearDownAfterClass() {
+        Bootstrap::cleanUpGlobals();
+    }
+}

--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -1,6 +1,6 @@
 <?php
 
-use Garden\Container\Container;
+use VanillaTests\NullContainer;
 
 // Alias classes for some limited PHPUnit v5 compatibility with v6.
 $classCompatibility = [
@@ -33,9 +33,8 @@ foreach ($files as $file) {
 // ===========================================================================
 require PATH_ROOT.'/environment.php';
 
-// Set up the dependency injection container.
-$bootstrap = new \VanillaTests\Bootstrap();
-$bootstrap->run(new Container());
+// This effectively disable the auto instanciation of a new container when calling Gdn::getContainer();
+Gdn::setContainer(new NullContainer());
 
 // Clear the test cache.
 \Gdn_FileSystem::removeFolder(PATH_ROOT.'/tests/cache');


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7204

- Separate unit tests that can share the same container from those who cannot. See `SharedBootstrapTestCase`
- Remove base bootstrapping from `phpunit.php`
    - Either extends `SharedBootstrapTestCase` or use `BootstrapTrait/SiteTestTrait`
- Remove code that made it harder to detect globals/container pollution
- Created the `NullContainer` class which is set in `Gdn` when there is supposed to be no container set. This prevents `Gdn::getContainer()` to lazy new up a container
- Add detection for globals/container pollution
    - BootstrapTrait now sets `NullContainer` inside `Gdn` on teardown
- Enforce `$baseUrl` to be supplied to `Bootstrap` class

To test you can add the following class to tests/Library/Core/
```php
<?php
/**
 * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
 * @copyright 2009-2018 Vanilla Forums Inc.
 * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
 */

namespace VanillaTests\Library\Core;

use PHPUnit\Framework\TestCase;
use VanillaTests\BootstrapTrait;

/**
 * Class BootstrapFailCorruptionTest.
 */
class BootstrapFailCorruptionTest extends TestCase {
    use BootstrapTrait;

    public function testCorruption() {
        $this->assertTrue(true);
    }
}
```