### PR TITLE
Fix hitting enter on autocomplete search suggestions causing form submission

### DIFF
--- a/library/src/scripts/components/forms/select/SearchBar.tsx
+++ b/library/src/scripts/components/forms/select/SearchBar.tsx
@@ -12,7 +12,7 @@ import classNames from "classnames";
 import { t } from "@library/application";
 import Button from "@library/components/forms/Button";
 import Heading from "@library/components/Heading";
-import { InputActionMeta } from "react-select/lib/types";
+import { InputActionMeta, ActionMeta as SelectActionMeta } from "react-select/lib/types";
 import * as selectOverrides from "./overwrites";
 import ButtonLoader from "@library/components/ButtonLoader";
 import { OptionProps } from "react-select/lib/components/Option";
@@ -102,7 +102,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                 onInputChange={this.handleInputChange}
                 components={this.componentOverwrites}
                 isClearable={false}
-                blurInputOnSelect={false}
+                blurInputOnSelect={true}
                 allowCreateWhileLoading={true}
                 controlShouldRenderValue={false}
                 isDisabled={disabled}
@@ -145,10 +145,18 @@ export default class SearchBar extends React.Component<IProps, IState> {
      * - Force the menu closed.
      * - Trigger a search.
      */
-    private handleOptionChange = (option: IComboBoxOption) => {
+    private handleOptionChange = (option: IComboBoxOption, actionMeta: SelectActionMeta) => {
         if (option) {
+            const data = option.data || {};
+            const { url } = option.data;
+
             this.props.onChange(option.label);
-            this.setState({ forceMenuClosed: true }, this.props.onSearch);
+
+            if (actionMeta.action === "select-option" && url) {
+                console.log(url);
+            } else {
+                this.setState({ forceMenuClosed: true }, this.props.onSearch);
+            }
         }
     };
 

--- a/library/src/scripts/components/forms/select/SearchBar.tsx
+++ b/library/src/scripts/components/forms/select/SearchBar.tsx
@@ -22,6 +22,8 @@ import ConditionalWrap from "@library/components/ConditionalWrap";
 import { search } from "@library/components/icons/header";
 import { MenuProps } from "react-select/lib/components/Menu";
 import ReactDOM from "react-dom";
+import { LinkContext } from "@library/components/navigation/LinkContextProvider";
+import { RouteComponentProps, withRouter } from "react-router";
 
 export interface IComboBoxOption<T = any> {
     value: string | number;
@@ -29,7 +31,7 @@ export interface IComboBoxOption<T = any> {
     data?: T;
 }
 
-interface IProps extends IOptionalComponentID {
+interface IProps extends IOptionalComponentID, RouteComponentProps<any> {
     disabled?: boolean;
     className?: string;
     placeholder: string;
@@ -62,6 +64,9 @@ interface IState {
  * Implements the search bar component
  */
 export default class SearchBar extends React.Component<IProps, IState> {
+    public static contextType = LinkContext;
+    public context!: React.ContextType<typeof LinkContext>;
+
     public static defaultProps: Partial<IProps> = {
         disabled: false,
         isBigInput: false,
@@ -102,7 +107,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                 onInputChange={this.handleInputChange}
                 components={this.componentOverwrites}
                 isClearable={false}
-                blurInputOnSelect={true}
+                blurInputOnSelect={false}
                 allowCreateWhileLoading={true}
                 controlShouldRenderValue={false}
                 isDisabled={disabled}
@@ -148,13 +153,12 @@ export default class SearchBar extends React.Component<IProps, IState> {
     private handleOptionChange = (option: IComboBoxOption, actionMeta: SelectActionMeta) => {
         if (option) {
             const data = option.data || {};
-            const { url } = option.data;
-
-            this.props.onChange(option.label);
+            const { url } = data;
 
             if (actionMeta.action === "select-option" && url) {
-                console.log(url);
+                this.context.pushSmartLocation(url);
             } else {
+                this.props.onChange(option.label);
                 this.setState({ forceMenuClosed: true }, this.props.onSearch);
             }
         }

--- a/library/src/scripts/components/navigation/LinkContextProvider.tsx
+++ b/library/src/scripts/components/navigation/LinkContextProvider.tsx
@@ -1,0 +1,105 @@
+/**
+ * @author Adam (charrondev) Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { formatUrl } from "@library/application";
+import { NavLinkProps, NavLink, RouteComponentProps, withRouter } from "react-router-dom";
+import { LocationDescriptor, createPath, createLocation, LocationDescriptorObject } from "history";
+
+export interface IWithLinkContext {
+    linkContext: string;
+    pushSmartLocation(location: LocationDescriptor);
+    isDynamicNavigation(location: LocationDescriptor): boolean;
+    makeHref(location: LocationDescriptor): string;
+}
+
+export const LinkContext = React.createContext<IWithLinkContext>({
+    linkContext: "https://testSite.com",
+    pushSmartLocation: () => {
+        throw new Error("Be sure to declare the <LinkContextProvider />");
+        return {} as any;
+    },
+    isDynamicNavigation: () => {
+        throw new Error("Be sure to declare the <LinkContextProvider />");
+        return false;
+    },
+    makeHref: () => {
+        throw new Error("Be sure to declare the <LinkContextProvider />");
+    },
+});
+
+interface IProps extends RouteComponentProps<any> {
+    linkContext: string;
+    children: React.ReactNode;
+    urlFormatter?: (url: string, withDomain?: boolean) => string;
+}
+
+export const LinkContextProvider = withRouter((props: IProps) => {
+    const makeHref = (location: LocationDescriptor): string => {
+        const { urlFormatter } = props;
+        const finalUrlFormatter = urlFormatter ? urlFormatter : formatUrl;
+        const stringUrl = typeof location === "string" ? location : createPath(location);
+        const href = finalUrlFormatter(stringUrl, true);
+        return href;
+    };
+
+    const isDynamicNavigation = (href: string): boolean => {
+        const link = document.createElement("a");
+        link.href = href;
+        const isCurrentPage = link.pathname === window.location.pathname;
+        return href.startsWith(props.linkContext) && !isCurrentPage;
+    };
+
+    const pushSmartLocation = (location: LocationDescriptor) => {
+        const href = makeHref(location);
+        if (isDynamicNavigation(href)) {
+            props.history.push(makeLocationDescriptorObject(location, href));
+        } else {
+            window.location.href = href;
+        }
+    };
+
+    return (
+        <LinkContext.Provider
+            value={{
+                linkContext: props.linkContext,
+                pushSmartLocation,
+                isDynamicNavigation,
+                makeHref,
+            }}
+        >
+            {props.children}
+        </LinkContext.Provider>
+    );
+});
+
+/**
+ * Create a new LocationDescriptor with a "relative" path.
+ *
+ * This way we ensure we use react-router's navigation and not a full refresh.
+ *
+ * @param initial The starting location. We may want to preserve state here if we can.
+ * @param newHref The new string url to point to.
+ */
+export function makeLocationDescriptorObject(initial: LocationDescriptor, newHref: string): LocationDescriptorObject {
+    // Get the search and pathName
+    const link = document.createElement("a");
+    link.href = newHref;
+    const { search, pathname } = link;
+
+    if (typeof initial === "string") {
+        return {
+            pathname,
+            search,
+        };
+    } else {
+        return {
+            ...initial,
+            pathname,
+            search,
+        };
+    }
+}

--- a/library/src/scripts/components/navigation/SmartLink.test.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.test.tsx
@@ -4,13 +4,14 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
+import { LinkContextProvider } from "@library/components/navigation/LinkContextProvider";
 import { expect } from "chai";
 import { mount } from "enzyme";
-import SmartLink, { LinkContext } from "./SmartLink";
 import { LocationDescriptor } from "history";
+import React from "react";
 import { MemoryRouter, Route } from "react-router";
 import { Link } from "react-router-dom";
+import SmartLink from "./SmartLink";
 
 const DOMAIN = "https://mysite.com";
 const SUBPATH = "/test";
@@ -19,13 +20,13 @@ const CONTEXT_BASE = DOMAIN + SUBPATH;
 function renderLocation(loc: LocationDescriptor, formatter: any) {
     return mount(
         <div>
-            <LinkContext.Provider value={CONTEXT_BASE}>
+            <LinkContextProvider linkContext={CONTEXT_BASE}>
                 <MemoryRouter>
                     <Route>
-                        <SmartLink urlFormatter={formatter} to={loc} />
+                        <SmartLink to={loc} />
                     </Route>
                 </MemoryRouter>
-            </LinkContext.Provider>
+            </LinkContextProvider>
         </div>,
     );
 }

--- a/library/src/scripts/components/navigation/SmartLink.test.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.test.tsx
@@ -20,13 +20,13 @@ const CONTEXT_BASE = DOMAIN + SUBPATH;
 function renderLocation(loc: LocationDescriptor, formatter: any) {
     return mount(
         <div>
-            <LinkContextProvider linkContext={CONTEXT_BASE}>
-                <MemoryRouter>
+            <MemoryRouter>
+                <LinkContextProvider linkContext={CONTEXT_BASE} urlFormatter={formatter}>
                     <Route>
                         <SmartLink to={loc} />
                     </Route>
-                </MemoryRouter>
-            </LinkContextProvider>
+                </LinkContextProvider>
+            </MemoryRouter>
         </div>,
     );
 }

--- a/library/src/scripts/components/navigation/SmartLink.tsx
+++ b/library/src/scripts/components/navigation/SmartLink.tsx
@@ -8,12 +8,9 @@ import React from "react";
 import { formatUrl } from "@library/application";
 import { NavLinkProps, NavLink } from "react-router-dom";
 import { LocationDescriptor, createPath, createLocation } from "history";
+import { IWithLinkContext, LinkContext, makeLocationDescriptorObject } from "./LinkContextProvider";
 
-export const LinkContext = React.createContext("https://changeme.dev.localhost");
-
-interface IProps extends NavLinkProps {
-    urlFormatter?: (url: string, withDomain?: boolean) => string;
-}
+interface IProps extends NavLinkProps {}
 
 /**
  * Link component that checks it's <LinkContext /> to know if it needs to do a full refresh
@@ -32,22 +29,17 @@ interface IProps extends NavLinkProps {
  * Result = https://test.com/root/someUrl/deeper/nested (full refresh)
  */
 export default function SmartLink(props: IProps) {
-    const { replace, urlFormatter, ...passthru } = props;
-    const finalUrlFormatter = urlFormatter ? urlFormatter : formatUrl;
-    const stringUrl = typeof props.to === "string" ? props.to : createPath(props.to);
-    const href = finalUrlFormatter(stringUrl, true);
-    const link = document.createElement("a");
-    link.href = href;
-    const isCurrentPage = link.pathname === window.location.pathname;
+    const { replace, ...passthru } = props;
 
     return (
         <LinkContext.Consumer>
-            {contextRoot => {
-                if (href.startsWith(contextRoot) && !isCurrentPage) {
+            {context => {
+                const href = context.makeHref(props.to);
+                if (context.isDynamicNavigation(href)) {
                     return (
                         <NavLink
                             {...passthru}
-                            to={makeDynamicHref(props.to, href)}
+                            to={makeLocationDescriptorObject(props.to, href)}
                             activeClassName="isCurrent"
                             tabIndex={props.tabIndex}
                             replace={replace}
@@ -59,32 +51,4 @@ export default function SmartLink(props: IProps) {
             }}
         </LinkContext.Consumer>
     );
-}
-
-/**
- * Create a new LocationDescriptor with a "relative" path.
- *
- * This way we ensure we use react-router's navigation and not a full refresh.
- *
- * @param initial The starting location. We may want to preserve state here if we can.
- * @param newHref The new string url to point to.
- */
-function makeDynamicHref(initial: LocationDescriptor, newHref: string): LocationDescriptor {
-    // Get the search and pathName
-    const link = document.createElement("a");
-    link.href = newHref;
-    const { search, pathname } = link;
-
-    if (typeof initial === "string") {
-        return {
-            pathname,
-            search,
-        };
-    } else {
-        return {
-            ...initial,
-            pathname,
-            search,
-        };
-    }
 }


### PR DESCRIPTION
The `SearchBar` component provides result suggestions while typing. Clicking on these suggestions can take you to the result. However, using keyboard navigation and hitting the enter key will submit the search form. The expected behavior is for hitting the enter key on a suggestion to navigate you to that record.

This update fixes the aforementioned issue with the following changes:

### Overview
1. Add `LinkContextProvider` module. This pulls much of the link context logic from `SmartLink` into reusable components and expands on them.
1. Update `SmartLink` to utilize `LinkContextProvider`.
1. Fix the `handleOptionChange` method in `SearchBar` not distinguishing between when a suggestion had been selected or a search had been submitted.
1. Update `SearchBar` to use `LinkContext`, introduced in the `LinkContextProvider` module, to provide relevant location changes (e.g. fully navigating away versus remaining in the app), depending on what search suggestion is selected.