### PR TITLE
Add the AfterSaveCategory event

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3016,7 +3016,9 @@ class CategoryModel extends Gdn_Model {
             // Force the user permissions to refresh.
             Gdn::userModel()->clearPermissions();
 
-            // $this->rebuildTree();
+            // Let the world know we succeeded in our mission.
+            $this->EventArguments['CategoryID'] = $CategoryID;
+            $this->fireEvent('AfterSaveCategory');
         } else {
             $CategoryID = false;
         }


### PR DESCRIPTION
Allow an event to hook after a category has been successfully saved, thus providing the CategoryID that is lacking in the `Before` call. I also deleted old commented code at the same line as where this event belonged.