### PR TITLE
Add markdown keyboard shortcuts to Rich Editor

### DIFF
--- a/plugins/rich-editor/src/scripts/@types/quill.d.ts
+++ b/plugins/rich-editor/src/scripts/@types/quill.d.ts
@@ -180,6 +180,7 @@ declare module "quill/core" {
         getText(index?: number, length?: number): string;
         insertEmbed(index: number, type: string, value: any, source?: Sources): DeltaStatic;
         insertText(index: number, text: string, source?: Sources): DeltaStatic;
+        insertText(index: number, text: string, source?: Sources): DeltaStatic;
         insertText(index: number, text: string, format: string, value: any, source?: Sources): DeltaStatic;
         insertText(index: number, text: string, formats: StringMap, source?: Sources): DeltaStatic;
         /**
@@ -367,7 +368,7 @@ declare module "quill/modules/keyboard" {
               [key: string]: string | boolean | number;
           };
 
-    interface Context {
+    interface ConfigurationContext {
         collapsed?: boolean;
         format?: Formats;
         offset?: number;
@@ -376,7 +377,22 @@ declare module "quill/modules/keyboard" {
         suffix?: RegExp;
     }
 
-    type KeyboardHandler = (selectedRange: RangeStatic) => boolean | null | undefined | void; // False to prevent default.
+    interface HandlerContext extends ConfigurationContext {
+        collapsed: boolean;
+        format: Formats;
+        offset: number;
+        empty: boolean;
+        prefix: string;
+        suffix: string;
+        event: KeyboardEvent;
+    }
+
+    interface IBindingObject extends ConfigurationContext, KeyBinding {
+        handler: KeyboardHandler;
+    }
+    export type BindingObject = IBindingObject | false | undefined;
+
+    type KeyboardHandler = (selectedRange: RangeStatic, context: HandlerContext) => boolean | null | undefined | void; // False to prevent default.
 
     export default class KeyboardModule extends Module {
         public static match(event: KeyboardEvent, binding: KeyBinding | string | number);

--- a/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
+++ b/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
@@ -5,7 +5,7 @@
  */
 
 import Quill, { RangeStatic, Blot } from "quill/core";
-import KeyboardModule from "quill/modules/keyboard";
+import KeyboardModule, { BindingObject, HandlerContext } from "quill/modules/keyboard";
 import Delta from "quill-delta";
 import Emitter from "quill/core/emitter";
 import {
@@ -27,6 +27,7 @@ import BlockquoteLineBlot from "@rich-editor/quill/blots/blocks/BlockquoteBlot";
 import SpoilerLineBlot from "@rich-editor/quill/blots/blocks/SpoilerBlot";
 import { ListItem } from "@rich-editor/quill/blots/blocks/ListBlot";
 import Formatter from "@rich-editor/quill/Formatter";
+import HeaderBlot from "@rich-editor/quill/blots/blocks/HeaderBlot";
 
 export default class KeyboardBindings {
     private static MULTI_LINE_BLOTS = [
@@ -35,7 +36,9 @@ export default class KeyboardBindings {
         CodeBlockBlot.blotName,
         ListItem.blotName,
     ];
-    public bindings: any = {};
+    public bindings: {
+        [key: string]: BindingObject;
+    } = {};
 
     constructor(private quill: Quill) {
         // Keyboard behaviours
@@ -380,11 +383,11 @@ export default class KeyboardBindings {
      * Create a keyboard shortcut to enable/disable a format. These differ from Quill's built in
      * keyboard shortcuts because they do not work if the selection contains a codeBlock or inline-code.
      */
-    private makeFormatHandler(format) {
+    private makeFormatHandler(format): BindingObject {
         return {
             key: format[0].toUpperCase(),
             shortKey: true,
-            handler: (range, context) => {
+            handler: (range: RangeStatic, context: HandlerContext) => {
                 if (
                     rangeContainsBlot(this.quill, CodeBlockBlot, range) ||
                     rangeContainsBlot(this.quill, CodeBlot, range)
@@ -392,7 +395,7 @@ export default class KeyboardBindings {
                     return;
                 }
 
-                this.quill.format(format, !context.format[format], Quill.sources.USER);
+                this.quill.format(format, !context.format![format], Quill.sources.USER);
             },
         };
     }

--- a/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
@@ -1,0 +1,269 @@
+import Quill, { RangeStatic, Blot } from "quill/core";
+import HeaderBlot from "@rich-editor/quill/blots/blocks/HeaderBlot";
+import BlockquoteLineBlot from "@rich-editor/quill/blots/blocks/BlockquoteBlot";
+import CodeBlot from "@rich-editor/quill/blots/inline/CodeBlot";
+import Delta from "quill-delta";
+import SpoilerLineBlot from "@rich-editor/quill/blots/blocks/SpoilerBlot";
+import CodeBlockBlot from "@rich-editor/quill/blots/blocks/CodeBlockBlot";
+
+interface IMarkdownMatch {
+    name: string;
+    pattern: RegExp;
+    preventsDefault?: boolean;
+    handler: (text: string, selection: RangeStatic, pattern: RegExp, lineStart: number) => void;
+}
+
+/**
+ * Module for handling standard markdown macros.
+ *
+ * Triggered by the enter key
+ * ```           -> Code Block
+ *
+ * Triggered by a space
+ * ###           -> Headings (2-5)
+ * >             -> Quote
+ * !>            -> Spoiler
+ * _text_        -> Italic
+ * __text__      -> Bold
+ * ___text___    -> Bold & Italic
+ * *text*        -> Italic
+ * **text**      -> Bold
+ * ***text***    -> Bold & Italic
+ * ~~text~~      -> Strike
+ * `text`        -> Code
+ */
+export default class MarkdownModule {
+    /** HTML tags to ignore keyboard shortcuts inside of. */
+    private ignoreTags = ["PRE"];
+
+    constructor(private quill: Quill) {}
+
+    /**
+     * Register the event handler for the markdown keyboard shortcuts.
+     */
+    public registerHandler() {
+        // Handler that looks for insert deltas that match specific characters
+        this.quill.root.addEventListener("keydown", this.keyDownHandler);
+    }
+
+    /**
+     * Check if the current quill line is valid for enabling keyboard shortcuts.
+     *
+     * @param line - The line blot to check.
+     */
+    private isValidLine(line: Blot): boolean {
+        if (!(line.domNode instanceof HTMLElement)) {
+            return false;
+        }
+
+        const { textContent, tagName } = line.domNode;
+        return typeof textContent !== "undefined" && !!textContent && this.ignoreTags.includes(tagName);
+    }
+
+    /**
+     * Handle a keydown event and trigger markdown actions.
+     */
+    private keyDownHandler = (event: KeyboardEvent) => {
+        if (!["Enter", " "].includes(event.key)) {
+            return;
+        }
+        const selection = this.quill.getSelection();
+        if (!selection) {
+            return;
+        }
+        const [line, offset] = this.quill.getLine(selection.index);
+        const text = line.domNode.textContent;
+        const lineStart = selection.index - offset;
+        if (!this.isValidLine(line)) {
+            return;
+        }
+
+        // Iterate through our matchers and execute the first one.
+        for (const match of this.matchers) {
+            const matchedText = text.match(match.pattern);
+            if (matchedText) {
+                if (match.preventsDefault) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+
+                // Cutoff the history before an after so this is it's own action to undo.
+                this.quill.history.cutoff();
+                match.handler(text, selection, match.pattern, lineStart);
+                this.quill.history.cutoff();
+                break;
+            }
+        }
+    };
+
+    private matchers: IMarkdownMatch[] = [
+        {
+            name: "header",
+            preventsDefault: true,
+            pattern: /^(#){1,6}/g,
+            handler: (text, selection, pattern) => {
+                const match = pattern.exec(text);
+                if (!match) {
+                    return;
+                }
+                const size = Math.min(Math.max(2, match[0].length), 5);
+
+                const offset = text.length; // 1 for the space.
+                const delta = new Delta()
+                    .retain(selection.index - offset)
+                    .delete(offset)
+                    .retain(1, { [HeaderBlot.blotName]: size });
+                this.quill.updateContents(delta, Quill.sources.USER);
+            },
+        },
+        {
+            name: "blockquote",
+            pattern: /^(>)/g,
+            handler: (text, selection) => {
+                const offset = text.length;
+                const delta = new Delta()
+                    .retain(selection.index - offset)
+                    .delete(offset)
+                    .retain(1, { [BlockquoteLineBlot.blotName]: true });
+                this.quill.updateContents(delta, Quill.sources.USER);
+            },
+        },
+        {
+            name: "spoiler",
+
+            pattern: /^\!>/g,
+            handler: (text, selection) => {
+                const offset = text.length;
+                const delta = new Delta()
+                    .retain(selection.index - offset)
+                    .delete(offset)
+                    .retain(1, { [SpoilerLineBlot.blotName]: true });
+                this.quill.updateContents(delta, Quill.sources.USER);
+            },
+        },
+        {
+            name: "code-block",
+            preventsDefault: true,
+            pattern: /^`{3}/g,
+            handler: (text, selection) => {
+                const delta = new Delta()
+                    .retain(selection.index - 3)
+                    .delete(4) // 1 more for the enter.
+                    .insert("\n", { "code-block": true });
+                this.quill.updateContents(delta, Quill.sources.USER);
+                this.quill.setSelection(selection.index - 3, 0, Quill.sources.USER);
+            },
+        },
+        {
+            name: "bolditalic",
+            pattern: /(?:\*|_){3}(.+?)(?:\*|_){3}/g,
+            handler: (text, selection, pattern, lineStart) => {
+                const match = pattern.exec(text);
+                if (!match) {
+                    return;
+                }
+                const annotatedText = match[0];
+                const matchedText = match[1];
+                const startIndex = lineStart + match.index;
+
+                if (text.match(/^([*_ \n]+)$/g)) {
+                    return;
+                }
+
+                this.quill.deleteText(startIndex, annotatedText.length);
+                this.quill.insertText(startIndex, matchedText, { bold: true, italic: true });
+                this.quill.format("bold", false);
+            },
+        },
+        {
+            name: "bold",
+            pattern: /(?:\*|_){2}(.+?)(?:\*|_){2}/g,
+            handler: (text, selection, pattern, lineStart) => {
+                const match = pattern.exec(text);
+                if (!match) {
+                    return;
+                }
+                const annotatedText = match[0];
+                const matchedText = match[1];
+                const startIndex = lineStart + match.index;
+
+                if (text.match(/^([*_ \n]+)$/g)) {
+                    return;
+                }
+
+                this.quill.deleteText(startIndex, annotatedText.length);
+                this.quill.insertText(startIndex, matchedText, { bold: true });
+                this.quill.format("bold", false);
+            },
+        },
+        {
+            name: "italic",
+            pattern: /(?:\*|_){1}(.+?)(?:\*|_){1}/g,
+            handler: (text, selection, pattern, lineStart) => {
+                const match = pattern.exec(text);
+                if (!match) {
+                    return;
+                }
+                const annotatedText = match[0];
+                const matchedText = match[1];
+                const startIndex = lineStart + match.index;
+
+                if (text.match(/^([*_ \n]+)$/g)) {
+                    return;
+                }
+
+                this.quill.deleteText(startIndex, annotatedText.length);
+                this.quill.insertText(startIndex, matchedText, { italic: true });
+                this.quill.format("italic", false);
+            },
+        },
+        {
+            name: "strikethrough",
+            pattern: /(?:~~)(.+?)(?:~~)/g,
+            handler: (text, selection, pattern, lineStart) => {
+                const match = pattern.exec(text);
+                if (!match) {
+                    return;
+                }
+                const annotatedText = match[0];
+                const matchedText = match[1];
+                const startIndex = lineStart + match.index;
+
+                if (text.match(/^([*_ \n]+)$/g)) {
+                    return;
+                }
+
+                this.quill.deleteText(startIndex, annotatedText.length);
+                this.quill.insertText(startIndex, matchedText, { strike: true });
+                this.quill.format("strike", false);
+            },
+        },
+        {
+            name: "code",
+            pattern: /(?:`)(.+?)(?:`)/g,
+            handler: (text, selection, pattern, lineStart) => {
+                const match = pattern.exec(text);
+                if (!match) {
+                    return;
+                }
+
+                if (this.quill.getFormat(selection)[CodeBlockBlot.blotName]) {
+                    return;
+                }
+
+                const annotatedText = match[0];
+                const matchedText = match[1];
+                const startIndex = lineStart + match.index;
+
+                if (text.match(/^([*_ \n]+)$/g)) {
+                    return;
+                }
+
+                this.quill.deleteText(startIndex, annotatedText.length);
+                this.quill.insertText(startIndex, matchedText, { [CodeBlot.blotName]: true });
+                this.quill.format(CodeBlot.blotName, false);
+                this.quill.insertText(this.quill.getSelection().index, " ");
+            },
+        },
+    ];
+}

--- a/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
@@ -57,7 +57,7 @@ export default class MarkdownModule {
         }
 
         const { textContent, tagName } = line.domNode;
-        return typeof textContent !== "undefined" && !!textContent && this.ignoreTags.includes(tagName);
+        return typeof textContent !== "undefined" && !!textContent && !this.ignoreTags.includes(tagName);
     }
 
     /**

--- a/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
+++ b/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
@@ -9,6 +9,7 @@ import Quill, { QuillOptionsStatic } from "quill/core";
 import ThemeBase from "quill/core/theme";
 import KeyboardBindings from "@rich-editor/quill/KeyboardBindings";
 import { richEditorClasses } from "@rich-editor/editor/richEditorClasses";
+import MarkdownModule from "@rich-editor/quill/MarkdownModule";
 
 export default class VanillaTheme extends ThemeBase {
     /**
@@ -26,6 +27,7 @@ export default class VanillaTheme extends ThemeBase {
         };
 
         super(quill, themeOptions);
+
         this.quill.root.classList.add(classesRichEditor.text);
         this.quill.root.classList.add("richEditor-text");
         this.quill.root.classList.add("userContent");
@@ -38,5 +40,8 @@ export default class VanillaTheme extends ThemeBase {
             ...this.options.modules.keyboard.bindings,
             ...keyboardBindings.bindings,
         };
+
+        // Attaches the markdown keyboard listener.
+        const markdownModule = new MarkdownModule(this.quill);
     }
 }

--- a/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
+++ b/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
@@ -43,5 +43,6 @@ export default class VanillaTheme extends ThemeBase {
 
         // Attaches the markdown keyboard listener.
         const markdownModule = new MarkdownModule(this.quill);
+        markdownModule.registerHandler();
     }
 }


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7159

![](https://media.giphy.com/media/jmwy2EEHCz0bVEcB9H/giphy.gif)

## Supported Shortcuts

### Triggered by the enter key
 * `` ``` ``         -> Code Block


### Triggered by a space
 * `###`           -> Headings (2-5)
 * `>`             -> Quote
 * `!>`            -> Spoiler
 * `_text_`        -> Italic
 * `__text__`      -> Bold
 * `___text___`    -> Bold & Italic
 * `*text*`        -> Italic
 * `**text**`      -> Bold
 * `***text***`    -> Bold & Italic
 * `~~text~~`      -> Strike
 * `` `text` ``        -> Code

## Implementation

- I've added a new module that implements these directly with it's own `keydown` handler. This way it can run before the built in `KeyboardModule`.
- I've made some of the types surrounding quill keyboard handlers a little bit more accurate.
- It's not really possible to write tests at the moment. We need additonal test infrastructure to simulate actual keyboard events. Issue here https://github.com/vanilla/vanilla/issues/8754 and pull request to unblock it (but still has a long way to go) here https://github.com/vanilla/vanilla/pull/8478