### PR TITLE
Fix Twitter callback URL for profile connections

### DIFF
--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -274,7 +274,7 @@ class TwitterPlugin extends Gdn_Plugin {
             $redirectUri .= (strpos($redirectUri, '?') === false ? '?' : '&').$query;
         }
 
-        $params = ['oauth_callback' => $redirectUri];
+        $params = ['callback_url' => $redirectUri];
 
         $url = 'https://api.twitter.com/oauth/request_token';
         $request = OAuthRequest::from_consumer_and_token($consumer, null, 'POST', $url, $params);


### PR DESCRIPTION
<strike>This was never correct</strike>(see below), but twitter did not check for a correct callback_url until recently:
https://twittercommunity.com/t/action-required-sign-in-with-twitter-users-must-whitelist-callback-urls/105342

related:
https://github.com/vanilla/docs/pull/299