### PR TITLE
Fix filter_var flags in anonymizeIP

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -67,7 +67,7 @@ if (!function_exists('anonymizeIP')) {
     function anonymizeIP(string $ip) {
         $result = false;
 
-        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 & FILTER_FLAG_IPV6)) {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6)) {
             // Need a packed version for bitwise operations.
             $packed = inet_pton($ip);
             if ($packed !== false) {


### PR DESCRIPTION
The call to `filter_var` in `anonymizeIP` is using a bitwise "and" for its flags, which is not what should be used. The bitwise "or" should be used, so the bits from both flags are included, instead of only overlapping bits.

[There is testing coverage for this function.](https://github.com/vanilla/vanilla/blob/380de43021ba29aa30a624fc8f67c145fa8dd071/tests/Library/Core/AnonymizeIPTest.php)