### PR TITLE
Fix custom exception handling being improperly attempted on API exceptions

### DIFF
--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -171,10 +171,12 @@ class Dispatcher {
                 continue;
             } catch (\Throwable $dispatchEx) {
                 $response = null;
-                $obj = $action->getCallback()[0] ?? false;
-                if ($obj instanceof CustomExceptionHandler) {
-                    if ($obj->hasHandler($dispatchEx)) {
-                        $response = $obj->handle($dispatchEx);
+                if ($action instanceof Action) {
+                    $obj = $action->getCallback()[0] ?? false;
+                    if ($obj instanceof CustomExceptionHandler) {
+                        if ($obj->hasHandler($dispatchEx)) {
+                            $response = $obj->handle($dispatchEx);
+                        }
                     }
                 }
                 if (empty($response)) {


### PR DESCRIPTION
Issue: dispatcher failed when $action is null.

Patch: Check $action type before try to detect CustomExceptionHandler

Relates to: https://github.com/vanilla/vanilla/pull/8021



