### PR TITLE
Fix JWT cookie decoding between servers with slightly offset times

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -7,6 +7,7 @@ use Vanilla\InjectableInterface;
 use Vanilla\Contracts;
 use Vanilla\Utility\ContainerUtils;
 use \Vanilla\Formatting\Formats;
+use Firebase\JWT\JWT;
 
 if (!defined('APPLICATION')) exit();
 /**
@@ -422,6 +423,9 @@ register_shutdown_function(function () use ($dic) {
 $dic->get('Gdn_Locale');
 
 require_once PATH_LIBRARY_CORE.'/functions.validation.php';
+
+// Configure JWT library to allow for five seconds of leeway.
+JWT::$leeway = 5;
 
 // Start Authenticators
 $dic->get('Authenticator')->startAuthenticator();


### PR DESCRIPTION
Decoding a JWT token includes validation of its "issued" and "expired" fields. If the token is decoded before its "issued" time, it isn't considered valid. This can be a problem when generating and decoding JWT tokens between servers if there is a slight difference in times between them.

The JWT library Vanilla uses is essentially a class of static methods. It contains the ability to configure the allowable variance in "issued" times in the library by way of setting the value of a static property in that class.

This update sets the "leeway" to five seconds, from zero, as part of Vanilla's bootstrapping process. Any usage of `Firebase\JWT\JWT` in the application will now allow for five seconds of difference between issued and expiration times.