### PR TITLE
Refresh page after adding/deleting bans

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -598,6 +598,7 @@ class SettingsController extends DashboardController {
                     try {
                         // Save the ban.
                         $newID = $this->Form->save();
+                        $this->jsonTarget('', '', 'Refresh');
                     } catch (Exception $ex) {
                         $this->Form->addError($ex);
                     }
@@ -613,6 +614,7 @@ class SettingsController extends DashboardController {
                 if ($this->Form->authenticatedPostBack()) {
                     $banModel->delete(['BanID' => $iD]);
                     $this->View = 'BanDelete';
+                    $this->jsonTarget('', '', 'Refresh');
                 }
                 break;
             case 'find':


### PR DESCRIPTION
Ever since bans are added from a popup (Dashboard v3) the page does not automatically refresh after changes have been made.
This is really confusing for users.