### PR TITLE
Continuous changes to get rid of deprecated val() function

### DIFF
--- a/applications/dashboard/library/class.nestedcollection.php
+++ b/applications/dashboard/library/class.nestedcollection.php
@@ -706,7 +706,7 @@ trait NestedCollection {
      * @param array $items The item list to flatten.
      * @return array The flattened items list.
      */
-    private function flattenArray($items) {
+    private function flattenArray(array $items) {
         $newItems = [];
         $itemslength = sizeof($items);
         $index = 0;
@@ -714,16 +714,16 @@ trait NestedCollection {
             $subItems = [];
 
             // Group item
-            if (val('type', $item) == 'group') {
-                if (val('items', $item)) {
+            if (($item['type'] ?? '') == 'group') {
+                if (($item['items'] ?? false)) {
                     $subItems = $item['items'];
                     unset($item['items']);
-                    if (val('text', $item)) {
+                    if (($item['text'] ?? false)) {
                         $newItems[] = $item;
                     }
                 }
             }
-            if ((val('type', $item) != 'group')) {
+            if (($item['type'] ?? '') != 'group') {
                 $newItems[] = $item;
             }
             if ($subItems) {

--- a/applications/dashboard/library/class.nestedcollection.php
+++ b/applications/dashboard/library/class.nestedcollection.php
@@ -552,7 +552,7 @@ trait NestedCollection {
         $i = 0;
         foreach ($items as &$item) {
             $item += ['_sort' => $i++];
-            if (val('items', $item)) {
+            if ($item['items'] ?? false) {
                 $this->sortItems($item['items']);
             }
         }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -4066,54 +4066,55 @@ class UserModel extends Gdn_Model {
     public function setCalculatedFields(&$user) {
         if (is_object($user)) {
             $this->setCalculatedFieldsObject($user);
-        } else {
-            if (is_string($v = ($user['Attributes'] ?? false))) {
-                $user['Attributes'] = dbdecode($v);
-            }
-            if (is_string($v = ($user['Permissions'] ?? false))) {
-                $user['Permissions'] = dbdecode($v);
-            }
-            if (is_string($v = ($user['Preferences'] ?? false))) {
-                $user['Preferences'] = dbdecode($v);
-            }
-
-            if ($v = ($user['Photo'] ?? false)) {
-                if (!isUrl($v)) {
-                    $photoUrl = Gdn_Upload::url(changeBasename($v, 'n%s'));
-                } else {
-                    $photoUrl = $v;
-                }
-                $user['PhotoUrl'] = $photoUrl;
-            }
-
-            $confirmed = ($user['Confirmed'] ?? null);
-            if ($confirmed !== null) {
-                $user['EmailConfirmed'] = $confirmed;
-            }
-            $verified = ($user['Verified'] ?? null);
-            if ($verified !== null) {
-                $user['BypassSpam'] = $verified;
-            }
-
-            // We store IPs in the UserIP table. To avoid unnecessary queries, the full list is not built here. Shim for BC.
-            $user['AllIPAddresses'] = [
-                $user['InsertIPAddress'] ?? false,
-                $user['LastIPAddress'] ?? false
-            ];
-
-            $user['_CssClass'] = '';
-            if ($user['Banned'] ?? false) {
-                $user['_CssClass'] = 'Banned';
-            }
-
-            $this->EventArguments['User'] = &$user;
-            $this->fireEvent('SetCalculatedFields');
+            return;
+        }
+        if (is_string($v = ($user['Attributes'] ?? false))) {
+            $user['Attributes'] = dbdecode($v);
+        }
+        if (is_string($v = ($user['Permissions'] ?? false))) {
+            $user['Permissions'] = dbdecode($v);
+        }
+        if (is_string($v = ($user['Preferences'] ?? false))) {
+            $user['Preferences'] = dbdecode($v);
         }
 
+        if ($v = ($user['Photo'] ?? false)) {
+            if (!isUrl($v)) {
+                $photoUrl = Gdn_Upload::url(changeBasename($v, 'n%s'));
+            } else {
+                $photoUrl = $v;
+            }
+            $user['PhotoUrl'] = $photoUrl;
+        }
+
+        $confirmed = ($user['Confirmed'] ?? null);
+        if ($confirmed !== null) {
+            $user['EmailConfirmed'] = $confirmed;
+        }
+        $verified = ($user['Verified'] ?? null);
+        if ($verified !== null) {
+            $user['BypassSpam'] = $verified;
+        }
+
+        // We store IPs in the UserIP table. To avoid unnecessary queries, the full list is not built here. Shim for BC.
+        $user['AllIPAddresses'] = [
+            $user['InsertIPAddress'] ?? false,
+            $user['LastIPAddress'] ?? false
+        ];
+
+        $user['_CssClass'] = '';
+        if ($user['Banned'] ?? false) {
+            $user['_CssClass'] = 'Banned';
+        }
+
+        $this->EventArguments['User'] = &$user;
+        $this->fireEvent('SetCalculatedFields');
     }
 
-    /*
-     * @deprecated IMHO This function should never be called vs object
+    /**
+     * Duplicates `setCalculatedFields()` for objects.
+     *
+     * @deprecated Call `setCalculatedFields()` with an array instead.
      */
     public function setCalculatedFieldsObject( &$user) {
         deprected(__FILE__.'setCalculatedFieldsObject( &$user)');

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -4068,17 +4068,17 @@ class UserModel extends Gdn_Model {
         if (is_object($user)) {
             $this->setCalculatedFieldsObject($user);
         } else {
-            if (is_string($v = $user['Attributes'] ?? false)) {
+            if (is_string($v = ($user['Attributes'] ?? false))) {
                 $user['Attributes'] = dbdecode($v);
             }
-            if (is_string($v = $user['Permissions'] ?? false)) {
+            if (is_string($v = ($user['Permissions'] ?? false))) {
                 $user['Permissions'] = dbdecode($v);
             }
-            if (is_string($v = $user['Preferences'] ?? false)) {
+            if (is_string($v = ($user['Preferences'] ?? false))) {
                 $user['Preferences'] = dbdecode($v);
             }
 
-            if ($v = $user['Photo'] ?? false) {
+            if ($v = ($user['Photo'] ?? false)) {
                 if (!isUrl($v)) {
                     $photoUrl = Gdn_Upload::url(changeBasename($v, 'n%s'));
                 } else {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -4103,7 +4103,7 @@ class UserModel extends Gdn_Model {
             ];
 
             $user['_CssClass'] = '';
-            if ($user['Banned']) {
+            if ($user['Banned'] ?? false) {
                 $user['_CssClass'] = 'Banned';
             }
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -4087,11 +4087,11 @@ class UserModel extends Gdn_Model {
                 $user['PhotoUrl'] = $photoUrl;
             }
 
-            $confirmed = $user['Confirmed'];
+            $confirmed = ($user['Confirmed'] ?? null);
             if ($confirmed !== null) {
                 $user['EmailConfirmed'] = $confirmed;
             }
-            $verified = $user['Verified'];
+            $verified = ($user['Verified'] ?? null);
             if ($verified !== null) {
                 $user['BypassSpam'] = $verified;
             }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1485,7 +1485,6 @@ class UserModel extends Gdn_Model {
 
         // Check page cache, then memcached
         $user = $this->getUserFromCache($iD, 'userid');
-
         // If not, query DB
         if ($user === Gdn_Cache::CACHEOP_FAILURE) {
             $user = parent::getID($iD, DATASET_TYPE_ARRAY);
@@ -1500,12 +1499,12 @@ class UserModel extends Gdn_Model {
             return false;
         }
 
-        // Apply calculated fields
-        $this->setCalculatedFields($user);
-
         // Allow FALSE returns
         if ($user === false || is_null($user)) {
             return false;
+        } else {
+            // Apply calculated fields
+            $this->setCalculatedFields($user);
         }
 
         if (is_array($user) && $datasetType == DATASET_TYPE_OBJECT) {

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -186,14 +186,14 @@ if (!function_exists('discussionOptionsToDropdown')):
      * @param DropdownModule|null $dropdown
      * @return DropdownModule
      */
-    function discussionOptionsToDropdown($options, $dropdown = null) {
+    function discussionOptionsToDropdown(array $options, $dropdown = null) {
         if (is_null($dropdown)) {
             $dropdown = new DropdownModule('dropdown', '', 'OptionsMenu');
         }
 
         if (!empty($options)) {
             foreach ($options as $option) {
-                $dropdown->addLink(val('Label', $option), val('Url', $option), NavModule::textToKey(val('Label', $option)), val('Class', $option));
+                $dropdown->addLink(($option['Label'] ?? ''), ($option['Url'] ?? ''), NavModule::textToKey(($option['Label'] ?? '')), ($option['Class'] ?? false));
             }
         }
 

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -548,7 +548,7 @@ if (!function_exists('cssClass')) {
         if (array_key_exists('UrlCode', $row)) {
             $cssClass .= ' Category-'.Gdn_Format::alphaNumeric($row['UrlCode']);
         }
-        if (val('CssClass', $row)) {
+        if ($row['CssClass'] ?? false) {
             $cssClass .= ' Item-'.$row['CssClass'];
         }
 
@@ -562,18 +562,18 @@ if (!function_exists('cssClass')) {
 
         // Discussion list classes.
         if ($inList) {
-            $cssClass .= val('Bookmarked', $row) == '1' ? ' Bookmarked' : '';
+            $cssClass .= ($row['Bookmarked'] ?? '') == '1' ? ' Bookmarked' : '';
 
-            $announce = val('Announce', $row);
+            $announce = $row['Announce'];
             if ($announce == 2) {
                 $cssClass .= ' Announcement Announcement-Category';
             } elseif ($announce) {
                 $cssClass .= ' Announcement Announcement-Everywhere';
             }
 
-            $cssClass .= val('Closed', $row) == '1' ? ' Closed' : '';
-            $cssClass .= val('InsertUserID', $row) == $session->UserID ? ' Mine' : '';
-            $cssClass .= val('Participated', $row) == '1' ? ' Participated' : '';
+            $cssClass .= ($row['Closed'] ?? '') == '1' ? ' Closed' : '';
+            $cssClass .= ($row['InsertUserID'] ?? false ) == $session->UserID ? ' Mine' : '';
+            $cssClass .= ($row['Participated'] ?? '') == '1' ? ' Participated' : '';
             if (array_key_exists('CountUnreadComments', $row) && $session->isValid()) {
                 $countUnreadComments = $row['CountUnreadComments'];
                 if ($countUnreadComments === true) {
@@ -583,7 +583,7 @@ if (!function_exists('cssClass')) {
                 } else {
                     $cssClass .= ' Unread';
                 }
-            } elseif (($isRead = val('Read', $row, null)) !== null) {
+            } elseif (($isRead = ($row['Read'])) !== null) {
                 // Category list
                 $cssClass .= $isRead ? ' Read' : ' Unread';
             }
@@ -600,14 +600,14 @@ if (!function_exists('cssClass')) {
             $cssClass .= isMeAction($row) ? ' MeAction' : '';
         }
 
-        if ($_CssClss = val('_CssClass', $row)) {
+        if ($_CssClss = ($row['_CssClass'] ?? false)) {
             $cssClass .= ' '.$_CssClss;
         }
 
         // Insert User classes.
-        if ($userID = val('InsertUserID', $row)) {
-            $user = Gdn::userModel()->getID($userID);
-            if ($_CssClss = val('_CssClass', $user)) {
+        if ($userID = ($row['InsertUserID'] ?? false)) {
+            $user = Gdn::userModel()->getID($userID, DATASET_TYPE_ARRAY);
+            if ($_CssClss = ($user['_CssClass'] ?? false)) {
                 $cssClass .= ' '.$_CssClss;
             }
         }


### PR DESCRIPTION
This PR belongs to epic https://github.com/vanilla/vanilla-patches/issues/331

Update setCalculatedFields in class.user.model to avoid calls to val()
Fixes: vanilla/vanilla-patches#325

Update cssClass function in fnctions.render.php to avoid val() calls
Fixes: vanilla/vanilla-patches#326

Update sortItems and addLink function in class.nestedcollection.php to avoid using val() function
Fixes vanilla/vanilla-patches#327

flattenArray fix for nestedcollection class to avoid val() calls 
Fixes: vanilla/vanilla-patches#329

Update discussionOptionsToDropdown function in dicussion/helper_functions.php to avoid val() calls
Fixes vanilla/vanilla-patches#328