### PR TITLE
Use system instead of passthru for build handoff

### DIFF
--- a/library/setup/ComposerHelper.php
+++ b/library/setup/ComposerHelper.php
@@ -90,7 +90,7 @@ class ComposerHelper {
 
         printf("\nBuilding frontend assets\n");
         printf("\n$buildCommand\n");
-        passthru($buildCommand, $buildResult);
+        system($buildCommand, $buildResult);
 
         if ($buildResult !== 0) {
             printf("The build failed with code $buildResult");


### PR DESCRIPTION
Using `system` instead of `passthru` allows you to see the progress of the the build command.

Previously it would run the whole build (takes a couple minutes) then spit out all of the output at once.