### PR TITLE
Fix quote config detection in Rich Editor addon

### DIFF
--- a/plugins/rich-editor/RichEditorPlugin.php
+++ b/plugins/rich-editor/RichEditorPlugin.php
@@ -27,7 +27,7 @@ class RichEditorPlugin extends Gdn_Plugin {
     public function setup() {
         saveToConfig('Garden.InputFormatter', self::FORMAT_NAME);
         saveToConfig('Garden.MobileInputFormatter', self::FORMAT_NAME);
-        saveToConfig('RichEditor.Quotes.Enable', true);
+        saveToConfig(self::QUOTE_CONFIG_ENABLE, true);
         saveToConfig('EnabledPlugins.Quotes', false);
     }
 


### PR DESCRIPTION
In rich editor has been a typo in one of the initial saveToConfig values, see [this issue](https://github.com/vanilla/vanilla/issues/8396)
Instead of fixing the typo I directly used the class constant which is used later on to set this config key. This makes it more robust and flexible than simply fixing the typo. 