### PR TITLE
Add points to the users API endpoints

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -146,6 +146,7 @@ class UsersApiController extends AbstractApiController {
                 'minLength' => 0,
                 'description' => 'URL to the user photo.'
             ],
+            'points:i',
             'emailConfirmed:b' => 'Has the email address for this user been confirmed?',
             'showEmail:b' => 'Is the email address visible to other users?',
             'bypassSpam:b' => 'Should submissions from this user bypass SPAM checks?',
@@ -916,7 +917,7 @@ class UsersApiController extends AbstractApiController {
      */
     public function userSchema($type = '') {
         if ($this->userSchema === null) {
-            $schema = Schema::parse(['userID', 'name', 'email', 'photoUrl', 'emailConfirmed',
+            $schema = Schema::parse(['userID', 'name', 'email', 'photoUrl', 'points', 'emailConfirmed',
                 'showEmail', 'bypassSpam', 'banned', 'dateInserted', 'dateLastActive', 'dateUpdated', 'roles?']);
             $schema = $schema->add($this->fullSchema());
             $this->userSchema = $this->schema($schema, 'User');

--- a/applications/dashboard/openapi/users.yml
+++ b/applications/dashboard/openapi/users.yml
@@ -627,12 +627,26 @@ components:
   schemas:
     User:
       properties:
-        banned:
-          description: Is the user banned?
+        userID:
+          description: ID of the user.
           type: integer
-        bypassSpam:
-          description: Should submissions from this user bypass SPAM checks?
-          type: boolean
+        name:
+          description: Name of the user.
+          minLength: 1
+          type: string
+        photoUrl:
+          description: URL to the user photo.
+          minLength: 0
+          nullable: true
+          type: string
+        email:
+          description: Email address of the user.
+          minLength: 0
+          type: string
+        roles:
+          items:
+            $ref: 'schemas.yml#/components/schemas/RoleFragment'
+          type: array
         dateInserted:
           description: When the user was created.
           format: date-time
@@ -647,25 +661,22 @@ components:
           format: date-time
           nullable: true
           type: string
-        email:
-          description: Email address of the user.
-          minLength: 0
-          type: string
+        points:
+          description: The total number of points the user has accumulated.
+          type: integer
+          default: 0
         emailConfirmed:
-          description: Has the email address for this user been confirmed?
+          description: Has the email address for the user been confirmed?
           type: boolean
         hidden:
           description: Is this user hiding their online status?
           type: boolean
-        name:
-          description: Name of the user.
-          minLength: 1
-          type: string
-        photoUrl:
-          description: URL to the user photo.
-          minLength: 0
-          nullable: true
-          type: string
+        bypassSpam:
+          description: Should submissions from this user bypass SPAM checks?
+          type: boolean
+        banned:
+          description: Is the user banned?
+          type: integer
         rank:
           x-addon: ranks
           properties:
@@ -690,21 +701,15 @@ components:
           description: ID of the user rank.
           nullable: true
           type: integer
-        roles:
-          items:
-            $ref: 'schemas.yml#/components/schemas/RoleFragment'
-          type: array
         showEmail:
           description: Is the email address visible to other users?
           type: boolean
-        userID:
-          description: ID of the user.
-          type: integer
       required:
       - userID
       - name
       - email
       - photoUrl
+      - points
       - emailConfirmed
       - showEmail
       - bypassSpam


### PR DESCRIPTION
Points is a standard field within the dashboard addon and is useful for API integrations.

This PR also includes a reordering of some of the properties in the user Open API definition.

Note that this change does not include any unit tests, but some unit tests in other repos will look for the points field after this is merged.