### PR TITLE
Implement missing accessible keyboard short cuts for new paragraph menu.

### DIFF
--- a/library/src/scripts/dom/TabHandler.ts
+++ b/library/src/scripts/dom/TabHandler.ts
@@ -76,6 +76,17 @@ export default class TabHandler {
     }
 
     /**
+     * Get all.
+     */
+    public getAll(from: Element | null = document.activeElement) {
+        if (!(from instanceof HTMLElement)) {
+            logError("Unable to tab to next element, `fromElement` given is not valid: ", from);
+            return null;
+        }
+        return this.tabbableElements.filter(this.createExcludeFilterWithExemption(from));
+    }
+
+    /**
      * Get the first focusable element.
      */
     public getInitial(): HTMLElement | null {

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
@@ -4,7 +4,11 @@
  * @license GPL-2.0-only
  */
 
-import TabHandler from "@library/dom/TabHandler";
+import React from "react";
+import classNames from "classnames";
+import ParagraphMenuBarTab from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuBarTab";
+import ParagraphMenuResetTab from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuResetTab";
+import ParagraphMenuHeadingsTabContent from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuHeadingsTabContent";
 import {
     blockquote,
     codeBlock,
@@ -16,21 +20,17 @@ import {
     listUnordered,
     spoiler,
 } from "@library/icons/editorIcons";
-import { globalVariables } from "@library/styles/globalStyleVars";
-import { srOnly, unit } from "@library/styles/styleHelpers";
-import { t } from "@library/utility/appUtils";
-import { richEditorClasses } from "@rich-editor/editor/richEditorClasses";
-import { IParagraphMenuState } from "@rich-editor/menuBar/paragraph/formats/formatting";
-import { IMenuBarRadioButton } from "@rich-editor/menuBar/paragraph/items/ParagraphMenuBarRadioGroup";
-import ParagraphMenuBarTab from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuBarTab";
-import ParagraphMenuHeadingsTabContent from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuHeadingsTabContent";
-import ParagraphMenuListsTabContent from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuListsTabContent";
-import ParagraphMenuResetTab from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuResetTab";
-import ParagraphMenuSpecialBlockTabContent from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuSpecialBlockTabContent";
-import classNames from "classnames";
 import { RangeStatic } from "quill/core";
-import React from "react";
+import { t } from "@library/utility/appUtils";
+import ParagraphMenuListsTabContent from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuListsTabContent";
+import { richEditorClasses } from "@rich-editor/editor/richEditorClasses";
+import { srOnly, unit } from "@library/styles/styleHelpers";
+import { IMenuBarRadioButton } from "@rich-editor/menuBar/paragraph/items/ParagraphMenuBarRadioGroup";
+import ParagraphMenuSpecialBlockTabContent from "@rich-editor/menuBar/paragraph/tabs/ParagraphMenuSpecialBlockTabContent";
 import { style } from "typestyle";
+import { globalVariables } from "@library/styles/globalStyleVars";
+import TabHandler from "@library/dom/TabHandler";
+import { IParagraphMenuState } from "@rich-editor/menuBar/paragraph/formats/formatting";
 import Formatter from "@rich-editor/quill/Formatter";
 
 interface IProps {
@@ -66,7 +66,7 @@ interface IMenuBarContent {
     indent?: () => void;
     outdent?: () => void;
     activeFormats: any;
-    openMenu: () => void;
+    openMenu: (callback: () => void) => void;
 }
 
 interface IState {
@@ -86,6 +86,8 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
     };
 
     private itemCount: number;
+    private openTabFunctions;
+    private menuBarLetterIndex: string[] = [];
 
     public render() {
         const { menuActiveFormats, formatter } = this.props;
@@ -99,8 +101,8 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         const menuContents: IMenuBarContent[] = [
             {
                 component: ParagraphMenuHeadingsTabContent,
-                accessibleInstructions: t("Toggle Heading Menu"),
-                label: t("Headings"),
+                accessibleInstructions: t("Headings Menu"),
+                label: t("Headings Menu"),
                 toggleMenu: this.toggleHeadingsMenu,
                 icon: this.props.topLevelIcons.headingMenuIcon,
                 activeFormats: menuActiveFormats.headings,
@@ -135,8 +137,8 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             },
             {
                 component: ParagraphMenuListsTabContent,
-                accessibleInstructions: t("Toggle Lists Menu"),
-                label: t("Lists"),
+                accessibleInstructions: t("Lists Menu"),
+                label: t("Lists Menu"),
                 toggleMenu: this.toggleListsMenu,
                 icon: this.props.topLevelIcons.listMenuIcon,
                 activeFormats: menuActiveFormats.lists,
@@ -200,14 +202,17 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         ];
 
         this.itemCount = menuContents.length + 1;
-
         const panelContent: JSX.Element[] = [];
+        this.openTabFunctions = [];
 
         const menus = menuContents.map((menu, index) => {
             const MyContent = menu.component;
             const myRovingIndex = () => {
                 this.props.setRovingIndex(index);
             };
+
+            this.openTabFunctions[index] = menu.openMenu;
+            this.menuBarLetterIndex[index] = menu.label.substr(0, 1);
 
             panelContent[index] = (
                 <div
@@ -247,6 +252,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                     legacyMode={this.props.legacyMode}
                     tabIndex={this.tabIndex(index)}
                     open={menu.open}
+                    selectFirstElement={this.selectLastElementInOpenPanel}
                 />
             );
         });
@@ -255,8 +261,11 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         const setParagraphIndex = () => {
             this.props.setRovingIndex(0);
         };
+        this.openTabFunctions[panelContent.length] = this.closeAllSubMenus;
+        const paragraphTitle = t("Paragraph (Removes paragraph style and sets to plain paragraph)");
+        this.menuBarLetterIndex[panelContent.length] = paragraphTitle.substr(0, 1);
         return (
-            <div onKeyDownCapture={this.handleMenuBarKeyDown}>
+            <div onKeyDown={this.handleMenuBarKeyDown}>
                 <div
                     role="menubar"
                     aria-label={this.props.label}
@@ -266,6 +275,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                     <div className={classes.menuBarToggles}>
                         {menus}
                         <ParagraphMenuResetTab
+                            title={paragraphTitle}
                             formatParagraphHandler={formatter.paragraph}
                             setRovingIndex={setParagraphIndex}
                             tabIndex={this.tabIndex(paragraphIndex)}
@@ -274,7 +284,9 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                         />
                     </div>
                 </div>
-                <div ref={this.props.panelsRef}>{panelContent}</div>
+                <div ref={this.props.panelsRef} onKeyDownCapture={this.handleMenuKeyDown}>
+                    {panelContent}
+                </div>
             </div>
         );
     }
@@ -296,12 +308,15 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             specialBlockMenuOpen: false,
         });
     };
-    private openHeadingsMenu = () => {
-        this.setState({
-            headingMenuOpen: true,
-            listMenuOpen: false,
-            specialBlockMenuOpen: false,
-        });
+    private openHeadingsMenu = (callback?: () => void) => {
+        this.setState(
+            {
+                headingMenuOpen: true,
+                listMenuOpen: false,
+                specialBlockMenuOpen: false,
+            },
+            callback,
+        );
     };
 
     private toggleListsMenu = () => {
@@ -312,12 +327,15 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         });
     };
 
