### PR TITLE
Fix breadcrumbs prop

### DIFF
--- a/library/src/scripts/components/Breadcrumbs.tsx
+++ b/library/src/scripts/components/Breadcrumbs.tsx
@@ -18,7 +18,7 @@ export interface ICrumb {
 export interface IProps {
     children: ICrumb[];
     className?: string;
-    forceDisplay: boolean;
+    forceDisplay?: boolean;
     minimumCrumbCount?: number;
 }
 


### PR DESCRIPTION
I had compilation problems on my localhost because there were missing "forceDisplay" props on "Breadcrumbs" components. I made it optional, as it will default to false.