### PR TITLE
Fix collapsing PHP_CodeSniffer scan results in build if issues detected

### DIFF
--- a/tests/travis/diff-standards.sh
+++ b/tests/travis/diff-standards.sh
@@ -19,21 +19,18 @@ PHPCS_DIFF_FILENAME=$BUILD_DIR/phpcs-diff.json
 
 cd $BUILD_DIR
 
-# Begin folding in Travis.
-[ $TRAVIS ] && echo "travis_fold:start:coding_standards"
-
 echo "Verify changed code against coding standards."
 
 # Without this, Travis only has a ref to the current branch in a shallow clone. Other branches cannot be compared.
 echo "Updating available refs..."
+[ $TRAVIS ] && echo "travis_fold:start:coding_standards_setup"
 git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
 git fetch --all
 
 GIT_DIFF=$(git diff $DIFF_BRANCH '*.php')
 if [ -z "$GIT_DIFF" ]; then
+    [ $TRAVIS ] && echo "travis_fold:end:coding_standards_setup"
     echo "No PHP file changes detected."
-
-    [ $TRAVIS ] && echo "travis_fold:end:coding_standards"
     exit 0
 fi
 echo "Exporting branch diff of $DIFF_BRANCH to $GIT_DIFF_FILENAME..."
@@ -44,14 +41,13 @@ echo "Exporting full PHP_CodeSniffer scan of changed files to $PHPCS_DIFF_FILENA
 rm -f $PHPCS_DIFF_FILENAME
 ./vendor/bin/phpcs --standard=./vendor/vanilla/standards/code-sniffer/Vanilla --report=json $(git diff --name-only $DIFF_BRANCH -- '*.php') > $PHPCS_DIFF_FILENAME
 
+[ $TRAVIS ] && echo "travis_fold:end:coding_standards_setup"
+
 echo "Comparing results of PHP_CodeSniffer scan with changed lines from branch diff..."
 echo ""
 ./vendor/bin/diffFilter --phpcs $GIT_DIFF_FILENAME $PHPCS_DIFF_FILENAME
 
 CODESNIFFER_RESULT=$?
-
-# End folding in Travis.
-[ $TRAVIS ] && echo "travis_fold:end:coding_standards"
 
 # Make sure this script exits with the same status as the PHP_CodeSniffer command.
 exit $CODESNIFFER_RESULT


### PR DESCRIPTION
The current PHP_CodeSniffer diff scan in Vanilla's Travis build implements folding its results in the build log. If no issues are detected, this isn't a big deal. However, if issues *are* detected, they can be a little tough to find in the log, because they'll likely be collapsed by default. This update shuffles around the start and end of the folding points to ensure the PHP_CodeSniffer status is always visible, while still collapsing the verbose setup steps that made folding necessary in the first place.

See it in action here: [Job #1018.1 on Travis](https://travis-ci.com/vanilla/vanilla/jobs/165615076)