### PR TITLE
Added explicit top and left positioning to absolute positioned hero image

### DIFF
--- a/themes/keystone/src/scss/components/_herobanner.scss
+++ b/themes/keystone/src/scss/components/_herobanner.scss
@@ -118,6 +118,8 @@
 
 .Herobanner-bgImage {
     position: absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     background-size: cover;


### PR DESCRIPTION
The hero image is absolutely positioned in Keystone, but was missing explicit top and left values. IE 11's default is weird, which is why it looked broken on the client's site.

For: https://github.com/vanilla/support/issues/629