### PR TITLE
Categories - Opt out of caching when recalculating discussion totals

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -1345,7 +1345,8 @@ class CategoryModel extends Gdn_Model {
         self::updateLastPost($discussion);
 
         // Update the aggregate discussion count for this category and all its parents.
-        self::incrementAggregateCount($categoryID, self::AGGREGATE_DISCUSSION);
+        self::incrementAggregateCount($categoryID, self::AGGREGATE_DISCUSSION, 1, false);
+        CategoryModel::clearCache();
 
         // Set the new LastCategoryID.
         self::setAsLastCategory($categoryID);
@@ -1408,7 +1409,8 @@ class CategoryModel extends Gdn_Model {
         self::updateLastPost($discussion, $comment);
 
         // Update the aggregate comment count for this category and all its parents.
-        self::incrementAggregateCount($categoryID, self::AGGREGATE_COMMENT);
+        self::incrementAggregateCount($categoryID, self::AGGREGATE_COMMENT, 1, false);
+        CategoryModel::clearCache();
 
         // Set the new LastCategoryID.
         self::setAsLastCategory($categoryID);


### PR DESCRIPTION
After discussion with @alex-mtl, we came up with this patch to opt out of recalculating the record totals when a comment or discussion are made.  There were attempts to improve caching functionality made with pr #7843, but it was never merged.   So based on the complexity of how category caching works in Vanilla, this patch was made as a bandaid until a better solution comes up.

Addresses #8058
