### PR TITLE
Fix notification sort in React MeBox components

### DIFF
--- a/library/src/scripts/components/mebox/pieces/NotificationsContents.tsx
+++ b/library/src/scripts/components/mebox/pieces/NotificationsContents.tsx
@@ -159,6 +159,15 @@ function mapStateToProps(state: INotificationsStoreState) {
                 : undefined,
     };
 
+    if (notifications.data) {
+        // Notifications are likely sorted by ID. Make sure they're sorted by the date they were created, in descending order.
+        notifications.data.sort((a: IMeBoxNotificationItem, b: IMeBoxNotificationItem) => {
+            const dateA = new Date(a.timestamp).getTime();
+            const dateB = new Date(b.timestamp).getTime();
+            return dateB - dateA;
+        });
+    }
+
     return {
         notifications,
     };


### PR DESCRIPTION
Notifications displayed in the React `MeBox` component are sorted by date, ascending, as a side effect of the rows being keyed by their ID when stored. Iterating through the items moves through the IDs from lowest to highest, which essentially means they'll be sorted by their inserted date in ascending order. This update essentially reverses the sort into descending order, so newer notifications are displayed first.