### PR TITLE
Enforce coding standards on changed code in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ npm-debug.log
 /cgi-bin/
 phpunit.xml
 yarn-error.log
+git-diff.txt
+phpcs-diff.json

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,9 @@
         "vanilla/vanilla-connect": "~0.0"
     },
     "require-dev": {
+        "exussum12/coverage-checker": "~0.10",
         "phpunit/phpunit": "~6.0",
+        "vanilla/standards": "~1.0",
         "voku/html-min": "~3.0"
     },
     "provide": {

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,8 @@
     },
     "scripts": {
         "pre-install-cmd": "Vanilla\\Setup\\ComposerHelper::preUpdate",
-        "pre-update-cmd": "Vanilla\\Setup\\ComposerHelper::preUpdate"
+        "pre-update-cmd": "Vanilla\\Setup\\ComposerHelper::preUpdate",
+        "lint-diff": "./tests/travis/diff-standards.sh"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f02241d58decb9f4d862a92bee6a7af2",
+    "content-hash": "857c4edeac49d207d810c5bfffd499d0",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -442,25 +442,28 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -493,20 +496,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-04-30T19:57:29+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.12",
+            "version": "v3.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0"
+                "reference": "810af2d35fc72b6cf5c01116806d2b65ccaaf2e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
-                "reference": "c5010cc1692ce1fa328b1fb666961eb3d4a85bb0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/810af2d35fc72b6cf5c01116806d2b65ccaaf2e2",
+                "reference": "810af2d35fc72b6cf5c01116806d2b65ccaaf2e2",
                 "shasum": ""
             },
             "require": {
@@ -552,7 +555,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-03T23:18:14+00:00"
+            "time": "2018-07-26T11:19:56+00:00"
         },
         {
             "name": "tburry/pquery",
@@ -1047,6 +1050,53 @@
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
+            "name": "exussum12/coverage-checker",
+            "version": "0.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/exussum12/coverageChecker.git",
+                "reference": "bc4f9c3a1ea23f1b3f8c03d6d99964ccc19e75bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/exussum12/coverageChecker/zipball/bc4f9c3a1ea23f1b3f8c03d6d99964ccc19e75bd",
+                "reference": "bc4f9c3a1ea23f1b3f8c03d6d99964ccc19e75bd",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^3.1||^4.0",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "bin": [
+                "bin/phpunitDiffFilter",
+                "bin/phpcsDiffFilter",
+                "bin/phpmdDiffFilter",
+                "bin/diffFilter"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "exussum12\\CoverageChecker\\": "src/",
+                    "exussum12\\CoverageChecker\\tests\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Scott Dutton",
+                    "email": "scott@exussum.co.uk"
+                }
+            ],
+            "description": "Allows checking the code coverage of a single pull request",
+            "time": "2018-07-11T19:12:17+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.7.0",
             "source": {
@@ -1090,6 +1140,57 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "bd088dc940a418f09cda079a9b5c7c478890fb8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bd088dc940a418f09cda079a9b5c7c478890fb8d",
+                "reference": "bd088dc940a418f09cda079a9b5c7c478890fb8d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5 || ^7.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2018-07-15T17:25:16+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1347,16 +1448,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.6",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
-                "reference": "33a7e3c4fda54e912ff6338c48823bd5c0f0b712",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
@@ -1368,12 +1469,12 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -1406,7 +1507,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-04-18T13:57:24+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1659,16 +1760,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.9",
+            "version": "6.5.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "093ca5508174cd8ab8efe44fd1dde447adfdec8f"
+                "reference": "7bab54cb366076023bbf457a2a0d513332cd40f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/093ca5508174cd8ab8efe44fd1dde447adfdec8f",
-                "reference": "093ca5508174cd8ab8efe44fd1dde447adfdec8f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7bab54cb366076023bbf457a2a0d513332cd40f2",
+                "reference": "7bab54cb366076023bbf457a2a0d513332cd40f2",
                 "shasum": ""
             },
             "require": {
@@ -1686,7 +1787,7 @@
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
                 "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
@@ -1739,20 +1840,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-07-03T06:40:40+00:00"
+            "time": "2018-08-07T07:05:35+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.7",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
-                "reference": "3eaf040f20154d27d6da59ca2c6e28ac8fd56dce",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
                 "shasum": ""
             },
             "require": {
@@ -1765,7 +1866,7 @@
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1798,7 +1899,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-05-29T13:50:43+00:00"
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2360,17 +2461,68 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "symfony/css-selector",
-            "version": "v3.4.12",
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/css-selector.git",
-                "reference": "d2ce52290b648ae33b5301d09bc14ee378612914"
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "628a481780561150481a9ec74709092b9759b3ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/d2ce52290b648ae33b5301d09bc14ee378612914",
-                "reference": "d2ce52290b648ae33b5301d09bc14ee378612914",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
+                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-07-26T23:47:18+00:00"
+        },
+        {
+            "name": "symfony/css-selector",
+            "version": "v3.4.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "edda5a6155000ff8c3a3f85ee5c421af93cca416"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/edda5a6155000ff8c3a3f85ee5c421af93cca416",
+                "reference": "edda5a6155000ff8c3a3f85ee5c421af93cca416",
                 "shasum": ""
             },
             "require": {
@@ -2410,7 +2562,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T12:49:49+00:00"
+            "time": "2018-07-26T09:06:28+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2451,6 +2603,32 @@
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "vanilla/standards",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vanilla/standards.git",
+                "reference": "440582912b75fe17cea66fc7831e03fc559e9c25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vanilla/standards/zipball/440582912b75fe17cea66fc7831e03fc559e9c25",
+                "reference": "440582912b75fe17cea66fc7831e03fc559e9c25",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "squizlabs/php_codesniffer": "~3.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "description": "Rules for Vanilla forums' coding standards.",
+            "time": "2018-08-14T17:19:15+00:00"
         },
         {
             "name": "voku/html-min",

--- a/tests/travis/diff-standards.sh
+++ b/tests/travis/diff-standards.sh
@@ -34,7 +34,7 @@ if [ -z "$GIT_DIFF" ]; then
     echo "No PHP file changes detected."
 
     [ -n "$TRAVIS" ] && echo "travis_fold:end:coding_standards"
-    exit
+    exit 0
 fi
 echo "Exporting branch diff of $DIFF_BRANCH to $GIT_DIFF_FILENAME..."
 rm -f $GIT_DIFF_FILENAME

--- a/tests/travis/diff-standards.sh
+++ b/tests/travis/diff-standards.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 
 if [ -z "$1" ]; then
-    echo "A branch is required." >&2
-    exit 1
+    echo "No branch provided. Linting against default branch master"
+    echo ""
+    DIFF_BRANCH="master"
+else
+    echo "Linting compared to provided branch $1"
+    DIFF_BRANCH=$1
 fi
-DIFF_BRANCH=$1
 
 if [ -z "$2" ]; then
     BUILD_DIR=$(pwd)
@@ -17,7 +20,8 @@ PHPCS_DIFF_FILENAME=$BUILD_DIR/phpcs-diff.json
 cd $BUILD_DIR
 
 # Begin folding in Travis.
-echo "travis_fold:start:coding_standards"
+[ -n "$TRAVIS" ] && echo "travis_fold:start:coding_standards"
+
 echo "Verify changed code against coding standards."
 
 # Without this, Travis only has a ref to the current branch in a shallow clone. Other branches cannot be compared.
@@ -25,10 +29,11 @@ echo "Updating available refs..."
 git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
 git fetch --all
 
-GIT_DIFF=$(git diff HEAD $DIFF_BRANCH '*.php')
+GIT_DIFF=$(git diff $DIFF_BRANCH '*.php')
 if [ -z "$GIT_DIFF" ]; then
     echo "No PHP file changes detected."
-    echo "travis_fold:end:coding_standards"
+
+    [ -n "$TRAVIS" ] && echo "travis_fold:end:coding_standards"
     exit
 fi
 echo "Exporting branch diff of $DIFF_BRANCH to $GIT_DIFF_FILENAME..."
@@ -37,10 +42,11 @@ echo -n "$GIT_DIFF" > $GIT_DIFF_FILENAME
 
 echo "Exporting full PHP_CodeSniffer scan of changed files to $PHPCS_DIFF_FILENAME..."
 rm -f $PHPCS_DIFF_FILENAME
-./vendor/bin/phpcs --standard=./vendor/vanilla/standards/code-sniffer/Vanilla --report=json $(git diff --name-only HEAD $DIFF_BRANCH -- '*.php') > $PHPCS_DIFF_FILENAME
+./vendor/bin/phpcs --standard=./vendor/vanilla/standards/code-sniffer/Vanilla --report=json $(git diff --name-only $DIFF_BRANCH -- '*.php') > $PHPCS_DIFF_FILENAME
 
 echo "Comparing results of PHP_CodeSniffer scan with changed lines from branch diff..."
+echo ""
 ./vendor/bin/diffFilter --phpcs $GIT_DIFF_FILENAME $PHPCS_DIFF_FILENAME
 
 # End folding in Travis.
-echo "travis_fold:end:coding_standards"
+[ -n "$TRAVIS" ] && echo "travis_fold:end:coding_standards"

--- a/tests/travis/diff-standards.sh
+++ b/tests/travis/diff-standards.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]; then
+    echo "A branch is required." >&2
+    exit 1
+fi
+DIFF_BRANCH=$1
+
+if [ -z "$2" ]; then
+    BUILD_DIR=$(pwd)
+else
+    BUILD_DIR=$2
+fi
+GIT_DIFF_FILENAME=$BUILD_DIR/git-diff.txt
+PHPCS_DIFF_FILENAME=$BUILD_DIR/phpcs-diff.json
+
+cd $BUILD_DIR
+
+# Begin folding in Travis.
+echo "travis_fold:start:coding_standards"
+echo "Verify changed code against coding standards."
+
+# Without this, Travis only has a ref to the current branch in a shallow clone. Other branches cannot be compared.
+echo "Updating available refs..."
+git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+git fetch --all
+
+GIT_DIFF=$(git diff HEAD $DIFF_BRANCH '*.php')
+if [ -z "$GIT_DIFF" ]; then
+    echo "No PHP file changes detected."
+    echo "travis_fold:end:coding_standards"
+    exit
+fi
+echo "Exporting branch diff of $DIFF_BRANCH to $GIT_DIFF_FILENAME..."
+rm -f $GIT_DIFF_FILENAME
+echo -n "$GIT_DIFF" > $GIT_DIFF_FILENAME
+
+echo "Exporting full PHP_CodeSniffer scan of changed files to $PHPCS_DIFF_FILENAME..."
+rm -f $PHPCS_DIFF_FILENAME
+./vendor/bin/phpcs --standard=./vendor/vanilla/standards/code-sniffer/Vanilla --report=json $(git diff --name-only HEAD $DIFF_BRANCH -- '*.php') > $PHPCS_DIFF_FILENAME
+
+echo "Comparing results of PHP_CodeSniffer scan with changed lines from branch diff..."
+./vendor/bin/diffFilter --phpcs $GIT_DIFF_FILENAME $PHPCS_DIFF_FILENAME
+
+# End folding in Travis.
+echo "travis_fold:end:coding_standards"

