### PR TITLE
Modify core code to support the Terms of User Manager plugin.

### DIFF
--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -131,13 +131,21 @@ if (!$hasUserID) {
                 <?php endif; ?>
 
                 <?php $this->fireEvent('RegisterBeforePassword'); ?>
-                <li id="ConnectPassword">
-                    <?php
+
+                <?php
+                /**
+                 *  HidePassword can be passed by any plugin that hooks into
+                 *  the EntryController that has rules that require this form to be
+                 *  shown but not the Password Field.
+                 */
+                if (!$this->data('HidePassword')) {
+                    echo '<li id="ConnectPassword">';
                     echo $this->Form->label('Password', 'ConnectPassword');
                     echo wrap($PasswordMessage, 'div', ['class' => 'FinePrint']);
                     echo $this->Form->input('ConnectPassword', 'password');
-                    ?>
-                </li>
+                    echo '</li>';
+                }
+                ?>
             </ul>
 
             <?php

--- a/applications/dashboard/views/entry/signin.php
+++ b/applications/dashboard/views/entry/signin.php
@@ -56,6 +56,7 @@ echo '</div>';
 ?>
     <div class="Buttons">
         <?php
+        $this->fireEvent('AfterPassword');
         echo $this->Form->button('Sign In', ['class' => 'Button Primary']);
         echo $this->Form->checkBox('RememberMe', t('Keep me signed in'), ['value' => '1', 'id' => 'SignInRememberMe']);
         ?>


### PR DESCRIPTION
 - Add a hook into the sign in form to support the TermsManager.
 - Add the ability to hide the password field.

The Terms Manager is an internal plugin that allows Admins to control when users agree to the terms of use, including when users connect over SSO.