### PR TITLE
Open newline after skip build warning

### DIFF
--- a/library/setup/ComposerHelper.php
+++ b/library/setup/ComposerHelper.php
@@ -55,7 +55,7 @@ class ComposerHelper {
     public static function postUpdate() {
         $skipBuild = getenv(self::DISABLE_AUTO_BUILD) ? true : false;
         if ($skipBuild) {
-            printf("\nSkipping automatic JS build because " . self::DISABLE_AUTO_BUILD . " env variable is set.");
+            printf("\nSkipping automatic JS build because " . self::DISABLE_AUTO_BUILD . " env variable is set.\n");
             return;
         }
 


### PR DESCRIPTION
Currently, post-commit hooks skipping the build causes your prompt to appear after this warning.