### PR TITLE
Update embed whitelist security policy provider to allow twitter and instagram embeds

### DIFF
--- a/library/Vanilla/Web/ContentSecurityPolicy/EmbedWhitelistContentSecurityPolicyProvider.php
+++ b/library/Vanilla/Web/ContentSecurityPolicy/EmbedWhitelistContentSecurityPolicyProvider.php
@@ -14,7 +14,9 @@ class EmbedWhitelistContentSecurityPolicyProvider implements ContentSecurityPoli
         'https://embed-cdn.gettyimages.com',
         'https://s.imgur.com',
         'https://platform.instagram.com',
-        'https://platform.twitter.com'
+        'https://platform.twitter.com',
+        'https://cdn.syndication.twimg.com',
+        'https://www.instagram.com/embed.js',
     ];
 
     /**


### PR DESCRIPTION
Update trusted domains whitelist (for content-security-policy implementation) for embed content 

Relates to: https://github.com/vanilla/knowledge/issues/898
