### PR TITLE
Add event-firing trait

### DIFF
--- a/library/Garden/EventManager/FireEventTrait.php
+++ b/library/Garden/EventManager/FireEventTrait.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Garden\EventManager;
+
+use RuntimeException;
+use Garden\EventManager;
+
+/**
+ * Trait for adding the ability to fire events with EventManager.
+ */
+trait FireEventTrait {
+
+    /** @var EventManager */
+    private $eventManager;
+
+    /**
+     * Fire an event.
+     *
+     * @param string $event The name of the event.
+     * @param mixed $args Any arguments to pass along to the event handlers.
+     * @return array
+     */
+    protected function fireEvent($event, ...$args) {
+        $result = $this->getEventManager()->fire($event, ...$args);
+        return $result;
+    }
+
+    /**
+     * Get the configured EventManager instance.
+     *
+     * @return EventManager
+     * @throws RuntimeException If EventManager dependency has not yet been set.
+     */
+    protected function getEventManager(): EventManager {
+        if (!($this->eventManager instanceof EventManager)) {
+            throw new RuntimeException("Instance of ".EventManager::class." not available.");
+        }
+
+        return $this->eventManager;
+    }
+
+    /**
+     * Set the EventManager dependency.
+     * @param EventManager $eventManager
+     */
+    protected function setEventManager(EventManager $eventManager) {
+        $this->eventManager = $eventManager;
+    }
+}

--- a/tests/Library/Garden/FireEventTraitTest.php
+++ b/tests/Library/Garden/FireEventTraitTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Garden;
+
+use Garden\EventManager;
+use PHPUnit\Framework\TestCase;
+use VanillaTests\Fixtures\EventManager\FireEventTraitModel;
+
+/**
+ * Tests for the {@link EventManager} class.
+ */
+class FireEventTraitTest extends TestCase {
+
+    /**
+     * Verify the trait fires events.
+     */
+    public function testFireEvent() {
+        $eventManager = new EventManager();
+        $eventFired = false;
+        $eventManager->bind("fireEventTrait_test", function () use (&$eventFired) {
+            $eventFired = true;
+        });
+
+        $model = new FireEventTraitModel($eventManager);
+        $this->assertFalse($eventFired);
+        $model->fireTestEvent();
+        $this->assertTrue($eventFired);
+    }
+}

--- a/tests/fixtures/src/EventManager/FireEventTraitModel.php
+++ b/tests/fixtures/src/EventManager/FireEventTraitModel.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures\EventManager;
+
+use Garden\EventManager;
+use Garden\EventManager\FireEventTrait;
+
+/**
+ * Class for testing the abilities of FireEventTrait.
+ */
+class FireEventTraitModel {
+
+    use FireEventTrait;
+
+    /**
+     * FireEventTraitModel constructor.
+     *
+     * @param EventManager $eventManager
+     */
+    public function __construct(EventManager $eventManager) {
+        $this->setEventManager($eventManager);
+    }
+
+    /**
+     * Fire a test event.
+     *
+     * @return array
+     */
+    public function fireTestEvent() {
+        $result = $this->fireEvent("fireEventTrait_test");
+        return $result;
+    }
+}


### PR DESCRIPTION
This update adds a trait for models to opt into some event-firing abilities. It is intended to replace `Gdn_Pluggable` for newer models. Only basic support for event firing has been added. `Gdn_Pluggable` had the ability to "fire as", as well as automatically firing events when PHP's magic [`__call` method](http://php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.methods) was invoked on an instance. These are both functionalities newer models should probably avoid, so they are not included here. In its current state, the trait is largely just an alias for `EventManager::fire`. However, as more model-centric event capabilities are needed, they can easily be added.

Closes #7826 