### PR TITLE
Add different fields frequently requested to /utility/exportprofiles

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -538,7 +538,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
                 'u.InviteUserID',
                 'u2.Name as InvitedByName',
                 'u.Location',
-                'group_concat(r.Name)',
+                'group_concat(r.Name) as Roles',
             ])
             ->from('User u')
             ->leftJoin('User u2', 'u.InviteUserID = u2.UserID and u.InviteUserID is not null')

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -522,28 +522,43 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
 
         // Determine profile fields we need to add.
         $fields = $this->getProfileFields();
-        $columnNames = ['Name', 'Email', 'Joined', 'Last Seen', 'Discussions', 'Comments', 'Points', 'InviteUserID', 'InvitedByName'];
+        $columnNames = ['Name', 'Email', 'Joined', 'Last Seen', 'LastIpAddress', 'Discussions', 'Comments', 'Points', 'InviteUserID', 'InvitedByName', 'Location', 'Roles'];
 
         // Set up our basic query.
         Gdn::sql()
-            ->select('u.Name')
-            ->select('u.Email')
-            ->select('u.DateInserted')
-            ->select('u.DateLastActive')
-            ->select('u.CountDiscussions')
-            ->select('u.CountComments')
-            ->select('u.Points')
-            ->select('u.InviteUserID')
-            ->select('u2.Name', '', 'InvitedByName')
+            ->select([
+                'u.Name',
+                'u.Email',
+                'u.DateInserted',
+                'u.DateLastActive',
+                'inet6_ntoa(u.LastIpAddress) as LastIpAddress',
+                'u.CountDiscussions',
+                'u.CountComments',
+                'u.Points',
+                'u.InviteUserID',
+                'u2.Name as InvitedByName',
+                'u.Location',
+                'group_concat(r.Name)',
+            ])
             ->from('User u')
             ->leftJoin('User u2', 'u.InviteUserID = u2.UserID and u.InviteUserID is not null')
+            ->join('UserRole ur', 'u.UserID = ur.UserID')
+            ->join('Role r', 'r.RoleID = ur.RoleID')
             ->where('u.Deleted', 0)
-            ->where('u.Admin <', 2);
+            ->where('u.Admin <', 2)
+            ->groupBy('u.UserID');
 
         if (val('DateOfBirth', $fields)) {
             $columnNames[] = 'Birthday';
             Gdn::sql()->select('u.DateOfBirth');
             unset($fields['DateOfBirth']);
+        }
+
+        if (Gdn::addonManager()->isEnabled('Ranks', \Vanilla\Addon::TYPE_ADDON)) {
+            $columnNames[] = 'Rank';
+            Gdn::sql()
+                ->select('ra.Name as Rank')
+                ->leftJoin('Rank ra', 'ra.RankID = u.RankID');
         }
 
         $i = 0;
@@ -566,7 +581,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         die();
 
         // Useful for query debug.
-        //$sender->render('blank');
+        // $sender->render('blank');
     }
 
     /**

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -522,7 +522,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
 
         // Determine profile fields we need to add.
         $fields = $this->getProfileFields();
-        $columnNames = ['Name', 'Email', 'Joined', 'Last Seen', 'LastIpAddress', 'Discussions', 'Comments', 'Points', 'InviteUserID', 'InvitedByName', 'Location', 'Roles'];
+        $columnNames = ['Name', 'Email', 'Joined', 'Last Seen', 'LastIPAddress', 'Discussions', 'Comments', 'Points', 'InviteUserID', 'InvitedByName', 'Location', 'Roles'];
 
         // Set up our basic query.
         Gdn::sql()

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -531,7 +531,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
                 'u.Email',
                 'u.DateInserted',
                 'u.DateLastActive',
-                'inet6_ntoa(u.LastIpAddress) as LastIpAddress',
+                'inet6_ntoa(u.LastIPAddress)',
                 'u.CountDiscussions',
                 'u.CountComments',
                 'u.Points',


### PR DESCRIPTION
Context
---
A customer requested we add the "Location" field to the endpoint. I thought it would be good to ask around and see what fields aren't a part of the current data this endpoint generate and add them to reduce the number of export request we receive.

Added fields
---
Location (customer request)
LastIPAddress
Roles (concatenated names)
Rank (name) (only if plugin is enabled)

Optimizations
---
I also made a small optimization by calling the `select()` function only once with an array instead of once for every field in the basic query.

Other info
---
This endpoint is capped at 100,000 users through the `$UserMegaThreshold` variable of the `UserModel`. If you have more than that it returns the message "you have too many users" before even trying to fetch them. Joining on roles shouldn't be so bad as the RoleID column are indexed. The RankID column however isn't and we do join on it to fetch the name. I tested it locally with 99,000 users and there was no performance issue whatsoever.

Testing
---
I recommend testing users with multiple roles, testing with and without ranks enabled.
