### PR TITLE
Allow editor to take a re-initialize prop

### DIFF
--- a/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
+++ b/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
@@ -36,6 +36,7 @@ interface ICommonProps {
     allowUpload: boolean;
     device?: Devices;
     initialValue?: DeltaOperation[];
+    reinitialize: boolean;
 }
 
 interface ILegacyProps extends ICommonProps {
@@ -273,6 +274,12 @@ export class Editor extends React.Component<IProps> {
             this.quill.enable();
         } else if (!oldProps.isLoading && this.props.isLoading) {
             this.quill.disable();
+        }
+
+        if (!oldProps.reinitialize && this.props.reinitialize) {
+            if (this.props.initialValue) {
+                this.setEditorContent(this.props.initialValue);
+            }
         }
     }
 

--- a/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
+++ b/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
@@ -36,7 +36,7 @@ interface ICommonProps {
     allowUpload: boolean;
     device?: Devices;
     initialValue?: DeltaOperation[];
-    reinitialize: boolean;
+    reinitialize?: boolean;
 }
 
 interface ILegacyProps extends ICommonProps {


### PR DESCRIPTION
Required to fix https://github.com/vanilla/knowledge/issues/388

Previously the editor was only re-initialized through the `key` prop, but that recreates the quill instance and throws away the user's current selection. This prop gives a more subtle approach.