### PR TITLE
Fix some fixed vanilla header bugs

### DIFF
--- a/library/src/scripts/contexts/DeviceContext.tsx
+++ b/library/src/scripts/contexts/DeviceContext.tsx
@@ -60,10 +60,18 @@ export class DeviceProvider extends React.Component<IProps, IState> {
     }
 
     /**
-     * There's a bug in webpack and there's no way to know the styles have loaded from webpack. In debug mode,
+     * @inheritdoc
      */
     public componentDidMount() {
+        // Force at least one setting of the device.
+        this.setState({ device: this.device });
+
+        // Add a listener to update the device when window size changes.
         window.addEventListener("resize", this.throttledUpdateOnResize);
+
+        // When the webpack hot reload is on, styles are mounted after the javascript.
+        // As a result the measurement here is incorrect and there is no event fired when the CSS finishes.
+        // Here we fake it with a delayed fake resize event.
         if (module.hot) {
             setTimeout(() => {
                 window.dispatchEvent(new Event("resize"));
@@ -81,15 +89,9 @@ export class DeviceProvider extends React.Component<IProps, IState> {
     /**
      * A throttled version of updateOnResize.
      */
-    private throttledUpdateOnResize = throttle(
-        () => {
-            this.setState({ device: this.device });
-        },
-        100,
-        {
-            leading: false,
-        },
-    );
+    private throttledUpdateOnResize = throttle(() => {
+        this.setState({ device: this.device });
+    }, 100);
 }
 
 /**

--- a/library/src/scripts/contexts/ScrollOffsetContext.tsx
+++ b/library/src/scripts/contexts/ScrollOffsetContext.tsx
@@ -117,6 +117,13 @@ export class ScrollOffsetProvider extends React.Component<IProps, IState> {
         requestAnimationFrame(() => {
             const wiggleRoom = 10;
             const newScrolledValue = window.scrollY;
+
+            // Always show if we are within the initial scrolloffset.
+            if (newScrolledValue < this.state.scrollOffset) {
+                this.setState({ isScrolledOff: false });
+                return;
+            }
+
             const isScrollingDown = newScrolledValue > this.previousScrollValue + wiggleRoom;
             const isScrollingUp = newScrolledValue < this.previousScrollValue - wiggleRoom;
             this.previousScrollValue = window.scrollY;


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/8272 brought along a couple small bugs:

This PR fixes them.

- The device size was not being properly initialized on mobile. I've updated it so that it is always initialized.
- Previously it was possible to scroll to the top of the document without the header coming back if you did it very slowly. This is not possible anymore.