### PR TITLE
Extract generic <Message /> component from <MessageAndRefresh />

### DIFF
--- a/library/src/scripts/messages/Message.tsx
+++ b/library/src/scripts/messages/Message.tsx
@@ -1,0 +1,53 @@
+/**
+ * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import classNames from "classnames";
+import { t } from "@library/utility/appUtils";
+import { LiveMessage } from "react-aria-live";
+import { messagesClasses } from "@library/messages/messageStyles";
+import Button from "@library/forms/Button";
+import { ButtonTypes } from "@library/forms/buttonStyles";
+
+export interface IMessageProps {
+    className?: string;
+    contents?: React.ReactNode;
+    stringContents: string;
+    clearOnUnmount?: boolean; // reannounces the message if the page gets rerendered. This is an important message, so we want this by default.
+    onConfirm?: () => void;
+    confirmText?: string;
+    onCancel?: () => void;
+    cancelText?: string;
+}
+
+export default function Message(props: IMessageProps) {
+    const classes = messagesClasses();
+    return (
+        <>
+            <div className={classNames(classes.root, props.className)}>
+                <div className={classNames(classes.wrap)}>
+                    <div className={classes.message}>{props.contents || props.stringContents}</div>
+                    {props.onConfirm && (
+                        <Button
+                            baseClass={ButtonTypes.TEXT_PRIMARY}
+                            onClick={props.onConfirm}
+                            className={classes.actionButton}
+                        >
+                            {props.confirmText || t("OK")}
+                        </Button>
+                    )}
+                    {props.onCancel && (
+                        <Button baseClass={ButtonTypes.TEXT} onClick={props.onCancel} className={classes.actionButton}>
+                            {props.cancelText || t("Cancel")}
+                        </Button>
+                    )}
+                </div>
+            </div>
+            {/* Does not visually render, but sends message to screen reader users*/}
+            <LiveMessage clearOnUnmount={!!props.clearOnUnmount} message={props.stringContents} aria-live="assertive" />
+        </>
+    );
+}

--- a/library/src/scripts/messages/MessageAndRefresh.tsx
+++ b/library/src/scripts/messages/MessageAndRefresh.tsx
@@ -4,51 +4,29 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
-import classNames from "classnames";
+import Message from "@library/messages/Message";
 import { t } from "@library/utility/appUtils";
-import { LiveMessage, LiveMessenger } from "react-aria-live";
-import { messagesClasses } from "@library/messages/messageStyles";
-import Button from "@library/forms/Button";
-import { ButtonTypes } from "@library/forms/buttonStyles";
+import React from "react";
 
-export interface IMessageAndRefreshProps {
+interface IProps {
     className?: string;
-    message: string;
-    clearOnUnmount?: boolean; // reannounces the message if the page gets rerendered. This is an important message, so we want this by default.
 }
 
 /**
  * Message with refresh button
  */
-export default class MessageAndRefresh extends React.PureComponent<IMessageAndRefreshProps> {
-    public static defaultProps: Partial<IMessageAndRefreshProps> = {
-        message: t("The application has been updated. Refresh to get the latest version."),
-        clearOnUnmount: true,
+export default function MessageAndRefresh(props: IProps) {
+    const contents = t("The application has been updated. Refresh to get the latest version.");
+    const refresh = () => {
+        window.location.href = window.location.href;
     };
-
-    public render() {
-        const classes = messagesClasses();
-        const refresh = () => {
-            window.location.href = window.location.href;
-        };
-        return (
-            <>
-                <div className={classNames(this.props.className, classes.root)}>
-                    <div className={classNames(classes.wrap)}>
-                        <div className={classes.message}>{this.props.message}</div>
-                        <Button baseClass={ButtonTypes.TEXT} onClick={refresh} className={classes.actionButton}>
-                            {t("Refresh")}
-                        </Button>
-                    </div>
-                </div>
-                {/* Does not visually render, but sends message to screen reader users*/}
-                <LiveMessage
-                    clearOnUnmount={!!this.props.clearOnUnmount}
-                    message={this.props.message}
-                    aria-live="assertive"
-                />
-            </>
-        );
-    }
+    return (
+        <Message
+            confirmText={t("Refresh")}
+            onConfirm={refresh}
+            contents={contents}
+            stringContents={contents}
+            className={props.className}
+        />
+    );
 }

--- a/library/src/scripts/messages/MessageAndRefreshFixed.tsx
+++ b/library/src/scripts/messages/MessageAndRefreshFixed.tsx
@@ -4,24 +4,15 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
-import { LiveMessage, LiveMessenger } from "react-aria-live";
+import MessageAndRefresh from "@library/messages/MessageAndRefresh";
 import { messagesClasses } from "@library/messages/messageStyles";
-import MessageAndRefresh, { IMessageAndRefreshProps } from "@library/messages/MessageAndRefresh";
-import classNames from "classnames";
+import React from "react";
 
-interface IProps extends IMessageAndRefreshProps {}
-
-/**
- * Message with refresh button, fixed position
- */
-export default class MessageAndRefreshFixed extends React.PureComponent<IProps> {
-    public render() {
-        const classes = messagesClasses();
-        return (
-            <div className={classes.fixed}>
-                <MessageAndRefresh {...this.props} className={classNames(this.props.className, classes.setWidth)} />
-            </div>
-        );
-    }
+export default function MessageAndRefreshFixed() {
+    const classes = messagesClasses();
+    return (
+        <div className={classes.fixed}>
+            <MessageAndRefresh className={classes.setWidth} />
+        </div>
+    );
 }

--- a/library/src/scripts/messages/messageStyles.ts
+++ b/library/src/scripts/messages/messageStyles.ts
@@ -6,7 +6,16 @@
 
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { unit, userSelect, colorOut, paddings, borders, fonts, allButtonStates } from "@library/styles/styleHelpers";
+import {
+    unit,
+    userSelect,
+    colorOut,
+    paddings,
+    borders,
+    fonts,
+    allButtonStates,
+    margins,
+} from "@library/styles/styleHelpers";
 import { percent, viewWidth } from "csx";
 import { FontWeightProperty } from "csstype";
 import { layoutVariables } from "@library/layout/layoutStyles";
@@ -85,11 +94,13 @@ export const messagesClasses = useThemeCache(() => {
         zIndex: 20,
     });
 
-    const root = style({
-        position: "relative",
-        margin: "auto",
-        width: percent(100),
-    });
+    const root = style(
+        {
+            position: "relative",
+            width: percent(100),
+        },
+        margins({ horizontal: "auto" }),
+    );
 
     const wrap = style(
         "wrap",
@@ -123,7 +134,7 @@ export const messagesClasses = useThemeCache(() => {
     const message = style("message", {
         ...userSelect(),
         ...fonts(vars.text.font),
-        flexGrow: 1,
+        flex: 1,
     });
 
     const setWidth = style("setWidth", {


### PR DESCRIPTION
I've extracted a more generic `<Message />` component from `<MessageAndRefresh />`. I've also tweaked the styles to make it a little more flexible. There are no current uses of this component as it was introduced this sprint.