### PR TITLE
Make conversion of lists to other formats more robust

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/ClipboardModule.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/ClipboardModule.test.ts
@@ -273,4 +273,18 @@ describe("ClipboardModule", () => {
             expect(ClipboardModule.splitLinkOperationsOutOfText(input)).equals(null);
         });
     });
+
+    describe("Pasting into lists", () => {
+        it("can paste content into a list item", () => {
+            quill.setContents([OpUtils.op("1"), OpUtils.list()]);
+            quill.clipboard.dangerouslyPasteHTML(1, "line");
+            expect(quill.getContents().ops).deep.eq([OpUtils.op("1line"), OpUtils.list()]);
+        });
+
+        it("can paste contents into an empty list item", () => {
+            quill.setContents([OpUtils.list()]);
+            quill.clipboard.dangerouslyPasteHTML(0, "line");
+            expect(quill.getContents().ops).deep.eq([OpUtils.op("line"), OpUtils.list()]);
+        });
+    });
 });

--- a/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.test.ts
@@ -20,7 +20,6 @@ import Delta from "quill-delta";
 import Quill from "quill/core";
 import { setupTestQuill } from "@rich-editor/__tests__/quillUtils";
 import OpUtils from "@rich-editor/__tests__/OpUtils";
-import Parchment from "parchment";
 
 describe("ListBlot", () => {
     before(() => {
@@ -259,7 +258,7 @@ describe("ListBlot", () => {
             //         - list item
             //           - list item
             //      - list item
-            // - list item
+            // 1. list item
 
             expect(quill.scroll.children).has.length(2);
 

--- a/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.test.ts
@@ -361,4 +361,11 @@ describe("ListBlot", () => {
             expect(nestedListGroup.children, "There should be 2 nested list items").has.length(2);
         });
     });
+
+    describe("insertion", () => {
+        it.only("can insert newlines", () => {
+            insertListBlot({ type: ListType.BULLETED, depth: 0 }, "1");
+            quill.updateContents([{ retain: 1 }, OpUtils.op("test\ntest")]);
+        });
+    });
 });

--- a/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.test.ts
@@ -378,7 +378,14 @@ describe("ListBlot", () => {
             ]);
         });
 
