### PR TITLE
AddonUpload - Address "Could not parse addon info array." error being thrown when addon.json exists

### DIFF
--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -196,11 +196,11 @@ class UpdateModel extends Gdn_Model {
                         $info = self::parseInfoArray($entry['Path']);
                     }
 
-                    if ($info === false || !is_array($info)) {
-                        continue;
+                    $result = self::checkAddon($info, $entry);
+                    if (!empty($result)) {
+                      continue;
                     }
 
-                    $result = self::checkAddon($info, $entry);
                     $addon = self::buildAddon($info);
                 }
             }

--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -148,19 +148,6 @@ class UpdateModel extends Gdn_Model {
                 $deleteEntries = true;
             }
 
-            // Set addon.json to the first entry if it exists and isn't already.
-            // This is a patch to avoid parseArrayInfo errors because getInfoZip is returning the entries
-            // in the right order.
-            $names = array_column($entries, 'Name');
-            $addonJSONExists = in_array('/addon.json', $names);
-
-            if ($entries[0]['Name'] !== '/addon.json' && $addonJSONExists) {
-                $tempArray = $entries[0];
-                $arrayKey = array_search('/addon.json', $names);
-                $entries[0] = $entries[$arrayKey];
-                $entries[$arrayKey] = $tempArray;
-            }
-
             foreach ($entries as $entry) {
                 if ($entry['Name'] == '/environment.php') {
                     // This could be the core vanilla package.
@@ -209,10 +196,11 @@ class UpdateModel extends Gdn_Model {
                         $info = self::parseInfoArray($entry['Path']);
                     }
 
-                    $result = self::checkAddon($info, $entry);
-                    if (!empty($result)) {
-                        break;
+                    if ($info === false || !is_array($info)) {
+                        continue;
                     }
+
+                    $result = self::checkAddon($info, $entry);
                     $addon = self::buildAddon($info);
                 }
             }

--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -198,7 +198,7 @@ class UpdateModel extends Gdn_Model {
 
                     $result = self::checkAddon($info, $entry);
                     if (!empty($result)) {
-                      continue;
+                        continue;
                     }
 
                     $addon = self::buildAddon($info);

--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -148,6 +148,19 @@ class UpdateModel extends Gdn_Model {
                 $deleteEntries = true;
             }
 
+            // Set addon.json to the first entry if it exists and isn't already.
+            // This is a patch to avoid parseArrayInfo errors because getInfoZip is returning the entries
+            // in the right order.
+            $names = array_column($entries, 'Name');
+            $addonJSONExists = in_array('/addon.json', $names);
+
+            if ($entries[0]['Name'] !== '/addon.json' && $addonJSONExists) {
+                $tempArray = $entries[0];
+                $arrayKey = array_search('/addon.json', $names);
+                $entries[0] = $entries[$arrayKey];
+                $entries[$arrayKey] = $tempArray;
+            }
+
             foreach ($entries as $entry) {
                 if ($entry['Name'] == '/environment.php') {
                     // This could be the core vanilla package.


### PR DESCRIPTION
When that uploading an addon an _"Could not parse addon info array."_  is thrown if the addon.json isn't set to the first entry in the entries array.  The $info variable we are passing to `UpdateModel::checkAddon` is `false` if none of the conditions in the IF block are met.   `UpdateModel::checkAddon` will then throw the error because it is expecting an array.  This checks if $info is `false` and is a valid array, if it is we iterate through the foreach again.

To reproduce:
Pre-requisite : Community Repo
1 ) Enable Addons Directory Application
2) navigate to /addon and try to upload the zip file below

Closes vanilla/community#145
Related to https://open.vanillaforums.com/discussion/36924/could-not-parse-addon-info-array-posting-update-to-addon#latest