### PR TITLE
Add Unit Test for SoundCloud Embed

### DIFF
--- a/library/Vanilla/Embeds/SoundCloudEmbed.php
+++ b/library/Vanilla/Embeds/SoundCloudEmbed.php
@@ -73,7 +73,7 @@ HTML;
      * @param string $html The html snippet send from the oembed call.
      * @return array $data
      */
-    private function parseResponseHtml(string $html): array {
+    public function parseResponseHtml(string $html): array {
         $data = [];
         preg_match('/(visual=(?<visual>true))/i', $html, $showVisual);
         if ($showVisual) {

--- a/tests/Library/Vanilla/Embeds/SoundCloudEmbedTest.php
+++ b/tests/Library/Vanilla/Embeds/SoundCloudEmbedTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace VanillaTests\Library\Vanilla\Embeds;
+
+use Vanilla\Embeds\SoundCloudEmbed;
+use VanillaTests\SharedBootstrapTestCase;
+
+
+class SoundCloudEmbedTest extends SharedBootstrapTestCase {
+
+    /**
+     * Test parsedHtmlResponse method.
+     *
+     * @param array $data HTML response from SoundCloud Embed.
+     * @param array $expected The expected result from the parsed html.
+     * @dataProvider htmlDataProvider
+     */
+    public function testParseHtmlResponse($data, $expected) {
+        $soundCloudEmbed = new SoundCloudEmbed();
+        $parsedHtml = $soundCloudEmbed->parseResponseHtml($data["html"]);
+        $this->assertEquals($expected, $parsedHtml);
+    }
+
+    /**
+     * Data Provider for testParseHtmlResponse.
+     *
+     * @return array $data
+     */
+    public function htmlDataProvider() {
+        $data = [
+            [
+                [
+                    "html" => "<iframe width=\"100%\" height=\"400\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F444968403&show_artwork=true\"></iframe>",
+                ],
+                [
+                    "attributes" => [
+                            "visual" => "true",
+                            "showArtwork" => "true",
+                            "postID" => "444968403",
+                            "embedUrl" => "https://w.soundcloud.com/player/?url=https://api.soundcloud.com/tracks/",
+                    ],
+                ],
+            ],
+            [
+                [
+                    "html" => "<iframe width=\"100%\" height=\"450\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Fusers%2F132790246&show_artwork=true\"></iframe>",
+                ],
+                [
+                    "attributes" => [
+                        "visual" => "true",
+                        "showArtwork" => "true",
+                        "postID" => "132790246",
+                        "embedUrl" => "https://w.soundcloud.com/player/?url=https://api.soundcloud.com/users/",
+                    ],
+                ],
+            ],
+            [
+                [
+                    "html" => "<iframe width=\"100%\" height=\"450\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F347750682&show_artwork=true\"></iframe>",
+                ],
+                [
+                    "attributes" => [
+                        "visual" => "true",
+                        "showArtwork" => "true",
+                        "postID" => "347750682",
+                        "embedUrl" => "https://w.soundcloud.com/player/?url=https://api.soundcloud.com/playlists/",
+                    ],
+                ],
+            ],
+        ];
+        return $data;
+    }
+}


### PR DESCRIPTION
This adds a test for the parsedHtmlResponse method in SoundCloud's Embed.
related to Vanilla#7406