### PR TITLE
Trigger native events for post and edit of a comment

### DIFF
--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -264,7 +264,13 @@ jQuery(document).ready(function($) {
         $('div.Information').fadeOut('fast', function() {
             $(this).remove();
         });
-        $(sender).closest('form').trigger('clearCommentForm');
+        var $form = $(sender).closest('form');
+        $form.trigger('clearCommentForm');
+
+        // Dispatch a native event for things that don't use jquery
+        var event = document.createEvent('CustomEvent');
+        event.initCustomEvent('X-ClearCommentForm', true, false, {});
+        $form[0].dispatchEvent(event);
     }
 
     // Set up paging

--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -313,6 +313,11 @@ jQuery(document).ready(function($) {
                     $(msg).afterTrigger(json.Data);
                     $(msg).hide();
                     $(document).trigger('EditCommentFormLoaded', [container]);
+
+                    // Dispatch a native event for things that don't use jquery
+                    var event = document.createEvent('CustomEvent');
+                    event.initCustomEvent('X-EditCommentFormLoaded', true, false, {});
+                    container[0].dispatchEvent(event);
                 },
                 complete: function() {
                     $(parent).find('span.TinyProgress').remove();


### PR DESCRIPTION
Required for https://github.com/vanilla/rich-editor/pull/70

This PR now fires some native events (with the same naming convention and browser compatible style as our `X-DOMContentLoaded` event which bridges our contentLoaded event).

This allows us to bridge our old js to our new ones that don't use jquery or interop directly.