### PR TITLE
Fix simple search formatting

### DIFF
--- a/applications/dashboard/models/class.searchmodel.php
+++ b/applications/dashboard/models/class.searchmodel.php
@@ -176,6 +176,9 @@ class SearchModel extends Gdn_Model {
         foreach ($result as $key => $value) {
             if (isset($value['Summary'])) {
                 $value['Summary'] = condense(Gdn_Format::to($value['Summary'], $value['Format']));
+                // We just converted it to HTML. Make sure everything downstream knows it.
+                // Taking this HTML and feeding it into the Rich Format for example, would be invalid.
+                $value['Format'] = 'Html';
                 $result[$key] = $value;
             }
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/8680

This only affected the search page _**Without Advanced Search**_.

There is some additional downstream formatting that is not aware of the change that occured here. Really what happen is that by formatting the summary with `Gdn_Format::to` it has been converted to HTML. I've update the type to accurately represent that.