### PR TITLE
All getState to be injected into ReduxActions

### DIFF
--- a/library/src/scripts/state/ReduxActions.ts
+++ b/library/src/scripts/state/ReduxActions.ts
@@ -141,8 +141,13 @@ export default class ReduxActions {
      *
      * @param dispatch A redux dispatch function.
      * @param api An API instance.
+     * @param getState Optionally override the getState method. (generally for testin purposes.)
      */
-    constructor(protected dispatch: any, protected api: AxiosInstance) {}
+    constructor(protected dispatch: any, protected api: AxiosInstance, getState?: () => any) {
+        if (getState) {
+            this.getState = getState;
+        }
+    }
 
     /**
      * Bind dispatch to an action creator.


### PR DESCRIPTION
This PR updates our `ReduxActions` class to allow it recieve it's `getState()` method as a constructor argument. This is useful for unit tests.