### PR TITLE
Bump tslint-config version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "@types/yargs": "11.1.1",
         "@vanillaforums/babel-preset": "1.0.5",
         "@vanillaforums/prettier-config": "1.0.0",
-        "@vanillaforums/tslint-config": "1.1.8",
+        "@vanillaforums/tslint-config": "1.1.9",
         "autoprefixer": "9.1.3",
         "axios-mock-adapter": "1.15.0",
         "babel-core": "6.26.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,10 +447,10 @@
   resolved "https://registry.yarnpkg.com/@vanillaforums/prettier-config/-/prettier-config-1.0.0.tgz#e08bae366a888ac130d90a9f9d0eeaf48f0f0f1d"
   integrity sha512-av01ftyfh5eQIH4Iuj0zFNLSiY+RggK6G68RDYE+H178TNpx2C5ZrI4agJzAWNZN0bwXEsaYEIVDvPNPHcJQyw==
 
-"@vanillaforums/tslint-config@1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@vanillaforums/tslint-config/-/tslint-config-1.1.8.tgz#3df21c51330bf9b6204ae9fdf7c02e21e6078970"
-  integrity sha512-OWIWsLFdp39y2EMscGY2U5B4S1zs0JDHbq0MRvvCib5zBphJph7JkT4seDkO/VxNPrnyGpSvQmn/4nDbpFv3vw==
+"@vanillaforums/tslint-config@1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@vanillaforums/tslint-config/-/tslint-config-1.1.9.tgz#a6f94d55877d00917876ff0c7ce5eca0eb7ebc66"
+  integrity sha512-YOXluGU65AhBNpwsV/t2PniMdezF4jBGjyCVajImm0ttPPA64RdAGJQnk/uLnvQEYTO1Tt1b0CJNY/OMO1dxTQ==
   dependencies:
     tslint-config-prettier "^1.10.0"
     tslint-react "^3.5.1"


### PR DESCRIPTION
This PR bumps the TSLint config version to the latest `1.1.8 -> 1.1.9`. [This change](https://github.com/vanilla/tslint-config/pull/5) removes the strict class member ordering rules.