### PR TITLE
Deprecate viewLocation global function.

### DIFF
--- a/library/core/functions.deprecated.php
+++ b/library/core/functions.deprecated.php
@@ -767,7 +767,7 @@ if (!function_exists('viewLocation')) {
      * @deprecated
      */
     function viewLocation($view, $controller, $folder) {
-        deprecated('viewLocation()');
+        \Vanilla\Utility\Deprecation::log();
         $paths = [];
 
         if (strpos($view, '/') !== false) {


### PR DESCRIPTION
Apply error log output on production for final check.

I did not find any calls to that function in our projects.

Relates to : #7776 

Fixes: #7790