### PR TITLE
memcache type error when posting comments

### DIFF
--- a/library/core/class.memcached.php
+++ b/library/core/class.memcached.php
@@ -440,7 +440,7 @@ class Gdn_Memcached extends Gdn_Cache {
         $expiry = (int)val(Gdn_Cache::FEATURE_EXPIRY, $finalOptions, 0);
         $useLocal = (bool)$finalOptions[Gdn_Cache::FEATURE_LOCAL];
 
-        $realKey = $this->makeKey($key, $finalOptions);
+        $realKey = $this->makeKey($key, $finalOptions ?? []);
 
         // Should auto sharding be enabled?
         $keySize = strlen(serialize($value));


### PR DESCRIPTION
Update array $finalOptions type casting.

We experienced errors on cluster 40011
`
Aug 21 09:29:30 app2.cl40011.vanilladev.com php-error:  2018-08-21T12:29:30Z	php-error	{"level":"Fatal","error":"Uncaught TypeError: Argument 2 passed to Gdn_Cache::makeKey() must be of the type array, null given, called in /var/www/frontend-b755a7995be475/library/core/class.memcached.php on line 443 and defined in /var/www/frontend-b755a7995be475/library/core/class.cache.php:644","program":"php-error","source":"app2.cl40011.vanilladev.com"}`
 to fix it here is the patch.