### PR TITLE
Backport: Add support to make PATCH request through ProxyRequest Class.

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -337,6 +337,7 @@ class ProxyRequest {
         $requestMethod = strtoupper($requestMethod);
         switch ($requestMethod) {
             case 'PUT':
+            case 'PATCH':
             case 'POST':
                 break;
 
@@ -486,6 +487,22 @@ class ProxyRequest {
             }
 
             curl_setopt($handler, CURLOPT_POST, true);
+            curl_setopt($handler, CURLOPT_POSTFIELDS, $postData);
+
+            if (!is_array($postData) && !is_object($postData)) {
+                $sendExtraHeaders['Content-Length'] = strlen($postData);
+            }
+
+            $this->RequestBody = $postData;
+        }
+
+        // Allow PATCH
+        if ($requestMethod == 'PATCH') {
+            if ($preEncodePost && is_array($postData)) {
+                $postData = http_build_query($postData);
+            }
+
+            curl_setopt($handler, CURLOPT_CUSTOMREQUEST, 'PATCH');
             curl_setopt($handler, CURLOPT_POSTFIELDS, $postData);
 
             if (!is_array($postData) && !is_object($postData)) {


### PR DESCRIPTION
Package cURL request properly when the PATCH verb is invoked. Presently we do not treat PATCH requests differently from GET requests which any integral modern API will not support.
