### PR TITLE
Fix lint-diff command reporting failure on success

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "857c4edeac49d207d810c5bfffd499d0",
+    "content-hash": "36a671c68244d1f4f8e849f06a24aed7",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -499,6 +499,65 @@
             "time": "2018-08-06T14:22:27+00:00"
         },
         {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v3.4.14",
             "source": {
@@ -608,6 +667,73 @@
                 "php"
             ],
             "time": "2016-01-14T20:55:00+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "6a5f676b77a90823c2d4eaf76137b771adf31323"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/6a5f676b77a90823c2d4eaf76137b771adf31323",
+                "reference": "6a5f676b77a90823c2d4eaf76137b771adf31323",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/debug": "^2.7",
+                "symfony/phpunit-bridge": "^3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                },
+                {
+                    "name": "Twig Team",
+                    "homepage": "https://twig.symfony.com/contributors",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "time": "2018-07-13T07:18:09+00:00"
         },
         {
             "name": "vanilla/garden-container",
@@ -1760,16 +1886,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.11",
+            "version": "6.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "7bab54cb366076023bbf457a2a0d513332cd40f2"
+                "reference": "24da433d7384824d65ea93fbb462e2f31bbb494e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7bab54cb366076023bbf457a2a0d513332cd40f2",
-                "reference": "7bab54cb366076023bbf457a2a0d513332cd40f2",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/24da433d7384824d65ea93fbb462e2f31bbb494e",
+                "reference": "24da433d7384824d65ea93fbb462e2f31bbb494e",
                 "shasum": ""
             },
             "require": {
@@ -1840,7 +1966,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-08-07T07:05:35+00:00"
+            "time": "2018-08-22T06:32:48+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -2606,16 +2732,16 @@
         },
         {
             "name": "vanilla/standards",
-            "version": "1.0",
+            "version": "1.02",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vanilla/standards.git",
-                "reference": "440582912b75fe17cea66fc7831e03fc559e9c25"
+                "reference": "3be8a283dbd5c4361e77ff2da12b9a85925c1795"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vanilla/standards/zipball/440582912b75fe17cea66fc7831e03fc559e9c25",
-                "reference": "440582912b75fe17cea66fc7831e03fc559e9c25",
+                "url": "https://api.github.com/repos/vanilla/standards/zipball/3be8a283dbd5c4361e77ff2da12b9a85925c1795",
+                "reference": "3be8a283dbd5c4361e77ff2da12b9a85925c1795",
                 "shasum": ""
             },
             "require": {
@@ -2628,7 +2754,7 @@
                 "GPL-2.0"
             ],
             "description": "Rules for Vanilla forums' coding standards.",
-            "time": "2018-08-14T17:19:15+00:00"
+            "time": "2018-08-27T14:34:07+00:00"
         },
         {
             "name": "voku/html-min",

--- a/tests/travis/diff-standards.sh
+++ b/tests/travis/diff-standards.sh
@@ -48,5 +48,10 @@ echo "Comparing results of PHP_CodeSniffer scan with changed lines from branch d
 echo ""
 ./vendor/bin/diffFilter --phpcs $GIT_DIFF_FILENAME $PHPCS_DIFF_FILENAME
 
+CODESNIFFER_RESULT=$?
+
 # End folding in Travis.
 [ $TRAVIS ] && echo "travis_fold:end:coding_standards"
+
+# Make sure this script exits with the same status as the PHP_CodeSniffer command.
+exit $CODESNIFFER_RESULT


### PR DESCRIPTION
Vanilla's composer "lint-diff" command can return a non-zero result, even if PHP_CodeSniffer returns a non-zero result, due to the Travis-specific code at the end of the script hijacking the default result. This update rectifies that by ensuring the underlying script always returns the result of the PHP_CodeSniffer command.

The composer.lock file is also updated here to use the latest version of Vanilla's coding standards.