### PR TITLE
Add current theme url to site meta

### DIFF
--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -287,6 +287,10 @@ class Gdn_Controller extends Gdn_Pluggable {
 
         parent::__construct();
         $this->ControllerName = strtolower($this->ClassName);
+
+        // Add current theme path to GDN object
+        $themeInfo = Gdn::themeManager()->getThemeInfo(Gdn::themeManager()->currentTheme());
+        $this->addDefinition('currentThemePath', $themeInfo["Dir"]);
     }
 
     /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -290,8 +290,9 @@ class Gdn_Controller extends Gdn_Pluggable {
         $this->ControllerName = strtolower($this->ClassName);
 
         $currentTheme = Gdn::getContainer()->get(\Vanilla\AddonManager::class)->getTheme();
-        $this->addDefinition('currentThemePath', $currentTheme->getSubdir());
-
+        if ($currentTheme) {
+            $this->addDefinition('currentThemePath', $currentTheme->getSubdir());
+        }
     }
 
     /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -12,7 +12,6 @@
  * @abstract
  */
 
-use Vanilla\Utility\ContainerUtils as ContainerUtilsAlias;
 use \Vanilla\Web\Asset\LegacyAssetModel;
 use Vanilla\Web\HttpStrictTransportSecurityModel;
 use Vanilla\Web\ContentSecurityPolicy\ContentSecurityPolicyModel;

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -290,7 +290,7 @@ class Gdn_Controller extends Gdn_Pluggable {
         $this->ControllerName = strtolower($this->ClassName);
 
         $currentTheme = Gdn::getContainer()->get(\Vanilla\AddonManager::class)->getTheme();
-        if ($currentTheme) {
+        if ($currentTheme instanceof \Vanilla\Addon) {
             $this->addDefinition('currentThemePath', $currentTheme->getSubdir());
         }
     }

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -12,6 +12,7 @@
  * @abstract
  */
 
+use Vanilla\Utility\ContainerUtils as ContainerUtilsAlias;
 use \Vanilla\Web\Asset\LegacyAssetModel;
 use Vanilla\Web\HttpStrictTransportSecurityModel;
 use Vanilla\Web\ContentSecurityPolicy\ContentSecurityPolicyModel;
@@ -288,9 +289,10 @@ class Gdn_Controller extends Gdn_Pluggable {
         parent::__construct();
         $this->ControllerName = strtolower($this->ClassName);
 
-        // Add current theme path to GDN object
-        $themeInfo = Gdn::themeManager()->getThemeInfo(Gdn::themeManager()->currentTheme());
-        $this->addDefinition('currentThemePath', $themeInfo["Dir"]);
+        /** Addon $currentTheme */
+        $currentTheme = Gdn::getContainer()->get('ThemeManager')->getThemeInfo($this->Theme);
+        $this->addDefinition('currentThemePath', $currentTheme["Dir"]);
+
     }
 
     /**

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -289,9 +289,8 @@ class Gdn_Controller extends Gdn_Pluggable {
         parent::__construct();
         $this->ControllerName = strtolower($this->ClassName);
 
-        /** Addon $currentTheme */
-        $currentTheme = Gdn::getContainer()->get('ThemeManager')->getThemeInfo($this->Theme);
-        $this->addDefinition('currentThemePath', $currentTheme["Dir"]);
+        $currentTheme = Gdn::getContainer()->get(\Vanilla\AddonManager::class)->getTheme();
+        $this->addDefinition('currentThemePath', $currentTheme->getSubdir());
 
     }
 

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -39,9 +39,6 @@
             stylesheetsInclude.push(editorWysiwygCSS + '?v=' + editorVersion);
         }
 
-        // If you want to include a custom stylesheet inside the iFrame of the wysiwyg
-        stylesheetsInclude.push(gdn.meta.currentThemePath + '/design/editorWysiwyg.css?v=' + editorVersion);
-
         /**
          * Fullpage actions--available to all editor views on page load.
          *

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -32,7 +32,7 @@
         var stylesheetsInclude = [assets + '/design/editor.css?v=' + editorVersion];
 
          // If you want to include a custom stylesheet inside the iFram of the wysiwyg
-        stylesheetsInclude.push(assets + '/design/editorStyles.css?v=' + editorVersion);
+        stylesheetsInclude.push(assets + '/design/editorWysiwyg.css?v=' + editorVersion);
 
 
         // Some communities may want to modify just the styling of the Wysiwyg

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -31,14 +31,9 @@
 
         var stylesheetsInclude = [assets + '/design/editor.css?v=' + editorVersion];
 
-        /*
-         // If you want to include other stylsheets from the main page in the iframe.
-         $('link').each(function(i, el) {
-         if (el.href.indexOf("style.css") !== -1 || el.href.indexOf("custom.css") !== -1) {
-         stylesheetsInclude.push(el.href);
-         }
-         });
-         */
+         // If you want to include a custom stylesheet inside the iFram of the wysiwyg
+        stylesheetsInclude.push(assets + '/design/editorStyles.css?v=' + editorVersion);
+
 
         // Some communities may want to modify just the styling of the Wysiwyg
         // while editing, so this file will let them.

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -39,7 +39,7 @@
             stylesheetsInclude.push(editorWysiwygCSS + '?v=' + editorVersion);
         }
 
-        // If you want to include a custom stylesheet inside the iFram of the wysiwyg
+        // If you want to include a custom stylesheet inside the iFrame of the wysiwyg
         stylesheetsInclude.push(gdn.meta.currentThemePath + '/design/editorWysiwyg.css?v=' + editorVersion);
 
         /**

--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -31,9 +31,6 @@
 
         var stylesheetsInclude = [assets + '/design/editor.css?v=' + editorVersion];
 
-         // If you want to include a custom stylesheet inside the iFram of the wysiwyg
-        stylesheetsInclude.push(assets + '/design/editorWysiwyg.css?v=' + editorVersion);
-
 
         // Some communities may want to modify just the styling of the Wysiwyg
         // while editing, so this file will let them.
@@ -41,6 +38,9 @@
         if (editorWysiwygCSS != '') {
             stylesheetsInclude.push(editorWysiwygCSS + '?v=' + editorVersion);
         }
+
+        // If you want to include a custom stylesheet inside the iFram of the wysiwyg
+        stylesheetsInclude.push(gdn.meta.currentThemePath + '/design/editorWysiwyg.css?v=' + editorVersion);
 
         /**
          * Fullpage actions--available to all editor views on page load.


### PR DESCRIPTION
This PR adds to the gdn object the current theme's url path. This can be used to import assets from the theme with JS.