### PR TITLE
Add CSS class for user mentions

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1939,7 +1939,7 @@ EOT;
                 if (self::$DisplayNoFollow) {
                     $attributes['rel'] = 'nofollow';
                 }
-                $parts[$i] = anchor('@'.$mention, url(str_replace('{name}', rawurlencode($mention), self::$MentionsUrlFormat), true), '', $attributes).$suffix;
+                $parts[$i] = anchor('@'.$mention, url(str_replace('{name}', rawurlencode($mention), self::$MentionsUrlFormat), true), 'atMention', $attributes).$suffix;
             } else {
                 $parts[$i] = '@' . $parts[$i];
             }


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7796

All mentions will now use the `atMention` CSS class, which is what is currently used by Rich Editor.