### PR TITLE
Set Rich-Editor and Keystone theme to enabled by default

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -101,6 +101,8 @@ $Configuration['Garden']['Thumbnail']['Size'] = 200;
 $Configuration['Garden']['Theme'] = 'keystone';
 $Configuration['Garden']['MobileTheme'] = 'keystone';
 $Configuration['Garden']['Menu']['Sort'] = ['Dashboard', 'Discussions', 'Questions', 'Activity', 'Applicants', 'Conversations', 'User'];
+$Configuration['Garden']['ThemeOptions']['Styles']['Key'] = 'Default';
+$Configuration['Garden']['ThemeOptions']['Styles']['Value'] = '%s_default';
 
 // Profiles.
 $Configuration['Garden']['Profile']['Public']= true;

--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -7,6 +7,7 @@ $Configuration = [];
 $Configuration['EnabledPlugins']['stubcontent'] = true;
 $Configuration['EnabledPlugins']['swagger-ui'] = true;
 $Configuration['EnabledApplications']['Dashboard'] = 'dashboard';
+$Configuration['EnabledPlugins']['rich-editor'] = true;
 
 // Database defaults.
 $Configuration['Database']['Engine'] = 'MySQL';
@@ -97,8 +98,8 @@ $Configuration['Garden']['Profile']['MaxWidth'] = 560;
 $Configuration['Garden']['Thumbnail']['Size'] = 200;
 
 // Appearance.
-$Configuration['Garden']['Theme'] = 'default';
-$Configuration['Garden']['MobileTheme'] = 'mobile';
+$Configuration['Garden']['Theme'] = 'keystone';
+$Configuration['Garden']['MobileTheme'] = 'keystone';
 $Configuration['Garden']['Menu']['Sort'] = ['Dashboard', 'Discussions', 'Questions', 'Activity', 'Applicants', 'Conversations', 'User'];
 
 // Profiles.
@@ -115,7 +116,8 @@ $Configuration['Garden']['Embed']['PageToForum'] = true;
 $Configuration['Garden']['SignIn']['Popup'] = true; // Should the sign-in link pop up or go to it's own page? (SSO requires going to it's own external page)
 
 // User experience & formatting.
-$Configuration['Garden']['InputFormatter'] = 'Markdown'; // Html, BBCode, Markdown, Text
+$Configuration['Garden']['InputFormatter'] = 'Rich'; // Html, BBCode, Markdown, Text, Rich
+$Configuration['Garden']['MobileInputFormatter'] = 'Rich';
 $Configuration['Garden']['Html']['AllowedElements'] = "a, abbr, acronym, address, area, audio, b, bdi, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, details, dfn, div, dl, dt, em, figure, figcaption, font, h1, h2, h3, h4, h5, h6, hgroup, hr, i, img, ins, kbd, li, map, mark, menu, meter, ol, p, pre, q, s, samp, small, span, strike, strong, sub, sup, summary, table, tbody, td, tfoot, th, thead, time, tr, tt, u, ul, var, video, wbr";
 $Configuration['Garden']['Search']['Mode'] = 'boolean'; // matchboolean, match, boolean, like
 $Configuration['Garden']['EditContentTimeout'] = 3600; // -1 means no timeout. 0 means immediate timeout. > 0 is in seconds. 60 * 60 = 3600 (aka 1hr)

--- a/tests/APIv2/AddonsTest.php
+++ b/tests/APIv2/AddonsTest.php
@@ -20,7 +20,7 @@ class AddonsTest extends AbstractAPIv2Test {
     ];
 
     private $coreThemes = [
-        'EmbedFriendly', 'bittersweet', 'default', 'mobile', // themes
+        'EmbedFriendly', 'bittersweet', 'default', 'mobile', 'keystone',  // themes
     ];
 
     private $hiddenAddons = [
@@ -105,10 +105,10 @@ class AddonsTest extends AbstractAPIv2Test {
      */
     public function testChangeTheme() {
         $desktop = $this->api()->get('/addons', ['type' => 'theme', 'enabled' => true, 'themeType' => 'desktop'])[0];
-        $this->assertEquals('default-theme', $desktop['addonID']);
+        $this->assertEquals('keystone-theme', $desktop['addonID']);
 
         $mobile = $this->api()->get('/addons', ['type' => 'theme', 'enabled' => true, 'themeType' => 'mobile'])[0];
-        $this->assertEquals('mobile-theme', $mobile['addonID']);
+        $this->assertEquals('keystone-theme', $mobile['addonID']);
 
         // Set the desktop and mobile theme.
         $this->api()->patch('/addons/bittersweet-theme', ['enabled' => true, 'themeType' => 'desktop']);


### PR DESCRIPTION
This set's Rich-Editor as the default editor for new vanilla installations.  The Keystone theme is set to the default theme for new vanilla installations.

Related to 
#7880 