### PR TITLE
Fix typo in Hero Image addon.json

### DIFF
--- a/plugins/heroimage/addon.json
+++ b/plugins/heroimage/addon.json
@@ -7,7 +7,7 @@
     "settingsUrl": "/settings/heroimage",
     "settingsPermission": "Garden.Settings.Manage",
     "documentationUrl": "https://docs.vanillaforums.com/help/addons/hero-image",
-    "author": [
+    "authors": [
         {
             "name": "Adam Charron",
             "email": "adam.c@vanillaforums.com"


### PR DESCRIPTION
This solves issue https://github.com/vanilla/vanilla/issues/8339
Without this fix the author of the plugin is shown as "Array".
