### PR TITLE
Add default value for MediaItemModule->addButton() $attributes parameter

### DIFF
--- a/applications/dashboard/modules/class.mediaitemmodule.php
+++ b/applications/dashboard/modules/class.mediaitemmodule.php
@@ -413,7 +413,7 @@ class MediaItemModule extends Gdn_Module {
      * @param $attributes The button attributes.
      * @return MediaItemModule $this
      */
-    public function addButton($text, $url, $attributes) {
+    public function addButton($text, $url, $attributes = ['class' => 'btn btn-secondary']) {
         if (is_string($attributes)) {
             $attr = ['class' => $attributes];
         } elseif (is_array($attributes)) {


### PR DESCRIPTION
This PR refers to [this issue](https://github.com/vanilla/vanilla/issues/8675). It changes the MediaItemModules addButton method to the following definition:
`public function addButton($text, $url, $attributes = ['class' => 'btn btn-secondary'])`
During process flow an empty $attributes parameter would have been replaced by exactly that array. 

Therefore passing it as default
1. makes this behaviour more obvious and
2. makes using this method more convenient 