### PR TITLE
Update Travis build to use Docker-enabled virtual machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,3 @@ notifications:
       - secure: "SsKmSAZFynBz4ZKm5NPyuXvNjIMyxpNMXsgfXVImG8xjQHdXjEpZAiyckK8E2lXBBypv59Oex6wsS0RvyxpI/mwQ9dTQ9ayurQxwH3V5Q/+pRbtXJOkP+DSIsHhRb9D4xa5nPbh4N48+QZvUFiH2ety9/gev4mtMkLv3lC0vgpc="
     template:
       - '%{repository_slug} build <a href="%{build_url}">#%{build_number}</a> (%{branch} - <a href="%{compare_url}">%{commit}</a> by %{author}): %{message}'
-
-# Run build in a Docker container. Reduces time between commit and start of build.
-sudo: false


### PR DESCRIPTION
This PR removes `sudo: false` from the config. `sudo: false` enables travis's container based configuration. This is being sunsetted this year in favour of their docker based infrastructure (default).

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

I'm pre-emptively updating this in accordance with the information there.

Also the comment there: "# Run build in a Docker container.  Reduces time between commit and start of build." Is backwards.