### PR TITLE
Add interface for validating media attachment updates

### DIFF
--- a/applications/dashboard/models/class.mediamodel.php
+++ b/applications/dashboard/models/class.mediamodel.php
@@ -40,7 +40,7 @@ class MediaModel extends Gdn_Model {
      * Add a foreign row validator.
      *
      * @param string $foreignType
-     * @param callable $validator
+     * @param ForeignValidatorInterface $validator
      * @return self
      */
     public function addForeignValidator(string $foreignType, ForeignValidatorInterface $validator): self {

--- a/applications/vanilla/models/CommentForeignValidator.php
+++ b/applications/vanilla/models/CommentForeignValidator.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums, Inc
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
+ */
+
+namespace Vanilla\Vanilla\Models;
+
+use CommentModel;
+use Gdn_Session as SessionInterface;
+
+/**
+ * Class CommentForeignValidator
+ */
+class CommentForeignValidator extends PostForeignValidator {
+
+    /**
+     * Setup.
+     *
+     * @param CommentModel $commentModel
+     * @param SessionInterface $session
+     */
+    public function __construct(CommentModel $commentModel, SessionInterface $session) {
+        parent::__construct($commentModel, $session);
+    }
+}

--- a/applications/vanilla/models/DiscussionForeignValidator.php
+++ b/applications/vanilla/models/DiscussionForeignValidator.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums, Inc
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
+ */
+
+namespace Vanilla\Vanilla\Models;
+
+use DiscussionModel;
+use Gdn_Session as SessionInterface;
+
+/**
+ * Class DiscussionForeignValidator
+ */
+class DiscussionForeignValidator extends PostForeignValidator {
+
+    /**
+     * Setup.
+     *
+     * @param DiscussionModel $discussionModel
+     * @param SessionInterface $session
+     */
+    public function __construct(DiscussionModel $discussionModel, SessionInterface $session) {
+        parent::__construct($discussionModel, $session);
+    }
+}

--- a/applications/vanilla/models/PostForeignValidator.php
+++ b/applications/vanilla/models/PostForeignValidator.php
@@ -33,7 +33,11 @@ abstract class PostForeignValidator implements ForeignValidatorInterface {
     }
 
     /**
-     * @inheritDoc
+     * Given a foreign type and record ID, verify whether or not the current user can attach a media item to it.
+     *
+     * @param string $foreignType
+     * @param string|int $foreignID
+     * @return bool
      */
     public function canAttach(string $foreignType, $foreignID): bool {
         $row = $this->model->getID($foreignID, DATASET_TYPE_ARRAY);

--- a/applications/vanilla/models/PostForeignValidator.php
+++ b/applications/vanilla/models/PostForeignValidator.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums, Inc
+ * @license http://www.opensource.org/licenses/gpl-2.0.php GPL
+ */
+
+namespace Vanilla\Vanilla\Models;
+
+use Gdn_Model;
+use Gdn_Session as SessionInterface;
+use Vanilla\Utility\Media\ForeignValidatorInterface;
+
+/**
+ * Class PostForeignValidator
+ */
+abstract class PostForeignValidator implements ForeignValidatorInterface {
+
+    /** @var Gdn_Model */
+    private $model;
+
+    /** @var SessionInterface */
+    private $session;
+
+    /**
+     * Setup.
+     *
+     * @param Gdn_Model $model
+     * @param SessionInterface $session
+     */
+    public function __construct(Gdn_Model $model, SessionInterface $session) {
+        $this->model = $model;
+        $this->session = $session;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function canAttach(string $foreignType, $foreignID): bool {
+        $row = $this->model->getID($foreignID, DATASET_TYPE_ARRAY);
+        if (!$row) {
+            return false;
+        }
+        return ($row["InsertUserID"] === $this->session->UserID || $this->session->checkRankedPermission("Garden.Moderation.Manage"));
+    }
+}

--- a/library/Vanilla/Utility/Media/ForeignValidatorInterface.php
+++ b/library/Vanilla/Utility/Media/ForeignValidatorInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Utility\Media;
+
+/**
+ * Interface for classes built to validate foreign row associations with media records.
+ */
+interface ForeignValidatorInterface {
+
+    /**
+     * Given a foreign type and record ID, verify whether or not the current user can attach a media item to it.
+     *
+     * @param string $foreignType
+     * @param string|int $foreignID
+     * @return bool
+     */
+    public function canAttach(string $foreignType, $foreignID): bool;
+}


### PR DESCRIPTION
This update adds an interface to standardize validation of a media item's attachment to a resource by the current user. This is currently event-driven, so this interface attempts to ensure all classes that need to validate media attachments do so with a standardized, consistent, strongly-typed hook method.