### PR TITLE
Backport: Only allow http/https in ProxyRequest (2.6)

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -429,6 +429,7 @@ class ProxyRequest {
         curl_setopt($handler, CURLOPT_USERAGENT, val('HTTP_USER_AGENT', $_SERVER, 'Vanilla/'.c('Vanilla.Version')));
         curl_setopt($handler, CURLOPT_CONNECTTIMEOUT, $connectTimeout);
         curl_setopt($handler, CURLOPT_HEADERFUNCTION, [$this, 'CurlHeader']);
+        curl_setopt($handler, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 
         if ($transferMode == 'binary') {
             curl_setopt($handler, CURLOPT_BINARYTRANSFER, true);


### PR DESCRIPTION
Backporting #7806 