### PR TITLE
Remove nonexistent CSS file from search controller

### DIFF
--- a/applications/dashboard/controllers/class.searchcontroller.php
+++ b/applications/dashboard/controllers/class.searchcontroller.php
@@ -57,7 +57,6 @@ class SearchController extends Gdn_Controller {
 
         $this->addCssFile('style.css');
         $this->addCssFile('vanillicon.css', 'static');
-        $this->addCssFile('menu.css');
         $this->addModule('GuestModule');
         parent::initialize();
         $this->setData('Breadcrumbs', [['Name' => t('Search'), 'Url' => '/search']]);


### PR DESCRIPTION
Debug trace:

    Could not find file 'menu.css' in folder 'dashboard'.