### PR TITLE
Fix JavaScript error when using Advanced Editor outside the Vanilla application

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -563,6 +563,9 @@ class EditorPlugin extends Gdn_Plugin {
         $c->addJsFile('jquery.iframe-transport.js', 'plugins/editor');
         $c->addJsFile('jquery.fileupload.js', 'plugins/editor');
 
+        // Mentions
+        $c->addJsFile('jquery.atwho.js');
+
         // Set definitions for JavaScript to read
         $c->addDefinition('editorVersion', $this->pluginInfo['Version']);
         $c->addDefinition('editorInputFormat', $this->Format);


### PR DESCRIPTION
We were having issues `Uncaught TypeError gdn.atCompleteInit is not a function` with the advanced editor in conversations and signatures after the recent changes to javascript.

The new "legacy" JavaScript doesn't add that gdn.atCompleteInit function to those pages, adding it by default will fix those issues.

Vanilla will only add the file once even if requested multiple times over the stack.

