### PR TITLE
Add the ability to debug styleFactory calls

### DIFF
--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -11,7 +11,8 @@ import gdn from "@library/gdn";
 import apiv2 from "@library/apiv2";
 
 // Inject the debug flag into the utility.
-debug(getMeta("debug", false));
+const debugValue = getMeta("context.debug", getMeta("debug", false));
+debug(debugValue);
 
 // Export the API to the global object.
 gdn.apiv2 = apiv2;

--- a/library/src/scripts/features/search/searchBarStyles.ts
+++ b/library/src/scripts/features/search/searchBarStyles.ts
@@ -11,7 +11,7 @@ import { borders, colorOut, unit } from "@library/styles/styleHelpers";
 import { calc, important, percent, px } from "csx";
 
 import { vanillaHeaderVariables } from "@library/headers/vanillaHeaderStyles";
-import { buttonClasses } from "@library/forms/buttonStyles";
+import { buttonClasses, buttonVariables } from "@library/forms/buttonStyles";
 import { layoutVariables } from "@library/layout/layoutStyles";
 
 export const searchBarVariables = useThemeCache(() => {
@@ -134,7 +134,7 @@ export const searchBarClasses = useThemeCache(() => {
                                 "&.inputText": {
                                     borderTopRightRadius: 0,
                                     borderBottomRightRadius: 0,
-                                    ...borders(classesButton.standard.border),
+                                    ...borders(buttonVariables().standard.borders),
                                 },
                             },
                         },

--- a/library/src/scripts/forms/FormError.tsx
+++ b/library/src/scripts/forms/FormError.tsx
@@ -40,7 +40,7 @@ export default class FormError extends React.Component<IProps> {
                             className={classNames(classes.actionButton, classes.activeButton)}
                         >
                             {this.props.isRetryLoading ? (
-                                <ButtonLoader buttonType={classesButtons.standard} />
+                                <ButtonLoader buttonType={ButtonTypes.STANDARD} />
                             ) : (
                                 t("Retry")
                             )}

--- a/library/src/scripts/headers/vanillaHeaderStyles.ts
+++ b/library/src/scripts/headers/vanillaHeaderStyles.ts
@@ -382,7 +382,7 @@ export const vanillaHeaderClasses = useThemeCache(() => {
         },
     });
 
-    const tabButtonActive = style("tabButtonActive", {
+    const tabButtonActive = {
         color: globalVars.mainColors.primary.toString(),
         $nest: {
             ".vanillaHeader-tabButtonContent": {
@@ -391,7 +391,7 @@ export const vanillaHeaderClasses = useThemeCache(() => {
                 borderRadius: px(vars.button.borderRadius),
             },
         },
-    });
+    };
 
     const tabButton = style("tabButton", {
         display: "block",

--- a/library/src/scripts/layout/components/widgetContainerStyles.ts
+++ b/library/src/scripts/layout/components/widgetContainerStyles.ts
@@ -6,7 +6,6 @@
 
 import { unit } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
-import { NestedCSSProperties } from "typestyle/lib/types";
 import { percent } from "csx";
 import { containerVariables } from "@library/layout/components/containerStyles";
 
@@ -14,7 +13,7 @@ export const widgetContainerClasses = useThemeCache(() => {
     const style = styleFactory("widgetContainerClasses");
     const vars = containerVariables();
 
-    const root: NestedCSSProperties = style({
+    const root = style({
         position: "relative",
         maxWidth: percent(100),
         margin: "auto",

--- a/library/src/scripts/layout/frame/frameStyles.ts
+++ b/library/src/scripts/layout/frame/frameStyles.ts
@@ -134,7 +134,7 @@ export const frameHeaderClasses = useThemeCache(() => {
         width: unit(formElVars.sizing.height),
     });
 
-    const action = style(true, "action", {
+    const action = style("action", {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",

--- a/library/src/scripts/layout/frame/frameStyles.ts
+++ b/library/src/scripts/layout/frame/frameStyles.ts
@@ -134,7 +134,7 @@ export const frameHeaderClasses = useThemeCache(() => {
         width: unit(formElVars.sizing.height),
     });
 
-    const action = style("action", {
+    const action = style(true, "action", {
         display: "flex",
         alignItems: "center",
         justifyContent: "center",

--- a/library/src/scripts/styles/styleUtils.ts
+++ b/library/src/scripts/styles/styleUtils.ts
@@ -12,6 +12,7 @@ import { ICoreStoreState } from "@library/redux/reducerRegistry";
 import memoize from "lodash/memoize";
 import merge from "lodash/merge";
 import { color } from "csx";
+import { log } from "@library/utility/utils";
 import { getThemeVariables } from "@library/theming/getThemeVariables";
 
 /**
@@ -20,25 +21,43 @@ import { getThemeVariables } from "@library/theming/getThemeVariables";
  * This works like debugHelper but automatically. The generated function behaves just like `style()`
  * but can automatically adds a debug name & allows the first argument to be a string subcomponent name.
  *
+ * Additionally passing the first parameter as true will log out out debug information about the styles.
+ *
  * @example
  * const style = styleFactory("myComponent");
  * const myClass = style({ color: "red" }); // .myComponent-sad421s
  * const mySubClass = style("subcomponent", { color: "red" }) // .myComponent-subcomponent-23sdaf43
+ * const withDebugMode = style(true, "subcomponent", {color: "red"}).
  */
 export function styleFactory(componentName: string) {
-    function styleCreator(subcomponentName: string, ...objects: Array<NestedCSSProperties | undefined>);
-    function styleCreator(...objects: Array<NestedCSSProperties | undefined>);
-    function styleCreator(...objects: Array<NestedCSSProperties | undefined | string>) {
+    function styleCreator(subcomponentName: string, ...objects: Array<NestedCSSProperties | undefined>): string;
+    function styleCreator(
+        debug: true,
+        subcomponentName: string,
+        ...objects: Array<NestedCSSProperties | undefined>
+    ): string;
+    function styleCreator(...objects: Array<NestedCSSProperties | undefined>): string;
+    function styleCreator(...objects: Array<NestedCSSProperties | undefined | string | boolean>): string {
         if (objects.length === 0) {
             return style();
         }
 
         let debugName = componentName;
+        let shouldLogDebug = false;
         let styleObjs: Array<NestedCSSProperties | undefined> = objects as any;
+        if (typeof objects[0] === "boolean" && objects[0] === true) {
+            styleObjs.shift();
+            shouldLogDebug = true;
+        }
         if (typeof objects[0] === "string") {
             const [subcomponentName, ...restObjects] = styleObjs;
             debugName += `-${subcomponentName}`;
             styleObjs = restObjects;
+        }
+
+        if (shouldLogDebug) {
+            log(`Debug component ${debugName}`);
+            log(styleObjs);
         }
 
         return style({ $debugName: debugName }, ...styleObjs);

--- a/library/src/scripts/styles/styleUtils.ts
+++ b/library/src/scripts/styles/styleUtils.ts
@@ -15,6 +15,8 @@ import { color } from "csx";
 import { log, logWarning } from "@library/utility/utils";
 import { getThemeVariables } from "@library/theming/getThemeVariables";
 
+export const DEBUG_STYLES = Symbol.for("Debug");
+
 /**
  * A better helper to generate human readable classes generated from TypeStyle.
  *
@@ -31,9 +33,9 @@ import { getThemeVariables } from "@library/theming/getThemeVariables";
  */
 export function styleFactory(componentName: string) {
     function styleCreator(subcomponentName: string, ...objects: NestedCSSProperties[]): string;
-    function styleCreator(debug: true, subcomponentName: string, ...objects: NestedCSSProperties[]): string;
+    function styleCreator(debug: symbol, subcomponentName: string, ...objects: NestedCSSProperties[]): string;
     function styleCreator(...objects: NestedCSSProperties[]): string;
-    function styleCreator(...objects: Array<NestedCSSProperties | string | boolean>): string {
+    function styleCreator(...objects: Array<NestedCSSProperties | string | symbol>): string {
         if (objects.length === 0) {
             return style();
         }
@@ -41,7 +43,7 @@ export function styleFactory(componentName: string) {
         let debugName = componentName;
         let shouldLogDebug = false;
         let styleObjs: Array<NestedCSSProperties | undefined> = objects as any;
-        if (typeof objects[0] === "boolean" && objects[0] === true) {
+        if (objects[0] === DEBUG_STYLES) {
             styleObjs.shift();
             shouldLogDebug = true;
         }

--- a/library/src/scripts/styles/styleUtils.ts
+++ b/library/src/scripts/styles/styleUtils.ts
@@ -12,7 +12,7 @@ import { ICoreStoreState } from "@library/redux/reducerRegistry";
 import memoize from "lodash/memoize";
 import merge from "lodash/merge";
 import { color } from "csx";
-import { log } from "@library/utility/utils";
+import { log, logWarning } from "@library/utility/utils";
 import { getThemeVariables } from "@library/theming/getThemeVariables";
 
 /**
@@ -30,14 +30,10 @@ import { getThemeVariables } from "@library/theming/getThemeVariables";
  * const withDebugMode = style(true, "subcomponent", {color: "red"}).
  */
 export function styleFactory(componentName: string) {
-    function styleCreator(subcomponentName: string, ...objects: Array<NestedCSSProperties | undefined>): string;
-    function styleCreator(
-        debug: true,
-        subcomponentName: string,
-        ...objects: Array<NestedCSSProperties | undefined>
-    ): string;
-    function styleCreator(...objects: Array<NestedCSSProperties | undefined>): string;
-    function styleCreator(...objects: Array<NestedCSSProperties | undefined | string | boolean>): string {
+    function styleCreator(subcomponentName: string, ...objects: NestedCSSProperties[]): string;
+    function styleCreator(debug: true, subcomponentName: string, ...objects: NestedCSSProperties[]): string;
+    function styleCreator(...objects: NestedCSSProperties[]): string;
+    function styleCreator(...objects: Array<NestedCSSProperties | string | boolean>): string {
         if (objects.length === 0) {
             return style();
         }
@@ -56,7 +52,7 @@ export function styleFactory(componentName: string) {
         }
 
         if (shouldLogDebug) {
-            log(`Debug component ${debugName}`);
+            logWarning(`Debugging component ${debugName}`);
             log(styleObjs);
         }
 


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8686
Closes https://github.com/vanilla/vanilla/issues/8687

This PR adds the ability for someone using `styleFactory` to debug their input into typestyle.

To do so just pass the imported `DEBUG_STYLES` symbol as the first param to the `style()` call.

I've used a symbol instead of a boolean or string so that it has an explicit name and it won't be confused with the first string parameter of the output name.

## Also

- I tightened up the type returned from `style()`. It's always a string. Then I fixed some broken places that were trying to use this string as a mixin.
- Fixed an issue where the debug value on the frontend wasn't being set properly in KB with hot reload enabled.