### PR TITLE
Add state token support to Gdn_OAuth2

### DIFF
--- a/library/Vanilla/Web/CacheControlMiddleware.php
+++ b/library/Vanilla/Web/CacheControlMiddleware.php
@@ -80,4 +80,16 @@ class CacheControlMiddleware {
 
         return $response;
     }
+
+    /**
+     * A convenience method for sending cache control headers directly to the response with the `header()` function.
+     *
+     * @param string $cacheControl The value of the cache control header.
+     */
+    public static function sendCacheControlHeaders(string $cacheControl) {
+        header("Cache-Control: $cacheControl");
+        foreach (static::getHttp10Headers($cacheControl) as $key => $value) {
+            header("$key: $value");
+        }
+    }
 }

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -268,7 +268,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         } else {
             $this->_Headers = array_merge($this->_Headers, [
                 'Cache-Control' => \Vanilla\Web\CacheControlMiddleware::PUBLIC_CACHE,
-                'vary' => \Vanilla\Web\CacheControlMiddleware::VARY_COOKIE,
+                'Vary' => \Vanilla\Web\CacheControlMiddleware::VARY_COOKIE,
             ]);
         }
 

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -22,7 +22,7 @@
  * any of its methods of constants.
  *
  */
-class Gdn_OAuth2 extends Gdn_Plugin {
+class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
 
     /** @var string token provided by authenticator  */
     protected $accessToken;
@@ -53,6 +53,11 @@ class Gdn_OAuth2 extends Gdn_Plugin {
 
     /** @var  @var string optional set the settings view */
     protected $settingsView;
+
+    /**
+     * @var SsoUtils
+     */
+    private $ssoUtils;
 
     /**
      * Set up OAuth2 access properties.
@@ -307,6 +312,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
      * @param $sender
      */
     public function gdn_pluginManager_afterStart_handler($sender) {
+        $sender->registerCallback("entryController_{$this->providerKey}Redirect_create", [$this, 'entryRedirectEndpoint']);
         $sender->registerCallback("entryController_{$this->providerKey}_create", [$this, 'entryEndpoint']);
         $sender->registerCallback("settingsController_{$this->providerKey}_create", [$this, 'settingsEndpoint']);
     }
@@ -330,6 +336,18 @@ class Gdn_OAuth2 extends Gdn_Plugin {
             'ProfileKeyUniqueID' => ['LabelCode' => 'User ID', 'Description' => 'The Key in the JSON array to designate UserID.']
         ];
         return $formFields;
+    }
+
+    /**
+     * Redirect to the OAuth redirect page with a verification nonce.
+     *
+     * @param EntryController $sender The controller initiating the request.
+     * @param string $target Where to redirect after signing in.
+     */
+    public function entryRedirectEndpoint(\EntryController $sender, $state = '') {
+        $state = $this->decodeState($state);
+        $url = $this->realAuthorizeUri($state);
+        redirectTo($url, 302, false);
     }
 
 
@@ -409,13 +427,25 @@ class Gdn_OAuth2 extends Gdn_Plugin {
     /** ------------------- Connection Related Methods --------------------- */
 
     /**
+     * Return the URL that sign-in buttons should use.
+     *
+     * @param array $state Optionally provide an array of variables to be sent to the provider.
+     * @return string Returns the sign-in URL.
+     */
+    public function authorizeUri($state = []): string {
+        $params = empty($state) ? '' : '?'.http_build_query(['state' => $this->encodeState($state)]);
+
+        return url("entry/{$this->providerKey}-redirect{$params}", true);
+    }
+
+    /**
      * Create the URI that can return an authorization.
      *
      * @param array $state Optionally provide an array of variables to be sent to the provider.
      *
      * @return string Endpoint of the provider.
      */
-    public function authorizeUri($state = []) {
+    protected function realAuthorizeUri(array $state = []): string {
         $provider = $this->provider();
 
         $uri = val('AuthorizeUrl', $provider);
@@ -431,9 +461,8 @@ class Gdn_OAuth2 extends Gdn_Plugin {
         // allow child class to overwrite or add to the authorize URI.
         $get = array_merge($defaultParams, $this->authorizeUriParams);
 
-        if (is_array($state)) {
-            $get['state'] = http_build_query($state);
-        }
+        $state['token'] = $this->ssoUtils->getStateToken();
+        $get['state'] = $this->encodeState($state);
 
         return $uri.'?'.http_build_query($get);
     }
@@ -442,12 +471,12 @@ class Gdn_OAuth2 extends Gdn_Plugin {
     /**
      * Generic API uses ProxyRequest class to fetch data from remote endpoints.
      *
-     * @param $uri Endpoint on provider's server.
+     * @param string $uri Endpoint on provider's server.
      * @param string $method HTTP method required by provider.
      * @param array $params Query string.
      * @param array $options Configuration options for the request (e.g. Content-Type).
      *
-     * @return mixed|type.
+     * @return mixed.
      *
      * @throws Exception.
      * @throws Gdn_UserException.
@@ -545,10 +574,15 @@ class Gdn_OAuth2 extends Gdn_Plugin {
         $this->log('Profile', $profile);
 
         if ($state) {
-            parse_str($state, $state);
+            $rawState = $state;
+            $state = $this->decodeState($state);
         } else {
             $state = ['r' => 'entry', 'uid' => null, 'd' => 'none'];
         }
+
+        $suppliedStateToken = $state['token'] ?? '';
+        $this->ssoUtils->verifyStateToken($this->providerKey, $suppliedStateToken);
+
         switch ($state['r']) {
             case 'profile':
                 // This is a connect request from the user's profile.
@@ -831,7 +865,7 @@ class Gdn_OAuth2 extends Gdn_Plugin {
     public function signInButton($type = 'button') {
         $target = Gdn::request()->post('Target', Gdn::request()->get('Target', url('', '/')));
         $url = $this->authorizeUri(['target' => $target]);
-        $providerName = val('Name', $this->provider);
+        $providerName = $this->provider['Name'] ?? 'OAuth';
         $linkLabel = sprintf(t('Sign in with %s'), $providerName);
         $result = socialSignInButton($providerName, $url, $type, ['rel' => 'nofollow', 'class' => 'default', 'title' => $linkLabel]);
         return $result;
@@ -917,6 +951,14 @@ class Gdn_OAuth2 extends Gdn_Plugin {
         return $result;
     }
 
+    /**
+     * Inject dependencies without affecting subclass constructors.
+     *
+     * @param SsoUtils $ssoUtils Used to generate SSO tokens.
+     */
+    public function setDependencies(SsoUtils $ssoUtils) {
+        $this->ssoUtils = $ssoUtils;
+    }
 
     /**
      * When DB_Logger is turned on, log SSO data.
@@ -932,6 +974,40 @@ class Gdn_OAuth2 extends Gdn_Plugin {
                 $message,
                 $data
             );
+        }
+    }
+
+    /**
+     * Encode an array into a state parameter.
+     *
+     * Some OAuth servers will mess up double URL encoding so use something safe here.
+     *
+     * @param array $state The state to encode.
+     * @return string Returns the encoded state.
+     */
+    protected function encodeState(array $state): string {
+        return base64_encode(json_encode($state));
+    }
+
+    /**
+     * Decode a state string into its original array.
+     *
+     * If the state cannot be decoded this method returns an empty string so the caller should be responsible for
+     * propagating any errors.
+     *
+     * @param string $state The state to decode.
+     * @return array Returns the decoded state.
+     */
+    protected function decodeState(string $state): array {
+        if (empty($state)) {
+            return [];
+        } else {
+            $r = json_decode(base64_decode($state), true);
+            if (is_array($r)) {
+                return $r;
+            } else {
+                return [];
+            }
         }
     }
 }

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -342,11 +342,13 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
      * Redirect to the OAuth redirect page with a verification nonce.
      *
      * @param EntryController $sender The controller initiating the request.
-     * @param string $target Where to redirect after signing in.
+     * @param  string $state The state to pass along the OAuth2 flow.
      */
     public function entryRedirectEndpoint(\EntryController $sender, $state = '') {
         $state = $this->decodeState($state);
         $url = $this->realAuthorizeUri($state);
+
+        \Vanilla\Web\CacheControlMiddleware::sendCacheControlHeaders(\Vanilla\Web\CacheControlMiddleware::NO_CACHE);
         redirectTo($url, 302, false);
     }
 

--- a/plugins/googlesignin/addon.json
+++ b/plugins/googlesignin/addon.json
@@ -11,7 +11,7 @@
     "icon": "google_signin.png",
     "key": "googlesignin",
     "type": "addon",
-    "documentationUrl": "https://docs.vanillaforums.com/help/sso/social-connect/#google-signin",
+    "documentationUrl": "https://docs.vanillaforums.com/help/sso/social-connect/#google",
     "authors": [
         {
             "name": "Support",


### PR DESCRIPTION
This PR uses the verification tokens from `SsoUtils` in `Gdn_OAuth2` to prevent CSRF and replay attacks when signing in via OAuth 2. Notes:

- `SsoUtils` is injected via the `Vanilla\InjectableInterface` to avoid affecting subclasses.
- The sign in has been changed into a redirect to avoid HTTP cache pollution. Even though we don’t fully respect cache headers, I’ve added the appropriate no cache headers before the redirect too.
- The state has been changed from a URL encoded array to a base 64 JSON array because I found that some OAuth servers can’t handle the double encoding.

Testing

I tested this with two subclasses of `Gdn_OAuth2`: The Google Sign-in addon and a custom subclass. Both worked and also threw the appropriate error when the token was wrong.

Closes https://github.com/vanilla/vanilla-patches/issues/564