### PR TITLE
Improve performance of <QueryString /> component

### DIFF
--- a/library/src/scripts/components/navigation/QueryString.tsx
+++ b/library/src/scripts/components/navigation/QueryString.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import qs from "qs";
 import { withRouter, RouteComponentProps } from "react-router";
 import isEqual from "lodash/isEqual";
+import throttle from "lodash/throttle";
 
 interface IProps extends RouteComponentProps<any> {
     value: {
@@ -33,13 +34,20 @@ class QueryString extends React.Component<IProps> {
         }
     }
 
-    private updateQueryString() {
-        const query = qs.stringify(this.props.value);
-        this.props.history.replace({
-            ...this.props.location,
-            search: query,
+    /**
+     * Update the query string of the window.
+     *
+     * This is throttle and put in request animation frame so that it does not take priority over the UI.
+     */
+    private updateQueryString = throttle(() => {
+        requestAnimationFrame(() => {
+            const query = qs.stringify(this.props.value);
+            this.props.history.replace({
+                ...this.props.location,
+                search: query,
+            });
         });
-    }
+    }, 100);
 }
 
 export default withRouter(QueryString);


### PR DESCRIPTION
When tied to the value of an input our `<QueryString />` component could take precedence in updating before the UI. This is likely due to the adjusting the window's history object not being instant. When quickly typing into an input tied to this component it could lag immensely. This has been rectified by:

- Throttling to only occur at most once every 100ms (on the tail end).
- Placing the update in a `requestAnimationFrame()`.