### PR TITLE
Fix duplicated language element/node in multiple rss feeds

### DIFF
--- a/applications/dashboard/views/activity/all_rss.php
+++ b/applications/dashboard/views/activity/all_rss.php
@@ -1,6 +1,5 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
     <description><?php echo Gdn_Format::text($this->Head->title()); ?></description>
-    <language><?php echo Gdn::config('Garden.Locale', 'en-US'); ?></language>
     <atom:link href="<?php echo htmlspecialchars(url($this->SelfUrl, true)); ?>" rel="self" type="application/rss+xml"/>
 <?php
 $Activities = $this->data('Activities', []);

--- a/applications/dashboard/views/profile/activity_rss.php
+++ b/applications/dashboard/views/profile/activity_rss.php
@@ -1,6 +1,5 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
     <description><?php echo Gdn_Format::text($this->Head->title()); ?></description>
-    <language><?php echo Gdn::config('Garden.Locale', 'en-US'); ?></language>
     <atom:link href="<?php echo htmlspecialchars(url($this->SelfUrl, true)); ?>" rel="self" type="application/rss+xml"/>
 <?php
 $Activities = $this->data('Activities', []);

--- a/applications/vanilla/views/discussions/index_rss.php
+++ b/applications/vanilla/views/discussions/index_rss.php
@@ -1,6 +1,5 @@
 <?php if (!defined('APPLICATION')) exit(); ?>
     <description><?php echo Gdn_Format::text($this->Head->title()); ?></description>
-    <language><?php echo Gdn::config('Garden.Locale', 'en-US'); ?></language>
     <atom:link href="<?php echo htmlspecialchars(url($this->SelfUrl, true)); ?>" rel="self" type="application/rss+xml"/>
 <?php
 foreach ($this->DiscussionData->result() as $Discussion) {


### PR DESCRIPTION
We still had a few rss fiels that included the "language" element themselves even though it's already included in the rss.master file.

As you can see here: https://github.com/vanilla/vanilla/blob/master/applications/dashboard/views/rss.master#L11

Example of error you would get in a rss feed validator

```
line 12, column 4: channel contains more than one language [help]
```


