### PR TITLE
Don’t escape unicode characters when saving the rich format

### DIFF
--- a/library/Vanilla/Formatting/Quill/Filterer.php
+++ b/library/Vanilla/Formatting/Quill/Filterer.php
@@ -30,7 +30,7 @@ class Filterer {
         $operations = Parser::jsonToOperations($content);
         // Re-encode the value to escape unicode values.
         $operations = $this->cleanupEmbeds($operations);
-        $operations = json_encode($operations);
+        $operations = json_encode($operations, JSON_UNESCAPED_UNICODE);
         return $operations;
     }
 


### PR DESCRIPTION
Escaping unicode makes searching for unicode rich posts impossible so leaving it unescaped is necessary. This change requires the database to be utf8mb4 or else emoji will break.

Closes #9076.