### PR TITLE
Add notifications to MeBox component

### DIFF
--- a/applications/dashboard/src/scripts/entries/forum.tsx
+++ b/applications/dashboard/src/scripts/entries/forum.tsx
@@ -18,12 +18,14 @@ import SignInPage from "@dashboard/pages/authenticate/SignInPage";
 import PasswordPage from "@dashboard/pages/authenticate/PasswordPage";
 import RecoverPasswordPage from "@dashboard/pages/recoverPassword/RecoverPasswordPage";
 import UsersModel from "@library/users/UsersModel";
+import NotificationsModel from "@library/notifications/NotificationsModel";
 
 initAllUserContent();
 
 // Redux
 registerReducer("authenticate", authenticateReducer);
 registerReducer("users", new UsersModel().reducer);
+registerReducer("notifications", new NotificationsModel().reducer);
 
 // Routing
 addComponent("App", Router);

--- a/library/src/scripts/@types/api/index.ts
+++ b/library/src/scripts/@types/api/index.ts
@@ -4,4 +4,5 @@
  */
 
 export * from "./core";
+export * from "./notifications";
 export * from "./users";

--- a/library/src/scripts/@types/api/notifications.ts
+++ b/library/src/scripts/@types/api/notifications.ts
@@ -3,12 +3,20 @@
  * @license GPL-2.0-only
  */
 
