### PR TITLE
Fix broken quoting

### DIFF
--- a/library/Vanilla/EmbeddedContent/Embeds/ErrorEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/ErrorEmbed.php
@@ -30,12 +30,12 @@ class ErrorEmbed extends AbstractEmbed {
         $this->exception = $exception;
 
         // Try to ensure we have some URL and some Data.
-        if (($url = $data['url'] ?? null) === null) {
+        if (($data['url'] ?? null) === null) {
             $data['url'] = t('');
         }
 
-        if (($type = $data['type'] ?? null) === null) {
-            $data['type'] = self::TYPE;
+        if (($data['embedType'] ?? null) === null) {
+            $data['embedType'] = self::TYPE;
         }
 
         if (debug()) {

--- a/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
@@ -29,9 +29,19 @@ class QuoteEmbed extends AbstractEmbed {
      * @inheritdoc
      */
     public function normalizeData(array $data): array {
+        $data = EmbedUtils::remapProperties($data, [
+            'name' => 'attributes.name',
+            'bodyRaw' => 'attributes.bodyRaw',
+            'format' => 'attributes.format',
+            'dateInserted' => 'attributes.dateInserted',
+            'insertUser' => 'attributes.insertUser',
+            'discussionID' => 'attributes.discussionID',
+            'commentID' => 'attributes.commentID',
+        ]);
+
         // Handle the IDs
-        $discussionID = $data['attributes']['discussionID'] ?? null;
-        $commentID = $data['attributes']['commentID'] ?? null;
+        $discussionID = $data['discussionID'] ?? null;
+        $commentID = $data['commentID'] ?? null;
 
         if ($discussionID !== null) {
             $data['recordID'] = $discussionID;
@@ -40,14 +50,6 @@ class QuoteEmbed extends AbstractEmbed {
             $data['recordID'] = $commentID;
             $data['recordType'] = 'comment';
         }
-
-        $data = EmbedUtils::remapProperties($data, [
-            'name' => 'attributes.name',
-            'bodyRaw' => 'attributes.bodyRaw',
-            'format' => 'attributes.format',
-            'dateInserted' => 'attributes.dateInserted',
-            'insertUser' => 'attributes.insertUser',
-        ]);
 
         // Format the body.
         if (!isset($data['body']) && isset($data['bodyRaw'])) {


### PR DESCRIPTION
Making new quotes are broken on master.

This is because the output of the quote APIs being passed in are not nested under `attributes` and don't get transformed properly. I've fixed that.

I also fixed an issue with the `ErrorEmbed` not setting the correct key to `error`. As a result the frontend would attempt to mount over it anyways (and sometimes work). This could cause the styling to get a little messed up.