### PR TITLE
Deprecate trueStripSlashes global function.

### DIFF
--- a/library/core/functions.deprecated.php
+++ b/library/core/functions.deprecated.php
@@ -742,7 +742,7 @@ if (!function_exists('trueStripSlashes')) {
          * @deprecated
          */
         function trueStripSlashes($string) {
-            deprecated('trueStripSlashes()');
+            \Vanilla\Utility\Deprecation::log();
             return stripslashes($string);
         }
     } else {
@@ -750,7 +750,7 @@ if (!function_exists('trueStripSlashes')) {
          * @deprecated
          */
         function trueStripSlashes($string) {
-            deprecated('trueStripSlashes()');
+            \Vanilla\Utility\Deprecation::log();
             return $string;
         }
     }


### PR DESCRIPTION
Deprecate trueStripSlashes global function.
Apply error log output on production for final check.

Relates to: #7776

Fixes: #7792