### PR TITLE
Add date and user field pipeline processors

### DIFF
--- a/library/Vanilla/Database/Operation/CurrentDateFieldProcessor.php
+++ b/library/Vanilla/Database/Operation/CurrentDateFieldProcessor.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Database\Operation;
+
+use Vanilla\Database\Operation;
+
+/**
+ * Database operation processor for including current date fields.
+ */
+class CurrentDateFieldProcessor implements Processor {
+
+    /**
+     * Add current date to write operations.
+     *
+     * @param Operation $databaseOperation
+     * @param callable $stack
+     * @return mixed
+     */
+    public function handle(Operation $databaseOperation, callable $stack) {
+        switch ($databaseOperation->getType()) {
+            case Operation::TYPE_INSERT:
+                $field = "DateInserted";
+                break;
+            case Operation::TYPE_UPDATE:
+                $field = "DateUpdated";
+                break;
+            default:
+                // Nothing to do here. Shortcut return.
+                return $stack($databaseOperation);
+        }
+
+        $fieldExists = $databaseOperation->getCaller()->getWriteSchema()->getField("properties.{$field}");
+        if ($fieldExists) {
+            $set = $databaseOperation->getSet();
+            $set[$field] = date("Y-m-d H:i:s");
+            $databaseOperation->setSet($set);
+        }
+
+        return $stack($databaseOperation);
+    }
+}

--- a/library/Vanilla/Database/Operation/CurrentUserFieldProcessor.php
+++ b/library/Vanilla/Database/Operation/CurrentUserFieldProcessor.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Database\Operation;
+
+use Gdn_Session;
+use Vanilla\Database\Operation;
+
+/**
+ * Database operation processor for including current user ID fields.
+ */
+class CurrentUserFieldProcessor implements Processor {
+
+    /** @var Gdn_Session */
+    private $session;
+
+    /**
+     * CurrentUserFieldProcessor constructor.
+     *
+     * @param Gdn_Session $session
+     */
+    public function __construct(Gdn_Session $session) {
+        $this->session = $session;
+    }
+
+    /**
+     * Add current user ID to write operations.
+     *
+     * @param Operation $databaseOperation
+     * @param callable $stack
+     * @return mixed
+     */
+    public function handle(Operation $databaseOperation, callable $stack) {
+        switch ($databaseOperation->getType()) {
+            case Operation::TYPE_INSERT:
+                $field = "InsertUserID";
+                break;
+            case Operation::TYPE_UPDATE:
+                $field = "UpdateUserID";
+                break;
+            default:
+                // Nothing to do here. Shortcut return.
+                return $stack($databaseOperation);
+        }
+
+        $fieldExists = $databaseOperation->getCaller()->getWriteSchema()->getField("properties.{$field}");
+        if ($fieldExists) {
+            $set = $databaseOperation->getSet();
+            $set[$field] = $this->session->UserID;
+            $databaseOperation->setSet($set);
+        }
+
+        return $stack($databaseOperation);
+    }
+}

