### PR TITLE
Add CommunityCategoryInput component

### DIFF
--- a/applications/vanilla/src/scripts/@types/api/categories.ts
+++ b/applications/vanilla/src/scripts/@types/api/categories.ts
@@ -1,0 +1,32 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+export interface ICategory {
+    categoryID: number;
+    name: string;
+    description: string;
+    parentCategoryID: number | null;
+    customPermissions: false;
+    isArchived: false;
+    urlcode: string;
+    url: string;
+    displayAs: CategoryDisplayAs;
+    countCategories: number;
+    countDiscussions: number;
+    countComments: number;
+    countAllDiscussions: number;
+    countAllComments: number;
+    followed: boolean;
+    depth: number;
+    children: ICategory[];
+}
+
+enum CategoryDisplayAs {
+    CATEGORIES = "categories",
+    DEFAULT = "default",
+    DISCUSSIONS = "discussions",
+    FLAT = "flat",
+    HEADING = "heading",
+}

--- a/applications/vanilla/src/scripts/categories/CategorySuggestionActions.ts
+++ b/applications/vanilla/src/scripts/categories/CategorySuggestionActions.ts
@@ -1,0 +1,31 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import ReduxActions, { bindThunkAction } from "@library/redux/ReduxActions";
+import actionCreatorFactory from "typescript-fsa";
+import { IApiError } from "@library/@types/api/core";
+import { debounce } from "lodash";
+import { ICategory } from "@vanilla/@types/api/categories";
+
+const createAction = actionCreatorFactory("@@categorySuggestions");
+
+export default class CategorySuggestionActions extends ReduxActions {
+    public static loadCategories = createAction.async<{ query: string }, ICategory[], IApiError>("GET");
+
+    private interalLoadCategories = (query: string) => {
+        const apiThunk = bindThunkAction(CategorySuggestionActions.loadCategories, async () => {
+            if (query === "") {
+                return [];
+            }
+
+            const params = { query };
+            const response = await this.api.get("/categories/search", { params });
+            return response.data;
+        })({ query });
+        return this.dispatch(apiThunk);
+    };
+
+    public loadCategories = debounce(this.interalLoadCategories, 100);
+}

--- a/applications/vanilla/src/scripts/categories/categoriesReducer.ts
+++ b/applications/vanilla/src/scripts/categories/categoriesReducer.ts
@@ -1,0 +1,35 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { LoadStatus, ILoadable } from "@library/@types/api/core";
+import { produce } from "immer";
+import CategorySuggestionActions from "@vanilla/categories/CategorySuggestionActions";
+import { reducerWithInitialState } from "typescript-fsa-reducers";
+import clone from "lodash/clone";
+import { ICategory } from "@vanilla/@types/api/categories";
+
+export interface ICategoriesState {
+    suggestions: ILoadable<ICategory[]>;
+}
+
+const INITIAL_STATE: ICategoriesState = {
+    suggestions: {
+        status: LoadStatus.PENDING,
+    },
+};
+
+export const categoriesReducer = produce(
+    reducerWithInitialState(clone(INITIAL_STATE))
+        .case(CategorySuggestionActions.loadCategories.done, (nextState, payload) => {
+            nextState.suggestions.status = LoadStatus.SUCCESS;
+            nextState.suggestions.data = payload.result;
+            return nextState;
+        })
+        .case(CategorySuggestionActions.loadCategories.failed, (nextState, payload) => {
+            nextState.suggestions.status = LoadStatus.ERROR;
+            nextState.suggestions.error = payload.error;
+            return nextState;
+        }),
+);

