### PR TITLE
Fix some API schema documentation bugs

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticateApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticateApiController.php
@@ -233,9 +233,8 @@ class AuthenticateApiController extends AbstractApiController {
                     'default' => true,
                     'x-instance-configurable' => true,
                 ],
-                'canLinkSession'=> [
-                    'type' => 'boolean',
-                    'description' => 'Whether or not, using the authenticator, the user can link his account from the profile page.',
+                'canAutoLinkUser:b' => [
+                    'description' => 'Whether or not the authenticator can automatically link the incoming user information to an existing user account by using email address.',
                     'default' => false,
                     'x-instance-configurable' => true,
                 ],

--- a/applications/dashboard/controllers/api/AuthenticateApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticateApiController.php
@@ -225,6 +225,23 @@ class AuthenticateApiController extends AbstractApiController {
      * @return Schema
      */
     public function getAuthenticatorPublicSchema() {
+        $ssoSchema = Schema::parse([
+            'sso:o?' => [
+                'canSignIn' => [
+                    'type' => 'boolean',
+                    'description' => 'Whether or not the authenticator can be used to sign in.',
+                    'default' => true,
+                    'x-instance-configurable' => true,
+                ],
+                'canLinkSession'=> [
+                    'type' => 'boolean',
+                    'description' => 'Whether or not, using the authenticator, the user can link his account from the profile page.',
+                    'default' => false,
+                    'x-instance-configurable' => true,
+                ],
+            ]
+        ]);
+
         $schema = Schema::parse([
             'authenticatorID' => null,
             'type' => null,
@@ -235,12 +252,7 @@ class AuthenticateApiController extends AbstractApiController {
         ])
             ->add(SSOAuthenticator::getAuthenticatorSchema())
             ->merge(
-                Schema::parse([
-                    'sso?' => [
-                        'canSignIn' => null,
-                        'canAutoLinkUser' => null,
-                    ]
-                ])->add(SSOAuthenticator::getAuthenticatorSchema()->getField('properties.sso'))
+                $ssoSchema
             )
         ;
 
@@ -291,7 +303,7 @@ class AuthenticateApiController extends AbstractApiController {
         $this->permission();
 
         $this->schema(
-            Schema::parse(['authenticatorID'])->merge($this->getAuthenticatorPublicSchema()),
+            Schema::parse(['authenticatorID' => $this->getAuthenticatorPublicSchema()->getField('properties.authenticatorID')]),
             'in'
         )->setDescription('Get an active authenticator.');
         $out = $this->schema($this->getAuthenticatorPublicSchema(), 'out');

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -62,7 +62,7 @@ class UsersApiController extends AbstractApiController {
      */
     public function delete($id, array $body) {
         $this->permission('Garden.Users.Delete');
-        
+
         $this->idParamSchema()->setDescription('Delete a user.');
 
         $in = $this->schema([
@@ -119,7 +119,7 @@ class UsersApiController extends AbstractApiController {
             'password:s' => 'Password of the user.',
             'hashMethod:s' => 'Hash method for the password.',
             'email:s' => [
-                'Email address of the user.',
+                'description' => 'Email address of the user.',
                 'minLength' => 0,
             ],
             'photo:s|n' => [
@@ -533,7 +533,10 @@ class UsersApiController extends AbstractApiController {
         }
 
         $in = $this->schema($inputProperties, 'in')->setDescription('Submit a new user registration.');
-        $out = $this->schema(['userID', 'name', 'email'], 'out')->add($this->fullSchema());
+        $out = $this->schema(
+            Schema::parse(['userID', 'name', 'email'])->add($this->fullSchema()),
+            'out'
+        );
 
         $in->validate($body);
 

--- a/applications/vanilla/controllers/api/DraftsApiController.php
+++ b/applications/vanilla/controllers/api/DraftsApiController.php
@@ -141,11 +141,10 @@ class DraftsApiController extends AbstractApiController {
         $this->permission('Garden.SignIn.Allow');
 
         $in = $this->idParamSchema('in')->setDescription('Get a draft for editing.');
-        $out = $this->schema([
-            'draftID',
-            'parentRecordID',
-            'attributes',
-        ], 'out')->add($this->fullSchema());
+        $out = $this->schema(
+            Schema::parse(['draftID', 'parentRecordID', 'attributes',])->add($this->fullSchema()),
+            'out'
+        );
 
         $row = $this->draftByID($id);
         if ($row['InsertUserID'] !== $this->getSession()->UserID) {
@@ -260,7 +259,10 @@ class DraftsApiController extends AbstractApiController {
 
         $this->idParamSchema();
         $in = $this->draftPostSchema('in')->setDescription('Update a draft.');
-        $out = $this->schema(['draftID', 'parentRecordID', 'attributes'], 'out')->add($this->fullSchema());
+        $out = $this->schema(
+            Schema::parse(['draftID', 'parentRecordID', 'attributes'])->add($this->fullSchema()),
+            'out'
+        );
 
         $row = $this->draftByID($id);
         if ($row['InsertUserID'] !== $this->getSession()->UserID) {


### PR DESCRIPTION
Upon validating our swagger file against the spec I discovered some issues. Some of these were simple typos in our controllers while others were ordering problems where the correct schema is constructed, but after the swagger event which is a nope.