-export interface INotification {
+// All available notification resource API fields.
+export interface INotification extends INotificationWritable, INotificationServerManaged {}
+
+// Valid fields for a patch request.
+export interface INotificationWritable {
+    read: boolean;
+}
+
+// Fields maintained by the site.
+interface INotificationServerManaged {
     notificationID: number;
     body: string;
     photoUrl: string | null;
     url: string;
     dateInserted: string;
     dateUpdated: string;
-    read: boolean;
 }

--- a/library/src/scripts/@types/api/notifications.ts
+++ b/library/src/scripts/@types/api/notifications.ts
@@ -1,0 +1,14 @@
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+export interface INotification {
+    notificationID: number;
+    body: string;
+    photoUrl: string | null;
+    url: string;
+    dateInserted: string;
+    dateUpdated: string;
+    read: boolean;
+}

--- a/library/src/scripts/components/LinkAsButton.tsx
+++ b/library/src/scripts/components/LinkAsButton.tsx
@@ -6,9 +6,9 @@
 
 import React from "react";
 import classNames from "classnames";
-import { getOptionalID, IOptionalComponentID } from "../componentIDs";
+import { IOptionalComponentID } from "../componentIDs";
 import { ButtonBaseClass } from "./forms/Button";
-import { Link } from "react-router-dom";
+import SmartLink from "@library/components/navigation/SmartLink";
 
 interface IProps extends IOptionalComponentID {
     children: React.ReactNode;
@@ -23,14 +23,14 @@ interface IProps extends IOptionalComponentID {
  * A Link component that looks like a Button component.
  */
 export default class LinkAsButton extends React.Component<IProps> {
-    public static defaultProps = {
+    public static defaultProps: Partial<IProps> = {
         baseClass: ButtonBaseClass.STANDARD,
     };
 
     public render() {
         const componentClasses = classNames(this.props.baseClass, this.props.className);
         return (
-            <Link
+            <SmartLink
                 className={componentClasses}
                 title={this.props.title}
                 aria-label={this.props.ariaLabel || this.props.title}
@@ -38,7 +38,7 @@ export default class LinkAsButton extends React.Component<IProps> {
                 to={this.props.to}
             >
                 {this.props.children}
-            </Link>
+            </SmartLink>
         );
     }
 }

--- a/library/src/scripts/components/headers/VanillaHeader.tsx
+++ b/library/src/scripts/components/headers/VanillaHeader.tsx
@@ -52,10 +52,9 @@ export class VanillaHeader extends React.Component<IProps, IState> {
         const countClass = "vanillaHeader-count";
         const buttonClass = "vanillaHeader-button";
 
-        const notificationProps = {
-            data: dummyNotificationsData.data,
+        const notificationProps: INotificationsProps = {
+            data: [],
             userSlug: currentUser!.name,
-            count: 108,
             countClass: classNames(countClass, "vanillaHeader-notificationsCount"),
         };
 
@@ -116,7 +115,7 @@ export class VanillaHeader extends React.Component<IProps, IState> {
                                             className={classNames("vanillaHeader-meBox", {
                                                 hasFlexBasis: this.state.openSearch,
                                             })}
-                                            notificationsProps={notificationProps as INotificationsProps}
+                                            notificationsProps={notificationProps}
                                             messagesProps={messagesProps as any}
                                             counts={dummyUserDropDownData}
                                             buttonClassName="vanillaHeader-button"
@@ -126,7 +125,7 @@ export class VanillaHeader extends React.Component<IProps, IState> {
                                     {isMobile &&
                                         !this.state.openSearch && (
                                             <CompactMeBox
-                                                notificationsProps={notificationProps as INotificationsProps}
+                                                notificationsProps={notificationProps}
                                                 messagesProps={messagesProps as any}
                                                 counts={dummyUserDropDownData}
                                                 buttonClass="vanillaHeader-button"

--- a/library/src/scripts/components/headers/pieces/VanillaMobileHomeHeader.tsx
+++ b/library/src/scripts/components/headers/pieces/VanillaMobileHomeHeader.tsx
@@ -46,10 +46,9 @@ export class VanillaMobileHomeHeader extends React.Component<IProps> {
         const countClass = "vanillaHeader-count";
         const buttonClass = "vanillaHeader-button";
 
-        const notificationProps = {
-            data: dummyNotificationsData.data,
+        const notificationProps: INotificationsProps = {
+            data: [],
             userSlug: currentUser!.name,
-            count: 108,
             countClass: classNames(countClass, "vanillaHeader-notificationsCount"),
         };
 
@@ -73,7 +72,7 @@ export class VanillaMobileHomeHeader extends React.Component<IProps> {
                                 logoClassName="vanillaHeader-logo isCentred"
                             />
                             <CompactMeBox
-                                notificationsProps={notificationProps as INotificationsProps}
+                                notificationsProps={notificationProps}
                                 messagesProps={messagesProps as any}
                                 counts={dummyUserDropDownData}
                                 buttonClass="vanillaHeader-button"

--- a/library/src/scripts/components/mebox/MeBox.tsx
+++ b/library/src/scripts/components/mebox/MeBox.tsx
@@ -11,7 +11,6 @@ import MessagesDropDown from "./pieces/MessagesDropDown";
 import UserDropdown from "./pieces/UserDropdown";
 import { INotificationsProps } from "@library/components/mebox/pieces/NotificationsContents";
 import { IMessagesContentsProps } from "@library/components/mebox/pieces/MessagesContents";
-import NotificationsActions from "@library/notifications/NotificationsActions";
 
 export interface IMeBoxProps {
     className?: string;

--- a/library/src/scripts/components/mebox/MeBox.tsx
+++ b/library/src/scripts/components/mebox/MeBox.tsx
@@ -11,6 +11,7 @@ import MessagesDropDown from "./pieces/MessagesDropDown";
 import UserDropdown from "./pieces/UserDropdown";
 import { INotificationsProps } from "@library/components/mebox/pieces/NotificationsContents";
 import { IMessagesContentsProps } from "@library/components/mebox/pieces/MessagesContents";
+import NotificationsActions from "@library/notifications/NotificationsActions";
 
 export interface IMeBoxProps {
     className?: string;

--- a/library/src/scripts/components/mebox/pieces/CompactMeBox.tsx
+++ b/library/src/scripts/components/mebox/pieces/CompactMeBox.tsx
@@ -131,7 +131,7 @@ export class CompactMeBox extends React.Component<IUserDropDownProps, IState> {
                                             <NotificationsToggle
                                                 open={false}
                                                 className="compactSearch-tabButtonContent"
-                                                count={this.props.notificationsProps.count}
+                                                count={this.props.notificationsProps.data.length}
                                                 countClass={this.props.notificationsProps.countClass}
                                             />
                                         ),
@@ -139,7 +139,7 @@ export class CompactMeBox extends React.Component<IUserDropDownProps, IState> {
                                             <NotificationsToggle
                                                 open={true}
                                                 className="compactSearch-tabButtonContent"
-                                                count={this.props.notificationsProps.count}
+                                                count={this.props.notificationsProps.data.length}
                                                 countClass={this.props.notificationsProps.countClass}
                                             />
                                         ),

--- a/library/src/scripts/components/mebox/pieces/MeBoxDropDownItem.tsx
+++ b/library/src/scripts/components/mebox/pieces/MeBoxDropDownItem.tsx
@@ -6,9 +6,8 @@
 
 import * as React from "react";
 import classNames from "classnames";
-import { UserPhoto, UserPhotoSize } from "@library/components/mebox/pieces/UserPhoto";
 import { IUserFragment } from "@library/@types/api/users";
-import { userWarning } from "@library/components/icons/header";
+import { noUserPhoto } from "@library/components/icons/header";
 import FlexSpacer from "@library/components/FlexSpacer";
 import { t } from "@library/application";
 import Translate from "@library/components/translation/Translate";
@@ -22,23 +21,21 @@ export enum MeBoxItemType {
 
 // Common to both notifications and messages dropdowns
 interface IMeBoxItem {
-    unread?: boolean;
-    timestamp: string;
-    to: string;
     className?: string;
     message: string;
+    photo?: string;
+    recordID: number;
+    timestamp: string;
+    to: string;
+    unread?: boolean;
 }
 
 export interface IMeBoxMessageItem extends IMeBoxItem {
     authors: IUserFragment[];
-    featuredUser: IUserFragment;
-    count: number;
     type: MeBoxItemType.MESSAGE;
 }
 
 export interface IMeBoxNotificationItem extends IMeBoxItem {
-    featuredUser: IUserFragment; // Whom is the message about?
-    warning?: boolean;
     type: MeBoxItemType.NOTIFICATION;
 }
 
@@ -49,21 +46,14 @@ type IProps = IMeBoxMessageItem | IMeBoxNotificationItem;
  */
 export default class MeBoxDropDownItem extends React.Component<IProps> {
     public render() {
-        const { unread, message, timestamp, to, featuredUser } = this.props;
+        const { unread, message, timestamp, to } = this.props;
 
-        let warning: boolean;
         let count: number;
         let subject: string;
         let authors: JSX.Element[];
 
-        if (this.props.type === MeBoxItemType.NOTIFICATION) {
-            // Notification
-            warning = !!this.props.warning;
-            subject = warning ? t("You've") : this.props.featuredUser.name;
-        } else {
+        if (this.props.type === MeBoxItemType.MESSAGE) {
             // Message
-            warning = false;
-            count = this.props.count;
             const authorCount = this.props.authors.length;
             if ("authors" in this.props && authorCount > 0) {
                 authors = this.props.authors!.map((user, index) => {
@@ -77,16 +67,10 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
             }
         }
 
-        const image = warning ? (
-            userWarning(`meBoxMessage-photo ${UserPhotoSize.MEDIUM} userPhoto`)
-        ) : (
-            <UserPhoto size={UserPhotoSize.MEDIUM} className="meBoxMessage-photo" userInfo={featuredUser!} />
-        );
-
         return (
             <li className={classNames("meBoxMessage", this.props.className)}>
                 <SmartLink to={to} className="meBoxMessage-link" tabIndex={0}>
-                    <div className="meBoxMessage-image">{image}</div>
+                    <div className="meBoxMessage-image">{noUserPhoto()}</div>
                     <div className="meBoxMessage-contents">
                         {!!authors! && <div className="meBoxMessage-message">{authors!}</div>}
                         <div className="meBoxMessage-message">

--- a/library/src/scripts/components/mebox/pieces/MeBoxDropDownItem.tsx
+++ b/library/src/scripts/components/mebox/pieces/MeBoxDropDownItem.tsx
@@ -23,7 +23,7 @@ export enum MeBoxItemType {
 interface IMeBoxItem {
     className?: string;
     message: string;
-    photo?: string;
+    photo: string | null;
     recordID: number;
     timestamp: string;
     to: string;
@@ -48,8 +48,8 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
     public render() {
         const { unread, message, timestamp, to } = this.props;
 
-        let count: number;
-        let subject: string;
+        const count: number = 0;
+        const subject: string = "";
         let authors: JSX.Element[];
 
         if (this.props.type === MeBoxItemType.MESSAGE) {
@@ -70,22 +70,24 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
         return (
             <li className={classNames("meBoxMessage", this.props.className)}>
                 <SmartLink to={to} className="meBoxMessage-link" tabIndex={0}>
-                    <div className="meBoxMessage-image">{noUserPhoto()}</div>
+                    <div className="meBoxMessage-image">
+                        {this.props.photo ? (
+                            <img className="meBoxMessage-photo" src={this.props.photo} />
+                        ) : (
+                            noUserPhoto()
+                        )}
+                    </div>
                     <div className="meBoxMessage-contents">
                         {!!authors! && <div className="meBoxMessage-message">{authors!}</div>}
-                        <div className="meBoxMessage-message">
-                            <Translate
-                                source={message}
-                                c0={<strong className="meBoxMessage-subject">{subject!}</strong>}
-                            />
-                        </div>
-                        {(timestamp || !!count!) && (
+                        {/* Current notifications API returns HTML-formatted messages. Should be updated to return something aside from raw HTML. */}
+                        <div className="meBoxMessage-message" dangerouslySetInnerHTML={{ __html: message }} />
+                        {(timestamp || !!count) && (
                             <div className="meBoxMessage-metas metas isFlexed">
                                 <DateTime timestamp={timestamp} className="meta" />
-                                {!!count! && (
+                                {!!count && (
                                     <span className="meta">
-                                        {count! === 1 && <Translate source="<0/> message" c0={1} />}
-                                        {count! > 1 && <Translate source="<0/> messages" c0={count!} />}
+                                        {count === 1 && <Translate source="<0/> message" c0={1} />}
+                                        {count > 1 && <Translate source="<0/> messages" c0={count} />}
                                     </span>
                                 )}
                             </div>

--- a/library/src/scripts/components/mebox/pieces/MeBoxDropDownItem.tsx
+++ b/library/src/scripts/components/mebox/pieces/MeBoxDropDownItem.tsx
@@ -74,7 +74,7 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
                         {this.props.photo ? (
                             <img className="meBoxMessage-photo" src={this.props.photo} />
                         ) : (
-                            noUserPhoto()
+                            noUserPhoto("meBoxMessage-photo")
                         )}
                     </div>
                     <div className="meBoxMessage-contents">

--- a/library/src/scripts/components/mebox/pieces/MeBoxDropDownItem.tsx
+++ b/library/src/scripts/components/mebox/pieces/MeBoxDropDownItem.tsx
@@ -70,11 +70,11 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
         return (
             <li className={classNames("meBoxMessage", this.props.className)}>
                 <SmartLink to={to} className="meBoxMessage-link" tabIndex={0}>
-                    <div className="meBoxMessage-image">
+                    <div className="meBoxMessage-imageContainer">
                         {this.props.photo ? (
-                            <img className="meBoxMessage-photo" src={this.props.photo} />
+                            <img className="meBoxMessage-image" src={this.props.photo} />
                         ) : (
-                            noUserPhoto("meBoxMessage-photo")
+                            noUserPhoto("meBoxMessage-image")
                         )}
                     </div>
                     <div className="meBoxMessage-contents">

--- a/library/src/scripts/components/mebox/pieces/MeBoxDropDownItemList.tsx
+++ b/library/src/scripts/components/mebox/pieces/MeBoxDropDownItemList.tsx
@@ -33,7 +33,6 @@ export default class MeBoxDropDownItemList extends React.Component<IVanillaHeade
                             return (
                                 <MeBoxDropDownItem
                                     {...item}
-                                    type={this.props.type as any}
                                     key={`MeBoxDropDownItemList-${this.props.type}-${key}`}
                                 />
                             );

--- a/library/src/scripts/components/mebox/pieces/MeBoxDropDownItemList.tsx
+++ b/library/src/scripts/components/mebox/pieces/MeBoxDropDownItemList.tsx
@@ -31,10 +31,7 @@ export default class MeBoxDropDownItemList extends React.Component<IVanillaHeade
                     <ul className="meBoxMessageList-items">
                         {this.props.data.map((item, key) => {
                             return (
-                                <MeBoxDropDownItem
-                                    {...item}
-                                    key={`MeBoxDropDownItemList-${this.props.type}-${key}`}
-                                />
+                                <MeBoxDropDownItem {...item} key={`MeBoxDropDownItemList-${this.props.type}-${key}`} />
                             );
                         })}
                     </ul>

--- a/library/src/scripts/components/mebox/pieces/MessagesDropDown.tsx
+++ b/library/src/scripts/components/mebox/pieces/MessagesDropDown.tsx
@@ -28,12 +28,11 @@ interface IState {
 export default class MessagesDropDown extends React.Component<IProps, IState> {
     private id = uniqueIDFromPrefix("messagesDropDown");
 
-    public state = {
+    public state: IState = {
         open: false,
     };
 
     public render() {
-        const count = this.props.count ? this.props.count : 0;
         return (
             <DropDown
                 id={this.id}

--- a/library/src/scripts/components/mebox/pieces/MessagesToggle.tsx
+++ b/library/src/scripts/components/mebox/pieces/MessagesToggle.tsx
@@ -33,7 +33,9 @@ export default class MessagesToggle extends React.PureComponent<IProps> {
         return (
             <div className={classNames(this.props.className, "messagesToggle")}>
                 {messages(this.props.open)}
-                <Count className={this.props.countClass} label={t("Messages: ")} count={this.props.count} />
+                {count > 0 && (
+                    <Count className={this.props.countClass} label={t("Messages: ")} count={this.props.count} />
+                )}
             </div>
         );
     }

--- a/library/src/scripts/components/mebox/pieces/NotificationsContents.tsx
+++ b/library/src/scripts/components/mebox/pieces/NotificationsContents.tsx
@@ -5,8 +5,6 @@
  */
 
 import * as React from "react";
-import { uniqueIDFromPrefix } from "@library/componentIDs";
-import DropDown from "@library/components/dropdown/DropDown";
 import { t } from "@library/application";
 import FrameHeader from "@library/components/frame/FrameHeader";
 import FrameBody from "@library/components/frame/FrameBody";
@@ -23,7 +21,6 @@ import classNames from "classnames";
 export interface INotificationsProps {
     data: IMeBoxNotificationItem[];
     userSlug: string;
-    count?: number;
     countClass?: string;
     panelBodyClass?: string;
     markAllRead?: () => void;
@@ -39,7 +36,6 @@ interface IProps extends INotificationsProps {
  */
 export default class NotificationsContents extends React.Component<IProps> {
     public render() {
-        const count = this.props.count ? this.props.count : 0;
         return (
             <Frame className={this.props.className}>
                 <FrameHeader className="isShadowed isCompact" title={t("Notifications")}>
@@ -71,7 +67,7 @@ export default class NotificationsContents extends React.Component<IProps> {
                         {t("All Notifications")}
                     </LinkAsButton>
                     {this.props.markAllRead &&
-                        count > 0 && (
+                        this.props.data.length > 0 && (
                             <Button
                                 onClick={this.props.markAllRead}
                                 baseClass={ButtonBaseClass.TEXT}

--- a/library/src/scripts/components/mebox/pieces/NotificationsDropDown.tsx
+++ b/library/src/scripts/components/mebox/pieces/NotificationsDropDown.tsx
@@ -18,6 +18,7 @@ import apiv2 from "@library/apiv2";
 import NotificationsActions from "@library/notifications/NotificationsActions";
 import { INotificationsStoreState } from "@library/notifications/NotificationsModel";
 import get from "lodash/get";
+import { INotification } from "@library/@types/api";
 
 interface IProps extends INotificationsProps {
     className?: string;
@@ -95,7 +96,7 @@ function mapStateToProps(state: INotificationsStoreState) {
     const notificationsByID = get(state, "notifications.notificationsByID.data", false);
 
     if (notificationsByID) {
-        for (const notification of Object.values(notificationsByID)) {
+        for (const notification of Object.values(notificationsByID) as INotification[]) {
             data.push({
                 message: notification.body,
                 photo: notification.photoUrl || null,

--- a/library/src/scripts/components/mebox/pieces/NotificationsDropDown.tsx
+++ b/library/src/scripts/components/mebox/pieces/NotificationsDropDown.tsx
@@ -33,7 +33,7 @@ interface IState {
 }
 
 /**
- * Implements Messages Drop down for header
+ * Implements Notifications menu for header
  */
 export class NotificationsDropDown extends React.Component<IProps, IState> {
     private id = uniqueIDFromPrefix("notificationsDropDown");
@@ -42,6 +42,11 @@ export class NotificationsDropDown extends React.Component<IProps, IState> {
         open: false,
     };
 
+    /**
+     * Get the React component to added to the page.
+     *
+     * @returns A DropDown component, configured to display notifications.
+     */
     public render() {
         return (
             <DropDown
@@ -70,15 +75,26 @@ export class NotificationsDropDown extends React.Component<IProps, IState> {
         );
     }
 
+    /**
+     * A method to be invoked immediately after a component is inserted into the tree.
+     */
     public componentDidMount() {
         void this.props.actions.getNotifications();
     }
 
+    /**
+     * Mark all of the current user's notifications as read, then refresh the store of notifications.
+     */
     private markAllNotificationsRead = async () => {
         await this.props.actions.markAllRead();
         void this.props.actions.getNotifications();
     };
 
+    /**
+     * Assign the open (visibile) state of this component.
+     *
+     * @param open Is this menu open and visible?
+     */
     private setOpen = open => {
         this.setState({
             open,
@@ -86,18 +102,29 @@ export class NotificationsDropDown extends React.Component<IProps, IState> {
     };
 }
 
+/**
+ * Create action creators on the component, bound to a Redux dispatch function.
+ *
+ * @param dispatch Redux dispatch function.
+ */
 function mapDispatchToProps(dispatch) {
     return {
         actions: new NotificationsActions(dispatch, apiv2),
     };
 }
 
+/**
+ * Update the component state, based on changes to the Redux store.
+ *
+ * @param state Current Redux store state.
+ */
 function mapStateToProps(state: INotificationsStoreState) {
     let countUnread: number = 0;
     const data: IMeBoxNotificationItem[] = [];
     const notificationsByID = get(state, "notifications.notificationsByID.data", false);
 
     if (notificationsByID) {
+        // Tally the total unread notifications. Massage rows into something that will fit into IMeBoxNotificationItem.
         for (const notification of Object.values(notificationsByID) as INotification[]) {
             if (notification.read === false) {
                 countUnread++;
@@ -113,8 +140,8 @@ function mapStateToProps(state: INotificationsStoreState) {
             });
         }
 
-        // Notifications are indexed by ID, which means they'll be sorted by date inserted, ascending. Adjust for that.
-        const test = data.sort((itemA: IMeBoxNotificationItem, itemB: IMeBoxNotificationItem) => {
+        // Notifications are indexed by ID, which means they'll be sorted by when they were inserted, ascending. Adjust for that.
+        data.sort((itemA: IMeBoxNotificationItem, itemB: IMeBoxNotificationItem) => {
             const timeA = new Date(itemA.timestamp).getTime();
             const timeB = new Date(itemB.timestamp).getTime();
 
@@ -134,6 +161,7 @@ function mapStateToProps(state: INotificationsStoreState) {
     };
 }
 
+// Connect Redux to the React component.
 export default connect(
     mapStateToProps,
     mapDispatchToProps,

--- a/library/src/scripts/components/mebox/pieces/NotificationsDropDown.tsx
+++ b/library/src/scripts/components/mebox/pieces/NotificationsDropDown.tsx
@@ -17,6 +17,7 @@ import { IMeBoxNotificationItem, MeBoxItemType } from "@library/components/mebox
 import apiv2 from "@library/apiv2";
 import NotificationsActions from "@library/notifications/NotificationsActions";
 import { INotificationsStoreState } from "@library/notifications/NotificationsModel";
+import get from "lodash/get";
 
 interface IProps extends INotificationsProps {
     className?: string;
@@ -33,7 +34,6 @@ interface IState {
  * Implements Messages Drop down for header
  */
 export class NotificationsDropDown extends React.Component<IProps, IState> {
-
     private id = uniqueIDFromPrefix("notificationsDropDown");
 
     public state: IState = {
@@ -75,7 +75,7 @@ export class NotificationsDropDown extends React.Component<IProps, IState> {
     private markAllNotificationsRead = async () => {
         await this.props.actions.markAllRead();
         void this.props.actions.getNotifications();
-    }
+    };
 
     private setOpen = open => {
         this.setState({
@@ -92,7 +92,7 @@ function mapDispatchToProps(dispatch) {
 
 function mapStateToProps(state: INotificationsStoreState) {
     const data: IMeBoxNotificationItem[] = [];
-    const notificationsByID = state.notifications.notificationsByID.data;
+    const notificationsByID = get(state, "notifications.notificationsByID.data", false);
 
     if (notificationsByID) {
         for (const notification of Object.values(notificationsByID)) {

--- a/library/src/scripts/components/mebox/pieces/NotificationsToggle.tsx
+++ b/library/src/scripts/components/mebox/pieces/NotificationsToggle.tsx
@@ -26,11 +26,13 @@ export default class NotificationsToggle extends React.PureComponent<IProps> {
         return (
             <div className={classNames("meBox-buttonContent", this.props.className)}>
                 {notifications(!!this.props.open)}
-                <Count
-                    className={classNames("vanillaHeader-notificationsCount", this.props.countClass)}
-                    label={t("Notifications: ")}
-                    count={this.props.count}
-                />
+                {count > 0 && (
+                    <Count
+                        className={classNames("vanillaHeader-notificationsCount", this.props.countClass)}
+                        label={t("Notifications: ")}
+                        count={this.props.count}
+                    />
+                )}
             </div>
         );
     }

--- a/library/src/scripts/notifications/NotificationsActions.ts
+++ b/library/src/scripts/notifications/NotificationsActions.ts
@@ -4,6 +4,7 @@
  */
 
 import ReduxActions, { ActionsUnion } from "@library/state/ReduxActions";
+import { INotification } from "@library/@types/api";
 
 /**
  * Redux actions for the current user's notification data.
@@ -17,7 +18,7 @@ export default class NotificationsActions extends ReduxActions {
         NotificationsActions.GET_NOTIFICATION_REQUEST,
         NotificationsActions.GET_NOTIFICATION_RESPONSE,
         NotificationsActions.GET_NOTIFICATION_ERROR,
-        {},
+        {} as INotification,
         {},
     );
 
@@ -29,7 +30,7 @@ export default class NotificationsActions extends ReduxActions {
         NotificationsActions.GET_NOTIFICATIONS_REQUEST,
         NotificationsActions.GET_NOTIFICATIONS_RESPONSE,
         NotificationsActions.GET_NOTIFICATIONS_ERROR,
-        {},
+        {} as INotification[],
         {},
     );
 
@@ -41,7 +42,7 @@ export default class NotificationsActions extends ReduxActions {
         NotificationsActions.MARK_READ_REQUEST,
         NotificationsActions.MARK_READ_RESPONSE,
         NotificationsActions.MARK_READ_ERROR,
-        {},
+        {} as INotification,
         {},
     );
 

--- a/library/src/scripts/notifications/NotificationsActions.ts
+++ b/library/src/scripts/notifications/NotificationsActions.ts
@@ -4,7 +4,7 @@
  */
 
 import ReduxActions, { ActionsUnion } from "@library/state/ReduxActions";
-import { INotification } from "@library/@types/api";
+import { INotification, INotificationWritable } from "@library/@types/api";
 
 /**
  * Redux actions for the current user's notification data.
@@ -14,6 +14,9 @@ export default class NotificationsActions extends ReduxActions {
     public static readonly GET_NOTIFICATION_RESPONSE = "@@notifications/GET_NOTIFICATION_RESPONSE";
     public static readonly GET_NOTIFICATION_ERROR = "@@notifications/GET_NOTIFICATION_ERROR";
 
+    /**
+     * Action creators for getting a single notification.
+     */
     public static getNotificationACs = ReduxActions.generateApiActionCreators(
         NotificationsActions.GET_NOTIFICATION_REQUEST,
         NotificationsActions.GET_NOTIFICATION_RESPONSE,
@@ -26,6 +29,9 @@ export default class NotificationsActions extends ReduxActions {
     public static readonly GET_NOTIFICATIONS_RESPONSE = "@@notifications/GET_NOTIFICATIONS_RESPONSE";
     public static readonly GET_NOTIFICATIONS_ERROR = "@@notifications/GET_NOTIFICATIONS_ERROR";
 
+    /**
+     * Action creators for getting a paginated list of the current user's notifications.
+     */
     public static getNotificationsACs = ReduxActions.generateApiActionCreators(
         NotificationsActions.GET_NOTIFICATIONS_REQUEST,
         NotificationsActions.GET_NOTIFICATIONS_RESPONSE,
@@ -38,46 +44,71 @@ export default class NotificationsActions extends ReduxActions {
     public static readonly MARK_READ_RESPONSE = "@@notifications/MARK_READ_RESPONSE";
     public static readonly MARK_READ_ERROR = "@@notifications/MARK_READ_ERROR";
 
+    /**
+     * Action creators for marking a single notification as read.
+     */
     public static markReadACs = ReduxActions.generateApiActionCreators(
         NotificationsActions.MARK_READ_REQUEST,
         NotificationsActions.MARK_READ_RESPONSE,
         NotificationsActions.MARK_READ_ERROR,
         {} as INotification,
-        {},
+        {} as INotificationWritable,
     );
 
     public static readonly MARK_ALL_READ_REQUEST = "@@notifications/MARK_ALL_READ_REQUEST";
     public static readonly MARK_ALL_READ_RESPONSE = "@@notifications/MARK_ALL_READ_RESPONSE";
     public static readonly MARK_ALL_READ_ERROR = "@@notifications/MARK_ALL_READ_ERROR";
 
+    /**
+     * Action creators for marking all of the current user's notifications as read.
+     */
     public static markAllReadACs = ReduxActions.generateApiActionCreators(
         NotificationsActions.MARK_ALL_READ_REQUEST,
         NotificationsActions.MARK_ALL_READ_RESPONSE,
         NotificationsActions.MARK_ALL_READ_ERROR,
         {},
-        {},
+        {} as INotificationWritable,
     );
 
+    /**
+     * Union of all possible action types in this class.
+     */
     public static readonly ACTION_TYPES:
         | ActionsUnion<typeof NotificationsActions.getNotificationACs>
         | ActionsUnion<typeof NotificationsActions.getNotificationsACs>
         | ActionsUnion<typeof NotificationsActions.markReadACs>
         | ActionsUnion<typeof NotificationsActions.markAllReadACs>;
 
+    /**
+     * Get a single notification.
+     *
+     * @param id Unique ID of the notification.
+     */
     public getNotification(id: number) {
         return this.dispatchApi("get", `/notifications/${id}`, NotificationsActions.getNotificationACs, {});
     }
 
+    /**
+     * Get a paginated list of notifications for the current user.
+     */
     public getNotifications() {
         return this.dispatchApi("get", "/notifications", NotificationsActions.getNotificationsACs, {});
     }
 
+    /**
+     * Mark a single notification as read.
+     *
+     * @param id Unique ID of the notification.
+     */
     public markRead(id: number) {
         return this.dispatchApi("patch", `/notifications/${id}`, NotificationsActions.markReadACs, {
             read: true,
         });
     }
 
+    /**
+     * Mark all notifications for the current user as read.
+     */
     public markAllRead() {
         return this.dispatchApi("patch", "/notifications", NotificationsActions.markAllReadACs, {
             read: true,

--- a/library/src/scripts/notifications/NotificationsActions.ts
+++ b/library/src/scripts/notifications/NotificationsActions.ts
@@ -1,0 +1,85 @@
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import ReduxActions, { ActionsUnion } from "@library/state/ReduxActions";
+
+/**
+ * Redux actions for the current user's notification data.
+ */
+export default class NotificationsActions extends ReduxActions {
+    public static readonly GET_NOTIFICATION_REQUEST = "@@notifications/GET_NOTIFICATION_REQUEST";
+    public static readonly GET_NOTIFICATION_RESPONSE = "@@notifications/GET_NOTIFICATION_RESPONSE";
+    public static readonly GET_NOTIFICATION_ERROR = "@@notifications/GET_NOTIFICATION_ERROR";
+
+    public static getNotificationACs = ReduxActions.generateApiActionCreators(
+        NotificationsActions.GET_NOTIFICATION_REQUEST,
+        NotificationsActions.GET_NOTIFICATION_RESPONSE,
+        NotificationsActions.GET_NOTIFICATION_ERROR,
+        {},
+        {},
+    );
+
+    public static readonly GET_NOTIFICATIONS_REQUEST = "@@notifications/GET_NOTIFICATIONS_REQUEST";
+    public static readonly GET_NOTIFICATIONS_RESPONSE = "@@notifications/GET_NOTIFICATIONS_RESPONSE";
+    public static readonly GET_NOTIFICATIONS_ERROR = "@@notifications/GET_NOTIFICATIONS_ERROR";
+
+    public static getNotificationsACs = ReduxActions.generateApiActionCreators(
+        NotificationsActions.GET_NOTIFICATIONS_REQUEST,
+        NotificationsActions.GET_NOTIFICATIONS_RESPONSE,
+        NotificationsActions.GET_NOTIFICATIONS_ERROR,
+        {},
+        {},
+    );
+
+    public static readonly MARK_READ_REQUEST = "@@notifications/MARK_READ_REQUEST";
+    public static readonly MARK_READ_RESPONSE = "@@notifications/MARK_READ_RESPONSE";
+    public static readonly MARK_READ_ERROR = "@@notifications/MARK_READ_ERROR";
+
+    public static markReadACs = ReduxActions.generateApiActionCreators(
+        NotificationsActions.MARK_READ_REQUEST,
+        NotificationsActions.MARK_READ_RESPONSE,
+        NotificationsActions.MARK_READ_ERROR,
+        {},
+        {},
+    );
+
+    public static readonly MARK_ALL_READ_REQUEST = "@@notifications/MARK_ALL_READ_REQUEST";
+    public static readonly MARK_ALL_READ_RESPONSE = "@@notifications/MARK_ALL_READ_RESPONSE";
+    public static readonly MARK_ALL_READ_ERROR = "@@notifications/MARK_ALL_READ_ERROR";
+
+    public static markAllReadACs = ReduxActions.generateApiActionCreators(
+        NotificationsActions.MARK_ALL_READ_REQUEST,
+        NotificationsActions.MARK_ALL_READ_RESPONSE,
+        NotificationsActions.MARK_ALL_READ_ERROR,
+        {},
+        {},
+    );
+
+    public static readonly ACTION_TYPES:
+        | ActionsUnion<typeof NotificationsActions.getNotificationACs>
+        | ActionsUnion<typeof NotificationsActions.getNotificationsACs>
+        | ActionsUnion<typeof NotificationsActions.markReadACs>
+        | ActionsUnion<typeof NotificationsActions.markAllReadACs>;
+
+    public getNotification(id: number) {
+        return this.dispatchApi("get", `/notifications/${id}`, NotificationsActions.getNotificationACs, {});
+    }
+
+    public getNotifications() {
+        return this.dispatchApi("get", "/notifications", NotificationsActions.getNotificationsACs, {});
+    }
+
+    public markRead(id: number) {
+        return this.dispatchApi("patch", `/notifications/${id}`, NotificationsActions.markReadACs, {
+            read: true,
+        });
+    }
+
+    public markAllRead() {
+        return this.dispatchApi("patch", "/notifications", NotificationsActions.markAllReadACs, {
+            read: true,
+        });
+    }
+}

--- a/library/src/scripts/notifications/NotificationsModel.ts
+++ b/library/src/scripts/notifications/NotificationsModel.ts
@@ -5,18 +5,21 @@
 
 import ReduxReducer from "@library/state/ReduxReducer";
 import produce from "immer";
-import { ILoadable, LoadStatus } from "@library/@types/api";
+import { ILoadable, LoadStatus, INotification } from "@library/@types/api";
 import NotificationsActions from "@library/notifications/NotificationsActions";
-import { INotification } from "@library/@types/api";
 
 interface INotificationsState {
     notificationsByID: ILoadable<{ [key: number]: INotification }>;
 }
 
-export default class UsersModel implements ReduxReducer<INotificationsState> {
+export interface INotificationsStoreState {
+    notifications: INotificationsState;
+}
+
+export default class NotificationsModel implements ReduxReducer<INotificationsState> {
     public readonly initialState: INotificationsState = {
         notificationsByID: {
-            data: [],
+            data: {},
             status: LoadStatus.PENDING,
         },
     };
@@ -25,22 +28,22 @@ export default class UsersModel implements ReduxReducer<INotificationsState> {
         state: INotificationsState = this.initialState,
         action: typeof NotificationsActions.ACTION_TYPES,
     ): INotificationsState => {
-        return produce(state, draft => {
+        return produce(state, nextState => {
             switch (action.type) {
                 case NotificationsActions.GET_NOTIFICATIONS_REQUEST:
-                    draft.notificationsByID.status = LoadStatus.LOADING;
+                    nextState.notificationsByID.status = LoadStatus.LOADING;
                     break;
                 case NotificationsActions.GET_NOTIFICATIONS_RESPONSE:
-                    draft.notificationsByID.status = LoadStatus.SUCCESS;
-                    draft.notificationsByID.data = {};
+                    nextState.notificationsByID.status = LoadStatus.SUCCESS;
+                    nextState.notificationsByID.data = {};
                     const notifications = action.payload.data as INotification[];
                     notifications.forEach(notification => {
-                        draft.notificationsByID.data![notification.notificationID] = notification;
+                        nextState.notificationsByID.data![notification.notificationID] = notification;
                     });
                     break;
                 case NotificationsActions.GET_NOTIFICATIONS_ERROR:
-                    draft.notificationsByID.status = LoadStatus.ERROR;
-                    draft.notificationsByID.error = action.payload;
+                    nextState.notificationsByID.status = LoadStatus.ERROR;
+                    nextState.notificationsByID.error = action.payload;
                     break;
             }
         });

--- a/library/src/scripts/notifications/NotificationsModel.ts
+++ b/library/src/scripts/notifications/NotificationsModel.ts
@@ -1,0 +1,48 @@
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import ReduxReducer from "@library/state/ReduxReducer";
+import produce from "immer";
+import { ILoadable, LoadStatus } from "@library/@types/api";
+import NotificationsActions from "@library/notifications/NotificationsActions";
+import { INotification } from "@library/@types/api";
+
+interface INotificationsState {
+    notificationsByID: ILoadable<{ [key: number]: INotification }>;
+}
+
+export default class UsersModel implements ReduxReducer<INotificationsState> {
+    public readonly initialState: INotificationsState = {
+        notificationsByID: {
+            data: [],
+            status: LoadStatus.PENDING,
+        },
+    };
+
+    public reducer = (
+        state: INotificationsState = this.initialState,
+        action: typeof NotificationsActions.ACTION_TYPES,
+    ): INotificationsState => {
+        return produce(state, draft => {
+            switch (action.type) {
+                case NotificationsActions.GET_NOTIFICATIONS_REQUEST:
+                    draft.notificationsByID.status = LoadStatus.LOADING;
+                    break;
+                case NotificationsActions.GET_NOTIFICATIONS_RESPONSE:
+                    draft.notificationsByID.status = LoadStatus.SUCCESS;
+                    draft.notificationsByID.data = {};
+                    const notifications = action.payload.data as INotification[];
+                    notifications.forEach(notification => {
+                        draft.notificationsByID.data![notification.notificationID] = notification;
+                    });
+                    break;
+                case NotificationsActions.GET_NOTIFICATIONS_ERROR:
+                    draft.notificationsByID.status = LoadStatus.ERROR;
+                    draft.notificationsByID.error = action.payload;
+                    break;
+            }
+        });
+    };
+}

--- a/library/src/scripts/notifications/NotificationsModel.ts
+++ b/library/src/scripts/notifications/NotificationsModel.ts
@@ -16,6 +16,9 @@ export interface INotificationsStoreState {
     notifications: INotificationsState;
 }
 
+/**
+ * Manage notification state in Redux.
+ */
 export default class NotificationsModel implements ReduxReducer<INotificationsState> {
     public readonly initialState: INotificationsState = {
         notificationsByID: {
@@ -24,6 +27,12 @@ export default class NotificationsModel implements ReduxReducer<INotificationsSt
         },
     };
 
+    /**
+     * Update the notifications state, based on the dispatched action.
+     *
+     * @param state Previous state of the store.
+     * @param action Name for the type of action that was dispatched.
+     */
     public reducer = (
         state: INotificationsState = this.initialState,
         action: typeof NotificationsActions.ACTION_TYPES,

--- a/library/src/scss/components/_meBoxMessage.scss
+++ b/library/src/scss/components/_meBoxMessage.scss
@@ -36,6 +36,9 @@ $meBoxMessage-unreadDot_width: 12px;
     width: $meBoxMessage-imageWidth;
     height: $meBoxMessage-imageWidth;
     flex-basis: $meBoxMessage-imageWidth;
+    border-radius: 50%;
+    overflow: hidden;
+    border: solid mixContentBgAndFg(95%) 1px;
 }
 
 

--- a/library/src/scss/components/_meBoxMessage.scss
+++ b/library/src/scss/components/_meBoxMessage.scss
@@ -5,7 +5,7 @@
  */
 
 $meBoxMessage-padding: 8px;
-$meBoxMessage-imageWidth: 40px;
+$meBoxMessage-imageContainerWidth: 40px;
 $meBoxMessage-unreadDot_width: 12px;
 
 .meBoxMessage {
@@ -31,16 +31,19 @@ $meBoxMessage-unreadDot_width: 12px;
 }
 
 
-.meBoxMessage-image {
+.meBoxMessage-imageContainer {
     position: relative;
-    width: $meBoxMessage-imageWidth;
-    height: $meBoxMessage-imageWidth;
-    flex-basis: $meBoxMessage-imageWidth;
+    width: $meBoxMessage-imageContainerWidth;
+    height: $meBoxMessage-imageContainerWidth;
+    flex-basis: $meBoxMessage-imageContainerWidth;
     border-radius: 50%;
     overflow: hidden;
     border: solid mixContentBgAndFg(95%) 1px;
 }
 
+.meBoxMessage-image {
+    @include objectFitWithFallback;
+}
 
 .meBoxMessage-status {
     position: relative;
@@ -64,7 +67,7 @@ $meBoxMessage-unreadDot_width: 12px;
         left: $meBoxMessage-padding;
         right: $meBoxMessage-padding;
     }
-    max-width: calc(100% - #{$meBoxMessage-unreadDot_width + $meBoxMessage-imageWidth});
+    max-width: calc(100% - #{$meBoxMessage-unreadDot_width + $meBoxMessage-imageContainerWidth});
 }
 
 


### PR DESCRIPTION
This update wires up live notification data into the `MeBox` component.

### Overview
1. Lots of miscellaneous small styling fixes.
1. `NotificationsActions` has been added, providing API thunks for the notifications resource.
1. `NotificationsModel` has been added, providing basic state management for notifications using the Redux store.
1. `NotificationsDropDown` has been connected to Redux to populate its content.
1. Relevant interfaces have been added for API responses from the notifications resource, local notifications state and parameters.
1. Minor tweaks to existing `MeBox` components to update their data, making it more flexible and accommodating to the data available from API responses.