### PR TITLE
Add variables and helper functions for hyphenation CSS props

### DIFF
--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -285,6 +285,17 @@ export const globalVariables = useThemeCache(() => {
         size: 1,
     });
 
+    // https://medium.com/@clagnut/all-you-need-to-know-about-hyphenation-in-css-2baee2d89179
+    // Requires language set on <html> tag
+    const userContentHyphenation = makeThemeVars("userContentHyphenation", {
+        minimumCharactersToHyphenate: 6,
+        minimumCharactersBeforeBreak: 3,
+        minimumCharactersAfterBreak: 3,
+        maximumConsecutiveBrokenLines: 2,
+        avoidLastWordToBeBroken: true,
+        hyphenationZone: "6em",
+    });
+
     return {
         utility,
         elementaryColors,
@@ -311,6 +322,7 @@ export const globalVariables = useThemeCache(() => {
         mixPrimaryAndFg,
         mixPrimaryAndBg,
         separator,
+        userContentHyphenation,
     };
 });
 

--- a/library/src/scripts/styles/textUtils.ts
+++ b/library/src/scripts/styles/textUtils.ts
@@ -5,6 +5,8 @@
 
 import { em } from "csx";
 import { NestedCSSSelectors, TLength } from "typestyle/lib/types";
+import { globalVariables } from "@library/styles/globalStyleVars";
+import { unit } from "@library/styles/styleHelpers";
 
 /**
  * Many fonts don't set the capital letter to take the whole line height. This mixin is used to line up the top of the Text with the top of the container.
@@ -54,4 +56,35 @@ export function lineHeightAdjustment(
     }
 
     return result;
+}
+
+export function defaultHyphenation() {
+    const vars = globalVariables().userContentHyphenation;
+    return {
+        "-ms-hyphens": "auto",
+        "-webkit-hyphens": "auto",
+        hyphens: "auto",
+        /* legacy properties */
+        "-webkit-hyphenate-limit-before": vars.minimumCharactersBeforeBreak,
+        "-webkit-hyphenate-limit-after": vars.minimumCharactersAfterBreak,
+        /* current proposal */
+        "-moz-hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${
+            vars.minimumCharactersAfterBreak
+        }` /* not yet supported */,
+        "-webkit-hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${
+            vars.minimumCharactersAfterBreak
+        }` /* not yet supported */,
+        "-ms-hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${
+            vars.minimumCharactersAfterBreak
+        }`,
+        "hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${
+            vars.minimumCharactersAfterBreak
+        }`,
+        // Maximum consecutive lines to have hyphenation
+        "-ms-hyphenate-limit-lines": vars.maximumConsecutiveBrokenLines,
+        "-webkit-hyphenate-limit-lines": vars.maximumConsecutiveBrokenLines,
+        "hyphenate-limit-lines": vars.maximumConsecutiveBrokenLines,
+        // Limit "zone" to hyphenate
+        "hyphenate-limit-zone": unit(vars.hyphenationZone),
+    };
 }


### PR DESCRIPTION
CSS now has good support for controlling hyphenation. This PR includes the CSS variables as well as a helper function to apply them (with all the fallbacks we need).

Note that this PR does not yet apply these styles, since I want to get approval for the values chosen. Issue created here to apply styles: https://github.com/vanilla/knowledge/issues/807