### PR TITLE
Fix args parsing an enable webpack bar in low memory situations

### DIFF
--- a/build/scripts/configs/makeBaseConfig.ts
+++ b/build/scripts/configs/makeBaseConfig.ts
@@ -159,13 +159,11 @@ ${chalk.green(aliases)}`;
     }
 
     // This is the only flag we are given by infrastructure to indicate we are in a lower memory environment.
-    if (!options.lowMemory) {
-        config.plugins.push(
-            new WebpackBar({
-                name: section,
-            }),
-        );
-    }
+    config.plugins.push(
+        new WebpackBar({
+            name: section,
+        }),
+    );
 
     return config;
 }

--- a/build/scripts/options.ts
+++ b/build/scripts/options.ts
@@ -14,6 +14,7 @@ yargs
     .option("verbose", {
         alias: "v",
         default: false,
+        boolean: true,
     })
     .options("mode", {
         default: BuildMode.PRODUCTION,
@@ -24,13 +25,16 @@ yargs
     .options("fix", {
         alias: "f",
         default: false,
+        boolean: true,
     })
     .options("low-memory", {
         default: false,
+        boolean: true,
     })
     .options("install", {
         alias: "i",
         default: false,
+        boolean: true,
     });
 
 export interface IBuildOptions {


### PR DESCRIPTION
The args parsing weren't properly parsing boolean values. This seems to have fallen apart when ops changed the way they passed us the arguments. They used to be passed as `--low-memory=true` now it's passed as `--low-memory`.

