### PR TITLE
Add informational message to discussion if it has a user-provided canonical URL

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -172,6 +172,14 @@ class DiscussionController extends VanillaController {
         if (empty($canonicalUrl)) {
             $this->canonicalUrl(discussionUrl($this->Discussion, pageNumber($this->Offset, $Limit, 0, false)));
         } else {
+            $canonicalMessage = new Message(
+                sprintf(
+                    \Gdn::locale()->translate('This discussion has a more <a href="%1$s">recent version</a>.'),
+                    htmlspecialchars(\Gdn::request()->url($canonicalUrl))
+                ),
+                Message::TYPE_INFORMATION
+            );
+            $this->addMessage($canonicalMessage);
             $this->canonicalUrl($canonicalUrl);
         }
         $this->checkPageRange($this->Offset, $ActualResponses);

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -173,9 +173,10 @@ class DiscussionController extends VanillaController {
             $this->canonicalUrl(discussionUrl($this->Discussion, pageNumber($this->Offset, $Limit, 0, false)));
         } else {
             $canonicalMessage = new Message(
-                sprintf(
-                    \Gdn::translate('This discussion has a more <a href="%1$s">recent version</a>.'),
-                    htmlspecialchars(\Gdn::request()->url($canonicalUrl))
+                str_replace(
+                    ["<0>", "</0>"],
+                    ['<a href="' . htmlspecialchars(\Gdn::request()->url($canonicalUrl)) . '">', "</a>"],
+                    \Gdn::translate('This discussion has a more <0>recent version</0>.')
                 ),
                 Message::TYPE_WARNING
             );

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -177,7 +177,7 @@ class DiscussionController extends VanillaController {
                     \Gdn::locale()->translate('This discussion has a more <a href="%1$s">recent version</a>.'),
                     htmlspecialchars(\Gdn::request()->url($canonicalUrl))
                 ),
-                Message::TYPE_INFORMATION
+                Message::TYPE_WARNING
             );
             $this->addMessage($canonicalMessage);
             $this->canonicalUrl($canonicalUrl);

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -8,6 +8,8 @@
  * @since 2.0
  */
 
+ use Vanilla\Message;
+
 /**
  * Handles accessing & displaying a single discussion via /discussion endpoint.
  */
@@ -25,6 +27,9 @@ class DiscussionController extends VanillaController {
     /** @var DiscussionModel */
     public $DiscussionModel;
 
+    /** @var Message[] */
+    private $messages = [];
+
     /**
      *
      *
@@ -40,6 +45,15 @@ class DiscussionController extends VanillaController {
                 break;
         }
         throw new Exception("DiscussionController->$name not found.", 400);
+    }
+
+    /**
+     * Add a message to be displayed on the discussion.
+     *
+     * @param Message $message
+     */
+    public function addMessage(Message $message) {
+        $this->messages[] = $message;
     }
 
     /**
@@ -285,6 +299,15 @@ class DiscussionController extends VanillaController {
             $this->DiscussionModel->structuredData((array)$this->Discussion)
         );
         $this->render();
+    }
+
+    /**
+     * Get current messages.
+     *
+     * @return Messages[]
+     */
+    public function getMessages(): array {
+        return $this->messages;
     }
 
     /**

--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -174,7 +174,7 @@ class DiscussionController extends VanillaController {
         } else {
             $canonicalMessage = new Message(
                 sprintf(
-                    \Gdn::locale()->translate('This discussion has a more <a href="%1$s">recent version</a>.'),
+                    \Gdn::translate('This discussion has a more <a href="%1$s">recent version</a>.'),
                     htmlspecialchars(\Gdn::request()->url($canonicalUrl))
                 ),
                 Message::TYPE_WARNING

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -1111,7 +1111,7 @@ class VanillaHooks implements Gdn_IPlugin {
     }
 
     /**
-     * Hook in before a discussion is rendered and display a canonical notice, if relevant.
+     * Hook in before a discussion is rendered and display any messages.
      *
      * @param mixed DiscussionController $sender
      * @param array array $args

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -1117,7 +1117,7 @@ class VanillaHooks implements Gdn_IPlugin {
      * @param array array $args
      */
     public function discussionController_beforeDiscussionDisplay_handler($sender, array $args) {
-        if (!is_object($sender) || !method_exists($sender, "getMessages")) {
+        if (!($sender instanceof DiscussionController)) {
             return;
         }
 

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -1111,6 +1111,23 @@ class VanillaHooks implements Gdn_IPlugin {
     }
 
     /**
+     * Hook in before a discussion is rendered and display a canonical notice, if relevant.
+     *
+     * @param mixed DiscussionController $sender
+     * @param array array $args
+     */
+    public function discussionController_beforeDiscussionDisplay_handler($sender, array $args) {
+        if (!is_object($sender) || !method_exists($sender, "getMessages")) {
+            return;
+        }
+
+        $messages = $sender->getMessages();
+        foreach ($messages as $message) {
+            echo $message;
+        }
+    }
+
+    /**
      * Automatically executed when application is enabled.
      *
      * @since 2.0.0

--- a/library/Vanilla/Message.php
+++ b/library/Vanilla/Message.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla;
+
+/**
+ * Represent a basic UI message.
+ */
+class Message {
+
+    const TYPE_ALERT = "Alert";
+
+    const TYPE_CASUAL = "Casual";
+
+    const TYPE_INFORMATION = "Info";
+
+    const TYPE_WARNING = "Warning";
+
+    /** @var string */
+    private $body;
+
+    /** @var array */
+    private $classes = ["DismissMessage"];
+
+    /** @var string */
+    private $type;
+
+    /**
+     * Create a new message.
+     *
+     * @param string $body
+     * @param string $type
+     */
+    public function __construct(string $body, string $type) {
+        $this->setBody($body);
+        $this->setType($type);
+    }
+
+    /**
+     * Render contents when the instance is referenced as a string.
+     *
+     * @return string
+     */
+    public function __toString() {
+        $classes = $this->classes;
+        $classes[] = "{$this->type}Message";
+        return '<div class="' . implode(" ", $classes) . '">' . $this->body . '</div>';
+    }
+
+    /**
+     * Set the content of this message.
+     *
+     * @param string $body
+     */
+    public function setBody(string $body) {
+        $this->body = $body;
+    }
+
+    /**
+     * Set the message type.
+     *
+     * @param string $type
+     */
+    public function setType(string $type) {
+        $validTypes = [static::TYPE_ALERT, static::TYPE_CASUAL, static::TYPE_INFORMATION, static::TYPE_WARNING];
+
+        if (!in_array($type, $validTypes)) {
+            throw new \InvalidArgumentException("Invalid type: {$type}. Type must be one of the following: " . implode(", ", $validTypes));
+        }
+
+        $this->type = $type;
+    }
+}

--- a/library/Vanilla/Message.php
+++ b/library/Vanilla/Message.php
@@ -20,7 +20,7 @@ class Message {
     const TYPE_WARNING = "Warning";
 
     /** @var string */
-    private $body;
+    private $htmlBody;
 
     /** @var array */
     private $classes = ["DismissMessage"];
@@ -31,11 +31,11 @@ class Message {
     /**
      * Create a new message.
      *
-     * @param string $body
+     * @param string $htmlBody
      * @param string $type
      */
-    public function __construct(string $body, string $type) {
-        $this->setBody($body);
+    public function __construct(string $htmlBody, string $type) {
+        $this->setHtmlBody($htmlBody);
         $this->setType($type);
     }
 
@@ -47,16 +47,16 @@ class Message {
     public function __toString() {
         $classes = $this->classes;
         $classes[] = "{$this->type}Message";
-        return '<div class="' . implode(" ", $classes) . '">' . $this->body . '</div>';
+        return '<div class="' . implode(" ", $classes) . '">' . $this->htmlBody . '</div>';
     }
 
     /**
-     * Set the content of this message.
+     * Set the HTML content of this message.
      *
-     * @param string $body
+     * @param string $htmlBody
      */
-    public function setBody(string $body) {
-        $this->body = $body;
+    public function setHtmlBody(string $htmlBody) {
+        $this->htmlBody = $htmlBody;
     }
 
     /**


### PR DESCRIPTION
The ability to set a discussion's canonical URL was recently added. There we no UI indicators that a discussion could potentially be pointing to a new resource. Those UI indicators are added here.

### Overview
1. Add `Vanilla\Message` class. This is a basic class that represents a site message. It is built to follow the established convention of message classes and structure (see [class.messagecontroller.php](https://github.com/vanilla/vanilla/blob/master/applications/dashboard/controllers/class.messagecontroller.php)).
1. Add backward-compatible display of messages when viewing a discussion. The BeforeDiscussionDisplay event is hooked into and messages are output at that point.
1. Add ability to set messages in `DiscussionController`. Messages may be added any time before rendering. When a discussion is rendered, the messages will be included before it.
1. Add a message to a discussion if a user-provided canonical URL is detected.

### Testing

To see the message on a discussion, you'll need to set its canonical URL. You can do this in a couple ways:
1. Set a discussion's canonical URL using the API (PUT /api/v2/discussions/{id}/canonical-url).
1. Edit a discussion in the database. Set its Attributes column to `{"CanonicalUrl":"/path/to/resource"}`.

Closes #8261