### PR TITLE
Update the description of Google Plus Sign In with deprecation warning.

### DIFF
--- a/plugins/GooglePlus/addon.json
+++ b/plugins/GooglePlus/addon.json
@@ -1,6 +1,6 @@
 {
     "name": "Google+ Social Connect",
-    "description": "Users may sign into your site using their Google Plus account.",
+    "description": "This plugin is deprecated. <a href='https://support.google.com/plus/answer/9217723'>Google is no longer supporting Google+ user authentication</a>. Please use the Google Sign In plugin.",
     "version": "1.1.0",
     "mobileFriendly": true,
     "settingsUrl": "/dashboard/social/googleplus",


### PR DESCRIPTION
Google+ is shutting down. Our Google+ Sign In plugin is being deprecated and has already been replaced by Google Sign In plugin. 

This PR gives admins a warning in the description of the Google+ plugin in the dashboard instructing them to use the Google Sign In and giving them a link to Google's FAQ.