### PR TITLE
Add Bookmark Discussion Integration Test

### DIFF
--- a/tests/APIv0/SmokeTest.php
+++ b/tests/APIv0/SmokeTest.php
@@ -62,6 +62,23 @@ class SmokeTest extends BaseTest {
     }
 
     /**
+     * Get a single discussion from an array of Discussions.
+     *
+     * @param array $discussions
+     * @return array $discussion
+     * @throws \Exception
+     */
+    protected function getSingleDiscussion(array $discussions): array {
+        $discussions = val('Discussions', $discussions);
+        if (empty($discussions)) {
+            throw new \Exception("There are no discussions to post to.");
+        }
+        $discussion = reset($discussions);
+
+        return $discussion;
+    }
+
+    /**
      * Test registering a user with the basic method.
      *
      * @large
@@ -384,70 +401,55 @@ class SmokeTest extends BaseTest {
     }
 
     /**
-     * Test adding a bookmark to discussion.
+     * Test adding a bookmark to a discussion.
      *
      * @depends testRegisterBasic
      * @depends testPostDiscussion
      */
-
     public function testDiscussionAddBookMark() {
         $api = $this->api();
-
         $api->setUser($this->getTestUser());
         $user = $api->getUser();
 
-
         $discussions = $this->api()->get('/discussions.json')->getBody();
-        $discussions = val('Discussions', $discussions);
-        if (empty($discussions)) {
-            throw new \Exception("There are no discussions to post to.");
-        }
-        $discussion = reset($discussions);
+        $discussion = $this->getSingleDiscussion($discussions);
         $discussionID = val('DiscussionID', $discussion);
+        $discussionName = val('Name', $discussion['Name']);
 
         $r = $api->post(
             "/discussion/bookmark/{$discussionID}/{$user['tk']}"
         );
-
         $statusCode = $r->getStatusCode();
         $this->assertEquals(200, $statusCode);
 
-        $postedBookMark = $this->api()->get("/discussion/{$discussionID}/{$discussion['Name']}.json")->getBody();
+        $postedBookMark = $this->api()->get("/discussion/{$discussionID}/{$discussionName}.json")->getBody();
         $isBookMarked = $postedBookMark['Discussion']['Bookmarked'];
         $this->assertEquals( 1, $isBookMarked);
-
     }
 
     /**
      * Test removing a bookmark from a discussion.
+     *
      * @depends testDiscussionAddBookMark
      */
-
     public function testRemoveDiscussionBookMark() {
         $api = $this->api();
-
         $api->setUser($this->getTestUser());
         $user = $api->getUser();
 
-
         $discussions = $this->api()->get('/discussions.json')->getBody();
-        $discussions = val('Discussions', $discussions);
-        if (empty($discussions)) {
-            throw new \Exception("There are no discussions to post to.");
-        }
-        $discussion = reset($discussions);
+        $discussion = $this->getSingleDiscussion($discussions);
         $discussionID = val('DiscussionID', $discussion);
+        $discussionName = val('Name', $discussion['Name']);
 
         $r = $api->post(
             "/discussion/bookmark/{$discussionID}/{$user['tk']}"
         );
-
         $statusCode = $r->getStatusCode();
         $this->assertEquals(200, $statusCode);
 
-        $postedBookMark = $this->api()->get("/discussion/{$discussionID}/{$discussion['Name']}.json")->getBody();
+        $postedBookMark = $this->api()->get("/discussion/{$discussionID}/{$discussionName}.json")->getBody();
         $isBookMarked = $postedBookMark['Discussion']['Bookmarked'];
         $this->assertEquals( 0, $isBookMarked);
-
     }
 }

