### PR TITLE
Update garden-http to version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/yaml": "^3.2",
         "tburry/pquery": "~1.1",
         "vanilla/garden-container": "^1.3.4",
-        "vanilla/garden-http": "~1.0",
+        "vanilla/garden-http": "~2.0",
         "vanilla/garden-schema": "~1.0",
         "vanilla/garden-password": "~1.0",
         "vanilla/htmlawed": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "276632fa2d34259857e6e4314b6f044e",
+    "content-hash": "995b24b115286e6935abdf0fa4d244ef",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -670,16 +670,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v2.11.0",
+            "version": "v2.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "c344879ae57dc1487b1df3e3d8325936125ba2cc"
+                "reference": "84a463403da1c81afbcedda8f0e788c78bd25a79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/c344879ae57dc1487b1df3e3d8325936125ba2cc",
-                "reference": "c344879ae57dc1487b1df3e3d8325936125ba2cc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/84a463403da1c81afbcedda8f0e788c78bd25a79",
+                "reference": "84a463403da1c81afbcedda8f0e788c78bd25a79",
                 "shasum": ""
             },
             "require": {
@@ -690,7 +690,7 @@
             "require-dev": {
                 "psr/container": "^1.0",
                 "symfony/debug": "^2.7",
-                "symfony/phpunit-bridge": "^3.4.19|^4.1.8"
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8|^5.0"
             },
             "type": "library",
             "extra": {
@@ -733,7 +733,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2019-05-31T06:21:42+00:00"
+            "time": "2019-06-05T11:17:07+00:00"
         },
         {
             "name": "vanilla/garden-container",
@@ -774,21 +774,21 @@
         },
         {
             "name": "vanilla/garden-http",
-            "version": "v1.1.4",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vanilla/garden-http.git",
-                "reference": "020b7b117ef99decef062be0978fb8d292c3e06c"
+                "reference": "d5d206ce0c197c5af214da6ab594bf8dc8888a8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vanilla/garden-http/zipball/020b7b117ef99decef062be0978fb8d292c3e06c",
-                "reference": "020b7b117ef99decef062be0978fb8d292c3e06c",
+                "url": "https://api.github.com/repos/vanilla/garden-http/zipball/d5d206ce0c197c5af214da6ab594bf8dc8888a8e",
+                "reference": "d5d206ce0c197c5af214da6ab594bf8dc8888a8e",
                 "shasum": ""
             },
             "require": {
                 "lib-curl": "*",
-                "php": ">=5.4.0"
+                "php": ">=7.0.0"
             },
             "require-dev": {
                 "vanilla/garden": "dev-master"
@@ -810,7 +810,7 @@
                 }
             ],
             "description": "An unbloated HTTP client library for building RESTful API clients.",
