### PR TITLE
Fix memory exhaustion while moving a discussion

### DIFF
--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -446,9 +446,8 @@ class ModerationController extends VanillaController {
 
             // Update recent posts and counts on all affected categories.
             foreach ($AffectedCategories as $categoryID => $counts) {
-                $DiscussionModel->updateDiscussionCount($categoryID);
+                CategoryModel::recalculateCounts($categoryID);
             }
-            (new CategoryModel())->counts('CountAllDiscussions');
             CategoryModel::clearCache();
             // Clear selections.
             if ($ClearSelection) {

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -446,7 +446,8 @@ class ModerationController extends VanillaController {
 
             // Update recent posts and counts on all affected categories.
             foreach ($AffectedCategories as $categoryID => $counts) {
-                CategoryModel::recalculateCounts($categoryID);
+                CategoryModel::recalculateRecentFields($categoryID);
+                CategoryModel::recalculateCountFields($categoryID);
             }
             CategoryModel::clearCache();
             // Clear selections.

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -448,7 +448,7 @@ class ModerationController extends VanillaController {
             foreach ($AffectedCategories as $categoryID => $counts) {
                 $DiscussionModel->updateDiscussionCount($categoryID);
             }
-            CategoryModel::recalculateAggregateCounts();
+            (new CategoryModel())->counts('CountAllDiscussions');
             CategoryModel::clearCache();
             // Clear selections.
             if ($ClearSelection) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -579,6 +579,12 @@ class CategoryModel extends Gdn_Model {
      *
      */
     protected static function buildCache($categoryID = null) {
+        if (!(
+            Gdn::cache()->activeEnabled()
+            && Gdn::cache()->type() != Gdn_Cache::CACHE_TYPE_NULL)
+        ) {
+            return;
+        };
         self::calculateData(self::$Categories);
         self::joinRecentPosts(self::$Categories, $categoryID);
 
@@ -3514,11 +3520,11 @@ SQL;
         }
 
         // Update the cache.
-        $categoriesToUpdate = self::instance()->getWhere(['CategoryID' => $updatedCategories]);
+        $categoriesToUpdate = self::instance()->getWhere(['CategoryID' => $updatedCategories])->resultArray();
         foreach ($categoriesToUpdate as $current) {
-            $currentID = val('CategoryID', $current);
-            $countAllDiscussions = val('CountAllDiscussions', $current);
-            $countAllComments = val('CountAllComments', $current);
+            $currentID = $current['CategoryID'];
+            $countAllDiscussions = $current['CountAllDiscussions'];
+            $countAllComments = $current['CountAllComments'];
             self::setCache(
                 $currentID,
                 ['CountAllDiscussions' => $countAllDiscussions, 'CountAllComments' => $countAllComments]
@@ -3557,7 +3563,7 @@ SQL;
      *
      * @return void
      */
-    private static function recalculateAggregateCounts() {
+    public static function recalculateAggregateCounts() {
         // First grab the max depth so you know where to loop.
         $depth = Gdn::sql()
             ->select('Depth', 'max')

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3668,34 +3668,16 @@ SQL;
      */
     public static function recalculateCounts(int $categoryId) {
         self::recalculateCategoryCounts($categoryId);
-        self::recalculateCategoryCountsAll($categoryId);
-
-        $categoryRow = Gdn::sql()
-            ->select('Depth')
-            ->select('ParentCategoryID')
-            ->from('Category')
-            ->where('CategoryID', $categoryId)
-            ->get()
-            ->firstRow(DATASET_TYPE_ARRAY);
-        $depth = (int)($categoryRow['Depth'] ?? 0);
-        $categoryId = $categoryRow['ParentCategoryID'] ?? 0;
-
-        if ($depth === 0) {
-            return;
-        }
-
-        while ($depth > 0) {
+        do {
             self::recalculateCategoryCountsAll($categoryId);
-            $depth--;
-
-            $parent = Gdn::sql()
+            $categoryRow = Gdn::sql()
                 ->select('ParentCategoryID')
                 ->from('Category')
                 ->where('CategoryID', $categoryId)
                 ->get()
                 ->firstRow(DATASET_TYPE_ARRAY);
-            $categoryId = $parent['ParentCategoryID'] ?? 0;
-        }
+            $categoryId = $categoryRow['ParentCategoryID'] ?? 0;
+        } while ($categoryId > 0);
     }
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3607,7 +3607,7 @@ SQL;
      * @param int $categoryId Category ID to update
      * @return void
      */
-    public static function recalculateCategoryCounts(int $categoryId) {
+    public static function recalculatePostCounts(int $categoryId) {
         $sql = Gdn::sql()
             ->select('DiscussionID', 'count', 'DiscussionCount')
             ->select('CountComments', 'sum', 'CountComments')
@@ -3640,7 +3640,7 @@ SQL;
      * @param int $categoryId Category ID to update
      * @return void
      */
-    public static function recalculateCategoryCountsAll(int $categoryId) {
+    public static function recalculateAggregatePostCounts(int $categoryId) {
         $row = Gdn::sql()
             ->select('CountAllDiscussions', 'sum', 'CountAllDiscussions')
             ->select('CountAllComments', 'sum', 'CountAllComments')
@@ -3667,9 +3667,9 @@ SQL;
      * @return void
      */
     public static function recalculateCounts(int $categoryId) {
-        self::recalculateCategoryCounts($categoryId);
+        self::recalculatePostCounts($categoryId);
         do {
-            self::recalculateCategoryCountsAll($categoryId);
+            self::recalculateAggregatePostCounts($categoryId);
             $categoryRow = Gdn::sql()
                 ->select('ParentCategoryID')
                 ->from('Category')

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3668,6 +3668,8 @@ SQL;
     /**
      * Recalculate all aggregate CountAllDiscussions and CountAllComments columns for category and all parents.
      *
+     * @param int $categoryId Category ID to update
+     *
      * @return void
      */
     public static function recalculateCounts(int $categoryId) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1525,7 +1525,8 @@ class CategoryModel extends Gdn_Model {
         if (count($discussion)>0) {
             $result['LastCommentID'] = $discussion['LastCommentID'] ?? null;
             $result['LastCategoryID'] = $discussion['CategoryID'] ?? null;
-            $result['LastDateInserted'] = !empty($discussion['DateLastComment']) ? $discussion['DateLastComment'] : $discussion['DateInserted'];
+            $result['LastDateInserted'] = !empty($discussion['DateLastComment']) ? $discussion['DateLastComment'] :
+                (!empty($discussion['DateUpdated']) ? $discussion['DateUpdated'] : $discussion['DateInserted']);
             $result['LastDiscussionID'] = $discussion['DiscussionID'];
         }
 
@@ -3722,12 +3723,13 @@ SQL;
             ->select('LastCommentID')
             ->from('Discussion')
             ->where('CategoryID', $categoryId)
-            ->orderBy('DateLastComment','desc')
+            ->orderBy('DateLastComment, DateUpdated, DateInserted','desc')
             ->limit(1)
             ->get()
             ->firstRow(DATASET_TYPE_ARRAY);
 
         $fieldsToUpdate = static::postRecentPostFieldSet($discussion);
+        //Let's update category fields only if latest discussion found has fresher timestamp
         while (empty($category['LastDateInserted'] ?? null) || $category['LastDateInserted'] < $fieldsToUpdate['LastDateInserted']) {
             Gdn::sql()
                 ->update('Category')

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3723,7 +3723,7 @@ SQL;
             ->select('LastCommentID')
             ->from('Discussion')
             ->where('CategoryID', $categoryId)
-            ->orderBy('DateLastComment, DateUpdated, DateInserted','desc')
+            ->orderBy('DateLastComment, DateUpdated, DateInserted', 'desc')
             ->limit(1)
             ->get()
             ->firstRow(DATASET_TYPE_ARRAY);

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1524,7 +1524,7 @@ class CategoryModel extends Gdn_Model {
 
         if (count($discussion)>0) {
             $result['LastCommentID'] = $discussion['LastCommentID'] ?? null;
-            $result['LastCategoryID'] = $discussion['CategoryID'] ?? null;
+            $result['LastCategoryID'] = $discussion['CategoryID'];
             $result['LastDateInserted'] = !empty($discussion['DateLastComment']) ? $discussion['DateLastComment'] :
                 (!empty($discussion['DateUpdated']) ? $discussion['DateUpdated'] : $discussion['DateInserted']);
             $result['LastDiscussionID'] = $discussion['DiscussionID'];
@@ -3719,18 +3719,22 @@ SQL;
             ->select('DiscussionID')
             ->select('DateLastComment')
             ->select('DateInserted')
-            ->select('CategoryID', '', 'LastCategoryID')
+            ->select('DateUpdated')
+            ->select('CategoryID')
             ->select('LastCommentID')
             ->from('Discussion')
             ->where('CategoryID', $categoryId)
-            ->orderBy('DateLastComment, DateUpdated, DateInserted', 'desc')
+            ->orderBy('DateLastComment', 'desc')
+            ->orderBy('DateUpdated', 'desc')
+            ->orderBy('DateInserted', 'desc')
             ->limit(1)
             ->get()
             ->firstRow(DATASET_TYPE_ARRAY);
 
         $fieldsToUpdate = static::postRecentPostFieldSet($discussion);
         //Let's update category fields only if latest discussion found has fresher timestamp
-        while (empty($category['LastDateInserted'] ?? null) || $category['LastDateInserted'] < $fieldsToUpdate['LastDateInserted']) {
+        while (empty($category['LastDateInserted'] ?? null)
+            || $category['LastDateInserted'] != $fieldsToUpdate['LastDateInserted']) {
             Gdn::sql()
                 ->update('Category')
                 ->set('LastCategoryID', $fieldsToUpdate['LastCategoryID'])

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -579,12 +579,6 @@ class CategoryModel extends Gdn_Model {
      *
      */
     protected static function buildCache($categoryID = null) {
-        if (!(
-            Gdn::cache()->activeEnabled()
-            && Gdn::cache()->type() != Gdn_Cache::CACHE_TYPE_NULL)
-        ) {
-            return;
-        };
         self::calculateData(self::$Categories);
         self::joinRecentPosts(self::$Categories, $categoryID);
 
@@ -3520,11 +3514,11 @@ SQL;
         }
 
         // Update the cache.
-        $categoriesToUpdate = self::instance()->getWhere(['CategoryID' => $updatedCategories])->resultArray();
+        $categoriesToUpdate = self::instance()->getWhere(['CategoryID' => $updatedCategories]);
         foreach ($categoriesToUpdate as $current) {
-            $currentID = $current['CategoryID'];
-            $countAllDiscussions = $current['CountAllDiscussions'];
-            $countAllComments = $current['CountAllComments'];
+            $currentID = val('CategoryID', $current);
+            $countAllDiscussions = val('CountAllDiscussions', $current);
+            $countAllComments = val('CountAllComments', $current);
             self::setCache(
                 $currentID,
                 ['CountAllDiscussions' => $countAllDiscussions, 'CountAllComments' => $countAllComments]

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3563,7 +3563,7 @@ SQL;
      *
      * @return void
      */
-    public static function recalculateAggregateCounts() {
+    private static function recalculateAggregateCounts() {
         // First grab the max depth so you know where to loop.
         $depth = Gdn::sql()
             ->select('Depth', 'max')


### PR DESCRIPTION
Closes #7105 

Avoid cache recalculations for CategoryModel during ajax response - just update DB and reset cache. 
Cache should be auto recovered/recalculated by any next call coming

### Note:

Main memory consumption was on setCache() of CategoryModel which has a call to buildCache(). Technically caching layer made request 2-3x times slower with abnormal memory usage during execution.

Before (request takes fro 1,5-3 s and php allocates memory from 2Mb to >100Mb during execution):
<img width="514" alt="screen shot 2018-09-24 at 4 50 39 pm" src="https://user-images.githubusercontent.com/15682507/45978343-1c394c80-c01a-11e8-8f85-a6046a0f5209.png">

After (request takes less than 0.5s memory allocation does not change from one request to another):
<img width="511" alt="screen shot 2018-09-24 at 4 51 02 pm" src="https://user-images.githubusercontent.com/15682507/45978351-23f8f100-c01a-11e8-897b-dd001c21e705.png">

As you can see there is a huge performance increase with new "no cache update" solution. 

Fixes: #7105 
