### PR TITLE
Delete BBCode fallback parser

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -258,97 +258,29 @@ class Gdn_Format {
     public static function bbCode($mixed) {
         if (!is_string($mixed)) {
             return self::to($mixed, 'BBCode');
-        } else {
-            // See if there is a custom BBCode formatter.
-            $bBCodeFormatter = Gdn::factory('BBCodeFormatter');
-            if (is_object($bBCodeFormatter)) {
-                // Standard BBCode parsing.
-                $mixed = $bBCodeFormatter->format($mixed);
-
-                // Always filter after basic parsing.
-                // Add htmLawed-compatible specification updates.
-                $options = [
-                    'codeBlockEntities' => false,
-                    'spec' => [
-                        'span' => [
-                            'style' => ['match' => '/^(color:(#[a-f\d]{3}[a-f\d]{3}?|[a-z]+))?;?$/i']
-                        ]
-                    ]
-                ];
-                $sanitized = Gdn_Format::htmlFilter($mixed, $options);
-
-                // Vanilla magic parsing.
-                $sanitized = Gdn_Format::processHTML($sanitized);
-
-                return $sanitized;
-            }
-
-            // Fallback to minimalist BBCode parsing.
-            try {
-                $mixed2 = $mixed;
-                // Deal with edge cases / pre-processing.
-                $mixed2 = str_replace("\r\n", "\n", $mixed2);
-                $mixed2 = preg_replace_callback(
-                    "#\[noparse\](.*?)\[/noparse\]#si",
-                    function($m) {
-                        return str_replace(['[',']',':', "\n"], ['&#91;','&#93;','&#58;', "<br />"], htmlspecialchars($m[1]));
-                    },
-                    $mixed2
-                );
-                $mixed2 = str_ireplace(["[php]", "[mysql]", "[css]"], "[code]", $mixed2);
-                $mixed2 = str_ireplace(["[/php]", "[/mysql]", "[/css]"], "[/code]", $mixed2);
-                $mixed2 = preg_replace_callback(
-                    "#\\n?\[code\](.*?)\[/code\]\\n?#si",
-                    function($m) {
-                        $str = htmlspecialchars(trim($m[1], "\n"));
-                        return '<pre>'.str_replace(['[',']',':', "\n"], ['&#91;','&#93;','&#58;', "<br />"], $str).'</pre>';
-                    },
-                    $mixed2
-                );
-                $mixed2 = str_replace("\n", "<br />", $mixed2);
-
-                // Basic BBCode tags.
-                $mixed2 = preg_replace("#\[b\](.*?)\[/b\]#si", '<b>\\1</b>', $mixed2);
-                $mixed2 = preg_replace("#\[i\](.*?)\[/i\]#si", '<i>\\1</i>', $mixed2);
-                $mixed2 = preg_replace("#\[u\](.*?)\[/u\]#si", '<u>\\1</u>', $mixed2);
-                $mixed2 = preg_replace("#\[s\](.*?)\[/s\]#si", '<s>\\1</s>', $mixed2);
-                $mixed2 = preg_replace("#\[strike\](.*?)\[/strike\]#si", '<s>\\1</s>', $mixed2);
-                $mixed2 = preg_replace("#\[quote=[\"']?([^\]]+)(;[\d]+)?[\"']?\](.*?)\[/quote\]#si", '<blockquote class="Quote" rel="\\1"><div class="QuoteAuthor">'.sprintf(t('%s said:'), '\\1').'</div><div class="QuoteText">\\3</div></blockquote>', $mixed2);
-                $mixed2 = preg_replace("#\[quote\](.*?)\[/quote\]#si", '<blockquote class="Quote"><div class="QuoteText">\\1</div></blockquote>', $mixed2);
-                $mixed2 = preg_replace("#\[cite\](.*?)\[/cite\]#si", '<blockquote class="Quote">\\1</blockquote>', $mixed2);
-                $mixed2 = preg_replace("#\[hide\](.*?)\[/hide\]#si", '\\1', $mixed2);
-                $mixed2 = preg_replace("#\[url\]((https?|ftp):\/\/.*?)\[/url\]#si", '<a rel="nofollow" href="\\1">\\1</a>', $mixed2);
-                $mixed2 = preg_replace("#\[url\](.*?)\[/url\]#si", '\\1', $mixed2);
-                $mixed2 = preg_replace("#\[url=[\"']?((https?|ftp):\/\/.*?)[\"']?\](.*?)\[/url\]#si", '<a rel="nofollow" href="\\1">\\3</a>', $mixed2);
-                $mixed2 = preg_replace("#\[url=[\"']?(.*?)[\"']?\](.*?)\[/url\]#si", '\\2', $mixed2);
-                $mixed2 = preg_replace("#\[img\]((https?|ftp):\/\/.*?)\[/img\]#si", '<img src="\\1" border="0" />', $mixed2);
-                $mixed2 = preg_replace("#\[img\](.*?)\[/img\]#si", '\\1', $mixed2);
-                $mixed2 = preg_replace("#\[img=[\"']?((https?|ftp):\/\/.*?)[\"']?\](.*?)\[/img\]#si", '<img src=\\1" border="0" alt="\\3" />', $mixed2);
-                $mixed2 = preg_replace("#\[img=[\"']?(.*?)[\"']?\](.*?)\[/img\]#si", '\\2', $mixed2);
-                $mixed2 = preg_replace("#\[thread\]([\d]+)\[/thread\]#si", '<a href="/discussion/\\1">/discussion/\\1</a>', $mixed2);
-                $mixed2 = preg_replace("#\[thread=[\"']?([\d]+)[\"']?\](.*?)\[/thread\]#si", '<a href="/discussion/\\1">\\2</a>', $mixed2);
-                $mixed2 = preg_replace("#\[post\]([\d]+)\[/post\]#si", '<a href="/discussion/comment/\\1#Comment_\\1">/discussion/comment/\\1</a>', $mixed2);
-                $mixed2 = preg_replace("#\[post=[\"']?([\d]+)[\"']?\](.*?)\[/post\]#si", '<a href="/discussion/comment/\\1#Comment_\\1">\\2</a>', $mixed2);
-                $mixed2 = preg_replace("#\[size=[\"']?(.*?)[\"']?\]#si", '<font size="\\1">', $mixed2);
-                $mixed2 = preg_replace("#\[font=[\"']?(.*?)[\"']?\]#si", '<font face="\\1">', $mixed2);
-                $mixed2 = preg_replace("#\[color=[\"']?(.*?)[\"']?\]#si", '<font color="\\1">', $mixed2);
-                $mixed2 = str_ireplace(["[/size]", "[/font]", "[/color]"], "</font>", $mixed2);
-                $mixed2 = str_ireplace(['[indent]', '[/indent]'], ['<div class="Indent">', '</div>'], $mixed2);
-                $mixed2 = str_ireplace(["[left]", "[/left]"], '', $mixed2);
-                $mixed2 = preg_replace_callback("#\[list\](.*?)\[/list\]#si", ['Gdn_Format', 'ListCallback'], $mixed2);
-
-                // Always filter after basic parsing.
-                $sanitized = Gdn_Format::htmlFilter($mixed2);
-
-                // Vanilla magic parsing.
-                $sanitized = Gdn_Format::processHTML($sanitized);
-
-                return $sanitized;
-
-            } catch (Exception $ex) {
-                return self::display($mixed);
-            }
         }
+
+        // See if there is a custom BBCode formatter.
+        $bBCodeFormatter = Gdn::getContainer()->get('BBCodeFormatter');
+        // Standard BBCode parsing.
+        $mixed = $bBCodeFormatter->format($mixed);
+
+        // Always filter after basic parsing.
+        // Add htmLawed-compatible specification updates.
+        $options = [
+            'codeBlockEntities' => false,
+            'spec' => [
+                'span' => [
+                    'style' => ['match' => '/^(color:(#[a-f\d]{3}[a-f\d]{3}?|[a-z]+))?;?$/i']
+                ]
+            ]
+        ];
+        $sanitized = Gdn_Format::htmlFilter($mixed, $options);
+
+        // Vanilla magic parsing.
+        $sanitized = Gdn_Format::processHTML($sanitized);
+
+        return $sanitized;
     }
 
     /**


### PR DESCRIPTION
This bespoke fallback BBCode parser was vanilla's original BBCode parsing before https://github.com/vanilla/vanilla/pull/3572. Previously that parser using nbbc was it's own plugin.

Since that PR we have had a proper BBCode parser registered in the factory/container in all installations so this fallback path was not used.

[Sometimes we override it in the container](https://github.com/search?q=org%3Avanilla+BBCodeFormatter&type=Code) but it is never removed in first party code.

This PR removes the bespoke formatter and only allows the formatter to be pulled from the container.

_Note:_ I'd recommend viewing the diff with whitespace disabled.