### PR TITLE
Backport: Put imports behind a feature flag and harden custom import paths (2.6)

### DIFF
--- a/applications/dashboard/controllers/class.importcontroller.php
+++ b/applications/dashboard/controllers/class.importcontroller.php
@@ -30,7 +30,7 @@ class ImportController extends DashboardController {
      * @access public
      */
     public function go($transientKey = '') {
-        $this->permission('Garden.Settings.Manage');
+        $this->checkAccess();
         if (!Gdn::session()->validateTransientKey($transientKey) && !Gdn::request()->isAuthenticatedPostBack()) {
             throw new Gdn_UserException('The CSRF token is invalid.', 403);
         }
@@ -92,13 +92,28 @@ class ImportController extends DashboardController {
     }
 
     /**
+     * Ensure that imports are enabled and that the user has permission.
+     */
+    private function checkAccess() {
+        $this->permission('Garden.Import'); // This permission doesn't exist, so only users with Admin == '1' will succeed.
+        \Vanilla\FeatureFlagHelper::throwIfNotEnabled(
+            'Import',
+            Gdn_UserException::class,
+            [
+                t('Imports are not enabled.', 'Imports are not enabled. Set the config Feature.Import.Enabled = true to enable imports.'),
+                403
+            ]
+        );
+    }
+
+    /**
      * Main import page.
      *
      * @since 2.0.0
      * @access public
      */
     public function index() {
-        $this->permission('Garden.Import'); // This permission doesn't exist, so only users with Admin == '1' will succeed.
+        $this->checkAccess();
         $timer = new Gdn_Timer();
 
         // Determine the current step.
@@ -112,7 +127,7 @@ class ImportController extends DashboardController {
         $existingPaths2 = safeGlob(PATH_UPLOADS.'/porter/export*', ['gz']);
         $existingPaths = array_merge($existingPaths, $existingPaths2);
         foreach ($existingPaths as $path) {
-            $importPaths[$path] = basename($path);
+            $importPaths[substr($path, strlen(PATH_UPLOADS))] = basename($path);
         }
         // Add the database as a path.
         $importPaths = array_merge(['db:' => t('This Database')], $importPaths);
@@ -152,9 +167,12 @@ class ImportController extends DashboardController {
                     $uploadedFiles[$importPath] = basename($filename);
                     $imp->Data['UploadedFiles'] = $uploadedFiles;
                 } elseif (($pathSelect = $this->Form->getFormValue('PathSelect'))) {
-                    if ($pathSelect == 'NEW') {
+                    if ($pathSelect === 'NEW') {
                         $validation->addValidationResult('ImportFile', 'ValidateRequired');
                     } else {
+                        if ($pathSelect !== 'db:') {
+                            $pathSelect = PATH_UPLOADS.$pathSelect;
+                        }
                         $imp->ImportPath = $pathSelect;
                     }
                 } elseif (!$imp->ImportPath && count($importPaths) == 0) {
@@ -216,7 +234,7 @@ class ImportController extends DashboardController {
      * @access public
      */
     public function restart($transientKey = '') {
-        $this->permission('Garden.Import'); // This permission doesn't exist, so only users with Admin == '1' will succeed.
+        $this->checkAccess();
         if (!Gdn::session()->validateTransientKey($transientKey) && !Gdn::request()->isAuthenticatedPostBack()) {
             throw new Gdn_UserException('The CSRF token is invalid.', 403);
         }

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -327,7 +327,14 @@ class DashboardHooks extends Gdn_Plugin {
             ->addLinkIf('Garden.Settings.Manage', t('Statistics'), '/dashboard/statistics', 'site-settings.statistics', '', $sort)
 
             ->addGroupIf('Garden.Settings.Manage', t('Forum Data'), 'forum-data', '', ['after' => 'site-settings'])
-            ->addLinkIf('Garden.Settings.Manage', t('Import'), '/dashboard/import', 'forum-data.import', '', $sort);
+            ->addLinkIf(
+                \Vanilla\FeatureFlagHelper::featureEnabled('Import') && $session->checkPermission('Garden.Import'),
+                t('Import'),
+                '/dashboard/import',
+                'forum-data.import',
+                '',
+                $sort
+            );
     }
 
     /**


### PR DESCRIPTION
Backporting #7798 
- Community imports are now behind a feature flag that is default disabled.
- Specific import paths must now be under PATH_UPLOADS and that path is always prepended to a custom path.