### PR TITLE
Escape discussion titles in views instead of model

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -976,7 +976,6 @@ class DiscussionModel extends Gdn_Model {
         $archiveTimestamp = Gdn_Format::toTimestamp(Gdn::config('Vanilla.Archive.Date', 0));
 
         // Fix up output
-        $discussion->Name = Gdn_Format::text($discussion->Name);
         $discussion->Attributes = dbdecode($discussion->Attributes);
         $discussion->Url = discussionUrl($discussion);
         $discussion->Tags = $this->formatTags($discussion->Tags);

--- a/applications/vanilla/views/discussion/index.php
+++ b/applications/vanilla/views/discussion/index.php
@@ -19,7 +19,7 @@ writeAdminCheck();
 
 echo '</div>';
 
-echo '<h1>'.$this->data('Discussion.Name').'</h1>';
+echo '<h1>'.htmlspecialchars($this->data('Discussion.Name')).'</h1>';
 
 echo "</div>\n\n";
 

--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -140,6 +140,7 @@ if (!function_exists('WriteDiscussion')) :
         if (!preg_match('/\w/u', $discussionName)) {
             $discussionName = t('Blank Discussion Topic');
         }
+        $discussionName = htmlspecialchars($discussionName);
         $sender->EventArguments['DiscussionName'] = &$discussionName;
 
         static $firstDiscussion = true;


### PR DESCRIPTION
Discussion titles are escaped in the discussion model instead of the view.
https://github.com/vanilla/vanilla/blob/8a485b2e536e78d40c9e4cc9bb6a14444fa8cb2e/applications/vanilla/models/class.discussionmodel.php#L979

This is not quite as bad as saving filtered text to the DB but it is really annoying for several reasons:

- HTML tags in titles get stripped #3474
- It blocks #2881
- Titles loaded back into the editor for editing have broken ampersand signs, showing `&amp;` literally to the user 

**This needs to be tested for possible XSS exploits.** Plugins may expect discussion titles from the model to be escaped.

There are still various places where Gdn_Format::text() is used instead of htmlspecialchars which would be more appropriate. This PR just adds `htmlspecialchars` where raw titles would be displayed otherwise.
