### PR TITLE
Add default body content validation

### DIFF
--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -101,7 +101,7 @@ class Gdn_Model extends Gdn_Pluggable {
         $this->Database = Gdn::database();
         $this->SQL = $this->Database->sql();
         if ($validation === null) {
-            $validation = new Gdn_Validation();
+            $validation = Gdn::getContainer()->get(Gdn_Validation::class);
         }
         $this->Validation = $validation;
         $this->Name = $name;


### PR DESCRIPTION
#7230 introduced the ability to verify post/content body formats. While it was enabled by default in instances created by the container, it was not enabled on `Gdn_Validation` instances created in `Gdn_Model::__construct`. For example, if you manually instantiate `CommentModel`, then saved a new comment with it, the additional body-validation rule wasn't run.

This update sees `Gdn_Model` grabbing its copy of `Gdn_Validation` from the container, which will be preconfigured for body format validation. If a row is being saved with a "Body" and "Format" field, and if `BodyFormatValidator` has a routine to handle the format, the row must pass body format validation.

Closes #7524