### PR TITLE
Allow JPEG uploads under the API v2 media endpoint

### DIFF
--- a/applications/dashboard/controllers/api/MediaApiController.php
+++ b/applications/dashboard/controllers/api/MediaApiController.php
@@ -293,7 +293,7 @@ class MediaApiController extends AbstractApiController {
         $this->permission('Garden.Uploads.Add');
 
         $uploadSchema = new UploadedFileSchema([
-            'allowedExtensions' => array_values(ImageResizer::getTypeExt())
+            'allowedExtensions' => array_keys(ImageResizer::getExtType())
         ]);
 
         $in = $this->schema([

--- a/library/Vanilla/ImageResizer.php
+++ b/library/Vanilla/ImageResizer.php
@@ -247,6 +247,19 @@ class ImageResizer {
     }
 
     /**
+     * Return an extension-to-type map.
+     *
+     * @return array
+     */
+    public static function getExtType() {
+        $extType = array_flip(static::$typeExt);
+        if (array_key_exists('jpg', $extType)) {
+            $extType['jpeg'] = $extType['jpg'];
+        }
+        return $extType;
+    }
+
+    /**
      * Get the image type from a file extension.
      *
      * This is a convenience method for looking up an image based on a mapping of file extension names to image types.
@@ -258,11 +271,9 @@ class ImageResizer {
      */
     public function imageTypeFromExt($path) {
         $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-        if ($ext === 'jpeg') {
-            return IMAGETYPE_JPEG;
-        }
-        if ($type = array_search($ext, self::$typeExt)) {
-            return $type;
+        $extType = static::getExtType();
+        if (array_key_exists($ext, $extType)) {
+            return $extType[$ext];
         }
         throw new \InvalidArgumentException("Unknown image type for extension '$ext'.", 400);
     }

--- a/library/Vanilla/UploadedFileSchema.php
+++ b/library/Vanilla/UploadedFileSchema.php
@@ -146,10 +146,16 @@ class UploadedFileSchema extends Schema {
             if (in_array($ext, $this->getAllowedExtensions())) {
                 $result = true;
             }
+        } else {
+            $ext = null;
         }
 
         if ($result !== true) {
-            $field->addError('invalid', ['messageCode' => '{field} is not an allowed upload type.']);
+            if ($ext === null) {
+                $field->addError('invalid', ['messageCode' => '{field} does not contain a file extension.']);
+            } else {
+                $field->addError('invalid', ['messageCode' => '{field} contains an invalid file extension: {ext}.', 'ext' => $ext]);
+            }
         }
 
         return $upload;


### PR DESCRIPTION
JPG is one of the allowed extensions under the API v2 media endpoint. Its four-letter-word counterpart, JPEG, is not. This update remedies that in the following way:

1. Creates a new `getExtType` method in the `ImageResizer` class. There are at least a couple areas of Vanilla that were already performing similar functionality in separate ways, using the data obtained from the `getTypeExt` method.
1. Moves a JPEG kludge from the `imageTypeFromExt` method into `getExtType`.
1. Refactors the `imageTypeFromExt` method to use `getExtType`.
1. Refactors the POST method of the media API controller to use `ImageResizer::getExtType`.
1. Improves error messaging when an invalid file extension is detected. Currently, the message reads "... is not an allowed upload type." It will now read "... contains an invalid file extension: [extension]."

Closes #7271 