### PR TITLE
Revert Mobiletheme default back to basic

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -99,7 +99,7 @@ $Configuration['Garden']['Thumbnail']['Size'] = 200;
 
 // Appearance.
 $Configuration['Garden']['Theme'] = 'keystone';
-$Configuration['Garden']['MobileTheme'] = 'keystone';
+$Configuration['Garden']['MobileTheme'] = 'basic';
 $Configuration['Garden']['Menu']['Sort'] = ['Dashboard', 'Discussions', 'Questions', 'Activity', 'Applicants', 'Conversations', 'User'];
 $Configuration['Garden']['ThemeOptions']['Styles']['Key'] = 'Default';
 $Configuration['Garden']['ThemeOptions']['Styles']['Value'] = '%s_default';

--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -99,7 +99,7 @@ $Configuration['Garden']['Thumbnail']['Size'] = 200;
 
 // Appearance.
 $Configuration['Garden']['Theme'] = 'keystone';
-$Configuration['Garden']['MobileTheme'] = 'basic';
+$Configuration['Garden']['MobileTheme'] = 'mobile';
 $Configuration['Garden']['Menu']['Sort'] = ['Dashboard', 'Discussions', 'Questions', 'Activity', 'Applicants', 'Conversations', 'User'];
 $Configuration['Garden']['ThemeOptions']['Styles']['Key'] = 'Default';
 $Configuration['Garden']['ThemeOptions']['Styles']['Value'] = '%s_default';

--- a/tests/APIv2/AddonsTest.php
+++ b/tests/APIv2/AddonsTest.php
@@ -108,7 +108,7 @@ class AddonsTest extends AbstractAPIv2Test {
         $this->assertEquals('keystone-theme', $desktop['addonID']);
 
         $mobile = $this->api()->get('/addons', ['type' => 'theme', 'enabled' => true, 'themeType' => 'mobile'])[0];
-        $this->assertEquals('keystone-theme', $mobile['addonID']);
+        $this->assertEquals('mobile-theme', $mobile['addonID']);
 
         // Set the desktop and mobile theme.
         $this->api()->patch('/addons/bittersweet-theme', ['enabled' => true, 'themeType' => 'desktop']);


### PR DESCRIPTION
Reverting mobiletheme setting in config-default back to basic.

previous changes made with #8302