### PR TITLE
Bypass cascade cache update when move discussion

### DIFF
--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -456,16 +456,16 @@ class ModerationController extends VanillaController {
 
                 // Offset the discussion count for this category and its parents.
                 if ($discussionOffset < 0) {
-                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset);
+                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, true);
                 } else {
-                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset);
+                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, true);
                 }
 
                 // Offset the comment count for this category and its parents.
                 if ($commentOffset < 0) {
-                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset);
+                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, true);
                 } else {
-                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset);
+                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, true);
                 }
             }
             CategoryModel::clearCache();

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -447,6 +447,7 @@ class ModerationController extends VanillaController {
             }
 
             // Update recent posts and counts on all affected categories.
+            CategoryModel::clearCache();
             foreach ($AffectedCategories as $categoryID => $counts) {
                 $CategoryModel->refreshAggregateRecentPost($categoryID, true);
 
@@ -467,6 +468,7 @@ class ModerationController extends VanillaController {
                     CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset);
                 }
             }
+            CategoryModel::clearCache();
 
             // Clear selections.
             if ($ClearSelection) {

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -456,16 +456,16 @@ class ModerationController extends VanillaController {
 
                 // Offset the discussion count for this category and its parents.
                 if ($discussionOffset < 0) {
-                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, true);
+                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, false);
                 } else {
-                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, true);
+                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, false);
                 }
 
                 // Offset the comment count for this category and its parents.
                 if ($commentOffset < 0) {
-                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, true);
+                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, false);
                 } else {
-                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, true);
+                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, false);
                 }
             }
             CategoryModel::clearCache();

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3514,6 +3514,7 @@ SQL;
         }
 
         // Update the cache.
+/*
         $categoriesToUpdate = self::instance()->getWhere(['CategoryID' => $updatedCategories]);
         foreach ($categoriesToUpdate as $current) {
             $currentID = val('CategoryID', $current);
@@ -3524,6 +3525,7 @@ SQL;
                 ['CountAllDiscussions' => $countAllDiscussions, 'CountAllComments' => $countAllComments]
             );
         }
+*/
     }
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3483,8 +3483,9 @@ SQL;
      * @param int $categoryID
      * @param string $type
      * @param int $offset A value, positive or negative, to offset a category's current aggregate post counts.
+     * @param bool $skipCache Flag to not update cache
      */
