### PR TITLE
Dispatcher should to camel-case controller methods when it canonicalizes them

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -513,7 +513,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
         if ($this->methodExists($controller, $first)) {
             array_shift($pathArgs);
-            return [$first, $pathArgs];
+            return [lcfirst($first), $pathArgs];
         } elseif ($this->methodExists($controller, "x$first")) {
             array_shift($pathArgs);
             deprecated(get_class($controller)."->x$first", get_class($controller)."->$first");


### PR DESCRIPTION
This addresses an issue during a refactor of the dispatcher to support dash-case names.
When dispatcher looks up a method it should use camelCase rather than CapitalCase.
This could still cause issues with the old behavior of the dispatcher, but is more sensible.

This should fix #7364, but will need some testing.