### PR TITLE
Fix unread status on discussions for guests

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -15,6 +15,9 @@ use Garden\EventManager;
  */
 class UserModel extends Gdn_Model {
 
+    /** @var int */
+    const GUEST_USER_ID = 0;
+
     /** Deprecated. */
     const DEFAULT_CONFIRM_EMAIL = 'You need to confirm your email address before you can continue. Please confirm your email address by clicking on the following link: {/entry/emailconfirm,exurl,domain}/{User.UserID,rawurlencode}/{EmailKey,rawurlencode}';
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1290,7 +1290,7 @@ class DiscussionModel extends Gdn_Model {
         }
 
         // If no user was provided, view from the perspective of a guest.
-        if (!filter_var($userID, FILTER_VALIDATE_INT)) {
+        if (!filter_var($watchUserID, FILTER_VALIDATE_INT)) {
             $watchUserID = UserModel::GUEST_USER_ID;
         }
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1039,6 +1039,11 @@ class DiscussionModel extends Gdn_Model {
                     $discussion->CountUnreadComments = 0;
                 }
             }
+
+            // Discussions are always unread to guests.
+            if (!Gdn::session()->isValid()) {
+                $discussion->Read = false;
+            }
         }
 
         // Logic for incomplete comment count.

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1284,9 +1284,9 @@ class DiscussionModel extends Gdn_Model {
             return new Gdn_DataSet([]);
         }
 
-        // Allow us to set perspective of a different user.
-        if (empty($watchUserID)) {
-            $watchUserID = $userID;
+        // If no user was provided, view from the perspective of a guest.
+        if (!filter_var($userID, FILTER_VALIDATE_INT)) {
+            $watchUserID = UserModel::GUEST_USER_ID;
         }
 
         // The point of this query is to select from one comment table, but filter and sort on another.
@@ -1303,7 +1303,7 @@ class DiscussionModel extends Gdn_Model {
             ->orderBy('d.DiscussionID', 'desc');
 
         // Join in the watch data.
-        if ($watchUserID > 0) {
+        if ($watchUserID > UserModel::GUEST_USER_ID) {
             $this->SQL
                 ->select('w.UserID', '', 'WatchUserID')
                 ->select('w.DateLastViewed, w.Dismissed, w.Bookmarked')
@@ -1312,7 +1312,7 @@ class DiscussionModel extends Gdn_Model {
                 ->join('UserDiscussion w', 'd2.DiscussionID = w.DiscussionID and w.UserID = '.$watchUserID, 'left');
         } else {
             $this->SQL
-                ->select('0', '', 'WatchUserID')
+                ->select((string) UserModel::GUEST_USER_ID, '', 'WatchUserID')
                 ->select('now()', '', 'DateLastViewed')
                 ->select('0', '', 'Dismissed')
                 ->select('0', '', 'Bookmarked')

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -413,7 +413,7 @@ class Gdn_Session {
      * @return boolean
      */
     public function isValid() {
-        return $this->UserID > UserModel::GUEST_USER_ID;
+        return $this->UserID > 0;
     }
 
     /**

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -413,7 +413,7 @@ class Gdn_Session {
      * @return boolean
      */
     public function isValid() {
-        return $this->UserID > 0;
+        return $this->UserID > UserModel::GUEST_USER_ID;
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/3456

## What was wrong

- When calling `Discussion::getByUser` with the guest or no user ID we would set use the userID of the user whose profile was being viewed (`empty(0) = empty(null) = false`). This was clearly incorrect. I've updated this to initialize the default to be the guest user ID.
- Our calculations for unread calculations are stupidly complex. Rather than dive into the nastiness of it (with no tests mind you) I've opted to just set the `Read` status to be `false` for guest users for all discussions.

## Housekeeping

- I've added a constant for the guest user ID and used it in a couple of places. I'm quite surprised that we didn't have one.