-        it.only("propert outdents nested children when it's format is replaced", () => {
+        it("propert outdents nested children when it's format is replaced", () => {
+            // Before
+            // - 1
+            //   - 1.1
+            //   - 1.2
+            //     - 1.2.1
+            //     - 1.2.2
+            //   - 1.3
             insertListBlot({ type: ListType.BULLETED, depth: 0 }, "1");
             insertListBlot({ type: ListType.BULLETED, depth: 1 }, "1.1");
             insertListBlot({ type: ListType.BULLETED, depth: 1 }, "1.2");
@@ -386,26 +393,26 @@ describe("ListBlot", () => {
             insertListBlot({ type: ListType.BULLETED, depth: 2 }, "1.2.2");
             insertListBlot({ type: ListType.BULLETED, depth: 1 }, "1.3");
 
-            // The inner items should be
+            quill.formatLine(6, 2, ListItem.blotName, false, Quill.sources.USER);
+            // After
             // - 1
-            //  - 1.1
-            //  - 1.2
-            //    - 1.2.1
-            //    - 1.2.2
-            //  - 1.3
+            //   - 1.1
+            // 1.2
+            // - 1.2.1
+            // - 1.2.2
+            // - 1.3
 
-            quill.formatLine(6, 8, ListItem.blotName, false, Quill.sources.USER);
             expect(quill.getContents().ops).deep.eq([
                 OpUtils.op("1"),
                 OpUtils.list(ListType.BULLETED),
                 OpUtils.op("1.1"),
                 OpUtils.list(ListType.BULLETED, 1),
                 OpUtils.op("1.2\n1.2.1"),
-                OpUtils.list(ListType.BULLETED, 1),
+                OpUtils.list(ListType.BULLETED, 0),
                 OpUtils.op("1.2.2"),
-                OpUtils.list(ListType.BULLETED, 1),
+                OpUtils.list(ListType.BULLETED, 0),
                 OpUtils.op("1.3"),
-                OpUtils.list(ListType.BULLETED, 1),
+                OpUtils.list(ListType.BULLETED, 0),
             ]);
         });
     });

--- a/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.ts
@@ -431,19 +431,6 @@ export class ListItemWrapper extends withWrapper(Container as any) {
         if (sibling instanceof ListItemWrapper) {
             sibling.flattenSelfAndSiblings(targetGroup, ref);
         }
-        // if (group && group.children.head instanceof ListItemWrapper) {
-        //     group.children.head.flattenSelfAndSiblings(targetGroup, ref);
-        //     group.children.head.insertInto(targetGroup, ref);
-        //     group.remove();
-        // }
-
-        // let next = this.next;
-        // while (next instanceof ListItemWrapper) {
-        //     const upcoming = next.next;
-        //     next.flattenSelfAndSiblings(targetGroup, ref);
-        //     next.insertInto(targetGroup, ref);
-        //     next = upcoming;
-        // }
     }
 
     /**
@@ -695,7 +682,29 @@ export class ListItem extends LineBlot {
     }
 
     /**
-     * FIX THIS AND DO IT PROPERLY.
+     * Flatten the item and all of it's sibling list items into the top level scroll.
+     *
+     * @example
+     * Before
+     * - Item 1
+     *   - Item 1.1
+     *   - Item 1.2
+     *     - Item 1.2.1
+     *     - Item 1.2.2
+     *   - Item 1.3
+     * - Item 2
+     *
+     * Call this method on Item 1.1
+     *
+     * After
+     * - Item 1
+     *   - Item 1.1
+     * - Item 1.2
+     * - Item 1.2.1
+     * - Item 1.2.2
+     * - Item 1.3
+     * - Item 2
+     *
      */
     private flattenSelfAndSiblings = () => {
         if (this.parent instanceof ListItemWrapper) {
@@ -714,8 +723,6 @@ export class ListItem extends LineBlot {
             }
             const ref = topListWrapper ? topListWrapper.next : undefined;
             this.parent.flattenSelfAndSiblings(topListGroup, ref);
-
-            // this.quill && this.quill.update(Quill.sources.API);
         }
     };
 
@@ -762,19 +769,6 @@ export class ListItem extends LineBlot {
      */
     public getValue(): IListObjectValue {
         return getValueFromElement(this.domNode);
-    }
-
-    /**
-     * Get the attached quill instance.
-     *
-     * This will _NOT_ work before attach() is called.
-     */
-    protected get quill(): Quill | null {
-        if (!this.scroll || !this.scroll.domNode.parentNode) {
-            return null;
-        }
-
-        return Quill.find(this.scroll.domNode.parentNode!);
     }
 }
 

--- a/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.ts
@@ -176,6 +176,17 @@ export class ListItemWrapper extends withWrapper(Container as any) {
     public static parentName = [UnorderedListGroup.blotName, OrderedListGroup.blotName];
 
     /**
+     * Create the dom node for th item and
+     *
+     * @param value
+     */
+    public static create(value: IListObjectValue) {
+        const element = super.create(value) as HTMLElement;
+        syncValueToElement(element, value);
+        return element;
+    }
+
+    /**
      * @override
      */
     public split(index: number, force?: boolean) {
@@ -383,15 +394,7 @@ export class ListItemWrapper extends withWrapper(Container as any) {
      * Utility for getting the value from the blot's domNode.
      */
     public getValue(): IListObjectValue {
-        const content = this.getListContent();
-        if (content) {
-            return content.getValue();
-        } else {
-            return {
-                type: ListType.BULLETED,
-                depth: 0,
-            };
-        }
+        return getValueFromElement(this.domNode);
     }
 
     /**
@@ -571,8 +574,7 @@ export class ListItem extends LineBlot {
     public updateIndentValue(newDepth: number) {
         newDepth = Math.min(MAX_NESTING_DEPTH, newDepth);
         this.domNode.setAttribute("data-depth", newDepth);
-        const updateID = Math.random() * 10000;
-        this.parent.domNode.setAttribute("data-update-id", updateID.toString(16));
+        this.parent.domNode.setAttribute("data-depth", newDepth);
         this.cache = {};
     }
 
@@ -604,30 +606,6 @@ export class ListItem extends LineBlot {
      */
     public canOutdent(): boolean {
         return this.getValue().depth > 0 || this.domNode.textContent === "";
-    }
-
-    /**
-     * @override
-     * Extended to keep our type value in sync with the parent we're closest too.
-     */
-    public attach() {
-        super.attach();
-        // Sync up our list type.
-        const listNode = this.domNode.closest("ul, ol");
-        if (!listNode) {
-            return;
-        }
-        const currentType = this.getValue().type;
-        let newType = currentType;
-        if (listNode.tagName === ListTag.OL) {
-            newType = ListType.ORDERED;
-        } else if (listNode.tagName === ListTag.UL) {
-            newType = ListType.BULLETED;
-        }
-
-        if (newType !== currentType) {
-            this.domNode.setAttribute("data-type", newType);
-        }
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8593

This PR fixes the issues specifically outlined in https://github.com/vanilla/vanilla/issues/8593 and adds unit tests for those scenarios.

_**If you encounter other list issues that are not specifically a regression from this pull request, please file a separate issue.**_

The most complicated operation occurs whens changing the paragraph format of some inner list item with children or siblings. After some discussions with @tburry We determined that for simplicity it was OK to flatten an items children and its following siblings when it changes formats as long as the user can undo the action.

See the following docblock for the implemented behaviour.

https://github.com/vanilla/vanilla/blob/347ca4dd81dfc56eaf4bf0f291445f81a31072eb/plugins/rich-editor/src/scripts/quill/blots/blocks/ListBlot.ts#L665-L684