### PR TITLE
Fix empty error message when saving a large discussion

### DIFF
--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -861,6 +861,9 @@ class Gdn_Validation {
     private function defaultErrorCode($invalid, $default) {
         if ($invalid instanceof Invalid && !empty($invalid->getMessageCode())) {
             return $invalid->getMessageCode();
+        } elseif (is_string($invalid)) {
+            // Backwards-compatible way for validation functions to return custom error messages.
+            return $invalid;
         }
         return $default;
     }


### PR DESCRIPTION
#7230 made some improvements to validation in Vanilla, but it also introduced a backwards-compatibility-breaking change where validation functions could no longer return a custom error message. Instead, validation functions are expected to return a boolean value or an instance of `Vanilla\Invalid`.

You could see this behavior manifested with the "ValidateLength" rule, which would fail if content exceeded a maximum length and return an error message stating how much longer the content was than allowed (e.g. "Body is 100 characters too long."). Since validation functions could no longer return custom error messages, the name of the rule was used to get the translation string and build the message in [Gdn_Form::errors](https://github.com/vanilla/vanilla/blob/ed28f187337e14c49aa5956ed67d48fb372dd8c2/library/core/class.form.php#L1575). Since the [ValidateLength message has two placeholders](https://github.com/vanilla/vanilla/blob/ed28f187337e14c49aa5956ed67d48fb372dd8c2/applications/dashboard/locale/en.php#L42), but was only receiving one parameter in this method, it was failing formatting and returning an empty string. Posts that were too long displayed an empty error message.

This update addresses this issue by updating the `Gdn_Validation::defaultErrorCode` method to check if the "is-valid" return value is a string. If it is, that value is used as the error message. Changes were not made to the validation functions (e.g. `validateLength`), because they are public and changing their return types would adversely affect existing compatibility.

Closes #7570