### PR TITLE
Add VanillaConnect plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 !/plugins/swagger-ui/
 !/plugins/Tagging/
 !/plugins/Twitter/
+!/plugins/vanillaconnect/
 !/plugins/VanillaStats/
 !/plugins/VanillaInThisDiscussion/
 !/plugins/vanillicon/

--- a/applications/dashboard/controllers/api/AuthenticatorsApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticatorsApiController.php
@@ -222,10 +222,18 @@ class AuthenticatorsApiController extends AbstractApiController  {
      */
     public function normalizeOutput(Authenticator $authenticator): array {
         $record = $authenticator->getAuthenticatorInfo();
+
+        // Move non base data into attributes
+        $schemaProperties = SSOAuthenticator::getAuthenticatorSchema()->getSchemaArray()['properties'];
+        $diffs = array_diff_key($record, $schemaProperties);
+        foreach($diffs as $key => $value) {
+            $authenticatorData['attributes'][$key] = $value;
+            unset($authenticatorData[$key]);
+        }
+
         $record['authenticatorID'] = strtolower($record['authenticatorID']);
         $record['type'] = strtolower($record['type']);
         $record['resourceUrl'] = strtolower(url('/api/v2/authenticators/'.$authenticator::getType().'/'.$authenticator->getID()));
-
         // Convert URLs from relative to absolute.
         foreach (['signInUrl', 'registerUrl', 'signOutUrl', 'ui.url', 'resourceUrl'] as $field) {
             $value = valr($field, $record, null);

--- a/applications/dashboard/controllers/class.authenticatecontroller.php
+++ b/applications/dashboard/controllers/class.authenticatecontroller.php
@@ -6,48 +6,40 @@
  */
 
 use Garden\Web\RequestInterface;
+use Vanilla\Models\AuthenticatorModel;
 use Vanilla\Models\SSOModel;
-use Vanilla\Models\SSOData;
 
 /**
  * Create /authenticate endpoint.
  */
 class AuthenticateController extends Gdn_Controller {
 
-    /**
-     * @var AuthenticateApiController
-     */
+    /** @var AuthenticateApiController */
     private $authenticateApiController;
 
-    /**
-     * @var Gdn_Form
-     */
+    /** @var AuthenticatorModel */
+    private $authenticatorModel;
+
+    /** @var Gdn_Form */
     private $form;
 
-    /**
-     * @var RequestInterface
-     */
+    /** @var RequestInterface */
     private $request;
 
-    /**
-     * @var SessionModel
-     */
+    /** @var SessionModel */
     private $sessionModel;
 
-    /**
-     * @var SSOModel
-     */
+    /** @var SSOModel */
     private $ssoModel;
 
-    /**
-     * @var UserModel
-     */
+    /** @var UserModel */
     private $userModel;
 
     /**
      * AuthenticateController constructor.
      *
      * @param AuthenticateApiController $authenticateApiController
+     * @param AuthenticatorModel $authenticatorModel
      * @param RequestInterface $request
      * @param SessionModel $sessionModel
      * @param SSOModel $ssoModel
@@ -55,6 +47,7 @@ class AuthenticateController extends Gdn_Controller {
      */
     public function __construct(
         AuthenticateApiController $authenticateApiController,
+        AuthenticatorModel $authenticatorModel,
         RequestInterface $request,
         SessionModel $sessionModel,
         SSOModel $ssoModel,
@@ -63,6 +56,7 @@ class AuthenticateController extends Gdn_Controller {
         parent::__construct();
 
         $this->authenticateApiController = $authenticateApiController;
+        $this->authenticatorModel = $authenticatorModel;
         $this->form = new Gdn_Form();
         $this->request = $request;
         $this->sessionModel = $sessionModel;
@@ -144,14 +138,29 @@ class AuthenticateController extends Gdn_Controller {
     /**
      *
      */
-    public function recoverpassword() {
+    public function recoverPassword() {
         $this->renderReact();
     }
 
     /**
      * Sign In Page
+     *
+     * @param string $authenticatorType
+     * @param string $authenticatorID
+     *
+     * @throws \Garden\Web\Exception\ClientException
+     * @throws \Garden\Web\Exception\NotFoundException
+     * @throws \Garden\Web\Exception\ServerException
      */
-    public function signin() {
+    public function signin($authenticatorType = '', $authenticatorID = '') {
+        if ($authenticatorType && $authenticatorID) {
+            $authenticator = $this->authenticatorModel->getAuthenticator($authenticatorType, $authenticatorID);
+            if (is_a($authenticator, \Vanilla\Authenticator\SSOAuthenticator::class)) {
+                $authenticator->initiateAuthentication();
+                return;
+            }
+        }
+
         $this->renderReact();
     }
 

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "vanilla/htmlawed": "~2.0",
         "vanilla/legacy-oauth": "~1.0",
         "vanilla/legacy-passwords": "~1.0",
-        "vanilla/nbbc": "~2.1"
+        "vanilla/nbbc": "~2.1",
+        "vanilla/vanilla-connect": "~0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcae90364aaf401b9b9ec6d4c62f0935",
+    "content-hash": "b034b507629cf3cfd4dbd84d7341fb8d",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -441,21 +441,77 @@
             "time": "2018-04-24T14:53:33+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.4.9",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "033cfa61ef06ee0847e056e530201842b6e926c3"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/033cfa61ef06ee0847e056e530201842b6e926c3",
-                "reference": "033cfa61ef06ee0847e056e530201842b6e926c3",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "time": "2018-04-30T19:57:29+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
+                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
@@ -496,7 +552,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-08T08:21:29+00:00"
+            "time": "2018-05-03T23:18:14+00:00"
         },
         {
             "name": "tburry/pquery",
@@ -682,16 +738,16 @@
         },
         {
             "name": "vanilla/garden-schema",
-            "version": "v1.7.6",
+            "version": "v1.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vanilla/garden-schema.git",
-                "reference": "0b478d230e60b5c8f402d84a7ee7809057026011"
+                "reference": "009802b184cd4c66a65257ba8b429f1a444b610a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vanilla/garden-schema/zipball/0b478d230e60b5c8f402d84a7ee7809057026011",
-                "reference": "0b478d230e60b5c8f402d84a7ee7809057026011",
+                "url": "https://api.github.com/repos/vanilla/garden-schema/zipball/009802b184cd4c66a65257ba8b429f1a444b610a",
+                "reference": "009802b184cd4c66a65257ba8b429f1a444b610a",
                 "shasum": ""
             },
             "require": {
@@ -714,7 +770,7 @@
                 }
             ],
             "description": "A simple data validation and cleaning library based on JSON Schema.",
-            "time": "2018-04-12T18:10:28+00:00"
+            "time": "2018-05-25T14:30:29+00:00"
         },
         {
             "name": "vanilla/htmlawed",
@@ -888,6 +944,48 @@
             ],
             "description": "A composer-compatible fork of the NBBC BBCode parsing library.",
             "time": "2016-04-26T18:19:47+00:00"
+        },
+        {
+            "name": "vanilla/vanilla-connect",
+            "version": "v0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vanilla/vanilla-connect-php.git",
+                "reference": "6f5c6635004d17824d974df6b0a2e30231db77d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vanilla/vanilla-connect-php/zipball/6f5c6635004d17824d974df6b0a2e30231db77d3",
+                "reference": "6f5c6635004d17824d974df6b0a2e30231db77d3",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "~5.0",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.0"
+            },
+            "type": "project",
+            "autoload": {
+                "exclude-from-classmap": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Vanilla\\": "src/Vanilla"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Alexandre (DaazKu) Chouinard",
+                    "email": "alexandre.c@vanillaforums.com"
+                }
+            ],
+            "time": "2018-06-12T17:47:35+00:00"
         }
     ],
     "packages-dev": [
@@ -1642,16 +1740,16 @@
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
+                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
+                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
                 "shasum": ""
             },
             "require": {
@@ -1697,7 +1795,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-01-06T05:45:45+00:00"
+            "time": "2018-05-29T13:50:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/library/Vanilla/Authenticator/Authenticator.php
+++ b/library/Vanilla/Authenticator/Authenticator.php
@@ -288,11 +288,11 @@ abstract class Authenticator {
      * @return array
      */
     final public function getAuthenticatorInfo(): array {
+        $typeInfo = static::getAuthenticatorTypeInfo();
         $defaults = $this->getAuthenticatorDefaultInfo();
         $instanceInfo = $this->getAuthenticatorInfoImpl();
-        $typeInfo = static::getAuthenticatorTypeInfo();
 
-        return static::getAuthenticatorSchema()->validate(array_replace_recursive($defaults, $instanceInfo, $typeInfo));
+        return static::getAuthenticatorSchema()->validate(array_replace_recursive($typeInfo, $defaults, $instanceInfo));
     }
 
     /**

--- a/library/Vanilla/Models/AuthenticatorModel.php
+++ b/library/Vanilla/Models/AuthenticatorModel.php
@@ -225,7 +225,7 @@ class AuthenticatorModel {
         $authenticatorClasses = $this->getAuthenticatorClasses($includeShims);
         $authenticators = [];
         foreach ($authenticatorClasses as $authenticatorClass) {
-            $authenticators = array_merge($authenticators, $this->getAuthenticatorsByType($authenticatorClass, $includeShims));
+            $authenticators = array_merge($authenticators, $this->getAuthenticatorsByClass($authenticatorClass, $includeShims));
         }
 
         return $authenticators;

--- a/library/Vanilla/Models/AuthenticatorModel.php
+++ b/library/Vanilla/Models/AuthenticatorModel.php
@@ -129,8 +129,6 @@ class AuthenticatorModel {
      *
      * @return Authenticator
      *
-     * @throws \Garden\Container\ContainerException
-     * @throws \Garden\Container\NotFoundException
      * @throws \Garden\Web\Exception\ClientException
      * @throws \Garden\Web\Exception\NotFoundException
      * @throws \Garden\Web\Exception\ServerException
@@ -177,7 +175,11 @@ class AuthenticatorModel {
         try {
             $authenticatorInstance = $this->container->getArgs($fullyQualifiedAuthenticationClass, [$authenticatorID]);
         } catch (Exception $e) {
-            $authenticatorInstance = $this->container->get($fullyQualifiedAuthenticationClass);
+            try {
+                $authenticatorInstance = $this->container->get($fullyQualifiedAuthenticationClass);
+            } catch (Exception $e) {
+                throw new ServerException('The authenticator was not found or could not be instantiated.');
+            }
         }
 
         $this->authenticatorInstances[$authenticatorType][$authenticatorID] = $authenticatorInstance;
@@ -193,8 +195,6 @@ class AuthenticatorModel {
      *
      * @return Authenticator
      *
-     * @throws \Garden\Container\ContainerException
-     * @throws \Garden\Container\NotFoundException
      * @throws \Garden\Web\Exception\ClientException
      * @throws \Garden\Web\Exception\NotFoundException
      * @throws \Garden\Web\Exception\ServerException
@@ -225,46 +225,64 @@ class AuthenticatorModel {
         $authenticatorClasses = $this->getAuthenticatorClasses($includeShims);
         $authenticators = [];
         foreach ($authenticatorClasses as $authenticatorClass) {
-            $authenticatorsInfo = null;
-            try {
-                $authenticatorsInfo = $this->authenticationProviderModel->getProvidersByScheme($authenticatorClass::getType());
-            } catch (Exception $e) {}
+            $authenticators = array_merge($authenticators, $this->getAuthenticatorsByType($authenticatorClass, $includeShims));
+        }
 
-            /** @var Authenticator $authenticatorInstance */
-            $authenticatorInstance = null;
+        return $authenticators;
+    }
 
-            if ($authenticatorsInfo) {
-                foreach ($authenticatorsInfo as $authenticatorInfo) {
-                    // Check if the container can find the Authenticator.
-                    try {
-                        $authenticatorInstance = $this->getAuthenticator($authenticatorInfo['AuthenticationSchemeAlias'], $authenticatorInfo['AuthenticationKey']);
-                        $authenticators[] = $authenticatorInstance;
-                    } catch (Exception $e) {
-                        throw new ServerException('Error while trying to instanciate authenticator '.$authenticatorClass, 500, [
-                            'authenticatorError' => $e,
-                            'authenticatorType' => $authenticatorInfo['AuthenticationSchemeAlias'],
-                            'authenticatorID' => $authenticatorInfo['AuthenticationKey'],
-                        ]);
-                    }
-                    $authenticatorInstance = null;
+    /**
+     * Get Authenticator instances.
+     *
+     * @param string $authenticatorClass
+     * @param bool $includeShims
+     *
+     * @return Authenticator[]
+     * @throws \Garden\Web\Exception\ServerException
+     */
+    public function getAuthenticatorsByClass(string $authenticatorClass, bool $includeShims = false): array {
+        if (!$includeShims && is_a($authenticatorClass, ShimAuthenticator::class, true)) {
+            return [];
+        }
+
+        $authenticatorsInfo = null;
+        $authenticators = [];
+        $authenticatorType = $authenticatorClass::getType();
+        try {
+            $authenticatorsInfo = $this->authenticationProviderModel->getProvidersByScheme($authenticatorType);
+        } catch (Exception $e) {
+        }
+
+        if ($authenticatorsInfo) {
+            foreach ($authenticatorsInfo as $authenticatorInfo) {
+                // Check if the container can find the Authenticator.
+                try {
+                    $authenticatorInstance = $this->getAuthenticator($authenticatorInfo['AuthenticationSchemeAlias'], $authenticatorInfo['AuthenticationKey']);
+                    $authenticators[] = $authenticatorInstance;
+                } catch (Exception $e) {
+                    throw new ServerException('Error while trying to instanciate authenticator '.$authenticatorClass, 500, [
+                        'authenticatorError' => $e,
+                        'authenticatorType' => $authenticatorType,
+                        'authenticatorID' => $authenticatorInfo['AuthenticationKey'],
+                    ]);
                 }
-            } else {
-                // Only try this for non SSOAuthenticator since we should have info in the DB for these.
-                if (!is_a($authenticatorClass, SSOAuthenticator::class, true)) {
-                    $type = $authenticatorClass::getType();
-                    try {
-                        $authenticatorInstance = $this->getAuthenticator($type,$type);
-                        $authenticators[] = $authenticatorInstance;
-                    } catch (Exception $e) {
-                        throw new ServerException('Error while trying to instanciate authenticator '.$authenticatorClass, 500, [
-                            'authenticatorError' => $e,
-                            'authenticatorType' => $type,
-                            'authenticatorID' => $type,
-                        ]);
-                    }
-                }
-
             }
+        } else {
+            // Only try this for non SSOAuthenticator since we should have info in the DB for these.
+            if (!is_a($authenticatorClass, SSOAuthenticator::class, true)) {
+
+                try {
+                    $authenticatorInstance = $this->getAuthenticator($authenticatorType, $authenticatorType);
+                    $authenticators[] = $authenticatorInstance;
+                } catch (Exception $e) {
+                    throw new ServerException('Error while trying to instanciate authenticator '.$authenticatorClass, 500, [
+                        'authenticatorError' => $e,
+                        'authenticatorType' => $authenticatorType,
+                        'authenticatorID' => $authenticatorType,
+                    ]);
+                }
+            }
+
         }
 
         return $authenticators;
@@ -332,8 +350,6 @@ class AuthenticatorModel {
      *
      * @return bool|\Vanilla\Authenticator\SSOAuthenticator
      *
-     * @throws \Garden\Container\ContainerException
-     * @throws \Garden\Container\NotFoundException
      * @throws \Garden\Schema\ValidationException
      * @throws \Garden\Web\Exception\ClientException
      * @throws \Garden\Web\Exception\NotFoundException
@@ -459,9 +475,16 @@ class AuthenticatorModel {
 
                 // Move property out of attributes.
                 foreach ($schemaProperties as $name => $definition) {
-                     if (!array_key_exists($name, $authenticatorData) && array_key_exists($name, $authenticatorData['attributes'])) {
+                    if (!array_key_exists($name, $authenticatorData) && array_key_exists($name, $authenticatorData['attributes'])) {
                         $authenticatorData[$name] = $authenticatorData['attributes'][$name];
                         unset($authenticatorData['attributes'][$name]);
+                    }
+
+                    // Convert empty string (from DB) to null if the schema allows null and the data is an empty string.
+                    if (is_array($definition['type']) && in_array('null', $definition['type'])) {
+                        if (array_key_exists($name, $authenticatorData) && $authenticatorData[$name] === '') {
+                            $authenticatorData[$name] = null;
+                        }
                     }
                 }
             } else {
@@ -494,9 +517,10 @@ class AuthenticatorModel {
                 setvalr($dotDelimitedField, $data, $value);
             }
         }
+        $data['type'] = $authenticator::getType();
 
         // Sparse validation to make sure all data is proper.
-        $authenticator::getAuthenticatorSchema()->validate($data, true);
+        $data = $authenticator::getAuthenticatorSchema()->validate($data, true);
 
         foreach ($this->authenticatorToDbFields as $from => $to) {
             if (array_key_exists($from, $data)) {
@@ -531,6 +555,21 @@ class AuthenticatorModel {
         ]);
 
         unset($this->authenticatorInstances[$authenticator->getType()][$authenticator->getID()]);
+    }
+
+    /**
+     * Delete an SSOAuthenticator instance.
+     *
+     * @param string $authenticatorType
+     * @param string $authenticatorID
+     */
+    public function deleteSSOAuthenticator(string $authenticatorType, string $authenticatorID) {
+        $this->authenticationProviderModel->delete([
+            'AuthenticationKey' => $authenticatorID,
+            'AuthenticationSchemeAlias' => $authenticatorType,
+        ]);
+
+        unset($this->authenticatorInstances[$authenticatorType][$authenticatorID]);
     }
 
     /**

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -643,6 +643,45 @@ if (!function_exists('flattenArray')) {
     }
 }
 
+if (!function_exists('unflattenArray')) {
+
+    /**
+     * Convert a flattened array into a multi dimensional array.
+     *
+     * See {@link flattenArray}
+     *
+     * @param string $sep The string used to separate keys.
+     * @param array $array The array to flatten.
+     * @return array|bool Returns the flattened array or false.
+     */
+    function unflattenArray($sep, $array) {
+        $result = [];
+
+        try {
+            foreach ($array as $flattenedKey => $value) {
+                $keys = explode($sep, $flattenedKey);
+
+                $target = &$result;
+                while (count($keys) > 1) {
+                    $key = array_shift($keys);
+                    if (!array_key_exists($key, $target)) {
+                        $target[$key] = [];
+                    }
+                    $target = &$target[$key];
+                }
+
+                $key = array_shift($keys);
+                $target[$key] = $value;
+                unset($target);
+            }
+        } catch (\Throwable $t) {
+            $result = false;
+        }
+
+        return $result;
+    }
+}
+
 if (!function_exists('safePrint')) {
     /**
      * Return/print human-readable and non casted information about a variable.

--- a/library/core/helpers/class.ssoutils.php
+++ b/library/core/helpers/class.ssoutils.php
@@ -27,6 +27,9 @@ class SsoUtils {
     /** @var string */
     private $cookieName;
 
+    /** @var string */
+    private $cookieSalt;
+
     /** @var Gdn_Session */
     private $session;
 

--- a/plugins/vanillaconnect/LICENSE.md
+++ b/plugins/vanillaconnect/LICENSE.md
@@ -1,0 +1,265 @@
+The GNU General Public License, Version 2, June 1991 (GPLv2)
+============================================================
+
+> Copyright &copy; 1989, 1991 Free Software Foundation, Inc.
+> 59 Temple Place, Suite 330
+> Boston, MA  02111-1307 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+
+Preamble
+--------
+
+The licenses for most software are designed to take away your freedom to share
+and change it. By contrast, the GNU General Public License is intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users. This General Public License applies to most
+of the Free Software Foundation's software and to any other program whose
+authors commit to using it. (Some other Free Software Foundation software is
+covered by the GNU Library General Public License instead.) You can apply it to
+your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our
+General Public Licenses are designed to make sure that you have the freedom to
+distribute copies of free software (and charge for this service if you wish),
+that you receive source code or can get it if you want it, that you can change
+the software or use pieces of it in new free programs; and that you know you can
+do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny
+you these rights or to ask you to surrender the rights. These restrictions
+translate to certain responsibilities for you if you distribute copies of the
+software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for a
+fee, you must give the recipients all the rights that you have. You must make
+sure that they, too, receive or can get the source code. And you must show them
+these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2) offer
+you this license which gives you legal permission to copy, distribute and/or
+modify the software.
+
+Also, for each author's protection and ours, we want to make certain that
+everyone understands that there is no warranty for this free software. If the
+software is modified by someone else and passed on, we want its recipients to
+know that what they have is not the original, so that any problems introduced by
+others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents. We wish
+to avoid the danger that redistributors of a free program will individually
+obtain patent licenses, in effect making the program proprietary. To prevent
+this, we have made it clear that any patent must be licensed for everyone's free
+use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+
+Terms And Conditions For Copying, Distribution And Modification
+---------------------------------------------------------------
+
+**0.** This License applies to any program or other work which contains a notice
+placed by the copyright holder saying it may be distributed under the terms of
+this General Public License. The "Program", below, refers to any such program or
+work, and a "work based on the Program" means either the Program or any
+derivative work under copyright law: that is to say, a work containing the
+Program or a portion of it, either verbatim or with modifications and/or
+translated into another language. (Hereinafter, translation is included without
+limitation in the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not covered by
+this License; they are outside its scope. The act of running the Program is not
+restricted, and the output from the Program is covered only if its contents
+constitute a work based on the Program (independent of having been made by
+running the Program). Whether that is true depends on what the Program does.
+
+**1.** You may copy and distribute verbatim copies of the Program's source code
+as you receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice and
+disclaimer of warranty; keep intact all the notices that refer to this License
+and to the absence of any warranty; and give any other recipients of the Program
+a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may at
+your option offer warranty protection in exchange for a fee.
+
+**2.** You may modify your copy or copies of the Program or any portion of it,
+thus forming a work based on the Program, and copy and distribute such
+modifications or work under the terms of Section 1 above, provided that you also
+meet all of these conditions:
+
+*   **a)** You must cause the modified files to carry prominent notices stating
+    that you changed the files and the date of any change.
+
+*   **b)** You must cause any work that you distribute or publish, that in whole
+    or in part contains or is derived from the Program or any part thereof, to
+    be licensed as a whole at no charge to all third parties under the terms of
+    this License.
+
+*   **c)** If the modified program normally reads commands interactively when
+    run, you must cause it, when started running for such interactive use in the
+    most ordinary way, to print or display an announcement including an
+    appropriate copyright notice and a notice that there is no warranty (or
+    else, saying that you provide a warranty) and that users may redistribute
+    the program under these conditions, and telling the user how to view a copy
+    of this License. (Exception: if the Program itself is interactive but does
+    not normally print such an announcement, your work based on the Program is
+    not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If identifiable
+sections of that work are not derived from the Program, and can be reasonably
+considered independent and separate works in themselves, then this License, and
+its terms, do not apply to those sections when you distribute them as separate
+works. But when you distribute the same sections as part of a whole which is a
+work based on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the entire whole,
+and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise the
+right to control the distribution of derivative or collective works based on the
+Program.
+
+In addition, mere aggregation of another work not based on the Program with the
+Program (or with a work based on the Program) on a volume of a storage or
+distribution medium does not bring the other work under the scope of this
+License.
+
+**3.** You may copy and distribute the Program (or a work based on it, under
+Section 2) in object code or executable form under the terms of Sections 1 and 2
+above provided that you also do one of the following:
+
+*   **a)** Accompany it with the complete corresponding machine-readable source
+    code, which must be distributed under the terms of Sections 1 and 2 above on
+    a medium customarily used for software interchange; or,
+
+*   **b)** Accompany it with a written offer, valid for at least three years, to
+    give any third party, for a charge no more than your cost of physically
+    performing source distribution, a complete machine-readable copy of the
+    corresponding source code, to be distributed under the terms of Sections 1
+    and 2 above on a medium customarily used for software interchange; or,
+
+*   **c)** Accompany it with the information you received as to the offer to
+    distribute corresponding source code. (This alternative is allowed only for
+    noncommercial distribution and only if you received the program in object
+    code or executable form with such an offer, in accord with Subsection b
+    above.)
+
+The source code for a work means the preferred form of the work for making
+modifications to it. For an executable work, complete source code means all the
+source code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and installation
+of the executable. However, as a special exception, the source code distributed
+need not include anything that is normally distributed (in either source or
+binary form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component itself
+accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the source code
+from the same place counts as distribution of the source code, even though third
+parties are not compelled to copy the source along with the object code.
+
+**4.** You may not copy, modify, sublicense, or distribute the Program except as
+expressly provided under this License. Any attempt otherwise to copy, modify,
+sublicense or distribute the Program is void, and will automatically terminate
+your rights under this License. However, parties who have received copies, or
+rights, from you under this License will not have their licenses terminated so
+long as such parties remain in full compliance.
+
+**5.** You are not required to accept this License, since you have not signed
+it. However, nothing else grants you permission to modify or distribute the
+Program or its derivative works. These actions are prohibited by law if you do
+not accept this License. Therefore, by modifying or distributing the Program (or
+any work based on the Program), you indicate your acceptance of this License to
+do so, and all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+**6.** Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the original
+licensor to copy, distribute or modify the Program subject to these terms and
+conditions. You may not impose any further restrictions on the recipients'
+exercise of the rights granted herein. You are not responsible for enforcing
+compliance by third parties to this License.
+
+**7.** If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues), conditions
+are imposed on you (whether by court order, agreement or otherwise) that
+contradict the conditions of this License, they do not excuse you from the
+conditions of this License. If you cannot distribute so as to satisfy
+simultaneously your obligations under this License and any other pertinent
+obligations, then as a consequence you may not distribute the Program at all.
+For example, if a patent license would not permit royalty-free redistribution of
+the Program by all those who receive copies directly or indirectly through you,
+then the only way you could satisfy both it and this License would be to refrain
+entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply and the
+section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or
+other property right claims or to contest validity of any such claims; this
+section has the sole purpose of protecting the integrity of the free software
+distribution system, which is implemented by public license practices. Many
+people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose that
+choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+**8.** If the distribution and/or use of the Program is restricted in certain
+countries either by patents or by copyrighted interfaces, the original copyright
+holder who places the Program under this License may add an explicit
+geographical distribution limitation excluding those countries, so that
+distribution is permitted only in or among countries not thus excluded. In such
+case, this License incorporates the limitation as if written in the body of this
+License.
+
+**9.** The Free Software Foundation may publish revised and/or new versions of
+the General Public License from time to time. Such new versions will be similar
+in spirit to the present version, but may differ in detail to address new
+problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies
+a version number of this License which applies to it and "any later version",
+you have the option of following the terms and conditions either of that version
+or of any later version published by the Free Software Foundation. If the
+Program does not specify a version number of this License, you may choose any
+version ever published by the Free Software Foundation.
+
+**10.** If you wish to incorporate parts of the Program into other free programs
+whose distribution conditions are different, write to the author to ask for
+permission. For software which is copyrighted by the Free Software Foundation,
+write to the Free Software Foundation; we sometimes make exceptions for this.
+Our decision will be guided by the two goals of preserving the free status of
+all derivatives of our free software and of promoting the sharing and reuse of
+software generally.
+
+
+No Warranty
+-----------
+
+**11.** BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR
+THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE
+STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM
+"AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+**12.** IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR
+INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA
+BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.

--- a/plugins/vanillaconnect/README.md
+++ b/plugins/vanillaconnect/README.md
@@ -1,0 +1,9 @@
+# VanillaConnect plugin
+
+VanillaConnect plugin allows SSO from a provider using the [VanillaConnect library](https://github.com/vanilla/vanilla-connect-php).
+
+# Documentation
+
+[PUT LINK TO THE DOCUMENTATION]
+
+

--- a/plugins/vanillaconnect/VanillaConnectAuthenticator.php
+++ b/plugins/vanillaconnect/VanillaConnectAuthenticator.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+namespace Vanilla\VanillaConnect;
+
+use Exception;
+use Garden\Schema\Schema;
+use Garden\Web\RequestInterface;
+use SsoUtils;
+use Vanilla\Authenticator\SSOAuthenticator;
+use Vanilla\Models\AuthenticatorModel;
+use Vanilla\Models\SSOData;
+
+/**
+ * Class VanillaConnectAuthenticator
+ */
+class VanillaConnectAuthenticator extends SSOAuthenticator {
+
+    /** Signing algorithm for JWT tokens. */
+    const JWT_ALGORITHM = 'HS256';
+
+    /** @var RequestInterface */
+    private $request;
+
+    /** @var SsoUtils */
+    private $ssoUtils;
+
+    /** @var VanillaConnect */
+    private $vanillaConnect;
+
+    /**
+     * VanillaConnectAuthenticator constructor.
+     *
+     * @throws Exception
+     *
+     * @param string $authenticatorID
+     * @param AuthenticatorModel $authenticatorModel
+     * @param RequestInterface $request
+     * @param SSOUtils $ssoUtils
+     */
+    public function __construct(
+        $authenticatorID,
+        AuthenticatorModel $authenticatorModel,
+        RequestInterface $request,
+        SsoUtils $ssoUtils
+    ) {
+        $this->ssoUtils = $ssoUtils;
+        $this->request = $request;
+
+        parent::__construct($authenticatorID, $authenticatorModel);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected static function getAuthenticatorTypeInfoImpl(): array {
+        return [
+            'ui' => [
+                // TODO fill these with proper value for the UI.
+                'photoUrl' => null,
+                'backgroundColor' => null,
+                'foregroundColor' => null,
+            ],
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getAuthenticatorSchema(): Schema {
+        $schema = parent::getAuthenticatorSchema()->merge(
+            Schema::parse([
+                'vanillaConnect:o' => Schema::parse([
+                    'clientID:s' => [
+                        'description' => 'VanillaConnect\'s client identifier.',
+                        'x-instance-required' => true,
+                        'x-instance-configurable' => true,
+                    ],
+                    'secret:s'=> [
+                        'description' => 'VanillaConnect\'s client secret.',
+                        'x-instance-required' => true,
+                        'x-instance-configurable' => true,
+                    ],
+                ])
+            ])
+        );
+
+        $removeConfigurable = [
+            'properties.sso.properties.canLinkSession',
+            'properties.sso.properties.canSignIn',
+        ];
+
+        foreach ($removeConfigurable as $fieldPath) {
+            $field = $schema->getField($fieldPath);
+            unset($field['x-instance-configurable']);
+            $schema->setField($fieldPath, $field);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAuthenticatorInfoImpl(): array {
+        $data = parent::getAuthenticatorInfoImpl();
+
+        $data['vanillaConnect'] = [
+            'clientID' => $this->vanillaConnect->getClientID(),
+            'secret' => $this->vanillaConnect->getSecret(),
+        ];
+
+        return $data;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function setAuthenticatorInfo(array $data) {
+        parent::setAuthenticatorInfo($data);
+
+        $this->vanillaConnect = new VanillaConnect($data['vanillaConnect']['clientID'], $data['vanillaConnect']['secret']);
+    }
+
+    /**
+     * Getter of clientID;
+     *
+     * @return string
+     */
+    public function getClientID() {
+        return $this->vanillaConnect->getClientID();
+    }
+
+    /**
+     * Transform a claim to a SSOData object.
+     *
+     * @param $claim
+     *
+     * @return SSOData
+     * @throws \Exception
+     */
+    private function claimToSSOData($claim) {
+        $uniqueID = $claim['id'];
+
+        foreach (array_keys(VanillaConnect::JWT_RESPONSE_CLAIM_TEMPLATE) as $key) {
+            unset($claim[$key]);
+        }
+
+        list($userData, $extraData) = SSOData::splitProviderData($claim);
+
+        $ssoData = new SSOData(
+            $this::getType(),
+            $this->getID(),
+            $uniqueID,
+            $userData,
+            $extraData
+        );
+        $ssoData->validate();
+
+        return $ssoData;
+    }
+
+    /**
+     * Get URL where the authentication response needs to be sent to.
+     *
+     * @param string $target
+     * @return string
+     */
+    private function getRedirectURL($target = null) {
+        $url = $this->request->getScheme().'://'.$this->request->getHost().'/authenticate/'.$this::getType().'/'.rawurlencode($this->getID());
+
+        if ($target) {
+            $target = safeURL($target);
+            $url .= '?target='.rawurlencode($target);
+        }
+
+        return $url;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function isUnique(): bool {
+        return false;
+    }
+
+    /**
+     * Extract `target=?` from the URL and return both the transformed URL and the target.
+     *
+     * @param $url
+     * @return array [$url, $target]
+     */
+    private function extractTargetFromURL($url) {
+        $query = [];
+        parse_str(parse_url($url, PHP_URL_QUERY), $query);
+        $query = array_change_key_case($query, CASE_LOWER);
+
+        $target = null;
+        if (!empty($query['target'])) {
+            $target = $query['target'];
+            $url = str_ireplace('target='.$query['target'], '', $url);
+            $url = str_replace('&&', '', $url);
+            $url = rtrim($url, '?&');
+        }
+
+        if ($target === '{target}') {
+            $query = $this->request->getQuery();
+            $query = array_change_key_case($query, CASE_LOWER);
+            if (!empty($query['target'])) {
+                $target = $query['target'];
+            }
+        }
+
+        return [$url, $target];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function initSSOAuthentication() {
+        list($url, $target) = $this->extractTargetFromURL(parent::getSignInUrl());
+        $url .= (strpos($url, '?') === false ? '?' : '&');
+        $url .= 'jwt='.$this->vanillaConnect->createRequestAuthJWT(
+            $this->ssoUtils->getStateToken(),
+            [
+                'redirect' => $this->getRedirectURL($target),
+                'authenticatorID' => $this->getID(),
+            ]
+        );
+
+        return redirectTo($url, 302, false);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function sso(RequestInterface $request): SSOData {
+        $query = $request->getQuery();
+        if (empty($query['jwt'])) {
+            throw new Exception('Missing parameter "jwt" from query string.');
+        }
+
+        if (!$this->vanillaConnect->validateResponse($query['jwt'], $claim)) {
+            throw new Exception("An error occurred during the JWT validation.\n".print_r($this->vanillaConnect->getErrors(), true));
+        }
+
+        $this->ssoUtils->verifyStateToken(self::getType().'-'.$this->getID().'-'.'sso', $claim['jti']);
+
+        return $this->claimToSSOData($claim);
+    }
+}

--- a/plugins/vanillaconnect/VanillaConnectPlugin.php
+++ b/plugins/vanillaconnect/VanillaConnectPlugin.php
@@ -1,0 +1,413 @@
+<?php
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+namespace Vanilla\VanillaConnect;
+
+use EntryController;
+use Garden\Schema\ValidationException;
+use Garden\Web\Exception\NotFoundException;
+use Garden\Web\RequestInterface;
+use Gdn_Configuration;
+use Gdn_Plugin;
+use Gdn_Session;
+use Logger;
+use SettingsController;
+use sprintft;
+use UserModel;
+use Vanilla\Models\AuthenticatorModel;
+use Vanilla\Models\SSOModel;
+
+class VanillaConnectPlugin extends Gdn_Plugin {
+
+    /** @var \Vanilla\Models\AuthenticatorModel  */
+    private $authenticatorModel;
+
+    /** @var Gdn_Configuration */
+    private $config;
+
+    /** @var RequestInterface */
+    private $request;
+
+    /** @var Gdn_Session */
+    private $session;
+
+    /** @var SSOModel */
+    private $ssoModel;
+
+    /** @var UserModel */
+    private $userModel;
+
+    /**
+     * VanillaConnectPlugin constructor.
+     *
+     * @param \Vanilla\Models\AuthenticatorModel
+     * @param Gdn_Configuration $config
+     * @param RequestInterface $request
+     * @param Gdn_Session $session
+     * @param SSOModel $ssoModel
+     * @param UserModel $userModel
+     */
+    public function __construct(
+        AuthenticatorModel $authenticatorModel,
+        Gdn_Configuration $config,
+        RequestInterface $request,
+        Gdn_Session $session,
+        SSOModel $ssoModel,
+        UserModel $userModel
+    ) {
+        parent::__construct();
+
+        $this->authenticatorModel = $authenticatorModel;
+        $this->config = $config;
+        $this->request = $request;
+        $this->session = $session;
+        $this->ssoModel = $ssoModel;
+        $this->userModel = $userModel;
+    }
+
+    /**
+     * Authenticate a user using the JWT supplied from the query parameter "vc_sso".
+     */
+    public function gdn_dispatcher_appStartup_handler() {
+        $query = $this->request->getQuery();
+
+        $jwt = !empty($query['vc_sso']) ? $query['vc_sso'] : null;
+        if ($jwt === null) {
+            return;
+        }
+        unset($query['vc_sso']);
+
+        try {
+            $authenticatorID = VanillaConnect::extractItemFromClaim('authenticatorID');
+            $vanillaConnectAuthenticator = $this->authenticatorModel->getAuthenticator(VanillaConnectAuthenticator::getType(), $authenticatorID);
+            $ssoData = $vanillaConnectAuthenticator->validatePushSSOAuthentication($jwt);
+
+            saveToConfig('Garden.Registration.SendConnectEmail', false, false);
+
+            if (!$this->ssoModel->sso($ssoData)) {
+                throw new \Exception('Unable to push connect the user.');
+            }
+        } catch (\Exception $e) {
+            Logger::log(Logger::ERROR, 'vanillaconnect_pushsso_error', [
+                'endpoint' => $this->request->getPath(),
+                'errorCode' => $e->getCode(),
+                'errorMessage' => $e->getMessage(),
+                'validationResults' => $this->ssoModel->getValidationResults(),
+                'jwt' => $jwt,
+            ]);
+        }
+
+        // Redirect the request with 'vc_sso' stripped from the query string.
+        if ($this->request->getMethod() !== 'POST') {
+            $queryString = http_build_query($query);
+            redirectTo($this->request->getPath().($queryString ? '?'.$queryString : ''));
+            exit();
+        }
+    }
+
+//
+//    Authenticators do not currently support the "default" option.
+//
+//    /**
+//     * Make the signIn button work when a VanillaConnect provider is set as the default.
+//     *
+//     * @param $sender
+//     * @param $args
+//     *
+//     * @throws \Garden\Container\ContainerException
+//     * @throws \Garden\Container\NotFoundException
+//     * @throws \Garden\Web\Exception\NotFoundException
+//     */
+//    public function entryController_overrideSignIn_handler($sender, $args) {
+//        if ($args['DefaultProvider']['AuthenticationSchemeAlias'] !== VanillaConnect::NAME) {
+//            return;
+//        }
+//
+//        $this->entryController_vanillaConnect_create(null, 'signin', $args['DefaultProvider']['AuthenticationKey']);
+//    }
+//
+//    /**
+//     * Allow user to be logged in when hitting the /sso endpoint.
+//     *
+//     * @param $sender
+//     * @param $args
+//     *
+//     * @throws \Garden\Container\ContainerException
+//     * @throws \Garden\Container\NotFoundException
+//     * @throws \Garden\Web\Exception\NotFoundException
+//     */
+//    public function rootController_sso_handler($sender, $args) {
+//        if ($args['DefaultProvider']['AuthenticationSchemeAlias'] !== VanillaConnect::NAME) {
+//            return;
+//        }
+//
+//        $this->entryController_vanillaConnect_create(null, 'signin', $args['DefaultProvider']['AuthenticationKey']);
+//    }
+
+    /**
+     * Put SignIn buttons in the guest box.
+     */
+    public function base_beforeSignInButton_handler() {
+        $authenticators = $this->authenticatorModel->getAuthenticatorsByClass(VanillaConnectAuthenticator::class);
+        foreach ($authenticators as $authenticator) {
+            echo "\n".$this->connectButton($authenticator);
+        }
+    }
+
+    /**
+     * Put SignIn buttons in mobile theme.
+     */
+    public function base_beforeSignInLink_handler() {
+        if ($this->session->isValid()) {
+            return;
+        }
+
+        $authenticators = $this->authenticatorModel->getAuthenticatorsByClass(VanillaConnectAuthenticator::class);
+        foreach ($authenticators as $authenticator) {
+            echo "\n".wrap($this->connectButton($authenticator, ['NoRegister' => true]), 'li', ['class' => 'Connect']);
+        }
+    }
+
+    /**
+     * Put SignIn buttons on /entry/signin
+     *
+     * @param EntryController $sender
+     *
+     * @throws \Garden\Web\Exception\ServerException
+     */
+    public function entryController_signIn_handler($sender) {
+        $authenticators = $this->authenticatorModel->getAuthenticatorsByClass(VanillaConnectAuthenticator::class);
+
+        $methods = $sender->data('Methods', []);
+
+        foreach ($authenticators as $authenticator) {
+            $methods[] = [
+                'Name' => $authenticator->getName(),
+                'SignInHtml' => $this->connectButton($authenticator),
+            ];
+        }
+
+        $sender->setData('Methods', $methods);
+    }
+
+    /**
+     * Generate the connect button for a specific provider.
+     *
+     * @param VanillaConnectAuthenticator $authenticator
+     * @param array $options
+     * @return string
+     */
+    private function connectButton(VanillaConnectAuthenticator $authenticator, $options = []) {
+        // Redirect to /authenticate/vanillaconnect which will redirect to the proper URL with the JWT.
+        $signInUrl = '/entry/vanillaconnect/signin/'.rawurlencode($authenticator->getID()).'?target='.rawurlencode($this->request->getPath());
+        $registerUrl = '/entry/vanillaconnect/register/'.rawurlencode($authenticator->getID()).'?target='.rawurlencode($this->request->getPath());
+
+        $result = '<div class="vanilla-connect">';
+        $result .= anchor(sprintf(t('Sign In with %s'), $authenticator->getName()), $signInUrl, 'Button Primary SignInLink');
+        if (!val('NoRegister', $options, false) && $registerUrl) {
+            $result .= ' '.anchor(sprintf(t('Register with %s', 'Register'), $authenticator->getName()), $registerUrl, 'Button RegisterLink');
+        }
+        $result .= '</div>';
+
+        return $result;
+    }
+
+    /**
+     * Create the entry/vanillaconnect endpoint.
+     *
+     * @param EntryController $sender
+     * @param string $action
+     * @param string $authenticatorID
+     *
+     * @throws \Garden\Web\Exception\ClientException
+     * @throws \Garden\Web\Exception\NotFoundException
+     * @throws \Garden\Web\Exception\ServerException
+     */
+    public function entryController_vanillaConnect_create($sender, $action = '', $authenticatorID = '') {
+        if (!in_array($action, ['signin', 'register'])) {
+            throw new NotFoundException();
+        }
+
+        /** @var \Vanilla\VanillaConnect\VanillaConnectAuthenticator $authenticator */
+        $authenticator = $this->authenticatorModel->getAuthenticator(VanillaConnectAuthenticator::getType(), $authenticatorID);
+
+        if ($action === 'signin') {
+            $url = $authenticator->initSSOAuthentication();
+        } else {
+            $url = $authenticator->getRegisterUrl();
+            redirectTo($url, 302, false);
+        }
+
+    }
+
+    /**
+     * Add VanillaConnect to the side menu.
+     *
+     * @param Gdn_Controller $sender
+     */
+    public function base_getAppSettingsMenuItems_handler($sender) {
+        $menu = $sender->EventArguments['SideMenu'];
+        $menu->addLink('connect', 'VanillaConnect', 'settings/vanillaconnect', 'Garden.Settings.Manage', ['class' => 'nav-jsconnect']);
+    }
+
+    /**
+     * Dispatch settings/vanillaconnect/{action}
+     *
+     * @param SettingsController $sender
+     * @param array $args
+     *
+     * @throws \Gdn_UserException
+     */
+    public function settingsController_vanillaconnect_create($sender, $args = []) {
+        $sender->permission('Garden.Settings.Manage');
+        $sender->setHighlightRoute();
+
+        switch (strtolower(val(0, $args))) {
+            case 'addedit':
+                $this->settings_addEdit($sender);
+                break;
+            case 'delete':
+                $this->settings_delete($sender);
+                break;
+            default:
+                $this->settings_index($sender);
+                break;
+        }
+    }
+
+    /**
+     * Add/Edit VanillaConnect providers.
+     *
+     * @param SettingsController $sender
+     *
+     * @throws \Gdn_UserException
+     */
+    protected function settings_addEdit($sender) {
+        /* @var \Gdn_Form $form */
+        $form = $sender->Form;
+
+        $authenticatorID = $sender->Request->get('authenticatorID');
+        if ($authenticatorID) {
+            /** @var \Vanilla\VanillaConnect\VanillaConnectAuthenticator $authenticator */
+            $authenticator = $this->authenticatorModel->getAuthenticatorByID($authenticatorID);
+        } else {
+            $authenticator = null;
+        }
+
+
+        if ($form->authenticatedPostBack()) {
+            $form->validateRule('vanillaConnect.clientID', 'ValidateRequired', sprintft('%s is required.', 'Client ID'));
+            $form->validateRule('vanillaConnect.clientID', 'regex:`^[a-z0-9_-]+$`i', sprintft('%s must contain only letters, numbers and dashes.', 'Client ID'));
+            $form->validateRule('vanillaConnect.secret', 'ValidateRequired', sprintft('%s is required.', 'Secret'));
+            $form->validateRule('name', 'ValidateRequired', sprintft('%s is required.', 'Provider Name'));
+            $form->validateRule('signInUrl', 'ValidateRequired', sprintft('%s is required.', 'Sign In URL'));
+            $form->validateRule('signInUrl', 'ValidateUrl');
+            $form->validateRule('registerUrl', 'ValidateUrl');
+            $form->validateRule('signOutUrl', 'ValidateUrl');
+
+            if (!$form->validationResults()) {
+                $fields = VanillaConnectAuthenticator::getConfigurableFields();
+                $nonEmptyData = array_filter($form->formValues(), function($value) {
+                    return $value !== '';
+                });
+                $data = unflattenArray('.', array_intersect_key($nonEmptyData, array_flip($fields)));
+
+                try {
+                    if ($authenticator) {
+                        $authenticator->updateAuthenticatorInfo($data);
+                    } else {
+                        $data['authenticatorID'] = 'vc_'.$data['vanillaConnect']['clientID'];
+                        $data['type'] = VanillaConnectAuthenticator::getType();
+                        $data['isActive'] = true;
+                        $this->authenticatorModel->createSSOAuthenticatorInstance($data);
+                    }
+                } catch(ValidationException $e) {
+                    $form->setValidationResults(['errors' => array_column($e->getValidation()->getErrors(), 'message')]);
+                }
+            }
+            if (!$form->validationResults()) {
+                $sender->setRedirectTo('/settings/vanillaconnect');
+            }
+        } else {
+            if ($authenticator) {
+                $form->setData(flattenArray('.', $authenticator->getAuthenticatorInfo()));
+            }
+        }
+
+        $configurableFields = VanillaConnectAuthenticator::getConfigurableFields();
+
+        $controls = [
+            'vanillaConnect.clientID' => [
+                'LabelCode' => t('Client ID'),
+                'Description' => t('The client ID uniquely identifies the site.'),
+            ],
+            'vanillaConnect.secret' => [
+                'LabelCode' => t('Secret'),
+                'Description' => t('The secret secures the sign in process.', 'The secret secures the sign in process. Do <b>NOT</b> give the secret out to anyone.'),
+            ],
+            'name' => [
+                'LabelCode' => t('Provider Name'),
+                'Description' => t('Enter a short name that identifies this provider.').' '.t('This is displayed on the sign in buttons.'),
+            ],
+            'signInUrl' => [
+                'LabelCode' => t('Sign In URL'),
+                'Description' => t('The url that users use to sign in.').' '.t('Use target={target} to redirect users to the page they were on or target=WhateverYouWant to redirect to a specific url.'),
+            ],
+            'registerUrl' => [
+                'LabelCode' => t('Registration URL'),
+                'Description' => t('The url that users use to register for a new account.'),
+            ],
+            'signOutUrl' => [
+                'LabelCode' => t('Sign Out URL'),
+                'Description' => t('The url that users use to sign out of your site.').' '.t('Only used if the provider is set to be used as the default sign in method.'),
+            ],
+            'sso.isTrusted' => [
+                'LabelCode' => t('Trusted'),
+                'Control' => 'toggle',
+                'Description' => t('This is a trusted provider and it can sync user\'s information, roles & permissions.'),
+            ],
+            'sso.canAutoLinkUser' => [
+                'LabelCode' => t('Link User'),
+                'Control' => 'toggle',
+                'Description' => t('This provider can link users to existing forum user by using the provided email address.'),
+            ],
+        ];
+        $sender->setData('_Controls', $controls);
+        $sender->setData('Title', sprintf(t($authenticatorID ? 'Edit %s' : 'Add %s'), t('Provider')));
+
+        $sender->render('settings_addedit', '', 'plugins/vanillaconnect');
+    }
+
+    /**
+     * Delete a VanillaConnect provider.
+     *
+     * @param SettingsController $sender
+     *
+     * @throws \Gdn_UserException
+     */
+    public function settings_delete($sender) {
+        $authenticatorID = $sender->Request->get('authenticatorID');
+        if ($sender->Form->authenticatedPostBack()) {
+            $this->authenticatorModel->deleteSSOAuthenticator(VanillaConnectAuthenticator::getType(), $authenticatorID);
+            $sender->setRedirectTo('/settings/vanillaconnect');
+            $sender->render('blank', 'utility', 'dashboard');
+        }
+    }
+
+    /**
+     * Display the VanillaConnect settings page.
+     *
+     * @param SettingsController $sender
+     *
+     * @throws \Garden\Web\Exception\ServerException
+     */
+    protected function settings_index($sender) {
+        $authenticators = $this->authenticatorModel->getAuthenticatorsByClass(VanillaConnectAuthenticator::class);
+        $sender->setData('authenticators', $authenticators);
+        $sender->render('settings', '', 'plugins/vanillaconnect');
+    }
+}

--- a/plugins/vanillaconnect/addon.json
+++ b/plugins/vanillaconnect/addon.json
@@ -1,0 +1,20 @@
+{
+    "name": "VanillaConnect",
+    "description": "VanillaConnect SSO.",
+    "key": "vanillaconnect",
+    "type": "addon",
+    "version": "1.0",
+    "settingsUrl": "/settings/vanillaconnect",
+    "usePopupSettings": false,
+    "settingsPermission": "Garden.Settings.Manage",
+    "authors": [
+        {
+            "name": "Alexandre (DaazKu) Chouinard",
+            "email": "alexandre.c@vanillaforums.com",
+            "homepage": "https://github.com/DaazKu"
+        }
+    ],
+    "require": {
+        "vanilla": ">=2.6"
+    }
+}

--- a/plugins/vanillaconnect/addon.json
+++ b/plugins/vanillaconnect/addon.json
@@ -7,6 +7,7 @@
     "settingsUrl": "/settings/vanillaconnect",
     "usePopupSettings": false,
     "settingsPermission": "Garden.Settings.Manage",
+    "hidden": true,
     "authors": [
         {
             "name": "Alexandre (DaazKu) Chouinard",

--- a/plugins/vanillaconnect/views/settings.php
+++ b/plugins/vanillaconnect/views/settings.php
@@ -1,0 +1,60 @@
+<?php if (!defined('APPLICATION')) exit();
+/**
+ * @author Alexandre (DaazKu) Chouinard <alexandre.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
+ */
+
+// TODO when the doc is created.
+//$links = '<ul>';
+//$links .= '<li>'.anchor(t('VanillaConnect Documentation'), 'http://docs.vanillaforums.com/features/sso/vanillaconnect/').'</li>';
+//$links .= '<li>'.anchor(t('VanillaConnect Client Libraries'), '').'</li>';
+//$links .= '</ul>';
+
+helpAsset(sprintf(t('About %s'), 'VanillaConnect'), t('You can connect to multiple sites that support VanillaConnect.'));
+//helpAsset(t('Need More Help?'), $links);
+
+echo heading(sprintf(t('%s Settings'), 'VanillaConnect'), t('Add Provider'), '/settings/vanillaconnect/addedit', 'btn btn-primary js-modal');
+?>
+
+<section>
+<?php
+    echo subheading(t('Signing In'));
+?>
+</section>
+<div class="table-wrap">
+    <table class="table-data js-tj">
+        <thead>
+        <tr>
+            <th><?php echo t('Client ID'); ?></th>
+            <th><?php echo t('Provider Name'); ?></th>
+            <th class="column-lg"><?php echo t('Sign In URL'); ?></th>
+            <th class="column-xs"><?php echo t('Trusted'); ?></th>
+            <th class="column-xs"><?php echo t('Auto link'); ?></th>
+            <th class="column-xs"></th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php
+        /** @var \Vanilla\VanillaConnect\VanillaConnectAuthenticator $authenticator */
+        foreach ($this->data('authenticators') as $authenticator):
+        ?>
+            <tr>
+                <td><?php echo htmlspecialchars($authenticator->getClientID()); ?></td>
+                <td><?php echo htmlspecialchars($authenticator->getName()); ?></td>
+                <td><?php echo htmlspecialchars($authenticator->getSignInUrl()); ?></td>
+                <td><?php echo $authenticator->isTrusted() ? t('Yes') : t('No') ?></td>
+                <td><?php echo $authenticator->canAutoLinkUser() ? t('Yes') : t('No') ?></td>
+                <td class="options">
+                    <div class="btn-group">
+                        <?php
+                        echo anchor(dashboardSymbol('edit'), '/settings/vanillaconnect/addedit?authenticatorID='.urlencode($authenticator->getID()), 'js-modal btn btn-icon', ['aria-label' => t('Edit'), 'title' => t('Edit')]);
+                        echo anchor(dashboardSymbol('delete'), '/settings/vanillaconnect/delete?authenticatorID='.urlencode($authenticator->getID()), 'js-modal-confirm btn btn-icon', ['aria-label' => t('Delete'), 'title' => t('Delete')]);
+                        ?>
+                    </div>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/plugins/vanillaconnect/views/settings_addedit.php
+++ b/plugins/vanillaconnect/views/settings_addedit.php
@@ -1,0 +1,11 @@
+<?php if (!defined('APPLICATION')) exit();
+
+echo wrap($this->data('Title'), 'h1');
+echo $this->Form->open(), $this->Form->errors();
+echo $this->Form->simple($this->data('_Controls'));
+
+echo '<div class="js-modal-footer form-footer buttons">';
+echo $this->Form->button('Save');
+echo '</div>';
+
+echo $this->Form->close();

--- a/tests/Library/Core/ArrayFunctionsTest.php
+++ b/tests/Library/Core/ArrayFunctionsTest.php
@@ -121,4 +121,43 @@ class ArrayFunctionsTest extends SharedBootstrapTestCase {
             ],
         ];
     }
+
+    /**
+     * Test {@link unflattenArray()}.
+     *
+     * @param array $array The input array to test.
+     * @param array $expected The expected flattened array.
+     * @dataProvider provideUnflattenArrayTests
+     */
+    public function testUnflattenArray($array, $expected) {
+        $value = unflattenArray('.', $array);
+        $this->assertEquals($expected, $value);
+    }
+
+    /**
+     * Provide test data for {@link unflattenArray()}.
+     *
+     * @return array Returns an array of test data.
+     */
+    public function provideUnflattenArrayTests() {
+        $r = [
+            'threeDeep' => [['a.b.c' => 'foo'], ['a' => ['b' => ['c' => 'foo']]]],
+            'emptyArray' => [[], []],
+            'realWorldExample' => [
+                [
+                    'a.b.c' => 'foo',
+                    'a.d.e' => 'bar'
+                ],
+                [
+                    'a' => [
+                        'b' => ['c' => 'foo'],
+                        'd' => ['e' => 'bar'],
+                    ],
+                ],
+            ],
+        ];
+
+        return $r;
+    }
+
 }

--- a/tests/fixtures/src/Authenticator/MockSSOAuthenticator.php
+++ b/tests/fixtures/src/Authenticator/MockSSOAuthenticator.php
@@ -39,7 +39,7 @@ class MockSSOAuthenticator extends SSOAuthenticator {
         $defaults = [
             'properties.name' => 'MockSSO',
             'properties.isActive' => true,
-            'properties.signInUrl' => '/MockSSOSignInPage',
+            'properties.signInUrl' => 'http://example.com/MockSSOSignInPage',
             'properties.sso.properties.canSignIn' => true,
             'properties.sso.properties.isTrusted' => true,
             'properties.sso.properties.canAutoLinkUser' => false,


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/6892

## Main

Add VanillaConnect plugin!

## Fluff

Improve AuthenticatorModel
- Add getAuthenticatorsByClass()
- Fix DB to Authenticator data problems with null vs empty string
- Add deleteSSOAuthenticator()

Add improvements to the SSOAuthenticator class
- Add initiateAuthentication() method which can be overriden to add additional arguments to the SignInUrl
- Add URI validation to URLs
- Add updateAuthenticatorInfo() method to mass update fields on an authenticator
- Override "name" per instance.

## How to test
- Install/update (composer too) https://github.com/vanilla/stub-sso-providers
- composer update this branch
- Add `$Configuration['EnabledPlugins']['vanillaconnect'] = true;` to your config.php
- Go in the dashboard and on the left sidebar click on VanillaConnect
- Add provider with the following (Assuming that you configured the stub with the default template)
    - ClientID: stub_vanillaconnect
    - Secret: 1234
    - ProviderName: Stub VConnect
    - SignInUrl: https://sso.vanilla.localhost/vanillaconnect/authenticate
- Sign out and try to sign in!

## What to test
- Dashboard form
- SignIn with LinkUser On/Off
- Break on https://github.com/vanilla/vanilla/pull/7348/files#diff-3286435e4ae64d2feb52edc9af381fe2R281 and get the REQUEST_URI. Once you are properly signed in, sign out and try to hit that URL again. You should have a nonce error.