### PR TITLE
Add first issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Vanilla info**
+1. Are you sure this is a core Vanilla problem and not caused by any addon you are using?
+2. Did you follow our generic troubleshooting steps already?
+3. What Vanilla version are you using?
+4. When did the issue start?
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Per GitHub community profile guidelines, adding a generic bug report template. We can refine this and add more templates as time goes on, but this is a fine starting point.