--- a/tests/travis/diff-standards.sh
+++ b/tests/travis/diff-standards.sh
@@ -20,7 +20,7 @@ PHPCS_DIFF_FILENAME=$BUILD_DIR/phpcs-diff.json
 cd $BUILD_DIR
 
 # Begin folding in Travis.
-[ -n "$TRAVIS" ] && echo "travis_fold:start:coding_standards"
+[ $TRAVIS ] && echo "travis_fold:start:coding_standards"
 
 echo "Verify changed code against coding standards."
 
@@ -33,7 +33,7 @@ GIT_DIFF=$(git diff $DIFF_BRANCH '*.php')
 if [ -z "$GIT_DIFF" ]; then
     echo "No PHP file changes detected."
 
-    [ -n "$TRAVIS" ] && echo "travis_fold:end:coding_standards"
+    [ $TRAVIS ] &&  echo "travis_fold:end:coding_standards"
     exit 0
 fi
 echo "Exporting branch diff of $DIFF_BRANCH to $GIT_DIFF_FILENAME..."
@@ -49,4 +49,4 @@ echo ""
 ./vendor/bin/diffFilter --phpcs $GIT_DIFF_FILENAME $PHPCS_DIFF_FILENAME
 
 # End folding in Travis.
-[ -n "$TRAVIS" ] && echo "travis_fold:end:coding_standards"
+[ $TRAVIS ] && echo "travis_fold:end:coding_standards"

