### PR TITLE
Create rendering fallback for badly formatted posts.

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -2452,22 +2452,13 @@ EOT;
         $operations = json_decode($deltas, true);
         $title = t("There was an error rendering this rich post");
 
-//        $warningIcon = <<<HTML
-//<svg class="embedLinkLoader-failIcon" title="{$title}" aria-label="{$title}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-//    <title>{$title}</title>
-//    <circle cx="8" cy="8" r="8" style="fill: #f5af15"/>
-//    <circle cx="8" cy="8" r="7.5" style="fill: none;stroke: #000;stroke-opacity: 0.122"/>
-//    <path d="M11,10.4V8h2v2.4L12.8,13H11.3Zm0,4h2v2H11Z" transform="translate(-4 -4)" style="fill: #fff"/>
-//</svg>
-//HTML;
-
         if (json_last_error() !== JSON_ERROR_NONE) {
             $link = "https://docs.vanillaforums.com/help/addons/rich-editor/#why-is-my-published-post-replaced-with-there-was-an-error-rendering-this-rich-post";
-            return "<p class='userContent-error'>".$title." <a href='$link' class='icon icon-warning-sign'></a></p>";
+            return "<p class='userContent-error'>".$title." <a href='$link' rel='nofollow' title='$title' class='icon icon-warning-sign'></a></p>";
         }
 
         $parser = Gdn::getContainer()->get(Vanilla\Formatting\Quill\Parser::class);
-        $renderer = Gdn::getContainer()->get(\Vanilla\Formatting\Quill\Renderer::class);
+        $renderer = Gdn::getContainer()->get(Vanilla\Formatting\Quill\Renderer::class);
 
         $blotGroups = $parser->parse($operations);
         return $renderer->render($blotGroups);

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -2443,16 +2443,27 @@ EOT;
     /**
      * Format text from Rich editor input.
      *
-     * @param string $delta A JSON encoded array of Quill deltas.
+     * @param string $deltas A JSON encoded array of Quill deltas.
      *
      * @throws Exception - When the deltas could not be JSON decoded.
      * @return string - The rendered HTML output.
      */
     public static function rich(string $deltas): string {
         $operations = json_decode($deltas, true);
+        $title = t("There was an error rendering this rich post");
+
+//        $warningIcon = <<<HTML
+//<svg class="embedLinkLoader-failIcon" title="{$title}" aria-label="{$title}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+//    <title>{$title}</title>
+//    <circle cx="8" cy="8" r="8" style="fill: #f5af15"/>
+//    <circle cx="8" cy="8" r="7.5" style="fill: none;stroke: #000;stroke-opacity: 0.122"/>
+//    <path d="M11,10.4V8h2v2.4L12.8,13H11.3Zm0,4h2v2H11Z" transform="translate(-4 -4)" style="fill: #fff"/>
+//</svg>
+//HTML;
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new Exception("JSON decoding of rich post content has failed.");
+            $link = "https://docs.vanillaforums.com/help/addons/rich-editor/#why-is-my-published-post-replaced-with-there-was-an-error-rendering-this-rich-post";
+            return "<p class='userContent-error'>".$title." <a href='$link' class='icon icon-warning-sign'></a></p>";
         }
 
         $parser = Gdn::getContainer()->get(Vanilla\Formatting\Quill\Parser::class);


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7057

When a post fails to decode properly, instead of throwing an exception, we now are returning some alternative post content. In this case a message that the post could not be rendered and an warning icon that links to our Rich Editor doc. @tburry Said our vanillicon icon was fine for this purpose.

This doc isn't written yet so I've scaffolded out a doc based on the advanced editor. https://github.com/vanilla/docs/pull/292/files#diff-515d6632463f089e470986f0331af87aR117

**After**
![image](https://user-images.githubusercontent.com/1770056/43006962-04e98552-8c05-11e8-8296-d777c0b49828.png)

## To trigger this error

1. Change the DB content of a `Rich` format post to something that isn't JSON. Adding some trailing slashes or characters should do the trick.