### PR TITLE
Fix the cssClass() function

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -143,7 +143,7 @@ if (!function_exists('writeListItem')):
     function writeListItem($category, $depth) {
         $children = $category['Children'];
         $categoryID = val('CategoryID', $category);
-        $cssClass = cssClass($category);
+        $cssClass = cssClass($category, false);
         $writeChildren = getWriteChildrenMethod($category, $depth);
         $rssIcon = '';
         $headingLevel = $depth + 2;

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -77,7 +77,7 @@ if (!function_exists('writeComment')) :
             $sender->CanEditComments = $session->checkPermission('Vanilla.Comments.Edit', true, 'Category', 'any') && c('Vanilla.AdminCheckboxes.Use');
         }
         // Prep event args
-        $cssClass = cssClass($comment, $currentOffset);
+        $cssClass = cssClass($comment, false);
         $sender->EventArguments['Comment'] = &$comment;
         $sender->EventArguments['Author'] = &$author;
         $sender->EventArguments['CssClass'] = &$cssClass;

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -530,6 +530,7 @@ if (!function_exists('cssClass')) {
      * Used by category, discussion, and comment lists.
      *
      * @param array|object $row
+     * @param bool $inList Whether or not we are in a discussion list.
      * @return string The CSS classes to be inserted into the row.
      */
     function cssClass($row, $inList = true) {
@@ -572,21 +573,22 @@ if (!function_exists('cssClass')) {
             }
 
             $cssClass .= ($row['Closed'] ?? '') == '1' ? ' Closed' : '';
-            $cssClass .= ($row['InsertUserID'] ?? false ) == $session->UserID ? ' Mine' : '';
             $cssClass .= ($row['Participated'] ?? '') == '1' ? ' Participated' : '';
-            if (array_key_exists('CountUnreadComments', $row) && $session->isValid()) {
-                $countUnreadComments = $row['CountUnreadComments'];
-                if ($countUnreadComments === true) {
-                    $cssClass .= ' New';
-                } elseif ($countUnreadComments == 0) {
-                    $cssClass .= ' Read';
-                } else {
-                    $cssClass .= ' Unread';
-                }
-            } elseif (($isRead = ($row['Read'])) !== null) {
-                // Category list
-                $cssClass .= $isRead ? ' Read' : ' Unread';
+        }
+
+        $cssClass .= ($row['InsertUserID'] ?? false ) == $session->UserID ? ' Mine' : '';
+        if (array_key_exists('CountUnreadComments', $row) && $session->isValid()) {
+            $countUnreadComments = $row['CountUnreadComments'];
+            if ($countUnreadComments === true) {
+                $cssClass .= ' New';
+            } elseif ($countUnreadComments == 0) {
+                $cssClass .= ' Read';
+            } else {
+                $cssClass .= ' Unread';
             }
+        } elseif (($isRead = ($row['Read'] ?? null)) !== null) {
+            // Category list
+            $cssClass .= $isRead ? ' Read' : ' Unread';
         }
 
         // Comment list classes


### PR DESCRIPTION
This function is used for several types of records and it looks for fields that do not apply.

- The `$inList` parameter is meant for discussion lists only so I make sure to pass **false** for comment and category lists.
- The some of the `$inList` fields are appropriate for other record types, so I moved it out of the if statement.