### PR TITLE
Extend Quill ExternaBlot to have url as content 

### DIFF
--- a/library/Vanilla/Formatting/Quill/BlotGroup.php
+++ b/library/Vanilla/Formatting/Quill/BlotGroup.php
@@ -13,6 +13,7 @@ use Vanilla\Formatting\Quill\Blots\CodeLineBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\CodeLineTerminatorBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\HeadingTerminatorBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\ParagraphLineTerminatorBlot;
+use Vanilla\Formatting\Quill\Blots\NullBlot;
 use Vanilla\Formatting\Quill\Blots\TextBlot;
 
 /**
@@ -285,6 +286,8 @@ class BlotGroup {
         $text = "";
         foreach ($this->blots as $blot) {
             if ($blot instanceof TextBlot) {
+                $text .= $blot->getContent();
+            } elseif ($blot instanceof NullBlot) {
                 $text .= $blot->getContent();
             }
         }

--- a/library/Vanilla/Formatting/Quill/BlotGroup.php
+++ b/library/Vanilla/Formatting/Quill/BlotGroup.php
@@ -8,12 +8,12 @@
 namespace Vanilla\Formatting\Quill;
 
 use Vanilla\Formatting\Quill\Blots\AbstractBlot;
+use Vanilla\Formatting\Quill\Blots\Embeds\ExternalBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\AbstractLineTerminatorBlot;
 use Vanilla\Formatting\Quill\Blots\CodeLineBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\CodeLineTerminatorBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\HeadingTerminatorBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\ParagraphLineTerminatorBlot;
-use Vanilla\Formatting\Quill\Blots\NullBlot;
 use Vanilla\Formatting\Quill\Blots\TextBlot;
 
 /**
@@ -285,9 +285,8 @@ class BlotGroup {
     public function getUnsafeText(): string {
         $text = "";
         foreach ($this->blots as $blot) {
-            if ($blot instanceof TextBlot) {
-                $text .= $blot->getContent();
-            } elseif ($blot instanceof NullBlot) {
+            if ($blot instanceof TextBlot
+                || $blot instanceof ExternalBlot) {
                 $text .= $blot->getContent();
             }
         }

--- a/library/Vanilla/Formatting/Quill/Blots/Embeds/ExternalBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Embeds/ExternalBlot.php
@@ -38,7 +38,10 @@ class ExternalBlot extends AbstractBlot {
         string $parseMode = Parser::PARSE_MODE_NORMAL
     ) {
         parent::__construct($currentOperation, $previousOperation, $nextOperation, $parseMode);
-
+        $this->content = $this->currentOperation["insert"]["embed-external"]['data']['url'] ?? '';
+        if ($this->content !== '') {
+            $this->content .= "\n";
+        }
         /** @var EmbedManager embedManager */
         $this->embedManager = Gdn::getContainer()->get(EmbedManager::class);
     }

--- a/library/Vanilla/Formatting/Quill/Blots/NullBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/NullBlot.php
@@ -39,10 +39,6 @@ class NullBlot extends AbstractBlot {
         return $this->content;
     }
 
-    public function getContent(): string {
-        return empty($this->content) ? $this->currentOperation["insert"]["embed-external"]["data"]["url"] ?? "" : $this->content;
-    }
-
     /**
      * A null blot should not have any affect on anything around it.
      * @inheritDoc

--- a/library/Vanilla/Formatting/Quill/Blots/NullBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/NullBlot.php
@@ -39,6 +39,10 @@ class NullBlot extends AbstractBlot {
         return $this->content;
     }
 
+    public function getContent(): string {
+        return empty($this->content) ? $this->currentOperation["insert"]["embed-external"]["data"]["url"] ?? "" : $this->content;
+    }
+
     /**
      * A null blot should not have any affect on anything around it.
      * @inheritDoc


### PR DESCRIPTION
Related to: https://github.com/vanilla/knowledge/issues/334

- extend ExternalBlot to have private $content with data->url  

- let BlotGroup to getContent() from ExternalBlots as well as from TextBlots