### PR TITLE
Add support for converting Garden Schema exceptions to Gdn_Validation

### DIFF
--- a/library/Vanilla/Utility/ModelUtils.php
+++ b/library/Vanilla/Utility/ModelUtils.php
@@ -16,6 +16,29 @@ use Gdn_Validation;
  * Class ModelUtils.
  */
 class ModelUtils {
+
+    /**
+     * Convert a Garden Schema validation exception into a Gdn_Validation instance.
+     *
+     * @param ValidationException $exception
+     */
+    public static function validationExceptionToValidationResult(ValidationException $exception): Gdn_Validation {
+        $result = new Gdn_Validation();
+        $validation = $exception->getValidation();
+        $errors = $validation->getErrors();
+
+        foreach ($errors as $error) {
+            $fieldName = $error["field"] ?? null;
+            $message = $error["message"] ?? null;
+            if ($fieldName && $message) {
+                $errorCode = str_replace($fieldName, "%s", $message);
+                $result->addValidationResult($fieldName, $errorCode);
+            }
+        }
+
+        return $result;
+    }
+
     /**
      * Given a model (old Gdn_Model mainly), analyze its validation property and return failures.
      *

--- a/library/Vanilla/Utility/ModelUtils.php
+++ b/library/Vanilla/Utility/ModelUtils.php
@@ -24,8 +24,7 @@ class ModelUtils {
      */
     public static function validationExceptionToValidationResult(ValidationException $exception): Gdn_Validation {
         $result = new Gdn_Validation();
-        $validation = $exception->getValidation();
-        $errors = $validation->getErrors();
+        $errors = $exception->getValidation()->getErrors();
 
         foreach ($errors as $error) {
             $fieldName = $error["field"] ?? null;

--- a/tests/Library/Vanilla/Utility/ModelUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/ModelUtilsTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Utility;
+
+use Gdn_Validation;
+use Garden\Schema\Validation;
+use Garden\Schema\ValidationException;
+use PHPUnit\Framework\TestCase;
+use Vanilla\Utility\ModelUtils;
+
+/**
+ * Tests for Vanilla\Utility\ModelUtilsTest class.
+ */
+class ModelUtilsTest extends TestCase {
+
+    /**
+     * Test converting a Garden Schema exception into its Gdn_Validation equivalent.
+     */
+    public function testValidationExceptionToValidationResult() {
+        $validation = new Validation();
+        $validation->addError("name", "name is required.");
+        $validation->addError("email", "email is required.");
+        $exception = new ValidationException($validation);
+
+        $expected = new Gdn_Validation();
+        $expected->addValidationResult("name", "%s is required.");
+        $expected->addValidationResult("email", "%s is required.");
+
+        $actual = ModelUtils::validationExceptionToValidationResult($exception);
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
This update adds basic support for converting a Garden Schema exception object into its `Gdn_Validation` equivalent. This allows API controllers to be used within legacy controllers and models, where `Gdn_Validation` is still heavily used and expected to report relevant messaging. A Garden Schema validation exception can be caught by these legacy classes, converted to a `Gdn_Validation` object and then handled with existing validation capabilities (e.g. displaying relevant errors on a form).
