### PR TITLE
Add /sso to default robots.txt

### DIFF
--- a/applications/dashboard/controllers/RobotsController.php
+++ b/applications/dashboard/controllers/RobotsController.php
@@ -22,6 +22,8 @@ Disallow: /messages/
 Disallow: /profile/comments/
 Disallow: /profile/discussions/
 Disallow: /search/
+Disallow: /sso/
+Disallow: /sso
 ROBOTS_DEFAULT;
 
     /** Content of robots.txt when the site is supposed to be "invisible" to crawlers and bots. */


### PR DESCRIPTION
Now that Vanilla has core robots.txt support, the default rules are being tightened up a little. Registration and sign-in pages, both local and SSO, should be "disallowed". The current ruleset already blocks the local registration and sign-in pages. However, now all pages under (and including) /sso will be similarly blocked.

Closes #8577