### PR TITLE
Fix changing window hash causing infinite loop

### DIFF
--- a/library/src/scripts/content/hashScrolling.ts
+++ b/library/src/scripts/content/hashScrolling.ts
@@ -8,14 +8,14 @@ import { useCallback, useEffect } from "react";
 import { initAllUserContent } from "@library/content/index";
 
 export function useHashScrolling() {
-    const offset = useScrollOffset();
-    const calcedOffset = offset.getCalcedHashOffset();
+    const { temporarilyDisabledWatching, getCalcedHashOffset } = useScrollOffset();
+    const calcedOffset = getCalcedHashOffset();
 
     useEffect(() => {
         void initAllUserContent().then(() => {
-            initHashScrolling(calcedOffset, () => offset.temporarilyDisabledWatching(500));
+            initHashScrolling(calcedOffset, () => temporarilyDisabledWatching(500));
         });
-    }, [calcedOffset, offset]);
+    }, [calcedOffset, temporarilyDisabledWatching]);
 }
 
 export function initHashScrolling(offset: number = 0, beforeScrollHandler?: () => void) {

--- a/library/src/scripts/layout/ScrollOffsetContext.tsx
+++ b/library/src/scripts/layout/ScrollOffsetContext.tsx
@@ -179,7 +179,7 @@ export class ScrollOffsetProvider extends React.Component<IProps, IState> {
         this.setState({ scrollOffset: offset });
     };
 
-    private getCalcedHashOffset(): number {
+    private getCalcedHashOffset = (): number => {
         const offsetElement = this.hashOffsetRef.current;
         if (!offsetElement) {
             return 0;
@@ -187,7 +187,7 @@ export class ScrollOffsetProvider extends React.Component<IProps, IState> {
 
         const rect = offsetElement.getBoundingClientRect();
         return rect.bottom;
-    }
+    };
 }
 
 export function useScrollOffset() {


### PR DESCRIPTION
Visiting a KB page with a hash in the URL would trigger an infinite loop.

It's fixed in this PR, by restructuring a method before passing it in and correcting the triggering conditions for this effect.

## To Test

Go to a KB article and click on one of the hash links.

Closes vanilla/knowledge#1100