### PR TITLE
Reduce JS bundle size through optimized imports

### DIFF
--- a/applications/vanilla/src/scripts/categories/CategorySuggestionActions.ts
+++ b/applications/vanilla/src/scripts/categories/CategorySuggestionActions.ts
@@ -6,7 +6,7 @@
 import ReduxActions, { bindThunkAction } from "@library/redux/ReduxActions";
 import actionCreatorFactory from "typescript-fsa";
 import { IApiError } from "@library/@types/api/core";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { ICategory } from "@vanilla/addon-vanilla/@types/api/categories";
 
 const createAction = actionCreatorFactory("@@categorySuggestions");

--- a/build/scripts/configs/makeBaseConfig.ts
+++ b/build/scripts/configs/makeBaseConfig.ts
@@ -124,6 +124,7 @@ ${chalk.green(aliases)}`;
         },
         performance: { hints: false },
         plugins: [
+            new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en|es|fr|pt|ch/),
             new webpack.DefinePlugin({
                 __BUILD__SECTION__: JSON.stringify(section),
             }),

--- a/library/src/scripts/features/users/suggestion/UserSuggestionModel.test.ts
+++ b/library/src/scripts/features/users/suggestion/UserSuggestionModel.test.ts
@@ -10,8 +10,7 @@ import UserSuggestionModel from "@library/features/users/suggestion/UserSuggesti
 import UserSuggestionActions from "@library/features/users/suggestion/UserSuggestionActions";
 import { expect } from "chai";
 import sinon from "sinon";
-import { Moment } from "moment";
-import moment from "moment";
+import moment, { Moment } from "moment";
 
 type SortProviderTuple = [string[], string, string[]];
 interface ISortTestData {

--- a/library/src/scripts/forms/DatePicker.tsx
+++ b/library/src/scripts/forms/DatePicker.tsx
@@ -7,9 +7,8 @@
 import React from "react";
 import { NullComponent } from "@library/forms/select/overwrites";
 import DayPickerInput from "react-day-picker/DayPickerInput";
-import moment from "moment";
 import { t } from "@library/utility/appUtils";
-import { Moment } from "moment";
+import moment, { Moment } from "moment";
 import Button from "@library/forms/Button";
 import { ButtonTypes } from "@library/forms/buttonStyles";
 import { guessOperatingSystem, OS } from "@vanilla/utils";

--- a/packages/vanilla-eslint-config/index.js
+++ b/packages/vanilla-eslint-config/index.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     parser: "@typescript-eslint/parser",
-    plugins: ["@typescript-eslint", "react", "react-hooks", "jsx-a11y"],
+    plugins: ["@typescript-eslint", "react", "react-hooks", "jsx-a11y", "lodash"],
     extends: [
         "eslint:recommended",
         "plugin:react/recommended",
@@ -69,6 +69,11 @@ module.exports = {
 
         // React hooks
         "react-hooks/rules-of-hooks": "error",
-        "react-hooks/exhaustive-deps": "warn"
+        "react-hooks/exhaustive-deps": "warn",
+
+        // Lodash
+        // Ensure we always do single package lodash imports.
+        // Eg. import debounce from "lodash/debounce"
+        "lodash/import-scope": ["error", "method"],
     },
 };

--- a/packages/vanilla-eslint-config/package.json
+++ b/packages/vanilla-eslint-config/package.json
@@ -14,6 +14,7 @@
         "eslint-plugin-import": "^2.17.3",
         "eslint-plugin-jsx-a11y": "^6.2.1",
         "eslint-plugin-react": "^7.13.0",
-        "eslint-plugin-react-hooks": "^1.6.0"
+        "eslint-plugin-react-hooks": "^1.6.0",
+        "eslint-plugin-lodash": "5.1.0"
     }
 }

--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -49,7 +49,7 @@ export default function EditorContent(props: IProps) {
     return <div className="richEditor-textWrap" ref={quillMountRef} />;
 }
 
-let hljs: any;
+let  hightLightJs : any;
 
 /**
  * Use a dynamically imported highlight.js to highlight text synchronously.
@@ -57,18 +57,18 @@ let hljs: any;
  * Ideally with a rewrite of the SyntaxModule we would have this working async all the time
  * but until then we need this hack.60FPS
  *
- * - If hljs is loaded, run it.
- * - Otherwise return the text back and start loading hljs.
+ * - If hightLightJs is loaded, run it.
+ * - Otherwise return the text back and start loading hightLightJs.
  */
 function highLightText(text: string): IAutoHighlightResult | string {
-    if (!hljs) {
+    if (!hightLightJs) {
         void import("highlight.js" /* webpackChunkName: "highlightJs" */).then(imported => {
-            hljs = imported.default;
-            hljs.highlightAuto(text).value;
+            hightLightJs = imported.default;
+            hightLightJs.highlightAuto(text).value;
         });
         return text;
     } else {
-        return hljs.highlightAuto(text).value;
+        return hightLightJs.highlightAuto(text).value;
     }
 }
 


### PR DESCRIPTION
reduced the size of the minified bundle by ~30%

- `highlight.js` dynamically imported (goes into it's own chunk and only used when needed).
- `moment.js` locales have been filtered down to the most common ones. There's not a great solution at the moment to dynamically import these. If some other date time format ends up being needed we can add it to the whitelist.
- Added a lint rule mandating single lodash imports.
- Removed the full lodash import in `<EditorContent />`.

Relates to: https://github.com/vanilla/knowledge/issues/695