### PR TITLE
[Flagging] Fix for translated link to content

### DIFF
--- a/plugins/Flagging/views/flag.php
+++ b/plugins/Flagging/views/flag.php
@@ -16,8 +16,7 @@ echo $this->Form->errors();
                 <?php echo t('FlagForReview', "You are about to flag this for moderator review. If you're sure you want to do this,
          please enter a brief reason below, then press 'Flag this!'."); ?>
             </div>
-            <?php echo t('FlagLinkContent', 'Link to content:').' '.anchor(t('FlagLinkFormat', "{$UcContext} #{$ElementID}"), $URL); ?> &ndash;
-            <?php echo htmlspecialchars($this->data('Plugin.Flagging.Data.ElementAuthor')); ?>
+            <?php echo t('FlagLinkContent', 'Link to content:').' '.anchor(sprintf(t('FlagLinkFormat', '%1$s #%2$s &ndash; %3$s'), t($UcContext), $ElementID, htmlspecialchars($this->data('Plugin.Flagging.Data.ElementAuthor'))), $URL); ?> 
         </li>
         <li>
             <?php


### PR DESCRIPTION
I just noticed context part was left original. Idea here is to give proper "Link to content" by providing common pattern under 'FlagLinkFormat' key with three arguments: *translated* context ("Discussion"/"Comment"), content ID and author's username, which was left out of pattern before.
