### PR TITLE
Add attachment endpoint to media API v2 resource

### DIFF
--- a/applications/dashboard/controllers/api/MediaApiController.php
+++ b/applications/dashboard/controllers/api/MediaApiController.php
@@ -312,13 +312,16 @@ class MediaApiController extends AbstractApiController {
         $in = $this->schema([
             "foreignType" => [
                 "description" => "Type of resource the media item will be attached to (e.g. comment).",
+                "enum" => [
+                    "embed",
+                ],
                 "type" => "string",
             ],
             "foreignID" => [
                 "description" => "Unique ID of the resource this media item will be attached to.",
                 "type" => "integer",
             ],
-        ], "in")->setDescription("Update a media item's attachment to another record.");
+        ], ["articlesPatchAttachment", "in"])->setDescription("Update a media item's attachment to another record.");
         $out = $this->schema($this->fullSchema(), "out");
 
         $body = $in->validate($body);

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -18,6 +18,18 @@ use Vanilla\Formatting\Embeds\EmbedManager;
 class VanillaHooks implements Gdn_IPlugin {
 
     /**
+     * Add to valid media attachment types.
+     *
+     * @param \Garden\Schema\Schema $schema
+     */
+    public function articlesPatchAttachmentSchema_init(\Garden\Schema\Schema $schema) {
+        $types = $schema->getField("properties.foreignType.enum");
+        $types[] = "comment";
+        $types[] = "discussion";
+        $schema->setField("properties.foreignType.enum", $types);
+    }
+
+    /**
      * Counter rebuilding.
      *
      * @param DbaController $sender

--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -23,6 +23,24 @@ class MediaTest extends AbstractAPIv2Test {
     private $baseUrl = '/media';
 
     /**
+     * Test updating a media item's attachment state.
+     */
+    public function testPatchAttachment() {
+        $row = $this->testPost();
+        $mediaID = $row["responseBody"]["mediaID"];
+
+        $updatedAttachment = [
+            "foreignID" => 31337,
+            "foreignType" => "discussion",
+        ];
+        $result = $this->api()->patch(
+            "{$this->baseUrl}/{$mediaID}/attachment",
+            $updatedAttachment
+        );
+        $this->assertArraySubset($updatedAttachment, $result->getBody());
+    }
+
+    /**
      * Test posting.
      *
      * @return array ['uploadedFile' => UploadedFile, 'responseBody' => $body]


### PR DESCRIPTION
Uploads made using the media API v2 resource are automatically given a "foreign type" of "embed" and a "foreign ID" value set to the current user's ID. There is currently no way to manually update a media item's attachment status using the API.

This update introduces the media "attachment" endpoint, which allows users the ability to edit the attachment status of media items. A patch request made to /api/v2/media/1/attachment will allow you to update the "foreign type" and "foreign ID" of a media item, thus updating its attachment status.

### Testing

1. Create a new upload using the media API v2 endpoint.
1. Grab the ID of the new upload.
1. Make a patch request to /api/v2/media/{id}/attachment using the `foreignType` and `foreignID` fields in the body of your request, where "{id}" is the upload ID grabbed in step two.
1. Get the media item using the same ID from step two (a get request to /api/v2/media/{id}). The `foreignType` and `foreignID` fields should be updated.

An integration test has been added to `MediaTest`.

Closes #8001 