### PR TITLE
Add CodePen Embed

### DIFF
--- a/applications/dashboard/src/scripts/app/index.tsx
+++ b/applications/dashboard/src/scripts/app/index.tsx
@@ -26,6 +26,7 @@ import "./user-content/embeds/imgur";
 import "./user-content/embeds/soundcloud";
 import "./user-content/embeds/getty";
 import "./user-content/embeds/giphy";
+import "./user-content/embeds/codepen";
 
 addComponent("App", Router);
 

--- a/applications/dashboard/src/scripts/app/user-content/embeds/codepen.ts
+++ b/applications/dashboard/src/scripts/app/user-content/embeds/codepen.ts
@@ -3,7 +3,7 @@
  * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
  */
 
-import { registerEmbed, IEmbedData, FOCUS_CLASS, IEmbedElements } from "@dashboard/embeds";
+import { registerEmbed, IEmbedData, IEmbedElements } from "@dashboard/embeds";
 
 registerEmbed("codepen", codePenRenderer);
 
@@ -12,13 +12,13 @@ registerEmbed("codepen", codePenRenderer);
  */
 export async function codePenRenderer(elements: IEmbedElements, data: IEmbedData) {
     const contentElement = elements.content;
-    const height = data.height ? data.height : 300;
+    const height = data.height || 300;
     const iframe = document.createElement("iframe");
     iframe.setAttribute("id", data.attributes.id);
     iframe.setAttribute("src", data.attributes.embedUrl);
     iframe.setAttribute("height", height.toString());
-    iframe.setAttribute("class", "cp_embed_iframe");
-    iframe.setAttribute("style", data.attributes.style);
+    iframe.style.width = data.attributes.style.width;
+    iframe.style.overflow = data.attributes.style.overflow;
     iframe.setAttribute("scrolling", "no");
 
     contentElement.appendChild(iframe);

--- a/applications/dashboard/src/scripts/app/user-content/embeds/codepen.ts
+++ b/applications/dashboard/src/scripts/app/user-content/embeds/codepen.ts
@@ -1,0 +1,25 @@
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+import { registerEmbed, IEmbedData, FOCUS_CLASS, IEmbedElements } from "@dashboard/embeds";
+
+registerEmbed("codepen", codePenRenderer);
+
+/**
+ * Renders codepen embeds.
+ */
+export async function codePenRenderer(elements: IEmbedElements, data: IEmbedData) {
+    const contentElement = elements.content;
+    const height = data.height ? data.height : 300;
+    const iframe = document.createElement("iframe");
+    iframe.setAttribute("id", data.attributes.id);
+    iframe.setAttribute("src", data.attributes.embedUrl);
+    iframe.setAttribute("height", height.toString());
+    iframe.setAttribute("class", "cp_embed_iframe");
+    iframe.setAttribute("style", data.attributes.style);
+    iframe.setAttribute("scrolling", "no");
+
+    contentElement.appendChild(iframe);
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -251,6 +251,7 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\GettyEmbed::class)])
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\GiphyEmbed::class)])
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\WistiaEmbed::class)])
+    ->addCall('addEmbed', [new Reference(Vanilla\Embeds\CodePenEmbed::class)])
     ->addCall('addEmbed', [new Reference(Vanilla\Embeds\ImageEmbed::class), Vanilla\Embeds\EmbedManager::PRIORITY_LOW])
     ->setShared(true)
 

--- a/library/Vanilla/Embeds/CodePenEmbed.php
+++ b/library/Vanilla/Embeds/CodePenEmbed.php
@@ -6,8 +6,6 @@
 
 namespace Vanilla\Embeds;
 
-use Exception;
-
 /**
  * CodePen Embed.
  */
