### PR TITLE
Fix fatal error on /discussions/tagged pages

### DIFF
--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -527,7 +527,7 @@ class TagModel extends Gdn_Model {
         $taggedDiscussions = $this->SQL
             ->select('td.DiscussionID')
             ->from('TagDiscussion td')
-            ->join('Tag t', 't.TagID = td.tagID')
+            ->join('Tag t', 't.TagID = td.TagID')
             ->whereIn('t.Name', $tags)
             ->limit($limit, $offset)
             ->get()->resultArray();
@@ -550,6 +550,7 @@ class TagModel extends Gdn_Model {
      * @param Gdn_SQLDriver $sql
      */
     public function setTagSql($sql, $tag, &$limit, &$offset = 0, $op = 'or') {
+        deprecated('TagModel->setTagSql()', 'TagModel->getDiscussions()', '2018-06-19');
         $sortField = 'd.DateLastComment';
         $sortDirection = 'desc';
         $tagSql = clone Gdn::sql();

--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -524,7 +524,7 @@ class TagModel extends Gdn_Model {
             $tags = array_map('trim', explode(',', $tag));
         }
 
-        $taggedDiscussions = $this->SQL
+        $taggedDiscussionIDs = $this->SQL
             ->select('td.DiscussionID')
             ->from('TagDiscussion td')
             ->join('Tag t', 't.TagID = td.TagID')
@@ -532,15 +532,18 @@ class TagModel extends Gdn_Model {
             ->limit($limit, $offset)
             ->get()->resultArray();
 
+        $taggedDiscussionIDs = array_column($taggedDiscussionIDs, 'DiscussionID');
+
         $discussionModel = new DiscussionModel();
         $discussions = $discussionModel->get(
-            $offset,
-            $limit,
+            0,
+            '',
             [
                 'Announce' => 'all',
-                'd.DiscussionID' => $taggedDiscussions,
+                'd.DiscussionID' => $taggedDiscussionIDs,
             ]
         );
+
         return $discussions;
     }
 

--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -524,7 +524,7 @@ class TagModel extends Gdn_Model {
             $tags = array_map('trim', explode(',', $tag));
         }
 
-        $taggedDiscussions = Gdn::sql()
+        $taggedDiscussions = $this->SQL
             ->select('td.DiscussionID')
             ->from('TagDiscussion td')
             ->join('Tag t', 't.TagID = td.tagID')

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -817,11 +817,7 @@ class DiscussionsController extends VanillaController {
         $this->AnnounceData = false;
         $this->setData('Announcements', [], true);
 
-        $discussionModel = new DiscussionModel();
-
-        $tagModel->setTagSql($discussionModel->SQL, $tag, $limit, $offset, $this->Request->get('op', 'or'));
-
-        $this->DiscussionData = $discussionModel->get($offset, $limit, ['Announce' => 'all']);
+        $this->DiscussionData = $tagModel->getDiscussions($tag, $limit, $offset);
 
         $this->setData('Discussions', $this->DiscussionData, true);
         $this->setJson('Loading', $offset.' to '.$limit);


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7355

You can read full scope on this in the issue above.

The `setTagSql()` method of the TagModel was used in 2 places. We deprecated it.

In the DiscussionsController, tagged() endpoint/method and in the `getDiscussions()` method of the TagModel, which is never used. From that we decided to refactor how we fetched tagged discussions for the endpoint entirely.

We are now using the refactored `getDiscussions()` method of the TagModel that wasn't used before to fetch discussions in the tagged endpoint.