### PR TITLE
Fix dashboard/editor bower install during deployment as root

### DIFF
--- a/applications/dashboard/package.json
+++ b/applications/dashboard/package.json
@@ -23,7 +23,7 @@
         "@vanilla/library": "*"
     },
     "scripts": {
-        "install": "bower install",
+        "install": "bower install --allow-root",
         "build": "grunt",
         "watch": "grunt watch"
     }

--- a/plugins/editor/package.json
+++ b/plugins/editor/package.json
@@ -16,7 +16,7 @@
         "time-grunt": "2.0.0"
     },
     "scripts": {
-        "install": "bower install",
+        "install": "bower install --allow-root",
         "build": "grunt",
         "watch": "grunt watch"
     }


### PR DESCRIPTION
Our recent changes to yarn workspaces means that node modules get installed for all plugins.

Our deployment process runs as `root` w/ a sudoers config, so this flag has to be passed for the post install to work.