### PR TITLE
Fix some case sensitivity issues with emoji extender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@
 !/plugins/ButtonBar/
 !/plugins/Debugger/
 !/plugins/editor/
-!/plugins/EmojiExtender/
+!/plugins/emojiextender/
 !/plugins/Facebook/
 !/plugins/Flagging/
 !/plugins/GettingStarted/

--- a/plugins/emojiextender/EmojiExtenderPlugin.php
+++ b/plugins/emojiextender/EmojiExtenderPlugin.php
@@ -116,7 +116,7 @@ class EmojiExtenderPlugin extends Gdn_Plugin {
      */
     public function getEmojiSets() {
         if (!isset($this->emojiSets)) {
-            $root = '/plugins/EmojiExtender/emoji';
+            $root = '/plugins/emojiextender/emoji';
 
             $this->addEmojiSet(
                 '',

--- a/plugins/emojiextender/addon.json
+++ b/plugins/emojiextender/addon.json
@@ -4,7 +4,7 @@
     "version": "1.1",
     "license": "GNU GPL2",
     "icon": "emoji_set.png",
-    "settingsUrl": "/settings/EmojiExtender",
+    "settingsUrl": "/settings/emojiextender",
     "mobileFriendly": true,
     "key": "emojiextender",
     "type": "addon",


### PR DESCRIPTION
Backport will need to target `release/3.0` and `release/2019.007`.

Fixes https://github.com/vanilla/support/issues/456