### PR TITLE
Update typescript config to handle no-implicit-this

### DIFF
--- a/applications/dashboard/src/scripts/legacy/atwho.ts
+++ b/applications/dashboard/src/scripts/legacy/atwho.ts
@@ -261,6 +261,9 @@ export function initializeAtComplete(editorElement, iframe?: any) {
         // be false most of the time; the exception is when
         // it's true.
         if (!atQuote) {
+            // Supressing this error because this is legacy that is complicated to refactor.
+            // In the case here `this` is the atwho library which we don't have types.
+            // @ts-ignore
             insert = this.at + insert;
         }
 

--- a/build/entries/polyfills.ts
+++ b/build/entries/polyfills.ts
@@ -48,12 +48,12 @@ export function polyfillClosest() {
 
     if (!Element.prototype.closest) {
         Element.prototype.closest = function closest(s) {
-            let el = this;
+            let el: Node | null = this;
             if (document.documentElement && !document.documentElement.contains(el)) {
                 return null;
             }
             do {
-                if (el.matches && el.matches(s)) {
+                if (el instanceof Element && el.matches && el.matches(s)) {
                     return el;
                 }
                 el = el.parentElement || el.parentNode;

--- a/library/src/scripts/content/embeds/video.tsx
+++ b/library/src/scripts/content/embeds/video.tsx
@@ -119,9 +119,9 @@ function PlayIcon() {
 /**
  * Handle a click on a video.
  */
-function handlePlayVideo() {
+function handlePlayVideo(event: MouseEvent, triggeringElement: HTMLElement) {
     // Inside of delegate event `this` is the current target of the event.
-    const playButton: HTMLElement = this;
+    const playButton: HTMLElement = triggeringElement;
     const container = playButton.closest(".embedVideo-ratio");
     if (container) {
         const url = playButton.dataset.url as string;

--- a/library/src/scripts/content/spoilers.ts
+++ b/library/src/scripts/content/spoilers.ts
@@ -13,8 +13,8 @@ export function initSpoilers() {
 /**
  * Toggle a spoiler open and closed.
  */
-function handleToggleSpoiler() {
-    const toggleButton: HTMLElement = this;
+function handleToggleSpoiler(event: MouseEvent, triggeringElement: HTMLElement) {
+    const toggleButton = triggeringElement;
 
     const spoilerContainer = toggleButton.closest(".spoiler");
     if (spoilerContainer) {

--- a/library/src/scripts/flyouts/FlyoutToggle.tsx
+++ b/library/src/scripts/flyouts/FlyoutToggle.tsx
@@ -114,23 +114,22 @@ export default class FlyoutToggle extends React.PureComponent<
                     {this.props.buttonContents}
                 </Button>
 
-                {!this.props.disabled &&
-                    this.state.isVisible && (
-                        <React.Fragment>
-                            {this.props.openAsModal ? (
-                                <Modal
-                                    label={t("title")}
-                                    size={ModalSizes.SMALL}
-                                    exitHandler={this.closeMenuHandler}
-                                    elementToFocusOnExit={this.buttonRef.current!}
-                                >
-                                    {this.props.children(childrenData)}
-                                </Modal>
-                            ) : (
-                                this.props.children(childrenData)
-                            )}
-                        </React.Fragment>
-                    )}
+                {!this.props.disabled && this.state.isVisible && (
+                    <React.Fragment>
+                        {this.props.openAsModal ? (
+                            <Modal
+                                label={t("title")}
+                                size={ModalSizes.SMALL}
+                                exitHandler={this.closeMenuHandler}
+                                elementToFocusOnExit={this.buttonRef.current!}
+                            >
+                                {this.props.children(childrenData)}
+                            </Modal>
+                        ) : (
+                            this.props.children(childrenData)
+                        )}
+                    </React.Fragment>
+                )}
             </div>
         );
     }

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -705,11 +705,11 @@ export const dropShadow = (vals: IDropShadowShorthand | IDropShadow | "none" | "
     } else if ("nonColorProps" in vals) {
         return { dropShadow: `${vals.nonColorProps} ${vals.color.toString()}` };
     } else {
-        const { x, y, blur, spread, inset, shadowColor } = this.props;
+        const { x, y, blur, spread, inset, color } = vals;
         return {
             dropShadow: `${x ? x + " " : ""}${y ? y + " " : ""}${blur ? blur + " " : ""}${
                 spread ? spread + " " : ""
-            }${shadowColor}${inset ? " inset" : ""}`,
+            }${color}${inset ? " inset" : ""}`,
         };
     }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,8 @@
     "compilerOptions": {
         "allowJs": true,
         "jsx": "react",
-        "lib": [
-            "es2018",
-            "dom",
-            "dom.iterable"
-        ],
+        "lib": ["es2018", "dom", "dom.iterable"],
+        "noImplicitThis": true,
         "allowSyntheticDefaultImports": true,
         "moduleResolution": "node",
         "strictNullChecks": true,
@@ -22,24 +19,15 @@
             "@knowledge/*": ["./plugins/knowledge/src/scripts/*"],
             "@testroot/*": ["./tests/javascript/*"]
         },
-        "typeRoots": [
-            "@types",
-            "./node_modules/@types"
-        ],
+        "typeRoots": ["@types", "./node_modules/@types"],
         "skipLibCheck": true,
         "sourceMap": true,
         "plugins": [
             {
-                "name": "typescript-tslint-plugin",
+                "name": "typescript-tslint-plugin"
             }
         ]
     },
-    "include": [
-        "**/*.ts",
-        "**/*.tsx"
-    ],
-    "exclude": [
-        "**/*.js",
-        "**/*.jsx"
-    ]
+    "include": ["**/*.ts", "**/*.tsx"],
+    "exclude": ["**/*.js", "**/*.jsx"]
 }


### PR DESCRIPTION
After https://github.com/vanilla/vanilla/commit/5f55fd88891a0195269998aa7394c4540892b43e I believe we have some potential issues with moving usages from class components into function components.

I've enabled the `noImplicitThis` typescript flag, which throws an error if the value of `this` cannot be statically determined. I had to replace a few usages when enabling this, and fixed one big in our dropShadow helper.