### PR TITLE
Fix various issues with Flyouts converting to Modals on mobile

### DIFF
--- a/library/src/scripts/dom/EscapeListener.ts
+++ b/library/src/scripts/dom/EscapeListener.ts
@@ -3,6 +3,34 @@
  * @license GPL-2.0-only
  */
 
+import { useEffect } from "react";
+
+/**
+ * React hook for listening for an escape press on the keyboard inside root element.
+ *
+ * When escape is pressed, the return element will be focused if provided or the callback will will be called.
+ */
+export function useEscapeListener({
+    root,
+    returnElement,
+    callback,
+}: {
+    root?: HTMLElement | null;
+    returnElement?: HTMLElement | null;
+    callback?: (event: KeyboardEvent) => void;
+}) {
+    useEffect(() => {
+        if (root === null || returnElement === null) {
+            // Bail out if these are null. That means we have unfilled refs. Undefined means they were not passed and we should use the defaults.
+            return;
+        }
+        const actualRoot = root || document.documentElement;
+        const escapeListener = new EscapeListener(actualRoot, returnElement, callback);
+        escapeListener.start();
+        return escapeListener.stop;
+    }, [root, returnElement, callback]);
+}
+
 /**
  * Register an keyboard listener for the escape key.
  */
@@ -14,7 +42,7 @@ export default class EscapeListener {
      */
     public constructor(
         private root: HTMLElement,
-        private returnElement: HTMLElement,
+        private returnElement?: HTMLElement,
         private callback?: (event: KeyboardEvent) => void,
     ) {}
 
@@ -42,7 +70,7 @@ export default class EscapeListener {
         if (event.key === "Escape") {
             if (this.root.contains(document.activeElement)) {
                 event.preventDefault();
-                this.returnElement.focus();
+                this.returnElement && this.returnElement.focus();
                 this.callback && this.callback(event);
             }
         }

--- a/library/src/scripts/dom/FocusWatcher.ts
+++ b/library/src/scripts/dom/FocusWatcher.ts
@@ -2,6 +2,27 @@
  * @copyright 2009-2019 Vanilla Forums Inc.
  * @license GPL-2.0-only
  */
+import { useEffect } from "react";
+
+/**
+ * React hook for creating and destroying a FocusWatcher. See FocusWatcher documentation.
+ */
+export function useFocusWatcher(
+    rootNode: Element | null,
+    changeHandler: (hasFocus: boolean) => void,
+    bypass?: boolean,
+) {
+    useEffect(() => {
+        if (bypass) {
+            return;
+        }
+        if (rootNode !== null) {
+            const focusWatcher = new FocusWatcher(rootNode, changeHandler);
+            focusWatcher.start();
+            return focusWatcher.stop;
+        }
+    }, [rootNode, changeHandler, bypass]);
+}
 
 /**
  * Register a callback for focusin and focusin out events. The main improvement here over registering
@@ -21,20 +42,20 @@ export default class FocusWatcher {
     /**
      * Register the event listeners from this class.
      */
-    public start() {
+    public start = () => {
         this.rootNode.addEventListener("focusout", this.handleFocusOut, true);
         this.rootNode.addEventListener("focusin", this.handleFocusIn, true);
         document.addEventListener("click", this.handleClick);
-    }
+    };
 
     /**
      * Remove the event listeners from this class.
      */
-    public stop() {
+    public stop = () => {
         this.rootNode.removeEventListener("focusout", this.handleFocusOut, true);
         this.rootNode.removeEventListener("focusin", this.handleFocusIn, true);
         document.removeEventListener("click", this.handleClick);
-    }
+    };
 
     /**
      * Handle when an element loses focus.

--- a/library/src/scripts/flyouts/DropDown.tsx
+++ b/library/src/scripts/flyouts/DropDown.tsx
@@ -34,7 +34,7 @@ export interface IProps extends IDeviceProps {
     disabled?: boolean;
     toggleButtonClassName?: string;
     initialFocusElement?: HTMLElement | null;
-    setExternalButtonRef?: (ref: React.RefObject<HTMLButtonElement>) => void;
+    buttonRef?: React.RefObject<HTMLButtonElement>;
     onVisibilityChange?: (isVisible: boolean) => void;
     openAsModal?: boolean;
     title?: string;
@@ -85,7 +85,7 @@ class DropDown extends React.Component<IProps, IState> {
                 buttonClassName={this.props.buttonClassName}
                 selectedItemLabel={this.selectedText}
                 disabled={this.props.disabled}
-                setExternalButtonRef={this.props.setExternalButtonRef}
+                buttonRef={this.props.buttonRef}
                 toggleButtonClassName={this.props.toggleButtonClassName}
                 onVisibilityChange={this.props.onVisibilityChange}
                 openAsModal={openAsModal}

--- a/library/src/scripts/flyouts/DropDown.tsx
+++ b/library/src/scripts/flyouts/DropDown.tsx
@@ -33,6 +33,7 @@ export interface IProps extends IDeviceProps {
     buttonBaseClass?: ButtonTypes;
     disabled?: boolean;
     toggleButtonClassName?: string;
+    initialFocusElement?: HTMLElement | null;
     setExternalButtonRef?: (ref: React.RefObject<HTMLButtonElement>) => void;
     onVisibilityChange?: (isVisible: boolean) => void;
     openAsModal?: boolean;
@@ -88,6 +89,7 @@ class DropDown extends React.Component<IProps, IState> {
                 toggleButtonClassName={this.props.toggleButtonClassName}
                 onVisibilityChange={this.props.onVisibilityChange}
                 openAsModal={openAsModal}
+                initialFocusElement={this.props.initialFocusElement}
             >
                 {params => {
                     return (

--- a/library/src/scripts/flyouts/FlyoutToggle.tsx
+++ b/library/src/scripts/flyouts/FlyoutToggle.tsx
@@ -38,7 +38,7 @@ export interface IFlyoutToggleProps {
     renderAbove?: boolean;
     renderLeft?: boolean;
     toggleButtonClassName?: string;
-    setExternalButtonRef?: (ref: React.RefObject<HTMLButtonElement>) => void;
+    buttonRef?: React.RefObject<HTMLButtonElement>;
     openAsModal: boolean;
     initialFocusElement?: HTMLElement | null;
 }
@@ -63,7 +63,9 @@ export default function FlyoutToggle(props: IProps) {
     const contentID = ID + "-contents";
 
     // Focus management & visibility
-    const buttonRef = useRef<HTMLButtonElement>(null);
+    const ownButtonRef = useRef<HTMLButtonElement>(null);
+    const buttonRef = props.buttonRef || ownButtonRef;
+
     const controllerRef = useRef<HTMLDivElement>(null);
     const [isVisible, setVisibility] = useState(false);
     useEffect(() => {
@@ -138,9 +140,6 @@ export default function FlyoutToggle(props: IProps) {
         returnElement: buttonRef.current,
         callback: closeMenuHandler,
     });
-    if (props.setExternalButtonRef) {
-        props.setExternalButtonRef(buttonRef);
-    }
 
     const classes = dropDownClasses();
     const buttonClasses = classNames(props.buttonClassName, props.toggleButtonClassName, {

--- a/library/src/scripts/layout/DeviceContext.tsx
+++ b/library/src/scripts/layout/DeviceContext.tsx
@@ -7,6 +7,8 @@
 import React, { useContext } from "react";
 import { Optionalize } from "@library/@types/utils";
 import throttle from "lodash/throttle";
+import { deviceCheckerClasses } from "@library/layout/deviceCheckerStyles";
+import { forceRenderStyles } from "typestyle";
 
 export enum Devices {
     MOBILE = "mobile",
@@ -41,9 +43,11 @@ export class DeviceProvider extends React.Component<IProps, IState> {
     private deviceChecker: React.RefObject<HTMLDivElement> = React.createRef();
 
     public render() {
+        const classes = deviceCheckerClasses();
+        forceRenderStyles();
         return (
             <>
-                <div ref={this.deviceChecker} className="deviceChecker" />
+                <div ref={this.deviceChecker} className={classes.root} />
                 <DeviceContext.Provider value={this.state.device}>{this.props.children}</DeviceContext.Provider>
             </>
         );

--- a/library/src/scripts/layout/deviceCheckerStyles.tsx
+++ b/library/src/scripts/layout/deviceCheckerStyles.tsx
@@ -1,0 +1,35 @@
+/*!
+ * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { styleFactory } from "@library/styles/styleUtils";
+import { important, px } from "csx";
+import { layoutVariables } from "@library/layout/layoutStyles";
+
+export function deviceCheckerClasses() {
+    const style = styleFactory("deviceChecker");
+    const queries = layoutVariables().mediaQueries();
+
+    const root = style(
+        {
+            visibility: important("hidden"),
+            height: important(0),
+            margin: important(0),
+            padding: important(0),
+            width: px(4),
+        },
+        queries.noBleed({
+            width: px(3),
+        }),
+        queries.twoColumns({
+            width: px(2),
+        }),
+        queries.oneColumn({
+            width: px(1),
+        }),
+    );
+
+    return { root };
+}

--- a/plugins/rich-editor/src/scripts/editor/EditorEmbedBar.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorEmbedBar.tsx
@@ -44,7 +44,7 @@ export function EditorEmbedBar(props: IProps) {
             >
                 {isMobile && (
                     <li className={classNames("richEditor-menuItem", classesRichEditor.menuItem)} role="menuitem">
-                        <ParagraphMenusBarToggle disabled={isLoading} mobile={true} />
+                        <ParagraphMenusBarToggle renderAbove={legacyMode} disabled={isLoading} mobile={true} />
                     </li>
                 )}
                 {!isMobile && (

--- a/plugins/rich-editor/src/scripts/editor/ForumEditor.tsx
+++ b/plugins/rich-editor/src/scripts/editor/ForumEditor.tsx
@@ -14,6 +14,7 @@ import { richEditorClasses } from "@rich-editor/editor/richEditorClasses";
 import classNames from "classnames";
 import React from "react";
 import { Provider } from "react-redux";
+import { DeviceProvider } from "@library/layout/DeviceContext";
 
 interface IProps {
     legacyTextArea: HTMLInputElement;
@@ -29,19 +30,21 @@ export function ForumEditor(props: IProps) {
     const classes = richEditorClasses(true);
     return (
         <Provider store={store}>
-            <Editor
-                isPrimaryEditor={true}
-                legacyMode={true}
-                allowUpload={hasPermission("uploads.add")}
-                isLoading={false}
-            >
-                <div className={classNames("richEditor-frame", "InputBox", classes.legacyFrame, classes.root)}>
-                    <EditorContent legacyTextArea={props.legacyTextArea} />
-                    <EditorParagraphMenu />
-                    <EditorInlineMenus />
-                    <EditorEmbedBar />
-                </div>
-            </Editor>
+            <DeviceProvider>
+                <Editor
+                    isPrimaryEditor={true}
+                    legacyMode={true}
+                    allowUpload={hasPermission("uploads.add")}
+                    isLoading={false}
+                >
+                    <div className={classNames("richEditor-frame", "InputBox", classes.legacyFrame, classes.root)}>
+                        <EditorContent legacyTextArea={props.legacyTextArea} />
+                        <EditorParagraphMenu />
+                        <EditorInlineMenus />
+                        <EditorEmbedBar />
+                    </div>
+                </Editor>
+            </DeviceProvider>
         </Provider>
     );
 }

--- a/plugins/rich-editor/src/scripts/editor/richEditorClasses.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorClasses.ts
@@ -119,8 +119,6 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        height: unit(vars.paragraphMenuHandle.size),
-        width: unit(globalVars.icon.sizes.default),
         top: important(0),
     });
 

--- a/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
@@ -41,7 +41,7 @@ interface IState extends IRequiredComponentID {
 
 export class EmbedFlyout extends React.PureComponent<IProps, IState> {
     private embedModule: EmbedInsertionModule;
-    private initalFocusRef: React.RefObject<any> = React.createRef();
+    private inputRef = React.createRef<HTMLInputElement>();
 
     public constructor(props) {
         super(props);
@@ -84,6 +84,7 @@ export class EmbedFlyout extends React.PureComponent<IProps, IState> {
                     renderAbove={!!this.props.renderAbove}
                     renderLeft={!!this.props.renderLeft}
                     selfPadded={true}
+                    initialFocusElement={this.inputRef.current}
                 >
                     <Frame>
                         <FrameBody>
@@ -100,7 +101,7 @@ export class EmbedFlyout extends React.PureComponent<IProps, IState> {
                                 onKeyDown={this.buttonKeyDownHandler}
                                 aria-labelledby={this.titleID}
                                 aria-describedby={this.descriptionID}
-                                ref={this.initalFocusRef}
+                                ref={this.inputRef}
                             />
                         </FrameBody>
                         <FrameFooter>

--- a/plugins/rich-editor/src/scripts/flyouts/EmojiFlyout.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/EmojiFlyout.tsx
@@ -5,7 +5,12 @@
  */
 
 import React from "react";
-import { getRequiredID, IOptionalComponentID, IRequiredComponentID } from "@library/utility/idUtils";
+import {
+    getRequiredID,
+    IOptionalComponentID,
+    IRequiredComponentID,
+    uniqueIDFromPrefix,
+} from "@library/utility/idUtils";
 import FlyoutToggle, { IFlyoutToggleChildParameters } from "@library/flyouts/FlyoutToggle";
 import { t } from "@library/utility/appUtils";
 import { embed, emoji } from "@library/icons/editorIcons";
@@ -16,20 +21,16 @@ import { forceSelectionUpdate } from "@rich-editor/quill/utility";
 import { ButtonTypes } from "@library/forms/buttonStyles";
 import { IconForButtonWrap } from "@rich-editor/editor/pieces/IconForButtonWrap";
 
-interface IProps extends IOptionalComponentID {
+interface IProps {
     disabled?: boolean;
     renderAbove?: boolean;
     renderLeft?: boolean;
     legacyMode: boolean;
 }
 
-export default class EmojiFlyout extends React.Component<IProps, IRequiredComponentID> {
-    public constructor(props) {
-        super(props);
-        this.state = {
-            id: getRequiredID(props, "emojiPopover"),
-        };
-    }
+export default class EmojiFlyout extends React.Component<IProps> {
+    private titleRef = React.createRef<HTMLElement>();
+    private id = uniqueIDFromPrefix("emojiPopover");
 
     /**
      * @inheritDoc
@@ -39,7 +40,7 @@ export default class EmojiFlyout extends React.Component<IProps, IRequiredCompon
 
         return (
             <FlyoutToggle
-                id={this.state.id}
+                id={this.id}
                 className="emojiPicker"
                 buttonClassName={classNames("richEditor-button", "richEditor-embedButton", classesRichEditor.button)}
                 onVisibilityChange={forceSelectionUpdate}
@@ -50,11 +51,13 @@ export default class EmojiFlyout extends React.Component<IProps, IRequiredCompon
                 renderAbove={this.props.renderAbove}
                 renderLeft={this.props.renderLeft}
                 openAsModal={false}
+                initialFocusElement={this.titleRef.current}
             >
                 {(options: IFlyoutToggleChildParameters) => {
                     return (
                         <EmojiPicker
                             {...options}
+                            titleRef={this.titleRef}
                             renderAbove={this.props.renderAbove}
                             renderLeft={this.props.renderLeft}
                             contentID={options.id}

--- a/plugins/rich-editor/src/scripts/flyouts/pieces/EmojiPicker.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/pieces/EmojiPicker.tsx
@@ -42,6 +42,7 @@ interface IProps extends IWithEditorProps, IFlyoutToggleChildParameters {
     renderAbove?: boolean;
     renderLeft?: boolean;
     legacyMode: boolean;
+    titleRef?: React.RefObject<HTMLElement | null>;
 }
 
 interface IState {
@@ -154,7 +155,7 @@ export class EmojiPicker extends React.PureComponent<IProps, IState> {
                 descriptionID={this.descriptionID}
                 titleID={this.titleID}
                 title={this.state.title}
-                titleRef={this.props.initialFocusRef}
+                titleRef={this.props.titleRef}
                 accessibleDescription={description}
                 alertMessage={this.state.alertMessage}
                 additionalHeaderContent={extraHeadingContent}

--- a/plugins/rich-editor/src/scripts/flyouts/pieces/insertMediaClasses.ts
+++ b/plugins/rich-editor/src/scripts/flyouts/pieces/insertMediaClasses.ts
@@ -32,9 +32,14 @@ export const insertMediaClasses = useThemeCache(() => {
     });
 
     const insert = style("insert", {
-        width: percent(100),
-        position: "relative",
-        marginBottom: px(10),
+        $nest: {
+            "&&": {
+                // Nest deeper to override margins from the forum.
+                width: percent(100),
+                position: "relative",
+                marginBottom: px(10),
+            },
+        },
     });
     const button = style("button", {
         position: "relative",

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
@@ -44,6 +44,7 @@ interface IProps extends IWithEditorProps {
     disabled?: boolean;
     mobile?: boolean;
     lastGoodSelection: RangeStatic;
+    renderAbove?: boolean;
 }
 
 interface IState {
@@ -131,8 +132,6 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
                 className={classNames(
                     { isMenuInset: !this.props.legacyMode },
                     !!this.props.mobile ? classes.paragraphMenuMobile : classes.paragraphMenu,
-                    !!this.props.mobile ? classes.menuItem : "",
-                    !!this.props.mobile ? classes.button : "",
                 )}
                 onKeyDown={this.handleMenuBarKeyDown}
                 ref={this.selfRef}
@@ -145,7 +144,10 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
                     aria-controls={this.menuID}
                     aria-expanded={this.isMenuVisible}
                     disabled={this.props.disabled}
-                    className={pilcrowClasses}
+                    className={classNames(pilcrowClasses, {
+                        [classes.button]: this.props.mobile,
+                        [classes.menuItem]: this.props.mobile,
+                    })}
                     aria-haspopup="menu"
                     onClick={this.pilcrowClickHandler}
                     onKeyDown={this.handleEscape}
@@ -279,7 +281,7 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
             classes.position,
             classes.menuBar,
             classesDropDown.likeDropDownContent,
-            scrollBounds.height - bounds.bottom <= 170 ? "isUp" : "isDown",
+            this.props.renderAbove || scrollBounds.height - bounds.bottom <= 170 ? "isUp" : "isDown",
         );
     }
 


### PR DESCRIPTION
Required Companion PR https://github.com/vanilla/knowledge/pull/887
Closes https://github.com/vanilla/knowledge/issues/768

I fixed the bug by refactoring the `FlyoutToggle` component. I converted use react hooks which allowed me reason about the various state interactions a lot easier. In order to facilitate this I created 2 new hooks. `useEscapeListener` and `useFocusWatcher` which assist in setting up and tearing down their associated classes within the lifecycle of a react element.

Additionally the way initial focus is set in flyouts has changed slightly. I've updated a couple of usages that were not focusing properly. Notably the rich editor emoji picker & embed menu should now properly focus their initial elements.

## Other

- I added the `DeviceChecker` to the forum and converted its styles to use TypeStyle. This allows `<Flyouts />` to open themeselves as modals on mobile devices on the forum (Eg. the embed menu which was recently converted).
- Previously the paragraph menu was opening the wrong direction on the forum. I've fixed this using a new prop. Additionally I resolved an issue with the hover affect of the menu causing all sub-menus to recieve the hover cover on mobile.