### PR TITLE
Extend DiscussionModel to 'join' selected columns data to any array or ResultSet

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -232,7 +232,7 @@ class CommentModel extends Gdn_Model {
      */
     public function getWhere($where = false, $orderFields = '', $orderDirection = 'asc', $limit = false, $offset = false) {
         $where = $this->stripWherePrefixes($where);
-        list($where, $options) = $this->splitWhere($where, ['joinUsers' => true]);
+        list($where, $options) = $this->splitWhere($where, ['joinUsers' => true, 'joinDiscussions' => false]);
 
         // Build up an inner select of comments to force late-loading.
         $innerSelect = $this->select($where, $orderFields, $orderDirection, $limit, $offset, 'c3');
@@ -250,6 +250,10 @@ class CommentModel extends Gdn_Model {
             Gdn::userModel()->joinUsers($result, ['InsertUserID', 'UpdateUserID']);
         }
 
+        if ($options['joinDiscussions']) {
+            $discussionModel = GDN::getContainer()->get(DiscussionModel::class);
+            $discussionModel->joinDiscussionData($result, 'DiscussionID', $options['joinDiscussions']);
+        }
         $this->setCalculatedFields($result);
 
         return $result;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3287,7 +3287,7 @@ class DiscussionModel extends Gdn_Model {
      *              where 'field' - is discussion model column name (ex: Name, Body, Type)
      *              and 'alias' - is the column name to add|replace to $data array (ex: DiscussionName, DiscussionBody)
      */
-    public function joinDiscussionData( &$dataSet, string $discussionID, array $fields) {
+    public function joinDiscussionData(&$dataSet, string $discussionID, array $fields) {
         if ($dataSet instanceof Gdn_DataSet) {
             $data = $dataSet->result();
             $arrayMode = $dataSet->datasetType() === DATASET_TYPE_ARRAY;
@@ -3295,7 +3295,6 @@ class DiscussionModel extends Gdn_Model {
             $data = &$dataSet;
             $arrayMode = true;
         }
-
         if ($arrayMode) {
             $discussionIDs = array_column($data, $discussionID);
         } else {
@@ -3331,7 +3330,6 @@ class DiscussionModel extends Gdn_Model {
                 } else {
                     $row->$alias = $discussion[$alias];
                 }
-
             }
         }
     }


### PR DESCRIPTION
- Add joinDiscussionData to DiscussionModel
- Add related call to CommentModel when 'joinDiscussion' in `getWhere()`

Relates to: https://github.com/vanilla/knowledge/issues/653
