### PR TITLE
Fix category validation when moving a discussion

### DIFF
--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -389,7 +389,7 @@ class ModerationController extends VanillaController {
             $Category = CategoryModel::categories($CategoryID);
             $this->Form->validateRule('CategoryID', 'function:ValidateRequired', 'Category is required');
             $this->Form->setValidationResults($CategoryModel->validationResults());
-            if ($this->Form->errorCount() == 0) {
+            if ($this->Form->errorCount() === 0) {
                 $RedirectLink = $this->Form->getFormValue('RedirectLink');
 
                 // User must have add permission on the target category

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -387,104 +387,107 @@ class ModerationController extends VanillaController {
             // Retrieve the category id
             $CategoryID = $this->Form->getFormValue('CategoryID');
             $Category = CategoryModel::categories($CategoryID);
-            $RedirectLink = $this->Form->getFormValue('RedirectLink');
-
-            // User must have add permission on the target category
-            if (!$Category['PermsDiscussionsAdd']) {
-                throw forbiddenException('@'.t('You do not have permission to add discussions to this category.'));
-            }
-
-            $AffectedCategories = [];
-
-            // Iterate and move.
-            foreach ($AllowedDiscussions as $DiscussionID) {
-                $Discussion = val($DiscussionID, $DiscussionData);
-
-                // Create the shadow redirect.
-                if ($RedirectLink) {
-                    $DiscussionModel->defineSchema();
-                    $MaxNameLength = val('Length', $DiscussionModel->Schema->getField('Name'));
-
-                    $RedirectDiscussion = [
-                        'Name' => sliceString(sprintf(t('Moved: %s'), $Discussion['Name']), $MaxNameLength),
-                        'DateInserted' => $Discussion['DateLastComment'],
-                        'Type' => 'redirect',
-                        'CategoryID' => $Discussion['CategoryID'],
-                        'Body' => formatString(t('This discussion has been <a href="{url,html}">moved</a>.'), ['url' => discussionUrl($Discussion)]),
-                        'Format' => 'Html',
-                        'Closed' => true
-                    ];
-
-                    // Pass a forced input formatter around this exception.
-                    if (c('Garden.ForceInputFormatter')) {
-                        $InputFormat = c('Garden.InputFormatter');
-                        saveToConfig('Garden.InputFormatter', 'Html', false);
-                    }
-
-                    $RedirectID = $DiscussionModel->save($RedirectDiscussion);
-
-                    // Reset the input formatter
-                    if (c('Garden.ForceInputFormatter')) {
-                        saveToConfig('Garden.InputFormatter', $InputFormat, false);
-                    }
-
-                    if (!$RedirectID) {
-                        $this->Form->setValidationResults($DiscussionModel->validationResults());
-                        break;
-                    }
-                }
-
-                $DiscussionModel->setField($DiscussionID, 'CategoryID', $CategoryID);
-
-                if (!isset($AffectedCategories[$Discussion['CategoryID']])) {
-                    $AffectedCategories[$Discussion['CategoryID']] = [-1, -$Discussion['CountComments']];
-                } else {
-                    $AffectedCategories[$Discussion['CategoryID']][0] -= 1;
-                    $AffectedCategories[$Discussion['CategoryID']][1] -= $Discussion['CountComments'];
-                }
-                if (!isset($AffectedCategories[$CategoryID])) {
-                    $AffectedCategories[$CategoryID] = [1, $Discussion['CountComments']];
-                } else {
-                    $AffectedCategories[$CategoryID][0] += 1;
-                    $AffectedCategories[$CategoryID][1] += $Discussion['CountComments'];
-                }
-            }
-
-            // Update recent posts and counts on all affected categories.
-            CategoryModel::clearCache();
-            foreach ($AffectedCategories as $categoryID => $counts) {
-                $CategoryModel->refreshAggregateRecentPost($categoryID, true);
-
-                // Prepare to adjust post counts for this category and its ancestors.
-                list($discussionOffset, $commentOffset) = $counts;
-
-                // Offset the discussion count for this category and its parents.
-                if ($discussionOffset < 0) {
-                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, false);
-                } else {
-                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, false);
-                }
-
-                // Offset the comment count for this category and its parents.
-                if ($commentOffset < 0) {
-                    CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, false);
-                } else {
-                    CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, false);
-                }
-            }
-            CategoryModel::clearCache();
-
-            // Clear selections.
-            if ($ClearSelection) {
-                Gdn::userModel()->saveAttribute($Session->UserID, 'CheckedDiscussions', false);
-                ModerationController::informCheckedDiscussions($this);
-            }
-
+            $this->Form->validateRule('CategoryID', 'function:ValidateRequired', 'Category is required');
+            $this->Form->setValidationResults($CategoryModel->validationResults());
             if ($this->Form->errorCount() == 0) {
-                $this->jsonTarget('', '', 'Refresh');
+                $RedirectLink = $this->Form->getFormValue('RedirectLink');
+
+                // User must have add permission on the target category
+                if (!$Category['PermsDiscussionsAdd']) {
+                    throw forbiddenException('@' . t('You do not have permission to add discussions to this category.'));
+                }
+
+                $AffectedCategories = [];
+
+                // Iterate and move.
+                foreach ($AllowedDiscussions as $DiscussionID) {
+                    $Discussion = val($DiscussionID, $DiscussionData);
+
+                    // Create the shadow redirect.
+                    if ($RedirectLink) {
+                        $DiscussionModel->defineSchema();
+                        $MaxNameLength = val('Length', $DiscussionModel->Schema->getField('Name'));
+
+                        $RedirectDiscussion = [
+                            'Name' => sliceString(sprintf(t('Moved: %s'), $Discussion['Name']), $MaxNameLength),
+                            'DateInserted' => $Discussion['DateLastComment'],
+                            'Type' => 'redirect',
+                            'CategoryID' => $Discussion['CategoryID'],
+                            'Body' => formatString(t('This discussion has been <a href="{url,html}">moved</a>.'), ['url' => discussionUrl($Discussion)]),
+                            'Format' => 'Html',
+                            'Closed' => true
+                        ];
+
+                        // Pass a forced input formatter around this exception.
+                        if (c('Garden.ForceInputFormatter')) {
+                            $InputFormat = c('Garden.InputFormatter');
+                            saveToConfig('Garden.InputFormatter', 'Html', false);
+                        }
+
+                        $RedirectID = $DiscussionModel->save($RedirectDiscussion);
+
+                        // Reset the input formatter
+                        if (c('Garden.ForceInputFormatter')) {
+                            saveToConfig('Garden.InputFormatter', $InputFormat, false);
+                        }
+
+                        if (!$RedirectID) {
+                            $this->Form->setValidationResults($DiscussionModel->validationResults());
+                            break;
+                        }
+                    }
+
+                    $DiscussionModel->setField($DiscussionID, 'CategoryID', $CategoryID);
+
+                    if (!isset($AffectedCategories[$Discussion['CategoryID']])) {
+                        $AffectedCategories[$Discussion['CategoryID']] = [-1, -$Discussion['CountComments']];
+                    } else {
+                        $AffectedCategories[$Discussion['CategoryID']][0] -= 1;
+                        $AffectedCategories[$Discussion['CategoryID']][1] -= $Discussion['CountComments'];
+                    }
+                    if (!isset($AffectedCategories[$CategoryID])) {
+                        $AffectedCategories[$CategoryID] = [1, $Discussion['CountComments']];
+                    } else {
+                        $AffectedCategories[$CategoryID][0] += 1;
+                        $AffectedCategories[$CategoryID][1] += $Discussion['CountComments'];
+                    }
+                }
+
+                // Update recent posts and counts on all affected categories.
+                CategoryModel::clearCache();
+                foreach ($AffectedCategories as $categoryID => $counts) {
+                    $CategoryModel->refreshAggregateRecentPost($categoryID, true);
+
+                    // Prepare to adjust post counts for this category and its ancestors.
+                    list($discussionOffset, $commentOffset) = $counts;
+
+                    // Offset the discussion count for this category and its parents.
+                    if ($discussionOffset < 0) {
+                        CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, false);
+                    } else {
+                        CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_DISCUSSION, $discussionOffset, false);
+                    }
+
+                    // Offset the comment count for this category and its parents.
+                    if ($commentOffset < 0) {
+                        CategoryModel::decrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, false);
+                    } else {
+                        CategoryModel::incrementAggregateCount($categoryID, CategoryModel::AGGREGATE_COMMENT, $commentOffset, false);
+                    }
+                }
+                CategoryModel::clearCache();
+
+                // Clear selections.
+                if ($ClearSelection) {
+                    Gdn::userModel()->saveAttribute($Session->UserID, 'CheckedDiscussions', false);
+                    ModerationController::informCheckedDiscussions($this);
+                }
+
+                if ($this->Form->errorCount() == 0) {
+                    $this->jsonTarget('', '', 'Refresh');
+                }
             }
         }
-
         $this->render();
     }
 }


### PR DESCRIPTION
closes https://github.com/vanilla/vanilla/issues/9008

### Details

As a moderator, when moving a discussion without selecting a category, we get this error.
![Screen Shot 2019-07-05 at 1 58 39 PM](https://user-images.githubusercontent.com/31856281/60738636-0bb0ed80-9f2d-11e9-8db2-72a573bbbc64.png)
![Screen Shot 2019-07-05 at 1 58 32 PM](https://user-images.githubusercontent.com/31856281/60738648-13709200-9f2d-11e9-9a26-8c262fcdcb9f.png)

w'ere currently checking for permission to add a discussion in 
https://github.com/vanilla/vanilla/blob/ebf117f95a0d68020e3d37afc87df2cdc86ab7a8/applications/vanilla/controllers/class.moderationcontroller.php#L394

### Fix

Add CategoryID validation.

To Test

Move a discussion without selecting a category, you should be served with the below validation error.
![Screen Shot 2019-07-16 at 3 56 44 PM](https://user-images.githubusercontent.com/31856281/61325263-54e12700-a7e2-11e9-9448-5a30c5549255.png)

