### PR TITLE
Fix bootstrapping issues in ValidationTest

### DIFF
--- a/tests/Library/Core/ValidationTest.php
+++ b/tests/Library/Core/ValidationTest.php
@@ -8,13 +8,13 @@
 namespace VanillaTests\Library\Core;
 
 use Gdn_Validation;
-use PHPUnit\Framework\TestCase;
+use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Invalid;
 
 /**
  * Tests for the **Gdn_Validation** object.
  */
-class ValidationTest extends TestCase {
+class ValidationTest extends SharedBootstrapTestCase {
 
     /**
      * Test the ability to validate a post body's formatting.


### PR DESCRIPTION
The build began failing after #7230 was merged, because it was a months-old branch and recent changes were made to bootstraping and tests. This update implements those changes in this old test class to restore the build.