### PR TITLE
Add button loader component and update ModalConfirm to use it

### DIFF
--- a/library/src/scripts/components/ButtonLoader.tsx
+++ b/library/src/scripts/components/ButtonLoader.tsx
@@ -1,0 +1,22 @@
+/**
+ * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import * as React from "react";
+import { t } from "@library/application";
+
+/**
+ * A smart loading component. Takes up the full page and only displays in certain scenarios.
+ */
+export default class ButtonLoader extends React.Component {
+    public render() {
+        return (
+            <React.Fragment>
+                <div className="buttonLoader" aria-hidden="true" />
+                <h1 className="sr-only">{t("Loading")}</h1>
+            </React.Fragment>
+        );
+    }
+}

--- a/library/src/scripts/components/modal/ModalConfirm.tsx
+++ b/library/src/scripts/components/modal/ModalConfirm.tsx
@@ -12,6 +12,8 @@ import SmartAlign from "@library/components/SmartAlign";
 import ModalSizes from "@library/components/modal/ModalSizes";
 import { getRequiredID } from "@library/componentIDs";
 import Modal from "@library/components/modal/Modal";
+import MediumLoader from "@library/components/MediumLoader";
+import ButtonLoader from "@library/components/ButtonLoader";
 
 interface IProps {
     title: string; // required for accessibility
@@ -20,6 +22,7 @@ interface IProps {
     onCancel: () => void;
     onConfirm: () => void;
     children: React.ReactNode;
+    isConfirmLoading?: boolean;
 }
 
 interface IState {
@@ -46,23 +49,24 @@ export default class ModalConfirm extends React.Component<IProps, IState> {
     }
 
     public render() {
+        const { onCancel, onConfirm, srOnlyTitle, isConfirmLoading, title, children } = this.props;
         return (
-            <Modal size={ModalSizes.SMALL} elementToFocus={this.cancelID} exitHandler={this.props.onCancel}>
+            <Modal size={ModalSizes.SMALL} elementToFocus={this.cancelID} exitHandler={onCancel}>
                 <Frame>
-                    <FrameHeader closeFrame={this.props.onCancel} srOnlyTitle={this.props.srOnlyTitle!}>
-                        {this.props.title}
+                    <FrameHeader closeFrame={onCancel} srOnlyTitle={srOnlyTitle!}>
+                        {title}
                     </FrameHeader>
                     <FrameBody>
                         <FramePanel>
-                            <SmartAlign className="frameBody-contents">{this.props.children}</SmartAlign>
+                            <SmartAlign className="frameBody-contents">{children}</SmartAlign>
                         </FramePanel>
                     </FrameBody>
                     <FrameFooter>
-                        <Button id={this.cancelID} onClick={this.props.onCancel}>
+                        <Button id={this.cancelID} onClick={onCancel}>
                             {t("Cancel")}
                         </Button>
-                        <Button onClick={this.props.onConfirm} className="buttonPrimary">
-                            {t("Ok")}
+                        <Button onClick={onConfirm} className="buttonPrimary" disabled={isConfirmLoading}>
+                            {isConfirmLoading ? <ButtonLoader /> : t("Ok")}
                         </Button>
                     </FrameFooter>
                 </Frame>

--- a/library/src/scss/components/_loader.scss
+++ b/library/src/scss/components/_loader.scss
@@ -6,7 +6,7 @@
 
 $fullPageLoader-size            : 100px;
 $fullPageLoader-thickness       : 6px;
-$mediumLoader-size            : 50px;
+$mediumLoader-size            : 20px;
 $mediumLoader-thickness       : 6px;
 
 .fullPageLoader {

--- a/library/src/scss/mixins/_mixin.spinnerLoader.scss
+++ b/library/src/scss/mixins/_mixin.spinnerLoader.scss
@@ -11,9 +11,9 @@
     border-radius: 50%;
     border: {
         top: $thickness solid $color;
-        right: $thickness solid rgba($color, 0.2);
-        bottom: $thickness solid rgba($color, 0.2);
-        left: $thickness solid rgba($color, 0.2);
+        right: $thickness solid rgba($color, 0.3);
+        bottom: $thickness solid rgba($color, 0.3);
+        left: $thickness solid rgba($color, 0.3);
     }
     transform: translateZ(0);
     animation: spinnerLoader $speed infinite ease-in-out;


### PR DESCRIPTION
## ButtonLoader

Adds a button loader component. It is a loader that fits perfectly in our `Button` component. Accompanying CSS has been added for normal button styles and the primary button style. I slightly tweaked the opacity of the loader component for better contrast against a coloured background.

![image](https://duaw26jehqd4r.cloudfront.net/items/1T1F043r0N232T3T442C/Screen%20Recording%202018-10-16%20at%2004.17%20PM.gif?v=ee19e331)

## ModalConfirm

ModalConfirm now takes 1 additional prop, `isConfirmLoading` which will display the loader in place or the confirm text.