### PR TITLE
Fix various style issues

### DIFF
--- a/library/src/scripts/styles/bodyStyles.ts
+++ b/library/src/scripts/styles/bodyStyles.ts
@@ -3,17 +3,16 @@
  * @license GPL-2.0-only
  */
 
-import { backgroundImage, colorOut } from "@library/styles/styleHelpers";
+import { background, colorOut } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { cssRule } from "typestyle";
 import { globalVariables } from "@library/styles/globalStyleVars";
-import get from "lodash/get";
 import { percent, viewHeight } from "csx";
 
 export const bodyCSS = useThemeCache(() => {
     const globalVars = globalVariables();
     cssRule("html, body", {
-        backgroundColor: colorOut(globalVars.body.bg),
+        backgroundColor: colorOut(globalVars.body.backgroundImage.color),
         color: colorOut(globalVars.mainColors.fg),
     });
 });
@@ -21,17 +20,18 @@ export const bodyCSS = useThemeCache(() => {
 export const bodyClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const style = styleFactory("fullBackground");
-    const image = get(globalVars, "body.backgroundImage", undefined);
-    const root = style({
-        display: !image ? "none" : "block",
-        ...backgroundImage(image),
-        backgroundColor: colorOut(globalVars.body.bg),
-        position: "fixed",
-        top: 0,
-        left: 0,
-        width: percent(100),
-        height: viewHeight(100),
-    });
+    const image = globalVars.body.backgroundImage;
+    const root = style(
+        {
+            display: !image ? "none" : "block",
+            position: "fixed",
+            top: 0,
+            left: 0,
+            width: percent(100),
+            height: viewHeight(100),
+        },
+        background(image),
+    );
 
     return { root };
 });

--- a/library/src/scripts/styles/compactSearchStyles.ts
+++ b/library/src/scripts/styles/compactSearchStyles.ts
@@ -5,11 +5,12 @@
  */
 
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { unit } from "@library/styles/styleHelpers";
+import { unit, colorOut } from "@library/styles/styleHelpers";
 import { formElementsVariables } from "@library/components/forms/formElementStyles";
 import { vanillaHeaderVariables } from "@library/styles/vanillaHeaderStyles";
 import { percent, px } from "csx";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
