### PR TITLE
Add database support for generic drafts

### DIFF
--- a/applications/dashboard/models/DraftModel.php
+++ b/applications/dashboard/models/DraftModel.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Dashboard\Models;
+
+use Gdn_Session;
+use Vanilla\Database\Operation\CurrentUserFieldProcessor;
+use Vanilla\Database\Operation\CurrentDateFieldProcessor;
+use Vanilla\Database\Operation\JsonFieldProcessor;
+use Vanilla\Models\PipelineModel;
+
+/**
+ * Handle all-purpose drafts.
+ */
+class DraftModel extends PipelineModel {
+
+    /** @var Gdn_Session */
+    private $session;
+
+    /**
+     * DraftModel constructor.
+     *
+     * @param Gdn_Session $session
+     */
+    public function __construct(Gdn_Session $session) {
+        parent::__construct("contentDraft");
+        $this->session = $session;
+
+        $dateProcessor = new CurrentDateFieldProcessor();
+        $dateProcessor->setInsertFields(["dateInserted", "dateUpdated"])
+            ->setUpdateFields(["dateUpdated"]);
+        $this->addPipelineProcessor($dateProcessor);
+
+        $userProcessor = new CurrentUserFieldProcessor($this->session);
+        $userProcessor->setInsertFields(["insertUserID", "updateUserID"])
+            ->setUpdateFields(["updateUserID"]);
+        $this->addPipelineProcessor($userProcessor);
+
+        $jsonProcessor = new JsonFieldProcessor();
+        $jsonProcessor->setFields(["attributes"]);
+        $this->addPipelineProcessor($jsonProcessor);
+    }
+}

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -854,7 +854,8 @@ $Construct
 $Construct
     ->table("contentDraft")
     ->primaryKey("contentDraftID")
-    ->column("recordType", "varchar(64)", false, ["index", "index.parentRecord"])
+    ->column("recordType", "varchar(64)", false, ["index", "index.record", "index.parentRecord"])
+    ->column("recordID", "int", true, "index.record")
     ->column("parentRecordID", "int", true, "index.parentRecord")
     ->column("attributes", "text")
     ->column("insertUserID", "int", false, "index")

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -851,6 +851,18 @@ $Construct
     ->column('UpdateIPAddress', 'ipaddress', true)
     ->set($Explicit, $Drop);
 
