### PR TITLE
Add action property to Splash component

### DIFF
--- a/library/src/scripts/layout/FlexSpacer.tsx
+++ b/library/src/scripts/layout/FlexSpacer.tsx
@@ -22,9 +22,8 @@ export default class FlexSpacer extends React.Component<IProps> {
     public render() {
         const content = ` `;
         const Tag = this.props.tag || "div";
-        const flexSpacerClass = style(flexHelper().spacer());
         return (
-            <Tag className={classNames(flexSpacerClass, this.props.className)} aria-hidden={true} tabIndex={-1}>
+            <Tag className={classNames(this.props.className)} aria-hidden={true} tabIndex={-1}>
                 {content}
                 {this.props.children && <span className="sr-only">{this.props.children}</span>}
             </Tag>

--- a/library/src/scripts/splash/Splash.tsx
+++ b/library/src/scripts/splash/Splash.tsx
@@ -8,6 +8,7 @@ import IndependentSearch from "@library/features/search/IndependentSearch";
 import { buttonClasses, ButtonTypes } from "@library/forms/buttonStyles";
 import Container from "@library/layout/components/Container";
 import { Devices, IDeviceProps, withDevice } from "@library/layout/DeviceContext";
+import FlexSpacer from "@library/layout/FlexSpacer";
 import Heading from "@library/layout/Heading";
 import { PanelWidgetHorizontalPadding } from "@library/layout/PanelLayout";
 import { splashStyles } from "@library/splash/splashStyles";
@@ -35,8 +36,11 @@ export class Splash extends React.Component<IProps> {
                 <Container>
                     <div className={classes.innerContainer}>
                         <PanelWidgetHorizontalPadding>
-                            {title && <Heading title={title} className={classes.title} />}
-                            {action}
+                            <div className={classes.titleWrap}>
+                                <FlexSpacer className={classes.titleFlexSpacer} />
+                                {title && <Heading title={title} className={classes.title} />}
+                                <div className={classNames(classes.text, classes.titleFlexSpacer)}>{action}</div>
+                            </div>
                             <div className={classes.searchContainer}>
                                 <IndependentSearch
                                     className={classes.searchContainer}

--- a/library/src/scripts/splash/Splash.tsx
+++ b/library/src/scripts/splash/Splash.tsx
@@ -4,18 +4,19 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
-import classNames from "classnames";
-import Heading from "@library/layout/Heading";
-import { t } from "@library/utility/appUtils";
-import { buttonClasses, ButtonTypes } from "@library/forms/buttonStyles";
-import { Devices, IDeviceProps, withDevice } from "@library/layout/DeviceContext";
-import { PanelWidgetHorizontalPadding } from "@library/layout/PanelLayout";
 import IndependentSearch from "@library/features/search/IndependentSearch";
-import { splashStyles } from "@library/splash/splashStyles";
+import { buttonClasses, ButtonTypes } from "@library/forms/buttonStyles";
 import Container from "@library/layout/components/Container";
+import { Devices, IDeviceProps, withDevice } from "@library/layout/DeviceContext";
+import Heading from "@library/layout/Heading";
+import { PanelWidgetHorizontalPadding } from "@library/layout/PanelLayout";
+import { splashStyles } from "@library/splash/splashStyles";
+import { t } from "@library/utility/appUtils";
+import classNames from "classnames";
+import React from "react";
 
 interface IProps extends IDeviceProps {
+    action?: React.ReactNode;
     title: string; // Often the message to display isn't the real H1
     className?: string;
 }
@@ -27,7 +28,7 @@ export class Splash extends React.Component<IProps> {
     public render() {
         const classes = splashStyles();
         const buttons = buttonClasses();
-        const { title, className } = this.props;
+        const { action, title, className } = this.props;
         return (
             <div className={classNames(className, classes.root)}>
                 <div className={classes.outerBackground} />
@@ -35,6 +36,7 @@ export class Splash extends React.Component<IProps> {
                     <div className={classes.innerContainer}>
                         <PanelWidgetHorizontalPadding>
                             {title && <Heading title={title} className={classes.title} />}
+                            {action}
                             <div className={classes.searchContainer}>
                                 <IndependentSearch
                                     className={classes.searchContainer}

--- a/library/src/scripts/splash/splashStyles.ts
+++ b/library/src/scripts/splash/splashStyles.ts
@@ -7,8 +7,15 @@
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { formElementsVariables } from "@library/forms/formElementStyles";
-import { FontWeightProperty, PaddingProperty, TextAlignLastProperty, TextShadowProperty } from "csstype";
-import { percent, px } from "csx";
+import {
+    BackgroundColorProperty,
+    BoxShadowProperty,
+    FontWeightProperty,
+    PaddingProperty,
+    TextAlignLastProperty,
+    TextShadowProperty,
+} from "csstype";
+import { percent, px, quote, translateX } from "csx";
 import {
     centeredBackgroundProps,
     colorOut,
@@ -20,6 +27,7 @@ import {
     paddings,
     unit,
     background,
+    absolutePosition,
 } from "@library/styles/styleHelpers";
 import { transparentColor } from "@library/forms/buttonStyles";
 import { assetUrl } from "@library/utility/appUtils";
@@ -139,6 +147,16 @@ export const splashVariables = useThemeCache(() => {
         },
     });
 
+    const shadow = makeThemeVars("shadow", {
+        color: modifyColorBasedOnLightness(text.fg, text.shadowMix).fade(text.shadowOpacity),
+        full: "none" as BoxShadowProperty,
+        background: modifyColorBasedOnLightness(text.fg, text.shadowMix).fade(
+            text.shadowOpacity,
+        ) as BackgroundColorProperty,
+    });
+    shadow.full = `0 1px 15px ${colorOut(shadow.color)}`;
+    shadow.background = shadow.color.fade(0.3);
+
     return {
         outerBackground,
         spacing,
@@ -151,6 +169,7 @@ export const splashVariables = useThemeCache(() => {
         search,
         searchDrawer,
         searchBar,
+        shadow,
     };
 });
 
@@ -250,11 +269,26 @@ export const splashStyles = useThemeCache(() => {
         width: unit(vars.searchContainer.width),
         margin: "auto",
     });
+
     const titleFlexSpacer = style("titleFlexSpacer", {
+        position: "relative",
         height: unit(formElementVars.sizing.height),
         width: unit(formElementVars.sizing.height),
         flexBasis: unit(formElementVars.sizing.height),
-        paddingLeft: unit((formElementVars.sizing.height - globalVars.icon.sizes.default) / 2),
+        transform: translateX(px(formElementVars.sizing.height - globalVars.icon.sizes.default / 2 - 13)),
+        $nest: {
+            ".searchBar-actionButton:after": {
+                content: quote(""),
+                ...absolutePosition.middleOfParent(),
+                width: px(20),
+                height: px(20),
+                backgroundColor: colorOut(vars.shadow.background),
+                boxShadow: vars.shadow.full,
+            },
+            ".icon-compose": {
+                zIndex: 1,
+            },
+        },
     });
 
     return {

--- a/library/src/scripts/splash/splashStyles.ts
+++ b/library/src/scripts/splash/splashStyles.ts
@@ -157,6 +157,8 @@ export const splashVariables = useThemeCache(() => {
 export const splashStyles = useThemeCache(() => {
     const vars = splashVariables();
     const style = styleFactory("splash");
+    const formElementVars = formElementsVariables();
+    const globalVars = globalVariables();
 
     const root = style({
         position: "relative",
@@ -188,20 +190,11 @@ export const splashStyles = useThemeCache(() => {
             top: unit(vars.title.marginTop),
             bottom: unit(vars.title.marginBottom),
         }),
+        flexGrow: 1,
     });
 
     const text = style("text", {
-        display: "block",
         color: colorOut(vars.text.fg),
-        width: unit(vars.title.maxWidth),
-        maxWidth: percent(100),
-        margin: `auto auto 0`,
-        textAlign: "center",
-        $nest: {
-            "& + .splash-p": {
-                marginTop: unit(vars.search.margin),
-            },
-        },
     });
 
     const buttonBorderColor = get(vars, "searchBar.button.borderColor", false);
@@ -247,6 +240,23 @@ export const splashStyles = useThemeCache(() => {
 
     const buttonLoader = style("buttonLoader", {});
 
+    const titleAction = style("titleAction", {
+        color: colorOut(vars.text.fg),
+    });
+    const titleWrap = style("titleWrap", {
+        display: "flex",
+        flexWrap: "nowrap",
+        alignItems: "center",
+        width: unit(vars.searchContainer.width),
+        margin: "auto",
+    });
+    const titleFlexSpacer = style("titleFlexSpacer", {
+        height: unit(formElementVars.sizing.height),
+        width: unit(formElementVars.sizing.height),
+        flexBasis: unit(formElementVars.sizing.height),
+        paddingLeft: unit((formElementVars.sizing.height - globalVars.icon.sizes.default) / 2),
+    });
+
     return {
         root,
         outerBackground,
@@ -258,5 +268,8 @@ export const splashStyles = useThemeCache(() => {
         searchContainer,
         input,
         buttonLoader,
+        titleAction,
+        titleFlexSpacer,
+        titleWrap,
     };
 });

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -61,7 +61,7 @@ const fontFallbacks = [
     "Segoe UI Symbol",
 ];
 
-export const colorOut = (colorValue: ColorValues, makeImportant = false) => {
+export const colorOut = (colorValue: ColorValues | string, makeImportant = false) => {
     if (!colorValue) {
         return undefined;
     } else {


### PR DESCRIPTION
The `Splash` component now has an `action` property, which will allow a custom button to be included when the component is rendered.

### Overview.
1. Add `action` property to `Splash` component. The property is referenced in the component's `render` method.
1. Fix `FlexSpacer` component including styles it did not need, which brought along `flex-grow` rules that could conflict with other styles.
1. Updated styles in `splashStyles` to accommodate the new action button area.

Relates to vanilla/knowledge#862