### PR TITLE
Allow resource routes to specify a root controller

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -147,7 +147,6 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->rule(\Garden\Web\Dispatcher::class)
     ->setShared(true)
     ->addCall('addRoute', ['route' => new Reference('@api-v2-route'), 'api-v2'])
-    ->addCall('addRoute', ['route' => new Reference("@page-route"), 'page-route'])
     ->addCall('addRoute', ['route' => new \Garden\Container\Callback(function () {
         return new \Garden\Web\PreflightRoute('/api/v2', true);
     })])
@@ -180,11 +179,6 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->rule('@view-application/json')
     ->setClass(\Vanilla\Web\JsonView::class)
     ->setShared(true)
-
-    ->rule('@page-route')
-    ->setClass(\Garden\Web\ResourceRoute::class)
-    ->setConstructorArgs(['/', '*\\%sPageController'])
-    ->addCall('setMeta', ['CONTENT_TYPE', 'text/html; charset=utf-8'])
 
     ->rule(\Garden\ClassLocator::class)
     ->setClass(\Vanilla\VanillaClassLocator::class)

--- a/library/Garden/Web/ResourceRoute.php
+++ b/library/Garden/Web/ResourceRoute.php
@@ -36,6 +36,11 @@ class ResourceRoute extends Route {
     private $controllerPattern;
 
     /**
+     * @var string
+     */
+    private $rootController;
+
+    /**
      * @var ContainerInterface
      */
     private $container;
@@ -80,6 +85,8 @@ class ResourceRoute extends Route {
         // First check and strip the base path.
         if (stripos($path, $this->basePath) === 0) {
             $pathPart = substr($path, strlen($this->basePath));
+        } elseif ($this->basePath === $path.'/' && !empty($this->rootController)) {
+            $pathPart = '';
         } else {
             return null;
         }
@@ -88,11 +95,22 @@ class ResourceRoute extends Route {
 
         // First look for the controller.
         $resource = array_shift($pathArgs);
-        $controllerSlug = $this->filterName($resource);
-        foreach ((array)$this->controllerPattern as $controllerPattern) {
-            $controllerClass = $this->classLocator->findClass(sprintf($controllerPattern, $controllerSlug));
-            if ($controllerClass) {
-                break;
+
+        if (empty($resource) && !empty($this->rootController)) {
+            $controllerClass = $this->rootController;
+        } else {
+            $controllerSlug = $this->filterName($resource);
+            foreach ((array)$this->controllerPattern as $controllerPattern) {
+                $controllerClass = $this->classLocator->findClass(sprintf($controllerPattern, $controllerSlug));
+                if ($controllerClass) {
+                    break;
+                }
+            }
+
+            // No specific controller was found, so try the root controller.
+            if (!isset($controllerClass) && !empty($this->rootController)) {
+                $controllerClass = $this->rootController;
+                array_unshift($pathArgs, $resource);
             }
         }
         if (!isset($controllerClass)) {
@@ -473,6 +491,27 @@ class ResourceRoute extends Route {
      */
     public function setControllerPattern($controllerPattern) {
         $this->controllerPattern = $controllerPattern;
+        return $this;
+    }
+
+    /**
+     * Get the root controller name.
+     *
+     * The root controller is called if there is no match for any controllers.
+     *
+     * @return string
+     */
+    public function getRootController(): string {
+        return $this->rootController;
+    }
+
+    /**
+     * Set the root controller name.
+     *
+     * @param string $class
+     */
+    public function setRootController(string $class) {
+        $this->rootController = $class;
         return $this;
     }
 }

--- a/tests/Library/Garden/Web/ResourceRouteTest.php
+++ b/tests/Library/Garden/Web/ResourceRouteTest.php
@@ -265,6 +265,8 @@ class ResourceRouteTest extends TestCase {
     }
 
     /**
+     * Test allowing resource routes to specify a root controller.
+     *
      * @param string $method The HTTP method of the request.
      * @param string $path The path to test.
      * @param array|null $expectedCall The expected callback signature in the form `[className, methodName]`.

--- a/tests/fixtures/src/ArticlesHelpController.php
+++ b/tests/fixtures/src/ArticlesHelpController.php
@@ -7,8 +7,18 @@
 
 namespace VanillaTests\Fixtures;
 
+/**
+ * Class ArticlesHelpController
+ *
+ * @package VanillaTests\Fixtures
+ */
 class ArticlesHelpController {
-    public function get(int $id) {
 
+    /**
+     * Dummy GET method.
+     *
+     * @param int $id
+     */
+    public function get(int $id) {
     }
 }

--- a/tests/fixtures/src/ArticlesHelpController.php
+++ b/tests/fixtures/src/ArticlesHelpController.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Fixtures;
+
+class ArticlesHelpController {
+    public function get(int $id) {
+
+    }
+}

--- a/tests/fixtures/src/RootHelpController.php
+++ b/tests/fixtures/src/RootHelpController.php
@@ -7,12 +7,24 @@
 
 namespace VanillaTests\Fixtures;
 
+/**
+ * Class RootHelpController
+ *
+ * @package VanillaTests\Fixtures
+ */
 class RootHelpController {
-    public function index() {
 
+    /**
+     * Dummy index method.
+     */
+    public function index() {
     }
 
+    /**
+     * Dummy GET method.
+     *
+     * @param string $code
+     */
     public function get(string $code) {
-
     }
 }

--- a/tests/fixtures/src/RootHelpController.php
+++ b/tests/fixtures/src/RootHelpController.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace VanillaTests\Fixtures;
+
+class RootHelpController {
+    public function index() {
+
+    }
+
+    public function get(string $code) {
+
+    }
+}


### PR DESCRIPTION
Resource routes can now specify a root controller that will be looked at after specific controllers fail, allowing the root of a path to be specifically routed to.