### PR TITLE
Escape the title in Gdn_Theme::logo()

### DIFF
--- a/library/core/class.theme.php
+++ b/library/core/class.theme.php
@@ -383,8 +383,11 @@ class Gdn_Theme {
      */
     public static function logo($properties = []) {
         $logo = c('Garden.Logo');
+        $title = c('Garden.Title', 'Title');
 
         if ($logo) {
+            $properties += ['alt' => $title];
+
             // Only trim slash from relative paths.
             if (!stringBeginsWith($logo, '//')) {
                 $logo = ltrim($logo, '/');
@@ -399,15 +402,11 @@ class Gdn_Theme {
             if (empty($properties['title']) && c('Garden.LogoTitle')) {
                 $properties['title'] = c('Garden.LogoTitle');
             }
-        }
 
-        // Use the site title as alt if none was given.
-        $title = c('Garden.Title', 'Title');
-        if (empty($properties['alt'])) {
-            $properties['alt'] = $title;
+            echo img(Gdn_Upload::url($logo), $properties);
+        } else {
+            echo htmlEsc($title);
         }
-
-        echo $logo ? img(Gdn_Upload::url($logo), $properties) : $title;
     }
 
     /**


### PR DESCRIPTION
When a site doesn’t have an uploaded logo image then the site’s title is used. However, the title is not escaped. Even though the title is permission gated it is a good practice to escape the title in this function nonetheless.

I polled all of our sites and see that the only sites that would be affected all have “&” in their titles.

Closes https://github.com/vanilla/vanilla-patches/issues/391.