### PR TITLE
Fix double escaping in Quill rendering

### DIFF
--- a/library/Vanilla/Quill/Blots/CodeBlockBlot.php
+++ b/library/Vanilla/Quill/Blots/CodeBlockBlot.php
@@ -26,7 +26,7 @@ class CodeBlockBlot extends TextBlot {
      * @inheritDoc
      */
     public function render(): string {
-        $result = $this->content;
+        $result = htmlspecialchars($this->content);
 
         // Add newlines which live in the next operation.
         if ($this->nextOperation) {

--- a/library/Vanilla/Quill/Blots/TextBlot.php
+++ b/library/Vanilla/Quill/Blots/TextBlot.php
@@ -33,8 +33,6 @@ class TextBlot extends AbstractBlot {
 
         // Grab the insert text for the content.
         $this->content = $this->currentOperation["insert"] ?? "";
-        // Sanitize
-        $this->content = htmlspecialchars($this->content);
     }
 
     /**


### PR DESCRIPTION
The text blot was escaping its content on construct and on render. As a result all special characters were getting double encoded. I've fallen back to escaping just in the render. This required me to update the `CodeBlockBlot` to also escape in its render. This is the only blot that overrides `TextBlot::render()`.