### PR TITLE
Revert "Add ability for all addons to create settings controllers"

### DIFF
--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -428,23 +428,6 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
     }
 
     /**
-     * Get the enabled addon folders.
-     *
-     * @return string[] An array of addon folders.
-     */
-    private function getEnabledAddonFolders(): array {
-        $addonFolders = [];
-        $addons = $this->addonManager->getEnabled();
-
-        /* @var Addon $addon */
-        foreach ($addons as $addon) {
-            $addonFolders[] = $addon->getKey();
-        }
-        $addonFolders = array_unique($addonFolders);
-        return $addonFolders;
-    }
-
-    /**
      *
      *
      * @param string $enabledApplications
@@ -492,7 +475,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
      */
     private function findController(array $parts) {
         // Look for the old-school application name as the first part of the path.
-        if (in_array(($parts[0] ?? false), $this->getEnabledAddonFolders())) {
+        if (in_array(($parts[0] ?? false), $this->getEnabledApplicationFolders())) {
             $application = array_shift($parts);
         } else {
             $application = '';


### PR DESCRIPTION
This reverts commit 66b422874c1eda4a454ba603fa737f0b55cc0fa0 from https://github.com/vanilla/vanilla/pull/8190. Is was causing some naming conflict issues as @alex-mtl predicted.

We'll come up with a better solution later. For now we are falling back to uglier URLs where this was being used. https://github.com/vanilla/knowledge/pull/656
