### PR TITLE
Don’t allow the passing of the RankID directly to connect endpoints.

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -432,7 +432,7 @@ class EntryController extends Gdn_Controller {
         $currentData = $this->Form->formValues();
         $filteredData = Gdn::userModel()->filterForm($currentData, true);
         $filteredData = array_replace($filteredData, arrayTranslate($currentData, ['TransientKey', 'hpt']));
-        unset($filteredData['Roles'], $filteredData['RoleID']);
+        unset($filteredData['Roles'], $filteredData['RoleID'],  $filteredData['RankID']);
         $this->Form->formValues($filteredData);
 
         // Fire ConnectData event & error handling.

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -432,7 +432,7 @@ class EntryController extends Gdn_Controller {
         $currentData = $this->Form->formValues();
         $filteredData = Gdn::userModel()->filterForm($currentData, true);
         $filteredData = array_replace($filteredData, arrayTranslate($currentData, ['TransientKey', 'hpt']));
-        unset($filteredData['Roles'], $filteredData['RoleID'],  $filteredData['RankID']);
+        unset($filteredData['Roles'], $filteredData['RoleID'], $filteredData['RankID']);
         $this->Form->formValues($filteredData);
 
         // Fire ConnectData event & error handling.


### PR DESCRIPTION
This PR will remove the RankID from being filtered out of the data being inserted into the User table and instead, filter it out in the entry endpoint. This way SSO plugins can allow trusted sources to pass the RankID. This is the same way we handle Roles.