### PR TITLE
Fix broken embeds

### DIFF
--- a/applications/dashboard/src/scripts/app/user-content/embeds/twitter.ts
+++ b/applications/dashboard/src/scripts/app/user-content/embeds/twitter.ts
@@ -70,15 +70,15 @@ export async function renderTweet(element: Element, data: IEmbedData) {
 
         // Render the embed.
         const options = { conversation: "none" };
-        await window.twttr.widgets.createTweet(data.attributes.statusID, element, options);
+        window.twttr.widgets.createTweet(data.attributes.statusID, element, options).then(() => {
+            // Remove a url if there is one around.
+            const url = element.querySelector(".tweet-url");
+            if (url) {
+                url.remove();
+            }
 
-        // Remove a url if there is one around.
-        const url = element.querySelector(".tweet-url");
-        if (url) {
-            url.remove();
-        }
-
-        // Fade it in.
-        element.classList.add("twitter-card-loaded");
+            // Fade it in.
+            element.classList.add("twitter-card-loaded");
+        });
     }
 }

--- a/library/Vanilla/Quill/Blots/Embeds/ExternalBlot.php
+++ b/library/Vanilla/Quill/Blots/Embeds/ExternalBlot.php
@@ -36,7 +36,8 @@ class ExternalBlot extends AbstractBlockEmbedBlot {
     /**
      * @inheritDoc
      */
-    protected function renderContent(array $data): string {
+    protected function renderContent(array $value): string {
+        $data = $value['data'] ?? [];
         $type = $data['type'] ?? '';
         try {
             $embedRendered = $this->embedManager->renderData($data);


### PR DESCRIPTION
MUST go with https://github.com/vanilla/rich-editor/pull/59/files

Fixes:
- Broken twitter embed in safari and chrome
- Broken server rendering from https://github.com/vanilla/rich-editor/pull/59/files

## To Test

Twitter embeds should now work in safari and in firefox (if tracking protection is disabled).