### PR TITLE
Fix post autosave when drafts are empty or untouched

### DIFF
--- a/applications/vanilla/js/autosave.js
+++ b/applications/vanilla/js/autosave.js
@@ -6,7 +6,7 @@ jQuery(document).ready(function($) {
         if (!options.button)
             return false;
 
-        var lastVal = null;
+        var lastVal = $(textarea).val();
 
         var save = function() {
             var currentVal = $(textarea).val();

--- a/applications/vanilla/js/autosave.js
+++ b/applications/vanilla/js/autosave.js
@@ -10,8 +10,15 @@ jQuery(document).ready(function($) {
 
         var save = function() {
             var currentVal = $(textarea).val();
-            if (currentVal != undefined && currentVal != '' && currentVal != lastVal) {
-                lastVal = currentVal
+            var defaultValues = [
+                undefined,
+                null,
+                '',
+                '[{"insert":"\n"}]',
+                lastVal
+            ];
+            if (!defaultValues.includes(currentVal)) {
+                lastVal = currentVal;
                 $(options.button).click();
             }
         };


### PR DESCRIPTION
fix https://github.com/vanilla/support/issues/285

## The problem

Because the content of the Rich Editor is saved into JSON objects, empty objects are frequently saved in the database since blank posts aren't considered empty. Same thing is happening when editing a discussion. Because `lastVal` is set to null in `autosave.js`, the value of the textarea is always compared to null the first time.

## The fix

The `lastVal` variable in the `autosave.js` file is now set to the initial textarea value instead of null. The fix is pretty simple, but will prevent any empty and unchanged posts from being saved automatically.