### PR TITLE
Fix flattenArray function not computing keys properly

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -625,14 +625,14 @@ if (!function_exists('flattenArray')) {
     function flattenArray($sep, $array) {
         $result = [];
 
-        $fn = function ($array, $px = '') use ($sep, &$fn, &$result) {
+        $fn = function ($array, $previousLevel = null) use ($sep, &$fn, &$result) {
             foreach ($array as $key => $value) {
-                $px = $px ? "{$px}{$sep}{$key}" : $key;
+                $currentLevel = $previousLevel ? "{$previousLevel}{$sep}{$key}" : $key;
 
                 if (is_array($value)) {
-                    $fn($value, $px);
+                    $fn($value, $currentLevel);
                 } else {
-                    $result[$px] = $value;
+                    $result[$currentLevel] = $value;
                 }
             }
         };

--- a/tests/Library/Core/ArrayFunctionsTest.php
+++ b/tests/Library/Core/ArrayFunctionsTest.php
@@ -35,7 +35,19 @@ class ArrayFunctionsTest extends SharedBootstrapTestCase {
         $r = [
             'threeDeep' => [['a' => ['b' => ['c' => 'foo']]], ['a.b.c' => 'foo']],
             'emptyArray' => [[], []],
-            'emptyArrayElement' => [['a' => 1, 'b' => []], ['a' => 1]]
+            'emptyArrayElement' => [['a' => 1, 'b' => []], ['a' => 1]],
+            'realWorldExample' => [
+                [
+                    'a' => [
+                        'b' => ['c' => 'foo'],
+                        'd' => ['e' => 'bar'],
+                    ],
+                ],
+                [
+                    'a.b.c' => 'foo',
+                    'a.d.e' => 'bar'
+                ]
+            ],
         ];
 
         return $r;


### PR DESCRIPTION
We added the flattenArray function in #4323 but it has a nasty bug where it corrupts keys when flattening.

I fixed the function and added an extra basic unit test.