### PR TITLE
Throw a deprecation warning when using Gdn_SQLDriver::whereNotIn with empty arrays

### DIFF
--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -2141,6 +2141,9 @@ abstract class Gdn_SQLDriver {
         if (count($in) > 0) {
             $inExpr = '('.implode(', ', $in).')';
         } else {
+            if ($op == 'not in') {
+                deprecated('Gdn_SQLDriver::whereNotIn() with empty $values array');
+            }
             $inExpr = '(null)';
         }
 

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -2142,7 +2142,8 @@ abstract class Gdn_SQLDriver {
             $inExpr = '('.implode(', ', $in).')';
         } else {
             if ($op == 'not in') {
-                deprecated('Gdn_SQLDriver::whereNotIn() with empty $values array');
+                deprecated('Gdn_SQLDriver::whereNotIn() was called with empty $values array. This will no longer be supported in a future release.');
+                \Vanilla\Utility\Deprecation::log();
             }
             $inExpr = '(null)';
         }


### PR DESCRIPTION
Throw a deprecation warning when using Gdn_SQLDriver::whereNotIn with empty arrays

You may want to use `Gdn_SQLDriver::whereNotIn` in a chained manner like this:

```php
    $result = Gdn::sql()
        ->from('User')
        ->whereNotIn('UserID', $excludeUserIDs)
        ->get();
```

However, this will never return anything, if `$excludeUserIDs` is empty, because of a logic error in `Gdn_SQLDriver::_whereIn`. **Even though you don't want to exclude anything, nothing will be returned.**

Note that this is a bug, not a matter of preference: The function does exactly the opposite of what the name implies in that case.

Thus, a check like this is always necessary when using `Gdn_SQLDriver::whereNotIn`, obstructing fluent use:

```php
    $sql = Gdn::sql()
        ->from('User');

    if (!empty($excludeUserIDs)) {
        $sql->whereNotIn('UserID', $excludeUserIDs);
    }

    $result = $sql->get();
```

Since there may be private plugins that rely on this bug (e.g. in destructive write or delete statements), a deprecation warning is thrown in order to find all occurences.

I personally doubt, there are many such usages, because for this method to be any useful, you always need to check the array you pass into it for emptyness. All occurences that I know of do exactly that or some other hack/workaround like excluding ID "0".

Once enough confidence is built, that there are no reliances on this behaviour, the actual fix (#7715) can be applied and `MessageModel::getMessagesForLocation`, `PermissionModel::getJunctionPermissions` and probably more methods can be simplified.
