### PR TITLE
Fix toolbar positioning in rich editor

### DIFF
--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -18,7 +18,7 @@ import {
     unit,
     userSelect,
 } from "@library/styles/styleHelpers";
-import { TLength } from "typestyle/lib/types";
+import { TLength, NestedCSSProperties } from "typestyle/lib/types";
 import { componentThemeVariables, styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { formElementsVariables } from "@library/forms/formElementStyles";
 import { ColorHelper, important, percent, px } from "csx";
@@ -329,6 +329,16 @@ export const buttonSizing = (height, minWidth, fontSize, paddingHorizontal, form
     };
 };
 
+export const buttonResetMixin = (): NestedCSSProperties => ({
+    "-webkit-appearance": "none",
+    appearance: "none",
+    border: 0,
+    background: "none",
+    cursor: "pointer",
+    color: "inherit",
+    font: "inherit",
+});
+
 export const generateButtonClass = (buttonTypeVars: IButtonType, buttonName: string, setZIndexOnState = false) => {
     const globalVars = globalVariables();
     const formElVars = formElementsVariables();
@@ -337,7 +347,7 @@ export const generateButtonClass = (buttonTypeVars: IButtonType, buttonName: str
     const zIndex = setZIndexOnState ? 1 : undefined;
     const buttonDimensions = buttonTypeVars.sizing || false;
 
-    return style({
+    return style(buttonResetMixin(), {
         ...defaultTransition("border"),
         textOverflow: "ellipsis",
         overflow: "hidden",
@@ -445,7 +455,7 @@ export const buttonClasses = useThemeCache(() => {
         translucid: generateButtonClass(vars.translucid, ButtonTypes.TRANSLUCID),
         inverted: generateButtonClass(vars.inverted, ButtonTypes.INVERTED),
         tab: "buttonAsTab",
-        icon: "buttonAsIcon",
+        icon: buttonUtilityClasses().buttonIcon,
         text: "buttonAsText",
         custom: "",
     };
@@ -464,7 +474,7 @@ export const buttonUtilityClasses = useThemeCache(() => {
         marginLeft: important("auto"),
     });
 
-    const buttonIcon = style("icon", {
+    const buttonIcon = style("icon", buttonResetMixin(), {
         alignItems: "center",
         display: "flex",
         height: unit(formElementVars.sizing.height),

--- a/library/src/scripts/navigation/CloseButton.tsx
+++ b/library/src/scripts/navigation/CloseButton.tsx
@@ -8,10 +8,9 @@ import classNames from "classnames";
 import { t } from "@library/utility/appUtils";
 import { ButtonTypes } from "@library/forms/buttonStyles";
 import Button from "@library/forms/Button";
-import { ILegacyProps } from "@library/@types/legacy";
 import { close } from "@library/icons/common";
 
-interface IProps extends Partial<ILegacyProps> {
+interface IProps {
     className?: string;
     disabled?: boolean;
     onClick: any;
@@ -24,7 +23,6 @@ interface IProps extends Partial<ILegacyProps> {
  */
 export default class CloseButton extends React.PureComponent<IProps> {
     public static defaultProps = {
-        legacyMode: false,
         baseClass: ButtonTypes.ICON,
     };
 

--- a/plugins/rich-editor/src/scripts/flyouts/pieces/Flyout.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/pieces/Flyout.tsx
@@ -112,7 +112,6 @@ export class Flyout extends React.Component<IProps, IState> {
                     <CloseButton
                         onClick={this.props.onCloseClick}
                         className={classNames("richEditor-close", classesRichEditor.close)}
-                        legacyMode={this.props.legacyMode}
                     />
 
                     {this.props.additionalHeaderContent && this.props.additionalHeaderContent}

--- a/plugins/rich-editor/src/scripts/toolbars/inlineToolbarClasses.ts
+++ b/plugins/rich-editor/src/scripts/toolbars/inlineToolbarClasses.ts
@@ -17,11 +17,11 @@ export const inlineToolbarClasses = useThemeCache((legacyMode: boolean = false) 
     const root = style({
         $nest: {
             "&.isUp": {
+                transform: `translateY(-12px)`,
                 $nest: {
                     ".richEditor-nubPosition": {
-                        transform: `translateY(${!legacyMode ? "-1px" : "9px"}) translateX(-50%)`,
-                        alignItems: "flex-end",
-                        bottom: percent(100),
+                        bottom: 0,
+                        zIndex: 10,
                     },
                     ".richEditor-nub": {
                         transform: `translateY(-50%) rotate(135deg)`,
@@ -30,8 +30,11 @@ export const inlineToolbarClasses = useThemeCache((legacyMode: boolean = false) 
                 },
             },
             "&.isDown": {
-                transform: `translateY(50%)`,
+                transform: `translateY(12px)`,
                 $nest: {
+                    ".richEditor-nubPosition": {
+                        bottom: percent(100),
+                    },
                     ".richEditor-nub": {
                         transform: `translateY(50%) rotate(-45deg)`,
                         marginTop: unit(offsetForNub),

--- a/plugins/rich-editor/src/scripts/toolbars/pieces/InlineToolbarLinkInput.tsx
+++ b/plugins/rich-editor/src/scripts/toolbars/pieces/InlineToolbarLinkInput.tsx
@@ -64,7 +64,6 @@ export class InlineToolbarLinkInput extends React.PureComponent<IProps, {}> {
                 <CloseButton
                     className={classNames("richEditor-close", classesRichEditor.close)}
                     onClick={this.props.onCloseClick}
-                    legacyMode={this.props.legacyMode}
                 />
             </div>
         );

--- a/plugins/rich-editor/src/scripts/toolbars/pieces/ToolbarContainer.tsx
+++ b/plugins/rich-editor/src/scripts/toolbars/pieces/ToolbarContainer.tsx
@@ -12,6 +12,7 @@ import { IWithEditorProps, withEditor } from "@rich-editor/editor/context";
 import { nubClasses } from "@rich-editor/toolbars/pieces/nubClasses";
 import { inlineToolbarClasses } from "@rich-editor/toolbars/inlineToolbarClasses";
 import { richEditorVariables } from "@rich-editor/editor/richEditorVariables";
+import { forceRenderStyles } from "typestyle";
 
 interface IProps extends IWithEditorProps {
     selection: RangeStatic;
@@ -102,6 +103,7 @@ export class ToolbarContainer extends React.PureComponent<IProps, IState> {
      * Mount quill listeners.
      */
     public componentDidMount() {
+        forceRenderStyles();
         const richEditorVars = richEditorVariables();
         this.setState({
             flyoutWidth: this.flyoutRef.current ? this.flyoutRef.current.offsetWidth : null,

--- a/plugins/rich-editor/src/scripts/toolbars/pieces/ToolbarPositioner.tsx
+++ b/plugins/rich-editor/src/scripts/toolbars/pieces/ToolbarPositioner.tsx
@@ -227,9 +227,9 @@ class ToolbarPositioner extends React.Component<IProps, IState> {
         const vars = richEditorVariables();
         const { flyoutHeight, nubHeight, verticalAlignment } = this.props;
 
-        const offset = 0;
-        let position = bounds.top - flyoutHeight - offset;
-        let nubPosition = flyoutHeight;
+        const offset = this.props.legacyMode ? 0 : vars.spacing.paddingTop;
+        let position = bounds.top - flyoutHeight + offset;
+        let nubPosition = flyoutHeight - 1;
         let nubPointsDown = true;
 
         const isNearStart = bounds.top <= vars.menuButton.size * 2;


### PR DESCRIPTION
I noticed that the positioning of Rich Editor toolbars were not really accurate in the forum while working on another issue. It seems to have gotten a little jumbled up during the style conversion.

I've gone in and fixed (the offsets needed to be adjusted a bit) as well as some translates.

I also fixed some minor issues with icon buttons not applying properly on the forum by adding an actual typestyle class with a reset. I also removed the now unused `legacyMode` prop from `<CloseButton>`.