### PR TITLE
Add advanced search check to mobile searchbox

### DIFF
--- a/themes/keystone/views/default.master.tpl
+++ b/themes/keystone/views/default.master.tpl
@@ -186,7 +186,11 @@
                                 <div class="Frame-row SearchBoxMobile">
                                     {if !$SectionGroups && !inSection(["SearchResults"])}
                                         <div class="SearchBox js-sphinxAutoComplete" role="search">
-                                            {module name="AdvancedSearchModule"}
+                                            {if $hasAdvancedSearch === true}
+                                                {module name="AdvancedSearchModule"}
+                                            {else}
+                                                {searchbox}
+                                            {/if}
                                         </div>
                                     {/if}
                                 </div>

--- a/themes/theme-boilerplate/views/default.master.tpl
+++ b/themes/theme-boilerplate/views/default.master.tpl
@@ -55,7 +55,11 @@
                                 <div class="Frame-row SearchBoxMobile">
                                     {if !$SectionGroups && !inSection(["SearchResults"])}
                                         <div class="SearchBox js-sphinxAutoComplete" role="search">
-                                            {module name="AdvancedSearchModule"}
+                                            {if $hasAdvancedSearch === true}
+                                                {module name="AdvancedSearchModule"}
+                                            {else}
+                                                {searchbox}
+                                            {/if}
                                         </div>
                                     {/if}
                                 </div>


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/8956

The mobile search boxes here were missing the check for advanced search. As a result the module would not appear on mobile unless advanced search was enabled.