### PR TITLE
Update Phing build with more exclusions

### DIFF
--- a/build/package-include.txt
+++ b/build/package-include.txt
@@ -16,5 +16,5 @@ plugins/**
 README.md
 resources/**
 themes/**
-uploads/**
+uploads/
 vendor/**


### PR DESCRIPTION
Fixes file leaks in our distro build:
* [x] Remove contents of `uploads` from build.

Awaiting feedback in https://open.vanillaforums.com/discussion/36771/security-update-vanilla-2-6-4#latest