### PR TITLE
Rename AssetModel and add aliases

### DIFF
--- a/library/Vanilla/AliasLoader.php
+++ b/library/Vanilla/AliasLoader.php
@@ -23,6 +23,8 @@ class AliasLoader {
      * @inheritdoc
      */
     protected static function provideAliases(): array {
-        return [];
+        return [
+            \Vanilla\Web\Assets\LegacyAssetModel::class => 'AssetModel',
+        ];
     }
 }

--- a/library/Vanilla/AliasLoader.php
+++ b/library/Vanilla/AliasLoader.php
@@ -24,7 +24,7 @@ class AliasLoader {
      */
     protected static function provideAliases(): array {
         return [
-            \Vanilla\Web\Assets\LegacyAssetModel::class => 'AssetModel',
+            \Vanilla\Web\Assets\LegacyAssetModel::class => ['AssetModel'],
         ];
     }
 }

--- a/library/Vanilla/Web/Assets/LegacyAssetModel.php
+++ b/library/Vanilla/Web/Assets/LegacyAssetModel.php
@@ -555,8 +555,8 @@ class LegacyAssetModel extends Gdn_Model {
         $keys = [];
 
         foreach ($resources as $key => $options) {
-           $version = $options['version'] ?? '';
-           $keys[] = "{$key} -> {$version}";
+            $version = $options['version'] ?? '';
+            $keys[] = "{$key} -> {$version}";
         }
 
         return md5(implode("\n", $keys));

--- a/library/core/class.thememanager.php
+++ b/library/core/class.thememanager.php
@@ -318,7 +318,7 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
      *
      *
      * @param $themeName
-     * @return mixed
+     * @return array|bool
      */
     public function getThemeInfo($themeName) {
         $theme = $this->addonManager->lookupTheme($themeName);


### PR DESCRIPTION
Issue: https://github.com/vanilla/vanilla/issues/7942

This PR does the initial moving of the `AssetModel` into core in preparation for a larger refactoring/update. The followup steps are outlined in https://github.com/vanilla/vanilla/issues/7942.

## Renaming
This PR renames the class `AssetModel` ->`Vanilla\Web\Assets\LegacyAssetModel`.

I opted for this name because it is my intention to pull parent classes out of it, and try and to not update all of the existing usages in the Vanilla proactively.

## Alias

I've added an alias to the old name. This should be apparent because everything still works even though __no__ usages have been changed as of this PR.

This class has no special rules in our container or factory so didn't need any updates there.

This class _does_ extend Gdn_Pluggable so I've manually set the `ClassName` property to the old value so events are still fired with the same names.

## Light refactoring and documentation
- A few doc blocks have been updated/expanded.
- I removed the deprecated `val()` calls from this class and replaced them with equivalents. I did a pretty thorough investigation of these before changing them.

## To test

Load up various pages of vanilla with different themes enabled. Notice all styles are still present.
