### PR TITLE
Add call to tick API v2 endpoint when tracking a page view

### DIFF
--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -10,6 +10,8 @@ import { log, logError, debug } from "@library/utility/utils";
 import gdn from "@library/gdn";
 import apiv2 from "@library/apiv2";
 import { mountInputs } from "@library/forms/mountInputs";
+import { onPageView } from "./pageViews/pageViewTracking";
+import { History } from "history";
 
 // Inject the debug flag into the utility.
 const debugValue = getMeta("context.debug", getMeta("debug", false));
@@ -17,6 +19,13 @@ debug(debugValue);
 
 // Export the API to the global object.
 gdn.apiv2 = apiv2;
+
+// Record the page view.
+onPageView((params: { history: History }) => {
+    void apiv2.post("/tick").then(() => {
+        window.dispatchEvent(new Event("analyticsTick"));
+    });
+});
 
 log("Bootstrapping");
 _executeReady()

--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -23,7 +23,7 @@ gdn.apiv2 = apiv2;
 // Record the page view.
 onPageView((params: { history: History }) => {
     void apiv2.post("/tick").then(() => {
-        window.dispatchEvent(new Event("analyticsTick"));
+        window.dispatchEvent(new CustomEvent("analyticsTick"));
     });
 });
 

--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -10,7 +10,7 @@ import { log, logError, debug } from "@library/utility/utils";
 import gdn from "@library/gdn";
 import apiv2 from "@library/apiv2";
 import { mountInputs } from "@library/forms/mountInputs";
-import { onPageView } from "./pageViews/pageViewTracking";
+import { onPageView } from "@library/pageViews/pageViewTracking";
 import { History } from "history";
 
 // Inject the debug flag into the utility.


### PR DESCRIPTION
Client-side page view events will now use the `onPageView` function to make a request to the tick API v2 resource on every page load. Successful completion of this request will also dispatch a custom "analyticsTick" event, which is a native implementation of [the existing jQuery event triggered in global.js](https://github.com/vanilla/vanilla/blob/56624c7f454d5f6879c43b90e629bd61ff8e761e/js/global.js#L847).