### PR TITLE
Fix some AJAX forms not properly redirecting

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3048,7 +3048,9 @@ if (!function_exists('redirectTo')) {
         // This would cause http://evil.domain\@trusted.domain/ to be converted to http://evil.domain/@trusted.domain/
         $url = str_replace('\\', '%5c', $url);
 
-        if (Gdn::controller() !== null && in_array(Gdn::controller()->deliveryType(), [DELIVERY_TYPE_ASSET, DELIVERY_TYPE_VIEW], true) && Gdn::controller()->deliveryMethod() === DELIVERY_METHOD_JSON) {
+        if (Gdn::controller() !== null
+            && in_array(Gdn::controller()->deliveryType(), [DELIVERY_TYPE_ASSET, DELIVERY_TYPE_VIEW], true)
+            && Gdn::controller()->deliveryMethod() === DELIVERY_METHOD_JSON) {
             // This is a bit of a kludge, but it solves a perpetual gotcha when we switch full page forms to AJAX forms and forget about redirects.
             echo json_encode([
                 'FormSaved' => true,

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3047,7 +3047,16 @@ if (!function_exists('redirectTo')) {
         // Encode backslashes because most modern browsers convert backslashes to slashes.
         // This would cause http://evil.domain\@trusted.domain/ to be converted to http://evil.domain/@trusted.domain/
         $url = str_replace('\\', '%5c', $url);
-        safeHeader('Location: '.$url, true, $statusCode);
+
+        if (Gdn::controller() !== null && in_array(Gdn::controller()->deliveryType(), [DELIVERY_TYPE_ASSET, DELIVERY_TYPE_VIEW], true) && Gdn::controller()->deliveryMethod() === DELIVERY_METHOD_JSON) {
+            // This is a bit of a kludge, but it solves a perpetual gotcha when we switch full page forms to AJAX forms and forget about redirects.
+            echo json_encode([
+                'FormSaved' => true,
+                'RedirectUrl' => $url,
+            ]);
+        } else {
+            safeHeader('Location: ' . $url, true, $statusCode);
+        }
         exit();
     }
 }


### PR DESCRIPTION
We have a long standing difficulty when converting regular pages to AJAX pages where everything works except for redirects. Currently we go through and change calls to `redirectTo()` to `Gdn_Controller::redirectTo()` and have had to do that over and over again.

This change proposes putting some logic within `redirectTo()` itself to properly render the correct redirect code if the call is being made within an AJAX request. This is a bit of a kludge, but I figured I would put this out for code review because it is a trade off between a kludge and constantly doing the same bug fix over and over again.