### PR TITLE
Use glob character ranges for case-sensitive filesystem scans

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -496,14 +496,11 @@ class Addon {
     private function scanClassPaths() {
         $dirs = [
             '',
-            '/controllers',
-            '/Controllers',
+            '/[Cc]ontrollers',
             '/library',
             '/src',
-            '/models',
-            '/Models',
-            '/modules',
-            '/Modules',
+            '/[Mm]odels',
+            '/[Mm]odules',
             '/settings/class.hooks.php'
         ];
 


### PR DESCRIPTION
Case-sensitive filesystems were giving us issues when the addon scanning was done on a case-insensitive filesystem. This change should ensure that as much as possible the file that is cached is the correct case within our accepted file naming conventions.