### PR TITLE
Fixed text input styles for iOS devices

### DIFF
--- a/library/src/scripts/forms/inputStyles.tsx
+++ b/library/src/scripts/forms/inputStyles.tsx
@@ -5,12 +5,20 @@
 
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
-import { borders, colorOut, IBordersSameAllSidesStyles, placeholderStyles } from "@library/styles/styleHelpers";
+import {
+    borders,
+    colorOut,
+    IBordersSameAllSidesStyles,
+    placeholderStyles,
+    textInputSizingFromFixedHeight,
+} from "@library/styles/styleHelpers";
 import { px } from "csx";
 import { cssRule } from "typestyle";
+import { formElementsVariables } from "@library/forms/formElementStyles";
 
 export const inputVariables = useThemeCache(() => {
     const globalVars = globalVariables();
+    const formElementVars = formElementsVariables();
     const makeThemeVars = variableFactory("input");
 
     const colors = makeThemeVars("colors", {
@@ -22,16 +30,31 @@ export const inputVariables = useThemeCache(() => {
         },
     });
 
+    const sizing = makeThemeVars("sizing", {
+        height: formElementVars.sizing.height,
+    });
+
+    const font = makeThemeVars("font", {
+        size: globalVars.fonts.size.large,
+    });
+
     const border: IBordersSameAllSidesStyles = makeThemeVars("borders", globalVars.border);
 
-    return { colors, border };
+    return {
+        colors,
+        border,
+        sizing,
+        font,
+    };
 });
 
 export const inputClasses = useThemeCache(() => {
     const vars = inputVariables();
     const style = styleFactory("input");
+    const formElementVars = formElementsVariables();
 
     const textStyles = {
+        ...textInputSizingFromFixedHeight(vars.sizing.height, vars.font.size, formElementVars.border.fullWidth),
         backgroundColor: colorOut(vars.colors.bg),
         color: colorOut(vars.colors.fg),
         ...borders(vars.border),

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -181,7 +181,7 @@ export const textInputSizingFromFixedHeight = (height: number, fontSize: number 
             right: unit(paddingTop * 2),
         }),
     };
-}
+};
 
 // must be nested
 export const placeholderStyles = (styles: NestedCSSProperties) => {

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -154,12 +154,11 @@ export function inputLineHeight(height: number, paddingTop: number, fullBorderWi
     return unit(height - (2 * paddingTop + fullBorderWidth));
 }
 
-export const textInputSizing = (height: number, fontSize: number, paddingTop: number, fullBorderWidth: number) => {
+export const textInputSizingFromSpacing = (fontSize: number, paddingTop: number, fullBorderWidth: number) => {
     return {
         fontSize: unit(fontSize),
         width: percent(100),
-        height: unit(height),
-        lineHeight: inputLineHeight(height, paddingTop, fullBorderWidth),
+        lineHeight: 1.5,
         ...paddings({
             top: unit(paddingTop),
             bottom: unit(paddingTop),
@@ -168,6 +167,21 @@ export const textInputSizing = (height: number, fontSize: number, paddingTop: nu
         }),
     };
 };
+
+export const textInputSizingFromFixedHeight = (height: number, fontSize: number , fullBorderWidth: number) => {
+    const paddingTop = (height - fullBorderWidth - (fontSize * 1.5)) / 2;
+    return {
+        fontSize: unit(fontSize),
+        width: percent(100),
+        lineHeight: 1.5,
+        ...paddings({
+            top: unit(paddingTop),
+            bottom: unit(paddingTop),
+            left: unit(paddingTop * 2),
+            right: unit(paddingTop * 2),
+        }),
+    };
+}
 
 // must be nested
 export const placeholderStyles = (styles: NestedCSSProperties) => {

--- a/plugins/rich-editor/src/scripts/editor/richEditorFormClasses.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorFormClasses.ts
@@ -6,15 +6,15 @@
 import {
     paddings,
     placeholderStyles,
-    textInputSizing,
     colorOut,
     unit,
     absolutePosition,
     pointerEvents,
     margins,
     negative,
+    textInputSizingFromSpacing,
 } from "@library/styles/styleHelpers";
-import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
+import {styleFactory, useThemeCache} from "@library/styles/styleUtils";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { formElementsVariables } from "@library/forms/formElementStyles";
 import { calc, percent, px } from "csx";
@@ -39,13 +39,12 @@ export const richEditorFormClasses = useThemeCache((legacyMode: boolean = false)
         }),
     });
 
-    const title = style("title", {
+    const title = style( "title", {
         $nest: {
             "&.inputText, &&": {
-                ...textInputSizing(
-                    vars.title.height,
+                ...textInputSizingFromSpacing(
                     vars.title.fontSize,
-                    globalVars.gutter.half,
+                    0,
                     formElementVars.border.fullWidth,
                 ),
                 color: colorOut(formElementVars.colors.fg),

--- a/plugins/rich-editor/src/scripts/editor/richEditorFormClasses.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorFormClasses.ts
@@ -14,7 +14,7 @@ import {
     negative,
     textInputSizingFromSpacing,
 } from "@library/styles/styleHelpers";
-import {styleFactory, useThemeCache} from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { formElementsVariables } from "@library/forms/formElementStyles";
 import { calc, percent, px } from "csx";
@@ -39,14 +39,10 @@ export const richEditorFormClasses = useThemeCache((legacyMode: boolean = false)
         }),
     });
 
-    const title = style( "title", {
+    const title = style("title", {
         $nest: {
             "&.inputText, &&": {
-                ...textInputSizingFromSpacing(
-                    vars.title.fontSize,
-                    0,
-                    formElementVars.border.fullWidth,
-                ),
+                ...textInputSizingFromSpacing(vars.title.fontSize, 0, formElementVars.border.fullWidth),
                 color: colorOut(formElementVars.colors.fg),
                 backgroundColor: colorOut(formElementVars.colors.bg),
                 position: "relative",


### PR DESCRIPTION
Fixes issue on iOS devices where some input text fields are being cut off.

I split the "textInputSizing" into 2 functions, one that calculates its own height based on the font size and padding and the other that figures out the padding based on the target height.

