### PR TITLE
Embedded Comments - Inherit dashboard post format type

### DIFF
--- a/applications/vanilla/views/discussion/embed.php
+++ b/applications/vanilla/views/discussion/embed.php
@@ -9,6 +9,7 @@ if (!function_exists('WriteComment'))
     include($this->fetchViewLocation('helper_functions', 'discussion'));
 
 ?>
+
 <div class="Embed">
     <?php
     echo '<span class="BeforeCommentHeading">';
@@ -38,6 +39,7 @@ if (!function_exists('WriteComment'))
         if ($this->Pager->lastPage()) {
             $LastCommentID = $this->addDefinition('LastCommentID');
             if (!$LastCommentID || $this->Data['Discussion']->LastCommentID > $LastCommentID)
+                $this->Data['Discussion'] = (is_array($this->Data['Discussion'])) ? (object)$this->Data['Discussion'] : $this->Data['Discussion'];
                 $this->addDefinition('LastCommentID', (int)$this->Data['Discussion']->LastCommentID);
             $this->addDefinition('Vanilla_Comments_AutoRefresh', Gdn::config('Vanilla.Comments.AutoRefresh', 0));
         }

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -66,6 +66,8 @@ if (!function_exists('writeComment')) :
         // Whether to order the name & photo with the latter first.
         static $userPhotoFirst = null;
 
+        $comment = (is_array($comment)) ? (object)$comment: $comment;
+
         if ($userPhotoFirst === null) {
             $userPhotoFirst = c('Vanilla.Comment.UserPhotoFirst', true);
         }
@@ -608,7 +610,7 @@ if (!function_exists('writeEmbedCommentForm')) :
                 echo $controller->Form->open(['id' => 'Form_Comment']);
                 echo $controller->Form->errors();
                 echo $controller->Form->hidden('Name');
-                echo wrap($controller->Form->bodyBox('Body', ['Format' => 'TextEx']));
+                echo wrap($controller->Form->bodyBox('Body'));
                 echo "<div class=\"Buttons\">\n";
 
                 $allowSigninPopup = c('Garden.SignIn.Popup');

--- a/plugins/rich-editor/RichEditorPlugin.php
+++ b/plugins/rich-editor/RichEditorPlugin.php
@@ -119,9 +119,12 @@ class RichEditorPlugin extends Gdn_Plugin {
     protected function addQuoteButton($sender, $args) {
         // There are some case were Discussion is not set as an event argument so we use the sender data instead.
         $discussion = $sender->data('Discussion');
+        $discussion = (is_array($discussion)) ? (object)$discussion : $discussion;
+
         if (!$discussion) {
             return;
         }
+
 
         if (!Gdn::session()->UserID) {
             return;


### PR DESCRIPTION
Per vanilla/vanilla#8738 we mounted an editor for embedded content and set the format type for those comments to TextEx.  The format of TextEx causes a mismatch with that of the form and would cause content to render incorrectly.  Quotes rendering was especially off (see below).  

This allows for the comment form to inherit the format type set in the dashboard so that there would be no conflict in rendering.  So changes had to be made in embed view and the rich editor plugin to ensure the data being accessed was an object instead of an array.  This was done to make sure rich content would display correctly on the page where the embedded comments were displayed.

Example of Embedded Comment with a quote
```
> @user1 said:
> Quoted Text form the body of the comment
> 

This looks weird ^
```

## To test:

Ensure you have embedded comments functioning

1) Test posting and embedded comment
2) Test quoting the the posted comment
3) Repeat steps with all different formats available

Close #8748



