### PR TITLE
Add Hoverable component & hover support to navigation tree

### DIFF
--- a/library/src/scripts/components/siteNav/SiteNav.tsx
+++ b/library/src/scripts/components/siteNav/SiteNav.tsx
@@ -20,6 +20,7 @@ interface IProps extends RouteComponentProps<{}> {
     children: INavigationTreeItem[];
     collapsible: boolean;
     bottomCTA: React.ReactNode;
+    onItemHover?(item: INavigationTreeItem);
 }
 
 export interface IState {
@@ -42,6 +43,7 @@ export class SiteNav extends React.Component<IProps, IState> {
                               titleID={this.titleID}
                               depth={0}
                               collapsible={this.props.collapsible}
+                              onItemHover={this.props.onItemHover}
                           />
                       );
                   })

--- a/library/src/scripts/components/siteNav/SiteNavNode.tsx
+++ b/library/src/scripts/components/siteNav/SiteNavNode.tsx
@@ -12,6 +12,7 @@ import SmartLink from "@library/components/navigation/SmartLink";
 import TabHandler from "@library/TabHandler";
 import classNames from "classnames";
 import * as React from "react";
+import Hoverable from "@library/utils/Hoverable";
 
 interface IProps extends INavigationTreeItem {
     activeRecord: IActiveRecord;
@@ -20,6 +21,7 @@ interface IProps extends INavigationTreeItem {
     openParent?: () => void;
     depth: number;
     collapsible?: boolean;
+    onItemHover?(item: INavigationTreeItem);
 }
 
 interface IState {
@@ -57,6 +59,7 @@ export default class SiteNavNode extends React.Component<IProps, IState> {
                         openParent={this.openSelfAndParents}
                         depth={this.props.depth + 1}
                         collapsible={collapsible}
+                        onItemHover={this.props.onItemHover}
                     />
                 );
             });
@@ -88,17 +91,22 @@ export default class SiteNavNode extends React.Component<IProps, IState> {
                     </span>
                 )}
                 <div className={classNames("siteNavNode-contents")}>
-                    <SmartLink
-                        onKeyDownCapture={this.handleKeyDown}
-                        className={classNames("siteNavNode-link", {
-                            hasChildren,
-                            isFirstLevel: this.props.depth === 0,
-                        })}
-                        tabIndex={0}
-                        to={this.props.url}
-                    >
-                        <span className="siteNavNode-label">{this.props.name}</span>
-                    </SmartLink>
+                    <Hoverable onHover={this.handleHover} duration={50}>
+                        {provided => (
+                            <SmartLink
+                                {...provided}
+                                onKeyDownCapture={this.handleKeyDown}
+                                className={classNames("siteNavNode-link", {
+                                    hasChildren,
+                                    isFirstLevel: this.props.depth === 0,
+                                })}
+                                tabIndex={0}
+                                to={this.props.url}
+                            >
+                                <span className="siteNavNode-label">{this.props.name}</span>
+                            </SmartLink>
+                        )}
+                    </Hoverable>
                     {hasChildren && (
                         <ul
                             className={classNames("siteNavNode-children", depthClass, {
@@ -113,6 +121,15 @@ export default class SiteNavNode extends React.Component<IProps, IState> {
             </li>
         );
     }
+
+    /**
+     * Call the hover callback with the item data.
+     */
+    private handleHover = () => {
+        if (this.props.onItemHover) {
+            this.props.onItemHover(this.props);
+        }
+    };
 
     /**
      * Opens node. Optional callback if it's already open.

--- a/library/src/scripts/utils/Hoverable.tsx
+++ b/library/src/scripts/utils/Hoverable.tsx
@@ -1,0 +1,99 @@
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+
+interface IProps {
+    duration: number;
+    onHover: React.MouseEventHandler | undefined;
+    once?: boolean;
+    children: (providedProps: IProvidedProps) => React.ReactNode;
+}
+
+interface IProvidedProps {
+    onMouseEnter: React.MouseEventHandler;
+    onMouseLeave: React.MouseEventHandler;
+}
+
+/**
+ * Component with render props for handling a hover after a certain duration.
+ *
+ * Simply spread the provided props over the element you want to track the hover of.
+ *
+ * @example
+ * <Hoverable duration={250} onHover={myCallback}>
+ *     {providedProps => {
+ *          <div {...providedProps} className="someClass">
+ *              // Some deeply neested child.
+ *          </div>
+ *     }}
+ * </Hoverable>
+ */
+export default class Hoverable extends React.Component<IProps> {
+    public static defaultProps = {
+        once: true,
+    };
+
+    /**
+     * @inheritdoc
+     */
+    public render(): React.ReactNode {
+        return this.props.children({
+            onMouseEnter: this.mouseEnterHandler,
+            onMouseLeave: this.mouseLeaveHandler,
+        });
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public componentWillUnmount() {
+        this.dismissTimeout();
+    }
+
+    private hoverTimeout: NodeJS.Timeout;
+    private hasExecuted = false;
+
+    /**
+     * Handle the hover event by checking if we've already called ourselves then calling the passed callback.
+     */
+    private handleHover = (event: React.MouseEvent) => {
+        if (this.hasExecuted && this.props.once) {
+            return;
+        }
+
+        this.hasExecuted = true;
+        if (this.props.onHover) {
+            this.props.onHover(event);
+        }
+    };
+
+    /**
+     * Set a timeout when the mouse enters. If the timeout is not removed we have a hover.
+     */
+    private mouseEnterHandler = (event: React.MouseEvent) => {
+        this.hoverTimeout = setTimeout(() => {
+            this.handleHover(event);
+        }, this.props.duration);
+    };
+
+    /**
+     * Remove the timeout for the hover so it doesn't execute again (or at all).
+     */
+    private mouseLeaveHandler = (event: React.MouseEvent) => {
+        this.dismissTimeout();
+    };
+
+    /**
+     * Cleanup timeouts and properties to reset.
+     */
+    private dismissTimeout() {
+        this.hasExecuted = false;
+        if (this.hoverTimeout) {
+            clearTimeout(this.hoverTimeout);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new component `<Hoverable />` which triggers a callback after a certain duration of mouseover.

An example usage has been provided in the class doc and the first implementation has been added on the `SiteNav` component. Nothing in this PR currently uses that component but a function implementation can be found here https://github.com/vanilla/knowledge/pull/463