### PR TITLE
Storing IPV6 and update dashboard search by ip

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2570,8 +2570,8 @@ class UserModel extends Gdn_Model {
         }
         $keywords = trim($keywords);
 
-        // Check for an IP address.
-        if (preg_match('`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`', $keywords)) {
+        // Check for an IPV4/IPV6 address.
+        if (filter_var($keywords, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4|FILTER_FLAG_IPV6)) {
             $ipAddress = $keywords;
             $this->addIpFilters($ipAddress, ['LastIPAddress']);
         } elseif (strtolower($keywords) == 'banned') {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2571,7 +2571,7 @@ class UserModel extends Gdn_Model {
         $keywords = trim($keywords);
 
         // Check for an IPV4/IPV6 address.
-        if (filter_var($keywords, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4|FILTER_FLAG_IPV6)) {
+        if (filter_var($keywords, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4|FILTER_FLAG_IPV6) !== false) {
             $ipAddress = $keywords;
             $this->addIpFilters($ipAddress, ['LastIPAddress']);
         } elseif (strtolower($keywords) == 'banned') {

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -774,7 +774,6 @@ class Gdn_Request implements RequestInterface {
             }
         }
 
-        $ip = forceIPv4($ip);
         $this->_environmentElement('ADDRESS', $ip);
 
         // Request Scheme

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1270,6 +1270,8 @@ if (!function_exists('forceIPv4')) {
      * @param string $iP The IP address to force.
      * @return string Returns the IPv4 address version of {@link IP}.
      * @since 2.1
+     *
+     * @deprecated we are now storing IPV6, IPV4 notation is not required
      */
     function forceIPv4($iP) {
         if ($iP === '::1') {

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -915,7 +915,7 @@ if (!function_exists('formatIP')) {
         if (filter_var($iP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             $result = $html ? htmlspecialchars($iP) : $iP;
         } elseif (filter_var($iP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
-            $result = $html ? wrap(t('IPv6'), 'span', ['title' => $iP]) : $iP;
+            $result = $html ? "<span title='$iP'>".t('IPv6')."</span>" : $iP;
         }
 
         return $result;


### PR DESCRIPTION
closes [#70](https://github.com/vanilla/support/issues/70)

To test this you can use $_SERVER['REMOTE_ADDR'] = '2001:0db8:85a3:0000:0000:8a2e:0370:7334' for an IPV6.

### Functionalities changed

- Storing IPV6 instead of '0.0.0.2' in the database
- Dashboard search for IPV6
- Dashboard search for IPV6 displays IPV6 value when hovering over the IP (previously, it just displayed IPV6)
