### PR TITLE
Whitelist Phing includes in conf folder

### DIFF
--- a/build/package-include.txt
+++ b/build/package-include.txt
@@ -2,7 +2,9 @@
 applications/**
 bootstrap.php
 cache/**
-conf/**
+conf/.htaccess
+conf/config-defaults.php
+conf/constants.php
 dist/**
 container.html
 environment.php


### PR DESCRIPTION
We're currently including the entire contents of `conf/` in Phing builds. This resulted in the accidental release of confidential information when the localhost contents of my config.php went live in a release (I recently changed my localhost setup to install directly out of my git repo for test running). We should whitelist exactly what we expect in the build from that folder to prevent future mishaps.