### PR TITLE
Add slack notifications to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ install: true
 env:
   - VANILLA_BUILD_DISABLE_AUTO_BUILD=true
 
-# Send status update notifications to a HipChat room.
+# Send cron job notification to our Slack room.
 notifications:
   slack:
     on_pull_requests: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,10 +143,5 @@ env:
 
 # Send status update notifications to a HipChat room.
 notifications:
-  hipchat:
-    format: html
-    on_success: change
-    rooms:
-      - secure: "SsKmSAZFynBz4ZKm5NPyuXvNjIMyxpNMXsgfXVImG8xjQHdXjEpZAiyckK8E2lXBBypv59Oex6wsS0RvyxpI/mwQ9dTQ9ayurQxwH3V5Q/+pRbtXJOkP+DSIsHhRb9D4xa5nPbh4N48+QZvUFiH2ety9/gev4mtMkLv3lC0vgpc="
-    template:
-      - '%{repository_slug} build <a href="%{build_url}">#%{build_number}</a> (%{branch} - <a href="%{compare_url}">%{commit}</a> by %{author}): %{message}'
+  slack:
+    secure: Wxsh9jI4Noq8BQtEl7CjfsHtQRmVo5l7jCDkY0W7zqHqnPRUBiAd847uPcBRUcWE8zYWDLXqtTHJMc/ctyLodentArgvHTtBIw6gp2QaFFFYe1WE0tPSYmhGa9GjI46D2/a4rCjNo1uIpytoHGTSp6RNBhY3TFKqZf+qy6RnIcU=

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,4 +144,5 @@ env:
 # Send status update notifications to a HipChat room.
 notifications:
   slack:
+    on_pull_requests: false
     secure: Wxsh9jI4Noq8BQtEl7CjfsHtQRmVo5l7jCDkY0W7zqHqnPRUBiAd847uPcBRUcWE8zYWDLXqtTHJMc/ctyLodentArgvHTtBIw6gp2QaFFFYe1WE0tPSYmhGa9GjI46D2/a4rCjNo1uIpytoHGTSp6RNBhY3TFKqZf+qy6RnIcU=


### PR DESCRIPTION
Parts of our travis build only run in daily cron jobs, but right now we have no centralized place to collect these cron job reports.

This PR:
- Removes the defunct hipchat integration.
- Adds a slack integration to our `#dev-ci` room using a token encrypted with `travis encrypt` for our cron job builds.