### PR TITLE
Fix pasting URL in Rich Editor's embed menu

### DIFF
--- a/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
@@ -74,7 +74,6 @@ export default function EmbedFlyout(props: IProps) {
     const buttonClickHandler = (event: React.MouseEvent<any>) => {
         event.preventDefault();
         submitUrl();
-        window.console.log("buttonClickHandler (event.nativeEvent): ", event);
     };
 
     /**
@@ -150,9 +149,7 @@ export default function EmbedFlyout(props: IProps) {
     );
 
     function handleVisibilityChange() {
-        if (inputRef.current) {
-            inputRef.current.focus();
-        }
+        inputRef.current && inputRef.current.focus();
         forceSelectionUpdate();
     }
 }

--- a/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
@@ -91,6 +91,12 @@ export default function EmbedFlyout(props: IProps) {
     const classesRichEditor = richEditorClasses(legacyMode);
     const classesInsertMedia = insertMediaClasses();
     const placeholderText = `https://`;
+
+    function handleVisibilityChange() {
+        inputRef.current && inputRef.current.focus();
+        forceSelectionUpdate();
+    }
+
     return (
         <>
             <DropDown
@@ -147,9 +153,4 @@ export default function EmbedFlyout(props: IProps) {
             </DropDown>
         </>
     );
-
-    function handleVisibilityChange() {
-        inputRef.current && inputRef.current.focus();
-        forceSelectionUpdate();
-    }
 }

--- a/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
@@ -20,9 +20,8 @@ import { insertMediaClasses } from "@rich-editor/flyouts/pieces/insertMediaClass
 import { forceSelectionUpdate } from "@rich-editor/quill/utility";
 import classNames from "classnames";
 import KeyboardModule from "quill/modules/keyboard";
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { style } from "typestyle";
-import { handleInputChange } from "react-select/lib/utils";
 
 interface IProps {
     disabled?: boolean;
@@ -67,7 +66,6 @@ export default function EmbedFlyout(props: IProps) {
             event.stopPropagation();
             isInputValid && submitUrl();
         }
-        window.console.log("buttonKeyDownHandler (event.nativeEvent): ", event.nativeEvent);
     };
 
     /**
@@ -83,11 +81,13 @@ export default function EmbedFlyout(props: IProps) {
      * Control the inputs value.
      */
     const inputChangeHandler = (event: React.ChangeEvent<any>) => {
-        setUrl(event.target.value);
-        setInputValid(isAllowedUrl(normalizeUrl(url)));
-
-        window.console.log("inputChangeHandler: ", event.target.value);
+        setUrl(normalizeUrl(event.target.value));
     };
+
+    // We need to check the value after we've set it with setUrl
+    useEffect(() => {
+        setInputValid(isAllowedUrl(url));
+    }, [url]);
 
     const classesRichEditor = richEditorClasses(legacyMode);
     const classesInsertMedia = insertMediaClasses();
@@ -101,7 +101,7 @@ export default function EmbedFlyout(props: IProps) {
                 title={t("Insert Media")}
                 paddedList={true}
                 onClose={clearInput}
-                onVisibilityChange={forceSelectionUpdate}
+                onVisibilityChange={handleVisibilityChange}
                 disabled={props.disabled}
                 buttonContents={<IconForButtonWrap icon={embed()} />}
                 buttonBaseClass={ButtonTypes.CUSTOM}
@@ -148,4 +148,11 @@ export default function EmbedFlyout(props: IProps) {
             </DropDown>
         </>
     );
+
+    function handleVisibilityChange() {
+        if (inputRef.current) {
+            inputRef.current.focus();
+        }
+        forceSelectionUpdate();
+    }
 }

--- a/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
+++ b/plugins/rich-editor/src/scripts/flyouts/EmbedFlyout.tsx
@@ -22,6 +22,7 @@ import classNames from "classnames";
 import KeyboardModule from "quill/modules/keyboard";
 import React, { useMemo, useRef, useState } from "react";
 import { style } from "typestyle";
+import { handleInputChange } from "react-select/lib/utils";
 
 interface IProps {
     disabled?: boolean;
@@ -66,6 +67,7 @@ export default function EmbedFlyout(props: IProps) {
             event.stopPropagation();
             isInputValid && submitUrl();
         }
+        window.console.log("buttonKeyDownHandler (event.nativeEvent): ", event.nativeEvent);
     };
 
     /**
@@ -74,6 +76,7 @@ export default function EmbedFlyout(props: IProps) {
     const buttonClickHandler = (event: React.MouseEvent<any>) => {
         event.preventDefault();
         submitUrl();
+        window.console.log("buttonClickHandler (event.nativeEvent): ", event);
     };
 
     /**
@@ -82,6 +85,8 @@ export default function EmbedFlyout(props: IProps) {
     const inputChangeHandler = (event: React.ChangeEvent<any>) => {
         setUrl(event.target.value);
         setInputValid(isAllowedUrl(normalizeUrl(url)));
+
+        window.console.log("inputChangeHandler: ", event.target.value);
     };
 
     const classesRichEditor = richEditorClasses(legacyMode);

--- a/plugins/rich-editor/src/scripts/toolbars/InlineToolbar.tsx
+++ b/plugins/rich-editor/src/scripts/toolbars/InlineToolbar.tsx
@@ -177,10 +177,6 @@ export class InlineToolbar extends React.PureComponent<IProps, IState> {
                 key: "k",
                 metaKey: true,
             },
-            {
-                key: "ctrolv",
-                metaKey: true,
-            },
             {},
             this.commandKHandler,
         );

--- a/plugins/rich-editor/src/scripts/toolbars/InlineToolbar.tsx
+++ b/plugins/rich-editor/src/scripts/toolbars/InlineToolbar.tsx
@@ -177,6 +177,10 @@ export class InlineToolbar extends React.PureComponent<IProps, IState> {
                 key: "k",
                 metaKey: true,
             },
+            {
+                key: "ctrolv",
+                metaKey: true,
+            },
             {},
             this.commandKHandler,
         );


### PR DESCRIPTION
This PR fixes an issue with the rich editor's embed menu. When pasting a valid URL, it did not validate it properly without a change to the text.

I also took the liberty of setting focus inside the menu, since it's a single action dropdown, we can set the focus there.

Closes: https://github.com/vanilla/support/issues/627