### PR TITLE
Implement memory optimizations

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -892,12 +892,12 @@ class CategoryModel extends Gdn_Model {
         if (is_numeric($category)) {
             $category = static::categories($category);
         }
-        if (is_object($category)) {
-            $permissionCategoryID = ($category->PermissionCategoryID ?? -1);
-            $categoryID = ($category->CategoryID ?? false);
-        } else {
+        if (is_array($category)) {
             $permissionCategoryID = ($category['PermissionCategoryID'] ?? -1);
             $categoryID = ($category['CategoryID'] ?? false);
+        } else {
+            $permissionCategoryID = ($category->PermissionCategoryID ?? -1);
+            $categoryID = ($category->CategoryID ?? false);
         }
 
         $result = Gdn::session()->checkPermission($permission, $fullMatch, 'Category', $permissionCategoryID)

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -889,14 +889,22 @@ class CategoryModel extends Gdn_Model {
      * @return bool Returns **true** if the current user has the permission or **false** otherwise.
      */
     public static function checkPermission($category, $permission, $fullMatch = true) {
-        if (is_numeric($category)) {
-            $category = static::categories($category);
+        if (!is_array($category)) {
+            if (is_numeric($category)) {
+                $category = static::categories($category);
+                $permissionCategoryID = ($category['PermissionCategoryID'] ?? -1);
+                $categoryID = ($category['CategoryID'] ?? false);
+            } else {
+                $permissionCategoryID = ($category->PermissionCategoryID ?? -1);
+                $categoryID = ($category->CategoryID ?? false);
+            }
+        } else {
+            $permissionCategoryID = ($category['PermissionCategoryID'] ?? -1);
+            $categoryID = ($category['CategoryID'] ?? false);
         }
 
-        $permissionCategoryID = val('PermissionCategoryID', $category, -1);
-
         $result = Gdn::session()->checkPermission($permission, $fullMatch, 'Category', $permissionCategoryID)
-            || Gdn::session()->checkPermission($permission, $fullMatch, 'Category', val('CategoryID', $category));
+            || Gdn::session()->checkPermission($permission, $fullMatch, 'Category', $categoryID);
 
         return $result;
     }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -597,18 +597,18 @@ class CategoryModel extends Gdn_Model {
      *
      * @param array &$category The category to calculate.
      */
-    private static function calculate(&$category) {
+    private static function calculate(array &$category) {
         $category['Url'] = self::categoryUrl($category, false, '/');
 
-        if (val('Photo', $category)) {
-            $category['PhotoUrl'] = Gdn_Upload::url($category['Photo']);
+        if ($photo = ($category['Photo'] ?? false)) {
+            $category['PhotoUrl'] = Gdn_Upload::url($photo);
         } else {
             $category['PhotoUrl'] = '';
         }
 
         self::calculateDisplayAs($category);
 
-        if (!val('CssClass', $category)) {
+        if (!($category['CssClass'] ?? false)) {
             $category['CssClass'] = 'Category-'.$category['UrlCode'];
         }
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -889,15 +889,12 @@ class CategoryModel extends Gdn_Model {
      * @return bool Returns **true** if the current user has the permission or **false** otherwise.
      */
     public static function checkPermission($category, $permission, $fullMatch = true) {
-        if (!is_array($category)) {
-            if (is_numeric($category)) {
-                $category = static::categories($category);
-                $permissionCategoryID = ($category['PermissionCategoryID'] ?? -1);
-                $categoryID = ($category['CategoryID'] ?? false);
-            } else {
-                $permissionCategoryID = ($category->PermissionCategoryID ?? -1);
-                $categoryID = ($category->CategoryID ?? false);
-            }
+        if (is_numeric($category)) {
+            $category = static::categories($category);
+        }
+        if (is_object($category)) {
+            $permissionCategoryID = ($category->PermissionCategoryID ?? -1);
+            $categoryID = ($category->CategoryID ?? false);
         } else {
             $permissionCategoryID = ($category['PermissionCategoryID'] ?? -1);
             $categoryID = ($category['CategoryID'] ?? false);

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -191,12 +191,12 @@ class CategoryModel extends Gdn_Model {
      * @param array &$category The category to calculate.
      * @param bool|null $addUserCategory
      */
-    private function calculateUser(&$category, $addUserCategory = null) {
+    private function calculateUser(array &$category, $addUserCategory = null) {
         // Kludge to make sure that the url is absolute when reaching the user's screen (or API).
         $category['Url'] = self::categoryUrl($category, '', true);
 
         if (!isset($category['PhotoUrl'])) {
-            if ($photo = val('Photo', $category)) {
+            if ($photo = ($category['Photo'] ?? false)) {
                 $category['PhotoUrl'] = Gdn_Upload::url($photo);
             }
         }
@@ -217,8 +217,8 @@ class CategoryModel extends Gdn_Model {
         if ($addUserCategory || ($addUserCategory === null && $this->joinUserCategory())) {
             $userCategories = $this->getUserCategories();
 
-            $dateMarkedRead = val('DateMarkedRead', $category);
-            $userData = val($category['CategoryID'], $userCategories);
+            $dateMarkedRead = ($category['DateMarkedRead'] ?? false );
+            $userData = ($userCategories[$category['CategoryID']] ?? false);
             if ($userData) {
                 $userDateMarkedRead = $userData['DateMarkedRead'];
 
@@ -235,7 +235,7 @@ class CategoryModel extends Gdn_Model {
             }
 
             // Calculate the following field.
-            $following = !((bool)val('Archived', $category) || (bool)val('Unfollow', $userData, false));
+            $following = !((bool)($category['Archived'] ?? false) || (bool)($userData['Unfollow'] ?? false));
             $category['Following'] = $following;
 
             $category['Followed'] = boolval($userData['Followed']);
@@ -244,8 +244,8 @@ class CategoryModel extends Gdn_Model {
             if (strcasecmp($category['DisplayAs'], 'heading') === 0) {
                 $category['Read'] = false;
             } elseif ($dateMarkedRead) {
-                if (val('LastDateInserted', $category)) {
-                    $category['Read'] = Gdn_Format::toTimestamp($dateMarkedRead) >= Gdn_Format::toTimestamp($category['LastDateInserted']);
+                if ($lastDateInserted = ($category['LastDateInserted'] ?? false)) {
+                    $category['Read'] = Gdn_Format::toTimestamp($dateMarkedRead) >= Gdn_Format::toTimestamp($lastDateInserted);
                 } else {
                     $category['Read'] = true;
                 }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1747,8 +1747,8 @@ class CategoryModel extends Gdn_Model {
             foreach ($iDs as $iD) {
                 $category = $categories[$iD];
 
-                $dateMarkedRead = val('DateMarkedRead', $category);
-                $row = val($iD, $userData);
+                $dateMarkedRead = ($category['DateMarkedRead'] ?? false);
+                $row = ($userData[$iD] ?? false);
                 if ($row) {
                     $userDateMarkedRead = $row['DateMarkedRead'];
 
@@ -1763,7 +1763,7 @@ class CategoryModel extends Gdn_Model {
                 }
 
                 // Calculate the following field.
-                $following = !((bool)val('Archived', $category) || (bool)val('Unfollow', $row, false));
+                $following = !((bool)($category['Archived'] ?? false) || (bool)($row['Unfollow'] ?? false));
                 $categories[$iD]['Following'] = $following;
 
                 $categories[$iD]['Followed'] = boolval($row['Followed']);
@@ -1772,8 +1772,8 @@ class CategoryModel extends Gdn_Model {
                 if ($category['DisplayAs'] == 'Heading') {
                     $categories[$iD]['Read'] = false;
                 } elseif ($dateMarkedRead) {
-                    if (val('LastDateInserted', $category)) {
-                        $categories[$iD]['Read'] = Gdn_Format::toTimestamp($dateMarkedRead) >= Gdn_Format::toTimestamp($category['LastDateInserted']);
+                    if ($lastDateInserted = ($category['LastDateInserted'] ?? false)) {
+                        $categories[$iD]['Read'] = Gdn_Format::toTimestamp($dateMarkedRead) >= Gdn_Format::toTimestamp($lastDateInserted);
                     } else {
                         $categories[$iD]['Read'] = true;
                     }

--- a/library/core/class.cache.php
+++ b/library/core/class.cache.php
@@ -410,15 +410,14 @@ abstract class Gdn_Cache {
      */
     abstract public function add($key, $value, $options = []);
 
-    public function stripKey($key, $options) {
-        $usePrefix = !val(Gdn_Cache::FEATURE_NOPREFIX, $options, false);
-        $forcePrefix = val(Gdn_Cache::FEATURE_FORCEPREFIX, $options, null);
+    public function stripKey($key, array $options) {
+        $usePrefix = !($options[Gdn_Cache::FEATURE_NOPREFIX] ?? false);
 
         if ($usePrefix) {
+            $forcePrefix = ($options[Gdn_Cache::FEATURE_FORCEPREFIX] ?? null);
             $key = substr($key, strlen($this->getPrefix($forcePrefix)) + 1);
         }
         return $key;
-
     }
 
     /**
@@ -642,12 +641,12 @@ abstract class Gdn_Cache {
         return true;
     }
 
-    public function makeKey($key, $options) {
-        $usePrefix = !val(Gdn_Cache::FEATURE_NOPREFIX, $options, false);
-        $forcePrefix = val(Gdn_Cache::FEATURE_FORCEPREFIX, $options, null);
+    public function makeKey($key, array $options) {
+        $usePrefix = !($options[Gdn_Cache::FEATURE_NOPREFIX] ?? false);
 
         $prefix = '';
         if ($usePrefix) {
+            $forcePrefix = ($options[Gdn_Cache::FEATURE_FORCEPREFIX] ?? null);
             $prefix = $this->getPrefix($forcePrefix).'!';
         }
 

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -784,15 +784,16 @@ class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
      * @return mixed Returns whatever the event handler returns or **false** of there is not event handler.
      */
     public function callEventHandler($sender, $className, $eventName, $handlerType = 'handler') {
-        $eventKey = strtolower("{$className}_{$eventName}");
-        $handlerType = strtolower($handlerType);
+        $eventKey = "{$className}_{$eventName}";
         $originalEventKey = $eventKey.'_'.$handlerType;
 
         switch ($handlerType) {
             case 'handler':
+            case 'Handler':
                 // Do nothing.
                 break;
             case 'create':
+            case 'Create':
                 $eventKey = $originalEventKey.'_method';
                 break;
             default:

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1568,7 +1568,7 @@ class Gdn_Request implements RequestInterface {
      *    2.1   Added the // option to $WithDomain.
      *    2.2   Added the / option to $WithDomain.
      */
-    public function url(string $path = '', $withDomain = false, $ssl = null) {
+    public function url($path = '', $withDomain = false, $ssl = null) {
         static $allowSSL = null;
         $staticKey = ($withDomain ? '1-' : '0-').($ssl ? '1-' : '0-').$path;
         if ($r = (self::$urls[$staticKey] ?? false)) {

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -100,7 +100,7 @@ class Gdn_Request implements RequestInterface {
      *
      * @var array
      */
-    public static $urls = [];
+    protected static $urls = [];
 
     /**
      * Instantiate a new instance of the {@link Gdn_Request} class.

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1681,7 +1681,7 @@ class Gdn_Request implements RequestInterface {
             $result .= $hash;
         }
 
-        self::$urls[$staticKey] = ''.$result;
+        self::$urls[$staticKey] = $result;
         return $result;
     }
 

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -87,12 +87,12 @@ class Gdn_Request implements RequestInterface {
     protected $_RequestArguments;
 
     /**
-    /*  Holds domain plus port as a string to avoid multiple calculations
+     *  Holds domain plus port as a string to avoid multiple calculations
      * https://github.com/vanilla/vanilla/issues/7617
      *
      * @var string ex: vanilla.local:8080
      */
-    public static $host = false;
+    protected static $hostEndPoint;
 
     /**
     /*  Holds url() results to avoid recalls vs same path
@@ -1630,15 +1630,15 @@ class Gdn_Request implements RequestInterface {
         // Having en empty string in here will prepend a / in front of the URL on implode.
         $parts = [''];
         if ($withDomain !== '/') {
-            if (!empty(self::$host)) {
-                $host = self::$host;
+            if (self::$hostEndPoint !== null) {
+                $host = self::$hostEndPoint;
             } else {
                 $port = $this->port();
                 $host = $this->host();
                 if (!in_array($port, [80, 443]) && (strpos($host, ':'.$port) === false)) {
                     $host .= ':'.$port;
                 }
-                self::$host = $host;
+                self::$hostEndPoint = $host;
             }
 
             if ($withDomain === '//') {

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1611,7 +1611,7 @@ class Gdn_Request implements RequestInterface {
         }
 
         if (substr($path, 0, 2) == '//' || in_array(strpos($path, '://'), [4, 5])) { // Accounts for http:// and https:// - some querystring params may have "://", and this would cause things to break.
-            self::$urls[$staticKey] = ''.$path;
+            self::$urls[$staticKey] = $path;
             return $path;
         }
 

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1570,7 +1570,7 @@ class Gdn_Request implements RequestInterface {
      */
     public function url($path = '', $withDomain = false, $ssl = null) {
         static $allowSSL = null;
-        $staticKey = ($withDomain?'1-':'0-').($ssl?'1-':'0-').json_encode($path);
+        $staticKey = ($withDomain ? '1-' : '0-').($ssl ? '1-' : '0-').json_encode($path);
         if ($r = (self::$urls[$staticKey] ?? false)) {
             return $r;
         }

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1568,9 +1568,9 @@ class Gdn_Request implements RequestInterface {
      *    2.1   Added the // option to $WithDomain.
      *    2.2   Added the / option to $WithDomain.
      */
-    public function url($path = '', $withDomain = false, $ssl = null) {
+    public function url(string $path = '', $withDomain = false, $ssl = null) {
         static $allowSSL = null;
-        $staticKey = ($withDomain ? '1-' : '0-').($ssl ? '1-' : '0-').json_encode($path);
+        $staticKey = ($withDomain ? '1-' : '0-').($ssl ? '1-' : '0-').$path;
         if ($r = (self::$urls[$staticKey] ?? false)) {
             return $r;
         }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3773,7 +3773,7 @@ if (!function_exists('url')) {
      * @return string Returns the resulting URL.
      */
     function url($path = '', $withDomain = false) {
-        $result = Gdn::request()->url($path, $withDomain);
+        $result = Gdn::request()->url(strval($path), $withDomain);
         return $result;
     }
 }


### PR DESCRIPTION
remove unnecessary strtolower() calls  in pluginmanager
Fixes: #7615

Implement few static variables to avoid unnecessary calls to port() and host() functions
in function url() of Gdn_Request class 
Fixes: #7617

Update calculate() function of class.categorymodel to avoid val() calls
Fixes: vanilla/vanilla-patches#343

Refactor calculateUser function of class.categorymodel to avoid val() calls
Fixes: vanilla/vanilla-patches#348

Refactor stripKey function of class.cache (memcached) to avoid val() calls
Fixes: vanilla/vanilla-patches#352

Refactor makeKey function of class.cache (memcached) to avoid val() calls
Fixes: vanilla/vanilla-patches#351

Refactor joinUserData function of class.categorymodel to avoid val() calls
Fixes: vanilla/vanilla-patches#349