### PR TITLE
Instantiate logger from container in Logger

### DIFF
--- a/library/core/class.logger.php
+++ b/library/core/class.logger.php
@@ -95,7 +95,7 @@ class Logger {
      */
     public static function getLogger() {
         if (!self::$instance) {
-            self::$instance = new \Vanilla\Logger();
+            self::$instance = Gdn::getContainer()->get(\Vanilla\Logger::class);
         }
         return self::$instance;
     }


### PR DESCRIPTION
Vanilla has configuration rules for its `Vanilla\Logger` instance in the bootstrap. However, this instance is not used by the `Logger` class, which creates a fresh instance of `Vanilla\Logger`. Any logging calls made through `Logger` are not using the configured copy of `Vanilla\Logger` from the container.

`Logger::getLogger` has been updated to grab the class's `Vanilla\Logger` instance from the container, which should be configured per the application's bootstrap.