### PR TITLE
Set Markdown as input formatter when Rich Editor is disabled

### DIFF
--- a/plugins/rich-editor/RichEditorPlugin.php
+++ b/plugins/rich-editor/RichEditorPlugin.php
@@ -32,8 +32,8 @@ class RichEditorPlugin extends Gdn_Plugin {
     }
 
     public function onDisable() {
-        removeFromConfig('Garden.InputFormatter');
-        removeFromConfig('Garden.MobileInputFormatter');
+        Gdn::config()->saveToConfig('Garden.InputFormatter', 'Markdown');
+        Gdn::config()->saveToConfig('Garden.MobileInputFormatter', 'Markdown');
     }
 
     /**


### PR DESCRIPTION
As described [here](https://github.com/vanilla/vanilla/issues/8690), when the Rich Editor is disabled it removes the input formatter lines from the config which causes Vanilla to use the values from config-defaults, but "Rich" is the format in config-defaults. Therefore the remains "Rich" which causes errors and is not the intention of those lines in the onDisable() method.

When Rich Editor is disabled the format must be set to some format which doesn't require a special editor. I've chosen Markdown but that was quite arbitrary. I feel allowing HTML "surprisingly" might be a bad decision, Text would be  to barebone and Markdown feels somewhat more modern than BBCode.