### PR TITLE
KB Styles - refactoring helper functions, improve color types, splash styles, background images

### DIFF
--- a/library/src/scripts/components/headers/VanillaHeaderNav.tsx
+++ b/library/src/scripts/components/headers/VanillaHeaderNav.tsx
@@ -6,12 +6,12 @@
 
 import { percent, px, quote, calc } from "csx";
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { debugHelper, unit } from "@library/styles/styleHelpers";
-import { style } from "typestyle";
+import { unit } from "@library/styles/styleHelpers";
 import { vanillaHeaderVariables } from "@library/styles/vanillaHeaderStyles";
 import { flexHelper } from "@library/styles/styleHelpers";
 import { layoutVariables } from "@library/styles/layoutStyles";
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
+import { styleFactory } from "@library/styles/styleUtils";
 
 export function vanillaHeaderNavigation() {
     const globalVars = globalVariables();
@@ -46,14 +46,13 @@ export default function vanillaHeaderNavClasses() {
     const vars = vanillaHeaderNavigation();
     const mediaQueries = layoutVariables().mediaQueries();
     const flex = flexHelper();
-    const debug = debugHelper("vanillaHeaderNav");
+    const style = styleFactory("vanillaHeaderNav");
 
     const root = style({
         position: "relative",
     });
 
     const navigation = style({
-        ...debug.name(),
         ...flex.middle(),
         height: percent(100),
         color: "inherit",
@@ -68,8 +67,8 @@ export default function vanillaHeaderNavClasses() {
     });
 
     const items = style(
+        "items",
         {
-            ...debug.name("items"),
             ...flex.middle(),
             height: unit(vars.item.size),
             $nest: {
@@ -93,8 +92,7 @@ export default function vanillaHeaderNavClasses() {
         }),
     );
 
-    const link = style({
-        ...debug.name("link"),
+    const link = style("link", {
         display: "flex",
         justifyContent: "center",
         alignItems: "stretch",
@@ -109,8 +107,7 @@ export default function vanillaHeaderNavClasses() {
         },
     });
 
-    const linkContent = style({
-        ...debug.name("linkContent"),
+    const linkContent = style("linkContent", {
         ...flex.middleLeft(),
         position: "relative",
         $nest: {

--- a/library/src/scripts/components/layouts/PanelLayout.tsx
+++ b/library/src/scripts/components/layouts/PanelLayout.tsx
@@ -7,11 +7,11 @@ import * as React from "react";
 import { Devices, IDeviceProps } from "@library/components/DeviceChecker";
 import classNames from "classnames";
 import { ScrollOffsetContext } from "@library/contexts/ScrollOffsetContext";
-import { style } from "typestyle";
 import { NestedCSSProperties } from "typestyle/lib/types";
 import throttle from "lodash/throttle";
 import { withDevice } from "@library/contexts/DeviceContext";
-import { debugHelper, inheritHeightClass } from "@library/styles/styleHelpers";
+import { inheritHeightClass } from "@library/styles/styleHelpers";
+import { styleFactory } from "@library/styles/styleUtils";
 
 interface IProps extends IDeviceProps {
     className?: string;
@@ -285,7 +285,7 @@ class PanelLayout extends React.Component<IProps> {
         const { isFixed } = this.props;
         const leftPanelEl = this.leftPanelRef.current;
         const rightPanelEl = this.rightPanelRef.current;
-        const debug = debugHelper("panelFixed");
+        const style = styleFactory("panelFixed");
 
         // The classes default to visually hidden (but still visible to screen readers) until fully calced.
         // The content may already be rendered, but we need a second layout pass for computed values.
@@ -303,21 +303,19 @@ class PanelLayout extends React.Component<IProps> {
 
         if (leftPanelEl) {
             const leftPanelRect = this.getCachedBoundingRect(leftPanelEl);
-            left = style({
+            left = style("leftPanel", {
                 ...base,
                 top: leftPanelRect.top + "px",
                 left: leftPanelRect.left + "px",
-                ...debug.name("leftPanel"),
             });
         }
 
         if (rightPanelEl) {
             const rightPanelRect = this.getCachedBoundingRect(rightPanelEl);
-            right = style({
+            right = style("rightPanel", {
                 ...base,
                 top: rightPanelRect.top + "px",
                 left: rightPanelRect.left + "px",
-                ...debug.name("rightPanel"),
             });
         }
 

--- a/library/src/scripts/components/navigation/backLinkStyles.ts
+++ b/library/src/scripts/components/navigation/backLinkStyles.ts
@@ -6,28 +6,26 @@
 
 import { px } from "csx";
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { debugHelper, srOnly, userSelect } from "@library/styles/styleHelpers";
+import { srOnly, userSelect } from "@library/styles/styleHelpers";
 import { style } from "typestyle";
 import { layoutVariables } from "@library/styles/layoutStyles";
 import { vanillaHeaderVariables } from "@library/styles/vanillaHeaderStyles";
-import { useThemeCache } from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 
 const backLinkClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const mediaQueries = layoutVariables().mediaQueries();
-    const debug = debugHelper("backLink");
+    const style = styleFactory("backLink");
     const headerVars = vanillaHeaderVariables();
 
     const root = style({
-        ...debug.name(),
         ...userSelect(),
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "flex-start",
     });
 
-    const link = style({
-        ...debug.name("link"),
+    const link = style("link", {
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "flex-start",
@@ -42,8 +40,8 @@ const backLinkClasses = useThemeCache(() => {
     });
 
     const label = style(
+        "label",
         {
-            ...debug.name("label"),
             lineHeight: px(globalVars.icon.sizes.default),
             fontWeight: globalVars.fonts.weights.semiBold,
             whiteSpace: "nowrap",

--- a/library/src/scripts/components/navigation/backLinkStyles.ts
+++ b/library/src/scripts/components/navigation/backLinkStyles.ts
@@ -7,7 +7,6 @@
 import { px } from "csx";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { srOnly, userSelect } from "@library/styles/styleHelpers";
-import { style } from "typestyle";
 import { layoutVariables } from "@library/styles/layoutStyles";
 import { vanillaHeaderVariables } from "@library/styles/vanillaHeaderStyles";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";

--- a/library/src/scripts/components/nextPrevious/NextPrevious.tsx
+++ b/library/src/scripts/components/nextPrevious/NextPrevious.tsx
@@ -113,8 +113,7 @@ export default class NextPrevious extends React.Component<IProps> {
             color: globalVars.mainColors.fg.toString(),
         });
 
-        const directionLabel = style({
-            ...debug.name("label"),
+        const directionLabel = style("label", {
             display: "block",
             fontSize: px(globalVars.fonts.size.small),
             lineHeight: globalVars.lineHeights.condensed,
@@ -122,8 +121,7 @@ export default class NextPrevious extends React.Component<IProps> {
             marginBottom: px(2),
         });
 
-        const title = style({
-            ...debug.name("title"),
+        const title = style("title", {
             display: "block",
             position: "relative",
             fontSize: px(globalVars.fonts.size.medium),
@@ -131,16 +129,14 @@ export default class NextPrevious extends React.Component<IProps> {
             fontWeight: globalVars.fonts.weights.semiBold,
         });
 
-        const chevron = style({
-            ...debug.name("chevron"),
+        const chevron = style("chevron", {
             position: "absolute",
             top: px((vars.fonts.title * vars.lineHeights.title) / 2),
             transform: `translateY(-50%)`,
             color: globalVars.mixBgAndFg(0.75).toString(),
         });
 
-        const chevronLeft = style({
-            ...debug.name("chevronLeft"),
+        const chevronLeft = style("chevronLeft", {
             left: px(0),
             marginLeft: px(-globalVars.icon.sizes.default),
         });

--- a/library/src/scripts/components/nextPrevious/NextPrevious.tsx
+++ b/library/src/scripts/components/nextPrevious/NextPrevious.tsx
@@ -6,14 +6,13 @@
 
 import React from "react";
 import classNames from "classnames";
-import { style } from "typestyle";
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { componentThemeVariables, debugHelper } from "@library/styles/styleHelpers";
+import { componentThemeVariables } from "@library/styles/styleHelpers";
 import ScreenReaderContent from "@library/components/ScreenReaderContent";
 import Heading from "@library/components/Heading";
 import AdjacentLink, { LeftRight } from "@library/components/nextPrevious/AdjacentLink";
 import { px } from "csx";
-import { useThemeCache } from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 
 interface IUrlItem {
     name: string;
@@ -96,7 +95,7 @@ export default class NextPrevious extends React.Component<IProps> {
     public nextPreviousStyles = useThemeCache(() => {
         const globalVars = globalVariables();
         const vars = this.nextPreviousVariables();
-        const debug = debugHelper("nextPrevious");
+        const style = styleFactory("nextPrevious");
         const activeStyles = {
             color: vars.colors.title.toString(),
             $nest: {
@@ -112,49 +111,47 @@ export default class NextPrevious extends React.Component<IProps> {
             flexWrap: "wrap",
             justifyContent: "space-between",
             color: globalVars.mainColors.fg.toString(),
-            ...debug.name(),
         });
 
         const directionLabel = style({
+            ...debug.name("label"),
             display: "block",
             fontSize: px(globalVars.fonts.size.small),
             lineHeight: globalVars.lineHeights.condensed,
             color: vars.colors.label.toString(),
             marginBottom: px(2),
-            ...debug.name("label"),
         });
 
         const title = style({
+            ...debug.name("title"),
             display: "block",
             position: "relative",
             fontSize: px(globalVars.fonts.size.medium),
             lineHeight: globalVars.lineHeights.condensed,
             fontWeight: globalVars.fonts.weights.semiBold,
-            ...debug.name("title"),
         });
 
         const chevron = style({
+            ...debug.name("chevron"),
             position: "absolute",
             top: px((vars.fonts.title * vars.lineHeights.title) / 2),
             transform: `translateY(-50%)`,
             color: globalVars.mixBgAndFg(0.75).toString(),
-            ...debug.name("chevron"),
         });
 
         const chevronLeft = style({
+            ...debug.name("chevronLeft"),
             left: px(0),
             marginLeft: px(-globalVars.icon.sizes.default),
-            ...debug.name("chevronLeft"),
         });
 
-        const chevronRight = style({
+        const chevronRight = style("chevronRight", {
             right: px(0),
             marginRight: px(-globalVars.icon.sizes.default),
-            ...debug.name("chevronRight"),
         });
 
         // Common to both left and right
-        const adjacent = style({
+        const adjacent = style("adjacent", {
             display: "block",
             marginTop: px(8),
             marginBottom: px(8),
@@ -164,21 +161,18 @@ export default class NextPrevious extends React.Component<IProps> {
                 "&:hover": activeStyles,
                 "&:active": activeStyles,
             },
-            ...debug.name("adjacent"),
         });
 
-        const previous = style({
+        const previous = style("previous", {
             paddingLeft: px(globalVars.icon.sizes.default),
             paddingRight: px(globalVars.icon.sizes.default / 2),
-            ...debug.name("previous"),
         });
 
-        const next = style({
+        const next = style("next", {
             marginLeft: "auto",
             textAlign: "right",
             paddingRight: px(globalVars.icon.sizes.default),
             paddingLeft: px(globalVars.icon.sizes.default / 2),
-            ...debug.name("next"),
         });
 
         return { root, adjacent, previous, next, title, chevron, directionLabel, chevronLeft, chevronRight };

--- a/library/src/scripts/styles/attachmentIconsStyles.ts
+++ b/library/src/scripts/styles/attachmentIconsStyles.ts
@@ -5,19 +5,10 @@
  */
 
 import { globalVariables } from "@library/styles/globalStyleVars";
-import {
-    borders,
-    componentThemeVariables,
-    debugHelper,
-    allLinkStates,
-    margins,
-    absolutePosition,
-    unit,
-} from "@library/styles/styleHelpers";
-import { style } from "typestyle";
+import { componentThemeVariables, margins } from "@library/styles/styleHelpers";
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { calc, px, percent } from "csx";
-import { useThemeCache } from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 
 export const attachmentIconVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -45,53 +36,49 @@ export const attachmentIconsClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const formElementVars = formElementsVariables();
     const vars = attachmentIconVariables();
-    const debug = debugHelper("attachmentIcons");
+    const style = styleFactory("attachmentIcons");
 
     const root = style({
         display: "block",
         position: "relative",
-        ...debug.name(),
     });
 
-    const items = {
+    const items = style("items", {
         display: "flex",
         flexWrap: "wrap",
         alignItems: "flex-start",
         justifyContent: "flex-end",
         width: calc(`100% + ${px(vars.spacing.default * 2)}`),
         overflow: "hidden",
-        ...debug.name("items"),
         ...margins({
             top: -vars.spacing.default,
             left: -vars.spacing.default,
             right: globalVars.meta.spacing.default,
         }),
-    };
+    });
 
-    const item = {
+    const item = style("item", {
         margin: vars.spacing.default,
         ...debug.name("item"),
-    };
+    });
 
     return { root, items, item };
 });
 
 export const attachmentIconClasses = useThemeCache(() => {
     const vars = attachmentIconVariables();
-    const debug = debugHelper("attachmentIcon");
+    const style = styleFactory("attachmentIcon");
 
     const root = style({
         display: "block",
         width: px(vars.icon.size),
         height: px(vars.icon.size),
         boxShadow: `0 0 0 1px ${vars.shadow.color}`,
-        ...debug.name(),
     });
 
-    const error = style({
+    const error = style("error", {
         width: px(vars.icon.size),
         height: px(vars.icon.errorIconHeight),
-        ...debug.name("error"),
     });
 
     return { root, error };

--- a/library/src/scripts/styles/attachmentIconsStyles.ts
+++ b/library/src/scripts/styles/attachmentIconsStyles.ts
@@ -6,7 +6,6 @@
 
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { componentThemeVariables, margins } from "@library/styles/styleHelpers";
-import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { calc, px, percent } from "csx";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 
@@ -34,7 +33,6 @@ export const attachmentIconVariables = useThemeCache(() => {
 
 export const attachmentIconsClasses = useThemeCache(() => {
     const globalVars = globalVariables();
-    const formElementVars = formElementsVariables();
     const vars = attachmentIconVariables();
     const style = styleFactory("attachmentIcons");
 
@@ -59,7 +57,6 @@ export const attachmentIconsClasses = useThemeCache(() => {
 
     const item = style("item", {
         margin: vars.spacing.default,
-        ...debug.name("item"),
     });
 
     return { root, items, item };

--- a/library/src/scripts/styles/attachmentStyles.ts
+++ b/library/src/scripts/styles/attachmentStyles.ts
@@ -17,6 +17,7 @@ import {
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { percent, px } from "csx";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
+import { transparentColor } from "@library/styles/buttonStyles";
 
 export const attachmentVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -116,7 +117,7 @@ export const attachmentClasses = useThemeCache(() => {
         padding: px(vars.padding.default),
         width: percent(100),
         ...borders({
-            color: "transparent",
+            color: transparentColor,
             width: 2,
             radius: 0,
         }),

--- a/library/src/scripts/styles/attachmentStyles.ts
+++ b/library/src/scripts/styles/attachmentStyles.ts
@@ -8,17 +8,15 @@ import { globalVariables } from "@library/styles/globalStyleVars";
 import {
     borders,
     componentThemeVariables,
-    debugHelper,
     allLinkStates,
     margins,
-    absolutePosition,
     unit,
     userSelect,
+    absolutePosition,
 } from "@library/styles/styleHelpers";
-import { style } from "typestyle";
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { percent, px } from "csx";
-import { useThemeCache } from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 
 export const attachmentVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -70,7 +68,7 @@ export const attachmentClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const formElementVars = formElementsVariables();
     const vars = attachmentVariables();
-    const debug = debugHelper("attachment");
+    const style = styleFactory("attachment");
 
     const root = style({
         display: "block",
@@ -101,17 +99,15 @@ export const attachmentClasses = useThemeCache(() => {
                 },
             },
         },
-        ...debug.name(),
     });
 
-    const link = style({
+    const link = style("link", {
         ...allLinkStates({
             textDecoration: "none",
         }),
-        ...debug.name("link"),
     });
 
-    const box = style({
+    const box = style("box", {
         position: "relative",
         display: "flex",
         flexWrap: "nowrap",
@@ -124,50 +120,44 @@ export const attachmentClasses = useThemeCache(() => {
             width: 2,
             radius: 0,
         }),
-        ...debug.name("box"),
     });
 
-    const format = style({
+    const format = style("format", {
         flexBasis: px(globalVars.icon.sizes.small + vars.padding.default),
         height: unit(globalVars.icon.sizes.small),
         paddingRight: unit(vars.padding.default),
         flexShrink: 1,
-        ...debug.name("format"),
     });
 
-    const main = style({
+    const main = style("main", {
         display: "flex",
         flexDirection: "column",
         alignItems: "flex-start",
         justifyContent: "flex-start",
         flexGrow: 1,
-        ...debug.name("main"),
     });
 
-    const title = style({
+    const title = style("title", {
         fontSize: px(vars.text.fontSize),
         color: vars.title.color.toString(),
         fontWeight: globalVars.fonts.weights.semiBold,
         lineHeight: px(globalVars.icon.sizes.small),
-        ...debug.name("title"),
     });
 
-    const metas = style({
+    const metas = style("metas", {
         marginBottom: px(0),
         lineHeight: globalVars.lineHeights.condensed,
-        ...debug.name("metas"),
     });
 
-    const close = style({
+    const close = style("close", {
         ...margins({
             top: px(-((formElementVars.sizing.height - globalVars.icon.sizes.default) / 2)),
             right: px(-((formElementVars.sizing.height - globalVars.icon.sizes.default) / 2)),
         }),
         pointerEvents: "all",
-        ...debug.name("close"),
     });
 
-    const loadingProgress = style({
+    const loadingProgress = style("loadingProgress", {
         ...absolutePosition.bottomLeft(),
         transition: `width ease-out .2s`,
         height: px(3),
@@ -175,10 +165,9 @@ export const attachmentClasses = useThemeCache(() => {
         width: 0,
         maxWidth: percent(100),
         backgroundColor: globalVars.mainColors.primary.toString(),
-        ...debug.name("loadingProgress"),
     });
 
-    const loadingContent = style({
+    const loadingContent = style("loadingContent", {
         $nest: {
             ".attachment-format": {
                 opacity: vars.loading.opacity,
@@ -187,7 +176,6 @@ export const attachmentClasses = useThemeCache(() => {
                 opacity: vars.loading.opacity,
             },
         },
-        ...debug.name("loadingContent"),
     });
 
     return { root, link, box, format, main, title, metas, close, loadingProgress, loadingContent };

--- a/library/src/scripts/styles/bodyStyles.ts
+++ b/library/src/scripts/styles/bodyStyles.ts
@@ -21,10 +21,10 @@ export const bodyCSS = useThemeCache(() => {
 export const bodyClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const style = styleFactory("fullBackground");
-    const image = get(globalVars, "body.backgroundImage.image", undefined);
+    const image = get(globalVars, "body.backgroundImage", undefined);
     const root = style({
         display: !image ? "none" : "block",
-        ...backgroundImage({ image }),
+        ...backgroundImage(image),
         backgroundColor: toStringColor(globalVars.body.bg),
         position: "fixed",
         top: 0,

--- a/library/src/scripts/styles/bodyStyles.ts
+++ b/library/src/scripts/styles/bodyStyles.ts
@@ -3,15 +3,16 @@
  * @license GPL-2.0-only
  */
 
-import { backgroundCover, toStringColor } from "@library/styles/styleHelpers";
+import { backgroundImage, toStringColor } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { cssRule } from "typestyle";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import get from "lodash/get";
+import { percent, viewHeight } from "csx";
 
 export const bodyCSS = useThemeCache(() => {
     const globalVars = globalVariables();
-    cssRule("body", {
+    cssRule("html, body", {
         backgroundColor: toStringColor(globalVars.body.bg),
         color: toStringColor(globalVars.mainColors.fg),
     });
@@ -19,9 +20,17 @@ export const bodyCSS = useThemeCache(() => {
 
 export const bodyClasses = useThemeCache(() => {
     const globalVars = globalVariables();
-    const style = styleFactory("body");
+    const style = styleFactory("fullBackground");
+    const image = get(globalVars, "body.backgroundImage.image", undefined);
     const root = style({
-        ...backgroundCover(get(globalVars, "body.backgroundImage.image", null)),
+        display: !image ? "none" : "block",
+        ...backgroundImage({ image }),
+        backgroundColor: toStringColor(globalVars.body.bg),
+        position: "fixed",
+        top: 0,
+        left: 0,
+        width: percent(100),
+        height: viewHeight(100),
     });
 
     return { root };

--- a/library/src/scripts/styles/buttonStyles.ts
+++ b/library/src/scripts/styles/buttonStyles.ts
@@ -10,7 +10,7 @@ import {
     borders,
     componentThemeVariables,
     flexHelper,
-    getColorDependantOnLightness,
+    modifyColorBasedOnLightness,
     spinnerLoader,
     toStringColor,
     unit,
@@ -109,22 +109,22 @@ export const buttonVariables = useThemeCache(() => {
         },
         hover: {
             fg: globalVars.mainColors.fg,
-            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
+            bg: modifyColorBasedOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
             borderColor: globalVars.mixBgAndFg(0.1),
         },
         active: {
             fg: globalVars.mainColors.fg,
-            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
+            bg: modifyColorBasedOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
             borderColor: globalVars.mixBgAndFg(0.1),
         },
         focus: {
             fg: globalVars.mainColors.fg,
-            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
+            bg: modifyColorBasedOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
             borderColor: globalVars.mixBgAndFg(0.1),
         },
         focusAccessible: {
             fg: globalVars.mainColors.fg,
-            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
+            bg: modifyColorBasedOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
             borderColor: globalVars.mixBgAndFg(0.1),
         },
     });

--- a/library/src/scripts/styles/buttonStyles.ts
+++ b/library/src/scripts/styles/buttonStyles.ts
@@ -7,8 +7,10 @@
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import {
+    borders,
     componentThemeVariables,
     flexHelper,
+    getColorDependantOnLightness,
     spinnerLoader,
     toStringColor,
     unit,
@@ -19,6 +21,7 @@ import { BorderRadiusProperty, BorderStyleProperty, WidthProperty } from "csstyp
 import { ColorHelper, percent, px } from "csx";
 import memoize from "lodash/memoize";
 import { TLength } from "typestyle/lib/types";
+import get from "lodash/get";
 
 export const buttonStyles = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -43,37 +46,54 @@ export const buttonStyles = useThemeCache(() => {
     return { padding, sizing, border };
 });
 
-export type ColorHelperAndTransparent = ColorHelper | "transparent";
+export type ColorValues = ColorHelper | "transparent" | undefined;
+
+export const transparentColor = "transparent" as ColorValues;
 
 export interface IButtonType {
-    fg: ColorHelperAndTransparent;
-    bg: ColorHelperAndTransparent;
-    spinnerColor: ColorHelper;
+    fg: ColorValues;
+    bg?: ColorValues;
     border: {
-        color: ColorHelperAndTransparent;
-        width: WidthProperty<TLength>;
-        style: BorderStyleProperty;
-        radius: BorderRadiusProperty<TLength>;
+        color: ColorValues;
+        width?: WidthProperty<TLength>;
+        style?: BorderStyleProperty;
+        radius?: BorderRadiusProperty<TLength>;
     };
     hover: {
-        fg: ColorHelperAndTransparent;
-        bg: ColorHelperAndTransparent;
-        borderColor: ColorHelperAndTransparent;
+        fg: ColorValues;
+        bg?: ColorValues;
+        border?: {
+            color: ColorValues;
+            style?: BorderStyleProperty;
+            radius?: BorderRadiusProperty<TLength>;
+        };
     };
     focus: {
-        fg: ColorHelperAndTransparent;
-        bg: ColorHelperAndTransparent;
-        borderColor: ColorHelperAndTransparent;
+        fg: ColorValues;
+        bg?: ColorValues;
+        border?: {
+            color: ColorValues;
+            style?: BorderStyleProperty;
+            radius?: BorderRadiusProperty<TLength>;
+        };
     };
     active: {
-        fg: ColorHelperAndTransparent;
-        bg: ColorHelperAndTransparent;
-        borderColor: ColorHelperAndTransparent;
+        fg: ColorValues;
+        bg?: ColorValues;
+        border?: {
+            color: ColorValues;
+            style?: BorderStyleProperty;
+            radius?: BorderRadiusProperty<TLength>;
+        };
     };
     focusAccessible: {
-        fg: ColorHelperAndTransparent;
-        bg: ColorHelperAndTransparent;
-        borderColor: ColorHelperAndTransparent;
+        fg: ColorValues;
+        bg?: ColorValues;
+        border?: {
+            color: ColorValues;
+            style?: BorderStyleProperty;
+            radius?: BorderRadiusProperty<TLength>;
+        };
     };
 }
 
@@ -84,32 +104,47 @@ export const buttonVariables = useThemeCache(() => {
     const standard: IButtonType = makeThemeVars("basic", {
         fg: globalVars.mainColors.fg,
         bg: globalVars.mainColors.bg,
-        spinnerColor: globalVars.mainColors.primary,
         border: {
             color: globalVars.mixBgAndFg(0.24),
-            width: px(1),
-            style: "solid",
-            radius: globalVars.border.radius,
         },
         hover: {
             fg: globalVars.mainColors.fg,
-            bg: globalVars.mainColors.bg.darken(0.1),
-            borderColor: globalVars.mixBgAndFg(0.4).darken(0.1),
+            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
+            borderColor: globalVars.mixBgAndFg(0.1),
         },
         active: {
             fg: globalVars.mainColors.fg,
-            bg: globalVars.mainColors.bg.darken(0.1),
-            borderColor: globalVars.mixBgAndFg(0.4).darken(0.1),
+            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
+            borderColor: globalVars.mixBgAndFg(0.1),
         },
         focus: {
             fg: globalVars.mainColors.fg,
-            bg: globalVars.mainColors.bg.darken(0.1),
-            borderColor: globalVars.mixBgAndFg(0.8).darken(0.1),
+            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
+            borderColor: globalVars.mixBgAndFg(0.1),
         },
         focusAccessible: {
             fg: globalVars.mainColors.fg,
-            bg: globalVars.mainColors.bg.darken(0.3),
-            borderColor: globalVars.mainColors.bg.darken(1),
+            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.fg, 0.1),
+            borderColor: globalVars.mixBgAndFg(0.1),
+        },
+    });
+
+    const compact: IButtonType = makeThemeVars("compact", {
+        fg: globalVars.mainColors.fg,
+        border: {
+            color: transparentColor,
+        },
+        hover: {
+            fg: globalVars.mainColors.primary,
+        },
+        active: {
+            fg: globalVars.mainColors.primary,
+        },
+        focus: {
+            fg: globalVars.mainColors.primary,
+        },
+        focusAccessible: {
+            fg: globalVars.mainColors.primary,
         },
     });
 
@@ -119,9 +154,6 @@ export const buttonVariables = useThemeCache(() => {
         spinnerColor: globalVars.elementaryColors.white,
         border: {
             color: globalVars.mainColors.primary,
-            width: px(1),
-            style: "solid",
-            radius: globalVars.border.radius,
         },
         hover: {
             fg: globalVars.elementaryColors.white,
@@ -148,13 +180,9 @@ export const buttonVariables = useThemeCache(() => {
     const transparentButtonColor = globalVars.mainColors.bg;
     const transparent: IButtonType = makeThemeVars("transparent", {
         fg: transparentButtonColor,
-        bg: "transparent" as any,
-        spinnerColor: globalVars.mainColors.primary,
+        bg: transparentColor,
         border: {
             color: transparentButtonColor,
-            width: px(1),
-            style: "solid",
-            radius: globalVars.border.radius,
         },
         hover: {
             fg: transparentButtonColor,
@@ -201,6 +229,7 @@ export const generateButtonClass = (buttonType: IButtonType, buttonName: string,
         textOverflow: "ellipsis",
         overflow: "hidden",
         maxWidth: percent(100),
+        ...borders(buttonType.border),
         ...userSelect(),
         ...buttonSizing(
             formElVars.sizing.height,
@@ -219,10 +248,6 @@ export const generateButtonClass = (buttonType: IButtonType, buttonName: string,
         cursor: "pointer",
         color: toStringColor(buttonType.fg),
         backgroundColor: toStringColor(buttonType.bg),
-        borderColor: toStringColor(buttonType.border.color),
-        borderRadius: unit(buttonType.border.radius),
-        borderStyle: buttonType.border.style,
-        borderWidth: unit(buttonType.border.width),
         $nest: {
             "&:not([disabled])": {
                 $nest: {
@@ -232,25 +257,26 @@ export const generateButtonClass = (buttonType: IButtonType, buttonName: string,
                     "&:hover": {
                         zIndex,
                         backgroundColor: toStringColor(buttonType.hover.bg),
-                        borderColor: toStringColor(buttonType.hover.borderColor),
+                        border: get(buttonType, "hover.border", {}),
                         color: toStringColor(buttonType.hover.fg),
+                        ...borders(buttonType.border),
                     },
                     "&:focus": {
                         zIndex,
                         backgroundColor: toStringColor(buttonType.focus.bg),
-                        borderColor: toStringColor(buttonType.focus.borderColor),
+                        border: get(buttonType, "focus.border", {}),
                         color: toStringColor(buttonType.focus.fg),
                     },
                     "&:active": {
                         zIndex,
                         backgroundColor: toStringColor(buttonType.active.bg),
-                        borderColor: toStringColor(buttonType.active.borderColor),
+                        border: get(buttonType, "hover.active", {}),
                         color: toStringColor(buttonType.active.fg),
                     },
                     "&.focus-visible": {
                         zIndex,
                         backgroundColor: toStringColor(buttonType.focus.bg),
-                        borderColor: toStringColor(buttonType.focus.borderColor),
+                        border: get(buttonType, "hover.accessibleFocus", {}),
                         color: toStringColor(buttonType.focus.fg),
                     },
                 },
@@ -263,6 +289,7 @@ export enum ButtonTypes {
     STANDARD = "standard",
     PRIMARY = "primary",
     TRANSPARENT = "transparent",
+    COMPACT = "compact",
 }
 
 export const buttonClasses = useThemeCache(() => {
@@ -271,21 +298,23 @@ export const buttonClasses = useThemeCache(() => {
         primary: generateButtonClass(vars.primary, "primary"),
         standard: generateButtonClass(vars.standard, "standard"),
         transparent: generateButtonClass(vars.transparent, "transparent"),
+        compact: generateButtonClass(vars.transparent, "compact"),
     };
 });
 
 export const buttonLoaderClasses = memoize((buttonType: IButtonType) => {
     const themeVars = componentThemeVariables("buttonLoader");
+    const globalVars = globalVariables();
     const flexUtils = flexHelper();
     const style = styleFactory("buttonLoader");
     const root = style({
         ...flexUtils.middle(),
-        padding: px(4),
+        padding: unit(4),
         height: percent(100),
         width: percent(100),
         $nest: {
             "&:after": spinnerLoader({
-                color: buttonType.spinnerColor,
+                color: get(buttonType, "spinnerColor", globalVars.mainColors.primary),
                 dimensions: 20,
             }),
         },

--- a/library/src/scripts/styles/checkRadioStyles.ts
+++ b/library/src/scripts/styles/checkRadioStyles.ts
@@ -10,7 +10,6 @@ import {
     unit,
     borders,
     componentThemeVariables,
-    debugHelper,
     defaultTransition,
     srOnly,
     disabledInput,
@@ -18,10 +17,9 @@ import {
     toStringColor,
     userSelect,
 } from "@library/styles/styleHelpers";
-import { style } from "typestyle";
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { em, important, percent, px } from "csx";
-import { useThemeCache } from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 
 export const checkRadioVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -86,13 +84,12 @@ export const checkRadioVariables = useThemeCache(() => {
 export const checkRadioClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const vars = checkRadioVariables();
-    const debug = debugHelper("checkRadio");
+    const style = styleFactory("checkRadio");
     const flexes = flexHelper();
 
     //.radioButton,
     //.checkbox
     const root = style({
-        ...debug.name(),
         display: "flex",
         flexWrap: "wrap",
         alignItems: "center",
@@ -122,16 +119,14 @@ export const checkRadioClasses = useThemeCache(() => {
 
     //.radioButton-label,
     // .checkbox-label
-    const label = style({
-        ...debug.name("label"),
+    const label = style("label", {
         lineHeight: unit(vars.sizing.width),
         marginLeft: unit(8),
         cursor: "pointer",
         ...userSelect(),
     });
 
-    const labelNote = style({
-        ...debug.name("labelNote"),
+    const labelNote = style("labelNote", {
         display: "inline-block",
         fontSize: unit(vars.labelNote.fontSize),
         marginLeft: unit(24),
@@ -141,8 +136,7 @@ export const checkRadioClasses = useThemeCache(() => {
 
     // .radioButton-disk,
     // .checkbox-box
-    const iconContainer = style({
-        ...debug.name("iconContainer"),
+    const iconContainer = style("iconContainer", {
         ...defaultTransition("border", "background", "opacity"),
         position: "relative",
         display: "inline-block",
@@ -154,8 +148,7 @@ export const checkRadioClasses = useThemeCache(() => {
         ...borders(vars.border),
     });
 
-    const radioIcon = style({
-        ...debug.name("radioIcon"),
+    const radioIcon = style("radioIcon", {
         ...absolutePosition.middleLeftOfParent(),
         display: "none",
         width: unit(vars.radioButton.icon.width),
@@ -163,8 +156,7 @@ export const checkRadioClasses = useThemeCache(() => {
         margin: "auto",
     });
 
-    const checkIcon = style({
-        ...debug.name("checkBoxIcon"),
+    const checkIcon = style("checkBoxIcon", {
         ...absolutePosition.middleOfParent(),
         display: "none",
         width: unit(vars.checkBox.check.width),
@@ -173,15 +165,13 @@ export const checkRadioClasses = useThemeCache(() => {
         margin: "auto",
     });
 
-    const disk = style({
-        ...debug.name("disk"),
+    const disk = style("disk", {
         borderRadius: percent(50),
     });
 
     // .radioButton-state,
     // .checkbox-state
-    const state = style({
-        ...debug.name("state"),
+    const state = style("state", {
         ...absolutePosition.fullSizeOfParent(),
         color: vars.main.checked.fg.toString(),
     });
@@ -193,9 +183,8 @@ export const checkRadioClasses = useThemeCache(() => {
 
     // .radioButton-input,
     // .checkbox-input
-    const input = style({
+    const input = style("input", {
         ...srOnly(),
-        ...debug.name("input"),
         $nest: {
             "&:not([disabled]):focus, &:not([disabled]):active, &:not([disabled]).focus-visible ": {
                 $nest: {
@@ -207,7 +196,6 @@ export const checkRadioClasses = useThemeCache(() => {
                 },
             },
             "&:checked + .radioButton-disk, &:checked + .checkbox-box": {
-                ...debug.name("checked"),
                 backgroundColor: important(vars.main.checked.bg.toString()),
                 borderColor: vars.main.checked.fg.toString(),
                 $nest: {

--- a/library/src/scripts/styles/compactMeBoxStyles.ts
+++ b/library/src/scripts/styles/compactMeBoxStyles.ts
@@ -6,7 +6,6 @@
 
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { absolutePosition, unit, componentThemeVariables, flexHelper } from "@library/styles/styleHelpers";
-import { style } from "typestyle";
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { calc, percent, px } from "csx";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";

--- a/library/src/scripts/styles/compactMeBoxStyles.ts
+++ b/library/src/scripts/styles/compactMeBoxStyles.ts
@@ -5,11 +5,11 @@
  */
 
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { absolutePosition, unit, componentThemeVariables, debugHelper, flexHelper } from "@library/styles/styleHelpers";
+import { absolutePosition, unit, componentThemeVariables, flexHelper } from "@library/styles/styleHelpers";
 import { style } from "typestyle";
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { calc, percent, px } from "csx";
-import { useThemeCache } from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 
 export const compactMeBoxVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -28,28 +28,24 @@ export const compactMeBoxVariables = useThemeCache(() => {
 export const compactMeBoxClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const vars = compactMeBoxVariables();
-    const debug = debugHelper("compactMeBox");
+    const style = styleFactory("compactMeBox");
 
     const root = style({
         display: "block",
-        ...debug.name(),
     });
 
-    const openButton = style({
+    const openButton = style("openButton", {
         color: globalVars.elementaryColors.white.toString(),
-        ...debug.name("openButton"),
     });
 
-    const contents = style({
+    const contents = style("contents", {
         position: "relative",
         display: "flex",
         flexDirection: "column",
         height: percent(100),
-        ...debug.name("contents"),
     });
 
-    const closeModal = style({
-        ...debug.name("closeModal"),
+    const closeModal = style("closeModal", {
         $nest: {
             "&&": {
                 ...absolutePosition.topRight(),
@@ -59,43 +55,37 @@ export const compactMeBoxClasses = useThemeCache(() => {
         },
     });
 
-    const tabList = style({
+    const tabList = style("tabList", {
         marginRight: unit(vars.tab.width),
         height: unit(vars.tab.height),
         flexBasis: unit(vars.tab.width),
         color: globalVars.mainColors.fg.toString(),
-        ...debug.name("tabList"),
     });
 
-    const tabButtonContent = style({
+    const tabButtonContent = style("tabButtonContent", {
         ...flexHelper().middle(),
         position: "relative",
         width: unit(vars.tab.width),
         height: unit(vars.tab.height),
-        ...debug.name("tabButtonContent"),
     });
 
-    const tabPanels = style({
+    const tabPanels = style("tabPanels", {
         height: calc(`100vh - ${vars.tab.height}`),
         borderTop: `1px solid ${globalVars.overlay.border.color.toString()}`,
-        ...debug.name("tabPanels"),
     });
 
-    const tabButton = style({
+    const tabButton = style("tabButton", {
         ...flexHelper().middle(),
-        ...debug.name("tabButton"),
     });
 
-    const panel = style({
+    const panel = style("panel", {
         flexGrow: 1,
         borderTop: 0,
         borderRadius: 0,
-        ...debug.name("panel"),
     });
 
-    const body = style({
+    const body = style("body", {
         flexGrow: 1,
-        ...debug.name("body"),
     });
 
     return { root, openButton, contents, closeModal, tabList, tabPanels, tabButton, tabButtonContent, panel, body };

--- a/library/src/scripts/styles/compactSearchStyles.ts
+++ b/library/src/scripts/styles/compactSearchStyles.ts
@@ -5,21 +5,19 @@
  */
 
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { unit, debugHelper } from "@library/styles/styleHelpers";
-import { style } from "typestyle";
+import { unit } from "@library/styles/styleHelpers";
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { vanillaHeaderVariables } from "@library/styles/vanillaHeaderStyles";
 import { percent, px } from "csx";
-import { useThemeCache } from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 
 export const compactSearchClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const formElementVars = formElementsVariables();
     const vanillaHeaderVars = vanillaHeaderVariables();
-    const debug = debugHelper("compactSearch");
+    const style = styleFactory("compactSearch");
 
     const root = style({
-        ...debug.name(),
         $nest: {
             ".searchBar": {
                 flexGrow: 1,
@@ -53,23 +51,20 @@ export const compactSearchClasses = useThemeCache(() => {
         },
     });
 
-    const contents = style({
+    const contents = style("contents", {
         display: "flex",
         alignItems: "center",
         flexWrap: "nowrap",
-        ...debug.name("contents"),
     });
 
-    const close = style({
+    const close = style("close", {
         color: "inherit",
         whiteSpace: "nowrap",
         fontWeight: globalVars.fonts.weights.semiBold,
-        ...debug.name("close"),
     });
 
-    const cancelContents = style({
+    const cancelContents = style("cancelContents", {
         padding: px(4),
-        ...debug.name("cancelContents"),
     });
     return { root, contents, close, cancelContents };
 });

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -68,11 +68,6 @@ export const globalVariables = useThemeCache(() => {
 
     const body = makeThemeVars("body", {
         bg: mainColors.bg,
-        backgroundImage: {
-            image: "",
-            repeat: false,
-            height: viewHeight(100),
-        },
     });
 
     const border = makeThemeVars("border", {

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import { getColorDependantOnLightness, toStringColor } from "@library/styles/styleHelpers";
+import { modifyColorBasedOnLightness, toStringColor } from "@library/styles/styleHelpers";
 import { useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { color, ColorHelper, percent, viewHeight } from "csx";
 
@@ -27,7 +27,7 @@ export const globalVariables = useThemeCache(() => {
         fg: color("#555a62"),
         bg: color("#fff"),
         primary: colorPrimary,
-        secondary: getColorDependantOnLightness(colorPrimary, colorPrimary, 0.1, true),
+        secondary: modifyColorBasedOnLightness(colorPrimary, colorPrimary, 0.1, true),
     });
 
     const mixBgAndFg = (weight: number) => {
@@ -212,7 +212,7 @@ export const globalVariables = useThemeCache(() => {
         },
     };
 
-    const overlayBg = getColorDependantOnLightness(mainColors.fg, mainColors.fg, 0.5, true);
+    const overlayBg = modifyColorBasedOnLightness(mainColors.fg, mainColors.fg, 0.5, true);
     const overlay = {
         dropShadow: `2px -2px 5px ${toStringColor(overlayBg.fade(0.3))}`,
         border: {

--- a/library/src/scripts/styles/searchBarStyles.ts
+++ b/library/src/scripts/styles/searchBarStyles.ts
@@ -8,7 +8,7 @@ import { formElementsVariables } from "@library/components/forms/formElementStyl
 import { buttonVariables } from "@library/styles/buttonStyles";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { layoutVariables } from "@library/styles/layoutStyles";
-import { borders, debugHelper, toStringColor, unit } from "@library/styles/styleHelpers";
+import { borders, toStringColor, unit } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { vanillaHeaderVariables } from "@library/styles/vanillaHeaderStyles";
 import { calc, important, percent, px } from "csx";
@@ -63,7 +63,6 @@ export const searchBarClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const vars = searchBarVariables();
     const vanillaHeaderVars = vanillaHeaderVariables();
-    const debug = debugHelper("searchBar");
     const buttonVars = buttonVariables();
     const formElementVars = formElementsVariables();
     const mediaQueries = layoutVariables().mediaQueries();
@@ -220,7 +219,7 @@ export const searchBarClasses = useThemeCache(() => {
     });
 
     // Has a search button attached.
-    const compoundValueContainer = style(debug.name("compoundValueContainer"), {
+    const compoundValueContainer = style("compoundValueContainer", {
         borderTopRightRadius: 0,
         borderBottomRightRadius: 0,
     });

--- a/library/src/scripts/styles/searchBarStyles.ts
+++ b/library/src/scripts/styles/searchBarStyles.ts
@@ -97,8 +97,8 @@ export const searchBarClasses = useThemeCache(() => {
                 },
                 "& .searchBar-submitButton": {
                     position: "relative",
-                    borderTopLeftRadius: 0,
-                    borderBottomLeftRadius: 0,
+                    borderTopLeftRadius: important(0),
+                    borderBottomLeftRadius: important(0),
                     marginLeft: -1,
                     minWidth: unit(vars.search.minWidth),
                     flexBasis: unit(vars.search.minWidth),

--- a/library/src/scripts/styles/searchBarStyles.ts
+++ b/library/src/scripts/styles/searchBarStyles.ts
@@ -8,10 +8,11 @@ import { formElementsVariables } from "@library/components/forms/formElementStyl
 import { buttonVariables } from "@library/styles/buttonStyles";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { layoutVariables } from "@library/styles/layoutStyles";
-import { debugHelper, toStringColor, unit } from "@library/styles/styleHelpers";
+import { borders, debugHelper, toStringColor, unit } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { vanillaHeaderVariables } from "@library/styles/vanillaHeaderStyles";
 import { calc, important, percent, px } from "csx";
+import get from "lodash/get";
 
 export const searchBarVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -122,7 +123,7 @@ export const searchBarClasses = useThemeCache(() => {
                                 "&.inputText": {
                                     borderTopRightRadius: 0,
                                     borderBottomRightRadius: 0,
-                                    borderColor: buttonVars.standard.focus.borderColor.toString(),
+                                    ...borders(get(buttonVars.standard, "border")),
                                 },
                             },
                         },

--- a/library/src/scripts/styles/shadowHelpers.ts
+++ b/library/src/scripts/styles/shadowHelpers.ts
@@ -8,6 +8,7 @@ import { useThemeCache } from "@library/styles/styleUtils";
 import { BorderRadiusProperty } from "csstype";
 import { color, ColorHelper } from "csx";
 import { TLength } from "typestyle/lib/types";
+import { borders, IBorderStyles, IDropShadow } from "@library/styles/styleHelpers";
 
 export const shadowHelper = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -59,3 +60,21 @@ export const shadowHelper = useThemeCache(() => {
 
     return { embed, embedHover, dropDown, modal, contrast };
 });
+
+export const shadowOrBorderBasedOnLightness = (
+    referenceColor: ColorHelper,
+    borderStyles: object,
+    shadowStyles: object,
+    flip?: boolean,
+) => {
+    console.log("referenceColor", referenceColor.toHexString());
+    console.log("referenceColor.lightness()", referenceColor.lightness());
+
+    if (referenceColor.lightness() >= 0.5 && !flip) {
+        // Shadow for light colors
+        return shadowStyles;
+    } else {
+        // Border for dark colors
+        return borderStyles;
+    }
+};

--- a/library/src/scripts/styles/shadowHelpers.ts
+++ b/library/src/scripts/styles/shadowHelpers.ts
@@ -67,9 +67,6 @@ export const shadowOrBorderBasedOnLightness = (
     shadowStyles: object,
     flip?: boolean,
 ) => {
-    console.log("referenceColor", referenceColor.toHexString());
-    console.log("referenceColor.lightness()", referenceColor.lightness());
-
     if (referenceColor.lightness() >= 0.5 && !flip) {
         // Shadow for light colors
         return shadowStyles;

--- a/library/src/scripts/styles/splashStyles.ts
+++ b/library/src/scripts/styles/splashStyles.ts
@@ -24,6 +24,7 @@ import { FontWeightProperty, PaddingProperty, TextAlignLastProperty, TextShadowP
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { TLength } from "typestyle/lib/types";
 import get from "lodash/get";
+import { transparentColor } from "@library/styles/buttonStyles";
 
 export const splashVariables = useThemeCache(() => {
     const makeThemeVars = variableFactory("splash");
@@ -206,7 +207,7 @@ export const splashStyles = useThemeCache(() => {
     const buttonBg = get(vars, "searchBar.button.bg", false);
     const buttonFg = get(vars, "searchBar.button.fg", false);
     let hoverBg = get(vars, "searchBar.button.hoverBg", false);
-    if (!hoverBg || buttonBg === "transparent") {
+    if (!hoverBg || buttonBg === transparentColor) {
         hoverBg = buttonFg ? buttonFg.fade(0.2) : buttonBorderColor ? buttonBorderColor.fade(0.2) : undefined;
     }
 

--- a/library/src/scripts/styles/splashStyles.ts
+++ b/library/src/scripts/styles/splashStyles.ts
@@ -11,7 +11,7 @@ import {
     centeredBackgroundProps,
     font,
     getBackgroundImage,
-    getColorDependantOnLightness,
+    modifyColorBasedOnLightness,
     IFont,
     paddings,
     toStringColor,
@@ -79,7 +79,7 @@ export const splashVariables = useThemeCache(() => {
             size: globalVars.fonts.size.title,
             weight: globalVars.fonts.weights.semiBold as FontWeightProperty,
             align: text.align as TextAlignLastProperty,
-            shadow: `0 1px 15px ${getColorDependantOnLightness(text.fg, text.fg, text.shadowMix).fade(
+            shadow: `0 1px 15px ${modifyColorBasedOnLightness(text.fg, text.fg, text.shadowMix).fade(
                 text.shadowOpacity,
             )}` as TextShadowProperty,
         },

--- a/library/src/scripts/styles/splashStyles.ts
+++ b/library/src/scripts/styles/splashStyles.ts
@@ -7,8 +7,10 @@
 import { assetUrl, isAllowedUrl, themeAsset } from "@library/application";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import {
+    backgroundImage,
     centeredBackgroundProps,
     font,
+    getBackgroundImage,
     getColorDependantOnLightness,
     IFont,
     paddings,
@@ -159,16 +161,7 @@ export const splashStyles = useThemeCache(() => {
         backgroundColor: toStringColor(vars.outerBackground.bg),
     });
 
-    let backgroundImage = vars.outerBackground.image;
-    let opacity;
-
-    if (backgroundImage.charAt(0) === "~") {
-        backgroundImage = themeAsset(backgroundImage.substr(1, backgroundImage.length - 1));
-    } else if (!isAllowedUrl(backgroundImage)) {
-        backgroundImage = vars.outerBackground.fallbackImage;
-        opacity = 0.4; // only for default bg
-    }
-
+    const image = getBackgroundImage(vars.outerBackground.image, vars.outerBackground.fallbackImage);
     const outerBackground = style("outerBackground", {
         ...centeredBackgroundProps(),
         display: "block",
@@ -177,9 +170,8 @@ export const splashStyles = useThemeCache(() => {
         left: px(0),
         width: percent(100),
         height: percent(100),
-        backgroundSize: "cover",
-        backgroundImage: url(backgroundImage),
-        opacity,
+        ...backgroundImage(vars.outerBackground),
+        opacity: vars.outerBackground.fallbackImage && image === vars.outerBackground.fallbackImage ? 0.4 : undefined,
     });
 
     const innerContainer = style("innerContainer", {

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -45,8 +45,9 @@ import { TLength } from "typestyle/lib/types";
 import { getThemeVariables } from "@library/theming/ThemeProvider";
 import { isAllowedUrl, themeAsset } from "@library/application";
 import get from "lodash/get";
+import { ColorValues } from "@library/styles/buttonStyles";
 
-export const toStringColor = (colorValue: ColorHelper | "transparent") => {
+export const toStringColor = (colorValue: ColorValues) => {
     if (!colorValue) {
         return undefined;
     } else {
@@ -249,7 +250,7 @@ const spinnerLoaderAnimation = keyframes({
 });
 
 interface ISingleBorderStyle {
-    color?: ColorHelper | "transparent";
+    color?: ColorValues;
     width?: BorderWidthProperty<TLength>;
     style?: BorderStyleProperty;
 }
@@ -599,7 +600,7 @@ export const userSelect = (value: UserSelectProperty = "none", isImportant: bool
 };
 
 export interface IFont {
-    color?: ColorHelper | "transparent";
+    color?: ColorValues;
     size?: FontSizeProperty<TLength>;
     weight?: FontWeightProperty;
     lineHeight?: LineHeightProperty<TLength>;
@@ -612,7 +613,7 @@ export const font = (props: IFont) => {
         return {
             fontSize: get(props, "size") ? unit(props.size) : undefined,
             fontWeight: get(props, "weight") ? (props.weight as FontWeightProperty) : undefined,
-            color: get(props, "color") ? toStringColor(props.color as ColorHelper | "transparent") : undefined,
+            color: get(props, "color") ? toStringColor(props.color as ColorValues) : undefined,
             lineHeight: get(props, "lineHeight") ? unit(props.lineHeight) : undefined,
             textAlign: get(props, "align") ? (props.align as TextAlignLastProperty) : undefined,
             textShadow: get(props, "shadow") ? (props.shadow as TextShadowProperty) : undefined,
@@ -623,7 +624,7 @@ export const font = (props: IFont) => {
 };
 
 export interface IBackgroundImage {
-    color?: ColorHelper | "transparent";
+    color?: ColorValues;
     attachment?: BackgroundAttachmentProperty;
     position?: BackgroundPositionProperty<TLength>;
     repeat?: BackgroundRepeatProperty;

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -186,7 +186,7 @@ export const debugHelper = (componentName: string) => {
  * @param percentage - The amount you want to mix the two colors
  * @param flip - By default we darken light colours and lighten darks, but if you want to get the opposite result, use this param
  */
-export const getColorDependantOnLightness = (
+export const modifyColorBasedOnLightness = (
     referenceColor: ColorHelper,
     colorToModify: ColorHelper,
     weight: number,
@@ -195,7 +195,7 @@ export const getColorDependantOnLightness = (
     if (weight > 1 || weight < 0) {
         throw new Error("mixAmount must be a value between 0 and 1 inclusively.");
     }
-    if (referenceColor.lightness() >= 0.5 || flip) {
+    if (referenceColor.lightness() >= 0.5 && !flip) {
         // Lighten color
         return colorToModify.mix(color("#000"), 1 - weight) as ColorHelper;
     } else {
@@ -255,17 +255,17 @@ interface ISingleBorderStyle {
     style?: BorderStyleProperty;
 }
 
-interface IBorderStyles extends ISingleBorderStyle {
+export interface IBorderStyles extends ISingleBorderStyle {
     radius?: BorderRadiusProperty<TLength>;
 }
 
-export const borders = (styles: IBorderStyles = {}) => {
+export const borders = (props: IBorderStyles = {}) => {
     const vars = globalVariables();
     return {
-        borderColor: styles.color ? styles.color.toString() : toStringColor(vars.border.color),
-        borderWidth: styles.width ? unit(styles.width) : unit(vars.border.width),
-        borderStyle: styles.style ? styles.style : vars.border.style,
-        borderRadius: styles.radius ? unit(styles.radius) : unit(vars.border.radius),
+        borderColor: get(props, "color") ? toStringColor(props.color as any) : toStringColor(vars.border.color),
+        borderWidth: get(props, "width") ? unit(props.width) : unit(vars.border.width),
+        borderStyle: get(props, "style") ? props.style : vars.border.style,
+        borderRadius: get(props, "radius") ? props.radius : vars.border.radius,
     };
 };
 

--- a/library/src/scripts/styles/subcommunityListStyles.ts
+++ b/library/src/scripts/styles/subcommunityListStyles.ts
@@ -4,7 +4,6 @@
  * @license GPL-2.0-only
  */
 
-import { globalVariables } from "@library/styles/globalStyleVars";
 import { layoutVariables } from "@library/styles/layoutStyles";
 import { componentThemeVariables, debugHelper, unit } from "@library/styles/styleHelpers";
 import { useThemeCache } from "@library/styles/styleUtils";
@@ -13,7 +12,6 @@ import { style } from "typestyle";
 
 export const subcommunityListVariables = useThemeCache(() => {
     const themeVars = componentThemeVariables("subcommunityList");
-    const globalVars = globalVariables();
     const spacing = {
         padding: 24,
         ...themeVars.subComponentStyles("spacing"),
@@ -28,7 +26,6 @@ export const subcommunityListVariables = useThemeCache(() => {
 });
 
 export const subcommunityListClasses = useThemeCache(() => {
-    const globalVars = globalVariables();
     const vars = subcommunityListVariables();
     const debug = debugHelper("subcommunityList");
     const mediaQueries = layoutVariables().mediaQueries();

--- a/library/src/scripts/styles/subcommunityTitleStyles.ts
+++ b/library/src/scripts/styles/subcommunityTitleStyles.ts
@@ -5,13 +5,16 @@
  */
 
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { shadowHelper } from "@library/styles/shadowHelpers";
+import { shadowHelper, shadowOrBorderBasedOnLightness } from "@library/styles/shadowHelpers";
 import {
     absolutePosition,
+    borders,
     componentThemeVariables,
     debugHelper,
     defaultTransition,
+    modifyColorBasedOnLightness,
     paddings,
+    toStringColor,
     unit,
     userSelect,
 } from "@library/styles/styleHelpers";
@@ -92,7 +95,6 @@ export const subcommunityTileClasses = useThemeCache(() => {
     });
 
     const link = style({
-        ...shadow.embed(),
         ...defaultTransition("box-shadow"),
         ...paddings(vars.link.padding),
         display: "block",
@@ -100,11 +102,24 @@ export const subcommunityTileClasses = useThemeCache(() => {
         cursor: "pointer",
         flexGrow: 1,
         color: vars.link.fg.toString(),
-        backgroundColor: vars.link.bg.toString(),
+        backgroundColor: toStringColor(vars.link.bg),
         minHeight: unit(vars.link.minHeight),
+        ...shadowOrBorderBasedOnLightness(
+            vars.link.bg,
+            borders({
+                color: vars.link.fg.fade(0.3),
+            }),
+            shadow.embed(vars.link.fg),
+        ),
         $nest: {
             "&:hover": {
-                ...shadow.embedHover(),
+                ...shadowOrBorderBasedOnLightness(
+                    vars.link.bg,
+                    borders({
+                        color: vars.link.fg.fade(0.5),
+                    }),
+                    shadow.embedHover(),
+                ),
             },
         },
         ...debug.name("link"),

--- a/library/src/scripts/styles/vanillaHeaderStyles.ts
+++ b/library/src/scripts/styles/vanillaHeaderStyles.ts
@@ -11,7 +11,7 @@ import {
     componentThemeVariables,
     debugHelper,
     flexHelper,
-    getColorDependantOnLightness,
+    modifyColorBasedOnLightness,
     toStringColor,
     unit,
     userSelect,
@@ -84,17 +84,17 @@ export const vanillaHeaderVariables = useThemeCache(() => {
 
     const buttonContents = makeThemeVars("buttonContents", {
         hover: {
-            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.primary, 0.1, true),
+            bg: modifyColorBasedOnLightness(globalVars.mainColors.fg, globalVars.mainColors.primary, 0.1, true),
         },
         active: {
-            bg: getColorDependantOnLightness(globalVars.mainColors.fg, globalVars.mainColors.primary, 0.2, true),
+            bg: modifyColorBasedOnLightness(globalVars.mainColors.fg, globalVars.mainColors.primary, 0.2, true),
         },
     });
 
     const signIn = makeThemeVars("signIn", {
-        bg: getColorDependantOnLightness(globalVars.mainColors.primary, globalVars.mainColors.primary, 0.1, true),
+        bg: modifyColorBasedOnLightness(globalVars.mainColors.primary, globalVars.mainColors.primary, 0.1, true),
         hover: {
-            bg: getColorDependantOnLightness(globalVars.mainColors.primary, globalVars.mainColors.primary, 0.2, true),
+            bg: modifyColorBasedOnLightness(globalVars.mainColors.primary, globalVars.mainColors.primary, 0.2, true),
         },
     });
 
@@ -396,7 +396,7 @@ export const vanillaHeaderClasses = useThemeCache(() => {
         $nest: {
             ".vanillaHeader-tabButtonContent": {
                 color: vars.colors.fg.toString(),
-                backgroundColor: getColorDependantOnLightness(vars.colors.fg, vars.colors.bg, 1).toString(),
+                backgroundColor: modifyColorBasedOnLightness(vars.colors.fg, vars.colors.bg, 1).toString(),
                 borderRadius: px(vars.button.borderRadius),
             },
         },

--- a/library/src/scripts/styles/widgetStyleVars.ts
+++ b/library/src/scripts/styles/widgetStyleVars.ts
@@ -22,7 +22,7 @@ export const widgetVariables = useThemeCache(() => {
     });
 
     const color = makeThemeVars("color", {
-        bg: "transparent",
+        bg: transparentColor,
         fg: globalVars.mainColors.fg,
     });
 

--- a/library/src/scripts/styles/widgetStyleVars.ts
+++ b/library/src/scripts/styles/widgetStyleVars.ts
@@ -5,6 +5,7 @@
 
 import { useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { globalVariables } from "@library/styles/globalStyleVars";
+import { transparentColor } from "@library/styles/buttonStyles";
 
 export const widgetVariables = useThemeCache(() => {
     const globalVars = globalVariables();


### PR DESCRIPTION
Various improvements for KB styles:

- Refactored several (but not all) instances of debugHelper with styleFactory
- Better handling of color types and transparencies
- Added body color and background options
- Renamed `getColorDependantOnLightness` in favour of `modifyColorBasedOnLightness` for clarity
- Added function `shadowOrBorderBasedOnLightness` to conditionally use a shadow or border based on color value
- Converted Slash styles and hooked up options
- Fixed style helper functions to not get errors if options don't exist in props passed
- Added get background function that checks for fallbacks and prepares image url for styles