### PR TITLE
Update travis build config to xenial and add PHP 7.3 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,32 @@
 jobs:
   fast_finish: true
   include:
+    # PHP 7.3 Job. This only runs in the daily cron jobs.
+    # Once infrastructure has been updated to 7.3+ this will be run on pull requests.
+    - name: PHP 7.3
+      language: php
+      php: 7.3
+      if: type = cron
+      addons:
+        apt:
+          packages:
+            - nginx
+            - realpath
+        hosts:
+          - vanilla.test
+      before_script:
+        - phpenv config-rm xdebug.ini # Remove xdebug for better performance.
+        - composer self-update
+        - composer install --optimize-autoloader
+        - tests/travis/setup.sh
+      cache:
+        directories:
+          - $HOME/.composer/cache/files
+      script:
+        - tests/travis/main.sh
+        - ls -lah ./conf
+        - cat /tmp/error.log
+        - cat /tmp/access.log
     # PHP 7.2 Job. This should always run.
     - name: PHP 7.2
       language: php
@@ -51,7 +77,7 @@ jobs:
         - ls -lah ./conf
         - cat /tmp/error.log
         - cat /tmp/access.log
-    # PHP 7.1 Job. This only runs in the daily cron jobs.
+    # PHP 7.0 Job. This only runs in the daily cron jobs.
     - name: PHP 7.0
       language: php
       php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # Configure the build.
+dist: xenial
 jobs:
   fast_finish: true
   include:
@@ -15,6 +16,8 @@ jobs:
             - realpath
         hosts:
           - vanilla.test
+      services:
+        - mysql
       before_script:
         - phpenv config-rm xdebug.ini # Remove xdebug for better performance.
         - composer self-update
@@ -39,6 +42,8 @@ jobs:
             - realpath
         hosts:
           - vanilla.test
+      services:
+        - mysql
       before_script:
         - phpenv config-rm xdebug.ini # Remove xdebug for better performance.
         - composer self-update
@@ -64,6 +69,8 @@ jobs:
             - realpath
         hosts:
           - vanilla.test
+      services:
+        - mysql
       before_script:
         - phpenv config-rm xdebug.ini # Remove xdebug for better performance.
         - composer self-update
@@ -89,6 +96,8 @@ jobs:
             - realpath
         hosts:
           - vanilla.test
+      services:
+        - mysql
       before_script:
         - phpenv config-rm xdebug.ini # Remove xdebug for better performance.
         - composer self-update
@@ -107,6 +116,9 @@ jobs:
       language: node_js
       node_js: lts/*
       addons:
+        apt:
+          sources:
+            - google-chrome
         chrome: stable
       before_script:
         - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3 # Ensure a consistent yarn version


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/6485
Closes https://github.com/vanilla/vanilla/issues/8144

## New PHP 7.3 job

I've added a PHP `7.3` job which only runs on the daily cron jobs. Once we've deployed our own infrastructure with `7.3`, we can make the `7.3` build the one that runs every pull request and move 7.2 onto the cron job.

## Xenial upgade

I've put the build on the xenial ubuntu 16.04 distribution. This necessitated a couple changes outlined in [travis's xenial documentation](https://docs.travis-ci.com/user/reference/xenial/).

- Manually enable the MySQL service.
- Manually add the Google Chrome apt repository.

**Other noteworthy changes**

- The MySQL is version 5.7, which has strict mode enabled by default