### PR TITLE
Fix IpEncodeDecodeTest including unnecessary bootstrapping

### DIFF
--- a/tests/Library/Core/IpEncodeDecodeTest.php
+++ b/tests/Library/Core/IpEncodeDecodeTest.php
@@ -7,7 +7,6 @@
 
 use PHPUnit\Framework\TestCase;
 
-
 /**
  * Test some of the global functions that operate (or mostly operate) on arrays.
  */

--- a/tests/Library/Core/IpEncodeDecodeTest.php
+++ b/tests/Library/Core/IpEncodeDecodeTest.php
@@ -5,14 +5,13 @@
  * @license GPL-2.0-only
  */
 
-namespace VanillaTests\Library\Core;
+use PHPUnit\Framework\TestCase;
 
-use VanillaTests\SharedBootstrapTestCase;
 
 /**
  * Test some of the global functions that operate (or mostly operate) on arrays.
  */
-class IpEncodeDecodeTest extends SharedBootstrapTestCase {
+class IpEncodeDecodeTest extends TestCase {
     /**
      * Test encoding/decoding IPs in array.
      *


### PR DESCRIPTION
Related [#7928](https://github.com/vanilla/vanilla/pull/7928)

Extending TestCase class for the referenced UnitTest instead of "SharedBootstrapTestCase" which is not required for this particular unit test.