### PR TITLE
Use CategoryModel::checkPermission to validate user's permission to view discussions in categories.

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2904,7 +2904,12 @@ class DiscussionModel extends Gdn_Model {
         }
         $userModel = Gdn::userModel();
         // Get category permission.
-        $hasPermission = $userID && $userModel->getCategoryViewPermission($userID, val('CategoryID', $discussion), $permission);
+        $categoryID = val('CategoryID', $discussion);
+        if ($userID && Gdn::session()->UserID === $userID) {
+            $hasPermission = CategoryModel::checkPermission($categoryID, $permission);
+        } else {
+            $hasPermission = $userID && $userModel->getCategoryViewPermission($userID, $categoryID, $permission);
+        }
         // Check if we've timed out.
         if (strpos(strtolower($permission), 'edit' !== false)) {
             $hasPermission &= self::editContentTimeout($discussion);

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -584,7 +584,6 @@ class VanillaHooks implements Gdn_IPlugin {
 
             $options = ['ForeignID' => $permissionCategoryID];
             $result = Gdn::userModel()->checkPermission($userID, $permission, $options);
-
             return $result;
         }
         return false;

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -583,7 +583,11 @@ class VanillaHooks implements Gdn_IPlugin {
             }
 
             $options = ['ForeignID' => $permissionCategoryID];
-            $result = Gdn::userModel()->checkPermission($userID, $permission, $options);
+
+            $result = (Gdn::session()->isValid())
+                ? Gdn::session()->checkPermission($permission)
+                : Gdn::userModel()->checkPermission($userID, $permission, $options);
+
             return $result;
         }
         return false;

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -583,10 +583,7 @@ class VanillaHooks implements Gdn_IPlugin {
             }
 
             $options = ['ForeignID' => $permissionCategoryID];
-
-            $result = (Gdn::session()->isValid())
-                ? Gdn::session()->checkPermission($permission)
-                : Gdn::userModel()->checkPermission($userID, $permission, $options);
+            $result = Gdn::userModel()->checkPermission($userID, $permission, $options);
 
             return $result;
         }


### PR DESCRIPTION
The DiscussionModel::checkPermission calls userModel_getCategoryViewPermission_created hook  to validate if a user has permission to view a discussion in a certain category.  The permission check in this hook is done against the user.  The Ranks plugin sets the user permission on the session, so the the permissions in the session don't match those in the database.  Certain actions(warn, report) are denied as a result.  This was because 

1) only Administrator and Moderators were given privileges on that category.  
2) This permission check was done against the user's role permissions, not the rank permissions which are set in the session.

To avoid this CategoryModel::checkPermission is called if there's a valid session matching the userid  and we fall back to userModel::getCategoryViewPermission.

To test you need to the following

Based off master
1) Enable Ranks, Reporting and Warnings
2) Import customer's Ranks table
3) Create a category
4) Set custom privileges  where Admins and Moderators only haver permissions (see areanet's reported post category)
5) Create user with Role: Member - Rank:Administrator
6) Sign in as that user
7) Move in a discussion into the newly created category
8) Attempt to Flag the discussion (ie. Report\Warn)
- You should receive a permission error
9) Checkout fix branch
10) repeat step 8
- It should be successful

Closes vanilla/support#92
