### PR TITLE
Add new basic base model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require": {
         "php": ">=7.0.0",
+        "ext-json": "*",
         "container-interop/container-interop": "^1.1",
         "chrisjean/php-ico": "~1.0",
         "firebase/php-jwt": "~5.0",

--- a/library/Vanilla/Model.php
+++ b/library/Vanilla/Model.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla;
+
+use Garden\Schema\Schema;
+use Garden\Schema\ValidationException;
+use Garden\Schema\ValidationField;
+
+/**
+ * Basic model class.
+ */
+class Model {
+
+    /** @var \Gdn_Database */
+    private $database;
+
+    /** @var Schema */
+    private $readSchema;
+
+    /** @var string */
+    private $table;
+
+    /** @var Schema */
+    private $writeSchema;
+
+    /**
+     * Basic model constructor.
+     *
+     * @param string $table
+     * @param \Gdn_Database $database
+     */
+    public function __construct(string $table, \Gdn_Database $database) {
+        $this->table = $table;
+        $this->database = $database;
+
+        $schema = $this->database->simpleSchema($table);
+        $this->setReadSchema(clone $schema)
+            ->setWriteSchema(clone $schema);
+    }
+
+    /**
+     * Attempt to decode a encoded string value into a more complex type.
+     *
+     * @param mixed $value Raw database value.
+     * @param ValidationField $field An object representing the Garden Schema field.
+     * @return mixed Unpacked attributes field value.
+     */
+    private function filterValueDecode($value, ValidationField $field) {
+        if ($value === null || $value === '') {
+            $value = null;
+        } elseif (is_string($value)) {
+            $value = json_decode($value, true);
+            if ($value === null) {
+                $value = unserialize($value);
+                if ($value === false) {
+                    $value = null;
+                }
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * Attempt to decode a encoded string value into a more complex type.
+     *
+     * @param mixed $value Raw database value.
+     * @param ValidationField $field An object representing the Garden Schema field.
+     * @return mixed Unpacked attributes field value.
+     * @throws \Exception If there was an error encoding the value.
+     */
+    private function filterValueEncode($value, ValidationField $field) {
+        if ($value === null || $value === '') {
+            $value = null;
+        } else {
+            $value = json_encode($value, JSON_UNESCAPED_SLASHES);
+            $jsonError = json_last_error();
+            if ($jsonError !== JSON_ERROR_NONE) {
+                throw new \Exception("An error was encountered while encoding the JSON value ({$jsonError}).");
+            }
+        }
+        return $value;
+    }
+
+    /**
+     * Get resource rows from a database table.
+     *
+     * @param array $where Conditions for the select query.
+     * @param array $options Options for the select query.
+     * @return array Rows matching the conditions and within the parameters specified in the options.
+     * @throws ValidationException If a row fails to validate against the schema.
+     */
+    public function get(array $where = [], array $options = []): array {
+        $orderFields = $options['orderFields'] ?? '';
+        $orderDirection = $options['orderDirection'] ?? 'asc';
+        $limit = $options['limit'] ?? false;
+        $offset = $options['offset'] ?? 0;
+
+        $result = $this->sql()
+            ->getWhere($this->table, $where, $orderFields, $orderDirection, $limit, $offset)
+            ->resultArray();
+
+        $schema = Schema::parse([':a' => $this->readSchema]);
+        $result = $schema->validate($result);
+
+        return $result;
+    }
+
+    /**
+     * Add a resource row.
+     *
+     * @param array $set Field values to set.
+     * @return mixed ID of the inserted row.
+     * @throws \Exception If an error is encountered while performing the query.
+     */
+    public function insert(array $set) {
+        $set = $this->writeSchema->validate($set);
+        $result = $this->sql()->insert($this->table, $set);
+        if ($result === false) {
+            throw new \Exception('An unknown error was encountered while inserting the row.');
+        }
+        return $result;
+    }
+
+    /**
+     * Set the read/output schema for the model.
+     *
+     * @param Schema $schema Schema representing the resource's database table.
+     * @return Model Current instance for fluent calls.
+     */
+    private function setReadSchema(Schema $schema): Model {
+        // Transform Attributes field values, if available.
+        $attributes = $schema->getField('properties.Attributes');
+        if ($attributes) {
+            $attributeTypes = $schema->getField('properties.Attributes.type', []);
+            if (!empty($attributeTypes)) {
+                $attributeTypes = array_unique(array_merge($attributeTypes, ['array', 'object']));
+                $schema->setField('properties.Attributes.type', $attributeTypes);
+            }
+            $schema->addFilter('Attributes', function ($value, ValidationField $field) {
+                return $this->filterValueDecode($value, $field);
+            });
+        }
+
+        $this->readSchema = $schema;
+        return $this;
+    }
+
+    /**
+     * Set the write/input schema for the model.
+     *
+     * @param Schema $schema Schema representing the resource's database table.
+     * @return Model Current instance for fluent calls.
+     */
+    private function setWriteSchema(Schema $schema): Model {
+        // Transform Attributes field values, if available.
+        $attributes = $schema->getField('properties.Attributes');
+        if ($attributes) {
+            $schema->addFilter('Attributes', function ($value, ValidationField $field) {
+                return $this->filterValueEncode($value, $field);
+            });
+        }
+
+        $this->writeSchema = $schema;
+        return $this;
+    }
+
+    /**
+     * Get a clean SQL driver instance.
+     *
+     * @return \Gdn_SQLDriver
+     */
+    private function sql(): \Gdn_SQLDriver {
+        $sql = clone $this->database->sql();
+        $sql->reset();
+        return $sql;
+    }
+
+    /**
+     * Update existing resource rows.
+     *
+     * @param array $set Field values to set.
+     * @param array $where Conditions to restrict the update.
+     * @throws \Exception If an error is encountered while performing the query.
+     * @return bool True if no errors were encountered when performing the query.
+     */
+    public function update(array $set, array $where): bool {
+        $set = $this->writeSchema->validate($set, true);
+        $result = $this->sql()->put($this->table, $set, $where);
+        if (!($result instanceof \Gdn_DataSet)) {
+            throw new \Exception('An unknown error was encountered while performing the update.');
+        }
+        return true;
+    }
+}

--- a/library/Vanilla/Utility/SchemaFilters.php
+++ b/library/Vanilla/Utility/SchemaFilters.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace Vanilla\Utility;
+
+use Garden\Schema\ValidationField;
+
+/**
+ * A collection of field filter functions, compatible with Garden Schema.
+ */
+class SchemaFilters {
+
+    /**
+     * Attempt to decode a encoded string value into a more complex type.
+     *
+     * @param mixed $value Raw database value.
+     * @param ValidationField $field An object representing the Garden Schema field.
+     * @return mixed Unpacked attributes field value.
+     */
+    public static function encodeValue($value, ValidationField $field) {
+        if ($value === null || $value === '') {
+            $value = null;
+        } else {
+            $value = StringUtils::jsonEncodeChecked($value, JSON_UNESCAPED_SLASHES);
+        }
+        return $value;
+    }
+
+    /**
+     * Attempt to decode a encoded string value into a more complex type.
+     *
+     * @param mixed $value Raw database value.
+     * @param ValidationField $field An object representing the Garden Schema field.
+     * @return mixed Unpacked attributes field value.
+     */
+    public static function decodeValue($value, ValidationField $field) {
+        if ($value === null || $value === '') {
+            $value = null;
+        } elseif (is_string($value)) {
+            $value = json_decode($value, true);
+            if ($value === null) {
+                try {
+                    $value = unserialize($value);
+                } catch (\Exception $e) {
+                    $value = null;
+                }
+            }
+        }
+
+        return $value;
+    }
+}

--- a/library/Vanilla/Utility/StringUtils.php
+++ b/library/Vanilla/Utility/StringUtils.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+namespace Vanilla\Utility;
+
+/**
+ * A collection of string utilities.
+ */
+class StringUtils {
+    /**
+     * Encode a value as JSON or throw an exception on error.
+     *
+     * @param mixed $value
+     * @param int|null $options
+     * @return string
+     * @throws \Exception If an error was encountered during encoding.
+     */
+    public static function jsonEncodeChecked($value, $options = null) {
+        if ($options === null) {
+            $options = \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES;
+        }
+        $encoded = json_encode($value, $options);
+        $errorMessage = null;
+        switch (json_last_error()) {
+            case \JSON_ERROR_NONE:
+                // Do absolutely nothing since all went well!
+                break;
+            case \JSON_ERROR_UTF8:
+                $errorMessage = 'Malformed UTF-8 characters, possibly incorrectly encoded';
+                break;
+            case \JSON_ERROR_RECURSION:
+                $errorMessage = 'One or more recursive references in the value to be encoded.';
+                break;
+            case \JSON_ERROR_INF_OR_NAN:
+                $errorMessage = 'One or more NAN or INF values in the value to be encoded';
+                break;
+            case \JSON_ERROR_UNSUPPORTED_TYPE:
+                $errorMessage = 'A value of a type that cannot be encoded was given.';
+                break;
+            default:
+                $errorMessage = 'An unknown error has occurred.';
+        }
+        if ($errorMessage !== null) {
+            throw new \Exception("JSON encoding error: {$errorMessage}", 500);
+        }
+        return $encoded;
+    }
+}

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2332,34 +2332,7 @@ if (!function_exists('jsonEncodeChecked')) {
      * @throws Exception
      */
     function jsonEncodeChecked($value, $options = null) {
-         if ($options === null) {
-            $options = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES;
-        }
-        $encoded = json_encode($value, $options);
-        $errorMessage = null;
-        switch (json_last_error()) {
-            case JSON_ERROR_NONE:
-                // Do absolutely nothing since all went well!
-                break;
-            case JSON_ERROR_UTF8:
-                $errorMessage = 'Malformed UTF-8 characters, possibly incorrectly encoded';
-                break;
-            case JSON_ERROR_RECURSION:
-                $errorMessage = 'One or more recursive references in the value to be encoded.';
-                break;
-            case JSON_ERROR_INF_OR_NAN:
-                $errorMessage = 'One or more NAN or INF values in the value to be encoded';
-                break;
-            case JSON_ERROR_UNSUPPORTED_TYPE:
-                $errorMessage = 'A value of a type that cannot be encoded was given.';
-                break;
-            default:
-                $errorMessage = 'An unknown error has occurred.';
-        }
-        if ($errorMessage !== null) {
-            throw new Exception("JSON encoding error: {$errorMessage}", 500);
-        }
-        return $encoded;
+        return \Vanilla\Utility\StringUtils::jsonEncodeChecked($value, $options);
     }
 }
 

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1915,26 +1915,28 @@ abstract class Gdn_SQLDriver {
         }
 
         foreach ($field as $f => $v) {
-            if (is_array($v) || is_object($v)) {
+            if ($v instanceof DateTimeImmutable) {
+                $v = $v->format(MYSQL_DATE_FORMAT);
+            } elseif (is_array($v) || is_object($v)) {
                 throw new Exception('Invalid value type ('.gettype($v).') in INSERT/UPDATE statement.', 500);
-            } else {
-                $escapedName = $this->escapeFieldReference($f, true);
-                if (in_array(substr($f, -1),  ['+', '-'], true)) {
-                    // This is an increment/decrement.
-                    $op = substr($f, -1);
-                    $f = substr($f, 0, -1);
-                    $escapedName = $this->escapeFieldReference($f, true);
+            }
 
-                    $parameter = $this->namedParameter($f, $createNewNamedParameter);
-                    $this->_NamedParameters[$parameter] = $v;
-                    $this->_Sets[$escapedName] = "$escapedName $op $parameter";
-                } elseif ($escapeString) {
-                    $namedParameter = $this->namedParameter($f, $createNewNamedParameter);
-                    $this->_NamedParameters[$namedParameter] = $v;
-                    $this->_Sets[$escapedName] = $namedParameter;
-                } else {
-                    $this->_Sets[$escapedName] = $v;
-                }
+            $escapedName = $this->escapeFieldReference($f, true);
+            if (in_array(substr($f, -1),  ['+', '-'], true)) {
+                // This is an increment/decrement.
+                $op = substr($f, -1);
+                $f = substr($f, 0, -1);
+                $escapedName = $this->escapeFieldReference($f, true);
+
+                $parameter = $this->namedParameter($f, $createNewNamedParameter);
+                $this->_NamedParameters[$parameter] = $v;
+                $this->_Sets[$escapedName] = "$escapedName $op $parameter";
+            } elseif ($escapeString) {
+                $namedParameter = $this->namedParameter($f, $createNewNamedParameter);
+                $this->_NamedParameters[$namedParameter] = $v;
+                $this->_Sets[$escapedName] = $namedParameter;
+            } else {
+                $this->_Sets[$escapedName] = $v;
             }
         }
 


### PR DESCRIPTION
In this update, we're adding a new base model. This will be an ongoing process, but this is the first step necessary for removing dependency on the existing `Gdn_Model` base model.

### Changes

1. New base model.
    1. This is intended to be a very slim model. Currently, it only supports three operations: insert, update and get. More methods will be added in future iterations.
    1. The model lives in the `Vanilla` namespace. This was chosen over `Garden`, because it has a dependency on `Gdn_Database`.
    1. The database object is injected into the model, which should be beneficial for testing.
    1. Validation is now done with Garden Schema, much like Vanilla's API. `Gdn_Validation` is out.
    1. Similar to `Gdn_Model`, a model's table schema is fetched from the database to build the data schema. Whereas `Gdn_Model` lazy loaded the schema, `Vanilla\Model` will load the schema when the instance is built by the container, since all of its operations require a schema. Everything is private, so the option to switch to lazy loading should be trivial.
1. My IDE complained whenever I used PHP's JSON functions, because the project's stated requirements in its Composer config did not cite JSON. Now it does.
1. A new static class for general-purpose field filters has been added. These filters are intended for use with Garden Schema instances that Vanilla uses. Currently, there are only two: one for unpacking a JSON/serialized field and one for packing (encoding as JSON) a value. Currently, this is functionality targeted at attributes fields.
1. There is now a "string utilities" class. It has one method: `jsonEncodeChecked`. This was previously a global function. It's guts have been moved into the utility class. The function now calls the utility method. It had no outside dependencies, so it seemed like a good candidate for transplanting.
1. `Gdn_Database` has two new methods: `simpleDataType` (private) and `simpleSchema` (public). These methods are used to translate a database schema into a Garden Schema instance. This instance can then be used by models for basic data validation, directly against their database table.
1. A small change has been made to `Gdn_SQLDriver::set`. If it receives a value that is an instance of `DateTimeImmutable`, it will convert that value into a datetime string for insertion into the database. This was primarily done to avoid the need to revert Garden Schema's translation of datetime strings to `DateTimeImmutable` objects when such fields are validated.