### PR TITLE
Add explicit exception for accessing disabled features

### DIFF
--- a/applications/dashboard/controllers/api/AuthenticateApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticateApiController.php
@@ -65,7 +65,7 @@ class AuthenticateApiController extends AbstractApiController {
         SSOModel $ssoModel,
         UserModel $userModel
     ) {
-        \Vanilla\FeatureFlagHelper::throwIfNotEnabled(self::FEATURE_FLAG);
+        \Vanilla\FeatureFlagHelper::ensureFeature(self::FEATURE_FLAG);
         $this->authenticatorApiController = $authenticatorApiController;
         $this->config = $config;
         $this->request = $request;

--- a/applications/dashboard/controllers/api/AuthenticatorsApiController.php
+++ b/applications/dashboard/controllers/api/AuthenticatorsApiController.php
@@ -35,7 +35,7 @@ class AuthenticatorsApiController extends AbstractApiController  {
      * @param AuthenticatorModel $authenticatorModel
      */
     public function __construct(AuthenticatorModel $authenticatorModel) {
-        \Vanilla\FeatureFlagHelper::throwIfNotEnabled(AuthenticateApiController::FEATURE_FLAG);
+        \Vanilla\FeatureFlagHelper::ensureFeature(AuthenticateApiController::FEATURE_FLAG);
         $this->authenticatorModel = $authenticatorModel;
     }
 

--- a/applications/dashboard/controllers/class.authenticatecontroller.php
+++ b/applications/dashboard/controllers/class.authenticatecontroller.php
@@ -54,7 +54,7 @@ class AuthenticateController extends Gdn_Controller {
         SSOModel $ssoModel,
         UserModel $userModel
     ) {
-        \Vanilla\FeatureFlagHelper::throwIfNotEnabled(AuthenticateApiController::FEATURE_FLAG);
+        \Vanilla\FeatureFlagHelper::ensureFeature(AuthenticateApiController::FEATURE_FLAG);
         parent::__construct();
 
         $this->authenticateApiController = $authenticateApiController;

--- a/applications/dashboard/controllers/class.importcontroller.php
+++ b/applications/dashboard/controllers/class.importcontroller.php
@@ -96,13 +96,9 @@ class ImportController extends DashboardController {
      */
     private function checkAccess() {
         $this->permission('Garden.Import'); // This permission doesn't exist, so only users with Admin == '1' will succeed.
-        \Vanilla\FeatureFlagHelper::throwIfNotEnabled(
+        \Vanilla\FeatureFlagHelper::ensureFeature(
             'Import',
-            Gdn_UserException::class,
-            [
-                t('Imports are not enabled.', 'Imports are not enabled. Set the config Feature.Import.Enabled = true to enable imports.'),
-                403
-            ]
+            t('Imports are not enabled.', 'Imports are not enabled. Set the config Feature.Import.Enabled = true to enable imports.')
         );
     }
 

--- a/library/Vanilla/Exception/FeatureNotEnabledException.php
+++ b/library/Vanilla/Exception/FeatureNotEnabledException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Exception;
+
+use Garden\Web\Exception\ServerException;
+
+/**
+ * An exception for when access to a disabled feature is attempted.
+ */
+class FeatureNotEnabledException extends ServerException {
+}

--- a/library/Vanilla/FeatureFlagHelper.php
+++ b/library/Vanilla/FeatureFlagHelper.php
@@ -2,13 +2,15 @@
 
 namespace Vanilla;
 
-use Gdn;
 use Vanilla\Exception\FeatureNotEnabledException;
+use Garden\StaticCacheConfigTrait;
 
 /**
  * A helper class for gatekeeping code behind feature flags.
  */
 class FeatureFlagHelper {
+
+    use StaticCacheConfigTrait;
 
     /**
      * Is a feature enabled?
@@ -18,7 +20,7 @@ class FeatureFlagHelper {
      */
     public static function featureEnabled(string $feature): bool {
         // We're going to enforce the root "Feature" namespace.
-        $configValue = Gdn::config("Feature.{$feature}.Enabled");
+        $configValue = self::c("Feature.{$feature}.Enabled");
         // Force a true boolean.
         $result = filter_var($configValue, FILTER_VALIDATE_BOOLEAN);
         return $result;
@@ -50,6 +52,7 @@ class FeatureFlagHelper {
      * @deprecated 2.7 Use FeatureFlagHelper::ensureFeature instead.
      */
     public static function throwIfNotEnabled(string $feature, string $exceptionClass = \Exception::class, array $exceptionArguments = []) {
+        Utility\Deprecation::log();
         if (self::featureEnabled($feature) === false) {
             if ($exceptionClass === \Exception::class && empty($exceptionArguments)) {
                 $exceptionArguments = [t('This feature is not enabled.')];

--- a/library/Vanilla/FeatureFlagHelper.php
+++ b/library/Vanilla/FeatureFlagHelper.php
@@ -3,8 +3,7 @@
 namespace Vanilla;
 
 use Gdn;
-use Gdn_Configuration;
-use Exception;
+use Vanilla\Exception\FeatureNotEnabledException;
 
 /**
  * A helper class for gatekeeping code behind feature flags.
@@ -19,10 +18,27 @@ class FeatureFlagHelper {
      */
     public static function featureEnabled(string $feature): bool {
         // We're going to enforce the root "Feature" namespace.
-        $configValue = c("Feature.{$feature}.Enabled");
+        $configValue = Gdn::config("Feature.{$feature}.Enabled");
         // Force a true boolean.
         $result = filter_var($configValue, FILTER_VALIDATE_BOOLEAN);
         return $result;
+    }
+
+    /**
+     * If the feature is not enabled, throw an exception.
+     *
+     * @param string $feature The config-friendly name of the feature.
+     * @param string $message A user-friendly message to used in the exception.
+     * @param int $code Numeric code for the exception. Should be a relevant HTTP response code.
+     * @throws FeatureNotEnabledException If the feature is not enabled.
+     */
+    public static function ensureFeature(string $feature, string $message = "", int $code = 403) {
+        if (self::featureEnabled($feature) === false) {
+            if ($message === "") {
+                $message = t("This feature is not enabled.");
+            }
+            throw new FeatureNotEnabledException($message, $code);
+        }
     }
 
     /**
@@ -31,10 +47,11 @@ class FeatureFlagHelper {
      * @param string $feature The config-friendly name of the feature.
      * @param string $exceptionClass The fully-qualified class name of the exception to throw.
      * @param array $exceptionArguments Any parameters to be passed to the exception class's constructor.
+     * @deprecated 2.7 Use FeatureFlagHelper::ensureFeature instead.
      */
-    public static function throwIfNotEnabled(string $feature, string $exceptionClass = Exception::class, array $exceptionArguments = []) {
+    public static function throwIfNotEnabled(string $feature, string $exceptionClass = \Exception::class, array $exceptionArguments = []) {
         if (self::featureEnabled($feature) === false) {
-            if ($exceptionClass === Exception::class && empty($exceptionArguments)) {
+            if ($exceptionClass === \Exception::class && empty($exceptionArguments)) {
                 $exceptionArguments = [t('This feature is not enabled.')];
             }
             throw new $exceptionClass(...$exceptionArguments);


### PR DESCRIPTION
It was proposed in #7797 that Vanilla throw a specific, explicit exception for whenever access to disabled feature is detected with the `FeatureFlagHelper` class. This update implements that exception.

### Summary of Changes
1. Add `FeatureNotEnabledException` class.
1. Add `FeatureFlagHelper::ensureFeature` method. This method does the same thing `FeatureFlagHelper::throwIfNotEnabled` did, only it forces a standard exception.
1. Deprecated `FeatureFlagHelper::throwIfNotEnabled` in favor of `FeatureFlagHelper::ensureFeature`.
1. Remove call to global `c` function in favor of `Gdn::config` in `FeatureFlagHelper::featureEnabled`.
1. Update all calls to `FeatureFlagHelper::throwIfNotEnabled`, including the one added in #7798.