### PR TITLE
Roles: userRole table not getting updated after role is deleted, leaving orphaned records

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -746,15 +746,14 @@ class RoleModel extends Gdn_Model {
                 ->set('UserRole.RoleID', $newRoleID)
                 ->where(['UserRole.RoleID' => $roleID])
                 ->put();
-        } else {
-            $this->SQL->delete('UserRole', ['RoleID' => $roleID]);
         }
-
+        
         // Remove permissions for this role.
         $permissionModel = Gdn::permissionModel();
         $permissionModel->delete($roleID);
 
         // Remove the role
+        $this->SQL->delete('UserRole', ['RoleID' => $roleID]);
         $result = $this->SQL->delete('Role', ['RoleID' => $roleID]);
         return $result;
     }


### PR DESCRIPTION
### Details
closes #7758 
When a role is deleted with a replacement role selected , table GDN_UserRole is getting orphaned role records.

### To test this

- Delete a role 
- Select a replacement role
- Check GDN_UserRole table (role is not deleted)