### PR TITLE
Add event draftModel_beforeSaveDiscussion when saving a draft

### DIFF
--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -7,7 +7,7 @@
  * @package Vanilla
  * @since 2.0
  */
-
+use Garden\EventManager;
 /**
  * Manages unpublished drafts of comments and discussions.
  */
@@ -181,6 +181,10 @@ class DraftModel extends Gdn_Model {
         if (val('Sink', $formPostValues, '') === false) {
             unset($formPostValues['Sink']);
         }
+        $args = ['FormPostValues' => $formPostValues];
+        /** @var \Garden\EventManager $eventManager */
+        $eventManager = Gdn::getContainer()->get(EventManager::class);
+        $eventManager->fireFilter('draftModel_beforeSaveDiscussion', $this, $args);
 
         // Validate the form posted values
         if ($this->validate($formPostValues, $insert)) {

--- a/applications/vanilla/models/class.draftmodel.php
+++ b/applications/vanilla/models/class.draftmodel.php
@@ -8,6 +8,7 @@
  * @since 2.0
  */
 use Garden\EventManager;
+
 /**
  * Manages unpublished drafts of comments and discussions.
  */


### PR DESCRIPTION
related [#1885](https://github.com/vanilla/internal/pull/1885)
related [#459](https://github.com/vanilla/support/issues/459)

This PR fires the event added in the referenced PR to check if the user saving the draft has rank restrictions for posting links.
