### PR TITLE
Fix application folder name under Windows 

### DIFF
--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -101,7 +101,7 @@ class Gdn_ApplicationManager {
      */
     private function calcOldInfoArray(Addon $addon) {
         $info = Gdn_pluginManager::calcOldInfoArray($addon);
-        $directories = explode(DS, $addon->getSubdir());
+        $directories = explode('/', $addon->getSubdir());
         $info['Folder'] = $directories[count($directories) - 1];
 
         return $info;


### PR DESCRIPTION
Fixes #7263.

### Bug Description

Vanilla currently returns an incorrect folder name for applications when Vanilla is run on Windows. This causes applications to not be enabled because Vanilla depends on a properly set value for elements in the EnabledApplications array in config.php.

**Actual values on Windows:**
```
$Configuration['EnabledApplications']['Conversations'] = '/applications/conversations';
$Configuration['EnabledApplications']['Vanilla'] = '/applications/vanilla';
```

**Expected values:**
```
$Configuration['EnabledApplications']['Conversations'] = 'conversations';
$Configuration['EnabledApplications']['Vanilla'] = 'vanilla';
```

The Conversations and Vanilla applications are just two examples to show how the EnabledApplications array looks like on Windows.

On Linux environments, the values are good as expected.

You can reproduce this on a Windows environment by (1) a new installation of Vanilla or (2) by enabling any application via the dashboard.

**Environments used for reproducing this issue:**
1. Windows Server 2019, IIS 10, PHP 7.2.7 (VC15 x64), MariaDB 10.3.13
2. Windows 10 with WAMP/XAMPP/Laragon software stack. My Laragon setup has: Apache 2.4.37, PHP 7.3.2, MariaDB 10.3.13

### Fix Description

Note: Windows supports both backslashes and forward slashes as a path separator.

$addon->getSubdir() returns a string with forward slashes (e.g. `/applications/conversations`) in both Windows and Linux.  DS is `\` on Windows and `/` on Linux; therefore, `explode(DS, $addon->getSubdir())` won't work as intended. I suggest changing DS to `'/'`.