### PR TITLE
[Backport 2.8] Fix disabling of keystone

### DIFF
--- a/library/core/class.thememanager.php
+++ b/library/core/class.thememanager.php
@@ -585,6 +585,7 @@ class Gdn_ThemeManager extends Gdn_Pluggable {
 
         if ($oldTheme !== $themeName) {
             $this->themeHook($themeName, self::ACTION_ENABLE, true);
+            $this->themeHook($oldTheme, self::ACTION_DISABLE, true);
             Logger::event(
                 'theme_changed',
                 Logger::NOTICE,

--- a/themes/keystone/class.keystone.themehooks.php
+++ b/themes/keystone/class.keystone.themehooks.php
@@ -43,6 +43,15 @@ class KeystoneThemeHooks extends Gdn_Plugin {
     }
 
     /**
+     * Cleanup when the theme is turned off.
+     */
+    public function onDisable() {
+        saveToConfig([
+            'Feature.NewFlyouts.Enabled' => false,
+        ]);
+    }
+
+    /**
      * Runs every page load
      *
      * @param Gdn_Controller $sender This could be any controller

--- a/themes/theme-boilerplate/class.vanillathemeboilerplate.themehooks.php
+++ b/themes/theme-boilerplate/class.vanillathemeboilerplate.themehooks.php
@@ -38,6 +38,15 @@ class VanillaThemeBoilerplateThemeHooks extends Gdn_Plugin {
     }
 
     /**
+     * Cleanup when the theme is turned off.
+     */
+    public function onDisable() {
+        saveToConfig([
+            'Feature.NewFlyouts.Enabled' => false,
+        ]);
+    }
+
+    /**
      * Runs every page load
      *
      * @param Gdn_Controller $sender This could be any controller


### PR DESCRIPTION
Backport of #8318

> Keystone and theme boilerplate set a feature flag that enables backwards incompatible changes in the mebox and flyouts.
> 
> This PR add the shutdown method so they remove it when they are disabled. Otherwise changing from keystone to and older theme breaks flyouts.
> 
> I had to add the shutdown hook in the theme manager as well