-    private openListsMenu = () => {
-        this.setState({
-            headingMenuOpen: false,
-            listMenuOpen: true,
-            specialBlockMenuOpen: false,
-        });
+    private openListsMenu = (callback?: () => void) => {
+        this.setState(
+            {
+                headingMenuOpen: false,
+                listMenuOpen: true,
+                specialBlockMenuOpen: false,
+            },
+            callback,
+        );
     };
 
     private toggleSpecialBlockMenu = () => {
@@ -328,12 +346,15 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         });
     };
 
-    private openSpecialBlockMenu = () => {
-        this.setState({
-            headingMenuOpen: false,
-            listMenuOpen: false,
-            specialBlockMenuOpen: true,
-        });
+    private openSpecialBlockMenu = (callback?: () => void) => {
+        this.setState(
+            {
+                headingMenuOpen: false,
+                listMenuOpen: false,
+                specialBlockMenuOpen: true,
+            },
+            callback,
+        );
     };
 
     private closeMenuAndSetCursor = () => {
@@ -383,6 +404,15 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         return this.props.rovingIndex === index ? 0 : -1;
     };
 
+    private moveRovingIndexForward = (callback?: () => void) => {
+        const targetIndex = (this.props.rovingIndex + 1) % this.itemCount;
+        this.props.setRovingIndex(targetIndex, callback);
+    };
+    private moveRovingIndexBackwards = (callback?: () => void) => {
+        const targetIndex = (this.props.rovingIndex - 1 + this.itemCount) % this.itemCount;
+        this.props.setRovingIndex(targetIndex, callback);
+    };
+
     /**
      * From an accessibility point of view, this is a Editor Menubar. The only difference is it has a toggled visibility
      *
@@ -402,6 +432,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                 if (!this.hasMenuOpen()) {
                     event.stopPropagation();
                     event.preventDefault();
+                    this.closeAllSubMenus();
                     this.props.setRovingIndex(0);
                 }
                 break;
@@ -410,39 +441,131 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                 if (!this.hasMenuOpen()) {
                     event.stopPropagation();
                     event.preventDefault();
+                    this.closeAllSubMenus();
                     this.props.setRovingIndex(this.itemCount - 1);
                 }
                 break;
             // Moves focus to the next item in the menubar.
             // If focus is on the last item, moves focus to the first item.
             case "ArrowRight":
+                event.stopPropagation();
+                event.preventDefault();
                 if (!this.hasMenuOpen()) {
-                    event.stopPropagation();
-                    event.preventDefault();
-                    this.props.setRovingIndex((this.props.rovingIndex + 1) % this.itemCount);
+                    this.moveRovingIndexForward();
+                } else {
+                    this.moveRovingIndexForward(() => {
+                        this.openTabFunctions[this.props.rovingIndex]();
+                    });
                 }
                 break;
             // Moves focus to the previous item in the menubar.
             // If focus is on the first item, moves focus to the last item.
             case "ArrowLeft":
+                event.stopPropagation();
+                event.preventDefault();
                 if (!this.hasMenuOpen()) {
-                    event.stopPropagation();
-                    event.preventDefault();
-                    this.props.setRovingIndex((this.props.rovingIndex + (this.itemCount - 1)) % this.itemCount);
+                    this.moveRovingIndexBackwards();
+                } else {
+                    this.moveRovingIndexBackwards(() => {
+                        this.openTabFunctions[this.props.rovingIndex]();
+                    });
                 }
                 break;
             // 	Opens submenu and moves focus to last item in the submenu.
             case "ArrowUp":
-                if (this.hasMenuOpen()) {
-                    event.stopPropagation();
-                    this.closeAllSubMenus();
-                    this.selectCurrentTab();
-                }
+                event.preventDefault();
+                event.stopPropagation();
+
+                this.openTabFunctions[this.props.rovingIndex](() => {
+                    this.selectLastElementInOpenPanel();
+                });
+                break;
+            // Opens submenu and moves focus to first item in the submenu.
+            case "ArrowDown":
+                event.preventDefault();
+                event.stopPropagation();
+                this.openTabFunctions[this.props.rovingIndex](() => {
+                    this.selectFirstElementInOpenPanel();
+                });
                 break;
             // Moves focus to next item in the menubar having a name that starts with the typed character.
             // If none of the items have a name starting with the typed character, focus does not move.
             default:
-                // TODO
+                this.menuBarLetterIndex.forEach((letter, index) => {
+                    if (event.key.toLowerCase() === letter.toLowerCase()) {
+                        this.props.setRovingIndex(index);
+                        return;
+                    }
+                });
+                break;
+        }
+    };
+
+    /**
+     * From an accessibility point of view, this is a Editor Menubar. The only difference is it has a toggled visibility
+     *
+     * @see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-2/menubar-2.html
+     */
+    private handleMenuKeyDown = (event: React.KeyboardEvent<any>) => {
+        switch (`${event.key}${event.shiftKey ? "-Shift" : ""}`) {
+            // Opens submenu and moves focus to first item in the submenu.
+            case "ArrowDown":
+                if (this.hasMenuOpen() && this.props.panelsRef.current) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    const tabHandler = new TabHandler(this.props.panelsRef.current);
+                    if (tabHandler) {
+                        const next = tabHandler.getNext(document.activeElement, false, true);
+                        if (next) {
+                            next.focus();
+                        }
+                    }
+                }
+                break;
+            // Moves focus to previous item in the submenu.
+            // If focus is on the first item, moves focus to the last item.
+            case "ArrowUp":
+                if (this.hasMenuOpen() && this.props.panelsRef.current) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    const tabHandler = new TabHandler(this.props.panelsRef.current);
+                    if (tabHandler) {
+                        const previous = tabHandler.getNext(document.activeElement, true, true);
+                        if (previous) {
+                            previous.focus();
+                        }
+                    }
+                }
+                break;
+            // Moves focus to the first item in the submenu.
+            case "Home":
+                if (this.hasMenuOpen()) {
+                    event.preventDefault();
+                    this.selectFirstElementInOpenPanel();
+                }
+                break;
+            // Moves focus to the first item in the submenu.
+            case "End":
+                if (this.hasMenuOpen()) {
+                    event.preventDefault();
+                    this.selectLastElementInOpenPanel();
+                }
+                break;
+            // Moves focus to the next item having a name that starts with the typed character.
+            // If none of the items have a name starting with the typed character, focus does not move.
+            default:
+                if (this.props.panelsRef.current) {
+                    const tabHandler = new TabHandler(this.props.panelsRef.current);
+                    const items = tabHandler.getAll(this.props.panelsRef.current);
+                    if (items && items.length > 0) {
+                        items.reverse().forEach(item => {
+                            const letter = item.dataset.firstletter || null;
+                            if (letter && letter === event.key.toLowerCase()) {
+                                item.focus();
+                            }
+                        });
+                    }
+                }
                 break;
         }
     };

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
@@ -291,12 +291,6 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         );
     }
 
