### PR TITLE
Add logo and mobileLogo to theme API resource responses

### DIFF
--- a/applications/dashboard/controllers/api/ThemesApiController.php
+++ b/applications/dashboard/controllers/api/ThemesApiController.php
@@ -154,8 +154,6 @@ class ThemesApiController extends AbstractApiController {
             Schema::parse([
                 'type:s',
                 'themeID:s',
-                'logos:s?',
-                'mobileLogo:s?',
                 'assets?' => $this->assetsSchema()
             ]),
             $type

--- a/applications/dashboard/openapi/themes.yml
+++ b/applications/dashboard/openapi/themes.yml
@@ -205,10 +205,6 @@ components:
       properties:
         assets:
           $ref: "#/components/schemas/ThemeAssets"
-        logo:
-          type: string
-        mobileLogo:
-          type: string
         type:
           type: string
           enum:
@@ -242,6 +238,10 @@ components:
           type: string
         variables:
           $ref: "#/components/schemas/ThemeVariablesAsset"
+        logo:
+          $ref: "#/components/schemas/ThemeLogoAsset"
+        mobileLogo:
+          $ref: "#/components/schemas/ThemeMobileLogoAsset"
       type: object
     ThemeAssetNotFound:
       properties:
@@ -350,5 +350,31 @@ components:
             - json
       required:
         - data
+        - type
+      type: object
+    ThemeLogoAsset:
+      description: Site logo to be displayed in the theme.
+      properties:
+        url:
+          type: string
+        type:
+          type: string
+          enum:
+            - image
+      required:
+        - url
+        - type
+      type: object
+    ThemeMobileLogoAsset:
+      description: Site logo to be displayed in the theme when viewed on a mobile device.
+      properties:
+        url:
+          type: string
+        type:
+          type: string
+          enum:
+            - image
+      required:
+        - url
         - type
       type: object

--- a/library/Vanilla/Theme/ImageAsset.php
+++ b/library/Vanilla/Theme/ImageAsset.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+ namespace Vanilla\Theme;
+
+ /**
+  * Image theme asset.
+  */
+class ImageAsset extends Asset {
+
+    /** @var string Absolute URL to the image. */
+    private $url;
+
+    /** @var string Type of asset. */
+    private $type = "image";
+
+    /**
+     * Configure the image asset.
+     *
+     * @param string $url Absolute URL to the image asset.
+     */
+    public function __construct(string $url) {
+        $this->url = $url;
+    }
+
+    /**
+     * Represent the image asset as an array.
+     *
+     * @return array
+     */
+    public function asArray(): array {
+        return [
+            "type" => $this->type,
+            "url" => $this->url,
+        ];
+    }
+
+    /**
+     * Get the absolute image URL.
+     *
+     * @return string
+     */
+    public function getUrl(): string {
+        return $this->url;
+    }
+}

--- a/tests/APIv2/ThemesTest.php
+++ b/tests/APIv2/ThemesTest.php
@@ -6,6 +6,8 @@
 
 namespace VanillaTests\APIv2;
 
+use Gdn_Configuration;
+use Gdn_Upload;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
 
@@ -81,5 +83,33 @@ class ThemesTest extends AbstractAPIv2Test {
         foreach ($expectedAssets as $asset) {
             $this->assertArrayHasKey($asset, $body["assets"], "Theme does not have expected asset: {$asset}");
         }
+    }
+
+    /**
+     * Test getting a theme's logo.
+     *
+     * @depends testGetByName
+     */
+    public function testLogo() {
+        $logo = "logo.png";
+        self::container()->get(Gdn_Configuration::class)->set("Garden.Logo", $logo);
+
+        $response = $this->api()->get("themes/asset-test");
+        $body = json_decode($response->getRawBody(), true);
+        $this->assertEquals($body["assets"]["logo"]["url"], Gdn_Upload::url($logo));
+    }
+
+    /**
+     * Test getting a theme's mobile logo.
+     *
+     * @depends testGetByName
+     */
+    public function testMobileLogo() {
+        $mobileLogo = "mobileLogo.png";
+        self::container()->get(Gdn_Configuration::class)->set("Garden.MobileLogo", $mobileLogo);
+
+        $response = $this->api()->get("themes/asset-test");
+        $body = json_decode($response->getRawBody(), true);
+        $this->assertEquals($body["assets"]["mobileLogo"]["url"], Gdn_Upload::url($mobileLogo));
     }
 }


### PR DESCRIPTION
The themes API resource has been updated to include the site's desktop and mobile logos, if present.

### Overview
1. Add `logo` and `mobileLogo` asset to themes API resource responses. These assets are only included if the site has configured them.
1. Add `ImageAsset` class to represent an image asset of a resource.
1. Add tests for verifying the proper desktop and mobile logos are returned by the API when configured on a site.
1. Update OpenAPI spec for the themes resource to include the new assets.
1. Fix location of `ThemesApiController`. This controller was previously under Vanilla. Now, it lives under Dashboard.

### Notes
The original spec had "logo" and "mobileLogo" as top-level fields in the response of a theme. However, they were flagged as TBD, which I take to mean they were only there as placeholders for future discussion. After further internal conversation, it has been decided the logos will be presented as assets. As such, the previous top-level keys have been removed.