### PR TITLE
Pockets: Fix typo in pockets permissions

### DIFF
--- a/plugins/pockets/addon.json
+++ b/plugins/pockets/addon.json
@@ -2,7 +2,7 @@
     "name": "Pockets",
     "description": "Administrators may add raw HTML to various places on the site. This plugin is very powerful, but can easily break your site if you make a mistake.",
     "version": "1.4",
-    "registerPermrissions": {
+    "registerPermissions": {
         "Plugins.Pockets.Manage": "Garden.Settings.Manage",
         "0": "Garden.NoAds.Allow"
     },


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/215

### Details
registerPermissions was written as registerPermrissions causing the pockets permission not to get added to permissions table when the plugin is enabled.
