### PR TITLE
Fix IPV6 compatibility when viewing eventlog

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -4216,7 +4216,7 @@ if (!function_exists('ipDecodeRecursive')) {
     function ipDecodeRecursive($input) {
         walkAllRecursive($input, function(&$val, $key = null, $parent = null) {
             if (is_string($val)) {
-                if (stringEndsWith($key, 'IPAddress', true) || stringEndsWith($parent, 'IPAddresses', true)) {
+                if (stringEndsWith($key, 'IPAddress', true) || stringEndsWith($parent, 'IPAddresses', true) || ($key == 'IP')) {
                     $val = ipDecode($val);
                 }
             }


### PR DESCRIPTION
**Closes** [#1748](https://github.com/vanilla/internal/issues/1748)

### Details
When viewing the eventlog in settings/eventlog.json, calling ipDecodeRecursive with $key == 'IP' in [class.controller.php#L1580](https://github.com/vanilla/vanilla/blob/master/library/core/class.controller.php#L1580) is not getting decoded in [functions.general.php#L4219](https://github.com/vanilla/vanilla/blob/master/library/core/functions.general.php#L4219). 