### PR TITLE
Fix: imgur embeds not rendering correctly

### DIFF
--- a/library/Vanilla/Formatting/Embeds/ImgurEmbed.php
+++ b/library/Vanilla/Formatting/Embeds/ImgurEmbed.php
@@ -28,7 +28,7 @@ class ImgurEmbed extends Embed {
      */
     public function matchUrl(string $url) {
         $data = [];
-
+        $url = str_replace(['.jpg', '.jpeg', '.png'], '', $url);
         if ($this->isNetworkEnabled()) {
             preg_match('/https?:\/\/(?:m.)?imgur\.com\/(?:(?<album>a|gallery)\/)?(?<postID>[a-z0-9]+)/i', $url, $matches);
 

--- a/library/Vanilla/Formatting/Embeds/ImgurEmbed.php
+++ b/library/Vanilla/Formatting/Embeds/ImgurEmbed.php
@@ -28,6 +28,7 @@ class ImgurEmbed extends Embed {
      */
     public function matchUrl(string $url) {
         $data = [];
+        // Strip image extensions. URLs with image extensions are not supported.
         $url = str_replace(['.jpg', '.jpeg', '.png'], '', $url);
         if ($this->isNetworkEnabled()) {
             preg_match('/https?:\/\/(?:m.)?imgur\.com\/(?:(?<album>a|gallery)\/)?(?<postID>[a-z0-9]+)/i', $url, $matches);


### PR DESCRIPTION
closes [#249](https://github.com/vanilla/support/issues/249)

### Details

Using rich-editor, some imgur image embeds with image extensions were failing.
On imgur site, links looks something like https://i.imgur.com/1okCy50. this link embed is currently handled. 
What users are doing is 
![Screen Shot 2019-03-28 at 2 17 59 PM](https://user-images.githubusercontent.com/31856281/55182602-67b4ea80-5164-11e9-8ac7-248e20f09219.png) 

this gives https://i.imgur.com/1okCy50.jpg which we don't handle in our embeds because of the image extension at the end

Our [ImgurEmbed.php](https://github.com/vanilla/vanilla/blob/master/library/Vanilla/Formatting/Embeds/ImgurEmbed.php) does not handle this type of link.

Based on a feedback from RnD, we should strip those extensions.


### To Test

- Using rich-editor, try to post these 2 images
- https://i.imgur.com/RuFna0O.jpg (should fail)
- https://imgur.com/gallery/mzto8oD (should work)
![image](https://user-images.githubusercontent.com/19805402/53965685-ab658880-40bf-11e9-869d-1620a188e83d.png)
