### PR TITLE
button bar: remove failing test

### DIFF
--- a/tests/APIv2/AddonsTest.php
+++ b/tests/APIv2/AddonsTest.php
@@ -158,19 +158,7 @@ class AddonsTest extends AbstractAPIv2Test {
             }
         }
     }
-
-    /**
-     * You shouldn't be able to enable two conflicting plugins at the same time.
-     *
-     * @expectedException \Exception
-     * @expectedExceptionCode 409
-     * @expectedExceptionMessage Advanced Editor conflicts with: Button Bar.
-     */
-    public function testConflictingAddons() {
-        $this->api()->patch('/addons/buttonbar', ['enabled' => true]);
-        $this->api()->patch('/addons/editor', ['enabled' => true]);
-    }
-
+    
     /**
      * Provide a list of hidden addons.
      *


### PR DESCRIPTION
This test was removed on master in [#8293](https://github.com/vanilla/vanilla/pull/8293)

