### PR TITLE
PromotedContent: fixed score type validation

### DIFF
--- a/applications/vanilla/modules/class.promotedcontentmodule.php
+++ b/applications/vanilla/modules/class.promotedcontentmodule.php
@@ -431,10 +431,7 @@ class PromotedContentModule extends Gdn_Module {
             $minScore = val('Score', $parameters, null);
         }
 
-        if (!is_integer($minScore)) {
-            $minScore = false;
-        }
-
+        $minScore = filter_var($minScore, FILTER_VALIDATE_INT);
         // Check cache
         $selectorScoreCacheKey = "modules.promotedcontent.score.{$minScore}";
         $content = Gdn::cache()->get($selectorScoreCacheKey);


### PR DESCRIPTION
Closes #7312 

When calling the promotedcontent api with a score selector, the api was returning all discussions. Validation of  $minScore was failing because of its string value. 
**To test**
api/v1/discussions/promoted.json?selector=score&selection=2
should return all discussion with score >2