### PR TITLE
Fix regression disabling of categories

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -565,8 +565,8 @@ class Gdn_Form extends Gdn_Pluggable {
         if (is_array($safeCategoryData)) {
             foreach ($safeCategoryData as $categoryID => $category) {
                 $depth = val('Depth', $category, 0);
-                $isHeading = ($depth == 1 && $doHeadings) || val('DisplayAs', $category) !== 'Discussions';
-                $disabled = ($isHeading && !$enableHeadings) && !$category['AllowDiscussions'];
+                $isHeading = ($depth == 1 && $doHeadings) || $category['DisplayAs'] !== 'Discussions' || !$category['AllowDiscussions'];
+                $disabled = $isHeading && !$enableHeadings ;
                 $selected = in_array($categoryID, $value) && $hasValue;
                 if ($forceCleanSelection && $depth > 1) {
                     $selected = true;

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -565,8 +565,8 @@ class Gdn_Form extends Gdn_Pluggable {
         if (is_array($safeCategoryData)) {
             foreach ($safeCategoryData as $categoryID => $category) {
                 $depth = val('Depth', $category, 0);
-                $isHeading = ($depth == 1 && $doHeadings) || val('DisplayAs', $category) === 'Heading';
-                $disabled = ($isHeading && !$enableHeadings) && (!$category['AllowDiscussions'] || val('DisplayAs', $category) != 'Discussions');
+                $isHeading = ($depth == 1 && $doHeadings) || val('DisplayAs', $category) !== 'Discussions';
+                $disabled = ($isHeading && !$enableHeadings) && !$category['AllowDiscussions'];
                 $selected = in_array($categoryID, $value) && $hasValue;
                 if ($forceCleanSelection && $depth > 1) {
                     $selected = true;

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -566,7 +566,7 @@ class Gdn_Form extends Gdn_Pluggable {
             foreach ($safeCategoryData as $categoryID => $category) {
                 $depth = val('Depth', $category, 0);
                 $isHeading = ($depth == 1 && $doHeadings) || $category['DisplayAs'] !== 'Discussions' || !$category['AllowDiscussions'];
-                $disabled = $isHeading && !$enableHeadings ;
+                $disabled = $isHeading && !$enableHeadings;
                 $selected = in_array($categoryID, $value) && $hasValue;
                 if ($forceCleanSelection && $depth > 1) {
                     $selected = true;


### PR DESCRIPTION
I bungled another #8448 which resulted in enabled nested/flat categories in the post discussion dropdown. I'm assigning two senior reviewers to bail me out here.

Closes vanilla/support#259