### PR TITLE
Fix password reset redirect (Backport)

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1898,7 +1898,7 @@ class EntryController extends Gdn_Controller {
                         '{username} has reset their password.'
                     );
                     Gdn::session()->start($user->UserID, true);
-                    redirectTo('/');
+                    $this->setRedirectTo('/', false);
                 }
             }
 


### PR DESCRIPTION
After resetting your password the site should redirect to the homepage. This stopped working after the form moved to AJAX.