### PR TITLE
Add array access to object rows in DataSet results

### DIFF
--- a/library/database/class.dataset.php
+++ b/library/database/class.dataset.php
@@ -123,7 +123,7 @@ class Gdn_DataSet implements IteratorAggregate, Countable, JsonSerializable {
                             //$this->_Result[$Index] = (array)$this->_Result[$Index];
                             break;
                         case DATASET_TYPE_OBJECT:
-                            $row = (object)$row;
+                            $row = new ArrayObject($row, ArrayObject::ARRAY_AS_PROPS);
                             //$this->_Result[$Index] = (object)$this->_Result[$Index];
                             break;
                     }
@@ -193,7 +193,12 @@ class Gdn_DataSet implements IteratorAggregate, Countable, JsonSerializable {
 
         // Calling fetchAll on insert/update/delete queries will raise an error!
         if (preg_match('/^(insert|update|delete)/', trim(strtolower($this->_PDOStatement->queryString))) !== 1) {
-            $result = $this->_PDOStatement->fetchAll($this->_DatasetType == DATASET_TYPE_ARRAY ? PDO::FETCH_ASSOC : PDO::FETCH_OBJ);
+            $result = $this->_PDOStatement->fetchAll(PDO::FETCH_ASSOC);
+            if ($this->_DatasetType != DATASET_TYPE_ARRAY) {
+                foreach ($result as &$row) {
+                    $row = new ArrayObject($row, ArrayObject::ARRAY_AS_PROPS);
+                }
+            }
         } else {
             $this->_Result = $result;
         }


### PR DESCRIPTION
Idea by @charrondev here: https://github.com/vanilla/vanilla/pull/7692#pullrequestreview-150776737

However, Gdn_DataSet does not benefit from array access as the result set is an array anyway.
But the rows it contains can be either objects or arrays.

If these objects implement the `ArrayAccess` interface, result rows can be accessed as both `$row['DiscussionID']` and `$row->DiscussionID` interchangeably. This would allow refactoring all views to use array notation _right now_, independently of model changes, and would ease the transition to array only return types.

Conveniently, there is already a PHP standard class that implements all array functionality:
http://php.net/manual/en/class.arrayobject.php

Using the `ARRAY_AS_PROPS` flag makes this "backwards compatible" as it allows changing getting/setting properties using both notations.

This is for discussion only as I haven't done any extensive checks. That said, I didn't notice any changes using this on my live forum and no errors popped up.

---

Notes:

1. This would seem to be the elegant way to do this, but it does not work:

    $this->_PDOStatement->fetchAll(PDO::FETCH_CLASS, ArrayObject::class)

...as just setting object properties via fetchAll does not populate the internal `Arrayobject::storage` array that manages the data.

2. All checks for `is_object` work, but raw array to `(object)` casts should be avoided using this (probably a good idea anyway).
