### PR TITLE
Check if the formvalues are set

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -680,6 +680,7 @@ class PostController extends VanillaController {
 
             if (isset($FormValues['DiscussionID'])) {
                 $formID = (int)$FormValues['DiscussionID'];
+                $DiscussionID = (int)$DiscussionID;
                 if ($formID !== $DiscussionID) {
                     throw new Exception('DiscussionID mismatch.');
                 }

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -679,7 +679,8 @@ class PostController extends VanillaController {
             $FormValues = $this->Form->formValues();
 
             if (isset($FormValues['DiscussionID'])) {
-                if ($FormValues['DiscussionID'] !== $DiscussionID) {
+                $formID = int($FormValues['DiscussionID']);
+                if ($formID !== $DiscussionID) {
                     throw new Exception('DiscussionID mismatch.');
                 }
             }

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -679,7 +679,7 @@ class PostController extends VanillaController {
             $FormValues = $this->Form->formValues();
 
             if (isset($FormValues['DiscussionID'])) {
-                $formID = int($FormValues['DiscussionID']);
+                $formID = (int)$FormValues['DiscussionID'];
                 if ($formID !== $DiscussionID) {
                     throw new Exception('DiscussionID mismatch.');
                 }

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -678,8 +678,10 @@ class PostController extends VanillaController {
             // Save as a draft?
             $FormValues = $this->Form->formValues();
 
-            if ($FormValues['DiscussionID'] !== $DiscussionID) {
-                throw new Exception('DiscussionID mismatch.');
+            if (isset($FormValues['DiscussionID'])) {
+                if ($FormValues['DiscussionID'] !== $DiscussionID) {
+                    throw new Exception('DiscussionID mismatch.');
+                }
             }
 
             $filters = ['Score'];


### PR DESCRIPTION
This checks if the discussion form value is set and then do a comparison.  This handles the discussionid mismatch error being thrown.
