### PR TITLE
Fix inability to reference HTML tags in discussion titles

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -217,14 +217,17 @@ class PostController extends VanillaController {
             // Prep form with current data for editing
             if (isset($this->Discussion)) {
                 $this->Form->setData($this->Discussion);
-            } elseif (isset($this->Draft))
+            } elseif (isset($this->Draft)) {
                 $this->Form->setData($this->Draft);
-            else {
+            } else {
                 if ($this->Category !== null) {
                     $this->Form->setData(['CategoryID' => $this->Category->CategoryID]);
                 }
                 $this->populateForm($this->Form);
             }
+            
+            // Decode HTML entities escaped by DiscussionModel::calculate() here.
+            $this->Form->setValue('Name', htmlspecialchars_decode($this->Form->getValue('Name')));
 
         } elseif ($this->Form->authenticatedPostBack()) { // Form was submitted
             // Save as a draft?

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -976,7 +976,7 @@ class DiscussionModel extends Gdn_Model {
         $archiveTimestamp = Gdn_Format::toTimestamp(Gdn::config('Vanilla.Archive.Date', 0));
 
         // Fix up output
-        $discussion->Name = Gdn_Format::text($discussion->Name);
+        $discussion->Name = htmlspecialchars($discussion->Name);
         $discussion->Attributes = dbdecode($discussion->Attributes);
         $discussion->Url = discussionUrl($discussion);
         $discussion->Tags = $this->formatTags($discussion->Tags);


### PR DESCRIPTION
Safe alternative to #7717 

Using htmlspecialchars instead of Gdn_format::text() has several advantages:

- You can talk about HTML elements in discussion titles, because tags are encoded, not stripped, fixes #3474
- Encoded output can be fully decoded, fixing the `&amp;` bug described in my previous PR
- It does not preserve line breaks like Gdn_format::text(); does with default parameters, fixes #5185

To see the difference test what happens to a discussion title like this:

    <WOW!> This is <br> a title & it contains an ampersand sign.
