### PR TITLE
Add frontend component for prev/next pagination

### DIFF
--- a/library/src/scripts/simplePager/SimplePager.tsx
+++ b/library/src/scripts/simplePager/SimplePager.tsx
@@ -29,7 +29,6 @@ export default class SimplePager extends React.Component<IProps> {
                 {prev && (
                     <LinkAsButton
                         className={classNames(["simplePager-button", "simplePager-prev", { isSingle }])}
-                        key="simplePagerPrev"
                         to={this.makeUrl(prev)}
                     >
                         {t("Previous")}
@@ -38,7 +37,6 @@ export default class SimplePager extends React.Component<IProps> {
                 {next && (
                     <LinkAsButton
                         className={classNames(["simplePager-button", "simplePager-next", { isSingle }])}
-                        key="simplePagerNext"
                         to={this.makeUrl(next)}
                     >
                         {t("Next")}

--- a/library/src/scripts/simplePager/SimplePager.tsx
+++ b/library/src/scripts/simplePager/SimplePager.tsx
@@ -1,0 +1,57 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import * as React from "react";
+import { t } from "@library/application";
+import SimplePagerModel, { LinkPages } from "@library/simplePager/SimplePagerModel";
+import LinkAsButton from "@library/components/LinkAsButton";
+import classNames from "classnames";
+
+interface IProps {
+    url: string;
+    pages: LinkPages;
+}
+
+/**
+ * Basic pagination. Only previous/next buttons are included.
+ */
+export default class SimplePager extends React.Component<IProps> {
+    public render() {
+        const { next, prev } = this.props.pages;
+
+        const buttons = [] as JSX.Element[];
+        const isSingle = (prev && !next) || (!prev && next);
+
+        if (prev) {
+            buttons.push(
+                <LinkAsButton
+                    className={classNames(["simplePager-button", "simplePager-prev", { isSingle }])}
+                    key="simplePagerPrev"
+                    to={this.makeUrl(prev)}
+                >
+                    {t("Previous")}
+                </LinkAsButton>,
+            );
+        }
+        if (next) {
+            buttons.push(
+                <LinkAsButton
+                    className={classNames(["simplePager-button", "simplePager-next", { isSingle }])}
+                    key="simplePagerNext"
+                    to={this.makeUrl(next)}
+                >
+                    {t("Next")}
+                </LinkAsButton>,
+            );
+        }
+
+        return <div className="simplePager">{buttons}</div>;
+    }
+
+    private makeUrl(page: number): string {
+        const { url } = this.props;
+        return url.replace(":page:", page.toString());
+    }
+}

--- a/library/src/scripts/simplePager/SimplePager.tsx
+++ b/library/src/scripts/simplePager/SimplePager.tsx
@@ -3,15 +3,15 @@
  * @license GPL-2.0-only
  */
 
-import * as React from "react";
 import { t } from "@library/application";
-import SimplePagerModel, { LinkPages } from "@library/simplePager/SimplePagerModel";
 import LinkAsButton from "@library/components/LinkAsButton";
+import { ILinkPages } from "@library/simplePager/SimplePagerModel";
 import classNames from "classnames";
+import * as React from "react";
 
 interface IProps {
     url: string;
-    pages: LinkPages;
+    pages: ILinkPages;
 }
 
 /**

--- a/library/src/scripts/simplePager/SimplePager.tsx
+++ b/library/src/scripts/simplePager/SimplePager.tsx
@@ -24,30 +24,28 @@ export default class SimplePager extends React.Component<IProps> {
         const buttons = [] as JSX.Element[];
         const isSingle = (prev && !next) || (!prev && next);
 
-        if (prev) {
-            buttons.push(
-                <LinkAsButton
-                    className={classNames(["simplePager-button", "simplePager-prev", { isSingle }])}
-                    key="simplePagerPrev"
-                    to={this.makeUrl(prev)}
-                >
-                    {t("Previous")}
-                </LinkAsButton>,
-            );
-        }
-        if (next) {
-            buttons.push(
-                <LinkAsButton
-                    className={classNames(["simplePager-button", "simplePager-next", { isSingle }])}
-                    key="simplePagerNext"
-                    to={this.makeUrl(next)}
-                >
-                    {t("Next")}
-                </LinkAsButton>,
-            );
-        }
-
-        return <div className="simplePager">{buttons}</div>;
+        return (
+            <div className="simplePager">
+                {prev && (
+                    <LinkAsButton
+                        className={classNames(["simplePager-button", "simplePager-prev", { isSingle }])}
+                        key="simplePagerPrev"
+                        to={this.makeUrl(prev)}
+                    >
+                        {t("Previous")}
+                    </LinkAsButton>
+                )}
+                {next && (
+                    <LinkAsButton
+                        className={classNames(["simplePager-button", "simplePager-next", { isSingle }])}
+                        key="simplePagerNext"
+                        to={this.makeUrl(next)}
+                    >
+                        {t("Next")}
+                    </LinkAsButton>
+                )}
+            </div>
+        );
     }
 
     private makeUrl(page: number): string {

--- a/library/src/scripts/simplePager/SimplePagerModel.ts
+++ b/library/src/scripts/simplePager/SimplePagerModel.ts
@@ -1,0 +1,55 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import qs from "qs";
+
+/**
+ * Represent pages potentially returned from a Link header.
+ */
+export interface ILinkPages {
+    next?: number;
+    prev?: number;
+    limit?: number;
+}
+
+export default class SimplePagerModel {
+    public static parseLinkHeader(header: string, param: string, limitParam?: string): ILinkPages {
+        const result = {} as ILinkPages;
+
+        header.split(",").map(link => {
+            link = link.trim();
+
+            // Needs to fit our expected format.
+            const parts = link.match(/<([0-9a-zA-Z$\-_.+!*'(),:/?=&%#]+)>;\s+rel="(next|prev)"/);
+            if (!parts) {
+                return;
+            }
+
+            // Extract the relevant bits.
+            const [fullMatch, url, rel] = parts;
+
+            // Confirm we have a query string.
+            const search = url.match(/\?([^#]+)/);
+            if (!search || !search[1]) {
+                return;
+            }
+
+            // Break out the query string into individual parameters.
+            const searchParameters = qs.parse(search[1]);
+
+            // Grab the next or prev page number.
+            if (searchParameters[param]) {
+                result[rel] = searchParameters[param];
+            }
+
+            // Grab the limit from the current link.
+            if (limitParam && searchParameters[limitParam]) {
+                result.limit = searchParameters[param];
+            }
+        });
+
+        return result;
+    }
+}

--- a/library/src/scss/components/_simplePager.scss
+++ b/library/src/scss/components/_simplePager.scss
@@ -1,0 +1,13 @@
+.simplePager {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    margin: 10px 0;
+}
+
+.simplePager-button {
+    margin: 8px;
+    &.isSingle {
+        min-width: 208px;
+    }
+}


### PR DESCRIPTION
This update introduces the `SimplePager` frontend component, as well as `SimplePagerModel` for parsing data to be used with the component.

### Overview
1. Add `SimplePager` component. This component will display 1-2 buttons, depending on the available pages.
1. Add `SimplePagerModel`. This model currently contains a single method, which allows parsing page parameters out of a link HTTP header for "previous" and "next" pages.