-    private static function adjustAggregateCounts($categoryID, $type, $offset) {
+    private static function adjustAggregateCounts($categoryID, $type, $offset, bool $skipCache = false) {
         $offset = intval($offset);
 
         if (empty($categoryID)) {
@@ -3514,18 +3515,18 @@ SQL;
         }
 
         // Update the cache.
-/*
-        $categoriesToUpdate = self::instance()->getWhere(['CategoryID' => $updatedCategories]);
-        foreach ($categoriesToUpdate as $current) {
-            $currentID = val('CategoryID', $current);
-            $countAllDiscussions = val('CountAllDiscussions', $current);
-            $countAllComments = val('CountAllComments', $current);
-            self::setCache(
-                $currentID,
-                ['CountAllDiscussions' => $countAllDiscussions, 'CountAllComments' => $countAllComments]
-            );
+        if (!$skipCache) {
+            $categoriesToUpdate = self::instance()->getWhere(['CategoryID' => $updatedCategories]);
+            foreach ($categoriesToUpdate as $current) {
+                $currentID = val('CategoryID', $current);
+                $countAllDiscussions = val('CountAllDiscussions', $current);
+                $countAllComments = val('CountAllComments', $current);
+                self::setCache(
+                    $currentID,
+                    ['CountAllDiscussions' => $countAllDiscussions, 'CountAllComments' => $countAllComments]
+                );
+            }
         }
-*/
     }
 
     /**
@@ -3534,11 +3535,12 @@ SQL;
      * @param int $categoryID A valid category ID.
      * @param string $type One of the CategoryModel::AGGREGATE_* constants.
      * @param int $offset The value to increment the aggregate counts by.
+     * @param bool $skipCache Flag to not update cache
      */
-    public static function incrementAggregateCount($categoryID, $type, $offset = 1) {
+    public static function incrementAggregateCount($categoryID, $type, $offset = 1, bool $skipCache = false) {
         // Make sure we're dealing with a positive offset.
         $offset = abs($offset);
-        self::adjustAggregateCounts($categoryID, $type, $offset);
+        self::adjustAggregateCounts($categoryID, $type, $offset, $skipCache);
     }
 
     /**
@@ -3547,11 +3549,12 @@ SQL;
      * @param int $categoryID A valid category ID.
      * @param string $type One of the CategoryModel::AGGREGATE_* constants.
      * @param int $offset The value to increment the aggregate counts by.
+     * @param bool $skipCache Flag to not update cache
      */
-    public static function decrementAggregateCount($categoryID, $type, $offset = 1) {
+    public static function decrementAggregateCount($categoryID, $type, $offset = 1, bool $skipCache = false) {
         // Make sure we're dealing with a negative offset.
         $offset = (-1 * abs($offset));
-        self::adjustAggregateCounts($categoryID, $type, $offset);
+        self::adjustAggregateCounts($categoryID, $type, $offset, $skipCache);
     }
 
     /**

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3483,9 +3483,12 @@ SQL;
      * @param int $categoryID
      * @param string $type
      * @param int $offset A value, positive or negative, to offset a category's current aggregate post counts.
-     * @param bool $skipCache Flag to not update cache
+     * @param bool $cache This param was implemented just for particular patch
+     *        check details https://github.com/vanilla/vanilla/issues/7105
+     *        and https://github.com/vanilla/vanilla/pull/7843
+     *        please avoid of using it.
      */
-    private static function adjustAggregateCounts($categoryID, $type, $offset, bool $skipCache = false) {
+    private static function adjustAggregateCounts($categoryID, $type, $offset, bool $cache = true) {
         $offset = intval($offset);
 
         if (empty($categoryID)) {
@@ -3515,7 +3518,7 @@ SQL;
         }
 
         // Update the cache.
-        if (!$skipCache) {
+        if ($cache) {
             $categoriesToUpdate = self::instance()->getWhere(['CategoryID' => $updatedCategories]);
             foreach ($categoriesToUpdate as $current) {
                 $currentID = val('CategoryID', $current);
@@ -3535,12 +3538,15 @@ SQL;
      * @param int $categoryID A valid category ID.
      * @param string $type One of the CategoryModel::AGGREGATE_* constants.
      * @param int $offset The value to increment the aggregate counts by.
-     * @param bool $skipCache Flag to not update cache
+     * @param bool $cache This param was implemented just for particular patch
+     *        check details https://github.com/vanilla/vanilla/issues/7105
+     *        and https://github.com/vanilla/vanilla/pull/7843
+     *        please avoid of using it.
      */
-    public static function incrementAggregateCount($categoryID, $type, $offset = 1, bool $skipCache = false) {
+    public static function incrementAggregateCount($categoryID, $type, $offset = 1, bool $cache = true) {
         // Make sure we're dealing with a positive offset.
         $offset = abs($offset);
-        self::adjustAggregateCounts($categoryID, $type, $offset, $skipCache);
+        self::adjustAggregateCounts($categoryID, $type, $offset, $cache);
     }
 
     /**
@@ -3549,12 +3555,15 @@ SQL;
      * @param int $categoryID A valid category ID.
      * @param string $type One of the CategoryModel::AGGREGATE_* constants.
      * @param int $offset The value to increment the aggregate counts by.
-     * @param bool $skipCache Flag to not update cache
+     * @param bool $cache This param was implemented just for particular patch
+     *        check details https://github.com/vanilla/vanilla/issues/7105
+     *        and https://github.com/vanilla/vanilla/pull/7843
+     *        please avoid of using it.
      */
-    public static function decrementAggregateCount($categoryID, $type, $offset = 1, bool $skipCache = false) {
+    public static function decrementAggregateCount($categoryID, $type, $offset = 1, bool $cache = true) {
         // Make sure we're dealing with a negative offset.
         $offset = (-1 * abs($offset));
-        self::adjustAggregateCounts($categoryID, $type, $offset, $skipCache);
+        self::adjustAggregateCounts($categoryID, $type, $offset, $cache);
     }
 
     /**


### PR DESCRIPTION
This tricky fix should temporary disable cascade cache update of CategoryModel when **confirmdiscussionmoves** action of ModerationController and reset Category cache.

This should increase performance and decrease memory usage on this action.
Any next incoming request should get fresh data and reinitialize CategoryModel cache keys and values 

Relates to #7843 

Fixes #7105 