### PR TITLE
Fix /api/v2/media/scrape requests not sending valid user agent when scraping

### DIFF
--- a/library/Vanilla/PageScraper.php
+++ b/library/Vanilla/PageScraper.php
@@ -101,6 +101,7 @@ class PageScraper {
         }
 
         $this->httpRequest->setMethod(HttpRequest::METHOD_GET);
+        $this->httpRequest->setHeader('User-Agent', $this->userAgent());
         $this->httpRequest->setUrl($url);
         $result = $this->httpRequest->send();
         return $result;
@@ -178,5 +179,15 @@ class PageScraper {
     public function registerMetadataParser(Parser $parser) {
         $this->metadataParsers[] = $parser;
         return $this->metadataParsers;
+    }
+
+    /**
+     * User agent to identify the client to remote services.
+     *
+     * @return string
+     */
+    private function userAgent() {
+        $version = defined('APPLICATION_VERSION') ? APPLICATION_VERSION : '0.0';
+        return "Vanilla/{$version}";
     }
 }


### PR DESCRIPTION
`PageScraper` was not sending a user agent along with its requests. This caused some sites (e.g. Facebook) to reject requests with an "upgrade your browser" message. A user agent is now sent along with the request. Facebook no longer rejects requests with this particular error.

Closes #7529