### PR TITLE
Fix filterer regression and add test case

### DIFF
--- a/library/Vanilla/Formatting/Quill/Filterer.php
+++ b/library/Vanilla/Formatting/Quill/Filterer.php
@@ -26,7 +26,7 @@ class Filterer {
     public function filter(string $content): string {
         $operations = Parser::jsonToOperations($content);
         // Re-encode the value to escape unicode values.
-        $this->stripUselessEmbedData($operations);
+        $operations = $this->stripUselessEmbedData($operations);
         $operations = json_encode($operations);
         return $operations;
     }
@@ -40,7 +40,7 @@ class Filterer {
      *
      * @param array[] $operations The quill operations to loop through.
      */
-    private function stripUselessEmbedData(array &$operations) {
+    private function stripUselessEmbedData(array &$operations): array {
         foreach ($operations as $key => $op) {
             // If a dataPromise is still stored on the embed, that means it never loaded properly on the client.
             $dataPromise = $op['insert']['embed-external']['dataPromise'] ?? null;
@@ -64,6 +64,6 @@ class Filterer {
             }
         }
 
-        sort($operations);
+        return array_values($operations);
     }
 }

--- a/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
@@ -31,6 +31,10 @@ class FiltererTest extends TestCase {
         $filterer = new Filterer();
 
         $filteredOutput = $filterer->filter($input);
+
+        // Normalize inputted & outputter JSON
+        $output = json_encode(json_decode($output));
+        $filteredOutput = json_encode(json_decode($filteredOutput));
         $this->assertEquals($output, $filteredOutput);
     }
 
@@ -63,6 +67,41 @@ class FiltererTest extends TestCase {
    }
 JSON;
 
+        $codeBlock = <<<JSON
+[
+    {
+        "insert": ".TestClass {"
+    },
+    {
+        "attributes": {
+            "code-block": true
+        },
+        "insert": "\\n"
+    },
+    {
+        "insert": "   height: 24px"
+    },
+    {
+        "attributes": {
+            "code-block": true
+        },
+        "insert": "\\n"
+    },
+    {
+        "insert": "}"
+    },
+    {
+        "attributes": {
+            "code-block": true
+        },
+        "insert": "\\n"
+    },
+    {
+        "insert": "\\n"
+    }
+]
+JSON;
+
         return [
             [
                 "[$loadingEmbed, {\"insert\":\"\\n\"}]",
@@ -75,6 +114,11 @@ JSON;
             [
                 "[{\"insert\":\"Just a normal post\"}, {\"insert\":\"nothing special here\"}]",
                 "[{\"insert\":\"Just a normal post\"},{\"insert\":\"nothing special here\"}]"
+            ],
+            [
+                // This shouldn't be altered at all.
+                $codeBlock,
+                $codeBlock,
             ]
         ];
     }


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8539

https://github.com/vanilla/vanilla/pull/8492 fixed a pretty nasty bug, but created a regression by using `sort` to ensure that we had an indexed array instead of using `array_values`.

I've fixed that and added a test case covering code blocks which were an example of what was being broken by this `sort`.