### PR TITLE
Add focus visible polyfill

### DIFF
--- a/library/src/scripts/dom.ts
+++ b/library/src/scripts/dom.ts
@@ -8,6 +8,7 @@
 import { log, hashString } from "@library/utility";
 import twemoji from "twemoji";
 import debounce from "lodash/debounce";
+import "focus-visible";
 
 /**
  * Use the browser's built-in functionality to quickly and safely escape a string.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "body-scroll-lock": "2.5.10",
         "classnames": "2.2.6",
         "emojibase-data": "3.1.0",
+        "focus-visible": "4.1.5",
         "immer": "1.7.2",
         "lodash": "4.17.11",
         "lodash.debounce": "4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4145,6 +4145,11 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
+focus-visible@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-4.1.5.tgz#50b44e2e84c24b831ceca3cce84d57c2b311c855"
+  integrity sha512-yo/njtk/BB4Z2euzaZe3CZrg4u5s5uEi7ZwbHBJS2quHx51N0mmcx9nTIiImUGlgy+vf26d0CcQluahBBBL/Fw==
+
 follow-redirects@^1.0.0, follow-redirects@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"


### PR DESCRIPTION
This PR adds a `:focus-visible` polyfill. https://github.com/WICG/focus-visible

This adds a class fallback for the `:focus-visible`  CSS pseudo-selector, for browsers that don't support. Currently only Firefox has native support, but Chrome has it behind a flag and Safari is considering it for their upcoming release.

This allows us to apply big bold focus styles for keyboard navigating users, without cluttering up the UI for users navigating with a mouse or pointing device.

## Note

I've added this to `@library/dom` instead of our main polyfill feature because the main polyfill feature is meant to be targeting non-evergreen browsers (it's all or nothing). I don't want chrome/safari users receiving our full promise/async/await/generator polyfills so I've not including this in that criteria.

Once the actual selector is supported in all ever green browsers (chrome, firefox, safari, edge) for 2 major versions we should consider moving this into the polyfill file. 
