### PR TITLE
Fix auto marking categories as read

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -716,7 +716,7 @@ class CommentModel extends Gdn_Model {
 
         } else {
             // Make sure the discussion isn't archived.
-            $archiveDate = c('Vanilla.Archive.Date', false);
+            $archiveDate = Gdn::config('Vanilla.Archive.Date', false);
             if (!$archiveDate || (Gdn_Format::toTimestamp($discussion->DateLastComment) > Gdn_Format::toTimestamp($archiveDate))) {
                 $newComments = true;
 
@@ -741,7 +741,7 @@ class CommentModel extends Gdn_Model {
 
         // If this discussion is in a category that has been marked read,
         // check if reading this thread causes it to be completely read again.
-        $categoryID = val('CategoryID', $discussion);
+        $categoryID = $discussion->CategoryID;
         if (!$categoryID) {
             return;
         }
@@ -749,12 +749,12 @@ class CommentModel extends Gdn_Model {
         if (!$category) {
             return;
         }
-        $dateMarkedRead = val('DateMarkedRead', $category);
+        $dateMarkedRead = $category->DateMarkedRead;
         if (!$dateMarkedRead) {
             return;
         }
         // Fuzzy way of looking back about 2 pages into the past.
-        $lookBackCount = c('Vanilla.Discussions.PerPage', 50) * 2;
+        $lookBackCount = Gdn::config('Vanilla.Discussions.PerPage', 50) * 2;
 
         // Find all discussions with content from after DateMarkedRead.
         $discussionModel = new DiscussionModel();

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -749,19 +749,17 @@ class CommentModel extends Gdn_Model {
         if (!$category) {
             return;
         }
+        $wheres = ['CategoryID' => $categoryID];
         $dateMarkedRead = $category->DateMarkedRead;
-        if (!$dateMarkedRead) {
-            return;
+        if ($dateMarkedRead) {
+            $wheres['DateLastComment>'] = $dateMarkedRead;
         }
         // Fuzzy way of looking back about 2 pages into the past.
         $lookBackCount = Gdn::config('Vanilla.Discussions.PerPage', 50) * 2;
 
         // Find all discussions with content from after DateMarkedRead.
         $discussionModel = new DiscussionModel();
-        $discussions = $discussionModel->get(0, $lookBackCount + 1, [
-            'CategoryID' => $categoryID,
-            'DateLastComment>' => $dateMarkedRead
-        ]);
+        $discussions = $discussionModel->get(0, $lookBackCount + 1, $wheres);
         unset($discussionModel);
 
         // Abort if we get back as many as we asked for, meaning a


### PR DESCRIPTION
Categories that has never been marked as read weren't automatically marked as read when all discussions in such a discussion have been read.

This PR solves issue https://github.com/vanilla/vanilla/issues/6856
