### PR TITLE
Fix broken mention rendering in Rich Editor

### DIFF
--- a/library/Vanilla/Formatting/Quill/Filterer.php
+++ b/library/Vanilla/Formatting/Quill/Filterer.php
@@ -46,24 +46,23 @@ class Filterer {
      */
     private function cleanupEmbeds(array &$operations): array {
         foreach ($operations as $key => &$op) {
-            $insert = &$op['insert'];
-            if (!is_array($insert)) {
-                // Only array type inserts can be embeds.
+            if (!is_array($op['insert']['embed-external'] ?? null)) {
                 continue;
             }
+            $embed = &$op['insert']['embed-external'];
 
             // If a dataPromise is still stored on the embed, that means it never loaded properly on the client.
             // We want to strip these embeds that haven't finished properly loading.
-            $dataPromise = $op['insert']['embed-external']['dataPromise'] ?? null;
+            $dataPromise = $embed['dataPromise'] ?? null;
             if ($dataPromise !== null) {
                 unset($operations[$key]);
             }
 
-            $embedData = &$op['insert']['embed-external']['data'] ?? null;
-            if ($embedData === null) {
+            if (!is_array($embed['data'] ?? null)) {
                 // We only care about embeds operations.
                 continue;
             }
+            $embedData = &$embed['data'];
 
 
             if (!$embedData) {

--- a/tests/Library/Vanilla/Formatting/Quill/RendererTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/RendererTest.php
@@ -7,6 +7,7 @@
 
 namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
+use Vanilla\Formatting\Quill\Filterer;
 use VanillaTests\Library\Vanilla\Formatting\AssertsFixtureRenderingTrait;
 use Vanilla\Formatting\Quill\Parser;
 use Vanilla\Formatting\Quill\Renderer;
@@ -29,10 +30,13 @@ class RendererTest extends SharedBootstrapTestCase {
      * @throws \Garden\Container\NotFoundException
      */
     protected function render(array $ops): string {
+        $filterer = \Gdn::getContainer()->get(Filterer::class);
         $renderer = \Gdn::getContainer()->get(Renderer::class);
         $parser = \Gdn::getContainer()->get(Parser::class);
 
-        return $renderer->render($parser->parse($ops));
+        // We need to filter to test properly.
+        $filteredValue = json_decode($filterer->filter(json_encode($ops)), true);
+        return $renderer->render($parser->parse($filteredValue));
     }
 
     /**


### PR DESCRIPTION
Getting the embed data pointer on line 62 was creating that value and assigning it to null if it did not exist. This caused non-external embeds, such as a mentions to end up with a structure similar to the following:


```json
{
  "insert": {
    "mention": {},
    "external-embed": { "data": null }
  }
}
```

This would have been caught if we ran all the rendering tests through the filterer first, so I've done, which should improve coverage of the filterer immensely.

See posts like this https://staff.vanillaforums.com/discussion/comment/3086/