### PR TITLE
Add Analytics Client interface and stub

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -297,6 +297,10 @@ $dic->setInstance('Garden\Container\Container', $dic)
     ->rule(Vanilla\Formatting\FormatService::class)
     ->addCall('registerFormat', [Formats\RichFormat::FORMAT_KEY, Formats\RichFormat::class])
     ->setShared(true)
+
+    ->rule(\Vanilla\Analytics\Client::class)
+    ->setShared(true)
+    ->addAlias(\Vanilla\Contracts\Analytics\ClientInterface::class)
 ;
 
 // Run through the bootstrap with dependencies.

--- a/library/Vanilla/Analytics/ActionConstants.php
+++ b/library/Vanilla/Analytics/ActionConstants.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Analytics;
+
+/**
+ * Action constants for analytics operations.
+ */
+class ActionConstants {
+    public const GET_CONFIG = "@@analytics/GET_CONFIG";
+    public const GET_EVENT_DEFAULTS = "@@analytics/GET_EVENT_DEFAULTS";
+}

--- a/library/Vanilla/Analytics/Client.php
+++ b/library/Vanilla/Analytics/Client.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Analytics;
+
+use Vanilla\Contracts\Analytics\ClientInterface;
+
+/**
+ * Provide basic event tracking as an analytics client.
+ */
+class Client implements ClientInterface {
+    /**
+     * Get configuration details relevant to the analytics service.
+     *
+     * @param bool $includeDangerous Include sensitive values (i.e. read keys) in the config.
+     * @return array
+     */
+    public function config(bool $includeDangerous = false): array {
+        return [];
+    }
+
+    /**
+     * Get an array of default event fields (e.g. user).
+     *
+     * @return array
+     */
+    public function eventDefaults(): array {
+        return [];
+    }
+
+    /**
+     * Record a single event.
+     *
+     * @param array $data
+     */
+    public function recordEvent(array $data) {
+        // To be implemented at a later date.
+    }
+}

--- a/library/Vanilla/Contracts/Analytics/ClientInterface.php
+++ b/library/Vanilla/Contracts/Analytics/ClientInterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Contracts\Analytics;
+
+/**
+ * An interface for an analytics client to track events.
+ */
+interface ClientInterface {
+
+    /**
+     * Get configuration details relevant to the analytics service.
+     *
+     * @param bool $includeDangerous Include sensitive values (i.e. read keys) in the config.
+     * @return array
+     */
+    public function config(bool $includeDangerous = false): array;
+
+    /**
+     * Get an array of default event fields (e.g. user).
+     *
+     * @return array
+     */
+    public function eventDefaults(): array;
+
+    /**
+     * Record a single event.
+     *
+     * @param array $data
+     */
+    public function recordEvent(array $data);
+}


### PR DESCRIPTION
This update adds a couple new things:

1. A standard interface for analytics clients to be used by Vanilla and its addons.
1. A stub class that implements the aforementioned interface.

### Overview
1. Add `Vanilla\Contracts\Analytics\ClientInterface`. This interface defines the shape analytics clients in Vanilla should follow.
1. Add `Vanilla\Analytics\Client`. This class is meant to be a placeholder stub for now. Addons can safely inject this "client" class as a dependency.
1. Add `Vanilla\Analytics\ActionConstants`. This is intended to be a class of constants representing front-end action slugs. These slugs will likely be associated with Redux actions.

No functional changes to Vanilla are included.

Relates to #8559