### PR TITLE
Add better types and more constants

### DIFF
--- a/library/src/scripts/components/dropdown/items/DropDownItemLink.tsx
+++ b/library/src/scripts/components/dropdown/items/DropDownItemLink.tsx
@@ -25,13 +25,15 @@ export interface IDropDownItemLink {
  * Implements link type of item for DropDownMenu
  */
 export default class DropDownItemLink extends React.Component<IDropDownItemLink> {
+    public static readonly CSS_CLASS = "dropDownItem-link";
+
     public render() {
         const { children, name, isModalLink, className, to } = this.props;
         const linkContents = children ? children : name;
         const LinkComponent = isModalLink ? ModalLink : SmartLink;
         return (
             <DropDownItem className={classNames("dropDown-linkItem", className)}>
-                <LinkComponent to={to} title={name} lang={this.props.lang} className="dropDownItem-link">
+                <LinkComponent to={to} title={name} lang={this.props.lang} className={DropDownItemLink.CSS_CLASS}>
                     {linkContents}
                 </LinkComponent>
             </DropDownItem>

--- a/library/src/scripts/components/modal/ModalRouter.tsx
+++ b/library/src/scripts/components/modal/ModalRouter.tsx
@@ -8,8 +8,8 @@ import React from "react";
 import { Switch, RouteComponentProps, withRouter } from "react-router-dom";
 
 interface IProps extends RouteComponentProps<{}> {
-    modalRoutes: JSX.Element[];
-    pageRoutes: JSX.Element[];
+    modalRoutes: React.ReactNode[];
+    pageRoutes: React.ReactNode[];
 }
 
 /**


### PR DESCRIPTION
- Adds a new constant `DropDownItemLink.CSS_CLASS`.
- Adjusts types on the `ModalRouter` to use the wider type `React.ReactNode` (can be multiple types of components, null or string) as opposed to the much narrower `JSX.Element`.