### PR TITLE
Make new base model class more accessible to its child classes

### DIFF
--- a/library/Vanilla/Models/Model.php
+++ b/library/Vanilla/Models/Model.php
@@ -108,6 +108,15 @@ class Model implements InjectableInterface {
     }
 
     /**
+     * Get the database table name.
+     *
+     * @return string
+     */
+    protected function getTable(): string {
+        return $this->table;
+    }
+
+    /**
      * Select a single row.
      *
      * @param array $where Conditions for the select query.
@@ -161,7 +170,7 @@ class Model implements InjectableInterface {
      *
      * @return \Gdn_SQLDriver
      */
-    private function sql(): \Gdn_SQLDriver {
+    protected function sql(): \Gdn_SQLDriver {
         $sql = clone $this->database->sql();
         $sql->reset();
         return $sql;

--- a/library/Vanilla/Models/PipelineModel.php
+++ b/library/Vanilla/Models/PipelineModel.php
@@ -96,7 +96,7 @@ class PipelineModel extends Model implements InjectableInterface {
         $databaseOperation->setType(Operation::TYPE_UPDATE);
         $databaseOperation->setCaller($this);
         $databaseOperation->setSet($set);
-        $databaseOperation->setSet($where);
+        $databaseOperation->setWhere($where);
         $result = $this->pipeline->process($databaseOperation, function (Operation $databaseOperation) {
             return parent::update(
                 $databaseOperation->getSet(),


### PR DESCRIPTION
When `Vanilla\Model\Model` was created, it was mostly made private. In recent development projects, I've seen reason to allow access to some of these private members from child classes. So, that's what I'm doing here.

1. The `sql` method is now protected, instead of private.
1. There's a protected accessor method for the `table` property.
1. I fixed a dumb copy-paste error in `PipelineModel`.