### PR TITLE
Fix button styling regressions

### DIFF
--- a/library/src/scripts/forms/Button.tsx
+++ b/library/src/scripts/forms/Button.tsx
@@ -40,6 +40,8 @@ export const getDynamicClassFromButtonType = (type: ButtonTypes | undefined) => 
         switch (type) {
             case ButtonTypes.STANDARD:
                 return classes.standard;
+            case ButtonTypes.TEXT:
+                return classes.text;
             case ButtonTypes.TEXT_PRIMARY:
                 return classes.textPrimary;
             case ButtonTypes.ICON:

--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -434,7 +434,7 @@ export const buttonClasses = useThemeCache(() => {
     const vars = buttonVariables();
     return {
         primary: generateButtonClass(vars.primary),
-        standard: generateButtonClass(vars.standard, false, true),
+        standard: generateButtonClass(vars.standard),
         transparent: generateButtonClass(vars.transparent),
         compact: generateButtonClass(vars.compact),
         compactPrimary: generateButtonClass(vars.compactPrimary),

--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -434,7 +434,7 @@ export const buttonClasses = useThemeCache(() => {
     const vars = buttonVariables();
     return {
         primary: generateButtonClass(vars.primary),
-        standard: generateButtonClass(vars.standard),
+        standard: generateButtonClass(vars.standard, false, true),
         transparent: generateButtonClass(vars.transparent),
         compact: generateButtonClass(vars.compact),
         compactPrimary: generateButtonClass(vars.compactPrimary),

--- a/library/src/scripts/forms/styleHelperButtonGenerator.ts
+++ b/library/src/scripts/forms/styleHelperButtonGenerator.ts
@@ -16,7 +16,7 @@ import merge from "lodash/merge";
 import { NestedCSSProperties } from "typestyle/lib/types";
 import { globalVariables } from "@library/styles/globalStyleVars";
 
-const generateButtonClass = (buttonTypeVars: IButtonType, setZIndexOnState = false, debug = false) => {
+const generateButtonClass = (buttonTypeVars: IButtonType, setZIndexOnState = false) => {
     const formElVars = formElementsVariables();
     const buttonGlobals = buttonGlobalVariables();
     const style = styleFactory(`button-${buttonTypeVars.name}`);
@@ -173,7 +173,7 @@ const generateButtonClass = (buttonTypeVars: IButtonType, setZIndexOnState = fal
             },
         },
     };
-    debug && console.log(result);
+
     return style(result);
 };
 

--- a/library/src/scripts/forms/styleHelperButtonGenerator.ts
+++ b/library/src/scripts/forms/styleHelperButtonGenerator.ts
@@ -16,7 +16,7 @@ import merge from "lodash/merge";
 import { NestedCSSProperties } from "typestyle/lib/types";
 import { globalVariables } from "@library/styles/globalStyleVars";
 
-const generateButtonClass = (buttonTypeVars: IButtonType, setZIndexOnState = false) => {
+const generateButtonClass = (buttonTypeVars: IButtonType, setZIndexOnState = false, debug = false) => {
     const formElVars = formElementsVariables();
     const buttonGlobals = buttonGlobalVariables();
     const style = styleFactory(`button-${buttonTypeVars.name}`);
@@ -32,30 +32,30 @@ const generateButtonClass = (buttonTypeVars: IButtonType, setZIndexOnState = fal
             active: {},
             borders: {},
             focusAccessible: {},
-        } as IButtonType,
+        },
         buttonTypeVars,
     );
     // Remove debug and fallback
     const defaultBorder = borders(buttonTypeVars.borders, globalVariables().border);
 
-    const hoverBorder = borders(
-        buttonTypeVars.hover && buttonTypeVars.hover.borders ? merge(defaultBorder, buttonTypeVars.hover.borders) : {},
-    );
-    const activeBorder = borders(
-        buttonTypeVars.active && buttonTypeVars.active.borders
-            ? merge(defaultBorder, buttonTypeVars.active.borders)
-            : {},
-    );
-    const focusBorder = borders(
-        buttonTypeVars.focus && buttonTypeVars.focus.borders ? merge(defaultBorder, buttonTypeVars.focus.borders) : {},
-    );
-    const focusAccessibleBorder = borders(
-        buttonTypeVars.focusAccessible && buttonTypeVars.focusAccessible.borders
-            ? merge(defaultBorder, buttonTypeVars.focusAccessible.borders)
-            : {},
-    );
+    const hoverBorder = {
+        ...defaultBorder,
+        ...borders(buttonTypeVars.hover && buttonTypeVars.hover.borders),
+    };
 
-    return style({
+    const activeBorder = {
+        ...defaultBorder,
+        ...borders(buttonTypeVars.active && buttonTypeVars.active.borders),
+    };
+    const focusBorder = {
+        ...defaultBorder,
+        ...borders(buttonTypeVars.focus && buttonTypeVars.focus.borders),
+    };
+    const focusAccessibleBorder = {
+        ...defaultBorder,
+        ...borders(buttonTypeVars.focusAccessible && buttonTypeVars.focusAccessible.borders),
+    };
+    const result: NestedCSSProperties = {
         ...buttonResetMixin(),
         textOverflow: "ellipsis",
         overflow: "hidden",
@@ -172,7 +172,9 @@ const generateButtonClass = (buttonTypeVars: IButtonType, setZIndexOnState = fal
                 opacity: formElVars.disabled.opacity,
             },
         },
-    } as NestedCSSProperties);
+    };
+    debug && console.log(result);
+    return style(result);
 };
 
 export default generateButtonClass;

--- a/library/src/scripts/headers/mebox/pieces/MessagesContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/MessagesContents.tsx
@@ -19,13 +19,13 @@ import MeBoxDropDownItemList from "@library/headers/mebox/pieces/MeBoxDropDownIt
 import { t } from "@library/utility/appUtils";
 import Frame from "@library/layout/frame/Frame";
 import classNames from "classnames";
-import { compose } from "redux";
 import FrameBody from "@library/layout/frame/FrameBody";
 import FrameFooter from "@library/layout/frame/FrameFooter";
 import { LoadStatus } from "@library/@types/api/core";
 import { IConversation, GetConversationsExpand } from "@library/@types/api/conversations";
 import { IUserFragment } from "@library/@types/api/users";
 import { connect } from "react-redux";
+import { compose } from "@library/icons/header";
 
 /**
  * Implements Messages Contents to be included in drop down or tabs
@@ -56,7 +56,7 @@ export class MessagesContents extends React.Component<IProps> {
                         <LinkAsButton
                             className={classNames(buttonUtils.pushLeft)}
                             to={"/messages/inbox"}
-                            baseClass={ButtonTypes.TEXT}
+                            baseClass={ButtonTypes.TEXT_PRIMARY}
                         >
                             {t("All Messages")}
                         </LinkAsButton>

--- a/library/src/scripts/headers/mebox/pieces/NotificationsContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/NotificationsContents.tsx
@@ -73,7 +73,7 @@ export class NotificationsContents extends React.Component<IProps> {
                         </LinkAsButton>
                         <Button
                             onClick={this.markAllRead}
-                            baseClass={ButtonTypes.TEXT}
+                            baseClass={ButtonTypes.TEXT_PRIMARY}
                             className={classNames("frameFooter-markRead", classesFrameFooter.markRead)}
                         >
                             {t("Mark All Read")}

--- a/library/src/scripts/layout/pageHeadingStyles.tsx
+++ b/library/src/scripts/layout/pageHeadingStyles.tsx
@@ -47,6 +47,8 @@ export const pageHeadingClasses = useThemeCache(() => {
     });
 
     const main = style("main", {
+        display: "flex",
+        flexWrap: "nowrap",
         position: "relative",
         width: percent(100),
         flexGrow: 1,

--- a/library/src/scripts/routing/LinkAsButton.tsx
+++ b/library/src/scripts/routing/LinkAsButton.tsx
@@ -32,7 +32,10 @@ export default class LinkAsButton extends React.Component<IProps> {
 
     public render() {
         const { baseClass, className, title, ariaLabel, to, children, tabIndex, ...restProps } = this.props;
-        const componentClasses = classNames(getDynamicClassFromButtonType(baseClass), className);
+        const componentClasses = classNames(
+            getDynamicClassFromButtonType(baseClass || ButtonTypes.STANDARD),
+            className,
+        );
         return (
             <SmartLink
                 className={componentClasses}

--- a/library/src/scripts/styles/styleHelpersTypography.ts
+++ b/library/src/scripts/styles/styleHelpersTypography.ts
@@ -13,11 +13,11 @@ import {
     LineHeightProperty,
     MaxWidthProperty,
     OverflowXProperty,
-    TextAlignLastProperty,
     TextOverflowProperty,
     TextShadowProperty,
     TextTransformProperty,
     WhiteSpaceProperty,
+    TextAlignProperty,
 } from "csstype";
 import { NestedCSSProperties, TLength } from "typestyle/lib/types";
 import { colorOut } from "@library/styles/styleHelpersColors";
@@ -83,12 +83,12 @@ export interface IFont {
     weight?: FontWeightProperty | number;
     lineHeight?: LineHeightProperty<TLength>;
     shadow?: TextShadowProperty;
-    align?: TextAlignLastProperty;
+    align?: TextAlignProperty;
     family?: FontFamilyProperty[];
     transform?: TextTransformProperty;
 }
 
-export const fonts = (props: IFont) => {
+export const fonts = (props: IFont): NestedCSSProperties => {
     if (props) {
         const fontSize = props.size !== undefined ? unit(props.size) : undefined;
         const fontWeight = props.weight !== undefined ? props.weight : undefined;
@@ -107,9 +107,9 @@ export const fonts = (props: IFont) => {
             textShadow,
             fontFamily,
             textTransform,
-        } as NestedCSSProperties;
+        };
     } else {
-        return {} as NestedCSSProperties;
+        return {};
     }
 };
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/knowledge/issues/1086

- Fixes missing `TEXT` style in switch statement.
- Fixes incorrect `compose` icon import.
- Fixes generation of various border styles creating an incoming text color.
- Adds a missing base class in `<LinkAsButton />`.