### PR TITLE
Update SmartLink to allow replacing of current history item

### DIFF
--- a/library/src/scripts/components/navigation/SmartLink.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.tsx
@@ -32,7 +32,7 @@ interface IProps extends NavLinkProps {
  * Result = https://test.com/root/someUrl/deeper/nested (full refresh)
  */
 export default function SmartLink(props: IProps) {
-    const { urlFormatter, ...passthru } = props;
+    const { replace, urlFormatter, ...passthru } = props;
     const finalUrlFormatter = urlFormatter ? urlFormatter : formatUrl;
     const stringUrl = typeof props.to === "string" ? props.to : createPath(props.to);
     const href = finalUrlFormatter(stringUrl, true);
@@ -50,6 +50,7 @@ export default function SmartLink(props: IProps) {
                             to={makeDynamicHref(props.to, href)}
                             activeClassName="isCurrent"
                             tabIndex={props.tabIndex}
+                            replace={replace}
                         />
                     );
                 } else {


### PR DESCRIPTION
`SmartLink` renders either an anchor or a [`NavLink`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/NavLink.md), a `react-router-dom` module. `NavLink` extends [`Link`](https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/api/Link.md) (also a `react-router-dom` module), which supports a `replace` property, allowing the current history item to be replaced, instead of appending a new item for the link. This update adds support for handing this property down from `SmartLink` to `NavLink`.