### PR TITLE
Trim trailing whitespace from rich editor contents

### DIFF
--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -251,9 +251,9 @@ class Parser {
      */
     private function stripTrailingNewlines(array &$operations) {
         $lastIndex = count($operations) - 1;
-        $lastInsert = &$operations[$lastIndex]["insert"] ?? null;
-        if ($lastInsert !== null && $this->isOperationBareInsert($lastInsert)) {
-            $lastInsert = preg_replace('/\s+$/', "\n", $lastInsert);
+        $lastOp = &$operations[$lastIndex];
+        if ($this->isOperationBareInsert($lastOp)) {
+            $lastOp["insert"] = preg_replace('/\s+$/', "\n", $lastOp["insert"]);
         }
     }
 }

--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -252,7 +252,7 @@ class Parser {
     private function stripTrailingNewlines(array &$operations) {
         $lastIndex = count($operations) - 1;
         $lastInsert = &$operations[$lastIndex]["insert"] ?? null;
-        if ($lastInsert) {
+        if ($lastInsert !== null && $this->isOperationBareInsert($lastInsert)) {
             $lastInsert = preg_replace('/\s+$/', "\n", $lastInsert);
         }
     }

--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -104,6 +104,7 @@ class Parser {
      * @return BlotGroupCollection
      */
     public function parse(array $operations, string $parseMode = self::PARSE_MODE_NORMAL): BlotGroupCollection {
+        $this->stripTrailingNewlines($operations);
         $operations = $this->splitPlainTextNewlines($operations);
         return new BlotGroupCollection($operations, $this->blotClasses, $parseMode);
     }
@@ -238,5 +239,21 @@ class Parser {
         }
 
         return $newOperations;
+    }
+
+    /**
+     * Strip trailing whitespace off of the end of rich-editor contents.
+     *
+     * The last line is always a line terminator so we know that we can strip strip any whitespace and replace it with
+     * a single line-terminator.
+     *
+     * @param array[] $operations The quill operations to loop through.
+     */
+    private function stripTrailingNewlines(array &$operations) {
+        $lastIndex = count($operations) - 1;
+        $lastInsert = &$operations[$lastIndex]["insert"] ?? null;
+        if ($lastInsert) {
+            $lastInsert = preg_replace('/\s+$/', "\n", $lastInsert);
+        }
     }
 }

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -115,7 +115,7 @@ class ParserTest extends SharedBootstrapTestCase {
             ],
             [
                 ["class" => TextBlot::class, "content" => "After3lines"],
-                $this->makeParagraphLine(2),
+                $this->makeParagraphLine(1),
             ],
         ];
         $this->assertParseResults($ops, $result);

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -82,6 +82,18 @@ class ParserTest extends SharedBootstrapTestCase {
     /**
      * Test the parsing of normal text.
      */
+    public function testTrailingNewlines() {
+        $ops = [["insert" => "SomeText\n\n\n\n"]];
+        $result = [[
+            ["class" => TextBlot::class, "content" => "SomeText"],
+            $this->makeParagraphLine(),
+        ]];
+        $this->assertParseResults($ops, $result);
+    }
+
+    /**
+     * Test the parsing of normal text.
+     */
     public function testNormalText() {
         $ops = [["insert" => "SomeText\n"]];
         $result = [[


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8192

The issue has a pretty good overview of the reason for this change. I've implemented it in the parser, by stripping the trailing newlines before we split them up. I've added a test case as well.