### PR TITLE
Fix broken tslint config

### DIFF
--- a/.tslint.js
+++ b/.tslint.js
@@ -1,3 +1,0 @@
-module.exports = {
-    extends: ["@vanillaforums/tslint-config"],
-};

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "test": "karma start ./tests/javascript/karma.conf.js --single-run",
         "test:watch": "karma start ./tests/javascript/karma.conf.js",
         "test:debug": "karma start ./tests/javascript/karma.conf.js --browsers ChromeDebug",
-        "lint:ts": "tslint -c ./.tslint.js -e './**/node_modules/**' -e './**/src/**/*.{js,jsx}' -p ./tsconfig.json -t stylish",
-        "lint:ts:fix": "tslint -c ./.tslint.js -e './**/node_modules/**' -e './**/src/**/*.{js,jsx}' -p ./tsconfig.json -t stylish --fix"
+        "lint:ts": "tslint -c ./tslint.json -e './**/node_modules/**' -e './**/src/**/*.{js,jsx}' -p ./tsconfig.json -t stylish",
+        "lint:ts:fix": "tslint -c ./tslint.json -e './**/node_modules/**' -e './**/src/**/*.{js,jsx}' -p ./tsconfig.json -t stylish --fix"
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,3 @@
+{
+    "extends": ["@vanillaforums/tslint-config"]
+}


### PR DESCRIPTION
Certain IDEs like PHPStorm can't read anything other than a JSON config file. This converts the file back to JSON. The vanilla cli's linting was also never updated to point to the non-json file location so that will not be affected.