### PR TITLE
Add discussionsApiController_beforeGet event in /api/v2/discussions/:id

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -223,7 +223,7 @@ class DiscussionsApiController extends AbstractApiController {
         $out = $this->schema($this->discussionSchema(), 'out');
 
         $query = $in->validate($query);
-        
+
         $this->getEventManager()->fireFilter('discussionsApiController_beforeGet', $this, $id, $query);
 
         $row = $this->discussionByID($id);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -223,6 +223,8 @@ class DiscussionsApiController extends AbstractApiController {
         $out = $this->schema($this->discussionSchema(), 'out');
 
         $query = $in->validate($query);
+        
+        $this->getEventManager()->fireFilter('discussionsApiController_beforeGet', $this, $id, $query);
 
         $row = $this->discussionByID($id);
         if (!$row) {


### PR DESCRIPTION
This allows groups to hook into /api/v2/discussions/:id and override the permissions so that group members can view secret group discussions.

related to vanilla/internal#1629
blocks vanilla/internal#1662