### PR TITLE
Tweak the locale settings help text

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1244,7 +1244,7 @@ class SettingsController extends DashboardController {
         $this->permission('Garden.Settings.Manage');
 
         $this->title(t('Locales'));
-        $this->setHighlightRoute('dashboard/settings/locales');
+        $this->setHighlightRoute('/settings/locales');
         $this->addJsFile('addons.js');
 
         $LocaleModel = new LocaleModel();

--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -162,7 +162,8 @@ $Definition['Check out the new community forum I\'ve just set up.'] = 'Hi Pal!
 
 Check out the new community forum I\'ve just set up. It\'s a great place for us to chat with each other online.';
 $Definition['Large images will be scaled down.'] = 'Large images will be scaled down to a max width of %spx and a max height of %spx.';
-$Definition['Locales allow you to support other languages on your site.'] = 'Locales allow you to support other languages on your site. Enable and disable locales you want to make available here.';
+$Definition['Locales allow you to support other languages on your site.'] =
+    'Locales allow you to support other languages on your site. Enable and disable locales you want to make available here.';
 $Definition['Test Email Message'] = '<p>This is a test email message.</p>'.
     '<p>You can configure the appearance of your forum\'s emails by navigating to the Email page in the dashboard.</p>';
 $Definition['oauth2Instructions'] = '<p>Configure your forum to connect with an OAuth2 application by putting your unique Client ID, Client Secret, and required endpoints. You will probably need to provide your SSO application with an allowed callback URL, in part, to validate requests. The callback url for this forum is <code>%s</code></p>';

--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -162,6 +162,7 @@ $Definition['Check out the new community forum I\'ve just set up.'] = 'Hi Pal!
 
 Check out the new community forum I\'ve just set up. It\'s a great place for us to chat with each other online.';
 $Definition['Large images will be scaled down.'] = 'Large images will be scaled down to a max width of %spx and a max height of %spx.';
+$Definition['Locales allow you to support other languages on your site.'] = 'Locales allow you to support other languages on your site. Enable and disable locales you want to make available here.';
 $Definition['Test Email Message'] = '<p>This is a test email message.</p>'.
     '<p>You can configure the appearance of your forum\'s emails by navigating to the Email page in the dashboard.</p>';
 $Definition['oauth2Instructions'] = '<p>Configure your forum to connect with an OAuth2 application by putting your unique Client ID, Client Secret, and required endpoints. You will probably need to provide your SSO application with an allowed callback URL, in part, to validate requests. The callback url for this forum is <code>%s</code></p>';

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -351,7 +351,7 @@ class DashboardHooks extends Gdn_Plugin {
             ->addLinkIf('Garden.Settings.Manage', t('Applications'), '/dashboard/settings/applications', 'add-ons.applications', '', $sort)
 
             ->addGroup(t('Technical'), 'site-settings', '', ['after' => 'reputation'])
-            ->addLinkIf('Garden.Settings.Manage', t('Locales'), '/dashboard/settings/locales', 'site-settings.locales', '', $sort)
+            ->addLinkIf('Garden.Settings.Manage', t('Locales'), '/settings/locales', 'site-settings.locales', '', $sort)
             ->addLinkIf('Garden.Settings.Manage', t('Outgoing Email'), '/dashboard/settings/email', 'site-settings.email', '', $sort)
             ->addLinkIf('Garden.Settings.Manage', t('Security'), '/dashboard/settings/security', 'site-settings.security', '', $sort)
             ->addLinkIf('Garden.Settings.Manage', t('Routes'), '/dashboard/routes', 'site-settings.routes', '', $sort)

--- a/applications/dashboard/views/settings/plugins.php
+++ b/applications/dashboard/views/settings/plugins.php
@@ -18,7 +18,7 @@ if ($addonType === 'applications') {
     $title = '';
     $helpTitle = sprintf(t('About %s'), t('Locales'));
     $pathHelp = sprintf(
-        t('LocaleHelp', 'Locales allow you to support other languages on your site. Once a locale has been added to your %s folder, you can enable or disable it here.'),
+        t('Locales allow you to support other languages on your site.'),
         '<code>'.PATH_ROOT.'/locales</code>'
     );
     $getMore = wrap(anchor(t('Get More Locales').' <span class="icon icon-external-link"></span>', $addonUrl), 'li');

--- a/applications/dashboard/views/settings/plugins.php
+++ b/applications/dashboard/views/settings/plugins.php
@@ -17,10 +17,7 @@ if ($addonType === 'applications') {
 } elseif ($addonType === 'locales') {
     $title = '';
     $helpTitle = sprintf(t('About %s'), t('Locales'));
-    $pathHelp = sprintf(
-        t('Locales allow you to support other languages on your site.'),
-        '<code>'.PATH_ROOT.'/locales</code>'
-    );
+    $pathHelp = t('Locales allow you to support other languages on your site.');
     $getMore = wrap(anchor(t('Get More Locales').' <span class="icon icon-external-link"></span>', $addonUrl), 'li');
     $availableAddons = $this->data('AvailableLocales');
     $enabledAddons = $this->data('EnabledLocales');


### PR DESCRIPTION
While reviewing some locale strings I noticed two very similar strings. On top of that neither of them were used in the app, but rather a third string that we don’t currently translate.

This PR changes the string to one in our locales repo with a translation.