### PR TITLE
Fix generating NavLink in SmartLink when search string present

### DIFF
--- a/library/src/scripts/components/navigation/SmartLink.test.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.test.tsx
@@ -56,7 +56,7 @@ describe("<SmartLink />", () => {
             expect(result.find(Link).length).eq(0);
         });
     });
-    it("uses relative URLs navigation links within its context", () => {
+    it("uses relative URLs and react links within its context", () => {
         const valid: [LocationDescriptor, string][] = [
             [CONTEXT_BASE + "/somePath", SUBPATH + "/somePath"],
             [

--- a/library/src/scripts/components/navigation/SmartLink.test.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @author Adam (charrondev) Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { expect } from "chai";
+import { mount } from "enzyme";
+import SmartLink, { LinkContext } from "./SmartLink";
+import { LocationDescriptor } from "history";
+import { MemoryRouter, Route } from "react-router";
+import { Link } from "react-router-dom";
+
+const DOMAIN = "https://mysite.com";
+const SUBPATH = "/test";
+const CONTEXT_BASE = DOMAIN + SUBPATH;
+
+function renderLocation(loc: LocationDescriptor, formatter: any) {
+    return mount(
+        <div>
+            <LinkContext.Provider value={CONTEXT_BASE}>
+                <MemoryRouter>
+                    <Route>
+                        <SmartLink urlFormatter={formatter} to={loc} />
+                    </Route>
+                </MemoryRouter>
+            </LinkContext.Provider>
+        </div>,
+    );
+}
+
+describe("<SmartLink />", () => {
+    const urlFormatter = (url: string, withDomain: boolean) => url;
+
+    const passthroughs: [LocationDescriptor, string][] = [
+        ["https://test.com", "https://test.com"],
+        ["https://myforum.com/somePath", "https://myforum.com/somePath"],
+        ["http://test.com", "http://test.com"],
+        [DOMAIN + "/someOther", DOMAIN + "/someOther"],
+        [
+            {
+                pathname: "/somePathName",
+                search: "?someSearch=true",
+            },
+            "/somePathName?someSearch=true",
+        ],
+        ["//test.com", "//test.com"],
+        ["/test/relative/path", "/test/relative/path"],
+    ];
+
+    it("renders links on different domains as plain normal browser links.", () => {
+        passthroughs.forEach(([loc, expectedHref]) => {
+            const result = renderLocation(loc, urlFormatter);
+            expect(result.find("a").prop("href"), `Input was ${loc}`).eq(expectedHref);
+            expect(result.find(Link).length).eq(0);
+        });
+    });
+    it("uses relative URLs navigation links within its context", () => {
+        const valid: [LocationDescriptor, string][] = [
+            [CONTEXT_BASE + "/somePath", SUBPATH + "/somePath"],
+            [
+                CONTEXT_BASE + "/someOtherPath?withQuery=true&OtherQuery=false",
+                SUBPATH + "/someOtherPath?withQuery=true&OtherQuery=false",
+            ],
+            [
+                {
+                    pathname: CONTEXT_BASE + "/nested/deeper",
+                    search: "?someQuery=true",
+                },
+                SUBPATH + "/nested/deeper?someQuery=true",
+            ],
+        ];
+
+        valid.forEach(([loc, expectedHref]) => {
+            const result = renderLocation(loc, urlFormatter);
+            expect(result.find("a").prop("href"), `Input was ${loc}`).eq(expectedHref);
+            expect(result.find(Link).length).eq(1);
+        });
+    });
+
+    it("uses the urlFormatter passed to parse urls, even if they are not directly in the subpath", () => {
+        const FORCED_RESULT = "https://directFormatterResult.com";
+        const forcedFormatter = (input, withDomain) => FORCED_RESULT;
+
+        const data = [CONTEXT_BASE + "/test", SUBPATH + "/testOther"];
+        data.forEach(loc => {
+            const result = renderLocation(loc, forcedFormatter);
+            const FORCED_RESULT = "https://directFormatterResult.com";
+            expect(result.find("a").prop("href"), `Input was ${loc}`).eq(FORCED_RESULT);
+        });
+    });
+});

--- a/library/src/scripts/components/navigation/SmartLink.test.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.test.tsx
@@ -33,7 +33,7 @@ function renderLocation(loc: LocationDescriptor, formatter: any) {
 describe("<SmartLink />", () => {
     const urlFormatter = (url: string, withDomain: boolean) => url;
 
-    const passthroughs: [LocationDescriptor, string][] = [
+    const passthroughs: Array<[LocationDescriptor, string]> = [
         ["https://test.com", "https://test.com"],
         ["https://myforum.com/somePath", "https://myforum.com/somePath"],
         ["http://test.com", "http://test.com"],
@@ -57,7 +57,7 @@ describe("<SmartLink />", () => {
         });
     });
     it("uses relative URLs and react links within its context", () => {
-        const valid: [LocationDescriptor, string][] = [
+        const valid: Array<[LocationDescriptor, string]> = [
             [CONTEXT_BASE + "/somePath", SUBPATH + "/somePath"],
             [
                 CONTEXT_BASE + "/someOtherPath?withQuery=true&OtherQuery=false",
@@ -86,7 +86,6 @@ describe("<SmartLink />", () => {
         const data = [CONTEXT_BASE + "/test", SUBPATH + "/testOther"];
         data.forEach(loc => {
             const result = renderLocation(loc, forcedFormatter);
-            const FORCED_RESULT = "https://directFormatterResult.com";
             expect(result.find("a").prop("href"), `Input was ${loc}`).eq(FORCED_RESULT);
         });
     });

--- a/library/src/scripts/components/navigation/SmartLink.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.tsx
@@ -36,16 +36,21 @@ export default function SmartLink(props: IProps) {
 
                 if (href.startsWith(contextRoot)) {
                     let newTo: LocationDescriptor;
-                    const newPath = props.to.toString().replace(window.location.origin, "");
+                    const relativeUrl = props.to.toString().replace(window.location.origin, "");
+                    const link = document.createElement("a");
+                    link.href = relativeUrl;
+                    const { search, pathname } = link;
 
                     if (typeof props.to === "string") {
                         newTo = {
-                            pathname: newPath,
+                            pathname,
+                            search,
                         };
                     } else {
                         newTo = {
                             ...props.to,
-                            pathname: newPath,
+                            pathname,
+                            search,
                         };
                     }
 

--- a/library/src/scripts/components/navigation/SmartLink.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.tsx
@@ -40,7 +40,7 @@ export default function SmartLink(props: IProps) {
         <LinkContext.Consumer>
             {contextRoot => {
                 if (href.startsWith(contextRoot)) {
-                    return <NavLink {...passthru} to={makeSmartLocation(props.to, href)} />;
+                    return <NavLink {...passthru} to={makeDynamicHref(props.to, href)} />;
                 } else {
                     return <a {...passthru} href={href} />;
                 }
@@ -49,7 +49,15 @@ export default function SmartLink(props: IProps) {
     );
 }
 
-function makeSmartLocation(initial: LocationDescriptor, newHref: string): LocationDescriptor {
+/**
+ * Create a new LocationDescriptor with a "relative" path.
+ *
+ * This way we ensure we use react-router's navigation and not a full refresh.
+ *
+ * @param initial The starting location. We may want to preserve state here if we can.
+ * @param newHref The new string url to point to.
+ */
+function makeDynamicHref(initial: LocationDescriptor, newHref: string): LocationDescriptor {
     // Get the search and pathName
     const link = document.createElement("a");
     link.href = newHref;


### PR DESCRIPTION
The `SmartLink` component generates a child `NavLink` component by massaging an incoming URL. However, if the incoming URL contains a search/query string, it can be passed through as the `pathname` property. This can adversely affect routing in the application. The search/query string should be separated and passed through as the `search` property. This update performs that separation when using the `SmartLink` component.