### PR TITLE
Add notifications to users quoted in Rich posts

### DIFF
--- a/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
@@ -58,10 +58,21 @@ class QuoteEmbed extends AbstractEmbed {
     }
 
     /**
+     * Get the name of the user being quoted.
+     *
+     * @return string
+     */
+    public function getUsername(): string {
+        return $this->data['insertUser']['name'];
+    }
+
+    /**
      * @inheritdoc
      */
     protected function schema(): Schema {
         return Schema::parse([
+            'recordID:i',
+            'recordType:s',
             'body:s', // The body is need currnetly during edit mode,
             // to prevent needing extra server roundtrips to render them.
             'bodyRaw:s|a', // Raw body is the source of truth for the embed.

--- a/library/Vanilla/Formatting/Quill/BlotGroup.php
+++ b/library/Vanilla/Formatting/Quill/BlotGroup.php
@@ -7,6 +7,7 @@
 
 namespace Vanilla\Formatting\Quill;
 
+use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
 use Vanilla\Formatting\Quill\Blots\AbstractBlot;
 use Vanilla\Formatting\Quill\Blots\Embeds\ExternalBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\AbstractLineTerminatorBlot;
@@ -278,7 +279,7 @@ class BlotGroup {
     }
 
     /**
-     * Get all of the mention blots in the group.
+     * Get all of the usernames that are mentioned in the blot group.
      *
      * Mentions that are inside of Blockquote's are excluded. We don't want to be sending notifications when big quote
      * replies build up.
@@ -294,8 +295,16 @@ class BlotGroup {
         foreach ($this->blots as $blot) {
             if ($blot instanceof Blots\Embeds\MentionBlot) {
                 $names[] = $blot->getUsername();
+            } elseif ($blot instanceof ExternalBlot) {
+                $embed = $blot->getEmbed();
+                if ($embed instanceof QuoteEmbed) {
+                    $names[] = $embed->getUsername();
+                }
             }
         }
+
+        // De-duplicate the usernames.
+        $names = array_unique($names);
 
         return $names;
     }

--- a/library/Vanilla/Formatting/Quill/Blots/Embeds/ExternalBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Embeds/ExternalBlot.php
@@ -7,6 +7,7 @@
 namespace Vanilla\Formatting\Quill\Blots\Embeds;
 
 use Gdn;
+use Vanilla\EmbeddedContent\AbstractEmbed;
 use Vanilla\EmbeddedContent\EmbedService;
 use Vanilla\Formatting\Quill\Blots\AbstractBlot;
 use Vanilla\Formatting\Quill\Parser;
@@ -55,6 +56,16 @@ class ExternalBlot extends AbstractBlot {
     }
 
     /**
+     * Get an Embed class instance that backs the embed.
+     *
+     * @return AbstractEmbed
+     */
+    public function getEmbed(): AbstractEmbed {
+        $data = $this->getEmbedData();
+        return $this->embedService->createEmbedFromData($data);
+    }
+
+    /**
      * Render out the content of the blot using the EmbedService.
      * @inheritDoc
      */
@@ -63,16 +74,15 @@ class ExternalBlot extends AbstractBlot {
             return $this->renderQuote();
         }
 
-        $value = $this->currentOperation["insert"]["embed-external"] ?? [];
-        $data = $value['data'] ?? $value;
-        try {
-            return $this->embedService->createEmbedFromData($data)->renderHtml();
-        } catch (\Exception $e) {
-            // TODO: Add better error handling here.
-            return '';
-        }
+        return $this->getEmbed()->renderHtml();
     }
 
+    /**
+     * Render the version of the embed if it is inside of a quote embed.
+     * Eg. A nested embed.
+     *
+     * @return string
+     */
     public function renderQuote(): string {
         $value = $this->currentOperation["insert"]["embed-external"] ?? [];
         $data = $value['data'] ?? $value;

--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -111,18 +111,21 @@ class Parser {
     }
 
     /**
-     * Parse out the usernames of everyone mentioned in a post.
+     * Parse out the usernames of everyone mentioned or quoted in a post.
      *
      * @param array $operations
      * @return string[]
      */
     public function parseMentionUsernames(array $operations): array {
-        if (!in_array(Blots\Embeds\MentionBlot::class, $this->blotClasses)) {
+        if (!in_array(Blots\Embeds\MentionBlot::class, $this->blotClasses)
+            && !in_array(Blots\Embeds\ExternalBlot::class, $this->blotClasses)
+        ) {
             return [];
         }
 
         $blotGroups = $this->parse($operations);
         $mentionUsernames = [];
+        /** @var BlotGroup $blotGroup */
         foreach ($blotGroups as $blotGroup) {
             $mentionUsernames = array_merge($mentionUsernames, $blotGroup->getMentionUsernames());
         }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -247,9 +247,7 @@ class Bootstrap {
             ->setClass(\Vanilla\Web\WebLinking::class)
             ->setShared(true)
 
-            ->rule(\Vanilla\Formatting\Embeds\EmbedManager::class)
-            ->addCall('addCoreEmbeds')
-            ->addCall('setNetworkEnabled', [false])
+            ->rule(\Vanilla\EmbeddedContent\EmbedService::class)
             ->setShared(true)
 
             ->rule(\Vanilla\PageScraper::class)

--- a/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/ParserTest.php
@@ -7,6 +7,8 @@
 
 namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
+use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
+use Vanilla\EmbeddedContent\EmbedService;
 use Vanilla\Formatting\Quill\Blots\Embeds\ExternalBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\HeadingTerminatorBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\BlockquoteLineTerminatorBlot;
@@ -15,6 +17,7 @@ use Vanilla\Formatting\Quill\Blots\Lines\SpoilerLineTerminatorBlot;
 use Vanilla\Formatting\Quill\Blots\Lines\ParagraphLineTerminatorBlot;
 use Vanilla\Formatting\Quill\Blots\NullBlot;
 use Vanilla\Formatting\Quill\Blots\TextBlot;
+use VanillaTests\Fixtures\EmbeddedContent\EmbedFixtures;
 use VanillaTests\SharedBootstrapTestCase;
 use Vanilla\Formatting\Quill\Parser;
 
@@ -348,13 +351,30 @@ class ParserTest extends SharedBootstrapTestCase {
             ["insert" => "\n"],
             $this->makeMention("@mentionInABlockquote"),
             ["attributes" => ["blockquote-line" => true], "insert" => "\n"],
+            ["insert" => "\n"],
+
+            // Comment and discussion quotes send a notification.
+            EmbedFixtures::embedInsert(EmbedFixtures::discussion("discussionUser")),
+            EmbedFixtures::embedInsert(EmbedFixtures::comment("commentUser")),
+
+            // No duplication should happen.
+            $this->makeMention("duplicate"),
+            $this->makeMention("duplicate"),
         ];
 
         $expectedUsernames = [
             "realMention",
             "Some Other meénetioön 🙃",
             "realMention$$.asdf Number 2",
+            "discussionUser",
+            "commentUser",
+            "duplicate"
         ];
+
+        // Make sure the quote embed is registered.
+        /** @var EmbedService $embedService */
+        $embedService = \Gdn::getContainer()->get(EmbedService::class);
+        $embedService->registerEmbed(QuoteEmbed::class, QuoteEmbed::TYPE);
 
         /** @var Parser $parser */
         $parser = \Gdn::getContainer()->get(Parser::class);
@@ -362,6 +382,12 @@ class ParserTest extends SharedBootstrapTestCase {
         $this->assertSame($expectedUsernames, $actualUsernames);
     }
 
+    /**
+     * Make a mention of a user.
+     *
+     * @param string $name
+     * @return array
+     */
     private function makeMention(string $name) {
         return ["insert" => [
             "mention" => [

--- a/tests/fixtures/src/EmbeddedContent/EmbedFixtures.php
+++ b/tests/fixtures/src/EmbeddedContent/EmbedFixtures.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures\EmbeddedContent;
+
+use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
+
+/**
+ * Fixtures for the embed system values.
+ */
+class EmbedFixtures {
+
+    /**
+     * Wrap some embed data in a full insert.
+     *
+     * @param mixed $data The value of the embed.
+     *
+     * @return array
+     */
+    public static function embedInsert($data): array {
+        return [
+            "insert" => [
+                "embed-external" => [
+                    "data" => $data,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Generate a discussion embed fixture.
+     *
+     * @param string $username
+     *
+     * @return array
+     */
+    public static function discussion(string $username = "DiscussionQuote Username"): array {
+        return [
+            "url" => "https://dev.vanilla.localhost/discussion/8/test-file-upload",
+            "embedType" => QuoteEmbed::TYPE,
+            "recordType" => "discussion",
+            "recordID" => 8,
+            "name" => "discussion embed fixture title",
+            "bodyRaw" => [[ "insert" => "test test\\n" ]],
+            "dateInserted" => "2019-06-14T14:09:45+00:00",
+            "dateUpdated" => null,
+            "insertUser" => [
+                "userID" => 4,
+                "name" => $username,
+                "photoUrl" => "https://images.v-cdn.net/stubcontent/avatar_01.png",
+                "dateLastActive" => "2019-06-14T18:32:27+00:00",
+            ],
+            "format" => "Rich"
+        ];
+    }
+    /**
+     * Generate a discussion embed fixture.
+     *
+     * @param string $username
+     *
+     * @return array
+     */
+    public static function comment(string $username = "CommentQuote Username"): array {
+        return [
+            "url" => "https://dev.vanilla.localhost/discussion/comment/5",
+            "embedType" => QuoteEmbed::TYPE,
+            "recordType" => "comment",
+            "recordID" => 8,
+            "bodyRaw" => [[ "insert" => "test test\\n" ]],
+            "dateInserted" => "2019-06-14T14:09:45+00:00",
+            "dateUpdated" => null,
+            "insertUser" => [
+                "userID" => 4,
+                "name" => $username,
+                "photoUrl" => "https://images.v-cdn.net/stubcontent/avatar_01.png",
+                "dateLastActive" => "2019-06-14T18:32:27+00:00",
+            ],
+            "format" => "Rich"
+        ];
+    }
+}


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8406

- Updates `Quill\Parser` to check for `QuoteEmbeds` in addition to `MentionBlots` inside of `parseUsernames`.
- Updates tests to cover quotes, and duplication of mentions.
- Adds some fixtures for creating embeds.
- Adds some minimal configuration of the `EmbedService` in the test bootstrap and removes config for the now-removed `EmbedManager`.