### PR TITLE
User profile: Fix duplicate titles when enabling ranks plugin

### DIFF
--- a/applications/dashboard/views/profile/user.php
+++ b/applications/dashboard/views/profile/user.php
@@ -7,9 +7,11 @@ $Session = Gdn::session();
 
         echo '<span class="Gloss">';
         Gdn_Theme::bulletRow();
-        if ($this->User->Title) {
-            echo Gdn_Theme::bulletItem('Title');
-            echo ' '.bullet().' '.wrap(htmlspecialchars($this->User->Title), 'span', ['class' => 'User-Title']);
+        if (!c('EnabledPlugins.Ranks')) {
+            if ($this->User->Title) {
+                echo Gdn_Theme::bulletItem('Title');
+                echo ' ' . bullet() . ' ' . wrap(htmlspecialchars($this->User->Title), 'span', ['class' => 'User-Title']);
+            }
         }
 
         $this->fireEvent('UsernameMeta');


### PR DESCRIPTION
closes [#182](https://github.com/vanilla/support/issues/182)

### Cause 

When Ranks plugin is enabled, it adds user rank in
https://github.com/vanilla/internal/blob/master/plugins/Ranks/class.ranks.plugin.php#L318

but then the User-Title gets added in 
https://github.com/vanilla/vanilla/blob/1fd5661deaafe66487c13d896e8eb5fcf9222a9d/applications/dashboard/views/profile/user.php#L10
which causes that duplication.

### Fix

Check if the ranks plugin is already enabled before adding the user title.