### PR TITLE
Don’t allow users to sink a discussion from the /post/*discussion endpoints

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -118,6 +118,11 @@ class DiscussionModel extends Gdn_Model {
         $this->setMediaForeignTable($this->Name);
         $this->setMediaModel(Gdn::getContainer()->get(MediaModel::class));
         $this->setSessionInterface(Gdn::getContainer()->get("Session"));
+
+        $this->addFilterField([
+            'Sink',
+            'Score',
+        ]);
     }
 
     /**


### PR DESCRIPTION
Adds sink as a filter field so that sinking can’t be done by general purpose endpoints. Closes https://github.com/vanilla/vanilla-patches/issues/576.

Tested:

- Adding a discussion with Sink: 1. The sink was set to 0.
- Editing a discussion with Sink: 1. The sink didn't change.
- Sinking/unsinking a discussion. Still works.