### PR TITLE
Add embed for imgur

### DIFF
--- a/applications/dashboard/src/scripts/app/index.tsx
+++ b/applications/dashboard/src/scripts/app/index.tsx
@@ -22,6 +22,7 @@ import "./user-content/embeds/link";
 import "./user-content/embeds/twitter";
 import "./user-content/embeds/video";
 import "./user-content/embeds/instagram";
+import "./user-content/embeds/imgur";
 
 addComponent("App", Router);
 

--- a/applications/dashboard/src/scripts/app/user-content/embeds/imgur.ts
+++ b/applications/dashboard/src/scripts/app/user-content/embeds/imgur.ts
@@ -14,7 +14,7 @@ registerEmbed("imgur", renderImgur);
 /**
  * Renders posted imgur embeds.
  */
-async function convertImgurEmbeds() {
+export async function convertImgurEmbeds() {
     const images = Array.from(document.querySelectorAll(".imgur-embed-pub"));
     if (images.length > 0) {
         await ensureScript("//s.imgur.com/min/embed.js");
@@ -40,7 +40,7 @@ export async function renderImgur(element: Element, data: IEmbedData) {
     await ensureScript("//s.imgur.com/min/embed.js");
 
     const url = "imgur.com/" + data.attributes.postID;
-    const isAlbum = false;
+    const isAlbum = data.attributes.isAlbum;
     const dataSet = isAlbum ? "a/" + data.attributes.postID : data.attributes.postID;
 
     if (!window.imgurEmbed) {
@@ -52,6 +52,9 @@ export async function renderImgur(element: Element, data: IEmbedData) {
     blockQuote.setAttribute("lang", "en");
     blockQuote.dataset.id = dataSet;
     blockQuote.setAttribute("href", url);
-    convertImgurEmbeds();
+
     element.appendChild(blockQuote);
+    setImmediate(() => {
+        convertImgurEmbeds().then();
+    });
 }

--- a/applications/dashboard/src/scripts/app/user-content/embeds/imgur.ts
+++ b/applications/dashboard/src/scripts/app/user-content/embeds/imgur.ts
@@ -1,0 +1,47 @@
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+import { registerEmbed, IEmbedData } from "@dashboard/embeds";
+import { ensureScript } from "@dashboard/dom";
+import { onContent } from "@dashboard/application";
+
+// Setup imgur embeds.
+onContent(convertImgurEmbeds);
+registerEmbed("imgur", renderImgur);
+
+/**
+ * Renders posted imgur embeds.
+ */
+async function convertImgurEmbeds() {
+    await ensureScript("//s.imgur.com/min/embed.js");
+
+    if (!window.imgurEmbed) {
+        throw new Error("The Imgur post failed to load");
+    }
+}
+
+/**
+ * Render a single imgur embed.
+ */
+export async function renderImgur(element: Element, data: IEmbedData) {
+    await ensureScript("//s.imgur.com/min/embed.js");
+
+    const url = "imgur.com/" + data.attributes.postID;
+    console.log(data.attributes.postID);
+    const isAblum = data.attributes.isAblum;
+    const dataSet = isAblum ? "a/" + data.attributes.postID : data.attributes.postID;
+
+    if (!window.imgurEmbed) {
+        throw new Error("The Imgur post failed to load");
+    }
+
+    const blockQuote = document.createElement("blockquote");
+    blockQuote.classList.add("imgur-embed-pub");
+    blockQuote.setAttribute("lang", "en");
+    blockQuote.dataset.id = dataSet;
+    blockQuote.setAttribute("href", url);
+
+    element.appendChild(blockQuote);
+}

--- a/applications/dashboard/src/scripts/app/user-content/embeds/imgur.ts
+++ b/applications/dashboard/src/scripts/app/user-content/embeds/imgur.ts
@@ -14,7 +14,7 @@ registerEmbed("imgur", renderImgur);
 /**
  * Renders posted imgur embeds.
  */
-export async function convertImgurEmbeds() {
+async function convertImgurEmbeds() {
     const images = Array.from(document.querySelectorAll(".imgur-embed-pub"));
     if (images.length > 0) {
         await ensureScript("//s.imgur.com/min/embed.js");
@@ -24,7 +24,8 @@ export async function convertImgurEmbeds() {
         }
 
         if (window.imgurEmbed.createIframe) {
-            for (let i = 0; i < images.length; i++) {
+            const imagesLength = images.length;
+            for (let i = 0; i < imagesLength; i++) {
                 window.imgurEmbed.createIframe();
             }
         } else {
@@ -55,6 +56,6 @@ export async function renderImgur(element: Element, data: IEmbedData) {
 
     element.appendChild(blockQuote);
     setImmediate(() => {
-        convertImgurEmbeds().then();
+        void convertImgurEmbeds();
     });
 }

--- a/applications/dashboard/src/scripts/app/user-content/embeds/imgur.ts
+++ b/applications/dashboard/src/scripts/app/user-content/embeds/imgur.ts
@@ -38,15 +38,9 @@ async function convertImgurEmbeds() {
  * Render a single imgur embed.
  */
 export async function renderImgur(element: Element, data: IEmbedData) {
-    await ensureScript("//s.imgur.com/min/embed.js");
-
     const url = "imgur.com/" + data.attributes.postID;
     const isAlbum = data.attributes.isAlbum;
     const dataSet = isAlbum ? "a/" + data.attributes.postID : data.attributes.postID;
-
-    if (!window.imgurEmbed) {
-        throw new Error("The Imgur post failed to load");
-    }
 
     const blockQuote = document.createElement("blockquote");
     blockQuote.classList.add("imgur-embed-pub");

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -246,13 +246,15 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\VimeoEmbed::class)])
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\ImgurEmbed::class)])
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\SoundCloudEmbed::class)])
+    ->addCall('addEmbed', [new Reference(Vanilla\Embeds\InstagramEmbed::class)])
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\ImageEmbed::class), Vanilla\Embeds\EmbedManager::PRIORITY_LOW])
     ->setShared(true)
 
     ->rule(Vanilla\PageScraper::class)
     ->addCall('registerMetadataParser', [new Reference(Vanilla\Metadata\Parser\OpenGraphParser::class)])
     ->addCall('registerMetadataParser', [new Reference(Vanilla\Metadata\Parser\JsonLDParser::class)])
