### PR TITLE
Activate X-Request-With header validation instead of Transient key for entry controller

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -71,6 +71,8 @@ class EntryController extends Gdn_Controller {
         parent::initialize();
         Gdn_Theme::section('Entry');
 
+        $this->CssClass .= " AjaxForm";
+
         if ($this->UserModel->isNameUnique() && !$this->UserModel->isEmailUnique()) {
             $this->setData('RecoverPasswordLabelCode', 'Enter your username to continue.');
         } else {

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -104,8 +104,6 @@ class EntryController extends Gdn_Controller {
      * @param string $authenticationSchemeAlias Type of authentication we're attempting.
      */
     public function auth($authenticationSchemeAlias = 'default') {
-        Gdn::session()->ensureTransientKey();
-
         $this->EventArguments['AuthenticationSchemeAlias'] = $authenticationSchemeAlias;
         $this->fireEvent('BeforeAuth');
 
@@ -1039,8 +1037,6 @@ class EntryController extends Gdn_Controller {
         if (!$this->Request->isPostBack()) {
             $this->checkOverride('SignIn', $this->target());
         }
-
-        Gdn::session()->ensureTransientKey();
 
         $this->addJsFile('entry.js');
         $this->setData('Title', t('Sign In'));


### PR DESCRIPTION
Remove unnecessary calls of

Gdn::session()->ensureTransientKey();

since we have a check down there, which can be confirmed with X-Request-With header

$this->Request->isAuthenticatedPostBack()

Closes: #8578 
Closes: #8714