@@ -50,7 +48,6 @@ class CodePenEmbed extends Embed {
      * @inheritdoc
      */
     public function renderData(array $data): string {
-
         $height = $data['height'] ?? '';
         $embedUrl = $data['attributes']['embedUrl'] ?? '';
         $style = $data['attributes']['style'] ?? '';

--- a/library/Vanilla/Embeds/CodePenEmbed.php
+++ b/library/Vanilla/Embeds/CodePenEmbed.php
@@ -26,7 +26,7 @@ class CodePenEmbed extends Embed {
      */
     public function matchUrl(string $url) {
         $data = [];
-        $oembedData =[];
+        $oembedData = [];
 
         if ($this->isNetworkEnabled()) {
             $oembedData = $this->oembed("https://codepen.io/api/oembed?url=".urlencode($url)."&format=json");

--- a/library/Vanilla/Embeds/CodePenEmbed.php
+++ b/library/Vanilla/Embeds/CodePenEmbed.php
@@ -48,12 +48,14 @@ class CodePenEmbed extends Embed {
      * @inheritdoc
      */
     public function renderData(array $data): string {
-       $overflowValues = ['visible', 'hidden', 'scroll', 'auto', 'initial', 'inherit'];
+        $overflowValues = ['visible', 'hidden', 'scroll', 'auto', 'initial', 'inherit'];
         $height = $data['height'] ?? "";
         $embedUrl = $data['attributes']['embedUrl'] ?? "";
-        $width = is_numeric($data['attributes']['style']['width']) ? $data['attributes']['style']['width'] : "";
+        $width = $data['attributes']['style']['width'] ?? "";
+        $width = is_numeric($width) ? $width : "";
         $validWidth = ($width >= 1 && $width <= 100) ? $width : 100;
-        $overflow = in_array($data['attributes']['style']['overflow'], $overflowValues) ? $data['attributes']['style']['overflow'] : "";
+        $overflow = $data['attributes']['style']['overflow'] ?? "";
+        $overflow = in_array($overflow, $overflowValues) ? $overflow : "";
         $style = "width: ".$validWidth."%; overflow: ". $overflow.";";
         $id = $data['attributes']['id'];
 

--- a/library/Vanilla/Embeds/CodePenEmbed.php
+++ b/library/Vanilla/Embeds/CodePenEmbed.php
@@ -48,9 +48,11 @@ class CodePenEmbed extends Embed {
      * @inheritdoc
      */
     public function renderData(array $data): string {
-        $height = $data['height'] ?? '';
-        $embedUrl = $data['attributes']['embedUrl'] ?? '';
-        $style = $data['attributes']['style'] ?? '';
+        $height = $data['height'] ?? "";
+        $embedUrl = $data['attributes']['embedUrl'] ?? "";
+        $width = $data['attributes']['style']['width'] ?? "";
+        $overflow = $data['attributes']['style']['overflow'] ?? "";
+        $style = "width: ".$width."%; overflow: ". $overflow.";";
         $id = $data['attributes']['id'];
 
         $encodedHeight = htmlspecialchars($height);
@@ -61,7 +63,7 @@ class CodePenEmbed extends Embed {
         $result = <<<HTML
 <div class="embedExternal embedCodePen">
     <div class="embedExternal-content">
-        <iframe class="cp_embed_iframe" scrolling="no" id="{$encodedId}" height="{$encodedHeight}" src="{$encodedEmbedUrl}" style="{$encodedStyle}"></iframe>
+        <iframe scrolling="no" id="{$encodedId}" height="{$encodedHeight}" src="{$encodedEmbedUrl}" style="{$encodedStyle}"></iframe>
     </div>
 </div>
 HTML;
@@ -87,8 +89,9 @@ HTML;
             $data['embedUrl'] .= '?theme-id=0';
         }
 
-        if (preg_match('/style="(?<style>.*?)"/i', $html, $style)) {
-            $data['style'] = $style['style'];
+        if (preg_match('/style="width:(?<width> [0-9]+%); overflow: (?<overflow>hidden);"/i', $html, $style)) {
+            $data['style']['width'] = $style['width'] ?? '';
+            $data['style']['overflow'] = $style['overflow'] ?? '';
         }
 
         return $data;

--- a/library/Vanilla/Embeds/CodePenEmbed.php
+++ b/library/Vanilla/Embeds/CodePenEmbed.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace Vanilla\Embeds;
+
+use Exception;
+
+/**
+ * CodePen Embed.
+ */
+class CodePenEmbed extends Embed {
+
+    /** @inheritdoc */
+    protected $domains = ['codepen.io'];
+
+    /**
+     * CodePenEmbed constructor.
+     */
+    public function __construct() {
+        parent::__construct('codepen', 'image');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function matchUrl(string $url) {
+        $data = [];
+        $oembedData =[];
+
+        if ($this->isNetworkEnabled()) {
+            $oembedData = $this->oembed("https://codepen.io/api/oembed?url=".urlencode($url)."&format=json");
+        }
+
+        if ($oembedData) {
+            if (array_key_exists('html', $oembedData)) {
+                $data['attributes'] = $this->parseHtml($oembedData['html']);
+            }
+            if (array_key_exists('height', $oembedData)) {
+                $data['height'] = $oembedData['height'];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function renderData(array $data): string {
+
+        $height = $data['height'] ?? '';
+        $embedUrl = $data['attributes']['embedUrl'] ?? '';
+        $style = $data['attributes']['style'] ?? '';
+        $id = $data['attributes']['id'];
+
+        $encodedHeight = htmlspecialchars($height);
+        $encodedEmbedUrl = htmlspecialchars($embedUrl);
+        $encodedStyle = htmlspecialchars($style);
+        $encodedId = htmlspecialchars($id);
+
+        $result = <<<HTML
+<div class="embedExternal embedCodePen">
+    <div class="embedExternal-content">
+        <iframe class="cp_embed_iframe" scrolling="no" id="{$encodedId}" height="{$encodedHeight}" src="{$encodedEmbedUrl}" style="{$encodedStyle}"></iframe>
+    </div>
+</div>
+HTML;
+        return $result;
+    }
+
+    /**
+     * Parse the oembed reponse for the required data.
+     *
+     * @param string $html The data returned from the oembed call.
+     * @return array
+     */
+    private function parseHtml($html): array {
+        $data = [];
+
+        if (preg_match('/id="(?<id>[a-zA-Z0-9_-]+)"/i', $html, $id)) {
+            $data['id'] = $id['id'];
+        }
+
+        if (preg_match('/src="(?<url>https:\/\/codepen.io\/.*)\?/i', $html, $url)) {
+            $data['embedUrl'] = $url['url'];
+            //set the default theme
+            $data['embedUrl'] .='?theme-id=0';
+        }
+
+        if (preg_match('/style="(?<style>.*?)"/i', $html, $style)) {
+            $data['style'] = $style['style'];
+        }
+
+        return $data;
+    }
+}

--- a/library/Vanilla/Embeds/CodePenEmbed.php
+++ b/library/Vanilla/Embeds/CodePenEmbed.php
@@ -48,11 +48,13 @@ class CodePenEmbed extends Embed {
      * @inheritdoc
      */
     public function renderData(array $data): string {
+       $overflowValues = ['visible', 'hidden', 'scroll', 'auto', 'initial', 'inherit'];
         $height = $data['height'] ?? "";
         $embedUrl = $data['attributes']['embedUrl'] ?? "";
-        $width = $data['attributes']['style']['width'] ?? "";
-        $overflow = $data['attributes']['style']['overflow'] ?? "";
-        $style = "width: ".$width."%; overflow: ". $overflow.";";
+        $width = is_numeric($data['attributes']['style']['width']) ? $data['attributes']['style']['width'] : "";
+        $validWidth = ($width >= 1 && $width <= 100) ? $width : 100;
+        $overflow = in_array($data['attributes']['style']['overflow'], $overflowValues) ? $data['attributes']['style']['overflow'] : "";
+        $style = "width: ".$validWidth."%; overflow: ". $overflow.";";
         $id = $data['attributes']['id'];
 
         $encodedHeight = htmlspecialchars($height);

--- a/library/Vanilla/Embeds/CodePenEmbed.php
+++ b/library/Vanilla/Embeds/CodePenEmbed.php
@@ -87,7 +87,7 @@ HTML;
         if (preg_match('/src="(?<url>https:\/\/codepen.io\/.*)\?/i', $html, $url)) {
             $data['embedUrl'] = $url['url'];
             //set the default theme
-            $data['embedUrl'] .='?theme-id=0';
+            $data['embedUrl'] .= '?theme-id=0';
         }
 
         if (preg_match('/style="(?<style>.*?)"/i', $html, $style)) {

--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -386,6 +386,7 @@ class MediaTest extends AbstractAPIv2Test {
             ['https://gph.is/2sTbvh0', 'giphy'],
             ['https://media.giphy.com/media/2vqIyGV2S3HTGafbKo/giphy.gif', 'giphy'],
             ['https://vanillaforums-1.wistia.com/medias/vjidqnyg0a', 'wistia'],
+            ['https://codepen.io/cchabilall83/pen/gKymEp', 'codepen'],
         ];
 
         return $urls;

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -239,6 +239,7 @@ class Bootstrap {
             ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\GettyEmbed::class)])
             ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\GiphyEmbed::class)])
             ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\WistiaEmbed::class)])
+            ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\CodePenEmbed::class)])
             ->addCall('addEmbed', [new Reference(\Vanilla\Embeds\ImageEmbed::class), \Vanilla\Embeds\EmbedManager::PRIORITY_LOW])
             ->addCall('setNetworkEnabled', [false])
             ->setShared(true)

--- a/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
+++ b/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
@@ -8,6 +8,7 @@ namespace VanillaTests\Library\Vanilla\Embeds;
 
 use Exception;
 use Garden\Http\HttpRequest;
+use Vanilla\Embeds\CodePenEmbed;
 use Vanilla\Embeds\GettyEmbed;
 use Vanilla\Embeds\GiphyEmbed;
 use Vanilla\Embeds\ImgurEmbed;
@@ -56,6 +57,7 @@ class EmbedManagerTest extends SharedBootstrapTestCase {
             ->addEmbed(new GettyEmbed())
             ->addEmbed(new GiphyEmbed())
             ->addEmbed(new WistiaEmbed())
+            ->addEmbed(new CodePenEmbed())
             ->addEmbed(new ImageEmbed(), EmbedManager::PRIORITY_LOW)
             ->setNetworkEnabled(false);
         return $embedManager;
@@ -68,6 +70,27 @@ class EmbedManagerTest extends SharedBootstrapTestCase {
      */
     public function provideRenderedData() {
         $data = [
+            [
+                [
+                    "url" => "https://codepen.io/slafleche/pen/qYrgVx",
+                    "type" => "codepen",
+                    "name" => null,
+                    "body" => null,
+                    "photoUrl" => null,
+                    "height" => 300,
+                    "width" => null,
+                    "attributes" => [
+                        "id" => "cp_embed_qYrgVx",
+                        "embedUrl" => "https://codepen.io/slafleche/embed/preview/qYrgVx?theme-id=0",
+                        "style" => "width: 100%; overflow: hidden;",
+                    ]
+                ],
+'<div class="embedExternal embedCodePen">
+    <div class="embedExternal-content">
+        <iframe class="cp_embed_iframe" scrolling="no" id="cp_embed_qYrgVx" height="300" src="https://codepen.io/slafleche/embed/preview/qYrgVx?theme-id=0" style="width: 100%; overflow: hidden;"></iframe>
+    </div>
+</div>',
+            ],
             [
                 [
                     "url" => "https://vanillaforums.com/images/metaIcons/vanillaForums.png",

--- a/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
+++ b/tests/Library/Vanilla/Embeds/EmbedManagerTest.php
@@ -82,12 +82,15 @@ class EmbedManagerTest extends SharedBootstrapTestCase {
                     "attributes" => [
                         "id" => "cp_embed_qYrgVx",
                         "embedUrl" => "https://codepen.io/slafleche/embed/preview/qYrgVx?theme-id=0",
-                        "style" => "width: 100%; overflow: hidden;",
+                        "style" => [
+                            "width" => "100",
+                            "overflow" => "hidden",
+                        ],
                     ]
                 ],
 '<div class="embedExternal embedCodePen">
     <div class="embedExternal-content">
-        <iframe class="cp_embed_iframe" scrolling="no" id="cp_embed_qYrgVx" height="300" src="https://codepen.io/slafleche/embed/preview/qYrgVx?theme-id=0" style="width: 100%; overflow: hidden;"></iframe>
+        <iframe scrolling="no" id="cp_embed_qYrgVx" height="300" src="https://codepen.io/slafleche/embed/preview/qYrgVx?theme-id=0" style="width: 100%; overflow: hidden;"></iframe>
     </div>
 </div>',
             ],

--- a/tests/Library/Vanilla/Quill/Sanitize/ExternalEmbed/CodePenSanitizeTest.php
+++ b/tests/Library/Vanilla/Quill/Sanitize/ExternalEmbed/CodePenSanitizeTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0
+ */
+
+namespace VanillaTests\Library\Vanilla\Quill\Sanitize\ExternalEmbed;
+
+use VanillaTests\Library\Vanilla\Quill\Sanitize\SanitizeTest;
+
+class CodePenSanitizeTest extends SanitizeTest {
+
+    /**
+     * @inheritdoc
+     */
+    protected function insertContentOperations(string $content): array {
+        $operations = [
+            [
+                "insert" => [
+                    "embed-external" => [
+                        "url" => null,
+                        "type" => "codepen",
+                        "name" => null,
+                        "body" => null,
+                        "photoUrl" => null,
+                        "height" => $content,
+                        "width" => null,
+                        "attributes" => [
+                            'id' => $content,
+                            'embedUrl' => $content,
+                            'style' => $content,
+                        ],
+                    ]
+                ]
+            ],
+            ["insert" => "\n"]
+        ];
+
+        return $operations;
+    }
+}

--- a/tests/Library/Vanilla/Quill/Sanitize/ExternalEmbed/CodePenSanitizeTest.php
+++ b/tests/Library/Vanilla/Quill/Sanitize/ExternalEmbed/CodePenSanitizeTest.php
@@ -7,8 +7,42 @@
 namespace VanillaTests\Library\Vanilla\Quill\Sanitize\ExternalEmbed;
 
 use VanillaTests\Library\Vanilla\Quill\Sanitize\SanitizeTest;
+use VanillaTests\Library\Vanilla\Quill\Sanitize\CSSInjectionTrait;
 
 class CodePenSanitizeTest extends SanitizeTest {
+
+    use CSSInjectionTrait;
+
+    /**
+     * @inheritdoc
+     */
+    protected function cssOperations(string $string): array {
+        $operations = [
+            [
+                "insert" => [
+                    "embed-external" => [
+                        "url" => "http://codepen.io/example",
+                        "type" => "codepen",
+                        "name" => null,
+                        "body" => null,
+                        "photoUrl" => null,
+                        "height" => 300,
+                        "width" => null,
+                        "attributes" => [
+                            "id" => "example",
+                            "embedUrl" => "http://codepen.io/example/embed/preview",
+                            'style' => [
+                                'width' => $string,
+                                'overflow' => $string,
+                            ],
+                        ],
+                    ]
+                ]
+            ],
+            ["insert" => "\n"]
+        ];
+        return $operations;
+    }
 
     /**
      * @inheritdoc
@@ -28,7 +62,10 @@ class CodePenSanitizeTest extends SanitizeTest {
                         "attributes" => [
                             'id' => $content,
                             'embedUrl' => $content,
-                            'style' => $content,
+                            'style' => [
+                                'width' => $content,
+                                'overflow' => $content,
+                            ],
                         ],
                     ]
                 ]


### PR DESCRIPTION
This feature adds  CodePen embed functionality.

A request is made to CodePen's API endpoint, and the data returned is parsed and used to reconstruct CodePen's iframe embed.  The height, id, class, iframe src and some styles where extracted from the html code sent back in the response.  The iframe is responsive so not additional css styles are needed.  

Additional media, embed, quill tests were added.

Closes Vanilla#7408