### PR TITLE
Normalize reaction Model

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -868,11 +868,19 @@ $Construct
 $Construct
     ->table("reaction")
     ->primaryKey("reactionID")
-    ->column("ownerType", "varchar(64)", false, ["index", "index.record"])
-    ->column("reactionType", "varchar(64)", false, ["index", "index.record"])
-    ->column("recordType", "varchar(64)", false, ["index", "index.record"])
+    ->column("reactionOwnerID", "int", false, ["index", "index.record"])
     ->column("recordID", "int", false, "index.record")
     ->column("reactionValue", "int", false)
+    ->column("insertUserID", "int", false, ["index"])
+    ->column("dateInserted", "datetime")
+    ->set($Explicit, $Drop);
+
+$Construct
+    ->table("reactionOwner")
+    ->primaryKey("reactionOwnerID")
+    ->column("ownerType", "varchar(64)", false, ["index", "unique.record"])
+    ->column("reactionType", "varchar(64)", false, ["index", "unique.record"])
+    ->column("recordType", "varchar(64)", false, ["index", "unique.record"])
     ->column("insertUserID", "int", false, ["index"])
     ->column("dateInserted", "datetime")
     ->set($Explicit, $Drop);

--- a/library/Vanilla/Models/ReactionOwnerModel.php
+++ b/library/Vanilla/Models/ReactionOwnerModel.php
@@ -38,6 +38,12 @@ class ReactionOwnerModel extends PipelineModel {
         $this->addPipelineProcessor($userProcessor);
     }
 
+    /**
+     * Get unique reactionOwnerID for the combination of filters: ownerType, reactionType, recordType
+     *
+     * @param array $filters Structure of 3 elements: ownerType, reactionType, recordType
+     * @return int Result reactionOwnerID
+     */
     public function getReactionOwnerID(array $filters): int {
         $schema = Schema::parse([
             'ownerType:s',

--- a/library/Vanilla/Models/ReactionOwnerModel.php
+++ b/library/Vanilla/Models/ReactionOwnerModel.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models;
+
+use Garden\Schema\Schema;
+use Gdn_Session;
+use Vanilla\Database\Operation\CurrentUserFieldProcessor;
+use Vanilla\Database\Operation\CurrentDateFieldProcessor;
+
+/**
+ * Handle reactions types (owner (app, addon) + record type (model, table) + reaction type).
+ * ex: knowledgebase + article + helpful
+ */
+class ReactionOwnerModel extends PipelineModel {
+
+    /** @var Gdn_Session */
+    private $session;
+
+    /**
+     * ReactionOwnerModel constructor.
+     *
+     * @param Gdn_Session $session
+     */
+    public function __construct(Gdn_Session $session) {
+        parent::__construct("reactionOwner");
+        $this->session = $session;
+
+        $dateProcessor = new CurrentDateFieldProcessor();
+        $dateProcessor->setInsertFields(["dateInserted"]);
+        $this->addPipelineProcessor($dateProcessor);
+
+        $userProcessor = new CurrentUserFieldProcessor($this->session);
+        $userProcessor->setInsertFields(["insertUserID"]);
+        $this->addPipelineProcessor($userProcessor);
+    }
+
+    public function getReactionOwnerID(array $filters): int {
+        $schema = Schema::parse([
+            'ownerType:s',
+            'reactionType:s',
+            'recordType:s'
+        ]);
+        $filters = $schema->validate($filters);
+        $res = $this->get($filters);
+        if (empty($res)) {
+            $id = $this->insert($filters);
+        } else {
+            $id = $res[0]['reactionOwnerID'];
+        }
+        return $id;
+    }
+}


### PR DESCRIPTION
Move ownerType, reactionType and RecordType to separate table.

# WARNING
We need to drop GDN_reaction table and reinitialize it after since few columns where deleted and we can't delete them through utility/update. 
 
Relates to: #8379 