### PR TITLE
Fix warning for use statement in Conversation hooks

### DIFF
--- a/applications/conversations/settings/class.hooks.php
+++ b/applications/conversations/settings/class.hooks.php
@@ -10,7 +10,6 @@
 
 use Garden\Container\Container;
 use Garden\Container\Reference;
-use ConversationCounterProvider;
 
 /**
  * Handles hooks into Dashboard and Vanilla.


### PR DESCRIPTION
PHP is throwing a warning for an unnecessary `use` statement in Conversations' hooks.

> The use statement with non-compound name ConversationCounterProvider has no effect

It's been removed.