### PR TITLE
Fix permission required for quoting a discussion

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -357,7 +357,7 @@ class DiscussionsApiController extends AbstractApiController {
         $discussion['Url'] = discussionUrl($discussion);
 
         if ($discussion['InsertUserID'] !== $this->getSession()->UserID) {
-            $this->discussionModel->categoryPermission('Vanilla.Discussions.Edit', $discussion['CategoryID']);
+            $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $discussion['CategoryID']);
         }
 
         $isRich = $discussion['Format'] === 'Rich';


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8463

It turns out that https://github.com/vanilla/vanilla/issues/8463 was actually an issue and was incorrectly closed.

I've switched the required permission on the `/api/v2/discussions/:id/quote` endpoint to be View instead of Edit. This aligns with the permissions set on the comment quote endpoint.