### PR TITLE
Add some additional redux utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
         "tabbable": "3.1.1",
         "tsc-watch": "1.0.31",
         "twemoji": "2.5.1",
+        "typescript-fsa": "2.5.0",
+        "typescript-fsa-reducers": "1.2.0",
         "typestyle": "2.0.1",
         "validator": "10.8.0"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11522,6 +11522,16 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript-fsa-reducers@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/typescript-fsa-reducers/-/typescript-fsa-reducers-1.2.0.tgz#015043b22440ce517e696f24564f7233b6a5a67b"
+  integrity sha512-JGIqBDf4SV+pE8CDenTqtr13cts7kwS3/YbYhLoKZZMZWSIhwn+xwwbrg/oEfvftLykyE9PXrySy6A62m6gEaw==
+
+typescript-fsa@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/typescript-fsa/-/typescript-fsa-2.5.0.tgz#1baec01b5e8f5f34c322679d1327016e9e294faf"
+  integrity sha1-G67AG16PXzTDImedEycBbp4pT68=
+
 typescript-tslint-plugin@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/typescript-tslint-plugin/-/typescript-tslint-plugin-0.2.1.tgz#6a0361cd311bdc9dcec2e70c8a54cab16829e47f"


### PR DESCRIPTION
## Changes

- Adds 2 new redux dependencies. `typescript-fsa` & `typescript-fsa-reducers`. These 2 packages allow simpler and safer declaration of actions and reducers. 
- Adds a new utility function `bindThunkAction` and accompanying types.

Here's an example fo what some actions and reducers look like with these new utilities.

```ts
// Actions
const dispatch = getDispatchFromSomeWhere(); // This is normally provided by react-redux
const actionCreator = actionCreatorFactory("@@knowledge-base");

const GET_ACS = actionCreator.async<undefined, IKnowledgeBase[], IApiError>("GET_ALL");

function getAll = () => {
    const thunk = bindThunkAction(KnowledgeBaseActions.GET_ACS, async () => {
        const response = await this.api.get("/knowledge-bases");
        return response.data;
    })();
    return this.dispatch(thunk);
};

// Reducer
const reducer = reducerWithoutInitialState<IKnowledgeBasesState>()
    .case(GET_ACS.started, state => {
        state.knowledgeBasesByID.status = LoadStatus.LOADING;
        return state;
    })
    .case(GET_ACS.done, (state, payload) => {
        const normalized: { [id: number]: IKnowledgeBase } = {};
        for (const kb of payload.result) {
            normalized[kb.knowledgeBaseID] = kb;
        }
        state.knowledgeBasesByID.status = LoadStatus.SUCCESS;
        state.knowledgeBasesByID.data = normalized;
        return state;
    })
    .case(GET_ACS.failed, (state, action) => {
        state.knowledgeBasesByID.error = action.error;
        return state;
    });
```