### PR TITLE
Fix token & standard authentication not happening at same time during request

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -670,11 +670,8 @@ class DashboardHooks extends Gdn_Plugin {
      *
      * @param Gdn_Auth $sender
      */
-    public function gdn_auth_startAuthenticator_handler($sender) {
+    public function gdn_auth_startAuthenticator_handler() {
         $this->checkAccessToken();
-        if (Gdn::session()->isValid()) {
-            $sender->authHandled = true;
-        }
     }
 
     /**

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -666,9 +666,7 @@ class DashboardHooks extends Gdn_Plugin {
     }
 
     /**
-     * Check is we have a valid token associated with the request.
-     *
-     * @param Gdn_Auth $sender
+     * Check if we have a valid token associated with the request.
      */
     public function gdn_auth_startAuthenticator_handler() {
         $this->checkAccessToken();

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -667,6 +667,9 @@ class DashboardHooks extends Gdn_Plugin {
 
     /**
      * Check if we have a valid token associated with the request.
+     * The checkAccessToken was previously done in gdn_dispatcher_appStartup_handler hook.
+     * It was changed to have the access token auth happen as close as possible to standard auth.
+     * It's necessary to do it via events until Vanilla overhauls its authentication workflow.
      */
     public function gdn_auth_startAuthenticator_handler() {
         $this->checkAccessToken();

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -665,6 +665,11 @@ class DashboardHooks extends Gdn_Plugin {
         }
     }
 
+    /**
+     * Hooking on the startAuthenticator event of the auth class.
+     *
+     * @param $sender Auth
+     */
     public function gdn_auth_startAuthenticator_handler($sender) {
         $this->checkAccessToken();
         if (Gdn::session()->isValid()) {

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -624,7 +624,7 @@ class DashboardHooks extends Gdn_Plugin {
     public function gdn_dispatcher_appStartup_handler($sender) {
         safeHeader('P3P: CP="CAO PSA OUR"', true);
 
-        if ($sSO = Gdn::request()->get('sso')) {
+        if ($sso = Gdn::request()->get('sso')) {
             saveToConfig('Garden.Registration.SendConnectEmail', false, false);
 
             $deliveryMethod = $sender->getDeliveryMethod(Gdn::request());
@@ -633,7 +633,7 @@ class DashboardHooks extends Gdn_Plugin {
             $userID = false;
             try {
                 $currentUserID = Gdn::session()->UserID;
-                $userID = Gdn::userModel()->sso($sSO);
+                $userID = Gdn::userModel()->sso($sso);
             } catch (Exception $ex) {
                 trace($ex, TRACE_ERROR);
             }
@@ -663,7 +663,13 @@ class DashboardHooks extends Gdn_Plugin {
                 redirectTo($url);
             }
         }
+    }
+
+    public function gdn_auth_startAuthenticator_handler($sender) {
         $this->checkAccessToken();
+        if (Gdn::session()->isValid()) {
+            $sender->authHandled = true;
+        }
     }
 
     /**

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -668,7 +668,7 @@ class DashboardHooks extends Gdn_Plugin {
     /**
      * Check is we have a valid token associated with the request.
      *
-     * @param $sender
+     * @param Gdn_Auth $sender
      */
     public function gdn_auth_startAuthenticator_handler($sender) {
         $this->checkAccessToken();

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -666,9 +666,9 @@ class DashboardHooks extends Gdn_Plugin {
     }
 
     /**
-     * Hooking on the startAuthenticator event of the auth class.
+     * Check is we have a valid token associated with the request.
      *
-     * @param $sender Auth
+     * @param $sender
      */
     public function gdn_auth_startAuthenticator_handler($sender) {
         $this->checkAccessToken();

--- a/library/core/class.auth.php
+++ b/library/core/class.auth.php
@@ -60,7 +60,7 @@ class Gdn_Auth extends Gdn_Pluggable {
         $this->fireEvent('startAuthenticator');
 
         // Start the 'session'
-        if ($this->authHandled === false) {
+        if (!Gdn::session()->isValid()) {
             Gdn::session()->start(false, false);
         }
 

--- a/library/core/class.auth.php
+++ b/library/core/class.auth.php
@@ -78,7 +78,6 @@ class Gdn_Auth extends Gdn_Pluggable {
         if (Gdn::session()->isValid() && !Gdn::session()->checkPermission('Garden.SignIn.Allow')) {
             return Gdn::authenticator()->authenticateWith('user')->deauthenticate();
         }
-
     }
 
     public function registerAuthenticator($AuthenticationSchemeAlias) {

--- a/library/core/class.auth.php
+++ b/library/core/class.auth.php
@@ -55,8 +55,14 @@ class Gdn_Auth extends Gdn_Pluggable {
         if (!c('Garden.Installed', false)) {
             return;
         }
+
+        $this->authHandled = false;
+        $this->fireEvent('startAuthenticator');
+
         // Start the 'session'
-        Gdn::session()->start(false, false);
+        if ($this->authHandled === false) {
+            Gdn::session()->start(false, false);
+        }
 
         // Get list of enabled authenticators
         $authenticationSchemes = Gdn::config('Garden.Authenticator.EnabledSchemes', []);
@@ -72,6 +78,7 @@ class Gdn_Auth extends Gdn_Pluggable {
         if (Gdn::session()->isValid() && !Gdn::session()->checkPermission('Garden.SignIn.Allow')) {
             return Gdn::authenticator()->authenticateWith('user')->deauthenticate();
         }
+
     }
 
     public function registerAuthenticator($AuthenticationSchemeAlias) {

--- a/library/core/class.auth.php
+++ b/library/core/class.auth.php
@@ -56,6 +56,7 @@ class Gdn_Auth extends Gdn_Pluggable {
             return;
         }
 
+        // This event was created for token based authentication to hook on. See hook for more info.
         $this->fireEvent('startAuthenticator');
 
         // Start the 'session'

--- a/library/core/class.auth.php
+++ b/library/core/class.auth.php
@@ -56,7 +56,6 @@ class Gdn_Auth extends Gdn_Pluggable {
             return;
         }
 
-        $this->authHandled = false;
         $this->fireEvent('startAuthenticator');
 
         // Start the 'session'


### PR DESCRIPTION
Issue: https://github.com/vanilla/vanilla/issues/7950

After talking a little with both Ryan and Todd, the goal here was to trigger the token based authentication at the same "time" than standard auth to prevent different behaviours depending on your auth method as explained in the issue linked above. After taking both of your inputs into consideration this is what I came up with.

We add an event in the startAuthenticator method of the Auth class. We then change on what even the checkAccessToken method of the dashboard hooks is being called. Before `gdn_dispatcher_appStartup_handler` ,now `gdn_auth_startAuthenticator_handler`.

I have tested the changes in this PR and the API now works as expected. Let me know what you guys  think @initvector @tburry.

There is also a small casening fix in there.