### PR TITLE
Tagged Discussions: Update tagged discussions sort order

### DIFF
--- a/applications/dashboard/models/class.tagmodel.php
+++ b/applications/dashboard/models/class.tagmodel.php
@@ -521,7 +521,7 @@ class TagModel extends Gdn_Model {
      * @return Gdn_DataSet
      * @throws Exception
      */
-    public function getDiscussions($tag, $limit, $offset, $sortField = 'DiscussionID', $sortDirection = 'desc') {
+    public function getDiscussions($tag, $limit, $offset, $sortField = 'd.DateLastComment', $sortDirection = 'desc') {
         if (!is_array($tag)) {
             $tags = array_map('trim', explode(',', $tag));
         }
@@ -530,8 +530,10 @@ class TagModel extends Gdn_Model {
             ->select('td.DiscussionID')
             ->from('TagDiscussion td')
             ->join('Tag t', 't.TagID = td.TagID')
+            ->join('Discussion d', 'd.DiscussionID = td.DiscussionID')
             ->whereIn('t.Name', $tags)
             ->limit($limit, $offset)
+            ->orderBy($sortField, $sortDirection)
             ->get()->resultArray();
 
         $taggedDiscussionIDs = array_column($taggedDiscussionIDs, 'DiscussionID');
@@ -541,9 +543,7 @@ class TagModel extends Gdn_Model {
             [
                 'Announce' => 'all',
                 'd.DiscussionID' => $taggedDiscussionIDs,
-            ],
-            $sortField,
-            $sortDirection
+            ]
         );
 
         return $discussions;


### PR DESCRIPTION
closes [#87](https://github.com/vanilla/support/issues/87)
related [#7642](https://github.com/vanilla/vanilla/pull/7642)

### Description
PR [#7642](https://github.com/vanilla/vanilla/pull/7642) was ordering discussion by page on DiscussionID. I modified the query to order tagged discussion by DateLastComment.

### To Test

1. Tag enough discussions so that you can have multiple pages on /discussions/tagged/{Tag.Name}.
1. Get the full list of discussions for a tag, sorted by the `DateLastComment` field. You can use a database query for this.
1. View /discussions/tagged/{Tag.Name}, using your chosen tag. Verify the results are the same as your list from step two for the first page.
1. Advance to the second page. Verify your list from step two continues in the same order on this page.

