### PR TITLE
Fix broken polyfill loading

### DIFF
--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -202,7 +202,9 @@ class AssetModel extends Gdn_Model {
      * @return string
      */
     public function getInlinePolyfillJSContent(): string {
-        $polyfillFileUrl = asset("/js/polyfills/core-polyfills.js?h=".$this->cacheBuster(), false);
+        $dashboardAddon = $this->addonManager->lookupAddon("dashboard");
+        $polyfillFileUrl = $dashboardAddon->path("/js/polyfills/dashboard-polyfills.min.js?h="
+            .$this->cacheBuster(), Addon::TYPE_ADDON);
 
         $debug = c("Debug", false);
         $logAdding = $debug ? "console.log('Older browser detected. Initiating polyfills.');" : "";


### PR DESCRIPTION
The path to our polyfills have been broken after some changes to the files location. I've updated that location here. It is now putting together the path the same way the automatically loaded dashboard js scripts do.

Things like the rich editor should now work in Edge and IE again.