### PR TITLE
Improve attachment validation in media API v2 resource

### DIFF
--- a/applications/dashboard/controllers/api/MediaApiController.php
+++ b/applications/dashboard/controllers/api/MediaApiController.php
@@ -5,6 +5,7 @@
  */
 
 use Garden\Schema\Schema;
+use Garden\Web\Exception\ClientException;
 use Garden\Web\Exception\NotFoundException;
 use Vanilla\ApiUtils;
 use Vanilla\Formatting\Embeds\EmbedManager;
@@ -344,6 +345,16 @@ class MediaApiController extends AbstractApiController {
 
         $original = $this->mediaByID($id);
         $this->editPermission($original);
+
+        $canAttach = $this->getEventManager()->fireFilter(
+            "canAttachMedia",
+            ($body["foreignType"] === "embed" && $body["foreignID"] === $this->getSession()->UserID),
+            $body["foreignType"],
+            $body["foreignID"]
+        );
+        if ($canAttach !== true) {
+            throw new ClientException("Unable to attach to this record. It may not exist or you may have improper permissions to access it.");
+        }
 
         $this->mediaModel->update(
             [

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -30,6 +30,33 @@ class VanillaHooks implements Gdn_IPlugin {
     }
 
     /**
+     * Verify the current user can attach a media item to a Vanilla post.
+     *
+     * @param bool $canAttach
+     * @param string $foreignType
+     * @param int $foreignID
+     * @return bool
+     */
+    public function canAttachMedia_handler(bool $canAttach, string $foreignType, int $foreignID): bool {
+        switch ($foreignType) {
+            case "comment":
+                $model = new CommentModel();
+                break;
+            case "discussion":
+                $model = new DiscussionModel();
+                break;
+            default:
+                return $canAttach;
+        }
+
+        $row = $model->getID($foreignID, DATASET_TYPE_ARRAY);
+        if (!$row) {
+            return false;
+        }
+        return ($row["InsertUserID"] === Gdn::session()->UserID || Gdn::session()->checkRankedPermission("Garden.Moderation.Manage"));
+    }
+
+    /**
      * Counter rebuilding.
      *
      * @param DbaController $sender

--- a/tests/APIv2/MediaTest.php
+++ b/tests/APIv2/MediaTest.php
@@ -29,8 +29,9 @@ class MediaTest extends AbstractAPIv2Test {
         $row = $this->testPost();
         $mediaID = $row["responseBody"]["mediaID"];
 
+        // Attachments default as "embed" and to the current user. Try attaching to a discussion.
         $updatedAttachment = [
-            "foreignID" => 31337,
+            "foreignID" => 1,
             "foreignType" => "discussion",
         ];
         $result = $this->api()->patch(


### PR DESCRIPTION
#8024 added support for attaching a media item to a resource. This update improves on that by adding an event, allowing addons to verify the resource exists and the current user has permission to attach media items to it.

This has been implemented in Vanilla. If a user did not create a post, and doesn't have the moderation permission, they shouldn't be able to attach to it. Similarly, if the post does not exist, the attach operation should also fail. Lastly, if attaching to "embed" (the default `foreignType`), a user can only attack to their own user ID.