### PR TITLE
Fix broken editor styles in KB

### DIFF
--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -19,7 +19,7 @@ import classNames from "classnames";
 import hljs from "highlight.js";
 import throttle from "lodash/throttle";
 import Quill, { DeltaOperation, QuillOptionsStatic, Sources } from "quill/core";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useMemo } from "react";
 
 const DEFAULT_CONTENT = [{ insert: "\n" }];
 
@@ -92,21 +92,20 @@ function useQuillAttributeSync(placeholder?: string) {
     const { legacyMode, quill } = useEditor();
     const classesRichEditor = richEditorClasses(legacyMode);
     const classesUserContent = userContentClasses();
-    const quillRootClasses = classNames(
-        quill && quill.root.classList.value,
-        "richEditor-text",
-        "userContent",
-        classesRichEditor.text,
-        {
-            // These classes shouln't be applied until the forum is converted to the new styles.
-            [classesUserContent.root]: !legacyMode,
-        },
+    const quillRootClasses = useMemo(
+        () =>
+            classNames("richEditor-text", "userContent", classesRichEditor.text, {
+                // These classes shouln't be applied until the forum is converted to the new styles.
+                [classesUserContent.root]: !legacyMode,
+            }),
+        [],
     );
 
     useEffect(() => {
-        if (quill && !quill.root.classList.contains(classesRichEditor.text)) {
-            // Initialize some CSS classes onto the quill root.
-            quill.root.classList.value = quillRootClasses;
+        if (quill) {
+            // Initialize some CSS classes onto the quill root.quillRootClasses
+            // quill && quill.root.classList.value,
+            quill.root.classList.value += " " + quillRootClasses;
         }
     }, [quill, quillRootClasses]);
 


### PR DESCRIPTION
It seems I broke the user content styles in the editor with the performance fix in https://github.com/vanilla/vanilla/pull/9012

As a result, user content styles weren't properly being applied in KB.

I've opted for a new approach to preventing the infinite appending of classes.