### PR TITLE
Add ability to set the canonical URL for a discussion over the API

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -674,7 +674,7 @@ class DiscussionsApiController extends AbstractApiController {
      * @param int $id The ID of the discussion.
      * @param array $body The request body.
      *       Ex: ["canonicalUrl" => "https://mydomain.com/some+path/"]
-     * @throws NotFoundException if unable to find the discussion.
+     * @throws NotFoundException If unable to find the discussion.
      * @return array
      */
     public function put_canonical($id, array $body) {
@@ -708,7 +708,7 @@ class DiscussionsApiController extends AbstractApiController {
      * Remove canonical url for a discussion.
      *
      * @param int $id The ID of the discussion.
-     * @throws NotFoundException if unable to find the discussion.
+     * @throws NotFoundException If unable to find the discussion.
      * @return array
      */
     public function delete_canonical($id) {
@@ -726,7 +726,7 @@ class DiscussionsApiController extends AbstractApiController {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.Edit', $categoryID);
         }
         $attributes = $row['Attributes'];
-        if(!empty($attributes['CanonicalUrl'] ?? '')) {
+        if (!empty($attributes['CanonicalUrl'] ?? '')) {
             unset($attributes['CanonicalUrl']);
             $this->discussionModel->setProperty($id, 'Attributes', dbencode($attributes));
         }

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -695,7 +695,7 @@ class DiscussionsApiController extends AbstractApiController {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.Edit', $categoryID);
         }
 
-        $attributes = $row['Attributes'];
+        $attributes = $row['Attributes'] ?? [];
         $attributes['CanonicalUrl'] = $body['canonicalUrl'];
         $this->discussionModel->setProperty($id, 'Attributes', dbencode($attributes));
 

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -30,6 +30,9 @@ class DiscussionsApiController extends AbstractApiController {
     private $discussionPostSchema;
 
     /** @var Schema */
+    private $discussionPutCanonicalSchema;
+
+    /** @var Schema */
     private $idParamSchema;
 
     /** @var UserModel */
@@ -163,6 +166,24 @@ class DiscussionsApiController extends AbstractApiController {
     }
 
     /**
+     * Get a discussion set canonical url schema.
+     *
+     * @param string $type The type of schema.
+     * @return Schema Returns a schema object.
+     */
+    public function discussionPutCanonicalSchema($type = '') {
+        if ($this->discussionPutCanonicalSchema === null) {
+            $this->discussionPutCanonicalSchema = $this->schema(
+                Schema::parse([
+                    'canonicalUrl',
+                ])->add($this->fullSchema()),
+                'DiscussionPutCanonical'
+            );
+        }
+        return $this->schema($this->discussionPutCanonicalSchema, $type);
+    }
+
+    /**
      * Get the full discussion schema.
      *
      * @param string $type The type of schema.
@@ -207,6 +228,7 @@ class DiscussionsApiController extends AbstractApiController {
             'countViews:i' => 'The number of views on the discussion.',
             'score:i|n' => 'Total points associated with this post.',
             'url:s?' => 'The full URL to the discussion.',
+            'canonicalUrl:s' => 'The full canonical URL to the discussion.',
             'lastPost?' => $this->getPostFragmentSchema(),
             'bookmarked:b' => 'Whether or not the discussion is bookmarked by the current user.',
             'unread:b' => 'Whether or not the discussion should have an unread indicator.',
@@ -644,5 +666,69 @@ class DiscussionsApiController extends AbstractApiController {
 
         $result = $this->discussionByID($id);
         return $out->validate($result);
+    }
+
+    /**
+     * Set canonical url for a discussion.
+     *
+     * @param int $id The ID of the discussion.
+     * @param array $body The request body.
+     *       Ex: ["canonicalUrl" => "https://mydomain.com/some+path/"]
+     * @throws NotFoundException if unable to find the discussion.
+     * @return array
+     */
+    public function put_canonical($id, array $body) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $this->idParamSchema('in');
+        $in = $this->discussionPutCanonicalSchema('in')->setDescription('Set canonical url for a discussion.');
+        $out = $this->schema($this->discussionSchema(), 'out');
+
+        $body = $in->validate($body);
+
+        $row = $this->discussionByID($id);
+        if (!empty($row['Attributes']['CanonicalUrl'] ?? '')) {
+            throw new \Garden\Web\Exception\ClientException('Canonical url already set for this discussion.', 409);
+        };
+        $categoryID = $row['CategoryID'];
+        if ($row['InsertUserID'] !== $this->getSession()->UserID) {
+            $this->discussionModel->categoryPermission('Vanilla.Discussions.Edit', $categoryID);
+        }
+
+        $attributes = $row['Attributes'];
+        $attributes['CanonicalUrl'] = $body['canonicalUrl'];
+        $this->discussionModel->setProperty($id, 'Attributes', dbencode($attributes));
+
+        $result = $this->discussionByID($id);
+        $result = $this->normalizeOutput($result);
+        return $out->validate($result);
+    }
+
+    /**
+     * Remove canonical url for a discussion.
+     *
+     * @param int $id The ID of the discussion.
+     * @throws NotFoundException if unable to find the discussion.
+     * @return array
+     */
+    public function delete_canonical($id) {
+        $this->permission('Garden.SignIn.Allow');
+
+        $in =$this->schema(
+            Schema::parse(['id:i' => 'The discussion ID.']),
+            'in'
+        );
+        $out = $this->schema([], 'out');
+
+        $row = $this->discussionByID($id);
+        $categoryID = $row['CategoryID'];
+        if ($row['InsertUserID'] !== $this->getSession()->UserID) {
+            $this->discussionModel->categoryPermission('Vanilla.Discussions.Edit', $categoryID);
+        }
+        $attributes = $row['Attributes'];
+        if(!empty($attributes['CanonicalUrl'] ?? '')) {
+            unset($attributes['CanonicalUrl']);
+            $this->discussionModel->setProperty($id, 'Attributes', dbencode($attributes));
+        }
     }
 }

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -677,7 +677,7 @@ class DiscussionsApiController extends AbstractApiController {
      * @throws NotFoundException If unable to find the discussion.
      * @return array
      */
-    public function put_canonical($id, array $body) {
+    public function put_canonicalUrl($id, array $body) {
         $this->permission('Garden.SignIn.Allow');
 
         $this->idParamSchema('in');
@@ -711,7 +711,7 @@ class DiscussionsApiController extends AbstractApiController {
      * @throws NotFoundException If unable to find the discussion.
      * @return array
      */
-    public function delete_canonical($id) {
+    public function delete_canonicalUrl($id) {
         $this->permission('Garden.SignIn.Allow');
 
         $in =$this->schema(

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -154,8 +154,12 @@ class DiscussionController extends VanillaController {
         $this->setData('_LatestItem', $LatestItem);
 
         // Set the canonical url to have the proper page title.
-        $this->canonicalUrl(discussionUrl($this->Discussion, pageNumber($this->Offset, $Limit, 0, false)));
-
+        $canonicalUrl = ($this->Discussion->Attributes['CanonicalUrl'] ?? '');
+        if (empty($canonicalUrl)) {
+            $this->canonicalUrl(discussionUrl($this->Discussion, pageNumber($this->Offset, $Limit, 0, false)));
+        } else {
+            $this->canonicalUrl($canonicalUrl);
+        }
         $this->checkPageRange($this->Offset, $ActualResponses);
 
         // Load the comments
@@ -885,7 +889,12 @@ body { background: transparent !important; }
             }
 
             // Set the canonical url to have the proper page title.
-            $this->canonicalUrl(discussionUrl($discussion, pageNumber($this->Offset, $limit)));
+            $canonicalUrl = ($discussion->Attributes['CanonicalUrl'] ?? '');
+            if (empty($canonicalUrl)) {
+                $this->canonicalUrl(discussionUrl($discussion, pageNumber($this->Offset, $limit)));
+            } else {
+                $this->canonicalUrl($canonicalUrl);
+            }
 
             // Load the comments.
             $currentOrderBy = $this->CommentModel->orderBy();

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1007,6 +1007,7 @@ class DiscussionModel extends Gdn_Model {
         $discussion->Name = htmlspecialchars($discussion->Name);
         $discussion->Attributes = dbdecode($discussion->Attributes);
         $discussion->Url = discussionUrl($discussion);
+        $discussion->CanonicalUrl = $discussion->Attributes['CanonicalUrl'] ?? $discussion->Url;
         $discussion->Tags = $this->formatTags($discussion->Tags);
 
         // Join in the category.
@@ -1107,7 +1108,6 @@ class DiscussionModel extends Gdn_Model {
         }
         $discussion->pinned = $pinned;
         $discussion->pinLocation = $pinLocation;
-
         $this->EventArguments['Discussion'] = &$discussion;
         $this->fireEvent('SetCalculatedFields');
     }

--- a/applications/vanilla/openapi/discussions.yml
+++ b/applications/vanilla/openapi/discussions.yml
@@ -797,6 +797,57 @@ paths:
       tags:
       - Discussions
       summary: Remove a user's reaction.
+  '/discussions/{id}/canonical':
+    put:
+      parameters:
+      - description: The discussion ID.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Discussion'
+          description: Success
+        '404':
+          description: Not Found
+        '400':
+          description: Bad Request
+      tags:
+      - Discussions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                canonicalUrl:
+                  description: Canonical url for discussion.
+                  type: string
+              required:
+              - canonicalUrl
+              type: object
+        required: true
+      summary: Set custom canonical url for a discussion.
+    delete:
+      parameters:
+      - description: The discussion ID.
+        in: path
+        name: id
+        required: true
+        schema:
+          type: integer
+      responses:
+        '204':
+          description: Success
+        '404':
+          description: Not Found
+      tags:
+      - Discussions
+      summary: Remove custom canonical url for a discussion.
 components:
   schemas:
     CategoryFragment:

--- a/applications/vanilla/openapi/discussions.yml
+++ b/applications/vanilla/openapi/discussions.yml
@@ -797,7 +797,7 @@ paths:
       tags:
       - Discussions
       summary: Remove a user's reaction.
-  '/discussions/{id}/canonical':
+  '/discussions/{id}/canonical-url':
     put:
       parameters:
       - description: The discussion ID.

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -9,6 +9,7 @@ namespace VanillaTests\APIv2;
 
 use CategoryModel;
 use DiscussionModel;
+use Garden\Web\Exception\ClientException;
 
 /**
  * Test the /api/v2/discussions endpoints.
@@ -154,5 +155,24 @@ class DiscussionsTest extends AbstractResourceTest {
         }
 
         parent::testPatchSparse($field);
+    }
+
+    public function testPutCanonicalUrl() {
+        $row = $this->testPost();
+        $url = '/canonical/url/test';
+        $discussion = $this->api()->put($this->baseUrl.'/'.$row['discussionID'].'/canonical-url', ['canonicalUrl' => $url])->getBody();
+        $this->assertArrayHasKey('canonicalUrl', $discussion);
+        $this->assertEquals($url, $discussion['canonicalUrl']);
+    }
+
+    public function testOverwriteCanonicalUrl() {
+        $row = $this->testPost();
+        $url = '/canonical/url/test';
+        $discussion = $this->api()->put($this->baseUrl.'/'.$row['discussionID'].'/canonical-url', ['canonicalUrl' => $url])->getBody();
+        $this->assertArrayHasKey('canonicalUrl', $discussion);
+        $this->assertEquals($url, $discussion['canonicalUrl']);
+
+        $this->expectException();
+       $this->api()->put($this->baseUrl.'/'.$row['discussionID'].'/canonical-url', ['canonicalUrl' => $url.'overwrite']);
     }
 }

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -9,7 +9,6 @@ namespace VanillaTests\APIv2;
 
 use CategoryModel;
 use DiscussionModel;
-use Garden\Web\Exception\ClientException;
 
 /**
  * Test the /api/v2/discussions endpoints.
@@ -157,6 +156,9 @@ class DiscussionsTest extends AbstractResourceTest {
         parent::testPatchSparse($field);
     }
 
+    /**
+     * Test PUT /discussions/{id}/canonical-url when not set
+     */
     public function testPutCanonicalUrl() {
         $row = $this->testPost();
         $url = '/canonical/url/test';
@@ -165,6 +167,9 @@ class DiscussionsTest extends AbstractResourceTest {
         $this->assertEquals($url, $discussion['canonicalUrl']);
     }
 
+    /**
+     * Test PUT /discussions/{id}/canonical-url when already set up
+     */
     public function testOverwriteCanonicalUrl() {
         $row = $this->testPost();
         $url = '/canonical/url/test';
@@ -172,7 +177,26 @@ class DiscussionsTest extends AbstractResourceTest {
         $this->assertArrayHasKey('canonicalUrl', $discussion);
         $this->assertEquals($url, $discussion['canonicalUrl']);
 
-        $this->expectException();
-       $this->api()->put($this->baseUrl.'/'.$row['discussionID'].'/canonical-url', ['canonicalUrl' => $url.'overwrite']);
+        $this->expectException(\Garden\Web\Exception\ClientException::class);
+        $this->api()->put($this->baseUrl.'/'.$row['discussionID'].'/canonical-url', ['canonicalUrl' => $url.'overwrite']);
+    }
+
+    /**
+     * Test DELETE /discussions/{id}/canonical-url
+     */
+    public function testDeleteCanonicalUrl() {
+        $row = $this->testPost();
+        $url = '/canonical/url/test';
+        $discussion = $this->api()->put($this->baseUrl.'/'.$row['discussionID'].'/canonical-url', ['canonicalUrl' => $url])->getBody();
+        $response = $this->api()->delete($this->baseUrl.'/'.$row['discussionID'].'/canonical-url');
+
+        $this->assertEquals('204 No Content', $response->getStatus());
+
+        $discussion = $response->getBody();
+        $this->assertTrue(empty($discussion));
+
+        $discussion = $this->api()->get($this->baseUrl.'/'.$row['discussionID'])->getBody();
+        $this->assertNotEquals($url, $discussion['canonicalUrl']);
+        $this->assertEquals($discussion['url'], $discussion['canonicalUrl']);
     }
 }


### PR DESCRIPTION
New DiscussionsAPI endpoints:

```
PUT /discussions/{id}/canonical 

DELETE /discussions/{id}/canonical
```
Update openapi schema.
Update discussion controller  to update meta tag `canonical` with custom `canonicalUrl` when present

Relates to: #8260