### PR TITLE
Add TK information to csrf failure event

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -686,12 +686,19 @@ class Gdn_Session {
             $return = ($forceValid && Gdn::request()->isPostBack()) ||
                 (hash_equals($this->_TransientKey, $foreignKey) && !empty($this->_TransientKey));
         }
+        $return = false;
+
+
         if (!$return && $forceValid !== true) {
             if (Gdn::session()->User) {
                 Logger::event(
                     'csrf_failure',
                     Logger::ERROR,
-                    'Invalid transient key for {username}.'
+                    'Invalid transient key for {username}.',
+                    [
+                        "User TK" => $foreignKey,
+                        "Site TK" => $this->_TransientKey,
+                    ]
                 );
             } else {
                 Logger::event(

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -686,8 +686,6 @@ class Gdn_Session {
             $return = ($forceValid && Gdn::request()->isPostBack()) ||
                 (hash_equals($this->_TransientKey, $foreignKey) && !empty($this->_TransientKey));
         }
-        $return = false;
-
 
         if (!$return && $forceValid !== true) {
             if (Gdn::session()->User) {


### PR DESCRIPTION
This adds the users and sites transient key to the the db logger when there is a csrf failure event.


