### PR TITLE
Fix editor content queue infinite loop

### DIFF
--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -159,7 +159,7 @@ function useInitialValue() {
 function useOperationsQueue() {
     const { operationsQueue, quill, clearOperationsQueue } = useEditor();
     useEffect(() => {
-        if (!operationsQueue || !quill) {
+        if (!operationsQueue || !quill || operationsQueue.length === 0) {
             return;
         }
         operationsQueue.forEach(operation => {
@@ -172,10 +172,10 @@ function useOperationsQueue() {
                 quill.updateContents([offsetOperations, ...operation]);
             }
         });
-        if (clearOperationsQueue) {
-            clearOperationsQueue();
-        }
-    }, [operationsQueue, clearOperationsQueue]);
+        return () => {
+            clearOperationsQueue && clearOperationsQueue();
+        };
+    }, [quill, operationsQueue, clearOperationsQueue]);
 }
 
 /**


### PR DESCRIPTION
There's no issue for this, I just came across it.

There was a slow running infinite loop in EditorContent. You could see this by throwing a console.log() in the render.

It would render approximately 60 times a second due this effect constantly clearing the operations.

Essentially:

1. Check `!operationsQueue` for bailout.
2. `operationsQueue` is `[]` so no bailout.
3. No operations to run.
4. Clear queue.
5. Causes re-render. Go back to step 1

I fixed this by

- Accepting an empty array as a bailout condition for this hook.
- Returning the cleanup method for scheduling with react, instead of running it synchronously.