### PR TITLE
Fix tagged discussions page not including the most recent discussions

### DIFF
--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -519,7 +519,7 @@ class TagModel extends Gdn_Model {
      * @return Gdn_DataSet
      * @throws Exception
      */
-    public function getDiscussions($tag, $limit, $offset) {
+    public function getDiscussions($tag, $limit, $offset, $sortField = 'DiscussionID', $sortDirection = 'desc') {
         if (!is_array($tag)) {
             $tags = array_map('trim', explode(',', $tag));
         }
@@ -530,7 +530,7 @@ class TagModel extends Gdn_Model {
             ->join('Tag t', 't.TagID = td.TagID')
             ->whereIn('t.Name', $tags)
             ->limit($limit, $offset)
-            ->orderBy('td.DiscussionID', 'desc')
+            ->orderBy($sortField, $sortDirection)
             ->get()->resultArray();
 
         $taggedDiscussionIDs = array_column($taggedDiscussionIDs, 'DiscussionID');

--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -516,6 +516,8 @@ class TagModel extends Gdn_Model {
      * @param string|array $tag tag name(s)
      * @param int $limit limit number of result
      * @param int $offset start result at this offset
+     * @param string $sortField column to sort results by
+     * @param string $sortDirection the direction to sort the discussions
      * @return Gdn_DataSet
      * @throws Exception
      */

--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -532,7 +532,6 @@ class TagModel extends Gdn_Model {
             ->join('Tag t', 't.TagID = td.TagID')
             ->whereIn('t.Name', $tags)
             ->limit($limit, $offset)
-            ->orderBy($sortField, $sortDirection)
             ->get()->resultArray();
 
         $taggedDiscussionIDs = array_column($taggedDiscussionIDs, 'DiscussionID');
@@ -544,10 +543,7 @@ class TagModel extends Gdn_Model {
                 'd.DiscussionID' => $taggedDiscussionIDs,
             ],
             $sortField,
-            $sortDirection,
-            '',
-            0
-
+            $sortDirection
         );
 
         return $discussions;

--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -530,6 +530,7 @@ class TagModel extends Gdn_Model {
             ->join('Tag t', 't.TagID = td.TagID')
             ->whereIn('t.Name', $tags)
             ->limit($limit, $offset)
+            ->orderBy('td.DiscussionID', 'desc')
             ->get()->resultArray();
 
         $taggedDiscussionIDs = array_column($taggedDiscussionIDs, 'DiscussionID');

--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -538,13 +538,16 @@ class TagModel extends Gdn_Model {
         $taggedDiscussionIDs = array_column($taggedDiscussionIDs, 'DiscussionID');
 
         $discussionModel = new DiscussionModel();
-        $discussions = $discussionModel->get(
-            0,
-            '',
+        $discussions = $discussionModel->getWhere(
             [
                 'Announce' => 'all',
                 'd.DiscussionID' => $taggedDiscussionIDs,
-            ]
+            ],
+            $sortField,
+            $sortDirection,
+            '',
+            0
+
         );
 
         return $discussions;


### PR DESCRIPTION
Closes [#7641](https://github.com/vanilla/vanilla/issues/7641)

discussions/tagged/{tag} was not displaying latest discussions.
