### PR TITLE
Fix duplicate users from In this discussion module

### DIFF
--- a/plugins/VanillaInThisDiscussion/class.inthisdiscussionmodule.php
+++ b/plugins/VanillaInThisDiscussion/class.inthisdiscussionmodule.php
@@ -40,8 +40,8 @@ class InThisDiscussionModule extends Gdn_Module {
             ->from('User u')
             ->join('Comment c', 'u.UserID = c.InsertUserID')
             ->where('c.DiscussionID', $discussionID)
-            ->groupBy('u.UserID, u.Name, u.Photo, c.DateInserted')
-            ->orderBy('c.DateInserted', 'desc')
+            ->groupBy('u.UserID, u.Name, u.Photo')
+            ->orderBy('DateLastActive', 'desc')
             ->limit($limit)
             ->get();
     }

--- a/plugins/VanillaInThisDiscussion/class.inthisdiscussionmodule.php
+++ b/plugins/VanillaInThisDiscussion/class.inthisdiscussionmodule.php
@@ -26,11 +26,10 @@ class InThisDiscussionModule extends Gdn_Module {
     }
 
     /**
+     * Fetch every unique user from the discussion in the order they first posted.
      *
-     *
-     * @param $discussionID
-     * @param int $limit
-     * @throws Exception
+     * @param int $discussionID The discussion ID to fetch.
+     * @param int $limit The max number of users to fetch.
      */
     public function getData($discussionID, $limit = 50) {
         $sQL = Gdn::sql();


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/8394 introduced a bug where suers

I approved the PR not realizing that these items were meant to be unique. The fix was to remove that unnecessary piece in the `GROUP BY` and use the aggregate selected value `DateLastActive` for the `ORDER BY`.

I updated the function doc block too.