### PR TITLE
Advanced editor: Fix error message handling when uploading a duplicated file

### DIFF
--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -583,6 +583,7 @@ class EditorPlugin extends Gdn_Plugin {
         $c->addDefinition('canUpload', $this->canUpload());
         $c->addDefinition('fileErrorSize', t('editor.fileErrorSize', 'File size is too large.'));
         $c->addDefinition('fileErrorFormat', t('editor.fileErrorFormat', 'File format is not allowed.'));
+        $c->addDefinition('fileErrorAlreadyExists', t('editor.fileErrorAlreadyExists', 'File already uploaded.'));
         $c->addDefinition('fileErrorSizeFormat', t('editor.fileErrorSizeFormat', 'File size is too large and format is not allowed.'));
 
         $additionalDefinitions = [];

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1074,20 +1074,20 @@
                                     // File dropped is not allowed!
                                     var message;
 
-                                    if (!validSize && !validFile) {
-                                        message = gdn.definition('fileErrorSizeFormat', 'editor') + ' (max ' + maxUploadSize + ' bytes)';
-                                    } else {
-
-                                        if (!validSize) {
-                                            message = gdn.definition('fileErrorSize', 'editor') + ' (max ' + maxUploadSize + ' bytes)';
-                                        }
-
-                                        if (!validFile) {
-                                            message = gdn.definition('fileErrorFormat', 'editor');
-                                        }
+                                    if (!validSize) {
+                                        message = gdn.definition('fileErrorSize', 'editor') + ' (max ' + maxUploadSize + ' bytes)';
+                                        gdn.informMessage(message);
                                     }
 
-                                    gdn.informMessage(message);
+                                    if (!validFile) {
+                                        message = gdn.definition('fileErrorFormat', 'editor');
+                                        gdn.informMessage(message);
+                                    }
+
+                                    if (fileAlreadyExists) {
+                                        message = gdn.definition('fileErrorAlreadyExists', 'editor');
+                                        gdn.informMessage(message);
+                                    }
                                 }
                             });
                         }


### PR DESCRIPTION
The problem
---
Although our code was previously looking for a "file that already existed" when uploading a new file through the editor we never accounted for that error when dealing with the possible error messages, resulting in displaying a pop up error message "undefined". This condition is based on the filename.

You can see what I'm explaining here:

https://github.com/vanilla/vanilla/blob/master/plugins/editor/js/editor.js#L1055

We check if the 3 conditions are met otherwise we go into the else statement but we never account for the possibility of fileAlreadyExists being true while creating the error message.

The fix
---

I basically only added the message for the "file already existing" error, but, I did refactored a little bit how we build the error message. Instead of having multiple if statements to build the different possible messages or doing some concatenation where we need to check if we need some spaces, line breaks, periods, etc.. I simply split them into 3 different messages that can be triggered if the condition is met. I also like this output better from a user experience.



