### PR TITLE
Fix scroll positioning issues

### DIFF
--- a/library/src/scripts/content/UserContent.tsx
+++ b/library/src/scripts/content/UserContent.tsx
@@ -33,6 +33,7 @@ export default function UserContent(props: IProps) {
         const targetID = window.location.hash.replace("#", "");
         const element = document.querySelector(`[data-id="${targetID}"]`) as HTMLElement;
         if (element) {
+            offset.temporarilyDisabledWatching(500);
             const top = window.pageYOffset + element.getBoundingClientRect().top - offset.getCalcedHashOffset();
             window.scrollTo({ top, behavior: "smooth" });
         }

--- a/library/src/scripts/content/UserContent.tsx
+++ b/library/src/scripts/content/UserContent.tsx
@@ -9,6 +9,7 @@ import className from "classnames";
 import { initAllUserContent } from "@library/content";
 import { userContentClasses } from "@library/content/userContentStyles";
 import { useScrollOffset } from "@library/layout/ScrollOffsetContext";
+import { forceRenderStyles } from "typestyle";
 
 interface IProps {
     className?: string;
@@ -33,6 +34,7 @@ export default function UserContent(props: IProps) {
         const targetID = window.location.hash.replace("#", "");
         const element = document.querySelector(`[data-id="${targetID}"]`) as HTMLElement;
         if (element) {
+            forceRenderStyles();
             offset.temporarilyDisabledWatching(500);
             const top = window.pageYOffset + element.getBoundingClientRect().top - offset.getCalcedHashOffset();
             window.scrollTo({ top, behavior: "smooth" });

--- a/library/src/scripts/content/UserContent.tsx
+++ b/library/src/scripts/content/UserContent.tsx
@@ -10,6 +10,7 @@ import { initAllUserContent } from "@library/content";
 import { userContentClasses } from "@library/content/userContentStyles";
 import { useScrollOffset } from "@library/layout/ScrollOffsetContext";
 import { forceRenderStyles } from "typestyle";
+import { useHashScrolling } from "@library/content/hashScrolling";
 
 interface IProps {
     className?: string;
@@ -23,38 +24,11 @@ interface IProps {
  */
 export default function UserContent(props: IProps) {
     const classes = userContentClasses();
-    const offset = useScrollOffset();
-
-    /**
-     * Scroll to the window's current hash value.
-     */
-    const scrollToHash = useCallback((event?: HashChangeEvent) => {
-        event && event.preventDefault();
-
-        const targetID = window.location.hash.replace("#", "");
-        const element = document.querySelector(`[data-id="${targetID}"]`) as HTMLElement;
-        if (element) {
-            forceRenderStyles();
-            offset.temporarilyDisabledWatching(500);
-            const top = window.pageYOffset + element.getBoundingClientRect().top - offset.getCalcedHashOffset();
-            window.scrollTo({ top, behavior: "smooth" });
-        }
-    }, []);
 
     useEffect(() => {
         initAllUserContent();
     });
-
-    useEffect(() => {
-        scrollToHash();
-    }, []);
-
-    useEffect(() => {
-        window.addEventListener("hashchange", scrollToHash);
-        return () => {
-            window.removeEventListener("hashchange", scrollToHash);
-        };
-    }, [scrollToHash]);
+    useHashScrolling();
 
     return (
         <div

--- a/library/src/scripts/content/hashScrolling.ts
+++ b/library/src/scripts/content/hashScrolling.ts
@@ -1,0 +1,47 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+import { forceRenderStyles } from "typestyle";
+import { useScrollOffset } from "@library/layout/ScrollOffsetContext";
+import { useCallback, useEffect } from "react";
+
+export function useHashScrolling() {
+    const offset = useScrollOffset();
+    const calcedOffset = offset.getCalcedHashOffset();
+    const callback = useCallback(() => {
+        return initHashScrolling(calcedOffset, () => offset.temporarilyDisabledWatching(500));
+    }, [calcedOffset]);
+
+    useEffect(() => {
+        callback();
+    }, [callback]);
+}
+
+export function initHashScrolling(offset: number = 0, beforeScrollHandler?: () => void) {
+    /**
+     * Scroll to the window's current hash value.
+     */
+    const scrollToHash = (event?: HashChangeEvent) => {
+        event && event.preventDefault();
+
+        const targetID = window.location.hash.replace("#", "");
+        const element =
+            (document.querySelector(`[data-id="${targetID}"]`) as HTMLElement) || document.getElementById(targetID);
+        if (element) {
+            forceRenderStyles();
+            beforeScrollHandler && beforeScrollHandler();
+            // setTimeout(() => {
+            const top = window.pageYOffset + element.getBoundingClientRect().top - offset;
+            window.scrollTo({ top, behavior: "smooth" });
+            // },)
+        }
+    };
+
+    scrollToHash();
+
+    window.addEventListener("hashchange", scrollToHash);
+    return () => {
+        window.removeEventListener("hashchange", scrollToHash);
+    };
+}

--- a/library/src/scripts/headers/VanillaHeader.tsx
+++ b/library/src/scripts/headers/VanillaHeader.tsx
@@ -18,7 +18,7 @@ import Container from "@library/layout/components/Container";
 import ConditionalWrap from "@library/layout/ConditionalWrap";
 import { withDevice, IDeviceProps, Devices } from "@library/layout/DeviceContext";
 import FlexSpacer from "@library/layout/FlexSpacer";
-import { ScrollOffsetContext } from "@library/layout/ScrollOffsetContext";
+import { ScrollOffsetContext, HashOffsetReporter } from "@library/layout/ScrollOffsetContext";
 import BackLink from "@library/routing/links/BackLink";
 import { IWithPagesProps, withPages } from "@library/routing/PagesContext";
 import { sticky } from "@library/styles/styleHelpers";
@@ -94,75 +94,80 @@ export class VanillaHeader extends React.Component<IProps, IState> {
         containerElement.classList.value = outerCssClasses;
 
         return ReactDOM.createPortal(
-            <Container>
-                <PanelWidgetHorizontalPadding>
-                    <div className={classNames("vanillaHeader-bar", classes.bar)}>
-                        {!this.state.openSearch && isMobile && (
-                            <BackLink
-                                className={classNames(
-                                    "vanillaHeader-leftFlexBasis",
-                                    "vanillaHeader-backLink",
-                                    classes.leftFlexBasis,
-                                )}
-                                linkClassName={classes.button}
-                                fallbackElement={<FlexSpacer className="pageHeading-leftSpacer" />}
-                            />
-                        )}
+            <HashOffsetReporter>
+                <Container>
+                    <PanelWidgetHorizontalPadding>
+                        <div className={classNames("vanillaHeader-bar", classes.bar)}>
+                            {!this.state.openSearch && isMobile && (
+                                <BackLink
+                                    className={classNames(
+                                        "vanillaHeader-leftFlexBasis",
+                                        "vanillaHeader-backLink",
+                                        classes.leftFlexBasis,
+                                    )}
+                                    linkClassName={classes.button}
+                                    fallbackElement={<FlexSpacer className="pageHeading-leftSpacer" />}
+                                />
+                            )}
 
-                        {!isMobile && (
-                            <HeaderLogo
-                                className={classNames("vanillaHeader-logoContainer", classes.logoContainer)}
-                                logoClassName="vanillaHeader-logo"
-                                logoType={LogoType.DESKTOP}
-                            />
-                        )}
-                        {!this.state.openSearch && !isMobile && (
-                            <VanillaHeaderNav
-                                {...dummyNavigationData}
-                                className={classNames("vanillaHeader-nav", classes.nav)}
-                                linkClassName={classNames("vanillaHeader-navLink", classes.topElement)}
-                                linkContentClassName="vanillaHeader-navLinkContent"
-                            />
-                        )}
-                        {showMobileDropDown && (
-                            <MobileDropDown
-                                title={this.props.title!}
-                                buttonClass={classNames("vanillaHeader-mobileDropDown", classes.topElement)}
+                            {!isMobile && (
+                                <HeaderLogo
+                                    className={classNames("vanillaHeader-logoContainer", classes.logoContainer)}
+                                    logoClassName="vanillaHeader-logo"
+                                    logoType={LogoType.DESKTOP}
+                                />
+                            )}
+                            {!this.state.openSearch && !isMobile && (
+                                <VanillaHeaderNav
+                                    {...dummyNavigationData}
+                                    className={classNames("vanillaHeader-nav", classes.nav)}
+                                    linkClassName={classNames("vanillaHeader-navLink", classes.topElement)}
+                                    linkContentClassName="vanillaHeader-navLinkContent"
+                                />
+                            )}
+                            {showMobileDropDown && (
+                                <MobileDropDown
+                                    title={this.props.title!}
+                                    buttonClass={classNames("vanillaHeader-mobileDropDown", classes.topElement)}
+                                >
+                                    {this.props.mobileDropDownContent}
+                                </MobileDropDown>
+                            )}
+
+                            <ConditionalWrap
+                                className={classNames("vanillaHeader-rightFlexBasis", classes.rightFlexBasis)}
+                                condition={!!showMobileDropDown}
                             >
-                                {this.props.mobileDropDownContent}
-                            </MobileDropDown>
-                        )}
-
-                        <ConditionalWrap
-                            className={classNames("vanillaHeader-rightFlexBasis", classes.rightFlexBasis)}
-                            condition={!!showMobileDropDown}
-                        >
-                            <CompactSearch
-                                className={classNames("vanillaHeader-compactSearch", classes.compactSearch, {
-                                    isCentered: this.state.openSearch,
-                                })}
-                                focusOnMount
-                                open={this.state.openSearch}
-                                onSearchButtonClick={this.openSearch}
-                                onCloseSearch={this.closeSearch}
-                                cancelButtonClassName={classNames(
-                                    "vanillaHeader-searchCancel",
-                                    classes.topElement,
-                                    classes.searchCancel,
-                                )}
-                                cancelContentClassName="meBox-buttonContent"
-                                buttonClass={classes.button}
-                                showingSuggestions={this.state.showingSuggestions}
-                                onOpenSuggestions={this.setOpenSuggestions}
-                                onCloseSuggestions={this.setCloseSuggestions}
-                                buttonContentClassName={classNames(classesMeBox.buttonContent, "meBox-buttonContent")}
-                                clearButtonClass={classes.clearButtonClass}
-                            />
-                            {isMobile ? this.renderMobileMeBox() : this.renderDesktopMeBox()}
-                        </ConditionalWrap>
-                    </div>
-                </PanelWidgetHorizontalPadding>
-            </Container>,
+                                <CompactSearch
+                                    className={classNames("vanillaHeader-compactSearch", classes.compactSearch, {
+                                        isCentered: this.state.openSearch,
+                                    })}
+                                    focusOnMount
+                                    open={this.state.openSearch}
+                                    onSearchButtonClick={this.openSearch}
+                                    onCloseSearch={this.closeSearch}
+                                    cancelButtonClassName={classNames(
+                                        "vanillaHeader-searchCancel",
+                                        classes.topElement,
+                                        classes.searchCancel,
+                                    )}
+                                    cancelContentClassName="meBox-buttonContent"
+                                    buttonClass={classes.button}
+                                    showingSuggestions={this.state.showingSuggestions}
+                                    onOpenSuggestions={this.setOpenSuggestions}
+                                    onCloseSuggestions={this.setCloseSuggestions}
+                                    buttonContentClassName={classNames(
+                                        classesMeBox.buttonContent,
+                                        "meBox-buttonContent",
+                                    )}
+                                    clearButtonClass={classes.clearButtonClass}
+                                />
+                                {isMobile ? this.renderMobileMeBox() : this.renderDesktopMeBox()}
+                            </ConditionalWrap>
+                        </div>
+                    </PanelWidgetHorizontalPadding>
+                </Container>
+            </HashOffsetReporter>,
             containerElement,
         );
     }

--- a/library/src/scripts/layout/PanelLayout.tsx
+++ b/library/src/scripts/layout/PanelLayout.tsx
@@ -97,7 +97,7 @@ class PanelLayout extends React.Component<IProps> {
 
         const fixedPanelClass = style(sticky(), {
             $debugName: "fixedPanelClasses",
-            top: headerVars.sizing.height * 2 + 18,
+            top: headerVars.sizing.height * 2,
             height: percent(100),
             overflow: "auto",
         });


### PR DESCRIPTION
Relates to https://github.com/vanilla/knowledge/issues/908

- Refactors `<UserContent />` to use hooks & make it aware of the scroll offset context.
- Add the hash offset to `ScrollOffsetContext` so that it works with custom theme headers (and our own header). This will use the calculated offset from the top of the page as the anchor point when scrolling to hash urls. I've wrapped `VanillaHeader` with this.
- Add method to disable the scroll offset temporarily. This is important because we can only calculate the target position at the beginning of the scroll. Everything looks incorrect if the headers adjust themselves in the middle of the scroll.