### PR TITLE
Fix pasting of code into the rich editor

### DIFF
--- a/library/Vanilla/Formatting/Quill/Blots/Lines/CodeLineTerminatorBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Lines/CodeLineTerminatorBlot.php
@@ -26,7 +26,8 @@ class CodeLineTerminatorBlot extends AbstractLineTerminatorBlot {
      * @inheritdoc
      */
     public static function matches(array $operation): bool {
-        return static::opAttrsContainKeyWithValue($operation, "codeBlock");
+        return static::opAttrsContainKeyWithValue($operation, "codeBlock")
+            || static::opAttrsContainKeyWithValue($operation, "code-block");
     }
 
     public function renderLineStart(): string {

--- a/library/Vanilla/Formatting/Quill/Formats/AbstractFormat.php
+++ b/library/Vanilla/Formatting/Quill/Formats/AbstractFormat.php
@@ -81,7 +81,7 @@ abstract class AbstractFormat {
         foreach($operations as $op) {
             $attributes = val("attributes", $op, []);
             $lookupKeys = static::getAttributeLookupKey();
-            if (!is_array()) {
+            if (!is_array($lookupKeys)) {
                 $lookupKeys = [$lookupKeys];
             }
 

--- a/library/Vanilla/Formatting/Quill/Formats/AbstractFormat.php
+++ b/library/Vanilla/Formatting/Quill/Formats/AbstractFormat.php
@@ -47,9 +47,9 @@ abstract class AbstractFormat {
     /**
      * Get the string of the attribute key in the insert that determines if the blot applies or not. This key should lead to a boolean value in the attributes array of the insert.
      *
-     * @return string
+     * @return string|array
      */
-    abstract protected static function getAttributeLookupKey(): string;
+    abstract protected static function getAttributeLookupKey();
 
     /**
      * Get the formats allowed that cannot be "nested" inside this one.
@@ -80,8 +80,15 @@ abstract class AbstractFormat {
 
         foreach($operations as $op) {
             $attributes = val("attributes", $op, []);
-            if (array_key_exists(static::getAttributeLookupKey(), $attributes)) {
-                $result = true;
+            $lookupKeys = static::getAttributeLookupKey();
+            if (!is_array()) {
+                $lookupKeys = [$lookupKeys];
+            }
+
+            foreach ($lookupKeys as $lookupKey) {
+                if (array_key_exists($lookupKey, $attributes)) {
+                    $result = true;
+                }
             }
         }
 

--- a/library/Vanilla/Formatting/Quill/Formats/Code.php
+++ b/library/Vanilla/Formatting/Quill/Formats/Code.php
@@ -12,8 +12,8 @@ class Code extends AbstractFormat {
     /**
      * @inheritDoc
      */
-    protected static function getAttributeLookupKey(): string {
-        return "codeInline";
+    protected static function getAttributeLookupKey(): array {
+        return ["codeInline", "code"];
     }
 
     /**

--- a/plugins/rich-editor/src/scripts/__tests__/OpUtils.ts
+++ b/plugins/rich-editor/src/scripts/__tests__/OpUtils.ts
@@ -46,7 +46,7 @@ export default class OpUtils {
     public static strike(content: string = "TEST") {
         return OpUtils.op(content, { [StrikeBlot.blotName]: true });
     }
-    public static codeInline(content: string = "TEST") {
+    public static code(content: string = "TEST") {
         return OpUtils.op(content, { [CodeBlot.blotName]: true });
     }
     public static link(href: string = OpUtils.DEFAULT_LINK, content: string = "TEST") {
@@ -91,8 +91,8 @@ export const inlineFormatOps = [
         name: "link",
     },
     {
-        op: OpUtils.codeInline(),
-        name: "codeInline",
+        op: OpUtils.code(),
+        name: "code",
     },
 ];
 export const blockFormatOps = [

--- a/plugins/rich-editor/src/scripts/components/toolbars/pieces/InlineToolbarMenuItems.tsx
+++ b/plugins/rich-editor/src/scripts/components/toolbars/pieces/InlineToolbarMenuItems.tsx
@@ -56,7 +56,7 @@ export default class InlineToolbarMenuItems extends React.PureComponent<IProps> 
             {
                 label: t("Format as Inline Code"),
                 icon: icons.code(),
-                isActive: activeFormats.codeInline === true,
+                isActive: activeFormats.code === true,
                 onClick: this.formatCode,
             },
             {

--- a/plugins/rich-editor/src/scripts/components/toolbars/pieces/ParagraphToolbarMenuItems.tsx
+++ b/plugins/rich-editor/src/scripts/components/toolbars/pieces/ParagraphToolbarMenuItems.tsx
@@ -11,6 +11,9 @@ import Formatter from "@rich-editor/quill/Formatter";
 import { IFormats, RangeStatic } from "quill/core";
 import { spoiler, codeBlock, blockquote, heading3, heading2, pilcrow } from "@library/components/icons/editorIcons";
 import classNames from "classnames";
+import CodeBlockBlot from "@rich-editor/quill/blots/blocks/CodeBlockBlot";
+import BlockquoteLineBlot from "@rich-editor/quill/blots/blocks/BlockquoteBlot";
+import SpoilerLineBlot from "@rich-editor/quill/blots/blocks/SpoilerBlot";
 
 interface IProps {
     formatter: Formatter;
@@ -42,7 +45,7 @@ export default class ParagraphToolbarMenuItems extends React.PureComponent<IProp
     private get menuItemData() {
         const { activeFormats } = this.props;
         let isParagraphEnabled = true;
-        ["header", "blockquote-line", "codeBlock", "spoiler-line"].forEach(item => {
+        ["header", BlockquoteLineBlot.blotName, CodeBlockBlot.blotName, SpoilerLineBlot.blotName].forEach(item => {
             if (item in activeFormats) {
                 isParagraphEnabled = false;
             }
@@ -76,22 +79,22 @@ export default class ParagraphToolbarMenuItems extends React.PureComponent<IProp
                 icon: blockquote(),
                 label: t("Format as blockquote"),
                 onClick: this.formatBlockquote,
-                isActive: activeFormats["blockquote-line"] === true,
-                isDisabled: activeFormats["blockquote-line"] === true,
+                isActive: activeFormats[BlockquoteLineBlot.blotName] === true,
+                isDisabled: activeFormats[BlockquoteLineBlot.blotName] === true,
             },
             {
                 icon: codeBlock(),
                 label: t("Format as code block"),
                 onClick: this.formatCodeBlock,
-                isActive: activeFormats.codeBlock === true,
-                isDisabled: activeFormats.codeBlock === true,
+                isActive: activeFormats[CodeBlockBlot.blotName] === true,
+                isDisabled: activeFormats[CodeBlockBlot.blotName] === true,
             },
             {
                 icon: spoiler("richEditorButton-icon"),
                 label: t("Format as spoiler"),
                 onClick: this.formatSpoiler,
-                isActive: activeFormats["spoiler-line"] === true,
-                isDisabled: activeFormats["spoiler-line"] === true,
+                isActive: activeFormats[SpoilerLineBlot.blotName] === true,
+                isDisabled: activeFormats[SpoilerLineBlot.blotName] === true,
             },
         ];
     }

--- a/plugins/rich-editor/src/scripts/quill/Formatter.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/Formatter.test.ts
@@ -9,6 +9,7 @@ import Quill, { RangeStatic } from "quill/core";
 import { expect } from "chai";
 import OpUtils, { inlineFormatOps, blockFormatOps } from "@rich-editor/__tests__/OpUtils";
 import registerQuill from "./registerQuill";
+import CodeBlockBlot from "@rich-editor/quill/blots/blocks/CodeBlockBlot";
 
 describe("Formatter", () => {
     let quill: Quill;
@@ -29,21 +30,21 @@ describe("Formatter", () => {
     describe("bold()", () => {
         const formattingFunction = () => formatter.bold(getFullRange());
         testBasicInlineFormatting(formattingFunction, OpUtils.bold);
-        testStackedInlineFormatting("bold", formattingFunction, ["italic", "strike", "link", "codeInline"]);
+        testStackedInlineFormatting("bold", formattingFunction, ["italic", "strike", "link", "code"]);
         testInlineAgainstLineFormatting("bold", formattingFunction);
     });
 
     describe("italic()", () => {
         const formattingFunction = () => formatter.italic(getFullRange());
         testBasicInlineFormatting(formattingFunction, OpUtils.italic);
-        testStackedInlineFormatting("italic", formattingFunction, ["bold", "strike", "link", "codeInline"]);
+        testStackedInlineFormatting("italic", formattingFunction, ["bold", "strike", "link", "code"]);
         testInlineAgainstLineFormatting("italic", formattingFunction);
     });
 
     describe("strike()", () => {
         const formattingFunction = () => formatter.strike(getFullRange());
         testBasicInlineFormatting(formattingFunction, OpUtils.strike);
-        testStackedInlineFormatting("strike", formattingFunction, ["bold", "italic", "link", "codeInline"]);
+        testStackedInlineFormatting("strike", formattingFunction, ["bold", "italic", "link", "code"]);
         testInlineAgainstLineFormatting("strike", formattingFunction);
     });
 
@@ -53,7 +54,7 @@ describe("Formatter", () => {
         testStackedInlineFormatting(
             "link",
             formattingFunction,
-            ["bold", "italic", "strike", "codeInline"],
+            ["bold", "italic", "strike", "code"],
             OpUtils.DEFAULT_LINK,
         );
         testInlineAgainstLineFormatting("link", formattingFunction, OpUtils.DEFAULT_LINK);
@@ -61,9 +62,9 @@ describe("Formatter", () => {
 
     describe("codeInline()", () => {
         const formattingFunction = () => formatter.codeInline(getFullRange());
-        testBasicInlineFormatting(formattingFunction, OpUtils.codeInline);
-        testStackedInlineFormatting("codeInline", formattingFunction, ["bold", "italic", "strike", "link"]);
-        testInlineAgainstLineFormatting("codeInline", formattingFunction);
+        testBasicInlineFormatting(formattingFunction, OpUtils.code);
+        testStackedInlineFormatting("code", formattingFunction, ["bold", "italic", "strike", "link"]);
+        testInlineAgainstLineFormatting("code", formattingFunction);
     });
 
     describe("h2()", () => {
@@ -96,8 +97,8 @@ describe("Formatter", () => {
 
     describe("codeBlock()", () => {
         const formattingFunction = (range = getFullRange()) => formatter.codeBlock(range);
-        testNoLineFormatInlinePreservation("codeBlock", formattingFunction, OpUtils.codeBlock());
-        testLineFormatExclusivity("codeBlock", formattingFunction, OpUtils.codeBlock());
+        testNoLineFormatInlinePreservation(CodeBlockBlot.blotName, formattingFunction, OpUtils.codeBlock());
+        testLineFormatExclusivity(CodeBlockBlot.blotName, formattingFunction, OpUtils.codeBlock());
         testCodeBlockFormatStripping(formattingFunction);
     });
 
@@ -129,7 +130,7 @@ describe("Formatter", () => {
     function testStackedInlineFormatting(
         formatToTest: string,
         formatterFunction: () => void,
-        testAgainst: Exclude<Array<keyof typeof OpUtils>, "prototype">,
+        testAgainst: string[],
         enableValue: any = true,
     ) {
         describe(`Adding ${formatToTest} to existing inline formats`, () => {
@@ -250,7 +251,7 @@ describe("Formatter", () => {
                 {
                     insert: "asdf asdf @member  asdfasdf asl;dfjadasdf ",
                 },
-                { attributes: { codeBlock: true }, insert: "\n" },
+                { attributes: { [CodeBlockBlot.blotName]: true }, insert: "\n" },
             ];
             assertQuillInputOutput(initial, expected, formatterFunction);
         });

--- a/plugins/rich-editor/src/scripts/quill/KeyboardBindings.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/KeyboardBindings.test.ts
@@ -8,9 +8,10 @@ import Delta from "quill-delta";
 import Quill from "quill/core";
 import KeyboardBindings from "@rich-editor/quill/KeyboardBindings";
 import { expect } from "chai";
+import CodeBlockBlot from "@rich-editor/quill/blots/blocks/CodeBlockBlot";
 const LINE_FORMATS = ["blockquote-line", "spoiler-line"];
 
-const MULTI_LINE_FORMATS = [...LINE_FORMATS, "codeBlock"];
+const MULTI_LINE_FORMATS = [...LINE_FORMATS, CodeBlockBlot.blotName];
 
 describe("KeyboardBindings", () => {
     let quill: Quill;
@@ -69,7 +70,7 @@ describe("KeyboardBindings", () => {
 
     it("handleCodeBlockEnter", () => {
         const delta = new Delta().insert("line\n\n\n", {
-            codeBlock: true,
+            [CodeBlockBlot.blotName]: true,
         });
         quill.setContents(delta);
 
@@ -85,7 +86,7 @@ describe("KeyboardBindings", () => {
             {
                 insert: "\n",
                 attributes: {
-                    ["codeBlock"]: true,
+                    [CodeBlockBlot.blotName]: true,
                 },
             },
             {
@@ -180,7 +181,7 @@ describe("KeyboardBindings", () => {
             length: 0,
         };
 
-        if (blotName === "codeBlock") {
+        if (blotName === CodeBlockBlot.blotName) {
             keyboardBindings.handleCodeBlockBackspace(selection);
         } else {
             keyboardBindings.handleMultiLineBackspace(selection);

--- a/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
+++ b/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
@@ -24,9 +24,11 @@ import EmbedInsertionModule from "@rich-editor/quill/EmbedInsertionModule";
 import LinkBlot from "quill/formats/link";
 import BlockBlot from "quill/blots/block";
 import CodeBlot from "@rich-editor/quill/blots/inline/CodeBlot";
+import BlockquoteLineBlot from "@rich-editor/quill/blots/blocks/BlockquoteBlot";
+import SpoilerLineBlot from "@rich-editor/quill/blots/blocks/SpoilerBlot";
 
 export default class KeyboardBindings {
-    private static MULTI_LINE_BLOTS = ["spoiler-line", "blockquote-line", "codeBlock"];
+    private static MULTI_LINE_BLOTS = [SpoilerLineBlot.blotName, BlockquoteLineBlot.blotName, CodeBlockBlot.blotName];
     public bindings: any = {};
 
     constructor(private quill: Quill) {
@@ -155,7 +157,7 @@ export default class KeyboardBindings {
             return true;
         }
 
-        const delta = new Delta().retain(range.index).retain(1, { codeBlock: false });
+        const delta = new Delta().retain(range.index).retain(1, { [CodeBlockBlot.blotName]: false });
         this.quill.updateContents(delta, Emitter.sources.USER);
 
         return false;
@@ -316,7 +318,7 @@ export default class KeyboardBindings {
         this.bindings["CodeBlock Enter"] = {
             key: KeyboardModule.keys.ENTER,
             collapsed: true,
-            format: ["codeBlock"],
+            format: [CodeBlockBlot.blotName],
             handler: this.handleCodeBlockEnter,
         };
     }
@@ -416,7 +418,7 @@ export default class KeyboardBindings {
         this.bindings["CodeBlock Backspace"] = {
             key: KeyboardModule.keys.BACKSPACE,
             collapsed: true,
-            format: ["codeBlock"],
+            format: [CodeBlockBlot.blotName],
             handler: this.handleCodeBlockBackspace,
         };
     }

--- a/plugins/rich-editor/src/scripts/quill/blots/blocks/CodeBlockBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/blocks/CodeBlockBlot.ts
@@ -10,11 +10,6 @@ import Break from "quill/blots/break";
 import Cursor from "quill/blots/cursor";
 
 export default class CodeBlockBlot extends CodeBlock {
-    public static blotName = "codeBlock";
-    public static tagName = "code";
-    public static className = "codeBlock";
-    public static allowedChildren = [Text, Break, Cursor];
-
     public static create(value) {
         const domNode = super.create(value) as HTMLElement;
         domNode.setAttribute("spellcheck", false);

--- a/plugins/rich-editor/src/scripts/quill/blots/blocks/CodeBlockBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/blocks/CodeBlockBlot.ts
@@ -5,9 +5,6 @@
  */
 
 import CodeBlock from "quill/formats/code";
-import Text from "quill/blots/text";
-import Break from "quill/blots/break";
-import Cursor from "quill/blots/cursor";
 
 export default class CodeBlockBlot extends CodeBlock {
     public static create(value) {

--- a/plugins/rich-editor/src/scripts/quill/blots/inline/CodeBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/inline/CodeBlot.ts
@@ -7,14 +7,11 @@
 import { Code } from "quill/formats/code";
 
 export default class CodeBlot extends Code {
-    public static blotName = "codeInline";
-    public static tagName = "code";
-    public static className = "codeInline";
-
     constructor(domNode) {
         super(domNode);
         domNode.classList.add("code");
         domNode.classList.add("isInline");
+        domNode.classList.add("codeInline");
         domNode.setAttribute("spellcheck", false);
     }
 }

--- a/tests/fixtures/editor-rendering/codeBlock/input.json
+++ b/tests/fixtures/editor-rendering/codeBlock/input.json
@@ -4,5 +4,12 @@
     { "insert": "Line 3" },
     { "attributes": { "codeBlock": true }, "insert": "\n\n\n\n" },
     { "insert": "Line 7" },
-    { "attributes": { "codeBlock": true }, "insert": "\n" }
+    { "attributes": { "codeBlock": true }, "insert": "\n" },
+    { "insert":  "New Format\n" },
+    { "insert": "Line 1" },
+    { "attributes": { "code-block": true }, "insert": "\n\n" },
+    { "insert": "Line 3" },
+    { "attributes": { "code-block": true }, "insert": "\n\n\n\n" },
+    { "insert": "Line 7" },
+    { "attributes": { "code-block": true }, "insert": "\n" }
 ]

--- a/tests/fixtures/editor-rendering/codeBlock/output.html
+++ b/tests/fixtures/editor-rendering/codeBlock/output.html
@@ -6,3 +6,12 @@ Line 3
 
 Line 7
 </code>
+<p>New Format</p>
+<code class="code codeBlock" spellcheck="false">Line 1
+
+Line 3
+
+
+
+Line 7
+</code>

--- a/tests/fixtures/editor-rendering/inline-formatting/input.json
+++ b/tests/fixtures/editor-rendering/inline-formatting/input.json
@@ -2,6 +2,7 @@
     { "attributes": { "italic": true }, "insert": "italic " },
     { "attributes": { "bold": true }, "insert": "bold " },
     { "attributes": { "italic": true, "bold": true }, "insert": "italic-bold " },
+    { "attributes": { "code": true }, "insert": "code inline new format" },
     { "attributes": { "strike": true }, "insert": "strike" },
     { "attributes": { "codeInline": true }, "insert": "code inline" },
     { "insert": "\n" }

--- a/tests/fixtures/editor-rendering/inline-formatting/output.html
+++ b/tests/fixtures/editor-rendering/inline-formatting/output.html
@@ -3,6 +3,7 @@
     <strong>bold
         <em>italic-bold </em>
     </strong>
+    <code class="code codeInline" spellcheck="false">code inline new format</code>
     <s>strike</s>
     <code class="code codeInline" spellcheck="false">code inline</code>
 </p>


### PR DESCRIPTION
Closes #7746

Additionally closes a recently noticed issues (that doesn't seem to have an issue filed) where if a code block was the last thing pasted, the editor could get into a weird undefined state. This will also simplify the implementation of https://github.com/vanilla/vanilla/issues/6612 greatly.

## Fixes

This PR fixes the pasting of code blocks and inline code into the editor. To test just copy paste a large document such as https://docs.vanillaforums.com/help/embedding into the editor and notice how the code blocks are pasted.

## How

By reverting some our changes to the code-block &  code elements. Quill's clipboard module [has a laundry list of exceptions](https://github.com/quilljs/quill/blob/develop/modules/clipboard.js#L282) for code blocks and we were bypassing them all because it expects the blotNames to be `code-block` and `code` and for the HTML tag of the code block to be a `pre`.

I've reverted the changes we had made here to the base blots. By all appearances the styles of the items seem to be correct because I've kept around the `codeInline` and `codeBlock` classes on the items which is what we style on.

This also required updating our server rendering to look for these attribute names in addition to the ones we already had. I've implemented this and updated our rendering tests to contain both versions of the attribute names.