### PR TITLE
Improve rich editor rendering error html

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -2454,7 +2454,7 @@ EOT;
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             $link = "https://docs.vanillaforums.com/help/addons/rich-editor/#why-is-my-published-post-replaced-with-there-was-an-error-rendering-this-rich-post";
-            return "<p class='userContent-error'>".$title." <a href='$link' rel='nofollow' title='$title' class='icon icon-warning-sign'></a></p>";
+            return "<div class='DismissMessage Warning userContent-error'>$title <a href='$link' rel='nofollow' title='$title'><span class='icon icon-warning-sign userContent-errorIcon'></span></a></div>";
         }
 
         $parser = Gdn::getContainer()->get(Vanilla\Formatting\Quill\Parser::class);


### PR DESCRIPTION
This PR updates the HTML of our rich editor post rendering error to use some CSS classes from used by our notifications and warnings/and notes.

Eg. From warnings and notes
![image](https://user-images.githubusercontent.com/1770056/43152966-003644aa-8f3e-11e8-96aa-c1c3abe92e74.png)

---

## Changes
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/1770056/43152875-bfc4dac6-8f3d-11e8-920b-d8cd3b2be49c.png)|![image](https://user-images.githubusercontent.com/1770056/43152896-d0df0dd6-8f3d-11e8-8b83-d5082e82bb49.png)|
