### PR TITLE
Backport: Fix broken link to Google Sign In settings page.

### DIFF
--- a/plugins/googlesignin/addon.json
+++ b/plugins/googlesignin/addon.json
@@ -3,7 +3,7 @@
     "description": "Users may sign into your site using their Google account.",
     "version": "1.0.0",
     "mobileFriendly": true,
-    "settingsUrl": "/settings/google",
+    "settingsUrl": "/settings/googlesignin",
     "settingsPermission": "Garden.Settings.Manage",
     "hidden": false,
     "socialConnect": true,


### PR DESCRIPTION
The recently launched Google Sign In plugin does not link correctly to its settings page in the Dashboard.