### PR TITLE
Fix deployment cache buster incrementing when called

### DIFF
--- a/tests/Library/Vanilla/Web/Asset/DeploymentCacheBusterTest.php
+++ b/tests/Library/Vanilla/Web/Asset/DeploymentCacheBusterTest.php
@@ -67,4 +67,19 @@ class DeploymentCacheBusterTest extends TestCase {
             "The buster should change after the grace period."
         );
     }
+
+    /**
+     * Test that subsequent calls for the buster's value should be equal.
+     */
+    public function testConsistentValue() {
+        $buster = new DeploymentCacheBuster(
+            new \DateTimeImmutable(1000),
+            500
+        );
+
+        $valueA = $buster->value();
+        $valueB = $buster->value();
+
+        $this->assertEquals($valueA, $valueB);
+    }
 }


### PR DESCRIPTION
`DeploymentCacheBuster` had some logic that would reset the instance's `deploymentTime` property if calling the `value` method and the "grace period" had elapsed. The property would be incremented by the value of `GRACE_PERIOD`, each time. This property would then be used as the basis for generating the cache-busting key. If `value` is only called once, this isn't a problem. However, Vanilla keeps a _shared_ instance of the cache buster. If `value` were invoked multiple times in the same request, you'd see different values for the cache buster.

The value of `deploymentTime` is no longer reset after the object is instantiated. The return value of `value` should now be consistent in requests. A basic test has been added to verify this behavior.