-            "time": "2019-06-03T21:18:24+00:00"
+            "time": "2018-06-08T18:45:31+00:00"
         },
         {
             "name": "vanilla/garden-password",

--- a/library/Garden/Web/RequestInterface.php
+++ b/library/Garden/Web/RequestInterface.php
@@ -39,7 +39,7 @@ interface RequestInterface {
      * @param string $method The HTTP method.
      * @return $this
      */
-    public function setMethod($method);
+    public function setMethod(string $method);
 
     /**
      * Get the root folder of the request.

--- a/library/Garden/Web/RequestInterface.php
+++ b/library/Garden/Web/RequestInterface.php
@@ -153,7 +153,7 @@ interface RequestInterface {
      * @param mixed $value The new value.
      * @return $this
      */
-    public function setHeader($header, $value);
+    public function setHeader(string $header, $value);
 
     /**
      * Checks if a header exists by the given case-insensitive name.

--- a/library/Garden/Web/RequestInterface.php
+++ b/library/Garden/Web/RequestInterface.php
@@ -144,7 +144,7 @@ interface RequestInterface {
      * @param string $header The name of the header.
      * @return string Returns the header value or an empty string.
      */
-    public function getHeader($header);
+    public function getHeader(string $header);
 
     /**
      * Set a header value.

--- a/library/Garden/Web/RequestInterface.php
+++ b/library/Garden/Web/RequestInterface.php
@@ -161,7 +161,7 @@ interface RequestInterface {
      * @param string $header Case-insensitive header name.
      * @return bool Returns **true** if the header exists or **false** otherwise.
      */
-    public function hasHeader($header);
+    public function hasHeader(string $header): bool;
 
     /**
      * Conditionally gets the domain of the request.

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -418,7 +418,7 @@ class Gdn_Request implements RequestInterface {
     /**
      * {@inheritdoc}
      */
-    public function hasHeader($header) {
+    public function hasHeader(string $header): bool {
         return !empty($this->getHeader($header));
     }
 

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -379,7 +379,7 @@ class Gdn_Request implements RequestInterface {
     /**
      * {@inheritdoc}
      */
-    public function setHeader($header, $value) {
+    public function setHeader(string $header, $value) {
         $this->setValueOn(self::INPUT_SERVER, $this->headerKey($header), $value);
         return $this;
     }

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -480,7 +480,7 @@ class Gdn_Request implements RequestInterface {
      * @param string $method The new HTTP method.
      * @return $this
      */
-    public function setMethod($method) {
+    public function setMethod(string $method) {
         $this->requestMethod($method);
         return $this;
     }

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -372,7 +372,7 @@ class Gdn_Request implements RequestInterface {
     /**
      * {@inheritdoc}
      */
-    public function getHeader($header) {
+    public function getHeader(string $header) {
         return $this->getValueFrom(self::INPUT_SERVER, $this->headerKey($header), '');
     }
 

--- a/tests/InternalRequest.php
+++ b/tests/InternalRequest.php
@@ -76,7 +76,7 @@ class InternalRequest extends HttpRequest implements RequestInterface {
     /**
      * {@inheritdoc}
      */
-    public function send() {
+    public function send(): HttpResponse {
         $this->container->setInstance(\Gdn_Request::class, $this->convertToLegacyRequest());
 
         $cookieStash = $_COOKIE;

--- a/tests/fixtures/src/Request.php
+++ b/tests/fixtures/src/Request.php
@@ -85,7 +85,7 @@ class Request implements RequestInterface {
      * @param string $method The HTTP method.
      * @return $this
      */
-    public function setMethod($method) {
+    public function setMethod(string $method) {
         $this->method = $method;
         return $this;
     }
@@ -216,7 +216,7 @@ class Request implements RequestInterface {
      * @param mixed $default The default value if the header does not exist.
      * @return mixed Returns the header value or {@link $default}.
      */
-    public function getHeader($header, $default = null) {
+    public function getHeader(string $header, $default = null) {
         return isset($this->headers[$header]) ? $this->headers[$header] : $default;
     }
 

--- a/tests/fixtures/src/Request.php
+++ b/tests/fixtures/src/Request.php
@@ -204,7 +204,7 @@ class Request implements RequestInterface {
      * @param mixed $value The value of the header.
      * @return $this
      */
-    public function setHeader($header, $value) {
+    public function setHeader(string $header, $value) {
         $this->headers[$header] = $value;
         return $this;
     }

--- a/tests/fixtures/src/Request.php
+++ b/tests/fixtures/src/Request.php
@@ -233,7 +233,7 @@ class Request implements RequestInterface {
      * @param string $header Case-insensitive header name.
      * @return bool Returns **true** if the header exists or **false** otherwise.
      */
-    public function hasHeader($header) {
+    public function hasHeader(string $header): bool {
         return !empty($this->headers[$header]);
     }
 


### PR DESCRIPTION
Our Garden HTTP version was out of date. I've brought it up to the latest version.

There was a slight change in the `HttpRequest` class provided by garden http that required minor updates to some strengthen tighten up some types.