### PR TITLE
Add event in theme options view to assist with customizing the page

### DIFF
--- a/applications/dashboard/views/settings/themeoptions.php
+++ b/applications/dashboard/views/settings/themeoptions.php
@@ -68,6 +68,8 @@ echo $this->Form->errors();
 </section>
 <?php endif; ?>
 
+<?php $this->fireEvent('AfterCustomStyles'); ?>
+
 <?php if ($hasCustomText): ?>
 <section>
     <?php echo subheading(t('Text')); ?>


### PR DESCRIPTION
Closes #7900 

This view has no hooks, the new core theme [Keystone](https://github.com/vanilla/themes/tree/feature/keystone) depends on this event to add more options