### PR TITLE
Reduce build memory usage with --low-memory flag

### DIFF
--- a/build/scripts/configs/makeBaseConfig.ts
+++ b/build/scripts/configs/makeBaseConfig.ts
@@ -112,9 +112,6 @@ ${chalk.green(aliases)}`;
             new webpack.DefinePlugin({
                 __BUILD__SECTION__: JSON.stringify(section),
             }),
-            new WebpackBar({
-                name: section,
-            }),
         ] as any[],
         resolve: {
             modules: modulePaths,
@@ -150,6 +147,15 @@ ${chalk.green(aliases)}`;
 
     if (options.fix) {
         config.plugins.unshift(getPrettierPlugin());
+    }
+
+    // This is the only flag we are given by infrastructure to indicate we are in a lower memory environment.
+    if (!options.lowMemory) {
+        config.plugins.push(
+            new WebpackBar({
+                name: section,
+            }),
+        );
     }
 
     return config;

--- a/build/scripts/configs/makeProdConfig.ts
+++ b/build/scripts/configs/makeProdConfig.ts
@@ -37,7 +37,7 @@ export async function makeProdConfig(entryModel: EntryModel, section: string) {
         path: path.join(DIST_DIRECTORY, section),
         library: `vanilla${section}`,
     };
-    baseConfig.devtool = "source-map";
+    baseConfig.devtool = "cheap-source-map";
     baseConfig.optimization = {
         noEmitOnErrors: true,
         namedModules: false,
@@ -83,6 +83,12 @@ export async function makeProdConfig(entryModel: EntryModel, section: string) {
         minimizer: [
             new TerserWebpackPlugin({
                 cache: true,
+                // Exclude swagger-ui from minification which is a large bundle and costly to minify.
+                exclude: /swagger-ui/,
+                terserOptions: {
+                    warnings: false,
+                    ie8: false,
+                },
                 parallel: true,
                 sourceMap: true, // set to true if you want JS source maps
             }),

--- a/build/scripts/options.ts
+++ b/build/scripts/options.ts
@@ -25,7 +25,7 @@ yargs
         alias: "f",
         default: false,
     })
-    .options("disable-validation", {
+    .options("low-memory", {
         default: false,
     })
     .options("install", {
@@ -38,7 +38,7 @@ export interface IBuildOptions {
     verbose: boolean;
     fix: boolean;
     install: boolean;
-    disableValidation: boolean;
+    lowMemory: boolean;
     enabledAddonKeys: string[];
     configFile: string;
     phpConfig: any;
@@ -81,7 +81,7 @@ export async function getOptions(): Promise<IBuildOptions> {
         mode: yargs.argv.mode,
         verbose: yargs.argv.verbose,
         enabledAddonKeys,
-        disableValidation: yargs.argv["disable-validation"],
+        lowMemory: yargs.argv["low-memory"],
         configFile: yargs.argv.config,
         fix: yargs.argv.fix,
         phpConfig: config,

--- a/library/setup/ComposerHelper.php
+++ b/library/setup/ComposerHelper.php
@@ -17,6 +17,7 @@ class ComposerHelper {
 
     const NODE_ARGS_ENV = "VANILLA_BUILD_NODE_ARGS";
     const DISABLE_VALIDATION_ENV = "VANILLA_BUILD_DISABLE_CODE_VALIDATION";
+    const LOW_MEMORY_ENV = "VANILLA_BUILD_LOW_MEMORY";
     const DISABLE_AUTO_BUILD = "VANILLA_BUILD_DISABLE_AUTO_BUILD";
 
     /**
@@ -80,8 +81,12 @@ class ComposerHelper {
         }
 
         $nodeArgs = getenv(self::NODE_ARGS_ENV) ?: "";
-        $disableValidationFlag = getenv(self::DISABLE_VALIDATION_ENV) ? "--disable-validation" : "";
-        $buildCommand = "TS_NODE_PROJECT=$tsConfig node $nodeArgs -r $tsNodeRegister $buildScript -i $disableValidationFlag";
+
+        // The disable validation flag was used to enable low memory optimizations.
+        // The build no longer does any validation, however, so a new env variable has been added.
+        // So, we check for both.
+        $lowMemoryFlag = getenv(self::DISABLE_VALIDATION_ENV) || getenv(self::LOW_MEMORY_ENV) ? "--low-memory" : "";
+        $buildCommand = "TS_NODE_PROJECT=$tsConfig node $nodeArgs -r $tsNodeRegister $buildScript -i $lowMemoryFlag";
 
         printf("\nBuilding frontend assets\n");
         printf("\n$buildCommand\n");


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8133

- Adds a new option/environmental variable check, `VANILLA_BUILD_LOW_MEMORY` and `--low-memory`. The old environmental variable `VANILLA_BUILD_DISABLE_CODE_VALIDATION` triggers this flag as well to ease the migration. See inf change here https://github.com/vanilla/vanillainfrastructure/pull/183.
- When this flag is enabled, do the following:
  - Run builds sequentially instead of using webpack's multi-compiler. (Can reduce required memory by  up to 4x in my tests, and likely more as we add more "parallel" builds)
  - Disable the `WebpackBar` plugin when the flag is enabled. This provides a progress bar for the completion time of the build. Removed ~100mb of peak usage (20% of our cap) in my profiling.
- Make a few other speed/memory optimizations
  - Exclude the swagger-ui plugin from being minified with terser.
  - Switch the production sourcemap type from `source-map` to `cheap-source-map`.

## Testing

For all my testing I've been using [this `memusg` script](https://gist.github.com/netj/526585). With that the full command similar to what gets run on infra is:

```sh
TS_NODE_PROJECT=/git/srv/vanilla/build/tsconfig.json node --max-old-space-size=500 -r /git/srv/vanilla/node_modules/ts-node/register /git/srv/vanilla/build/scripts/build.ts -i --low-memory
```

Obviously file paths will be different on your end.