### PR TITLE
Throw relevant message when SQLDriver cannot be instantiated

### DIFF
--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -514,7 +514,7 @@ class Gdn_Database {
             $name = $this->Engine.'Driver';
             $this->_SQL = Gdn::factory($name);
             if (!$this->_SQL) {
-                $this->_SQL = new stdClass();
+                throw new Exception("Could not instantiate database driver '$name'.");
             }
             $this->_SQL->Database = $this;
         }


### PR DESCRIPTION
In some weird case it's possible that vanilla could be hit with no proper configuration. When that's the case we should throw a relevant error message instead of "masking the error".

This is especially relevant since we added type hinting on method where we expect Gdn_SQLDriver.
We get the following error message:
```
Uncaught TypeError: Argument 1 passed to CategoryCollection::__construct() 
must be an instance of Gdn_SQLDriver, instance of stdClass given...
```
and it is quite confusing.

I did a fresh install with no problems and the `testAltInstall()` test works no problems.

I'd just like some context about https://github.com/vanilla/vanilla/commit/8d02cbd1d432f9e72c468686bf225388b4847f6d before determining if this fix is "ok" or if it will break some things I am unaware of.