### PR TITLE
Fix ban rules fatal error on search by not escaping field in SQL query

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2597,7 +2597,7 @@ class UserModel extends Gdn_Model {
         $this->fireEvent('AfterUserQuery');
 
         if (isset($where)) {
-            $this->SQL->where($where);
+            $this->SQL->where($where, null, false);
         }
 
         if (!empty($roleID)) {
@@ -2715,7 +2715,7 @@ class UserModel extends Gdn_Model {
         }
 
         if (isset($where)) {
-            $this->SQL->where($where);
+            $this->SQL->where($where, null, false);
         }
 
         $this->SQL


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7564


Simply following the call stack from the issue above, when creating one of the where clauses, escaping the field results in something like this:
```
`inet6_ntoa(LastIPAddress)` like :inet6_ntoaLastIPAddress
```
We are including the MySQL native function in the column name when escaping the field.

We are doing that in 2 places that are resulting in a fatal error when searching for users through ban rules on a IP Address rule.

By setting the `$escapeFieldSql` parameter of the where method of the SQL object we will prevent adding the back ticks as illustrated above, users cannot alter that field and therefore changing this to not be escaped should not open us to any SQL exploit.

This is a result of this https://github.com/vanilla/vanilla-patches/pull/249. We already fixed a few of these occurrences in the past and as per Todd we are not interested in a lower SQL fix for the moment.