### PR TITLE
Add caching of config val in Gdn_Session::checkPermission

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -16,6 +16,7 @@ use Vanilla\Permissions;
  * Handles user information throughout a session. This class is a singleton.
  */
 class Gdn_Session {
+    use \Garden\StaticCacheConfigTrait;
 
     /**
      * Parameter name for incoming CSRF tokens.
@@ -127,7 +128,7 @@ class Gdn_Session {
      */
     public function checkPermission($permission, $fullMatch = true, $junctionTable = '', $junctionID = '') {
         if ($junctionID === 'any' || $junctionID === '' || empty($junctionTable) ||
-            c("Garden.Permissions.Disabled.{$junctionTable}")) {
+            self::c("Garden.Permissions.Disabled.{$junctionTable}")) {
             $junctionID = null;
         }
 


### PR DESCRIPTION
Ongoing optimization.

Implement StaticCacheConfigTrait on Gdn_Session to avoid multiple c() global function calls

Relates to #7734 and #7689

Fixes: https://github.com/vanilla/vanilla/issues/7759