### PR TITLE
Fix refactoring gone wrong

### DIFF
--- a/library/core/class.auth.php
+++ b/library/core/class.auth.php
@@ -262,7 +262,7 @@ class Gdn_Auth extends Gdn_Pluggable {
      * @return object
      * @throws Exception
      */
-    public function Authenticator($default = 'default') {
+    public function getAuthenticator($default = 'default') {
         if (!$this->_Authenticator) {
             $this->authenticateWith($default);
         }


### PR DESCRIPTION
Seems like getAuthenticator got unintentionally renamed Authenticator by mistake.

https://github.com/vanilla/vanilla/commit/cb680b454a08ce79335134ec7e0d900e569eef63#diff-08f731f7271fdcee4302d371b457308cR265