### PR TITLE
Add index to GDN_Comment.Score

### DIFF
--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -212,7 +212,7 @@ $Construct
     ->column('InsertIPAddress', 'ipaddress', true)
     ->column('UpdateIPAddress', 'ipaddress', true)
     ->column('Flag', 'tinyint', 0)
-    ->column('Score', 'float', null)
+    ->column('Score', 'float', null, ['index'])
     ->column('Attributes', 'text', true)
     //->column('Source', 'varchar(20)', true)
     ->set($Explicit, $Drop);


### PR DESCRIPTION
closes [#253](https://github.com/vanilla/support/issues/253)

Details in the referenced ticket.

Score column had no index causing slow queries post deploy.