### PR TITLE
Fixed new folder icon size

### DIFF
--- a/library/src/scripts/icons/common.tsx
+++ b/library/src/scripts/icons/common.tsx
@@ -7,6 +7,7 @@
 import React from "react";
 import classNames from "classnames";
 import { t } from "@library/utility/appUtils";
+import { iconStyles } from "@library/icons/iconStyles";
 
 const currentColorFill = {
     fill: "currentColor",
@@ -184,10 +185,11 @@ export function dropDownMenu(className?: string) {
 }
 
 export function newFolder(className?: string, title: string = t("New Folder")) {
+    const classes = iconStyles();
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
-            className={classNames("icon", "icon-dropDownMenu", className)}
+            className={classNames(classes.newFolder, className)}
             viewBox="0 0 22 19"
             aria-hidden="true"
         >

--- a/library/src/scripts/icons/iconStyles.ts
+++ b/library/src/scripts/icons/iconStyles.ts
@@ -1,0 +1,44 @@
+/*
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
+import { em } from "csx";
+import { unit } from "@library/styles/styleHelpers";
+
+export const iconVariables = useThemeCache(() => {
+    const themeVars = variableFactory("defaultIconSizes");
+
+    const defaultIcon = themeVars("defaultIcon", {
+        width: 24,
+        height: 24,
+    });
+
+    const newFolderIcon = themeVars("newFolderIcon", {
+        width: 17,
+        height: 14.67,
+    });
+
+    return { defaultIcon, newFolderIcon };
+});
+
+export const iconStyles = useThemeCache(() => {
+    const vars = iconVariables();
+    const style = styleFactory("iconSizes");
+
+    const standard = style("defaultIcon", {
+        width: unit(vars.defaultIcon.width),
+        height: unit(vars.defaultIcon.height),
+    });
+
+    const newFolder = style("newFolder", {
+        width: unit(vars.newFolderIcon.width),
+        height: unit(vars.newFolderIcon.height),
+    });
+
+    return {
+        standard,
+        newFolder,
+    };
+});


### PR DESCRIPTION
Many of our icon styles are still in CSS, so I've created icon size partial for icon sizes. This PR only fixes the size of the new folder icon, but more sizes will get added in the future.

Also see: https://github.com/vanilla/knowledge/pull/1081

Closes: https://github.com/vanilla/knowledge/issues/956