### PR TITLE
Mark minified javascript files as binary to git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,10 +10,7 @@
 # Mark built files as binary
 *.map binary
 composer.lock binary
-/js/admin/** binary
-/js/app/** binary
-/js/bootstrap-admin/** binary
-/js/bootstrap-app/** binary
+*.min.js binary
 
 # Skip files on archive
 .editorconfig export-ignore


### PR DESCRIPTION
Previously we were marking only particular JS directories as binary, but we can pretty safely assume that any minified JS file is a binary to git. These things are not mergeable.