### PR TITLE
Fix mounting of editor in forum with FormTitleWrapper

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/FocusModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/FocusModule.ts
@@ -47,14 +47,17 @@ export default class EmbedFocusModule extends Module {
         super(quill, options);
 
         this.editorRoot = this.quill.root.closest(".richEditor") as HTMLElement;
-        this.formWrapper = this.editorRoot.closest(".FormWrapper") as HTMLElement;
+        this.formWrapper = (this.editorRoot.closest(".FormWrapper") ||
+            this.editorRoot.closest(".FormTitleWrapper")) as HTMLElement;
 
         if (!this.editorRoot) {
             throw new Error("Cannot initialize the EmbedFocusModule without an editorRoot (.richEditor class)");
         }
 
         if (!this.formWrapper) {
-            throw new Error("Cannot initialize the EmbedFocusModule without an FormWrapper (.FormWrapper class)");
+            throw new Error(
+                "Cannot initialize the EmbedFocusModule without a FormWrapper (.FormWrapper or .FormTitleWrapper class)",
+            );
         }
 
         // Add a tabindex onto the contenteditable so that our utilities know it is focusable.


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7686

Most notably this affected the signature page.

The `EmbedFocusModule` requires some form container to mount itself, which in legacy mode needs to be provided by the forum's HTML markup. Some lesser used forms used `FormTitleWrapper` instead of `FormWrapper` so I've added support for it.

## Testing

- Enable the signature plugin and set rich editor as the default formatter.
- Sign in
- Navigate to `/profile/edit/signatures`
- The editor will fail to load without this PR.
