### PR TITLE
Fixed broken soundcloud embed urls

### DIFF
--- a/applications/dashboard/src/scripts/app/user-content/embeds/soundcloud.ts
+++ b/applications/dashboard/src/scripts/app/user-content/embeds/soundcloud.ts
@@ -17,7 +17,7 @@ export async function soundCloudRenderer(elements: IEmbedElements, data: IEmbedD
     const visual = data.attributes.visual ? data.attributes.visual : "false";
 
     // Ensure this is a track.
-    if (data.attributes.track == null) {
+    if (data.attributes.postID == null) {
         throw new Error("Soundcloud embed fail, the track could not be found");
     }
 
@@ -28,12 +28,7 @@ export async function soundCloudRenderer(elements: IEmbedElements, data: IEmbedD
     iframe.setAttribute("frameborder", "no");
     iframe.setAttribute(
         "src",
-        "https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/" +
-            data.attributes.track +
-            "&visual=" +
-            showArtwork +
-            "&show_artwork=" +
-            visual,
+        data.attributes.embedUrl + data.attributes.postID + "&visual=" + showArtwork + "&show_artwork=" + visual,
     );
     contentElement.appendChild(iframe);
 }

--- a/library/Vanilla/Embeds/SoundCloudEmbed.php
+++ b/library/Vanilla/Embeds/SoundCloudEmbed.php
@@ -65,7 +65,11 @@ HTML;
 
     /**
      * Parses the oembed repsonse html for permalink and other data.
-     *
+     * SoundCloud embed types that are supports include tracks, sets and users.
+     * example urls:
+     * https://soundcloud.com/thisforbaby/lil-baby-ft-drake-yes-indeed
+     * https://soundcloud.com/uiceheidd
+     * https://soundcloud.com/liluzivert/sets/luv-is-rage-2-1
      * @param string $html The html snippet send from the oembed call.
      * @return array $data
      */

--- a/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
+++ b/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
@@ -220,14 +220,62 @@ class EmbedManagerTest extends SharedBootstrapTestCase {
                     "attributes" => [
                         "visual" => "true",
                         "showArtwork" => "true",
-                        "track" => "2F174656930",
-                        "url" => "https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/"
+                        "postID" => "2F174656930",
+                        "embedUrl" => "https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/"
                     ],
                 ],
 '<div class="embedExternal embedSoundCloud">
     <div class="embedExternal-content">
         <iframe width="100%" scrolling="no" frameborder="no"
             src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/2F174656930&amp;show_artwork=true&amp;visual=true">
+        </iframe>
+    </div>
+</div>'
+            ],
+            [
+                [
+                    "url" => "https://soundcloud.com/uiceheidd",
+                    "type" => "soundcloud",
+                    "name" => null,
+                    "body" => null,
+                    "photoUrl" => null,
+                    "height" => 300,
+                    "width" => null,
+                    "attributes" => [
+                        "visual" => "true",
+                        "showArtwork" => "true",
+                        "postID" => "330864225",
+                        "embedUrl" => "https://w.soundcloud.com/player/?url=https://api.soundcloud.com/users/"
+                    ],
+                ],
+                '<div class="embedExternal embedSoundCloud">
+    <div class="embedExternal-content">
+        <iframe width="100%" scrolling="no" frameborder="no"
+            src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/users/330864225&amp;show_artwork=true&amp;visual=true">
+        </iframe>
+    </div>
+</div>'
+            ],
+            [
+                [
+                    "url" => "https://soundcloud.com/uiceheidd/sets/juicewrld-the-mixtape",
+                    "type" => "soundcloud",
+                    "name" => null,
+                    "body" => null,
+                    "photoUrl" => null,
+                    "height" => 300,
+                    "width" => null,
+                    "attributes" => [
+                        "visual" => "true",
+                        "showArtwork" => "true",
+                        "postID" => "23ff550",
+                        "embedUrl" => "https://w.soundcloud.com/player/?url=https://api.soundcloud.com/playlists/"
+                    ],
+                ],
+                '<div class="embedExternal embedSoundCloud">
+    <div class="embedExternal-content">
+        <iframe width="100%" scrolling="no" frameborder="no"
+            src="https://w.soundcloud.com/player/?url=https://api.soundcloud.com/playlists/23ff550&amp;show_artwork=true&amp;visual=true">
         </iframe>
     </div>
 </div>'


### PR DESCRIPTION
This fix allows for SoundCloud "sets" and "user" pages to be embeddable.  The embed url is different in each case, as is the the specific id that is used.  The parsehtml function was modified to filter out whether the url is a track, set or user and returns a post id and embed url for each case.  Additional testing was added to ensure the proper response.

Test links

Closes Vanilla#7366
