### PR TITLE
Fix Category following for members

### DIFF
--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -71,7 +71,7 @@ class CategoryController extends VanillaController {
         $form = new Gdn_Form();
         $categoryID = $form->getFormValue('CategoryID', $categoryID);
         $followed = $form->getFormValue('Followed', null);
-        $hasPermission = $categoryModel::checkPermission($categoryModel->CategoryID, 'Vanilla.Discussions.View');
+        $hasPermission = $categoryModel::checkPermission($categoryID, 'Vanilla.Discussions.View');
         if (!$hasPermission) {
             throw permissionException('Vanilla.Discussion.View');
         }


### PR DESCRIPTION
**Issue:**
Currently non administrators\moderators are unable to follow categories.

**Details:**
A permission check in the CategoryController::Followed endpoint was failing because it was receiving _null_ instead of the categoryid.

**To Test:**

1) create a category 
2) have a member try to follow the account.
3) A _Vanilla.Discussions.View_ should appear

Addresses Vanilla/Support#511
