### PR TITLE
Remove redundant missing category error

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1963,9 +1963,7 @@ class DiscussionModel extends Gdn_Model {
         if ($categoryID !== false) {
             $checkPermission = val('CheckPermission', $settings, true);
             $category = CategoryModel::categories($categoryID);
-            if (!$category) {
-                $this->Validation->addValidationResult('CategoryID', "@Category {$categoryID} does not exist.");
-            } elseif ($checkPermission && !CategoryModel::checkPermission($category, 'Vanilla.Discussions.Add')) {
+           if ($category && $checkPermission && !CategoryModel::checkPermission($category, 'Vanilla.Discussions.Add')) {
                 $this->Validation->addValidationResult('CategoryID', 'You do not have permission to post in this category');
             }
         }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1963,7 +1963,7 @@ class DiscussionModel extends Gdn_Model {
         if ($categoryID !== false) {
             $checkPermission = val('CheckPermission', $settings, true);
             $category = CategoryModel::categories($categoryID);
-           if ($category && $checkPermission && !CategoryModel::checkPermission($category, 'Vanilla.Discussions.Add')) {
+            if ($category && $checkPermission && !CategoryModel::checkPermission($category, 'Vanilla.Discussions.Add')) {
                 $this->Validation->addValidationResult('CategoryID', 'You do not have permission to post in this category');
             }
         }


### PR DESCRIPTION
closes [#421](https://github.com/vanilla/support/issues/421)

### Details

When creating a discussion without selecting a category, we are getting a redundant missing category error.

![Screen Shot 2019-05-31 at 2 20 55 PM](https://user-images.githubusercontent.com/31856281/58726282-54660b80-83af-11e9-9121-e6d368409d40.png)

### Reason 

(1*)[class.discussionmodel.php#L1967](https://github.com/vanilla/vanilla/blob/eb9b742d4234d0254db1107333470f6c7cec6955/applications/vanilla/models/class.discussionmodel.php#L1967) (adds "Category does not exist")
& 
(2*)[class.discussionmodel.php#L2052](https://github.com/vanilla/vanilla/blob/eb9b742d4234d0254db1107333470f6c7cec6955/applications/vanilla/models/class.discussionmodel.php#L2052) (adds "Category is required")
