### PR TITLE
Implement Vanilla\Web\Page and Vanilla\Web\PageDispatchController

### DIFF
--- a/library/Garden/CustomExceptionHandler.php
+++ b/library/Garden/CustomExceptionHandler.php
@@ -20,7 +20,7 @@ interface CustomExceptionHandler {
      * @param \Throwable $e
      * @return bool
      */
-    public function hasHandler(\Throwable $e): bool;
+    public function hasExceptionHandler(\Throwable $e): bool;
 
     /**
      * Exception handler method
@@ -28,5 +28,5 @@ interface CustomExceptionHandler {
      * @param \Throwable $e
      * @return Data Returns Garden\Web\Data object
      */
-    public function handle(\Throwable $e): Data;
+    public function handleException(\Throwable $e): Data;
 }

--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -174,8 +174,8 @@ class Dispatcher {
                 if ($action instanceof Action) {
                     $obj = $action->getCallback()[0] ?? false;
                     if ($obj instanceof CustomExceptionHandler) {
-                        if ($obj->hasHandler($dispatchEx)) {
-                            $response = $obj->handle($dispatchEx);
+                        if ($obj->hasExceptionHandler($dispatchEx)) {
+                            $response = $obj->handleException($dispatchEx);
                         }
                     }
                 }

--- a/library/Vanilla/Models/SiteMeta.php
+++ b/library/Vanilla/Models/SiteMeta.php
@@ -37,13 +37,17 @@ class SiteMeta implements \JsonSerializable {
     /** @var int */
     private $maxUploadSize;
 
+    /** @var string */
+    private $localeKey;
+
     /**
      * SiteMeta constructor.
      *
      * @param RequestInterface $request The request to gather data from.
      * @param Contracts\ConfigurationInterface $config The configuration object.
+     * @param \Gdn_Locale $locale
      */
-    public function __construct(RequestInterface $request, Contracts\ConfigurationInterface $config) {
+    public function __construct(RequestInterface $request, Contracts\ConfigurationInterface $config, \Gdn_Locale $locale) {
         $this->host = $request->getHost();
 
         // We the roots from the request in the form of "" or "/asd" or "/asdf/asdf"
@@ -61,6 +65,9 @@ class SiteMeta implements \JsonSerializable {
         $this->allowedExtensions = $config->get('Garden.Upload.AllowedFileExtensions', []);
         $maxSize = $config->get('Garden.Upload.MaxFileSize', ini_get('upload_max_filesize'));
         $this->maxUploadSize = \Gdn_Upload::unformatFileSize($maxSize);
+
+        // localization
+        $this->localeKey = $locale->current();
     }
 
     /**
@@ -83,6 +90,7 @@ class SiteMeta implements \JsonSerializable {
             ],
             'ui' => [
                 'siteName' => $this->siteTitle,
+                'localeKey' => $this->localeKey,
             ],
             'upload' => [
                 'maxSize' => $this->maxUploadSize,
@@ -138,5 +146,12 @@ class SiteMeta implements \JsonSerializable {
      */
     public function getMaxUploadSize(): int {
         return $this->maxUploadSize;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocaleKey(): string {
+        return $this->localeKey;
     }
 }

--- a/library/Vanilla/Web/JsInterpop/PHPAsJsVariable.php
+++ b/library/Vanilla/Web/JsInterpop/PHPAsJsVariable.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Web\JsInterpop;
+
+/**
+ * Class that handles rendering an PHP object or array in a javascript context.
+ */
+class PHPAsJsVariable {
+
+    /** @var string */
+    private $variableName;
+
+    /** @var array|object */
+    private $data;
+
+    /**
+     * Constructor.
+     *
+     * @param string $variableName The name of variable to expose the script on the frontend.
+     * @param array|object $data The JSON serializable data that should be serialized for a javascript context.
+     */
+    public function __construct(string $variableName, $data) {
+        $this->variableName = $variableName;
+        $this->data = $data;
+    }
+
+    /**
+     * Render the string representation of the script contents.
+     *
+     * @return string
+     */
+    public function __toString() {
+        return 'window["' . $this->variableName . '"]=' . json_encode($this->data) . ";\n";
+    }
+}

--- a/library/Vanilla/Web/JsInterpop/PhpAsJsVariable.php
+++ b/library/Vanilla/Web/JsInterpop/PhpAsJsVariable.php
@@ -10,7 +10,7 @@ namespace Vanilla\Web\JsInterpop;
 /**
  * Class that handles rendering an PHP object or array in a javascript context.
  */
-class PHPAsJsVariable {
+class PhpAsJsVariable {
 
     /** @var string */
     private $variableName;

--- a/library/Vanilla/Web/JsInterpop/ReduxAction.php
+++ b/library/Vanilla/Web/JsInterpop/ReduxAction.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Web\JsInterpop;
+
+use Garden\Web\Data;
+
+/**
+ * Class ReduxAction.
+ */
+class ReduxAction implements \JsonSerializable {
+    /**
+     * @var string $type Redux action type
+     */
+    protected $type;
+    /**
+     * @var array $payload Redux action payload
+     */
+    protected $payload;
+
+    /**
+     * Create an redux action
+     *
+     * @param string $type Redux action type to create
+     * @param Data $data Redux payload data.
+     * @param array $requestParams The params if this is a FSA. This opts in to the new action structure (FSA).
+     */
+    public function __construct(string $type, Data $data, array $requestParams = null) {
+        $this->type = $type;
+        $this->payload = $requestParams !== null ? ['result' => $data, 'params' => $requestParams] : ['data' => $data];
+    }
+
+    /**
+     * Get the array for JSON serialization.
+     */
+    public function jsonSerialize(): array {
+        return $this->value();
+    }
+
+
+    /**
+     * Return an array of redux action to be sent.
+     *
+     * @return array
+     */
+    public function value(): array {
+        return [
+            "type" => $this->type,
+            "payload" => $this->payload,
+        ];
+    }
+}

--- a/library/Vanilla/Web/JsInterpop/ReduxErrorAction.php
+++ b/library/Vanilla/Web/JsInterpop/ReduxErrorAction.php
@@ -14,7 +14,7 @@ use Garden\Web\Data;
  */
 class ReduxErrorAction extends ReduxAction {
 
-    private const ACTION_TYPE = "@@kbPage/ERROR";
+    private const ACTION_TYPE = "@@serverPage/ERROR";
 
     /**
      * @param \Throwable $throwable The exception to create the error for.

--- a/library/Vanilla/Web/JsInterpop/ReduxErrorAction.php
+++ b/library/Vanilla/Web/JsInterpop/ReduxErrorAction.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Web\JsInterpop;
+
+use Garden\Web\Data;
+
+/**
+ * A redux error action to render a frontend error page.
+ */
+class ReduxErrorAction extends ReduxAction {
+
+    private const ACTION_TYPE = "@@kbPage/ERROR";
+
+    /**
+     * @param \Throwable $throwable The exception to create the error for.
+     */
+    public function __construct(\Throwable $throwable) {
+        parent::__construct(self::ACTION_TYPE, new Data($throwable));
+    }
+
+    /**
+     * Return an array of redux action to be sent.
+     *
+     * @return array
+     */
+    public function value(): array {
+        return [
+            "type" => $this->type,
+            "payload" => $this->payload,
+        ];
+    }
+}

--- a/library/Vanilla/Web/Page.php
+++ b/library/Vanilla/Web/Page.php
@@ -117,6 +117,8 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
         $this->inlineScripts[] = new PhpAsJsVariable('__ACTIONS__', $this->reduxActions);
         $this->addMetaTag('og:site_name', ['property' => 'og:site_name', 'content' => 'Vanilla']);
         $viewData = [
+            'title' => $this->seoTitle,
+            'description' => $this->seoDescription,
             'canonicalUrl' => $this->canonicalUrl,
             'locale' => $this->siteMeta->getLocaleKey(),
             'debug' => $this->siteMeta->getDebugModeEnabled(),
@@ -255,13 +257,19 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
     /**
      * Render and set the SEO page content.
      *
-     * @param string $viewPath The path to the view to render.
-     * @param array $viewData The data to render the view with.
+     * @param string $viewPathOrView The path to the view to render or the rendered view.
+     * @param array $viewData The data to render the view if we gave a path.
      *
      * @return self Own instance for chaining.
      */
-    protected function setSeoContent(string $viewPath, array $viewData): self {
-        $this->seoContent = $this->renderTwig($viewPath, $viewData);
+    protected function setSeoContent(string $viewPathOrView, array $viewData = null): self {
+        // No view data so assume the view is rendered already.
+        if ($viewData === null) {
+            $this->seoContent = $viewPathOrView;
+            return $this;
+        }
+
+        $this->seoContent = $this->renderTwig($viewPathOrView, $viewData);
 
         return $this;
     }

--- a/library/Vanilla/Web/Page.php
+++ b/library/Vanilla/Web/Page.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Web;
+
+use Garden\CustomExceptionHandler;
+use Garden\Web\Data;
+use Garden\Web\Exception\ServerException;
+use Vanilla\Contracts\Web\AssetInterface;
+use Vanilla\InjectableInterface;
+use Vanilla\Knowledge\Models\Breadcrumb;
+use Vanilla\Models\SiteMeta;
+use Vanilla\Web\Asset\WebpackAssetProvider;
+use Vanilla\Web\JsInterpop\PHPAsJsVariable;
+use Vanilla\Web\JsInterpop\ReduxAction;
+use Vanilla\Web\JsInterpop\ReduxErrorAction;
+
+/**
+ * Class representing a single page in the application.
+ */
+abstract class Page implements InjectableInterface, CustomExceptionHandler {
+
+    use TwigRenderTrait;
+
+    /** @var string */
+    private $canonicalUrl;
+
+    /** @var string */
+    private $seoTitle;
+
+    /** @var string */
+    private $seoDescription;
+
+    /** @var Breadcrumb[]|null */
+    private $seoBreadcrumbs;
+
+    /** @var string|null */
+    private $seoContent;
+
+    /** @var array */
+    private $metaTags = [];
+
+    /** @var AssetInterface[] */
+    protected $scripts = [];
+
+    /** @var $styles [] */
+    protected $styles = [];
+
+    /** @var string[] */
+    protected $inlineScripts = [];
+
+    /** @var string[] */
+    protected $inlineStyles = [];
+
+    /** @var ReduxAction[] */
+    private $reduxActions = [];
+
+    /** @var bool */
+    private $requiresSeo = true;
+
+    /** @var int The page status code. */
+    private $statusCode = 200;
+
+    /**
+     * Prepare the page contents.
+     *
+     * @return void
+     */
+    abstract public function initialize();
+
+    /** @var SiteMeta */
+    protected $siteMeta;
+
+    /** @var \Gdn_Request */
+    protected $request;
+
+    /** @var \Gdn_Session */
+    protected $session;
+
+    /** @var WebpackAssetProvider */
+    protected $assetProvider;
+
+    /**
+     * Dependendency Injecvtion.
+     *
+     * @param SiteMeta $siteMeta
+     * @param \Gdn_Request $request
+     * @param \Gdn_Session $session
+     * @param WebpackAssetProvider $assetProvider
+     */
+    public function setDependencies(
+        SiteMeta $siteMeta,
+        \Gdn_Request $request,
+        \Gdn_Session $session,
+        WebpackAssetProvider $assetProvider
+    ) {
+        $this->siteMeta = $siteMeta;
+        $this->request = $request;
+        $this->session = $session;
+        $this->assetProvider = $assetProvider;
+    }
+
+    /**
+     * Render the page content and wrap it in a data object for the dispatcher.
+     *
+     * @return Data Data object for global dispatcher.
+     */
+    public function render(): Data {
+        $this->validateSeo();
+
+        $this->inlineScripts[] = new PHPAsJsVariable('gdn', [
+            'meta' => $this->siteMeta,
+        ]);
+        $this->inlineScripts[] = new PHPAsJsVariable('__ACTIONS__', $this->reduxActions);
+        $this->addMetaTag('og:site_name', ['property' => 'og:site_name', 'content' => 'Vanilla']);
+        $viewData = [
+            'canonicalUrl' => $this->canonicalUrl,
+            'locale' => $this->siteMeta->getLocaleKey(),
+            'debug' => $this->siteMeta->getDebugModeEnabled(),
+            'scripts' => $this->scripts,
+            'inlineScripts' => $this->inlineScripts,
+            'styles' => $this->styles,
+            'inlineStyles' => $this->inlineStyles,
+            'seoContent' => $this->seoContent,
+            'metaTags' => $this->metaTags,
+            'cssClasses' => ['isLoading'],
+        ];
+        $viewContent = $this->renderTwig('resources/views/default-master.twig', $viewData);
+
+        return new Data($viewContent, $this->statusCode);
+    }
+
+    /**
+     * Validate that we have sufficient SEO data.
+     *
+     * @throws ServerException If the page has not implemented valid SEO metrics in debug mode.
+     */
+    private function validateSeo() {
+        $hasInvalidSeo =
+            $this->siteMeta->getDebugModeEnabled() &&
+            $this->requiresSeo &&
+            (
+                $this->seoTitle === null ||
+                $this->seoBreadcrumbs === null ||
+                $this->seoContent === null ||
+                $this->seoDescription === null ||
+                $this->canonicalUrl === null
+            );
+        if ($hasInvalidSeo) {
+            throw new ServerException('Page SEO data is not fully implemented');
+        }
+    }
+
+    /**
+     * Indicate to crawlers that they should not index this page.
+     *
+     * @return self Own instance for chaining.
+     */
+    public function blockRobots(): self {
+        header('X-Robots-Tag: noindex', true);
+        $this->addMetaTag('robots', ['name' => 'robots', 'content' => 'noindex']);
+
+        return $this;
+    }
+
+    /**
+     * Add a redux action for the frontend to handle.
+     *
+     * @param ReduxAction $action The action to add.
+     *
+     * @return self Own instance for chaining.
+     */
+    protected function addReduxAction(ReduxAction $action): self {
+        $this->reduxActions[] = $action;
+
+        return $this;
+    }
+
+    /**
+     * Enable or disable validation of server side SEO content. This is only important on certain pages.
+     *
+     * @param bool $required
+     *
+     * @return self Own instance for chaining.
+     */
+    protected function setSeoRequired(bool $required = true): self {
+        $this->requiresSeo = $required;
+
+        return $this;
+    }
+
+    /**
+     * Set the page title (in the browser tab).
+     *
+     * @param string $title The title to set.
+     * @param bool $withSiteTitle Whether or not to append the global site title.
+     *
+     * @return self Own instance for chaining.
+     */
+    protected function setSeoTitle(string $title, bool $withSiteTitle = true): self {
+        if ($withSiteTitle) {
+            if ($title === "") {
+                $title = $this->siteMeta->getSiteTitle();
+            } else {
+                $title .= " - " . $this->siteMeta->getSiteTitle();
+            }
+        }
+        $this->seoTitle = $title;
+
+        return $this;
+    }
+
+    /**
+     * Set an the site meta description.
+     *
+     * @param string $description
+     *
+     * @return self Own instance for chaining.
+     */
+    protected function setSeoDescription(string $description): self {
+        $this->seoDescription = $description;
+
+        return $this;
+    }
+
+    /**
+     * Set an the canonical URL for the page.
+     *
+     * @param string $path Either a partial path or a full URL.
+     *
+     * @return self Own instance for chaining.
+     */
+    protected function setCanonicalUrl(string $path): self {
+        $this->canonicalUrl = $this->request->url($path, true);
+
+        return $this;
+    }
+
+    /**
+     * Set an array of breadcrumbs.
+     *
+     * @param array $crumbs
+     *
+     * @return self Own instance for chaining.
+     */
+    protected function setSeoBreadcrumbs(array $crumbs): self {
+        $this->seoBreadcrumbs = $crumbs;
+
+        return $this;
+    }
+
+    /**
+     * Render and set the SEO page content.
+     *
+     * @param string $viewPath The path to the view to render.
+     * @param array $viewData The data to render the view with.
+     *
+     * @return self Own instance for chaining.
+     */
+    protected function setSeoContent(string $viewPath, array $viewData): self {
+        $this->seoContent = $this->renderTwig($viewPath, $viewData);
+
+        return $this;
+    }
+
+    /**
+     * Set page meta tag attributes.
+     *
+     * @param string $tag Tag name.
+     * @param array $attributes Array of attributes to set for tag.
+     *
+     * @return self Own instance for chaining.
+     */
+    protected function addMetaTag(string $tag, array $attributes): self {
+        $this->metaTags[$tag] = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function hasExceptionHandler(\Throwable $e): bool {
+        switch ($e->getCode()) {
+            case 404:
+            case 403:
+                return true;
+                break;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function handleException(\Throwable $e): Data {
+        $this->requiresSeo = false;
+        $this->statusCode = $e->getCode();
+        $this->addReduxAction(new ReduxErrorAction($e))
+            ->setSeoTitle($e->getMessage())
+            ->addMetaTag('robots', ['name' => 'robots', 'content' => 'noindex'])
+            ->setSeoContent('resources/views/error.twig', ['error' => $e])
+        ;
+
+        return $this->render();
+    }
+
+    /**
+     * Redirect user to sign in page if they are not signed in.
+     *
+     * @param string $redirectTarget URI user should be redirected back when log in.
+     *
+     * @return $this
+     */
+    public function requiresSession(string $redirectTarget): self {
+        if (!$this->session->isValid()) {
+            header(
+                'Location: /entry/signin?Target=' . urlencode($redirectTarget),
+                true,
+                302
+            );
+            exit();
+        } else {
+            return $this;
+        }
+    }
+}

--- a/library/Vanilla/Web/Page.php
+++ b/library/Vanilla/Web/Page.php
@@ -12,10 +12,9 @@ use Garden\Web\Data;
 use Garden\Web\Exception\ServerException;
 use Vanilla\Contracts\Web\AssetInterface;
 use Vanilla\InjectableInterface;
-use Vanilla\Knowledge\Models\Breadcrumb;
 use Vanilla\Models\SiteMeta;
 use Vanilla\Web\Asset\WebpackAssetProvider;
-use Vanilla\Web\JsInterpop\PHPAsJsVariable;
+use Vanilla\Web\JsInterpop\PhpAsJsVariable;
 use Vanilla\Web\JsInterpop\ReduxAction;
 use Vanilla\Web\JsInterpop\ReduxErrorAction;
 
@@ -35,7 +34,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
     /** @var string */
     private $seoDescription;
 
-    /** @var Breadcrumb[]|null */
+    /** @var array|null */
     private $seoBreadcrumbs;
 
     /** @var string|null */
@@ -112,10 +111,10 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
     public function render(): Data {
         $this->validateSeo();
 
-        $this->inlineScripts[] = new PHPAsJsVariable('gdn', [
+        $this->inlineScripts[] = new PhpAsJsVariable('gdn', [
             'meta' => $this->siteMeta,
         ]);
-        $this->inlineScripts[] = new PHPAsJsVariable('__ACTIONS__', $this->reduxActions);
+        $this->inlineScripts[] = new PhpAsJsVariable('__ACTIONS__', $this->reduxActions);
         $this->addMetaTag('og:site_name', ['property' => 'og:site_name', 'content' => 'Vanilla']);
         $viewData = [
             'canonicalUrl' => $this->canonicalUrl,

--- a/library/Vanilla/Web/PageDispatchController.php
+++ b/library/Vanilla/Web/PageDispatchController.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Web;
+
+use Garden\Container\Container;
+use Garden\Container\ContainerException;
+use Garden\Container\NotFoundException;
+use Garden\CustomExceptionHandler;
+use Garden\Web\Data;
+
+/**
+ * A controller used for mapping from the the dispatcher to individual page components.
+ *
+ * @see \Garden\Web\Dispatcher
+ * @see \Vanilla\Web\Page
+ */
+class PageDispatchController implements CustomExceptionHandler {
+
+    /** @var Page The active page. */
+    private $activePage;
+
+    /** @var Container */
+    private $container;
+
+    /**
+     * Dependency Injection.
+     * It's generally an antipattern to inject the container, but this is a dispatcher.
+     *
+     * @param Container $container The container object for locating and creating page classes.
+     */
+    public function __construct(Container $container) {
+        $this->container = $container;
+    }
+
+
+    /**
+     * Instantiate a page class and set it as the active instance.
+     *
+     * @param string $pageClass
+     * @return Page The instance of the requested page.
+     * @throws NotFoundException If the page class couldn't be located.
+     * @throws ContainerException Error while retrieving the entry.
+     */
+    protected function usePage(string $pageClass): Page {
+        $page = $this->container->get($pageClass);
+        $this->activePage = $page;
+        return $page;
+    }
+
+    /** @var string Class to use for useSimplePage */
+    protected $simplePageClass = SimpleTitlePage::class;
+
+    /**
+     * Instantiate a SimpleTitlePage with a title and set it as the active instance.
+     *
+     * @param string $title The title to use.
+     * @return Page
+     */
+    protected function useSimplePage(string $title): Page {
+        /** @var Page $page */
+        $page = $this->container->get($this->simplePageClass);
+        $page->initialize($title);
+        $this->activePage = $page;
+        return $page;
+    }
+
+    /**
+     * Forward the call onto our active page if we have one.
+     * @inheritdoc
+     */
+    public function hasExceptionHandler(\Throwable $e): bool {
+        if ($this->activePage) {
+            return $this->activePage->hasExceptionHandler($e);
+        }
+        return false;
+    }
+
+    /**
+     * Use or active pages handler.
+     * @inheritdoc
+     */
+    public function handleException(\Throwable $e): Data {
+        return $this->activePage->handleException($e);
+    }
+}

--- a/library/Vanilla/Web/SimpleTitlePage.php
+++ b/library/Vanilla/Web/SimpleTitlePage.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Web;
+
+/**
+ * Page class that only require a title. Useful for when the page doesn't need SEO and content is rendered in JS.
+ */
+class SimpleTitlePage extends Page {
+
+    /**
+     * @inheritdoc
+     */
+    public function initialize(string $title = "") {
+        $this->setSeoRequired(false);
+        $this->setSeoTitle($title);
+    }
+}

--- a/library/src/scss/layouts/_container.scss
+++ b/library/src/scss/layouts/_container.scss
@@ -4,7 +4,8 @@
  * @license GPL-2.0-only
  */
 
-.container {
+.container,
+.noScriptContainer {
     display: flex;
     flex-direction: column;
     position: relative;
@@ -27,4 +28,9 @@
             right: $global-gutter_quarterSize;
         }
     }
+}
+
+.noScriptContainer {
+    max-width: $global-middleColumn_width;
+    padding-top: 24px;
 }

--- a/resources/views/default-master.twig
+++ b/resources/views/default-master.twig
@@ -43,13 +43,18 @@
             <div id="app" class="page-minHeight">
             {%- if seoContent -%}
                 <noscript>
-
-                    <h1>
-                        {{- title -}}
-                    </h1>
-
-                    {{- seoContent }}
-
+                    <style>
+                        body.isLoading {
+                            max-height: initial;
+                            height: initial;
+                        }
+                    </style>
+                    <div class="noScriptContainer">
+                        <h1 class="heading heading-1 pageTitle">
+                            {{- title -}}
+                        </h1>
+                        {{- seoContent|raw }}
+                    </div>
                 </noscript>
             {%- endif -%}
 

--- a/resources/views/default-master.twig
+++ b/resources/views/default-master.twig
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="{{ locale }}">
+    <head>
+        <title>{{ title }}</title>
+        <meta name="description" content="{{ description }}">
+
+        {% for meta in metaTags -%}
+            <meta{% for attribute,value in meta %} {{ attribute }}="{{ value }}"{% endfor %} />
+        {% endfor %}
+
+        {% for script in inlineScripts -%}
+            <script>
+                {{- script|raw -}}
+            </script>
+        {% endfor %}
+
+        {% for script in scripts -%}
+            <script defer src="{{ script.getWebPath() }}"></script>
+        {% endfor %}
+
+        <script type="application/ld+json">
+            {{ breadcrumbs|raw }}
+        </script>
+
+        {% for stylesheet in styles -%}
+            <link href="{{ stylesheet.getWebPath() }}" rel="stylesheet" type="text/css" />
+        {% endfor -%}
+
+        {%- if canonicalUrl -%}
+            <link rel="canonical" href="{{ canonicalUrl }}"/>
+        {%- endif -%}
+
+        <noscript>
+            <style>
+                .fullPageLoader { display: none }
+            </style>
+        </noscript>
+
+    </head>
+    <body class="{{ cssClasses|join(' ') }}">
+        <div id="page" class="page">
+            <div id="vanillaHeader"></div>
+            <div id="app" class="page-minHeight">
+            {%- if seoContent -%}
+                <noscript>
+
+                    <h1>
+                        {{- title -}}
+                    </h1>
+
+                    {{- seoContent }}
+
+                </noscript>
+            {%- endif -%}
+
+                <div class="fullPageLoader"></div>
+            </div>
+            <div id="footerContainer">
+                {#{{ include('partials/footer.twig') }}#}
+            </div>
+        </div>
+        <div id="modals"></div>
+        <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
+        <script>
+            WebFont.load({
+                google: {
+                    families: ['Open Sans:400,400italic,600,700'] // Will be dynamic at some point
+                }
+            });
+        </script>
+    </body>
+</html>

--- a/resources/views/default-master.twig
+++ b/resources/views/default-master.twig
@@ -44,7 +44,7 @@
             {%- if seoContent -%}
                 <noscript>
                     <style>
-                        body.isLoading {
+                        body.isLoading .page {
                             max-height: initial;
                             height: initial;
                         }

--- a/resources/views/error.twig
+++ b/resources/views/error.twig
@@ -1,0 +1,3 @@
+<main>
+    <h1>{{ error.status }} - {{ error.message }}</h1>
+</main>


### PR DESCRIPTION
This PR takes what we were working on with `Vanilla\Knowledge\Controllers\PageController`, iterates on it, and brings it to core.

There are a few different concepts here that differentiate it from our previous attempts at a new controller.

## Guiding principles

- **Each page should be represented by 1 class**. This mirrors how our frontend pages are implemented. This also makes dependency injection a little bit cleaner. In our existing structure 1 controller may need to inject dependencies for 5-10 separate pages, even if they aren't always used.
- **Our backend controllers have a much more limited purpose now.**
  - Rendering a simple page template
  - Rendering assets and data for the frontend.
  - _Sometimes_ rendering out SEO data like description, `<noscript />` views, and canonical URLs.

## `Vanilla\Web\Page`

- Implements a fluent method syntax for declaring SEO metadata (or lack of it).
  - `contentView`
  - `title`
  - `description`
  - `breadcrumbs` (JSON-ld)
  - `canonicalUrl`
- Implements validation that all SEO data is provided if `requiresSeo` is true (defaults) true. This will throw an exception in debug mode.
- Renders a new master view with twig.
- Implements a custom exception handler that works with the `Garden\Web\Dispatcher`.
- Works with `Vanilla\Web\Asset`s instead of strings.
- Built in support for passing data from PHP to the frontend with `Vanilla\Web\JsInterop\ReduxAction` and `Vanilla\Web\JsInterop\PhpAsJsVariable`.

## `Vanilla\Web\PageDispatchController`

While `Page` represents the building block of page rendering. Right now they are not dispatch-able directly from `Vanilla\Web\Dispatcher`. Hopefully with https://github.com/vanilla/vanilla/issues/8119 they will be, but until we make that team decision I've written an interoperability layer between the `Garden\Web\Dispatcher` and `Vanilla\Web\Page`. It lets you map between our existing dispatch system and a `Page` with `usePage` which will construct your page instance, set its custom exception handler, and return you the page to render.

I've also provided a `SimpleTitlePage` which can be used for pages that don't require and SEO outside of a title. This basically renders a page with no 
SEO content except with the given title.

Usage tends to look like the following:

```php
class MyPageController extends Vanilla\Web\PageDispatchController {

    // Dedicated page
    public function get_categories(string $path): Data {
        /** @var CategoryPage $page */
        $page = $this->usePage(CategoryPage::class);
        $page->initialize($path);
        return $page->render();
    }

    // Simplest type
    public function index(): Data {
        return $this->useSimplePage('Help')->render();
    }

    // Simple type - block crawlers, and require sign in.
    public function get_drafts(): Data {
        return $this
            ->useSimplePage('Drafts')
            ->blockRobots()
            ->requiresSession('/kb/drafts')
            ->render()
        ;
    }
}
```

## Limitations & exclusions

- I've left parts of the default master template @slafleche had been working with alone, even if they aren't perfect. We can iterate on this in the future. For example, we always load a google font at the end of the doc. This will likely be iterated on in our upcoming theme work.
- Currently there is no special way to provide breadcrumbs. This will be iterated in an upcoming PR adding a `BreadcrumbModel`.