### PR TITLE
Implements static cache fetchViewLocation for dropdownmodule

### DIFF
--- a/applications/dashboard/modules/class.dropdownmodule.php
+++ b/applications/dashboard/modules/class.dropdownmodule.php
@@ -71,6 +71,7 @@
 class DropdownModule extends Gdn_Module {
 
     use NestedCollection;
+    use \Garden\StaticCacheViewLocationTrait;
 
     /**
      * @var string The id value of the trigger.

--- a/library/Garden/StaticCacheViewLocationTrait.php
+++ b/library/Garden/StaticCacheViewLocationTrait.php
@@ -7,8 +7,6 @@
 
 namespace Garden;
 
-use Gdn;
-
 /**
  * For classes which extend Gdn_Module to cache fetchViewLocation response.
  */

--- a/library/Garden/StaticCacheViewLocationTrait.php
+++ b/library/Garden/StaticCacheViewLocationTrait.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL v2
+ */
+
+namespace Garden;
+
+use Gdn;
+
+/**
+ * For classes which extend Gdn_Module to cache fetchViewLocation response.
+ */
+trait StaticCacheViewLocationTrait {
+    /**
+     * @var array $views Saved in static cache view files path
+     */
+    protected static $views = [];
+
+    /**
+     * Method overwrites parent method to cache response statically
+     *
+     * @param string $view Template name
+     * @param string $applicationFolder App folder to check for template
+     *
+     * @return array|mixed
+     */
+    public function fetchViewLocation($view = '', $applicationFolder = '') {
+        $key = $applicationFolder . ':' . $view;
+        if (!array_key_exists($key, self::$views)) {
+            $viewPath = parent::fetchViewLocation($view, $applicationFolder);
+            self::$views[$key] = $viewPath;
+        }
+        return self::$views[$key];
+    }
+}


### PR DESCRIPTION
This is part of ongoing optimization.
 
New trait StaticCacheViewLocationTrait for modules
Apply StaticCacheViewLocationTrait to DropdownModule

Relates to original optimization PR:
https://github.com/vanilla/vanilla/pull/7689/files

Fixes: #7754 