### PR TITLE
Add function to anonymize IP addresses

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -57,6 +57,30 @@ if (!function_exists('absoluteSource')) {
     }
 }
 
+if (!function_exists('anonymizeIP')) {
+    /**
+     * Anonymize an IPv4 or IPv6 address.
+     *
+     * @param string $ip An IPv4 or IPv6 address.
+     * @return bool|string Anonymized IP address on success. False on failure.
+     */
+    function anonymizeIP(string $ip) {
+        $result = false;
+
+        if (filter_var($ip, FILTER_VALIDATE_IP)) {
+            // Need a packed version for bitwise operations.
+            $packed = inet_pton($ip);
+            if ($packed !== false) {
+                // Remove the last octet of an IPv4 address or the last 80 bits of an IPv6 address.
+                $mask = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? inet_pton('255.255.255.0') : inet_pton('ffff:ffff:ffff::');
+                $result = inet_ntop($packed & $mask);
+            }
+        }
+
+        return $result;
+    }
+}
+
 if (!function_exists('arrayCombine')) {
     /**
      * PHP's array_combine has a limitation that doesn't allow array_combine to work if either of the arrays are empty.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -67,12 +67,13 @@ if (!function_exists('anonymizeIP')) {
     function anonymizeIP(string $ip) {
         $result = false;
 
-        if (filter_var($ip, FILTER_VALIDATE_IP)) {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 & FILTER_FLAG_IPV6)) {
             // Need a packed version for bitwise operations.
             $packed = inet_pton($ip);
             if ($packed !== false) {
                 // Remove the last octet of an IPv4 address or the last 80 bits of an IPv6 address.
-                $mask = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? inet_pton('255.255.255.0') : inet_pton('ffff:ffff:ffff::');
+                // IP v4 addresses are 32 bits (4 bytes). IP v6 addresses are 128 bits (16 bytes).
+                $mask = strlen($packed) == 4 ? inet_pton('255.255.255.0') : inet_pton('ffff:ffff:ffff::');
                 $result = inet_ntop($packed & $mask);
             }
         }

--- a/tests/Library/Core/AnonymizeIPTest.php
+++ b/tests/Library/Core/AnonymizeIPTest.php
@@ -18,6 +18,7 @@ class AnonymizeIPTest extends \PHPUnit\Framework\TestCase {
         $result = [
             ['8.8.8.8', '8.8.8.0'],
             ['2001:4860:4860::8888', '2001:4860:4860::'],
+            ['2001:db8:85a3:0:0:8a2e:0370:7334', '2001:db8:85a3::'],
             ['1', false],
         ];
         return $result;

--- a/tests/Library/Core/AnonymizeIPTest.php
+++ b/tests/Library/Core/AnonymizeIPTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Library\Core;
+
+/**
+ * Test anonymizing IP addresses.
+ */
+class AnonymizeIPTest extends \PHPUnit\Framework\TestCase {
+
+    /**
+     * @return array
+     */
+    public function provideIPAddresses(): array {
+        $result = [
+            ['8.8.8.8', '8.8.8.0'],
+            ['2001:4860:4860::8888', '2001:4860:4860::'],
+            ['1', false],
+        ];
+        return $result;
+    }
+
+    /**
+     * @param string $ip
+     * @param string|bool $anonymized
+     * @dataProvider provideIPAddresses
+     */
+    public function testAnonymization($ip, $anonymized) {
+        $result = anonymizeIP($ip);
+        $this->assertSame($anonymized, $result);
+    }
+}

--- a/tests/Library/Core/AnonymizeIPTest.php
+++ b/tests/Library/Core/AnonymizeIPTest.php
@@ -19,6 +19,8 @@ class AnonymizeIPTest extends \PHPUnit\Framework\TestCase {
     public function provideIPAddresses(): array {
         $result = [
             ['8.8.8.8', '8.8.8.0'],
+            ['8.8.4.4', '8.8.4.0'],
+            ['192.168.1.1', '192.168.1.0'],
             ['2001:4860:4860::8888', '2001:4860:4860::'],
             ['2001:db8:85a3:0:0:8a2e:0370:7334', '2001:db8:85a3::'],
             ['1', false],

--- a/tests/Library/Core/AnonymizeIPTest.php
+++ b/tests/Library/Core/AnonymizeIPTest.php
@@ -12,6 +12,8 @@ namespace VanillaTests\Library\Core;
 class AnonymizeIPTest extends \PHPUnit\Framework\TestCase {
 
     /**
+     * Provide data for testing the anonymizeIP function.
+     *
      * @return array
      */
     public function provideIPAddresses(): array {
@@ -25,8 +27,10 @@ class AnonymizeIPTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
-     * @param string $ip
-     * @param string|bool $anonymized
+     * Test the anonymizeIP function.
+     *
+     * @param string $ip An IPv4 or IPv6 address.
+     * @param string|bool $anonymized The expected anonymized version of `$ip`.
      * @dataProvider provideIPAddresses
      */
     public function testAnonymization($ip, $anonymized) {

--- a/tests/Library/Core/AnonymizeIPTest.php
+++ b/tests/Library/Core/AnonymizeIPTest.php
@@ -23,9 +23,10 @@ class AnonymizeIPTest extends \PHPUnit\Framework\TestCase {
             ['192.168.1.1', '192.168.1.0'],
             ['2001:4860:4860::8888', '2001:4860:4860::'],
             ['2001:db8:85a3:0:0:8a2e:0370:7334', '2001:db8:85a3::'],
+            ['::1', '::'],
             ['1', false],
         ];
-        return $result;
+        return array_column($result, null, 0);
     }
 
     /**


### PR DESCRIPTION
This update adds the `anonymizeIP` function for anonymizing IP addresses. The result is based on [IP anonymization in Google Analytics](https://support.google.com/analytics/answer/2763052?hl=en).

> The IP anonymization feature in Analytics sets the last octet of IPv4 user IP addresses and the last 80 bits of IPv6 addresses to zeros [...]

If the function receives an invalid IP address, the result is `false`.