### PR TITLE
Implement getter/setter for MediaItemModule->tag

### DIFF
--- a/applications/dashboard/modules/class.mediaitemmodule.php
+++ b/applications/dashboard/modules/class.mediaitemmodule.php
@@ -313,6 +313,22 @@ class MediaItemModule extends Gdn_Module {
     }
 
     /**
+     * @return string The top-level HTML element for the Media Item.
+     */
+    public function getTag() {
+        return $this->tag;
+    }
+
+    /**
+     * @param string $tag The top-level HTML element for the Media Item.
+     * @return MediaItemModule $this
+     */
+    public function setTag($tag) {
+        $this->tag = $tag;
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function getToggle() {


### PR DESCRIPTION
This fixes [issue](https://github.com/vanilla/vanilla/issues/8674).

The MediaItemModule->tag property can be set when the module is created, but it cannot be changed later or accessed in a view. This PR implements a `setTag()` and `getTag()` method to make this property usable.