### PR TITLE
Reported Posts: fix reported activity posts displaying as html

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1804,7 +1804,7 @@ if (!function_exists('getRecord')) {
                         throw permissionException();
                     }
 
-                    $row['Name'] = formatString($row['HeadlineFormat'], $row);
+                    $row['Name'] = $row['ActivityName'];
                     $row['Body'] = $row['Story'];
                 }
                 break;


### PR DESCRIPTION
closes [#175](https://github.com/vanilla/support/issues/175)

This bug was noticed after a recent change in [#7724](https://github.com/vanilla/vanilla/pull/7724)
**To Replicate** 

- Find a profile with a comment in their Activity
- Using an admin/mod account, flag that comment for the report. 
- The author of the comment will be sent to 'Reported Posts' with the expanded html as the title. 

![image](https://user-images.githubusercontent.com/7501633/52075689-8460e780-2552-11e9-8d0a-463884331d8d.png)
