### PR TITLE
Fix parser errors in Quill renderer

### DIFF
--- a/library/Vanilla/Formatting/Quill/BlotGroup.php
+++ b/library/Vanilla/Formatting/Quill/BlotGroup.php
@@ -207,16 +207,20 @@ class BlotGroup {
             return null;
         }
         $blot = $this->blots[0];
+        $overridingBlot = $this->getOverridingBlot();
 
+        return $overridingBlot ?? $blot;
+    }
+
+    public function getOverridingBlot() {
         foreach ($this->overridingBlots as $overridingBlot) {
             $index = $this->getIndexForBlotOfType($overridingBlot);
             if ($index >= 0) {
-                $blot = $this->blots[$index];
-                break;
+                return $this->blots[$index];
             }
         }
 
-        return $blot;
+        return null;
     }
 
     /**

--- a/library/Vanilla/Formatting/Quill/BlotGroup.php
+++ b/library/Vanilla/Formatting/Quill/BlotGroup.php
@@ -207,12 +207,17 @@ class BlotGroup {
             return null;
         }
         $blot = $this->blots[0];
-        $overridingBlot = $this->getOverridingBlot();
+        $overridingBlot = $this->getPrimaryBlot();
 
         return $overridingBlot ?? $blot;
     }
 
-    public function getOverridingBlot() {
+    /**
+     * Get the primary blot for the group.
+     *
+     * @return null|AbstractBlot
+     */
+    public function getPrimaryBlot() {
         foreach ($this->overridingBlots as $overridingBlot) {
             $index = $this->getIndexForBlotOfType($overridingBlot);
             if ($index >= 0) {

--- a/library/Vanilla/Formatting/Quill/Blots/HeadingBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/HeadingBlot.php
@@ -29,7 +29,7 @@ class HeadingBlot extends TextBlot {
      * @throws \Exception
      */
     public function getGroupOpeningTag(): string {
-        return "<h" . $this->getHeadingLevel() . ">";
+        return "<h".$this->getHeadingLevel().">";
     }
 
     /**
@@ -37,7 +37,7 @@ class HeadingBlot extends TextBlot {
      * @throws \Exception
      */
     public function getGroupClosingTag(): string {
-        return "</h" . $this->getHeadingLevel() . ">";
+        return "</h".$this->getHeadingLevel().">";
     }
 
     /**
@@ -54,11 +54,11 @@ class HeadingBlot extends TextBlot {
      * @throws \Exception if the level is not a valid integer.
      */
     private function getHeadingLevel(): int {
-        // Heading attributes live in the next operation.
-        $level = $this->nextOperation["attributes"]["header"] ?? null;
-        if (!in_array($level, self::$validLevels)) {
-            throw new \Exception("Invalid heading level");
-        }
-        return $level;
+        $defaultLevel = 2;
+        // Heading attributes generally live in the next operation.
+        // For empty headings there is only one operation, so it could be in the current op.
+        return $this->hasConsumedNextOp()
+                ? $this->nextOperation["attributes"]["header"] ?? $defaultLevel
+                : $this->currentOperation["attributes"]["header"] ?? $defaultLevel;
     }
 }

--- a/library/Vanilla/Formatting/Quill/Blots/Lines/AbstractLineBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Lines/AbstractLineBlot.php
@@ -7,6 +7,7 @@
 
 namespace Vanilla\Formatting\Quill\Blots\Lines;
 
+use Vanilla\Formatting\Quill\BlotGroup;
 use Vanilla\Formatting\Quill\Blots\TextBlot;
 
 /**
@@ -35,6 +36,21 @@ abstract class AbstractLineBlot extends TextBlot {
         }
 
         return $result;
+    }
+
+    /**
+     * If the group already has an overriding blot and it is not the same type as this blot, we start a new group.
+     *
+     * @param BlotGroup $group The group to check.
+     * @return bool
+     */
+    public function shouldClearCurrentGroup(BlotGroup $group): bool {
+        $overridingBlot = $group->getOverridingBlot();
+        if ($overridingBlot) {
+            return get_class($overridingBlot) !== get_class($this);
+        } else {
+            return parent::shouldClearCurrentGroup($group);
+        }
     }
 
     /**

--- a/library/Vanilla/Formatting/Quill/Blots/Lines/AbstractLineBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Lines/AbstractLineBlot.php
@@ -45,7 +45,7 @@ abstract class AbstractLineBlot extends TextBlot {
      * @return bool
      */
     public function shouldClearCurrentGroup(BlotGroup $group): bool {
-        $overridingBlot = $group->getOverridingBlot();
+        $overridingBlot = $group->getPrimaryBlot();
         if ($overridingBlot) {
             return get_class($overridingBlot) !== get_class($this);
         } else {

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -7,159 +7,234 @@
 
 namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
+use SebastianBergmann\CodeCoverage\Report\Text;
 use Vanilla\Formatting\Quill\Blots\Embeds\ExternalBlot;
 use Vanilla\Formatting\Quill\Blots\HeadingBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\BlockquoteLineBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\ListLineBlot;
+use Vanilla\Formatting\Quill\Blots\Lines\SpoilerLineBlot;
+use Vanilla\Formatting\Quill\Blots\NullBlot;
 use Vanilla\Formatting\Quill\Blots\TextBlot;
 use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Formatting\Quill\Parser;
 
 class ParserTest extends SharedBootstrapTestCase {
+
     /**
-     * @dataProvider dataProvider
-     * @throws \Garden\Container\ContainerException
-     * @throws \Garden\Container\NotFoundException
+     * @param array $ops
+     * @param array $expected
      */
-    public function testParse($ops, $expected) {
-        $parser = \Gdn::getContainer()->get(Parser::class);
-        $actual = $parser->parseIntoTestData($ops);
-        $this->assertSame($expected, $actual);
+    public function assertParseResults(array $ops, array $expected) {
+        $error = "The parser failed to instantiate through the container";
+        try {
+            $parser = \Gdn::getContainer()->get(Parser::class);
+        } catch (\Exception $e) {
+            $this->fail($error);
+        }
+
+        if ($parser) {
+            $actual = $parser->parseIntoTestData($ops);
+            $this->assertSame($expected, $actual);
+        } else {
+            $this->fail($error);
+        }
     }
 
-    public function dataProvider() {
-        return [
-            [
-                [[
-                    "insert" => [
-                        "embed-external" => [
-                            "url" => "https://vanillaforums.com/images/metaIcons/vanillaForums.png",
-                            "type" => "image",
-                            "name" => null,
-                            "body" => null,
-                            "photoUrl" => "https://vanillaforums.com/images/metaIcons/vanillaForums.png",
-                            "height" => 630,
-                            "width" => 1200,
-                            "attributes" => [],
-                        ],
-                    ],
-                ]],
-                [
-                    [["class" => ExternalBlot::class, "content" => ""]],
+    public function testParseExternalBlot() {
+        $ops = [[
+            "insert" => [
+                "embed-external" => [
+                    "url" => "https://vanillaforums.com/images/metaIcons/vanillaForums.png",
+                    "type" => "image",
+                    "name" => null,
+                    "body" => null,
+                    "photoUrl" => "https://vanillaforums.com/images/metaIcons/vanillaForums.png",
+                    "height" => 630,
+                    "width" => 1200,
+                    "attributes" => [],
                 ],
             ],
-            [
-                [["insert" => "\n"]],
-                [], // A plain newline is an empty editor.
-            ],
-            [
-                [["insert" => "SomeText\n"]],
-                [
-                    [["class" => TextBlot::class, "content" => "SomeText"]],
-                ],
-            ],
-            [
-                [["insert" => "Sometext\n\n\nAfter3lines\n\n"]],
-                [
-                    [["class" => TextBlot::class, "content" => "Sometext"]],
-                    [["class" => TextBlot::class, "content" => "\n"]],
-                    [["class" => TextBlot::class, "content" => "\n"]],
-                    [["class" => TextBlot::class, "content" => "After3lines"]],
-                    [["class" => TextBlot::class, "content" => "\n"]],
-                ],
-            ],
-            [
-                [
-                    ["insert" => "Line 1"],
-                    ["attributes" => ["blockquote-line" => true], "insert" => "\n\n"],
-                    ["insert" => "Line 3"],
-                    ["attributes" => ["blockquote-line" => true], "insert" => "\n\n\n\n"],
-                    ["insert" => "Line 7"],
-                    ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
-                    ["insert" => "Normal Text\nSome other text"],
-                ],
-                [
-                    [
-                        ["class" => BlockquoteLineBlot::class, "content" => "Line 1"],
-                        ["class" => BlockquoteLineBlot::class, "content" => "Line 3"],
-                        ["class" => BlockquoteLineBlot::class, "content" => "Line 7"],
-                    ],
-                    [["class" => TextBlot::class, "content" => "Normal Text"]],
-                    [["class" => TextBlot::class, "content" => "Some other text"]],
-                ],
-            ],
-            [
-                [
-                    ["insert" => "Line 1"],
-                    ["attributes" => ["blockquote-line" => true], "insert" => "\n\n"],
-                    ["insert" => "Line 3"],
-                    ["attributes" => ["blockquote-line" => true], "insert" => "\n\n\n\n"],
-                    ["insert" => "Line 7"],
-                    ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
-                    ["insert" => "Normal Text\n"],
-                ],
-                [
-                    [
-                        ["class" => BlockquoteLineBlot::class, "content" => "Line 1"],
-                        ["class" => BlockquoteLineBlot::class, "content" => "Line 3"],
-                        ["class" => BlockquoteLineBlot::class, "content" => "Line 7"],
-                    ],
-                    [["class" => TextBlot::class, "content" => "Normal Text"]],
-                ],
-            ],
-            [
-                [
-                    ["attributes" => ["link" => "https =>//google.com"], "insert" => "ogl"],
-                    ["insert" => "\n\nText after line breaks."],
-                    ["attributes" => ["strike" => true], "insert" => "strike"],
-                    ["insert" => "\n\n\n\n"],
-                    ["attributes" => ["strike" => true], "insert" => "Mutliple more breaks."],
-                    ["insert" => "\n"],
-                ],
-                [
-                    [["class" => TextBlot::class, "content" => "ogl"]],
-                    [["class" => TextBlot::class, "content" => "\n"]],
-                    [
-                        ["class" => TextBlot::class, "content" => "Text after line breaks."],
-                        ["class" => TextBlot::class, "content" => "strike"],
-                    ],
-                    [["class" => TextBlot::class, "content" => "\n"]],
-                    [["class" => TextBlot::class, "content" => "\n"]],
-                    [["class" => TextBlot::class, "content" => "\n"]],
-                    [["class" => TextBlot::class, "content" => "Mutliple more breaks."]],
-                ],
-            ],
-            [
-                [
-                    ["insert" => "Quote"],
-                    ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
-                    ["insert" => "Quote"],
-                    ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
-                    ["insert" => "List"],
-                    ["attributes" => ["list" => "bullet"], "insert" => "\n"],
-                    ["insert" => "List"],
-                    ["attributes" => ["list" => "bullet"], "insert" => "\n"],
-                ],
-                [
-                    [
-                        ["class" => BlockquoteLineBlot::class, "content" => "Quote"],
-                        ["class" => BlockquoteLineBlot::class, "content" => "Quote"],
-                    ],
-                    [
-                        ["class" => ListLineBlot::class, "content" => "List"],
-                        ["class" => ListLineBlot::class, "content" => "List"],
-                    ],
-                ],
-            ],
-            [
-                [
-                    ["attributes" => ["header" => 2], "content" => "\n"]
-                ],
-                [
-                    [["class" => HeadingBlot::class, "content" => ""]]
-                ]
-            ]
+        ]];
+
+        $results = [[["class" => ExternalBlot::class, "content" => ""]]];
+        $this->assertParseResults($ops, $results);
+    }
+
+    /**
+     * A single newline should result in an empty rendered post.
+     *
+     * A plain newline represents the editor's default empty state.
+     */
+    public function testSingleNewline() {
+        $ops = [["insert" => "\n"]];
+        $result = [];
+        $this->assertParseResults($ops, $result);
+    }
+
+    /**
+     * Test the parsing of normal text.
+     */
+    public function testNormalText() {
+        $ops = [["insert" => "SomeText\n"]];
+        $result = [[["class" => TextBlot::class, "content" => "SomeText"]]];
+        $this->assertParseResults($ops, $result);
+    }
+
+    /**
+     * Test the parsing of newlines.
+     */
+    public function testNewlineParsing() {
+        $ops = [["insert" => "Sometext\n\n\nAfter3lines\n\n"]];
+        $result = [
+            [["class" => TextBlot::class, "content" => "Sometext"]],
+            [["class" => TextBlot::class, "content" => "\n"]],
+            [["class" => TextBlot::class, "content" => "\n"]],
+            [["class" => TextBlot::class, "content" => "After3lines"]],
+            [["class" => TextBlot::class, "content" => "\n"]],
         ];
+        $this->assertParseResults($ops, $result);
+    }
+
+    /**
+     * Test the parsing of block level blots. Lines, headings, etc.
+     */
+    public function testBlockBlotNewlines() {
+        $this->assertCorrectLineBlotParsing("list", "bullet", ListLineBlot::class);
+        $this->assertCorrectLineBlotParsing("list", "ordered", ListLineBlot::class);
+        $this->assertCorrectLineBlotParsing("spoiler-line", true, SpoilerLineBlot::class);
+        $this->assertCorrectLineBlotParsing("blockquote-line", true, BlockquoteLineBlot::class);
+        $this->assertCorrectNonLineBlockBlockParsing("header", 1, HeadingBlot::class);
+        $this->assertCorrectNonLineBlockBlockParsing("header", 2, HeadingBlot::class);
+    }
+
+    /**
+     * Assert that a particular line blot class parses correctly.
+     *
+     * @param string $attrKey The attribute key for the operation.
+     * @param $attrValue The attribute value for the operation.
+     * @param string $className The Name of the line blot class.
+     */
+    private function assertCorrectLineBlotParsing(string $attrKey, $attrValue, string $className) {
+        $ops = [
+            ["insert" => "Line 1"],
+            ["attributes" => [$attrKey => $attrValue], "insert" => "\n\n"],
+            ["insert" => "Line 3"],
+            ["attributes" => [$attrKey => $attrValue], "insert" => "\n\n\n\n"],
+            ["insert" => "Line 7"],
+            ["attributes" => [$attrKey => $attrValue], "insert" => "\n"],
+            ["insert" => "Normal Text\nSome other text"],
+        ];
+        $result = [
+            [
+                ["class" => $className, "content" => "Line 1"],
+                ["class" => $className, "content" => "Line 3"],
+                ["class" => $className, "content" => "Line 7"],
+            ],
+            [["class" => TextBlot::class, "content" => "Normal Text"]],
+            [["class" => TextBlot::class, "content" => "Some other text"]],
+        ];
+        $this->assertParseResults($ops, $result);
+    }
+
+    /**
+     * Assert that a particular block blot (not a line blot) class parses correctly.
+     *
+     * Ex. Heading.
+     *
+     * @param string $attrKey The attribute key for the operation.
+     * @param $attrValue The attribute value for the operation.
+     * @param string $className The Name of the line blot class.
+     */
+    private function assertCorrectNonLineBlockBlockParsing(string $attrKey, $attrValue, string $className) {
+        $ops = [
+            ["insert" => "Line 1"],
+            ["attributes" => [$attrKey => $attrValue], "insert" => "\n\n"],
+            ["insert" => "Line 3"],
+            ["attributes" => [$attrKey => $attrValue], "insert" => "\n\n\n\n"],
+            ["insert" => "Line 7"],
+            ["attributes" => [$attrKey => $attrValue], "insert" => "\n"],
+            ["insert" => "Normal Text\nSome other text"],
+        ];
+        $result = [
+            [["class" => $className, "content" => "Line 1"]],
+            [["class" => $className, "content" => "Line 3"]],
+            [["class" => $className, "content" => "Line 7"]],
+            [["class" => TextBlot::class, "content" => "Normal Text"]],
+            [["class" => TextBlot::class, "content" => "Some other text"]],
+        ];
+        $this->assertParseResults($ops, $result);
+    }
+
+    /**
+     * Test that line breaks with a lot of mixed in formatting parses correctly.
+     */
+    public function testFormattingWithLineBreaks() {
+        $ops = [
+            ["attributes" => ["link" => "https =>//google.com"], "insert" => "ogl"],
+            ["insert" => "\n\nText after line breaks."],
+            ["attributes" => ["strike" => true], "insert" => "strike"],
+            ["insert" => "\n\n\n\n"],
+            ["attributes" => ["strike" => true], "insert" => "Mutliple more breaks."],
+            ["insert" => "\n"],
+        ];
+
+        $result = [
+            [["class" => TextBlot::class, "content" => "ogl"]],
+            [["class" => TextBlot::class, "content" => "\n"]],
+            [
+                ["class" => TextBlot::class, "content" => "Text after line breaks."],
+                ["class" => TextBlot::class, "content" => "strike"],
+            ],
+            [["class" => TextBlot::class, "content" => "\n"]],
+            [["class" => TextBlot::class, "content" => "\n"]],
+            [["class" => TextBlot::class, "content" => "\n"]],
+            [["class" => TextBlot::class, "content" => "Mutliple more breaks."]],
+        ];
+
+        $this->assertParseResults($ops, $result);
+    }
+
+    /**
+     * Ensure that line blots clear the groups from different lines blots.
+     * https://github.com/vanilla/vanilla/issues/7522
+     */
+    public function testLineBlotClearing() {
+        $ops = [
+            ["insert" => "Quote"],
+            ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
+            ["insert" => "Quote"],
+            ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
+            ["insert" => "List"],
+            ["attributes" => ["list" => "bullet"], "insert" => "\n"],
+            ["insert" => "List"],
+            ["attributes" => ["list" => "bullet"], "insert" => "\n"],
+        ];
+        $result = [
+            [
+                ["class" => BlockquoteLineBlot::class, "content" => "Quote"],
+                ["class" => BlockquoteLineBlot::class, "content" => "Quote"],
+            ],
+            [
+                ["class" => ListLineBlot::class, "content" => "List"],
+                ["class" => ListLineBlot::class, "content" => "List"],
+            ],
+        ];
+
+        $this->assertParseResults($ops, $result);
+    }
+
+    /**
+     * Verify rendering of empty heading blots.
+     * https://github.com/vanilla/vanilla/issues/7522
+     */
+    public function testEmptyHeadingBlots() {
+        $ops = [["attributes" => ["header" => 2], "content" => "\n"]];
+        $result = [[["class" => HeadingBlot::class, "content" => ""]]];
+        $this->assertParseResults($ops, $result);
+
+        $ops = [["attributes" => ["header" => 5], "content" => "\n"]];
+        $result = [[["class" => NullBlot::class, "content" => ""]]];
+        $this->assertParseResults($ops, $result);
     }
 
     /**

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -8,6 +8,7 @@
 namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
 use Vanilla\Formatting\Quill\Blots\Embeds\ExternalBlot;
+use Vanilla\Formatting\Quill\Blots\HeadingBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\BlockquoteLineBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\ListLineBlot;
 use Vanilla\Formatting\Quill\Blots\TextBlot;
@@ -150,6 +151,14 @@ class ParserTest extends SharedBootstrapTestCase {
                     ],
                 ],
             ],
+            [
+                [
+                    ["attributes" => ["header" => 2], "content" => "\n"]
+                ],
+                [
+                    [["class" => HeadingBlot::class, "content" => ""]]
+                ]
+            ]
         ];
     }
 

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -9,6 +9,7 @@ namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
 use Vanilla\Formatting\Quill\Blots\Embeds\ExternalBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\BlockquoteLineBlot;
+use Vanilla\Formatting\Quill\Blots\Lines\ListLineBlot;
 use Vanilla\Formatting\Quill\Blots\TextBlot;
 use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Formatting\Quill\Parser;
@@ -125,6 +126,28 @@ class ParserTest extends SharedBootstrapTestCase {
                     [["class" => TextBlot::class, "content" => "\n"]],
                     [["class" => TextBlot::class, "content" => "\n"]],
                     [["class" => TextBlot::class, "content" => "Mutliple more breaks."]],
+                ],
+            ],
+            [
+                [
+                    ["insert" => "Quote"],
+                    ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
+                    ["insert" => "Quote"],
+                    ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
+                    ["insert" => "List"],
+                    ["attributes" => ["list" => "bullet"], "insert" => "\n"],
+                    ["insert" => "List"],
+                    ["attributes" => ["list" => "bullet"], "insert" => "\n"],
+                ],
+                [
+                    [
+                        ["class" => BlockquoteLineBlot::class, "content" => "Quote"],
+                        ["class" => BlockquoteLineBlot::class, "content" => "Quote"],
+                    ],
+                    [
+                        ["class" => ListLineBlot::class, "content" => "List"],
+                        ["class" => ListLineBlot::class, "content" => "List"],
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7522

The easiest one to reproduce was to make a post with an empty heading, which would throw an exception. I've made a few changes to rectify this.

## Fixing the heading issue

The heading issue sprung from a few things. I was not recognizing that a heading blot (specific in only ever being 1 line), could be made of only 1 operation. A heading with content is made up of 2 operations. 

1. Contains the content of the heading and inline attributes
2. Contains a single newline and the heading level.

An empty heading produces only the 2nd operation.

I've rectified this by using the existing Blot::hasConsumedNextOp() to determine where I need to look for the heading level. I also removed the Exception for an invalid heading level. With the current setup a blot with an invalid heading level should not match a heading blot (it actually won't match any blot, a null blot will be created, which renders nothing). I've still added a default fallback (h2) in case something weird happens here.

A parser test case has been added for a heading with 

## Fixing bullets getting collapsed into blockquotes.

To resolve this I've overriden `shouldClearCurrentGroup()` on the abstract line blot. If there is a different override blot on the group (the one that describes what tags wrap the group) then group will be cleared and a new one started.

A parser test has been added for.

## Restructuring the Parser tests.

I've removed the provider from the parser tests so that tests could have more context about what they are for, and when they might fail. I also added a couple more line blots tests by pulling out a couple additional assertion methods.