### PR TITLE
Removed "debug" mode from button generation

### DIFF
--- a/library/src/scripts/forms/styleHelperButtonGenerator.ts
+++ b/library/src/scripts/forms/styleHelperButtonGenerator.ts
@@ -55,133 +55,124 @@ const generateButtonClass = (buttonTypeVars: IButtonType, setZIndexOnState = fal
             : {},
     );
 
-    return style(
-        DEBUG_STYLES as any,
-        {
-            ...buttonResetMixin(),
-            textOverflow: "ellipsis",
-            overflow: "hidden",
-            maxWidth: percent(100),
-            color: colorOut(
-                buttonTypeVars.colors && buttonTypeVars.colors.fg ? buttonTypeVars.colors.fg : buttonGlobals.colors.fg,
-            ),
-            backgroundColor: colorOut(
-                buttonTypeVars.colors && buttonTypeVars.colors.bg ? buttonTypeVars.colors.bg : buttonGlobals.colors.bg,
-            ),
-            ...fonts({
-                ...buttonGlobals.font,
-                ...buttonTypeVars.fonts,
-            }),
-            ...defaultBorder,
-            ...buttonSizing(
-                buttonDimensions && buttonDimensions.minHeight
-                    ? buttonDimensions.minHeight
-                    : buttonGlobals.sizing.minHeight,
-                buttonDimensions && buttonDimensions.minWidth
-                    ? buttonDimensions.minWidth
-                    : buttonGlobals.sizing.minWidth,
-                buttonTypeVars.fonts && buttonTypeVars.fonts.size ? buttonTypeVars.fonts.size : buttonGlobals.font.size,
-                buttonTypeVars.padding && buttonTypeVars.padding.side
-                    ? buttonTypeVars.padding.side
-                    : buttonGlobals.padding.side,
-                formElVars,
-            ),
-            display: "inline-flex",
-            alignItems: "center",
-            position: "relative",
-            textAlign: "center",
-            whiteSpace: "nowrap",
-            verticalAlign: "middle",
-            justifyContent: "center",
-            touchAction: "manipulation",
-            cursor: "pointer",
-            minWidth: buttonGlobals.sizing.minWidth,
-            minHeight: buttonGlobals.sizing.minHeight,
-            $nest: {
-                "&:not([disabled])": {
-                    $nest: {
-                        "&:not(.focus-visible)": {
-                            outline: 0,
-                        },
-                        "&:hover": {
-                            zIndex,
-                            color: colorOut(
-                                buttonTypeVars.hover && buttonTypeVars.hover.colors && buttonTypeVars.hover.colors.fg
-                                    ? buttonTypeVars.hover.colors.fg
-                                    : undefined,
-                            ),
-                            backgroundColor: colorOut(
-                                buttonTypeVars.hover && buttonTypeVars.hover.colors && buttonTypeVars.hover.colors.bg
-                                    ? buttonTypeVars.hover.colors.bg
-                                    : undefined,
-                            ),
-                            ...fonts(
-                                buttonTypeVars.hover && buttonTypeVars.hover.fonts ? buttonTypeVars.hover.fonts : {},
-                            ),
-                            ...hoverBorder,
-                        },
-                        "&:focus": {
-                            zIndex,
-                            color: colorOut(
-                                buttonTypeVars.focus!.colors && buttonTypeVars.focus!.colors.fg
-                                    ? buttonTypeVars.focus!.colors.fg
-                                    : undefined,
-                            ),
-                            backgroundColor: colorOut(
-                                buttonTypeVars.focus!.colors && buttonTypeVars.focus!.colors.bg
-                                    ? buttonTypeVars.focus!.colors.bg
-                                    : undefined,
-                            ),
+    return style({
+        ...buttonResetMixin(),
+        textOverflow: "ellipsis",
+        overflow: "hidden",
+        maxWidth: percent(100),
+        color: colorOut(
+            buttonTypeVars.colors && buttonTypeVars.colors.fg ? buttonTypeVars.colors.fg : buttonGlobals.colors.fg,
+        ),
+        backgroundColor: colorOut(
+            buttonTypeVars.colors && buttonTypeVars.colors.bg ? buttonTypeVars.colors.bg : buttonGlobals.colors.bg,
+        ),
+        ...fonts({
+            ...buttonGlobals.font,
+            ...buttonTypeVars.fonts,
+        }),
+        ...defaultBorder,
+        ...buttonSizing(
+            buttonDimensions && buttonDimensions.minHeight
+                ? buttonDimensions.minHeight
+                : buttonGlobals.sizing.minHeight,
+            buttonDimensions && buttonDimensions.minWidth ? buttonDimensions.minWidth : buttonGlobals.sizing.minWidth,
+            buttonTypeVars.fonts && buttonTypeVars.fonts.size ? buttonTypeVars.fonts.size : buttonGlobals.font.size,
+            buttonTypeVars.padding && buttonTypeVars.padding.side
+                ? buttonTypeVars.padding.side
+                : buttonGlobals.padding.side,
+            formElVars,
+        ),
+        display: "inline-flex",
+        alignItems: "center",
+        position: "relative",
+        textAlign: "center",
+        whiteSpace: "nowrap",
+        verticalAlign: "middle",
+        justifyContent: "center",
+        touchAction: "manipulation",
+        cursor: "pointer",
+        minWidth: buttonGlobals.sizing.minWidth,
+        minHeight: buttonGlobals.sizing.minHeight,
+        $nest: {
+            "&:not([disabled])": {
+                $nest: {
+                    "&:not(.focus-visible)": {
+                        outline: 0,
+                    },
+                    "&:hover": {
+                        zIndex,
+                        color: colorOut(
+                            buttonTypeVars.hover && buttonTypeVars.hover.colors && buttonTypeVars.hover.colors.fg
+                                ? buttonTypeVars.hover.colors.fg
+                                : undefined,
+                        ),
+                        backgroundColor: colorOut(
+                            buttonTypeVars.hover && buttonTypeVars.hover.colors && buttonTypeVars.hover.colors.bg
+                                ? buttonTypeVars.hover.colors.bg
+                                : undefined,
+                        ),
+                        ...fonts(buttonTypeVars.hover && buttonTypeVars.hover.fonts ? buttonTypeVars.hover.fonts : {}),
+                        ...hoverBorder,
+                    },
+                    "&:focus": {
+                        zIndex,
+                        color: colorOut(
+                            buttonTypeVars.focus!.colors && buttonTypeVars.focus!.colors.fg
+                                ? buttonTypeVars.focus!.colors.fg
+                                : undefined,
+                        ),
+                        backgroundColor: colorOut(
+                            buttonTypeVars.focus!.colors && buttonTypeVars.focus!.colors.bg
+                                ? buttonTypeVars.focus!.colors.bg
+                                : undefined,
+                        ),
 
-                            ...fonts(
-                                buttonTypeVars.focus && buttonTypeVars.focus.fonts ? buttonTypeVars.focus.fonts : {},
-                            ),
-                            ...focusBorder,
-                        },
-                        "&:active": {
-                            zIndex,
-                            color: colorOut(
-                                buttonTypeVars.active!.colors && buttonTypeVars.active!.colors.fg
-                                    ? buttonTypeVars.active!.colors.fg
-                                    : undefined,
-                            ),
-                            backgroundColor: colorOut(
-                                buttonTypeVars.active!.colors && buttonTypeVars.active!.colors.bg
-                                    ? buttonTypeVars.active!.colors.bg
-                                    : undefined,
-                            ),
-                            ...fonts(
-                                buttonTypeVars.active && buttonTypeVars.active.fonts ? buttonTypeVars.active.fonts : {},
-                            ),
-                            ...activeBorder,
-                        },
-                        "&.focus-visible": {
-                            zIndex,
-                            color: colorOut(
-                                buttonTypeVars.focusAccessible!.colors && buttonTypeVars.focusAccessible!.colors.fg
-                                    ? buttonTypeVars.focusAccessible!.colors.fg
-                                    : undefined,
-                            ),
-                            backgroundColor: colorOut(
-                                buttonTypeVars.focusAccessible!.colors && buttonTypeVars.focusAccessible!.colors.bg
-                                    ? buttonTypeVars.focusAccessible!.colors.bg
-                                    : undefined,
-                            ),
-                            ...fonts(
-                                buttonTypeVars.focusAccessible && buttonTypeVars.focusAccessible.fonts
-                                    ? buttonTypeVars.focusAccessible.fonts
-                                    : {},
-                            ),
-                            ...focusAccessibleBorder,
-                        },
+                        ...fonts(buttonTypeVars.focus && buttonTypeVars.focus.fonts ? buttonTypeVars.focus.fonts : {}),
+                        ...focusBorder,
+                    },
+                    "&:active": {
+                        zIndex,
+                        color: colorOut(
+                            buttonTypeVars.active!.colors && buttonTypeVars.active!.colors.fg
+                                ? buttonTypeVars.active!.colors.fg
+                                : undefined,
+                        ),
+                        backgroundColor: colorOut(
+                            buttonTypeVars.active!.colors && buttonTypeVars.active!.colors.bg
+                                ? buttonTypeVars.active!.colors.bg
+                                : undefined,
+                        ),
+                        ...fonts(
+                            buttonTypeVars.active && buttonTypeVars.active.fonts ? buttonTypeVars.active.fonts : {},
+                        ),
+                        ...activeBorder,
+                    },
+                    "&.focus-visible": {
+                        zIndex,
+                        color: colorOut(
+                            buttonTypeVars.focusAccessible!.colors && buttonTypeVars.focusAccessible!.colors.fg
+                                ? buttonTypeVars.focusAccessible!.colors.fg
+                                : undefined,
+                        ),
+                        backgroundColor: colorOut(
+                            buttonTypeVars.focusAccessible!.colors && buttonTypeVars.focusAccessible!.colors.bg
+                                ? buttonTypeVars.focusAccessible!.colors.bg
+                                : undefined,
+                        ),
+                        ...fonts(
+                            buttonTypeVars.focusAccessible && buttonTypeVars.focusAccessible.fonts
+                                ? buttonTypeVars.focusAccessible.fonts
+                                : {},
+                        ),
+                        ...focusAccessibleBorder,
                     },
                 },
-                "&[disabled]": {
-                    opacity: formElVars.disabled.opacity,
-                },
             },
-        } as NestedCSSProperties,
-    );
+            "&[disabled]": {
+                opacity: formElVars.disabled.opacity,
+            },
+        },
+    } as NestedCSSProperties);
 };
 
 export default generateButtonClass;


### PR DESCRIPTION
This looks like a big PR, but the only diff is [one line](https://github.com/vanilla/vanilla/compare/fix%2Fremove-debug-mode?expand=1#diff-86e7c89b254b6218b71eb5cae47b0a6cL59). I removed the debug mode on the button generation. It was generating warnings in the console.