### PR TITLE
Fix inability to restore some discussions from the moderation queue

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1009,7 +1009,8 @@ class DiscussionModel extends Gdn_Model {
         }
 
         // Allow for discussions to be archived
-        if ($discussion->DateLastComment && Gdn_Format::toTimestamp($discussion->DateLastComment) <= $archiveTimestamp) {
+        $dateLastCommentTimestamp = $discussion->DateLastComment ? Gdn_Format::toTimestamp($discussion->DateLastComment) : null;
+        if ($dateLastCommentTimestamp && $dateLastCommentTimestamp <= $archiveTimestamp) {
             $discussion->Closed = '1';
             if ($discussion->CountCommentWatch) {
                 $discussion->CountUnreadComments = $discussion->CountComments - $discussion->CountCommentWatch;
@@ -2058,7 +2059,9 @@ class DiscussionModel extends Gdn_Model {
 
                     $isValid = true;
                     $invalidReturnType = false;
-                    $this->EventArguments['DiscussionData'] = array_merge($fields, ['DiscussionID' => $discussionID]);
+                    $insertUserID = val('InsertUserID', $stored);
+                    $dateInserted=  val('DateInserted', $stored);
+                    $this->EventArguments['DiscussionData'] = array_merge($fields, ['DiscussionID' => $discussionID, 'InsertUserID' => $insertUserID,'DateInserted' => $dateInserted]);
                     $this->EventArguments['IsValid'] = &$isValid;
                     $this->EventArguments['InvalidReturnType'] = &$invalidReturnType;
                     $this->fireEvent('AfterValidateDiscussion');

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2060,7 +2060,7 @@ class DiscussionModel extends Gdn_Model {
                     $isValid = true;
                     $invalidReturnType = false;
                     $insertUserID = val('InsertUserID', $stored);
-                    $dateInserted=  val('DateInserted', $stored);
+                    $dateInserted = val('DateInserted', $stored);
                     $this->EventArguments['DiscussionData'] = array_merge($fields, ['DiscussionID' => $discussionID, 'InsertUserID' => $insertUserID,'DateInserted' => $dateInserted]);
                     $this->EventArguments['IsValid'] = &$isValid;
                     $this->EventArguments['InvalidReturnType'] = &$invalidReturnType;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1009,7 +1009,7 @@ class DiscussionModel extends Gdn_Model {
         }
 
         // Allow for discussions to be archived
-        $dateLastCommentTimestamp = $discussion->DateLastComment ? Gdn_Format::toTimestamp($discussion->DateLastComment) : null;
+        $dateLastCommentTimestamp = Gdn_Format::toTimestamp($discussion->DateLastComment);
         if ($dateLastCommentTimestamp && $dateLastCommentTimestamp <= $archiveTimestamp) {
             $discussion->Closed = '1';
             if ($discussion->CountCommentWatch) {


### PR DESCRIPTION
Fixes [#1592](https://github.com/vanilla/internal/issues/1592)

**Issue 1**

When Premoderated category plugin is enabled, after a discussion get edited for a second time, we get the error "Field 'InsertUserID' doesn't have a default value|Gdn_Database|Query|replace `GDN_Discussion` "
this got fixed by adding the missing fields to the array before saving the data to GDN_Log

**Issue 2**

After a discussion gets approved, it is marked as closed when the value of DateLastComment is set to "0000-00-00 00:00:00"
https://github.com/vanilla/vanilla/blob/be20cf00c2a40e35f69c5dc187bdde9b7f3731a1/applications/vanilla/models/class.discussionmodel.php#L1012
