### PR TITLE
Add asset model method for getting JS locale script

### DIFF
--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -254,14 +254,14 @@ class AssetModel extends Gdn_Model {
     /**
      * Get the resource path for a javascript bundle of a particular locale bundle.
      *
-     * @param string $localeKey The key of the locale to lookup
+     * @param string $localeKey The key of the locale to lookup.
      *
      * @return string The path the locale javascript file.
      */
     public function getJSLocalePath(string $localeKey): string {
         // We need a web-root url, not an asset URL because this is an API endpoint resource that is dynamically generated.
         // It cannot have the assetPath joined onto the beginning.
-        return Gdn::request()->url('/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js", true);
+        return Gdn::request()->url("/api/v2/locales/$localeKey/translations.js", true);
     }
 
     /**

--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -252,6 +252,18 @@ class AssetModel extends Gdn_Model {
     }
 
     /**
+     * Get the resource path for a javascript bundle of a particular locale bundle.
+     *
+     * @param string $localeKey The key of the locale to lookup
+     *
+     * @return string The path the locale javascript file.
+     */
+    public function getJSLocalePath(string $localeKey): string {
+        $busta = $this->cacheBuster();
+        return '/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js?etag=$busta";
+    }
+
+    /**
      * Sorting callback
      *
      * @param $a

--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -259,8 +259,7 @@ class AssetModel extends Gdn_Model {
      * @return string The path the locale javascript file.
      */
     public function getJSLocalePath(string $localeKey): string {
-        $cacheBuster = $this->cacheBuster();
-        return '/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js?etag=$cacheBuster";
+        return '/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js";
     }
 
     /**

--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -259,7 +259,8 @@ class AssetModel extends Gdn_Model {
      * @return string The path the locale javascript file.
      */
     public function getJSLocalePath(string $localeKey): string {
-        return '/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js";
+        // We need a web-root url, not an asset URL because this is an API endpoint resource that is dynamically generated.
+        return Gdn::request()->url('/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js");
     }
 
     /**

--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -260,7 +260,8 @@ class AssetModel extends Gdn_Model {
      */
     public function getJSLocalePath(string $localeKey): string {
         // We need a web-root url, not an asset URL because this is an API endpoint resource that is dynamically generated.
-        return Gdn::request()->url('/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js");
+        // It cannot have the assetPath joined onto the beginning.
+        return Gdn::request()->url('/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js", true);
     }
 
     /**

--- a/applications/dashboard/models/class.assetmodel.php
+++ b/applications/dashboard/models/class.assetmodel.php
@@ -259,8 +259,8 @@ class AssetModel extends Gdn_Model {
      * @return string The path the locale javascript file.
      */
     public function getJSLocalePath(string $localeKey): string {
-        $busta = $this->cacheBuster();
-        return '/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js?etag=$busta";
+        $cacheBuster = $this->cacheBuster();
+        return '/api/v2/locales/' . rawurlencode($localeKey) . "/translations.js?etag=$cacheBuster";
     }
 
     /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1880,7 +1880,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
                 // Add the client-side translations.
                 // This is done in the controller rather than the asset model because the translations are not linked to compiled code.
-                $this->Head->addScript(url('/api/v2/locales/'.rawurlencode(Gdn::locale()->current())."/translations.js?etag=$busta", true), 'text/javascript', false, ['defer' => 'true']);
+                $this->Head->addScript($AssetModel->getJSLocalePath(Gdn::locale()->current()), 'text/javascript', false, ['defer' => 'true']);
 
                 $polyfillContent = $AssetModel->getInlinePolyfillJSContent();
                 $this->Head->addScript(null, null, false, ["content" => $polyfillContent]);

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1880,7 +1880,8 @@ class Gdn_Controller extends Gdn_Pluggable {
 
                 // Add the client-side translations.
                 // This is done in the controller rather than the asset model because the translations are not linked to compiled code.
-                $this->Head->addScript($AssetModel->getJSLocalePath(Gdn::locale()->current()), 'text/javascript', false, ['defer' => 'true']);
+                $localePath = $AssetModel->getJSLocalePath(Gdn::locale()->current());
+                $this->Head->addScript($localePath."?h=$busta", 'text/javascript', false, ['defer' => 'true']);
 
                 $polyfillContent = $AssetModel->getInlinePolyfillJSContent();
                 $this->Head->addScript(null, null, false, ["content" => $polyfillContent]);


### PR DESCRIPTION
In pursuit of https://github.com/vanilla/knowledge/issues/197

## Changes

Refactors the generation of a script URL for a given asset by moving it to `AssetModel:: getJSLocalePath()` so it can be used outside of a `Gdn_Controller`.

Functionality should be unchanged.
