### PR TITLE
Give addons more customization options when creating new notifications

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -508,10 +508,14 @@ class ConversationModel extends ConversationsModel {
      *
      * @param array $formPostValues Values submitted via form.
      * @param array $settings
+     * @param array $options
      *   - ConversationOnly If set, no message will be created.
      * @return int Unique ID of conversation created or updated.
      */
-    public function save($formPostValues, $settings = []) {
+    public function save($formPostValues, $settings = [], $options = []) {
+        if (!is_array($options)) {
+            $options = [];
+        }
         $deprecated = $settings instanceof ConversationMessageModel;
         $createMessage =  $deprecated || empty($settings['ConversationOnly']);
 
@@ -663,7 +667,7 @@ class ConversationModel extends ConversationsModel {
 
                 $notifyUserIDs = array_column($unreadData, 'UserID');
 
-                $this->notifyUsers($conversation, $message, $notifyUserIDs);
+                $this->notifyUsers($conversation, $message, $notifyUserIDs, $options + ['FirstMessage' => true]);
             }
 
         } else if ($createMessage) {

--- a/applications/conversations/models/class.conversationsmodel.php
+++ b/applications/conversations/models/class.conversationsmodel.php
@@ -139,8 +139,9 @@ abstract class ConversationsModel extends Gdn_Model {
      * @param array|object $conversation
      * @param array|object $message
      * @param array $notifyUserIDs
+     * @param array $options
      */
-    protected function notifyUsers($conversation, $message, $notifyUserIDs) {
+    protected function notifyUsers($conversation, $message, $notifyUserIDs, $options = []) {
         $conversation = (array)$conversation;
         $message = (array)$message;
 
@@ -151,14 +152,19 @@ abstract class ConversationsModel extends Gdn_Model {
             'RecordType' => 'Conversation',
             'RecordID' => $conversation['ConversationID'],
             'Story' => $message['Body'],
-            'ActionText' => t('Reply'),
+            'ActionText' => $options['ActionText'] ?? t('Reply'),
             'Format' => val('Format', $message, c('Garden.InputFormatter')),
-            'Route' => "/messages/{$conversation['ConversationID']}#Message_{$message['MessageID']}"
+            'Route' => $options['Url'] ?? "/messages/{$conversation['ConversationID']}#Message_{$message['MessageID']}"
         ];
 
-        $subject = val('subject', $conversation);
+        $subject = $conversation['Subject'] ?? '';
         if ($subject) {
-            $activity['Story'] = sprintf(t('Re: %s'), $subject).'<br>'.$body;
+            if (empty($options['FirstMessage'])) {
+                $subject = sprintf(t('Re: %s'), $subject);
+            }
+            $options['EmailSubject'] = $subject;
+        } else {
+            $options = [];
         }
 
         $activityModel = new ActivityModel();
@@ -168,7 +174,7 @@ abstract class ConversationsModel extends Gdn_Model {
             }
 
             $activity['NotifyUserID'] = $userID;
-            $activityModel->queue($activity, 'ConversationMessage');
+            $activityModel->queue($activity, 'ConversationMessage', $options);
         }
         $activityModel->saveQueue();
     }

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -980,11 +980,23 @@ class ActivityModel extends Gdn_Model {
      *
      *
      * @param $activity
-     * @param bool $noDelete
+     * @param array $options Options to modify the behavior of the emailing.
+     *
+     * - **NoDelete**: Don't delete an email-only activity once the email is sent.
+     * - **EmailSubject**: A custom subject for the email.
      * @return bool
      * @throws Exception
      */
-    public function email(&$activity, $noDelete = false) {
+    public function email(&$activity,  $options = []) {
+        // The $options parameter used to be $noDelete bool, this is the backwards compat.
+        if (is_bool($options)) {
+            $options = ['NoDelete' => $options];
+        }
+        $options += [
+            'NoDelete' => false,
+            'EmailSubject' => '',
+        ];
+
         if (is_numeric($activity)) {
             $activityID = $activity;
             $activity = $this->getID($activityID);
@@ -1024,16 +1036,22 @@ class ActivityModel extends Gdn_Model {
             $activity['Headline'] = Gdn_Format::activityHeadline($activity, '', $user['UserID']);
         }
 
+        $subject = $options['EmailSubject'] ?: Gdn_Format::plainText($activity['Headline']);
+
         // Build the email to send.
         $email = new Gdn_Email();
-        $email->subject(sprintf(t('[%1$s] %2$s'), c('Garden.Title'), Gdn_Format::plainText($activity['Headline'])));
+        $email->subject(sprintf(
+            t('[%1$s] %2$s'),
+            c('Garden.Title'),
+            $subject
+        ));
         $email->to($user);
 
         $url = externalUrl(val('Route', $activity) == '' ? '/' : val('Route', $activity));
 
         $emailTemplate = $email->getEmailTemplate()
             ->setButton($url, val('ActionText', $activity, t('Check it out')))
-            ->setTitle(Gdn_Format::plainText(val('Headline', $activity)));
+            ->setTitle($subject);
 
         if ($message = $this->getEmailMessage($activity)) {
             $emailTemplate->setMessage($message, true);
@@ -1057,7 +1075,7 @@ class ActivityModel extends Gdn_Model {
             }
 
             // Delete the activity now that it has been emailed.
-            if (!$noDelete && !$activity['Notified']) {
+            if (!$options['NoDelete'] && !$activity['Notified']) {
                 if (val('ActivityID', $activity)) {
                     $this->delete($activity['ActivityID']);
                 } else {
@@ -1504,7 +1522,7 @@ class ActivityModel extends Gdn_Model {
 
         $delete = false;
         if ($activity['Emailed'] == self::SENT_PENDING) {
-            $this->email($activity);
+            $this->email($activity, $options);
             $delete = val('_Delete', $activity);
         }
 


### PR DESCRIPTION
This modifies the activity being created when a group invite is sent out.  The options passed to conversation model, allow the activity created in conversationmodel::notifyusers to be overridden.  Acitivitymodel::email is then passed options to construct and email with these parameters.