### PR TITLE
Akismet spam restore- update ip encoding

### DIFF
--- a/applications/dashboard/models/class.logmodel.php
+++ b/applications/dashboard/models/class.logmodel.php
@@ -866,7 +866,7 @@ class LogModel extends Gdn_Pluggable {
             $tableName = $log['RecordType'];
         }
 
-        $data = ipEncode($log['Data']);
+        $data = ipEncodeRecursive($log['Data']);
 
         if (isset($data['Attributes'])) {
             $attr = 'Attributes';


### PR DESCRIPTION
We fixed restoring of SPAM in [7653](https://github.com/vanilla/vanilla/pull/7653)
### Problem
but when restoring a SPAM that was caught by Akismet, we get the error 
![screen shot 2018-08-22 at 9 35 55 am](https://user-images.githubusercontent.com/31856281/44466659-cfafbb00-a5ee-11e8-9109-a8a9cb753a57.png) 
because of `$data = ipEncode($log['Data']);` 