--- a/applications/vanilla/src/scripts/categories/categoriesReducer.ts
+++ b/applications/vanilla/src/scripts/categories/categoriesReducer.ts
@@ -22,6 +22,10 @@ const INITIAL_STATE: ICategoriesState = {
 
 export const categoriesReducer = produce(
     reducerWithInitialState(clone(INITIAL_STATE))
+        .case(CategorySuggestionActions.loadCategories.started, (nextState, payload) => {
+            nextState.suggestions.status = LoadStatus.LOADING;
+            return nextState;
+        })
         .case(CategorySuggestionActions.loadCategories.done, (nextState, payload) => {
             nextState.suggestions.status = LoadStatus.SUCCESS;
             nextState.suggestions.data = payload.result;

--- a/applications/vanilla/src/scripts/entries/knowledge.tsx
+++ b/applications/vanilla/src/scripts/entries/knowledge.tsx
@@ -1,0 +1,9 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { registerReducer } from "@library/redux/reducerRegistry";
+import { forumReducer } from "@vanilla/redux/reducer";
+
+registerReducer("forum", forumReducer);

--- a/applications/vanilla/src/scripts/forms/CommunityCategoryInput.tsx
+++ b/applications/vanilla/src/scripts/forms/CommunityCategoryInput.tsx
@@ -9,22 +9,49 @@ import CategorySuggestionActions from "@vanilla/categories/CategorySuggestionAct
 import { IForumStoreState } from "@vanilla/redux/state";
 import React from "react";
 import { connect } from "react-redux";
+import { OptionProps } from "react-select/lib/components/Option";
+import { NoOptionsMessage } from "@library/forms/select/overwrites";
+import { LoadStatus } from "@library/@types/api/core";
+
+interface IProps extends ISelectLookupProps {
+    isLoading: boolean;
+}
 
 /**
  * Form component for searching/selecting a category.
  */
-export class CommunityCategoryInput extends React.Component<ISelectLookupProps> {
-    public static defaultProps: Partial<ISelectLookupProps> = {
+export class CommunityCategoryInput extends React.Component<IProps> {
+    public static defaultProps: Partial<IProps> = {
+        isLoading: false,
         label: t("Community Category"),
     };
 
     public render() {
-        return <SelectLookup {...this.props} label={this.props.label} />;
+        console.log(this.props.isLoading);
+        return (
+            <SelectLookup
+                {...this.props}
+                label={this.props.label}
+                noOptionsMessage={this.noOptionsMessage}
+                placeholder=""
+            />
+        );
+    }
+
+    private noOptionsMessage(props: OptionProps<any>): JSX.Element | null {
+        let text = "";
+        if (props.selectProps.inputValue === "") {
+            text = t("Search for a category");
+        } else {
+            text = t("No categories found");
+        }
+        return <NoOptionsMessage {...props}>{text}</NoOptionsMessage>;
     }
 }
 
 function mapStateToProps(state: IForumStoreState, ownProps: ISelectLookupProps) {
     return {
+        isLoading: state.forum.categories.suggestions.status === LoadStatus.LOADING,
         suggestions: state.forum.categories.suggestions,
     };
 }

--- a/applications/vanilla/src/scripts/forms/CommunityCategoryInput.tsx
+++ b/applications/vanilla/src/scripts/forms/CommunityCategoryInput.tsx
@@ -27,7 +27,6 @@ export class CommunityCategoryInput extends React.Component<IProps> {
     };
 
     public render() {
-        console.log(this.props.isLoading);
         return (
             <SelectLookup
                 {...this.props}

--- a/applications/vanilla/src/scripts/forms/CommunityCategoryInput.tsx
+++ b/applications/vanilla/src/scripts/forms/CommunityCategoryInput.tsx
@@ -1,0 +1,45 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+import apiv2 from "@library/apiv2";
+import { ISelectLookupProps, SelectLookup } from "@library/forms/select/SelectLookup";
+import { t } from "@library/utility/appUtils";
+import CategorySuggestionActions from "@vanilla/categories/CategorySuggestionActions";
+import { IForumStoreState } from "@vanilla/redux/state";
+import React from "react";
+import { connect } from "react-redux";
+
+/**
+ * Form component for searching/selecting a category.
+ */
+export class CommunityCategoryInput extends React.Component<ISelectLookupProps> {
+    public static defaultProps: Partial<ISelectLookupProps> = {
+        label: t("Community Category"),
+    };
+
+    public render() {
+        return <SelectLookup {...this.props} label={this.props.label} />;
+    }
+}
+
+function mapStateToProps(state: IForumStoreState, ownProps: ISelectLookupProps) {
+    return {
+        suggestions: state.forum.categories.suggestions,
+    };
+}
+
+function mapDispatchToProps(dispatch: any) {
+    const categorySuggestionActions = new CategorySuggestionActions(dispatch, apiv2);
+
+    return {
+        lookup: categorySuggestionActions.loadCategories,
+    };
+}
+
+const withRedux = connect(
+    mapStateToProps,
+    mapDispatchToProps,
+);
+
+export default withRedux(CommunityCategoryInput);

--- a/applications/vanilla/src/scripts/redux/reducer.ts
+++ b/applications/vanilla/src/scripts/redux/reducer.ts
@@ -1,0 +1,12 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { categoriesReducer } from "@vanilla/categories/categoriesReducer";
+import { combineReducers } from "redux";
+import { IForumState } from "./state";
+
+export const forumReducer = combineReducers<IForumState>({
+    categories: categoriesReducer,
+});

--- a/applications/vanilla/src/scripts/redux/state.ts
+++ b/applications/vanilla/src/scripts/redux/state.ts
@@ -1,0 +1,14 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { ICategoriesState } from "@vanilla/categories/categoriesReducer";
+
+export interface IForumState {
+    categories: ICategoriesState;
+}
+
+export interface IForumStoreState {
+    forum: IForumState;
+}

--- a/library/src/scripts/forms/select/SelectLookup.tsx
+++ b/library/src/scripts/forms/select/SelectLookup.tsx
@@ -1,0 +1,57 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+import { ILoadable, LoadStatus } from "@library/@types/api/core";
+import { IComboBoxOption } from "@library/features/search/SearchBar";
+import SelectOne from "@library/forms/select/SelectOne";
+import React from "react";
+
+export interface ISelectLookupProps {
+    label: string;
+    lookup: (value: string) => {};
+    onChange: (category: IComboBoxOption) => void;
+    suggestions: ILoadable<any>;
+    value: IComboBoxOption | undefined;
+}
+
+/**
+ * Form component for searching/selecting a category.
+ */
+export class SelectLookup<P extends ISelectLookupProps = ISelectLookupProps> extends React.Component<P> {
+    public static defaultProps: Partial<ISelectLookupProps> = {
+        suggestions: {
+            status: LoadStatus.PENDING,
+        },
+    };
+
+    public render() {
+        const { label, suggestions } = this.props;
+        let options: IComboBoxOption[] | undefined;
+        if (suggestions.status === LoadStatus.SUCCESS && suggestions.data) {
+            options = suggestions.data.map(suggestion => {
+                return {
+                    value: suggestion.categoryID,
+                    label: suggestion.name,
+                };
+            });
+        }
+
+        return (
+            <SelectOne
+                label={label}
+                options={options}
+                onChange={this.props.onChange}
+                onInputChange={this.onInputChange}
+                value={this.props.value}
+            />
+        );
+    }
+
+    /**
+     * React to changes in the token input.
+     */
+    private onInputChange = (value: string) => {
+        this.props.lookup(value);
+    };
+}

--- a/library/src/scripts/forms/select/SelectLookup.tsx
+++ b/library/src/scripts/forms/select/SelectLookup.tsx
@@ -4,21 +4,18 @@
  */
 import { ILoadable, LoadStatus } from "@library/@types/api/core";
 import { IComboBoxOption } from "@library/features/search/SearchBar";
-import SelectOne from "@library/forms/select/SelectOne";
+import SelectOne, { ISelectOneProps } from "@library/forms/select/SelectOne";
 import React from "react";
 
-export interface ISelectLookupProps {
-    label: string;
+export interface ISelectLookupProps extends ISelectOneProps {
     lookup: (value: string) => {};
-    onChange: (category: IComboBoxOption) => void;
     suggestions: ILoadable<any>;
-    value: IComboBoxOption | undefined;
 }
 
 /**
  * Form component for searching/selecting a category.
  */
-export class SelectLookup<P extends ISelectLookupProps = ISelectLookupProps> extends React.Component<P> {
+export class SelectLookup extends React.Component<ISelectLookupProps> {
     public static defaultProps: Partial<ISelectLookupProps> = {
         suggestions: {
             status: LoadStatus.PENDING,
@@ -26,7 +23,7 @@ export class SelectLookup<P extends ISelectLookupProps = ISelectLookupProps> ext
     };
 
     public render() {
-        const { label, suggestions } = this.props;
+        const { suggestions } = this.props;
         let options: IComboBoxOption[] | undefined;
         if (suggestions.status === LoadStatus.SUCCESS && suggestions.data) {
             options = suggestions.data.map(suggestion => {
@@ -37,15 +34,7 @@ export class SelectLookup<P extends ISelectLookupProps = ISelectLookupProps> ext
             });
         }
 
-        return (
-            <SelectOne
-                label={label}
-                options={options}
-                onChange={this.props.onChange}
-                onInputChange={this.onInputChange}
-                value={this.props.value}
-            />
-        );
+        return <SelectOne {...this.props} options={options} onInputChange={this.onInputChange} />;
     }
 
     /**

--- a/library/src/scripts/forms/select/SelectOne.tsx
+++ b/library/src/scripts/forms/select/SelectOne.tsx
@@ -14,7 +14,7 @@ import Paragraph from "@library/layout/Paragraph";
 import { IFieldError } from "@library/@types/api/core";
 import * as selectOverrides from "@library/forms/select/overwrites";
 
-interface IProps extends IOptionalComponentID {
+export interface ISelectOneProps extends IOptionalComponentID {
     label: string;
     disabled?: boolean;
     className?: string;
@@ -32,7 +32,7 @@ interface IProps extends IOptionalComponentID {
 /**
  * Implements the search bar component
  */
-export default class SelectOne extends React.Component<IProps> {
+export default class SelectOne extends React.Component<ISelectOneProps> {
     private id: string;
     private prefix = "SelectOne";
     private inputID: string;

--- a/library/src/scripts/forms/select/SelectOne.tsx
+++ b/library/src/scripts/forms/select/SelectOne.tsx
@@ -19,12 +19,14 @@ interface IProps extends IOptionalComponentID {
     disabled?: boolean;
     className?: string;
     placeholder?: string;
-    options: IComboBoxOption[];
+    options: IComboBoxOption[] | undefined;
     onChange: (data: IComboBoxOption) => void;
+    onInputChange?: (value: string) => void;
     labelNote?: string;
     noteAfterInput?: string;
     errors?: IFieldError[];
     searchable?: boolean;
+    value: IComboBoxOption | undefined;
 }
 
 /**
@@ -64,6 +66,7 @@ export default class SelectOne extends React.Component<IProps> {
                         options={options}
                         inputId={this.inputID}
                         onChange={this.props.onChange}
+                        onInputChange={this.props.onInputChange}
                         components={this.componentOverwrites}
                         isClearable={true}
                         isDisabled={disabled}
@@ -75,6 +78,7 @@ export default class SelectOne extends React.Component<IProps> {
                         aria-invalid={hasErrors}
                         aria-describedby={describedBy}
                         isSearchable={searchable}
+                        value={this.props.value}
                     />
                     <Paragraph className="inputBlock-labelNote" children={this.props.noteAfterInput} />
                     <ErrorMessages id={this.errorID} errors={this.props.errors} />

--- a/library/src/scripts/forms/select/SelectOne.tsx
+++ b/library/src/scripts/forms/select/SelectOne.tsx
@@ -38,7 +38,7 @@ export default class SelectOne extends React.Component<ISelectOneProps> {
     private inputID: string;
     private errorID: string;
 
-    constructor(props: IProps) {
+    constructor(props: ISelectOneProps) {
         super(props);
         this.id = getRequiredID(props, this.prefix);
         this.inputID = this.id + "-input";

--- a/library/src/scripts/forms/select/SelectOne.tsx
+++ b/library/src/scripts/forms/select/SelectOne.tsx
@@ -4,15 +4,18 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
-import ErrorMessages from "@library/forms/ErrorMessages";
-import { getRequiredID, IOptionalComponentID } from "@library/utility/idUtils";
-import Select from "react-select";
-import { IComboBoxOption } from "@library/features/search/SearchBar";
-import classNames from "classnames";
-import Paragraph from "@library/layout/Paragraph";
 import { IFieldError } from "@library/@types/api/core";
+import { IComboBoxOption } from "@library/features/search/SearchBar";
+import ErrorMessages from "@library/forms/ErrorMessages";
 import * as selectOverrides from "@library/forms/select/overwrites";
+import Paragraph from "@library/layout/Paragraph";
+import { getRequiredID, IOptionalComponentID } from "@library/utility/idUtils";
+import classNames from "classnames";
+import React from "react";
+import Select from "react-select";
+import { OptionProps } from "react-select/lib/components/Option";
+import { styleFactory } from "@library/styles/styleUtils";
+import { style } from "typestyle";
 
 export interface ISelectOneProps extends IOptionalComponentID {
     label: string;
@@ -27,6 +30,8 @@ export interface ISelectOneProps extends IOptionalComponentID {
     errors?: IFieldError[];
     searchable?: boolean;
     value: IComboBoxOption | undefined;
+    noOptionsMessage?: ((props: OptionProps<any>) => JSX.Element | null);
+    isLoading?: boolean;
 }
 
 /**
@@ -53,6 +58,23 @@ export default class SelectOne extends React.Component<ISelectOneProps> {
             describedBy = this.errorID;
         }
 
+        const inputWrapClass = style({
+            $nest: {
+                ".inputBlock-inputText": {
+                    paddingRight: 30,
+                    position: "relative",
+                },
+                ".SelectOne__indicators": {
+                    position: "absolute",
+                    top: 0,
+                    right: 6,
+                    bottom: 0,
+                },
+                ".SelectOne__indicator": {
+                    cursor: "pointer",
+                },
+            },
+        });
         return (
             <div className={this.props.className}>
                 <label htmlFor={this.inputID} className="inputBlock-labelAndDescription">
@@ -60,7 +82,7 @@ export default class SelectOne extends React.Component<ISelectOneProps> {
                     <Paragraph className="inputBlock-labelNote" children={this.props.labelNote} />
                 </label>
 
-                <div className="inputBlock-inputWrap">
+                <div className={classNames("inputBlock-inputWrap", inputWrapClass)}>
                     <Select
                         id={this.id}
                         options={options}
@@ -79,6 +101,8 @@ export default class SelectOne extends React.Component<ISelectOneProps> {
                         aria-describedby={describedBy}
                         isSearchable={searchable}
                         value={this.props.value}
+                        placeholder={this.props.placeholder}
+                        isLoading={this.props.isLoading}
                     />
                     <Paragraph className="inputBlock-labelNote" children={this.props.noteAfterInput} />
                     <ErrorMessages id={this.errorID} errors={this.props.errors} />
@@ -91,12 +115,12 @@ export default class SelectOne extends React.Component<ISelectOneProps> {
     * Overwrite components in Select component
     */
     private componentOverwrites = {
-        IndicatorsContainer: selectOverrides.NullComponent,
         Menu: selectOverrides.Menu,
         MenuList: selectOverrides.MenuList,
         Option: selectOverrides.SelectOption,
         ValueContainer: selectOverrides.ValueContainer,
-        NoOptionsMessage: selectOverrides.NoOptionsMessage,
+        NoOptionsMessage: this.props.noOptionsMessage || selectOverrides.NoOptionsMessage,
+        LoadingMessage: selectOverrides.OptionLoader,
     };
 
     /**

--- a/library/src/scripts/forms/select/overwrites.tsx
+++ b/library/src/scripts/forms/select/overwrites.tsx
@@ -18,6 +18,7 @@ import classNames from "classnames";
 import { OptionProps } from "react-select/lib/components/Option";
 import { close } from "@library/icons/common";
 import { components } from "react-select";
+import { searchBarClasses } from "@library/features/search/searchBarStyles";
 
 /**
  * Overwrite for the controlContainer component in React Select
@@ -50,7 +51,13 @@ export function Menu(props: MenuProps<any>) {
     return (
         <components.Menu
             {...props}
-            className={classNames("suggestedTextInput-menu", "dropDown-contents", "isParentWidth", classes.contents)}
+            className={classNames(
+                "suggestedTextInput-menu",
+                "dropDown-contents",
+                "isParentWidth",
+                classes.contents,
+                searchBarClasses().results,
+            )}
         />
     );
 }


### PR DESCRIPTION
This update introduces the `CommunityCategoryInput` component.

### Overview

1. Add `SelectLookup` component. This component allows a straightforward way to create a select menu with options that update as the user types. This is essentially a specialized version of `SelectOne`.
1. Fix type errors in `SelectOne`.
1. Add frontend classes for looking up community (forum) categories. This includes actions (`CategorySuggestionActions`) to perform lookups via the API based on a full or partial category name, as well as a reducer (`categoriesReducer`) to save category-related data to the state.
1. Add `CommunityCategoryInput` component. This component provides category suggestions based on user input, ultimately allowing a user to select a single specific category.