### PR TITLE
Fix categoryDropDown when editing drafts with DoHeadings enabled

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -149,8 +149,7 @@ class PostController extends VanillaController {
             if (val('DisplayAs', $this->Category) == 'Discussions' && !$draftID) {
                 $this->ShowCategorySelector = false;
             } else {
-                // Get all our subcategories to add to the category if we are in a Header or Categories category.
-                $this->Context = CategoryModel::getSubtree($this->CategoryID);
+                $this->Context = $categoryModel->getTree($this->CategoryID);
             }
         }
 

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -148,8 +148,6 @@ class PostController extends VanillaController {
             $this->Form->addHidden('CategoryID', $this->Category->CategoryID);
             if (val('DisplayAs', $this->Category) == 'Discussions' && !$draftID) {
                 $this->ShowCategorySelector = false;
-            } else {
-                $this->Context = $categoryModel->getTree($this->CategoryID);
             }
         }
 


### PR DESCRIPTION
Close Vanilla/Vanilla#5641
When you save a draft in child category with Vanilla.Categories.DoHeadings enabled (Parent Category is considered heading so you can't post in it), you're unable to edit the draft.  The root of the issue can be traced back to the postcontroller discussion method where the draft's category id is used to find the category subtree for that specific draft and assigned the context.  The context is passed on to the categoryDropDrown method, where the it now assumes the top level of the subtree is the parent category and disables it.  Removing the assignment of context from the postcontroller fixes this issue.

I've tested with categories displayed as heading, nested, flat and discussion and could not find any adverse effects.

There is same issue in the subcommunities plugin but the fix is not as apparent.