### PR TITLE
Add translations api to private community block exceptions

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -32,6 +32,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
     /** @var array List of exceptions not to block */
     private $blockExceptions = [
         '#^api/v\d+/applicants(/|$)#' => self::BLOCK_NEVER,
+        '#^api/v\d+/locales.*#' => self::BLOCK_NEVER,
         '#^asset(/|$)#' => self::BLOCK_NEVER,
         '#^authenticate(/|$)#' => self::BLOCK_NEVER,
         '#^discussions/getcommentcounts(/|$)#' => self::BLOCK_NEVER,


### PR DESCRIPTION
https://github.com/vanilla/vanilla/issues/8244 is related, but this PR does not resolve the entire issue. It only affects 1 possible situation.

This PR whitelists the locales API while private communities is enabled. This can resolve an issue where the API (requested as a JS file) gets redirected to signin, which is not valid JS and crashes the pages JS.