### PR TITLE
Allow starting values for color picker form control

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -381,7 +381,8 @@ class Gdn_Form extends Gdn_Pluggable {
 
         // Default starting color for color input. Color inputs require one, Chrome will throw a warning if one
         // doesn't exist. The javascript will override this.
-        $colorAttributes['value'] = '#ffffff';
+        $colorAttributes['value'] = $options['value'] ?? '#ffffff';
+        $valueAttributes['value'] = $colorAttributes['value'];
 
         $cssClass = 'js-color-picker color-picker input-group';
         $dataAttribute = $allowEmpty ? 'data-allow-empty="true"' : 'data-allow-empty="false"';

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -373,25 +373,25 @@ class Gdn_Form extends Gdn_Pluggable {
     public function color($fieldName, $options = []) {
         Gdn::controller()->addJsFile('colorpicker.js');
 
-        $valueAttributes['class'] = 'js-color-picker-value color-picker-value Hidden';
-        $textAttributes['class'] = 'js-color-picker-text color-picker-text';
-        $colorAttributes['class'] = 'js-color-picker-color color-picker-color';
-
-        // Default starting color for color input. Color inputs require one, Chrome will throw a warning if one
-        // doesn't exist. The javascript will override this.
-        $colorAttributes['value'] = $options['Value'] ?? '#ffffff';
-        $valueAttributes['value'] = $colorAttributes['value'];
-
         $cssClass = 'js-color-picker color-picker input-group';
+        $allowEmpty = $options['AllowEmpty'] ?? '';
+        $dataAttribute = $allowEmpty ? ' data-allow-empty="true"' : ' data-allow-empty="false"';
 
-        $allowEmpty = $options['AllowEmpty'] ?? false;
-        if ($allowEmpty) {
-            $dataAttribute = 'data-allow-empty="true"';
-        } else {
-            $dataAttribute = 'data-allow-empty="false"';
+        $valueAttributes['class'] = 'js-color-picker-value color-picker-value Hidden';
+        if (isset($options['Value'])) {
+            $valueAttributes['value'] = $options['Value'];
         }
 
-        return '<div id="'.$this->escapeFieldName($fieldName).'" class="'.$cssClass.'" '.$dataAttribute.'>'
+        $textAttributes['class'] = 'js-color-picker-text color-picker-text';
+
+        // Default dummy starting color for color input. Color inputs require one, Chrome will throw a warning if one
+        // doesn't exist. The javascript will ignore this.
+        $colorAttributes = [
+            'class' => 'js-color-picker-color color-picker-color',
+            'value' => '#ffffff'
+        ];
+
+        return '<div id="'.$this->escapeFieldName($fieldName).'" class="'.$cssClass.'"'.$dataAttribute.'>'
         .$this->input($fieldName, 'text', $valueAttributes)
         .$this->input($fieldName.'-text', 'text', $textAttributes)
         .'<span class="js-color-picker-preview color-picker-preview"></span>'

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -365,8 +365,9 @@ class Gdn_Form extends Gdn_Pluggable {
      * is set to true. The hex value to be saved is the value of the input with the color-picker-value class.
      *
      * @param string $fieldName Name of the field being posted with this input.
-     * @param array $options Currently supports a key of 'AllowEmpty' which signifies whether to accept empty
-     * values for the color picker
+     * @param array $options An array of options with the following keys:
+     *      'AllowEmpty' (bool) Whether to accept empty values for the color picker, defaults to false
+     *      'Value' (string) Hex color code for the color picker to start with, defaults to "#ffffff"
      * @return string The form element for a color picker.
      */
     public function color($fieldName, $options = []) {

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -371,9 +371,6 @@ class Gdn_Form extends Gdn_Pluggable {
      * @return string The form element for a color picker.
      */
     public function color($fieldName, $options = []) {
-
-        $allowEmpty = val('AllowEmpty', $options, false);
-
         Gdn::controller()->addJsFile('colorpicker.js');
 
         $valueAttributes['class'] = 'js-color-picker-value color-picker-value Hidden';
@@ -386,7 +383,13 @@ class Gdn_Form extends Gdn_Pluggable {
         $valueAttributes['value'] = $colorAttributes['value'];
 
         $cssClass = 'js-color-picker color-picker input-group';
-        $dataAttribute = $allowEmpty ? 'data-allow-empty="true"' : 'data-allow-empty="false"';
+
+        $allowEmpty = $options['AllowEmpty'] ?? false;
+        if ($allowEmpty) {
+            $dataAttribute = 'data-allow-empty="true"';
+        } else {
+            $dataAttribute = 'data-allow-empty="false"';
+        }
 
         return '<div id="'.$this->escapeFieldName($fieldName).'" class="'.$cssClass.'" '.$dataAttribute.'>'
         .$this->input($fieldName, 'text', $valueAttributes)

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -379,7 +379,7 @@ class Gdn_Form extends Gdn_Pluggable {
 
         // Default starting color for color input. Color inputs require one, Chrome will throw a warning if one
         // doesn't exist. The javascript will override this.
-        $colorAttributes['value'] = $options['value'] ?? '#ffffff';
+        $colorAttributes['value'] = $options['Value'] ?? '#ffffff';
         $valueAttributes['value'] = $colorAttributes['value'];
 
         $cssClass = 'js-color-picker color-picker input-group';

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -373,23 +373,23 @@ class Gdn_Form extends Gdn_Pluggable {
     public function color($fieldName, $options = []) {
         Gdn::controller()->addJsFile('colorpicker.js');
 
-        $cssClass = 'js-color-picker color-picker input-group';
-        $allowEmpty = $options['AllowEmpty'] ?? '';
-        $dataAttribute = $allowEmpty ? ' data-allow-empty="true"' : ' data-allow-empty="false"';
-
         $valueAttributes['class'] = 'js-color-picker-value color-picker-value Hidden';
+        $textAttributes['class'] = 'js-color-picker-text color-picker-text';
+        $colorAttributes['class'] = 'js-color-picker-color color-picker-color';
+
         if (isset($options['Value'])) {
             $valueAttributes['value'] = $options['Value'];
+            $colorAttributes['value'] = $options['Value'];
+        } else {
+            // Default dummy starting color for color input. Color inputs require one, Chrome
+            // will throw a warning if one doesn't exist. The javascript will ignore this.
+            $colorAttributes['value'] = '#ffffff';
         }
 
-        $textAttributes['class'] = 'js-color-picker-text color-picker-text';
+        $cssClass = 'js-color-picker color-picker input-group';
 
-        // Default dummy starting color for color input. Color inputs require one, Chrome will throw a warning if one
-        // doesn't exist. The javascript will ignore this.
-        $colorAttributes = [
-            'class' => 'js-color-picker-color color-picker-color',
-            'value' => '#ffffff'
-        ];
+        $allowEmpty = $options['AllowEmpty'] ?? '';
+        $dataAttribute = $allowEmpty ? ' data-allow-empty="true"' : ' data-allow-empty="false"';
 
         return '<div id="'.$this->escapeFieldName($fieldName).'" class="'.$cssClass.'"'.$dataAttribute.'>'
         .$this->input($fieldName, 'text', $valueAttributes)

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -388,7 +388,7 @@ class Gdn_Form extends Gdn_Pluggable {
 
         $cssClass = 'js-color-picker color-picker input-group';
 
-        $allowEmpty = $options['AllowEmpty'] ?? '';
+        $allowEmpty = $options['AllowEmpty'] ?? false;
         $dataAttribute = $allowEmpty ? ' data-allow-empty="true"' : ' data-allow-empty="false"';
 
         return '<div id="'.$this->escapeFieldName($fieldName).'" class="'.$cssClass.'"'.$dataAttribute.'>'


### PR DESCRIPTION
This fixes: https://github.com/vanilla/vanilla/issues/8575

The color picker always started with a default value. With this change the starting value can be passed to the form control like that: ` $form->color('FieldName', ['Value' => '#0099aa'])`