### PR TITLE
Fix tabs being intercepted by code blocks when using Rich Editor

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
+++ b/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
@@ -260,8 +260,8 @@ export default class KeyboardBindings {
     private resetDefaultBindings() {
         // Nullify the tab key.
         (this.bindings as any).tab = false;
-        this.bindings["indent codeBlock"] = false;
-        this.bindings["outdent codeBlock"] = false;
+        this.bindings["indent code-block"] = false;
+        this.bindings["outdent code-block"] = false;
         this.bindings["remove tab"] = false;
         this.bindings["code exit"] = false;
     }


### PR DESCRIPTION
Rich Editor's key bindings setup has a routine for resetting some of Quill's defaults. One of these defaults controls how tabs are handled in code blocks. Quill has two key bindings: [one for indenting in code blocks and one for outdenting in code blocks](https://github.com/quilljs/quill/blob/f74616e838a96d4269de4c59e74ff848085c734a/modules/keyboard.js#L221). Quill refers to code blocks in this rule as kebab case (e.g. code-blocks). However, Rich Editor refers to code blocks with camel case (codeBlocks) while attempting to override the bindings. This meant Rich Editor was not actually overriding the code block indent and outdent bindings.

Rich Editor's key bindings have been updated to properly override the Quill default code block indent and outdent configs, as intended.

Closes vanilla/knowledge#629