### PR TITLE
Fix: seeing group announcements in recent discussions

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -178,7 +178,13 @@ class PostController extends VanillaController {
         } else {
             // New discussion? Make sure a discussion ID didn't sneak in.
             $this->Form->removeFormValue('DiscussionID');
-
+            // Make sure a group discussion doesn't get announced outside the groups category.
+            $formAnnounce = $this->Form->_FormValues['Announce'];
+            if (isset($formAnnounce) && $formAnnounce === '1') {
+                if (isset($this->Data['Group'])) {
+                    $this->Form->setFormValue('Announce', '2');
+                }
+            }
             // Permission to add.
             if ($this->Category) {
                 $this->categoryPermission($this->Category, 'Vanilla.Discussions.Add');


### PR DESCRIPTION
closes [#256](https://github.com/vanilla/support/issues/256)
### To Test

- Create a Group
- Create a discussion inside a group and Announce it
- Check GDN_Discussion.Announce for the created discussion, it should be set to 2 instead of 1

### In this PR
I added a check to test when we have a discussion created inside a group, in that case I am setting Announce to 2. The reason I did this change is explained below.
### Issue Explained
After investigating this, the fix in the referenced issue would not solve the problem (running the db update to set announce to 2 would fix the problem for the currently created discussions inside groups) initially this was thought to be related to their data, which is not the case. Every time a new discussion is created inside a group, and announce is checked,GDN_Discussion.Announce would be set to 1. 
This is because of [discussion.php#L53](https://github.com/vanilla/vanilla/blob/f93195115e19e0bc7bab802bc922e862adcdb755/applications/vanilla/views/post/discussion.php#L53) $Options would be equal to
`<li><label for="Form_Announce1" class="CheckBoxLabel"><input type="hidden" name="Checkboxes[]" value="Anounce" /><input type="checkbox" id="Form_Announce1" name="Announce" value="1" class="" /> Announce</label></li>`

The problem is that we are using the value of Value="1" and setting announce to that value.

When creating a discussion from inside a group, from postController we can check if a discussion was created from inside a group 
<img width="248" alt="Screen Shot 2019-04-01 at 8 21 07 AM" src="https://user-images.githubusercontent.com/31856281/55327036-2f105c00-5457-11e9-85bc-2bc9e5866dd0.png">
then we can force set announce to 2 in case it was set in _FormValues.
