### PR TITLE
Fix ProxyRequest so that it can handle content-less 204 responses.

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -140,10 +140,12 @@ class ProxyRequest {
         $startTime = microtime(true);
         $response = curl_exec($handler);
         $this->ResponseTime = microtime(true) - $startTime;
-        $this->ResponseStatus = curl_getinfo($handler, CURLINFO_HTTP_CODE);
-        if (!$this->responseClass('2xx')) {
-            $this->ResponseBody = curl_error($handler) ?? t('An error has occurred, please try again.');
+
+        if ($response === false) {
+            $this->ResponseBody = curl_error($handler);
+            $this->ResponseStatus = 400;
         } else {
+            $this->ResponseStatus = curl_getinfo($handler, CURLINFO_HTTP_CODE);
             $this->ContentType = strtolower(curl_getinfo($handler, CURLINFO_CONTENT_TYPE));
             $this->ContentLength = (int)curl_getinfo($handler, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
 

--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -141,9 +141,8 @@ class ProxyRequest {
         $response = curl_exec($handler);
         $this->ResponseTime = microtime(true) - $startTime;
         $this->ResponseStatus = curl_getinfo($handler, CURLINFO_HTTP_CODE);
-        if ($response === false || !$this->responseClass('2xx')) {
-            $this->ResponseBody = curl_error($handler);
-            $this->ResponseStatus = 400;
+        if (!$this->responseClass('2xx')) {
+            $this->ResponseBody = curl_error($handler) ?? t('An error has occurred, please try again.');
         } else {
             $this->ContentType = strtolower(curl_getinfo($handler, CURLINFO_CONTENT_TYPE));
             $this->ContentLength = (int)curl_getinfo($handler, CURLINFO_CONTENT_LENGTH_DOWNLOAD);

--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -140,12 +140,11 @@ class ProxyRequest {
         $startTime = microtime(true);
         $response = curl_exec($handler);
         $this->ResponseTime = microtime(true) - $startTime;
-
-        if ($response == false) {
+        $this->ResponseStatus = curl_getinfo($handler, CURLINFO_HTTP_CODE);
+        if ($response === false || !$this->responseClass('2xx')) {
             $this->ResponseBody = curl_error($handler);
             $this->ResponseStatus = 400;
         } else {
-            $this->ResponseStatus = curl_getinfo($handler, CURLINFO_HTTP_CODE);
             $this->ContentType = strtolower(curl_getinfo($handler, CURLINFO_CONTENT_TYPE));
             $this->ContentLength = (int)curl_getinfo($handler, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
 


### PR DESCRIPTION
Presently in the ProxyRequest class we expect successful responses to have a response body. Many APIs will return no content and a 204 response code when PATCHing or PUTing. This is being interpreted as a failure. 

This PR will check if the response code is not 2XX before concluding there was a negative response.

[See this document for more information about 204 responses](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204)