### PR TITLE
Fix longform Vimeo URLs not embedding

### DIFF
--- a/library/Vanilla/EmbeddedContent/Factories/VimeoEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/VimeoEmbedFactory.php
@@ -43,7 +43,7 @@ class VimeoEmbedFactory extends AbstractEmbedFactory {
      * @inheritdoc
      */
     protected function getSupportedPathRegex(string $domain): string {
-        return "`^(/[a-z,[0-9]+){1,2}$`";
+        return "`^/\d+(/[a-z0-9]+)?$`";
     }
 
     /**

--- a/library/Vanilla/EmbeddedContent/Factories/VimeoEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/VimeoEmbedFactory.php
@@ -43,7 +43,7 @@ class VimeoEmbedFactory extends AbstractEmbedFactory {
      * @inheritdoc
      */
     protected function getSupportedPathRegex(string $domain): string {
-        return "`^/?\d+(\?|$)`";
+        return "`^(/[a-z,[0-9]+){1,2}$`";
     }
 
     /**

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/VimeoEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/VimeoEmbedFactoryTest.php
@@ -47,7 +47,8 @@ class VimeoEmbedFactoryTest extends ContainerTestCase {
      */
     public function supportedDomainsProvider(): array {
         return [
-            [ "https://vimeo.com/207028770" ]
+            [ "https://vimeo.com/207028770" ],
+            [ "https://vimeo.com/344997253/ab1b6f2867" ], // Alternate video syntax
         ];
     }
 


### PR DESCRIPTION
This regression was introduced with the refactoring. Noticed while doing some testing for https://github.com/vanilla/support/issues/631

I've added the URL type as well as the test for ti.