### PR TITLE
Make ensureScript more robust

### DIFF
--- a/applications/dashboard/src/scripts/dom.ts
+++ b/applications/dashboard/src/scripts/dom.ts
@@ -287,6 +287,7 @@ export function convertToSafeEmojiCharacters(stringOrNode: string | Node) {
 
 // A weakmap so we can store multiple load callbacks per script.
 const loadEventCallbacks: WeakMap<Node, Array<(event) => void>> = new WeakMap();
+const rejectionCache: Map<string, Error> = new Map();
 
 /**
  * Dynamically load a javascript file.
@@ -294,6 +295,9 @@ const loadEventCallbacks: WeakMap<Node, Array<(event) => void>> = new WeakMap();
 export function ensureScript(scriptUrl: string) {
     return new Promise((resolve, reject) => {
         const existingScript: HTMLScriptElement | null = document.querySelector(`script[src='${scriptUrl}']`);
+        if (rejectionCache.has(scriptUrl)) {
+            reject(rejectionCache.get(scriptUrl));
+        }
         if (existingScript) {
             if (loadEventCallbacks.has(existingScript)) {
                 // Add another resolveCallback into the weakmap.
@@ -309,17 +313,22 @@ export function ensureScript(scriptUrl: string) {
             const script = document.createElement("script");
             script.type = "text/javascript";
             script.src = scriptUrl;
-            script.onerror = err => {
-                reject(err);
+            script.onerror = (event: ErrorEvent) => {
+                const error = new Error("Failed to load a required embed script");
+                rejectionCache.set(scriptUrl, error);
+                reject(error);
             };
 
-            setTimeout(() => {
-                reject(`Loading of the script ${scriptUrl} has timed out.`);
+            const timeout = setTimeout(() => {
+                const error = new Error(`Loading of the script ${scriptUrl} has timed out.`);
+                rejectionCache.set(scriptUrl, error);
+                reject(error);
             }, 10000);
 
             loadEventCallbacks.set(script, [resolve]);
 
             script.onload = event => {
+                clearTimeout(timeout);
                 const callbacks = loadEventCallbacks.get(script);
                 callbacks && callbacks.forEach(callback => callback(event));
                 loadEventCallbacks.delete(script);


### PR DESCRIPTION
Goes with https://github.com/vanilla/rich-editor/pull/59

Ensure script will now work far more consistently in different browsers.

Whats new:

- Rejections are cached. _Why: Firefox does not re-throw the script rejection. Additionally a timeout error will be rethrown immediately if someone tries to load the script again._
- Creates a new error instead of throwing the `ErrorEvent`. onerror(err) gives an inconsistent value for `err` in some browsers it is an `ErrorEvent`, in others its and `Error` and `ErrorEvent` itself is not consistent. Instead I'm just creating my own error.
- clears the timeout on success so an error is not unnecessarily thrown (or cached).

This can all be tested in the new embed loader PR https://github.com/vanilla/rich-editor/pull/59.