### PR TITLE
Fix translations from the locales API endpoint not being cacheable

### DIFF
--- a/library/Garden/Web/ResourceRoute.php
+++ b/library/Garden/Web/ResourceRoute.php
@@ -114,10 +114,16 @@ class ResourceRoute extends Route {
      * Convert a dash-cased name into capital case.
      *
      * @param string $name The name to convert.
+     * @param bool $ext Whether or not to look for a file extension.
      * @return string Returns the filtered name.
      */
-    private function filterName($name) {
+    private function filterName($name, bool $ext = false) {
         $result = implode('', array_map('ucfirst', explode('-', $name)));
+
+        // Get the extension too.
+        if ($ext && $pos = strrpos($result, '.')) {
+            $result[$pos] = '_';
+        }
         return $result;
     }
 
@@ -379,7 +385,7 @@ class ResourceRoute extends Route {
         $result = [];
 
         if (isset($pathArgs[0])) {
-            $name = lcfirst($this->filterName($pathArgs[0]));
+            $name = lcfirst($this->filterName($pathArgs[0], count($pathArgs) === 1));
             $result[] = ["{$method}_{$name}", 0];
 
             if ($method === 'get') {
@@ -387,7 +393,7 @@ class ResourceRoute extends Route {
             }
         }
         if (isset($pathArgs[1])) {
-            $name = lcfirst($this->filterName($pathArgs[1]));
+            $name = lcfirst($this->filterName($pathArgs[1], count($pathArgs) === 2));
             $result[] = ["{$method}_{$name}", 1];
 
             if ($method === 'get') {

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1878,7 +1878,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
                 // Add the client-side translations.
                 // This is done in the controller rather than the asset model because the translations are not linked to compiled code.
-                $this->Head->addScript(url('/api/v2/locales/'.rawurlencode(Gdn::locale()->current())."/translations?js=1&x-cache=1&h=$busta", true), 'text/javascript', false, ['defer' => 'true']);
+                $this->Head->addScript(url('/api/v2/locales/'.rawurlencode(Gdn::locale()->current())."/translations.js?etag=$busta", true), 'text/javascript', false, ['defer' => 'true']);
 
                 $polyfillContent = $AssetModel->getInlinePolyfillJSContent();
                 $this->Head->addScript(null, null, false, ["content" => $polyfillContent]);

--- a/tests/Library/Garden/Web/ResourceRouteTest.php
+++ b/tests/Library/Garden/Web/ResourceRouteTest.php
@@ -103,6 +103,10 @@ class ResourceRouteTest extends SharedBootstrapTestCase {
             'bad index' => ['GET', '/discussions/index', null],
             'bad get' => ['GET', '/discussions/get/123', null],
             'bad post' => ['PATCH', '/discussions/post', null],
+
+            // File extensions.
+            'foo.js' => ['GET', '/discussions/123/foo.js', [$dc, 'get_foo_js'], ['id' => '123']],
+            'foos.js' => ['GET', '/discussions/foos.js', [$dc, 'index_foos_js'], []],
         ];
 
         return $r;

--- a/tests/fixtures/src/DiscussionsController.php
+++ b/tests/fixtures/src/DiscussionsController.php
@@ -122,4 +122,12 @@ class DiscussionsController {
     public function index_idsub($id) {
 
     }
+
+    public function get_foo_js($id) {
+
+    }
+
+    public function index_foos_js() {
+
+    }
 }


### PR DESCRIPTION
- Modify the router to define endpoints with file extensions. Adding a .js file extension to a URL gets Varnish to kick in its caching.
- Send back appropriate cache control headers for translations.