### PR TITLE
Fix IP address not being available in tests

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -329,6 +329,7 @@ class Bootstrap {
     public function setGlobals(Container $container) {
         // Set some server globals.
         $baseUrl = $this->getBaseUrl();
+        $_SERVER['REMOTE_ADDR'] = '::1'; // Simulate requests from local IPv6 address.
         $_SERVER['HTTP_HOST'] = parse_url($baseUrl, PHP_URL_HOST);
         $_SERVER['SERVER_PORT'] = parse_url($baseUrl, PHP_URL_PORT) ?: null;
         $_SERVER['SCRIPT_NAME'] = parse_url($baseUrl, PHP_URL_PATH);


### PR DESCRIPTION
#7647 improved Vanilla's handling of IPv6, but in the process it removed a call to `forceIPv4` from request processing. This call would force a dummy IP address, if none was detected. Since Vanilla wasn't setting up an IP address in its tests, this function was picking up the slack. Once that function was removed, IP addresses were no longer being set in tests, and we began seeing failures in builds (although, strangely, not in core).

This update sets up tests to use the IPv6 localhost address. This should make it a little easier to test IPv6 support, as well as give us an actual IP address for the portions of Vanilla that depend on one being available.