### PR TITLE
Ongoing removal of val from codebase

### DIFF
--- a/applications/dashboard/library/class.nestedcollection.php
+++ b/applications/dashboard/library/class.nestedcollection.php
@@ -503,7 +503,7 @@ trait NestedCollection {
      * @param array $item The item to generate CSS class for.
      * @return string The generated CSS class.
      */
-    private function buildCssClass($prefix, $item) {
+    private function buildCssClass($prefix, array $item = []) {
         $result = '';
         if ($prefix) {
             $prefix .= '-';
@@ -511,12 +511,12 @@ trait NestedCollection {
         if (!$this->useCssPrefix) {
             $prefix = '';
         }
-        if (val('key', $item)) {
-            if (is_array(val('key', $item))) {
-                $result .= $prefix.implode('-', val('key', $item));
+        if ($cssClass = ($item['key'] ?? false)) {
+            if (is_array($cssClass)) {
+                $result .= $prefix.implode('-', $cssClass);
             }
             else {
-                $result .= $prefix.str_replace('.', '-', val('key', $item));
+                $result .= $prefix.str_replace('.', '-', $cssClass);
             }
         }
         return trim($result);

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1034,7 +1034,7 @@ class UserModel extends Gdn_Model {
         $userIDs = [];
         foreach ($data as $row) {
             foreach ($columns as $columnName) {
-                $iD = val($columnName, $row);
+                $iD = (is_object($row))? ($row->$columnName ?? false) : ($row[$columnName] ?? false);
                 if (is_numeric($iD)) {
                     $userIDs[$iD] = 1;
                 }
@@ -1051,13 +1051,15 @@ class UserModel extends Gdn_Model {
         }
 
         // Join the user data using prefixes (ex: 'Name' for 'InsertUserID' becomes 'InsertName')
-        $join = val('Join', $options, ['Name', 'Email', 'Photo']);
+        $join = ($options['Join'] ?? ['Name', 'Email', 'Photo']);
 
         foreach ($data2 as &$row) {
+            $isObj = is_object($row);
             foreach ($prefixes as $px) {
-                $iD = val($px.'UserID', $row);
+                $pxUserId = $px.'UserID';
+                $iD = $isObj ? ($row->$pxUserId ?? false) : ($row[$pxUserId] ?? false);
                 if (is_numeric($iD)) {
-                    $user = val($iD, $users, false);
+                    $user = ($users[$iD] ?? false);
                     foreach ($join as $column) {
                         $value = $user[$column];
                         if ($column == 'Photo') {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1059,7 +1059,7 @@ class UserModel extends Gdn_Model {
                 $pxUserId = $px.'UserID';
                 $iD = $isObj ? ($row->$pxUserId ?? false) : ($row[$pxUserId] ?? false);
                 if (is_numeric($iD)) {
-                    $user = ($users[$iD] ?? false);
+                    $user = $users[$iD] ?? false;
                     foreach ($join as $column) {
                         $value = $user[$column];
                         if ($column == 'Photo') {

--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -525,8 +525,8 @@ if (!class_exists('HeadModule', false)) {
                 $tag = $attributes[self::TAG_KEY];
 
                 // Inline the content of the tag, if necessary.
-                if (val('_hint', $attributes) == 'inline') {
-                    $path = val('_path', $attributes);
+                if (($attributes['_hint'] ?? false) == 'inline') {
+                    $path = ($attributes['_path'] ?? false);
                     if ($path && !stringBeginsWith($path, 'http')) {
                         $attributes[self::CONTENT_KEY] = file_get_contents($path);
 

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -705,7 +705,7 @@ class CategoryCollection {
      * @param array &$result The working result.
      */
     private function flattenTreeInternal(array $category, array &$result) {
-        $children = ($category['Children'] ?? []);
+        $children = $category['Children'] ?? [];
         $category['Children'] = [];
         $result[] = $category;
 

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -705,7 +705,7 @@ class CategoryCollection {
      * @param array &$result The working result.
      */
     private function flattenTreeInternal(array $category, array &$result) {
-        $children = val('Children', $category, []);
+        $children = ($category['Children'] ?? []);
         $category['Children'] = [];
         $result[] = $category;
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -455,7 +455,7 @@ class CategoryModel extends Gdn_Model {
         $filterHideDiscussions = $options['filterHideDiscussions'] ?? false;
 
         foreach ($categories as $categoryID => $category) {
-            if ($filterHideDiscussions && val('HideAllDiscussions', $category)) {
+            if ($filterHideDiscussions && ($category['HideAllDiscussions'] ?? false)) {
                 $unfiltered = false;
                 continue;
             }

--- a/library/SmartyPlugins/function.asset.php
+++ b/library/SmartyPlugins/function.asset.php
@@ -17,19 +17,19 @@
  * @param object $smarty Smarty The smarty object rendering the template.
  * @return string The rendered asset.
  */
-function smarty_function_asset($params, &$smarty) {
-    $name = val('name', $params);
-	$tag = val('tag', $params, '');
-	$id = val('id', $params, $name);
+function smarty_function_asset(array $params, &$smarty) {
+    $name = ($params['name'] ?? false);
+    $tag = ($params['tag'] ?? '');
+    $id = ($params['id'] ?? $name);
 
-	$class = val('class', $params, '');
-	if ($class != '') {
-		$class = ' class="'.$class.'"';
+    $class = ($params['class'] ?? '');
+    if ($class != '') {
+        $class = ' class="'.$class.'"';
     }
-	
-	$controller = Gdn::controller();
+
+    $controller = Gdn::controller();
     $controller->EventArguments['AssetName'] = $name;
-   
+
     $result = '';
 
     ob_start();
@@ -37,11 +37,11 @@ function smarty_function_asset($params, &$smarty) {
     $result .= ob_get_clean();
 
     $asset = $controller->getAsset($name);
-   
+
     if (is_object($asset)) {
         $asset->AssetName = $name;
-      
-        if (val('Visible', $asset, true)) {
+
+        if (($asset->Visible ?? true)) {
             $asset = $asset->toString();
         } else {
             $asset = '';
@@ -53,7 +53,7 @@ function smarty_function_asset($params, &$smarty) {
     } else {
         $result .= $asset;
     }
-   
+
     ob_start();
     $controller->fireEvent('AfterRenderAsset');
     $result .= ob_get_clean();

--- a/library/SmartyPlugins/function.asset.php
+++ b/library/SmartyPlugins/function.asset.php
@@ -18,9 +18,9 @@
  * @return string The rendered asset.
  */
 function smarty_function_asset(array $params, &$smarty) {
-    $name = ($params['name'] ?? false);
-    $tag = ($params['tag'] ?? '');
-    $id = ($params['id'] ?? $name);
+    $name = $params['name'] ?? false;
+    $tag = $params['tag'] ?? '';
+    $id = $params['id'] ?? $name;
 
     $class = ($params['class'] ?? '');
     if ($class != '') {

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1361,7 +1361,7 @@ if (!function_exists('_formatStringCallback')) {
         $field = trim($parts[0]);
         $format = trim(($parts[1] ?? ''));
         $subFormat = isset($parts[2]) ? strtolower(trim($parts[2])) : '';
-        $formatArgs = ($parts[3] ?? '');
+        $formatArgs = $parts[3] ?? '';
 
         if (in_array($format, ['currency', 'integer', 'percent'])) {
             $formatArgs = $subFormat;

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1359,9 +1359,9 @@ if (!function_exists('_formatStringCallback')) {
         // Parse out the field and format.
         $parts = explode(',', $match);
         $field = trim($parts[0]);
-        $format = trim(val(1, $parts, ''));
-        $subFormat = strtolower(trim(val(2, $parts, '')));
-        $formatArgs = val(3, $parts, '');
+        $format = trim(($parts[1] ?? ''));
+        $subFormat = isset($parts[2]) ? strtolower(trim($parts[2])) : '';
+        $formatArgs = ($parts[3] ?? '');
 
         if (in_array($format, ['currency', 'integer', 'percent'])) {
             $formatArgs = $subFormat;
@@ -1489,11 +1489,11 @@ if (!function_exists('_formatStringCallback')) {
                             $result = $formatArgs;
                             break;
                         case 'p':
-                            $result = val(5, $parts, val(4, $parts));
+                            $result = ($parts[5] ?? ($parts[4] ?? false));
                             break;
                         case 'u':
                         default:
-                            $result = val(4, $parts);
+                            $result = ($parts[4] ?? false);
                     }
 
                     break;


### PR DESCRIPTION
Refactor joinUsers function of class.usermodel to avoid val() calls
Fixes: vanilla/vanilla-patches#350

Refactor _formatStringCallback function of functions.general to avoid val() calls
Fixes: vanilla/vanilla-patches#361

Refactor getVisibleCategories function of class.categorymodel to avoid val() calls
Fixes: vanilla/vanilla-patches#360

Refactor buildCssClass function of class.nestedcollection to avoid val() calls
Fixes: vanilla/vanilla-patches#359

Refactor toString function of class.headmodule to avoid val() calls
Fixes: vanilla/vanilla-patches#364

Refactor flattenTreeInternal function of class.categorycollection to avoid val() calls
Fixes: vanilla/vanilla-patches#365

Refactor smarty_function_asset function of function.asset.php to avoid val() calls
Fixes: vanilla/vanilla-patches#366