### PR TITLE
Fix incorrect editor selection handling

### DIFF
--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -367,6 +367,9 @@ function useSynchronization() {
             return;
         }
 
+        // Call intially with the value.
+        updateHandler(Quill.events.TEXT_CHANGE, null, null, Quill.sources.API);
+
         quill.on(Quill.events.EDITOR_CHANGE, updateHandler);
         return () => {
             quill.off(Quill.events.EDITOR_CHANGE, updateHandler);

--- a/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
+++ b/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
@@ -62,9 +62,10 @@ export default class VanillaTheme extends ThemeBase {
         };
 
         // Track user selection events.
-        this.quill.on("selection-change", (range, oldRange, source) => {
-            if (range && source !== Quill.sources.SILENT) {
-                this.lastGoodSelection = range;
+        this.quill.on(Quill.events.EDITOR_CHANGE, (type, value, oldValue, source) => {
+            const selection = this.quill.getSelection();
+            if (selection && source !== Quill.sources.SILENT) {
+                this.lastGoodSelection = selection;
             }
         });
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/8957

Some recent refactoring introduced a bug where certain editor events were not being properly tracked.

This is fixed by 2 things:

1. Tracking the `EDITOR_CHANGE` event instead of the `selection-change` event.
2. Initializing the synchronization handler when first mounting the editor.