### PR TITLE
Add the CacheControlMiddleware and tweak default caching

### DIFF
--- a/applications/dashboard/controllers/class.authenticatecontroller.php
+++ b/applications/dashboard/controllers/class.authenticatecontroller.php
@@ -63,6 +63,8 @@ class AuthenticateController extends Gdn_Controller {
         $this->sessionModel = $sessionModel;
         $this->ssoModel = $ssoModel;
         $this->userModel = $userModel;
+
+        $this->setHeader('Cache-Control', \Vanilla\Web\CacheControlMiddleware::NO_CACHE);
     }
 
     /**

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -45,6 +45,7 @@ class EntryController extends Gdn_Controller {
         if (Gdn::request()->get('display') === 'popup') {
             $this->MasterView = 'popup';
         }
+        $this->setHeader('Cache-Control', \Vanilla\Web\CacheControlMiddleware::NO_CACHE);
     }
 
     /**

--- a/applications/dashboard/controllers/class.utilitycontroller.php
+++ b/applications/dashboard/controllers/class.utilitycontroller.php
@@ -37,6 +37,14 @@ class UtilityController extends DashboardController {
     ];
 
     /**
+     * UtilityController constructor.
+     */
+    public function __construct() {
+        parent::__construct();
+        $this->setHeader('Cache-Control', \Vanilla\Web\CacheControlMiddleware::NO_CACHE);
+    }
+
+    /**
      * Runs before every call to this controller.
      */
     public function initialize() {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -152,6 +152,7 @@ $dic->setInstance('Garden\Container\Container', $dic)
     })])
     ->addCall('setAllowedOrigins', ['isTrustedDomain'])
     ->addCall('addMiddleware', [new Reference('@smart-id-middleware')])
+    ->addCall('addMiddleware', [new Reference(\Vanilla\Web\CacheControlMiddleware::class)])
 
     ->rule('@smart-id-middleware')
     ->setClass(\Vanilla\Web\SmartIDMiddleware::class)

--- a/library/Vanilla/Web/CacheControlMiddleware.php
+++ b/library/Vanilla/Web/CacheControlMiddleware.php
@@ -11,16 +11,35 @@ use Garden\Web\Data;
 use Garden\Web\RequestInterface;
 use Gdn_Session as SessionInterface;
 
+/**
+ * Dispatcher middleware for handling caching headers.
+ */
 class CacheControlMiddleware {
+
+    /** @var string Standard Cache-Control header string for public, cacheable content. */
     const PUBLIC_CACHE = 'public, max-age=120';
+
+    /** @var string Standard Cache-Control header for content that should not be cached. */
     const NO_CACHE = 'private, no-cache, max-age=0, must-revalidate';
 
+    /** @var SessionInterface An instance of the current user session. */
     private $session;
 
+    /**
+     * CacheControlMiddleware constructor.
+     *
+     * @param SessionInterface $session
+     */
     public function __construct(SessionInterface $session) {
         $this->session = $session;
     }
 
+    /**
+     * Translate a Cache-Control header into HTTP/1.0 Expires and Pragma headers.
+     *
+     * @param string $cacheControl A valid Cache-Control header value.
+     * @return array
+     */
     public static function getHttp10Headers(string $cacheControl): array {
         $result = [];
 

--- a/library/Vanilla/Web/CacheControlMiddleware.php
+++ b/library/Vanilla/Web/CacheControlMiddleware.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla\Web;
+
+use Garden\Web\Data;
+use Garden\Web\RequestInterface;
+use Gdn_Session as SessionInterface;
+
+class CacheControlMiddleware {
+    const PUBLIC_CACHE = 'public, max-age=120';
+    const NO_CACHE = 'private, no-cache, max-age=0, must-revalidate';
+
+    private $session;
+
+    public function __construct(SessionInterface $session) {
+        $this->session = $session;
+    }
+
+    public static function getHttp10Headers(string $cacheControl): array {
+        $result = [];
+
+        if (preg_match('`max-age=(\d+)`', $cacheControl, $m)) {
+            if ($m[1] === '0') {
+                $result['Expires'] = 'Sat, 01 Jan 2000 00:00:00 GMT';
+                $result['Pragma'] = 'no-cache';
+            } else {
+                $result['Expires'] = gmdate('D, d M Y H:i:s T', time() + $m[1]);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Invoke the smart ID middleware on a request.
+     *
+     * @param RequestInterface $request The incoming request.
+     * @param callable $next The next middleware.
+     * @return mixed Returns the response of the inner middleware.
+     */
+    public function __invoke(RequestInterface $request, callable $next) {
+        $response = Data::box($next($request));
+
+        if (!$response->hasHeader('Cache-Control')) {
+            $response->setHeader(
+                'Cache-Control',
+                $this->session->isValid() || $request->getMethod() !== 'GET' ?  self::NO_CACHE : self::PUBLIC_CACHE
+            );
+        }
+        foreach (static::getHttp10Headers($response->getHeader('Cache-Control')) as $key => $value) {
+            $response->setHeader($key, $value);
+        }
+
+        return $response;
+    }
+}


### PR DESCRIPTION
This PR is an attempt to put the application’s cache headers inline with our Varnish overrides so that the application has more control over browser and proxy caching.

- Signed in users don’t cache by default. This behavior is unchanged.
- Guests cache requests for two minutes.
- The CacheControlMiddleware handles caching for the API.
- Since endpoints can now opt-out of caching the /authenticate, /utility and /entry endpoints now do so.
- HTTP 1.0 headers are removed and added when headers are sent. This allows programmers to only code with just the Cache-Control header.

This is a fairly significant change so I’m requesting people from Ops also review the PR. We should also test this on infrastructure before merging.