### PR TITLE
Enforce add-on types and keys

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -515,7 +515,7 @@ class AddonManager {
      * @return Addon|null Returns an addon object or null if one isn't found.
      */
     private function lookupSingleCachedAddon($addonDirName, $type) {
-        if (empty($addonDirName)) {
+        if (empty($addonDirName) || !static::validateKey($addonDirName)) {
             return null;
         }
 
@@ -743,7 +743,9 @@ class AddonManager {
      * @return Addon|null
      */
     public function lookupAddon($key) {
-        static::validateKey($key);
+        if (!static::validateKey($key)) {
+            return false;
+        }
 
         $this->ensureMultiCache();
 
@@ -763,7 +765,6 @@ class AddonManager {
      * @return bool Returns
      */
     public function isEnabled($key, $type) {
-        static::validateKey($key);
         static::validateType($type);
 
         if ($type === Addon::TYPE_ADDON) {
@@ -873,8 +874,6 @@ class AddonManager {
      * @return null|Addon Returns an {@link Addon} object for the locale pack or **null** if it can't be found.
      */
     public function lookupLocale($localeDirName) {
-        static::validateKey($localeDirName);
-
         $result = $this->lookupSingleCachedAddon($localeDirName, Addon::TYPE_LOCALE);
         return $result;
     }
@@ -992,8 +991,6 @@ class AddonManager {
      * @return null|Addon Returns an {@link Addon} object for the theme or **null** if it can't be found.
      */
     public function lookupTheme($themeDirName) {
-        static::validateKey($themeDirName);
-
         $result = $this->lookupSingleCachedAddon($themeDirName, Addon::TYPE_THEME);
         return $result;
     }
@@ -1357,8 +1354,10 @@ class AddonManager {
      * @param string $key The key to validate.
      */
     private static function validateKey(string $key) {
-        if (!preg_match('`^[a-z0-9_-]+$`i', $key)) {
-            throw new \InvalidArgumentException("Invalid addon key: $key", 400);
+        if (!preg_match('`^[a-z0-9_-]*$`i', $key)) {
+            trigger_error("Invalid addon key: $key.", E_USER_NOTICE);
+            return false;
         }
+        return true;
     }
 }

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -794,7 +794,7 @@ class AddonManagerTest extends SharedBootstrapTestCase {
     /**
      * Test a bad theme key.
      *
-     * @expectedException \InvalidArgumentException
+     * @expectedException PHPUnit\Framework\Error\Notice
      */
     public function testBadThemeKey() {
         $am = $this->createTestManager();

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -803,6 +803,20 @@ class AddonManagerTest extends SharedBootstrapTestCase {
     }
 
     /**
+     * Looking up an empty addon key should return null, no error.
+     */
+    public function testEmptyKeyLookup() {
+        $am = $this->createTestManager();
+
+        $addon = $am->lookupAddon('');
+        $this->assertNull($addon);
+        $addon = $am->lookupTheme('');
+        $this->assertNull($addon);
+        $addon = $am->lookupLocale('');
+        $this->assertNull($addon);
+    }
+
+    /**
      * Make an addon manager that has conflicting addons..
      *
      * @return AddonManager

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -657,13 +657,12 @@ class AddonManagerTest extends SharedBootstrapTestCase {
         $addon = $am->lookupAddon('bad-require');
         $r = $am->lookupRequirements($addon, AddonManager::REQ_MISSING | AddonManager::REQ_VERSION);
 
-        $this->assertArrayHasKey('asd!', $r);
+        $this->assertArrayHasKey('asd', $r);
         $this->assertArrayHasKey('namespaced-plugin', $r);
 
-        $this->assertSame(AddonManager::REQ_MISSING, $r['asd!']['status']);
+        $this->assertSame(AddonManager::REQ_MISSING, $r['asd']['status']);
         $this->assertSame(AddonManager::REQ_VERSION, $r['namespaced-plugin']['status']);
     }
-
 
     /**
      * Test an addon with an invalid require key.
@@ -779,6 +778,28 @@ class AddonManagerTest extends SharedBootstrapTestCase {
         $locale = $am->lookup('test-locale');
         $this->assertEquals('test', $locale->getKey());
         $this->assertEquals(Addon::TYPE_LOCALE, $locale->getType());
+    }
+
+    /**
+     * Test addon type checking.
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testBadType() {
+        $am = $this->createTestManager();
+
+        $addons = $am->lookupAllByType('../../../fixtures/error');
+    }
+
+    /**
+     * Test a bad theme key.
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testBadThemeKey() {
+        $am = $this->createTestManager();
+
+        $theme = $am->lookupTheme('../../../../fixtures/error-index');
     }
 
     /**

--- a/tests/fixtures/plugins/bad-require/addon.json
+++ b/tests/fixtures/plugins/bad-require/addon.json
@@ -3,7 +3,7 @@
     "name": "Requirements can't be met",
     "type": "addon",
     "require": {
-        "asd!": ">1.0",
+        "asd": ">1.0",
         "namespaced-plugin": ">= 4320"
     }
 }


### PR DESCRIPTION
Enforce what add-on types and keys can be passed to the `AddonManager` so that appropriate error messages are surfaced to the user.