### PR TITLE
Deprecate ApplicationManager, ThemeManager, PluginManager, PluginManager, Pluggable

### DIFF
--- a/library/core/class.applicationmanager.php
+++ b/library/core/class.applicationmanager.php
@@ -14,6 +14,8 @@ use Vanilla\AddonManager;
 
 /**
  * Manages available applications, enabling and disabling them.
+ *
+ * @deprecated 3.0 Use Vanilla\AddonManager.
  */
 class Gdn_ApplicationManager {
 

--- a/library/core/class.gdn.php
+++ b/library/core/class.gdn.php
@@ -102,6 +102,7 @@ class Gdn {
      * Get the application manager
      *
      * @return Gdn_ApplicationManager
+     * @deprecated 3.0 - Use Vanilla\AddonManager.
      */
     public static function applicationManager() {
         return self::factory(self::AliasApplicationManager);
@@ -431,6 +432,7 @@ class Gdn {
      * Get the plugin manager for the application.
      *
      * @return Gdn_PluginManager
+     * @deprecated 3.0 - Use Garden\EventManager or Vanilla\AddonManager.
      */
     public static function pluginManager() {
         if (self::$_PluginManager === null) {
@@ -538,6 +540,7 @@ class Gdn {
      * Get the plugin manager for the application.
      *
      * @return Gdn_ThemeManager
+     * @deprecated 3.0 - Use Vanilla\AddonManager.
      */
     public static function themeManager() {
         return self::factory(self::AliasThemeManager);

--- a/library/core/class.pluggable.php
+++ b/library/core/class.pluggable.php
@@ -17,7 +17,7 @@
  * has the ability to throw custom events at any time, which can then be
  * handled by plugins.
  *
- * @abstract
+ * @deprecated 3.0 - Use Garden\EventManager
  */
 abstract class Gdn_Pluggable {
 
@@ -94,6 +94,9 @@ abstract class Gdn_Pluggable {
      * Fire the next event off a custom parent class
      *
      * @param mixed $options Either the parent class, or an option array
+     *
+     * @return $this
+     * @deprecated 3.0 - Use Garden\EventManager::fire()
      */
     public function fireAs($options) {
         if (!is_array($options)) {
@@ -111,6 +114,10 @@ abstract class Gdn_Pluggable {
      *  public function senderClassName_EventName_Handler($Sender) {}
      *
      * @param string $eventName The name of the event being fired.
+     * @param mixed $arguments Arguemnts to pass through to the event handlers.
+     *
+     * @return mixed
+     * @deprecated 3.0 - Use Garden\EventManager::fire()
      */
     public function fireEvent($eventName, $arguments = null) {
         if (!$this->ClassName) {

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -20,6 +20,8 @@ use Vanilla\AddonManager;
  *
  * A singleton class used to identify extensions, register them in a central
  * location, and instantiate/call them when necessary.
+ *
+ * @deprecated 3.0 - Use Vanilla\AddonManager.
  */
 class Gdn_PluginManager extends Gdn_Pluggable implements ContainerInterface {
 

--- a/library/core/class.thememanager.php
+++ b/library/core/class.thememanager.php
@@ -15,6 +15,8 @@ use Vanilla\AddonManager;
 
 /**
  * Manages available themes, enabling and disabling them.
+ *
+ * @deprecated 3.0 Use Vanilla\AddonManager.
  */
 class Gdn_ThemeManager extends Gdn_Pluggable {
 


### PR DESCRIPTION
This PR deprecates the following classes:

- `Gdn_ApplicationManager`
- `Gdn_ThemeManager`
- `Gdn_PluginManager`
- `Gdn_Pluggable`

Additionally, methods to fetch instances of these have deprecated. I also explicitly deprecated some pluggable methods.

**Note:** I did not use the `deprecate` call because we don't have intention of retroactively replacing all usages of these. However, we do not want new development to make use of these methods.