### PR TITLE
Fix DateFilterSchema or-equal-to comparisons on date-only values not including full date

### DIFF
--- a/library/Vanilla/DateFilterSchema.php
+++ b/library/Vanilla/DateFilterSchema.php
@@ -187,7 +187,6 @@ class DateFilterSchema extends Schema {
                     ];
                     break;
                 case "<=":
-                case ">=":
                     $dateTimes = [$dateTimes[0]->modify('+1 day')->modify('-1 second')];
                     break;
             }

--- a/library/Vanilla/DateFilterSchema.php
+++ b/library/Vanilla/DateFilterSchema.php
@@ -178,11 +178,19 @@ class DateFilterSchema extends Schema {
         }
 
         // If all we have is a date, give us a range in that date.
-        if ($operator == '=' && !preg_match('/\d\d:\d\d:\d\d/', $date)) {
-            $dateTimes = [
-                $dateTimes[0],
-                $dateTimes[0]->modify('+1 day')->modify('-1 second'),
-            ];
+        if (!preg_match('/\d\d:\d\d:\d\d/', $date)) {
+            switch ($operator) {
+                case "=":
+                    $dateTimes = [
+                        $dateTimes[0],
+                        $dateTimes[0]->modify('+1 day')->modify('-1 second'),
+                    ];
+                    break;
+                case "<=":
+                case ">=":
+                    $dateTimes = [$dateTimes[0]->modify('+1 day')->modify('-1 second')];
+                    break;
+            }
         }
 
         $result = [

--- a/tests/Library/Vanilla/DateFilterSchemaTest.php
+++ b/tests/Library/Vanilla/DateFilterSchemaTest.php
@@ -60,7 +60,7 @@ class DateFilterSchemaTest extends SharedBootstrapTestCase {
             '>=2017-09-01' => [
                 '>=2017-09-01',
                 '>=',
-                [new DateTimeImmutable('2017-09-01')],
+                [new DateTimeImmutable('2017-09-01 23:59:59')],
             ],
             '<2017-07-01' => [
                 '<2017-07-01',
@@ -179,7 +179,7 @@ class DateFilterSchemaTest extends SharedBootstrapTestCase {
             'Greater-Than or Equal (Date)' => [
                 'dateInserted',
                 $schema->validate('>=2017-01-01'),
-                ['dateInserted >=' => new DateTimeImmutable('2017-01-01 00:00:00')]
+                ['dateInserted >=' => new DateTimeImmutable('2017-01-01 23:59:59')]
             ],
             'Greater-Than or Equal (DateTime)' => [
                 'dateInserted',
@@ -199,7 +199,7 @@ class DateFilterSchemaTest extends SharedBootstrapTestCase {
             'Less-Than or Equal (Date)' => [
                 'dateInserted',
                 $schema->validate('<=2017-01-01'),
-                ['dateInserted <=' => new DateTimeImmutable('2017-01-01 00:00:00')]
+                ['dateInserted <=' => new DateTimeImmutable('2017-01-01 23:59:59')]
             ],
             'Less-Than or Equal (DateTime)' => [
                 'dateInserted',

--- a/tests/Library/Vanilla/DateFilterSchemaTest.php
+++ b/tests/Library/Vanilla/DateFilterSchemaTest.php
@@ -60,7 +60,7 @@ class DateFilterSchemaTest extends SharedBootstrapTestCase {
             '>=2017-09-01' => [
                 '>=2017-09-01',
                 '>=',
-                [new DateTimeImmutable('2017-09-01 23:59:59')],
+                [new DateTimeImmutable('2017-09-01 00:00:00')],
             ],
             '<2017-07-01' => [
                 '<2017-07-01',
@@ -179,7 +179,7 @@ class DateFilterSchemaTest extends SharedBootstrapTestCase {
             'Greater-Than or Equal (Date)' => [
                 'dateInserted',
                 $schema->validate('>=2017-01-01'),
-                ['dateInserted >=' => new DateTimeImmutable('2017-01-01 23:59:59')]
+                ['dateInserted >=' => new DateTimeImmutable('2017-01-01 00:00:00')]
             ],
             'Greater-Than or Equal (DateTime)' => [
                 'dateInserted',

--- a/tests/Library/Vanilla/DateFilterSphinxSchemaTest.php
+++ b/tests/Library/Vanilla/DateFilterSphinxSchemaTest.php
@@ -69,7 +69,7 @@ class DateFilterSphinxSchemaTest extends SharedBootstrapTestCase {
             'Greater-Than or Equal (Date)' => [
                 '>=2017-01-01',
                 [
-                    'startDate' => new DateTimeImmutable('2017-01-01 23:59:59'),
+                    'startDate' => new DateTimeImmutable('2017-01-01 00:00:00'),
                     'endDate' => null,
                     'exclude' => false
                 ]

--- a/tests/Library/Vanilla/DateFilterSphinxSchemaTest.php
+++ b/tests/Library/Vanilla/DateFilterSphinxSchemaTest.php
@@ -69,7 +69,7 @@ class DateFilterSphinxSchemaTest extends SharedBootstrapTestCase {
             'Greater-Than or Equal (Date)' => [
                 '>=2017-01-01',
                 [
-                    'startDate' => new DateTimeImmutable('2017-01-01 00:00:00'),
+                    'startDate' => new DateTimeImmutable('2017-01-01 23:59:59'),
                     'endDate' => null,
                     'exclude' => false
                 ]
@@ -102,7 +102,7 @@ class DateFilterSphinxSchemaTest extends SharedBootstrapTestCase {
                 '<=2017-01-01',
                 [
                     'startDate' => null,
-                    'endDate' => new DateTimeImmutable('2017-01-01 00:00:00'),
+                    'endDate' => new DateTimeImmutable('2017-01-01 23:59:59'),
                     'exclude' => false
                 ]
             ],


### PR DESCRIPTION
`DateFilterSchema` (and by extension `DateFilterSphinxSchema`) do not include the full date when performing a simple comparison on a date-only value. For example, You might expect "<=2018-01-01" to match on anything less-than-but-including January 1, 2018. What you would actually get is just less-than January 1, 2018. The comparison is exclusive.

This update tweaks the logic in `DateFilterSchema::parseSimple` to include the whole day of a date-only value when using an or-equal-to comparison.

Closes #8047