### PR TITLE
Fix broken emoji extender event name

### DIFF
--- a/plugins/emojiextender/EmojiExtenderPlugin.php
+++ b/plugins/emojiextender/EmojiExtenderPlugin.php
@@ -34,6 +34,7 @@ class EmojiExtenderPlugin extends Gdn_Plugin {
      */
     public function __construct() {
         parent::__construct();
+        $this->ClassName = "EmojiExtenderPlugin";
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/491

The previous refactoring here added a namespace, which alterred the default class name for the plugin.

`Gdn_Pluggable` depends on this automatically determined plugin to figure out the event name by default.