### PR TITLE
Fix pocket plugin implicit import reference name

### DIFF
--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -676,9 +676,6 @@ class PocketsPlugin extends Gdn_Plugin {
      * Runs on utility/update.
      */
     public function structure() {
-        // Pocket class isn't autoloaded on Enable.
-        require_once('library/Pocket.php');
-
         $St = Gdn::structure();
         $St->table('Pocket')
             ->primaryKey('PocketID')

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -677,7 +677,7 @@ class PocketsPlugin extends Gdn_Plugin {
      */
     public function structure() {
         // Pocket class isn't autoloaded on Enable.
-        require_once('library/class.pocket.php');
+        require_once('library/Pocket.php');
 
         $St = Gdn::structure();
         $St->table('Pocket')


### PR DESCRIPTION
https://github.com/vanilla/vanilla/commit/69abf732fbdfcd4c561df14a4bef3163be5784d9#diff-49e665719a2162db7c163395a91eda47 introduced an issue that causes pockets plugin to break `utility/update` or `utility/structure` or to turn on due to some implicit referencing of the file name.

It turns out the addon manager autoloads these now so PR just removes the reference instead of updating it.