### PR TITLE
Fix query escaping throwing error when deleting a role

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -401,7 +401,7 @@ class RoleModel extends Gdn_Model {
                 ->from('UserRole ur')
                 ->join('UserRole urs', 'ur.UserID = urs.UserID')
                 ->groupBy('urs.UserID')
-                ->having('count(urs.RoleID) =', '1', true, false)
+                ->having('count(urs.RoleID) =', '1', false, false)
                 ->where('ur.RoleID', $roleID)
                 ->get()
                 ->firstRow();
@@ -742,7 +742,7 @@ class RoleModel extends Gdn_Model {
                 ->update('UserRole')
                 ->join('UserRole urs', 'UserRole.UserID = urs.UserID')
                 ->groupBy('urs.UserID')
-                ->having('count(urs.RoleID) =', '1', true, false)
+                ->having('count(urs.RoleID) =', '1', false, false)
                 ->set('UserRole.RoleID', $newRoleID)
                 ->where(['UserRole.RoleID' => $roleID])
                 ->put();


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/41

The changes to escaping broke this, even though we never needed to escape the "field" of the having clause in the first place.