### PR TITLE
Prefix the default analytics subdomain with https in vanillastats

### DIFF
--- a/plugins/VanillaStats/class.vanillastats.plugin.php
+++ b/plugins/VanillaStats/class.vanillastats.plugin.php
@@ -40,7 +40,7 @@ class VanillaStatsPlugin extends Gdn_Plugin {
      * VanillaStatsPlugin constructor.
      */
     public function __construct() {
-        $this->AnalyticsServer = c('Garden.Analytics.Remote', 'analytics.vanillaforums.com');
+        $this->AnalyticsServer = c('Garden.Analytics.Remote', 'https://analytics.vanillaforums.com');
         $this->VanillaID = Gdn::installationID();
 
         $isVanillaAnalyticEnabled = Gdn::addonManager()->isEnabled('vanillaanalytics', Vanilla\Addon::TYPE_ADDON);


### PR DESCRIPTION
Implementing the fix Ryan suggested. Regardless of the current protocol (http or https), the analytics subdomain will always be prefixed by https to avoid these preflight/CORS errors.

Closes https://github.com/vanilla/support/issues/79