### PR TITLE
Fix twig view for rendering when rich editor fails to load.

### DIFF
--- a/library/Vanilla/Formatting/Formats/RichFormat.php
+++ b/library/Vanilla/Formatting/Formats/RichFormat.php
@@ -62,7 +62,6 @@ class RichFormat extends BaseFormat {
         try {
             $operations = Quill\Parser::jsonToOperations($content);
         } catch (FormattingException $e) {
-            trigger_error($e->getMessage(), E_USER_WARNING);
             return $this->renderErrorMessage();
         }
 

--- a/library/Vanilla/Formatting/Formats/RichFormat.php
+++ b/library/Vanilla/Formatting/Formats/RichFormat.php
@@ -62,6 +62,7 @@ class RichFormat extends BaseFormat {
         try {
             $operations = Quill\Parser::jsonToOperations($content);
         } catch (FormattingException $e) {
+            trigger_error($e->getMessage(), E_USER_WARNING);
             return $this->renderErrorMessage();
         }
 
@@ -202,6 +203,6 @@ class RichFormat extends BaseFormat {
             'errorUrl' => 'https://docs.vanillaforums.com/help/addons/rich-editor/#why-is-my-published-post-replaced-with-there-was-an-error-rendering-this-rich-post',
         ];
 
-        return $this->renderTwig('resources/userContentError', $data);
+        return $this->renderTwig('resources/views/userContentError.twig', $data);
     }
 }

--- a/resources/views/userContentError.twig
+++ b/resources/views/userContentError.twig
@@ -1,6 +1,6 @@
 <div class='DismissMessage Warning userContent-error'>
-    $title
-    <a href='$link' rel='nofollow' title='$title'>
-        <span class='icon icon-warning-sign userContent-errorIcon'>Warning</span>
+    <a href='{{ errorUrl }}' rel='nofollow' title='{{ title }}'>
+        <span class='icon icon-warning-sign userContent-errorIcon'><span class="sr-only">Warning</span></span>
+        {{ title }}
     </a>
 </div>


### PR DESCRIPTION
We have a catch all view render if a rich post fails to render properly.

The view path for this view was misconfiguring causing a fatal error. This can be seen easily in the following post.

https://open.vanillaforums.com/discussion/20286/github-1364-allow-users-to-delete-their-own-posts

This PR

- Fixes the view path
- Fixes the view content to use proper variables.
- Adds a warning if when the error is encountered.