### PR TITLE
Add notifications API v2 resource

### DIFF
--- a/applications/dashboard/controllers/api/NotificationsApiController.php
+++ b/applications/dashboard/controllers/api/NotificationsApiController.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Dashboard\Api;
+
+use AbstractApiController;
+use ActivityModel;
+use Garden\Schema\Schema;
+use Garden\Web\Data;
+use Garden\Web\Exception\ClientException;
+use Garden\Web\Exception\NotFoundException;
+use Vanilla\ApiUtils;
+
+/**
+ * Manage notifications for the current user.
+ */
+class NotificationsApiController extends AbstractApiController {
+
+    /** Default limit on number of rows allowed in a page of a paginated response. */
+    const PAGE_SIZE_DEFAULT = 30;
+
+    /** @var ActivityModel */
+    private $activityModel;
+
+    /**
+     * NotificationsApiController constructor.
+     *
+     * @param ActivityModel $activityModel
+     */
+    public function __construct(ActivityModel $activityModel) {
+        $this->activityModel = $activityModel;
+    }
+
+    /**
+     * Get a single notification.
+     *
+     * @param int $id
+     * @return array
+     * @throws \Garden\Schema\ValidationException If the request fails validation.
+     * @throws \Garden\Schema\ValidationException If the response fails validation.
+     * @throws \Garden\Web\Exception\HttpException If the user has a permission-based ban in their session.
+     * @throws \Vanilla\Exception\PermissionException If the user does not have permission to access the notification.
+     */
+    public function get(int $id): array {
+        $this->permission("Garden.SignIn.Allow");
+
+        $this->idParamSchema()->setDescription("Get a single notification.");
+        $out = $this->schema($this->notificationSchema(), "out");
+
+        $row = $this->notificationByID($id);
+        $this->notificationPermission($row);
+        $row = $this->normalizeOutput($row);
+
+        $result = $out->validate($row);
+        return $result;
+    }
+
+    /**
+     * Get an notification ID schema. Useful for documenting ID parameters in the URL path.
+     *
+     * @return Schema
+     */
+    private function idParamSchema() {
+        static $schema;
+
+        if ($schema === null) {
+            $schema = $this->schema([
+                "id" => "The notification ID."
+            ], "in");
+        }
+
+        return $schema;
+    }
+
+    /**
+     * List notifications for the current user.
+     *
+     * @param array $query
+     * @return array
+     * @throws \Garden\Schema\ValidationException If the request fails validation.
+     * @throws \Garden\Schema\ValidationException If the response fails validation.
+     * @throws \Garden\Web\Exception\HttpException If the user has a permission-based ban in their session.
+     * @throws \Vanilla\Exception\PermissionException If the user does not have permission to access notifications.
+     * @throws \Exception If unable to parse pagination input.
+     */
+    public function index(array $query): array {
+        $this->permission("Garden.SignIn.Allow");
+
+        $in = $this->schema([
+            "page" => [
+                "description" => "Page number. See [Pagination](https://docs.vanillaforums.com/apiv2/#pagination).",
+                "default" => 1,
+                "minimum" => 1,
+            ],
+        ], "in")->setDescription("List notifications for the current user.");
+        $out = $this->schema([
+            ":a" => $this->notificationSchema()
+        ], "out");
+
+        $query = $in->validate($query);
+        list($offset, $limit) = offsetLimit("p".$query["page"], self::PAGE_SIZE_DEFAULT);
+
+        $rows = $this->activityModel->getWhere([
+            "NotifyUserID" => $this->getSession()->UserID
+        ], "", "", $limit, $offset)->resultArray();
+        foreach ($rows as &$row) {
+            $row = $this->normalizeOutput($row);
+        }
+
+        $result = $out->validate($rows);
+        return $result;
+    }
+
+    /**
+     * Normalize a database record to match the API schema definition.
+     *
+     * @param array $row
+     * @return array
+     */
+    private function normalizeOutput(array $row): array {
+        $row["notificationID"] = $row["ActivityID"];
+        $row["photoUrl"] = $row["Photo"];
+        $row["read"] = $row["Notified"] === ActivityModel::SENT_OK;
+
+        $body = formatString($row["Headline"], $row);
+        // Replace anchors with bold text until notifications can be spun off from activities.
+        $row["body"] = preg_replace("#<a [^>]+>(.+)</a>#Ui", "<strong>$1</strong>", $body);
+
+        $row = ApiUtils::convertOutputKeys($row);
+        return $row;
+    }
+
+    /**
+     * Get a single notification by its activity ID.
+     *
+     * @param int $id
+     * @return array
+     * @throws NotFoundException If the notification could not be found.
+     */
+    private function notificationByID(int $id): array {
+        $notification = $this->activityModel->getWhere([
+            "ActivityID" => $id,
+            "NotifyUserID >" => 0,
+        ])->firstRow(DATASET_TYPE_ARRAY);
+        if (empty($notification)) {
+            throw new NotFoundException("Notification");
+        }
+        return $notification;
+    }
+
+    /**
+     * Verify the current user has permission to access a notification.
+     *
+     * @param array $notification
+     * @throws ClientException If the user is attempting to access a notification that is not their own.
+     */
+    private function notificationPermission(array $notification) {
+        if ($notification["NotifyUserID"] !== $this->getSession()->UserID) {
+            throw new ClientException("You do not have access to the notification(s).", 403);
+        }
+    }
+
+    /**
+     * Get a schema representing all available notification fields.
+     *
+     * @return Schema
+     */
+    private function notificationSchema(): Schema {
+        static $schema;
+
+        if ($schema === null) {
+            $schema = $this->schema([
+                "notificationID" => [
+                    "description" => "A unique ID to identify the notification.",
+                    "type" => "integer",
+                ],
+                "body" => [
+                    "description" => "The notification text. This contains some HTML, but only <b> tags.",
+                    "type" => "string",
+                ],
+                "photoUrl" => [
+                    "allowNull" => true,
+                    "description" => "An avatar or thumbnail associated with the notification.",
+                    "type" => "string",
+                ],
+                "url" => [
+                    "description" => "The target of the notification.",
+                    "type" => "string",
+                ],
+                "dateInserted" => [
+                    "description" => "When the notification was first made.",
+                    "type" => "datetime",
+                ],
+                "dateUpdated" => [
+                    // phpcs:ignore
+                    "description" => "When the notification was last updated.\n\nNotifications on the same record will group together into a single notification, updating just the dateUpdated property.",
+                    "type" => "datetime",
+                ],
+                "read" => [
+                    "description" => "Whether or not the notification has been seen.",
+                    "type" => "boolean",
+                ],
+            ], "NotificationSchema");
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Update a notification.
+     *
+     * @param int $id
+     * @param array $body
+     * @return array
+     * @throws \Garden\Schema\ValidationException If the request fails validation.
+     * @throws \Garden\Schema\ValidationException If the response fails validation.
+     * @throws \Garden\Web\Exception\HttpException If the user has a permission-based ban in their session.
+     * @throws \Vanilla\Exception\PermissionException If the user does not have permission to access the notification.
+     */
+    public function patch(int $id, array $body): array {
+        $this->permission("Garden.SignIn.Allow");
+
+        $this->idParamSchema();
+        $in = $this->schema(Schema::parse([
+            "read?" => [
+                "description" => "Mark the notification read/unread.",
+                "enum" => [true]
+            ]
+        ])->add($this->notificationSchema()), "in")->setDescription("Update a notification.");
+        $out = $this->schema($this->notificationSchema(), "out");
+
+        $body = $in->validate($body);
+
+        $row = $this->notificationByID($id);
+        $this->notificationPermission($row);
+
+        if (array_key_exists("read", $body)) {
+            $this->activityModel->markSingleRead($id);
+        }
+
+        $row = $this->notificationByID($id);
+        $row = $this->normalizeOutput($row);
+        $result = $out->validate($row);
+        return $result;
+    }
+
+    /**
+     * Update all notifications.
+     *
+     * @param array $body
+     * @return Data
+     * @throws \Garden\Schema\ValidationException If the request fails validation.
+     * @throws \Garden\Schema\ValidationException If the response fails validation.
+     * @throws \Garden\Web\Exception\HttpException If the user has a permission-based ban in their session.
+     * @throws \Vanilla\Exception\PermissionException If the user does not have permission to access notifications.
+     */
+    public function patch_index(array $body): Data {
+        $this->permission("Garden.SignIn.Allow");
+
+        $in = $this->schema(Schema::parse([
+            "read?" => [
+                "description" => "Mark the notification read/unread.",
+                "enum" => [true]
+            ]
+        ])->add($this->notificationSchema()), "in")->setDescription("Update all notifications.");
+        $out = $this->schema([], "out");
+
+        $body = $in->validate($body);
+
+        if (array_key_exists("read", $body)) {
+            $this->activityModel->markRead($this->getSession()->UserID);
+        }
+
+        return new Data(null, ["status" => 204]);
+    }
+}

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1621,6 +1621,19 @@ class ActivityModel extends Gdn_Model {
     }
 
     /**
+     * Update a single activity's notification fields to reflect a read status.
+     *
+     * @param int $activityID
+     */
+    public function markSingleRead(int $activityID) {
+        $this->SQL->put(
+            "Activity",
+            ["Notified" => self::SENT_OK, "Emailed" => self::SENT_OK],
+            ["ActivityID" => $activityID]
+        );
+    }
+
+    /**
      *
      *
      * @param $userID

--- a/library/Garden/Web/ResourceRoute.php
+++ b/library/Garden/Web/ResourceRoute.php
@@ -405,6 +405,12 @@ class ResourceRoute extends Route {
 
         if ($method === 'get') {
             $result[] = ['index', null];
+        } elseif ($method === "patch" && empty($pathArgs)) {
+            /**
+             * Kludge to allow patch requests to a resource's index. Necessary because current dispatching cannot
+             * differentiate between an index or resource-specific reqeust by the method name, only its parameters.
+             */
+            $result[] = ['patch_index', null];
         } elseif ($method === 'post' && !empty($pathArgs)) {
             // This is a bit of a kludge to allow POST to be used against the usual PATCH method to allow for
             // multipart/form-data on PATCH (edit) endpoints.

--- a/tests/APIv2/NotificationsApiTest.php
+++ b/tests/APIv2/NotificationsApiTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\APIv2;
+
+use ActivityModel;
+
+/**
+ * Verify functionality of the notifications API v2 resource.
+ */
+class NotificationsApiTest extends AbstractAPIv2Test {
+
+    /** @var int Debug activity type. */
+    const ACTIVITY_TYPE_ID = 10;
+
+    /** @var ActivityModel */
+    private $activityModel;
+
+    /**
+     * Add a notification for the current user.
+     *
+     * @return int Activity ID of the new notification.
+     */
+    private function addNotification(): int {
+        $result = $this->activityModel->insert([
+            "ActivityTypeID" => self::ACTIVITY_TYPE_ID,
+            "DateInserted" => date("Y-m-d H:i:s", now()),
+            "DateUpdated" => date("Y-m-d H:i:s", now()),
+            "Emailed" => ActivityModel::SENT_PENDING,
+            "NotifyUserID" => $this->api()->getUserID(),
+            "Notified" => ActivityModel::SENT_PENDING,
+        ]);
+        return $result;
+    }
+
+    /**
+     * This method is called before a test is executed.
+     * @throws \Garden\Container\ContainerException If an error was encountered while retrieving an entry from the container.
+     * @throws \Garden\Container\NotFoundException If unable to find an entry in the container.
+     */
+    public function setUp() {
+        parent::setUp();
+        $this->activityModel = $this->container()->get(ActivityModel::class);
+    }
+
+    /**
+     * Test GET /notifications/<id>.
+     */
+    public function testGet() {
+        $id = $this->addNotification();
+
+        $response = $this->api()->get("/notifications/{$id}");
+        $this->assertEquals($response->getStatusCode(), 200);
+
+        $notification = $response->getBody();
+        $this->assertEquals($id, $notification["notificationID"]);
+    }
+
+    /**
+     * Test GET /notifications.
+     */
+    public function testGetIndex() {
+        $originalIndex = $this->api()->get("/notifications");
+        $this->assertEquals(200, $originalIndex->getStatusCode());
+
+        for ($i = 1; $i <= 10; $i++) {
+            $notificationIDs[] = $this->addNotification();
+        }
+
+        $newIndex = $this->api()->get("/notifications");
+
+        $originalRows = $originalIndex->getBody();
+        $newRows = $newIndex->getBody();
+        $this->assertEquals(count($originalRows) + count($notificationIDs), count($newRows));
+        // The index should be a proper indexed array.
+        for ($i = 0; $i < count($newRows); $i++) {
+            $this->assertArrayHasKey($i, $newRows);
+        }
+
+        $this->pagingTest("/notifications");
+    }
+
+    /**
+     * Test PATCH /notifications.
+     */
+    public function testPatchIndex() {
+        $this->assertTrue(true);
+    }
+
+    /**
+     * Test PATCH /notifications/<id>.
+     */
+    public function testPatch() {
+        $id = $this->addNotification();
+
+        $getResponse = $this->api()->get("/notifications/{$id}");
+        $this->assertEquals($getResponse->getStatusCode(), 200);
+
+        // Verify the new notification is unread.
+        $notification = $getResponse->getBody();
+        $this->assertEquals($id, $notification["notificationID"]);
+        $this->assertEquals(false, $notification["read"]);
+
+        // Flag the notification as read.
+        $patchResponse = $this->api()->patch("/notifications/{$id}", ["read" => true]);
+        $this->assertEquals($patchResponse->getStatusCode(), 200);
+
+        // Get the updated notification.
+        $updatedGetResponse = $this->api()->get("/notifications/{$id}");
+        $this->assertEquals($updatedGetResponse->getStatusCode(), 200);
+
+        // Verify it's flagged as read.
+        $updatedNotification = $updatedGetResponse->getBody();
+        $this->assertEquals($id, $updatedNotification["notificationID"]);
+        $this->assertEquals(true, $updatedNotification["read"]);
+    }
+}

--- a/tests/APIv2/NotificationsApiTest.php
+++ b/tests/APIv2/NotificationsApiTest.php
@@ -38,6 +38,7 @@ class NotificationsApiTest extends AbstractAPIv2Test {
 
     /**
      * This method is called before a test is executed.
+     *
      * @throws \Garden\Container\ContainerException If an error was encountered while retrieving an entry from the container.
      * @throws \Garden\Container\NotFoundException If unable to find an entry in the container.
      */


### PR DESCRIPTION
This update introduces the notifications API v2 resource and *mostly* adheres to [the original spec](https://github.com/vanilla/roadmap/blob/master/api/notifications.md). I believe the only significant deviation was the introduction of a "limit" parameter on the index endpoint. This was due for consistency with pagination across other endpoints.

There will likely be additions or modifications to this resource as it is developed against, but I want to get the spec-complete state merged in.

### Incoming Kludge
Vanilla's magic API routing doesn't efficiently handle differentiating between patching a specific resource row and patching "all" resource rows (e.g. "index"). This is due to both being dispatched to a controller's `patch` method and the determination of whether or not "index" or "row" is based off whether or not the `$id` parameter is in the method's signature. Since can't overload methods in PHP, and we're not prepared to deep-dive into refactoring routing at this moment, I've kludged it and commented on the kludge.

Closes #6040 