### PR TITLE
Only check an activity’s permission if it was found

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1797,10 +1797,11 @@ if (!function_exists('getRecord')) {
                 /** @var ActivityModel $activityModel */
                 $activityModel = $container->get(ActivityModel::class);
                 $row = $activityModel->getID($id, DATASET_TYPE_ARRAY);
-                if (!$activityModel->canView($row)) {
-                    throw permissionException();
-                }
                 if ($row) {
+                    if (!$activityModel->canView($row)) {
+                        throw permissionException();
+                    }
+
                     $row['Name'] = formatString($row['HeadlineFormat'], $row);
                     $row['Body'] = $row['Story'];
                 }


### PR DESCRIPTION
This also prevents an error caused by a newly added type hint.