### PR TITLE
Fix inability to remove embeds in rich posts

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/HistoryModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/HistoryModule.ts
@@ -4,10 +4,10 @@
  * @license GPL-2.0-only
  */
 
-import get from "lodash/get";
-import BaseHistoryModule from "quill/modules/history";
-import { DeltaOperation, DeltaStatic } from "quill/core";
 import { FOCUS_CLASS } from "@library/embeds";
+import { DeltaOperation, DeltaStatic } from "quill/core";
+import BaseHistoryModule from "quill/modules/history";
+import ExternalEmbedBlot from "./blots/embeds/ExternalEmbedBlot";
 
 const SHORTKEY = /Mac/i.test(navigator.platform) ? "metaKey" : "ctrlKey";
 
@@ -16,9 +16,6 @@ const SHORTKEY = /Mac/i.test(navigator.platform) ? "metaKey" : "ctrlKey";
  * and hack around the fact that Quill doesn't have first class support for asynchronusly rendering things.
  */
 export default class HistoryModule extends BaseHistoryModule {
-    private readonly EMBED_KEY = "insert.embed-external";
-    private readonly EMBED_CONFIRM_KEY = "insert.embed-external.loaderData.loaded";
-    private readonly CODE_KEY = "attributes.codeBlock";
     private readonly Z_KEYCODE = 90;
 
     /**
@@ -32,7 +29,95 @@ export default class HistoryModule extends BaseHistoryModule {
         document.addEventListener("keydown", this.undoKeyboardListener, true);
     }
 
-    public undoKeyboardListener = (event: KeyboardEvent) => {
+    private actionIsEmbedCompletion(undoDelta: DeltaStatic, redoDelta: DeltaStatic) {
+        const hasDeleteRecordOfLoadingEmbed = this.operationsContain(redoDelta.ops, this.isEmbedLoadedInsert);
+        const hasAddRecordOfLoadingEmbed = this.operationsContain(undoDelta.ops, this.isEmbedLoadedInsert);
+        return hasDeleteRecordOfLoadingEmbed || hasAddRecordOfLoadingEmbed;
+    }
+
+    /**
+     * Does the operation contain a code-block insert?
+     * @param operation Content operation.
+     */
+    private isCodeBlock = (operation: DeltaOperation | undefined): boolean => {
+        return (
+            typeof operation === "object" &&
+            "attributes" in operation &&
+            typeof operation.attributes === "object" &&
+            "code-block" in operation.attributes &&
+            operation.attributes["code-block"]
+        );
+    };
+
+    /**
+     * Does the operation include an external embed insert?
+     * @param operation Content operation.
+     */
+    private isEmbedInsert = (operation: DeltaOperation | undefined): boolean => {
+        return this.isInsertOperation(operation) && ExternalEmbedBlot.blotName in operation!.insert;
+    };
+
+    /**
+     * Does the operation include a fully-loaded external embed insert?
+     * @param operation Content operation.
+     */
+    private isEmbedLoadedInsert = (operation: DeltaOperation | undefined): boolean => {
+        return this.isEmbedInsert(operation) && "data" in operation!.insert[ExternalEmbedBlot.blotName];
+    };
+
+    /**
+     * Does the operation contain any inserts?
+     * @param operation Content operation.
+     */
+    private isInsertOperation = (operation: DeltaOperation | undefined): boolean => {
+        return typeof operation === "object" && "insert" in operation && typeof operation.insert === "object";
+    };
+
+    /**
+     * Iterate through a list of operations and, using a callback, determine if any contain a match.
+     * @param ops List of change operations.
+     * @param callback Function to check for the presence of a specific type of operation.
+     */
+    private operationsContain(ops: DeltaOperation[] | undefined, callback: (DeltaOperation) => boolean) {
+        if (!ops) {
+            return false;
+        }
+
+        for (const op of ops) {
+            if (callback(op)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Record changes made to the content.
+     * @param changeDelta New operations on the content.
+     * @param oldDelta Previous content state.
+     */
+    public record(changeDelta: DeltaStatic, oldDelta: DeltaStatic) {
+        if (this.operationsContain(changeDelta.ops, this.isEmbedInsert)) {
+            this.cutoff();
+        }
+
+        if (this.operationsContain(changeDelta.ops, this.isCodeBlock)) {
+            this.cutoff();
+        }
+
+        const undoDelta = this.quill.getContents().diff(oldDelta);
+        if (this.actionIsEmbedCompletion(undoDelta, changeDelta)) {
+            return;
+        }
+        super.record(changeDelta, oldDelta);
+    }
+
+    /**
+     * Given a keyboard event, determine if an undo or re-do operation should be performed on the content.
+     * @param event Keyboard input event.
+     */
+    private undoKeyboardListener = (event: KeyboardEvent) => {
         // Quill's Keyboard.match() FAILS to match a shortkey + z for some reason. Just check it ourself.
         if (event.keyCode === this.Z_KEYCODE && event[SHORTKEY]) {
             if (document.activeElement && document.activeElement.classList.contains(FOCUS_CLASS)) {
@@ -44,40 +129,4 @@ export default class HistoryModule extends BaseHistoryModule {
             }
         }
     };
-
-    public record(changeDelta: DeltaStatic, oldDelta: DeltaStatic) {
-        if (this.operationsContainKey(changeDelta.ops, this.EMBED_KEY)) {
-            this.cutoff();
-        }
-
-        if (this.operationsContainKey(changeDelta.ops, this.CODE_KEY)) {
-            this.cutoff();
-        }
-
-        const undoDelta = this.quill.getContents().diff(oldDelta);
-        if (this.actionIsEmbedCompletion(undoDelta, changeDelta)) {
-            return;
-        }
-        super.record(changeDelta, oldDelta);
-    }
-
-    public actionIsEmbedCompletion(undoDelta: DeltaStatic, redoDelta: DeltaStatic) {
-        const hasDeleteRecordOfLoadingEmbed = this.operationsContainKey(redoDelta.ops, this.EMBED_CONFIRM_KEY);
-        const hasAddRecordOfLoadingEmbed = this.operationsContainKey(undoDelta.ops, this.EMBED_CONFIRM_KEY);
-        return hasDeleteRecordOfLoadingEmbed || hasAddRecordOfLoadingEmbed;
-    }
-
-    private operationsContainKey(ops: DeltaOperation[] | undefined, key: string) {
-        if (!ops) {
-            return false;
-        }
-
-        for (const op of ops) {
-            if (get(op, key, false)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }

--- a/plugins/rich-editor/src/scripts/quill/HistoryModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/HistoryModule.ts
@@ -106,7 +106,7 @@ export default class HistoryModule extends BaseHistoryModule {
         }
 
         if (this.operationsContain(changeDelta.ops, this.isCodeBlock)) {
-            // Avoid merging several changes as single undo/redo if a code block was added.
+            // Avoid merging preceding changes as single undo/redo when a code block is added.
             this.cutoff();
         }
 

--- a/plugins/rich-editor/src/scripts/quill/HistoryModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/HistoryModule.ts
@@ -6,10 +6,9 @@
 
 import { FOCUS_CLASS } from "@library/embeds";
 import { DeltaOperation, DeltaStatic } from "quill/core";
+import CodeBlock from "quill/formats/code";
 import BaseHistoryModule from "quill/modules/history";
 import ExternalEmbedBlot from "./blots/embeds/ExternalEmbedBlot";
-import CodeBlock from "quill/formats/code";
-import { delay } from "bluebird";
 
 const SHORTKEY = /Mac/i.test(navigator.platform) ? "metaKey" : "ctrlKey";
 

--- a/plugins/rich-editor/src/scripts/quill/blots/embeds/ExternalEmbedBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/embeds/ExternalEmbedBlot.ts
@@ -188,6 +188,11 @@ export default class ExternalEmbedBlot extends FocusableEmbedBlot {
 
         resolvedPromise
             .then(data => {
+                // DOM node has been removed from the document.
+                if (!document.contains(this.domNode)) {
+                    return;
+                }
+
                 const newValue: IEmbedValue = {
                     data,
                     loaderData: value.loaderData,
@@ -201,6 +206,10 @@ export default class ExternalEmbedBlot extends FocusableEmbedBlot {
             })
             .catch(e => {
                 logError(e);
+                // DOM node has been removed from the document.
+                if (!document.contains(this.domNode)) {
+                    return;
+                }
                 const errorData: IErrorData = {
                     error: e,
                     type: value.loaderData.type === "file" ? ErrorBlotType.FILE : ErrorBlotType.STANDARD,


### PR DESCRIPTION
Embeds created in a rich post were previously difficult to remove. You could _delete_ them, but not _undo_ them. This seems to have been caused by some refactoring.

### Overview

1. Fix checking for invalid key when determining if a blot is a "loaded" embed. Previously, the history module was checking for the presence of a `loaderData.loaded` property in an embed.  This property does not exist. An embed blot can be considered "loaded" if it has a populated `data` attribute. The check has been updated to reflect this.
1. Fix embed blot attempting to convert from loader to full embed when the embed's DOM node is no longer available.  When an embed is inserted, it is added in its "loading" state while the content is being fetched. If the embed is deleted before the content finishes fetching (i.e. the promise resolves), the content should not attempt to load.
1. Refactor `HistoryModule`. The `get` function has been dropped in favor of more type-specific comparisons. Unused imports and constants have been removed as part of this. Method visibility has been lowered, where possible.

### Testing

- [x] Create an embed. Wait for it to fully load. Undo it. Redo it. The embed should be removed and re-added.
- [x] Create an embed. Cause an error in its loading (e.g. go offline). Undo it. Redo it. The error should be removed when you undo. It should not reappear when you attempt to redo.
- [x] Create an embed. Undo it, before it can fully load (may need to throttle your connection). The embed should not reappear on its own. Redo the embed. It should reappear, either in its loading state or its loaded state, depending on if the content request has completed.
- [x] Create an embed. Do not wait for it to fully load (may need to throttle your connection). Type some additional content. Once the embed loads, attempt to undo everything up-to-and-including the embed. The content should be removed in the order you added it (i.e. the embed shouldn't be the first thing to be removed after it loads).

Closes #7526 