### PR TITLE
SSOAuthenticator creation improvements

### DIFF
--- a/library/Vanilla/Authenticator/Authenticator.php
+++ b/library/Vanilla/Authenticator/Authenticator.php
@@ -59,7 +59,7 @@ abstract class Authenticator {
     }
 
     /**
-     * Get this authenticate Schema.
+     * Get this Authenticator schema.
      *
      * @return Schema
      */

--- a/library/Vanilla/Authenticator/Authenticator.php
+++ b/library/Vanilla/Authenticator/Authenticator.php
@@ -64,14 +64,14 @@ abstract class Authenticator {
      * @return Schema
      */
     public static function getAuthenticatorSchema(): Schema {
-        return self::getAuthenticatorTypeSchema()->merge(
+        return static::getAuthenticatorTypeSchema()->merge(
             Schema::parse([
                 'authenticatorID:s' => 'Authenticator instance\'s identifier.',
                 'type' => null,
                 'name' => null,
-                'signInUrl:s|n' => 'The configured relative sign in URL of the provider.',
-                'registerUrl:s|n' => 'The configured relative register URL of the provider.',
-                'signOutUrl:s|n' => 'The configured relative sign out URL of the provider.',
+                'signInUrl:s' => 'The configured sign in URL of the provider.',
+                'signOutUrl:s|n' => 'The configured sign out URL of the provider.',
+                'registerUrl:s|n' => 'The configured register URL of the provider.',
                 'ui:o' => static::getUiSchema(),
                 'isActive:b' => 'Whether or not the Authenticator can be used.',
                 'isUnique' => null,
@@ -293,7 +293,6 @@ abstract class Authenticator {
         $typeInfo = static::getAuthenticatorTypeInfo();
 
         return static::getAuthenticatorSchema()->validate(array_replace_recursive($defaults, $instanceInfo, $typeInfo));
-
     }
 
     /**

--- a/library/Vanilla/Authenticator/SSOAuthenticator.php
+++ b/library/Vanilla/Authenticator/SSOAuthenticator.php
@@ -19,21 +19,24 @@ use Vanilla\Models\SSOData;
 abstract class SSOAuthenticator extends Authenticator {
 
     /** @var bool */
-    private $active = true;
+    private $active;
 
     /**
      * Determine whether the authenticator can automatically link users by email.
      *
      * @var bool
      */
-    private $autoLinkUser = false;
+    private $autoLinkUser;
 
     /**
      * Whether or not, using the authenticator, the user can link his account from the profile page.'
      *
      * @var bool
      */
-    private $linkSession = false;
+    private $linkSession;
+
+    /** @var string  */
+    private $name;
 
     /**
      * Tells whether the data returned by this authenticator is authoritative or not.
@@ -41,15 +44,14 @@ abstract class SSOAuthenticator extends Authenticator {
      *
      * @var bool
      */
-    private $signIn = false;
+    private $signIn;
 
     /**
-     * Tells whether the data returned by this authenticator is authoritative or not.
-     * User info/roles can only be synchronized by trusted authenticators.
+     * Whether or not the authenticator can be used to sign in.
      *
      * @var bool
      */
-    private $trusted = false;
+    private $trusted;
 
     /** @var string */
     private $signInUrl;
@@ -63,7 +65,7 @@ abstract class SSOAuthenticator extends Authenticator {
     /** @var AuthenticatorModel */
     protected $authenticatorModel;
 
-    /** @var bool Prevent this object from saving itself in the DB when using set{$propery}() when constructing the object. */
+    /** @var bool Prevent this object from saving itself in the DB when using set{$property}() when constructing the object. */
     protected $saveState = false;
 
     /**
@@ -86,6 +88,132 @@ abstract class SSOAuthenticator extends Authenticator {
 
         parent::__construct($authenticatorID);
         $this->saveState = true;
+    }
+
+    /**
+     * Get this Authenticator schema.
+     *
+     * x-instance-required: This property is required when creating a new instance. See {@link getRequiredFields}.
+     * x-instance-configurable: This property is configurable and can be provided when creating a new instance. See {@link getConfigurableFields}.
+     *
+     * @return Schema
+     */
+    public static function getAuthenticatorSchema(): Schema {
+        $schema = parent::getAuthenticatorSchema()->merge(
+            Schema::parse([
+                'sso:o' => Schema::parse([
+                    'canSignIn:b' => [
+                        'description' => 'Whether or not the authenticator can be used to sign in.',
+                        'default' => false,
+                        'x-instance-required' => true,
+                        'x-instance-configurable' => true,
+                    ],
+                    'canLinkSession:b'=> [
+                        'description' => 'Whether or not, using the authenticator, the user can link his account from the profile page.',
+                        'default' => false,
+                        'x-instance-required' => true,
+                        'x-instance-configurable' => true,
+                    ],
+                    'isTrusted:b' => [
+                        'description' => 'Whether or not the authenticator is trusted to synchronize user information.',
+                        'default' => false,
+                        'x-instance-required' => true,
+                        'x-instance-configurable' => true,
+                    ],
+                    'canAutoLinkUser:b' => [
+                        'description' => 'Whether or not the authenticator can automatically link the incoming user information to an existing user account by using email address.',
+                        'default' => false,
+                        'x-instance-required' => true,
+                        'x-instance-configurable' => true,
+                    ],
+                ])
+            ])
+        );
+
+        $schema->setField('properties.authenticatorID.x-instance-required', true);
+        $schema->setField('properties.authenticatorID.x-instance-configurable', true);
+
+        $schema->setField('properties.type.x-instance-required', true);
+        $schema->setField('properties.type.x-instance-configurable', true);
+
+        $schema->setField('properties.isActive.x-instance-required', true);
+        $schema->setField('properties.isActive.x-instance-configurable', true);
+
+        $schema->setField('properties.name.x-instance-required', true);
+        $schema->setField('properties.name.x-instance-configurable', true);
+
+        $schema->setField('properties.signInUrl.x-instance-required', true);
+        $schema->setField('properties.signInUrl.x-instance-configurable', true);
+
+        $schema->setField('properties.signOutUrl.x-instance-configurable', true);
+
+        $schema->setField('properties.registerUrl.x-instance-configurable', true);
+
+        return $schema;
+    }
+
+    /**
+     * Returns a list of [flattened.Schema.Property => metaPropertyValue] which have a specific meta property.
+     *
+     * For example you could use this function to have a list of all properties and sub-properties that have a
+     * default value set by doing: getSchemaPropertiesFilteredByExistingMeta($schema, 'default');
+     *
+     * See {@link getRequiredFields()} for an example.
+     *
+     * @param \Garden\Schema\Schema $schema
+     * @param $metaProperty
+     *
+     * @return array
+     */
+    private static function getSchemaPropertiesFilteredByExistingMeta(Schema $schema, $metaProperty) {
+        $properties = $schema->getField('properties');
+        $result = [];
+
+        foreach ($properties as $name => $data) {
+            if ($data instanceof Schema) {
+                $prefix = $name;
+                $subResults = self::getSchemaPropertiesFilteredByExistingMeta($data, $metaProperty);
+                foreach($subResults as $name => $value) {
+                    $result["$prefix.$name"] = $value;
+                }
+            } else {
+                if (array_key_exists($metaProperty, $data)) {
+                    $result[$name] = $data[$metaProperty];
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * List of properties that MUST be passed to this type of authenticator when creating it.
+     *
+     * @return array A list of flattened keys/sub-keys of properties.
+     */
+    final public static function getRequiredFields() {
+        return array_keys(self::getSchemaPropertiesFilteredByExistingMeta(static::getAuthenticatorSchema(), 'x-instance-required'));
+    }
+
+    /**
+     * List of properties that can be passed to this type of authenticator when creating it.
+     *
+     * @return array list of flattened keys/sub-keys of properties.
+     */
+    final public static function getConfigurableFields() {
+        return array_keys(self::getSchemaPropertiesFilteredByExistingMeta(static::getAuthenticatorSchema(), 'x-instance-configurable'));
+    }
+
+    /**
+     * Return an array of all configurable fields that have a default value.
+     *
+     * @return array
+     */
+    final public static function getConfigurableFieldsDefaultValue() {
+        $configurableFields = array_flip(self::getConfigurableFields());
+        $fieldsWithDefaults = self::getSchemaPropertiesFilteredByExistingMeta(static::getAuthenticatorSchema(), 'default');
+
+        return array_intersect_key($fieldsWithDefaults, $configurableFields);
     }
 
     /**
@@ -116,31 +244,29 @@ abstract class SSOAuthenticator extends Authenticator {
      * @throws \Garden\Schema\ValidationException
      */
     protected function setAuthenticatorInfo(array $data) {
-        // SSO Stuff
-        if ($data['sso']['canSignIn'] ?? false) {
-            $this->setSignIn(true);
+        // Let's set the defaults (based on the schema definition).
+        foreach (self::getSchemaPropertiesFilteredByExistingMeta(static::getAuthenticatorSchema(), 'default') as $dotDelimitedField => $value) {
+            if (!arrayPathExists(explode('.', $dotDelimitedField), $data)) {
+                setvalr($dotDelimitedField, $data, $value);
+            }
         }
-        if ($data['sso']['canLinkSession'] ?? false) {
-            $this->setLinkSession(true);
-        }
-        if ($data['sso']['isTrusted'] ?? false) {
-            $this->setTrusted(true);
-        }
-        if ($data['sso']['canAutoLinkUser'] ?? false) {
-            $this->setAutoLinkUser(true);
-        }
+
+        $this->setSignIn($data['sso']['canSignIn'] ?? false);
+        $this->setLinkSession($data['sso']['canLinkSession'] ?? false);
+        $this->setTrusted($data['sso']['isTrusted'] ?? false);
+        $this->setAutoLinkUser($data['sso']['canAutoLinkUser'] ?? false);
 
         // Set data to appropriate target.
         foreach($data as $key => $value) {
-            // Set directly to variable.
-            if (property_exists($this, $key)) {
-                $this->{$key} = $value;
             // Set through method name can{Something}.
-            } else if (substr($key, 0, 3) === 'can' && method_exists($this, $key)) {
+            if (substr($key, 0, 3) === 'can' && method_exists($this, $key)) {
                 $this->{$key}($value);
-            // Set through method name set{Something}. Note that the property should be named is{Something}.
+            // Set through method name set{Something}. Note that the property has to be named is{Something}.
             } else if (preg_match('/^is([A-Z].+)/', $key, $matches) && method_exists($this, 'set'.$matches[1])) {
                 $this->{'set'.$matches[1]}($value);
+            // Set directly to variable.
+            } else if (property_exists($this, $key)) {
+                $this->{$key} = $value;
             }
         }
     }
@@ -163,21 +289,14 @@ abstract class SSOAuthenticator extends Authenticator {
     }
 
     /**
-     * Get this authenticate Schema.
-     *
-     * @return Schema
+     * @inheritdoc
      */
-    public static function getAuthenticatorSchema(): Schema {
-        return parent::getAuthenticatorSchema()->merge(
-            Schema::parse([
-                'sso:o' => Schema::parse([
-                    'canSignIn:b' => 'Whether or not the authenticator can be used to sign in.',
-                    'canLinkSession:b' => 'Whether or not, using the authenticator, the user can link his account from the profile page.',
-                    'isTrusted:b' => 'Whether or not the authenticator is trusted to synchronize user information.',
-                    'canAutoLinkUser:b' => 'Whether or not the authenticator can automatically link the incoming user information to an existing user account by using email address.',
-                ])
-            ])
-        );
+    protected function getAuthenticatorInfoImpl(): array {
+        return [
+            'ui' => [
+                'buttonName' => sprintft('Sign In with %s', $this->name),
+            ],
+        ];
     }
 
     /**
@@ -230,7 +349,9 @@ abstract class SSOAuthenticator extends Authenticator {
      * @param int $userID
      * @return bool
      */
-    abstract public function isUserLinked(int $userID): bool;
+    public function isUserLinked(int $userID): bool {
+        return $this->authenticatorModel->isUserLinkedToSSOAuthenticator(self::getType(), $this->getID(), $userID);
+    }
 
     /**
      * Getter of linkSession.
@@ -251,6 +372,33 @@ abstract class SSOAuthenticator extends Authenticator {
      */
     public function setLinkSession(bool $linkSession) {
         $this->linkSession = $linkSession;
+
+        if ($this->saveState) {
+            $this->authenticatorModel->saveSSOAuthenticatorData($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Getter of name.
+     *
+     * @return string
+     */
+    public function getName(): string {
+        return $this->name;
+    }
+
+    /**
+     * Setter of $name
+     *
+     * @param string $name
+     *
+     * @return $this
+     * @throws \Garden\Schema\ValidationException
+     */
+    public function setName(string $name) {
+        $this->name = $name;
 
         if ($this->saveState) {
             $this->authenticatorModel->saveSSOAuthenticatorData($this);

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -132,6 +132,43 @@ if (!function_exists('arrayKeyExistsI')) {
     }
 }
 
+if (!function_exists('arrayPathExists')) {
+    /**
+     * Whether a sequence of keys (path) exists or not in an array.
+     *
+     * This function should only be used if isset($array[$key1][$key2]) cannot be used because the value could be null.
+     *
+     * @param array $keys The sequence of keys (path) to test against the array.
+     * @param array $array The array to search.
+     * @param mixed $value The path value.
+     *
+     * @return bool Returns true if the path exists in the array or false otherwise.
+     */
+    function arrayPathExists(array $keys, array $array, &$value = null) {
+        if (!count($keys) || !count($array)) {
+            return false;
+        }
+
+        $target = $array;
+        do {
+            $key = array_shift($keys);
+
+            if (array_key_exists($key, $target)) {
+                $target = $target[$key];
+            } else {
+                return false;
+            }
+        } while (($countKeys = count($keys)) && is_array($target));
+
+        $found = $countKeys === 0;
+        if ($found) {
+            $value = $target;
+        }
+
+        return $found;
+    }
+}
+
 if (!function_exists('arrayReplaceConfig')) {
     /**
      * Replaces elements from an override array into a default array recursively, overwriting numeric arrays entirely.
@@ -3516,7 +3553,7 @@ if (!function_exists('safeURL')) {
      *
      * "Safe" means that the domain of the URL is trusted.
      *
-     * @param $destination Destination URL or path.
+     * @param string $destination Destination URL or path.
      * @return string The destination if safe, /home/leaving?Target=$destination if not.
      */
     function safeURL($destination) {

--- a/tests/Library/Core/ArrayFunctionsTest.php
+++ b/tests/Library/Core/ArrayFunctionsTest.php
@@ -40,4 +40,73 @@ class ArrayFunctionsTest extends SharedBootstrapTestCase {
 
         return $r;
     }
+
+    /**
+     * Test {@link testArrayPathExists()}.
+     *
+     * @dataProvider provideArrayPathExistsTests
+     *
+     * @param $keys
+     * @param $array
+     * @param $expectedResult
+     * @param $expectedValue
+     *
+     * @param $expected
+     */
+    public function testArrayPathExists($keys, $array, $expectedResult, $expectedValue) {
+        $this->assertEquals($expectedResult, arrayPathExists($keys, $array, $value));
+        $this->assertEquals($expectedValue, $value);
+    }
+
+    /**
+     * Provide test data for {@link arrayPathExists()}.
+     *
+     * @return array Returns an array of test data.
+     */
+    public function provideArrayPathExistsTests() {
+        return [
+            'noKeys' => [
+                [],
+                ['a' => ['aa' => null]],
+                false,
+                null,
+            ],
+            'noKeysWithNullTypeIndexOnFirstLevel' => [
+                [],
+                [null => true],
+                false,
+                null,
+            ],
+            'nullStringKeyWithNullTypeIndex' => [
+                ['a', 'null'],
+                ['a' => [null => null]],
+                false,
+                null,
+            ],
+            'nestedIsNotAnArray' => [
+                ['a', 'b', 'c'],
+                ['a' => ['b' => true, 'd' => ['c']]],
+                false,
+                null,
+            ],
+            'nullTypeKeyWithNullTypeIndex' => [
+                ['a', null],
+                ['a' => [null => null]],
+                true,
+                null,
+            ],
+            'nullStringKeyWithNullStringIndex' => [
+                ['a', 'null'],
+                ['a' => ['null' => 'Something']],
+                true,
+                'Something',
+            ],
+            'deeplyNested' => [
+                ['a', 'aa', 'aaa', 'aaaa'],
+                ['a' => ['aa' => ['aaa' => ['aaaa' => []]]]],
+                true,
+                [],
+            ],
+        ];
+    }
 }

--- a/tests/fixtures/src/Authenticator/MockAuthenticator.php
+++ b/tests/fixtures/src/Authenticator/MockAuthenticator.php
@@ -68,7 +68,7 @@ class MockAuthenticator extends Authenticator {
      * @inheritDoc
      */
     public function getSignInUrl() {
-        return null;
+        return '/MockAuthenticatorSignIn';
     }
 
     /**


### PR DESCRIPTION
## Core function
- Added `arrayPathExists()` and it's unit test since `valr()` doesn't work properly with null values.
Example:
```php
$array = ['a' => ['aa' => ['aaa'  => null]]];
$default = -1;

$path1Value = arrayPathExists(['a', 'aa', 'aaa'], $array, $value) ? $value : $default; // null
$path2Value = arrayPathExists(['b', 'aa'], $array, $value) ? $value : $default; // -1
```

## Authenticator related
- signInUrl is now required by all authenticators.
- Leverage Schema for different purpose
    - Add `getRequiredFields` which returns a list of fields the MUST be provided when creating an instance of a specific authenticator type. Fields can be marked as required by setting the `x-instance-required` property in the Authenticator's schema.
    - Add `getConfigurableFields` which returns a list of fields that can be provided when creating an instance of a specific authenticator type. Fields can be marked as required by setting the `x-instance-configurable` property in the Authenticator's schema.
        - If a configurable field is not provided the default set on the schema is used.
- AuthenticatorModel now only serialize configurable fields into the database. This prevents "static" data from being unnecessary put in the database.
- Improved validation added in SSOAuthenticator and AuthenticatorModel when trying to create a new instance. (Missing required fields are now returned in the ValidationException)