### PR TITLE
Update the security wording for easier translation

### DIFF
--- a/applications/dashboard/views/settings/security.php
+++ b/applications/dashboard/views/settings/security.php
@@ -29,7 +29,7 @@ echo $form->errors();
                     );
                     ?>
                     </p>
-                    <p><strong><?php echo t('Note'); ?>:</strong> <?php echo t('Specify one domain per line. Use * for wildcard matches.'); ?></p>
+                    <p><?php echo t('Specify one domain per line. Use * for wildcard matches.'); ?></p>
                 </div>
             </div>
             <div class="input-wrap">
@@ -46,8 +46,7 @@ echo $form->errors();
             <div class="label-wrap">
                 <?php echo $form->label('Max-age', 'Garden.Security.Hsts.MaxAge'); ?>
                 <div class="info">
-                    <p><strong><?php echo t('Note'); ?>:</strong>
-                        <?php echo t(
+                    <p><?php echo t(
                             'We recommend starting with a max age of 1 week'
                                     . ' and then increasing it to 1 month then 1 year once you see your site works as expected.'
                         ); ?>
@@ -78,7 +77,7 @@ echo $form->errors();
                         );
                         ?>
                     </p>
-                    <p><?php echo t('Note: Only enable this feature if you are sure that all of your subdomains are configured for HTTPS with valid certificates.'); ?></p>
+                    <p><?php echo t('Warning: Only enable this feature if you are sure that all of your subdomains are configured for HTTPS with valid certificates.'); ?></p>
                 </div>
             </div>
             <div class="input-wrap-right">


### PR DESCRIPTION
It does look nicer to have HTML in our descriptions, but it makes translation more difficult. In addition, concatenating strings means that some languages may not work properly.

This change simplifies the text so that translations can be more easily maintained.