--- a/tests/APIv0/SmokeTest.php
+++ b/tests/APIv0/SmokeTest.php
@@ -414,7 +414,7 @@ class SmokeTest extends BaseTest {
         $discussions = $this->api()->get('/discussions.json')->getBody();
         $discussion = $this->getSingleDiscussion($discussions);
         $discussionID = val('DiscussionID', $discussion);
-        $discussionName = val('Name', $discussion['Name']);
+        $discussionName = val('Name', $discussion);
 
         $r = $api->post(
             "/discussion/bookmark/{$discussionID}/{$user['tk']}"
@@ -440,7 +440,7 @@ class SmokeTest extends BaseTest {
         $discussions = $this->api()->get('/discussions.json')->getBody();
         $discussion = $this->getSingleDiscussion($discussions);
         $discussionID = val('DiscussionID', $discussion);
-        $discussionName = val('Name', $discussion['Name']);
+        $discussionName = val('Name', $discussion);
 
         $r = $api->post(
             "/discussion/bookmark/{$discussionID}/{$user['tk']}"

--- a/tests/APIv0/SmokeTest.php
+++ b/tests/APIv0/SmokeTest.php
@@ -382,4 +382,72 @@ class SmokeTest extends BaseTest {
 
         $api->get("categories.json?CategoryIdentifier={$categoryID}");
     }
+
+    /**
+     * Test adding a bookmark to discussion.
+     *
+     * @depends testRegisterBasic
+     * @depends testPostDiscussion
+     */
+
+    public function testDiscussionAddBookMark() {
+        $api = $this->api();
+
+        $api->setUser($this->getTestUser());
+        $user = $api->getUser();
+
+
+        $discussions = $this->api()->get('/discussions.json')->getBody();
+        $discussions = val('Discussions', $discussions);
+        if (empty($discussions)) {
+            throw new \Exception("There are no discussions to post to.");
+        }
+        $discussion = reset($discussions);
+        $discussionID = val('DiscussionID', $discussion);
+
+        $r = $api->post(
+            "/discussion/bookmark/{$discussionID}/{$user['tk']}"
+        );
+
+        $statusCode = $r->getStatusCode();
+        $this->assertEquals(200, $statusCode);
+
+        $postedBookMark = $this->api()->get("/discussion/{$discussionID}/{$discussion['Name']}.json")->getBody();
+        $isBookMarked = $postedBookMark['Discussion']['Bookmarked'];
+        $this->assertEquals( 1, $isBookMarked);
+
+    }
+
+    /**
+     * Test removing a bookmark from a discussion.
+     * @depends testDiscussionAddBookMark
+     */
+
+    public function testRemoveDiscussionBookMark() {
+        $api = $this->api();
+
+        $api->setUser($this->getTestUser());
+        $user = $api->getUser();
+
+
+        $discussions = $this->api()->get('/discussions.json')->getBody();
+        $discussions = val('Discussions', $discussions);
+        if (empty($discussions)) {
+            throw new \Exception("There are no discussions to post to.");
+        }
+        $discussion = reset($discussions);
+        $discussionID = val('DiscussionID', $discussion);
+
+        $r = $api->post(
+            "/discussion/bookmark/{$discussionID}/{$user['tk']}"
+        );
+
+        $statusCode = $r->getStatusCode();
+        $this->assertEquals(200, $statusCode);
+
+        $postedBookMark = $this->api()->get("/discussion/{$discussionID}/{$discussion['Name']}.json")->getBody();
+        $isBookMarked = $postedBookMark['Discussion']['Bookmarked'];
+        $this->assertEquals( 0, $isBookMarked);
+
+    }
 }

--- a/tests/APIv0/SmokeTest.php
+++ b/tests/APIv0/SmokeTest.php
@@ -278,6 +278,7 @@ class SmokeTest extends BaseTest {
      *
      * @depends testRegisterBasic
      * @large
+     * @return array Single discussion.
      */
     public function testPostDiscussion() {
         $api = $this->api();
@@ -410,7 +411,7 @@ class SmokeTest extends BaseTest {
 
     /**
      * Test removing a bookmark from a discussion.
-     * 
+     *
      * @depends testRegisterBasic
      * @depends testPostDiscussion
      */

--- a/tests/APIv0/SmokeTest.php
+++ b/tests/APIv0/SmokeTest.php
@@ -410,7 +410,7 @@ class SmokeTest extends BaseTest {
 
     /**
      * Test removing a bookmark from a discussion.
-
+     * 
      * @depends testRegisterBasic
      * @depends testPostDiscussion
      */

--- a/tests/APIv0/SmokeTest.php
+++ b/tests/APIv0/SmokeTest.php
@@ -430,7 +430,6 @@ class SmokeTest extends BaseTest {
         $isBookMarked = $bookMarkedDiscussion['Discussion']['Bookmarked'];
         $this->assertEquals(1, $isBookMarked);
 
-
         $r = $api->post("/discussion/bookmark/{$discussionID}/{$user['tk']}");
         $statusCode = $r->getStatusCode();
         $this->assertEquals(200, $statusCode);


### PR DESCRIPTION
These ApiV0 integrations tests, tests the users ability to a bookmark on a discussion and remove a bookmark on a discussion. The remove bookmark test (testRemoveDiscussionBookMark()) depends on the add bookmark test (testDiscussionAddBookMark()) to setup a bookmarked discussion.

closes Vanilla#7087