### PR TITLE
New Paragraph Menu - Keyboard shortcuts

### DIFF
--- a/plugins/rich-editor/src/scripts/editor/richEditorClasses.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorClasses.ts
@@ -245,6 +245,10 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
         },
     });
 
+    const topLevelButtonActive = style("topLevelButtonActive", {
+        color: colorOut(globalVars.mainColors.primary),
+    });
+
     const menuItem = style("menuItem", {
         display: "block",
         padding: 0,
@@ -343,6 +347,7 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
         embedBar,
         menuItem,
         button,
+        topLevelButtonActive,
         icon,
         close,
         flyoutDescription,

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
@@ -212,6 +212,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                         {...menu}
                         setRovingIndex={myRovingIndex}
                         disabled={!menu.open}
+                        closeMenu={this.props.close}
                         closeMenuAndSetCursor={this.closeMenuAndSetCursor}
                     />
                 </div>
@@ -256,11 +257,11 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                     <div className={classes.menuBarToggles}>
                         {menus}
                         <ParagraphMenuResetTab
-                            isActive={menuActiveFormats.paragraph}
                             formatParagraphHandler={textFormats.paragraph}
                             setRovingIndex={setParagraphIndex}
                             tabIndex={this.tabIndex(paragraphIndex)}
                             closeMenuAndSetCursor={this.closeMenuAndSetCursor}
+                            isMenuVisible={this.props.isMenuVisible}
                         />
                     </div>
                 </div>

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
@@ -324,7 +324,7 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
      * Close the paragraph menu and place the selection at the end of the current selection if there is one.
      */
     private close = (focusToggle: boolean = false) => {
-        this.setState({ hasFocus: true });
+        this.setState({ hasFocus: false });
         const { lastGoodSelection } = this.props;
         if (!focusToggle) {
             const newSelection = {

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
@@ -23,6 +23,17 @@ import { srOnly } from "@library/styles/styleHelpers";
 import { style } from "typestyle";
 import tabbable from "tabbable";
 import TabHandler from "@library/dom/TabHandler";
+import {
+    blockquote,
+    codeBlock,
+    heading2,
+    heading3,
+    heading4,
+    heading5,
+    listOrdered,
+    listUnordered,
+    spoiler,
+} from "@library/icons/editorIcons";
 
 export enum IMenuBarItemTypes {
     CHECK = "checkbox",
@@ -50,7 +61,8 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
     private buttonID: string;
     private selfRef: React.RefObject<HTMLDivElement> = React.createRef();
     private buttonRef: React.RefObject<HTMLButtonElement> = React.createRef();
-    private menuRef: React.RefObject<HTMLDivElement> = React.createRef();
+    private menusRef: React.RefObject<HTMLDivElement> = React.createRef();
+    private panelsRef: React.RefObject<HTMLDivElement> = React.createRef();
     private formatter: Formatter;
     private focusWatcher: FocusWatcher;
 
@@ -113,6 +125,7 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
 
         const textFormats = paragraphFormats(this.formatter, this.props.lastGoodSelection);
         const menuActiveFormats = menuState(this.props.activeFormats);
+        const topLevelIcons = this.topLevelIcons(menuActiveFormats);
 
         return (
             <div
@@ -153,7 +166,8 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
                     role="menu"
                 >
                     <ParagraphMenuBar
-                        menuRef={this.menuRef}
+                        menusRef={this.menusRef}
+                        panelsRef={this.panelsRef}
                         parentID={this.ID}
                         label={"Paragraph Format Menu"}
                         isMenuVisible={this.isMenuVisible}
@@ -164,6 +178,7 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
                         menuActiveFormats={menuActiveFormats}
                         rovingIndex={this.state.rovingTabIndex}
                         setRovingIndex={this.setRovingIndex}
+                        topLevelIcons={topLevelIcons}
                     />
                 </div>
             </div>
@@ -176,6 +191,35 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
     private get isPilcrowVisible() {
         return this.props.currentSelection;
     }
+
+    private topLevelIcons = menuActiveFormats => {
+        let headingMenuIcon = heading2();
+        if (menuActiveFormats.headings.heading3) {
+            headingMenuIcon = heading3();
+        } else if (menuActiveFormats.headings.heading4) {
+            headingMenuIcon = heading4();
+        } else if (menuActiveFormats.headings.heading5) {
+            headingMenuIcon = heading5();
+        }
+
+        let specialBlockMenuIcon = blockquote();
+        if (menuActiveFormats.specialFormats.codeBlock) {
+            specialBlockMenuIcon = codeBlock();
+        } else if (menuActiveFormats.specialFormats.spoiler) {
+            specialBlockMenuIcon = spoiler();
+        }
+
+        let listMenuIcon = listUnordered();
+        if (menuActiveFormats.lists.ordered) {
+            listMenuIcon = listOrdered();
+        }
+
+        return {
+            headingMenuIcon,
+            listMenuIcon,
+            specialBlockMenuIcon,
+        };
+    };
 
     /**
      * Show the menu if we have a valid selection, and a valid focus.
@@ -265,8 +309,8 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
     private pilcrowClickHandler = (event: React.MouseEvent<any>) => {
         event.preventDefault();
         this.setState({ hasFocus: !this.state.hasFocus }, () => {
-            if (this.state.hasFocus && this.menuRef.current) {
-                const menu: HTMLElement = this.menuRef.current;
+            if (this.state.hasFocus && this.menusRef.current) {
+                const menu: HTMLElement = this.menusRef.current!;
                 const tabHandler = new TabHandler(menu);
                 const nextEl = tabHandler.getInitial();
                 if (nextEl) {

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/items/ParagraphMenuBarRadioGroup.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/items/ParagraphMenuBarRadioGroup.tsx
@@ -21,6 +21,7 @@ export interface IParagraphMenuBarRadioGroupProps {
     className?: string;
     items: IMenuBarRadioButton[];
     handleClick: (data: IMenuBarRadioButton, index: number) => void;
+    disabled?: boolean;
 }
 
 /**
@@ -48,6 +49,7 @@ export default class ParagraphMenuBarRadioGroup extends React.PureComponent<IPar
                                 text={item.text}
                                 type={IMenuBarItemTypes.RADIO}
                                 onClick={onClick}
+                                disabled={item.disabled || !!this.props.disabled}
                                 key={`checkRadio-${index}`}
                             />
                         );

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/pieces/ParagraphMenuCheckRadio.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/pieces/ParagraphMenuCheckRadio.tsx
@@ -17,6 +17,7 @@ export interface IMenuCheckRadio {
     checked: boolean;
     icon: JSX.Element;
     text: string;
+    disabled?: boolean;
 }
 
 interface IProps {
@@ -25,6 +26,7 @@ interface IProps {
     text: string;
     type: IMenuBarItemTypes;
     onClick: (event: any) => void;
+    disabled?: boolean;
 }
 
 /**
@@ -56,6 +58,8 @@ export default class ParagraphMenuCheckRadio extends React.PureComponent<IProps>
                 aria-checked={checked}
                 type="button"
                 onClick={onClick}
+                disabled={!!this.props.disabled}
+                tabIndex={!!this.props.disabled ? -1 : 0}
             >
                 <span className={classes.icon}>{icon}</span>
                 <span className={classes.checkRadioLabel}>{text}</span>

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
@@ -42,9 +42,6 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
         this.componentID = this.ID + "-component";
         this.menuID = this.ID + "-menu";
         this.buttonID = this.ID + "-button";
-        this.state = {
-            open: false,
-        };
     }
 
     public render() {
@@ -70,7 +67,7 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
                         aria-expanded={isMenuVisible}
                         aria-haspopup="menu"
                         onClick={handleClick}
-                        className={classes.button}
+                        className={classNames(classes.button, this.props.open ? classes.topLevelButtonActive : "")}
                         tabIndex={this.props.tabIndex}
                         ref={this.toggleButtonRef}
                     >

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
@@ -35,6 +35,7 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
     private buttonID;
     private selfRef;
     private toggleButtonRef: React.RefObject<HTMLButtonElement> = React.createRef();
+    private handleClick;
 
     constructor(props: IProps) {
         super(props);
@@ -42,18 +43,20 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
         this.componentID = this.ID + "-component";
         this.menuID = this.ID + "-menu";
         this.buttonID = this.ID + "-button";
+
+        this.handleClick = (event: React.MouseEvent) => {
+            this.props.setRovingIndex();
+            this.props.toggleMenu(() => {
+                this.toggleButtonRef.current && this.toggleButtonRef.current.focus();
+            });
+        };
     }
 
     public render() {
         const { className, isMenuVisible, toggleMenu, children, icon } = this.props;
         if (open) {
             const classes = richEditorClasses(this.props.legacyMode);
-            const handleClick = (event: React.MouseEvent) => {
-                this.props.setRovingIndex();
-                this.props.toggleMenu(() => {
-                    this.toggleButtonRef.current && this.toggleButtonRef.current.focus();
-                });
-            };
+
             // If the roving index matches my index, or no roving index is set and we're on the first tab
             return (
                 <div id={this.componentID} ref={this.selfRef} className={classNames(className)}>
@@ -66,10 +69,11 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
                         aria-controls={this.menuID}
                         aria-expanded={isMenuVisible}
                         aria-haspopup="menu"
-                        onClick={handleClick}
+                        onClick={this.handleClick}
                         className={classNames(classes.button, this.props.open ? classes.topLevelButtonActive : "")}
                         tabIndex={this.props.tabIndex}
                         ref={this.toggleButtonRef}
+                        onKeyDown={this.handleMenuBarKeyDown}
                     >
                         {icon}
                         <ScreenReaderContent>{this.props.accessibleButtonLabel}</ScreenReaderContent>
@@ -81,7 +85,36 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
         }
     }
 
+    public componentDidMount() {
+        if (!this.props.open && this.props.tabIndex === 0) {
+            this.toggleButtonRef.current && this.toggleButtonRef.current.focus();
+        }
+    }
+
+    public componentDidUpdate() {
+        if (!this.props.open && this.props.tabIndex === 0) {
+            this.toggleButtonRef.current && this.toggleButtonRef.current.focus();
+        }
+    }
+
     public getMenuContentsID() {
         return this.menuID;
     }
+
+    /**
+     * From an accessibility point of view, this is a Editor Menubar. The only difference is it has a toggled visibility
+     *
+     * @see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-2/menubar-2.html
+     */
+    private handleMenuBarKeyDown = (event: React.KeyboardEvent<any>) => {
+        switch (`${event.key}${event.shiftKey ? "-Shift" : ""}`) {
+            // Opens submenu and moves focus to first item in the submenu.
+            case "ArrowDown":
+                if (!this.props.open) {
+                    event.preventDefault();
+                    this.handleClick();
+                }
+                break;
+        }
+    };
 }

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuHeadingsTabContent.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuHeadingsTabContent.tsx
@@ -17,6 +17,7 @@ interface IProps {
     closeMenuAndSetCursor: () => void;
     className?: string;
     setRovingIndex: () => void;
+    disabled?: boolean;
 }
 
 /**
@@ -36,6 +37,7 @@ export default class ParagraphMenuHeadingsTabContent extends React.Component<IPr
                 handleClick={handleClick}
                 label={t("Headings")}
                 items={this.props.items}
+                disabled={this.props.disabled}
             />
         );
     }

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuHeadingsTabContent.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuHeadingsTabContent.tsx
@@ -14,6 +14,7 @@ import { richEditorClasses } from "@rich-editor/editor/richEditorClasses";
 
 interface IProps {
     items: IMenuBarRadioButton[];
+    closeMenu: () => void;
     closeMenuAndSetCursor: () => void;
     className?: string;
     setRovingIndex: () => void;

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuListsTabContent.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuListsTabContent.tsx
@@ -16,6 +16,7 @@ import { indent, outdent } from "@library/icons/editorIcons";
 import { richEditorClasses } from "@rich-editor/editor/richEditorClasses";
 
 interface IProps {
+    closeMenu: () => void;
     closeMenuAndSetCursor: () => void;
     items: IMenuBarRadioButton[];
     setRovingIndex: () => void;
@@ -33,8 +34,8 @@ export default class ParagraphMenuListsTabContent extends React.Component<IProps
         const checkRadioClasses = paragraphMenuCheckRadioClasses();
         const handleClick = (data: IMenuBarRadioButton, index: number) => {
             this.props.items[index].formatFunction();
-            this.props.closeMenuAndSetCursor();
             this.props.setRovingIndex();
+            this.props.closeMenuAndSetCursor();
         };
         return (
             <>

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuListsTabContent.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuListsTabContent.tsx
@@ -21,6 +21,7 @@ interface IProps {
     setRovingIndex: () => void;
     indent: () => void;
     outdent: () => void;
+    disabled?: boolean;
 }
 
 /**
@@ -42,6 +43,7 @@ export default class ParagraphMenuListsTabContent extends React.Component<IProps
                     label={t("List Types")}
                     items={this.props.items}
                     handleClick={handleClick}
+                    disabled={!!this.props.disabled}
                 />
                 <ParagraphMenuSeparator />
                 <div className={checkRadioClasses.group}>
@@ -49,6 +51,8 @@ export default class ParagraphMenuListsTabContent extends React.Component<IProps
                         className={classNames(checkRadioClasses.checkRadio)}
                         type="button"
                         onClick={this.props.indent}
+                        disabled={!!this.props.disabled}
+                        tabIndex={!!this.props.disabled ? -1 : 0}
                     >
                         <span className={checkRadioClasses.icon}>{indent()}</span>
                         <span className={checkRadioClasses.checkRadioLabel}>{t("Indent")}</span>
@@ -57,6 +61,8 @@ export default class ParagraphMenuListsTabContent extends React.Component<IProps
                         className={classNames(checkRadioClasses.checkRadio)}
                         type="button"
                         onClick={this.props.outdent}
+                        disabled={!!this.props.disabled}
+                        tabIndex={!!this.props.disabled ? -1 : 0}
                     >
                         <span className={checkRadioClasses.icon}>{outdent()}</span>
                         <span className={checkRadioClasses.checkRadioLabel}>{t("Outdent")}</span>

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuResetTab.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuResetTab.tsx
@@ -52,4 +52,16 @@ export default class ParagraphMenuResetTab extends React.PureComponent<IProps> {
             </button>
         );
     }
+
+    public componentDidMount() {
+        if (this.props.tabIndex === 0) {
+            this.buttonRef.current && this.buttonRef.current.focus();
+        }
+    }
+
+    public componentDidUpdate() {
+        if (this.props.tabIndex === 0) {
+            this.buttonRef.current && this.buttonRef.current.focus();
+        }
+    }
 }

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuResetTab.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuResetTab.tsx
@@ -14,12 +14,12 @@ import ScreenReaderContent from "@library/layout/ScreenReaderContent";
 interface IProps {
     formatParagraphHandler: () => void;
     className?: string;
-    isActive: boolean;
     isDisabled?: boolean;
     tabIndex: 0 | -1;
     setRovingIndex: (callback?: () => void) => void;
     closeMenuAndSetCursor: () => void;
     legacyMode?: boolean;
+    isMenuVisible: boolean;
 }
 
 /**
@@ -54,13 +54,13 @@ export default class ParagraphMenuResetTab extends React.PureComponent<IProps> {
     }
 
     public componentDidMount() {
-        if (this.props.tabIndex === 0) {
+        if (this.props.isMenuVisible && this.props.tabIndex === 0) {
             this.buttonRef.current && this.buttonRef.current.focus();
         }
     }
 
     public componentDidUpdate() {
-        if (this.props.tabIndex === 0) {
+        if (this.props.isMenuVisible && this.props.tabIndex === 0) {
             this.buttonRef.current && this.buttonRef.current.focus();
         }
     }

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuSpecialBlockTabContent.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuSpecialBlockTabContent.tsx
@@ -16,6 +16,7 @@ interface IProps {
     items: IMenuBarRadioButton[];
     closeMenuAndSetCursor: () => void;
     className?: string;
+    disabled?: boolean;
 }
 
 /**
@@ -34,6 +35,7 @@ export default class ParagraphMenuBlockTabContent extends React.Component<IProps
                 handleClick={handleClick}
                 label={t("Special Formats")}
                 items={this.props.items}
+                disabled={this.props.disabled}
             />
         );
     }

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuSpecialBlockTabContent.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuSpecialBlockTabContent.tsx
@@ -14,6 +14,7 @@ import { richEditorClasses } from "@rich-editor/editor/richEditorClasses";
 
 interface IProps {
     items: IMenuBarRadioButton[];
+    closeMenu: () => void;
     closeMenuAndSetCursor: () => void;
     className?: string;
     disabled?: boolean;


### PR DESCRIPTION
This PR is adding keyboard shortcuts for the new paragraph menu. Note there will be another PR for the missing shortcuts.

MenuBar:
- Escape: (closes submenu if open) or closes menuBar (i.e. paragraph menu)
- Home: jump to first element
- End: jump to last element
- Arrow Right : jump to next element (wraps)
- Arrow Left: jump to last element (wraps)
- Arrow Down : opens menu and selects first item if available
- Arrow Up: closes menu


Other changes: 
- Refactored calculation for top level icons
- Keep menu's state when we close the paragraph menu. (i.e. if you were in the list tab, you'll be there again when you open the menu up again)