### PR TITLE
Make page scroll down to embedded comments when user logs into embedded comments.

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -615,7 +615,7 @@ if (!function_exists('writeEmbedCommentForm')) :
 
                 // If we aren't ajaxing this call then we need to target the url of the parent frame.
                 $returnUrl = $controller->data('ForeignSource.vanilla_url', Gdn::request()->pathAndQuery());
-                $returnUrl = trim($returnUrl,'/').'#vanilla-comments';
+                $returnUrl = trim($returnUrl, '/').'#vanilla-comments';
 
                 if ($session->isValid()) {
                     $authenticationUrl = url(signOutUrl($returnUrl), true);

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -615,6 +615,7 @@ if (!function_exists('writeEmbedCommentForm')) :
 
                 // If we aren't ajaxing this call then we need to target the url of the parent frame.
                 $returnUrl = $controller->data('ForeignSource.vanilla_url', Gdn::request()->pathAndQuery());
+                $returnUrl = trim($returnUrl,'/').'#vanilla-comments';
 
                 if ($session->isValid()) {
                     $authenticationUrl = url(signOutUrl($returnUrl), true);


### PR DESCRIPTION
This PR would close https://github.com/vanilla/vanilla/issues/8422

Pass the DOM element id of the embedded comments (#vanilla-comments) to the sign in URL on embedded comments. This hash will be passed as part of the redirect URL through the log in workflow so that when the authenticated user will come back to the page where the embedded comments are they will be brought to the commenting form.