### PR TITLE
Fix spam logging & log restoring by packing IPs before insertions

### DIFF
--- a/applications/dashboard/models/class.logmodel.php
+++ b/applications/dashboard/models/class.logmodel.php
@@ -866,7 +866,7 @@ class LogModel extends Gdn_Pluggable {
             $tableName = $log['RecordType'];
         }
 
-        $data = $log['Data'];
+        $data = ipEncode($log['Data']);
 
         if (isset($data['Attributes'])) {
             $attr = 'Attributes';

--- a/applications/dashboard/models/class.spammodel.php
+++ b/applications/dashboard/models/class.spammodel.php
@@ -103,6 +103,9 @@ class SpamModel extends Gdn_Pluggable {
 
         // Log the spam entry.
         if ($spam && val('Log', $options, true)) {
+            // Make sure all IP addresses are packed before insertion
+            $data = ipEncodeRecursive($data);
+
             $logOptions = [];
             switch ($recordType) {
                 case 'Registration':


### PR DESCRIPTION
What this PR does
---
We recently updated our handling of IPv6. We found 2 cases where IPs aren't encoded/packed prior to insertion.

We need to encode IPs before inserting them into the Log table to make sure we aren't busting the column limit. This PR does this. We also need to encode IPs before inserting them when restoring from the log, our current process decodes them on fetch. This PR does this.

Strict Mode & IPv6
---
FYI, With our current IP columns set to `VARBINARY 16`, without MySQL strict mode it will actually truncate the value for IPv6, hence, storing a erroneous IP, but with MySQL strict mode it will fail entirely, throwing a `Data too long for column ...` error.