### PR TITLE
Enforce prettier in CI and fix some typescript formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,13 @@ jobs:
             - google-chrome
         chrome: stable
       script:
+        - set -e
+        - yarn prettier --check "**/src/scripts/**/*"
         - yarn build
-        - yarn test
         - yarn check-types
+        - yarn test
         - ./tests/travis/audit.sh
+        - set +e
 
 install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.3 # Ensure a consistent yarn version

--- a/library/src/scripts/content/_codeDark.scss
+++ b/library/src/scripts/content/_codeDark.scss
@@ -3,4 +3,4 @@
  * @license GPL-2.0-only
  */
 
- @import "~highlight.js/styles/darcula.css";
+@import "~highlight.js/styles/darcula.css";

--- a/library/src/scripts/content/countStyles.ts
+++ b/library/src/scripts/content/countStyles.ts
@@ -1,20 +1,19 @@
-
 /*
  * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
  * @copyright 2009-2019 Vanilla Forums Inc.
  * @license GPL-2.0-only
  */
 
-import {absolutePosition, colorOut, debugHelper, unit} from "@library/styles/styleHelpers";
+import { absolutePosition, colorOut, debugHelper, unit } from "@library/styles/styleHelpers";
 import { globalVariables } from "@library/styles/globalStyleVars";