+import { searchBarVariables } from "@library/styles/searchBarStyles";
 
 export const compactSearchClasses = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -23,12 +24,15 @@ export const compactSearchClasses = useThemeCache(() => {
                 flexGrow: 1,
             },
             ".searchBar-valueContainer.suggestedTextInput-inputText": {
-                height: unit(formElementVars.sizing.height),
-                backgroundColor: vanillaHeaderVars.colors.bg.darken(0.05).toString(),
+                height: unit(searchBarVariables().sizing.height),
+                backgroundColor: colorOut(vanillaHeaderVars.colors.bg.darken(0.05)),
                 border: 0,
             },
             ".searchBar__placeholder": {
                 color: globalVars.mainColors.bg.toString(),
+            },
+            ".searchBar-icon": {
+                color: colorOut(vanillaHeaderVars.colors.fg),
             },
             ".searchBar__control": {
                 opacity: 0.8,

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -19,6 +19,7 @@ export const globalVariables = useThemeCache(() => {
 
     const elementaryColors = {
         black: color("#000"),
+        grey: color("#555a62"),
         white: color("#fff"),
         transparent: `transparent`,
     };

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -208,7 +208,7 @@ export const globalVariables = useThemeCache(() => {
             opacity: 0.75,
         },
         hover: {
-            color: mixPrimaryAndBg(0.2),
+            color: mixPrimaryAndBg(0.08),
             opacity: 1,
         },
         selected: {
@@ -216,11 +216,11 @@ export const globalVariables = useThemeCache(() => {
             opacity: 1,
         },
         active: {
-            color: mixPrimaryAndBg(0.22),
+            color: mixPrimaryAndBg(0.2),
             opacity: 1,
         },
         focus: {
-            color: mixPrimaryAndBg(0.21),
+            color: mixPrimaryAndBg(0.15),
             opacity: 1,
         },
     });

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import { modifyColorBasedOnLightness, colorOut } from "@library/styles/styleHelpers";
+import { modifyColorBasedOnLightness, colorOut, IBackground } from "@library/styles/styleHelpers";
 import { useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { color, ColorHelper, percent, viewHeight } from "csx";
 
@@ -66,8 +66,14 @@ export const globalVariables = useThemeCache(() => {
         },
     });
 
-    const body = makeThemeVars("body", {
-        bg: mainColors.bg,
+    interface IBody {
+        backgroundImage: IBackground;
+    }
+
+    const body: IBody = makeThemeVars("body", {
+        backgroundImage: {
+            color: mainColors.bg,
+        },
     });
 
     const border = makeThemeVars("border", {

--- a/library/src/scripts/styles/shadowHelpers.ts
+++ b/library/src/scripts/styles/shadowHelpers.ts
@@ -13,26 +13,27 @@ import { ColorValues } from "@library/styles/buttonStyles";
 
 export const shadowHelper = useThemeCache(() => {
     const globalVars = globalVariables();
+    const shadowBaseColor = globalVars.elementaryColors.grey;
 
-    const embed = (baseColor: ColorHelper = globalVars.elementaryColors.black) => {
+    const embed = (baseColor: ColorHelper = shadowBaseColor) => {
         return {
             boxShadow: `0 1px 3px 0 ${baseColor.fade(0.3)}`,
         };
     };
 
-    const embedHover = (baseColor: ColorHelper = globalVars.elementaryColors.black) => {
+    const embedHover = (baseColor: ColorHelper = shadowBaseColor) => {
         return {
-            boxShadow: `0 1px 3px 0 ${baseColor.fade(0.7)}`,
+            boxShadow: `0 1px 3px 0 ${baseColor.fade(0.5)}`,
         };
     };
 
-    const dropDown = (baseColor: ColorHelper = color("#000")) => {
+    const dropDown = (baseColor: ColorHelper = shadowBaseColor) => {
         return {
             boxShadow: `0 5px 10px 0 ${baseColor.fade(0.3)}`,
         };
     };
 
-    const modal = (baseColor: ColorHelper = color("#000")) => {
+    const modal = (baseColor: ColorHelper = shadowBaseColor) => {
         return {
             boxShadow: `0 5px 20px ${baseColor.fade(0.5)}`,
         };

--- a/library/src/scripts/styles/shadowHelpers.ts
+++ b/library/src/scripts/styles/shadowHelpers.ts
@@ -5,10 +5,11 @@
 
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { useThemeCache } from "@library/styles/styleUtils";
-import { BorderRadiusProperty } from "csstype";
+import { BorderRadiusProperty, Color } from "csstype";
 import { color, ColorHelper } from "csx";
 import { TLength } from "typestyle/lib/types";
 import { borders, IBorderStyles, IDropShadow } from "@library/styles/styleHelpers";
+import { ColorValues } from "@library/styles/buttonStyles";
 
 export const shadowHelper = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -62,12 +63,12 @@ export const shadowHelper = useThemeCache(() => {
 });
 
 export const shadowOrBorderBasedOnLightness = (
-    referenceColor: ColorHelper,
+    referenceColor: ColorValues,
     borderStyles: object,
     shadowStyles: object,
     flip?: boolean,
 ) => {
-    if (referenceColor.lightness() >= 0.5 && !flip) {
+    if (referenceColor instanceof ColorHelper && referenceColor.lightness() >= 0.5 && !flip) {
         // Shadow for light colors
         return shadowStyles;
     } else {

--- a/library/src/scripts/styles/shadowHelpers.ts
+++ b/library/src/scripts/styles/shadowHelpers.ts
@@ -3,13 +3,12 @@
  * @license GPL-2.0-only
  */
 
+import { ColorValues } from "@library/styles/buttonStyles";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { useThemeCache } from "@library/styles/styleUtils";
-import { BorderRadiusProperty, Color } from "csstype";
-import { color, ColorHelper } from "csx";
+import { BorderRadiusProperty } from "csstype";
+import { ColorHelper } from "csx";
 import { TLength } from "typestyle/lib/types";
-import { borders, IBorderStyles, IDropShadow } from "@library/styles/styleHelpers";
-import { ColorValues } from "@library/styles/buttonStyles";
 
 export const shadowHelper = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -23,7 +22,7 @@ export const shadowHelper = useThemeCache(() => {
 
     const embedHover = (baseColor: ColorHelper = shadowBaseColor) => {
         return {
-            boxShadow: `0 1px 3px 0 ${baseColor.fade(0.5)}`,
+            boxShadow: `0 1px 3px 0 ${baseColor.fade(0.3)}, 0 2px 4px 0 ${baseColor.darken(0.5).fade(0.22)}`,
         };
     };
 

--- a/library/src/scripts/styles/splashStyles.ts
+++ b/library/src/scripts/styles/splashStyles.ts
@@ -7,7 +7,7 @@
 import { assetUrl, isAllowedUrl, themeAsset } from "@library/application";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import {
-    backgroundImage,
+    background,
     centeredBackgroundProps,
     font,
     getBackgroundImage,
@@ -16,6 +16,7 @@ import {
     paddings,
     colorOut,
     unit,
+    IBackground,
 } from "@library/styles/styleHelpers";
 import { useThemeCache, styleFactory, variableFactory } from "@library/styles/styleUtils";
 import { percent, px, url } from "csx";
@@ -46,8 +47,8 @@ export const splashVariables = useThemeCache(() => {
         },
     });
 
-    const outerBackground = makeThemeVars("outerBackground", {
-        bg: globalVars.mainColors.primary,
+    const outerBackground: IBackground = makeThemeVars("outerBackground", {
+        color: globalVars.mainColors.primary,
         backgroundPosition: "50% 50%",
         backgroundSize: "cover",
         image: assetUrl("/resources/design/fallbackSplashBackground.svg"),
@@ -159,7 +160,7 @@ export const splashStyles = useThemeCache(() => {
 
     const root = style({
         position: "relative",
-        backgroundColor: colorOut(vars.outerBackground.bg),
+        backgroundColor: colorOut(vars.outerBackground.color),
     });
 
     const image = getBackgroundImage(vars.outerBackground.image, vars.outerBackground.fallbackImage);
@@ -171,7 +172,7 @@ export const splashStyles = useThemeCache(() => {
         left: px(0),
         width: percent(100),
         height: percent(100),
-        ...backgroundImage(vars.outerBackground),
+        ...background(vars.outerBackground),
         opacity: vars.outerBackground.fallbackImage && image === vars.outerBackground.fallbackImage ? 0.4 : undefined,
     });
 

--- a/library/src/scripts/styles/subcommunityTitleStyles.ts
+++ b/library/src/scripts/styles/subcommunityTitleStyles.ts
@@ -104,6 +104,7 @@ export const subcommunityTileClasses = useThemeCache(() => {
         flexGrow: 1,
         color: vars.link.fg.toString(),
         backgroundColor: colorOut(vars.link.bg),
+        borderRadius: unit(2),
         minHeight: unit(vars.link.minHeight),
         ...shadowOrBorderBasedOnLightness(
             globalVars.body.backgroundImage.color,

--- a/library/src/scripts/styles/subcommunityTitleStyles.ts
+++ b/library/src/scripts/styles/subcommunityTitleStyles.ts
@@ -106,7 +106,7 @@ export const subcommunityTileClasses = useThemeCache(() => {
         backgroundColor: colorOut(vars.link.bg),
         minHeight: unit(vars.link.minHeight),
         ...shadowOrBorderBasedOnLightness(
-            globalVars.body.bg,
+            globalVars.body.backgroundImage.color,
             borders({
                 color: vars.link.fg.fade(0.3),
             }),
@@ -115,7 +115,7 @@ export const subcommunityTileClasses = useThemeCache(() => {
         $nest: {
             "&:hover": {
                 ...shadowOrBorderBasedOnLightness(
-                    globalVars.body.bg,
+                    globalVars.body.backgroundImage.color,
                     borders({
                         color: vars.link.fg.fade(0.5),
                     }),


### PR DESCRIPTION
- Fixes some incorrect assertions were being made about the what properties were available that were masked by a `get` call.
- Fixes the `background` and `getBackgroundImage` utility functions so that they return the proper image.
- Fixes shadow utilities to align with mockups.
- Fixes active/focus states calculation to align with mockups using default colours.
- Fix alignment and colour of the VanillaHeader search bar "search" icon.