### PR TITLE
Fix testGetEdit so that unique records can be used

### DIFF
--- a/tests/APIv2/AbstractResourceTest.php
+++ b/tests/APIv2/AbstractResourceTest.php
@@ -140,7 +140,7 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
     public function testGetEdit($record = null) {
         if ($record === null) {
             $record = $this->record();
-            $row = $this->testPost();
+            $row = $this->testPost($record);
         } else {
             $row = $record;
         }

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -176,15 +176,6 @@ class CategoriesTest extends AbstractResourceTest {
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function testGetEdit($record = null) {
-        $row = $this->testPost();
-        $result = parent::testGetEdit($row);
-        return $result;
-    }
-
-    /**
      * Test getting a list of followed categories.
      */
     public function testIndexFollowed() {

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -169,15 +169,6 @@ class UsersTest extends AbstractResourceTest {
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function testGetEdit($record = null) {
-        $row = $this->testPost();
-        $result = parent::testGetEdit($row);
-        return $result;
-    }
-
-    /**
      * Test getting current user info when the user is a guest.
      */
     public function testMeGuest() {


### PR DESCRIPTION
`AbstractResourceTest` was created a record for use locally, then creating a new one inside of its `testPost()` call by not passing it along. As a result it was not possible to properly test controllers with resources with unique keys (such as `urlCode`) without overriding the method.

By simply passing along the record we just created I was able to remove the override and allow for unique record types.