### PR TITLE
API v2 Roles: Fix permissions updates overwriting all saved permissions for a category

### DIFF
--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -524,7 +524,7 @@ class RolesApiController extends AbstractApiController {
                     'CategoryID' => $perm['JunctionID'],
                     'CustomPermissions' => true,
                     'Permissions' => [$perm]
-                ]);
+                ], ['overWrite' => $overwrite]);
             } else {
                 $this->permissionModel->save($perm);
             }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3005,8 +3005,8 @@ class CategoryModel extends Gdn_Model {
                         // The permissions were posted in the web format provided by settings/addcategory and settings/editcategory
                         $permissions = $permissionModel->pivotPermissions(val('Permission', $FormPostValues, []), ['JunctionID' => $CategoryID]);
                     }
-                    
-                    if ($Settings['overWrite'] ?? empty($Settings) ) {
+
+                    if ($Settings['overWrite'] ?? empty($Settings)) {
                         $permissionModel->saveAll($permissions, ['JunctionID' => $CategoryID, 'JunctionTable' => 'Category']);
                     } else {
                         foreach ($permissions as $perm) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3005,7 +3005,14 @@ class CategoryModel extends Gdn_Model {
                         // The permissions were posted in the web format provided by settings/addcategory and settings/editcategory
                         $permissions = $permissionModel->pivotPermissions(val('Permission', $FormPostValues, []), ['JunctionID' => $CategoryID]);
                     }
-                    $permissionModel->saveAll($permissions, ['JunctionID' => $CategoryID, 'JunctionTable' => 'Category']);
+
+                    if ($Settings['overWrite'] === true) {
+                        $permissionModel->saveAll($permissions, ['JunctionID' => $CategoryID, 'JunctionTable' => 'Category']);
+                    } else {
+                        foreach ($permissions as $perm) {
+                            $permissionModel->save($perm);
+                        }
+                    }
 
                     if (!$Insert) {
                         // Figure out my last permission and tree info.

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3005,10 +3005,8 @@ class CategoryModel extends Gdn_Model {
                         // The permissions were posted in the web format provided by settings/addcategory and settings/editcategory
                         $permissions = $permissionModel->pivotPermissions(val('Permission', $FormPostValues, []), ['JunctionID' => $CategoryID]);
                     }
-
-                    $overWrite = (array_key_exists('overWrite', $Settings)) ? $Settings['overWrite'] : false;
-
-                    if ($overWrite || is_null($Settings)) {
+                    
+                    if ($Settings['overWrite'] ?? empty($Settings) ) {
                         $permissionModel->saveAll($permissions, ['JunctionID' => $CategoryID, 'JunctionTable' => 'Category']);
                     } else {
                         foreach ($permissions as $perm) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3006,7 +3006,9 @@ class CategoryModel extends Gdn_Model {
                         $permissions = $permissionModel->pivotPermissions(val('Permission', $FormPostValues, []), ['JunctionID' => $CategoryID]);
                     }
 
-                    if ($Settings['overWrite'] === true) {
+                    $overWrite = (array_key_exists('overWrite', $Settings)) ? $Settings['overWrite'] : false;
+
+                    if ($overWrite || is_null($Settings)) {
                         $permissionModel->saveAll($permissions, ['JunctionID' => $CategoryID, 'JunctionTable' => 'Category']);
                     } else {
                         foreach ($permissions as $perm) {

--- a/tests/APIv2/RolesTest.php
+++ b/tests/APIv2/RolesTest.php
@@ -187,6 +187,53 @@ class RolesTest extends AbstractResourceTest {
         $this->assertFalse($this->hasPermission('site.manage', 'global', $permissions));
         $this->assertFalse($this->hasPermission('comments.add', 'category', $permissions, 1));
     }
+    /**
+     * Test updating permissions with PATCH /roles/:id/permissions
+     */
+    public function testPatchPermissionOverWrite() {
+        $role = $this->getPermissionsRole([[
+            'type' => 'category',
+            'id' =>  1,
+            'permissions' => [
+                'discussions.view' => true,
+                'discussions.add' => true,
+                'comments.add' => true
+            ]
+           ]]);
+
+        $role2 = $this->getPermissionsRole([[
+            'type' => 'category',
+            'id' => 1,
+            'permissions' => [
+                'discussions.view' => true,
+                'discussions.add' => true,
+                'comments.add' => true
+            ]
+        ]]);
+
+        $this->api()->patch(
+            "{$this->baseUrl}/{$role['roleID']}/permissions",
+            [
+                [
+                    'type' => 'category',
+                    'id' => 1,
+                    'permissions' => [
+                        'discussions.add' => true,
+                        'comments.add' => false
+                    ]
+                ]
+            ]
+        );
+
+        $permissions1 = $this->getPermissions($role['roleID']);
+        $permissions2 = $this->getPermissions($role2['roleID']);
+
+        $this->assertTrue($this->hasPermission('discussions.add', 'category', $permissions1, 1));
+        $this->assertFalse($this->hasPermission('comments.add', 'category', $permissions1, 1));
+
+        $this->assertTrue($this->hasPermission('discussions.add', 'category', $permissions2, 1));
+        $this->assertTrue($this->hasPermission('comments.add', 'category', $permissions2, 1));
+    }
 
     public function testPutPermissionsEndpoint() {
         $role = $this->getPermissionsRole();


### PR DESCRIPTION
**Issue:**

When the saving custom category permissions by role via the api endpoint, it overwrites the custom permissions set on the category.

**Solution:**

Send a flag whether to overwrite all the category permissions in Category::Save.  Unit test to make sure a call to /roles/{id)/permissions doesn't overwrite other roles permissions.

**To Test:**

1)  Create category with custom permissions
2) Create 2 roles and give them different permissions.
3) send a call to /api/v2/roles/35/permissions to modify a roles permissions.  
4) the other roles permissions should have disappeared.

closes vanilla/support#111
