### PR TITLE
Remove unnecessary event fire 'beforeTranslate'

### DIFF
--- a/library/Garden/StaticCacheConfigTrait.php
+++ b/library/Garden/StaticCacheConfigTrait.php
@@ -27,7 +27,7 @@ trait StaticCacheConfigTrait {
      *
      * @return array
      */
-    protected static function c(string $key, $default) {
+    protected static function f(string $key, $default) {
         return Gdn::config($key, $default);
     }
 }

--- a/library/Garden/StaticCacheTranslationTrait.php
+++ b/library/Garden/StaticCacheTranslationTrait.php
@@ -27,7 +27,7 @@ trait StaticCacheTranslationTrait {
      *
      * @return array
      */
-    protected static function t(string $key, $default) {
+    protected static function f(string $key, $default) {
         return Gdn::translate($key, $default);
     }
 }

--- a/library/core/class.locale.php
+++ b/library/core/class.locale.php
@@ -357,7 +357,7 @@ class Gdn_Locale extends Gdn_Pluggable {
 
         $this->EventArguments['Code'] = $code;
         $this->EventArguments['Default'] = $default;
-        if (Gdn::config('EnabledPlugins.localligator', false)) {
+        if (Gdn::config('Debug', false)) {
             $this->fireEvent('BeforeTranslate');
         }
 

--- a/library/core/class.locale.php
+++ b/library/core/class.locale.php
@@ -355,9 +355,9 @@ class Gdn_Locale extends Gdn_Pluggable {
             }
         }
 
-        $this->EventArguments['Code'] = $code;
-        $this->EventArguments['Default'] = $default;
         if (Gdn::config('Debug', false)) {
+            $this->EventArguments['Code'] = $code;
+            $this->EventArguments['Default'] = $default;
             $this->fireEvent('BeforeTranslate');
         }
 

--- a/library/core/class.locale.php
+++ b/library/core/class.locale.php
@@ -15,6 +15,7 @@ use Vanilla\AddonManager;
  * for different locales. It is a singleton class.
  */
 class Gdn_Locale extends Gdn_Pluggable {
+    use \Garden\StaticCacheConfigTrait;
 
     /**  @var string The name of the currently loaded Locale. */
     public $Locale = '';
@@ -355,7 +356,7 @@ class Gdn_Locale extends Gdn_Pluggable {
             }
         }
 
-        if (Gdn::config('Debug', false)) {
+        if (self::c('Debug', false)) {
             $this->EventArguments['Code'] = $code;
             $this->EventArguments['Default'] = $default;
             $this->fireEvent('BeforeTranslate');

--- a/library/core/class.locale.php
+++ b/library/core/class.locale.php
@@ -357,7 +357,9 @@ class Gdn_Locale extends Gdn_Pluggable {
 
         $this->EventArguments['Code'] = $code;
         $this->EventArguments['Default'] = $default;
-        $this->fireEvent('BeforeTranslate');
+        if (Gdn::config('EnabledPlugins.localligator', false)) {
+            $this->fireEvent('BeforeTranslate');
+        }
 
         return $translation;
     }


### PR DESCRIPTION
Fixes: https://github.com/vanilla/vanilla/issues/7735

Add condition to fire event `beforeTranslate`.

## Additionally
Fixes some issue with original StaticCacheConfigTrait and StaticCacheTranslationTrait (was not calling correct method and because of that was not caching the response)

