### PR TITLE
Add config toggle to Vanilla\Utility\Deprecation::log

### DIFF
--- a/library/Vanilla/Utility/Deprecation.php
+++ b/library/Vanilla/Utility/Deprecation.php
@@ -40,7 +40,7 @@ class Deprecation {
      */
     public static function log() {
         // Set Vanilla.Deprecation.Enabled to false to disable log output
-        if (self::c('Vanilla.Deprecation.Enabled', true)) {
+        if (self::c('Garden.Log.Deprecation', true)) {
             $info = debug_backtrace()[1];
             if (!key_exists($info['function'], self::$calls)) {
                 $fileName = str_replace(PATH_ROOT, '', $info['file']);

--- a/library/Vanilla/Utility/Deprecation.php
+++ b/library/Vanilla/Utility/Deprecation.php
@@ -7,10 +7,13 @@
 
 namespace Vanilla\Utility;
 
+use Garden\StaticCacheConfigTrait;
+
 /**
  * Class Deprecation.
  */
 class Deprecation {
+    use StaticCacheConfigTrait;
     protected static $calls = [];
 
     /**
@@ -36,13 +39,15 @@ class Deprecation {
      * @return void
      */
     public static function log() {
-        $info = debug_backtrace()[1];
-        if (!key_exists($info['function'], self::$calls)) {
-            $fileName = str_replace(PATH_ROOT, '', $info['file']);
-            $message = 'Deprecated function '.$info['function'].' called from '.$fileName.' at line : '.$info['line'];
-            trigger_error($message, E_USER_DEPRECATED);
-            error_log($message, E_USER_ERROR);
-            self::$calls[$info['function']] = true;
+        if (self::c('Vanilla.Deprecation.Enabled', true)) {
+            $info = debug_backtrace()[1];
+            if (!key_exists($info['function'], self::$calls)) {
+                $fileName = str_replace(PATH_ROOT, '', $info['file']);
+                $message = 'Deprecated function '.$info['function'].' called from '.$fileName.' at line : '.$info['line'];
+                trigger_error($message, E_USER_DEPRECATED);
+                error_log($message, E_USER_ERROR);
+                self::$calls[$info['function']] = true;
+            }
         }
     }
 }

--- a/library/Vanilla/Utility/Deprecation.php
+++ b/library/Vanilla/Utility/Deprecation.php
@@ -39,7 +39,7 @@ class Deprecation {
      * @return void
      */
     public static function log() {
-        // Set Vanilla.Deprecation.Enabled to false to disable log output
+        // Set Garden.Log.Deprecation to false to disable log output
         if (self::c('Garden.Log.Deprecation', true)) {
             $info = debug_backtrace()[1];
             if (!key_exists($info['function'], self::$calls)) {

--- a/library/Vanilla/Utility/Deprecation.php
+++ b/library/Vanilla/Utility/Deprecation.php
@@ -39,6 +39,7 @@ class Deprecation {
      * @return void
      */
     public static function log() {
+        // Set Vanilla.Deprecation.Enabled to false to disable log output
         if (self::c('Vanilla.Deprecation.Enabled', true)) {
             $info = debug_backtrace()[1];
             if (!key_exists($info['function'], self::$calls)) {

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3569,6 +3569,7 @@ if (!function_exists('translateContent')) {
      * @param string $default The default value to be displayed if the translation code is not found.
      * @return string The translated string or $code if there is no value in $default.
      * @see Gdn::translate()
+     * @deprecated
      */
     function translateContent($code, $default = false) {
         \Vanilla\Utility\Deprecation::log();


### PR DESCRIPTION
Add check for config 'Vanilla.Deprecation.Enabled' if false - to not output any deprecation error

This will allow to disable log flooding if ever deprecated function detected on particular client instance.