### PR TITLE
Pinterest: Fix Canadian url embeds when using advanced editor

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1445,7 +1445,10 @@ class Gdn_Format {
                 'regex' => ['/https?:\/\/(?:www\.)?instagr(?:\.am|am\.com)\/p\/([\w-]+)/i']
             ],
             'Pinterest' => [
-                'regex' => ['/https?:\/\/(?:www\.)?pinterest\.com\/pin\/([\d]+)/i']
+                'regex' => [
+                    '/https?:\/\/(?:www\.)?pinterest\.com\/pin\/([\d]+)/i',
+                    '/https?:\/\/(?:www\.)?pinterest\.ca\/pin\/([\d]+)/i'
+                ]
             ],
             'Getty' => [
                 'regex' => ['/https?:\/\/embed.gettyimages\.com\/([\w=?&;+-_]*)\/([\d]*)\/([\d]*)/i']


### PR DESCRIPTION
related [#139](https://github.com/vanilla/support/issues/139)

### Details
Pinterest does not auto-embed for Canadian users. They are re-directed to pinterest.ca and the code is set up only for .com.


This PR fixes Pinterest auto-embeds for Canadian URL using Advanced Editor.


