### PR TITLE
Update size limitations of generic drafts to allow larger content

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -857,7 +857,7 @@ $Construct
     ->column("recordType", "varchar(64)", false, ["index", "index.record", "index.parentRecord"])
     ->column("recordID", "int", true, "index.record")
     ->column("parentRecordID", "int", true, "index.parentRecord")
-    ->column("attributes", "text")
+    ->column("attributes", "mediumtext")
     ->column("insertUserID", "int", false, "index")
     ->column("dateInserted", "datetime")
     ->column("updateUserID", "int")


### PR DESCRIPTION
The new drafts table stores its attributes as a MySQL text field, which have a limit of approximately sixty-five thousand characters. We're changing the field type to a "medium text" field, which has a limit of approximately sixteen million characters.