### PR TITLE
Backport: Fix sharing discussions

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1669,8 +1669,7 @@ if (!function_exists('getRecord')) {
                 if (!$discussionModel->canView($row)) {
                     throw permissionException();
                 }
-                $row['Url'] = discussionUrl($row);
-                $row['ShareUrl'] = $row->Url;
+                $row['ShareUrl'] = $row['Url'] = discussionUrl($row);
                 break;
             case 'comment':
                 /** @var CommentModel $commentModel */


### PR DESCRIPTION
Backporting #7461

> A recent refactor moved to retrieving discussions as arrays, instead of objects, in `getRecord`. Most of the references were updated, but it looks like `ShareUrl` slipped through the cracks. This update ensures it is properly set.