### PR TITLE
Category-Following: Displaying Unfollow option when filtering by followed categories

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1736,7 +1736,7 @@ class CategoryModel extends Gdn_Model {
      * @param bool $addUserCategory
      */
     public static function joinUserData(&$categories, $addUserCategory = true) {
-        $iDs = array_column($categories,'CategoryID', 'CategoryID');
+        $iDs = array_column($categories, 'CategoryID', 'CategoryID');
         $categoriesKeys = array_column($categories, 'CategoryID');
         $categories = array_combine($categoriesKeys, $categories);
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1736,7 +1736,9 @@ class CategoryModel extends Gdn_Model {
      * @param bool $addUserCategory
      */
     public static function joinUserData(&$categories, $addUserCategory = true) {
-        $iDs = array_keys($categories);
+        $iDs = array_column($categories,'CategoryID','CategoryID');
+        $categoriesKeys = array_column($categories, 'CategoryID');
+        $categories = array_combine($categoriesKeys, $categories);
 
         if ($addUserCategory) {
             $userData = self::instance()->getUserCategories();

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1736,7 +1736,7 @@ class CategoryModel extends Gdn_Model {
      * @param bool $addUserCategory
      */
     public static function joinUserData(&$categories, $addUserCategory = true) {
-        $iDs = array_column($categories,'CategoryID','CategoryID');
+        $iDs = array_column($categories,'CategoryID', 'CategoryID');
         $categoriesKeys = array_column($categories, 'CategoryID');
         $categories = array_combine($categoriesKeys, $categories);
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1737,8 +1737,7 @@ class CategoryModel extends Gdn_Model {
      */
     public static function joinUserData(&$categories, $addUserCategory = true) {
         $iDs = array_column($categories, 'CategoryID', 'CategoryID');
-        $categoriesKeys = array_column($categories, 'CategoryID');
-        $categories = array_combine($categoriesKeys, $categories);
+        $categories = array_combine($iDs, $categories);
 
         if ($addUserCategory) {
             $userData = self::instance()->getUserCategories();


### PR DESCRIPTION
closes [7901](https://github.com/vanilla/vanilla/issues/7901)
details in the referenced ticket.



### Current behaviour
Ex.  a user is following 2 categories with CategroyIDs[1,3]
When debugging this, if you put a break point in [class.categorymodel.php#L1742](https://github.com/vanilla/vanilla/blob/master/applications/vanilla/models/class.categorymodel.php#L1742) we had [$iDs](https://github.com/vanilla/vanilla/blob/master/applications/vanilla/models/class.categorymodel.php#L1739) 
![screen shot 2018-10-04 at 11 11 18 am](https://user-images.githubusercontent.com/31856281/46483974-d40eec80-c7c6-11e8-8bbe-48597dd85f18.png)
![screen shot 2018-10-04 at 11 22 14 am](https://user-images.githubusercontent.com/31856281/46484440-cf970380-c7c7-11e8-9f7a-8d6d469b6bcb.png)

userData would be

![screen shot 2018-10-04 at 11 11 33 am](https://user-images.githubusercontent.com/31856281/46483999-e1c47200-c7c6-11e8-9c53-641203d7792c.png)
[ $row = ($userData[$iD] ?? false);](https://github.com/vanilla/vanilla/blob/master/applications/vanilla/models/class.categorymodel.php#L1748) would be false , and when in view "Following" . instead of having the option to Unfollow a category, you would still see the "Follow" option.

### Changes
I updated $categories array_keys to be the value of each category id.

![screen shot 2018-10-04 at 11 20 18 am](https://user-images.githubusercontent.com/31856281/46484338-95c5fd00-c7c7-11e8-9ee4-0e2587d39dc7.png)
![screen shot 2018-10-04 at 11 21 25 am](https://user-images.githubusercontent.com/31856281/46484373-a9716380-c7c7-11e8-892f-db3faa717561.png)


### To Test

- Enable category-following
- Follow categories
- select view "Following", click the cogwheel. you should have the option to Unfollow the categories.
