### PR TITLE
Fix IPV6 compatibility when viewing eventlog

### DIFF
--- a/library/core/class.logger.php
+++ b/library/core/class.logger.php
@@ -287,7 +287,7 @@ class Logger {
         $defaults = [
             'userid' => Gdn::session()->UserID,
             'username' => val("Name", Gdn::session()->User, 'anonymous'),
-            'ip' => Gdn::request()->ipAddress(),
+            'ipaddress' => Gdn::request()->ipAddress(),
             'timestamp' => time(),
             'method' => Gdn::request()->requestMethod(),
             'domain' => rtrim(url('/', true), '/'),


### PR DESCRIPTION
**Closes** [#1748](https://github.com/vanilla/internal/issues/1748)
**Related** [#1750](https://github.com/vanilla/internal/pull/1750)

I changed IP to IPAddress because of the issue mentioned in the referenced task 1748 and after the change in 1750.





