### PR TITLE
Add tests for moving posts with the moderation controller

### DIFF
--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -25,7 +25,7 @@ class ModerationControllerTest extends BaseTest {
     /**
      * Initial config set up for test
      */
-    public function testModerationDiscussionMoveInintDB() {
+    public function testInitDB() {
         $this->api()->saveToConfig([
             'Garden.Registration.Method' => 'Basic',
             'Garden.Registration.ConfirmEmail' => false,
@@ -279,7 +279,7 @@ class ModerationControllerTest extends BaseTest {
      *
      * @large
      *
-     * @depends testModerationDiscussionMoveInintDB
+     * @depends testInitDB
      */
     public function testMoveNewDiscussionsEmptyCategories() {
         $this->createAndMove('cat1', 'cat2', 'd1_case1');
@@ -298,7 +298,7 @@ class ModerationControllerTest extends BaseTest {
      *
      * @large
      *
-     * @depends testModerationDiscussionMoveInintDB
+     * @depends testInitDB
      * @depends testMoveNewDiscussionsEmptyCategories
      */
     public function testMoveExistingDiscussionToEmptyCategory() {
@@ -321,7 +321,7 @@ class ModerationControllerTest extends BaseTest {
      *
      * @large
      *
-     * @depends testModerationDiscussionMoveInintDB
+     * @depends testInitDB
      * @depends testMoveNewDiscussionsEmptyCategories
      * @depends testMoveExistingDiscussionToEmptyCategory
      */
@@ -337,7 +337,7 @@ class ModerationControllerTest extends BaseTest {
      *
      * @large
      *
-     * @depends testModerationDiscussionMoveInintDB
+     * @depends testInitDB
      * @depends testMoveNewDiscussionsEmptyCategories
      * @depends testMoveExistingDiscussionToEmptyCategory
      * @depends testMoveExistingDiscussionToNotEmptyCategory
@@ -354,7 +354,7 @@ class ModerationControllerTest extends BaseTest {
      *
      * @large
      *
-     * @depends testModerationDiscussionMoveInintDB
+     * @depends testInitDB
      * @depends testMoveNewDiscussionsEmptyCategories
      * @depends testMoveExistingDiscussionToEmptyCategory
      * @depends testMoveExistingDiscussionToNotEmptyCategory
@@ -378,7 +378,7 @@ class ModerationControllerTest extends BaseTest {
      *
      * @large
      *
-     * @depends testModerationDiscussionMoveInintDB
+     * @depends testInitDB
      * @depends testMoveNewDiscussionsEmptyCategories
      * @depends testMoveExistingDiscussionToEmptyCategory
      * @depends testMoveExistingDiscussionToNotEmptyCategory

--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -34,6 +34,9 @@ class ModerationControllerTest extends BaseTest {
      */
     protected static $discussions = [];
 
+    /**
+     * This method is called before the first test of this test class is run.
+     */
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
         self::$api->saveToConfig([

--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: alexander
+ * Date: 2018-09-27
+ * Time: 11:31 AM
+ */
+
+namespace VanillaTests\APIv0\Controllers;
+
+use VanillaTests\APIv0\BaseTest;
+
+class ModerationControllerTest extends BaseTest {
+    protected static $testUser;
+
+    protected static $categories = [];
+
+    protected static $discussions = [];
+
+    protected static $validResponses = [
+        'CountAllDiscussions' => [
+            'cat1' => 2,
+            'cat1_1' => 2,
+            'cat1_1_1' => 2,
+            'cat1_2' => 0,
+            'cat1_2_1' => 0,
+            'cat2' => 0,
+            'cat2_1' => 0,
+            'cat2_1_1' => 0,
+            'cat2_2' => 0,
+
+        ]
+    ];
+
+    public static function setUpBeforeClass() {
+        parent::setUpBeforeClass();
+    }
+
+    public function testModerationDiscussionMoveInintDB() {
+        $this->api()->saveToConfig([
+            'Garden.Registration.Method' => 'Basic',
+            'Garden.Registration.ConfirmEmail' => false,
+            'Garden.Registration.SkipCaptcha' => true,
+        ]);
+
+        $testUser = $this->addAdminUser();
+
+        self::$categories['cat1'] = $cat1 = $this->addCategory(['Name' => 'Root Cat 1',
+            'UrlCode' => 'root-cat-1',
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat1_1'] = $cat1_1 = $this->addCategory(['Name' => 'Level2 Child 1 of Cat 1',
+            'UrlCode' => 'cat-1-child-1',
+            'ParentCategoryID' => $cat1['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat1_1_1'] = $cat1_1_1 = $this->addCategory(['Name' => 'Level3 Child 1-1-1',
+            'UrlCode' => 'cat-1-child-1-1',
+            'ParentCategoryID' => $cat1_1['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat1_2'] = $cat1_2 = $this->addCategory(['Name' => 'Level2 Child 2 of Cat 1',
+            'UrlCode' => 'cat-1-child-2',
+            'ParentCategoryID' => $cat1['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat2'] = $cat2 = $this->addCategory(['Name' => 'Root Cat 2',
+            'UrlCode' => 'root-cat-2',
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat2_1'] = $cat2_1 = $this->addCategory(['Name' => 'Level2 Child 1 of Cat 2',
+            'UrlCode' => 'cat-2-child-1',
+            'ParentCategoryID' => $cat2['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat2_1_1'] = $cat2_1_1 = $this->addCategory(['Name' => 'Level3 Child 2-1-1',
+            'UrlCode' => 'cat-2-child-1-1',
+            'ParentCategoryID' => $cat2_1['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat2_2'] = $cat2_2 = $this->addCategory(['Name' => 'Level2 Child 2 of Cat 2',
+            'UrlCode' => 'cat-2-child-2',
+            'ParentCategoryID' => $cat2['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+
+        $discussion = $this->addDiscussion([
+            'CategoryID' => $cat1_1_1['CategoryID'],
+            'Name' => 'Discussion 1 of cat-1-1-1',
+            'Body' => 'Test '.rand(1,9999999999)
+        ]);
+
+        $discussion = $this->addDiscussion([
+            'CategoryID' => $cat1_1_1['CategoryID'],
+            'Name' => 'Discussion 2 of cat-1-1-1',
+            'Body' => 'Test '.rand(1,9999999999)
+        ]);
+        //throw new \Exception(json_encode($discussion));
+
+        $this->assertTrue( true);
+    }
+
+    protected static function addDiscussion(array $discussion) {
+        $r = self::$api->post(
+            '/post/discussion.json',
+            $discussion
+        );
+        if ($r->getStatusCode() != 200) {
+            throwException('Failed to create new discussion: ' . json_encode($discussion));
+        }
+        $body = $r->getBody();
+        return $body['Discussion'];
+    }
+
+    protected static function addCategory(array $category) {
+        $r = self::$api->post(
+            '/vanilla/settings/addcategory.json',
+            $category
+        );
+        if ($r->getStatusCode() != 200) {
+            throwException('Failed to create new category: ' . json_encode($category));
+        }
+        $body = $r->getBody();
+        return $body['Category'];
+    }
+
+    protected static function getCategory(int $categoryId) {
+        $r = self::$api->get(
+            '/vanilla/settings/getcategory.json',
+            ['CategoryID'=>$categoryId]
+        );
+        if ($r->getStatusCode() != 200) {
+            throwException('Failed to get category: ' . $categoryId);
+        }
+        $body = $r->getBody();
+        return $body['Category'];
+    }
+
+    /**
+     * @depends testModerationDiscussionMoveInintDB
+     */
+    public function testCountAllDiscussions() {
+        foreach (self::$categories as $catKey => $category) {
+            $cat = $this->getCategory($category['CategoryID']);
+            $this->assertEquals(self::$validResponses['CountAllDiscussions'][$catKey], $cat['CountAllDiscussions']);
+        }
+
+    }
+//        $r = $this->api()->post('/moderation/confirmdiscussionmoves?discussionid=7359', [
+//            'Move' => 'Move',
+//            'CategpryID' => 1
+//        ]);
+//
+//        $body = $r->getBody();
+//        $status = $r->getStatusCode();
+//
+//        $this->assertEquals('200' , $status);
+//        $this->assertEquals(0 , strlen($body));
+//    }
+
+//    public function testConfirmDiscussionMoves() {
+//        $r = $this->api()->post('/moderation/confirmdiscussionmoves?discussionid=7359', [
+//            'Move' => 'Move',
+//            'CategpryID' => 1
+//        ]);
+//
+//        $body = $r->getBody();
+//        $status = $r->getStatusCode();
+//
+//        $this->assertEquals('200' , $status);
+//        $this->assertEquals(0 , strlen($body));
+//    }
+
+
+    /**
+     * Test adding an admin user.
+     *
+     * @large
+     */
+    public function addAdminUser() {
+        $system = $this->api()->querySystemUser(true);
+        $this->api()->setUser($system);
+
+        $adminUser = [
+            'Name' => 'Admin',
+            'Email' => 'admin@example.com',
+            'Password' => 'adminsecure',
+        ];
+
+        // Get the admin roles.
+        $adminRole = $this->api()->queryOne("select * from GDN_Role where Name = :name", [':name' => 'Administrator']);
+        $this->assertNotEmpty($adminRole);
+        $adminUser['RoleID'] = [$adminRole['RoleID']];
+
+        $this->api()->saveToConfig([
+            'Garden.Email.Disabled' => true,
+        ]);
+        $r = $this->api()->post(
+            '/user/add.json',
+            http_build_query($adminUser)
+        );
+        $b = $r->getBody();
+        $this->assertResponseSuccess($r);
+
+        // Query the user in the database.
+        $dbUser = $this->api()->queryUserKey('Admin', true);
+
+        // Query the admin role.
+        $userRoles = $this->api()->query("select * from GDN_UserRole where UserID = :userID", [':userID' => $dbUser['UserID']]);
+        $userRoleIDs = array_column($userRoles, 'RoleID');
+        $this->assertEquals($adminUser['RoleID'], $userRoleIDs);
+
+        return $dbUser;
+    }
+}

--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -22,120 +22,17 @@ class ModerationControllerTest extends BaseTest {
 
     protected static $discussions = [];
 
-    public static function setUpBeforeClass() {
-        parent::setUpBeforeClass();
-    }
 
     public function testModerationDiscussionMoveInintDB() {
         $this->api()->saveToConfig([
             'Garden.Registration.Method' => 'Basic',
             'Garden.Registration.ConfirmEmail' => false,
             'Garden.Registration.SkipCaptcha' => true,
+            //'Cache.Enabled' => false,
         ]);
 
         self::$testUser = $this->addAdminUser();
         $this->api()->setUser(self::$testUser);
-
-        self::$categories['cat1'] = $cat1 = $this->addCategory(['Name' => 'Root Cat 1',
-            'UrlCode' => 'root-cat-1',
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat1_1'] = $cat1_1 = $this->addCategory(['Name' => 'Level2 Child 1 of Cat 1',
-            'UrlCode' => 'cat-1-child-1',
-            'ParentCategoryID' => $cat1['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat1_1_1'] = $cat1_1_1 = $this->addCategory(['Name' => 'Level3 Child 1-1-1',
-            'UrlCode' => 'cat-1-child-1-1',
-            'ParentCategoryID' => $cat1_1['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat1_2'] = $cat1_2 = $this->addCategory(['Name' => 'Level2 Child 2 of Cat 1',
-            'UrlCode' => 'cat-1-child-2',
-            'ParentCategoryID' => $cat1['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat1_2_1'] = $cat1_2_1 = $this->addCategory(['Name' => 'Level3 Child 1 of Cat 1-2',
-            'UrlCode' => 'cat-1-child-2-1',
-            'ParentCategoryID' => $cat1_2['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat2'] = $cat2 = $this->addCategory(['Name' => 'Root Cat 2',
-            'UrlCode' => 'root-cat-2',
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat2_1'] = $cat2_1 = $this->addCategory(['Name' => 'Level2 Child 1 of Cat 2',
-            'UrlCode' => 'cat-2-child-1',
-            'ParentCategoryID' => $cat2['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat2_1_1'] = $cat2_1_1 = $this->addCategory(['Name' => 'Level3 Child 2-1-1',
-            'UrlCode' => 'cat-2-child-1-1',
-            'ParentCategoryID' => $cat2_1['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat2_2'] = $cat2_2 = $this->addCategory(['Name' => 'Level2 Child 2 of Cat 2',
-            'UrlCode' => 'cat-2-child-2',
-            'ParentCategoryID' => $cat2['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat2_2_1'] = $cat2_2_1 = $this->addCategory(['Name' => 'Level3 Child 1 of Cat 2-2',
-            'UrlCode' => 'cat-2-child-2-1',
-            'ParentCategoryID' => $cat2_2['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat2_2_1_1'] = $cat2_2_1_1 = $this->addCategory(['Name' => 'Level4 Child 1 of Cat 2-2-1',
-            'UrlCode' => 'cat-2-child-2-1-1',
-            'ParentCategoryID' => $cat2_2_1['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat2_2_1_1_1'] = $cat2_2_1_1_1 = $this->addCategory(['Name' => 'Level5 Child 1 of Cat 2-2-1-1',
-            'UrlCode' => 'cat-2-child-2-1-1-1',
-            'ParentCategoryID' => $cat2_2_1_1['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$categories['cat2_2_1_1_1_1'] = $cat2_2_1_1_1_1 = $this->addCategory(['Name' => 'Level6 Child 1 of Cat 2-2-1-1-1',
-            'UrlCode' => 'cat-2-child-2-1-1-1-1',
-            'ParentCategoryID' => $cat2_2_1_1_1['CategoryID'],
-            'DisplayAs' => 'Discussions']);
-
-        self::$discussions['d1_c1-1-1'] = $discussion = $this->addDiscussion([
-            'CategoryID' => $cat1_1_1['CategoryID'],
-            'Name' => 'Discussion 1 of cat1-1-1',
-            'Body' => 'Test '.rand(1,9999999999)
-        ], 'cat1_1_1');
-
-
-        $comment = $this->addComment([
-            'DiscussionID' => $discussion['DiscussionID'],
-            'Body' => 'Moderation controller test. LINE: '.__LINE__.' DATE: '.date('r')
-        ], 'cat1_1_1');
-
-        self::$discussions['d2_c1-1-1'] = $discussion = $this->addDiscussion([
-            'CategoryID' => $cat1_1_1['CategoryID'],
-            'Name' => 'Discussion 2 of cat1-1-1',
-            'Body' => 'Test '.rand(1,9999999999)
-        ], 'cat1_1_1');
-
-
-
-        self::$discussions['d1_c2_2_1_1_1_1'] = $discussion = $this->addDiscussion([
-            'CategoryID' => $cat2_2_1_1_1_1['CategoryID'],
-            'Name' => 'Discussion 1 of cat2_2_1_1_1_1',
-            'Body' => 'Test '.rand(1,9999999999)
-        ], 'cat2_2_1_1_1_1');
-
-
-        self::$discussions['d2_c2_2_1_1_1_1'] = $discussion = $this->addDiscussion([
-            'CategoryID' => $cat2_2_1_1_1_1['CategoryID'],
-            'Name' => 'Discussion 2 of cat2_2_1_1_1_1',
-            'Body' => 'Test '.rand(1,9999999999)
-        ], 'cat2_2_1_1_1_1');
-
-        $comment = $this->addComment([
-            'DiscussionID' => $discussion['DiscussionID'],
-            'Body' => 'Moderation controller test. LINE: '.__LINE__.' DATE: '.date('r')
-        ], 'cat2_2_1_1_1_1');
 
 
         $this->assertTrue( true);
@@ -166,18 +63,32 @@ class ModerationControllerTest extends BaseTest {
     }
 
     protected static function updateValidValuesOnMoveDiscussion(array $discussion, string $srcCategoryKey, string $destCategoryKey, bool $updateRecent = true, array $srcDiscussionToUpdate = []) {
-
+        self::$discussions[$discussion['discussionKey']]['CategoryID'] = self::$categories[$destCategoryKey]['CategoryID'];
         // Right now CountDiscussions field is not updated at all  - which is wrong
         // @todo We need to uncomment next 2 lines when bug is fixed
         // self::updateValidValues($destCategoryKey,'CountDiscussions','++');
         // self::updateValidValues($srcCategoryKey,'CountDiscussions','--');
+
+
         self::updateValidValues($destCategoryKey , 'CountAllDiscussions', '++');
         self::updateValidValues($srcCategoryKey , 'CountAllDiscussions', '--');
         if ($updateRecent) {
-            self::updateValidValues($destCategoryKey , 'LastDateInserted', $discussion['DateInserted']);
-            self::updateValidValues($destCategoryKey , 'LastDiscussionID', $discussion['DiscussionID']);
+            if ($discussion['DateInserted'] > self::$categories[$destCategoryKey]['LastDateInserted']) {
+                self::updateValidValues($destCategoryKey , 'LastDateInserted', $discussion['DateInserted']);
+                self::updateValidValues($destCategoryKey , 'LastDiscussionID', $discussion['DiscussionID']);
+            } else {
+                //echo $destCategoryKey.':'.$discussion['DateInserted'].':'.self::$categories[$destCategoryKey]['LastDateInserted']."\n";
+                self::updateValidValues($destCategoryKey , 'LastDateInserted', self::$categories[$destCategoryKey]['LastDateInserted']);
+                self::updateValidValues($destCategoryKey , 'LastDiscussionID', self::$categories[$destCategoryKey]['LastDiscussionID']);
+            }
+
+            // Right now LastDateInserted and LastDiscussionID fields are not updated against source Category - which is wrong
+            // @todo We need to uncomment next 2 lines when bug is fixed
             //self::updateValidValues($srcCategoryKey , 'LastDateInserted', ($srcDiscussion['DateInserted'] ?? null));
             //self::updateValidValues($srcCategoryKey , 'LastDiscussionID', ($srcDiscussion['DiscussionID'] ?? null));
+            // @todo until then lets update in non-recursive mode to reproduce current data flow
+            self::updateValidValues($srcCategoryKey , 'LastDateInserted', ($srcDiscussionToUpdate['DateInserted'] ?? null), false);
+            self::updateValidValues($srcCategoryKey , 'LastDiscussionID', ($srcDiscussionToUpdate['DiscussionID'] ?? null), false);
         }
 
     }
@@ -201,8 +112,28 @@ class ModerationControllerTest extends BaseTest {
 
         return $body['Discussion'];
     }
+    protected function moveDiscussion(array $discussion, string $srcCatKey, string $destCatKey, array $srcDiscussion = []) {
+        $r = self::$api->post('/moderation/confirmdiscussionmoves.json?discussionid='.$discussion['DiscussionID'], [
+        'Move' => 'Move',
+        'CategoryID' => self::$categories[$destCatKey]['CategoryID']
+        ]);
 
-    protected static function addCategory(array $category) {
+        $this->updateValidValuesOnMoveDiscussion($discussion, $srcCatKey, $destCatKey, true , $srcDiscussion);
+    }
+
+    protected static function addCategory(array $category, string $catKey = '') {
+        if (!empty($catKey)) {
+            if (($pos = strrpos($catKey, '_')) > 0) {
+                $catKey = substr($catKey, 0, $pos);
+                if (!($parentCat = (self::$categories[$catKey] ?? false))) {
+                    self::$categories[$catKey] = $parentCat = self::addCategory(['Name' => ' Test cat '.$catKey,
+                        'UrlCode' => 'test-cat-'.$catKey,
+                        'DisplayAs' => 'Discussions'], $catKey);
+                }
+                $category['ParentCategoryID'] = $parentCat['CategoryID'];
+            }
+        }
+
         $r = self::$api->post(
             '/vanilla/settings/addcategory.json',
             $category
@@ -235,7 +166,7 @@ class ModerationControllerTest extends BaseTest {
 
     protected static function getCategory(int $categoryId) {
         $r = self::$api->get(
-            '/vanilla/settings/getcategory.json',
+            '/vanilla/settings/getcategory.json?'.rand(0,1000),
             ['CategoryID'=>$categoryId]
         );
         if ($r->getStatusCode() != 200) {
@@ -248,7 +179,7 @@ class ModerationControllerTest extends BaseTest {
     /**
      * @depends testModerationDiscussionMoveInintDB
      */
-    public function testCategories() {
+    public function recheckCategories() {
         foreach (self::$categories as $catKey => $category) {
             $cat = $this->getCategory($category['CategoryID']);
             $this->assertEquals($category['CountAllDiscussions'], $cat['CountAllDiscussions'], 'CountAllDiscussions failed on  '.$catKey);
@@ -267,26 +198,77 @@ class ModerationControllerTest extends BaseTest {
 
     /**
      * Use case #1:
-     * Src cat Lvl6 (cat2_2_1_1_1_1) has 1 discussion with 1 comment
-     * Dest cat Lvl3 (cat1_2_1) has 0 discussions
+     * Src cat Lvl1-6 has 1 discussion
+     * Dest cat Lvl1-6 has 0 discussions
      *
-     * @depends testCategories
+     * @depends testModerationDiscussionMoveInintDB
      */
-    public function testConfirmDiscussionMoves() {
-        $discussion = self::$discussions['d1_c2_2_1_1_1_1'];
-        $category = self::$categories['cat1_2_1'];
-        $r = $this->api()->post('/moderation/confirmdiscussionmoves.json?discussionid='.$discussion['DiscussionID'], [
-            'Move' => 'Move',
-            'CategoryID' => $category['CategoryID']
-        ]);
+    public function testCase1() {
+        $this->createAndMove('cat1', 'cat2', 'd1_case1');
+        $this->createAndMove('cat1_1_1', 'cat2_1_1', 'd1_case2');
+        $this->createAndMove('cat1_1_1_1', 'cat2_1_1_1', 'd1_case3');
+        $this->createAndMove('cat1_1_1_1_1', 'cat2_1_1_1_1', 'd1_case4');
+        $this->createAndMove('cat1_1_1_1_1_1', 'cat2_1_1_1_1_1', 'd1_case5');
+        $this->createAndMove('cat1_1_1_1_1_1_1', 'cat2_1_1_1_1_1_1', 'd1_case6');
+        $this->recheckCategories();
+    }
 
-        $body = $r->getBody();
-        $status = $r->getStatusCode();
+    /**
+     * Use case #2:
+     * Src cat Lvl1-6 has 1 discussion
+     * Dest cat cat3_1_1 has 0-1-2-3 discussions
+     *
+     * @depends testCase1
+     */
+    public function testCase2() {
+        $destCatKey = 'cat3_1_1';
+        self::$categories[$destCatKey] = $destCategory = self::addCategory([
+            'Name' => 'Test cat '.$destCatKey,
+            'UrlCode' => 'test-cat-'.$destCatKey,
+            'DisplayAs' => 'Discussions'], $destCatKey);
+        $this->moveDiscussion(self::$discussions['d1_case1'], 'cat2', $destCatKey, self::$discussions['d1_case6']);
+        $this->moveDiscussion(self::$discussions['d1_case2'], 'cat2_1_1', $destCatKey, self::$discussions['d1_case6']);
+        $this->moveDiscussion(self::$discussions['d1_case3'], 'cat2_1_1_1', $destCatKey, self::$discussions['d1_case6']);
+        $this->moveDiscussion(self::$discussions['d1_case4'], 'cat2_1_1_1_1', $destCatKey, self::$discussions['d1_case6']);
+        $this->recheckCategories();
+    }
 
-        $this->assertEquals('200' , $status);
-        $this->assertArrayHasKey('isHomepage' , $body);
-        $this->updateValidValuesOnMoveDiscussion($discussion, 'cat2_2_1_1_1_1', 'cat1_2_1');
-        $this->testCategories();
+    /**
+     * Use case #3:
+     * Src cat Lvl1-6
+     * Dest cat cat2_1 has 0-1-2-3 discussions
+     * but has LastDiscussionID fresher than we move in.
+     *
+     * @depends testCase2
+     */
+    public function testCase3() {
+        $destCatKey = 'cat2_1';
+        $this->moveDiscussion(self::$discussions['d1_case1'], 'cat3_1_1', $destCatKey, self::$discussions['d1_case4']);
+        $this->moveDiscussion(self::$discussions['d1_case2'], 'cat3_1_1', $destCatKey, self::$discussions['d1_case4']);
+        $this->recheckCategories();
+    }
+
+    public function createAndMove(string $srcCatKey, string $destCatKey, string $discussionKey ) {
+        if ( !($srcCategory = (self::$categories[$srcCatKey] ?? false))) {
+            self::$categories[$srcCatKey] = $srcCategory = self::addCategory([
+                'Name' => 'Test cat '.$srcCatKey,
+                'UrlCode' => 'test-cat-'.$srcCatKey,
+                'DisplayAs' => 'Discussions'], $srcCatKey);
+        }
+        $discussion = self::$discussions[$discussionKey] = self::addDiscussion([
+            'Name' => 'Discussion 1 of '.$srcCatKey,
+            'Body' => 'Test '.$srcCatKey.' '.$destCatKey,
+            'CategoryID' => $srcCategory['CategoryID']
+        ],$srcCatKey);
+        $discussion['discussionKey'] = self::$discussions[$discussionKey]['discussionKey'] = $discussionKey;
+        if ( !($destCategory = (self::$categories[$destCatKey] ?? false))) {
+            self::$categories[$destCatKey] = $destCategory = self::addCategory([
+                'Name' => ' Test cat ' . $destCatKey,
+                'UrlCode' => 'test-cat-' . $destCatKey,
+                'DisplayAs' => 'Discussions'
+            ], $destCatKey);
+        }
+        $this->moveDiscussion($discussion, $srcCatKey, $destCatKey);
     }
 
 

--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -6,12 +6,14 @@
  * Time: 11:31 AM
  */
 
-namespace VanillaTests\APIv0\Controllers;
+namespace VanillaTests\Controllers;
 
 use VanillaTests\APIv0\BaseTest;
 
 class ModerationControllerTest extends BaseTest {
     protected static $testUser;
+
+    protected $user;
 
     protected static $categories = [];
 
@@ -24,12 +26,82 @@ class ModerationControllerTest extends BaseTest {
             'cat1_1_1' => 2,
             'cat1_2' => 0,
             'cat1_2_1' => 0,
+            'cat2' => 2,
+            'cat2_1' => 0,
+            'cat2_1_1' => 0,
+            'cat2_2' => 2,
+            'cat2_2_1' => 2,
+            'cat2_2_1_1' => 2,
+            'cat2_2_1_1_1' => 2,
+            'cat2_2_1_1_1_1' => 2,
+        ],
+        'CountAllComments' => [
+            'cat1' => 1,
+            'cat1_1' => 1,
+            'cat1_1_1' => 1,
+            'cat1_2' => 0,
+            'cat1_2_1' => 0,
+            'cat2' => 1,
+            'cat2_1' => 0,
+            'cat2_1_1' => 0,
+            'cat2_2' => 1,
+            'cat2_2_1' => 1,
+            'cat2_2_1_1' => 1,
+            'cat2_2_1_1_1' => 1,
+            'cat2_2_1_1_1_1' => 1,
+
+        ],
+        'CountCategories' => [
+            'cat1' => 0,
+            'cat1_1' => 0,
+            'cat1_1_1' => 0,
+            'cat1_2' => 0,
+            'cat1_2_1' => 0,
             'cat2' => 0,
             'cat2_1' => 0,
             'cat2_1_1' => 0,
             'cat2_2' => 0,
+            'cat2_2_1' => 0,
+            'cat2_2_1_1' => 0,
+            'cat2_2_1_1_1' => 0,
+            'cat2_2_1_1_1_1' => 0,
 
-        ]
+        ],
+        'CountDiscussions' => [
+            'cat1' => 0,
+            'cat1_1' => 0,
+            'cat1_1_1' => 2,
+            'cat1_2' => 0,
+            'cat1_2_1' => 0,
+            'cat2' => 0,
+            'cat2_1' => 0,
+            'cat2_1_1' => 0,
+            'cat2_2' => 0,
+            'cat2_2_1' => 0,
+            'cat2_2_1_1' => 0,
+            'cat2_2_1_1_1' => 0,
+            'cat2_2_1_1_1_1' => 2,
+
+        ],
+        'CountComments' => [
+            'cat1' => 0,
+            'cat1_1' => 0,
+            'cat1_1_1' => 1,
+            'cat1_2' => 0,
+            'cat1_2_1' => 0,
+            'cat2' => 0,
+            'cat2_1' => 0,
+            'cat2_1_1' => 0,
+            'cat2_2' => 0,
+            'cat2_2_1' => 0,
+            'cat2_2_1_1' => 0,
+            'cat2_2_1_1_1' => 0,
+            'cat2_2_1_1_1_1' => 1,
+
+        ],
+        'DateInserted' => [],
+        'DateUpdated' => [],
+
     ];
 
     public static function setUpBeforeClass() {
@@ -41,9 +113,12 @@ class ModerationControllerTest extends BaseTest {
             'Garden.Registration.Method' => 'Basic',
             'Garden.Registration.ConfirmEmail' => false,
             'Garden.Registration.SkipCaptcha' => true,
+            'Vanilla.Discussions.Add'=>true,
+            'Vanilla.Discussions.Edit'=>true,
         ]);
 
-        $testUser = $this->addAdminUser();
+        self::$testUser = $this->addAdminUser();
+        $this->api()->setUser(self::$testUser);
 
         self::$categories['cat1'] = $cat1 = $this->addCategory(['Name' => 'Root Cat 1',
             'UrlCode' => 'root-cat-1',
@@ -62,6 +137,11 @@ class ModerationControllerTest extends BaseTest {
         self::$categories['cat1_2'] = $cat1_2 = $this->addCategory(['Name' => 'Level2 Child 2 of Cat 1',
             'UrlCode' => 'cat-1-child-2',
             'ParentCategoryID' => $cat1['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat1_2_1'] = $cat1_2_1 = $this->addCategory(['Name' => 'Level3 Child 1 of Cat 1-2',
+            'UrlCode' => 'cat-1-child-2-1',
+            'ParentCategoryID' => $cat1_2['CategoryID'],
             'DisplayAs' => 'Discussions']);
 
         self::$categories['cat2'] = $cat2 = $this->addCategory(['Name' => 'Root Cat 2',
@@ -83,21 +163,89 @@ class ModerationControllerTest extends BaseTest {
             'ParentCategoryID' => $cat2['CategoryID'],
             'DisplayAs' => 'Discussions']);
 
+        self::$categories['cat2_2_1'] = $cat2_2_1 = $this->addCategory(['Name' => 'Level3 Child 1 of Cat 2-2',
+            'UrlCode' => 'cat-2-child-2-1',
+            'ParentCategoryID' => $cat2_2['CategoryID'],
+            'DisplayAs' => 'Discussions']);
 
-        $discussion = $this->addDiscussion([
+        self::$categories['cat2_2_1_1'] = $cat2_2_1_1 = $this->addCategory(['Name' => 'Level4 Child 1 of Cat 2-2-1',
+            'UrlCode' => 'cat-2-child-2-1-1',
+            'ParentCategoryID' => $cat2_2_1['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat2_2_1_1_1'] = $cat2_2_1_1_1 = $this->addCategory(['Name' => 'Level5 Child 1 of Cat 2-2-1-1',
+            'UrlCode' => 'cat-2-child-2-1-1-1',
+            'ParentCategoryID' => $cat2_2_1_1['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+        self::$categories['cat2_2_1_1_1_1'] = $cat2_2_1_1_1_1 = $this->addCategory(['Name' => 'Level6 Child 1 of Cat 2-2-1-1-1',
+            'UrlCode' => 'cat-2-child-2-1-1-1-1',
+            'ParentCategoryID' => $cat2_2_1_1_1['CategoryID'],
+            'DisplayAs' => 'Discussions']);
+
+        self::$discussions['d1_c1-1-1'] = $discussion = $this->addDiscussion([
             'CategoryID' => $cat1_1_1['CategoryID'],
             'Name' => 'Discussion 1 of cat-1-1-1',
             'Body' => 'Test '.rand(1,9999999999)
         ]);
 
-        $discussion = $this->addDiscussion([
+        $comment = $this->addComment([
+            'DiscussionID' => $discussion['DiscussionID'],
+            'Body' => 'Moderation controller test. LINE: '.__LINE__.' DATE: '.date('r')
+        ]);
+
+        self::$discussions['d2_c1-1-1'] = $discussion = $this->addDiscussion([
             'CategoryID' => $cat1_1_1['CategoryID'],
             'Name' => 'Discussion 2 of cat-1-1-1',
             'Body' => 'Test '.rand(1,9999999999)
         ]);
-        //throw new \Exception(json_encode($discussion));
+
+        $this->updateValidValues('cat1_1_1' , 'LastDateInserted', $discussion['DateInserted']);
+
+        self::$discussions['d1_c2_2_1_1_1_1'] = $discussion = $this->addDiscussion([
+            'CategoryID' => $cat2_2_1_1_1_1['CategoryID'],
+            'Name' => 'Discussion 1 of cat2_2_1_1_1_1',
+            'Body' => 'Test '.rand(1,9999999999)
+        ]);
+
+        self::$discussions['d2_c2_2_1_1_1_1'] = $discussion = $this->addDiscussion([
+            'CategoryID' => $cat2_2_1_1_1_1['CategoryID'],
+            'Name' => 'Discussion 2 of cat2_2_1_1_1_1',
+            'Body' => 'Test '.rand(1,9999999999)
+        ]);
+
+        $comment = $this->addComment([
+            'DiscussionID' => $discussion['DiscussionID'],
+            'Body' => 'Moderation controller test. LINE: '.__LINE__.' DATE: '.date('r')
+        ]);
+
+        $this->updateValidValues('cat2_2_1_1_1_1' , 'LastDateInserted', $comment['DateInserted']);
 
         $this->assertTrue( true);
+    }
+
+    protected function updateValidValues(string $catKey, string $fieldToUpdate, $newValue, bool $recursively = true) {
+        do {
+            $continue = false;
+            switch ($newValue) {
+                case '++':
+                    self::$validResponses[$fieldToUpdate][$catKey]++;
+                    break;
+                case '--':
+                    self::$validResponses[$fieldToUpdate][$catKey]--;
+                    break;
+                default:
+                    self::$categories[$catKey][$fieldToUpdate] = $newValue;
+            }
+
+            if ($recursively) {
+                if (($pos = strrpos($catKey, '_')) > 0) {
+                    $continue = true;
+                    $catKey = substr($catKey, 0, $pos);
+                }
+            }
+
+        } while ($continue);
     }
 
     protected static function addDiscussion(array $discussion) {
@@ -124,6 +272,20 @@ class ModerationControllerTest extends BaseTest {
         return $body['Category'];
     }
 
+    protected static function addComment(array $comment) {
+        $r = self::$api->post(
+            '/post/comment.json',
+            $comment
+        );
+        if ($r->getStatusCode() != 200) {
+            throwException('Failed to add new comment: ' . json_encode($comment));
+        }
+        $body = $r->getBody();
+        return $body['Comment'];
+    }
+
+
+
     protected static function getCategory(int $categoryId) {
         $r = self::$api->get(
             '/vanilla/settings/getcategory.json',
@@ -139,37 +301,51 @@ class ModerationControllerTest extends BaseTest {
     /**
      * @depends testModerationDiscussionMoveInintDB
      */
-    public function testCountAllDiscussions() {
+    public function testCategories() {
         foreach (self::$categories as $catKey => $category) {
             $cat = $this->getCategory($category['CategoryID']);
-            $this->assertEquals(self::$validResponses['CountAllDiscussions'][$catKey], $cat['CountAllDiscussions']);
+            $this->assertEquals(self::$validResponses['CountAllDiscussions'][$catKey], $cat['CountAllDiscussions'], 'CountAllDiscussions failed on  '.$catKey);
+            $this->assertEquals(self::$validResponses['CountAllComments'][$catKey], $cat['CountAllComments'], 'CountAllComments failed on  '.$catKey);
+            $this->assertEquals(self::$validResponses['CountCategories'][$catKey], $cat['CountCategories'], 'CountCategories failed on  '.$catKey);
+            $this->assertEquals(self::$validResponses['CountDiscussions'][$catKey], $cat['CountDiscussions'], 'CountDiscussions failed on  '.$catKey.' '.json_encode($cat));
+            $this->assertEquals(self::$validResponses['CountComments'][$catKey], $cat['CountComments'], 'CountComments failed on  '.$catKey);
+            $this->assertEquals($category['DateInserted'], $cat['DateInserted'], 'DateInserted failed on  '.$catKey);
+            $this->assertEquals($category['DateUpdated'], $cat['DateUpdated'], 'DateUpdated failed on  '.$catKey);
+            $this->assertEquals($category['LastDateInserted'], $cat['LastDateInserted'], 'LastDateInserted failed on  '.$catKey);
+
         }
 
     }
-//        $r = $this->api()->post('/moderation/confirmdiscussionmoves?discussionid=7359', [
-//            'Move' => 'Move',
-//            'CategpryID' => 1
-//        ]);
-//
-//        $body = $r->getBody();
-//        $status = $r->getStatusCode();
-//
-//        $this->assertEquals('200' , $status);
-//        $this->assertEquals(0 , strlen($body));
-//    }
 
-//    public function testConfirmDiscussionMoves() {
-//        $r = $this->api()->post('/moderation/confirmdiscussionmoves?discussionid=7359', [
-//            'Move' => 'Move',
-//            'CategpryID' => 1
-//        ]);
-//
-//        $body = $r->getBody();
-//        $status = $r->getStatusCode();
-//
-//        $this->assertEquals('200' , $status);
-//        $this->assertEquals(0 , strlen($body));
-//    }
+    /**
+     * @depends testCategories
+     */
+    public function testConfirmDiscussionMoves() {
+        $discussion = self::$discussions['d1_c2_2_1_1_1_1'];
+        $category = self::$categories['cat1_2_1'];
+        $r = $this->api()->post('/moderation/confirmdiscussionmoves.json?discussionid='.$discussion['DiscussionID'], [
+            'Move' => 'Move',
+            'CategoryID' => $category['CategoryID']
+        ]);
+
+        $body = $r->getBody();
+        $status = $r->getStatusCode();
+
+        $this->assertEquals('200' , $status);
+        $this->assertArrayHasKey('isHomepage' , $body);
+
+
+        $this->updateValidValues('cat1_2_1' , 'CountAllDiscussions', '++');
+        // Right now CountDiscussions field is not updated at all  - which is wrong
+        // @todo We need to uncomment next 2 lines when bug is fixed
+        // self::$validResponses['CountDiscussions']['cat1_2_1']++;
+        // self::$validResponses['CountDiscussions']['cat2_2_1_1_1_1']--;
+        $this->updateValidValues('cat2_2_1_1_1_1' , 'CountAllDiscussions', '--');
+
+        $this->updateValidValues('cat1_2_1' , 'LastDateInserted', $discussion['DateInserted']);
+
+        $this->testCategories();
+    }
 
 
     /**

--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -269,7 +269,6 @@ class ModerationControllerTest extends BaseTest {
      * vs actual data getting from app/test database through APIv0
      */
     public function recheckCategories() {
-        self::FIELDS_CHECK_LIST;
         foreach (self::$categories as $catKey => $category) {
             $cat = $this->getCategory($category['CategoryID']);
             foreach (self::FIELDS_CHECK_LIST as $field) {
@@ -313,10 +312,12 @@ class ModerationControllerTest extends BaseTest {
             'Name' => 'Test cat '.$destCatKey,
             'UrlCode' => 'test-cat-'.$destCatKey,
             'DisplayAs' => 'Discussions'], $destCatKey);
-        $this->moveDiscussion(self::$discussions['d1_case1'], 'cat2', $destCatKey, self::$discussions['d1_case6']);
-        $this->moveDiscussion(self::$discussions['d1_case2'], 'cat2_1_1', $destCatKey, self::$discussions['d1_case6']);
-        $this->moveDiscussion(self::$discussions['d1_case3'], 'cat2_1_1_1', $destCatKey, self::$discussions['d1_case6']);
+        //We need to test both order from latest to older and backward from older to most recent
+        //reverse order brings more changes on data on each call
         $this->moveDiscussion(self::$discussions['d1_case4'], 'cat2_1_1_1_1', $destCatKey, self::$discussions['d1_case6']);
+        $this->moveDiscussion(self::$discussions['d1_case3'], 'cat2_1_1_1', $destCatKey, self::$discussions['d1_case6']);
+        $this->moveDiscussion(self::$discussions['d1_case2'], 'cat2_1_1', $destCatKey, self::$discussions['d1_case6']);
+        $this->moveDiscussion(self::$discussions['d1_case1'], 'cat2', $destCatKey, self::$discussions['d1_case6']);
         $this->recheckCategories();
     }
 

--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -15,94 +15,12 @@ class ModerationControllerTest extends BaseTest {
 
     protected $user;
 
+    /**
+     * @var array Array of categories holding initial/valid values for tests
+     */
     protected static $categories = [];
 
     protected static $discussions = [];
-
-    protected static $validResponses = [
-        'CountAllDiscussions' => [
-            'cat1' => 2,
-            'cat1_1' => 2,
-            'cat1_1_1' => 2,
-            'cat1_2' => 0,
-            'cat1_2_1' => 0,
-            'cat2' => 2,
-            'cat2_1' => 0,
-            'cat2_1_1' => 0,
-            'cat2_2' => 2,
-            'cat2_2_1' => 2,
-            'cat2_2_1_1' => 2,
-            'cat2_2_1_1_1' => 2,
-            'cat2_2_1_1_1_1' => 2,
-        ],
-        'CountAllComments' => [
-            'cat1' => 1,
-            'cat1_1' => 1,
-            'cat1_1_1' => 1,
-            'cat1_2' => 0,
-            'cat1_2_1' => 0,
-            'cat2' => 1,
-            'cat2_1' => 0,
-            'cat2_1_1' => 0,
-            'cat2_2' => 1,
-            'cat2_2_1' => 1,
-            'cat2_2_1_1' => 1,
-            'cat2_2_1_1_1' => 1,
-            'cat2_2_1_1_1_1' => 1,
-
-        ],
-        'CountCategories' => [
-            'cat1' => 0,
-            'cat1_1' => 0,
-            'cat1_1_1' => 0,
-            'cat1_2' => 0,
-            'cat1_2_1' => 0,
-            'cat2' => 0,
-            'cat2_1' => 0,
-            'cat2_1_1' => 0,
-            'cat2_2' => 0,
-            'cat2_2_1' => 0,
-            'cat2_2_1_1' => 0,
-            'cat2_2_1_1_1' => 0,
-            'cat2_2_1_1_1_1' => 0,
-
-        ],
-        'CountDiscussions' => [
-            'cat1' => 0,
-            'cat1_1' => 0,
-            'cat1_1_1' => 2,
-            'cat1_2' => 0,
-            'cat1_2_1' => 0,
-            'cat2' => 0,
-            'cat2_1' => 0,
-            'cat2_1_1' => 0,
-            'cat2_2' => 0,
-            'cat2_2_1' => 0,
-            'cat2_2_1_1' => 0,
-            'cat2_2_1_1_1' => 0,
-            'cat2_2_1_1_1_1' => 2,
-
-        ],
-        'CountComments' => [
-            'cat1' => 0,
-            'cat1_1' => 0,
-            'cat1_1_1' => 1,
-            'cat1_2' => 0,
-            'cat1_2_1' => 0,
-            'cat2' => 0,
-            'cat2_1' => 0,
-            'cat2_1_1' => 0,
-            'cat2_2' => 0,
-            'cat2_2_1' => 0,
-            'cat2_2_1_1' => 0,
-            'cat2_2_1_1_1' => 0,
-            'cat2_2_1_1_1_1' => 1,
-
-        ],
-        'DateInserted' => [],
-        'DateUpdated' => [],
-
-    ];
 
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
@@ -185,20 +103,26 @@ class ModerationControllerTest extends BaseTest {
 
         self::$discussions['d1_c1-1-1'] = $discussion = $this->addDiscussion([
             'CategoryID' => $cat1_1_1['CategoryID'],
-            'Name' => 'Discussion 1 of cat-1-1-1',
+            'Name' => 'Discussion 1 of cat1-1-1',
             'Body' => 'Test '.rand(1,9999999999)
         ]);
+        $this->updateValidValues('cat1_1_1' , 'CountDiscussions', '++', false);
+        $this->updateValidValues('cat1_1_1' , 'CountAllDiscussions', '++');
 
         $comment = $this->addComment([
             'DiscussionID' => $discussion['DiscussionID'],
             'Body' => 'Moderation controller test. LINE: '.__LINE__.' DATE: '.date('r')
         ]);
+        $this->updateValidValues('cat1_1_1' , 'CountComments', '++', false);
+        $this->updateValidValues('cat1_1_1' , 'CountAllComments', '++');
 
         self::$discussions['d2_c1-1-1'] = $discussion = $this->addDiscussion([
             'CategoryID' => $cat1_1_1['CategoryID'],
-            'Name' => 'Discussion 2 of cat-1-1-1',
+            'Name' => 'Discussion 2 of cat1-1-1',
             'Body' => 'Test '.rand(1,9999999999)
         ]);
+        $this->updateValidValues('cat1_1_1' , 'CountDiscussions', '++', false);
+        $this->updateValidValues('cat1_1_1' , 'CountAllDiscussions', '++');
 
         $this->updateValidValues('cat1_1_1' , 'LastDateInserted', $discussion['DateInserted']);
 
@@ -207,18 +131,24 @@ class ModerationControllerTest extends BaseTest {
             'Name' => 'Discussion 1 of cat2_2_1_1_1_1',
             'Body' => 'Test '.rand(1,9999999999)
         ]);
+        $this->updateValidValues('cat2_2_1_1_1_1' , 'CountDiscussions', '++', false);
+        $this->updateValidValues('cat2_2_1_1_1_1' , 'CountAllDiscussions', '++');
 
         self::$discussions['d2_c2_2_1_1_1_1'] = $discussion = $this->addDiscussion([
             'CategoryID' => $cat2_2_1_1_1_1['CategoryID'],
             'Name' => 'Discussion 2 of cat2_2_1_1_1_1',
             'Body' => 'Test '.rand(1,9999999999)
         ]);
+        $this->updateValidValues('cat2_2_1_1_1_1' , 'CountDiscussions', '++', false);
+        $this->updateValidValues('cat2_2_1_1_1_1' , 'CountAllDiscussions', '++');
 
         $comment = $this->addComment([
             'DiscussionID' => $discussion['DiscussionID'],
             'Body' => 'Moderation controller test. LINE: '.__LINE__.' DATE: '.date('r')
         ]);
 
+        $this->updateValidValues('cat2_2_1_1_1_1' , 'CountComments', '++', false);
+        $this->updateValidValues('cat2_2_1_1_1_1' , 'CountAllComments', '++');
         $this->updateValidValues('cat2_2_1_1_1_1' , 'LastDateInserted', $comment['DateInserted']);
 
         $this->assertTrue( true);
@@ -229,10 +159,12 @@ class ModerationControllerTest extends BaseTest {
             $continue = false;
             switch ($newValue) {
                 case '++':
-                    self::$validResponses[$fieldToUpdate][$catKey]++;
+                    //self::$validResponses[$fieldToUpdate][$catKey]++;
+                    self::$categories[$catKey][$fieldToUpdate]++;
                     break;
                 case '--':
-                    self::$validResponses[$fieldToUpdate][$catKey]--;
+                    //self::$validResponses[$fieldToUpdate][$catKey]--;
+                    self::$categories[$catKey][$fieldToUpdate]--;
                     break;
                 default:
                     self::$categories[$catKey][$fieldToUpdate] = $newValue;
@@ -304,11 +236,11 @@ class ModerationControllerTest extends BaseTest {
     public function testCategories() {
         foreach (self::$categories as $catKey => $category) {
             $cat = $this->getCategory($category['CategoryID']);
-            $this->assertEquals(self::$validResponses['CountAllDiscussions'][$catKey], $cat['CountAllDiscussions'], 'CountAllDiscussions failed on  '.$catKey);
-            $this->assertEquals(self::$validResponses['CountAllComments'][$catKey], $cat['CountAllComments'], 'CountAllComments failed on  '.$catKey);
-            $this->assertEquals(self::$validResponses['CountCategories'][$catKey], $cat['CountCategories'], 'CountCategories failed on  '.$catKey);
-            $this->assertEquals(self::$validResponses['CountDiscussions'][$catKey], $cat['CountDiscussions'], 'CountDiscussions failed on  '.$catKey.' '.json_encode($cat));
-            $this->assertEquals(self::$validResponses['CountComments'][$catKey], $cat['CountComments'], 'CountComments failed on  '.$catKey);
+            $this->assertEquals($category['CountAllDiscussions'], $cat['CountAllDiscussions'], 'CountAllDiscussions failed on  '.$catKey);
+            $this->assertEquals($category['CountAllComments'], $cat['CountAllComments'], 'CountAllComments failed on  '.$catKey);
+            $this->assertEquals($category['CountCategories'], $cat['CountCategories'], 'CountCategories failed on  '.$catKey);
+            $this->assertEquals($category['CountDiscussions'], $cat['CountDiscussions'], 'CountDiscussions failed on  '.$catKey.' '.json_encode($cat));
+            $this->assertEquals($category['CountComments'], $cat['CountComments'], 'CountComments failed on  '.$catKey);
             $this->assertEquals($category['DateInserted'], $cat['DateInserted'], 'DateInserted failed on  '.$catKey);
             $this->assertEquals($category['DateUpdated'], $cat['DateUpdated'], 'DateUpdated failed on  '.$catKey);
             $this->assertEquals($category['LastDateInserted'], $cat['LastDateInserted'], 'LastDateInserted failed on  '.$catKey);

--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -11,15 +11,13 @@ namespace VanillaTests\Controllers;
 use VanillaTests\APIv0\BaseTest;
 
 class ModerationControllerTest extends BaseTest {
-    protected static $testUser;
-
-    protected $user;
-
     /**
-     * @var array Array of categories holding initial/valid values for tests
+     * @var array Array of categories holding initial and continually updated valid values for tests
      */
     protected static $categories = [];
-
+    /**
+     * @var array Array of discussions holding initial and continually updated valid values for tests
+     */
     protected static $discussions = [];
 
 
@@ -31,11 +29,7 @@ class ModerationControllerTest extends BaseTest {
             //'Cache.Enabled' => false,
         ]);
 
-        self::$testUser = $this->addAdminUser();
-        $this->api()->setUser(self::$testUser);
-
-
-        $this->assertTrue( true);
+        $this->api()->setUser($this->addAdminUser());
     }
 
     protected static function updateValidValues(string $catKey, string $fieldToUpdate, $newValue, bool $recursively = true) {
@@ -203,7 +197,7 @@ class ModerationControllerTest extends BaseTest {
      *
      * @depends testModerationDiscussionMoveInintDB
      */
-    public function testCase1() {
+    public function testMoveNewDiscussionsEmptyCategories() {
         $this->createAndMove('cat1', 'cat2', 'd1_case1');
         $this->createAndMove('cat1_1_1', 'cat2_1_1', 'd1_case2');
         $this->createAndMove('cat1_1_1_1', 'cat2_1_1_1', 'd1_case3');
@@ -218,9 +212,9 @@ class ModerationControllerTest extends BaseTest {
      * Src cat Lvl1-6 has 1 discussion
      * Dest cat cat3_1_1 has 0-1-2-3 discussions
      *
-     * @depends testCase1
+     * @depends testMoveNewDiscussionsEmptyCategories
      */
-    public function testCase2() {
+    public function testMoveExistingDiscussionToEmptyCategory() {
         $destCatKey = 'cat3_1_1';
         self::$categories[$destCatKey] = $destCategory = self::addCategory([
             'Name' => 'Test cat '.$destCatKey,
@@ -239,9 +233,9 @@ class ModerationControllerTest extends BaseTest {
      * Dest cat cat2_1 has 0-1-2-3 discussions
      * but has LastDiscussionID fresher than we move in.
      *
-     * @depends testCase2
+     * @depends testMoveExistingDiscussionToEmptyCategory
      */
-    public function testCase3() {
+    public function testMoveExistingDiscussionToNotEmptyCategory() {
         $destCatKey = 'cat2_1';
         $this->moveDiscussion(self::$discussions['d1_case1'], 'cat3_1_1', $destCatKey, self::$discussions['d1_case4']);
         $this->moveDiscussion(self::$discussions['d1_case2'], 'cat3_1_1', $destCatKey, self::$discussions['d1_case4']);

--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -13,6 +13,18 @@ use VanillaTests\APIv0\BaseTest;
  * Class ModerationControllerTest: tests confirmdiscussionmoves action
  */
 class ModerationControllerTest extends BaseTest {
+    const FIELDS_CHECK_LIST = [
+        'CountAllDiscussions',
+        'CountAllComments',
+        'CountCategories',
+        'CountDiscussions',
+        'CountComments',
+        'DateInserted',
+        'DateUpdated',
+        'LastDateInserted',
+        'LastDiscussionID',
+        'LastCommentID'
+    ];
     /**
      * @var array Array of categories holding initial and continually updated valid values for tests
      */
@@ -30,7 +42,7 @@ class ModerationControllerTest extends BaseTest {
             'Garden.Registration.Method' => 'Basic',
             'Garden.Registration.ConfirmEmail' => false,
             'Garden.Registration.SkipCaptcha' => true,
-            //'Cache.Enabled' => false,
+            'Cache.Enabled' => false,
         ]);
 
         $this->api()->setUser($this->addAdminUser());
@@ -257,18 +269,12 @@ class ModerationControllerTest extends BaseTest {
      * vs actual data getting from app/test database through APIv0
      */
     public function recheckCategories() {
+        self::FIELDS_CHECK_LIST;
         foreach (self::$categories as $catKey => $category) {
             $cat = $this->getCategory($category['CategoryID']);
-            $this->assertEquals($category['CountAllDiscussions'], $cat['CountAllDiscussions'], 'CountAllDiscussions failed on  '.$catKey);
-            $this->assertEquals($category['CountAllComments'], $cat['CountAllComments'], 'CountAllComments failed on  '.$catKey);
-            $this->assertEquals($category['CountCategories'], $cat['CountCategories'], 'CountCategories failed on  '.$catKey);
-            $this->assertEquals($category['CountDiscussions'], $cat['CountDiscussions'], 'CountDiscussions failed on  '.$catKey);
-            $this->assertEquals($category['CountComments'], $cat['CountComments'], 'CountComments failed on  '.$catKey);
-            $this->assertEquals($category['DateInserted'], $cat['DateInserted'], 'DateInserted failed on  '.$catKey);
-            $this->assertEquals($category['DateUpdated'], $cat['DateUpdated'], 'DateUpdated failed on  '.$catKey);
-            $this->assertEquals($category['LastDateInserted'], $cat['LastDateInserted'], 'LastDateInserted failed on  '.$catKey);
-            $this->assertEquals($category['LastDiscussionID'], $cat['LastDiscussionID'], 'LastDiscussionID failed on  '.$catKey);
-            $this->assertEquals($category['LastCommentID'], $cat['LastCommentID'], 'LastCommentID failed on  '.$catKey);
+            foreach (self::FIELDS_CHECK_LIST as $field) {
+                $this->assertEquals($category[$field], $cat[$field], $field.' failed on  '.$catKey);
+            }
         }
     }
 

--- a/tests/APIv0/Controllers/ModerationControllerTest.php
+++ b/tests/APIv0/Controllers/ModerationControllerTest.php
@@ -277,6 +277,8 @@ class ModerationControllerTest extends BaseTest {
      * Src cat Lvl1-6 has 1 discussion
      * Dest cat Lvl1-6 has 0 discussions
      *
+     * @large
+     *
      * @depends testModerationDiscussionMoveInintDB
      */
     public function testMoveNewDiscussionsEmptyCategories() {
@@ -293,6 +295,8 @@ class ModerationControllerTest extends BaseTest {
      * Use case #2:
      * Src cat Lvl1-6 has 1 discussion
      * Dest cat cat3_1_1 has 0-1-2-3 discussions
+     *
+     * @large
      *
      * @depends testModerationDiscussionMoveInintDB
      * @depends testMoveNewDiscussionsEmptyCategories
@@ -315,6 +319,8 @@ class ModerationControllerTest extends BaseTest {
      * Move existing discussion to non empty category
      * where destination category already has LastDiscussionID fresher than we move in.
      *
+     * @large
+     *
      * @depends testModerationDiscussionMoveInintDB
      * @depends testMoveNewDiscussionsEmptyCategories
      * @depends testMoveExistingDiscussionToEmptyCategory
@@ -328,6 +334,8 @@ class ModerationControllerTest extends BaseTest {
     /**
      * Use case #4:
      * Move most recent discussion from one category to another
+     *
+     * @large
      *
      * @depends testModerationDiscussionMoveInintDB
      * @depends testMoveNewDiscussionsEmptyCategories
@@ -343,6 +351,8 @@ class ModerationControllerTest extends BaseTest {
     /**
      * Use case #5:
      * New comment add to existing discussion and move that discussion after
+     *
+     * @large
      *
      * @depends testModerationDiscussionMoveInintDB
      * @depends testMoveNewDiscussionsEmptyCategories
@@ -365,6 +375,8 @@ class ModerationControllerTest extends BaseTest {
      * After that move we expect it to have most recent fields updated
      * Then move some previous discussion into the same destCategory
      * We expect detCategory recent field to not be updated
+     *
+     * @large
      *
      * @depends testModerationDiscussionMoveInintDB
      * @depends testMoveNewDiscussionsEmptyCategories
@@ -392,6 +404,8 @@ class ModerationControllerTest extends BaseTest {
      * Helper function:
      * automatically creates source and destination categories with its parents recursively
      * create discussion under source category and move it to destination
+     *
+     * @large
      *
      * @param string $srcCatKey
      * @param string $destCatKey

--- a/tests/travis/templates/vanilla/cgi-bin/saveconfig.php
+++ b/tests/travis/templates/vanilla/cgi-bin/saveconfig.php
@@ -54,8 +54,8 @@ class SimpleConfig {
      * @return bool Returns **true** on success or **false** on failure.
      */
     private function unlink($path) {
-        $r = unlink($path);
         $this->flushPathCache($path);
+        $r = unlink($path);
         return $r;
     }
 
@@ -69,7 +69,7 @@ class SimpleConfig {
             // This fixes a bug with some configurations of apc.
             @apc_delete_file($path);
         } elseif (function_exists('opcache_invalidate')) {
-            @opcache_invalidate($path);
+            @opcache_invalidate($path, true);
         }
     }
 


### PR DESCRIPTION
## Unit (integration) tests  for ModerationController 

### covers `confirmdiscussionmoves` action for several cases:

1. Source and Destination category are brand new **Lvl1** (root).
Discussion is **new and has no comments.**
Initial Category set to Source
Discussion moved to Destination category.
**_Note:_** **Lvl2** skipped to keep it empty but to check aggregated fields to be updated correctly
Source and Destination category are brand new **Lvl3-4-5-6-7**.
Discussion is new and has no comments.
Discussion moved to Destination category same level.

2. Source categories are **existing** **Lvl1-3-4-5** destination categories from previous step.
Destination category is brand **new** **Lvl3**.
Discussions are **existing** created on previous step.
4 Discussions from 4 **different Source** categories are moved to the **same Destination** category.

3. Source category is **existing Lvl3** category created on previous step 2.
Destination category is **existing Lvl2** category created on step 1.
Discussions are **existing** moved on previous step.
2 Discussions from the **same Source** category are moved to the **same Destination** category.

4. Source category is **existing Lvl7** category created on step 1.
Destination category is **existing Lvl3** category created on step 1.
Discussion is **existing most recent** created on step 1.
**4.1**  Source category is **existing Lvl6** category created on step 1.
Destination category is **existing Lvl3** category created on step 2.
Discussion is **existing** created on step 1.
**4.2** Source category is **existing Lvl3** category just used as Destination in 4.1.
Destination category is **existing Lvl2** category created on step 1 and used as Destination in step 2.
Discussion is the **existing** one just moved in 4.1.

5. Source category is **existing Lvl2** category created on step 1.
Destination category is **existing Lvl3** category created on step 3.
Discussion is the **existing** the 1st one created on step 1
but with fresh **new comment** just added.

6. Source category is **existing Lvl2** category created on step 1.
Destination category is **existing Lvl3** category created on step 1.
Discussion is the **existing** one created on step 1
but with fresh **new comment** just added.
**6.1** Source category is **existing Lvl3** category created on step 3.
Destination category is **existing Lvl3** category created on step 1.
Discussion is the **existing with comment**  just created on step 5.

Relates to #7869 