### PR TITLE
Remove Garden.AllowJSONP from config

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -953,4 +953,9 @@ if (c('Plugins.TouchIcon.Uploaded')) {
     removeFromConfig('Plugins.TouchIcon.Uploaded');
 }
 
+// Remove AllowJSONP globally
+if (c('Garden.AllowJSONP')) {
+    removeFromConfig('Garden.AllowJSONP');
+}
+
 Gdn::router()->setRoute('apple-touch-icon.png', 'utility/showtouchicon', 'Internal');


### PR DESCRIPTION
### Details

This PR will remove Garden.AllowJSONP form the config on utility/update.

Related [#410](https://github.com/vanilla/vanilla-patches/issues/410)
