### PR TITLE
Fix error message "Unknown column" appearing when bookmarking a discussion

### DIFF
--- a/applications/vanilla/modules/class.bookmarkedmodule.php
+++ b/applications/vanilla/modules/class.bookmarkedmodule.php
@@ -42,12 +42,10 @@ class BookmarkedModule extends Gdn_Module {
                 $discussionModel = new DiscussionModel();
                 DiscussionModel::categoryPermissions();
 
-                $discussionModel->SQL->whereIn('d.DiscussionID', $bookmarkIDs);
-
                 $bookmarks = $discussionModel->get(
                     0,
                     $this->Limit,
-                    ['w.Bookmarked' => '1']
+                    ['d.DiscussionID' => $bookmarkIDs]
                 );
                 $this->setData('Bookmarks', $bookmarks);
             } else {


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7341

Remove separate addition of a where clause prior to the get function that created pollution of SQL objects. Simply added the where condition as a parameter of the `get` function.

I removed the original condition `'w.Bookmarked' => '1'` in the where parameter of the get function as we already fetch the bookmarkIDs with the same condition a little higher in the code.

```
$bookmarkIDs = Gdn::sql()
                ->select('DiscussionID')
                ->from('UserDiscussion')
                ->where('UserID', Gdn::session()->UserID)
                ->where('Bookmarked', 1)
                ->get()->resultArray();
```

That condition seemed useless.