### PR TITLE
Fix quill rendering of heading with inline formats in it

### DIFF
--- a/library/Vanilla/Formatting/Quill/BlotGroup.php
+++ b/library/Vanilla/Formatting/Quill/BlotGroup.php
@@ -10,7 +10,6 @@ namespace Vanilla\Formatting\Quill;
 use Vanilla\Formatting\Quill\Blots\AbstractBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\AbstractLineBlot;
 use Vanilla\Formatting\Quill\Blots\CodeBlockBlot;
-use Vanilla\Formatting\Quill\Blots\HeadingBlot;
 use Vanilla\Formatting\Quill\Blots\TextBlot;
 
 /**
@@ -29,7 +28,6 @@ class BlotGroup {
      * Blots that can determine the surrounding tag over the other blot types.
      */
     private $overridingBlots = [
-        HeadingBlot::class,
         CodeBlockBlot::class,
         AbstractLineBlot::class,
     ];

--- a/library/Vanilla/Formatting/Quill/Blots/Lines/HeadingBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Lines/HeadingBlot.php
@@ -5,14 +5,15 @@
  * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
  */
 
-namespace Vanilla\Formatting\Quill\Blots;
+namespace Vanilla\Formatting\Quill\Blots\Lines;
+use Vanilla\Formatting\Quill\BlotGroup;
 
 /**
  * Blot to represent headings.
  *
  * Currently only 2 levels are allowed.
  */
-class HeadingBlot extends TextBlot {
+class HeadingBlot extends AbstractLineBlot {
 
     /** @var array Valid heading levels. */
     private static $validLevels = [2, 3];
@@ -40,11 +41,27 @@ class HeadingBlot extends TextBlot {
         return "</h".$this->getHeadingLevel().">";
     }
 
-    /**
-     * @inheritDoc
-     */
+    public function renderLineStart(): string {
+        return "";
+    }
+
+    public function renderLineEnd(): string {
+        return "";
+    }
+
     public function isOwnGroup(): bool {
         return true;
+    }
+
+    /**
+     * The heading blot can be the ONLY overriding blot in a group. Even other headings.
+     *
+     * @param BlotGroup $group
+     * @return bool
+     */
+    public function shouldClearCurrentGroup(BlotGroup $group): bool {
+        $overridingBlot = $group->getPrimaryBlot();
+        return !!$overridingBlot;
     }
 
     /**

--- a/library/Vanilla/Formatting/Quill/Blots/Lines/HeadingBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Lines/HeadingBlot.php
@@ -41,10 +41,20 @@ class HeadingBlot extends AbstractLineBlot {
         return "</h".$this->getHeadingLevel().">";
     }
 
+    /**
+     * Since headings are always one line, they don't need special line starts or ends.
+     *
+     * The group tags are enough.
+     */
     public function renderLineStart(): string {
         return "";
     }
 
+    /**
+     * Since headings are always one line, they don't need special line starts or ends.
+     *
+     * The group tags are enough.
+     */
     public function renderLineEnd(): string {
         return "";
     }

--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -62,8 +62,8 @@ class Parser {
             ->addBlot(Blots\Lines\SpoilerLineBlot::class)
             ->addBlot(Blots\Lines\BlockquoteLineBlot::class)
             ->addBlot(Blots\Lines\ListLineBlot::class)
+            ->addBlot(Blots\Lines\HeadingBlot::class)
             ->addBlot(Blots\CodeBlockBlot::class)
-            ->addBlot(Blots\HeadingBlot::class)
             ->addBlot(Blots\TextBlot::class)// This needs to be the last one!!!
             ->addFormat(Formats\Link::class)
             ->addFormat(Formats\Bold::class)

--- a/tests/Library/Vanilla/Formatting/Quill/BlotGroupTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/BlotGroupTest.php
@@ -9,7 +9,7 @@ namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
 use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Formatting\Quill\BlotGroup;
-use Vanilla\Formatting\Quill\Blots\HeadingBlot;
+use Vanilla\Formatting\Quill\Blots\Lines\HeadingBlot;
 use Vanilla\Formatting\Quill\Blots\TextBlot;
 
 class BlotGroupTest extends SharedBootstrapTestCase {

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -7,9 +7,8 @@
 
 namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
-use SebastianBergmann\CodeCoverage\Report\Text;
 use Vanilla\Formatting\Quill\Blots\Embeds\ExternalBlot;
-use Vanilla\Formatting\Quill\Blots\HeadingBlot;
+use Vanilla\Formatting\Quill\Blots\Lines\HeadingBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\BlockquoteLineBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\ListLineBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\SpoilerLineBlot;
@@ -234,6 +233,23 @@ class ParserTest extends SharedBootstrapTestCase {
 
         $ops = [["attributes" => ["header" => 5], "content" => "\n"]];
         $result = [[["class" => NullBlot::class, "content" => ""]]];
+        $this->assertParseResults($ops, $result);
+    }
+
+    public function testInlineFormattedHeadings() {
+        $ops = [
+            [ "attributes" => [ "bold" => true ], "insert" => "bold " ],
+            [ "attributes" => [ "italic" => true, "bold" => true ], "insert" => "italic " ],
+            [ "attributes" => [ "strike" => true ], "insert" => "strike" ],
+            [ "attributes" => [ "header" => 2 ], "insert" => "\n" ]
+        ];
+
+        $result = [[
+            ["class" => TextBlot::class, "content" => "bold "],
+            ["class" => TextBlot::class, "content" => "italic "],
+            ["class" => HeadingBlot::class, "content" => "strike"],
+        ]];
+
         $this->assertParseResults($ops, $result);
     }
 

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -236,6 +236,9 @@ class ParserTest extends SharedBootstrapTestCase {
         $this->assertParseResults($ops, $result);
     }
 
+    /**
+     * Ensure that a single heading can properly render when it contains multiple inline formats.
+     */
     public function testInlineFormattedHeadings() {
         $ops = [
             [ "attributes" => [ "bold" => true ], "insert" => "bold " ],


### PR DESCRIPTION
I came across this while working on the in-editor formatting https://github.com/vanilla/vanilla/issues/7516.

Heading blots were not rendering properly if there were multiple separate inline formatted items inside of them. Luckily this structure of operations is already a solved problem. Switching the HeadingBlot to inherit from the `AbstractLineBlot` instead of the `TextBlot` directly solves the issue.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/1770056/43419167-3877726a-940e-11e8-84f3-beb9c7c0bbb6.png)|![image](https://user-images.githubusercontent.com/1770056/43419145-28ea14ec-940e-11e8-8870-0c3c7d4cde8e.png)|

I've added a parser test for this particular scenario as well.


