### PR TITLE
Fix: Reset password link when password has been force reset by an admin

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1129,6 +1129,10 @@ class EntryController extends Gdn_Controller {
                                 'Reason' => 'Password',
                             ]);
                         }
+                    } catch (Gdn_CoreException $ex) {
+                        $errorMessage = htmlspecialchars(strip_tags($ex->getMessage()));
+                        $errorMessage .= sprintf(' Click <a href=%s>here</a> to reset your password', url('/entry/passwordrequest'));
+                        $this->Form->addError($errorMessage);
                     } catch (Gdn_UserException $ex) {
                         $this->Form->addError($ex);
                     }

--- a/library/core/class.coreexception.php
+++ b/library/core/class.coreexception.php
@@ -17,6 +17,7 @@ class Gdn_CoreException extends Exception {
      * Constructs the Gdn_ApplicationException.
      *
      * @param string $message A user readable message for the exception.
+     * @param int $code The error code.
      * @param Exception $previous The previous exception used for exception chaining.
      */
     public function __construct($message, $code = 400, $previous = null) {

--- a/library/core/class.coreexception.php
+++ b/library/core/class.coreexception.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Gdn_CoreException
+ *
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ * @package Core
+ * @since 2.0
+ */
+
+/**
+ * A wrapper for the Exception class so that methods can throw a specific
+ * application as a means of validation or user error, rather than a critical exception.
+ */
+class Gdn_CoreException extends Exception {
+    /**
+     * Constructs the Gdn_ApplicationException.
+     *
+     * @param string $message A user readable message for the exception.
+     * @param Exception $previous The previous exception used for exception chaining.
+     */
+    public function __construct($message, $code = 400, $previous = null) {
+        parent::__construct($message, (int)$code, $previous);
+    }
+}

--- a/library/core/class.passwordhash.php
+++ b/library/core/class.passwordhash.php
@@ -88,12 +88,10 @@ class Gdn_PasswordHash {
                 $result = $this->getAlgorithm('Punbb')->verify($password, $storedHash);
                 break;
             case 'reset':
-                $resetUrl = url('entry/passwordrequest'.(Gdn::request()->get('display') ? '?display='.urlencode(Gdn::request()->get('display')) : ''));
-                throw new Gdn_UserException(sprintf(t('You need to reset your password.', 'You need to reset your password. This is most likely because an administrator recently changed your account information. Click <a href="%s">here</a> to reset your password.'), $resetUrl));
+                throw new Gdn_CoreException(t('You need to reset your password.', 'You need to reset your password. This is most likely because an administrator recently changed your account information.'));
                 break;
             case 'random':
-                $resetUrl = url('entry/passwordrequest'.(Gdn::request()->get('display') ? '?display='.urlencode(Gdn::request()->get('display')) : ''));
-                throw new Gdn_UserException(sprintf(t('You don\'t have a password.', 'Your account does not have a password assigned to it yet. Click <a href="%s">here</a> to reset your password.'), $resetUrl));
+                throw new Gdn_CoreException(t('You don\'t have a password.', 'Your account does not have a password assigned to it yet.'));
                 break;
             case 'smf':
                 $result = $this->getAlgorithm('Smf')->verify($password, $storedHash);

--- a/library/core/class.passwordhash.php
+++ b/library/core/class.passwordhash.php
@@ -88,7 +88,8 @@ class Gdn_PasswordHash {
                 $result = $this->getAlgorithm('Punbb')->verify($password, $storedHash);
                 break;
             case 'reset':
-                throw new Gdn_CoreException(t('You need to reset your password.', 'You need to reset your password. This is most likely because an administrator recently changed your account information.'));
+                throw new Gdn_CoreException(t('You need to reset your password.', 'You need to reset your password.
+                 This is most likely because an administrator recently changed your account information.'));
                 break;
             case 'random':
                 throw new Gdn_CoreException(t('You don\'t have a password.', 'Your account does not have a password assigned to it yet.'));


### PR DESCRIPTION
closes [#8850](https://github.com/vanilla/vanilla/issues/8850)
### Details

An admin can force reset a user's password from the dashbaord
<img width="457" alt="Screen Shot 2019-05-23 at 2 44 52 PM" src="https://user-images.githubusercontent.com/31856281/58278174-67eaf400-7d69-11e9-8408-c121e2b84644.png">

Next time the user tries to log in, you get
<img width="544" alt="Screen Shot 2019-05-23 at 2 47 49 PM" src="https://user-images.githubusercontent.com/31856281/58278317-c31ce680-7d69-11e9-8c11-9e3046b4a409.png">

"here" is text and not a link.

### Cause

The error message has an html tag
(1*) that gets stripped in (2*).

### Ref.
(1*) [class.passwordhash.php#L92](https://github.com/vanilla/vanilla/blob/978119bdc451284b2cd4785e66319d3292152f7b/library/core/class.passwordhash.php#L92)
(2*) [class.form.php#L2278](https://github.com/vanilla/vanilla/blob/master/library/core/class.form.php#L2278)

### To Test

From the dashboard, edit a user, select "Force user to reset their password and send a notification email"
Login, verify the resetpassword link.

### Changes
I added a new exception class to handle html in the error message at the same time keeping code sanitization in place.
