### PR TITLE
Fix forum post editing not working with Rich Editor

### DIFF
--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -194,7 +194,7 @@ function useLegacyTextAreaSync(textArea?: HTMLInputElement) {
         if (initialValue) {
             resetQuillContent(quill, JSON.parse(initialValue));
         }
-    }, [textArea]);
+    }, [legacyMode, textArea, quill]);
 
     useEffect(() => {
         if (!legacyMode || !textArea || !quill) {
@@ -220,7 +220,7 @@ function useLegacyTextAreaSync(textArea?: HTMLInputElement) {
             quill.off(Quill.events.TEXT_CHANGE, handleChange);
             form && form.removeEventListener("X-ClearCommentForm", handleFormClear);
         };
-    });
+    }, [legacyMode, textArea, quill]);
 }
 
 /**


### PR DESCRIPTION
Needs backport to `release/3.0` (so we can actually get the release out).

Issue https://github.com/vanilla/vanilla/issues/8889

I'm not closing the issue because tests will come as a followup. This is just to unblock the release.

The issue ended up being some missing dependencies in the `useEffect` calls. There is an ESLint rule that can automatically detect this kind of thing, and I've detailed it as part of this issue https://github.com/vanilla/vanilla/issues/8719.

It's called [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks) is part of the official react monorepo, and would have caught this bug. Some integration tests around the `legacyMode` for rich editor would have caught this as well though, so I intend to add some this sprint.