--- a/library/Vanilla/Models/Model.php
+++ b/library/Vanilla/Models/Model.php
@@ -21,13 +21,13 @@ class Model implements InjectableInterface {
     private $database;
 
     /** @var Schema */
-    private $readSchema;
+    protected $readSchema;
 
     /** @var string */
     private $table;
 
     /** @var Schema */
-    private $writeSchema;
+    protected $writeSchema;
 
     /**
      * Basic model constructor.
@@ -63,7 +63,7 @@ class Model implements InjectableInterface {
     /**
      * Make sure we have configured schemas available to the instance.
      */
-    private function ensureSchemas() {
+    protected function ensureSchemas() {
         if ($this->readSchema === null || $this->writeSchema === null) {
             $schema = $this->database->simpleSchema($this->table);
 

--- a/library/Vanilla/Models/PipelineModel.php
+++ b/library/Vanilla/Models/PipelineModel.php
@@ -7,6 +7,7 @@
 namespace Vanilla\Models;
 
 use Exception;
+use Garden\Schema\Schema;
 use Vanilla\Database\Operation;
 use Vanilla\Database\Operation\Pipeline;
 use Vanilla\Database\Operation\Processor;
@@ -18,7 +19,7 @@ use Vanilla\InjectableInterface;
 class PipelineModel extends Model implements InjectableInterface {
 
     /** @var Pipeline */
-    private $pipeline;
+    protected $pipeline;
 
     /**
      * Model constructor.
@@ -63,6 +64,26 @@ class PipelineModel extends Model implements InjectableInterface {
             );
         });
         return $result;
+    }
+
+    /**
+     * Get the model's read schema.
+     *
+     * @return Schema
+     */
+    public function getReadSchema(): Schema {
+        $this->ensureSchemas();
+        return $this->readSchema;
+    }
+
+    /**
+     * Get the model's write schema.
+     *
+     * @return Schema
+     */
+    public function getWriteSchema(): Schema {
+        $this->ensureSchemas();
+        return $this->writeSchema;
     }
 
     /**

--- a/tests/Library/Vanilla/Database/CurrentDateFieldProcessorTest.php
+++ b/tests/Library/Vanilla/Database/CurrentDateFieldProcessorTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Database;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use Vanilla\Database\Operation;
+use Vanilla\Database\Operation\CurrentDateFieldProcessor;
+use VanillaTests\Fixtures\BasicPipelineModel;
+
+/**
+ * Class for testing the "current date field" database operation processor.
+ */
+class CurrentDateFieldProcessorTest extends TestCase {
+
+    /**
+     * Verify processor adds fields to insert operations.
+     *
+     * @param string $type
+     * @param array|null $dateFields
+     * @dataProvider provideOperations
+     */
+    public function testAddInsertFields(string $type, $dateFields) {
+        $model = new BasicPipelineModel("Example");
+        $processor = new CurrentDateFieldProcessor();
+        $model->addPipelineProcessor($processor);
+
+        $operation = new Operation();
+        $operation->setType($type);
+        $operation->setCaller($model);
+        $model->doOperation($operation);
+
+        $set = $operation->getSet();
+        if ($dateFields === null) {
+            $this->assertEmpty($set);
+        } else {
+            foreach ($set as $setField => $setValue) {
+                if (!in_array($setField, $dateFields)) {
+                    // Throw a failure exception.
+                    $this->fail("Unexpected field: {$setField}");
+                }
+
+                // Attempt to parse into a DateTime object to validate the value.
+                $dateTime = DateTime::createFromFormat("Y-m-d H:i:s", $setValue);
+                if ($dateTime instanceof DateTime) {
+                    // Verify what went in is what comes back out.
+                    $this->assertTrue($dateTime->format("Y-m-d H:i:s") === $setValue);
+                } else {
+                    $this->fail("Invalid date: {$setValue}");
+                }
+            }
+        }
+    }
+
+    /**
+     * Generate type and "sets" pairs for testing if the current date fields should be set (or not).
+     *
+     * @return array
+     */
+    public function provideOperations() {
+        return [
+            [Operation::TYPE_DELETE, null],
+            [Operation::TYPE_INSERT, ["DateInserted"]],
+            [Operation::TYPE_SELECT, null],
+            [Operation::TYPE_UPDATE, ["DateUpdated"]],
+        ];
+    }
+}

--- a/tests/Library/Vanilla/Database/CurrentUserFieldProcessorTest.php
+++ b/tests/Library/Vanilla/Database/CurrentUserFieldProcessorTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Database;
+
+use Gdn_Session;
+use PHPUnit\Framework\TestCase;
+use Vanilla\Database\Operation;
+use Vanilla\Database\Operation\CurrentUserFieldProcessor;
+use VanillaTests\Fixtures\BasicPipelineModel;
+
+/**
+ * Class for testing the "current user field" database operation processor.
+ */
+class CurrentUserFieldProcessorTest extends TestCase {
+
+    const CURRENT_USER_ID = 99;
+
+    /**
+     * Verify processor adds fields to insert operations.
+     *
+     * @param string $type
+     * @param array $expectedSet
+     * @dataProvider provideOperations
+     */
+    public function testAddInsertFields(string $type, array $expectedSet) {
+        $model = new BasicPipelineModel("Example");
+        $session = new Gdn_Session();
+        $session->UserID = self::CURRENT_USER_ID;
+        $processor = new CurrentUserFieldProcessor($session);
+        $model->addPipelineProcessor($processor);
+
+        $operation = new Operation();
+        $operation->setType($type);
+        $operation->setCaller($model);
+        $model->doOperation($operation);
+        $this->assertEquals($expectedSet, $operation->getSet());
+    }
+
+    /**
+     * Generate type and "sets" pairs for testing if the current user fields should be set (or not).
+     *
+     * @return array
+     */
+    public function provideOperations() {
+        return [
+            [Operation::TYPE_DELETE, []],
+            [Operation::TYPE_INSERT, ["InsertUserID" => self::CURRENT_USER_ID]],
+            [Operation::TYPE_SELECT, []],
+            [Operation::TYPE_UPDATE, ["UpdateUserID" => self::CURRENT_USER_ID]],
+        ];
+    }
+}

--- a/tests/fixtures/src/BasicPipelineModel.php
+++ b/tests/fixtures/src/BasicPipelineModel.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures;
+
+use Garden\Schema\Schema;
+use Vanilla\Database\Operation;
+use Vanilla\Models\PipelineModel;
+
+/**
+ * Class for basic PipelineModel testing.
+ */
+class BasicPipelineModel extends PipelineModel {
+
+    /**
+     * Perform a dummy database operation using the configured pipeline.
+     *
+     * @param Operation $databaseOperation
+     * @return Operation
+     */
+    public function doOperation(Operation $databaseOperation): Operation {
+        $this->pipeline->process($databaseOperation, function () {
+            return;
+        });
+        return $databaseOperation;
+    }
+
+    /**
+     * Make sure we have configured schemas available to the instance.
+     */
+    protected function ensureSchemas() {
+        $this->readSchema = $this->writeSchema = Schema::parse([
+            "UniqueID" => ["type" => "integer"],
+            "InsertUserID" => ["type" => "integer"],
+            "DateInserted" => ["type" => "datetime"],
+            "UpdateUserID" => ["type" => "integer"],
+            "DateUpdated" => ["type" => "datetime"],
+        ]);
+    }
+}


### PR DESCRIPTION
This update introduces the first two "pipeline processors": one for the current user ID, one for the current date-time. These classes will be responsible for automatically handling `InsertUserID`, `UpdateUserID`, `DateInserted` and `DateUpdated`.

1. When added as a processor on a `PipelineModel` instance, `CurrentUserFieldProcessor` will add the current user's user ID to an "InsertUserID" field for insert operations, and "UpdateUserID" for update operations.
1. Similar to the above, when `CurrentDateFieldProcessor` is added as a processor on an instance of `PipelineModel`, it will add the current date to the `DateInserted` field when performing an insert, or to the `DateUpdated` field when performing an update.

Tests are included to further illustrate usage.

Closes #7825 