### PR TITLE
KB: Location picker and embed flyout design tweaks

### DIFF
--- a/library/src/scripts/flyouts/DropDown.tsx
+++ b/library/src/scripts/flyouts/DropDown.tsx
@@ -39,6 +39,12 @@ export interface IProps extends IDeviceProps {
     openAsModal?: boolean;
     title?: string;
     selfPadded?: boolean;
+    flyoutSize?: FlyoutSizes;
+}
+
+export enum FlyoutSizes {
+    DEFAULT = "default",
+    MEDIUM = "medium",
 }
 
 export interface IState {
@@ -104,6 +110,7 @@ class DropDown extends React.Component<IProps, IState> {
                             renderAbove={!!this.props.renderAbove}
                             openAsModal={openAsModal}
                             selfPadded={this.props.selfPadded}
+                            flyoutSize={this.props.flyoutSize}
                         >
                             {title ? (
                                 <header className={classNames("frameHeader", classesFrameHeader.root)}>

--- a/library/src/scripts/flyouts/DropDownContents.tsx
+++ b/library/src/scripts/flyouts/DropDownContents.tsx
@@ -8,6 +8,7 @@ import * as React from "react";
 import classNames from "classnames";
 import { flyoutPosition } from "@rich-editor/flyouts/pieces/flyoutPosition";
 import { dropDownClasses } from "@library/flyouts/dropDownStyles";
+import { FlyoutSizes } from "@library/flyouts/DropDown";
 
 export interface IProps {
     id: string;
@@ -21,6 +22,7 @@ export interface IProps {
     legacyMode?: boolean;
     openAsModal?: boolean;
     selfPadded?: boolean;
+    flyoutSize?: FlyoutSizes;
 }
 /**
  * The contents of the flyouts (not the wrapper and not the button to toggle it).
@@ -29,8 +31,9 @@ export interface IProps {
 export default class DropDownContents extends React.Component<IProps> {
     public render() {
         const classes = dropDownClasses();
+        const size = this.props.flyoutSize ? this.props.flyoutSize : FlyoutSizes.DEFAULT;
         const asDropDownClasses = !this.props.openAsModal
-            ? classNames("dropDown-contents", classes.contents)
+            ? classNames("dropDown-contents", classes.contents, { isMedium: size === FlyoutSizes.MEDIUM })
             : undefined;
         const asModalClasses = this.props.openAsModal ? classNames("dropDown-asModal", classes.asModal) : undefined;
 

--- a/library/src/scripts/flyouts/dropDownStyles.ts
+++ b/library/src/scripts/flyouts/dropDownStyles.ts
@@ -26,7 +26,10 @@ export const dropDownVariables = useThemeCache(() => {
     const makeThemeVars = variableFactory("dropDown");
 
     const sizing = makeThemeVars("sizing", {
-        width: 250,
+        widths: {
+            default: 250,
+            medium: 350,
+        },
         minHeight: 600,
     });
 
@@ -109,7 +112,7 @@ export const dropDownClasses = useThemeCache(() => {
 
     const contents = style("contents", {
         position: "absolute",
-        minWidth: unit(vars.sizing.width),
+        minWidth: unit(vars.sizing.widths.default),
         backgroundColor: colorOut(vars.contents.bg),
         color: colorOut(vars.contents.fg),
         overflow: "auto",
@@ -117,6 +120,9 @@ export const dropDownClasses = useThemeCache(() => {
         ...borders(vars.contents.border),
         zIndex: 3,
         $nest: {
+            "&.isMedium": {
+                width: unit(vars.sizing.widths.medium),
+            },
             "&.isParentWidth": {
                 minWidth: "initial",
             },

--- a/library/src/scripts/layout/frame/FrameHeader.tsx
+++ b/library/src/scripts/layout/frame/FrameHeader.tsx
@@ -45,7 +45,7 @@ export default class FrameHeader extends React.PureComponent<IFrameHeaderProps> 
                     onClick={this.props.onBackClick}
                     className={classNames("frameHeader-backButton", classes.backButton)}
                 >
-                    {leftChevron("frameHeader-backIcon isSmall", true)}
+                    {leftChevron("frameHeader-backIcon", true)}
                 </Button>
             );
         }

--- a/library/src/scripts/layout/frame/frameStyles.ts
+++ b/library/src/scripts/layout/frame/frameStyles.ts
@@ -126,7 +126,7 @@ export const frameHeaderClasses = useThemeCache(() => {
         justifyContent: "center",
         alignItems: "flex-end",
         flexShrink: 1,
-        marginLeft: unit(-6),
+        transform: `translateX(-5px) translateY(-1px)`,
     });
 
     const heading = style("heading", {

--- a/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
@@ -4,7 +4,7 @@
  * @license GPL-2.0-only
  */
 
-import DropDown from "@library/flyouts/DropDown";
+import DropDown, { FlyoutSizes } from "@library/flyouts/DropDown";
 import Button from "@library/forms/Button";
 import { ButtonTypes } from "@library/forms/buttonStyles";
 import { embed } from "@library/icons/editorIcons";
@@ -25,6 +25,7 @@ import classNames from "classnames";
 import KeyboardModule from "quill/modules/keyboard";
 import React from "react";
 import { style } from "typestyle";
+import Flyout from "@rich-editor/flyouts/pieces/Flyout";
 
 interface IProps extends IWithEditorProps, IDeviceProps {
     disabled?: boolean;
@@ -85,6 +86,8 @@ export class EmbedFlyout extends React.PureComponent<IProps, IState> {
                     renderLeft={!!this.props.renderLeft}
                     selfPadded={true}
                     initialFocusElement={this.inputRef.current}
+                    flyoutSize={FlyoutSizes.MEDIUM}
+                    contentsClassName={!this.props.legacyMode ? classesRichEditor.flyoutOffset : ""}
                 >
                     <Frame
                         body={
@@ -96,7 +99,7 @@ export class EmbedFlyout extends React.PureComponent<IProps, IState> {
                                     className={classNames("InputBox", classesInsertMedia.insert, {
                                         inputText: !this.props.legacyMode,
                                     })}
-                                    placeholder={t("http://")}
+                                    placeholder={t("https://")}
                                     value={this.state.url}
                                     onChange={this.inputChangeHandler}
                                     onKeyDown={this.buttonKeyDownHandler}

--- a/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
@@ -65,6 +65,7 @@ export class EmbedFlyout extends React.PureComponent<IProps, IState> {
     public render() {
         const classesRichEditor = richEditorClasses(this.props.legacyMode);
         const classesInsertMedia = insertMediaClasses();
+        const placeholderText = `https://`;
         return (
             <>
                 <DropDown
@@ -99,7 +100,7 @@ export class EmbedFlyout extends React.PureComponent<IProps, IState> {
                                     className={classNames("InputBox", classesInsertMedia.insert, {
                                         inputText: !this.props.legacyMode,
                                     })}
-                                    placeholder={t("https://")}
+                                    placeholder={placeholderText}
                                     value={this.state.url}
                                     onChange={this.inputChangeHandler}
                                     onKeyDown={this.buttonKeyDownHandler}


### PR DESCRIPTION
Design tweaks for embed flyout:
- Now wider on desktop
- Fixed vertical positioning to match the emoji picker's position
- Updated placeholder text to be "https" instead of "http"

Design tweaks for location picker: 
- Fixed styles for back chevron "<"
- Fixed paddings so the selected state goes all the way to the edge

For: https://github.com/vanilla/knowledge/issues/914