### PR TITLE
Fix misleading build error message

### DIFF
--- a/build/scripts/Builder.ts
+++ b/build/scripts/Builder.ts
@@ -109,7 +109,7 @@ export default class Builder {
         if (buildOptions.mode === BuildMode.DEVELOPMENT && !hotReloadConfigSet) {
             const message = chalk.red(`
 You've enabled a development build without enabling hot reload. Add the following to your config.
-${chalk.yellowBright("$Configuration['HotReload']['Enabled'] = false;")}`);
+${chalk.yellowBright("$Configuration['HotReload']['Enabled'] = true;")}`);
             fail(message);
         }
 


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8009

As we saw from the demo today, this is backwards.