### PR TITLE
Make embedded sso (UserModel::connect) validation more relax for trusted providers

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -892,9 +892,9 @@ class UserModel extends Gdn_Model {
                     $userData['RoleID'] = $this->lookupRoleIDs($userData['Roles']);
                 }
 
-                $options['CheckCaptcha'] = isset($options['CheckCaptcha']) ? $options['CheckCaptcha'] : false;
+                $options['CheckCaptcha'] = $options['CheckCaptcha'] ?? false;
                 $options['NoConfirmEmail'] = isset($userData['Email']) || !UserModel::requireConfirmEmail();
-                $options['NoActivity'] = isset($options['NoActivity']) ? $options['NoActivity'] : true;
+                $options['NoActivity'] = $options['NoActivity'] ?? true;
                 $options['SaveRoles'] = $saveRolesRegister;
                 $options['ValidateName'] = !$isTrustedProvider;
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -774,6 +774,7 @@ class UserModel extends Gdn_Model {
      * @param array|int $currentUser
      * @param array $newUser Data to overwrite user with.
      * @param bool $force
+     * @param bool $isTrustedProvider
      * @since 2.1
      */
     public function syncUser($currentUser, $newUser, $force = false, $isTrustedProvider = false) {
@@ -841,7 +842,7 @@ class UserModel extends Gdn_Model {
         trace('UserModel->Connect()');
         $provider = Gdn_AuthenticationProviderModel::getProviderByKey($providerKey);
 
-        $isTrustedProvider = isset($provider['Trusted']) ? $provider['Trusted'] : false;
+        $isTrustedProvider = $provider['Trusted'] ?? false;
 
         $saveRoles = $saveRolesRegister = false;
 
@@ -864,7 +865,7 @@ class UserModel extends Gdn_Model {
 
         if ($userID) {
             // Save the user.
-            $this->syncUser($userID, $userData, false /*force*/, $isTrustedProvider);
+            $this->syncUser($userID, $userData, false, $isTrustedProvider);
             return $userID;
         } else {
             // The user hasn't already been connected. We want to see if we can't find the user based on some critera.
@@ -876,7 +877,7 @@ class UserModel extends Gdn_Model {
                 if ($user) {
                     $user = (array)$user;
                     // Save the user.
-                    $this->syncUser($user, $userData, false /*force*/, $isTrustedProvider);
+                    $this->syncUser($user, $userData, false, $isTrustedProvider);
                     $userID = $user['UserID'];
                 }
             }
@@ -895,7 +896,7 @@ class UserModel extends Gdn_Model {
                 $options['NoConfirmEmail'] = isset($userData['Email']) || !UserModel::requireConfirmEmail();
                 $options['NoActivity'] = isset($options['NoActivity']) ? $options['NoActivity'] : true;
                 $options['SaveRoles'] = $saveRolesRegister;
-                $options['ValidateName'] = $isTrustedProvider;
+                $options['ValidateName'] = !$isTrustedProvider;
 
                 trace($userData, 'Registering User');
                 $userID = $this->register($userData, $options);

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -876,7 +876,7 @@ class UserModel extends Gdn_Model {
                 if ($user) {
                     $user = (array)$user;
                     // Save the user.
-                    $this->syncUser($user, $userData,false /*force*/, $isTrustedProvider);
+                    $this->syncUser($user, $userData, false /*force*/, $isTrustedProvider);
                     $userID = $user['UserID'];
                 }
             }


### PR DESCRIPTION
Closes #7713 

The problem was with our new validation logic, users with embedded sso couldn't bypass the username validation even when coming from a trusted provider.

The goal here was to apply the same changes to the validation we already did in the EntryController `connect` endpoint. I tried to make it as consistent  to the EntryController as possible in the UserModel `connect` endpoint.

Steps I took to test this:

* Setup up an embedded site (with vanilla-docker)
* Setup up an embedded sso (JS Connect) (with vanilla-docker)
* `Registration.AutoConnect = true`
* I added the vanilla_sso string to my embedded site for every user I was testing (with stub-sso-providers JsSSOString method for JS Connect
* After creating a user and signin with him on the SSO, hitting the homepage of the embedded site was triggering a call to `UserModel->sso()` and `UserModel->connect()`.
* It was successfully registering & signin users
* It was failing to register users when I hard coded the provider to false to force a username validation.


