### PR TITLE
Allow search options, improve querystring init, fix tab context init

### DIFF
--- a/library/src/scripts/components/navigation/QueryString.tsx
+++ b/library/src/scripts/components/navigation/QueryString.tsx
@@ -17,6 +17,7 @@ interface IStringMap {
 interface IProps extends RouteComponentProps<any> {
     value: IStringMap;
     defaults?: IStringMap;
+    syncOnFirstMount?: boolean;
 }
 
 /**
@@ -27,8 +28,10 @@ class QueryString extends React.Component<IProps> {
         return null;
     }
 
-    public componentWillMount() {
-        this.updateQueryString();
+    public componentDidMount() {
+        if (this.props.syncOnFirstMount) {
+            this.updateQueryString();
+        }
     }
 
     public componentDidUpdate(prevProps: IProps) {

--- a/library/src/scripts/components/radioButtonsAsTabs/RadioButtonTab.tsx
+++ b/library/src/scripts/components/radioButtonsAsTabs/RadioButtonTab.tsx
@@ -11,8 +11,8 @@ import { ITabProps, withTabs } from "@library/contexts/TabContext";
 interface IProps extends ITabProps {
     label: string;
     className?: string;
-    data: any;
-    defaultTab: any;
+    data: string | number;
+    activeTab: string | number;
 }
 
 /**
@@ -27,7 +27,7 @@ class RadioButtonTab extends React.Component<IProps> {
                     type="radio"
                     onClick={this.onClick}
                     onKeyDown={this.onKeyDown}
-                    defaultChecked={this.props.defaultTab === this.props.data}
+                    checked={this.props.activeTab === this.props.data}
                     name={this.props.groupID}
                     value={this.props.label}
                 />

--- a/library/src/scripts/components/radioButtonsAsTabs/RadioButtonsAsTabs.tsx
+++ b/library/src/scripts/components/radioButtonsAsTabs/RadioButtonsAsTabs.tsx
@@ -15,7 +15,7 @@ interface IProps {
     className?: string;
     setData: (data: any) => void;
     children: React.ReactNode;
-    defaultTab: any;
+    activeTab: string | number;
     childClass?: string;
 }
 
@@ -36,7 +36,7 @@ export default class RadioButtonsAsTabs extends React.Component<IProps> {
                 value={{
                     groupID: this.groupID,
                     setData: this.props.setData,
-                    defaultTab: this.props.defaultTab,
+                    activeTab: this.props.activeTab,
                     childClass: this.props.childClass || "",
                 }}
             >

--- a/library/src/scripts/contexts/SearchContext.tsx
+++ b/library/src/scripts/contexts/SearchContext.tsx
@@ -13,7 +13,7 @@ const SearchContext = React.createContext<IWithSearchProps>({} as any);
 export default SearchContext;
 
 export interface ISearchOptionProvider {
-    autocomplete(query: string): Promise<Array<IComboBoxOption<ISearchOptionData>>>;
+    autocomplete(query: string, options?: { [key: string]: any }): Promise<Array<IComboBoxOption<ISearchOptionData>>>;
     makeSearchUrl(query: string): string;
 }
 

--- a/library/src/scripts/contexts/TabContext.tsx
+++ b/library/src/scripts/contexts/TabContext.tsx
@@ -10,7 +10,7 @@ import { Optionalize } from "@library/@types/utils";
 export interface ITabProps {
     setData: (data: any) => void;
     groupID: string;
-    defaultTab: any;
+    activeTab: string | number;
     childClass: string;
 }
 


### PR DESCRIPTION
Required for https://github.com/vanilla/knowledge/pull/605
- In most instances when using `QueryString` in a render method we don't want it render on first mount. This prevents us from reading the query string for initialization (will render and override it first). I've now made this behaviour opt-in.
- I've added options to the autocomplete interface.
- Fixes `TabContext` to work as a controlled component.

