### PR TITLE
Add frame ancestor fallback of embed remote URL

### DIFF
--- a/library/Vanilla/Web/ContentSecurityPolicy/DefaultContentSecurityPolicyProvider.php
+++ b/library/Vanilla/Web/ContentSecurityPolicy/DefaultContentSecurityPolicyProvider.php
@@ -30,7 +30,10 @@ class DefaultContentSecurityPolicyProvider implements ContentSecurityPolicyProvi
     public function getPolicies(): array {
         $policies = [];
         $policies = array_merge($policies, $this->getScriptSources());
-        $policies = array_merge($policies, $this->getFrameAncestors());
+
+        if ($this->config->get("Garden.Embed.Allow")) {
+            $policies = array_merge($policies, $this->getFrameAncestors());
+        }
 
         return $policies;
     }

--- a/library/Vanilla/Web/ContentSecurityPolicy/DefaultContentSecurityPolicyProvider.php
+++ b/library/Vanilla/Web/ContentSecurityPolicy/DefaultContentSecurityPolicyProvider.php
@@ -52,10 +52,15 @@ class DefaultContentSecurityPolicyProvider implements ContentSecurityPolicyProvi
     */
     private function getFrameAncestors(): array {
         $scriptSrcPolicies[] = new Policy(Policy::FRAME_ANCESTORS, '\'self\'');
-        if ($whitelist = $this->config->get('Garden.TrustedDomains', false)) {
-            $trusteddDomains = is_string($whitelist) ? explode("\n", $whitelist) : [];
-            if (count($trusteddDomains) > 0) {
-                $scriptSrcPolicies[] = new Policy(Policy::FRAME_ANCESTORS, implode(' ', $trusteddDomains));
+        $whitelist = $this->config->get('Garden.TrustedDomains', false);
+        $trusteddDomains = is_string($whitelist) ? array_filter(explode("\n", $whitelist)) : [];
+        if (count($trusteddDomains) > 0) {
+            $scriptSrcPolicies[] = new Policy(Policy::FRAME_ANCESTORS, implode(' ', $trusteddDomains));
+        } else {
+            $remoteUrl = $this->config->get("Garden.Embed.RemoteUrl", false);
+            $remoteDomain = is_string($remoteUrl) ? parse_url($remoteUrl, PHP_URL_HOST) : false;
+            if (is_string($remoteDomain)) {
+                $scriptSrcPolicies[] = new Policy(Policy::FRAME_ANCESTORS, $remoteDomain);
             }
         }
         return $scriptSrcPolicies;


### PR DESCRIPTION
Vanilla serves up a [`frame-ancestors` directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) as part of its `Content-Security-Policy` header. Essentially, it ensures you can only embed a site under specific hosts. Currently, the header only sends out trusted domains. This update will add a fallback: if no trusted domains are found, try to grab the host from `Garden.Embed.RemoteUrl`. This config value is managed on the Embed Settings page of the dashboard.

The `frame-ancestors` will also now only be sent if the site is configured to enable embedding. This should be the only time this directive is relevant. If the site is not configured for embedding, Vanilla will already [send an `X-Frame-Options` header](https://github.com/vanilla/vanilla/blob/afef3451fa70e5e15c8314bb32e2b2bc74e87503/applications/dashboard/settings/class.hooks.php#L246).

### Recommended Testing
1. Clear your Trusted Domains. Set a valid `Garden.Embed.RemoteUrl` value in your config. A request to the site should return a `frame-ancestors` directive with the host from the embed remote URL you set.
1. Clear your Trusted Domains. Set an **invalid** `Garden.Embed.RemoteUrl` value in your config (e.g. a non-URL string, an array, etc.). A request to the site should return a `frame-ancestors` directive that only contains "self".
1. Ensure you have at least one trusted domain configured. Set a valid `Garden.Embed.RemoteUrl` value in your config that is **not on one of your trusted domains**. A request to the site should return a `frame-ancestors` directive with only your trusted domain(s) and "self". The embed remote URL host should not be included.
1. Clear out Trusted Domains and remove any `Garden.Embed.RemoteUrl` config. A request to the site should return a `frame-ancestors` directive with only "self".
1. Disable embedding. You should no longer see the `frame-ancestors` directive.