### PR TITLE
Move icons styles from KB

### DIFF
--- a/library/src/scripts/theming/reset.ts
+++ b/library/src/scripts/theming/reset.ts
@@ -1,0 +1,8 @@
+/**
+ * Importing this file brings a bunch of styles with it!!!
+ *
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import "../../scss/_base.scss";

--- a/library/src/scss/_base.scss
+++ b/library/src/scss/_base.scss
@@ -9,6 +9,7 @@
 @import "~library-scss/utility/normalize";
 @import "~library-scss/utility/body";
 @import "~library-scss/utility/utilities";
+@import "~library-scss/utility/icons";
 @import "~library-scss/embeds/embeds";
 
 @import "~library-scss/utility/scaffolding";

--- a/library/src/scss/utility/_icons.scss
+++ b/library/src/scss/utility/_icons.scss
@@ -1,0 +1,107 @@
+/**
+ * @author Stéphane (slafleche) LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+ .icon {
+    display: inline-block;
+    width: $icon-default_size;
+    height: $icon-default_size;
+    vertical-align: middle;
+
+    &.isSmall {
+        width: $icon-small_size;
+        height: $icon-small_size;
+    }
+
+    &.isLarge {
+        width: $icon-large_size;
+        height: $icon-large_size;
+    }
+}
+
+.icon-close {
+    display: block;
+    margin: auto;
+    width: 12px;
+    height: 12px;
+}
+
+
+.icon-triangleDown,
+.icon-triangleRight {
+    display: block;
+    margin: auto;
+    width: 8px;
+    height: 8px;
+}
+
+.icon-help {
+    width: $icon-small_size;
+    height: $icon-small_size;
+}
+
+.icon-search {
+    width: 18px;
+    height: 24px;
+}
+
+.icon-notifications {
+    width: 18px;
+    height: 24px;
+}
+
+.icon-messages {
+    width: 20px;
+    height: 20px;
+}
+
+.icon-fake {
+    font-family: arial, sans-serif;
+}
+
+.icon-compose {
+    width: 20px;
+    height: 20px;
+}
+
+.icon-settings {
+    width: 18px;
+    height: 20px;
+}
+
+.icon-user {
+    width: 20px;
+}
+
+.icon-noUserPhoto {
+    width: 100%;
+    height: auto;
+}
+
+.icon-chevronUp {
+    width: 51px;
+    height: 17px;
+}
+
+
+.icon-folderOpen {
+    width: 18.612px;
+    height: 14px;
+}
+
+.icon-folderClosed {
+    width: 16px;
+    height: 14px;
+}
+
+.icon-article {
+    width: 16px;
+    height: 16px;
+}
+
+.icon-organize {
+    width: 18px;
+    height: 16px;
+}

--- a/library/src/scss/utility/_icons.scss
+++ b/library/src/scss/utility/_icons.scss
@@ -95,13 +95,3 @@
     width: 16px;
     height: 14px;
 }
-
-.icon-article {
-    width: 16px;
-    height: 16px;
-}
-
-.icon-organize {
-    width: 18px;
-    height: 16px;
-}


### PR DESCRIPTION
I've moved the icon base styles from KB. I need these setup for the retreat demo and it's too much work to convert to typestyle right now, so I'm just moving it.

I'm also adding a single JS import `@library/theming/reset` that will bring along the required style reset to make stuff like `<TitleBar />` and `<DropDown />` look correct.