--- a/tests/travis/main.sh
+++ b/tests/travis/main.sh
@@ -26,3 +26,10 @@ else
     echo "Skipping code coverage..."
     ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore
 fi
+
+# Run standards check on pull requests.
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    ./tests/travis/diff-standards.sh $TRAVIS_BRANCH $TRAVIS_BUILD_DIR
+else
+    echo "Skipping coding standards check..."
+fi


### PR DESCRIPTION
### Overview
This update adds enforcement of [vanilla/standards](https://github.com/vanilla/standards) rules on changed code in a pull request. It accomplishes it in the following way:

1. Run a `git diff` on the current branch's code versus the pull request's target branch's code. Travis creates a shallow clone with only refs for the current branch, so resetting the refs and grabbing branches is required to perform this step. Capture the output.
1. Perform a [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) scan, using the rules from Vanilla's coding standards repo, on all files with changes. Capture the output.
1. Use [coverageChecker](https://github.com/exussum12/coverageChecker), along with the output from the previous two steps, to filter out the PHP_CodeSniffer messages not specifically related to lines with changed code. If any messages make it through, the build will fail.

The aforementioned steps are only performed if the build was triggered by a pull request. This is different from a build being triggered by a code push, alone. The branch used for the build is actually a test merge with the base branch, generated by GitHub. If GitHub can't create this branch (i.e. there are merge conflicts), the pull request build cannot be run.

### Testing

1. Make a change to a line in a file that will trigger a coding standard error. For example, add a new parameter to a function, but don't include any spacing (e.g. `public function __construct($argA, $argB, $argC,$newArg=false)`).
1. ~~Commit the change.~~
1. Run the diff-standards.sh script. The script takes two parameters: branch and directory. The branch parameter is required. It will be the used for the diff. The second parameter is optional and defaults to the current working directory. From the root of the repo, you may execute the following command: ./tests/travis/diff-standards.sh master
    1. Alternatively, you can push the commit and wait for the build to complete. View the build log to verify success. Afterwards, undo the commit (`git reset --hard HEAD~1`) and overwrite the remote branch (`git push --force`).

### Notes

Folding in the Travis build log is implemented here. A successful coding standards scan should result in everything be collapsed under the first line. The line can be clicked on to expand all output. You can search a completed build's log for the "coding_standards" slug or just scroll down to find "Verify changed code against coding standards".

Closes #7393