### PR TITLE
Profile - display discussion and comment count when count greater than 0

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -739,9 +739,18 @@ class VanillaHooks implements Gdn_IPlugin {
                 $discussionsCount = getValueR('User.CountDiscussions', $sender, null);
                 $commentsCount = getValueR('User.CountComments', $sender, null);
 
-                $discussionsLabel .= '<span class="Aside">'.countString(bigPlural($discussionsCount, '%s discussion'), "/profile/count/discussions?userid=$userID").'</span>';
-
-                $commentsLabel .= '<span class="Aside">'.countString(bigPlural($commentsCount, '%s comment'), "/profile/count/comments?userid=$userID").'</span>';
+                if (!is_null($discussionsCount) && !empty($discussionsCount)) {
+                    $discussionsLabel .=
+                        '<span class="Aside">' .
+                        countString(bigPlural($discussionsCount, '%s discussion'), "/profile/count/discussions?userid=$userID")
+                        . '</span>';
+                }
+                if (!is_null($commentsCount)  && !empty($commentsCount)) {
+                    $commentsLabel .=
+                        '<span class="Aside">' .
+                        countString(bigPlural($commentsCount, '%s comment'), "/profile/count/comments?userid=$userID") .
+                        '</span>';
+                }
             }
             $sender->addProfileTab(t('Discussions'), userUrl($sender->User, '', 'discussions'), 'Discussions', $discussionsLabel);
             $sender->addProfileTab(t('Comments'), userUrl($sender->User, '', 'comments'), 'Comments', $commentsLabel);


### PR DESCRIPTION
**Issue**

On the profile page the discussion and comment tabs for newly created users display a blank bar because the user doesn't have any posted discussions or comments.  This is because the the default value for CountDiscussions and CountComments is NULL in the db.

**To Reproduce:**

1) Create New User
2) Go to the users Profile Page
3) Discussion\Comment tab should be display weird bar

**Solution:**

When building the Discussion and Comment Tabs validate the counts aren't NULL or 0, if they are don't display the count.

Closes Vanilla/Support#116