### PR TITLE
Allow the Memcached layer to use the container

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -49,6 +49,7 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->rule('Gdn_Cache')
     ->setShared(true)
     ->setFactory(['Gdn_Cache', 'initialize'])
+    ->setInherit(false)
     ->addAlias('Cache')
 
     // Configuration
@@ -337,12 +338,11 @@ $dic->setInstance('Garden\Container\Container', $dic)
 
 // Run through the bootstrap with dependencies.
 $dic->call(function (
-    Container $dic,
     Gdn_Configuration $config,
     \Vanilla\AddonManager $addonManager,
     \Garden\EventManager $eventManager,
     Gdn_Request $request // remove later
-) {
+) use ($dic) {
 
     // Load default baseline Garden configurations.
     $config->load(PATH_CONF.'/config-defaults.php');

--- a/library/core/class.cache.php
+++ b/library/core/class.cache.php
@@ -1,16 +1,15 @@
 <?php
 /**
- * Cache layer base class
- *
- * All cache objects should extend this to ensure a consistent public api for
- * caching.
- *
  * @author Tim Gunter <tim@vanillaforums.com>
  * @copyright 2009-2019 Vanilla Forums Inc.
  * @license GPL-2.0-only
- * @package Core
  * @since 2.0.10
- * @abstract
+ */
+
+/**
+ * The cache layer base class.
+ *
+ * All cache objects should extend this to ensure a consistent public api for caching.
  */
 abstract class Gdn_Cache {
 
@@ -159,7 +158,7 @@ abstract class Gdn_Cache {
             $cacheObject = new $activeCacheClass();
         }
 
-        // Null caches should not acount as enabled.
+        // Null caches should not count as enabled.
         if (!$forceEnable && $cacheObject->type() === Gdn_Cache::CACHE_TYPE_NULL) {
             saveToConfig('Cache.Enabled', false, false);
         }

--- a/library/core/class.memcached.php
+++ b/library/core/class.memcached.php
@@ -28,15 +28,28 @@ class Gdn_Memcached extends Gdn_Cache {
     /** @var Memcached  */
     private $memcache;
 
+    /**
+     * @var bool Whether or not the cache was injected.
+     */
+    private $injected = false;
+
     /** @var array */
     protected $weightedContainers;
 
     /**
      * Setup our Memcached configuration.
+     *
+     * @param Memcached $cache An optional cache driver. If this isn't supplied then one is created.
      */
-    public function __construct() {
+    public function __construct($cache = null) {
         parent::__construct();
         $this->cacheType = Gdn_Cache::CACHE_TYPE_MEMORY;
+
+        if ($cache !== null) {
+            $this->memcache = $cache;
+            $this->injected = true;
+            return;
+        }
 
         // Allow persistent connections
 
@@ -106,6 +119,10 @@ class Gdn_Memcached extends Gdn_Cache {
      * config file.
      */
     public function autorun() {
+        if ($this->injected) {
+            return;
+        }
+
         $servers = Gdn_Cache::activeStore('memcached');
         if (!is_array($servers)) {
             $servers = explode(',', $servers);

--- a/library/core/class.memcached.php
+++ b/library/core/class.memcached.php
@@ -45,6 +45,17 @@ class Gdn_Memcached extends Gdn_Cache {
         parent::__construct();
         $this->cacheType = Gdn_Cache::CACHE_TYPE_MEMORY;
 
+        $this->registerFeature(Gdn_Cache::FEATURE_COMPRESS, Memcached::OPT_COMPRESSION);
+        $this->registerFeature(Gdn_Cache::FEATURE_EXPIRY);
+        $this->registerFeature(Gdn_Cache::FEATURE_TIMEOUT);
+        $this->registerFeature(Gdn_Cache::FEATURE_NOPREFIX);
+        $this->registerFeature(Gdn_Cache::FEATURE_FORCEPREFIX);
+        $this->registerFeature(Gdn_Cache::FEATURE_SHARD);
+
+        if (c('Garden.Cache.Local', true)) {
+            $this->registerFeature(Gdn_Cache::FEATURE_LOCAL);
+        }
+
         if ($cache !== null) {
             $this->memcache = $cache;
             $this->injected = true;
@@ -69,17 +80,6 @@ class Gdn_Memcached extends Gdn_Cache {
             $this->memcache = new Memcached($poolKey);
         } else {
             $this->memcache = new Memcached;
-        }
-
-        $this->registerFeature(Gdn_Cache::FEATURE_COMPRESS, Memcached::OPT_COMPRESSION);
-        $this->registerFeature(Gdn_Cache::FEATURE_EXPIRY);
-        $this->registerFeature(Gdn_Cache::FEATURE_TIMEOUT);
-        $this->registerFeature(Gdn_Cache::FEATURE_NOPREFIX);
-        $this->registerFeature(Gdn_Cache::FEATURE_FORCEPREFIX);
-        $this->registerFeature(Gdn_Cache::FEATURE_SHARD);
-
-        if (c('Garden.Cache.Local', true)) {
-            $this->registerFeature(Gdn_Cache::FEATURE_LOCAL);
         }
 
         $this->StoreDefaults = [


### PR DESCRIPTION
This is the first PR in an incremental attempt to remove cache config from `Gdn_Cache` and instead move towards config in the bootstrap.

## Why remove cache config from `Gdn_Cache`?

- I want to start moving to a PSR cache requirement for most objects rather than our own built in cache object. Injecting the cache driver will allow us to reuse the same driver for `Gdn_Cache` backwards compatibility and the PSR cache.
- Being able to inject the underlying cache driver allows the server to more easily roll its own caching rather than have our cache object handle 100% of the config. Once we've done the injection we'll be able to gut most of the config logic from `Gdn_Cache` and simplify our code base.
- Longer term, I want to remove `Gdn_Cache`'s dependency on `Gdn_Configuration`.
- Once we've moved to a PSR cache we will be able to use cache chaining objects for custom cache strategies (ex. Try APC, then go to Memcached). Doing so will allow us to remove this kind of bespoke implementation from `Gdn_Configuration`.

## Changes

- The `Gdn_Memcached` class can now take its underlying `Memcached` object as a constructor arg.
- The `Gdn_Cache` container rule no longer inherits. Since its initialize method acts as a factory itself it should only be used by the base class.
- Fixed some doc blocks on `Gdn_Cache`.