### PR TITLE
Update <DateInput /> to use ISO string without a time.

### DIFF
--- a/library/src/scripts/components/forms/DateInput.tsx
+++ b/library/src/scripts/components/forms/DateInput.tsx
@@ -104,7 +104,6 @@ export default class DateInput extends React.PureComponent<IProps, IState> {
      * Handle a new date.
      */
     private updateDate = (date?: Moment | null, isEmpty: boolean = false) => {
-        console.log("Date changed", date, isEmpty);
         if (date) {
             this.setState({ hasBadValue: false });
             this.props.onChange(this.normalizeIsoString(date.toISOString()));
@@ -151,19 +150,9 @@ export default class DateInput extends React.PureComponent<IProps, IState> {
     };
 
     /**
-     * Handle text changes in the main input.
-     */
-    private handleTextChange = (event: React.ChangeEvent<any>) => {
-        const { value } = event.target.value;
-        const date = moment(event.target.value);
-        this.updateDate(date, value === "");
-    };
-
-    /**
      * Handle changes in the native input.
      */
     private handleNativeInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        console.log(event);
         this.updateDate(event.target.valueAsDate, event.target.value === "");
     };
 


### PR DESCRIPTION
Related issue: https://github.com/vanilla/knowledge/issues/345

This PR makes various improvements to the `<DateInput />`.

- Represent values as an ISO string without a time. This makes things more consistent for API endpoints that expect days without times. This component no longer specifies any times in outs datestrings.
- Better handle native input events.
  - Native inputs should now be working much better on iOS and Android.
  - All aspects of Android DatePicker are now working properly, including clear button.
  - iOS native DatePicker works, but the clear button does not. Followup issue here https://github.com/vanilla/vanilla/issues/8083 but @tburry told me to give it a low priority.
- Make date handling more consistent by using moment to parse dates instead of the `Date` constructor. I found the native `Date` was making weird timezone offsets when stripping of the time. Using `moment` to parse dates fixed this.