### PR TITLE
Fix PHP 7.1 version requirement

### DIFF
--- a/environment.php
+++ b/environment.php
@@ -7,7 +7,7 @@
  * @license GPL-2.0-only
  */
 
-if (PHP_VERSION_ID < 71000) {
+if (PHP_VERSION_ID < 70100) {
     die('Vanilla requires PHP 7.1 or greater.');
 }
 


### PR DESCRIPTION
#8571 increased Vanilla's PHP version requirement to 7.1. However, the value of `PHP_VERSION_ID` it was checking for was "71000", which would be 7.10. It should be "70100".

Per [php.net](https://www.php.net/manual/en/function.phpversion.php):
1. (`major_version` * 10000) + (`minor_version` * 100) + `release_version`
1. (7 * 1000) + (1 * 100) + 0
1. 70000 + 100 + 0
1. 70100

Guessing the build ducks this check.