### PR TITLE
Fix UTF-8 page scraping for HTML 5 pages

### DIFF
--- a/library/Vanilla/Formatting/Embeds/EmbedManager.php
+++ b/library/Vanilla/Formatting/Embeds/EmbedManager.php
@@ -9,6 +9,8 @@ namespace Vanilla\Formatting\Embeds;
 use Exception;
 use Gdn_Cache;
 use InvalidArgumentException;
+use Vanilla\Attributes;
+use Vanilla\PageScraper;
 
 /**
  * Manage scraping embed data and generating markup.
@@ -201,6 +203,10 @@ class EmbedManager {
 
         if ($data) {
             $this->cache->store($cacheKey, $data, [Gdn_Cache::FEATURE_EXPIRY => self::CACHE_EXPIRY]);
+        }
+
+        if (empty($data['attributes'])) {
+            $data['attributes'] = new Attributes();
         }
 
         return $data;

--- a/library/Vanilla/PageScraper.php
+++ b/library/Vanilla/PageScraper.php
@@ -51,7 +51,17 @@ class PageScraper {
 
         $document = new DOMDocument();
         $rawBody = $response->getRawBody();
+
+        // Add charset information for HTML 5 pages.
+        // https://stackoverflow.com/questions/39148170/utf-8-with-php-domdocument-loadhtml#39148511
+        if (!preg_match('`\s*<?xml`', $rawBody)) {
+            $encoding = mb_detect_encoding($rawBody);
+            $rawBody = "<?xml version=\"1.0\" encoding=\"$encoding\"?>$rawBody";
+        }
+
+        $err = libxml_use_internal_errors(true);
         $loadResult = $document->loadHTML($rawBody);
+        libxml_use_internal_errors($err);
         if ($loadResult === false) {
             throw new Exception('Failed to load document for parsing.');
         }

--- a/library/Vanilla/PageScraper.php
+++ b/library/Vanilla/PageScraper.php
@@ -204,7 +204,7 @@ class PageScraper {
 
         $document = $this->loadDocument($html);
 
-        if (!$document->encoding) {
+        if (!$document->encoding && !in_array($encoding, ['ASCII'], true)) {
             $document = $this->fixDocumentEncoding($document, $html);
         }
 

--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -9,6 +9,7 @@ namespace VanillaTests\APIv2;
 
 use Gdn_Upload;
 use Garden\Http\HttpResponse;
+use Vanilla\Attributes;
 use Vanilla\Formatting\Embeds\EmbedManager;
 use Vanilla\UploadedFile;
 use VanillaTests\Fixtures\Uploader;
@@ -169,6 +170,7 @@ class MediaTest extends AbstractAPIv2Test {
      * @return array
      */
     public function provideScrapeUrls() {
+        $empty = new Attributes();
         $testBaseUrl = getenv('TEST_BASEURL');
         $urls = [
             [
@@ -180,7 +182,7 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://vanillaforums.com/images/metaIcons/vanillaForums.png',
                     'height' => null,
                     'width' => null,
-                    'attributes' => []
+                    'attributes' => $empty,
                 ],
                 true
             ],
@@ -193,7 +195,7 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://example.com/image.bmp',
                     'height' => null,
                     'width' => null,
-                    'attributes' => [],
+                    'attributes' => $empty,
                 ]
             ],
             [
@@ -205,7 +207,7 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://example.com/image.gif',
                     'height' => null,
                     'width' => null,
-                    'attributes' => [],
+                    'attributes' => $empty,
                 ]
             ],
             [
@@ -217,7 +219,7 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://example.com/image.jpg',
                     'height' => null,
                     'width' => null,
-                    'attributes' => [],
+                    'attributes' => $empty,
                 ]
             ],
             [
@@ -229,7 +231,7 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://example.com/image.jpeg',
                     'height' => null,
                     'width' => null,
-                    'attributes' => [],
+                    'attributes' => $empty,
                 ]
             ],
             [
@@ -241,7 +243,7 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://example.com/image.png',
                     'height' => null,
                     'width' => null,
-                    'attributes' => [],
+                    'attributes' => $empty,
                 ]
             ],
             [
@@ -253,7 +255,7 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://example.com/image.svg',
                     'height' => null,
                     'width' => null,
-                    'attributes' => [],
+                    'attributes' => $empty,
                 ]
             ],
             [
@@ -265,7 +267,7 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://example.com/image.tif',
                     'height' => null,
                     'width' => null,
-                    'attributes' => [],
+                    'attributes' => $empty,
                 ]
             ],
             [
@@ -277,7 +279,7 @@ class MediaTest extends AbstractAPIv2Test {
                     'photoUrl' => 'https://example.com/image.tiff',
                     'height' => null,
                     'width' => null,
-                    'attributes' => [],
+                    'attributes' => $empty,
                 ]
             ],
             [
@@ -431,7 +433,7 @@ class MediaTest extends AbstractAPIv2Test {
         unset($body['url'], $body['type']);
         $this->assertCount(count($info), $body);
         foreach ($body as $key => $value) {
-            $this->assertEquals($info[$key], $value);
+            $this->assertEquals(json_encode($info[$key]), json_encode($value));
         }
     }
 

--- a/tests/Library/Vanilla/PageScraperTest.php
+++ b/tests/Library/Vanilla/PageScraperTest.php
@@ -98,8 +98,38 @@ class PageScraperTest extends SharedBootstrapTestCase {
     public function testFetch(string $file, array $expected) {
         $pageScraper = $this->pageScraper();
         $url = 'file://'.self::HTML_DIR."/{$file}";
-        $expected['Url'] = $url;
         $result = $pageScraper->pageInfo($url);
+        $expected['Url'] = $url;
         $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Scrape a file and return its result.
+     *
+     * @param string $file The file to scrape.
+     * @return array Returns page info.
+     * @throws Exception Throws an exception if there was a non-recoverable error scraping.
+     */
+    protected function scrapeFile(string $file) {
+        $scraper = $this->pageScraper();
+        $url = 'file://'.self::HTML_DIR."/{$file}";
+        $result = $scraper->pageInfo($url);
+
+        return $result;
+
+    }
+
+    /**
+     * Test page fetching with unicode characters.
+     */
+    public function testUnicodeFetch() {
+        $files = ['unicode.htm', 'unicode-xml.htm'];
+
+        foreach ($files as $file) {
+            $result = $this->scrapeFile($file);
+
+            $this->assertEquals('Test · Hello World', $result['Title']);
+            $this->assertEquals('😀😄😘<>', $result['Description']);
+        }
     }
 }

--- a/tests/Library/Vanilla/PageScraperTest.php
+++ b/tests/Library/Vanilla/PageScraperTest.php
@@ -41,7 +41,7 @@ class PageScraperTest extends SharedBootstrapTestCase {
             [
                 'jsonld.htm',
                 [
-                    'Title' => 'I am a standard title.',
+                    'Title' => 'I am a ständard title.',
                     'Description' => 'I am a standard description.',
                     'Images' => [],
                     'Attributes' => [
@@ -138,7 +138,7 @@ class PageScraperTest extends SharedBootstrapTestCase {
      * @return array Returns a data provider.
      */
     public function provideUnicodeFiles() {
-        $r = [['unicode.htm'], ['unicode-xml.htm'], ['unicode-xml-comment.htm'], ['unicode-http-equiv.htm']];
+        $r = [['unicode.htm'], ['unicode-xml.htm'], ['unicode-no-hint.htm'], ['unicode-xml-comment.htm'], ['unicode-http-equiv.htm']];
 
         return array_column($r, null, 0);
     }

--- a/tests/Library/Vanilla/PageScraperTest.php
+++ b/tests/Library/Vanilla/PageScraperTest.php
@@ -121,15 +121,47 @@ class PageScraperTest extends SharedBootstrapTestCase {
 
     /**
      * Test page fetching with unicode characters.
+     *
+     * @param string $file The file to test.
+     * @dataProvider provideUnicodeFiles
      */
-    public function testUnicodeFetch() {
-        $files = ['unicode.htm', 'unicode-xml.htm'];
+    public function testUnicodeFetch(string $file) {
+        $result = $this->scrapeFile($file);
 
-        foreach ($files as $file) {
-            $result = $this->scrapeFile($file);
+        $this->assertEquals('Test · Hello World', $result['Title']);
+        $this->assertEquals('😀😄😘<>', $result['Description']);
+    }
 
-            $this->assertEquals('Test · Hello World', $result['Title']);
-            $this->assertEquals('😀😄😘<>', $result['Description']);
-        }
+    /**
+     * Provide some unicode test files.
+     *
+     * @return array Returns a data provider.
+     */
+    public function provideUnicodeFiles() {
+        $r = [['unicode.htm'], ['unicode-xml.htm'], ['unicode-xml-comment.htm'], ['unicode-http-equiv.htm']];
+
+        return array_column($r, null, 0);
+    }
+
+    /**
+     * Test scraping a file that isn't in unicode to make sure it doesn't bork.
+     *
+     * @param string $file The name of the file to test.
+     * @dataProvider provideKOI8RFiles
+     */
+    public function testKoi8(string $file) {
+        $result = $this->scrapeFile($file);
+
+        $this->assertEquals('ЧАСНЫЕ ОБЪЯВЛЕНИЯ', $result['Title']);
+    }
+
+    /**
+     * Provide some KOI8-R test files.
+     *
+     * @return array Returns a data provider.
+     */
+    public function provideKOI8RFiles() {
+        $r = [['koi8-1.htm'], ['koi8-2.htm'], ['koi8-3.htm']];
+        return array_column($r, null, 0);
     }
 }

--- a/tests/fixtures/html/jsonld.htm
+++ b/tests/fixtures/html/jsonld.htm
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>I am a standard title.</title>
+    <title>I am a ständard title.</title>
     <meta name="description" content="I am a standard description." />
     <script type="application/ld+json">
         {

--- a/tests/fixtures/html/koi8-1.htm
+++ b/tests/fixtures/html/koi8-1.htm
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="KOI8-R" ?>
+<html><head>
+	<!--<meta http-equiv="Content-Type" content="text/html; charset=KOI8-R">-->
+	<title>ЧАСНЫЕ ОБЪЯВЛЕНИЯ</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/fixtures/html/koi8-2.htm
+++ b/tests/fixtures/html/koi8-2.htm
@@ -1,0 +1,9 @@
+<?xml encoding="KOI8-R"?>
+<html><head>
+	<meta http-equiv="Content-Type" content="text/html; charset=KOI8-R">
+	<title>ЧАСНЫЕ ОБЪЯВЛЕНИЯ</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/fixtures/html/koi8-3.htm
+++ b/tests/fixtures/html/koi8-3.htm
@@ -1,0 +1,8 @@
+<html><head>
+	<meta charset="KOI8-R">
+	<title>ЧАСНЫЕ ОБЪЯВЛЕНИЯ</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/tests/fixtures/html/unicode-http-equiv.htm
+++ b/tests/fixtures/html/unicode-http-equiv.htm
@@ -1,0 +1,9 @@
+<!doctype html>
+<head>
+    <title>Test · Hello World</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="description" content="😀😄😘<&gt;">
+<body>
+Hello World!!!
+</body>
+</html>

--- a/tests/fixtures/html/unicode-no-hint.htm
+++ b/tests/fixtures/html/unicode-no-hint.htm
@@ -1,0 +1,8 @@
+<!doctype html>
+<head>
+    <title>Test · Hello World</title>
+    <meta name="description" content="😀😄😘<&gt;">
+<body>
+Hello World!!!
+</body>
+</html>

--- a/tests/fixtures/html/unicode-xml-comment.htm
+++ b/tests/fixtures/html/unicode-xml-comment.htm
@@ -1,0 +1,11 @@
+<!-- This is not really valid, but let's test anyway. -->
+<?xml version="1.0" encoding="utf-8"?>
+<!doctype html>
+<head>
+    <title>Test · Hello World</title>
+    <meta charset="utf-8">
+    <meta name="description" content="😀😄😘<&gt;">
+<body>
+Hello World!!!
+</body>
+</html>

--- a/tests/fixtures/html/unicode-xml.htm
+++ b/tests/fixtures/html/unicode-xml.htm
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!doctype html>
+<head>
+    <title>Test · Hello World</title>
+    <meta charset="utf-8">
+    <meta name="description" content="😀😄😘<&gt;">
+<body>
+Hello World!!!
+</body>
+</html>

--- a/tests/fixtures/html/unicode.htm
+++ b/tests/fixtures/html/unicode.htm
@@ -1,0 +1,9 @@
+<!doctype html>
+<head>
+    <title>Test · Hello World</title>
+    <meta charset="utf-8">
+    <meta name="description" content="😀😄😘<&gt;">
+<body>
+Hello World!!!
+</body>
+</html>


### PR DESCRIPTION
Unfortunately, DOMDocument is built with a version of libxml that does not understand HTML5 too well. This cause UTF-8 characters to not be read properly. In an attempt to make our scraper work with the majority of HTML5 documents this small change adds a charset and hopefully doesn’t kill efficiency.

I am well aware that this does not 100% solve the problem. If anyone wants to take a stab at this issue I am fine with that given:

1. Some profiling is done to make sure a solution doesn’t make large documents kill our servers.
2. There are no regression bugs. I recommend adding more character cases to the test files or even a non utf-8 test file.