### PR TITLE
Add some additional typestyle variables and clean up "any" type usage

### DIFF
--- a/library/src/scripts/styles/buttonStyles.ts
+++ b/library/src/scripts/styles/buttonStyles.ts
@@ -42,34 +42,34 @@ export function buttonStyles(theme?: object) {
 type Unit = string | number;
 
 export interface IButtonType {
-    fg: string;
-    bg: string;
-    spinner: string;
+    fg: ColorHelper;
+    bg: ColorHelper;
+    spinner: ColorHelper;
     border: {
-        color: string;
+        color: ColorHelper;
         width: Unit;
         style: string;
         radius: Unit;
     };
     hover: {
-        color: string;
-        backgroundColor: string;
-        borderColor: string;
+        fg: ColorHelper;
+        bg: ColorHelper;
+        borderColor: ColorHelper;
     };
     focus: {
-        color: string;
-        backgroundColor: string;
-        borderColor: string;
+        fg: ColorHelper;
+        bg: ColorHelper;
+        borderColor: ColorHelper;
     };
     active: {
-        color: string;
-        backgroundColor: string;
-        borderColor: string;
+        fg: ColorHelper;
+        bg: ColorHelper;
+        borderColor: ColorHelper;
     };
     focusAccessible: {
-        color: string;
-        backgroundColor: string;
-        borderColor: string;
+        fg: ColorHelper;
+        bg: ColorHelper;
+        borderColor: ColorHelper;
     };
 }
 
@@ -78,110 +78,101 @@ export function buttonVariables(theme?: object) {
     const themeVars = componentThemeVariables(theme, "button");
 
     const standard: IButtonType = {
-        fg: globalVars.mainColors.fg.toString(),
-        bg: globalVars.mainColors.bg.toString(),
-        spinner: globalVars.mainColors.primary.toString(),
+        fg: globalVars.mainColors.fg,
+        bg: globalVars.mainColors.bg,
+        spinner: globalVars.mainColors.primary,
         border: {
-            color: globalVars.mixBgAndFg(0.24).toString(),
+            color: globalVars.mixBgAndFg(0.24),
             width: px(1),
             style: "solid",
             radius: globalVars.border.radius,
         },
         hover: {
-            color: globalVars.mainColors.fg.toString(),
-            backgroundColor: globalVars.mainColors.bg.darken(0.1).toString(),
-            borderColor: globalVars
-                .mixBgAndFg(0.4)
-                .darken(0.1)
-                .toString(),
+            fg: globalVars.mainColors.fg,
+            bg: globalVars.mainColors.bg.darken(0.1),
+            borderColor: globalVars.mixBgAndFg(0.4).darken(0.1),
         },
         active: {
-            color: globalVars.mainColors.fg.toString(),
-            backgroundColor: globalVars.mainColors.bg.darken(0.1).toString(),
-            borderColor: globalVars
-                .mixBgAndFg(0.4)
-                .darken(0.1)
-                .toString(),
+            fg: globalVars.mainColors.fg,
+            bg: globalVars.mainColors.bg.darken(0.1),
+            borderColor: globalVars.mixBgAndFg(0.4).darken(0.1),
         },
         focus: {
-            color: globalVars.mainColors.fg.toString(),
-            backgroundColor: globalVars.mainColors.bg.darken(0.1).toString(),
-            borderColor: globalVars
-                .mixBgAndFg(0.8)
-                .darken(0.1)
-                .toString(),
+            fg: globalVars.mainColors.fg,
+            bg: globalVars.mainColors.bg.darken(0.1),
+            borderColor: globalVars.mixBgAndFg(0.8).darken(0.1),
         },
         focusAccessible: {
-            color: globalVars.mainColors.fg.toString(),
-            backgroundColor: globalVars.mainColors.bg.darken(0.3).toString(),
-            borderColor: globalVars.mainColors.bg.darken(1).toString(),
+            fg: globalVars.mainColors.fg,
+            bg: globalVars.mainColors.bg.darken(0.3),
+            borderColor: globalVars.mainColors.bg.darken(1),
         },
         ...themeVars.subComponentStyles("basic"),
     };
 
     const primary: IButtonType = {
-        fg: globalVars.elementaryColors.white.toString(),
-        bg: globalVars.mainColors.primary.toString(),
-        spinner: globalVars.elementaryColors.white.toString(),
+        fg: globalVars.elementaryColors.white,
+        bg: globalVars.mainColors.primary,
+        spinner: globalVars.elementaryColors.white,
         border: {
-            color: globalVars.mainColors.primary.toString(),
+            color: globalVars.mainColors.primary,
             width: px(1),
             style: "solid",
             radius: globalVars.border.radius,
         },
         hover: {
-            color: globalVars.elementaryColors.white.toString(),
-            backgroundColor: globalVars.mainColors.secondary.toString(),
-            borderColor: globalVars.mainColors.primary.toString(),
+            fg: globalVars.elementaryColors.white,
+            bg: globalVars.mainColors.secondary,
+            borderColor: globalVars.mainColors.primary,
         },
         active: {
-            color: globalVars.elementaryColors.white.toString(),
-            backgroundColor: globalVars.mainColors.secondary.toString(),
-            borderColor: globalVars.mainColors.primary.toString(),
+            fg: globalVars.elementaryColors.white,
+            bg: globalVars.mainColors.secondary,
+            borderColor: globalVars.mainColors.primary,
         },
         focus: {
-            color: globalVars.elementaryColors.white.toString(),
-            backgroundColor: globalVars.mainColors.secondary.toString(),
-            borderColor: globalVars.mainColors.primary.toString(),
+            fg: globalVars.elementaryColors.white,
+            bg: globalVars.mainColors.secondary,
+            borderColor: globalVars.mainColors.primary,
         },
         focusAccessible: {
-            color: globalVars.elementaryColors.white.toString(),
-            backgroundColor: globalVars.mainColors.secondary.toString(),
-            borderColor: globalVars.mainColors.primary.toString(),
+            fg: globalVars.elementaryColors.white,
+            bg: globalVars.mainColors.secondary,
+            borderColor: globalVars.mainColors.primary,
         },
         ...themeVars.subComponentStyles("primary"),
     };
 
     const transparentButtonColor = globalVars.mainColors.bg;
     const transparent: IButtonType = {
-        fg: transparentButtonColor.toString(),
-        bg: "transparent",
-        spinner: globalVars.mainColors.primary.toString(),
+        fg: transparentButtonColor,
+        bg: color("transparent"),
+        spinner: globalVars.mainColors.primary,
         border: {
-            color: transparentButtonColor.toString(),
+            color: transparentButtonColor,
             width: px(1),
             style: "solid",
-            radius: globalVars.border.radius.toString(),
+            radius: globalVars.border.radius,
         },
         hover: {
-            color: transparentButtonColor.toString(),
-            backgroundColor: globalVars.elementaryColors.white.fade(0.1).toString(),
-            borderColor: transparentButtonColor.toString(),
+            fg: transparentButtonColor,
+            bg: globalVars.elementaryColors.white.fade(0.1),
+            borderColor: transparentButtonColor,
         },
         active: {
-            color: transparentButtonColor.toString(),
-            backgroundColor: globalVars.elementaryColors.white.fade(0.1).toString(),
-            borderColor: transparentButtonColor.toString(),
+            fg: transparentButtonColor,
+            bg: globalVars.elementaryColors.white.fade(0.1),
+            borderColor: transparentButtonColor,
         },
         focus: {
-            color: transparentButtonColor.toString(),
-            backgroundColor: globalVars.elementaryColors.white.fade(0.1).toString(),
-            borderColor: transparentButtonColor.toString(),
+            fg: transparentButtonColor,
+            bg: globalVars.elementaryColors.white.fade(0.1),
+            borderColor: transparentButtonColor,
         },
         focusAccessible: {
-            color: transparentButtonColor.toString(),
-            backgroundColor: globalVars.elementaryColors.white.fade(0.5).toString(),
-            borderColor: transparentButtonColor.toString(),
+            fg: transparentButtonColor,
+            bg: globalVars.elementaryColors.white.fade(0.5),
+            borderColor: transparentButtonColor,
         },
         ...themeVars.subComponentStyles("transparent"),
     };
@@ -231,9 +222,9 @@ export function generateButtonClass(
         minWidth: vars.sizing.minWidth,
         userSelect: "none",
         cursor: "pointer",
-        color: buttonType.fg,
-        backgroundColor: buttonType.bg,
-        borderColor: buttonType.border.color,
+        color: buttonType.fg.toString(),
+        backgroundColor: buttonType.bg.toString(),
+        borderColor: buttonType.border.color.toString(),
         borderRadius: buttonType.border.radius,
         borderStyle: buttonType.border.style,
         borderWidth: buttonType.border.width,
@@ -245,27 +236,27 @@ export function generateButtonClass(
                     },
                     "&:hover": {
                         zIndex,
-                        backgroundColor: buttonType.hover.backgroundColor,
-                        borderColor: buttonType.hover.borderColor,
-                        color: buttonType.hover.color,
+                        backgroundColor: buttonType.hover.bg.toString(),
+                        borderColor: buttonType.hover.borderColor.toString(),
+                        color: buttonType.hover.fg.toString(),
                     },
                     "&:focus": {
                         zIndex,
-                        backgroundColor: buttonType.focus.backgroundColor,
-                        borderColor: buttonType.focus.borderColor,
-                        color: buttonType.focus.color,
+                        backgroundColor: buttonType.focus.bg.toString(),
+                        borderColor: buttonType.focus.borderColor.toString(),
+                        color: buttonType.focus.fg.toString(),
                     },
                     "&:active": {
                         zIndex,
-                        backgroundColor: buttonType.active.backgroundColor,
-                        borderColor: buttonType.active.borderColor,
-                        color: buttonType.active.color,
+                        backgroundColor: buttonType.active.bg.toString(),
+                        borderColor: buttonType.active.borderColor.toString(),
+                        color: buttonType.active.fg.toString(),
                     },
                     "&.focus-visible": {
                         zIndex,
-                        backgroundColor: buttonType.focus.backgroundColor,
-                        borderColor: buttonType.focus.borderColor,
-                        color: buttonType.focus.color,
+                        backgroundColor: buttonType.focus.bg.toString(),
+                        borderColor: buttonType.focus.borderColor.toString(),
+                        color: buttonType.focus.fg.toString(),
                     },
                 },
             },

--- a/library/src/scripts/styles/buttonStyles.ts
+++ b/library/src/scripts/styles/buttonStyles.ts
@@ -15,6 +15,7 @@ import {
     getColorDependantOnLightness,
     spinnerLoader,
 } from "@library/styles/styleHelpers";
+import { WidthProperty, BorderRadiusProperty } from "csstype";
 
 export function buttonStyles(theme?: object) {
     const globalVars = globalVariables(theme);
@@ -39,17 +40,15 @@ export function buttonStyles(theme?: object) {
     return { padding, sizing, border };
 }
 
-type Unit = string | number;
-
 export interface IButtonType {
     fg: ColorHelper;
     bg: ColorHelper;
     spinner: ColorHelper;
     border: {
         color: ColorHelper;
-        width: Unit;
+        width: WidthProperty<string | number>;
         style: string;
-        radius: Unit;
+        radius: BorderRadiusProperty<string | number>;
     };
     hover: {
         fg: ColorHelper;

--- a/library/src/scripts/styles/buttonStyles.ts
+++ b/library/src/scripts/styles/buttonStyles.ts
@@ -145,7 +145,7 @@ export function buttonVariables(theme?: object) {
     const transparentButtonColor = globalVars.mainColors.bg;
     const transparent: IButtonType = {
         fg: transparentButtonColor,
-        bg: color("transparent"),
+        bg: "transparent" as any, // Cast because otherwise it turns if you wrap it in `color()`.
         spinner: globalVars.mainColors.primary,
         border: {
             color: transparentButtonColor,

--- a/library/src/scripts/styles/buttonStyles.ts
+++ b/library/src/scripts/styles/buttonStyles.ts
@@ -16,6 +16,7 @@ import {
     spinnerLoader,
 } from "@library/styles/styleHelpers";
 import { WidthProperty, BorderRadiusProperty } from "csstype";
+import { TLength } from "typestyle/lib/types";
 
 export function buttonStyles(theme?: object) {
     const globalVars = globalVariables(theme);
@@ -46,9 +47,9 @@ export interface IButtonType {
     spinner: ColorHelper;
     border: {
         color: ColorHelper;
-        width: WidthProperty<string | number>;
+        width: WidthProperty<TLength>;
         style: string;
-        radius: BorderRadiusProperty<string | number>;
+        radius: BorderRadiusProperty<TLength>;
     };
     hover: {
         fg: ColorHelper;

--- a/library/src/scripts/styles/buttonStyles.ts
+++ b/library/src/scripts/styles/buttonStyles.ts
@@ -39,34 +39,36 @@ export function buttonStyles(theme?: object) {
     return { padding, sizing, border };
 }
 
+type Unit = string | number;
+
 export interface IButtonType {
     fg: string;
     bg: string;
-    spinner: ColorHelper;
+    spinner: string;
     border: {
         color: string;
-        width: string;
+        width: Unit;
         style: string;
-        radius: string;
+        radius: Unit;
     };
     hover: {
-        fg: string;
-        bg: string;
+        color: string;
+        backgroundColor: string;
         borderColor: string;
     };
     focus: {
-        fg: string;
-        bg: string;
+        color: string;
+        backgroundColor: string;
         borderColor: string;
     };
     active: {
-        fg: string;
-        bg: string;
+        color: string;
+        backgroundColor: string;
         borderColor: string;
     };
     focusAccessible: {
-        fg: string;
-        bg: string;
+        color: string;
+        backgroundColor: string;
         borderColor: string;
     };
 }
@@ -78,7 +80,7 @@ export function buttonVariables(theme?: object) {
     const standard: IButtonType = {
         fg: globalVars.mainColors.fg.toString(),
         bg: globalVars.mainColors.bg.toString(),
-        spinner: globalVars.mainColors.primary,
+        spinner: globalVars.mainColors.primary.toString(),
         border: {
             color: globalVars.mixBgAndFg(0.24).toString(),
             width: px(1),
@@ -120,7 +122,7 @@ export function buttonVariables(theme?: object) {
     const primary: IButtonType = {
         fg: globalVars.elementaryColors.white.toString(),
         bg: globalVars.mainColors.primary.toString(),
-        spinner: globalVars.elementaryColors.white,
+        spinner: globalVars.elementaryColors.white.toString(),
         border: {
             color: globalVars.mainColors.primary.toString(),
             width: px(1),
@@ -154,12 +156,12 @@ export function buttonVariables(theme?: object) {
     const transparent: IButtonType = {
         fg: transparentButtonColor.toString(),
         bg: "transparent",
-        spinner: globalVars.mainColors.primary,
+        spinner: globalVars.mainColors.primary.toString(),
         border: {
             color: transparentButtonColor.toString(),
             width: px(1),
             style: "solid",
-            radius: globalVars.border.radius,
+            radius: globalVars.border.radius.toString(),
         },
         hover: {
             color: transparentButtonColor.toString(),
@@ -243,27 +245,27 @@ export function generateButtonClass(
                     },
                     "&:hover": {
                         zIndex,
-                        backgroundColor: buttonType.hover.bg,
+                        backgroundColor: buttonType.hover.backgroundColor,
                         borderColor: buttonType.hover.borderColor,
-                        color: buttonType.hover.fg,
+                        color: buttonType.hover.color,
                     },
                     "&:focus": {
                         zIndex,
-                        backgroundColor: buttonType.focus.bg,
+                        backgroundColor: buttonType.focus.backgroundColor,
                         borderColor: buttonType.focus.borderColor,
-                        color: buttonType.focus.fg,
+                        color: buttonType.focus.color,
                     },
                     "&:active": {
                         zIndex,
-                        backgroundColor: buttonType.active.bg,
+                        backgroundColor: buttonType.active.backgroundColor,
                         borderColor: buttonType.active.borderColor,
-                        color: buttonType.active.fg,
+                        color: buttonType.active.color,
                     },
                     "&.focus-visible": {
                         zIndex,
-                        backgroundColor: buttonType.focus.bg,
+                        backgroundColor: buttonType.focus.backgroundColor,
                         borderColor: buttonType.focus.borderColor,
-                        color: buttonType.focus.fg,
+                        color: buttonType.focus.color,
                     },
                 },
             },
@@ -298,7 +300,7 @@ export function buttonLoaderClasses(buttonType: IButtonType, theme?: object) {
         height: percent(100),
         width: percent(100),
         $nest: {
-            "&::after": spinnerLoader(buttonType.spinner, px(20)),
+            "&::after": spinnerLoader(buttonType.spinner, px(20)) as any,
         },
         ...themeVars.subComponentStyles("root"),
     });

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -10,8 +10,6 @@ export const globalVariables = (theme?: object) => {
     const colorPrimary = color("#0291db");
     const themeVars = componentThemeVariables(theme, "globalVariables");
 
-    const baseUnit = 6;
-
     const utility = {
         "percentage.third": percent(100 / 3),
         "percentage.nineSixteenths": percent((9 / 16) * 100),
@@ -154,7 +152,6 @@ export const globalVariables = (theme?: object) => {
     };
 
     return {
-        baseUnit,
         utility,
         elementaryColors,
         mainColors,

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -10,6 +10,8 @@ export const globalVariables = (theme?: object) => {
     const colorPrimary = color("#0291db");
     const themeVars = componentThemeVariables(theme, "globalVariables");
 
+    const baseUnit = 6;
+
     const utility = {
         "percentage.third": percent(100 / 3),
         "percentage.nineSixteenths": percent((9 / 16) * 100),
@@ -119,13 +121,18 @@ export const globalVariables = (theme?: object) => {
                 title: 26,
             },
         },
-
         weights: {
             normal: 400,
             semiBold: 600,
             bold: 700,
         },
         ...themeVars.subComponentStyles("fonts"),
+    };
+
+    const meta = {
+        fontSize: fonts.size.small,
+        color: mixBgAndFg(0.85),
+        margin: 4,
     };
 
     const icon = {
@@ -147,12 +154,14 @@ export const globalVariables = (theme?: object) => {
     };
 
     return {
+        baseUnit,
         utility,
         elementaryColors,
         mainColors,
         feedbackColors,
         body,
         border,
+        meta,
         gutter,
         panel,
         content,

--- a/library/src/scripts/styles/splashStyles.ts
+++ b/library/src/scripts/styles/splashStyles.ts
@@ -106,9 +106,7 @@ export function splashStyles(theme?: object) {
         color: vars.title.fg.toString(),
         paddingTop: px(vars.title.marginTop),
         marginBottom: px(vars.title.marginBottom),
-        textShadow: vars.title.textShadow
-            ? vars.title.textShadow
-            : `0 1px 25px ${getColorDependantOnLightness(vars.title.fg, vars.title.fg, 0.9).fade(0.4)}`,
+        textShadow: `0 1px 25px ${getColorDependantOnLightness(vars.title.fg, vars.title.fg, 0.9).fade(0.4)}`,
         ...debug.name("title"),
     });
 

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -208,7 +208,7 @@ const spinnerLoaderAnimation = keyframes({
 });
 
 export const spinnerLoader = (
-    spinnerColor: string = vars.mainColors.primary.toString(),
+    spinnerColor: ColorHelper = vars.mainColors.primary,
     dimensions = px(18),
     thicknesss = px(3),
     speed = "0.7s",
@@ -223,16 +223,10 @@ export const spinnerLoader = (
         width: dimensions,
         height: dimensions,
         borderRadius: percent(50),
-        borderTop: `${thicknesss} solid ${color(spinnerColor).toString()}`,
-        borderRight: `${thicknesss} solid ${color(spinnerColor)
-            .fade(0.3)
-            .toString()}`,
-        borderBottom: `${thicknesss} solid ${color(spinnerColor)
-            .fade(0.3)
-            .toString()}`,
-        borderLeft: `${thicknesss} solid ${color(spinnerColor)
-            .fade(0.3)
-            .toString()}`,
+        borderTop: `${thicknesss} solid ${spinnerColor.toString()}`,
+        borderRight: `${thicknesss} solid ${spinnerColor.fade(0.3).toString()}`,
+        borderBottom: `${thicknesss} solid ${spinnerColor.fade(0.3).toString()}`,
+        borderLeft: `${thicknesss} solid ${spinnerColor.fade(0.3).toString()}`,
         transform: "translateZ(0)",
         animation: `spillerLoader ${speed} infinite ease-in-out`,
         animationName: spinnerLoaderAnimation,

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -7,6 +7,7 @@ import { ColorHelper, important, percent, px, quote, viewHeight, viewWidth, colo
 import { BackgroundImageProperty, FlexWrapProperty } from "csstype";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { style, keyframes } from "typestyle";
+import { NestedCSSProperties } from "typestyle/lib/types";
 
 export function flexHelper() {
     const middle = (wrap = false) => {
@@ -101,6 +102,40 @@ export const debugHelper = (componentName: string) => {
         },
     };
 };
+
+/**
+ * A better helper to generate human readable classes generated from TypeStyle.
+ *
+ * This works like debugHelper but automatically. The generated function behaves just like `style()`
+ * but can automatically adds a debug name & allows the first argument to be a string subcomponent name.
+ *
+ * @example
+ * const style = styleFactory("myComponent");
+ * const myClass = style({ color: "red" }); // .myComponent-sad421s
+ * const mySubClass = style("subcomponent", { color: "red" }) // .myComponent-subcomponent-23sdaf43
+ *
+ */
+export function styleFactory(componentName: string) {
+    function styleCreator(subcomponentName: string, ...objects: Array<NestedCSSProperties | undefined>);
+    function styleCreator(...objects: Array<NestedCSSProperties | undefined>);
+    function styleCreator(...objects: Array<NestedCSSProperties | undefined | string>) {
+        if (objects.length === 0) {
+            return style();
+        }
+
+        let debugName = componentName;
+        let styleObjs: Array<NestedCSSProperties | undefined> = objects as any;
+        if (typeof objects[0] === "string") {
+            const [subcomponentName, ...restObjects] = styleObjs;
+            debugName += `-${subcomponentName}`;
+            styleObjs = restObjects;
+        }
+
+        return style({ $debugName: debugName }, ...styleObjs);
+    }
+
+    return styleCreator;
+}
 
 /*
  * Color modification based on colors lightness.

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -137,7 +137,7 @@ export const componentThemeVariables = (theme: any | undefined, componentName: s
     // const themeVars = get(theme, componentName, {});
     const themeVars = (theme && theme[componentName]) || {};
 
-    const subComponentStyles = (subElementName: string) => {
+    const subComponentStyles = (subElementName: string): object => {
         return (themeVars && themeVars[subElementName]) || {};
         // return get(themeVars, subElementName, {});
     };
@@ -173,7 +173,7 @@ const spinnerLoaderAnimation = keyframes({
 });
 
 export const spinnerLoader = (
-    spinnerColor: ColorHelper = vars.mainColors.primary,
+    spinnerColor: string = vars.mainColors.primary.toString(),
     dimensions = px(18),
     thicknesss = px(3),
     speed = "0.7s",
@@ -188,10 +188,16 @@ export const spinnerLoader = (
         width: dimensions,
         height: dimensions,
         borderRadius: percent(50),
-        borderTop: `${thicknesss} solid ${spinnerColor.toString()}`,
-        borderRight: `${thicknesss} solid ${spinnerColor.fade(0.3).toString()}`,
-        borderBottom: `${thicknesss} solid ${spinnerColor.fade(0.3).toString()}`,
-        borderLeft: `${thicknesss} solid ${spinnerColor.fade(0.3).toString()}`,
+        borderTop: `${thicknesss} solid ${color(spinnerColor).toString()}`,
+        borderRight: `${thicknesss} solid ${color(spinnerColor)
+            .fade(0.3)
+            .toString()}`,
+        borderBottom: `${thicknesss} solid ${color(spinnerColor)
+            .fade(0.3)
+            .toString()}`,
+        borderLeft: `${thicknesss} solid ${color(spinnerColor)
+            .fade(0.3)
+            .toString()}`,
         transform: "translateZ(0)",
         animation: `spillerLoader ${speed} infinite ease-in-out`,
         animationName: spinnerLoaderAnimation,

--- a/library/src/scss/layouts/_modal.scss
+++ b/library/src/scss/layouts/_modal.scss
@@ -99,6 +99,7 @@ $frame-footer_boxShadow: 0 -1px 2px 0 $overlay_bgColor;
     align-items: center;
     justify-content: center;
     height: $vanillaHeader_height;
+    min-height: $vanillaHeader_height;
     z-index: 1;
 
     @include mediaQuery-panelLayout_oneColumn {


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/pull/709
Closes https://github.com/vanilla/knowledge/issues/676

This PR:

- Fixes `subComponentStyles()`. Previously this had an implicit return type of `any` which when unioned with other types would cause them to be any. As a result many of the core variable objects had a type of `any`. I alterred the return type to be `object` and now the union types work properly. As a result I had to fix a few broken types. These broken types masked by `any` were the cause of https://github.com/vanilla/knowledge/issues/676
- Added variables for `meta` text and `baseUnit`.