### PR TITLE
Fix slow pruning of access token tables with a high number of rows

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -287,7 +287,7 @@ $Construct
     ->column('DateInserted', 'timestamp', ['Null' => false, 'Default' => 'current_timestamp'])
     ->column('InsertUserID', 'int', true)
     ->column('InsertIPAddress', 'ipaddress', false)
-    ->column('DateExpires', 'timestamp', ['Null' => false, 'Default' => 'current_timestamp'])
+    ->column('DateExpires', 'timestamp', ['Null' => false, 'Default' => 'current_timestamp'], 'index')
     ->column('Attributes', 'text', true)
     ->set($Explicit, $Drop);
 


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/624
closes https://github.com/vanilla/support/issues/630
### Details

GDN_DateExpires does not have an index, causing queries to generate a token to run slow.
