### PR TITLE
Backport: Add conditions to show or hide the entry/connect name field.

### DIFF
--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -55,7 +55,7 @@ if (!$hasUserID) {
          *  the EntryController that has rules that require this form to be
          *  shown but not the Name Field.
          */
-        if ($ConnectName || $ConnectPhoto || !$this->data('HideName')) : ?>
+        if ($ConnectName || $ConnectPhoto && !$this->data('HideName')) : ?>
             <div class="MeBox">
                 <?php
                 if ($ConnectPhoto) {
@@ -105,7 +105,7 @@ if (!$hasUserID) {
 
                 <?php
                     $PasswordMessage = t('ConnectLeaveBlank', 'Leave blank unless connecting to an existing account.');
-                    if ($displayConnectName) : ?>
+                    if ($displayConnectName && !$this->data('HideName')) : ?>
                 <li>
                     <?php
 

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -48,8 +48,14 @@ if (!$hasUserID) {
     <div class="FormWrapper">
         <?php
         echo $this->Form->open();
-        echo $this->Form->errors();
-        if ($ConnectName || $ConnectPhoto) : ?>
+            echo $this->Form->errors();
+
+        /**
+         *  HideName can be passed by any plugin that hooks into
+         *  the EntryController that has rules that require this form to be
+         *  shown but not the Name Field.
+         */
+        if ($ConnectName || $ConnectPhoto || !$this->data('HideName')) : ?>
             <div class="MeBox">
                 <?php
                 if ($ConnectPhoto) {

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -48,7 +48,7 @@ if (!$hasUserID) {
     <div class="FormWrapper">
         <?php
         echo $this->Form->open();
-            echo $this->Form->errors();
+        echo $this->Form->errors();
 
         /**
          *  HideName can be passed by any plugin that hooks into


### PR DESCRIPTION
Backport 8984

Add conditions to show or hide the connect name field based on arguments (data(‘HideName’)) passed from plugins.

If a plugin wants to inject business logic into /entry/connect script it will trigger showing the Password and the User Name field every time. There are various kludges that can be done to hide these fields but it gets way too messy.