-    public componentDidUpdate(prevProps: IProps) {
-        if (this.hasMenuOpen()) {
-            this.selectFirstElementInOpenPanel();
-        }
-    }
-
     public hasMenuOpen = () => {
         return this.state.specialBlockMenuOpen || this.state.headingMenuOpen || this.state.listMenuOpen;
     };

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
@@ -31,6 +31,9 @@ import { menuState } from "@rich-editor/menuBar/paragraph/formats/formatting";
 import { style } from "typestyle";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import TabHandler from "@library/dom/TabHandler";
+import BlockquoteLineBlot from "@rich-editor/quill/blots/blocks/BlockquoteBlot";
+import CodeBlockBlot from "@rich-editor/quill/blots/blocks/CodeBlockBlot";
+import SpoilerLineBlot from "@rich-editor/quill/blots/blocks/SpoilerBlot";
 
 interface IProps {
     className?: string;
@@ -86,6 +89,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
 
     private itemCount: number;
     private openTabFunctions;
+    private menuBarLetterIndex: string[] = [];
 
     public render() {
         const { menuActiveFormats, textFormats } = this.props;
@@ -99,8 +103,8 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         const menuContents: IMenuBarContent[] = [
             {
                 component: ParagraphMenuHeadingsTabContent,
-                accessibleInstructions: t("Toggle Heading Menu"),
-                label: t("Headings"),
+                accessibleInstructions: t("Headings Menu"),
+                label: t("Headings Menu"),
                 toggleMenu: this.toggleHeadingsMenu,
                 icon: this.props.topLevelIcons.headingMenuIcon,
                 activeFormats: menuActiveFormats.headings,
@@ -135,8 +139,8 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             },
             {
                 component: ParagraphMenuListsTabContent,
-                accessibleInstructions: t("Toggle Lists Menu"),
-                label: t("Lists"),
+                accessibleInstructions: t("Lists Menu"),
+                label: t("Lists Menu"),
                 toggleMenu: this.toggleListsMenu,
                 icon: this.props.topLevelIcons.listMenuIcon,
                 activeFormats: menuActiveFormats.lists,
@@ -161,8 +165,8 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             },
             {
                 component: ParagraphMenuSpecialBlockTabContent,
-                accessibleInstructions: t("Toggle Special Formats Menu"),
-                label: t("Special Formats"),
+                accessibleInstructions: t("Special Formats Menu"),
+                label: t("Special Formats Menu"),
                 toggleMenu: this.toggleSpecialBlockMenu,
                 icon: this.props.topLevelIcons.specialBlockMenuIcon,
                 activeFormats: menuActiveFormats.specialFormats,
@@ -202,6 +206,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             };
 
             this.openTabFunctions[index] = menu.openMenu;
+            this.menuBarLetterIndex[index] = menu.label.substr(0, 1);
 
             panelContent[index] = (
                 <div
@@ -227,7 +232,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
 
             return (
                 <ParagraphMenuBarTab
-                    accessibleButtonLabel={"Toggle Heading Menu"}
+                    accessibleButtonLabel={menu.accessibleInstructions}
                     className={menu.className}
                     index={index}
                     parentID={this.props.parentID}
@@ -251,6 +256,8 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             this.props.setRovingIndex(0);
         };
         this.openTabFunctions[panelContent.length] = this.closeAllSubMenus;
+        const paragraphTitle = t("Paragraph (Removes paragraph style and sets to plain paragraph)");
+        this.menuBarLetterIndex[panelContent.length] = paragraphTitle.substr(0, 1);
         return (
             <div onKeyDown={this.handleMenuBarKeyDown}>
                 <div
@@ -262,6 +269,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                     <div className={classes.menuBarToggles}>
                         {menus}
                         <ParagraphMenuResetTab
+                            title={paragraphTitle}
                             formatParagraphHandler={textFormats.paragraph}
                             setRovingIndex={setParagraphIndex}
                             tabIndex={this.tabIndex(paragraphIndex)}
@@ -386,12 +394,10 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
 
     private moveRovingIndexForward = (callback?: () => void) => {
         const targetIndex = (this.props.rovingIndex + 1) % this.itemCount;
-        console.log("target index: ", targetIndex);
         this.props.setRovingIndex(targetIndex, callback);
     };
     private moveRovingIndexBackwards = (callback?: () => void) => {
         const targetIndex = (this.props.rovingIndex - 1 + this.itemCount) % this.itemCount;
-        console.log("target index: ", targetIndex);
         this.props.setRovingIndex(targetIndex, callback);
     };
 
@@ -473,7 +479,13 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             // Moves focus to next item in the menubar having a name that starts with the typed character.
             // If none of the items have a name starting with the typed character, focus does not move.
             default:
-                // TODO
+                this.menuBarLetterIndex.forEach((letter, index) => {
+                    if (event.key.toLowerCase() === letter.toLowerCase()) {
+                        this.props.setRovingIndex(index);
+                        return;
+                    }
+                });
+
                 break;
         }
     };

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
@@ -65,7 +65,7 @@ interface IMenuBarContent {
     indent?: () => void;
     outdent?: () => void;
     activeFormats: any;
-    openMenu: () => void;
+    openMenu: (callback: () => void) => void;
 }
 
 interface IState {
@@ -85,6 +85,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
     };
 
     private itemCount: number;
+    private openTabFunctions;
 
     public render() {
         const { menuActiveFormats, textFormats } = this.props;
@@ -191,14 +192,16 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         ];
 
         this.itemCount = menuContents.length + 1;
-
         const panelContent: JSX.Element[] = [];
+        this.openTabFunctions = [];
 
         const menus = menuContents.map((menu, index) => {
             const MyContent = menu.component;
             const myRovingIndex = () => {
                 this.props.setRovingIndex(index);
             };
+
+            this.openTabFunctions[index] = menu.openMenu;
 
             panelContent[index] = (
                 <div
@@ -238,6 +241,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                     legacyMode={this.props.legacyMode}
                     tabIndex={this.tabIndex(index)}
                     open={menu.open}
+                    selectFirstElement={this.selectLastElementInOpenPanel}
                 />
             );
         });
@@ -246,8 +250,9 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         const setParagraphIndex = () => {
             this.props.setRovingIndex(0);
         };
+        this.openTabFunctions[panelContent.length] = this.closeAllSubMenus;
         return (
-            <div onKeyDownCapture={this.handleMenuBarKeyDown}>
+            <div onKeyDown={this.handleMenuBarKeyDown}>
                 <div
                     role="menubar"
                     aria-label={this.props.label}
@@ -265,15 +270,11 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                         />
                     </div>
                 </div>
-                <div ref={this.props.panelsRef}>{panelContent}</div>
+                <div ref={this.props.panelsRef} onKeyDownCapture={this.handleMenuKeyDown}>
+                    {panelContent}
+                </div>
             </div>
         );
-    }
-
-    public componentDidUpdate(prevProps: IProps) {
-        if (this.hasMenuOpen()) {
-            this.selectFirstElementInOpenPanel();
-        }
     }
 
     public hasMenuOpen = () => {
@@ -287,12 +288,15 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             specialBlockMenuOpen: false,
         });
     };
-    private openHeadingsMenu = () => {
-        this.setState({
-            headingMenuOpen: true,
-            listMenuOpen: false,
-            specialBlockMenuOpen: false,
-        });
+    private openHeadingsMenu = (callback?: () => void) => {
+        this.setState(
+            {
+                headingMenuOpen: true,
+                listMenuOpen: false,
+                specialBlockMenuOpen: false,
+            },
+            callback,
+        );
     };
 
     private toggleListsMenu = () => {
@@ -303,12 +307,15 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         });
     };
 
-    private openListsMenu = () => {
-        this.setState({
-            headingMenuOpen: false,
-            listMenuOpen: true,
-            specialBlockMenuOpen: false,
-        });
+    private openListsMenu = (callback?: () => void) => {
+        this.setState(
+            {
+                headingMenuOpen: false,
+                listMenuOpen: true,
+                specialBlockMenuOpen: false,
+            },
+            callback,
+        );
     };
 
     private toggleSpecialBlockMenu = () => {
@@ -319,12 +326,15 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         });
     };
 
-    private openSpecialBlockMenu = () => {
-        this.setState({
-            headingMenuOpen: false,
-            listMenuOpen: false,
-            specialBlockMenuOpen: true,
-        });
+    private openSpecialBlockMenu = (callback?: () => void) => {
+        this.setState(
+            {
+                headingMenuOpen: false,
+                listMenuOpen: false,
+                specialBlockMenuOpen: true,
+            },
+            callback,
+        );
     };
 
     private closeMenuAndSetCursor = () => {
@@ -374,6 +384,15 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
         return this.props.rovingIndex === index ? 0 : -1;
     };
 
+    private moveRovingIndexForward = (callback?: () => void) => {
+        const targetIndex = (this.props.rovingIndex + 1) % this.itemCount;
+        this.props.setRovingIndex(targetIndex, callback);
+    };
+    private moveRovingIndexBackwards = (callback?: () => void) => {
+        const targetIndex = (this.props.rovingIndex - 1 + this.itemCount) % this.itemCount;
+        this.props.setRovingIndex(targetIndex, callback);
+    };
+
     /**
      * From an accessibility point of view, this is a Editor Menubar. The only difference is it has a toggled visibility
      *
@@ -407,30 +426,122 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             // Moves focus to the next item in the menubar.
             // If focus is on the last item, moves focus to the first item.
             case "ArrowRight":
-                if (!this.hasMenuOpen()) {
-                    event.stopPropagation();
-                    event.preventDefault();
-                    this.props.setRovingIndex((this.props.rovingIndex + 1) % this.itemCount);
-                }
+                event.stopPropagation();
+                event.preventDefault();
+                this.moveRovingIndexForward(() => {
+                    this.openTabFunctions[this.props.rovingIndex]();
+                });
                 break;
             // Moves focus to the previous item in the menubar.
             // If focus is on the first item, moves focus to the last item.
             case "ArrowLeft":
-                if (!this.hasMenuOpen()) {
-                    event.stopPropagation();
-                    event.preventDefault();
-                    this.props.setRovingIndex((this.props.rovingIndex + (this.itemCount - 1)) % this.itemCount);
-                }
+                event.stopPropagation();
+                event.preventDefault();
+                this.moveRovingIndexBackwards(() => {
+                    this.openTabFunctions[this.props.rovingIndex]();
+                });
                 break;
             // 	Opens submenu and moves focus to last item in the submenu.
             case "ArrowUp":
-                if (this.hasMenuOpen()) {
-                    event.stopPropagation();
-                    this.closeAllSubMenus();
-                    this.selectCurrentTab();
-                }
+                event.preventDefault();
+                event.stopPropagation();
+
+                this.openTabFunctions[this.props.rovingIndex](() => {
+                    this.selectFirstElementInOpenPanel();
+                });
+                break;
+            // Opens submenu and moves focus to first item in the submenu.
+            case "ArrowDown":
+                event.preventDefault();
+                event.stopPropagation();
+
+                this.openTabFunctions[this.props.rovingIndex](() => {
+                    this.selectLastElementInOpenPanel();
+                });
                 break;
             // Moves focus to next item in the menubar having a name that starts with the typed character.
+            // If none of the items have a name starting with the typed character, focus does not move.
+            default:
+                // TODO
+                break;
+        }
+    };
+
+    /**
+     * From an accessibility point of view, this is a Editor Menubar. The only difference is it has a toggled visibility
+     *
+     * @see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-2/menubar-2.html
+     */
+    private handleMenuKeyDown = (event: React.KeyboardEvent<any>) => {
+        switch (`${event.key}${event.shiftKey ? "-Shift" : ""}`) {
+            // Closes submenu.
+            // Moves focus to next item in the menubar.
+            // Opens submenu of newly focused menubar item, keeping focus on that parent menubar item.
+            case "ArrowRight":
+                // if (this.hasMenuOpen()) {
+                //     event.preventDefault();
+                //     this.closeAllSubMenus();
+                //     this.moveRovingIndexForward(() => {
+                //         this.openTabs[this.props.rovingIndex] && this.openTabs[this.props.rovingIndex]();
+                //     });
+                // }
+                break;
+            // Closes submenu.
+            // Moves focus to previous item in the menubar.
+            // Opens submenu of newly focused menubar item, keeping focus on that parent menubar item.
+            case "ArrowLeft":
+                // if (this.hasMenuOpen()) {
+                //     event.preventDefault();
+                //     this.closeAllSubMenus();
+                //     this.moveRovingIndexBackwards(() => {
+                //         this.openTabs[this.props.rovingIndex] && this.openTabs[this.props.rovingIndex]();
+                //     });
+                // }
+                break;
+            // Opens submenu and moves focus to first item in the submenu.
+            case "ArrowDown":
+                if (this.hasMenuOpen() && this.props.panelsRef.current) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    const tabHandler = new TabHandler(this.props.panelsRef.current);
+                    if (tabHandler) {
+                        const next = tabHandler.getNext(document.activeElement, false, true);
+                        if (next) {
+                            next.focus();
+                        }
+                    }
+                }
+                break;
+            // Moves focus to previous item in the submenu.
+            // If focus is on the first item, moves focus to the last item.
+            case "ArrowUp":
+                if (this.hasMenuOpen() && this.props.panelsRef.current) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    const tabHandler = new TabHandler(this.props.panelsRef.current);
+                    if (tabHandler) {
+                        const previous = tabHandler.getNext(document.activeElement, true, true);
+                        if (previous) {
+                            previous.focus();
+                        }
+                    }
+                }
+                break;
+            // Moves focus to the first item in the submenu.
+            case "Home":
+                if (this.hasMenuOpen()) {
+                    event.preventDefault();
+                    this.selectFirstElementInOpenPanel();
+                }
+                break;
+            // Moves focus to the first item in the submenu.
+            case "End":
+                if (this.hasMenuOpen()) {
+                    event.preventDefault();
+                    this.selectLastElementInOpenPanel();
+                }
+                break;
+            // Moves focus to the next item having a name that starts with the typed character.
             // If none of the items have a name starting with the typed character, focus does not move.
             default:
                 // TODO

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
@@ -386,10 +386,12 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
 
     private moveRovingIndexForward = (callback?: () => void) => {
         const targetIndex = (this.props.rovingIndex + 1) % this.itemCount;
+        console.log("target index: ", targetIndex);
         this.props.setRovingIndex(targetIndex, callback);
     };
     private moveRovingIndexBackwards = (callback?: () => void) => {
         const targetIndex = (this.props.rovingIndex - 1 + this.itemCount) % this.itemCount;
+        console.log("target index: ", targetIndex);
         this.props.setRovingIndex(targetIndex, callback);
     };
 
@@ -412,6 +414,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                 if (!this.hasMenuOpen()) {
                     event.stopPropagation();
                     event.preventDefault();
+                    this.closeAllSubMenus();
                     this.props.setRovingIndex(0);
                 }
                 break;
@@ -420,6 +423,7 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                 if (!this.hasMenuOpen()) {
                     event.stopPropagation();
                     event.preventDefault();
+                    this.closeAllSubMenus();
                     this.props.setRovingIndex(this.itemCount - 1);
                 }
                 break;
@@ -428,18 +432,26 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             case "ArrowRight":
                 event.stopPropagation();
                 event.preventDefault();
-                this.moveRovingIndexForward(() => {
-                    this.openTabFunctions[this.props.rovingIndex]();
-                });
+                if (!this.hasMenuOpen()) {
+                    this.moveRovingIndexForward();
+                } else {
+                    this.moveRovingIndexForward(() => {
+                        this.openTabFunctions[this.props.rovingIndex]();
+                    });
+                }
                 break;
             // Moves focus to the previous item in the menubar.
             // If focus is on the first item, moves focus to the last item.
             case "ArrowLeft":
                 event.stopPropagation();
                 event.preventDefault();
-                this.moveRovingIndexBackwards(() => {
-                    this.openTabFunctions[this.props.rovingIndex]();
-                });
+                if (!this.hasMenuOpen()) {
+                    this.moveRovingIndexBackwards();
+                } else {
+                    this.moveRovingIndexBackwards(() => {
+                        this.openTabFunctions[this.props.rovingIndex]();
+                    });
+                }
                 break;
             // 	Opens submenu and moves focus to last item in the submenu.
             case "ArrowUp":
@@ -454,7 +466,6 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             case "ArrowDown":
                 event.preventDefault();
                 event.stopPropagation();
-
                 this.openTabFunctions[this.props.rovingIndex](() => {
                     this.selectLastElementInOpenPanel();
                 });
@@ -474,30 +485,6 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
      */
     private handleMenuKeyDown = (event: React.KeyboardEvent<any>) => {
         switch (`${event.key}${event.shiftKey ? "-Shift" : ""}`) {
-            // Closes submenu.
-            // Moves focus to next item in the menubar.
-            // Opens submenu of newly focused menubar item, keeping focus on that parent menubar item.
-            case "ArrowRight":
-                // if (this.hasMenuOpen()) {
-                //     event.preventDefault();
-                //     this.closeAllSubMenus();
-                //     this.moveRovingIndexForward(() => {
-                //         this.openTabs[this.props.rovingIndex] && this.openTabs[this.props.rovingIndex]();
-                //     });
-                // }
-                break;
-            // Closes submenu.
-            // Moves focus to previous item in the menubar.
-            // Opens submenu of newly focused menubar item, keeping focus on that parent menubar item.
-            case "ArrowLeft":
-                // if (this.hasMenuOpen()) {
-                //     event.preventDefault();
-                //     this.closeAllSubMenus();
-                //     this.moveRovingIndexBackwards(() => {
-                //         this.openTabs[this.props.rovingIndex] && this.openTabs[this.props.rovingIndex]();
-                //     });
-                // }
-                break;
             // Opens submenu and moves focus to first item in the submenu.
             case "ArrowDown":
                 if (this.hasMenuOpen() && this.props.panelsRef.current) {

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenuBar.tsx
@@ -485,7 +485,6 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
                         return;
                     }
                 });
-
                 break;
         }
     };
@@ -543,7 +542,18 @@ export default class ParagraphMenuBar extends React.Component<IProps, IState> {
             // Moves focus to the next item having a name that starts with the typed character.
             // If none of the items have a name starting with the typed character, focus does not move.
             default:
-                // TODO
+                if (this.props.panelsRef.current) {
+                    const tabHandler = new TabHandler(this.props.panelsRef.current);
+                    const items = tabHandler.getAll(this.props.panelsRef.current);
+                    if (items && items.length > 0) {
+                        items.reverse().forEach(item => {
+                            const letter = item.dataset.firstletter || null;
+                            if (letter && letter === event.key.toLowerCase()) {
+                                item.focus();
+                            }
+                        });
+                    }
+                }
                 break;
         }
     };

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/paragraphMenuBarStyles.ts
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/paragraphMenuBarStyles.ts
@@ -31,12 +31,15 @@ export const paragraphMenuCheckRadioClasses = useThemeCache(() => {
         $nest: {
             "&:hover": {
                 backgroundColor: colorOut(globalVars.states.hover.color),
+                zIndex: 1,
             },
             "&:active": {
                 backgroundColor: colorOut(globalVars.states.active.color),
+                zIndex: 1,
             },
             "&:focus": {
                 backgroundColor: colorOut(globalVars.states.focus.color),
+                zIndex: 1,
             },
         },
     });

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/pieces/ParagraphMenuCheckRadio.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/pieces/ParagraphMenuCheckRadio.tsx
@@ -60,6 +60,7 @@ export default class ParagraphMenuCheckRadio extends React.PureComponent<IProps>
                 onClick={onClick}
                 disabled={!!this.props.disabled}
                 tabIndex={!!this.props.disabled ? -1 : 0}
+                data-firstletter={text.toLowerCase().substr(0, 1)}
             >
                 <span className={classes.icon}>{icon}</span>
                 <span className={classes.checkRadioLabel}>{text}</span>

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
@@ -104,23 +104,4 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
     public getMenuContentsID() {
         return this.menuID;
     }
-
-    // /**
-    //  * From an accessibility point of view, this is a Editor Menubar. The only difference is it has a toggled visibility
-    //  *
-    //  * @see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-2/menubar-2.html
-    //  */
-    // private handleMenuBarKeyDown = (event: React.KeyboardEvent<any>) => {
-    //     switch (`${event.key}${event.shiftKey ? "-Shift" : ""}`) {
-    //         // Opens submenu and moves focus to first item in the submenu.
-    //         case "ArrowDown":
-    //             if (!this.props.open) {
-    //                 event.preventDefault();
-    //                 this.handleClick();
-    //             } else {
-    //                 this.props.selectFirstElement();
-    //             }
-    //             break;
-    //     }
-    // };
 }

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
@@ -50,6 +50,8 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
             this.props.toggleMenu(() => {
                 if (!this.props.open) {
                     this.toggleButtonRef.current && this.toggleButtonRef.current.focus();
+                } else {
+                    this.props.selectFirstElement();
                 }
             });
         };

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
@@ -23,6 +23,7 @@ interface IProps {
     legacyMode: boolean;
     tabIndex: 0 | -1;
     open: boolean;
+    selectFirstElement: () => void;
 }
 
 /**
@@ -47,7 +48,9 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
         this.handleClick = (event: React.MouseEvent) => {
             this.props.setRovingIndex();
             this.props.toggleMenu(() => {
-                this.toggleButtonRef.current && this.toggleButtonRef.current.focus();
+                if (!this.props.open) {
+                    this.toggleButtonRef.current && this.toggleButtonRef.current.focus();
+                }
             });
         };
     }
@@ -73,7 +76,6 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
                         className={classNames(classes.button, this.props.open ? classes.topLevelButtonActive : "")}
                         tabIndex={this.props.tabIndex}
                         ref={this.toggleButtonRef}
-                        onKeyDown={this.handleMenuBarKeyDown}
                     >
                         {icon}
                         <ScreenReaderContent>{this.props.accessibleButtonLabel}</ScreenReaderContent>
@@ -101,20 +103,22 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
         return this.menuID;
     }
 
-    /**
-     * From an accessibility point of view, this is a Editor Menubar. The only difference is it has a toggled visibility
-     *
-     * @see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-2/menubar-2.html
-     */
-    private handleMenuBarKeyDown = (event: React.KeyboardEvent<any>) => {
-        switch (`${event.key}${event.shiftKey ? "-Shift" : ""}`) {
-            // Opens submenu and moves focus to first item in the submenu.
-            case "ArrowDown":
-                if (!this.props.open) {
-                    event.preventDefault();
-                    this.handleClick();
-                }
-                break;
-        }
-    };
+    // /**
+    //  * From an accessibility point of view, this is a Editor Menubar. The only difference is it has a toggled visibility
+    //  *
+    //  * @see https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-2/menubar-2.html
+    //  */
+    // private handleMenuBarKeyDown = (event: React.KeyboardEvent<any>) => {
+    //     switch (`${event.key}${event.shiftKey ? "-Shift" : ""}`) {
+    //         // Opens submenu and moves focus to first item in the submenu.
+    //         case "ArrowDown":
+    //             if (!this.props.open) {
+    //                 event.preventDefault();
+    //                 this.handleClick();
+    //             } else {
+    //                 this.props.selectFirstElement();
+    //             }
+    //             break;
+    //     }
+    // };
 }

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuListsTabContent.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuListsTabContent.tsx
@@ -37,6 +37,8 @@ export default class ParagraphMenuListsTabContent extends React.Component<IProps
             this.props.setRovingIndex();
             this.props.closeMenuAndSetCursor();
         };
+        const indentLabel = t("Indent");
+        const outdentLabel = t("Outdent");
         return (
             <>
                 <ParagraphMenuBarRadioGroup
@@ -54,9 +56,10 @@ export default class ParagraphMenuListsTabContent extends React.Component<IProps
                         onClick={this.props.indent}
                         disabled={!!this.props.disabled}
                         tabIndex={!!this.props.disabled ? -1 : 0}
+                        data-firstletter={indentLabel.toLowerCase().substr(0, 1)}
                     >
                         <span className={checkRadioClasses.icon}>{indent()}</span>
-                        <span className={checkRadioClasses.checkRadioLabel}>{t("Indent")}</span>
+                        <span className={checkRadioClasses.checkRadioLabel}>{indentLabel}</span>
                     </button>
                     <button
                         className={classNames(checkRadioClasses.checkRadio)}
@@ -64,9 +67,10 @@ export default class ParagraphMenuListsTabContent extends React.Component<IProps
                         onClick={this.props.outdent}
                         disabled={!!this.props.disabled}
                         tabIndex={!!this.props.disabled ? -1 : 0}
+                        data-firstletter={outdentLabel.toLowerCase().substr(0, 1)}
                     >
                         <span className={checkRadioClasses.icon}>{outdent()}</span>
-                        <span className={checkRadioClasses.checkRadioLabel}>{t("Outdent")}</span>
+                        <span className={checkRadioClasses.checkRadioLabel}>{outdentLabel}</span>
                     </button>
                 </div>
             </>

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuResetTab.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuResetTab.tsx
@@ -20,6 +20,7 @@ interface IProps {
     closeMenuAndSetCursor: () => void;
     legacyMode?: boolean;
     isMenuVisible: boolean;
+    title: string;
 }
 
 /**
@@ -29,7 +30,6 @@ export default class ParagraphMenuResetTab extends React.PureComponent<IProps> {
     private buttonRef: React.RefObject<HTMLButtonElement> = React.createRef();
 
     public render() {
-        const title = t("Removes paragraph style and sets to plain paragraph");
         const classes = richEditorClasses(!!this.props.legacyMode);
         const handleClick = (event: React.MouseEvent) => {
             this.props.setRovingIndex();
@@ -40,8 +40,8 @@ export default class ParagraphMenuResetTab extends React.PureComponent<IProps> {
             <button
                 type="button"
                 disabled={this.props.isDisabled}
-                title={title}
-                aria-label={title}
+                title={this.props.title}
+                aria-label={this.props.title}
                 onClick={handleClick}
                 className={classNames(this.props.className, classes.button)}
                 ref={this.buttonRef}


### PR DESCRIPTION
All keyboard shortcuts should work now. Please read the spec here:

https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-2/menubar-2.html

Closes: https://github.com/vanilla/vanilla/issues/8434