-    ->setShared(true);
+    ->setShared(true)
+;
 
 // Run through the bootstrap with dependencies.
 $dic->call(function (

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -245,6 +245,7 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\YouTubeEmbed::class)])
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\VimeoEmbed::class)])
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\InstagramEmbed::class)])
+    ->addCall('addEmbed', [new Reference(Vanilla\Embeds\ImgurEmbed::class)])
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\ImageEmbed::class), Vanilla\Embeds\EmbedManager::PRIORITY_LOW])
     ->setShared(true)
 

--- a/library/Vanilla/Embeds/ImgurEmbed.php
+++ b/library/Vanilla/Embeds/ImgurEmbed.php
@@ -9,7 +9,7 @@ namespace Vanilla\Embeds;
 use Exception;
 
 /**
- * Imgure Embed.
+ * Imgur Embed.
  */
 class ImgurEmbed extends Embed {
 
@@ -44,7 +44,6 @@ class ImgurEmbed extends Embed {
             if (array_key_exists('album', $matches) && $matches['album'] == 'a') {
                 $data['attributes']['isAlbum'] = true;
             }
-
 
         if (!$data['attributes']['isAlbum']) {
             // Get the json for th imgur post

--- a/library/Vanilla/Embeds/ImgurEmbed.php
+++ b/library/Vanilla/Embeds/ImgurEmbed.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0
+ */
+
+namespace Vanilla\Embeds;
+
+
+use Garden\Http\HttpRequest;
+use Garden\Http\HttpResponse;
+use Vanilla\PageScraper;
+
+/**
+ * Instagram Embed.
+ */
+class ImgurEmbed extends Embed {
+
+    /** @inheritdoc */
+    protected $domains = ['imgur.com'];
+
+    /** @var PageScraper */
+    private $pageScraper;
+
+
+    /**
+     * ImgurEmbed constructor.
+     */
+    public function __construct() {
+        parent::__construct('imgur', 'image');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function matchUrl(string $url) {
+        $data = [];
+        $pageInfo = [];
+
+        if ($this->isNetworkEnabled()) {
+            preg_match('/https?:\/\/imgur\.com\/gallery\/(?<postID>[a-z0-9]+)/i', $url, $matches);
+            if (array_key_exists('postID', $matches)) {
+                if (!array_key_exists('attributes', $data)) {
+                    $data['attributes'] = [];
+                }
+                $data['attributes']['postID'] = $matches['postID'];
+            }
+        }
+
+        $jsonResponse = $this->httpRequest($url . ".json");
+        if ($jsonResponse->getStatusCode() == 200) {
+            $decodedResponse = json_decode($jsonResponse);
+            $data['attributes']['isAlbum'] = val('is_album', $decodedResponse->data->image); ;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function renderData(array $data): string {
+       $postID = htmlspecialchars($data['attributes']['postID']);
+       $dataID = ($data['attributes']['isAlbum']) ? "a/".$postID : $postID;
+
+        $result = <<<HTML
+        <div class="embed embedImgur">
+        <blockquote class="imgur-embed-pub" lang="en" data-id="{$dataID}"><a href="//imgur.com/{$postID}"></a>
+        </div>
+HTML;
+       return $result;
+    }
+}

--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -374,6 +374,7 @@ class MediaTest extends AbstractAPIv2Test {
             ['https://youtube.ca/watch?v=example', 'youtube'],
             ['https://www.instagram.com/p/BizC-PPFK1m', 'instagram'],
             ['https://soundcloud.com/syrebralvibes/the-eden-project-circles', 'soundcloud'],
+            ['https://imgur.com/gallery/10HROiq', 'imgur'],
         ];
 
         return $urls;

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -234,6 +234,7 @@ class Bootstrap {
             ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\VimeoEmbed::class)])
             ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\InstagramEmbed::class)])
             ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\SoundCloudEmbed::class)])
