### PR TITLE
Add new mention notifications and tests

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1241,7 +1241,12 @@ class CommentModel extends Gdn_Model {
             }
 
             // Notify any users who were mentioned in the comment.
-            $Usernames = getMentions($Fields['Body']);
+            if ($Fields['Format'] === 'Rich') {
+                $Usernames = Gdn_Format::getRichMentionUsernames($Fields['Body']);
+            } else {
+                $Usernames = getMentions($Fields['Body']);
+            }
+
             $userModel = Gdn::userModel();
             foreach ($Usernames as $i => $Username) {
                 $User = $userModel->getByUsername($Username);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2188,7 +2188,11 @@ class DiscussionModel extends Gdn_Model {
                     }
 
                     // Notify all of the users that were mentioned in the discussion.
-                    $usernames = getMentions($discussionName.' '.$story);
+                    if ($fields['Format'] === "Rich") {
+                        $usernames = Gdn_Format::getRichMentionUsernames($fields['Body']);
+                    } else {
+                        $usernames = getMentions($discussionName.' '.$story);
+                    }
 
                     // Use our generic Activity for events, not mentions
                     $this->EventArguments['Activity'] = $activity;

--- a/library/Vanilla/Formatting/Quill/BlotGroup.php
+++ b/library/Vanilla/Formatting/Quill/BlotGroup.php
@@ -146,6 +146,29 @@ class BlotGroup {
     }
 
     /**
+     * Get all of the mention blots in the group.
+     *
+     * Mentions that are inside of Blockquote's are excluded. We don't want to be sending notifications when big quote
+     * replies build up.
+     *
+     * @return string[]
+     */
+    public function getMentionUsernames() {
+        if ($this->getBlotForSurroundingTags() instanceof Blots\Lines\BlockquoteLineBlot) {
+            return [];
+        }
+
+        $names = [];
+        foreach ($this->blots as $blot) {
+            if ($blot instanceof Blots\Embeds\MentionBlot) {
+                $names[] = $blot->getUsername();
+            }
+        }
+
+        return $names;
+    }
+
+    /**
      * Add a blot to this block.
      *
      * @param AbstractBlot $blot

--- a/library/Vanilla/Formatting/Quill/Blots/Embeds/MentionBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Embeds/MentionBlot.php
@@ -12,12 +12,25 @@ namespace Vanilla\Formatting\Quill\Blots\Embeds;
  */
 class MentionBlot extends AbstractInlineEmbedBlot {
 
+    /** @var string */
+    private $username;
+
     /**
      * Prepend an @ onto the text content of the blot.
      */
     public function __construct(array $currentOperation, array $previousOperation, array $nextOperation) {
         parent::__construct($currentOperation, $previousOperation, $nextOperation);
-        $this->content = "@".$this->content;
+        $this->username = $this->content;
+        $this->content = "@".$this->username;
+    }
+
+    /**
+     * Return the username for the mention.
+     *
+     * @return string
+     */
+    public function getUsername(): string {
+        return $this->username;
     }
 
     /**

--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -50,15 +50,18 @@ class Parser {
 
     /**
      * Register all of the built in blots and formats to parse. Primarily for use in bootstrapping.
+     *
+     * The embeds NEED to be first here, otherwise something like a blockquote with only a mention in it will
+     * match only as a blockquote instead of as a mention.
      */
     public function addCoreBlotsAndFormats() {
         $this
-            ->addBlot(Blots\Lines\SpoilerLineBlot::class)
-            ->addBlot(Blots\Lines\BlockquoteLineBlot::class)
-            ->addBlot(Blots\Lines\ListLineBlot::class)
             ->addBlot(Blots\Embeds\ExternalBlot::class)
             ->addBlot(Blots\Embeds\MentionBlot::class)
             ->addBlot(Blots\Embeds\EmojiBlot::class)
+            ->addBlot(Blots\Lines\SpoilerLineBlot::class)
+            ->addBlot(Blots\Lines\BlockquoteLineBlot::class)
+            ->addBlot(Blots\Lines\ListLineBlot::class)
             ->addBlot(Blots\CodeBlockBlot::class)
             ->addBlot(Blots\HeadingBlot::class)
             ->addBlot(Blots\TextBlot::class)// This needs to be the last one!!!
@@ -95,6 +98,25 @@ class Parser {
         return $this->createBlotGroups($operations);
     }
 
+    /**
+     * Parse out the usernames of everyone mentioned in a post.
+     *
+     * @param array $operations
+     * @return string[]
+     */
+    public function parseMentionUsernames(array $operations): array {
+        if (!in_array(Blots\Embeds\MentionBlot::class, $this->blotClasses)) {
+            return [];
+        }
+
+        $blotGroups = $this->parse($operations);
+        $mentionUsernames = [];
+        foreach ($blotGroups as $blotGroup) {
+            $mentionUsernames = array_merge($mentionUsernames, $blotGroup->getMentionUsernames());
+        }
+
+        return $mentionUsernames;
+    }
 
     /**
      * Get the matching blot for a sequence of operations. Returns the default if no match is found.

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -2465,6 +2465,27 @@ EOT;
     }
 
     /**
+     * Get the usernames mention in a rich post.
+     *
+     * @param string $body The contents of a post body.
+     *
+     * @return string[]
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
+     */
+    public static function getRichMentionUsernames(string $body): array {
+        /** @var \Vanilla\Formatting\Quill\Parser $parser */
+        $parser = Gdn::getContainer()->get(\Vanilla\Formatting\Quill\Parser::class);
+        $operations = json_decode($body, true);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            return $parser->parseMentionUsernames($operations);
+        } else {
+            return [];
+        }
+    }
+
+    /**
      * Encode special CSS characters as hex.
      *
      * @param string $string

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -129,4 +129,39 @@ class ParserTest extends SharedBootstrapTestCase {
             ],
         ];
     }
+
+    /**
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
+     */
+    public function testParseMentions() {
+        $ops = [
+            ["insert" => "\n\n@totoallyNotAMention asdf @notAMention"],
+            $this->makeMention("realMention"),
+            $this->makeMention("Some Other meénetioön 🙃"),
+            $this->makeMention("realMention$$.asdf Number 2"),
+            ["insert" => "\n"],
+            $this->makeMention("@mentionInABlockquote"),
+            ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
+        ];
+
+        $expectedUsernames = [
+            "realMention",
+            "Some Other meénetioön 🙃",
+            "realMention$$.asdf Number 2",
+        ];
+
+        /** @var Parser $parser */
+        $parser = \Gdn::getContainer()->get(Parser::class);
+        $actualUsernames = $parser->parseMentionUsernames($ops);
+        $this->assertSame($expectedUsernames, $actualUsernames);
+    }
+
+    private function makeMention(string $name) {
+        return ["insert" => [
+            "mention" => [
+                "name" => $name,
+            ],
+        ]];
+    }
 }


### PR DESCRIPTION
Closes https://github.com/vanilla/rich-editor/issues/65

Acceptance criteria are in the issue.

Implements mention notifications for the Quill rendered mentions for discussions and comments.

## Manual testing

Create posts and comments with mentions using the Rich Editor and verify that the notifications are sent according to the acceptance criteria of the original issue.

## Implementation Details

I've opted to add another parse method to the Quill parser `parseMentions`. Additionally there is an other utility method added to `Gdn_Format` (soon to be `\Vanilla\Formatting\FormatUtility`) to instantiate the parser, do a json decode, and return the names. This will get an array of usernames mentioned in a post. This is then conditionally used in the CommentModel and DiscussionModel, instead of our global `getMentions`.

`getMentions()` is not passed the format, and I don't feel our global functions should be instantiating a quill parser, which is why I've opted to it this way. I could not find other usages of `getMentions()`. All other aspects of mention handling remains as part of our old system.