### PR TITLE
Implement Mutual exclusion functionality on the Vanilla's Base Model

### DIFF
--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -991,12 +991,12 @@ class Gdn_Model extends Gdn_Pluggable {
      * @return bool $keyHasBeenRelease Whether a master key has been released.
      */
     protected function releaseCacheLock($lockKey = ''):bool {
-        $keyHasBeenRelease = false;
+        $keyReleased = false;
 
         if (isset($lockKey)) {
-            $keyHasBeenRelease = Gdn::cache()->remove($lockKey);
+            $keyReleased = Gdn::cache()->remove($lockKey);
         }
 
-        return $keyHasBeenRelease;
+        return $keyReleased;
     }
 }

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -970,10 +970,17 @@ class Gdn_Model extends Gdn_Pluggable {
      * @return bool Whether a master key has been assigned.
      */
     protected static function buildCacheLock(string $lockKey, int $gracePeriod = 60): bool {
+        // If caching isn't enabled bail out
+        $cacheEnabled = Gdn_Cache::activeEnabled();
+        if(!$cacheEnabled) {
+            return true;
+        }
+
         /**
          * Attempt to add lock using our process ID. A failure likely means the
          * cache key already exists, which would mean the lock is already in place.
          */
+
         $instanceKey = getmypid();
         $added = Gdn::cache()->add($lockKey, $instanceKey, [
             Gdn_Cache::FEATURE_EXPIRY => $gracePeriod
@@ -992,6 +999,11 @@ class Gdn_Model extends Gdn_Pluggable {
      * @return bool Whether a master key has been released.
      */
     protected function releaseCacheLock(string $lockKey): bool {
+        // If caching isn't enabled bail out
+        $cacheEnabled = Gdn_Cache::activeEnabled();
+        if(!$cacheEnabled) {
+            return true;
+        }
         $keyReleased = Gdn::cache()->remove($lockKey);
         return $keyReleased;
     }

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -994,7 +994,7 @@ class Gdn_Model extends Gdn_Pluggable {
         $keyHasBeenRelease = false;
 
         if (isset($lockKey)) {
-           $keyHasBeenRelease = Gdn::cache()->remove($lockKey);
+            $keyHasBeenRelease = Gdn::cache()->remove($lockKey);
         }
 
         return $keyHasBeenRelease;

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -972,7 +972,7 @@ class Gdn_Model extends Gdn_Pluggable {
     protected static function buildCacheLock(string $lockKey, int $gracePeriod = 60): bool {
         // If caching isn't enabled bail out
         $cacheEnabled = Gdn_Cache::activeEnabled();
-        if(!$cacheEnabled) {
+        if (!$cacheEnabled) {
             return true;
         }
 
@@ -980,7 +980,6 @@ class Gdn_Model extends Gdn_Pluggable {
          * Attempt to add lock using our process ID. A failure likely means the
          * cache key already exists, which would mean the lock is already in place.
          */
-
         $instanceKey = getmypid();
         $added = Gdn::cache()->add($lockKey, $instanceKey, [
             Gdn_Cache::FEATURE_EXPIRY => $gracePeriod
@@ -1001,7 +1000,7 @@ class Gdn_Model extends Gdn_Pluggable {
     protected function releaseCacheLock(string $lockKey): bool {
         // If caching isn't enabled bail out
         $cacheEnabled = Gdn_Cache::activeEnabled();
-        if(!$cacheEnabled) {
+        if (!$cacheEnabled) {
             return true;
         }
         $keyReleased = Gdn::cache()->remove($lockKey);

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -996,11 +996,8 @@ class Gdn_Model extends Gdn_Pluggable {
      * @return bool $keyHasBeenRelease Whether a master key has been released.
      */
     protected function releaseCacheLock($lockKey = ''): bool {
-        $keyReleased = false;
 
-        if (isset($lockKey)) {
-            $keyReleased = Gdn::cache()->remove($lockKey);
-        }
+        $keyReleased = Gdn::cache()->remove($lockKey);
 
         return $keyReleased;
     }

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -991,7 +991,7 @@ class Gdn_Model extends Gdn_Pluggable {
      * @param string $lockKey Cache key to be assigned.
      * @return bool Whether a master key has been released.
      */
-    protected function releaseCacheLock($lockKey = ''): bool {
+    protected function releaseCacheLock(string $lockKey): bool {
         $keyReleased = Gdn::cache()->remove($lockKey);
         return $keyReleased;
     }

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -989,12 +989,10 @@ class Gdn_Model extends Gdn_Pluggable {
      * Releases a locked resource so that it can be used again.
      *
      * @param string $lockKey Cache key to be assigned.
-     * @return bool $keyHasBeenRelease Whether a master key has been released.
+     * @return bool Whether a master key has been released.
      */
     protected function releaseCacheLock($lockKey = ''): bool {
-
         $keyReleased = Gdn::cache()->remove($lockKey);
-
         return $keyReleased;
     }
 }


### PR DESCRIPTION
This adds the ability to lock resources by assigning a cache key to the process id trying to access it.  If there are competing processes for the same resources, the first one in will receive a master key that is cached.  If the cache key exists, an attempt to access the resource will fail.  Once the the process is complete, it can release the resource by calling Gdn_Model::releaseCacheLock.

Something similar was done on the categories model 
https://github.com/vanilla/vanilla/blob/9e495f412581c19aa21a2eccd7b0f4279f09b7c6/applications/vanilla/models/class.categorymodel.php#L549

This implementation will be a standard way to implement mutual exclusion across Vanilla.
