### PR TITLE
Remove vine’s external script

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1564,7 +1564,7 @@ EOT;
             case 'Vine':
                 return <<<EOT
 <div class="vine-video VideoWrap">
-   <iframe class="vine-embed" src="https://vine.co/v/{$matches[1]}/embed/simple" width="320" height="320" frameborder="0"></iframe><script async src="https://platform.vine.co/static/scripts/embed.js" charset="utf-8"></script>
+   <iframe class="vine-embed" src="https://vine.co/v/{$matches[1]}/embed/simple" width="320" height="320" frameborder="0"></iframe>
 </div>
 EOT;
                 break;


### PR DESCRIPTION
TLDR: Removing vine’s script seems to still allow their embeds to work minus autoplay. Since vine is defunct this is an acceptable tradeoff.

Including an external script for vine means that it can execute whatever code it wants on the page. This poses a security concern that we usually overlook for major sites.

However, another issue is tracking cookies. Sites are not able to block cookies set in such scripts. Making vine just an iframe allows scripts to that want to block all iframes also apply to vine. Since vine is defunct and only in archive mode it shouldn’t really be a holdout for scripts.