### PR TITLE
RichEditor - Enable compatibility with embedded content

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -642,7 +642,7 @@ if (!function_exists('writeEmbedCommentForm')) :
                 }
                 echo "</div>\n";
                 echo $controller->Form->close();
-            echo '</div> ';
+                echo '</div> ';
                 ?>
             </div>
         <?php

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -604,10 +604,11 @@ if (!function_exists('writeEmbedCommentForm')) :
             <h2><?php echo t('Leave a comment'); ?></h2>
             <div class="MessageForm CommentForm EmbedCommentForm">
                 <?php
+                echo '<div class="FormWrapper">';
                 echo $controller->Form->open(['id' => 'Form_Comment']);
                 echo $controller->Form->errors();
                 echo $controller->Form->hidden('Name');
-                echo wrap($controller->Form->textBox('Body', ['MultiLine' => true]), 'div', ['class' => 'TextBoxWrapper']);
+                echo wrap($controller->Form->bodyBox('Body', ['Format' => 'TextEx']));
                 echo "<div class=\"Buttons\">\n";
 
                 $allowSigninPopup = c('Garden.SignIn.Popup');
@@ -641,6 +642,7 @@ if (!function_exists('writeEmbedCommentForm')) :
                 }
                 echo "</div>\n";
                 echo $controller->Form->close();
+            echo '</div> ';
                 ?>
             </div>
         <?php


### PR DESCRIPTION
### Issue:
When the rich-editor is the default editor on a community, embedded comments doesn't work.  This is because the rich-editor isn't mounted and and textbox doesn't support the format type of rich.

### Solution:
The writeEmbedCommentForm method has been modified to use GDN_Form::bodyBox to allow for the editor to handle various formats.  A default format of _TextEx_ has been added.

### To Test:

1. ensure you can embed comments on your local
2. enable rich editor
3. From embedded comments from post a comment
4. Verify comment is posted can renders correctly on the site and local.
5. Ensure posting on you local isn't broken
6. Test with various posting formats

Closes vanilla/wordpress-vanilla#28 
Closes vanilla/support#272


