### PR TITLE
Fix new username validation being incorrectly applied to SSO connections by re-applying code lost in bad merge

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -499,8 +499,10 @@ class EntryController extends Gdn_Controller {
             return;
         }
 
+        $isTrustedProvider = $this->data('Trusted');
+
         // Check if we need to sync roles
-        if (($this->data('Trusted') || c('Garden.SSO.SyncRoles')) && $this->Form->getFormValue('Roles', null) !== null) {
+        if (($isTrustedProvider || c('Garden.SSO.SyncRoles')) && $this->Form->getFormValue('Roles', null) !== null) {
             $saveRoles = $saveRolesRegister = true;
 
             // Translate the role names to IDs.
@@ -546,7 +548,12 @@ class EntryController extends Gdn_Controller {
                 }
 
                 // Synchronize the user's data.
-                $userModel->save($data, ['NoConfirmEmail' => true, 'FixUnique' => true, 'SaveRoles' => $saveRoles]);
+                $userModel->save($data, [
+                    'NoConfirmEmail' => true,
+                    'FixUnique' => true,
+                    'SaveRoles' => $saveRoles,
+                    'ValidateName' => !$isTrustedProvider
+                ]);
                 $this->EventArguments['UserID'] = $userID;
                 $this->fireEvent('AfterConnectSave');
             }
@@ -626,7 +633,12 @@ class EntryController extends Gdn_Controller {
                                 }
 
                                 // Update the user.
-                                $userModel->save($data, ['NoConfirmEmail' => true, 'FixUnique' => true, 'SaveRoles' => $saveRoles]);
+                                $userModel->save($data, [
+                                    'NoConfirmEmail' => true,
+                                    'FixUnique' => true,
+                                    'SaveRoles' => $saveRoles,
+                                    'ValidateName' => !$isTrustedProvider
+                                ]);
                                 $this->EventArguments['UserID'] = $userID;
                                 $this->fireEvent('AfterConnectSave');
                             }
@@ -726,7 +738,8 @@ class EntryController extends Gdn_Controller {
                     'CheckCaptcha' => false,
                     'ValidateEmail' => false,
                     'NoConfirmEmail' => !$userProvidedEmail || !UserModel::requireConfirmEmail(),
-                    'SaveRoles' => $saveRolesRegister
+                    'SaveRoles' => $saveRolesRegister,
+                    'ValidateName' => !$isTrustedProvider
                 ];
                 $user = $this->Form->formValues();
                 $user['Password'] = randomString(16); // Required field.
@@ -865,7 +878,8 @@ class EntryController extends Gdn_Controller {
                 $userID = $userModel->register($user, [
                     'CheckCaptcha' => false,
                     'NoConfirmEmail' => !$userProvidedEmail || !UserModel::requireConfirmEmail(),
-                    'SaveRoles' => $saveRolesRegister
+                    'SaveRoles' => $saveRolesRegister,
+                    'ValidateName' => !$isTrustedProvider
                 ]);
                 $user['UserID'] = $userID;
 

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -25,6 +25,9 @@ if (!$hasUserID) {
     $firstTimeHere = !($this->Form->isPostBack() && $this->Form->getFormValue('Connect', null) !== null);
     $connectNameProvided = (bool)$this->Form->getFormValue('ConnectName');
 
+    $validationResults = $this->Form->validationResults();
+    $usernameNotValid = array_key_exists('Name', $validationResults) || array_key_exists('ConnectName', $validationResults);
+
     // Buckle up, deciding whether to show this field is intense.
     // Any of these 3 scenarios will do it:
     $displayConnectName =
@@ -34,7 +37,9 @@ if (!$hasUserID) {
         // 2) If you clicked submit and we found matches (but validation failed and you need to try again).
         || (!$firstTimeHere && count($ExistingUsers))
         // 3) We're forcing a manual username selection.
-        || !$allowConnect;
+        || !$allowConnect
+        // 4) There was an error with the submitted name.
+        || $usernameNotValid;
 }
 ?>
 <div class="Connect">


### PR DESCRIPTION
Why we need this
---
Users using SSO couldn't register with an "invalid" username. After investigation we realized that pr #7250 which introduced our new username validation logic was missing an important part of its implementation. At this point we are not exactly sure why (some merging voodoo perhaps).

Locally re-introducing these changes allowed invalid usernames (spaces and dots) to register properly if we are linking by email or if it's a complete new user without any linking to make.

A little history of what happened and when
---

1. A feature branch, feature/usermodel-name-validation, was created for work on updating username validation.
1. PR #7148, targeting feature/usermodel-name-validation,  was created on May 1st to update username validation.
1. PR #7163, also targeting feature/usermodel-name-validation, was created on May 2nd, spinning off portions of the first PR into a smaller diff for review. This PR then became a blocker for the first PR.
1. Code not relevant to #7163 made it into the branch during the split. It was reverted with 57de5ff8217ed50143a21347575492575e13ade8. This code still existed in #7148.
1. Both PRs were merged around the same time. According to GitHub, they were merged within the same minute.
1. PR #7250 was created on May 24 to merge feature/usermodel-name-validation into master. It was merged shortly thereafter.

The revert commit from #7163 seems to have targeted the original code from #7148 during the merge into the feature branch.