### PR TITLE
Fix addon scanning when an addon has a bad key

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -346,7 +346,9 @@ class AddonManager {
             try {
                 $addon = new Addon($subdir);
                 $key = $addon->getKey();
-                if (!array_key_exists($key, $addons)) {
+                if (!static::validateKey($key)) {
+                    trigger_error("The $type in $subdir has an invalid key: $key.", E_USER_WARNING);
+                } elseif (!array_key_exists($key, $addons)) {
                     $addons[$key] = $addon;
                 } else {
                     \Logger::error('Duplicate addon: {key}', [
@@ -394,7 +396,9 @@ class AddonManager {
             $paths = glob(PATH_ROOT."$subdir/*", GLOB_ONLYDIR | GLOB_NOSORT);
             foreach ($paths as $path) {
                 $basename = basename($path);
-                if (!array_key_exists($basename, $result)) {
+                if (!AddonManager::validateKey($basename)) {
+                    trigger_error("The $type in $subdir/$basename has an invalid key: $basename.", E_USER_WARNING);
+                } elseif (!array_key_exists($basename, $result)) {
                     $result[$basename] = substr($path, $strlen);
                 } else {
                     \Logger::error('Duplicate addon: {basename}', [

--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -346,9 +346,7 @@ class AddonManager {
             try {
                 $addon = new Addon($subdir);
                 $key = $addon->getKey();
-                if (!static::validateKey($key)) {
-                    trigger_error("The $type in $subdir has an invalid key: $key.", E_USER_WARNING);
-                } elseif (!array_key_exists($key, $addons)) {
+                if (!array_key_exists($key, $addons)) {
                     $addons[$key] = $addon;
                 } else {
                     \Logger::error('Duplicate addon: {key}', [
@@ -396,9 +394,7 @@ class AddonManager {
             $paths = glob(PATH_ROOT."$subdir/*", GLOB_ONLYDIR | GLOB_NOSORT);
             foreach ($paths as $path) {
                 $basename = basename($path);
-                if (!AddonManager::validateKey($basename)) {
-                    trigger_error("The $type in $subdir/$basename has an invalid key: $basename.", E_USER_WARNING);
-                } elseif (!array_key_exists($basename, $result)) {
+                if (!array_key_exists($basename, $result)) {
                     $result[$basename] = substr($path, $strlen);
                 } else {
                     \Logger::error('Duplicate addon: {basename}', [

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -823,7 +823,7 @@ class AddonManagerTest extends SharedBootstrapTestCase {
      * @dataProvider provideBadAddonKeyTypes
      */
     public function testBadAddonKeyScan($type) {
-        $err = error_reporting(E_ALL & ~E_USER_NOTICE & ~E_USER_WARNING);
+        $err = error_reporting(E_ALL & ~E_USER_NOTICE);
 
         try {
             $am = new AddonManager(

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -817,6 +817,43 @@ class AddonManagerTest extends SharedBootstrapTestCase {
     }
 
     /**
+     * Add-ons with bad keys should not be indexed.
+     *
+     * @param string $type
+     * @dataProvider provideBadAddonKeyTypes
+     */
+    public function testBadAddonKeyScan($type) {
+        $err = error_reporting(E_ALL & ~E_USER_NOTICE);
+
+        try {
+            $am = new AddonManager(
+                [
+                    Addon::TYPE_ADDON => "/tests/fixtures/bad-addons",
+                    Addon::TYPE_THEME => "/tests/fixtures/bad-themes",
+                ],
+                PATH_ROOT.'/tests/cache/am/bad-manager'
+            );
+
+            $addons = $am->lookupAllByType($type);
+            $this->assertEmpty($addons);
+        } finally {
+            error_reporting($err);
+        }
+    }
+
+    /**
+     * Provide data for `testBadAddonKeyScan`.
+     *
+     * @return array Returns a data provider.
+     */
+    public function provideBadAddonKeyTypes() {
+        return [
+            Addon::TYPE_ADDON => [Addon::TYPE_ADDON],
+            Addon::TYPE_THEME => [Addon::TYPE_THEME],
+        ];
+    }
+
+    /**
      * Make an addon manager that has conflicting addons..
      *
      * @return AddonManager

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -823,7 +823,7 @@ class AddonManagerTest extends SharedBootstrapTestCase {
      * @dataProvider provideBadAddonKeyTypes
      */
     public function testBadAddonKeyScan($type) {
-        $err = error_reporting(E_ALL & ~E_USER_NOTICE);
+        $err = error_reporting(E_ALL & ~E_USER_NOTICE & ~E_USER_WARNING);
 
         try {
             $am = new AddonManager(

--- a/tests/fixtures/bad-addons/CobbSalad 1.1/addon.json
+++ b/tests/fixtures/bad-addons/CobbSalad 1.1/addon.json
@@ -1,0 +1,5 @@
+{
+	"key": "CobbSalad 1.1",
+	"name": "Cobb",
+	"type": "addon"
+}

--- a/tests/fixtures/bad-themes/KingFrank 1.2/addon.json
+++ b/tests/fixtures/bad-themes/KingFrank 1.2/addon.json
@@ -1,0 +1,5 @@
+{
+	"key": "KingFrank 1.2",
+	"name": "King",
+	"type": "theme"
+}


### PR DESCRIPTION
Add-ons with invalid keys should not be included in scans, but should also not cause an exception.

Closes #7873.