### PR TITLE
Add “RedirectTo” to redirect JSON responses

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3055,6 +3055,7 @@ if (!function_exists('redirectTo')) {
             echo json_encode([
                 'FormSaved' => true,
                 'RedirectUrl' => $url,
+                'RedirectTo' => $url,
             ]);
         } else {
             safeHeader('Location: ' . $url, true, $statusCode);


### PR DESCRIPTION
Some of our javascript looks for “RedirectTo” instead of “RedirectUrl” so I’m adding both to the redirect JSON response.