### PR TITLE
Add ability to get fragment for the current user to users API v2 endpoint

### DIFF
--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -178,6 +178,50 @@ class UsersTest extends AbstractResourceTest {
     }
 
     /**
+     * Test getting current user info when the user is a guest.
+     */
+    public function testMeGuest() {
+        $this->api()->setUserID(0);
+
+        $response = $this->api()->get("{$this->baseUrl}/me");
+        $this->assertSame(200, $response->getStatusCode());
+
+        $expected = [
+            "userID" => 0,
+            "name" => "Guest",
+            "photoUrl" => \UserModel::getDefaultAvatarUrl(),
+            "dateLastActive" => null
+        ];
+        $actual = $response->getBody();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test getting current user info when the user is a valid member.
+     */
+    public function testMeMember() {
+        /** @var \UserModel $userModel */
+        $userModel = self::container()->get('UserModel');
+        $userID = $this->api()->getUserID();
+        $user = $userModel->getID($userID, DATASET_TYPE_ARRAY);
+        $dateLastActive = $user["DateLastActive"] ? date("c", strtotime($user["DateLastActive"])) : null;
+
+        $response = $this->api()->get("{$this->baseUrl}/me");
+        $this->assertSame(200, $response->getStatusCode());
+
+        $expected = [
+            "userID" => $userID,
+            "name" => $user["Name"],
+            "photoUrl" => userPhotoUrl($user),
+            "dateLastActive" => $dateLastActive
+        ];
+        $actual = $response->getBody();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
      * Test full-name filtering with GET /users/by-names.
      */
     public function testNamesFull() {


### PR DESCRIPTION
This update adds the ability to get information about the current user from the users API v2 endpoint. Requesting /api/v2/users/me should respond with values reflecting the current session. The existing "user fragment" schema is used for the output schema.

### Example "member" response
```json
{
    "userID": 1,
    "name": "Vanilla",
    "photoUrl": "//we.vanillicon.com/v2/b58996c504c5638798eb6b511e6f49af.svg",
    "dateLastActive": "2018-09-01T01:00:00+00:00"
}
```

### Example "guest" response
```json
{
    "userID": 0,
    "name": "Guest",
    "photoUrl": "http://example.com/applications/dashboard/design/images/defaulticon.png",
    "dateLastActive": null
}
```

Closes #7733 