### PR TITLE
Remove deprecated Gdn_Format::arrayAsAttributes method

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -201,21 +201,6 @@ class Gdn_Format {
     }
 
     /**
-     *
-     * @deprecated 9 Nov 2016
-     * @param array $array
-     * @return string
-     */
-    public static function arrayAsAttributes($array) {
-        deprecated('arrayAsAttributes');
-        $return = '';
-        foreach ($array as $property => $value) {
-            $return .= ' '.$property.'="'.$value.'"';
-        }
-        return $return;
-    }
-
-    /**
      * Takes an object and convert's it's properties => values to an associative
      * array of $array[Property] => Value sets.
      *


### PR DESCRIPTION
Removes `Gdn_Format::arrayAsAttributes()`. It was deprecated in 2016 and I couldn't find usages in any code in the `vanilla` or `vanillaforums` github organizations.

I can add a line to the open source release notes once this has merged indicating this function has been removed.