### PR TITLE
Fix OpenAPI validation test running in other repos using Vanilla

### DIFF
--- a/tests/Library/Vanilla/OpenAPIBuilderTest.php
+++ b/tests/Library/Vanilla/OpenAPIBuilderTest.php
@@ -19,6 +19,8 @@ class OpenAPIBuilderTest extends TestCase {
 
     /**
      * The OpenAPI build should validate against the OpenAPI spec.
+     *
+     * @large
      */
     public function testValidOpenAPI() {
         $am = new AddonManager(


### PR DESCRIPTION
Recently, #8382 migrated Vanilla's OpenAPI spec from dynamic-built to static files. Part of this change introduced a test to validate the fully-merged OpenAPI spec, using the Swagger CLI command. This command requires the build be altered to perform a global yarn install, since the Swagger CLI command is provided by node. Until other repos running tests with Vanilla have their builds updated to also include the global yarn install, they should be able to avoid this test. The current preferred method is by skipping the "large" group.

This update addresses the aforementioned issue by assigning the OpenAPI validation test into the ["large" group](https://phpunit.de/manual/6.5/en/appendixes.annotations.html#appendixes.annotations.large). Repos running Vanilla's test suite and excluding the large group should no longer see this test run.

Associated issues referenced in the log below.