### PR TITLE
Fix third-party embed scripts using relative protocol

### DIFF
--- a/library/src/scripts/embeddedContent/GettyImagesEmbed.tsx
+++ b/library/src/scripts/embeddedContent/GettyImagesEmbed.tsx
@@ -91,5 +91,5 @@ async function loadGettyImages(props: IProps) {
 
     /// DO NOT IGNORE
     /// This will turn totally sideways if window.gie is not populated before the script is initially loaded.
-    await ensureScript("//embed-cdn.gettyimages.com/widgets.js");
+    await ensureScript("https://embed-cdn.gettyimages.com/widgets.js");
 }

--- a/library/src/scripts/embeddedContent/ImgurEmbed.tsx
+++ b/library/src/scripts/embeddedContent/ImgurEmbed.tsx
@@ -34,7 +34,7 @@ export function ImgurEmbed(props: IProps): JSX.Element {
 async function convertImgurEmbeds() {
     const images = Array.from(document.querySelectorAll(".imgur-embed-pub"));
     if (images.length > 0) {
-        await ensureScript("//s.imgur.com/min/embed.js");
+        await ensureScript("https://s.imgur.com/min/embed.js");
 
         if (!window.imgurEmbed) {
             throw new Error("The Imgur post failed to load");

--- a/library/src/scripts/embeddedContent/InstagramEmbed.tsx
+++ b/library/src/scripts/embeddedContent/InstagramEmbed.tsx
@@ -50,7 +50,7 @@ export function InstagramEmbed(props: IProps): JSX.Element {
 async function convertInstagramEmbeds() {
     const instagramEmbeds = document.querySelectorAll(".instagram-media");
     if (instagramEmbeds.length > 0) {
-        await ensureScript("//platform.instagram.com/en_US/embeds.js");
+        await ensureScript("https://platform.instagram.com/en_US/embeds.js");
 
         if (!window.instgrm) {
             throw new Error("The Instagram post failed to load");

--- a/library/src/scripts/embeddedContent/TwitterEmbed.tsx
+++ b/library/src/scripts/embeddedContent/TwitterEmbed.tsx
@@ -85,7 +85,7 @@ async function renderTweet(contentElement: HTMLElement) {
 export async function convertTwitterEmbeds() {
     const tweets = Array.from(document.querySelectorAll(".js-twitterCard"));
     if (tweets.length > 0) {
-        await ensureScript("//platform.twitter.com/widgets.js");
+        await ensureScript("https://platform.twitter.com/widgets.js");
         if (window.twttr) {
             const promises = tweets.map(contentElement => {
                 return renderTweet(contentElement as HTMLElement);


### PR DESCRIPTION
A few embeds use relative-protocol URLs for including the third-party embed scripts. Now, they're explicitly secure URLs. There should be no functional change.