### PR TITLE
Fix IP ban field escaping

### DIFF
--- a/applications/dashboard/models/class.banmodel.php
+++ b/applications/dashboard/models/class.banmodel.php
@@ -100,7 +100,7 @@ class BanModel extends Gdn_Model {
                 $newUsers = $this->SQL
                     ->select('u.UserID, u.Banned')
                     ->from('User u')
-                    ->where($this->banWhere($newBan))
+                    ->where($this->banWhere($newBan), null, false)
                     ->where('Admin', 0)// No banning superadmins, pls.
                     ->get()->resultArray();
             } catch (Exception $e) {
@@ -427,7 +427,7 @@ class BanModel extends Gdn_Model {
             $countUsers = $this->SQL
                 ->select('UserID', 'count', 'CountUsers')
                 ->from('User u')
-                ->where($this->banWhere($data))
+                ->where($this->banWhere($data), null, false)
                 ->get()->value('CountUsers', 0);
         } catch (Exception $e) {
             Logger::log(


### PR DESCRIPTION
closes #7954 
Details of the issue in the referenced ticket.

### To test

- IP ban rules are applied to users when the rule is created
- Add an ip ban rule
- try to login with a non-admin user