### PR TITLE
Fix Rich Editor crashing on page load

### DIFF
--- a/library/src/scripts/theming/ThemeProvider.tsx
+++ b/library/src/scripts/theming/ThemeProvider.tsx
@@ -5,6 +5,7 @@
 
 import { LoadStatus } from "@library/@types/api";
 import apiv2 from "@library/apiv2";
+import { onReady } from "@library/application";
 import Backgrounds from "@library/components/body/Backgrounds";
 import { inputClasses } from "@library/components/forms/inputStyles";
 import Loader from "@library/components/Loader";
@@ -15,6 +16,13 @@ import ThemeActions from "@library/theming/ThemeActions";
 import { IThemeVariables } from "@library/theming/themeReducer";
 import React from "react";
 import { connect } from "react-redux";
+import { Store } from "redux";
+
+let store: Store | null = null;
+
+onReady(() => {
+    store = getStore<ICoreStoreState>();
+});
 
 export interface IWithThemeProps {
     theme: IThemeVariables;
@@ -62,10 +70,13 @@ class BaseThemeProvider extends React.Component<IProps> {
 }
 
 export function getThemeVariables() {
-    const store = getStore<ICoreStoreState>();
-    const assets = store.getState().theme.assets.data || {};
-    const variables = assets.variables || {};
-    return variables;
+    if (store !== null) {
+        const assets = store.getState().theme.assets.data || {};
+        const variables = assets.variables || {};
+        return variables;
+    } else {
+        return {};
+    }
 }
 
 interface IOwnProps {

--- a/plugins/rich-editor/src/scripts/entries/forum.ts
+++ b/plugins/rich-editor/src/scripts/entries/forum.ts
@@ -8,8 +8,8 @@ import editorReducer from "@rich-editor/state/editorReducer";
 import { registerReducer } from "@library/state/reducerRegistry";
 import { onReady, onContent } from "@library/application";
 
+registerReducer("editor", editorReducer);
 onReady(() => {
-    registerReducer("editor", editorReducer);
     void setupEditor();
 });
 onContent(setupEditor);


### PR DESCRIPTION
There exists the potential for Rich Editor to "crash" when loading for a discussion or comment. This is caused by `ThemeProvider` attempting to get the store before it's been properly initialized.

This update delays attempting to grab the store in `ThemeProvider` until after it's had a chance to fully initialize. After this fix was implemented, it became apparent Rich Editor was attempting to register its reducer too late, so that was also addressed here.

Closes #8530