### PR TITLE
Add ability for addons to extend theme variables

### DIFF
--- a/library/Vanilla/Models/ThemeModel.php
+++ b/library/Vanilla/Models/ThemeModel.php
@@ -17,7 +17,7 @@ use Vanilla\Theme\VariablesProviderInterface;
 class ThemeModel extends PipelineModel {
 
     /** @var VariablesProviderInterface[] */
-    private $variableProviders;
+    private $variableProviders = [];
 
     /** @var Gdn_Session */
     private $session;

--- a/library/Vanilla/Models/ThemeModel.php
+++ b/library/Vanilla/Models/ThemeModel.php
@@ -9,11 +9,15 @@ namespace Vanilla\Models;
 use Gdn_Session;
 use Vanilla\Database\Operation\CurrentUserFieldProcessor;
 use Vanilla\Database\Operation\CurrentDateFieldProcessor;
+use Vanilla\Theme\VariablesProviderInterface;
 
 /**
  * Handle custom themes.
  */
 class ThemeModel extends PipelineModel {
+
+    /** @var VariablesProviderInterface[] */
+    private $variableProviders;
 
     /** @var Gdn_Session */
     private $session;
@@ -36,5 +40,23 @@ class ThemeModel extends PipelineModel {
         $userProcessor->setInsertFields(["insertUserID", "updateUserID"])
             ->setUpdateFields(["updateUserID"]);
         $this->addPipelineProcessor($userProcessor);
+    }
+
+    /**
+     * Add a theme-variable provider.
+     *
+     * @param VariablesProviderInterface $provider
+     */
+    public function addVariableProvider(VariablesProviderInterface $provider) {
+        $this->variableProviders[] = $provider;
+    }
+
+    /**
+     * Get all configured theme-variable providers.
+     *
+     * @return array
+     */
+    public function getVariableProviders(): array {
+        return $this->variableProviders;
     }
 }

--- a/library/Vanilla/Theme/VariablesProviderInterface.php
+++ b/library/Vanilla/Theme/VariablesProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+ namespace Vanilla\Theme;
+
+ /**
+  * Interface for providing variables on a theme.
+  */
+interface VariablesProviderInterface {
+
+    /**
+     * Get variables to include with a theme.
+     *
+     * @return array
+     */
+    public function getVariables(): array;
+}


### PR DESCRIPTION
The variables asset of records returned from the themes API v2 resource can now be expanded on by addons.

### Overview
1. Add the `Vanilla\Theme\VariablesProviderInterface` interface. This defines the contract for addons who wish to register a theme-variables provider.
1. Add support for variable providers to `ThemeModel`. Currently, providers can only be registered and retrieved. No processing is applied through the model, since the variables asset is generated by `ThemesApiController`.
1. Add support for variable providers to `ThemesApiController`. Normalizing a theme now includes adjusting its variables asset, based on any variable providers configured in the controller's `ThemeModel`. It would be much better if this lived in the model, but it's been added to `ThemesApiController` since that's where all the asset generation is currently happening.

Relates to vanilla/knowledge#803