### PR TITLE
Fix contributors' agreement link in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Here are some quick and easy ways to get involved in the Vanilla Forums project.
 * Troubleshoot issues you run into on the [community forum](https://open.vanillaforums.com/discussions) so everyone can help & reference it later.
 * Improve our [public documentation](https://docs.vanillaforums.com/) by sending us suggested [edits as pull requests](https://github.com/vanilla/docs).
 * File detailed [issues](https://github.com/vanilla/vanilla/issues) on GitHub (version number, what you did, and actual vs expected outcomes).
-* Sign the [Contributors' Agreement](https://open.vanillaforums.com/contributors) to send us code.
+* Sign the [Contributors' Agreement](https://cla-assistant.io/vanilla/vanilla) to send us code.
 * Create new pull requests against the `master` branch.
 * Keep our to-do list fresh by reviewing our open issues for resolved or duplicated items.
 * Got an idea or suggestion? Use the [community forum](https://open.vanillaforums.com/discussions) to discuss it.


### PR DESCRIPTION
Broke when we moved to CLA Assistant last year.