### PR TITLE
Fix typo breaking image scrape

### DIFF
--- a/library/Vanilla/EmbeddedContent/Factories/ScrapeEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/ScrapeEmbedFactory.php
@@ -114,7 +114,7 @@ class ScrapeEmbedFactory extends FallbackEmbedFactory {
      */
     private function getContentType(string $url): ?string {
         // Get information about the request with a HEAD request.
-        $response = $this->httpClient->options($url);
+        $response = $this->httpClient->head($url);
 
         // Let's do some super inconsistent validation of what file types are allowed.
         $contentType = $response->getHeaderLines('content-type');


### PR DESCRIPTION
As a result of sending and `OPTIONS` request instead of a `HEAD` request as indicated in the comment, we were never able to properly determine the content-type fo the resource, and would fall back to the HTTP scraper.