### PR TITLE
Fix moderation/spam queue titles being formatted

### DIFF
--- a/applications/dashboard/models/class.logmodel.php
+++ b/applications/dashboard/models/class.logmodel.php
@@ -229,7 +229,7 @@ class LogModel extends Gdn_Pluggable {
                     break;
                 case 'Discussion':
                     $result =
-                        '<b>'.$this->formatKey('Name', $data).'</b><br />'.
+                        '<b>'.htmlspecialchars(val('Name', $data)).'</b><br />'.
                         $this->formatKey('Body', $data);
                     break;
                 case 'ActivityComment':


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/8989 introduced formatting to the bodies of moderation queue posts.

Unfortunately, the post titles ended up getting formatted as well. I've switched them to just filter the titles instead of calling `formatKey()`.