### PR TITLE
Fix base model update method improperly evaluating success criteria

### DIFF
--- a/library/Vanilla/Models/Model.php
+++ b/library/Vanilla/Models/Model.php
@@ -126,14 +126,12 @@ class Model implements InjectableInterface {
      * @param array $set Field values to set.
      * @param array $where Conditions to restrict the update.
      * @throws \Exception If an error is encountered while performing the query.
-     * @return bool True if no errors were encountered when performing the query.
+     * @return bool True.
      */
     public function update(array $set, array $where): bool {
         $set = $this->writeSchema->validate($set, true);
-        $result = $this->sql()->put($this->table, $set, $where);
-        if (!($result instanceof \Gdn_DataSet)) {
-            throw new \Exception('An unknown error was encountered while performing the update.');
-        }
+        $this->sql()->put($this->table, $set, $where);
+        // If fully executed without an exception bubbling up, consider this a success.
         return true;
     }
 }


### PR DESCRIPTION
Vanilla has a problem with sharing the result of two queries, so the strict result checking in the new base model's `update` method is *too* strict. It needs to be loosened up until #7720 has been addressed.

This update simplifies `Vanilla\Models\Model::update` to return a boolean `true` by default. If an error is encountered during the execution of an update query, the underlying function to `Gdn_SQLDriver` and `Gdn_Database` will be responsible for throwing relevant exceptions up to this level.