### PR TITLE
Refactored the way we use "type" for buttons

### DIFF
--- a/library/src/scripts/features/search/SearchBar.tsx
+++ b/library/src/scripts/features/search/SearchBar.tsx
@@ -293,7 +293,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                         </div>
                         <ConditionalWrap condition={!!this.props.hideSearchButton} className="sr-only">
                             <Button
-                                type="submit"
+                                submit={true}
                                 id={this.searchButtonID}
                                 baseClass={this.props.buttonBaseClass}
                                 className={classNames(

--- a/library/src/scripts/flyouts/FlyoutToggle.tsx
+++ b/library/src/scripts/flyouts/FlyoutToggle.tsx
@@ -171,7 +171,6 @@ export default function FlyoutToggle(props: IProps) {
                 id={buttonID}
                 onClick={buttonClickHandler}
                 className={buttonClasses}
-                type="button"
                 title={title}
                 aria-label={"name" in props ? props.name : undefined}
                 aria-controls={contentID}

--- a/library/src/scripts/flyouts/items/DropDownItemButton.tsx
+++ b/library/src/scripts/flyouts/items/DropDownItemButton.tsx
@@ -44,7 +44,6 @@ export default class DropDownItemButton extends React.Component<IDropDownItemBut
         return (
             <DropDownItem className={classNames(this.props.className, classesDropDown.item)}>
                 <Button
-                    type="button"
                     title={this.props.name}
                     onClick={buttonClick}
                     className={classNames(this.props.buttonClassName, classesDropDown.action)}

--- a/library/src/scripts/forms/Button.tsx
+++ b/library/src/scripts/forms/Button.tsx
@@ -12,7 +12,6 @@ import classNames from "classnames";
 interface IProps extends IOptionalComponentID {
     children: React.ReactNode;
     className?: string;
-    type?: string;
     disabled?: boolean;
     prefix?: string;
     legacyMode?: boolean;
@@ -38,8 +37,8 @@ export const getDynamicClassFromButtonType = (type: ButtonTypes | undefined) => 
         const buttonUtils = buttonUtilityClasses();
         const classes = buttonClasses();
         switch (type) {
-            case ButtonTypes.TEXT:
-                return classes.text;
+            case ButtonTypes.STANDARD:
+                return classes.standard;
             case ButtonTypes.TEXT_PRIMARY:
                 return classes.textPrimary;
             case ButtonTypes.ICON:
@@ -61,7 +60,7 @@ export const getDynamicClassFromButtonType = (type: ButtonTypes | undefined) => 
             case ButtonTypes.CUSTOM:
                 return classes.custom;
             default:
-                return classes.standard;
+                return "";
         }
     } else {
         return "";
@@ -75,7 +74,6 @@ export default class Button extends React.Component<IProps, IState> {
     public static defaultProps: Partial<IProps> = {
         id: undefined,
         disabled: false,
-        type: "button",
         prefix: "button",
         legacyMode: false,
         baseClass: ButtonTypes.STANDARD,
@@ -99,7 +97,7 @@ export default class Button extends React.Component<IProps, IState> {
             <button
                 id={this.state.id}
                 disabled={this.props.disabled}
-                type={this.props.type}
+                type="button" /* this is for buttons in forms, not to be confused with ButtonTypes */
                 className={componentClasses}
                 onClick={this.props.onClick}
                 title={this.props.title}

--- a/library/src/scripts/forms/Button.tsx
+++ b/library/src/scripts/forms/Button.tsx
@@ -18,6 +18,7 @@ interface IProps extends IOptionalComponentID {
     onClick?: (e) => void;
     onKeyDown?: (e) => void;
     title?: string;
+    submit?: boolean;
     ariaLabel?: string;
     baseClass?: ButtonTypes;
     ariaHidden?: boolean;
@@ -97,7 +98,7 @@ export default class Button extends React.Component<IProps, IState> {
             <button
                 id={this.state.id}
                 disabled={this.props.disabled}
-                type="button" /* this is for buttons in forms, not to be confused with ButtonTypes */
+                type={this.props.submit ? "submit" : "button"}
                 className={componentClasses}
                 onClick={this.props.onClick}
                 title={this.props.title}

--- a/library/src/scripts/forms/ButtonSubmit.tsx
+++ b/library/src/scripts/forms/ButtonSubmit.tsx
@@ -42,7 +42,7 @@ export default class ButtonSubmit extends React.Component<IProps, IOptionalCompo
             <Button
                 id={this.props.id}
                 disabled={this.props.disabled}
-                type="submit"
+                submit={true}
                 className={componentClasses}
                 prefix="submitButton"
                 legacyMode={this.props.legacyMode}

--- a/library/src/scripts/forms/select/ClearButton.tsx
+++ b/library/src/scripts/forms/select/ClearButton.tsx
@@ -24,7 +24,6 @@ export function ClearButton(props: IProps) {
         <Button
             baseClass={ButtonTypes.ICON}
             className={classNames("suggestedTextInput-clear", "searchBar-clear", props.className)}
-            type="button"
             onClick={props.onClick}
             title={t("Clear")}
             aria-label={t("Clear")}

--- a/library/src/scripts/navigation/CloseButton.tsx
+++ b/library/src/scripts/navigation/CloseButton.tsx
@@ -37,7 +37,6 @@ export default class CloseButton extends React.PureComponent<IProps> {
         return (
             <Button
                 disabled={this.props.disabled}
-                type="button"
                 className={componentClasses}
                 title={closeLabel}
                 onClick={this.props.onClick}


### PR DESCRIPTION
We were using "types" on buttons both for their HTML effects (like in forms) and also for classes. We had several class conflicts, so I decided to refactor the types. They no longer affect the classes, "baseClass" is the proper way to do that now.

"button" is the assumed type, but "submit" can also be specified when applicable.