### PR TITLE
Fix discussion 'most recent' not updating username when deleting last comment in a discussion

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1434,7 +1434,7 @@ class CommentModel extends Gdn_Model {
         $this->fireEvent('BeforeUpdateCommentCount');
 
         if ($discussion) {
-            if ($data) {
+            if ($data && $data['CountComments'] !== 0) {
                 $this->SQL->update('Discussion');
                 if (!$discussion['Sink'] && $data['DateLastComment']) {
                     $this->SQL->set('DateLastComment', $data['DateLastComment']);
@@ -1465,7 +1465,9 @@ class CommentModel extends Gdn_Model {
                     ->set('LastCommentID', null)
                     ->set('DateLastComment', 'DateInserted', false, false)
                     ->set('LastCommentUserID', null)
-                    ->where('DiscussionID', $discussionID);
+                    ->where('DiscussionID', $discussionID)
+                    ->put();
+
             }
         }
     }

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1467,7 +1467,6 @@ class CommentModel extends Gdn_Model {
                     ->set('LastCommentUserID', null)
                     ->where('DiscussionID', $discussionID)
                     ->put();
-
             }
         }
     }


### PR DESCRIPTION
closes [#141](https://github.com/vanilla/support/issues/141)

### Details

In Table Layout, when a comment is deleted from a discussion, discussion's most recent was not getting updated properly when the last comment in a discussion was deleted.
<img width="769" alt="screen shot 2019-01-27 at 11 51 51 am" src="https://user-images.githubusercontent.com/31856281/51804137-df30d100-222a-11e9-8833-ac0fd432d1aa.png">

### Reason

[class.commentmodel.php#L1437](https://github.com/vanilla/vanilla/blob/master/applications/vanilla/models/class.commentmodel.php#L1437) would always be true even if we have 
<img width="281" alt="screen shot 2019-01-27 at 11 20 48 am" src="https://user-images.githubusercontent.com/31856281/51804097-5ca81180-222a-11e9-8e34-552cc89a4c00.png">

In that case, [class.commentmodel.php#L1461](https://github.com/vanilla/vanilla/blob/master/applications/vanilla/models/class.commentmodel.php#L1461) would never evaluate and LastCommentUserID would never get updated causing 'Most Recent' to still display the username of the deleted comment.

Also, the update statement in [class.commentmodel.php#L1468](https://github.com/vanilla/vanilla/blob/master/applications/vanilla/models/class.commentmodel.php#L1468) was missing a put();

### This PR

I added a condition to check for CountComments, if it is 0 then this means the last comment in the discussion was delete.
