### PR TITLE
Make editor formatting settings global in the post page

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -55,9 +55,10 @@ class VanillaSettingsController extends Gdn_Controller {
         $validation = new Gdn_Validation();
         $configurationModel = new Gdn_ConfigurationModel($validation);
         $configurationModel->setField([
+            'Vanilla.Categories.MaxDisplayDepth',
             'Garden.InputFormatter',
             'Garden.MobileInputFormatter',
-            'Vanilla.Categories.MaxDisplayDepth',
+            'Plugins.editor.ForceWysiwyg',
             'Vanilla.Discussions.PerPage',
             'Vanilla.Comments.PerPage',
             'Garden.Html.AllowedElements',

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -40,10 +40,23 @@ class VanillaSettingsController extends Gdn_Controller {
         // Check permission
         $this->permission('Garden.Settings.Manage');
 
+        $formats = ['Text']; // Check for additional formats
+        $this->EventArguments['formats'] = &$formats;
+
+        $this->fireEvent('GetFormats');
+        // This was moved from the editor plugin. In order to maintain compatibility with existing event hooks
+        // We will need to fire this as EditorPlugin.
+        $this->EventArguments['formats'] = &$formats;
+        $this->fireAs('EditorPlugin');
+        $this->fireEvent('GetFormats');
+        $this->setData('formats', $formats);
+
         // Load up config options we'll be setting
         $validation = new Gdn_Validation();
         $configurationModel = new Gdn_ConfigurationModel($validation);
         $configurationModel->setField([
+            'Garden.InputFormatter',
+            'Garden.MobileInputFormatter',
             'Vanilla.Categories.MaxDisplayDepth',
             'Vanilla.Discussions.PerPage',
             'Vanilla.Comments.PerPage',
@@ -70,7 +83,8 @@ class VanillaSettingsController extends Gdn_Controller {
             $this->Form->setFormValue('Garden.Format.DisableUrlEmbeds', !$disableUrlEmbeds);
 
             // Define some validation rules for the fields being saved
-            $configurationModel->Validation->applyRule('Vanilla.Categories.MaxDisplayDepth', 'Required');
+            $configurationModel->Validation->applyRule('Garden.InputFormatter', 'Required');
+            $configurationModel->Validation->applyRule('Garden.MobileInputFormatter', 'Required');
             $configurationModel->Validation->applyRule('Vanilla.Categories.MaxDisplayDepth', 'Integer');
             $configurationModel->Validation->applyRule('Vanilla.Discussions.PerPage', 'Required');
             $configurationModel->Validation->applyRule('Vanilla.Discussions.PerPage', 'Integer');

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -40,15 +40,16 @@ class VanillaSettingsController extends Gdn_Controller {
         // Check permission
         $this->permission('Garden.Settings.Manage');
 
-        $formats = ['Text']; // Check for additional formats
-        $this->EventArguments['formats'] = &$formats;
+        /** @var \Garden\EventManager $eventManager */
+        $eventManager = Gdn::getContainer()->get(\Garden\EventManager::class);
 
-        $this->fireEvent('GetFormats');
+        $initialFormats = ['Text']; // Check for additional formats
+        $formats = $eventManager->fireFilter("getPostFormats", $initialFormats);
+
         // This was moved from the editor plugin. In order to maintain compatibility with existing event hooks
         // We will need to fire this as EditorPlugin.
-        $this->EventArguments['formats'] = &$formats;
-        $this->fireAs('EditorPlugin');
-        $this->fireEvent('GetFormats');
+        $eventManager->fireDeprecated("editorPlugin_getFormats", null, ['Formats' => &$formats]);
+
         $this->setData('formats', $formats);
 
         // Load up config options we'll be setting

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -55,11 +55,11 @@ class VanillaSettingsController extends Gdn_Controller {
         // Load up config options we'll be setting
         $validation = new Gdn_Validation();
         $configurationModel = new Gdn_ConfigurationModel($validation);
+
         $configurationModel->setField([
             'Vanilla.Categories.MaxDisplayDepth',
             'Garden.InputFormatter',
             'Garden.MobileInputFormatter',
-            'Plugins.editor.ForceWysiwyg',
             'Vanilla.Discussions.PerPage',
             'Vanilla.Comments.PerPage',
             'Garden.Html.AllowedElements',
@@ -102,6 +102,8 @@ class VanillaSettingsController extends Gdn_Controller {
                 $this->informMessage(t("Your changes have been saved."));
             }
         }
+
+        $eventManager->fire('vanillaSettingsController_postingConfigModel', $configurationModel);
 
         $this->setHighlightRoute('vanilla/settings/posting');
         $this->addJsFile('settings.js');

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -103,7 +103,12 @@ class VanillaSettingsController extends Gdn_Controller {
             }
         }
 
-        $eventManager->fire('vanillaSettingsController_postingConfigModel', $configurationModel);
+        // Fire an filter event gather extra form HTML for specific format items.
+        // The form is added so the form can be enhanced and the config model needs to passed to add extra fields.
+        $extraFormatFormHTML = $eventManager->fireFilter('postingSettings_formatSpecificFormItems', "",
+            $this->Form,
+            $configurationModel);
+        $this->setData('extraFormatFormHTML', $extraFormatFormHTML);
 
         $this->setHighlightRoute('vanilla/settings/posting');
         $this->addJsFile('settings.js');

--- a/applications/vanilla/views/vanillasettings/posting.php
+++ b/applications/vanilla/views/vanillasettings/posting.php
@@ -2,9 +2,15 @@
 helpAsset(t('Need More Help?'), anchor(t("Video tutorial on advanced settings"), 'settings/tutorials/category-management-and-advanced-settings'));
 ?>
 <h1><?php echo t('Posting Settings'); ?></h1>
+
 <?php
 /** @var Gdn_Form $form */
 $form = $this->Form;
+$formats = $this->data('formats');
+$formatOptions = [];
+foreach ($formats as $formatName) {
+    $formatOptions[$formatName] = $formatName;
+}
 echo $form->open();
 echo $form->errors();
 ?>
@@ -23,6 +29,52 @@ echo $form->errors();
             echo $form->toggle('Garden.Format.DisableUrlEmbeds', $embedsLabel, [], $embedsDesc, true);
             ?>
         </li>
+
+        <li class="form-group">
+            <?php
+            $formatDesc = '<p>Select the default format of the editor for posts in the community.</p><p><strong>Note:</strong> the editor will auto-detect the format of old posts when editing them and load their original formatting rules. Aside from this exception, the selected post format below will take precedence.</p>';
+            ?>
+            <div class="label-wrap">
+                <?php
+                echo $form->label('Post Format', 'Garden.InputFormatter');
+                echo wrap(
+                    $formatDesc,
+                    'div',
+                    ['class' => 'info']
+                );
+                ?>
+            </div>
+            <div class="input-wrap">
+                <?php echo $form->dropDown('Garden.InputFormatter', $formatOptions); ?>
+            </div>
+        </li>
+        <li class="form-group">
+            <?php
+            $forceWysiwygLabel = 'Reinterpret All Posts As Wysiwyg';
+            $forceWysiwygDesc = '<p class="info">Check the below option to tell the editor to reinterpret all old posts as Wysiwyg.</p> <p class="info"><strong>Note:</strong> This setting will only take effect if Wysiwyg was chosen as the Post Format above. The purpose of this option is to normalize the editor format. If older posts edited with another format, such as markdown or BBCode, are loaded, this option will force Wysiwyg.</p>';
+            echo $form->toggle('Plugins.editor.ForceWysiwyg', $forceWysiwygLabel, [], $forceWysiwygDesc);
+            ?>
+        </li>
+        <li class="form-group">
+            <?php
+            $mobileFormatDesc = '<p>Specify an editing format for mobile devices. If mobile devices should have the same experience, specify the same one as above. If users report issues with mobile editing, this is a good option to change.</p>';
+            ?>
+            <div class="label-wrap">
+                <?php
+                echo $form->label('Mobile Format', 'Garden.MobileInputFormatter');
+                echo wrap(
+                    $mobileFormatDesc,
+                    'div',
+                    ['class' => 'info']
+                );
+                ?>
+            </div>
+            <div class="input-wrap">
+                <?php echo $form->dropDown('Garden.MobileInputFormatter', $formatOptions); ?>
+            </div>
+        </li>
+
+
         <li class="form-group">
             <?php
             $Options = ['1' => '1', '2' => '2', '3' => '3', '4' => '4', '5' => '5', '0' => 'No limit'];

--- a/applications/vanilla/views/vanillasettings/posting.php
+++ b/applications/vanilla/views/vanillasettings/posting.php
@@ -32,16 +32,15 @@ echo $form->errors();
 
         <li class="form-group">
             <?php
-            $formatDesc = '<p>Select the default format of the editor for posts in the community.</p><p><strong>Note:</strong> the editor will auto-detect the format of old posts when editing them and load their original formatting rules. Aside from this exception, the selected post format below will take precedence.</p>';
+            $formatNotes1 = t('InputFormatter.Notes1', 'Select the default format of the editor for posts in the community.');
+            $formatNotes2 = t('InputFormatter.Notes2', 'The editor will auto-detect the format of old posts when editing them and load their 
+            original formatting rules. Aside from this exception, the selected post format below will take precedence.');
+            $label = '<p class="info">'.$formatNotes1.'</p><p class="info"><strong>'.t('Note:').' </strong>'.$formatNotes2.'</p>';
             ?>
             <div class="label-wrap">
                 <?php
                 echo $form->label('Post Format', 'Garden.InputFormatter');
-                echo wrap(
-                    $formatDesc,
-                    'div',
-                    ['class' => 'info']
-                );
+                echo $label;
                 ?>
             </div>
             <div class="input-wrap">
@@ -51,22 +50,23 @@ echo $form->errors();
         <li class="form-group">
             <?php
             $forceWysiwygLabel = 'Reinterpret All Posts As Wysiwyg';
-            $forceWysiwygDesc = '<p class="info">Check the below option to tell the editor to reinterpret all old posts as Wysiwyg.</p> <p class="info"><strong>Note:</strong> This setting will only take effect if Wysiwyg was chosen as the Post Format above. The purpose of this option is to normalize the editor format. If older posts edited with another format, such as markdown or BBCode, are loaded, this option will force Wysiwyg.</p>';
-            echo $form->toggle('Plugins.editor.ForceWysiwyg', $forceWysiwygLabel, [], $forceWysiwygDesc);
+            $forceWysiwygNote1 =  t('ForceWysiwyg.Notes1', 'Check the below option to tell the editor to reinterpret all old posts as Wysiwyg.');
+            $forceWysiwygNote2 = t('ForceWysiwyg.Notes2', 'This setting will only take effect if Wysiwyg was chosen as the Post Format above. The purpose of this option is to normalize the editor format. If older posts edited with another format, such as markdown or BBCode, are loaded, this option will force Wysiwyg.');
+            $label = '<p class="info">'.$forceWysiwygNote1.'</p><p class="info"><strong>'.t('Note:').' </strong>'.$forceWysiwygNote2.'</p>';
+            echo $form->toggle('Plugins.editor.ForceWysiwyg', $forceWysiwygLabel, [], $label);
             ?>
         </li>
         <li class="form-group">
             <?php
-            $mobileFormatDesc = '<p>Specify an editing format for mobile devices. If mobile devices should have the same experience, specify the same one as above. If users report issues with mobile editing, this is a good option to change.</p>';
+            $mobileFormatterNote1 = t('MobileInputFormatter.Notes1', 'Specify an editing format for mobile devices.');
+            $mobileFormatterNote2 =t('MobileInputFormatter.Notes', 'If mobile devices should have the same experience,
+specify the same one as above. If users report issues with mobile editing, this is a good option to change.');
+            $label = '<p class="info">'.$mobileFormatterNote1.'</p><p class="info"><strong>'.t('Note:').' </strong>'.$mobileFormatterNote2.'</p>';
             ?>
             <div class="label-wrap">
                 <?php
                 echo $form->label('Mobile Format', 'Garden.MobileInputFormatter');
-                echo wrap(
-                    $mobileFormatDesc,
-                    'div',
-                    ['class' => 'info']
-                );
+                echo '<p class="info">'.$label.'</p>';
                 ?>
             </div>
             <div class="input-wrap">

--- a/applications/vanilla/views/vanillasettings/posting.php
+++ b/applications/vanilla/views/vanillasettings/posting.php
@@ -59,7 +59,7 @@ echo $form->errors();
         <li class="form-group">
             <?php
             $mobileFormatterNote1 = t('MobileInputFormatter.Notes1', 'Specify an editing format for mobile devices.');
-            $mobileFormatterNote2 =t('MobileInputFormatter.Notes', 'If mobile devices should have the same experience,
+            $mobileFormatterNote2 =t('MobileInputFormatter.Notes2', 'If mobile devices should have the same experience,
 specify the same one as above. If users report issues with mobile editing, this is a good option to change.');
             $label = '<p class="info">'.$mobileFormatterNote1.'</p><p class="info"><strong>'.t('Note:').' </strong>'.$mobileFormatterNote2.'</p>';
             ?>

--- a/applications/vanilla/views/vanillasettings/posting.php
+++ b/applications/vanilla/views/vanillasettings/posting.php
@@ -49,9 +49,9 @@ echo $form->errors();
                 <?php echo $form->dropDown('Garden.InputFormatter', $formatOptions); ?>
             </div>
         </li>
-        <?php
-        echo $eventManager->fireFilter('vanillaSettingsController_postingFormatSpecificFormItems', "", $form);
-        ?>
+
+        <?php echo $this->data('extraFormatFormHTML') ?>
+
         <li class="form-group">
             <?php
             $mobileFormatterNote1 = t('MobileInputFormatter.Notes1', 'Specify an editing format for mobile devices.');

--- a/applications/vanilla/views/vanillasettings/posting.php
+++ b/applications/vanilla/views/vanillasettings/posting.php
@@ -6,6 +6,8 @@ helpAsset(t('Need More Help?'), anchor(t("Video tutorial on advanced settings"),
 <?php
 /** @var Gdn_Form $form */
 $form = $this->Form;
+/** @var \Garden\EventManager $eventManager */
+$eventManager = Gdn::getContainer()->get(\Garden\EventManager::class);
 $formats = $this->data('formats');
 $formatOptions = [];
 foreach ($formats as $formatName) {
@@ -47,15 +49,9 @@ echo $form->errors();
                 <?php echo $form->dropDown('Garden.InputFormatter', $formatOptions); ?>
             </div>
         </li>
-        <li class="form-group">
-            <?php
-            $forceWysiwygLabel = 'Reinterpret All Posts As Wysiwyg';
-            $forceWysiwygNote1 =  t('ForceWysiwyg.Notes1', 'Check the below option to tell the editor to reinterpret all old posts as Wysiwyg.');
-            $forceWysiwygNote2 = t('ForceWysiwyg.Notes2', 'This setting will only take effect if Wysiwyg was chosen as the Post Format above. The purpose of this option is to normalize the editor format. If older posts edited with another format, such as markdown or BBCode, are loaded, this option will force Wysiwyg.');
-            $label = '<p class="info">'.$forceWysiwygNote1.'</p><p class="info"><strong>'.t('Note:').' </strong>'.$forceWysiwygNote2.'</p>';
-            echo $form->toggle('Plugins.editor.ForceWysiwyg', $forceWysiwygLabel, [], $label);
-            ?>
-        </li>
+        <?php
+        echo $eventManager->fireFilter('vanillaSettingsController_postingFormatSpecificFormItems', "", $form);
+        ?>
         <li class="form-group">
             <?php
             $mobileFormatterNote1 = t('MobileInputFormatter.Notes1', 'Specify an editing format for mobile devices.');

--- a/plugins/editor/addon.json
+++ b/plugins/editor/addon.json
@@ -6,8 +6,6 @@
     "registerPermissions": {
         "Plugins.Attachments.Upload.Allow": "Garden.Profiles.Edit"
     },
-    "settingsUrl": "/settings/editor",
-    "settingsPermission": "Garden.Settings.Manage",
     "icon": "advanced-editor.png",
     "key": "editor",
     "type": "addon",

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1421,6 +1421,39 @@ class EditorPlugin extends Gdn_Plugin {
     }
 
     /**
+     * Add additional WYSIWYG specific form item to the dashboard posting page.
+     *
+     * @param string $additionalFormItemHTML
+     * @param Gdn_Form $form The Form instance from the page.
+     * @return string The built up form html
+     */
+    public function vanillaSettingsController_postingFormatSpecificFormItems_handler(
+        string $additionalFormItemHTML,
+        Gdn_Form $form
+    ): string {
+        $forceWysiwygLabel = 'Reinterpret All Posts As Wysiwyg';
+        $forceWysiwygNote1 =  t('ForceWysiwyg.Notes1', 'Check the below option to tell the editor to reinterpret all old posts as Wysiwyg.');
+        $forceWysiwygNote2 = t('ForceWysiwyg.Notes2', 'This setting will only take effect if Wysiwyg was chosen as the Post Format above. The purpose of this option is to normalize the editor format. If older posts edited with another format, such as markdown or BBCode, are loaded, this option will force Wysiwyg.');
+        $label = '<p class="info">'.$forceWysiwygNote1.'</p><p class="info"><strong>'.t('Note:').' </strong>'.$forceWysiwygNote2.'</p>';
+        $formToggle = $form->toggle('Plugins.editor.ForceWysiwyg', $forceWysiwygLabel, [], $label);
+
+        $additionalFormItemHTML .= "<li class='form-group'>$formToggle</li>";
+        return $additionalFormItemHTML;
+    }
+
+    /**
+     * Add the ForceWysiwyg setting to the form field.
+     *
+     * @param Gdn_ConfigurationModel $configurationModel
+     */
+    public function vanillaSettingsController_postingConfigModel_handler(
+        Gdn_ConfigurationModel $configurationModel
+    ) {
+        $configurationModel->setField('Plugins.editor.ForceWysiwyg');
+    }
+
+
+    /**
      * This settings from this page have been moved into vanilla core.
      */
     public function settingsController_editor_create() {

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1425,11 +1425,14 @@ class EditorPlugin extends Gdn_Plugin {
      *
      * @param string $additionalFormItemHTML
      * @param Gdn_Form $form The Form instance from the page.
+     * @param Gdn_ConfigurationModel $configModel The config model used for the Form.
+     *
      * @return string The built up form html
      */
-    public function vanillaSettingsController_postingFormatSpecificFormItems_handler(
+    public function postingSettings_formatSpecificFormItems_handler(
         string $additionalFormItemHTML,
-        Gdn_Form $form
+        Gdn_Form $form,
+        Gdn_ConfigurationModel $configModel
     ): string {
         $forceWysiwygLabel = 'Reinterpret All Posts As Wysiwyg';
         $forceWysiwygNote1 =  t('ForceWysiwyg.Notes1', 'Check the below option to tell the editor to reinterpret all old posts as Wysiwyg.');
@@ -1437,21 +1440,10 @@ class EditorPlugin extends Gdn_Plugin {
         $label = '<p class="info">'.$forceWysiwygNote1.'</p><p class="info"><strong>'.t('Note:').' </strong>'.$forceWysiwygNote2.'</p>';
         $formToggle = $form->toggle('Plugins.editor.ForceWysiwyg', $forceWysiwygLabel, [], $label);
 
+        $configModel->setField('Plugins.editor.ForceWysiwyg');
         $additionalFormItemHTML .= "<li class='form-group'>$formToggle</li>";
         return $additionalFormItemHTML;
     }
-
-    /**
-     * Add the ForceWysiwyg setting to the form field.
-     *
-     * @param Gdn_ConfigurationModel $configurationModel
-     */
-    public function vanillaSettingsController_postingConfigModel_handler(
-        Gdn_ConfigurationModel $configurationModel
-    ) {
-        $configurationModel->setField('Plugins.editor.ForceWysiwyg');
-    }
-
 
     /**
      * This settings from this page have been moved into vanilla core.

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1405,8 +1405,19 @@ class EditorPlugin extends Gdn_Plugin {
      * @param VanillaSettingsController $sender
      * @param $args
      */
-    public function vanillaSettingsController_getFormats_handler($sender, $args) {
+    public function getAdditionPostFormats_handler($add, $args) {
         $args['formats'] = array_merge($args['formats'], $this->Formats);
+    }
+
+    /**
+     * Add the rich editor format to the posting page.
+     *
+     * @param string[] $postFormats Existing post formats.
+     *
+     * @return string[] Additional post formats.
+     */
+    public function getPostFormats_handler(array $postFormats): array {
+        return array_merge($postFormats, $this->Formats);
     }
 
     /**

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -61,6 +61,10 @@ class EditorPlugin extends Gdn_Plugin {
         $this->AssetPath = asset('/plugins/editor');
         $this->pluginInfo = Gdn::pluginManager()->getPluginInfo('editor', Gdn_PluginManager::ACCESS_PLUGINNAME);
         $this->ForceWysiwyg = c('Plugins.editor.ForceWysiwyg', false);
+
+        // Check for additional formats that render with the Advanced Editor.
+        $this->EventArguments['formats'] = &$this->Formats;
+        $this->fireEvent('GetFormats');
     }
 
     /**

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -61,10 +61,6 @@ class EditorPlugin extends Gdn_Plugin {
         $this->AssetPath = asset('/plugins/editor');
         $this->pluginInfo = Gdn::pluginManager()->getPluginInfo('editor', Gdn_PluginManager::ACCESS_PLUGINNAME);
         $this->ForceWysiwyg = c('Plugins.editor.ForceWysiwyg', false);
-
-        // Check for additional formats
-        $this->EventArguments['formats'] = &$this->Formats;
-        $this->fireEvent('GetFormats');
     }
 
     /**
@@ -1400,25 +1396,20 @@ class EditorPlugin extends Gdn_Plugin {
     }
 
     /**
+     * Add the advanced editor formats to th posting page.
      *
-     * @param SettingsController $sender
-     * @param array $args
+     * @param VanillaSettingsController $sender
+     * @param $args
      */
-    public function settingsController_editor_create($sender, $args) {
-        $sender->permission('Garden.Settings.Manage');
-        $cf = new ConfigurationModule($sender);
+    public function vanillaSettingsController_getFormats_handler($sender, $args) {
+        $args['formats'] = array_merge($args['formats'], $this->Formats);
+    }
 
-        $formats = array_combine($this->Formats, $this->Formats);
-
-        $cf->initialize([
-            'Garden.InputFormatter' => ['LabelCode' => 'Post Format', 'Control' => 'DropDown', 'Description' => '<p>Select the default format of the editor for posts in the community.</p><p><strong>Note:</strong> the editor will auto-detect the format of old posts when editing them and load their original formatting rules. Aside from this exception, the selected post format below will take precedence.</p>', 'Items' => $formats],
-            'Plugins.editor.ForceWysiwyg' => ['LabelCode' => 'Reinterpret All Posts As Wysiwyg', 'Control' => 'Checkbox', 'Description' => '<p class="info">Check the below option to tell the editor to reinterpret all old posts as Wysiwyg.</p> <p class="info"><strong>Note:</strong> This setting will only take effect if Wysiwyg was chosen as the Post Format above. The purpose of this option is to normalize the editor format. If older posts edited with another format, such as markdown or BBCode, are loaded, this option will force Wysiwyg.</p>'],
-            'Garden.MobileInputFormatter' => ['LabelCode' => 'Mobile Format', 'Control' => 'DropDown', 'Description' => '<p>Specify an editing format for mobile devices. If mobile devices should have the same experience, specify the same one as above. If users report issues with mobile editing, this is a good option to change.</p>', 'Items' => $formats, 'DefaultValue' => c('Garden.MobileInputFormatter')]
-        ]);
-
-
-        $sender->setData('Title', t('Advanced Editor Settings'));
-        $cf->renderAll();
+    /**
+     * This settings from this page have been moved into vanilla core.
+     */
+    public function settingsController_editor_create() {
+        redirectTo('/vanilla/settings/posting', 301);
     }
 
     /**

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -1400,16 +1400,6 @@ class EditorPlugin extends Gdn_Plugin {
     }
 
     /**
-     * Add the advanced editor formats to th posting page.
-     *
-     * @param VanillaSettingsController $sender
-     * @param $args
-     */
-    public function getAdditionPostFormats_handler($add, $args) {
-        $args['formats'] = array_merge($args['formats'], $this->Formats);
-    }
-
-    /**
      * Add the rich editor format to the posting page.
      *
      * @param string[] $postFormats Existing post formats.


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7527

Moves the formatting options from the editor plugin to the dashboard posting page.

## Changes

- Adds config options `Garden.InputFormatter`, `Garden.InputFormatter`, `Plugins.editor.ForceWysiwyg` to the /settings/posting page.
- Advanced Editor settings are gone. In place of its previous settings page is a redirect to the /settings/posting page.
- Splits out the label descriptions into separate pieces without HTML in them and wraps them in translation functions.

## Related

- Allowing Rich Editor to hook into these settings: https://github.com/vanilla/rich-editor/pull/90
- Translation source strings in the locales repo: https://github.com/vanilla/locales/pull/69

## Notes

- I've verified that all 3 of the config settings persist when saved.
- The force WYSIWYG option still only appears when the wysywyg format is enabled.
- The IPB formatting plugins still successfully hooks into these settings. This is why I am firing the `GetFormats` events twice. Once as the `VanillaSettingsController` and once as the `EditorPlugin`.
- I've made `Text` the only option by default.

