### PR TITLE
Fix Drafts double escaping special characters

### DIFF
--- a/applications/vanilla/views/drafts/drafts.php
+++ b/applications/vanilla/views/drafts/drafts.php
@@ -10,7 +10,7 @@ foreach ($this->DraftData->resultArray() as $Draft) {
 
     $draftID = val('DraftID', $Draft);
     $discussionID = val('DiscussionID', $Draft);
-    $excerpt = htmlspecialchars(sliceString(Gdn_Format::plainText(val('Body', $Draft), val('Format', $Draft)), 200));
+    $excerpt = sliceString(Gdn_Format::plainText(val('Body', $Draft), val('Format', $Draft)), 200);
 
     $isDiscussion = (!is_numeric($discussionID) || $discussionID <= 0);
     $orphaned = !val('DiscussionExists', $Draft);


### PR DESCRIPTION
This fixes special characters being displayed incorrectly on the drafts index page because they were being displayed incorrectly.

Closes #7474