### PR TITLE
Add explicit rich editor scrolling container class and remove analytics setup in bootstrap

### DIFF
--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -10,8 +10,6 @@ import { log, logError, debug } from "@library/utility/utils";
 import gdn from "@library/gdn";
 import apiv2 from "@library/apiv2";
 import { mountInputs } from "@library/forms/mountInputs";
-import { initPageViewTracking } from "@library/pageViews/pageViewTracking";
-import { createBrowserHistory } from "history";
 
 // Inject the debug flag into the utility.
 const debugValue = getMeta("context.debug", getMeta("debug", false));
@@ -29,8 +27,6 @@ _executeReady()
             _mountComponents(e.target);
             mountInputs();
         });
-
-        initPageViewTracking(createBrowserHistory());
 
         const contentEvent = new CustomEvent("X-DOMContentReady", { bubbles: true, cancelable: false });
         document.dispatchEvent(contentEvent);

--- a/library/src/scripts/pageViews/pageViewTracking.ts
+++ b/library/src/scripts/pageViews/pageViewTracking.ts
@@ -22,7 +22,6 @@ export function onPageView(handler: PageViewHandler) {
  */
 export function initPageViewTracking(history: History) {
     const callHandlers = () => {
-        console.log("page view");
         handlers.forEach(handler => handler({ history }));
     };
 

--- a/library/src/scripts/pageViews/pageViewTracking.ts
+++ b/library/src/scripts/pageViews/pageViewTracking.ts
@@ -22,6 +22,7 @@ export function onPageView(handler: PageViewHandler) {
  */
 export function initPageViewTracking(history: History) {
     const callHandlers = () => {
+        console.log("page view");
         handlers.forEach(handler => handler({ history }));
     };
 

--- a/plugins/rich-editor/src/scripts/editor/ForumEditor.tsx
+++ b/plugins/rich-editor/src/scripts/editor/ForumEditor.tsx
@@ -12,9 +12,10 @@ import { EditorParagraphMenu } from "@rich-editor/editor/EditorParagraphMenu";
 import { EditorEmbedBar } from "@rich-editor/editor/EditorEmbedBar";
 import { richEditorClasses } from "@rich-editor/editor/richEditorClasses";
 import classNames from "classnames";
-import React from "react";
+import React, { useEffect } from "react";
 import { Provider } from "react-redux";
 import { DeviceProvider } from "@library/layout/DeviceContext";
+import { EDITOR_SCROLL_CONTAINER_CLASS } from "@rich-editor/quill/ClipboardModule";
 
 interface IProps {
     legacyTextArea: HTMLInputElement;
@@ -28,6 +29,13 @@ interface IProps {
 export function ForumEditor(props: IProps) {
     const store = getStore();
     const classes = richEditorClasses(true);
+    useEffect(() => {
+        document.body.classList.add(EDITOR_SCROLL_CONTAINER_CLASS);
+        return () => {
+            document.body.classList.remove(EDITOR_SCROLL_CONTAINER_CLASS);
+        };
+    }, []);
+
     return (
         <Provider store={store}>
             <DeviceProvider>

--- a/plugins/rich-editor/src/scripts/quill/ClipboardModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/ClipboardModule.ts
@@ -7,11 +7,12 @@
 import ClipboardBase from "quill/modules/clipboard";
 import Delta from "quill-delta";
 import Quill, { DeltaStatic } from "quill/core";
-import { rangeContainsBlot, getIDForQuill } from "@rich-editor/quill/utility";
+import { rangeContainsBlot } from "@rich-editor/quill/utility";
 import CodeBlockBlot from "@rich-editor/quill/blots/blocks/CodeBlockBlot";
 import CodeBlot from "@rich-editor/quill/blots/inline/CodeBlot";
-import { IStoreState } from "@rich-editor/@types/store";
 import ExternalEmbedBlot, { IEmbedValue } from "@rich-editor/quill/blots/embeds/ExternalEmbedBlot";
+
+export const EDITOR_SCROLL_CONTAINER_CLASS = "js-richEditorScrollContainer";
 
 export default class ClipboardModule extends ClipboardBase {
     /**
@@ -67,7 +68,7 @@ export default class ClipboardModule extends ClipboardBase {
             return;
         }
         const range = this.quill.getSelection();
-        const container = this.options.scrollingContainer;
+        const container = this.quill.root.closest(`.${EDITOR_SCROLL_CONTAINER_CLASS}`);
 
         // Get our scroll positions
         const scrollTop = document.documentElement!.scrollTop || document.body.scrollTop;


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/pull/1031

Looks like https://github.com/vanilla/vanilla/issues/7567 is happening on KB right now.

I'm adding an explicit class so we can manage these differently between KB and forum.

## Page View Event Setup

This has been moved out of bootstrap. It's not quite the right place for it.