### PR TITLE
Compact Search - Wire it up and fix bugs

### DIFF
--- a/library/src/scripts/components/SelectBox.tsx
+++ b/library/src/scripts/components/SelectBox.tsx
@@ -13,6 +13,8 @@ import DropDownItemButton from "@library/components/dropdown/items/DropDownItemB
 import { checkCompact, downTriangle } from "@library/components/icons/common";
 import DropDown from "@library/components/dropdown/DropDown";
 import { ButtonBaseClass } from "@library/components/forms/Button";
+import Frame from "@library/components/frame/Frame";
+import FrameBody from "@library/components/frame/FrameBody";
 
 export interface ISelectBoxItem {
     name: string;
@@ -133,7 +135,9 @@ export default class SelectBox extends React.Component<ISelfLabelledProps | IExt
                         renderAbove={this.props.renderAbove}
                         renderLeft={this.props.renderLeft}
                     >
-                        {selectItems}
+                        <Frame>
+                            <FrameBody className="dropDownItem-verticalPadding">{selectItems}</FrameBody>
+                        </Frame>
                     </DropDown>
                 </div>
             </div>

--- a/library/src/scripts/components/forms/select/ClearButton.tsx
+++ b/library/src/scripts/components/forms/select/ClearButton.tsx
@@ -20,7 +20,8 @@ interface IProps {
 export function ClearButton(props: IProps) {
     return (
         <Button
-            className={classNames(ButtonBaseClass.ICON, "suggestedTextInput-clear searchBar-clear")}
+            baseClass={ButtonBaseClass.ICON}
+            className={"suggestedTextInput-clear searchBar-clear"}
             type="button"
             onClick={props.onClick}
             title={t("Clear")}

--- a/library/src/scripts/components/forms/select/SearchBar.tsx
+++ b/library/src/scripts/components/forms/select/SearchBar.tsx
@@ -44,6 +44,7 @@ interface IProps extends IOptionalComponentID {
     getRef?: any;
     buttonClassName?: string;
     hideSearchButton?: boolean;
+    triggerSearchOnAllUpdates?: boolean;
 }
 
 interface IState {
@@ -137,7 +138,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
         if (option) {
             this.props.onChange(option.label);
             this.setState({ forceMenuClosed: true }, () => {
-                this.props.onSearch && this.props.onSearch();
+                this.props.triggerSearchOnAllUpdates && this.props.onSearch();
             });
         }
     };
@@ -241,7 +242,9 @@ export default class SearchBar extends React.Component<IProps, IState> {
     private clear = (event: React.SyntheticEvent) => {
         event.preventDefault();
         this.props.onChange("");
-        this.props.onSearch();
+        if (this.props.triggerSearchOnAllUpdates) {
+            this.props.onSearch();
+        }
         this.inputRef.current!.focus();
     };
 

--- a/library/src/scripts/components/forms/select/SearchBar.tsx
+++ b/library/src/scripts/components/forms/select/SearchBar.tsx
@@ -70,7 +70,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
     private prefix = "searchBar";
     private searchButtonID: string;
     private searchInputID: string;
-    private ref = React.createRef<AsyncCreatableSelect<any>>();
+    private inputRef: React.RefObject<AsyncCreatableSelect<any>> = React.createRef();
 
     constructor(props: IProps) {
         super(props);
@@ -110,6 +110,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                 backspaceRemovesValue={true}
                 createOptionPosition="first"
                 formatCreateLabel={this.createFormatLabel}
+                ref={this.inputRef}
             />
         );
     }
@@ -226,6 +227,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                                 "searchBar-submitButton",
                                 this.props.buttonClassName,
                             )}
+                            tabIndex={!!this.props.hideSearchButton ? -1 : 0}
                         >
                             {this.props.isLoading ? <ButtonLoader /> : t("Search")}
                         </Button>
@@ -239,8 +241,8 @@ export default class SearchBar extends React.Component<IProps, IState> {
     private clear = (event: React.SyntheticEvent) => {
         event.preventDefault();
         this.props.onChange("");
-        this.ref.current!.focus();
         this.props.onSearch();
+        this.inputRef.current!.focus();
     };
 
     /**
@@ -265,4 +267,8 @@ export default class SearchBar extends React.Component<IProps, IState> {
         DropdownIndicator: selectOverrides.NullComponent,
         LoadingMessage: selectOverrides.OptionLoader,
     };
+
+    public focus() {
+        this.inputRef.current!.focus();
+    }
 }

--- a/library/src/scripts/components/mebox/pieces/CompactSearch.tsx
+++ b/library/src/scripts/components/mebox/pieces/CompactSearch.tsx
@@ -15,6 +15,7 @@ import { search } from "@library/components/icons/header";
 import { uniqueIDFromPrefix } from "@library/componentIDs";
 import SearchOption from "@library/components/search/SearchOption";
 import { withApi, IApiProps } from "@library/contexts/ApiContext";
+import { Redirect } from "react-router-dom";
 
 export interface ICompactSearchProps extends IApiProps {
     className?: string;
@@ -25,13 +26,26 @@ export interface ICompactSearchProps extends IApiProps {
     cancelButtonClassName?: string;
 }
 
+interface IState {
+    query: string;
+    redirectTo: string | null;
+}
+
 /**
  * Implements Compact Search component for header
  */
-export class CompactSearch extends React.Component<ICompactSearchProps> {
+export class CompactSearch extends React.Component<ICompactSearchProps, IState> {
     private id = uniqueIDFromPrefix("compactSearch");
+    public state: IState = {
+        query: "",
+        redirectTo: null,
+    };
 
     public render() {
+        if (this.state.redirectTo) {
+            return <Redirect to={this.state.redirectTo} />;
+        }
+
         return (
             <div className="compactSearch">
                 {!this.props.open && (
@@ -55,9 +69,12 @@ export class CompactSearch extends React.Component<ICompactSearchProps> {
                             optionComponent={SearchOption}
                             noHeading={true}
                             title={t("Search")}
+                            value={this.state.query}
                             disabled={!this.props.open}
                             hideSearchButton={true}
-                            loadOptions={this.props.searchOptionProvider}
+                            onChange={this.searchChangeHandler}
+                            onSearch={this.submitHandler}
+                            loadOptions={this.props.searchOptionProvider.autocomplete}
                         />
                         <Button
                             onClick={this.props.onCloseSearch}
@@ -76,23 +93,14 @@ export class CompactSearch extends React.Component<ICompactSearchProps> {
         );
     }
 
-    /**
-     * Simple data loading function for the search bar/react-select.
-     */
-    private loadOptions = async (value: string) => {
-        const queryObj = {
-            name: value,
-            expand: ["user", "category"],
-        };
-        const query = qs.stringify(queryObj);
-        const response = await apiv2.get(`/knowledge/search?${query}`);
-        return response.data.map(result => {
-            return {
-                label: result.name,
-                value: result.name,
-                data: result,
-            };
-        });
+    private searchChangeHandler = (newQuery: string) => {
+        this.setState({ query: newQuery });
+    };
+
+    private submitHandler = () => {
+        const { searchOptionProvider } = this.props;
+        const { query } = this.state;
+        this.setState({ redirectTo: searchOptionProvider.makeSearchUrl(query) });
     };
 }
 

--- a/library/src/scripts/components/mebox/pieces/CompactSearch.tsx
+++ b/library/src/scripts/components/mebox/pieces/CompactSearch.tsx
@@ -14,8 +14,9 @@ import classNames from "classnames";
 import { search } from "@library/components/icons/header";
 import { uniqueIDFromPrefix } from "@library/componentIDs";
 import SearchOption from "@library/components/search/SearchOption";
+import { withApi, IApiProps } from "@library/contexts/ApiContext";
 
-export interface ICompactSearchProps {
+export interface ICompactSearchProps extends IApiProps {
     className?: string;
     placeholder?: string;
     open: boolean;
@@ -27,7 +28,7 @@ export interface ICompactSearchProps {
 /**
  * Implements Compact Search component for header
  */
-export default class CompactSearch extends React.Component<ICompactSearchProps> {
+export class CompactSearch extends React.Component<ICompactSearchProps> {
     private id = uniqueIDFromPrefix("compactSearch");
 
     public render() {
@@ -51,15 +52,12 @@ export default class CompactSearch extends React.Component<ICompactSearchProps> 
                         <SearchBar
                             id={this.id}
                             placeholder={this.props.placeholder}
-                            onChange={this.onSearch}
-                            loadOptions={this.loadOptions}
-                            value={""}
-                            onSearch={this.onSearch}
                             optionComponent={SearchOption}
                             noHeading={true}
                             title={t("Search")}
                             disabled={!this.props.open}
                             hideSearchButton={true}
+                            loadOptions={this.props.searchOptionProvider}
                         />
                         <Button
                             onClick={this.props.onCloseSearch}
@@ -77,10 +75,6 @@ export default class CompactSearch extends React.Component<ICompactSearchProps> 
             </div>
         );
     }
-
-    public onSearch = () => {
-        // Do nothing;
-    };
 
     /**
      * Simple data loading function for the search bar/react-select.
@@ -101,3 +95,5 @@ export default class CompactSearch extends React.Component<ICompactSearchProps> 
         });
     };
 }
+
+export default withApi<ICompactSearchProps>(CompactSearch);

--- a/library/src/scripts/components/mebox/pieces/CompactSearch.tsx
+++ b/library/src/scripts/components/mebox/pieces/CompactSearch.tsx
@@ -7,8 +7,6 @@
 import * as React from "react";
 import SearchBar from "@library/components/forms/select/SearchBar";
 import { t } from "@library/application";
-import qs from "qs";
-import apiv2 from "@library/apiv2";
 import Button, { ButtonBaseClass } from "@library/components/forms/Button";
 import classNames from "classnames";
 import { search } from "@library/components/icons/header";
@@ -16,6 +14,7 @@ import { uniqueIDFromPrefix } from "@library/componentIDs";
 import SearchOption from "@library/components/search/SearchOption";
 import { withApi, IApiProps } from "@library/contexts/ApiContext";
 import { Redirect } from "react-router-dom";
+import AsyncCreatableSelect from "react-select/lib/AsyncCreatable";
 
 export interface ICompactSearchProps extends IApiProps {
     className?: string;
@@ -36,6 +35,8 @@ interface IState {
  */
 export class CompactSearch extends React.Component<ICompactSearchProps, IState> {
     private id = uniqueIDFromPrefix("compactSearch");
+    private openSearchButton: React.RefObject<HTMLButtonElement> = React.createRef();
+    private searchInputRef: React.RefObject<SearchBar> = React.createRef();
     public state: IState = {
         query: "",
         redirectTo: null,
@@ -57,6 +58,7 @@ export class CompactSearch extends React.Component<ICompactSearchProps, IState> 
                         aria-haspopup="true"
                         baseClass={ButtonBaseClass.CUSTOM}
                         aria-controls={this.id}
+                        buttonRef={this.openSearchButton}
                     >
                         <div className="meBox-buttonContent">{search()}</div>
                     </Button>
@@ -75,6 +77,7 @@ export class CompactSearch extends React.Component<ICompactSearchProps, IState> 
                             onChange={this.searchChangeHandler}
                             onSearch={this.submitHandler}
                             loadOptions={this.props.searchOptionProvider.autocomplete}
+                            ref={this.searchInputRef}
                         />
                         <Button
                             onClick={this.props.onCloseSearch}
@@ -102,6 +105,14 @@ export class CompactSearch extends React.Component<ICompactSearchProps, IState> 
         const { query } = this.state;
         this.setState({ redirectTo: searchOptionProvider.makeSearchUrl(query) });
     };
+
+    public componentDidUpdate(prevProps) {
+        if (!prevProps.open && this.props.open) {
+            this.searchInputRef.current!.focus();
+        } else if (prevProps.open && !this.props.open) {
+            this.openSearchButton.current!.focus();
+        }
+    }
 }
 
 export default withApi<ICompactSearchProps>(CompactSearch);

--- a/library/src/scripts/components/mebox/pieces/CompactSearch.tsx
+++ b/library/src/scripts/components/mebox/pieces/CompactSearch.tsx
@@ -78,6 +78,7 @@ export class CompactSearch extends React.Component<ICompactSearchProps, IState> 
                             onSearch={this.submitHandler}
                             loadOptions={this.props.searchOptionProvider.autocomplete}
                             ref={this.searchInputRef}
+                            triggerSearchOnAllUpdates={false}
                         />
                         <Button
                             onClick={this.props.onCloseSearch}

--- a/library/src/scripts/components/search/SearchOption.tsx
+++ b/library/src/scripts/components/search/SearchOption.tsx
@@ -11,9 +11,16 @@ import { OptionProps } from "react-select/lib/components/Option";
 import { SelectOption } from "../forms/select/overwrites";
 import classNames from "classnames";
 import { IComboBoxOption } from "@library/components/forms/select/SearchBar";
+import { ICrumb } from "@library/components/Breadcrumbs";
+
+export interface ISearchOptionData {
+    crumbs: ICrumb[];
+    name: string;
+    dateUpdated: string;
+}
 
 interface IProps extends OptionProps<any> {
-    data: IComboBoxOption<any>;
+    data: IComboBoxOption<ISearchOptionData>;
 }
 
 /**
@@ -22,8 +29,8 @@ export default function SearchOption(props: IProps) {
     const { data, innerProps, isSelected, isFocused } = props;
 
     if (data.data) {
-        const { dateUpdated, knowledgeCategory } = data.data!;
-        const hasLocationData = knowledgeCategory && knowledgeCategory.breadcrumbs.length > 0;
+        const { dateUpdated, crumbs } = data.data!;
+        const hasLocationData = crumbs && crumbs.length > 0;
         return (
             <li className="suggestedTextInput-item">
                 <button
@@ -46,9 +53,7 @@ export default function SearchOption(props: IProps) {
                                     <DateTime className="meta" timestamp={dateUpdated} />
                                 </span>
                             )}
-                            {hasLocationData && (
-                                <BreadCrumbString className="meta" crumbs={knowledgeCategory!.breadcrumbs} />
-                            )}
+                            {hasLocationData && <BreadCrumbString className="meta" crumbs={crumbs} />}
                         </span>
                     </span>
                 </button>

--- a/library/src/scripts/contexts/ApiContext.tsx
+++ b/library/src/scripts/contexts/ApiContext.tsx
@@ -12,7 +12,7 @@ import { IComboBoxOption } from "@library/components/forms/select/SearchBar";
 const ApiContext = React.createContext<IApiProps>({} as any);
 export default ApiContext;
 
-interface ISearchOptionProvider {
+export interface ISearchOptionProvider {
     autocomplete(query: string): Promise<Array<IComboBoxOption<ISearchOptionData>>>;
     makeSearchUrl(query: string): string;
 }

--- a/library/src/scripts/contexts/ApiContext.tsx
+++ b/library/src/scripts/contexts/ApiContext.tsx
@@ -1,0 +1,45 @@
+/*
+ * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import * as React from "react";
+import { Omit } from "@library/@types/utils";
+import { AxiosInstance } from "axios";
+import { ISearchOptionData } from "@library/components/search/SearchOption";
+import { IComboBoxOption } from "@library/components/forms/select/SearchBar";
+const ApiContext = React.createContext<IApiProps>({} as any);
+export default ApiContext;
+
+interface ISearchOptionProvider {
+    autocomplete(query: string): Promise<Array<IComboBoxOption<ISearchOptionData>>>;
+    makeSearchUrl(query: string): string;
+}
+
+export interface IApiProps {
+    api: AxiosInstance;
+    searchOptionProvider: ISearchOptionProvider;
+}
+
+/**
+ * HOC to inject API context
+ *
+ * @param WrappedComponent - The component to wrap
+ */
+export function withApi<T extends IApiProps = IApiProps>(WrappedComponent: React.ComponentClass<IApiProps>) {
+    const displayName = WrappedComponent.displayName || WrappedComponent.name || "Component";
+    class ComponentWithDevice extends React.Component<Omit<T, keyof IApiProps>> {
+        public static displayName = `withApi(${displayName})`;
+        public render() {
+            return (
+                <ApiContext.Consumer>
+                    {context => {
+                        return <WrappedComponent {...context} {...this.props} />;
+                    }}
+                </ApiContext.Consumer>
+            );
+        }
+    }
+    return ComponentWithDevice;
+}

--- a/library/src/scss/_coreVariables.scss
+++ b/library/src/scss/_coreVariables.scss
@@ -429,7 +429,8 @@ $dropDown-item_minHeight                            : 45px;
     Header
 \* -------------------------------------------------------------- */
 
-$global-header_height                               : 50px !default;
+$vanillaHeader_height                               : 50px !default;
+$vanillaHeader_fg                                   : #fff !default;
 
 /* -------------------------------------------------------------- *\
     Footer

--- a/library/src/scss/components/_headerLogo.scss
+++ b/library/src/scss/components/_headerLogo.scss
@@ -7,6 +7,6 @@
 
 .headerLogo-logo {
     display: block;
-    height: #{$global-header_height - 3 * $utility-baseUnit};
+    height: #{$vanillaHeader_height - 3 * $utility-baseUnit};
     width: auto;
 }

--- a/library/src/scss/components/_meBox.scss
+++ b/library/src/scss/components/_meBox.scss
@@ -18,7 +18,7 @@ $meBox-dropDownContents_minWidth: 300px;
 
 .meBox-button {
     color: inherit;
-    height: $global-header_height;
+    height: $vanillaHeader_height;
     width: $meBox-button_size;
     padding: 0;
 

--- a/library/src/scss/components/_searchBar.scss
+++ b/library/src/scss/components/_searchBar.scss
@@ -9,11 +9,11 @@ $searchBar-searchIcon_space: 32px;
 
 .searchBar-clear {
     position: relative;
-    color: inherit;
     display: flex;
     box-sizing: border-box;
     height: $formElement-height;
     width: $formElement-height;
+    color: $vanillaHeader_fg;
 }
 
 .searchBar-form {
@@ -98,6 +98,7 @@ $searchBar-searchIcon_space: 32px;
 .searchBar__input {
     width: 100%;
     display: block !important;
+    color: $vanillaHeader-fg;
 
     input {
         width: 100%;

--- a/library/src/scss/components/_suggestedTextInput.scss
+++ b/library/src/scss/components/_suggestedTextInput.scss
@@ -64,12 +64,15 @@ $suggestedTextInput-clearButton_width: 16px;
     border-radius: 50%;
     margin-left: 3px;
     border: none;
+    opacity: .8;
 
+    &:active,
     &:hover,
     &:focus {
         border: none;
         box-shadow: none;
         color: $global-color_primary;
+        opacity: 1;
     }
 }
 

--- a/library/src/scss/components/_vanillaHeader.scss
+++ b/library/src/scss/components/_vanillaHeader.scss
@@ -7,14 +7,23 @@
 $vanillaHeader-logoSpacer_width: 48px;
 
 .vanillaHeader {
-    min-height: $global-header_height;
+    min-height: $vanillaHeader_height;
+
+    .suggestedTextInput-clear.searchBar-clear {
+        &:hover,
+        &:active,
+        &:focus {
+            color: $vanillaHeader-fg;
+        }
+    }
+
 }
 
 .vanillaHeader-bar {
     display: flex;
     justify-content: flex-start;
     align-items: center;
-    min-height: $global-header_height;
+    min-height: $vanillaHeader_height;
 }
 
 .vanillaHeader-headerLogo {
@@ -39,7 +48,7 @@ $vanillaHeader-logoSpacer_width: 48px;
 }
 
 .vanillaHeader-localesToggle {
-    height: $global-header_height;
+    height: $vanillaHeader_height;
 
     &.buttonAsText {
         &:hover,

--- a/library/src/scss/components/_vanillaHeaderNav.scss
+++ b/library/src/scss/components/_vanillaHeaderNav.scss
@@ -21,7 +21,7 @@ $vanillaHeaderNav-active_bottomOffset: 2px;
 
 .vanillaHeaderNav-item {
     @include flexCenterContent;
-    height: $global-header_height;
+    height: $vanillaHeader_height;
 }
 
 .vanillaHeaderNav-link {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "lodash.debounce": "4.0.8",
         "moment": "2.22.2",
         "numeral": "2.0.6",
+        "p-debounce": "1.0.0",
         "path-to-regexp": "2.4.0",
         "prop-types": "15.6.2",
         "qs": "6.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8487,6 +8487,11 @@ osenv@0, osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-debounce@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-1.0.0.tgz#cb7f2cbeefd87a09eba861e112b67527e621e2fd"
+  integrity sha1-y38svu/YegnrqGHhErZ1J+Yh4v0=
+
 p-defer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"


### PR DESCRIPTION
Wired up compact search, using new API context to make it easier to plug in searches anywhere.


Various bugs:
- Fixed styles of clear button
- Fixed focus handling for compact search
- Added prop to conditionally trigger updates on any changes in searchBar
- Debouced search (This required bringing an additional debounce function besides lodash/debounce so that it would work with async functions).