### PR TITLE
Create page view handlers and initialization

### DIFF
--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -10,6 +10,8 @@ import { log, logError, debug } from "@library/utility/utils";
 import gdn from "@library/gdn";
 import apiv2 from "@library/apiv2";
 import { mountInputs } from "@library/forms/mountInputs";
+import { initPageViewTracking } from "@library/pageViews/pageViewTracking";
+import { createBrowserHistory } from "history";
 
 // Inject the debug flag into the utility.
 const debugValue = getMeta("context.debug", getMeta("debug", false));
@@ -27,6 +29,8 @@ _executeReady()
             _mountComponents(e.target);
             mountInputs();
         });
+
+        initPageViewTracking(createBrowserHistory());
 
         const contentEvent = new CustomEvent("X-DOMContentReady", { bubbles: true, cancelable: false });
         document.dispatchEvent(contentEvent);

--- a/library/src/scripts/pageViews/pageViewTracking.test.ts
+++ b/library/src/scripts/pageViews/pageViewTracking.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { createMemoryHistory } from "history";
+import { onPageView, initPageViewTracking } from "@library/pageViews/pageViewTracking";
+import { expect } from "chai";
+import sinon from "sinon";
+
+describe("pageViewTracking", () => {
+    it("can handle page views", () => {
+        const history = createMemoryHistory();
+        const spy = sinon.spy();
+        onPageView(spy);
+        initPageViewTracking(history);
+
+        expect(spy.callCount).eq(1, "the initalization tracks a page view.");
+        history.push("/test1");
+        history.push("/test3");
+        history.push("/test4");
+        history.push("/test1");
+        expect(spy.callCount).eq(5, "Further page views are tracked.");
+    });
+});

--- a/library/src/scripts/pageViews/pageViewTracking.ts
+++ b/library/src/scripts/pageViews/pageViewTracking.ts
@@ -1,0 +1,30 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { History } from "history";
+
+export type PageViewHandler = (params: { history: History }) => void | Promise<void>;
+const handlers: PageViewHandler[] = [];
+
+/**
+ * Register a callback for a when a pageview is triggered.
+ *
+ * @param handler The handler for the page view.
+ */
+export function onPageView(handler: PageViewHandler) {
+    handlers.push(handler);
+}
+
+/**
+ * Initialize tracking of the page history and fire the handlers for the current page.
+ */
+export function initPageViewTracking(history: History) {
+    const callHandlers = () => {
+        handlers.forEach(handler => handler({ history }));
+    };
+
+    callHandlers();
+    history.listen(callHandlers);
+}


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8761

Adds page view tracking and unit tests. Just register your callbacks with `onPageView()`.