### PR TITLE
Fix over strict typing on Gdn_Format::quoteEmbed

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -2494,8 +2494,11 @@ EOT;
      *
      * @return string
      */
-    public static function quoteEmbed(string $body, string $format): string {
+    public static function quoteEmbed($body, string $format): string {
         if ($format === \Vanilla\Formatting\Formats\RichFormat::FORMAT_KEY) {
+            if (is_array($body)) {
+                $body = json_encode($body);
+            }
             return self::getRichFormatter()->renderQuote($body);
         }
 


### PR DESCRIPTION
The documented type for this method was      `* @param string|array $body The string or array body content of the post.` and it got typed as just a string.

This would cause crashes where rich quotes were used, so I've resolved it by restoring the previous less strict body type, and doing the string conversion before passing it along to the stricter `Format::renderQuote(string $body)`.