### PR TITLE
Fix inline toolbar menu causing scroll position to jump

### DIFF
--- a/plugins/rich-editor/src/scripts/toolbars/InlineToolbar.tsx
+++ b/plugins/rich-editor/src/scripts/toolbars/InlineToolbar.tsx
@@ -262,9 +262,13 @@ export class InlineToolbar extends React.PureComponent<IProps, IState> {
         }
     };
 
+    /**
+     * Clear the link input, focus quill, and restore the selection.
+     */
     private clearLinkInput() {
-        this.quill.setSelection(this.props.lastGoodSelection);
         this.setState({ isLinkMenuOpen: false, inputValue: "" });
+        this.quill.focus();
+        this.quill.setSelection(this.props.lastGoodSelection);
     }
 
     /**


### PR DESCRIPTION
Closes https://github.com/vanilla/knowledge/issues/977

Simply focusing the editor before the selection fixes prevents the scroll position from jumping.