### PR TITLE
Harden writeAttachments against infinite recursion

### DIFF
--- a/applications/dashboard/models/class.attachmentmodel.php
+++ b/applications/dashboard/models/class.attachmentmodel.php
@@ -345,6 +345,10 @@ class AttachmentModel extends Gdn_Model {
      * @return string Function name.
      */
     public static function getWriteAttachmentMethodName($type) {
+        if (empty($type)) {
+            return '';
+        }
+
         $method = str_replace('-', ' ', $type);
         $method = ucwords($method);
         $method = str_replace(' ', '', $method);

--- a/applications/dashboard/views/attachments/attachment.php
+++ b/applications/dashboard/views/attachments/attachment.php
@@ -14,7 +14,7 @@ if (!function_exists('WriteAttachment')) {
     function writeAttachment($attachment) {
 
         $customMethod = AttachmentModel::getWriteAttachmentMethodName($attachment['Type']);
-        if (function_exists($customMethod)) {
+        if (function_exists($customMethod) && strcasecmp($customMethod, 'writeAttachment') !== 0) {
             if (val('Error', $attachment)) {
                 writeErrorAttachment($attachment);
                 return;


### PR DESCRIPTION
Attachments without a type will return “writeAttachment” which gets called recursively then.