### PR TITLE
Fix users/me endpoint for Admin=2 users

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -486,7 +486,8 @@ class UsersApiController extends AbstractApiController {
             unset($dbRecord['Confirmed']);
         }
         if (array_key_exists('Admin', $dbRecord)) {
-            $dbRecord['isAdmin'] = $dbRecord['Admin'];
+            // The site creator is 1, System is 2.
+            $dbRecord['isAdmin'] = in_array($dbRecord['Admin'], [1, 2]);
             unset($dbRecord['Admin']);
         }
 


### PR DESCRIPTION
The `/api/v2/users/me` endpoint would fail with users with the `Admin` flag set to 2 (eg. `System` user). It was expecting only 1 or 0.

The error would look something like this:

```json
{
"message": "Validation Failed",
"status": 422,
"errors": [
{
"field": "isAdmin",
"code": "invalid",
"status": 422,
"message": "isAdmin is not a valid boolean."
}
]
}
```

This PR fixes that.