### PR TITLE
Allow headings of level 2-5 in the rich content renderer

### DIFF
--- a/library/Vanilla/Formatting/Quill/Blots/Lines/HeadingTerminatorBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Lines/HeadingTerminatorBlot.php
@@ -11,12 +11,12 @@ use Vanilla\Formatting\Quill\BlotGroup;
 /**
  * Blot to represent heading line terminators.
  *
- * Currently only 2 levels are allowed.
+ * Levels 2-5 are allowed.
  */
 class HeadingTerminatorBlot extends AbstractLineTerminatorBlot {
 
     /** @var array Valid heading levels. */
-    const VALID_LEVELS = [2, 3];
+    const VALID_LEVELS = [2, 3, 4, 5];
 
     /** @var int the default heading level if a none is provided. */
     const DEFAULT_LEVEL = 2;

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -309,7 +309,7 @@ class ParserTest extends SharedBootstrapTestCase {
         $result = [[["class" => HeadingTerminatorBlot::class, "content" => ""]]];
         $this->assertParseResults($ops, $result);
 
-        $ops = [["attributes" => ["header" => 5], "content" => "\n"]];
+        $ops = [["attributes" => ["header" => 10], "content" => "\n"]];
         $result = [[["class" => NullBlot::class, "content" => ""]]];
         $this->assertParseResults($ops, $result);
     }

--- a/tests/fixtures/formats/rich/html/headings/input.json
+++ b/tests/fixtures/formats/rich/html/headings/input.json
@@ -31,5 +31,23 @@
     },
     {
         "insert": "normal\n"
+    },
+    {
+        "insert": "h4"
+    },
+    {
+        "attributes": {
+            "header": 4
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "h5"
+    },
+    {
+        "attributes": {
+            "header": 5
+        },
+        "insert": "\n"
     }
 ]

--- a/tests/fixtures/formats/rich/html/headings/output.html
+++ b/tests/fixtures/formats/rich/html/headings/output.html
@@ -2,3 +2,5 @@
 <h2 data-id="h2-with-ref">h2 with ref</h2>
 <h3>h3</h3>
 <p>normal</p>
+<h4>h4</h4>
+<h5>h5</h5>


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8432

@slafleche Already wired up the new heading levels in the editor. This PR adds server rendering support for them.