### PR TITLE
Backport: Fix mobile input default being Rich when addon disabled

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -972,4 +972,11 @@ if (c('Garden.AllowJSONP')) {
     removeFromConfig('Garden.AllowJSONP');
 }
 
+// Avoid the mobile posts having the rich format fall through as the default when the addon is not enabled.
+$mobileInputFormatter = Gdn::config()->get("Garden.MobileInputFormatter");
+$richEditorEnabled = Gdn::addonManager()->isEnabled("rich-editor", \Vanilla\Addon::TYPE_ADDON);
+if ($mobileInputFormatter === "Rich" && $richEditorEnabled === false) {
+    Gdn::config()->set("Garden.MobileInputFormatter", Gdn::config()->get("Garden.InputFormatter"));
+}
+
 Gdn::router()->setRoute('apple-touch-icon.png', 'utility/showtouchicon', 'Internal');


### PR DESCRIPTION
Backport of #8335

> It's possible for the new Rich editor's format to become the default on some sites as the mobile input format, when the editor had not been enabled. This can cause new mobile posts entered in some other  intended format to be interpreted as a rich post and fail.
>
> This update adds a step in the dashboard's structure file to check if the mobile format is Rich and the Rich editor is disabled. If this condition is met, the format is reset to the site's desktop input formatter. This update can be executed using a request to /utility/update.