### PR TITLE
Fix embedding comments on local builds

### DIFF
--- a/js/embed.js
+++ b/js/embed.js
@@ -153,9 +153,8 @@ window.vanilla.embed = function(host) {
                 if (currentPath != message[1]) {
                     currentPath = message[1];
                     // Strip off the values that this script added
-                    currentPath = currentPath.replace('/index.php?p=', ''); // 1
-                    currentPath = stripParam(currentPath, 'remote='); // 2
-                    currentPath = stripParam(currentPath, 'locale='); // 3
+                    currentPath = stripParam(currentPath, 'remote='); // 1
+                    currentPath = stripParam(currentPath, 'locale='); // 2
                     window.location.hash = currentPath;
                 }
             }

--- a/js/embed.js
+++ b/js/embed.js
@@ -39,7 +39,6 @@ window.vanilla.embed = function(host) {
                 host = scripts[i].src;
                 host = host.replace('http://', '').replace('https://', '');
                 host = host.substr(0, host.indexOf(jsPath));
-                host += '/index.php?p=';
 
                 host_base_url = scripts[i].src;
                 host_base_url = host_base_url.substr(0, host_base_url.indexOf(jsPath));


### PR DESCRIPTION
We have not supported non-pretty URLs for a few years now (`/index.php?p=discussions` instead of `/discussions`). There remains one URL in the embedding Javascript that still routs using the `p` variable that breaks local builds and impedes local testing/development.

This PR will remove that line from embed.js.

This has been tested on infrastructure, and has no side-effects.

For testing: https://github.com/vanilla/stub-embed-providers/pull/3

