### PR TITLE
Strip the MessageID out of /conversations/addmessage

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -186,6 +186,8 @@ class MessagesController extends ConversationsController {
                 ['viewingUserID' => Gdn::session()->UserID]
             );
 
+            $this->Form->removeFormValue('MessageID');
+
             $this->EventArguments['Conversation'] = $conversation;
             $this->EventArguments['ConversationID'] = $conversationID;
             $this->fireEvent('BeforeAddMessage');


### PR DESCRIPTION
Don’t allow users to specify a message ID when posting a message. Closes https://github.com/vanilla/vanilla-patches/issues/575.

I tested this just by adding a hidden MessageID to the view.