### PR TITLE
Fix meta tags on default master template

### DIFF
--- a/resources/views/default-master.twig
+++ b/resources/views/default-master.twig
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="{{ locale }}">
     <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{{ title }}</title>
         <meta name="description" content="{{ description }}">
 


### PR DESCRIPTION
Closes https://github.com/vanilla/knowledge/issues/681

There were a few missing meta tags in our default master twig template that was causing issues on mobile browsers.