### PR TITLE
Add a fix to dashboard/registration/invitation target field

### DIFF
--- a/applications/dashboard/views/settings/registration.php
+++ b/applications/dashboard/views/settings/registration.php
@@ -75,11 +75,7 @@ echo $this->Form->errors(); ?>
         <?php echo $this->Form->label('Invitation target', 'Garden.Registration.InviteTarget'); ?>
     </div>
     <div class="input-wrap invite-url-code">
-        <?php
-            echo '<div class="community-domain padded-right">';
-            echo    Gdn::request()->urlDomain().(Gdn::request()->getRoot() !== '' ? Gdn::request()->getRoot().'/' : '/');
-            echo '</div>';
-            echo $this->Form->textBox('Garden.Registration.InviteTarget', ['value' => $this->InviteTarget]); ?>
+        <?php echo $this->Form->textBox('Garden.Registration.InviteTarget', ['value' => $this->InviteTarget]); ?>
     </div>
 </div>
 <div id="InvitationExpiration" class="form-group">


### PR DESCRIPTION
**Bug:**
Invitation target was misleading as it had a prefix with the community host suggesting it could only be set with a relative path. Turns out full paths also work as long as they are trusted.

**Fix:**
Removed the prefix.

Issue reported here: https://github.com/vanillaforums/king/issues/179