### PR TITLE
wip/queue integration

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -358,6 +358,11 @@ $dic->call(function (
     $config->overlayDynamic();
 
     /**
+     * Bootstrap the MessageQueue component
+     */
+    \Garden\MessageQueue\JobQueue::bootstrap($dic);
+
+    /**
      * Bootstrap Late
      *
      * All configurations are loaded, as well as the Application, Plugin and Theme
@@ -438,3 +443,8 @@ require_once PATH_LIBRARY_CORE.'/functions.render.php';
 if (!defined('CLIENT_NAME')) {
     define('CLIENT_NAME', 'vanilla');
 }
+
+// Trigger BeforeShutdown Event
+register_shutdown_function(function () use ($dic) {
+    $dic->get("Gdn_Dispatcher")->fireEvent("BeforeShutdown");
+});

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,16 @@
             "php": "7.0.26"
         }
     },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../garden-message-queue"
+        },
+        {
+            "type": "path",
+            "url": "../queue-interop"
+        }
+    ],
     "require": {
         "php": ">=7.0.0",
         "ext-json": "*",
@@ -48,14 +58,16 @@
         "vanilla/legacy-passwords": "~1.0",
         "vanilla/nbbc": "~2.1",
         "vanilla/vanilla-connect": "~0.0",
-        "twig/twig": "^2.5"
+        "twig/twig": "^2.5",
+        "vanilla/queue-interop": "@dev",
+        "vanilla/garden-message-queue":"@dev"
     },
     "require-dev": {
         "exussum12/coverage-checker": "~0.10",
         "phpunit/phpunit": "~6.0",
         "vanilla/standards": "~1.3",
         "voku/html-min": "~3.0",
-        "mikey179/vfsStream": "~1.6"
+        "mikey179/vfsstream": "~1.6"
     },
     "provide": {
         "ext-gd": "*"
@@ -74,7 +86,8 @@
         ],
         "psr-4": {
 			"Vanilla\\": "library/Vanilla",
-			"Garden\\": "library/Garden"
+			"Garden\\": "library/Garden",
+            "Vanilla\\Job\\": "job"
         }
     },
     "scripts": {

--- a/job/EchoJob.php
+++ b/job/EchoJob.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Job;
+
+use Garden\QueueInterop\AbstractJob;
+use Psr\Log\LogLevel;
+
+/**
+ * Vanilla Test Job: EchoJob
+ *
+ * @author Eric Vachaviolos <eric.v@vanillaforums.com>
+ */
+class EchoJob extends AbstractJob {
+
+    /**
+     * Run job
+     *
+     * @throws \Exception
+     */
+    public function run() {
+
+        $this->log(LogLevel::NOTICE, "Echo job running");
+
+        $message = $this->get('message');
+
+        $this->log(LogLevel::NOTICE, "  Echoing inputted message *** {msg} ***", [
+            'msg' => $message
+        ]);
+
+    }
+
+}

--- a/job/SendMailJob.php
+++ b/job/SendMailJob.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Job;
+
+use Garden\QueueInterop\AbstractJob;
+use Psr\Log\LogLevel;
+use Vanilla\VanillaMailer;
+
+/**
+ * Vanilla Job: SendMailJob
+ *
+ * @author Eduardo Garcia Julia <eduardo.garciajulia@vanillaforums.com>
+ */
+class SendMailJob extends AbstractJob {
+
+    /**
+     * Run job
+     *
+     * @throws \Exception
+     */
+    public function run() {
+
+        $this->log(LogLevel::NOTICE, "SendMail Job running");
+
+        /** @var PHPMailer */
+        $phpMailer = $this->get('phpMailer');
+
+        if ($phpMailer == null || !($phpMailer instanceof VanillaMailer)) {
+            $msg = "Vanilla\Job\SendMailJob: invalid phpMailer payload";
+            $this->log(LogLevel::ERROR, $msg);
+            throw new \Exception($msg);
+        }
+
+        error_log("Vanilla\Job\SendMailJob: '".$phpMailer->Subject."', to: ".var_export($phpMailer->getToAddresses(), true));
+
+        $phpMailer->setThrowExceptions(true);
+        if (!$phpMailer->send()) {
+            throw new \Exception($phpMailer->ErrorInfo);
+        }
+    }
+
+}

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -357,10 +357,10 @@ class Gdn_Email extends Gdn_Pluggable {
             throw new Exception('No valid email recipients.', self::ERR_SKIPPED);
         }
 
-        $this->PhpMailer->setThrowExceptions(true);
-        if (!$this->PhpMailer->send()) {
-            throw new Exception($this->PhpMailer->ErrorInfo);
-        }
+        // Schedules a SendMailJob
+        /* @var $jobQueue \Garden\MessageQueue\JobQueue */
+        $jobQueue = Gdn::getContainer()->get('JobQueue');
+        $jobQueue->addJob(Vanilla\Job\SendMailJob::class, ['phpMailer' => $this->PhpMailer]);
 
         return true;
     }

--- a/library/core/functions.compatibility.php
+++ b/library/core/functions.compatibility.php
@@ -452,51 +452,55 @@ if (!function_exists('valr')) {
     }
 }
 
