### PR TITLE
Fix discussion names with invalid markup causing validation errors in API v2 /discussions

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1003,7 +1003,6 @@ class DiscussionModel extends Gdn_Model {
     /**
      * Modifies and formats discussion data.
      *
-     * 
      * @param object $discussion
      */
     public function calculate(&$discussion) {

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1005,6 +1005,9 @@ class DiscussionModel extends Gdn_Model {
 
         // Fix up output
         $discussion->Name = Gdn_Format::text($discussion->Name);
+        if ($discussion && empty($discussion->Name)) {
+            $discussion->Name = '<!-- empty -->';
+        }
         $discussion->Attributes = dbdecode($discussion->Attributes);
         $discussion->Url = discussionUrl($discussion);
         $discussion->Tags = $this->formatTags($discussion->Tags);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1000,6 +1000,12 @@ class DiscussionModel extends Gdn_Model {
         }
     }
 
+    /**
+     * Modifies and formats discussion data.
+     *
+     * 
+     * @param object $discussion
+     */
     public function calculate(&$discussion) {
         $archiveTimestamp = Gdn_Format::toTimestamp(Gdn::config('Vanilla.Archive.Date', 0));
 


### PR DESCRIPTION
closes [8018](https://github.com/vanilla/vanilla/issues/8018)

### Details
When making an /discussions API v2 call with a discussion that has the name ex. "<cond testname"
the calls fails with the error "name is required". The name is getting filtered by strip_tags(); that returns an empty string when sent an invalid markup, in this case "<cond" does not get filtered to "cond".

### Reason
In class.format.php#L2153 we call html_entity_decode('&lt;cond testname', ENT_QUOTES, 'UTF-8'); discussion name is now "<cond testname".
at this point "<cond testname" should be filtered for invalid markup, because calling strip_tags with invalid markup will return an empty string (what is currently happening).
Next we call class.format.php#L2160 that is supposed to take care of the invalid markup but the Regex in place is not doing so.
In class.format.php#L2161 we call strip_tags(''<cond testname");that is causing the error (name is required).

strip_tags with invalid markup
echo strip_tags('<bad HTML string here<br>');  returns empty string
echo strip_tags('<bad HTML<br> Hello!');  returns empty string
echo strip_tags('<bad HTML> Hello!');  Hello!
/discussions API V2 call error
screen shot 2018-11-12 at 11 33 59 am

API V2 /discussions Call
API Ref. get_discussions
http://dev.vanilla.localhost/api/v2/discussions?access_token=..

### Note
Creating a discussion with the name "<cond" will fail with the error "You have entered an invalid discussion title". The above error was noticed because of migration data.

### Proposed solution

We decided to fix this at the _DiscussionModel_ level instead of _ApiController_ level, since this will also fix it for other scenarios where you have an inadvertently blank discussion title, like sending email in VanillaPop.


### To Test

Modify a discussion name from the db in GDN_Discussion table to <test, try adding discussions with invalid markup in their name.

 