### PR TITLE
Add Access-Control-Allow-Credentials to setAccessControl

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1457,6 +1457,7 @@ class Gdn_Controller extends Gdn_Pluggable {
             $originHost = parse_url($origin, PHP_URL_HOST);
             if ($originHost && isTrustedDomain($originHost)) {
                 $this->setHeader('Access-Control-Allow-Origin', $origin);
+                $this->setHeader("Access-Control-Allow-Credentials", "true");
             }
         }
     }


### PR DESCRIPTION
This update adds sending the [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials) CORS header to `Gdn_Controller::setAccessControl`, which currently only sends the [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) header. The new header tells the requesting browser it's okay to send the user's credentials (cookies) along with the request. Without this header, CORS-capable requests cannot be made as a signed-in user, only guests.