### PR TITLE
Refactor legacy flyouts

### DIFF
--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -1,0 +1,257 @@
+/**
+ * Legacy flyout code extracted from global.js
+ *
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+// Global vanilla library function.
+(function(window, $) {
+    var USE_NEW_FLYOUTS = gdn.getMeta("Feature.NewFlyouts.Enabled", false);
+
+    function accessibleButtonsInit() {
+        $(document).delegate("[role=button]", "keydown", function(event) {
+            var $button = $(this);
+            var ENTER_KEY = 13;
+            var SPACE_KEY = 32;
+            var isActiveElement = document.activeElement === $button[0];
+            var isSpaceOrEnter = event.keyCode === ENTER_KEY || event.keyCode === SPACE_KEY;
+            if (isActiveElement && isSpaceOrEnter) {
+                event.preventDefault();
+                $button.click();
+            }
+        });
+    }
+
+    function openFlyout($toggleFlyout, $flyout) {
+        // Opening a flyout will also close any button groups.
+        console.log("Clear button groups");
+        $(".ButtonGroup")
+            .removeClass("Open")
+            .setFlyoutAttributes();
+        
+        
+        $toggleFlyout
+            .addClass("Open")
+            .closest(".Item")
+            .addClass("Open");
+        $flyout.show();
+        $toggleFlyout.setFlyoutAttributes();
+    }
+
+    function closeFlyout($toggleFlyout, $flyout) {
+        $flyout.hide();
+        $toggleFlyout
+            .removeClass("Open")
+            .closest(".Item")
+            .removeClass("Open");
+        
+        $toggleFlyout.setFlyoutAttributes();
+    }
+
+    function closeAllFlyouts() {
+        closeFlyout($(".ToggleFlyout"), $(".Flyout"))
+    }
+
+    $(document).on("contentLoad", function(e) {
+        // Set up accessible flyouts
+        $(".ToggleFlyout, .editor-dropdown, .ButtonGroup").accessibleFlyoutsInit();
+        accessibleButtonsInit();
+    });
+
+    $(function() {
+        var hijackClick = function(e) {
+            var $elem = $(this);
+            var $parent = $(this).closest(".Item");
+            var $toggleFlyout = $elem.closest(".ToggleFlyout");
+            var href = $elem.attr("href");
+            var progressClass = $elem.hasClass("Bookmark") ? "Bookmarking" : "InProgress";
+
+            // If empty, or starts with a fragment identifier, do not send
+            // an async request.
+            if (!href || href.trim().indexOf("#") === 0) return;
+            gdn.disable(this, progressClass);
+            e.stopPropagation();
+
+            $.ajax({
+                type: "POST",
+                url: href,
+                data: { DeliveryType: "VIEW", DeliveryMethod: "JSON", TransientKey: gdn.definition("TransientKey") },
+                dataType: "json",
+                complete: function() {
+                    gdn.enable($elem.get(0));
+                    $elem.removeClass(progressClass);
+                    $elem.attr("href", href);
+                    $flyout = $toggleFlyout.find('.Flyout');
+
+                    closeFlyout($toggleFlyout, $flyout);
+                },
+                error: function(xhr) {
+                    gdn.informError(xhr);
+                },
+                success: function(json) {
+                    if (json === null) json = {};
+
+                    var informed = gdn.inform(json);
+                    gdn.processTargets(json.Targets, $elem, $parent);
+                    // If there is a redirect url, go to it.
+                    if (json.RedirectTo) {
+                        setTimeout(function() {
+                            window.location.replace(json.RedirectTo);
+                        }, informed ? 3000 : 0);
+                    }
+                },
+            });
+
+            return false;
+        };
+        $(document).delegate(".Hijack, .js-hijack", "click", hijackClick);
+
+        // Activate ToggleFlyout and ButtonGroup menus
+        $(document).delegate(".ButtonGroup > .Handle", "click", function() {
+            var $buttonGroup = $(this).closest(".ButtonGroup");
+            if (!$buttonGroup.hasClass("Open")) {
+                $(".ButtonGroup")
+                    .removeClass("Open")
+                    .setFlyoutAttributes();
+
+                // Open this one
+                $buttonGroup.addClass("Open").setFlyoutAttributes();
+            } else {
+                $(".ButtonGroup")
+                    .removeClass("Open")
+                    .setFlyoutAttributes();
+            }
+            return false;
+        });
+
+        var lastOpen = null;
+
+        $(document).delegate(".ToggleFlyout", "click", function(e) {
+            var $toggleFlyout = $(this);
+            var $flyout = $(".Flyout", this);
+            var isHandle = false;
+
+            if ($(e.target).closest(".Flyout").length === 0) {
+                e.stopPropagation();
+                isHandle = true;
+            } else if (
+                $(e.target).hasClass("Hijack") ||
+                $(e.target)
+                    .closest("a")
+                    .hasClass("Hijack")
+            ) {
+                return;
+            }
+            e.stopPropagation();
+
+            // Dynamically fill the flyout.
+            var rel = $(this).attr("rel");
+            if (rel) {
+                $(this).attr("rel", "");
+                $flyout.html('<div class="InProgress" style="height: 30px"></div>');
+
+                $.ajax({
+                    url: gdn.url(rel),
+                    data: { DeliveryType: "VIEW" },
+                    success: function(data) {
+                        $flyout.html(data);
+                    },
+                    error: function(xhr) {
+                        $flyout.html("");
+                        gdn.informError(xhr, true);
+                    },
+                });
+            }
+
+            // The old check.
+            var isFlyoutClosed = $flyout.css("display") == "none";
+            if (USE_NEW_FLYOUTS) {
+                // The new check.
+                isFlyoutClosed = $flyout.is(":visible");
+            }
+
+            if (isFlyoutClosed) {
+                if (lastOpen !== null) {
+                    $lastOpenFlyout = $(".Flyout", lastOpen);
+                    $lastOpenToggleFlyout = $(lastOpen);
+                    closeFlyout($lastOpenToggleFlyout, $lastOpenFlyout);
+                }
+
+                openFlyout($toggleFlyout, $flyout);
+                lastOpen = this;
+            } else {
+                closeFlyout($toggleFlyout, $flyout);
+            }
+
+            if (isHandle) return false;
+        });
+
+        // Close ToggleFlyout menu even if their links are hijacked
+        $(document).delegate(".ToggleFlyout a", "mouseup", function() {
+            if ($(this).hasClass("FlyoutButton")) return;
+            closeFlyout($(".ToggleFlyout"), $(".Flyout"))
+            $(this)
+                .closest(".ToggleFlyout")
+                .setFlyoutAttributes();
+        });
+
+        $(document).delegate(document, "click", function() {
+            if (lastOpen) {
+                $toggleFlyout = $(lastOpen);
+                $flyout = $(".Flyout", lastOpen);
+                closeFlyout($toggleFlyout, $flyout);
+            }
+        });
+    });
+
+    $.fn.extend({
+        accessibleFlyoutHandle: function(isOpen) {
+            $(this).attr("aria-expanded", isOpen.toString());
+        },
+
+        accessibleFlyout: function(isOpen) {
+            $(this).attr("aria-hidden", (!isOpen).toString());
+        },
+
+        setFlyoutAttributes: function() {
+            $(this).each(function() {
+                var $handle = $(this).find(
+                    ".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)",
+                );
+                var $flyout = $(this).find(".Flyout, .Dropdown");
+                var isOpen = $flyout.is(":visible");
+
+                $handle.accessibleFlyoutHandle(isOpen);
+                $flyout.accessibleFlyout(isOpen);
+            });
+        },
+
+        accessibleFlyoutsInit: function() {
+            var $context = $(this);
+
+            $context.each(function() {
+                $context
+                    .find(".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)")
+                    .each(function() {
+                        $(this)
+                            .attr("tabindex", "0")
+                            .attr("role", "button")
+                            .attr("aria-haspopup", "true");
+
+                        $(this).accessibleFlyoutHandle(false);
+                    });
+
+                $context.find(".Flyout, .Dropdown").each(function() {
+                    $(this).accessibleFlyout(false);
+
+                    $(this)
+                        .find("a")
+                        .each(function() {
+                            $(this).attr("tabindex", "0");
+                        });
+                });
+            });
+        },
+    });
+})(window, jQuery);

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -13,7 +13,7 @@
  */
 (function(window, $) {
     var USE_NEW_FLYOUTS = gdn.getMeta("useNewFlyouts", false);
-    var OPEN_CLASS = 'Open';
+    var OPEN_CLASS = "Open";
 
     /**
      * Content load handler, which is fired on first load, and when additional content is loaded in.
@@ -103,7 +103,7 @@
             .addClass(OPEN_CLASS)
             .closest(".Item")
             .addClass(OPEN_CLASS);
-        
+
         if (!USE_NEW_FLYOUTS) {
             $flyout.show();
         }
@@ -143,7 +143,7 @@
 
     /**
      * Take over the clicking of an element in order to make a post request.
-     * 
+     *
      * @param {MouseEvent} e The click event.
      */
     function handleHijackClick(e) {
@@ -206,7 +206,7 @@
 
     /**
      * Handle clicks on the flyout.
-     * 
+     *
      * @param {MouseEvent} e The click event to handle.
      */
     function handleToggleFlyoutClick(e) {
@@ -288,12 +288,12 @@
             $(this).attr("aria-hidden", (!isOpen).toString());
         },
 
-        setFlyoutAttributes: function () {
+        setFlyoutAttributes: function() {
             $toggleFlyouts = $(this);
-            $toggleFlyouts.each(function () {
+            $toggleFlyouts.each(function() {
                 $toggle = $(this);
                 var $handle = $(this).find(
-                    ".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)",
+                    ".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)"
                 );
                 var $flyout = $(this).find(".Flyout, .Dropdown");
                 var isOpen = $toggle.hasClass(OPEN_CLASS);

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -245,12 +245,12 @@
         if (isHandle) return false;
     }
 
+    /**
+     * Close all of the flyouts unless we are clicking on a button inside of a flyout.
+     */
     function handleToggleFlyoutMouseUp() {
         if ($(this).hasClass("FlyoutButton")) return;
         closeAllFlyouts();
-        $(this)
-            .closest(".ToggleFlyout")
-            .setFlyoutAttributes();
     }
 
     /**

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -24,12 +24,7 @@
     }
 
     function openFlyout($toggleFlyout, $flyout) {
-        // Opening a flyout will also close any button groups.
-        console.log("Clear button groups");
-        $(".ButtonGroup")
-            .removeClass("Open")
-            .setFlyoutAttributes();
-        
+        closeAllFlyouts();
         
         $toggleFlyout
             .addClass("Open")
@@ -51,6 +46,10 @@
 
     function closeAllFlyouts() {
         closeFlyout($(".ToggleFlyout"), $(".Flyout"))
+        // Clear the button groups that are open as well.
+        $(".ButtonGroup")
+            .removeClass("Open")
+            .setFlyoutAttributes();
     }
 
     $(document).on("contentLoad", function(e) {
@@ -110,22 +109,14 @@
         // Activate ToggleFlyout and ButtonGroup menus
         $(document).delegate(".ButtonGroup > .Handle", "click", function() {
             var $buttonGroup = $(this).closest(".ButtonGroup");
+            closeAllFlyouts();
             if (!$buttonGroup.hasClass("Open")) {
-                $(".ButtonGroup")
-                    .removeClass("Open")
-                    .setFlyoutAttributes();
 
                 // Open this one
                 $buttonGroup.addClass("Open").setFlyoutAttributes();
-            } else {
-                $(".ButtonGroup")
-                    .removeClass("Open")
-                    .setFlyoutAttributes();
             }
             return false;
         });
-
-        var lastOpen = null;
 
         $(document).delegate(".ToggleFlyout", "click", function(e) {
             var $toggleFlyout = $(this);
@@ -172,14 +163,7 @@
             }
 
             if (isFlyoutClosed) {
-                if (lastOpen !== null) {
-                    $lastOpenFlyout = $(".Flyout", lastOpen);
-                    $lastOpenToggleFlyout = $(lastOpen);
-                    closeFlyout($lastOpenToggleFlyout, $lastOpenFlyout);
-                }
-
                 openFlyout($toggleFlyout, $flyout);
-                lastOpen = this;
             } else {
                 closeFlyout($toggleFlyout, $flyout);
             }
@@ -190,18 +174,14 @@
         // Close ToggleFlyout menu even if their links are hijacked
         $(document).delegate(".ToggleFlyout a", "mouseup", function() {
             if ($(this).hasClass("FlyoutButton")) return;
-            closeFlyout($(".ToggleFlyout"), $(".Flyout"))
+            closeAllFlyouts();
             $(this)
                 .closest(".ToggleFlyout")
                 .setFlyoutAttributes();
         });
 
         $(document).delegate(document, "click", function() {
-            if (lastOpen) {
-                $toggleFlyout = $(lastOpen);
-                $flyout = $(".Flyout", lastOpen);
-                closeFlyout($toggleFlyout, $flyout);
-            }
+            closeAllFlyouts();
         });
     });
 

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -62,6 +62,8 @@
         });
     }
 
+    var BODY_CLASS = "flyoutIsOpen";
+
     function openFlyout($toggleFlyout, $flyout) {
         closeAllFlyouts();
 
@@ -71,6 +73,7 @@
             .addClass("Open");
         $flyout.show();
         $toggleFlyout.setFlyoutAttributes();
+        document.body.classList.add(BODY_CLASS);
     }
 
     function closeFlyout($toggleFlyout, $flyout) {
@@ -79,8 +82,8 @@
             .removeClass("Open")
             .closest(".Item")
             .removeClass("Open");
-
         $toggleFlyout.setFlyoutAttributes();
+        document.body.classList.remove(BODY_CLASS);
     }
 
     function closeAllFlyouts() {
@@ -89,6 +92,7 @@
         $(".ButtonGroup")
             .removeClass("Open")
             .setFlyoutAttributes();
+        document.body.classList.remove(BODY_CLASS);
     }
 
     $(document).on("contentLoad", function(e) {

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -7,9 +7,48 @@
 
 // Global vanilla library function.
 (function(window, $) {
-    var USE_NEW_FLYOUTS = gdn.getMeta("Feature.NewFlyouts.Enabled", false);
+    var USE_NEW_FLYOUTS = gdn.getMeta("useNewFlyouts", false);
+    console.log("New flyouts", USE_NEW_FLYOUTS);
 
-    function accessibleButtonsInit() {
+    function initFlyouts() {
+        var $handles = $(".ToggleFlyout, .editor-dropdown, .ButtonGroup");
+
+        $handles.each(function() {
+            $handles
+                .find(".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)")
+                .each(function() {
+                    $(this)
+                        .attr("tabindex", "0")
+                        .attr("role", "button")
+                        .attr("aria-haspopup", "true");
+
+                    $(this).accessibleFlyoutHandle(false);
+                });
+
+            $handles.find(".Flyout, .Dropdown").each(function() {
+                $(this).accessibleFlyout(false);
+
+                $(this)
+                    .find("a")
+                    .each(function() {
+                        $(this).attr("tabindex", "0");
+                    });
+            });
+        });
+
+        if (USE_NEW_FLYOUTS) {
+            var $contents = $(".Flyout, .ButtonGroup .Dropdown");
+            var wrap = document.createElement("span");
+            wrap.classList.add("mobileFlyoutOverlay");
+
+            $contents.each(function () {
+                if (!this.parentElement.classList.contains("mobileFlyoutOverlay")) {
+                    $(this).wrap(wrap);
+                }
+            });
+        }
+
+        // Button accessibility
         $(document).delegate("[role=button]", "keydown", function(event) {
             var $button = $(this);
             var ENTER_KEY = 13;
@@ -25,7 +64,7 @@
 
     function openFlyout($toggleFlyout, $flyout) {
         closeAllFlyouts();
-        
+
         $toggleFlyout
             .addClass("Open")
             .closest(".Item")
@@ -40,12 +79,12 @@
             .removeClass("Open")
             .closest(".Item")
             .removeClass("Open");
-        
+
         $toggleFlyout.setFlyoutAttributes();
     }
 
     function closeAllFlyouts() {
-        closeFlyout($(".ToggleFlyout"), $(".Flyout"))
+        closeFlyout($(".ToggleFlyout"), $(".Flyout"));
         // Clear the button groups that are open as well.
         $(".ButtonGroup")
             .removeClass("Open")
@@ -54,8 +93,7 @@
 
     $(document).on("contentLoad", function(e) {
         // Set up accessible flyouts
-        $(".ToggleFlyout, .editor-dropdown, .ButtonGroup").accessibleFlyoutsInit();
-        accessibleButtonsInit();
+        initFlyouts();
     });
 
     $(function() {
@@ -81,7 +119,7 @@
                     gdn.enable($elem.get(0));
                     $elem.removeClass(progressClass);
                     $elem.attr("href", href);
-                    $flyout = $toggleFlyout.find('.Flyout');
+                    $flyout = $toggleFlyout.find(".Flyout");
 
                     closeFlyout($toggleFlyout, $flyout);
                 },
@@ -111,7 +149,6 @@
             var $buttonGroup = $(this).closest(".ButtonGroup");
             closeAllFlyouts();
             if (!$buttonGroup.hasClass("Open")) {
-
                 // Open this one
                 $buttonGroup.addClass("Open").setFlyoutAttributes();
             }
@@ -159,7 +196,7 @@
             var isFlyoutClosed = $flyout.css("display") == "none";
             if (USE_NEW_FLYOUTS) {
                 // The new check.
-                isFlyoutClosed = $flyout.is(":visible");
+                isFlyoutClosed = !$flyout.is(":visible");
             }
 
             if (isFlyoutClosed) {
@@ -204,33 +241,6 @@
 
                 $handle.accessibleFlyoutHandle(isOpen);
                 $flyout.accessibleFlyout(isOpen);
-            });
-        },
-
-        accessibleFlyoutsInit: function() {
-            var $context = $(this);
-
-            $context.each(function() {
-                $context
-                    .find(".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)")
-                    .each(function() {
-                        $(this)
-                            .attr("tabindex", "0")
-                            .attr("role", "button")
-                            .attr("aria-haspopup", "true");
-
-                        $(this).accessibleFlyoutHandle(false);
-                    });
-
-                $context.find(".Flyout, .Dropdown").each(function() {
-                    $(this).accessibleFlyout(false);
-
-                    $(this)
-                        .find("a")
-                        .each(function() {
-                            $(this).attr("tabindex", "0");
-                        });
-                });
             });
         },
     });

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -365,6 +365,17 @@ class Gdn_Controller extends Gdn_Pluggable {
     }
 
     /**
+     * Mapping of how certain legacy javascript files have been split up.
+     * 
+     * If you include the key, all of the files in it's value will be included as well.
+     */
+    const SPLIT_JS_MAPPINGS = [
+        'global.js' => [
+            'flyouts.js',
+        ],
+    ];
+
+    /**
      * Adds a JS file to search for in the application or global js folder(s).
      *
      * @param string $fileName The js file to search for.
@@ -384,6 +395,13 @@ class Gdn_Controller extends Gdn_Pluggable {
         }
 
         $this->_JsFiles[] = $jsInfo;
+
+        if ($appFolder === '' && array_key_exists($fileName, self::SPLIT_JS_MAPPINGS)) {
+            $items = self::SPLIT_JS_MAPPINGS[$fileName];
+            foreach ($items as $item) {
+                $this->addJsFile($item, $appFolder, $options);
+            }
+        }
     }
 
     /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -649,6 +649,8 @@ class Gdn_Controller extends Gdn_Pluggable {
             'context' => [], 'ui' => []
         ];
 
+        $this->_Definitions['useNewFlyouts'] = \Vanilla\FeatureFlagHelper::featureEnabled('NewFlyouts');
+
         $this->_Definitions['context'] += [
             'host' => Gdn::request()->domain(),
             'basePath' => rtrim('/'.trim(Gdn::request()->webRoot(), '/'), '/'),

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -366,7 +366,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
     /**
      * Mapping of how certain legacy javascript files have been split up.
-     * 
+     *
      * If you include the key, all of the files in it's value will be included as well.
      */
     const SPLIT_JS_MAPPINGS = [


### PR DESCRIPTION
Required for/blocking https://github.com/vanilla/themes/issues/253

## Context

Our latest iteration of flyouts is done in react and switches between rendering the flyout as a dropdown on desktop and a modal on mobile. There were some really nasty javascript/stylesheet hacks to make mobile/responsive flyouts possible in the various client themes we've done in the past 2 years. 

The goal of this PR is to:
- Allow a new base theme to have nice responsive flyouts.
- Not break compatibility with any flyouts in our forum.
- Not break compatibility with any existing themes, including the numerous responsive ones that are unsetting/recreating the flyout event listeners themselves.
 make it possible for these to be removed for the new base theme.

## Plumbing

- Adds a feature flag `NewFlyouts`. I was debating calling this `NewLegacyFlyouts`.
- Updates `Gdn_Controller` to pass along this value to the frontend.
- Takes all flyout related code in `global.js` and moves it into `flyouts.js`. I did not put it on the new build because all of the themes using the workaround or unsetting event listeners will expect these event listeners to be set synchronously before their own javascript is loaded. The loading of built javascript is `deferred` and I intend to keep it that way.
- Updates `Gdn_Controller` to be able to load additional javascript files when certain ones are loaded. This will allows us to break down `global.js` without needing to worry about the 30-40 controllers spread across allow the repos that expect it to be loaded immediately after `global.js` (also if it was left for the controllers to manually add these broken out pieces, this would be a breaking change for open source at least). **TL;DR; if you include `global.js`, `flyouts.js` will be included immediately after it.** 
- Deleted ~50 lines of commented out code in `global.js`.

## `flyouts.js`

This file is 90% the same logic as it was in `global.js`. I've made a few changes though:

- Moved the duplicated logic of opening/closing a flyout into dedicated functions.
- Moved all event handler callbacks into named functions.
- Added docblocks to everything.
- Made Button Dropdowns and Flyouts aware of each other. Previously the opening a flyout would close the dropdown but not the other way around. This no works both ways. Eg. Only 1 dropdown/flyout may be open at a time.

When the `useNewFlyouts` config is set the following changes will take affect in order to offer more flexibility to themes:

- `$.hide()` and `$.show()` will no longer be called and `display == 'none'` will no longer be used to determine if a flyout is open or not. Instead only the CSS class will determine the open/closed state.
- On content load will wrap any `Flyout` or `Dropdown` in a `<span class='mobileFlyoutOverlay'></span>`. This is to allow easier styling of a background overlay from a theme.

## Testing

I've manually tested this with our core themes as well as some of our custom ones that do event overriding/setting. The current vanilla theme boilerplate uses this method. https://github.com/vanilla/themes

Note: Flyouts won't properly display in any existing theme. Themes will need to update their stylesheets to enable this the new feature flag.
