### PR TITLE
Fix Vimeo urls supported

### DIFF
--- a/library/Vanilla/Embeds/VimeoEmbed.php
+++ b/library/Vanilla/Embeds/VimeoEmbed.php
@@ -32,6 +32,11 @@ class VimeoEmbed extends VideoEmbed {
 
     /**
      * @inheritdoc
+     *
+     * The current regex supports the following Vimeo Urls.
+     * https://vimeo.com/277405526
+     * https://vimeo.com/channels/staffpicks/277826934
+     * https://vimeo.com/ondemand/nature365/113009024
      */
     public function matchUrl(string $url) {
 
@@ -57,7 +62,6 @@ class VimeoEmbed extends VideoEmbed {
             if (!$matches['videoID']) {
                 throw new Exception('Unable to get video ID.', 400);
             }
-
 
             if (array_key_exists('videoID', $matches)) {
                 $data = $data ?: [];


### PR DESCRIPTION
This fix allows for the vimeo embed to support some different url types and throws an exception if the video id can't be parsed by the posted url type.  The regex was also modified to parse only the url path instead of the full url.

The is an issue open to address how we treat the fallback embed type, so that we don't have to throw an error. Vanilla#7365

Test links:

https://vimeo.com/277405526
https://vimeo.com/channels/staffpicks/277826934
https://vimeo.com/ondemand/nature365/113009024


Closes Vanilla#7405