### PR TITLE
Fix CodePen embeds in Rich Editor

### DIFF
--- a/library/src/scripts/content/embeds/codepen.tsx
+++ b/library/src/scripts/content/embeds/codepen.tsx
@@ -14,8 +14,8 @@ export function initCodePenEmbeds() {
 export class CodePenEmbed extends BaseEmbed {
     public render() {
         const { attributes, height } = this.props.data;
-        const { id, src, style } = attributes;
+        const { id, embedUrl, style } = attributes;
 
-        return <iframe id={id} src={src} height={height || 300} style={style} scrolling="no" />;
+        return <iframe id={id} src={embedUrl} height={height || 300} style={style} scrolling="no" />;
     }
 }


### PR DESCRIPTION
The client-side CodePen embed class and the server-side CodePen embed class are not using the same attribute to build the iframe. The client-side class is looking for [`src` in the `attributes`](https://github.com/vanilla/vanilla/blob/276b178c5ba7182d1f3432b04dc7cfe8b7cdc741/library/src/scripts/content/embeds/codepen.tsx#L17), while the server-side class is looking for [`embedUrl` in `attributes`](https://github.com/vanilla/vanilla/blob/276b178c5ba7182d1f3432b04dc7cfe8b7cdc741/library/Vanilla/Formatting/Embeds/CodePenEmbed.php#L53). The server-side class renders. The client-side class does not.

The client-side CodePen embed class has been updated to use the proper attribute, `embedUrl`.

Closes vanilla/knowledge#973