### PR TITLE
Add Twitch Embed Unit Tests

### DIFF
--- a/library/Vanilla/Embeds/TwitchEmbed.php
+++ b/library/Vanilla/Embeds/TwitchEmbed.php
@@ -202,7 +202,7 @@ class TwitchEmbed extends VideoEmbed {
      *
      * @return string $param A filter parameter.
      */
-    public function filtersBooleanString($param): string {
+    private function filtersBooleanString($param): string {
         $param = ($param === "true") ? $param : "false";
         return $param;
     }

--- a/library/Vanilla/Embeds/TwitchEmbed.php
+++ b/library/Vanilla/Embeds/TwitchEmbed.php
@@ -21,7 +21,7 @@ class TwitchEmbed extends VideoEmbed {
     protected $domains = ['www.twitch.tv', 'clips.twitch.tv'];
 
     /** @var string */
-    private $urlType;
+    public $urlType;
 
     public function __construct()
     {
@@ -136,7 +136,7 @@ class TwitchEmbed extends VideoEmbed {
      *
      * @return string $embedUrl The url used to generate the embed.
      */
-    private function getEmbedUrl($videoID, $queryInfo = null): string {
+    public function getEmbedUrl($videoID, $queryInfo = null): string {
         $embedURL = '';
         $t ='';
         $autoplay ='';

--- a/tests/Library/Vanilla/Embeds/TwitchEmbedTest.php
+++ b/tests/Library/Vanilla/Embeds/TwitchEmbedTest.php
@@ -1,33 +1,20 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: chris
- * Date: 2018-07-10
- * Time: 11:54 AM
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
  */
 
 namespace VanillaTests\Library\Vanilla\Embeds;
 
-
-/**
- */
-namespace VanillaTests\Library\Vanilla\Embeds;
 use VanillaTests\SharedBootstrapTestCase;
-;
 use Vanilla\Embeds\TwitchEmbed;
 
-/**
- * Class TwitchEmbedTest
- *
- * @package VanillaTests\Library\Vanilla\Embeds
- */
 class TwitchEmbedTest extends SharedBootstrapTestCase {
-
     /**
      * Test the getUrlInformation method.
      *
-     * @array $data Url and urlType for the embed.
-     * @array $expected The expected video ID.
+     * @param array $data Url and urlType for the embed.
+     * @param array $expected The expected video ID.
      * @dataProvider urlProvider
      */
     public function testGetUrlInformation($data, $expected) {
@@ -39,14 +26,16 @@ class TwitchEmbedTest extends SharedBootstrapTestCase {
     }
 
     /**
-     * @param $data
-     * @param $expected
-     *  @dataProvider urlProvider
+     * Test the getEmbedUrl method.
+     *
+     * @param array $data The embed urlType, videoID and queryInfo.
+     * @param array $expected The expected embedUrl.
+     * @dataProvider urlProvider
      */
     public function testGetEmbedUrl($data, $expected) {
         $twitchEmbed = new TwitchEmbed();
         $twitchEmbed->urlType = $data['urlType'];
-        $embedURL = $twitchEmbed->getEmbedUrl($data['videoID'], $data['query']);
+        $embedURL = $twitchEmbed->getEmbedUrl($data['videoID'], $data['queryInfo']);
         $this->assertEquals($expected['embedUrl'], $embedURL);
     }
 
@@ -62,7 +51,7 @@ class TwitchEmbedTest extends SharedBootstrapTestCase {
                     "url" => "https://www.twitch.tv/collections/xV9NVtPzEhW8pg",
                     "urlType" => "collection",
                     "videoID" => "xV9NVtPzEhW8pg",
-                    "query" => null,
+                    "queryInfo" => null,
                 ],
                 [
                     "id" => "xV9NVtPzEhW8pg",
@@ -73,27 +62,51 @@ class TwitchEmbedTest extends SharedBootstrapTestCase {
                 [
                     "url" => "https://www.twitch.tv/videos/278205026",
                     "urlType" => "video",
+                    "videoID" => "278205026",
+                    "queryInfo" => null,
                 ],
                 [
                     "id" => "278205026",
+                    "embedUrl" => "https://player.twitch.tv/?video=v278205026",
+                ],
+            ],
+            [
+                [
+                    "url" => "https://www.twitch.tv/videos/278205026",
+                    "urlType" => "video",
+                    "videoID" => "278205026",
+                    "queryInfo" => [
+                        "t" => "t=01h15m50s",
+                        "autoplay" => "true"
+                    ],
+                ],
+                [
+                    "id" => "278205026",
+                    "embedUrl" => "https://player.twitch.tv/?video=v278205026&autoplay=true&t=01h15m50s",
                 ],
             ],
             [
                 [
                     "url" => "https://clips.twitch.tv/MoistWonderfulMooseRalpherZ",
                     "urlType" => "clip",
+                    "videoID" => "MoistWonderfulMooseRalpherZ",
+                    "queryInfo" => null,
                 ],
                 [
                     "id" => "MoistWonderfulMooseRalpherZ",
+                    "embedUrl" => "https://clips.twitch.tv/embed?clip=MoistWonderfulMooseRalpherZ",
                 ],
             ],
             [
                 [
                     "url" => "https://www.twitch.tv/ninja",
                     "urlType" => "channel",
+                    "videoID" => "ninja",
+                    "queryInfo" => null,
                 ],
                 [
                     "id" => "ninja",
+                    "embedUrl" => "https://player.twitch.tv/?channel=ninja",
                 ],
             ],
         ];

--- a/tests/Library/Vanilla/Embeds/TwitchEmbedTest.php
+++ b/tests/Library/Vanilla/Embeds/TwitchEmbedTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: chris
+ * Date: 2018-07-10
+ * Time: 11:54 AM
+ */
+
+namespace VanillaTests\Library\Vanilla\Embeds;
+
+
+/**
+ */
+namespace VanillaTests\Library\Vanilla\Embeds;
+use VanillaTests\SharedBootstrapTestCase;
+;
+use Vanilla\Embeds\TwitchEmbed;
+
+/**
+ * Class TwitchEmbedTest
+ *
+ * @package VanillaTests\Library\Vanilla\Embeds
+ */
+class TwitchEmbedTest extends SharedBootstrapTestCase {
+
+    /**
+     * Test the getUrlInformation method.
+     *
+     * @array $data Url and urlType for the embed.
+     * @array $expected The expected video ID.
+     * @dataProvider urlProvider
+     */
+    public function testGetUrlInformation($data, $expected) {
+        $twitchEmbed = new TwitchEmbed();
+        $urlInfo = $twitchEmbed->getUrlInformation($data['url']);
+
+        $this->assertEquals($expected['id'], $urlInfo);
+        $this->assertEquals($data['urlType'], $twitchEmbed->urlType);
+    }
+
+    /**
+     * @param $data
+     * @param $expected
+     *  @dataProvider urlProvider
+     */
+    public function testGetEmbedUrl($data, $expected) {
+        $twitchEmbed = new TwitchEmbed();
+        $twitchEmbed->urlType = $data['urlType'];
+        $embedURL = $twitchEmbed->getEmbedUrl($data['videoID'], $data['query']);
+        $this->assertEquals($expected['embedUrl'], $embedURL);
+    }
+
+    /**
+     * Data Provider for GetUrlInformation.
+     *
+     * @return array $data
+     */
+    public function urlProvider() {
+        $data = [
+            [
+                [
+                    "url" => "https://www.twitch.tv/collections/xV9NVtPzEhW8pg",
+                    "urlType" => "collection",
+                    "videoID" => "xV9NVtPzEhW8pg",
+                    "query" => null,
+                ],
+                [
+                    "id" => "xV9NVtPzEhW8pg",
+                    "embedUrl" => "https://player.twitch.tv/?collection=xV9NVtPzEhW8pg",
+                ],
+            ],
+            [
+                [
+                    "url" => "https://www.twitch.tv/videos/278205026",
+                    "urlType" => "video",
+                ],
+                [
+                    "id" => "278205026",
+                ],
+            ],
+            [
+                [
+                    "url" => "https://clips.twitch.tv/MoistWonderfulMooseRalpherZ",
+                    "urlType" => "clip",
+                ],
+                [
+                    "id" => "MoistWonderfulMooseRalpherZ",
+                ],
+            ],
+            [
+                [
+                    "url" => "https://www.twitch.tv/ninja",
+                    "urlType" => "channel",
+                ],
+                [
+                    "id" => "ninja",
+                ],
+            ],
+        ];
+        return $data;
+    }
+}


### PR DESCRIPTION
This allows for the getEmbedUrl and getUrlInformation methods in the Twitch Embed class to be test.
related to Vanilla#7406