-/**
- * Set a key to a value in a collection.
- *
- * Works with single keys or "dot" notation. If $key is an array, a simple
- * shallow array_merge is performed.
- *
- * @param string $key The key or property name of the value.
- * @param array &$collection The array or object to search.
- * @param mixed $value The value to set.
- * @return mixed Newly set value or if array merge.
- */
-function setvalr($key, &$collection, $value = null) {
-    if (is_array($key)) {
-        $collection = array_merge($collection, $key);
-        return null;
-    }
-
-    if (strpos($key, '.')) {
-        $path = explode('.', $key);
-
-        $selection = &$collection;
-        $mx = count($path) - 1;
-        for ($i = 0; $i <= $mx; ++$i) {
-            $subSelector = $path[$i];
-
-            if (is_array($selection)) {
-                if (!isset($selection[$subSelector])) {
-                    $selection[$subSelector] = [];
-                }
-                $selection = &$selection[$subSelector];
-            } elseif (is_object($selection)) {
-                if (!isset($selection->$subSelector)) {
-                    $selection->$subSelector = new stdClass();
-                }
-                $selection = &$selection->$subSelector;
-            } else {
-                return null;
-            }
+if (!function_exists('setvalr')) {
+    /**
+     * Set a key to a value in a collection.
+     *
+     * Works with single keys or "dot" notation. If $key is an array, a simple
+     * shallow array_merge is performed.
+     *
+     * @param string $key The key or property name of the value.
+     * @param array &$collection The array or object to search.
+     * @param mixed $value The value to set.
+     *
+     * @return mixed Newly set value or if array merge.
+     */
+    function setvalr($key, &$collection, $value = null)
+    {
+        if (is_array($key)) {
+            $collection = array_merge($collection, $key);
+            return null;
         }
-        return $selection = $value;
-    } else {
-        if (is_array($collection)) {
-            return $collection[$key] = $value;
+
+        if (strpos($key, '.')) {
+            $path = explode('.', $key);
+
+            $selection = &$collection;
+            $mx = count($path) - 1;
+            for ($i = 0; $i <= $mx; ++$i) {
+                $subSelector = $path[$i];
+
+                if (is_array($selection)) {
+                    if (!isset($selection[$subSelector])) {
+                        $selection[$subSelector] = [];
+                    }
+                    $selection = &$selection[$subSelector];
+                } elseif (is_object($selection)) {
+                    if (!isset($selection->$subSelector)) {
+                        $selection->$subSelector = new stdClass();
+                    }
+                    $selection = &$selection->$subSelector;
+                } else {
+                    return null;
+                }
+            }
+            return $selection = $value;
         } else {
-            return $collection->$key = $value;
+            if (is_array($collection)) {
+                return $collection[$key] = $value;
+            } else {
+                return $collection->$key = $value;
+            }
         }
     }
 }


### PR DESCRIPTION
Work in progress PR, the purpose is to get some feedback. **Not intended to be merged**.
Relates to: https://github.com/vanilla/garden-message-queue/pull/2

## bootstrap.php
+ added `\Garden\MessageQueue\JobQueue` bootstrap. Called before `/bootstrap.late.php` to give an opportunity to re-handle this later. 
+ Fire event `BeforeShutdown` in a register_shutdown_function after all the bootstrap process. That would make the callback the last function called (before shutdown). Firing the event at that moment would allow processing others register_shutdown_function, for example, the one handling cookies.
+ Be aware in case a Job is scheduled, garden-message-queue default's implementation would                 make a session_write_close() and a fastcgi_finish_request();

## job/SendMailJob.php
+ Naive implementation of a Job that sends mail. Gets a VanillaMailer instance and just send() it

## library/core/class.email.php
+ small tweak to use the SendMailJob

## library/core/functions.compatibility.php
+ Define function "setvalr" only if it doesn't exists yet

## job/EchoJob.php
+ Echo Job. Basic Job Implementation