### PR TITLE
Categories set allowdiscussions default to 1

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2889,7 +2889,7 @@ class CategoryModel extends Gdn_Model {
         $CategoryID = val('CategoryID', $FormPostValues);
         $NewName = val('Name', $FormPostValues, '');
         $UrlCode = val('UrlCode', $FormPostValues, '');
-        $AllowDiscussions = val('AllowDiscussions', $FormPostValues, '');
+        $AllowDiscussions = val('AllowDiscussions', $FormPostValues, 1);
         $CustomPermissions = (bool)val('CustomPermissions', $FormPostValues) || is_array(val('Permissions', $FormPostValues));
         $CustomPoints = val('CustomPoints', $FormPostValues, null);
 
@@ -2949,11 +2949,11 @@ class CategoryModel extends Gdn_Model {
             $Fields = $this->Validation->schemaValidationFields();
             $Fields = $this->coerceData($Fields);
             unset($Fields['CategoryID']);
-            $Fields['AllowDiscussions'] = (bool)val('AllowDiscussions', $Fields);
+            $Fields['AllowDiscussions'] = isset($Fields['AllowDiscussions']) ? (bool)$Fields['AllowDiscussions'] : (bool)$AllowDiscussions;
 
             if ($Insert === false) {
                 $OldCategory = $this->getID($CategoryID, DATASET_TYPE_ARRAY);
-                if (null === val('AllowDiscussions', $FormPostValues, null)) {
+                if (null === $AllowDiscussions) {
                     $AllowDiscussions = $OldCategory['AllowDiscussions']; // Force the allowdiscussions property
                 }
                 $Fields['AllowDiscussions'] = (bool)$AllowDiscussions;


### PR DESCRIPTION
Currently when a category is created if the allowdiscussions parameter isn't passed, the default is set to an empty string.  This is fine when a category is created in the dashboard as is the allowdiscussions parameter is always set to 1, but when creating a category through the api/v2/categories endpoint, the value is not passed so the default is '' (evaluates to false) and discussions aren't allowed in the created category. 

There's a lot of code the is redundant, as trying to do a refactor could cause some unforeseen side effects. 

Closes vanilla/support#90
