### PR TITLE
Fix function name on VanillaConnectAuthenticator

### DIFF
--- a/plugins/vanillaconnect/VanillaConnectAuthenticator.php
+++ b/plugins/vanillaconnect/VanillaConnectAuthenticator.php
@@ -261,7 +261,7 @@ class VanillaConnectAuthenticator extends SSOAuthenticator {
     /**
      * @inheritdoc
      */
-    public function initSSOAuthentication() {
+    public function initiateAuthentication() {
         list($url, $target) = $this->extractTargetFromURL(parent::getSignInUrl());
         $url .= (strpos($url, '?') === false ? '?' : '&');
         $url .= 'jwt='.$this->vanillaConnect->createRequestAuthJWT(


### PR DESCRIPTION
The function was renamed on the base class and I forgot to rename it on VanillaConnectAuthenticator