### PR TITLE
Rename AssetModel usages to Vanilla\Web\Assets\LegacyAssetModel

### DIFF
--- a/applications/dashboard/library/class.emailtemplate.php
+++ b/applications/dashboard/library/class.emailtemplate.php
@@ -4,6 +4,8 @@
  * @license GPL-2.0-only
  */
 
+use Vanilla\Web\Assets\LegacyAssetModel;
+
 /**
  * Class EmailTemplate
  *
@@ -114,7 +116,7 @@ class EmailTemplate extends Gdn_Pluggable implements Gdn_IEmailTemplate {
         $this->setDefaultEmailImage();
 
         // Set default view
-        $this->view = AssetModel::viewLocation($view, 'email', 'dashboard');
+        $this->view = LegacyAssetModel::viewLocation($view, 'email', 'dashboard');
     }
 
     /**
@@ -174,7 +176,7 @@ class EmailTemplate extends Gdn_Pluggable implements Gdn_IEmailTemplate {
      * @throws Exception
      */
     public function setView($view, $controllerName = 'email', $applicationFolder = 'dashboard') {
-        $this->view = AssetModel::viewLocation($view, $controllerName, $applicationFolder);
+        $this->view = LegacyAssetModel::viewLocation($view, $controllerName, $applicationFolder);
         return $this;
     }
 

--- a/library/Vanilla/Web/Assets/LegacyAssetModel.php
+++ b/library/Vanilla/Web/Assets/LegacyAssetModel.php
@@ -316,7 +316,7 @@ class LegacyAssetModel extends Gdn_Model {
             $filename = "/{$filename}";
             $path = PATH_ROOT.$filename;
             if (file_exists($path)) {
-                deprecated(htmlspecialchars($path).": AssetModel::CssPath() with direct paths");
+                deprecated(htmlspecialchars($path).": LegacyAssetModel::CssPath() with direct paths");
                 return [$path, $filename];
             }
             return false;
@@ -408,7 +408,7 @@ class LegacyAssetModel extends Gdn_Model {
             $filename = "/{$filename}";
             $path = PATH_ROOT.$filename;
             if (file_exists($path)) {
-                deprecated(htmlspecialchars($path).": AssetModel::JsPath() with direct paths");
+                deprecated(htmlspecialchars($path).": LegacyAssetModel::JsPath() with direct paths");
                 return [$path, $filename];
             }
             return false;
@@ -590,7 +590,7 @@ class LegacyAssetModel extends Gdn_Model {
      * @deprecated
      */
     public static function viewHandlers() {
-        deprecated('AssetModel::viewHandlers()');
+        deprecated('LegacyAssetModel::viewHandlers()');
 
         $exts = static::viewExtensions();
         $result = [];

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -12,6 +12,8 @@
  * @abstract
  */
 
+use \Vanilla\Web\Assets\LegacyAssetModel;
+
 /**
  * Controller base class.
  *
@@ -1807,15 +1809,15 @@ class Gdn_Controller extends Gdn_Pluggable {
             // Only get css & ui Components if this is NOT a syndication request
             if ($this->SyndicationMethod == SYNDICATION_NONE && is_object($this->Head)) {
 
-                $CssAnchors = AssetModel::getAnchors();
+                $CssAnchors = LegacyAssetModel::getAnchors();
 
                 $this->EventArguments['CssFiles'] = &$this->_CssFiles;
                 $this->fireEvent('BeforeAddCss');
 
-                $ETag = AssetModel::eTag();
+                $ETag = LegacyAssetModel::eTag();
                 $ThemeType = isMobile() ? 'mobile' : 'desktop';
-                /* @var \AssetModel $AssetModel */
-                $AssetModel = Gdn::getContainer()->get(\AssetModel::class);
+                /* @var LegacyAssetModel $AssetModel */
+                $AssetModel = Gdn::getContainer()->get(LegacyAssetModel::class);
 
                 // And now search for/add all css files.
                 foreach ($this->_CssFiles as $CssInfo) {
@@ -1837,7 +1839,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
                     $AppFolder = $CssInfo['AppFolder'];
                     $LookupFolder = !empty($AppFolder) ? $AppFolder : $this->ApplicationFolder;
-                    $Search = AssetModel::cssPath($CssFile, $LookupFolder, $ThemeType);
+                    $Search = LegacyAssetModel::cssPath($CssFile, $LookupFolder, $ThemeType);
                     if (!$Search) {
                         continue;
                     }
@@ -1905,7 +1907,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
                     $AppFolder = $JsInfo['AppFolder'];
                     $LookupFolder = !empty($AppFolder) ? $AppFolder : $this->ApplicationFolder;
-                    $Search = AssetModel::jsPath($JsFile, $LookupFolder, $ThemeType);
+                    $Search = LegacyAssetModel::jsPath($JsFile, $LookupFolder, $ThemeType);
                     if (!$Search) {
                         continue;
                     }

--- a/plugins/editor/class.editor.plugin.php
+++ b/plugins/editor/class.editor.plugin.php
@@ -544,7 +544,7 @@ class EditorPlugin extends Gdn_Plugin {
 
         // If user wants to modify styling of Wysiwyg content in editor,
         // they can override the styles with this file.
-        $cssInfo = AssetModel::cssPath('wysiwyg.css', 'plugins/editor');
+        $cssInfo = \Vanilla\Web\Assets\LegacyAssetModel::cssPath('wysiwyg.css', 'plugins/editor');
         if ($cssInfo) {
             $cssPath = asset($cssInfo[1]);
         }

--- a/plugins/swagger-ui/SwaggerUIPlugin.php
+++ b/plugins/swagger-ui/SwaggerUIPlugin.php
@@ -11,6 +11,7 @@ use AssetModel;
 use Gdn_Plugin;
 use SettingsController;
 use Vanilla\Addon;
+use Vanilla\Web\Assets\LegacyAssetModel;
 
 /**
  * Handles the swagger UI menu options.
@@ -47,7 +48,7 @@ class SwaggerUIPlugin extends Gdn_Plugin {
         $relScripts = ['js/custom.js'];
         $js = [];
         foreach ($relScripts as $path) {
-            $search = AssetModel::jsPath($path, $folder);
+            $search = LegacyAssetModel::jsPath($path, $folder);
             if (!$search) {
                 continue;
             }


### PR DESCRIPTION
Issue: #7942
Followup of: https://github.com/vanilla/vanilla/pull/7943

Updates usages in this repo to the new name. This PR does not change functionality. An alias already exists, but it is simply housekeeping.