### PR TITLE
Add support for React-based input validation in existing forms

### DIFF
--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -9,6 +9,7 @@ import { onContent, getMeta, _executeReady, _mountComponents } from "@library/ut
 import { log, logError, debug } from "@library/utility/utils";
 import gdn from "@library/gdn";
 import apiv2 from "@library/apiv2";
+import { mountInputs } from "@library/forms/mountInputs";
 
 // Inject the debug flag into the utility.
 const debugValue = getMeta("context.debug", getMeta("debug", false));
@@ -24,6 +25,7 @@ _executeReady()
         // Mount all data-react components.
         onContent(e => {
             _mountComponents(e.target);
+            mountInputs();
         });
 
         const contentEvent = new CustomEvent("X-DOMContentReady", { bubbles: true, cancelable: false });

--- a/library/src/scripts/forms/TextInput.tsx
+++ b/library/src/scripts/forms/TextInput.tsx
@@ -1,0 +1,85 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { slugify } from "@library/utility/utils";
+import classNames from "classnames";
+import React, { useCallback, useState } from "react";
+
+export enum InputStyle {
+    DASHBOARD = "dashboard",
+    MODERN = "modern",
+}
+
+export enum InputValidationFilter {
+    SLUG = "slug",
+    NUMBER = "number",
+}
+
+interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    inputStyle?: InputStyle; // Optionally a style for the input.
+    value?: string; // A value if you want a controlled component. Be sure to use onChange too.
+    validationFilter?: InputValidationFilter; // A live filter to apply.
+    type?: never; // The type is controlled by the component and validationFilter.
+}
+
+/**
+ * Text input component.
+ *
+ * Can optionaly take validation filters that will live filter the input.
+ */
+export function TextInput(props: IProps) {
+    const { inputStyle, validationFilter, className, onChange, value, defaultValue, ...rest } = props;
+    const [ownValue, setOwnValue] = useState(defaultValue);
+
+    // Get our change handler together.
+    // This will either be a self contained, controlled component (Eg. {@see mountInputs()}).
+    // Or this should be fully controlled by the outer component (takes value and onChange).
+    let actualValue = ownValue;
+    let actualOnChange: React.ChangeEventHandler<HTMLInputElement> | undefined = useCallback(
+        event => {
+            const filterMethod = getFilterMethodForMode(validationFilter);
+            setOwnValue(filterMethod(event.target.value));
+        },
+        [setOwnValue, validationFilter],
+    );
+    if ("value" in props) {
+        actualValue = props.value;
+        actualOnChange = props.onChange;
+    }
+
+    // Input type is determined by strictly by the validation filter.
+    const inputType = getInputType(validationFilter);
+    const classes = classNames(className, {
+        "form-control": props.inputStyle === InputStyle.DASHBOARD,
+    });
+
+    return <input {...rest} type={inputType} onChange={actualOnChange} value={actualValue} className={classes} />;
+}
+
+function getInputType(filterMode?: InputValidationFilter): string {
+    switch (filterMode) {
+        case InputValidationFilter.NUMBER:
+            return "number";
+        default:
+            return "text";
+    }
+}
+
+type FilterValidator = (value: string) => string;
+/**
+ * Get a filtering function from react.
+ *
+ * @param filterMode
+ */
+function getFilterMethodForMode(filterMode?: InputValidationFilter): FilterValidator {
+    switch (filterMode) {
+        case InputValidationFilter.NUMBER:
+            return (value: string) => value.replace(/[^0-9]/g, "");
+        case InputValidationFilter.SLUG:
+            return (value: string) => slugify(value, { allowMultipleDashes: true });
+        default:
+            return (value: string) => value;
+    }
+}

--- a/library/src/scripts/forms/mountInputs.tsx
+++ b/library/src/scripts/forms/mountInputs.tsx
@@ -1,0 +1,37 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { TextInput, InputValidationFilter } from "@library/forms/TextInput";
+import { mountReact } from "@library/dom/domUtils";
+import { log } from "@library/utility/utils";
+
+/**
+ * Mount <TextInput /> components on top of <input data-react-input/> elements.
+ *
+ * If the input has a "data-validation-filter" that will be applied as the validationFilter.
+ * Ideal for enhancing GDN_Form rendered forms.
+ */
+export function mountInputs() {
+    const inputs = document.querySelectorAll("[data-react-input]");
+    log(`Mounting React inputs over ${inputs.length} existing inputs.`);
+    inputs.forEach(input => {
+        if (input instanceof HTMLInputElement) {
+            const validationFilter = input.getAttribute("data-validation-filter") as InputValidationFilter;
+            mountReact(
+                <TextInput
+                    validationFilter={validationFilter}
+                    defaultValue={input.value}
+                    id={input.id}
+                    className={input.className}
+                    name={input.name}
+                />,
+                input,
+                undefined,
+                { overwrite: true },
+            );
+        }
+    });
+}

--- a/library/src/scripts/utility/utils.ts
+++ b/library/src/scripts/utility/utils.ts
@@ -160,12 +160,18 @@ export function compare<T extends string | number>(val1: T, val2: T): CompareRet
  *
  * @param str The string to parse.
  */
-export function slugify(str: string): string {
+export function slugify(
+    str: string,
+    options?: {
+        allowMultipleDashes?: boolean;
+    },
+): string {
+    const whiteSpaceNormalizeRegexp = options && options.allowMultipleDashes ? /[\s]+/g : /[-\s]+/g;
     return str
         .normalize("NFD") // Normalize accented characters into ASCII equivalents
-        .replace(/[^\w\s$*_+~.()'"!\-:@]/g, "") // REmove characters that don't URL encode well
+        .replace(/[^\w\s$*_+~.()'"\-!:@]/g, "") // REmove characters that don't URL encode well
         .trim() // Trim whitespace
-        .replace(/[-\s]+/g, "-") // Normalize whitespace
+        .replace(whiteSpaceNormalizeRegexp, "-") // Normalize whitespace
         .toLocaleLowerCase(); // Convert to locale aware lowercase.
 }
 


### PR DESCRIPTION
Relates to https://github.com/vanilla/knowledge/issues/846
Blocking https://github.com/vanilla/knowledge/issues/989

This PR

- adds some core utilities to allow mounting a React managed input component on top of an existing normal input (like from `GDN_Form`).
- Improvements to our `slugify` function to allow more flexibility.
- A `<TextInput />` component that can do realtime filtering of input.
- Automatically mounts `<TextInput />` components over fields with `data-react-input` attribute while preserving their existing attributes.
