### PR TITLE
Fix legacy script order in GDN controller

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1904,26 +1904,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
                 $this->Head->addScript('', 'text/javascript', false, ['content' => $this->definitionList(false)]);
 
-                // Webpack based scripts
-                /** @var \Vanilla\Web\Asset\WebpackAssetProvider $webpackAssetProvider */
-                $webpackAssetProvider = Gdn::getContainer()->get(\Vanilla\Web\Asset\WebpackAssetProvider::class);
-
-                $polyfillContent = $webpackAssetProvider->getInlinePolyfillContents();
-                $this->Head->addScript(null, null, false, ["content" => $polyfillContent]);
-
-                // Add the built webpack javascript files.
-                $section = $this->MasterView === 'admin' ? 'admin' : 'forum';
-                $jsAssets = $webpackAssetProvider->getScripts($section);
-                foreach ($jsAssets as $asset) {
-                    $this->Head->addScript($asset->getWebPath(), 'text/javascript', false, ['defer' => 'defer']);
-                }
-
-                // The the built stylesheets
-                $styleAssets = $webpackAssetProvider->getStylesheets($section);
-                foreach ($styleAssets as $asset) {
-                    $this->Head->addCss($asset->getWebPath(), null, false);
-                }
-
+                // Add legacy style scripts
                 foreach ($this->_JsFiles as $Index => $JsInfo) {
                     $JsFile = $JsInfo['FileName'];
                     if (!is_array($JsInfo['Options'])) {
@@ -1959,6 +1940,8 @@ class Gdn_Controller extends Gdn_Pluggable {
                         continue;
                     }
                 }
+
+                $this->addWebpackAssets();
             }
 
             // Add the favicon.
@@ -2040,6 +2023,31 @@ class Gdn_Controller extends Gdn_Pluggable {
             include($MasterViewPath);
         } else {
             $ViewHandler->render($MasterViewPath, $this);
+        }
+    }
+
+    /**
+     * Add the assets from WebpackAssetProvider to the page.
+     */
+    private function addWebpackAssets() {
+        // Webpack based scripts
+        /** @var \Vanilla\Web\Asset\WebpackAssetProvider $webpackAssetProvider */
+        $webpackAssetProvider = Gdn::getContainer()->get(\Vanilla\Web\Asset\WebpackAssetProvider::class);
+
+        $polyfillContent = $webpackAssetProvider->getInlinePolyfillContents();
+        $this->Head->addScript(null, null, false, ["content" => $polyfillContent]);
+
+        // Add the built webpack javascript files.
+        $section = $this->MasterView === 'admin' ? 'admin' : 'forum';
+        $jsAssets = $webpackAssetProvider->getScripts($section);
+        foreach ($jsAssets as $asset) {
+            $this->Head->addScript($asset->getWebPath(), 'text/javascript', false, ['defer' => 'defer']);
+        }
+
+        // The the built stylesheets
+        $styleAssets = $webpackAssetProvider->getStylesheets($section);
+        foreach ($styleAssets as $asset) {
+            $this->Head->addCss($asset->getWebPath(), null, false);
         }
     }
 


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/8415 introduced a feature flag to defer all of our legacy scripts. There was a slight issue though. Previously the fact they were synchronous and the new webpack scripts were deferred allowed their JS to still be loaded before the build scripts.

This broke some the `@library/legacy` scripts (some stuff I converted so I could unit test it) that relies on the rest of those scripts to be loaded.

In this PR I've moved the webpack scripts to load after the old scripts.

_This has no practical affect unless this new feature flag is enabled, which had not been released yet._

