### PR TITLE
Fix: Javascript error when interacting with reactions, bookmarks

### DIFF
--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -316,7 +316,7 @@
             $toggleFlyouts.each(function() {
                 $toggle = $(this);
                 var $handle = $(this).find(
-                    ".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)",
+                    ".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)"
                 );
                 var $flyout = $(this).find(".Flyout, .Dropdown");
                 var isOpen = $toggle.hasClass(OPEN_CLASS);


### PR DESCRIPTION
closes [#255](https://github.com/vanilla/support/issues/255)

This was causing an error when reacting in IE 11.