### PR TITLE
Fix users not appearing logged-in in embedded comments by breaking the cache.

### DIFF
--- a/js/embed.js
+++ b/js/embed.js
@@ -237,6 +237,8 @@ window.vanilla.embed = function(host) {
 
         if (embed_type == 'comments') {
             result = '//' + host + '/discussion/embed/'
+            // Break the cache.
+            + '&c=' + new Date().getTime()
             + '&vanilla_identifier=' + encodeURIComponent(foreign_id)
             + '&vanilla_url=' + encodeURIComponent(foreign_url);
 

--- a/js/embed.js
+++ b/js/embed.js
@@ -237,7 +237,7 @@ window.vanilla.embed = function(host) {
 
         if (embed_type == 'comments') {
             result = '//' + host + '/discussion/embed/'
-            // Break the cache.
+            // Break the cache. /embed/ gets cached, looks like you are not logged in.
             + '&c=' + new Date().getTime()
             + '&vanilla_identifier=' + encodeURIComponent(foreign_id)
             + '&vanilla_url=' + encodeURIComponent(foreign_url);


### PR DESCRIPTION
**The Problem**:
When embedding comments in an articling site or blog the embedded document can be cached by browsers. This means that a user who was not logged-in will be served the same embedded document after he logs in, making it impossible to add comments.

**The Fix**:
In the embed.js file that generates the iframe and injects the URL into it, add a time stamp to the URL.

**Test**:
I found that Firefox has the most aggressive browser caching. Create an embed comments page. 

 - Before checking out this fix, visit the embedded comments page not logged in. 
 - Click on the "Comment as..." button to log in.
 - When you come back you will still see the "Comment as.." button.
 - Checkout this fix and repeat the above steps. You will be see the message "You are logged in as.." next to the Comment button.

This will close #7927 
