### PR TITLE
Fix composer post-install always running code validation

### DIFF
--- a/library/setup/ComposerHelper.php
+++ b/library/setup/ComposerHelper.php
@@ -80,7 +80,7 @@ class ComposerHelper {
         }
 
         $nodeArgs = getenv(self::NODE_ARGS_ENV) ?: "";
-        $disableValidationFlag = getenv(self::DISABLE_VALIDATION_ENV) ? "--low-memory" : "";
+        $disableValidationFlag = getenv(self::DISABLE_VALIDATION_ENV) ? "--disable-validation" : "";
         $buildCommand = "TS_NODE_PROJECT=$tsConfig node $nodeArgs -r $tsNodeRegister $buildScript -i $disableValidationFlag";
 
         printf("\nBuilding frontend assets\n");


### PR DESCRIPTION
The wrong build flag was being passed from the post install script to the build tool. [The proper flag](https://github.com/vanilla/vanilla/blob/master/build/scripts/options.ts#L19) is `--disable-validation`. Previously it was called `--low-memory` but was changed at @DaazKu's suggestion. It seems all the variables got changed except for the string constants that makes up the flag.