-import {styleFactory, useThemeCache, variableFactory} from "@library/styles/styleUtils";
-import {ColorValues} from "@library/forms/buttonStyles";
+import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
+import { ColorValues } from "@library/forms/buttonStyles";
 
 export const countVariables = useThemeCache(() => {
     const globalVars = globalVariables();
     const themeVars = variableFactory("count");
 
-    const font = themeVars("font",{
+    const font = themeVars("font", {
         size: 10,
     });
 

--- a/library/src/scripts/forms/radioTabs/tabButtonListStyles.ts
+++ b/library/src/scripts/forms/radioTabs/tabButtonListStyles.ts
@@ -5,10 +5,10 @@
  */
 
 import { globalVariables } from "@library/styles/globalStyleVars";
-import {styleFactory, useThemeCache} from "@library/styles/styleUtils";
-import {colorOut, defaultTransition} from "@library/styles/styleHelpers";
-import {countClasses} from "@library/content/countStyles";
-import {compactMeBoxVariables} from "@library/headers/mebox/pieces/compactMeBoxStyles";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
+import { colorOut, defaultTransition } from "@library/styles/styleHelpers";
+import { countClasses } from "@library/content/countStyles";
+import { compactMeBoxVariables } from "@library/headers/mebox/pieces/compactMeBoxStyles";
 
 export const tabButtonListClasses = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -22,7 +22,7 @@ export const tabButtonListClasses = useThemeCache(() => {
         justifyContent: "stretch",
     });
 
-    const button = style("button",{
+    const button = style("button", {
         flexGrow: 1,
         color: colorOut(globalVars.mainColors.fg),
         $nest: {

--- a/library/src/scripts/headers/mebox/pieces/compactMeBoxStyles.ts
+++ b/library/src/scripts/headers/mebox/pieces/compactMeBoxStyles.ts
@@ -6,7 +6,7 @@
 
 import { absolutePosition, flexHelper, unit, sticky, colorOut } from "@library/styles/styleHelpers";
 import { globalVariables } from "@library/styles/globalStyleVars";
-import {styleFactory, useThemeCache, variableFactory} from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { calc, percent, viewHeight } from "csx";
 
 export const compactMeBoxVariables = useThemeCache(() => {

--- a/library/src/scripts/layout/smartAlignStyles.ts
+++ b/library/src/scripts/layout/smartAlignStyles.ts
@@ -4,7 +4,7 @@
  * @license GPL-2.0-only
  */
 
-import {styleFactory, useThemeCache} from "@library/styles/styleUtils";
+import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { percent } from "csx";
 
 export const smartAlignClasses = useThemeCache(() => {
@@ -17,7 +17,7 @@ export const smartAlignClasses = useThemeCache(() => {
         width: percent(100),
     });
 
-    const inner = style("inner",{
+    const inner = style("inner", {
         textAlign: "left",
     });
 

--- a/library/src/scripts/result/ResultMeta.tsx
+++ b/library/src/scripts/result/ResultMeta.tsx
@@ -30,22 +30,21 @@ export class ResultMeta extends React.Component<IProps> {
         const classesMetas = metasClasses();
         return (
             <React.Fragment>
-                {updateUser &&
-                    updateUser.name && (
-                        <span className={classNames(classesMetas.meta)}>
-                            {isDeleted ? (
-                                <span className={classNames("meta-inline", "isDeleted")}>
-                                    <Translate source="Deleted <0/>" c0={type} />
-                                </span>
-                            ) : (
-                                <Translate
-                                    source="<0/> by <1/>"
-                                    c0={type ? t(capitalizeFirstLetter(type)) : undefined}
-                                    c1={updateUser.name}
-                                />
-                            )}
-                        </span>
-                    )}
+                {updateUser && updateUser.name && (
+                    <span className={classNames(classesMetas.meta)}>
+                        {isDeleted ? (
+                            <span className={classNames("meta-inline", "isDeleted")}>
+                                <Translate source="Deleted <0/>" c0={type} />
+                            </span>
+                        ) : (
+                            <Translate
+                                source="<0/> by <1/>"
+                                c0={type ? t(capitalizeFirstLetter(type)) : undefined}
+                                c1={updateUser.name}
+                            />
+                        )}
+                    </span>
+                )}
 
                 <span className={classesMetas.meta}>
                     <Translate source="Last Updated: <0/>" c0={<DateTime timestamp={dateUpdated} />} />

--- a/plugins/rich-editor/src/scripts/editor/richEditorVariables.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorVariables.ts
@@ -10,8 +10,6 @@ import { globalVariables } from "@library/styles/globalStyleVars";
 import { useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { viewHeight } from "csx";
 
-
-
 export const richEditorVariables = useThemeCache(() => {
     const globalVars = globalVariables();
     const varsFormElements = formElementsVariables();

--- a/plugins/rich-editor/src/scripts/flyouts/pieces/flyoutClasses.ts
+++ b/plugins/rich-editor/src/scripts/flyouts/pieces/flyoutClasses.ts
@@ -9,7 +9,7 @@ import { borders, colorOut, longWordEllipsis, paddings, singleBorder, unit } fro
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { calc, percent } from "csx";
 import { richEditorVariables } from "@rich-editor/editor/richEditorVariables";
-import {important} from "csx";
+import { important } from "csx";
 
 export const richEditorFlyoutClasses = useThemeCache(() => {
     const vars = richEditorVariables();
@@ -21,7 +21,7 @@ export const richEditorFlyoutClasses = useThemeCache(() => {
         ...shadows.dropDown(),
         position: "absolute",
         left: 0,
-        width: unit( vars.richEditorWidth + vars.emojiBody.padding.horizontal * 2),
+        width: unit(vars.richEditorWidth + vars.emojiBody.padding.horizontal * 2),
         zIndex: 6,
         overflow: "hidden",
         backgroundColor: colorOut(vars.colors.bg),
@@ -59,7 +59,7 @@ export const richEditorFlyoutClasses = useThemeCache(() => {
 
     const body = style("body", {
         ...paddings(vars.emojiBody.padding),
-        width: unit( vars.richEditorWidth + vars.emojiBody.padding.horizontal * 2),
+        width: unit(vars.richEditorWidth + vars.emojiBody.padding.horizontal * 2),
     });
 
     const footer = style("footer", {

--- a/plugins/rich-editor/src/scripts/flyouts/pieces/insertEmojiClasses.ts
+++ b/plugins/rich-editor/src/scripts/flyouts/pieces/insertEmojiClasses.ts
@@ -65,7 +65,6 @@ export const insertEmojiClasses = useThemeCache(() => {
     const body = style("body", {
         height: unit(vars.emojiBody.height),
         maxHeight: viewHeight(80),
-
     });
 
     const popoverDescription = style("popoverDescription", {


### PR DESCRIPTION
In https://github.com/vanilla/knowledge/pull/953 we started enforcing prettier in CI for KB.

In this PR I've fixed a few formatting issues that slipped through and update the travis script to run prettier --check. I also re-ordered the JS commands to be similar to the KB travis setup (Eg. Run the fast things first).