### PR TITLE
Fix Advanced Editor flyouts on mobile with keystone

### DIFF
--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -29,11 +29,18 @@
         $(document).delegate(".Hijack, .js-hijack", "click", handleHijackClick);
         $(document).delegate(".ButtonGroup > .Handle", "click", handleButtonHandleClick);
         $(document).delegate(".ToggleFlyout", "click", handleToggleFlyoutClick);
-        $(document).delegate(".ToggleFlyout a", "mouseup", handleToggleFlyoutMouseUp);
-        $(document).delegate(".mobileFlyoutOverlay", "click", closeAllFlyouts);
-        $(document).delegate(".Flyout", "click", function(e) {
+        $(document).delegate(".ToggleFlyout a, .Dropdown a", "mouseup", handleToggleFlyoutMouseUp);
+        $(document).delegate(".mobileFlyoutOverlay", "click", function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            closeAllFlyouts();
+        });
+        $(document).delegate(".Flyout, .Dropdown", "click", function (e) {
             e.stopPropagation();
         });
+        $(document).on("click", function (e) {
+            closeAllFlyouts();
+        })
     });
 
     /**
@@ -140,7 +147,7 @@
     /**
      * Close all flyouts, including ButtonGroups.
      */
-    function closeAllFlyouts() {
+    function closeAllFlyouts(e) {
         closeFlyout($(".ToggleFlyout"), $(".Flyout"));
         // Clear the button groups that are open as well.
         $(".ButtonGroup")
@@ -153,6 +160,8 @@
             .setFlyoutAttributes();
         document.body.classList.remove(BODY_CLASS);
     }
+
+    window.closeAllFlyouts = closeAllFlyouts;
 
     /**
      * Take over the clicking of an element in order to make a post request.
@@ -229,8 +238,8 @@
         var isHandle = false;
 
         if ($(e.target).closest(".Flyout").length === 0) {
-            e.stopPropagation();
             isHandle = true;
+            e.stopPropagation();
         } else if (
             $(e.target).hasClass("Hijack") ||
             $(e.target)
@@ -263,6 +272,7 @@
      * Close all of the flyouts unless we are clicking on a button inside of a flyout.
      */
     function handleToggleFlyoutMouseUp() {
+        console.log("flyout mouseup");
         if ($(this).hasClass("FlyoutButton")) return;
         closeAllFlyouts();
     }

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -30,8 +30,8 @@
         $(document).delegate(".ButtonGroup > .Handle", "click", handleButtonHandleClick);
         $(document).delegate(".ToggleFlyout", "click", handleToggleFlyoutClick);
         $(document).delegate(".ToggleFlyout a", "mouseup", handleToggleFlyoutMouseUp);
-        $(document).delegate(".mobileFlyoutOverlay", 'click touchstart', closeAllFlyouts);
-        $(document).delegate('.Flyout', 'click touchstart', function(e) {
+        $(document).delegate(".mobileFlyoutOverlay", "click", closeAllFlyouts);
+        $(document).delegate(".Flyout", "click", function(e) {
             e.stopPropagation();
         });
     });
@@ -70,7 +70,7 @@
             var wrap = document.createElement("span");
             wrap.classList.add("mobileFlyoutOverlay");
 
-            $contents.each(function () {
+            $contents.each(function() {
                 var $item = $(this);
                 if (!this.parentElement.classList.contains("mobileFlyoutOverlay")) {
                     $item.wrap(wrap);
@@ -307,7 +307,7 @@
             $toggleFlyouts.each(function() {
                 $toggle = $(this);
                 var $handle = $(this).find(
-                    ".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)"
+                    ".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)",
                 );
                 var $flyout = $(this).find(".Flyout, .Dropdown");
                 var isOpen = $toggle.hasClass(OPEN_CLASS);

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -30,7 +30,10 @@
         $(document).delegate(".ButtonGroup > .Handle", "click", handleButtonHandleClick);
         $(document).delegate(".ToggleFlyout", "click", handleToggleFlyoutClick);
         $(document).delegate(".ToggleFlyout a", "mouseup", handleToggleFlyoutMouseUp);
-        $(document).delegate(document, "click", closeAllFlyouts);
+        $(document).delegate(".mobileFlyoutOverlay", 'click touchstart', closeAllFlyouts);
+        $(document).delegate('.Flyout', 'click touchstart', function(e) {
+            e.stopPropagation();
+        });
     });
 
     /**
@@ -142,6 +145,11 @@
         // Clear the button groups that are open as well.
         $(".ButtonGroup")
             .removeClass(OPEN_CLASS)
+            .setFlyoutAttributes();
+
+        // Kludge for legacy editor.
+        $(".editor-dropdown-open")
+            .removeClass("editor-dropdown-open")
             .setFlyoutAttributes();
         document.body.classList.remove(BODY_CLASS);
     }

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -272,7 +272,6 @@
      * Close all of the flyouts unless we are clicking on a button inside of a flyout.
      */
     function handleToggleFlyoutMouseUp() {
-        console.log("flyout mouseup");
         if ($(this).hasClass("FlyoutButton")) return;
         closeAllFlyouts();
     }

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -440,9 +440,8 @@
             });
 
             // Target all elements in the document that fire the dropdown close
-            // (some are written directly as class in view), then add the matches
             // from within the iframe, and attach the relevant callbacks to events.
-            $('.editor-dialog-fire-close').add($('.wysihtml5-sandbox').contents().find('.editor-dialog-fire-close'))
+            $('.wysihtml5-sandbox').contents().find('.editor-dialog-fire-close')
                 .off('mouseup.fireclose dragover.fireclose')
                 .on('mouseup.fireclose dragover.fireclose', function(e) {
                     $('.editor-dropdown').each(function(i, el) {


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8465

This whole legacy flyout situation is probably the biggest definition of spaghetti code that I've ever seen. I'm very glad we don't use it anymore.

Heres what I ended up doing:

- Improve the selectors of the keystone style flyout handling to close more things. Advanced Editor and core fight over settings handlers a lot, so I'm sorry if it's kind of ugly.
- A kludge for the WYSIWYG editor was covering too many selectors and causing flyouts to close and open again immediately. I narrowed the scope of that event handler.

## Testing

I've manually tested various permutations of the following:

- **Themes:** Keystone, Deflector, Basic Mobile
- **Editors:** Markdown, BBCode, WYSIWYG
- Desktop & Mobile devices.