### PR TITLE
Add eslint plugin for react hooks validation

### DIFF
--- a/library/src/scripts/content/hashScrolling.ts
+++ b/library/src/scripts/content/hashScrolling.ts
@@ -11,7 +11,7 @@ export function useHashScrolling() {
     const calcedOffset = offset.getCalcedHashOffset();
     const callback = useCallback(() => {
         return initHashScrolling(calcedOffset, () => offset.temporarilyDisabledWatching(500));
-    }, [calcedOffset]);
+    }, [offset, calcedOffset]);
 
     useEffect(() => {
         callback();

--- a/library/src/scripts/dom/TabHandler.ts
+++ b/library/src/scripts/dom/TabHandler.ts
@@ -14,12 +14,12 @@ export function useTabKeyboardHandler(
     excludedElements: Element[] = [],
     excludedRoots: Element[] = [],
 ): React.KeyboardEventHandler | undefined {
-    const makeTabHandler = () => {
+    const makeTabHandler = useCallback(() => {
         if (!root) {
             return;
         }
         return new TabHandler(root, excludedElements, excludedRoots);
-    };
+    }, [root, excludedElements, excludedRoots]);
 
     /**
      * Handle shift tab key presses.
@@ -29,19 +29,22 @@ export function useTabKeyboardHandler(
      *
      * @param event The react event.
      */
-    const handleShiftTab = useCallback((event: React.KeyboardEvent) => {
-        const tabHandler = makeTabHandler();
-        if (!tabHandler) {
-            return;
-        }
-        const nextElement = tabHandler.getNext(undefined, true);
-        if (nextElement) {
-            event.preventDefault();
+    const handleShiftTab = useCallback(
+        (event: React.KeyboardEvent) => {
+            const tabHandler = makeTabHandler();
+            if (!tabHandler) {
+                return;
+            }
+            const nextElement = tabHandler.getNext(undefined, true);
+            if (nextElement) {
+                event.preventDefault();
 
-            event.stopPropagation();
-            nextElement.focus();
-        }
-    }, []);
+                event.stopPropagation();
+                nextElement.focus();
+            }
+        },
+        [makeTabHandler],
+    );
 
     /**
      * Handle tab key presses.
@@ -51,18 +54,21 @@ export function useTabKeyboardHandler(
      *
      * @param event The react event.
      */
-    const handleTab = useCallback((event: React.KeyboardEvent) => {
-        const tabHandler = makeTabHandler();
-        if (!tabHandler) {
-            return;
-        }
-        const previousElement = tabHandler.getNext();
-        if (previousElement) {
-            event.preventDefault();
-            event.stopPropagation();
-            previousElement.focus();
-        }
-    }, []);
+    const handleTab = useCallback(
+        (event: React.KeyboardEvent) => {
+            const tabHandler = makeTabHandler();
+            if (!tabHandler) {
+                return;
+            }
+            const previousElement = tabHandler.getNext();
+            if (previousElement) {
+                event.preventDefault();
+                event.stopPropagation();
+                previousElement.focus();
+            }
+        },
+        [makeTabHandler],
+    );
 
     /**
      * Handle tab keyboard presses.

--- a/library/src/scripts/dom/hookUtils.tsx
+++ b/library/src/scripts/dom/hookUtils.tsx
@@ -33,7 +33,7 @@ export function useMeasure(ref: RefObject<HTMLElement | null>) {
             window.cancelAnimationFrame(animationFrameId!);
             ro.disconnect();
         };
-    }, [ref.current]);
+    }, [ref]);
 
     return bounds;
 }

--- a/library/src/scripts/flyouts/FlyoutToggle.tsx
+++ b/library/src/scripts/flyouts/FlyoutToggle.tsx
@@ -54,7 +54,7 @@ export interface IFlyoutTogglePropsWithTextLabel extends IFlyoutToggleProps {
 type IProps = IFlyoutTogglePropsWithIcon | IFlyoutTogglePropsWithTextLabel;
 
 export default function FlyoutToggle(props: IProps) {
-    const { initialFocusElement } = props;
+    const { initialFocusElement, onVisibilityChange, onClose } = props;
     const title = "name" in props ? props.name : props.selectedItemLabel;
 
     // IDs unique to the component instance.
@@ -75,8 +75,8 @@ export default function FlyoutToggle(props: IProps) {
                 initialFocusElement.focus();
             }
         }
-        props.onVisibilityChange && props.onVisibilityChange(isVisible);
-    }, [isVisible, initialFocusElement, props.onVisibilityChange]);
+        onVisibilityChange && onVisibilityChange(isVisible);
+    }, [isVisible, initialFocusElement, onVisibilityChange]);
 
     /**
      * Toggle Menu menu
@@ -85,11 +85,11 @@ export default function FlyoutToggle(props: IProps) {
         (e: React.MouseEvent) => {
             e.stopPropagation();
             setVisibility(!isVisible);
-            if (props.onVisibilityChange) {
-                props.onVisibilityChange(isVisible);
+            if (onVisibilityChange) {
+                onVisibilityChange(isVisible);
             }
         },
-        [isVisible, setVisibility, props.onVisibilityChange],
+        [isVisible, setVisibility, onVisibilityChange],
     );
 
     const closeMenuHandler = useCallback(
@@ -97,7 +97,7 @@ export default function FlyoutToggle(props: IProps) {
             event.stopPropagation();
             event.preventDefault();
 
-            props.onClose && props.onClose();
+            onClose && onClose();
 
             const { activeElement } = document;
             const parentElement = controllerRef.current;
@@ -110,11 +110,11 @@ export default function FlyoutToggle(props: IProps) {
                     buttonRef.current.classList.add("focus-visible");
                 }
             }
-            if (props.onVisibilityChange) {
-                props.onVisibilityChange(false);
+            if (onVisibilityChange) {
+                onVisibilityChange(false);
             }
         },
-        [props.onClose, controllerRef.current, buttonRef.current, props.onVisibilityChange],
+        [onClose, controllerRef, buttonRef, onVisibilityChange],
     );
 
     /**

--- a/library/src/scripts/headers/mebox/pieces/UserDropdown.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropdown.tsx
@@ -25,12 +25,13 @@ import { MeBoxIcon } from "@library/headers/mebox/pieces/MeBoxIcon";
 function UserDropDown(props: IProps) {
     const ID = useMemo(() => uniqueIDFromPrefix("userDropDown"), []);
     const [isOpen, setOpen] = useState(false);
+    const { checkCountData } = props;
 
     useEffect(() => {
         if (isOpen) {
-            props.checkCountData();
+            checkCountData();
         }
-    }, [isOpen, props.checkCountData]);
+    }, [isOpen, checkCountData]);
 
     const { userInfo } = props;
     if (!userInfo) {

--- a/library/src/scripts/layout/PageHeading.tsx
+++ b/library/src/scripts/layout/PageHeading.tsx
@@ -34,17 +34,10 @@ export function PageHeading(props: IPageHeading) {
     // public context!: React.ContextType<typeof LineHeightCalculatorContext>;
     // public titleRef: React.RefObject<HTMLHeadingElement>;
     const ref = useRef<HTMLHeadingElement>(null);
-    const { setFontSize, fontSize } = useFontSizeCalculator();
+    const { fontSize } = useFontSizeCalculator();
 
     const classes = pageHeadingClasses();
     const linkClasses = backLinkClasses();
-
-    useEffect(() => {
-        if (ref.current) {
-            const length = parseInt(getComputedStyle(ref.current)["font-size"], 10);
-            const before = !!length && setFontSize(length);
-        }
-    }, [ref.current, setFontSize]);
 
     return (
         <div className={classNames(classes.root, className)}>

--- a/packages/vanilla-eslint-config/index.js
+++ b/packages/vanilla-eslint-config/index.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     parser: "@typescript-eslint/parser",
-    plugins: ["@typescript-eslint", "react", "jsx-a11y"],
+    plugins: ["@typescript-eslint", "react", "react-hooks", "jsx-a11y"],
     extends: [
         "eslint:recommended",
         "plugin:react/recommended",
@@ -66,5 +66,9 @@ module.exports = {
         "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/await-thenable": "off",
         "@typescript-eslint/promise-function-async": "off",
+
+        // React hooks
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "warn"
     },
 };

--- a/packages/vanilla-eslint-config/package.json
+++ b/packages/vanilla-eslint-config/package.json
@@ -13,6 +13,7 @@
         "eslint-config-prettier": "^4.3.0",
         "eslint-plugin-import": "^2.17.3",
         "eslint-plugin-jsx-a11y": "^6.2.1",
-        "eslint-plugin-react": "^7.13.0"
+        "eslint-plugin-react": "^7.13.0",
+        "eslint-plugin-react-hooks": "^1.6.0"
     }
 }

--- a/plugins/rich-editor/src/scripts/editor/Editor.tsx
+++ b/plugins/rich-editor/src/scripts/editor/Editor.tsx
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { IEditorProps, EditorContext } from "@rich-editor/editor/context";
 import Quill from "quill/core";
 import { useDevice, Devices } from "@library/layout/DeviceContext";
@@ -21,7 +21,7 @@ export const Editor = (props: IEditorProps) => {
     const [quill, setQuillInstance] = useState<Quill | null>(null);
     const device = useDevice();
     const isMobile = device === Devices.MOBILE || device === Devices.XS;
-    const ID = uniqueIDFromPrefix("editor");
+    const ID = useMemo(() => uniqueIDFromPrefix("editor"), []);
     const descriptionID = ID + "-description";
 
     return (

--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -81,7 +81,9 @@ export function useQuillInstance(mountRef: React.RefObject<HTMLDivElement>, extr
                 window.quill = null;
             };
         }
-    }, [mountRef, extraOptions, setQuillInstance]);
+        // Causes an infinite loops if we specify mountRef.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [extraOptions, setQuillInstance]);
     return ref.current;
 }
 

--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -81,7 +81,7 @@ export function useQuillInstance(mountRef: React.RefObject<HTMLDivElement>, extr
                 window.quill = null;
             };
         }
-    }, [mountRef.current, extraOptions]);
+    }, [mountRef, extraOptions, setQuillInstance]);
     return ref.current;
 }
 
@@ -133,7 +133,7 @@ function useLoadStatus() {
                 quill.enable();
             }
         }
-    }, [isLoading, quill]);
+    }, [isLoading, quill, prevLoading]);
 }
 
 /**
@@ -150,7 +150,7 @@ function useInitialValue() {
                 quill.setContents(initialValue);
             }
         }
-    }, [quill, initialValue, reinitialize]);
+    }, [quill, initialValue, reinitialize, prevInitialValue, prevReinitialize]);
 }
 
 /**
@@ -258,9 +258,9 @@ function useQuoteButtonHandler() {
 function useGlobalSelectionHandler() {
     const updateHandler = useUpdateHandler();
 
-    const handleGlobalSelectionUpdate = () => {
+    const handleGlobalSelectionUpdate = useCallback(() => {
         updateHandler(Quill.events.SELECTION_CHANGE, null, null, Quill.sources.USER);
-    };
+    }, [updateHandler]);
 
     useEffect(() => {
         document.addEventListener(SELECTION_UPDATE, handleGlobalSelectionUpdate);
@@ -297,7 +297,7 @@ function useDebugPasteListener(textArea?: HTMLInputElement | HTMLTextAreaElement
         return () => {
             textArea.addEventListener("paste", pasteHandler);
         };
-    }, [legacyMode, quill]);
+    }, [legacyMode, quill, textArea]);
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,7 +2671,7 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.4", "@types/react@^16.8.4":
+"@types/react@*", "@types/react@^16.8.4":
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.4.tgz#134307f5266e866d5e7c25e47f31f9abd5b2ea34"
   integrity sha512-Mpz1NNMJvrjf0GcDqiK8+YeOydXfD8Mgag3UtqQ5lXYTsMnOiHcKmO48LiSWMb1rSHB9MV/jlgyNzeAVxWMZRQ==
@@ -7056,6 +7056,11 @@ eslint-plugin-jsx-a11y@^6.2.1:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
+eslint-plugin-react-hooks@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
 eslint-plugin-react@^7.13.0:
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.13.0.tgz#bc13fd7101de67996ea51b33873cd9dc2b7e5758"
@@ -7137,6 +7142,11 @@ espree@^5.0.1:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
+
+esprima@^2.6.0:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+  integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
 
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
@@ -10249,13 +10259,21 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.13.1, js-yaml@>=3.13.1, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0, js-yaml@~3.13.0, js-yaml@~3.6.0:
+js-yaml@3.13.1, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0, js-yaml@~3.13.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@~3.6.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
+  integrity sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^2.6.0"
 
 jsbn@~0.1.0:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,7 +2671,7 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.8.4":
+"@types/react@*", "@types/react@16.8.4", "@types/react@^16.8.4":
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.4.tgz#134307f5266e866d5e7c25e47f31f9abd5b2ea34"
   integrity sha512-Mpz1NNMJvrjf0GcDqiK8+YeOydXfD8Mgag3UtqQ5lXYTsMnOiHcKmO48LiSWMb1rSHB9MV/jlgyNzeAVxWMZRQ==
@@ -7143,11 +7143,6 @@ espree@^5.0.1:
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
-esprima@^2.6.0:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
-  integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
-
 esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
@@ -10259,21 +10254,13 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.13.1, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0, js-yaml@~3.13.0:
+js-yaml@3.13.1, js-yaml@>=3.13.1, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0, js-yaml@~3.13.0, js-yaml@~3.6.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@~3.6.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
-  integrity sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
__DO NOT MERGE THIS PR UNTIL https://github.com/vanilla/vanilla/pull/8941 IS MERGED__

Contributes to https://github.com/vanilla/vanilla/issues/8719 Other parts of that issue will be completed in followup PRs

- Adds `eslint-plugin-react-hooks` to `@vanilla/eslint-config`.
- Fixes loose usages of react hooks (the warnings are pretty darn good).