### PR TITLE
Replaced tabs by spaces, fix spacing, moved items to the bottom of the channel in rss.master

### DIFF
--- a/applications/dashboard/views/rss.master
+++ b/applications/dashboard/views/rss.master
@@ -1,27 +1,27 @@
 <?php echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 
 <rss version="2.0"
-	xmlns:content="http://purl.org/rss/1.0/modules/content/"
-	xmlns:dc="http://purl.org/dc/elements/1.1/"
-	xmlns:atom="http://www.w3.org/2005/Atom">
-	<channel>
-      <title><?php echo htmlspecialchars($this->Head->title()); ?></title>
-      <link><?php echo htmlspecialchars(url('/', true, true)); ?></link>
-      <pubDate><?php echo date('r'); ?></pubDate>
-      <?php
-         $this->renderAsset('RssHead');
+    xmlns:content="http://purl.org/rss/1.0/modules/content/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title><?php echo htmlspecialchars($this->Head->title()); ?></title>
+        <link><?php echo htmlspecialchars(url('/', true, true)); ?></link>
+        <pubDate><?php echo date('r'); ?></pubDate>
+        <language><?php echo Gdn::locale()->Locale; ?></language>
+        <?php
+            $this->renderAsset('RssHead');
 
-         /* Sample RSS Content:
-         <item>
-            <title>Atom-Powered Robots Run Amok</title>
-            <link>http://example.org/2003/12/13/atom03</link>
-            <guid isPermaLink="false">urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</guid>
-            <pubDate>Sat, 13 Dec 2003 18:30:02 GMT</pubDate>
-            <description>Some text.</description>
-         </item>
-         */
-         $this->renderAsset('Content');
-      ?>
-   <language><?php echo Gdn::locale()->Locale; ?></language>
+            /* Sample RSS Content:
+            <item>
+                <title>Atom-Powered Robots Run Amok</title>
+                <link>http://example.org/2003/12/13/atom03</link>
+                <guid isPermaLink="false">urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</guid>
+                <pubDate>Sat, 13 Dec 2003 18:30:02 GMT</pubDate>
+                <description>Some text.</description>
+            </item>
+            */
+            $this->renderAsset('Content');
+        ?>
    </channel>
 </rss>


### PR DESCRIPTION
Moving "items" at the bottom of the channel, as per

>According to the RSS Advisory Board's Best Practices Profile, all item elements should appear after all of the other elements in a channel.