### PR TITLE
Allow typing of state in getStore

### DIFF
--- a/applications/dashboard/src/scripts/state/getStore.ts
+++ b/applications/dashboard/src/scripts/state/getStore.ts
@@ -3,9 +3,10 @@
  * @license http://www.opensource.org/licenses/gpl-2.0.php GNU GPL v2
  */
 
-import { createStore, compose, applyMiddleware, combineReducers } from "redux";
+import { createStore, compose, applyMiddleware, combineReducers, Store } from "redux";
 import reducerRegistry from "./reducerRegistry";
 import thunk from "redux-thunk";
+import IState from "@dashboard/state/IState";
 
 // there may be an initial state to import
 const initialState = window.__INITIAL_STATE__ || {};
@@ -39,6 +40,6 @@ reducerRegistry.setChangeListener(reducers => {
     store.dispatch({ type: "RESET" });
 });
 
-export default function getStore() {
-    return store;
+export default function getStore<S = IState>() {
+    return store as Store<S>;
 }

--- a/applications/dashboard/src/scripts/state/getStore.ts
+++ b/applications/dashboard/src/scripts/state/getStore.ts
@@ -40,6 +40,6 @@ reducerRegistry.setChangeListener(reducers => {
     store.dispatch({ type: "RESET" });
 });
 
-export default function getStore<S = IState>() {
+export default function getStore<S extends IState = IState>() {
     return store as Store<S>;
 }


### PR DESCRIPTION
Allows you to optionally type the results of `getStore` as anything extending the the core state. This improves typing of `getStore` particularly for external plugins like the rich editor.

Required for https://github.com/vanilla/rich-editor/pull/77 to build properly.

