### PR TITLE
Add tests for SiteNav

### DIFF
--- a/library/src/scripts/components/navigation/LinkContextProvider.tsx
+++ b/library/src/scripts/components/navigation/LinkContextProvider.tsx
@@ -19,15 +19,13 @@ export interface IWithLinkContext {
 export const LinkContext = React.createContext<IWithLinkContext>({
     linkContext: "https://testSite.com",
     pushSmartLocation: () => {
-        throw new Error("Be sure to declare the <LinkContextProvider />");
-        return {} as any;
+        return;
     },
     isDynamicNavigation: () => {
-        throw new Error("Be sure to declare the <LinkContextProvider />");
         return false;
     },
     makeHref: () => {
-        throw new Error("Be sure to declare the <LinkContextProvider />");
+        return "/";
     },
 });
 

--- a/library/src/scripts/components/siteNav/SiteNav.test.tsx
+++ b/library/src/scripts/components/siteNav/SiteNav.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { INavigationTreeItem } from "@library/@types/api";
+import SiteNav from "@library/components/siteNav/SiteNav";
+import { expect } from "chai";
+import { mount } from "enzyme";
+import React, { ReactNode } from "react";
+import SiteNavNode, { IActiveRecord } from "./SiteNavNode";
+
+function renderSiteNav(activeRecord: IActiveRecord) {
+    return mount(
+        <SiteNav activeRecord={activeRecord} bottomCTA={null} collapsible={true}>
+            {naviationItems}
+        </SiteNav>,
+        { attachTo: document.body },
+    );
+}
+
+describe("<SiteNav />", () => {
+    it("initializes with a valid active record.", () => {
+        const activeRecord = {
+            recordID: 6,
+            recordType: "item",
+        };
+
+        const siteNav = renderSiteNav(activeRecord);
+        expect(siteNav.find(".isCurrent")).to.have.lengthOf(1);
+
+        const siteNavNode = siteNav
+            .find(".isCurrent")
+            .first()
+            .parents(SiteNavNode)
+            .first();
+        expect(siteNavNode.props()).to.have.property("recordID", activeRecord.recordID);
+        expect(siteNavNode.props()).to.have.property("recordType", activeRecord.recordType);
+    });
+
+    it("initializes with an invalid active record.", () => {
+        const activeRecord = {
+            recordID: 999,
+            recordType: "item",
+        };
+
+        const siteNav = renderSiteNav(activeRecord);
+        expect(siteNav.find(".isCurrent")).to.have.lengthOf(0);
+    });
+
+    it("changes the active record.", () => {
+        const firstActiveRecord = {
+            recordID: 6,
+            recordType: "item",
+        };
+        const secondActiveRecord = {
+            recordID: 2,
+            recordType: "item",
+        };
+
+        const siteNav = renderSiteNav(firstActiveRecord);
+        expect(siteNav.find(".isCurrent")).to.have.lengthOf(1);
+
+        const firstSiteNavNode = siteNav
+            .find(".isCurrent")
+            .first()
+            .parents(SiteNavNode)
+            .first();
+        expect(firstSiteNavNode.props()).to.have.property("recordID", firstActiveRecord.recordID);
+        expect(firstSiteNavNode.props()).to.have.property("recordType", firstActiveRecord.recordType);
+
+        siteNav.setProps({ activeRecord: secondActiveRecord });
+        expect(siteNav.find(".isCurrent")).to.have.lengthOf(1);
+
+        const secondSiteNavNode = siteNav
+            .find(".isCurrent")
+            .first()
+            .parents(SiteNavNode)
+            .first();
+        expect(secondSiteNavNode.props()).to.have.property("recordID", secondActiveRecord.recordID);
+        expect(secondSiteNavNode.props()).to.have.property("recordType", secondActiveRecord.recordType);
+    });
+});
+
+// Mock navigation data.
+const naviationItems: INavigationTreeItem[] = [
+    {
+        name: "Parent A",
+        url: "https://mysite.com/items/parent-a",
+        parentID: -1,
+        recordID: 1,
+        sort: null,
+        recordType: "item",
+        children: [
+            {
+                name: "Child A-1",
+                url: "https://mysite.com/items/child-a-1",
+                parentID: 1,
+                recordID: 4,
+                sort: null,
+                recordType: "item",
+                children: [],
+            },
+            {
+                name: "Child A-2",
+                url: "https://mysite.com/items/child-a-2",
+                parentID: 1,
+                recordID: 5,
+                sort: null,
+                recordType: "item",
+                children: [],
+            },
+            {
+                name: "Child A-3",
+                url: "https://mysite.com/items/child-a-3",
+                parentID: 1,
+                recordID: 6,
+                sort: null,
+                recordType: "item",
+                children: [],
+            },
+        ],
+    },
+    {
+        name: "Parent B",
+        url: "https://mysite.com/items/parent-b",
+        parentID: -1,
+        recordID: 2,
+        sort: null,
+        recordType: "item",
+        children: [],
+    },
+    {
+        name: "Parent C",
+        url: "https://mysite.com/items/parent-c",
+        parentID: -1,
+        recordID: 3,
+        sort: null,
+        recordType: "item",
+        children: [],
+    },
+];

--- a/library/src/scripts/components/siteNav/SiteNav.tsx
+++ b/library/src/scripts/components/siteNav/SiteNav.tsx
@@ -17,7 +17,7 @@ import Heading from "@library/components/Heading";
 import ConditionalWrap from "@library/components/ConditionalWrap";
 import { siteNavClasses } from "@library/styles/siteNavStyles";
 
-interface IProps extends RouteComponentProps<{}> {
+interface IProps {
     activeRecord: IActiveRecord;
     id?: string;
     className?: string;
@@ -190,4 +190,4 @@ export class SiteNav extends React.Component<IProps> {
     };
 }
 
-export default withRouter<IProps>(SiteNav);
+export default SiteNav;

--- a/library/src/scripts/components/siteNav/SiteNavContext.tsx
+++ b/library/src/scripts/components/siteNav/SiteNavContext.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react";
-import { logError } from "@library/utility";
+import { logWarning } from "@library/utility";
 
 type RecordToggle = (recordType: string, recordID: number) => void;
 
@@ -18,7 +18,7 @@ interface ISiteNavCtx {
 }
 
 const noop = () => {
-    logError("It looks like you forgot to initialize your SiteNavContext. Be sure to use `<SiteNavProvider />`");
+    logWarning("It looks like you forgot to initialize your SiteNavContext. Be sure to use `<SiteNavProvider />`");
 };
 
 const defaultContext: ISiteNavCtx = {

--- a/library/src/scripts/utility.ts
+++ b/library/src/scripts/utility.ts
@@ -94,6 +94,9 @@ export function log(...value: any[]) {
  * @param value - The value to log.
  */
 export function logError(...value: any[]) {
+    if (!_debug && process.env.NODE_ENV === "test") {
+        return;
+    }
     // tslint:disable-next-line:no-console
     console.error(...value);
 }
@@ -104,6 +107,9 @@ export function logError(...value: any[]) {
  * @param value - The value to log.
  */
 export function logWarning(...value: any[]) {
+    if (!_debug && process.env.NODE_ENV === "test") {
+        return;
+    }
     // tslint:disable-next-line:no-console
     console.warn(...value);
 }


### PR DESCRIPTION
This update adds some basic tests for `SiteNav`, in addition to introducing some changes to make those tests easier to write.

### Overview
1. Add test for initializing `SiteNav` with a valid active record.
1. Add test for initializing `SiteNav` with an invalid record.
1. Add test for changing the record on an existing instance of `SiteNav`.
1. Fix `SiteNav` requiring the application router. This was unnecessary.
1. Fix default configuration of `LinkContextProvider` throwing unnecessary fatal errors.

Closes #8104