### PR TITLE
Change Log: Fix - Default type displays as "unknown"

### DIFF
--- a/applications/dashboard/views/log/table.php
+++ b/applications/dashboard/views/log/table.php
@@ -83,7 +83,7 @@ include $this->fetchViewLocation('helper_functions');
                     ?>
                 </td>
                 <td class="PostType">
-                    <?php echo t($RecordLabel, t('Unknown')); ?>
+                    <?php echo t($RecordLabel, htmlspecialchars($RecordLabel)); ?>
                 </td>
                 <td class="DateCell">
                     <?php echo Gdn_Format::date($Row['DateInserted'], '%a %e %b %Y %r %Z'); ?>


### PR DESCRIPTION
closes [#8101](https://github.com/vanilla/vanilla/issues/8101)

### Details

Browsing to dashboard/log/edits, logs type is displaying as unknown.

![screen shot 2018-12-05 at 2 08 00 pm](https://user-images.githubusercontent.com/31856281/49537543-3c497f80-f897-11e8-9d83-af5193c07efa.png)

### Reason
[table.php#L86](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/views/log/table.php#L86)
we are sending a default value for the translation function in case RecordLabel translation is not available. We do not have translation of comment/discuissopn causing the function to chose the default value of unkown
### Related
This was originally handled in [#431](https://github.com/vanilla/vanilla-patches/pull/431) to avoid an Xss.

### Fix
We can htmlspecialchar the default value being sent to the translation function.

