### PR TITLE
Fix mounting rich editor on any content load events

### DIFF
--- a/plugins/rich-editor/src/scripts/entries/forum.ts
+++ b/plugins/rich-editor/src/scripts/entries/forum.ts
@@ -6,40 +6,29 @@
 
 import editorReducer from "@rich-editor/state/editorReducer";
 import { registerReducer } from "@library/state/reducerRegistry";
-import { onReady } from "@library/application";
+import { onReady, onContent } from "@library/application";
 import "../../scss/editor.scss";
 
 onReady(() => {
     registerReducer("editor", editorReducer);
     void setupEditor();
-    void setupCommentEditForm();
 });
+onContent(setupEditor);
+
+const MOUNTED_CLASS = "js-isMounted";
 
 /**
  * Set up the new discussion form if it exists.
  */
 async function setupEditor() {
-    const discussionFormContainer = document.querySelectorAll(".richEditor");
-    if (discussionFormContainer.length > 0) {
+    const editorMountPoints = document.querySelectorAll(".richEditor");
+    if (editorMountPoints.length > 0) {
         const mountEditor = await import(/* webpackChunkName: "mountEditor" */ "@rich-editor/mountEditor");
-        discussionFormContainer.forEach(mountEditor.default);
+        editorMountPoints.forEach(mountPoint => {
+            if (!mountPoint.classList.contains(MOUNTED_CLASS)) {
+                mountPoint.classList.add(MOUNTED_CLASS);
+                mountEditor.default(mountPoint);
+            }
+        });
     }
-}
-
-/**
- * Set up the editor if the someone clicks edit on a form.
- */
-async function setupCommentEditForm() {
-    document.addEventListener("X-EditCommentFormLoaded", async event => {
-        const container = event.target;
-        if (!(container instanceof Element)) {
-            return;
-        }
-
-        const richEditor = container.querySelector(".richEditor");
-        if (richEditor) {
-            const mountEditor = await import(/* webpackChunkName: "mountEditor" */ "@rich-editor/mountEditor");
-            mountEditor.default(richEditor);
-        }
-    });
 }


### PR DESCRIPTION
Closes https://github.com/vanilla/internal/issues/1705

This PR fixes the mounting of the editor anytime new HTML is added to the page. We were handling the specific event of a comment edit form being added to the page but there are many other places that might expect the editor to be mounted, see the linked issue.

After the creation of the editor we added 1 common event to handle all of these scenarios including comment edit boxes, so I've removed our specific handler and just used the `onContent()` handler form `@library/application`.

I also added some protected from duplicated mounting by settings a JS class once mounting has started.