+            ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\ImgurEmbed::class)])
             ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\ImageEmbed::class), \Vanilla\Embeds\EmbedManager::PRIORITY_LOW])
             ->addCall('setNetworkEnabled', [false])
             ->setShared(true)

--- a/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
+++ b/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
@@ -134,12 +134,12 @@ class EmbedManagerTest extends SharedBootstrapTestCase {
                     'height' => null,
                     'width' => null,
                     'attributes' => [
-                        'postID' => 'a/OsirufX',
-                        'isAlbum' => false,
+                        'postID' => 'OsirufX',
+                        'isAlbum' => true,
                     ],
                 ],
 '<div class="embed embedImgur">
-    <blockquote class="imgur-embed-pub" lang="en" data-id="a/OsirufX"><a href="https://imgur.com/a/OsirufX"></a></blockquote>
+    <blockquote class="imgur-embed-pub" lang="en" data-id="a/OsirufX"><a href="https://imgur.com/OsirufX"></a></blockquote>
 </div>'
             ],
             [

--- a/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
+++ b/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
@@ -8,6 +8,7 @@ namespace VanillaTests\Library\Vanilla\Embeds;
 
 use Exception;
 use Garden\Http\HttpRequest;
+use Vanilla\Embeds\ImgurEmbed;
 use Vanilla\Embeds\SoundCloudEmbed;
 use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Embeds\EmbedManager;
@@ -34,6 +35,7 @@ class EmbedManagerTest extends SharedBootstrapTestCase {
             ->addEmbed(new YouTubeEmbed())
             ->addEmbed(new VimeoEmbed())
             ->addEmbed(new InstagramEmbed())
+            ->addEmbed(new ImgurEmbed())
             ->addEmbed(new SoundCloudEmbed())
             ->addEmbed(new ImageEmbed(), EmbedManager::PRIORITY_LOW)
             ->setNetworkEnabled(false);
@@ -87,8 +89,8 @@ class EmbedManagerTest extends SharedBootstrapTestCase {
             ],
             [
                 [
-                    "url" =>"https://www.instagram.com/p/BizC-PPFK1m",
-                    "type" =>"instagram",
+                    'url' =>'https://www.instagram.com/p/BizC-PPFK1m',
+                    'type' =>'instagram',
                     'name' => null,
                     'body' => null,
                     'photoUrl' => null,
@@ -103,7 +105,44 @@ class EmbedManagerTest extends SharedBootstrapTestCase {
 '<div class="embed embedInstagram">
     <blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/p/BizC-PPFK1m" data-instgrm-version="8"/>
 </div>'
-            ],            [
+            ],
+            [
+                [
+                    'url' =>'https://imgur.com/gallery/10HROiq',
+                    'type' =>'imgur',
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'postID' => '10HROiq',
+                        'isAlbum' => false,
+                    ],
+                ],
+'<div class="embed embedImgur">
+    <blockquote class="imgur-embed-pub" lang="en" data-id="10HROiq"><a href="https://imgur.com/10HROiq"></a></blockquote>
+</div>'
+            ],
+            [
+                [
+                    'url' =>'https://imgur.com/gallery/OsirufX',
+                    'type' =>'imgur',
+                    'name' => null,
+                    'body' => null,
+                    'photoUrl' => null,
+                    'height' => null,
+                    'width' => null,
+                    'attributes' => [
+                        'postID' => 'a/OsirufX',
+                        'isAlbum' => false,
+                    ],
+                ],
+'<div class="embed embedImgur">
+    <blockquote class="imgur-embed-pub" lang="en" data-id="a/OsirufX"><a href="https://imgur.com/a/OsirufX"></a></blockquote>
+</div>'
+            ],
+            [
                 [
                     "url" => "https://soundcloud.com/syrebralvibes/the-eden-project-circles",
                     "type" => "soundcloud",

--- a/tests/Library/Vanilla/Quill/Sanitize/ExternalEmbed/ImgurSanitizeTest.php
+++ b/tests/Library/Vanilla/Quill/Sanitize/ExternalEmbed/ImgurSanitizeTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0
+ */
+
+namespace VanillaTests\Library\Vanilla\Quill\Sanitize\ExternalEmbed;
+
+use VanillaTests\Library\Vanilla\Quill\Sanitize\SanitizeTest;
+
+class ImgurSanitizeTest extends SanitizeTest {
+
+    /**
+     * @inheritdoc
+     */
+    protected function insertContentOperations(string $content): array {
+        $operations = [
+            [
+                "insert" => [
+                    "embed-external" => [
+                        "url" => null,
+                        "type" => "imgur",
+                        "name" => null,
+                        "body" => null,
+                        "photoUrl" => null,
+                        "height" => null,
+                        "width" => null,
+                        "attributes" => ["postID" => $content, "isAlbum" => $content]
+                    ]
+                ]
+            ],
+            ["insert" => "\n"]
+        ];
+
+        return $operations;
+    }
+}


### PR DESCRIPTION
This feature allows for the embedding of imgurs embeds

The imgur link is parsed to extract the postID and a call in made to imgur to get the json for that particular post, from the response it is determined if this post is in album or not.  
The data extracted from the media scrape is used to reconstruct imgurs  embed code and imgurs embed js script is used to render the post.
Data for imgurs embeds has been added to the the MediaTest and EmbedManagerTest as well as Quill Santize tests.
Closes #7209