### PR TITLE
Rollback garden-http to v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/yaml": "^3.2",
         "tburry/pquery": "~1.1",
         "vanilla/garden-container": "^1.3.4",
-        "vanilla/garden-http": "~2.0",
+        "vanilla/garden-http": "~1.0",
         "vanilla/garden-schema": "~1.0",
         "vanilla/garden-password": "~1.0",
         "vanilla/htmlawed": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "995b24b115286e6935abdf0fa4d244ef",
+    "content-hash": "276632fa2d34259857e6e4314b6f044e",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -774,21 +774,21 @@
         },
         {
             "name": "vanilla/garden-http",
-            "version": "v2.0.1",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vanilla/garden-http.git",
-                "reference": "d5d206ce0c197c5af214da6ab594bf8dc8888a8e"
+                "reference": "020b7b117ef99decef062be0978fb8d292c3e06c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vanilla/garden-http/zipball/d5d206ce0c197c5af214da6ab594bf8dc8888a8e",
-                "reference": "d5d206ce0c197c5af214da6ab594bf8dc8888a8e",
+                "url": "https://api.github.com/repos/vanilla/garden-http/zipball/020b7b117ef99decef062be0978fb8d292c3e06c",
+                "reference": "020b7b117ef99decef062be0978fb8d292c3e06c",
                 "shasum": ""
             },
             "require": {
                 "lib-curl": "*",
-                "php": ">=7.0.0"
+                "php": ">=5.4.0"
             },
             "require-dev": {
                 "vanilla/garden": "dev-master"
@@ -810,7 +810,7 @@
                 }
             ],
             "description": "An unbloated HTTP client library for building RESTful API clients.",
-            "time": "2018-06-08T18:45:31+00:00"
+            "time": "2019-06-03T21:18:24+00:00"
         },
         {
             "name": "vanilla/garden-password",

--- a/library/Vanilla/PageScraper.php
+++ b/library/Vanilla/PageScraper.php
@@ -89,7 +89,7 @@ class PageScraper {
      * @param string $url The URL where the request will be sent.
      * @return HttpResponse
      */
-    private function getUrl(string $url): HttpResponse {
+    protected function getUrl(string $url): HttpResponse {
         $urlParts = parse_url($url);
         if ($urlParts === false) {
             throw new InvalidArgumentException('Invalid URL.');

--- a/tests/Library/Vanilla/PageScraperTest.php
+++ b/tests/Library/Vanilla/PageScraperTest.php
@@ -26,6 +26,7 @@ class PageScraperTest extends SharedBootstrapTestCase {
     private function pageScraper() {
         // Create the test instance. Register the metadata handlers.
         $pageScraper = new PageScraper(new HttpRequest());
+        $pageScraper->setHtmlDir(self::HTML_DIR);
         $pageScraper->registerMetadataParser(new OpenGraphParser());
         $pageScraper->registerMetadataParser(new JsonLDParser());
         return $pageScraper;
@@ -97,9 +98,8 @@ class PageScraperTest extends SharedBootstrapTestCase {
      */
     public function testFetch(string $file, array $expected) {
         $pageScraper = $this->pageScraper();
-        $url = 'file://'.self::HTML_DIR."/{$file}";
-        $result = $pageScraper->pageInfo($url);
-        $expected['Url'] = $url;
+        $result = $pageScraper->pageInfo($file);
+        $expected["Url"] = $file;
         $this->assertEquals($expected, $result);
     }
 
@@ -112,11 +112,8 @@ class PageScraperTest extends SharedBootstrapTestCase {
      */
     protected function scrapeFile(string $file) {
         $scraper = $this->pageScraper();
-        $url = 'file://'.self::HTML_DIR."/{$file}";
-        $result = $scraper->pageInfo($url);
-
+        $result = $scraper->pageInfo($file);
         return $result;
-
     }
 
     /**

--- a/tests/fixtures/src/PageScraper.php
+++ b/tests/fixtures/src/PageScraper.php
@@ -6,10 +6,68 @@
 
 namespace VanillaTests\Fixtures;
 
+use Garden\Http\HttpResponse;
+
 /**
  * A PageScraper class, limited to local files.
  */
 class PageScraper extends \Vanilla\PageScraper {
-    /** @inheritDoc */
-    protected $validSchemes = ['file'];
+
+    /** @var string */
+    private $htmlDir;
+
+    /**
+     * Get the configured HTML directory.
+     */
+    public function getHtmlDir(): ?string {
+        return $this->htmlDir;
+    }
+
+    /**
+     * Load a file from the file system as a successful HTTP response.
+     *
+     * @param string $relativePath Path to the file, relative to the configured HTML directory.
+     * @return HttpResponse
+     */
+    protected function getUrl(string $relativePath): HttpResponse {
+        if ($this->htmlDir === null) {
+            throw new \RuntimeException("HTML directory has not been configured.");
+        }
+
+        $fullPath = realpath("{$this->htmlDir}/{$relativePath}");
+        if ($fullPath === false) {
+            throw new \InvalidArgumentException("File does not exist.");
+        }
+
+        if (pathinfo($fullPath, PATHINFO_DIRNAME) !== $this->htmlDir) {
+            throw new \RuntimeException("File is not in the HTML directory.");
+        }
+
+        if (is_readable($fullPath) === false) {
+            throw new \RuntimeException("Unable to read the file.");
+        }
+
+        $content = file_get_contents($fullPath);
+        $result = new HttpResponse(200, "", $content);
+        return $result;
+    }
+
+    /**
+     * Set the HTML file directory.
+     *
+     * @param string $dir
+     * @return self
+     */
+    public function setHtmlDir(string $dir): self {
+        $dir = rtrim($dir, "\\/");
+        if (file_exists($dir) === false) {
+            throw new \InvalidArgumentException("Directory does not exist.");
+        }
+        if (is_dir($dir) === false) {
+            throw new \InvalidArgumentException("Filename is not a directory.");
+        }
+
+        $this->htmlDir = $dir;
+        return $this;
+    }
 }


### PR DESCRIPTION
#8893 introduced the latest version of [vanilla/garden-http](https://github.com/vanilla/garden-http). Unfortunately, this version contained some breaking changes. Namely, stricter typing was introduced into classes Vanilla would be extending (e.g. `HttpClient`, `HttpRequest`). These extended classes in Vanilla also implement interfaces (e.g. `RequestInterface`) that no longer align with garden-http v2. These classes and interfaces will need to be refactored before garden-http v2 can be used in core Vanilla.

The garden-http version is being rolled back to its latest v1 release.

`PageScraperTest` had to be updated to avoid using garden-http, because of recent protocol restrictions in the library. The fixture used by `PageScraperTest` now reads file contents from the disk and serves them up as a `Garden\Web\HttpResponse` object.