### PR TITLE
Fix <Permission /> component

### DIFF
--- a/library/src/scripts/users/Permission.tsx
+++ b/library/src/scripts/users/Permission.tsx
@@ -80,7 +80,7 @@ export class Permission extends React.Component<IProps> {
 function mapDispatchToProps(dispatch) {
     const actions = new UsersActions(dispatch, apiv2);
     return {
-        requestData: () => actions.getMe,
+        requestData: actions.getMe,
     };
 }
 

--- a/library/src/scripts/users/UsersActions.ts
+++ b/library/src/scripts/users/UsersActions.ts
@@ -5,7 +5,8 @@
  */
 
 import ReduxActions, { ActionsUnion } from "@library/state/ReduxActions";
-import { IMe } from "@library/@types/api";
+import { IMe, LoadStatus } from "@library/@types/api";
+import { IUsersStoreState } from "@library/users/UsersModel";
 
 /**
  * Redux actions for the users data.
@@ -25,7 +26,12 @@ export default class UsersActions extends ReduxActions {
         {},
     );
 
-    public getMe = () => {
-        return this.dispatchApi("get", "/users/me", UsersActions.getMeACs, {});
+    public getMe = async () => {
+        const currentUser = this.getState<IUsersStoreState>().users.current;
+        if (currentUser.status === LoadStatus.LOADING) {
+            // Don't request the user more than once.
+            return;
+        }
+        return await this.dispatchApi("get", "/users/me", UsersActions.getMeACs, {});
     };
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/8471

This seems to have been broken recently. This PR fixes a typo in the `mapStateToProps()` and fixed a bug where the current user could be request more than once if multiple permission components were rendered in the same pass.

This component already has unit tests, but since the bug was outside of the component itself they weren't caught in the tests.

I'm opening an issue to add some integration tests covering rich editor rich would give full coverage to this as well some other components.