### PR TITLE
Fix profile edit when user re authenticates

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -397,11 +397,27 @@ class ProfileController extends Gdn_Controller {
             // If we're changing the email address, militarize our reauth with no cooldown allowed.
             $authOptions = [];
             $submittedEmail = $this->Form->getFormValue('Email', null);
+            // If User has to re authenticate get the original form values
+            $originalSubmission = (array_key_exists('OriginalSubmission', $_POST))
+                ? $_POST['OriginalSubmission']
+                : '';
+
             if ($submittedEmail !== null && $canEditEmail && $user['Email'] !== $submittedEmail) {
                 $authOptions['ForceTimeout'] = true;
             }
 
             $this->reauth($authOptions);
+
+            // If the Form was reloaded because of reauth, reset the the form values to the original submission values.
+            $originalFormValues = (isset($originalSubmission))
+                ? json_decode($originalSubmission, true)
+                : null;
+
+            if (is_array($originalFormValues)) {
+                foreach ($originalFormValues as $key => $value) {
+                    $this->Form->setFormValue($key, $value);
+                }
+            }
 
             $this->Form->setFormValue('UserID', $userID);
 


### PR DESCRIPTION
**Issue**
Currently if the user wish to modify a profiles email, they must re authenticate.  This in turns causes the the form to lose the original values and the email update is never saved.

**The Fix**
We check if there are original submission values in the $_POST array, if so after the user reauthenticates, the values are reapplied to the form and then saved.

**To Reproduce/ Test**
1) Go To Edit Profile
2) Change the users email
3) Click Save
4) Enter Password
5) Fields should be blank
6) Users email shouldn't be updated
7) Checkout branch and repeat steps.

Closes #8017