### PR TITLE
Enable Twig debug extension when Garden debug mode is true

### DIFF
--- a/library/Garden/TwigTrait.php
+++ b/library/Garden/TwigTrait.php
@@ -21,10 +21,10 @@ trait TwigTrait {
     protected static function twigInit() {
         $loader = new \Twig_Loader_Filesystem(self::$twigDefaultFolder);
         if (\Gdn::config('Debug') === true) {
-            $twigEnv  = new \Twig_Environment($loader, ['debug' => true]);
+            $twigEnv = new \Twig_Environment($loader, ['debug' => true]);
             $twigEnv->addExtension(new \Twig_Extension_Debug());
         } else {
-            $twigEnv  = new \Twig_Environment($loader);
+            $twigEnv = new \Twig_Environment($loader);
         }
         return $twigEnv;
     }

--- a/library/Garden/TwigTrait.php
+++ b/library/Garden/TwigTrait.php
@@ -21,7 +21,7 @@ trait TwigTrait {
     protected static function twigInit() {
         $loader = new \Twig_Loader_Filesystem(self::$twigDefaultFolder);
         if (\Gdn::config('Debug') === true) {
-            $twigEnv  = new \Twig_Environment($loader, ['debug'=>true]);
+            $twigEnv  = new \Twig_Environment($loader, ['debug' => true]);
             $twigEnv->addExtension(new \Twig_Extension_Debug());
         } else {
             $twigEnv  = new \Twig_Environment($loader);

--- a/library/Garden/TwigTrait.php
+++ b/library/Garden/TwigTrait.php
@@ -20,6 +20,12 @@ trait TwigTrait {
      */
     protected static function twigInit() {
         $loader = new \Twig_Loader_Filesystem(self::$twigDefaultFolder);
-        return new \Twig_Environment($loader);
+        if (\Gdn::config('Debug') === true) {
+            $twigEnv  = new \Twig_Environment($loader, ['debug'=>true]);
+            $twigEnv->addExtension(new \Twig_Extension_Debug());
+        } else {
+            $twigEnv  = new \Twig_Environment($loader);
+        }
+        return $twigEnv;
     }
 }


### PR DESCRIPTION
## Check `\Gdn::config('Debug')` and if true activates debug mode for Twig by enabling `Twig_Extension_Debug`

### To test it we need:

 - switch config 'Debug' true/false 
 - add `{{ dump() }}` section to your twig template

As a result we should be able depending on Debug mode to see or not to see the dump of variables passed to the twig template 

Fixes #7934 

