### PR TITLE
Fix various embed errors

### DIFF
--- a/applications/dashboard/design/admin.css
+++ b/applications/dashboard/design/admin.css
@@ -11312,10 +11312,10 @@ label.checkbox input.checkbox-input {
   line-height: 1.25;
   color: #555a62;
 }
-.userContent > *:not(.emoji):not(:last-child):not(br):not(.embedResponsive) {
+.userContent > *:not(.emoji):not(:last-child):not(br) {
   margin-bottom: 14px;
 }
-.userContent > *:not(.emoji):first-child:not(br):not(.embedResponsive) {
+.userContent > *:not(.emoji):first-child:not(br) {
   margin-top: -0.25em !important;
 }
 .userContent,

--- a/applications/dashboard/design/style-compat.css
+++ b/applications/dashboard/design/style-compat.css
@@ -923,10 +923,10 @@ label.checkbox input.checkbox-input {
   line-height: 1.25;
   color: #555a62;
 }
-.userContent > *:not(.emoji):not(:last-child):not(br):not(.embedResponsive) {
+.userContent > *:not(.emoji):not(:last-child):not(br) {
   margin-bottom: 14px;
 }
-.userContent > *:not(.emoji):first-child:not(br):not(.embedResponsive) {
+.userContent > *:not(.emoji):first-child:not(br) {
   margin-top: -0.25em !important;
 }
 .userContent,

--- a/applications/dashboard/js/dashboard.js
+++ b/applications/dashboard/js/dashboard.js
@@ -853,34 +853,6 @@ $(document).on('contentLoad', function(e) {
     }
 
     /**
-     * Add a CSS class to the navbar based on it scroll position.
-     *
-     * @param element - The scope of the function.
-     */
-    function navbarHeightInit(element) {
-        var $navbar = $('.js-navbar', element);
-
-        $navbar.addClass('navbar-short');
-        var navShortHeight = $navbar.outerHeight(true);
-        $navbar.removeClass('navbar-short');
-        var navHeight = $navbar.outerHeight(true);
-        var navOffset = navHeight - navShortHeight;
-
-        // If we load in the middle of the page, we should have a short navbar.
-        if ($(window).scrollTop() > navOffset) {
-            $navbar.addClass('navbar-short');
-        }
-
-        $(window).on('scroll', function() {
-            if ($(window).scrollTop() > navOffset) {
-                $navbar.addClass('navbar-short');
-            } else {
-                $navbar.removeClass('navbar-short');
-            }
-        });
-    }
-
-    /**
      * Initialize drop.js on any element with the class 'js-drop'. The element must have their id attribute set and
      * must specify the html content it will reveal when it is clicked.
      *
@@ -1161,7 +1133,6 @@ $(document).on('contentLoad', function(e) {
         prettyPrintInit(e.target); // prettifies <pre> blocks
         aceInit(e.target); // code editor
         collapseInit(e.target); // panel nav collapsing
-        navbarHeightInit(e.target); // navbar height settings
         dropInit(e.target); // navbar 'me' dropdown
         modalInit(); // modals (aka popups)
         clipboardInit(); // copy elements to the clipboard
@@ -1426,6 +1397,31 @@ $(document).on('contentLoad', function(e) {
             data: ajaxData,
             dataType: 'json'
         });
+    });
+
+    /**
+     * Turn a toolbar with the .js-toolbar-sticky class into a sticky toolbar.
+     *
+     * This is an opt-in class because it may not work or be appropriate on all pages.
+     */
+    $(window).scroll(function () {
+        var $toolbar = $('.js-toolbar-sticky');
+        var cssClass = 'is-stuck';
+
+        if ($(this).scrollTop() > $('header.navbar').height()) {
+            $toolbar
+                .addClass(cssClass)
+                .outerWidth($('.main').outerWidth() - 2)
+                .next('*')
+                .css('margin-top', $toolbar.outerHeight());
+        } else {
+            $toolbar.removeClass(cssClass).outerWidth('').next('*').css('margin-top', '');
+        }
+    });
+    $(window).resize(function () {
+        var $toolbar = $('.js-toolbar-sticky.is-stuck');
+
+        $toolbar.outerWidth($('.main').outerWidth() - 2);
     });
 })(jQuery);
 

--- a/applications/dashboard/scss/compatibility/editor/_richEditorLegacy.scss
+++ b/applications/dashboard/scss/compatibility/editor/_richEditorLegacy.scss
@@ -58,11 +58,11 @@ $richEditor_innerPadding                          : 12px !default;
     }
 
     > *:not(.emoji) {
-        &:not(:last-child):not(br):not(.embedResponsive) {
+        &:not(:last-child):not(br) {
             margin-bottom: $global-block_margin;
         }
-        
-        &:first-child:not(br):not(.embedResponsive) {
+
+        &:first-child:not(br) {
             margin-top: #{(1 - $global-base_lineHeight) * .5em} !important;
         }
     }

--- a/library/Vanilla/EmbeddedContent/Embeds/ErrorEmbed.twig
+++ b/library/Vanilla/EmbeddedContent/Embeds/ErrorEmbed.twig
@@ -1,7 +1,7 @@
 <a href="{{ sanitizeUrl(url) }}" data-embedJson="{{ data|json_encode }}" class="embedLinkLoader">
     {{ url }}
-    <svg class="embedLinkLoader-failIcon" title="${title}" aria-label="${title}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
-        <title>{{ errorMessage }}</title>
+    <svg class="embedLinkLoader-failIcon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+        <title>{{ t('There was an error displaying this embed.') }}</title>
         <circle cx="8" cy="8" r="8" style="fill: #f5af15"/>
         <circle cx="8" cy="8" r="7.5" style="fill: none;stroke: #000;stroke-opacity: 0.122"/>
         <path d="M11,10.4V8h2v2.4L12.8,13H11.3Zm0,4h2v2H11Z" transform="translate(-4 -4)" style="fill: #fff"/>

--- a/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
@@ -50,8 +50,9 @@ class QuoteEmbed extends AbstractEmbed {
         ]);
 
         // Format the body.
-        $data['body'] = \Gdn_Format::quoteEmbed($data['bodyRaw'], $data['format']);
-        unset($data['bodyRaw']);
+        if (!isset($data['body']) && isset($data['bodyRaw'])) {
+            $data['body'] = \Gdn_Format::quoteEmbed($data['bodyRaw'], $data['format']);
+        }
 
         return $data;
     }
@@ -62,6 +63,7 @@ class QuoteEmbed extends AbstractEmbed {
     protected function schema(): Schema {
         return Schema::parse([
             'body:s',
+            'bodyRaw:s|a',
             'format:s',
             'dateInserted:dt',
             'insertUser' => new UserFragmentSchema(),

--- a/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
@@ -62,8 +62,9 @@ class QuoteEmbed extends AbstractEmbed {
      */
     protected function schema(): Schema {
         return Schema::parse([
-            'body:s',
-            'bodyRaw:s|a',
+            'body:s', // The body is need currnetly during edit mode,
+            // to prevent needing extra server roundtrips to render them.
+            'bodyRaw:s|a', // Raw body is the source of truth for the embed.
             'format:s',
             'dateInserted:dt',
             'insertUser' => new UserFragmentSchema(),

--- a/library/Vanilla/Formatting/Formats/RichFormat.php
+++ b/library/Vanilla/Formatting/Formats/RichFormat.php
@@ -106,7 +106,6 @@ class RichFormat extends BaseFormat {
             $this->logBadInput($e);
             return $this->renderErrorMessage();
         }
-
     }
 
     /**

--- a/library/Vanilla/Formatting/Quill/Filterer.php
+++ b/library/Vanilla/Formatting/Quill/Filterer.php
@@ -92,7 +92,7 @@ class Filterer {
             }
 
             // Finally render the new body to overwrite the previous HTML body.
-            // We also need to ensure we've safely rendered the body to prevent XSS.
+            // We also need to ensure we've safely rendered the body to prevent innacurate content.
             $embedData['body'] = \Gdn_Format::quoteEmbed($bodyRaw, $format);
         }
 

--- a/library/Vanilla/Formatting/Quill/Filterer.php
+++ b/library/Vanilla/Formatting/Quill/Filterer.php
@@ -7,6 +7,7 @@
 
 namespace Vanilla\Formatting\Quill;
 
+use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
 use Vanilla\Formatting\Exception\FormattingException;
 
 /**
@@ -64,6 +65,7 @@ class Filterer {
                 continue;
             }
 
+
             if (!$embedData) {
                 // Clean up that messed up operation.
                 $operations[$key];
@@ -73,6 +75,12 @@ class Filterer {
             // Remove the rendered bodies. The raw bodies are the source of truth.
             $format = &$embedData['format'] ?? null;
             $bodyRaw = &$embedData['bodyRaw'] ?? null;
+            $type = &$embedData['type'] ?? null;
+
+            if ($type !== QuoteEmbed::TYPE) {
+                // We only care about quote embeds specifically.
+                continue;
+            }
 
             // Remove nested external embed data. We don't want it rendered and this will prevent it from being
             // searched.

--- a/library/Vanilla/Formatting/Quill/Filterer.php
+++ b/library/Vanilla/Formatting/Quill/Filterer.php
@@ -10,9 +10,10 @@ namespace Vanilla\Formatting\Quill;
 use Vanilla\Formatting\Exception\FormattingException;
 
 /**
- * Undocumented class
+ * Class for filtering Rich content before it gets inserted into the database.
  */
 class Filterer {
+
     /**
      * Filter the contents of a quill post.
      *
@@ -20,13 +21,14 @@ class Filterer {
      * - Strips useless embed data.
      *
      * @param string $content The content to filter.
+     * @return string
      *
      * @throws FormattingException If the JSON could not be converted to operations.
      */
     public function filter(string $content): string {
         $operations = Parser::jsonToOperations($content);
         // Re-encode the value to escape unicode values.
-        $operations = $this->stripUselessEmbedData($operations);
+        $operations = $this->cleanupEmbeds($operations);
         $operations = json_encode($operations);
         return $operations;
     }
@@ -39,31 +41,79 @@ class Filterer {
      * - Nested embed data.
      *
      * @param array[] $operations The quill operations to loop through.
+     * @return array
      */
-    private function stripUselessEmbedData(array &$operations): array {
-        foreach ($operations as $key => $op) {
+    private function cleanupEmbeds(array &$operations): array {
+        foreach ($operations as $key => &$op) {
+            $insert = &$op['insert'];
+            if (!is_array($insert)) {
+                // Only array type inserts can be embeds.
+                continue;
+            }
+
             // If a dataPromise is still stored on the embed, that means it never loaded properly on the client.
+            // We want to strip these embeds that haven't finished properly loading.
             $dataPromise = $op['insert']['embed-external']['dataPromise'] ?? null;
             if ($dataPromise !== null) {
                 unset($operations[$key]);
             }
 
+            $embedData = &$op['insert']['embed-external']['data'] ?? null;
+            if ($embedData === null) {
+                // We only care about embeds operations.
+                continue;
+            }
+
+            if (!$embedData) {
+                // Clean up that messed up operation.
+                $operations[$key];
+                continue;
+            }
+
+            // Remove the rendered bodies. The raw bodies are the source of truth.
+            $format = &$embedData['format'] ?? null;
+            $bodyRaw = &$embedData['bodyRaw'] ?? null;
+
             // Remove nested external embed data. We don't want it rendered and this will prevent it from being
             // searched.
-            $format = $op['insert']['embed-external']['data']['format'] ?? null;
-            if ($format === 'Rich') {
-                $bodyRaw = &$op['insert']['embed-external']['data']['bodyRaw'] ?? null;
-                if (is_array($bodyRaw)) {
-                    foreach ($bodyRaw as $subInsertIndex => &$subInsertOp) {
-                        $externalEmbed = &$bodyRaw[$subInsertIndex]['insert']['embed-external'] ?? null;
-                        if ($externalEmbed !== null) {
-                            unset($externalEmbed['data']);
+            if ($format === 'Rich' && is_array($bodyRaw)) {
+                // Iterate through the nested embed.
+                foreach ($bodyRaw as $subInsertIndex => &$subInsertOp) {
+                    $insert = &$subInsertOp['insert'];
+                    if (is_array($insert)) {
+                        $url = $insert['embed-external']['data']['url'] ?? null;
+                        if ($url !== null) {
+                            // Replace the embed with just a link.
+                            $linkEmbedOps = $this->makeLinkEmbedInserts($url);
+                            array_splice($bodyRaw, $subInsertIndex, 1, $linkEmbedOps);
                         }
                     }
                 }
             }
+
+            // Finally render the new body to overwrite the previous HTML body.
+            // We also need to ensure we've safely rendered the body to prevent XSS.
+            $embedData['body'] = \Gdn_Format::quoteEmbed($bodyRaw, $format);
         }
 
         return array_values($operations);
+    }
+
+    /**
+     * Make the contents of a link embed.
+     *
+     * @param string $url
+     * @return array
+     */
+    private function makeLinkEmbedInserts(string $url): array {
+        return [
+            [
+                'insert' => $url,
+                'attributes' => [
+                    'link' => $url,
+                ],
+            ],
+            [ 'insert' => "\n" ],
+        ];
     }
 }

--- a/library/src/scripts/embeddedContent/QuoteEmbed.tsx
+++ b/library/src/scripts/embeddedContent/QuoteEmbed.tsx
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useMemo } from "react";
 import { IBaseEmbedProps } from "@library/embeddedContent/embedService";
 import { IUserFragment } from "@library/@types/api/users";
 import { useUniqueID } from "@library/utility/idUtils";
@@ -14,6 +14,7 @@ import DateTime from "@library/content/DateTime";
 import { bottomChevron, topChevron } from "@library/icons/common";
 import CollapsableUserContent from "@library/content/CollapsableContent";
 import { EmbedContainer } from "@library/embeddedContent/EmbedContainer";
+import { EmbedContent } from "@library/embeddedContent/EmbedContent";
 
 interface IProps extends IBaseEmbedProps {
     body: string;
@@ -53,40 +54,47 @@ export function QuoteEmbed(props: IProps) {
 
     return (
         <EmbedContainer className="embedText embedQuote">
-            <blockquote className={bodyClasses}>
-                <div className="embedText-header embedQuote-header">
-                    {title}
-                    <SmartLink to={userUrl} className="embedQuote-userLink">
-                        <span className="embedQuote-userName">{insertUser.name}</span>
-                    </SmartLink>
-                    <SmartLink to={url} className="embedQuote-metaLink">
-                        <DateTime timestamp={dateInserted} className="embedText-dateTime embedQuote-dateTime meta" />
-                    </SmartLink>
+            <EmbedContent type="Quote" inEditor={props.inEditor}>
+                <blockquote className={bodyClasses}>
+                    <div className="embedText-header embedQuote-header">
+                        {title}
+                        <SmartLink to={userUrl} className="embedQuote-userLink">
+                            <span className="embedQuote-userName">{insertUser.name}</span>
+                        </SmartLink>
+                        <SmartLink to={url} className="embedQuote-metaLink">
+                            <DateTime
+                                timestamp={dateInserted}
+                                className="embedText-dateTime embedQuote-dateTime meta"
+                            />
+                        </SmartLink>
 
-                    {needsCollapseButton && (
-                        <button
-                            type="button"
-                            className="embedQuote-collapseButton"
-                            aria-label={t("Toggle Quote")}
-                            onClick={toggleCollapseState}
-                            aria-pressed={isCollapsed}
-                        >
-                            {isCollapsed ? bottomChevron("embedQuote-chevronDown") : topChevron("embedQuote-chevronUp")}
-                        </button>
-                    )}
-                </div>
-                <div className="embedText-main embedQuote-main">
-                    <div className="embedQuote-excerpt">
-                        <CollapsableUserContent
-                            setNeedsCollapser={setNeedsCollapseButton}
-                            isCollapsed={isCollapsed}
-                            id={id}
-                            preferredMaxHeight={100}
-                            dangerouslySetInnerHTML={{ __html: body }}
-                        />
+                        {needsCollapseButton && (
+                            <button
+                                type="button"
+                                className="embedQuote-collapseButton"
+                                aria-label={t("Toggle Quote")}
+                                onClick={toggleCollapseState}
+                                aria-pressed={isCollapsed}
+                            >
+                                {isCollapsed
+                                    ? bottomChevron("embedQuote-chevronDown")
+                                    : topChevron("embedQuote-chevronUp")}
+                            </button>
+                        )}
                     </div>
-                </div>
-            </blockquote>
+                    <div className="embedText-main embedQuote-main">
+                        <div className="embedQuote-excerpt">
+                            <CollapsableUserContent
+                                setNeedsCollapser={setNeedsCollapseButton}
+                                isCollapsed={isCollapsed}
+                                id={id}
+                                preferredMaxHeight={100}
+                                dangerouslySetInnerHTML={{ __html: body }}
+                            />
+                        </div>
+                    </div>
+                </blockquote>
+            </EmbedContent>
         </EmbedContainer>
     );
 }

--- a/library/src/scripts/embeddedContent/embedService.tsx
+++ b/library/src/scripts/embeddedContent/embedService.tsx
@@ -49,6 +49,11 @@ export function mountEmbed(mountPoint: HTMLElement, data: IBaseEmbedProps, inEdi
         logWarning(`Found embed with data`, data, `and no type on element`, mountPoint);
         return;
     }
+    const exception: string | null = "exception" in data ? data["exception"] : null;
+    if (exception !== null) {
+        logWarning(`Found embed with data`, data, `and and exception`, exception, ` on element`, mountPoint);
+        return;
+    }
     const EmbedClass = getEmbedForType(type);
     if (EmbedClass === null) {
         logWarning(

--- a/library/src/scripts/navigation/CloseButton.tsx
+++ b/library/src/scripts/navigation/CloseButton.tsx
@@ -24,7 +24,7 @@ interface IProps {
  */
 export default class CloseButton extends React.PureComponent<IProps> {
     public static defaultProps = {
-        baseClass: ButtonTypes.CUSTOM,
+        baseClass: ButtonTypes.ICON,
         compact: false,
     };
 

--- a/library/src/scripts/routing/links/LinkContextProvider.tsx
+++ b/library/src/scripts/routing/links/LinkContextProvider.tsx
@@ -17,15 +17,16 @@ export interface IWithLinkContext {
 }
 
 export const LinkContext = React.createContext<IWithLinkContext>({
-    linkContext: "https://testSite.com",
+    linkContext: formatUrl("/"),
     pushSmartLocation: () => {
         return;
     },
     isDynamicNavigation: () => {
         return false;
     },
-    makeHref: () => {
-        return "/";
+    makeHref: (location: LocationDescriptor) => {
+        const stringUrl = typeof location === "string" ? location : createPath(location);
+        return formatUrl(stringUrl, true);
     },
 });
 

--- a/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
@@ -8,6 +8,7 @@
 namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
 use PHPUnit\Framework\TestCase;
+use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
 use Vanilla\Formatting\Formats\RichFormat;
 use Vanilla\Formatting\Quill\Filterer;
 use VanillaTests\SharedBootstrapTestCase;
@@ -53,6 +54,7 @@ class FiltererTest extends SharedBootstrapTestCase {
                 'insert' => [
                     'embed-external' => [
                         'data' => [
+                            'type' => QuoteEmbed::TYPE,
                             'body' => "Fake body contents, should be replaced.",
                             'bodyRaw' => 'Rendered Body',
                             'format' => 'Markdown',
@@ -64,7 +66,8 @@ class FiltererTest extends SharedBootstrapTestCase {
                 'insert' => [
                     'embed-external' => [
                         'data' => [
-                            'format' => 'Rich',
+                            'type' => QuoteEmbed::TYPE,
+                            'format' => RichFormat::FORMAT_KEY,
                             'body' => '<div><script>alert("This should be replaced!")</script></div>',
                             'bodyRaw' => [
                                 [
@@ -101,6 +104,7 @@ class FiltererTest extends SharedBootstrapTestCase {
                 'insert' => [
                     'embed-external' => [
                         'data' => [
+                            'type' => QuoteEmbed::TYPE,
                             'body' => "<p>Rendered Body</p>\n",
                             'bodyRaw' => 'Rendered Body',
                             'format' => 'Markdown',
@@ -112,6 +116,7 @@ class FiltererTest extends SharedBootstrapTestCase {
                 'insert' => [
                     'embed-external' => [
                         'data' => [
+                            'type' => QuoteEmbed::TYPE,
                             'format' => 'Rich',
                             'body' => \Gdn_Format::quoteEmbed($expectedEmbedBodyRaw, RichFormat::FORMAT_KEY),
                             'bodyRaw' => $expectedEmbedBodyRaw,

--- a/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
@@ -65,7 +65,7 @@ class FiltererTest extends SharedBootstrapTestCase {
                     'embed-external' => [
                         'data' => [
                             'format' => 'Rich',
-                            'body' => '<div><script>alert("XSS!!!!")</script></div>',
+                            'body' => '<div><script>alert("This should be replaced!")</script></div>',
                             'bodyRaw' => [
                                 [
                                     'insert' => [

--- a/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
@@ -8,6 +8,7 @@
 namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
 use PHPUnit\Framework\TestCase;
+use Vanilla\Formatting\Formats\RichFormat;
 use Vanilla\Formatting\Quill\Filterer;
 use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Formatting\Quill\Formats\Bold;
@@ -17,7 +18,7 @@ use Vanilla\Formatting\Quill\Formats\Link;
 /**
  * General testing of Filterer.
  */
-class FiltererTest extends TestCase {
+class FiltererTest extends SharedBootstrapTestCase {
 
     /**
      * Assert that the filterer is validating json properly.
@@ -36,6 +37,91 @@ class FiltererTest extends TestCase {
         $output = json_encode(json_decode($output));
         $filteredOutput = json_encode(json_decode($filteredOutput));
         $this->assertEquals($output, $filteredOutput);
+    }
+
+    /**
+     * Test that
+     * - unneeded embed data gets stripped off.
+     * - XSS in the body is prevent. We always have a fully rendered body.
+     */
+    public function testFilterEmbedData() {
+        $filterer = new Filterer();
+        $replacedUrl = 'http://test.com/replaced';
+
+        $input = [
+            [
+                'insert' => [
+                    'embed-external' => [
+                        'data' => [
+                            'body' => "Fake body contents, should be replaced.",
+                            'bodyRaw' => 'Rendered Body',
+                            'format' => 'Markdown',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'insert' => [
+                    'embed-external' => [
+                        'data' => [
+                            'format' => 'Rich',
+                            'body' => '<div><script>alert("XSS!!!!")</script></div>',
+                            'bodyRaw' => [
+                                [
+                                    'insert' => [
+                                        'embed-external' => [
+                                            'data' => [
+                                                'url' => $replacedUrl,
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                [ 'insert' => 'After Embed\n' ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        // Contents replaced with a link.
+        $expectedEmbedBodyRaw = [
+            [
+                'insert' => $replacedUrl,
+                'attributes' => [
+                    'link' => $replacedUrl,
+                ],
+            ],
+            [ 'insert' => "\n" ],
+            [ 'insert' => 'After Embed\n' ],
+        ];
+
+        $expected = [
+            [
+                'insert' => [
+                    'embed-external' => [
+                        'data' => [
+                            'body' => "<p>Rendered Body</p>\n",
+                            'bodyRaw' => 'Rendered Body',
+                            'format' => 'Markdown',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'insert' => [
+                    'embed-external' => [
+                        'data' => [
+                            'format' => 'Rich',
+                            'body' => \Gdn_Format::quoteEmbed($expectedEmbedBodyRaw, RichFormat::FORMAT_KEY),
+                            'bodyRaw' => $expectedEmbedBodyRaw,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame(json_encode($expected), $filterer->filter(json_encode($input)));
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vanilla/internal/issues/1920
Fixes https://github.com/vanilla/vanilla/issues/9037

- Fixes some data corruption issues in some embeds leading to crashes.
- Updates `Quill\Filterer` to work better with the new embeds. Unit tests for additional coverage have been added. The inline comments should serve as some documentation.
- Fixes embed styles. No issue for this but embeds 1 after another were butted up against each other.
- Fixes a bug in `SmartLink` when used without it's context wrapper. The default behaviour is not to just pass links through the default format function if there is not context wrapper. More tests will come later in the sprint as I have a task for validating stuff around that.
- Fixes the button style on the EmbedFlyout.
- Updates the embed error title & prevent the frontend from writing over errored embeds, even if the type matches. New translation PR https://github.com/vanilla/locales/pull/201.

**Note**

The `dashboard.js` file that changed is a build artifact. The source is `main.js`. This change is happening again because it looks like https://github.com/vanilla/vanilla/commit/fc74b0d0f8a90f11b37c898bbbe19f99952d7f15 screwed up @tburry's dashboard changes again due to some conflicts, but a rebuild has resolved it again.

