### PR TITLE
Fixed styles for "no results" on the search page and a z-index issue

### DIFF
--- a/library/src/scripts/features/search/IndependentSearch.tsx
+++ b/library/src/scripts/features/search/IndependentSearch.tsx
@@ -78,7 +78,10 @@ export class IndependentSearch extends React.Component<ICompactSearchProps, ISta
                     contentClass={this.props.contentClass}
                     valueContainerClasses={this.props.valueContainerClasses}
                 />
-                <div ref={this.resultsRef} className={classNames("search-results", classesSearchBar.results)} />
+                <div
+                    ref={this.resultsRef}
+                    className={classNames("search-results", classesSearchBar.results, classesSearchBar.resultsAsModal)}
+                />
             </div>
         );
     }

--- a/library/src/scripts/features/search/searchBarStyles.ts
+++ b/library/src/scripts/features/search/searchBarStyles.ts
@@ -155,15 +155,6 @@ export const searchBarClasses = useThemeCache(() => {
     const results = style("results", {
         backgroundColor: colorOut(vars.results.bg),
         color: colorOut(vars.results.fg),
-        position: "absolute",
-        top: unit(vars.sizing.height),
-        left: 0,
-        overflow: "hidden",
-        ...borders({
-            radius: unit(vars.results.borderRadius),
-        }),
-        ...shadow.dropDown(),
-        zIndex: 1,
         $nest: {
             "&:empty": {
                 display: "none",
@@ -195,6 +186,18 @@ export const searchBarClasses = useThemeCache(() => {
                 },
             },
         },
+    });
+
+    const resultsAsModal = style("results", {
+        position: "absolute",
+        top: unit(vars.sizing.height),
+        left: 0,
+        overflow: "hidden",
+        ...borders({
+            radius: unit(vars.results.borderRadius),
+        }),
+        ...shadow.dropDown(),
+        zIndex: 1,
     });
 
     const valueContainer = style("valueContainer", {
@@ -351,6 +354,7 @@ export const searchBarClasses = useThemeCache(() => {
         iconContainer,
         icon,
         results,
+        resultsAsModal,
         menu,
     };
 });

--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -79,7 +79,7 @@ export class TitleBar extends React.Component<IProps, IState> {
             ...sticky(),
             $debugName: "isFixed",
             top: 0,
-            zIndex: 1,
+            zIndex: 2,
         });
 
         const outerCssClasses = classNames(


### PR DESCRIPTION
White preparing my demo I noticed 2 problems:


- No results in the search page was in a box shadow (as if it was in a modal)
- The search icon in the page was above the results in the titleBar

This PR fixes both issues.