### PR TITLE
Fix cache folder removal

### DIFF
--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
Vanilla's cache folder was accidentally removed with #8201. This update restores it to the state previous to that PR.