### PR TITLE
Fixed alignment for clear icon in search box

### DIFF
--- a/library/src/scss/components/_checkboxAndRadioButton.scss
+++ b/library/src/scss/components/_checkboxAndRadioButton.scss
@@ -31,7 +31,6 @@ $checkRadio-labelNote_opacity               : .7 !default;
     flex-wrap: wrap;
     align-items: center;
     white-space: nowrap;
-    margin: 0;
 
     &:hover {
         .radioButton-input:not([disabled]),

--- a/library/src/scss/components/_suggestedTextInput.scss
+++ b/library/src/scss/components/_suggestedTextInput.scss
@@ -59,7 +59,6 @@ $suggestedTextInput-clearButton_width: 16px;
 
 .suggestedTextInput-clear {
     padding: 0;
-    height: $suggestedTextInput-clearButton_width;
     width: $suggestedTextInput-clearButton_width;
     border-radius: 50%;
     margin-left: 3px;


### PR DESCRIPTION
The clear button in the search box was misaligned. Affects KB only.