### PR TITLE
Fix CategoryModel::getAll references to nonexistent parameters

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -928,7 +928,7 @@ class VanillaSettingsController extends Gdn_Controller {
         $this->title(t('Categories'));
 
         // Get category data
-        $categoryData = $this->CategoryModel->getAll('TreeLeft');
+        $categoryData = $this->CategoryModel->getAll();
 
         // Set CanDelete per-category so we can override later if we want.
         $canDelete = checkPermission(['Garden.Community.Manage', 'Garden.Settings.Manage']);

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2045,12 +2045,7 @@ class CategoryModel extends Gdn_Model {
      * Get list of categories (disregarding user permission for admins).
      *
      * @since 2.0.0
-     * @access public
-     *
-     * @param string $OrderFields Ignored.
-     * @param string $OrderDirection Ignored.
-     * @param int $Limit Ignored.
-     * @param int $Offset Ignored.
+     * 
      * @return object SQL results.
      */
     public function getAll() {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2045,7 +2045,7 @@ class CategoryModel extends Gdn_Model {
      * Get list of categories (disregarding user permission for admins).
      *
      * @since 2.0.0
-     * 
+     *
      * @return object SQL results.
      */
     public function getAll() {


### PR DESCRIPTION
These parameters were removed some time ago, but the doc block was never updated. I've additionally removed the 1 instance where a parameter was still being passed.

Related https://github.com/vanilla/vanilla/issues/3848