### PR TITLE
Remove "only" test flag from editor test

### DIFF
--- a/plugins/rich-editor/src/scripts/editor/EditorContent.test.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.test.tsx
@@ -18,7 +18,7 @@ describe("EditorContent", () => {
             expect(quill.getContents().ops).deep.eq(initialValue);
         });
 
-        it.only("can sync updates from quill to the textarea", async () => {
+        it("can sync updates from quill to the textarea", async () => {
             const { quill, textarea } = await setupLegacyEditor([]);
             const valueToSet = [OpUtils.op("Test Header"), OpUtils.heading(2)];
             quill.setContents(valueToSet, Quill.sources.USER);

--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -172,9 +172,7 @@ function useOperationsQueue() {
                 quill.updateContents([offsetOperations, ...operation]);
             }
         });
-        return () => {
-            clearOperationsQueue && clearOperationsQueue();
-        };
+        clearOperationsQueue && clearOperationsQueue();
     }, [quill, operationsQueue, clearOperationsQueue]);
 }
 


### PR DESCRIPTION
The editor test had a flag for only running one single test. This has been removed.

Bonus: `useOperationsQueue` was improperly clearing its cache. This has also been addressed.