### PR TITLE
Add styling and wireup for editor placeholder

### DIFF
--- a/library/src/scripts/content/userContentStyles.ts
+++ b/library/src/scripts/content/userContentStyles.ts
@@ -274,6 +274,10 @@ export const userContentClasses = useThemeCache(() => {
         lineHeight: globalVars.lineHeights.base,
         fontSize: vars.fonts.size,
         $nest: {
+            // A placeholder might be put in a ::before element. Make sure we match the line-height adjustment.
+            "&::before": {
+                marginTop: lineHeightAdjustment()["&::before"]!.marginTop,
+            },
             ...headings,
             ...lists,
             ...paragraphSpacing,

--- a/plugins/rich-editor/src/scripts/editor/richEditorClasses.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorClasses.ts
@@ -167,6 +167,18 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
         position: "relative",
         whiteSpace: important("pre-wrap"),
         outline: 0,
+        $nest: {
+            // When the editor is empty we should be displaying a placeholder.
+            "&.ql-blank::before": {
+                content: `attr(data-placeholder)`,
+                display: "block",
+                color: colorOut(vars.text.placeholder.color),
+                position: "absolute",
+                top: vars.text.offset,
+                left: 0,
+                cursor: "text",
+            },
+        },
     });
 
     const menuItems = style("menuItems", {

--- a/plugins/rich-editor/src/scripts/editor/richEditorVariables.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorVariables.ts
@@ -100,6 +100,9 @@ export const richEditorVariables = useThemeCache(() => {
 
     const text = makeThemeVars("text", {
         offset: 0,
+        placeholder: {
+            color: globalVars.mixBgAndFg(0.5),
+        },
     });
 
     const title = makeThemeVars("titleInput", {


### PR DESCRIPTION
Currently rich editor doesn't have a way to enable a placeholder.

This PR adds

- Support for providing quill options with the `options` parameter on rich editor.
- Styling support for this placeholder. This might seem a little odd, but a `::before` element is the only easy way to get some relatively positioned content into the editor that's not actually part of the content editable. The `.ql-blank` class is how quill applies this in its own styles (which we don't use). https://github.com/quilljs/quill/issues/1831#issuecomment-351938711