### PR TITLE
KB: Fixed unnecessary overflow hidden

### DIFF
--- a/library/src/scss/components/_vanillaHeader.scss
+++ b/library/src/scss/components/_vanillaHeader.scss
@@ -61,7 +61,6 @@ $vanillaHeader-compactSearch_maxWidth: 672px;
 
     @include mediaQuery-panelLayout_oneColumn {
         min-height: $vanillaHeader_mobile_height;
-        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
This overflow was causing a bug for the "compact search". KB only.