### PR TITLE
Add custom background image support to Splash component

### DIFF
--- a/library/src/scripts/splash/Splash.tsx
+++ b/library/src/scripts/splash/Splash.tsx
@@ -35,13 +35,7 @@ export class Splash extends React.Component<IProps> {
 
         return (
             <div className={classNames(className, classes.root)}>
-                <div
-                    className={classNames(
-                        classes.outerBackground,
-                        this.props.outerBackgroundImage &&
-                            classes.customOuterBackground(this.props.outerBackgroundImage),
-                    )}
-                />
+                <div className={classNames(classes.outerBackground(this.props.outerBackgroundImage))} />
                 <Container>
                     <div className={classes.innerContainer}>
                         <PanelWidgetHorizontalPadding>

--- a/library/src/scripts/splash/Splash.tsx
+++ b/library/src/scripts/splash/Splash.tsx
@@ -20,7 +20,7 @@ interface IProps extends IDeviceProps {
     action?: React.ReactNode;
     title?: string; // Often the message to display isn't the real H1
     className?: string;
-    backgroundImage?: string;
+    outerBackgroundImage?: string;
 }
 
 /**
@@ -38,7 +38,8 @@ export class Splash extends React.Component<IProps> {
                 <div
                     className={classNames(
                         classes.outerBackground,
-                        this.props.backgroundImage && classes.customBackground(this.props.backgroundImage),
+                        this.props.outerBackgroundImage &&
+                            classes.customOuterBackground(this.props.outerBackgroundImage),
                     )}
                 />
                 <Container>

--- a/library/src/scripts/splash/Splash.tsx
+++ b/library/src/scripts/splash/Splash.tsx
@@ -20,6 +20,7 @@ interface IProps extends IDeviceProps {
     action?: React.ReactNode;
     title?: string; // Often the message to display isn't the real H1
     className?: string;
+    backgroundImage?: string;
 }
 
 /**
@@ -34,7 +35,12 @@ export class Splash extends React.Component<IProps> {
 
         return (
             <div className={classNames(className, classes.root)}>
-                <div className={classes.outerBackground} />
+                <div
+                    className={classNames(
+                        classes.outerBackground,
+                        this.props.backgroundImage && classes.customBackground(this.props.backgroundImage),
+                    )}
+                />
                 <Container>
                     <div className={classes.innerContainer}>
                         <PanelWidgetHorizontalPadding>

--- a/library/src/scripts/splash/splashStyles.ts
+++ b/library/src/scripts/splash/splashStyles.ts
@@ -256,7 +256,7 @@ export const splashStyles = useThemeCache(() => {
         ...background(vars.outerBackground),
         opacity: vars.outerBackground.fallbackImage && image === vars.outerBackground.fallbackImage ? 0.4 : undefined,
     });
-    const customBackground = (url: string) => style("customBackground", { backgroundImage: `url(${url})` });
+    const customOuterBackground = (url: string) => style("customBackground", { backgroundImage: `url(${url})` });
 
     const innerContainer = style("innerContainer", {
         ...paddings(vars.spacing.padding),
@@ -383,7 +383,7 @@ export const splashStyles = useThemeCache(() => {
     return {
         root,
         outerBackground,
-        customBackground,
+        customOuterBackground,
         innerContainer,
         title,
         text,

--- a/library/src/scripts/splash/splashStyles.ts
+++ b/library/src/scripts/splash/splashStyles.ts
@@ -7,13 +7,8 @@
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { formElementsVariables } from "@library/forms/formElementStyles";
-import {
-    BackgroundColorProperty,
-    FontWeightProperty,
-    PaddingProperty,
-    TextShadowProperty,
-} from "csstype";
-import {important, percent, px, quote,translateX} from "csx";
+import { BackgroundColorProperty, FontWeightProperty, PaddingProperty, TextShadowProperty } from "csstype";
+import { important, percent, px, quote, translateX } from "csx";
 import {
     centeredBackgroundProps,
     colorOut,
@@ -25,17 +20,14 @@ import {
     paddings,
     unit,
     background,
-    absolutePosition, borders,
+    absolutePosition,
+    borders,
 } from "@library/styles/styleHelpers";
-import {
-    transparentColor,
-    IButtonType,
-    generateButtonClass,
-} from "@library/forms/buttonStyles";
+import { transparentColor, IButtonType, generateButtonClass } from "@library/forms/buttonStyles";
 import { assetUrl } from "@library/utility/appUtils";
-import {TLength} from "typestyle/lib/types";
+import { TLength } from "typestyle/lib/types";
 import { widgetVariables } from "@library/styles/widgetStyleVars";
-import {searchBarClasses} from "@library/features/search/searchBarStyles";
+import { searchBarClasses } from "@library/features/search/searchBarStyles";
 
 export const splashVariables = useThemeCache(() => {
     const makeThemeVars = variableFactory("splash");
@@ -96,7 +88,11 @@ export const splashVariables = useThemeCache(() => {
             size: globalVars.fonts.size.title,
             weight: globalVars.fonts.weights.semiBold as FontWeightProperty,
             align: "center",
-            shadow: `0 1px 1px ${colorOut(modifyColorBasedOnLightness(colors.contrast, text.shadowMix).fade(text.innerShadowOpacity))}, 0 1px 25px ${colorOut(modifyColorBasedOnLightness(colors.contrast, text.shadowMix).fade(text.outerShadowOpacity))}` as TextShadowProperty,
+            shadow: `0 1px 1px ${colorOut(
+                modifyColorBasedOnLightness(colors.contrast, text.shadowMix).fade(text.innerShadowOpacity),
+            )}, 0 1px 25px ${colorOut(
+                modifyColorBasedOnLightness(colors.contrast, text.shadowMix).fade(text.outerShadowOpacity),
+            )}` as TextShadowProperty,
         },
         marginTop: 28,
         marginBottom: 40,
@@ -139,19 +135,16 @@ export const splashVariables = useThemeCache(() => {
             size: formElVars.giantInput.fontSize,
         },
         border: {
-            leftColor: colors.input.fade(.4),
+            leftColor: colors.input.fade(0.4),
             radius: globalVars.border.radius,
         },
     });
 
     const shadow = makeThemeVars("shadow", {
-        color: modifyColorBasedOnLightness(colors.contrast, text.shadowMix).fade(.05),
+        color: modifyColorBasedOnLightness(colors.contrast, text.shadowMix).fade(0.05),
         full: `0 1px 15px ${colorOut(modifyColorBasedOnLightness(colors.contrast, text.shadowMix).fade(0.3))}`,
-        background: modifyColorBasedOnLightness(colors.contrast, text.shadowMix).fade(
-            0.1,
-        ) as BackgroundColorProperty,
+        background: modifyColorBasedOnLightness(colors.contrast, text.shadowMix).fade(0.1) as BackgroundColorProperty,
     });
-
 
     const searchButtonType: IButtonType = makeThemeVars("buttonTypeSplash", {
         spinnerColor: colors.contrast,
@@ -263,6 +256,7 @@ export const splashStyles = useThemeCache(() => {
         ...background(vars.outerBackground),
         opacity: vars.outerBackground.fallbackImage && image === vars.outerBackground.fallbackImage ? 0.4 : undefined,
     });
+    const customBackground = (url: string) => style("customBackground", { backgroundImage: `url(${url})` });
 
     const innerContainer = style("innerContainer", {
         ...paddings(vars.spacing.padding),
@@ -389,6 +383,7 @@ export const splashStyles = useThemeCache(() => {
     return {
         root,
         outerBackground,
+        customBackground,
         innerContainer,
         title,
         text,

--- a/library/src/scripts/splash/splashStyles.ts
+++ b/library/src/scripts/splash/splashStyles.ts
@@ -245,18 +245,22 @@ export const splashStyles = useThemeCache(() => {
     });
 
     const image = getBackgroundImage(vars.outerBackground.image, vars.outerBackground.fallbackImage);
-    const outerBackground = style("outerBackground", {
-        ...centeredBackgroundProps(),
-        display: "block",
-        position: "absolute",
-        top: px(0),
-        left: px(0),
-        width: percent(100),
-        height: percent(100),
-        ...background(vars.outerBackground),
-        opacity: vars.outerBackground.fallbackImage && image === vars.outerBackground.fallbackImage ? 0.4 : undefined,
-    });
-    const customOuterBackground = (url: string) => style("customBackground", { backgroundImage: `url(${url})` });
+    const outerBackground = (url?: string) => {
+        return style("outerBackground", {
+            ...centeredBackgroundProps(),
+            display: "block",
+            position: "absolute",
+            top: px(0),
+            left: px(0),
+            width: percent(100),
+            height: percent(100),
+            ...background(url ? { ...vars.outerBackground, image: url } : vars.outerBackground),
+            opacity:
+                !url && (vars.outerBackground.fallbackImage && image === vars.outerBackground.fallbackImage)
+                    ? 0.4
+                    : undefined,
+        });
+    };
 
     const innerContainer = style("innerContainer", {
         ...paddings(vars.spacing.padding),
@@ -383,7 +387,6 @@ export const splashStyles = useThemeCache(() => {
     return {
         root,
         outerBackground,
-        customOuterBackground,
         innerContainer,
         title,
         text,


### PR DESCRIPTION
`splashStyles` now returns a `customBackground` member, which is a function used to generate a background-image style. This is used by the `Splash` component to render a custom background.

### Overview
1. Add `customBackground` member to the result of `splashStyles`. This is a function that generates a background-image style.
1. Add `backgroundImage` prop to `Splash` component. If provided, this value will be used as the background image for the rendered element.
1. Fix styling inconsistencies in `splashStyles`. Thanks [Prettier](https://prettier.io).

Relates to vanilla/knowledge#936