### PR TITLE
Fix permission when following a category

### DIFF
--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -71,7 +71,7 @@ class CategoryController extends VanillaController {
         $form = new Gdn_Form();
         $categoryID = $form->getFormValue('CategoryID', $categoryID);
         $followed = $form->getFormValue('Followed', null);
-        $hasPermission = $categoryModel::checkPermission($categoryModel->CategoryID, 'Vanilla.Discussion.View');
+        $hasPermission = $categoryModel::checkPermission($categoryModel->CategoryID, 'Vanilla.Discussions.View');
         if (!$hasPermission) {
             throw permissionException('Vanilla.Discussion.View');
         }


### PR DESCRIPTION
closes [#335](https://github.com/vanilla/support/issues/335)
**Issue**

When following a category, we get the error
<img width="487" alt="Screen Shot 2019-04-15 at 7 50 23 PM" src="https://user-images.githubusercontent.com/31856281/56172503-c2996f00-5fb7-11e9-9cd0-6e6218226838.png">

**Fix**

Set permission name properly