### PR TITLE
Add view-all-ungrouped-url property to NavLinksWithHeadings

### DIFF
--- a/library/src/scripts/navigation/NavLinksWithHeadings.tsx
+++ b/library/src/scripts/navigation/NavLinksWithHeadings.tsx
@@ -20,6 +20,7 @@ interface IProps {
     classNames?: string;
     data: ILinkListData;
     accessibleViewAllMessage?: string;
+    ungroupedViewAllUrl?: string;
 }
 
 /**
@@ -33,7 +34,14 @@ export default class NavLinksWithHeadings extends Component<IProps> {
         const classes = navLinksClasses();
 
         if (ungrouped.length !== 0 || grouped.length !== 0) {
-            const ungroupedContent = <NavLinks title={t("Overview")} items={ungrouped} />;
+            const ungroupedContent = (
+                <NavLinks
+                    title={t("Overview")}
+                    items={ungrouped}
+                    accessibleViewAllMessage={this.props.accessibleViewAllMessage}
+                    url={this.props.ungroupedViewAllUrl}
+                />
+            );
             const groupedContent = grouped.map((group, i) => {
                 return (
                     <React.Fragment key={i}>

--- a/library/src/scripts/navigation/NavLinksWithHeadings.tsx
+++ b/library/src/scripts/navigation/NavLinksWithHeadings.tsx
@@ -21,6 +21,7 @@ interface IProps {
     data: ILinkListData;
     accessibleViewAllMessage?: string;
     ungroupedViewAllUrl?: string;
+    ungroupedTitle?: string;
 }
 
 /**
@@ -32,11 +33,12 @@ export default class NavLinksWithHeadings extends Component<IProps> {
         const grouped = this.props.data.groups || [];
         const groupLevel = Math.min((this.props.depth || 2) + 1, 6);
         const classes = navLinksClasses();
+        const ungroupedTitle = this.props.ungroupedTitle || t("Overview");
 
         if (ungrouped.length !== 0 || grouped.length !== 0) {
             const ungroupedContent = (
                 <NavLinks
-                    title={t("Overview")}
+                    title={ungroupedTitle}
                     items={ungrouped}
                     accessibleViewAllMessage={this.props.accessibleViewAllMessage}
                     url={this.props.ungroupedViewAllUrl}


### PR DESCRIPTION
The `NavLinksWithHeadings` component supports grouped and ungrouped content. Grouped content can have "View All" URLs, per group. The ungrouped content does not currently support a "View All" link.

`NavLinksWithHeadings` has a new property: `ungroupedViewAllUrl`. If this property is specified, a "View All" link can be displayed alongside the ungrouped content.