### PR TITLE
Add cache headers to entry controller and ensure vary header for Gdn_Controller

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -45,7 +45,6 @@ class EntryController extends Gdn_Controller {
         if (Gdn::request()->get('display') === 'popup') {
             $this->MasterView = 'popup';
         }
-        $this->setHeader('Cache-Control', \Vanilla\Web\CacheControlMiddleware::NO_CACHE);
     }
 
     /**

--- a/library/Vanilla/Web/CacheControlMiddleware.php
+++ b/library/Vanilla/Web/CacheControlMiddleware.php
@@ -22,6 +22,9 @@ class CacheControlMiddleware {
     /** @var string Standard Cache-Control header for content that should not be cached. */
     const NO_CACHE = 'private, no-cache, max-age=0, must-revalidate';
 
+    /** @var string Standard vary header when using public cache control based on session. */
+    const VARY_COOKIE = 'Accept-Encoding, Cookie';
+
     /** @var SessionInterface An instance of the current user session. */
     private $session;
 

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -267,6 +267,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         } else {
             $this->_Headers = array_merge($this->_Headers, [
                 'Cache-Control' => \Vanilla\Web\CacheControlMiddleware::PUBLIC_CACHE,
+                'vary' => \Vanilla\Web\CacheControlMiddleware::VARY_COOKIE,
             ]);
         }
 


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8581

After some discussions and testing the `vary` header is required so that the user does not get stuck on a cached page when returning some previously cached page.

I've removed the special case of no caching from the entry controller. It will now return standard cache headers (`no-cache` if the user has a session and `public, max-age 120` if not).