### PR TITLE
Allow the Travis CI API to also trigger full builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
     - name: PHP 7.1
       language: php
       php: 7.1
-      if: type = cron
+      if: type = cron OR type = api
       addons:
         apt:
           packages:


### PR DESCRIPTION
If we have an issue only on the cron build it would be nice to be able to trigger that build in order to test rather than wait a day for the cron to run.