### PR TITLE
Add favicon and theme-color to twig master template

### DIFF
--- a/library/Vanilla/Web/ThemedPage.php
+++ b/library/Vanilla/Web/ThemedPage.php
@@ -11,10 +11,10 @@ use Garden\Web\Exception\ServerException;
 use Vanilla\Models\SiteMeta;
 use Vanilla\Navigation\BreadcrumbModel;
 use Vanilla\Theme\JsonAsset;
-use Vanilla\Theme\ScriptsAsset;
 use Vanilla\Web\Asset\WebpackAssetProvider;
 use Vanilla\Web\ContentSecurityPolicy\ContentSecurityPolicyModel;
 use Vanilla\Web\JsInterpop\ReduxAction;
+use Vanilla\Contracts\ConfigurationInterface;
 
 /**
  * A Web\Page that makes use of custom theme data from the theming API.
@@ -34,9 +34,10 @@ abstract class ThemedPage extends Page {
         WebpackAssetProvider $assetProvider,
         BreadcrumbModel $breadcrumbModel,
         \ThemesApiController $themesApi = null, // Default required to conform to interface
-        ContentSecurityPolicyModel $cspModel
+        ContentSecurityPolicyModel $cspModel,
+        ConfigurationInterface $config
     ) {
-        parent::setDependencies($siteMeta, $request, $session, $assetProvider, $breadcrumbModel, $cspModel);
+        parent::setDependencies($siteMeta, $request, $session, $assetProvider, $breadcrumbModel, $cspModel, $config);
         $this->themesApi = $themesApi;
         $this->initAssets();
     }

--- a/resources/views/default-master.twig
+++ b/resources/views/default-master.twig
@@ -11,6 +11,14 @@
             <meta{% for attribute,value in meta %} {{ attribute }}="{{ value }}"{% endfor %} />
         {% endfor %}
 
+        {% if favIcon %}
+            <link rel="shortcut icon" href="{{ favIcon }}" type="image/x-icon" />
+        {% endif %}
+
+        {% if mobileAddressBarColor %}
+            <meta name="theme-color" content="{{ mobileAddressBarColor }}" />
+        {% endif %}
+
         {% for script in inlineScripts -%}
             <script nonce="{{ nonce }}">
                 {{- script|raw -}}


### PR DESCRIPTION
The default Twig template does not support either the site's configured favicon or mobile address bar color (theme-color). These settings can be found under the Branding area of the dashboard.

`Vanilla\Web\Page` has been updated to set these values and hand them down to the default Twig template. The default Twig template has been updated to use them. `Vanilla\Web\ThemedPage` has been updated to account for the new dependencies in `Vanilla\Web\Page`.