### PR TITLE
Make search autocomplete items links, improve querystring component, fix search bar clickability

### DIFF
--- a/library/src/scripts/components/forms/select/SearchBar.tsx
+++ b/library/src/scripts/components/forms/select/SearchBar.tsx
@@ -105,7 +105,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                 blurInputOnSelect={false}
                 allowCreateWhileLoading={true}
                 controlShouldRenderValue={false}
-                isDisabled={disabled || isLoading}
+                isDisabled={disabled}
                 loadOptions={this.props.loadOptions}
                 menuIsOpen={this.isMenuVisible}
                 classNamePrefix={this.prefix}

--- a/library/src/scripts/components/navigation/QueryString.tsx
+++ b/library/src/scripts/components/navigation/QueryString.tsx
@@ -10,10 +10,13 @@ import { withRouter, RouteComponentProps } from "react-router";
 import isEqual from "lodash/isEqual";
 import throttle from "lodash/throttle";
 
+interface IStringMap {
+    [key: string]: any;
+}
+
 interface IProps extends RouteComponentProps<any> {
-    value: {
-        [key: string]: any;
-    };
+    value: IStringMap;
+    defaults?: IStringMap;
 }
 
 /**
@@ -29,9 +32,39 @@ class QueryString extends React.Component<IProps> {
     }
 
     public componentDidUpdate(prevProps: IProps) {
-        if (!isEqual(prevProps.value, this.props.value)) {
+        if (
+            !isEqual(
+                this.getFilteredValue(prevProps.value, prevProps.defaults || {}),
+                this.getFilteredValue(this.props.value, this.props.defaults || {}),
+            )
+        ) {
             this.updateQueryString();
         }
+    }
+
+    /**
+     * Get a version of the query string object with only keys that have values.
+     */
+    private getFilteredValue(inputValue: IStringMap, defaults: IStringMap): IStringMap | null {
+        let filteredValue: IStringMap | null = null;
+
+        for (const [key, value] of Object.entries(inputValue)) {
+            if (value === null || value === undefined || value === "") {
+                continue;
+            }
+
+            if (defaults[key] === value) {
+                continue;
+            }
+
+            if (filteredValue === null) {
+                filteredValue = {};
+            }
+
+            filteredValue[key] = value;
+        }
+
+        return filteredValue;
     }
 
     /**
@@ -41,7 +74,7 @@ class QueryString extends React.Component<IProps> {
      */
     private updateQueryString = throttle(() => {
         requestAnimationFrame(() => {
-            const query = qs.stringify(this.props.value);
+            const query = qs.stringify(this.getFilteredValue(this.props.value, this.props.defaults || {}));
             this.props.history.replace({
                 ...this.props.location,
                 search: query,

--- a/library/src/scripts/components/navigation/SmartLink.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.tsx
@@ -7,7 +7,7 @@
 import React from "react";
 import { formatUrl } from "@library/application";
 import { NavLinkProps, NavLink } from "react-router-dom";
-import { LocationDescriptor, createPath } from "history";
+import { LocationDescriptor, createPath, createLocation } from "history";
 
 export const LinkContext = React.createContext("https://changeme.dev.localhost");
 
@@ -20,6 +20,7 @@ interface IProps extends NavLinkProps {
  * or a partial refresh of the page.
  *
  * If the passed `to` is a subset of the context then a partial navigation will be completed.
+ * If the resulting URL has the same pathname as the current page we will do a full refresh.
  *
  * Eg.
  * Context = https://test.com/root
@@ -35,11 +36,14 @@ export default function SmartLink(props: IProps) {
     const finalUrlFormatter = urlFormatter ? urlFormatter : formatUrl;
     const stringUrl = typeof props.to === "string" ? props.to : createPath(props.to);
     const href = finalUrlFormatter(stringUrl, true);
+    const link = document.createElement("a");
+    link.href = href;
+    const isCurrentPage = link.pathname === window.location.pathname;
 
     return (
         <LinkContext.Consumer>
             {contextRoot => {
-                if (href.startsWith(contextRoot)) {
+                if (href.startsWith(contextRoot) && !isCurrentPage) {
                     return <NavLink {...passthru} to={makeDynamicHref(props.to, href)} activeClassName="isCurrent" />;
                 } else {
                     return <a {...passthru} href={href} />;

--- a/library/src/scripts/components/search/SearchOption.tsx
+++ b/library/src/scripts/components/search/SearchOption.tsx
@@ -12,30 +12,34 @@ import { SelectOption } from "../forms/select/overwrites";
 import classNames from "classnames";
 import { IComboBoxOption } from "@library/components/forms/select/SearchBar";
 import { ICrumb } from "@library/components/Breadcrumbs";
+import SmartLink from "@library/components/navigation/SmartLink";
 
 export interface ISearchOptionData {
     crumbs: ICrumb[];
     name: string;
     dateUpdated: string;
+    url: string;
 }
 
-interface IProps extends OptionProps<any> {
+interface IProps extends OptionProps<ISearchOptionData> {
     data: IComboBoxOption<ISearchOptionData>;
 }
 
 /**
  */
 export default function SearchOption(props: IProps) {
-    const { data, innerProps, isSelected, isFocused } = props;
+    const { innerProps, isSelected, isFocused } = props;
+    const data = props.data.data;
 
-    if (data.data) {
-        const { dateUpdated, crumbs } = data.data!;
+    if (data) {
+        const { dateUpdated, crumbs, url } = data;
         const hasLocationData = crumbs && crumbs.length > 0;
         return (
             <li className="suggestedTextInput-item">
-                <button
+                <SmartLink
                     {...innerProps}
-                    type="button"
+                    to={url}
+                    onClick={undefined}
                     title={props.label}
                     aria-label={props.label}
                     className={classNames("suggestedTextInput-option", {
@@ -56,7 +60,7 @@ export default function SearchOption(props: IProps) {
                             {hasLocationData && <BreadCrumbString className="meta" crumbs={crumbs} />}
                         </span>
                     </span>
-                </button>
+                </SmartLink>
             </li>
         );
     } else {

--- a/library/src/scripts/components/search/SearchOption.tsx
+++ b/library/src/scripts/components/search/SearchOption.tsx
@@ -38,8 +38,11 @@ export default function SearchOption(props: IProps) {
             <li className="suggestedTextInput-item">
                 <SmartLink
                     {...innerProps}
-                    to={url}
+                    // We want to use the SmarkLink clickHandler, not the innerProps one from the SearchBar.
+                    // The innerProps click handler will trigger a search event (goes to search page).
+                    // The SmartLink will navigate to the result itself.
                     onClick={undefined}
+                    to={url}
                     title={props.label}
                     aria-label={props.label}
                     className={classNames("suggestedTextInput-option", {

--- a/library/src/scss/components/_suggestedTextInput.scss
+++ b/library/src/scss/components/_suggestedTextInput.scss
@@ -22,10 +22,13 @@ $suggestedTextInput-clearButton_width: 16px;
     width: 100%;
     padding: $suggestedTextInput-option_padding;
     text-align: left;
+    display: block;
+    color: inherit;
 
     &:hover,
     &:focus,
     &.isFocused {
+        color: inherit;
         background-color: $state-hover_color;
     }
 }


### PR DESCRIPTION
This PR is required for https://github.com/vanilla/knowledge/pull/461/files

- Have search autocomplete items jump directly to their URL when clicked.
- Updates the `<QueryString/>` component to only reflect non-null, non-default values in the querystring. This results in some much shorter/cleaner query strings, and resolves some issues when when not properly initializing null values when loading from the query string.
- No longer disables search bar while loading results. https://github.com/vanilla/knowledge/issues/414