### PR TITLE
Fix toggling verified status on user profile not properly refreshing

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -1186,7 +1186,9 @@ class UserController extends DashboardController {
 
         // First, set the field value.
         Gdn::userModel()->setField($UserID, 'Verified', $Verified);
-
+        // Send the current $verified value to userVerified.
+        $User = (object)$User;
+        $User->Verified = $Verified;
         // Send back the verified button.
         require_once $this->fetchViewLocation('helper_functions', 'Profile', 'Dashboard');
         $this->jsonTarget('.User-Verified', userVerified($User), 'ReplaceWith');

--- a/applications/dashboard/views/profile/helper_functions.php
+++ b/applications/dashboard/views/profile/helper_functions.php
@@ -7,9 +7,11 @@ if (!function_exists('UserVerified')):
      * @return string
      */
     function userVerified($user) {
-        $userID = val('UserID', $user);
+        $userID = $user->UserID;
+        $userVerified = $user->Verified;
+        $isRequestUserID = isset($_REQUEST['userid']);
 
-        if (val('Verified', $user)) {
+        if (($userVerified === 1 && !$isRequestUserID) || ($userVerified === 0 && $isRequestUserID)) {
             $label = t('Verified');
             $title = t('Verified Description', 'Verified users bypass spam and pre-moderation filters.');
             $url = "/user/verify.json?userid=$userID&verified=0";

--- a/applications/dashboard/views/profile/helper_functions.php
+++ b/applications/dashboard/views/profile/helper_functions.php
@@ -8,10 +8,8 @@ if (!function_exists('UserVerified')):
      */
     function userVerified($user) {
         $userID = val('UserID', $user);
-        $userVerified = val('Verified', $user);
-        $isRequestUserID = isset($_REQUEST['userid']);
 
-        if (($userVerified === 1 && !$isRequestUserID) || ($userVerified === 0 && $isRequestUserID)) {
+        if (val('Verified', $user)) {
             $label = t('Verified');
             $title = t('Verified Description', 'Verified users bypass spam and pre-moderation filters.');
             $url = "/user/verify.json?userid=$userID&verified=0";

--- a/applications/dashboard/views/profile/helper_functions.php
+++ b/applications/dashboard/views/profile/helper_functions.php
@@ -8,7 +8,7 @@ if (!function_exists('UserVerified')):
      */
     function userVerified($user) {
         $userID = val('UserID', $user);
-        $userVerified = $user->Verified;
+        $userVerified = val('Verified', $user);
         $isRequestUserID = isset($_REQUEST['userid']);
 
         if (($userVerified === 1 && !$isRequestUserID) || ($userVerified === 0 && $isRequestUserID)) {

--- a/applications/dashboard/views/profile/helper_functions.php
+++ b/applications/dashboard/views/profile/helper_functions.php
@@ -7,7 +7,7 @@ if (!function_exists('UserVerified')):
      * @return string
      */
     function userVerified($user) {
-        $userID = $user->UserID;
+        $userID = val('UserID', $user);
         $userVerified = $user->Verified;
         $isRequestUserID = isset($_REQUEST['userid']);
 


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/610

### Details

In order to switch a user from 'Not Verified' to 'Verified' from their profile, you have to click on 'Not Verified' and then reload the page for the change to take place.

### To Test
from a user's profile, as an admin:
1) Click on 'Not Verified/Verified' one time and then reload the page.  status updates
2) Click on 'Not Verified/Verified' twice.  This changes the status immediately and without a reload.

### Cause

**What should happen**

If a user is verified (GDN_User->Verified =1), clicking once on the 'verified' label , label should be updated to 'Not Verified'
$url should be updated to  $url = "/user/verify.json?userid=$userID&verified=1"; for when the user clicks next time (should become verified)

but instead what is happening is this 
if a user is verified this evaluates to true
https://github.com/vanilla/vanilla/blob/d6d660987720e247531a860afdcbf807deedbc07/applications/dashboard/views/profile/helper_functions.php#L12  (first click) label is still 'Verified' and the $url 
is $url = "/user/verify.json?userid=$userID&verified=0" instead of $url = "/user/verify.json?userid=$userID&verified=1" & $label= 'Not Verified'

### This PR
If the user is verified but did not click on the link, then keep the label as verified & $url as not verified.
If the user is not verified & the user clicked on the link then update the label to 'Verified' and the $url to 'Not Verified'.