### PR TITLE
Add expand parameter to discussions API get

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -226,7 +226,9 @@ class DiscussionsApiController extends AbstractApiController {
         $this->permission();
 
         $this->idParamSchema();
-        $in = $this->schema([], ['DiscussionGet', 'in'])->setDescription('Get a discussion.');
+        $in = $this->schema([
+            'expand?' => ApiUtils::getExpandDefinition([]) // Allow addons to expand additional fields.
+        ], ['DiscussionGet', 'in'])->setDescription('Get a discussion.');
         $out = $this->schema($this->discussionSchema(), 'out');
 
         $query = $in->validate($query);
@@ -241,7 +243,7 @@ class DiscussionsApiController extends AbstractApiController {
         $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $row['CategoryID']);
 
         $this->userModel->expandUsers($row, ['InsertUserID', 'LastUserID'], ['expand' => true]);
-        $row = $this->normalizeOutput($row);
+        $row = $this->normalizeOutput($row, $query["expand"] ?? []);
 
         $result = $out->validate($row);
 
@@ -278,7 +280,8 @@ class DiscussionsApiController extends AbstractApiController {
             $lastPost = [
                 'discussionID' => $dbRecord['DiscussionID'],
                 'dateInserted' => $dbRecord['DateLastComment'],
-                'insertUser' => $dbRecord['LastUser']
+                'insertUser' => $dbRecord['LastUser'],
+                "insertUserID" => $dbRecord["LastUserID"],
             ];
             if ($dbRecord['LastCommentID']) {
                 $lastPost['CommentID'] = $dbRecord['LastCommentID'];


### PR DESCRIPTION
Getting a single discussion via the API does not currently allow expanding any fields. This update adds that ability. To start there is nothing to expand, but addons may make use of this field by adding options to it.

As a bonus, I fixed an issue where `lastPost.inserUserID` might not be set, but is still required by the schema. It's probably been broken in some capacity for a long time.