### PR TITLE
Fix IPV6 user search count

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2734,8 +2734,8 @@ class UserModel extends Gdn_Model {
             ->select('u.UserID', 'count', 'UserCount')
             ->from('User u');
 
-        // Check for an IP address.
-        if (preg_match('`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`', $keywords)) {
+        // Check for an IPV4/IPV6 address.
+        if (filter_var($keywords, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4|FILTER_FLAG_IPV6) !== false) {
             $fields = ['LastIPAddress'];
             $this->addIpFilters($keywords, $fields);
         } else if ($roleID) {


### PR DESCRIPTION
closes #7887 

### Details

Searching for an IPV6 in the dashboard would display "0 users found" even if a result is returned.

### QA Steps

In dashboard/user search for an IPV6.
User count label should reflect the number of users returned.
![screen shot 2018-10-11 at 4 02 33 pm](https://user-images.githubusercontent.com/31856281/46830616-2758e000-cd6f-11e8-829b-e865a6110c43.png)



