### PR TITLE
Correct the link to the docs for Google Sign in.

### DIFF
--- a/plugins/googlesignin/addon.json
+++ b/plugins/googlesignin/addon.json
@@ -3,7 +3,7 @@
     "description": "Users may sign into your site using their Google account.",
     "version": "1.0.0",
     "mobileFriendly": true,
-    "settingsUrl": "/settings/googlesignin",
+    "settingsUrl": "/settings/google",
     "settingsPermission": "Garden.Settings.Manage",
     "hidden": false,
     "socialConnect": true,


### PR DESCRIPTION
The link to the documentation from the dashboard doesn't take the user to the GoogleSignIn section. This PR will fix that .