### PR TITLE
A config override for relative/absolute path in setCacheDir

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -1216,7 +1216,7 @@ class AddonManager implements Contracts\AddonProviderInterface {
      * @return AddonManager Returns `$this` for fluent calls.
      */
     public function setCacheDir($cacheDir) {
-        if ($cacheDir !== null && strpos($cacheDir, PATH_ROOT) !== 0) {
+        if ($cacheDir !== null && strpos($cacheDir, PATH_ROOT) !== 0 && Gdn::config('Cache.DirRelative', true)) {
             $cacheDir = PATH_ROOT.$cacheDir;
         }
         $this->cacheDir = $cacheDir;


### PR DESCRIPTION
I used `Cache.` config prefix becuase it already exists. I didn't use `Cache.Filecache.` becuase this is a lower level thing than filecache, and involves the object/class/addon caching regardless of type of cache.

Default is relative for backwards compatibility. 

Setting false will allow you to set an absolute path to the cache directory, as a constant in a similar way to the upload directory.  Useful for multi-tenancy arrangements.