### PR TITLE
Add discussion data when calling categroydropdown

### DIFF
--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -352,6 +352,9 @@ class ModerationController extends VanillaController {
         if ($DiscussionID) {
             $CheckedDiscussions = (array)$DiscussionID;
             $ClearSelection = false;
+            $discussion = $DiscussionModel->getID($DiscussionID, DATASET_TYPE_ARRAY);
+            $this->setData('CategoryID', $discussion['CategoryID']);
+            $this->setData('DiscussionType', $discussion['Type']);
         } else {
             $CheckedDiscussions = Gdn::userModel()->getAttribute($Session->User->UserID, 'CheckedDiscussions', []);
             if (!is_array($CheckedDiscussions)) {
@@ -368,6 +371,7 @@ class ModerationController extends VanillaController {
         // Check for edit permissions on each discussion
         $AllowedDiscussions = [];
         $DiscussionData = $DiscussionModel->SQL->select('DiscussionID, Name, DateLastComment, CategoryID, CountComments')->from('Discussion')->whereIn('DiscussionID', $DiscussionIDs)->get();
+
         $DiscussionData = Gdn_DataSet::index($DiscussionData->resultArray(), ['DiscussionID']);
         foreach ($DiscussionData as $DiscussionID => $Discussion) {
             $Category = CategoryModel::categories($Discussion['CategoryID']);

--- a/applications/vanilla/views/moderation/confirmdiscussionmoves.php
+++ b/applications/vanilla/views/moderation/confirmdiscussionmoves.php
@@ -31,7 +31,12 @@ if ($CountNotAllowed > 0) {
             <?php
             echo '<p><div class="Category">';
             echo $this->Form->label('Category', 'CategoryID'), ' ';
-            echo $this->Form->categoryDropDown();
+            $options = [
+                'Value' => $this->Data('CategoryID'),
+                'IncludeNull' => true,
+                'DiscussionType' => $this->Data('DiscussionType'),
+            ];
+            echo $this->Form->categoryDropDown('CategoryID', $options);
             echo '</div></p>';
             ?>
         </li>


### PR DESCRIPTION
related [#1789](https://github.com/vanilla/internal/issues/1789)

### Details

When moving a discussion, we are not sending the discussion's data, which in the case of ideation [class.ideation.plugin.php#L354](https://github.com/vanilla/internal/blob/master/plugins/ideation/class.ideation.plugin.php#L354) Type is false, and the proper ideation categories are not filtered, allowing moderators to move idea discussions to non-idea categories (cause api v2 /discussions call to fail).

