### PR TITLE
Social-Reactions: added nofollow attribute (Facebook, GooglePlus, Twitter)

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -177,8 +177,8 @@ class FacebookPlugin extends Gdn_Plugin {
             sprite('ReactFacebook', 'Sprite ReactSprite', t('Share on Facebook')),
             url("post/facebook/{$args['RecordType']}?id={$args['RecordID']}", true),
             'ReactButton PopupWindow',
-            ['rel' => 'nofollow'])
-        ;
+            ['rel' => 'nofollow']
+        );
     }
 
     /**

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -176,7 +176,8 @@ class FacebookPlugin extends Gdn_Plugin {
         echo anchor(
             sprite('ReactFacebook', 'Sprite ReactSprite', t('Share on Facebook')),
             url("post/facebook/{$args['RecordType']}?id={$args['RecordID']}", true),
-            'ReactButton PopupWindow', ['rel' => 'nofollow'])
+            'ReactButton PopupWindow',
+            ['rel' => 'nofollow'])
         ;
     }
 

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -176,7 +176,7 @@ class FacebookPlugin extends Gdn_Plugin {
         echo anchor(
             sprite('ReactFacebook', 'Sprite ReactSprite', t('Share on Facebook')),
             url("post/facebook/{$args['RecordType']}?id={$args['RecordID']}", true),
-            'ReactButton PopupWindow')
+            'ReactButton PopupWindow', ['rel' => 'nofollow'])
         ;
     }
 

--- a/plugins/GooglePlus/class.googleplus.plugin.php
+++ b/plugins/GooglePlus/class.googleplus.plugin.php
@@ -300,7 +300,7 @@ class GooglePlusPlugin extends Gdn_Plugin {
         $url = url("post/googleplus/{$args['RecordType']}?id={$args['RecordID']}", true);
         $cssClass = 'ReactButton PopupWindow';
 
-        echo ' '.anchor(sprite('ReactGooglePlus', 'ReactSprite', t('Share on Google+')), $url, $cssClass).' ';
+        echo ' '.anchor(sprite('ReactGooglePlus', 'ReactSprite', t('Share on Google+')), $url, $cssClass, ['rel' => 'nofollow']).' ';
     }
 
     /**

--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -897,7 +897,7 @@ class TwitterPlugin extends Gdn_Plugin {
             $cssClass = 'ReactButton PopupWindow';
         }
 
-        echo anchor(sprite('ReactTwitter', 'Sprite ReactSprite', t('Share on Twitter')), $url, $cssClass);
+        echo anchor(sprite('ReactTwitter', 'Sprite ReactSprite', t('Share on Twitter')), $url, $cssClass, ['rel' => 'nofollow']);
     }
 
     /**


### PR DESCRIPTION
Related [#7918](https://github.com/vanilla/vanilla/issues/7918)

### Details 

Adding nofollow attribute to "Twitter,Facebook,GooglePlus" after seeing a rise in 401 and 403 errors on links for social reactions in new Google Webmaster tools reports.
