### PR TITLE
Loosen categories api endpoints (list and search) to allow guest access

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -189,7 +189,7 @@ class CategoriesApiController extends AbstractApiController {
      * @return Data
      */
     public function get_search(array $query) {
-        $this->permission('Garden.SignIn.Allow');
+        $this->permission();
 
         $in = $this->schema([
             'query:s' => 'Category name filter.',
@@ -256,7 +256,7 @@ class CategoriesApiController extends AbstractApiController {
      * @return Data
      */
     public function index(array $query) {
-        $this->permission('Garden.SignIn.Allow');
+        $this->permission();
 
         $in = $this->schema([
             'parentCategoryID:i?' => 'Parent category ID.',


### PR DESCRIPTION
The `categories` and `categories/search` endpoints required `Garden.SignIn.Allow` permissions. We are loosening those endpoints to allow guest access.

Closes https://github.com/vanilla/vanilla/issues/7490