### PR TITLE
Fix: Embed Comments - PostController not checking for duplicate discussion ForeignID

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -469,6 +469,15 @@ class PostController extends VanillaController {
             $vanilla_identifier = $this->Form->getFormValue('vanilla_identifier', '');
             $isEmbeddedComments = $vanilla_url != '' && $vanilla_identifier != '';
 
+        // If we already have a discussion with this ForeginID, then add the discussion id to the form, to avoid creating duplicate discussions.
+        if ($isEmbeddedComments && !$DiscussionID) {
+            $Discussion = $this->DiscussionModel->getWhere(['ForeignID' => $vanilla_identifier])->firstRow(DATASET_TYPE_OBJECT);
+            if (!empty($Discussion)) {
+                $DiscussionID =  $this->DiscussionID = $Discussion->DiscussionID;
+                $this->Discussion = $Discussion;
+                $this->Form->setFormValue('DiscussionID', $DiscussionID);
+            }
+        }
             // Only allow vanilla identifiers of 32 chars or less - md5 if larger
             if (strlen($vanilla_identifier) > 32) {
                 $Attributes['vanilla_identifier'] = $vanilla_identifier;
@@ -863,7 +872,7 @@ class PostController extends VanillaController {
         if (property_exists($this, 'Discussion')) {
             $this->EventArguments['Discussion'] = $this->Discussion;
         }
-        if (property_exists($this, 'Comment')) {
+        if (property_exists($this,  'Comment')) {
             $this->EventArguments['Comment'] = $this->Comment;
         }
 

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -872,7 +872,7 @@ class PostController extends VanillaController {
         if (property_exists($this, 'Discussion')) {
             $this->EventArguments['Discussion'] = $this->Discussion;
         }
-        if (property_exists($this,  'Comment')) {
+        if (property_exists($this, 'Comment')) {
             $this->EventArguments['Comment'] = $this->Comment;
         }
 

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -469,15 +469,15 @@ class PostController extends VanillaController {
             $vanilla_identifier = $this->Form->getFormValue('vanilla_identifier', '');
             $isEmbeddedComments = $vanilla_url != '' && $vanilla_identifier != '';
 
-        // If we already have a discussion with this ForeginID, then add the discussion id to the form, to avoid creating duplicate discussions.
-        if ($isEmbeddedComments && !$DiscussionID) {
-            $Discussion = $this->DiscussionModel->getWhere(['ForeignID' => $vanilla_identifier])->firstRow(DATASET_TYPE_OBJECT);
-            if (!empty($Discussion)) {
-                $DiscussionID =  $this->DiscussionID = $Discussion->DiscussionID;
-                $this->Discussion = $Discussion;
-                $this->Form->setFormValue('DiscussionID', $DiscussionID);
+            // If we already have a discussion with this ForeginID, add the discussion id to the form, to avoid duplicate discussions.
+            if ($isEmbeddedComments && !$DiscussionID) {
+                $Discussion = $this->DiscussionModel->getWhere(['ForeignID' => $vanilla_identifier])->firstRow(DATASET_TYPE_OBJECT);
+                if (!empty($Discussion)) {
+                    $DiscussionID =  $this->DiscussionID = $Discussion->DiscussionID;
+                    $this->Discussion = $Discussion;
+                    $this->Form->setFormValue('DiscussionID', $DiscussionID);
+                }
             }
-        }
             // Only allow vanilla identifiers of 32 chars or less - md5 if larger
             if (strlen($vanilla_identifier) > 32) {
                 $Attributes['vanilla_identifier'] = $vanilla_identifier;


### PR DESCRIPTION
Closes #8111

### Details

PostController does not check if an embedded discussion's ForeignID is already posted, resulting in duplicate discussions created in Vanilla.

### To Replicate

- Setup https://github.com/vanilla/stub-embed-providers locally
- Open 2 tabs and try to post a comment in a discussion(that has not already been posted in Vanilla) without refreshing the page in the other tab.
- 2 discussions would be created in GDN_Discussion with the same ForeignIDs
<img width="349" alt="screen shot 2018-12-10 at 8 57 47 pm" src="https://user-images.githubusercontent.com/31856281/49773249-51bb1100-fcbe-11e8-9b0e-e2f81d975541.png">

### Reason

When trying to post a comment in the 2nd tab, the form does not know of the previous discussion id already posted, resulting in the creation of 2 discussions.

### In this PR

We are checking if there is a discussion already created based on the ForeginID, if this is the case, we add the DiscussionID to the form.