### PR TITLE
Fixed quote mention to user is also required in WYSIWYG

### DIFF
--- a/plugins/Quotes/class.quotes.plugin.php
+++ b/plugins/Quotes/class.quotes.plugin.php
@@ -516,7 +516,7 @@ BQ;
 
                     break;
                 case 'Wysiwyg':
-                    $attribution = sprintf(t('%s said:'), userAnchor($data, null, ['Px' => 'Insert']));
+                    $attribution = sprintf(t('%s said:'), userAnchor($data, null, ['Px' => 'Insert', 'Text' => '@'.$data->InsertName]));
                     $quoteBody = $data->Body;
 
                     // TODO: Strip inner quotes...


### PR DESCRIPTION
As soon as `userAnchor` function respects `Text` option, it will always return what we expect in WYSIWYG mode. Well, what if I wanted it to return some "Display Name" by default? I just copy `userAnchor` code and paste slightly modified version in my addon. And there is no better solution than using mention-style username atm, so this practice should always be there in Quotes plugin.
