### PR TITLE
Add a feature flag to to defer legacy scripts

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -43,6 +43,11 @@ class SettingsController extends DashboardController {
         if ($this->Menu) {
             $this->Menu->highlightRoute('/dashboard/settings');
         }
+
+        // Many dashboard pages display a pretty style flash when deferring all scripts.
+        // Disable deferred scripts on these pages until this is resolved.
+        // This is also less signficant here because these pages are not indexed by search engines.
+        $this->useDeferredLegacyScripts = false;
     }
 
     /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -153,6 +153,9 @@ class Gdn_Controller extends Gdn_Pluggable {
     /** @var string Name of the view that has been requested. Typically part of the view's file name. ie. $this->View.'.php' */
     public $View;
 
+    /** @var bool Indicate that the controller add the `defer` attribute to it's legacy scripts. */
+    protected $useDeferredLegacyScripts;
+
     /** @var array An array of CSS file names to search for in theme folders & include in the page. */
     protected $_CssFiles;
 
@@ -215,6 +218,7 @@ class Gdn_Controller extends Gdn_Pluggable {
      *
      */
     public function __construct() {
+        $this->useDeferredLegacyScripts = \Vanilla\FeatureFlagHelper::featureEnabled('DeferredLegacyScripts');
         $this->Application = '';
         $this->ApplicationFolder = '';
         $this->Assets = [];
@@ -1911,7 +1915,7 @@ class Gdn_Controller extends Gdn_Pluggable {
                 $section = $this->MasterView === 'admin' ? 'admin' : 'forum';
                 $jsAssets = $webpackAssetProvider->getScripts($section);
                 foreach ($jsAssets as $asset) {
-                    $this->Head->addScript($asset->getWebPath(), 'text/javascript', false, ['defer' => 'true']);
+                    $this->Head->addScript($asset->getWebPath(), 'text/javascript', false, ['defer' => 'defer']);
                 }
 
                 // The the built stylesheets
@@ -1926,6 +1930,10 @@ class Gdn_Controller extends Gdn_Pluggable {
                         $JsInfo['Options'] = [];
                     }
                     $Options = &$JsInfo['Options'];
+
+                    if ($this->useDeferredLegacyScripts) {
+                        $Options['defer'] = 'defer';
+                    }
 
                     if (isset($Cdns[$JsFile])) {
                         $JsFile = $Cdns[$JsFile];


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8065
Closes https://github.com/vanilla/vanilla/issues/7482
Of note to https://github.com/vanillaforums/hmd-global/issues/158

## `DeferredLegacyScripts` feature flag

Enabling this feature flag will cause all scripts to have the `defer` attribute set. This causes them to happen after document rendering in order but before the DOMContentLoaded event. This is what we currently do for all scripts using `WebpackAssetProvider` (eg. Kb, Rich Editor, some advanced editor behaviour).

This is a feature flag disabled by default because of some difficulties with jquery (see https://stackoverflow.com/a/46814123). It could also potentially cause issues with inline content scripts required jquery to be synchronously loaded. As a result something like this can only be enabled on a case by case basis without being a major breaking change. For more context see https://github.com/vanillaforums/hmd-global/issues/158#issuecomment-464856985

## Fix the defer attribute for webpack assets

From the W3C spec.

> If the attribute is present, its value must either be the empty string or a value that is an ASCII case-insensitive match for the attribute’s canonical name, with no leading or trailing white space.

I've opted for the ASCII match here because it was easiest to implement with the current system.

