### PR TITLE
Fix theme style regressions

### DIFF
--- a/library/src/scripts/components/IndependentSearch.tsx
+++ b/library/src/scripts/components/IndependentSearch.tsx
@@ -24,6 +24,7 @@ export interface ICompactSearchProps extends IWithSearchProps, RouteComponentPro
     onCloseSuggestions?: () => void;
     buttonContentClass?: string;
     cancelContentClassName?: string;
+    hideSearchButton?: boolean;
     isLarge?: boolean;
 }
 
@@ -64,6 +65,7 @@ export class IndependentSearch extends React.Component<ICompactSearchProps, ISta
                     buttonClassName={this.props.buttonClass}
                     className={classes.root}
                     isBigInput={this.props.isLarge}
+                    hideSearchButton={this.props.hideSearchButton}
                 />
                 <div ref={this.resultsRef} className={classNames("search-results", classesSearchBar.results)} />
             </div>

--- a/library/src/scripts/components/forms/select/SearchBar.tsx
+++ b/library/src/scripts/components/forms/select/SearchBar.tsx
@@ -266,6 +266,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                                 "isClearable",
                                 classes.valueContainer,
                                 {
+                                    [classes.compoundValueContainer]: !this.props.hideSearchButton,
                                     isLarge: this.props.isBigInput,
                                 },
                             )}

--- a/library/src/scripts/components/splash/Splash.tsx
+++ b/library/src/scripts/components/splash/Splash.tsx
@@ -10,7 +10,7 @@ import Heading from "@library/components/Heading";
 import Container from "@library/components/layouts/components/Container";
 import { PanelWidget, PanelWidgetHorizontalPadding } from "@library/components/layouts/PanelLayout";
 import { withDevice } from "@library/contexts/DeviceContext";
-import { IDeviceProps } from "@library/components/DeviceChecker";
+import { IDeviceProps, Devices } from "@library/components/DeviceChecker";
 import IndependentSearch from "@library/components/IndependentSearch";
 import { splashStyles, splashVariables } from "@library/styles/splashStyles";
 import { buttonClasses } from "@library/styles/buttonStyles";
@@ -42,6 +42,7 @@ export class Splash extends React.Component<IProps> {
                                     buttonClass={buttons.transparent}
                                     isLarge={true}
                                     placeholder={t("Search Articles")}
+                                    hideSearchButton={this.props.device === Devices.MOBILE}
                                 />
                             </div>
                         </PanelWidgetHorizontalPadding>

--- a/library/src/scripts/styles/compactSearchStyles.ts
+++ b/library/src/scripts/styles/compactSearchStyles.ts
@@ -26,7 +26,7 @@ export const compactSearchClasses = useThemeCache(() => {
             },
             ".searchBar-valueContainer.suggestedTextInput-inputText": {
                 height: unit(formElementVars.sizing.height),
-                backgroundColor: vanillaHeaderVars.colors.fg.fade(0.15).toString(),
+                backgroundColor: vanillaHeaderVars.colors.bg.darken(0.05).toString(),
                 border: 0,
             },
             ".searchBar__placeholder": {

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -58,7 +58,7 @@ export const globalVariables = useThemeCache(() => {
 
     const links = makeThemeVars("links", {
         colors: {
-            default: mainColors.fg,
+            default: mainColors.primary,
             hover: mainColors.secondary,
             focus: mainColors.secondary,
             accessibleFocus: mainColors.secondary,

--- a/library/src/scripts/styles/searchBarStyles.ts
+++ b/library/src/scripts/styles/searchBarStyles.ts
@@ -61,18 +61,6 @@ export const searchBarClasses = useThemeCache(() => {
             ...debug.name(),
             cursor: "pointer",
             $nest: {
-                "& .suggestedTextInput-inputText": {
-                    borderRight: 0,
-                    borderTopRightRadius: 0,
-                    borderBottomRightRadius: 0,
-                    $nest: {
-                        "&.inputText": {
-                            paddingTop: 0,
-                            paddingBottom: 0,
-                        },
-                    },
-                },
-
                 "& .suggestedTextInput-clear": {
                     $nest: {
                         "&, &.buttonIcon": {
@@ -203,6 +191,9 @@ export const searchBarClasses = useThemeCache(() => {
     const valueContainer = style({
         display: "flex",
         alignItems: "center",
+        borderRight: 0,
+        paddingTop: 0,
+        paddingBottom: 0,
         $nest: {
             "&&&": {
                 display: "flex",
@@ -213,6 +204,12 @@ export const searchBarClasses = useThemeCache(() => {
             },
         },
         ...debug.name("valueContainer"),
+    });
+
+    // Has a search button attached.
+    const compoundValueContainer = style(debug.name("compoundValueContainer"), {
+        borderTopRightRadius: 0,
+        borderBottomRightRadius: 0,
     });
 
     const actionButton = style({
@@ -289,6 +286,7 @@ export const searchBarClasses = useThemeCache(() => {
     return {
         root,
         valueContainer,
+        compoundValueContainer,
         actionButton,
         label,
         clear,

--- a/library/src/scripts/styles/siteNavStyles.ts
+++ b/library/src/scripts/styles/siteNavStyles.ts
@@ -14,7 +14,6 @@ import { style } from "typestyle";
 
 export const siteNavVariables = useThemeCache(() => {
     const globalVars = globalVariables();
-    const formElementVars = formElementsVariables();
     const themeVars = componentThemeVariables("siteNav");
 
     const node = {
@@ -146,6 +145,7 @@ export const siteNavNodeClasses = useThemeCache(() => {
             },
             "&.hasChildren": {
                 fontWeight: globalVars.fonts.weights.semiBold,
+                color: "inherit",
                 $nest: {
                     "&.isFirstLevel": {
                         fontSize: unit(globalVars.fonts.size.large),


### PR DESCRIPTION
This PR fixes a couple things got off spec in the current theme branch.

- Closes https://github.com/vanilla/knowledge/issues/731
  - Search in the header has fixed background
  - Search has correct border-radiuses when no search button is displayed.
  - Splash search does not show search button on mobile.
- SiteNav links now have active and hover colors again.
