### PR TITLE
Fix comment post editing in the forum

### DIFF
--- a/library/src/scripts/dom/domUtils.test.ts
+++ b/library/src/scripts/dom/domUtils.test.ts
@@ -55,13 +55,17 @@ describe("delegateEvent()", () => {
 
     it("identical events will not be registered twice", () => {
         const callback = sinon.spy();
-        delegateEvent("click", "", callback);
-        delegateEvent("click", "", callback);
-        delegateEvent("click", "", callback);
+        const hash1 = delegateEvent("click", "", callback);
+        const hash2 = delegateEvent("click", "", callback);
+        const hash3 = delegateEvent("click", "", callback);
 
         const button = document.querySelector(".filterSelector") as HTMLElement;
         button.click();
         sinon.assert.calledOnce(callback);
+
+        // Hashes should all be for the same handler.
+        expect(hash1).eq(hash2);
+        expect(hash2).eq(hash3);
     });
 
     describe("delegation filtering works()", () => {

--- a/library/src/scripts/dom/domUtils.tsx
+++ b/library/src/scripts/dom/domUtils.tsx
@@ -152,8 +152,9 @@ export function delegateEvent(
             eventName,
             wrappedCallback,
         };
-        return eventHash;
     }
+
+    return eventHash;
 }
 
 /**


### PR DESCRIPTION
This needs to make it to the 3.0 branch.

Works towards https://github.com/vanilla/vanilla/issues/8889

This PR fixes the comment editing specifically.

https://github.com/vanilla/vanilla/pull/8890 fixes the discussion editing.

## The fix

Our `delegateEvent` function checks if there is a hash of an event already. If there is, it will not set the listener (just re-use the same one). This method is supposed to return a hash which can be used to clear the delegated event, but in cases where the event was already set we were not removing the hash. This would cause a crash when `removeDelatedEvent()` would be called with `undefined`.

I fixed the method and updated a test to cover this case.