### PR TITLE
Fix for colour pickers in modals

### DIFF
--- a/applications/dashboard/controllers/class.dashboardcontroller.php
+++ b/applications/dashboard/controllers/class.dashboardcontroller.php
@@ -42,6 +42,7 @@ class DashboardController extends Gdn_Controller {
         $this->addJsFile('magnific-popup.min.js');
         $this->addJsFile('jquery.autosize.min.js');
         $this->addJsFile('global.js');
+        $this->addJsFile('colorpicker.js', 'dashboard');
 
         if (in_array($this->ControllerName, ['profilecontroller', 'activitycontroller'])) {
             $this->addCssFile('style.css');

--- a/applications/dashboard/js/dashboard.js
+++ b/applications/dashboard/js/dashboard.js
@@ -553,7 +553,11 @@ var DashboardModal = (function() {
                 success: function(json) {
                     var body = json.Data;
                     var content = self.parseBody(body);
-                    $('#' + self.id).htmlTrigger(self.addContentToTemplate(content));
+                    $('#' + self.id)
+                        .htmlTrigger(self.addContentToTemplate(content))
+                        .find(".js-color-picker").each(function() {
+                        colorPicker.start($(this));
+                    });
                 }
             });
         },


### PR DESCRIPTION
Vanilla doesn't initialize colour inputs in modals. The simplest fix is just to always check for color inputs in modals in the dashboard.