### PR TITLE
Add ability to expand category to index of discussions endpoint

### DIFF
--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -10,6 +10,9 @@ use Garden\Schema\Schema;
 abstract class AbstractApiController extends \Vanilla\Web\Controller {
 
     /** @var Schema */
+    private $categoryFragmentSchema;
+
+    /** @var Schema */
     private $userFragmentSchema;
 
     /** @var Schema */
@@ -43,6 +46,22 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller {
         if (array_key_exists($field, $row)) {
             $row[$field] = Gdn_Format::to($row[$field], $format) ?: '<!-- empty -->';
         }
+    }
+
+    /**
+     * Get the schema for categories joined to records.
+     *
+     * @return Schema Returns a schema.
+     */
+    public function getCategoryFragmentSchema() {
+        if ($this->categoryFragmentSchema === null) {
+            $this->categoryFragmentSchema = $this->schema([
+                'categoryID:i' => 'The ID of the category.',
+                'name:s' => 'The name of the category.',
+                'url:s' => 'Full URL to the category.',
+            ], 'CategoryFragment');
+        }
+        return $this->categoryFragmentSchema;
     }
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -830,6 +830,39 @@ class CategoryModel extends Gdn_Model {
     }
 
     /**
+     * Add multi-dimensional category data to an array.
+     *
+     * @param array $rows Results we need to associate category data with.
+     */
+    public function expandCategories(array &$rows) {
+        if (count($rows) === 0) {
+            // Nothing to do here.
+            return;
+        }
+
+        reset($rows);
+        $single = is_string(key($rows));
+
+        $populate = function(array &$row) {
+            if (array_key_exists('CategoryID', $row)) {
+                $category = self::categories($row['CategoryID']);
+                if ($category) {
+                    setValue('Category', $row, $category);
+                }
+            }
+        };
+
+        // Inject those categories.
+        if ($single) {
+            $populate($rows);
+        } else {
+            foreach ($rows as &$row) {
+                $populate($row);
+            }
+        }
+    }
+
+    /**
      * Remove categories that a user does not have permission to view.
      *
      * @param array $categoryIDs An array of categories to filter.


### PR DESCRIPTION
This update adds the ability to expand category data on rows returned in the discussions API v2 endpoint index.

1. `AbstractApiController::getCategoryFragmentSchema` has been added to implement a universal category fragment schema. This follows the same pattern as `getPostFragmentSchema` and `getUserFragmentSchema` in the same class.
1. `CategoryModel::expandCategories` has been added for joining category rows into other rows, under a "category" key. It essentially does the same thing as `UserModel::expandUsers`.
1. Support for "category" has been added to the "expand" parameter of the discussion endpoint's index.

Closes #6640