### PR TITLE
Move AfterBody event in boilerplate and keystone before the closing body tag

### DIFF
--- a/themes/keystone/views/default.master.tpl
+++ b/themes/keystone/views/default.master.tpl
@@ -220,7 +220,6 @@
                                         <!---------- Profile Page Header END ---------->
 
                                         {asset name="Content"}
-                                        {event name="AfterBody"}
                                     </main>
                                     <!---------- Main Content END ---------->
 
@@ -269,6 +268,7 @@
         </div>
     </div>
     <div id="modals"></div>
+    {event name="AfterBody"}
 </body>
 
 </html>

--- a/themes/theme-boilerplate/views/default.master.tpl
+++ b/themes/theme-boilerplate/views/default.master.tpl
@@ -79,7 +79,6 @@
                                             </div>
                                         {/if}
                                         {asset name="Content"}
-                                        {event name="AfterBody"}
                                     </main>
                                     <aside class="Panel Panel-main">
                                         {if !$SectionGroups}
@@ -101,6 +100,7 @@
         </div>
     </div>
     <div id="modals"></div>
+    {event name="AfterBody"}
 </body>
 
 </html>


### PR DESCRIPTION
This solves https://github.com/vanilla/vanilla/issues/8856

Boilerplate (and therefore Keystone, too) moved the AfterBody event upwards in the DOM tree. This PR moves it right before the closing body tag again