### PR TITLE
Fix emails not being formatted for Rich, BBCode, Markdown

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -969,8 +969,13 @@ class ActivityModel extends Gdn_Model {
             $message = $prefix;
         }
 
-        if ($story = val('Story', $activity)) {
-            $message .= $story;
+        $isArray = is_array($activity);
+
+        $story = $isArray ? $activity['Story'] ?? null : $activity->Story ?? null;
+        $format = $isArray ? $activity['Format'] ?? null : $activity->Format ?? null;
+
+        if ($story && $format) {
+            $message .= Gdn_Format::to($story, $format);
         }
 
         return $message;


### PR DESCRIPTION
https://github.com/vanilla/vanilla/issues/7592

We simply weren't doing any formatting before sending emails. This looked ok for text and HTML formats which would render fine in emails, but this also affected rich, bbcode, and markdown which would send along unformatted text to the emails.