### PR TITLE
Fix accessibility issues with modals regarding aria-hidden element and body scroll

### DIFF
--- a/library/src/scripts/components/frame/FrameHeader.tsx
+++ b/library/src/scripts/components/frame/FrameHeader.tsx
@@ -17,6 +17,7 @@ interface ICommonFrameHeaderProps extends ICommonHeadingProps {
     closeFrame: () => void;
     onBackClick?: () => void;
     srOnlyTitle?: boolean;
+    titleID?: string;
 }
 
 export interface IStringTitle extends ICommonFrameHeaderProps {
@@ -62,6 +63,7 @@ export default class FrameHeader extends React.PureComponent<IFrameHeaderProps> 
             <header className={classNames("frameHeader", this.props.className)}>
                 {backLink}
                 <Heading
+                    id={this.props.titleID}
                     title={stringTitle!}
                     depth={this.props.depth}
                     className={classNames("frameHeader-heading", { "sr-only": this.props.srOnlyTitle })}

--- a/library/src/scripts/components/modal/Modal.tsx
+++ b/library/src/scripts/components/modal/Modal.tsx
@@ -23,7 +23,6 @@ interface ITextDescription {
 interface IModalCommonProps {
     className?: string;
     exitHandler?: () => void;
-    appContainer?: Element;
     pageContainer?: Element;
     container?: Element;
     description?: string;
@@ -48,7 +47,6 @@ interface IModalHeadingDescription extends IModalCommonProps, IHeadingDescriptio
  */
 export default class Modal extends React.Component<IModalTextDescription | IModalHeadingDescription> {
     public static defaultProps = {
-        appContainer: document.getElementById("app"),
         pageContainer: document.getElementById("page"),
         container: document.getElementById("modals"),
     };

--- a/library/src/scripts/components/modal/Modal.tsx
+++ b/library/src/scripts/components/modal/Modal.tsx
@@ -27,7 +27,7 @@ interface IModalCommonProps {
     container?: Element;
     description?: string;
     children: React.ReactNode;
-    elementToFocus?: React.RefObject<HTMLElement>;
+    elementToFocus?: HTMLElement;
     size: ModalSizes;
 }
 
@@ -95,8 +95,9 @@ export default class Modal extends React.Component<IModalTextDescription | IModa
                     ref={this.selfRef}
                     onKeyDown={this.handleTabbing}
                     onClick={this.handleModalClick}
-                    aria-describedby={this.descriptionID}
                     aria-label={"label" in this.props ? this.props.label : undefined}
+                    aria-labelledby={"titleID" in this.props ? this.props.titleID : undefined}
+                    aria-describedby={this.props.description ? this.descriptionID : undefined}
                 >
                     {this.props.description && (
                         <div id={this.descriptionID} className="sr-only">
@@ -152,14 +153,14 @@ export default class Modal extends React.Component<IModalTextDescription | IModa
      */
     private focusInitialElement() {
         let targetElement;
-        if (this.props.elementToFocus && this.props.elementToFocus.current) {
-            targetElement = this.props.elementToFocus.current;
+        if (this.props.elementToFocus) {
+            targetElement = this.props.elementToFocus;
         } else {
             targetElement = this.tabHandler.getInitial();
         }
-        const elementToFocus = !!targetElement ? targetElement : document.body;
-        elementToFocus.focus();
-        Modal.focusHistory.push(elementToFocus);
+        targetElement = !!targetElement ? targetElement : document.body;
+        targetElement.focus();
+        Modal.focusHistory.push(targetElement);
     }
 
     /**

--- a/library/src/scripts/components/modal/ModalConfirm.tsx
+++ b/library/src/scripts/components/modal/ModalConfirm.tsx
@@ -12,7 +12,6 @@ import SmartAlign from "@library/components/SmartAlign";
 import ModalSizes from "@library/components/modal/ModalSizes";
 import { getRequiredID } from "@library/componentIDs";
 import Modal from "@library/components/modal/Modal";
-import MediumLoader from "@library/components/MediumLoader";
 import ButtonLoader from "@library/components/ButtonLoader";
 
 interface IProps {
@@ -37,23 +36,30 @@ export default class ModalConfirm extends React.Component<IProps, IState> {
         srOnlyTitle: false,
     };
 
+    private cancelRef;
+    private id;
+
     constructor(props) {
         super(props);
-        this.state = {
-            id: getRequiredID(props, "modalConfirm-"),
-        };
+        this.cancelRef = React.createRef();
+        this.id = getRequiredID(props, "confirmModal");
     }
 
-    public get cancelID() {
-        return this.state.id + "-cancelButton";
+    public get titleID() {
+        return this.id + "-title";
     }
 
     public render() {
         const { onCancel, onConfirm, srOnlyTitle, isConfirmLoading, title, children } = this.props;
         return (
-            <Modal size={ModalSizes.SMALL} elementToFocus={this.cancelID} exitHandler={onCancel}>
+            <Modal
+                size={ModalSizes.SMALL}
+                elementToFocus={this.cancelRef.current}
+                exitHandler={onCancel}
+                titleID={this.titleID}
+            >
                 <Frame>
-                    <FrameHeader closeFrame={onCancel} srOnlyTitle={srOnlyTitle!}>
+                    <FrameHeader titleID={this.titleID} closeFrame={onCancel} srOnlyTitle={srOnlyTitle!}>
                         {title}
                     </FrameHeader>
                     <FrameBody>
@@ -62,7 +68,7 @@ export default class ModalConfirm extends React.Component<IProps, IState> {
                         </FramePanel>
                     </FrameBody>
                     <FrameFooter>
-                        <Button id={this.cancelID} onClick={onCancel}>
+                        <Button ref={this.cancelRef} onClick={onCancel}>
                             {t("Cancel")}
                         </Button>
                         <Button onClick={onConfirm} className="buttonPrimary" disabled={isConfirmLoading}>

--- a/library/src/scripts/components/modal/ModalLoader.tsx
+++ b/library/src/scripts/components/modal/ModalLoader.tsx
@@ -9,6 +9,7 @@ import { withRouter, RouteComponentProps } from "react-router-dom";
 import FullPageLoader from "@library/components/FullPageLoader";
 import ModalSizes from "@library/components/modal/ModalSizes";
 import Modal from "@library/components/modal/Modal";
+import { t } from "@library/application";
 
 interface IProps extends RouteComponentProps<{}> {}
 
@@ -18,7 +19,7 @@ interface IProps extends RouteComponentProps<{}> {}
 class ModalLoader extends React.Component<IProps> {
     public render() {
         return (
-            <Modal size={ModalSizes.FULL_SCREEN} exitHandler={this.navigateToBacklink}>
+            <Modal label={t("Loading Modal")} size={ModalSizes.FULL_SCREEN} exitHandler={this.navigateToBacklink}>
                 <FullPageLoader />
             </Modal>
         );


### PR DESCRIPTION
I noticed there were a few accessibility issues with the modal component:

The `aria-hidden` was being added to the "app", but not the page. I.E. it wasn't including the header and footer in there. (requires: https://github.com/vanilla/knowledge/pull/259)

We also enabled scrolling no matter what when we closed a modal. This is incorrect as there could be another modal underneath. I've added a static "stack" of modals to the Modal component so we can keep track of where we are. Now we only remove the `aria-hidden` and enable scrolling only if we're removing the last modal in the stack.

I've also fixed an issue with the labels/description. The description is optional. If we use a heading element to describe the modal, there's no need for a label, but if we don't have one, we must add a label. Note also I switched the id of the heading for a ref. For documentation: https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal