### PR TITLE
Fix: sending a message without recipient when name is empty

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -547,15 +547,16 @@ class ConversationModel extends ConversationsModel {
             $to = explode(',', $formPostValues['To']);
             $to = array_map('trim', $to);
 
-            $recipientUserIDs = $this->SQL
-                ->select('UserID')
-                ->from('User')
-                ->whereIn('Name', $to)
-                ->get()->resultArray();
-            $recipientUserIDs = array_column($recipientUserIDs, 'UserID');
-            $formPostValues['RecipientUserID'] = $recipientUserIDs;
-        }
-
+                $recipientUserIDs = $this->SQL
+                    ->select('UserID')
+                    ->from('User')
+                    ->where('Name <>', '')
+                    ->whereIn('Name', $to)
+                    ->get()->resultArray()
+                ;
+                $recipientUserIDs = array_column($recipientUserIDs, 'UserID');
+                $formPostValues['RecipientUserID'] = $recipientUserIDs;
+            }
         if (c('Garden.ForceInputFormatter')) {
             $formPostValues['Format'] = c('Garden.InputFormatter');
         }


### PR DESCRIPTION
Closes [#273](https://github.com/vanilla/support/issues/273)

### Details

When sending a private message without adding a recipient, we should get the error "You must select at least one recipient." However this is not the case when we have users in the database with no name(migrated data?). 

This is because the SQL in
[class.conversationmodel.php#L550](https://github.com/vanilla/vanilla/blob/00261ecb587a19c1590f1f0c1db6b13ca92da504/applications/conversations/models/class.conversationmodel.php#L550)  would return a list of all recpients with no name, thus not triggering the validation in [class.conversationmodel.php#L572](https://github.com/vanilla/vanilla/blob/00261ecb587a19c1590f1f0c1db6b13ca92da504/applications/conversations/models/class.conversationmodel.php#L572)

### To Test

- Create a user, wipe with name from the db.
- Send a message without adding a recipient.