### PR TITLE
Remove extra line break margins

### DIFF
--- a/applications/dashboard/design/style-compat.css
+++ b/applications/dashboard/design/style-compat.css
@@ -1378,11 +1378,11 @@ label.checkbox input.checkbox-input {
   line-height: 1.25;
 }
 
-.userContent > *:not(.emoji):not(:last-child) {
+.userContent > *:not(.emoji):not(:last-child):not(br) {
   margin-bottom: 14px;
 }
 
-.userContent > *:not(.emoji):first-child {
+.userContent > *:not(.emoji):first-child:not(br) {
   margin-top: -0.25em !important;
 }
 

--- a/applications/dashboard/scss/editor/_richEditor.scss
+++ b/applications/dashboard/scss/editor/_richEditor.scss
@@ -593,11 +593,11 @@ $richEditor-mobileEmbedBreakPoint                 : 550px !default;
     }
 
     > *:not(.emoji) {
-        &:not(:last-child) {
+        &:not(:last-child):not(br) {
             margin-bottom: $global-block_margin;
         }
 
-        &:first-child {
+        &:first-child:not(br) {
             margin-top: #{(1 - $global-base_lineHeight) * .5em} !important;
         }
     }


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/83

Removes the extra margins in Firefox. Breaks should not be receiving additional margins.

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/1770056/44601319-0b42b480-a7aa-11e8-82de-ad1ffd3674d8.png)|![image](https://user-images.githubusercontent.com/1770056/44601279-f1a16d00-a7a9-11e8-96c7-f08fa3aa3524.png)|
