### PR TITLE
Fix inline code styles

### DIFF
--- a/library/src/scripts/content/userContentStyles.ts
+++ b/library/src/scripts/content/userContentStyles.ts
@@ -43,7 +43,7 @@ const userContentVariables = useThemeCache(() => {
 
     const code = makeThemeVars("code", {
         fontSize: em(0.85),
-        borderRadius: 0,
+        borderRadius: 2,
         // bg target rgba(127, 127, 127, .15);
         bg: blocks.bg,
         fg: blocks.fg,
@@ -174,7 +174,6 @@ export const userContentClasses = useThemeCache(() => {
     const codeStyles: NestedCSSSelectors = {
         "& .code": {
             position: "relative",
-            verticalAlign: "middle",
             fontSize: vars.code.fontSize,
             fontFamily: `Menlo, Monaco, Consolas, "Courier New", monospace`,
             maxWidth: percent(100),


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/8635

Inline code was not styled properly for the new `userContentStyles`. This PR fixes it.