+$Construct
+    ->table("contentDraft")
+    ->primaryKey("contentDraftID")
+    ->column("recordType", "varchar(64)", false, ["index", "index.parentRecord"])
+    ->column("parentRecordID", "int", true, "index.parentRecord")
+    ->column("attributes", "text")
+    ->column("insertUserID", "int", false, "index")
+    ->column("dateInserted", "datetime")
+    ->column("updateUserID", "int")
+    ->column("dateUpdated", "datetime")
+    ->set($Explicit, $Drop);
+
 // If the AllIPAddresses column exists, attempt to migrate legacy IP data to the UserIP table.
 if (!$captureOnly && $AllIPAddressesExists) {
     $limit = 10000;

--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -853,7 +853,7 @@ $Construct
 
 $Construct
     ->table("contentDraft")
-    ->primaryKey("contentDraftID")
+    ->primaryKey("draftID")
     ->column("recordType", "varchar(64)", false, ["index", "index.record", "index.parentRecord"])
     ->column("recordID", "int", true, "index.record")
     ->column("parentRecordID", "int", true, "index.parentRecord")

--- a/applications/dashboard/src/scripts/@types/api/draft.ts
+++ b/applications/dashboard/src/scripts/@types/api/draft.ts
@@ -1,0 +1,16 @@
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+export interface IDraft {
+    draftID: number;
+    recordType: string;
+    recordID?: number | null;
+    parentRecordID: number | null;
+    attributes: any;
+    insertUserID: number;
+    dateInserted: string;
+    updateUserID: number;
+    dateUpdated: string;
+}

--- a/library/Vanilla/Database/Operation/JsonFieldProcessor.php
+++ b/library/Vanilla/Database/Operation/JsonFieldProcessor.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Database\Operation;
+
+use Vanilla\Database\Operation;
+
+/**
+ * Database operation processor for packing and unpacking JSON fields.
+ */
+class JsonFieldProcessor implements Processor {
+
+    /** @var array */
+    private $fields = [];
+
+    /**
+     * Get the list of fields to be packed and unpacked.
+     *
+     * @return array
+     */
+    public function getFields(): array {
+        return $this->fields;
+    }
+
+    /**
+     * Pack or unpack JSON fields, based on the database operation type.
+     *
+     * @param Operation $operation
+     * @param callable $stack
+     * @return mixed
+     */
+    public function handle(Operation $operation, callable $stack) {
+        if (in_array($operation->getType(), [Operation::TYPE_INSERT, Operation::TYPE_UPDATE])) {
+            $this->packFields($operation);
+            return $stack($operation);
+        } elseif ($operation->getType() === Operation::TYPE_SELECT) {
+            $result = $stack($operation);
+            return $this->unpackFields($result);
+        }
+    }
+
+    /**
+     * Pack JSON fields for write operations.
+     *
+     * @param Operation $operation
+     * @throws \Exception If JSON field data is not valid JSON.
+     */
+    private function packFields(Operation $operation) {
+        $set = $operation->getSet();
+        foreach ($this->getFields() as $field) {
+            if (array_key_exists($field, $set)) {
+                $packed = json_encode($set[$field]);
+                if ($packed === false) {
+                    throw new \Exception("Unable to encode field as JSON.");
+                }
+                $set[$field] = $packed;
+            }
+        }
+        $operation->setSet($set);
+    }
+
+    /**
+     * Set the list of fields to be packed and unpacked.
+     *
+     * @param array $fields
+     * @return self
+     */
+    public function setFields(array $fields): self {
+        $this->fields = $fields;
+        return $this;
+    }
+
+    /**
+     * Unpack JSON fields for read operations.
+     *
+     * @param array $results
+     * @return array
+     */
+    private function unpackFields(array $results): array {
+        $fields = $this->getFields();
+        foreach ($results as &$row) {
+            foreach ($fields as $field) {
+                if (array_key_exists($field, $row)) {
+                    $row[$field] = json_decode($row[$field], true);
+                }
+            }
+        }
+        return $results;
+    }
+}

--- a/library/Vanilla/Models/DraftModel.php
+++ b/library/Vanilla/Models/DraftModel.php
@@ -4,7 +4,7 @@
  * @license GPL-2.0-only
  */
 
-namespace Vanilla\Dashboard\Models;
+namespace Vanilla\Models;
 
 use Gdn_Session;
 use Vanilla\Database\Operation\CurrentUserFieldProcessor;

--- a/library/Vanilla/Models/Model.php
+++ b/library/Vanilla/Models/Model.php
@@ -61,6 +61,25 @@ class Model implements InjectableInterface {
     }
 
     /**
+     * Delete resource rows.
+     *
+     * @param array $where Conditions to restrict the deletion.
+     * @param array $options Options for the delete query.
+     *    - limit (int): Limit on the results to be deleted.
+     * @throws Exception If an error is encountered while performing the query.
+     * @return bool True.
+     */
+    public function delete(array $where, array $options = []): bool {
+        // Lazy load schemas.
+        $this->ensureSchemas();
+        $limit = $options["limit"] ?? false;
+
+        $this->sql()->delete($this->table, $where, $limit);
+        // If fully executed without an exception bubbling up, consider this a success.
+        return true;
+    }
+
+    /**
      * Make sure we have configured schemas available to the instance.
      */
     protected function ensureSchemas() {

--- a/library/Vanilla/Models/Model.php
+++ b/library/Vanilla/Models/Model.php
@@ -127,7 +127,7 @@ class Model implements InjectableInterface {
      *    - offset (int): Row offset before capturing the result.
      * @return array
      * @throws ValidationException If a row fails to validate against the schema.
-     * @throws Exception If no rows could be found.
+     * @throws NoResultsException If no rows could be found.
      */
     public function selectSingle(array $where = [], array $options = []): array {
         $options["limit"] = 1;

--- a/tests/Library/Vanilla/Database/JsonFieldProcessorTest.php
+++ b/tests/Library/Vanilla/Database/JsonFieldProcessorTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Database;
+
+use PHPUnit\Framework\TestCase;
+use Vanilla\Database\Operation;
+use Vanilla\Database\Operation\JsonFieldProcessor;
+use VanillaTests\Fixtures\BasicPipelineModel;
+
+/**
+ * Class for testing automatically packing and unpacking a JSON field.
+ */
+class JsonFieldProcessorTest extends TestCase {
+
+    /**
+     * Generate data for testing unpacking JSON fields for read operations.
+     *
+     * @return array
+     */
+    public function provideReadOperations() {
+        $complexType = ["foo" => "bar"];
+        $json = json_encode($complexType);
+        return [
+            [Operation::TYPE_SELECT, ["attributes" => $json], ["attributes" => $complexType]],
+            [Operation::TYPE_SELECT, ["notAttributes" => $json], ["notAttributes" => $json]],
+        ];
+    }
+
+    /**
+     * Generate data for testing packing as JSON for write operations.
+     *
+     * @return array
+     */
+    public function provideWriteOperations() {
+        $complexType = ["foo" => "bar"];
+        $json = json_encode($complexType);
+        return [
+            [Operation::TYPE_INSERT, ["attributes" => $complexType], ["attributes" => $json]],
+            [Operation::TYPE_UPDATE, ["attributes" => $complexType], ["attributes" => $json]],
+            [Operation::TYPE_INSERT, ["notAttributes" => $complexType], ["notAttributes" => $complexType]],
+        ];
+    }
+
+    /**
+     * Verify processor packs fields for write operations.
+     *
+     * @param string $type
+     * @param array $set
+     * @param array $expected
+     * @dataProvider provideWriteOperations
+     */
+    public function testPackFields(string $type, array $set, array $expected) {
+        $model = new BasicPipelineModel("Example");
+        $processor = new JsonFieldProcessor();
+        $processor->setFields(["attributes"]);
+        $model->addPipelineProcessor($processor);
+
+        $operation = new Operation();
+        $operation->setType($type);
+        $operation->setCaller($model);
+        $operation->setSet($set);
+        $model->doOperation($operation);
+        $this->assertEquals($expected, $operation->getSet());
+    }
+
+    /**
+     * Verify processor unpacks fields for read operations.
+     *
+     * @param string $type
+     * @param array $row
+     * @param array $expected
+     * @dataProvider provideReadOperations
+     */
+    public function testUnpackFields(string $type, array $row, array $expected) {
+        $model = new BasicPipelineModel("Example");
+        $processor = new JsonFieldProcessor();
+        $processor->setFields(["attributes"]);
+        $model->addPipelineProcessor($processor);
+
+        $operation = new Operation();
+        $operation->setType(Operation::TYPE_SELECT);
+        $operation->setCaller($model);
+        $result = $model->doSelectOperation($operation, [
+            $row
+        ]);
+        $this->assertEquals([$expected], $result);
+    }
+}

--- a/tests/Library/Vanilla/Database/JsonFieldProcessorTest.php
+++ b/tests/Library/Vanilla/Database/JsonFieldProcessorTest.php
@@ -22,11 +22,18 @@ class JsonFieldProcessorTest extends TestCase {
      * @return array
      */
     public function provideReadOperations() {
-        $complexType = ["foo" => "bar"];
-        $json = json_encode($complexType);
+        $expected = [
+            "foo" => "bar",
+            "bar" => "baz",
+            "attributes" => [
+                "one" => 1,
+                "two" => "deux",
+            ]
+        ];
+        $row = $expected;
+        $row["attributes"] = json_encode($row["attributes"]);
         return [
-            [Operation::TYPE_SELECT, ["attributes" => $json], ["attributes" => $complexType]],
-            [Operation::TYPE_SELECT, ["notAttributes" => $json], ["notAttributes" => $json]],
+            [Operation::TYPE_SELECT, $row, $expected],
         ];
     }
 
@@ -36,12 +43,19 @@ class JsonFieldProcessorTest extends TestCase {
      * @return array
      */
     public function provideWriteOperations() {
-        $complexType = ["foo" => "bar"];
-        $json = json_encode($complexType);
+        $set = [
+            "foo" => "bar",
+            "bar" => "baz",
+            "attributes" => [
+                "one" => 1,
+                "two" => "deux",
+            ]
+        ];
+        $expected = $set;
+        $expected["attributes"] = json_encode($expected["attributes"]);
         return [
-            [Operation::TYPE_INSERT, ["attributes" => $complexType], ["attributes" => $json]],
-            [Operation::TYPE_UPDATE, ["attributes" => $complexType], ["attributes" => $json]],
-            [Operation::TYPE_INSERT, ["notAttributes" => $complexType], ["notAttributes" => $complexType]],
+            [Operation::TYPE_INSERT, $set, $expected],
+            [Operation::TYPE_UPDATE, $set, $expected],
         ];
     }
 
@@ -82,11 +96,9 @@ class JsonFieldProcessorTest extends TestCase {
         $model->addPipelineProcessor($processor);
 
         $operation = new Operation();
-        $operation->setType(Operation::TYPE_SELECT);
+        $operation->setType($type);
         $operation->setCaller($model);
-        $result = $model->doSelectOperation($operation, [
-            $row
-        ]);
+        $result = $model->doSelectOperation($operation, [$row]);
         $this->assertEquals([$expected], $result);
     }
 }

--- a/tests/fixtures/src/BasicPipelineModel.php
+++ b/tests/fixtures/src/BasicPipelineModel.php
@@ -29,6 +29,20 @@ class BasicPipelineModel extends PipelineModel {
     }
 
     /**
+     * Perform a dummy "select" database operation using the configured pipeline.
+     *
+     * @param Operation $databaseOperation
+     * @param array $dummyResult
+     * @return Operation
+     */
+    public function doSelectOperation(Operation $databaseOperation, array $dummyResult): array {
+        $result = $this->pipeline->process($databaseOperation, function () use ($dummyResult) {
+            return $dummyResult;
+        });
+        return $result;
+    }
+
+    /**
      * Make sure we have configured schemas available to the instance.
      */
     protected function ensureSchemas() {


### PR DESCRIPTION
Vanilla's [drafts API v2 resource](https://docs.vanillaforums.com/help/apiv2/swagger/#/Drafts/get_drafts) uses a generic format, but performs request translations to map fields to the existing, Vanilla-specific (i.e. discussions and comments) drafts table. The next step in moving towards revising drafts is introduced here: adding a new table for truly generic drafts and a model for managing them. The new database table is based on the API schema, which itself is based off #5535 (and its comments).

### Overview
1. Add the new drafts table. Drafts are being overhauled, slowly, one step at a time. The new drafts table will need to exist alongside the existing Vanilla drafts table, until the next phase of refactoring sees everything moving to the new table structure.
1. Add `Vanilla\Models\DraftModel` to manage data in the new drafts table. Thanks to pipelines, this is a very basic model. However, it does perform some on-the-fly JSON packing/unpacking, which leads us to...
1. Add `Vanilla\Database\Operation\JsonFieldProcessor` for automatically packing and unpacking JSON fields.
1. Add tests for the `JsonFieldProcessor` class.
1. Add ability to simulate select operations in `BasicPipelineModel`, a fixture used in tests.
1. Update comment block on the new base model's `selectSingle` method.

Closes #8000