### PR TITLE
Add twig support to the existing Gdn_Controller view infrastructure

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -265,6 +265,10 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->setClass('Gdn_Smarty')
     ->setShared(true)
 
+    ->rule('ViewHandler.twig')
+    ->setClass(\Vanilla\Web\LegacyTwigViewHandler::class)
+    ->setShared(true)
+
     ->rule('Gdn_Form')
     ->addAlias('Form')
 

--- a/library/Vanilla/Contracts/Web/LegacyViewHandlerInterface.php
+++ b/library/Vanilla/Contracts/Web/LegacyViewHandlerInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Contracts\Web;
+
+/**
+ * A web asset interface.
+ */
+interface LegacyViewHandlerInterface {
+    /**
+     * Render the given view.
+     *
+     * @param string $path The path to the view's file.
+     * @param \Gdn_Controller $controller The controller that is rendering the view.
+     */
+    public function render($path, $controller);
+}

--- a/library/Vanilla/Contracts/Web/LegacyViewHandlerInterface.php
+++ b/library/Vanilla/Contracts/Web/LegacyViewHandlerInterface.php
@@ -8,7 +8,7 @@
 namespace Vanilla\Contracts\Web;
 
 /**
- * A web asset interface.
+ * An interface for a view handler for Gdn_Controller.
  */
 interface LegacyViewHandlerInterface {
     /**

--- a/library/Vanilla/Web/LegacyTwigViewHandler.php
+++ b/library/Vanilla/Web/LegacyTwigViewHandler.php
@@ -9,7 +9,7 @@ namespace Vanilla\Web;
 use Vanilla\Contracts\Web\LegacyViewHandlerInterface;
 
 /**
- * Gdn_Controller view handler for smarty.
+ * Gdn_Controller view handler for twig.
  */
 class LegacyTwigViewHandler implements LegacyViewHandlerInterface {
     use \Garden\TwigTrait;

--- a/library/Vanilla/Web/LegacyTwigViewHandler.php
+++ b/library/Vanilla/Web/LegacyTwigViewHandler.php
@@ -15,7 +15,7 @@ class LegacyTwigViewHandler implements LegacyViewHandlerInterface {
     use \Garden\TwigTrait;
 
     /**
-     * @inheritdoc
+     * Render the given view.
      *
      * @param string $path
      * @param \Gdn_Controller $controller

--- a/library/Vanilla/Web/LegacyTwigViewHandler.php
+++ b/library/Vanilla/Web/LegacyTwigViewHandler.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Web;
+
+use Vanilla\Contracts\Web\LegacyViewHandlerInterface;
+
+/**
+ * Gdn_Controller view handler for smarty.
+ */
+class LegacyTwigViewHandler implements LegacyViewHandlerInterface {
+    use \Garden\TwigTrait;
+
+    /**
+     * @inheritdoc
+     *
+     * @param string $path
+     * @param \Gdn_Controller $controller
+     */
+    public function render($path, $controller) {
+        $path = str_replace(PATH_ROOT, '', $path);
+        echo self::twigInit()->render($path, $controller->Data);
+    }
+}

--- a/library/core/class.smarty.php
+++ b/library/core/class.smarty.php
@@ -12,7 +12,7 @@
 /**
  * Vanilla implementation of Smarty templating engine.
  */
-class Gdn_Smarty {
+class Gdn_Smarty implements \Vanilla\Contracts\Web\LegacyViewHandlerInterface {
 
     /** @var Smarty The smarty object used for the template. */
     protected $_Smarty = null;


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/issues/487

While working on some new dashboard pages it became apparent that we were going to want support for twig in our old controllers as well.

This PR:

- Adds an interface to for our legacy ViewHandlers (Gdn_Smarty) was the only implementation.
- Adds a new view handler using the `Garden\TwigTrait` that supports rendering twig templates.
- Adds a couple of utility methods to our twig instance (translation and url building).