### PR TITLE
Fix/revert backport 7451

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -151,7 +151,7 @@ class DiscussionsController extends VanillaController {
 
         // Check for individual categories.
         $categoryIDs = $this->getCategoryIDs();
-        $where = $announcementsWhere = [];
+        $where = [];
         if ($this->data('Followed')) {
             $followedCategories = array_keys($categoryModel->getFollowed(Gdn::session()->UserID));
             $visibleCategoriesResult = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
@@ -162,7 +162,7 @@ class DiscussionsController extends VanillaController {
             }
             $where['d.CategoryID'] = $visibleFollowedCategories;
         } elseif ($categoryIDs) {
-            $where['d.CategoryID'] = $announcementsWhere['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
+            $where['d.CategoryID'] = CategoryModel::filterCategoryPermissions($categoryIDs);
         } else {
             $visibleCategoriesResult = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
             if ($visibleCategoriesResult !== true) {
@@ -182,7 +182,7 @@ class DiscussionsController extends VanillaController {
         $this->setData('CountDiscussions', $CountDiscussions);
 
         // Get Announcements
-        $this->AnnounceData = $Offset == 0 ? $DiscussionModel->getAnnouncements($announcementsWhere) : false;
+        $this->AnnounceData = $Offset == 0 ? $DiscussionModel->getAnnouncements($where) : false;
         $this->setData('Announcements', $this->AnnounceData !== false ? $this->AnnounceData : [], true);
 
         // Get Discussions

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -151,8 +151,6 @@ class DiscussionsController extends VanillaController {
 
         // Check for individual categories.
         $categoryIDs = $this->getCategoryIDs();
-        // Fix to segregate announcement conditions until announcement caching has been reworked.
-        // See https://github.com/vanilla/vanilla/issues/7241
         $where = $announcementsWhere = [];
         if ($this->data('Followed')) {
             $followedCategories = array_keys($categoryModel->getFollowed(Gdn::session()->UserID));

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -334,7 +334,7 @@ class DiscussionModel extends Gdn_Model {
      */
     public function discussionSummaryQuery($additionalFields = [], $join = true) {
         // Verify permissions (restricting by category if necessary)
-        $perms = CategoryModel::instance()->getVisibleCategoryIDs(['filterHideDiscussions' => true]);
+        $perms = self::categoryPermissions();
 
         if ($perms !== true) {
             $this->SQL->whereIn('d.CategoryID', $perms);


### PR DESCRIPTION
Original PR https://github.com/vanilla/vanilla/pull/7240
Backport PR https://github.com/vanilla/vanilla/pull/7451

We need to revert this on 2.6 as it's breaking announcements in groups and also breaking bookmarks. Both aren't showing on the pages at all when they should. I think we are missing some requirements, perhaps some other stuff needs to be backported as well for this to work properly.