### PR TITLE
Give clearer error message when no state token is found.

### DIFF
--- a/library/core/helpers/class.ssoutils.php
+++ b/library/core/helpers/class.ssoutils.php
@@ -90,7 +90,7 @@ class SsoUtils {
      */
     public function verifyStateToken($context, $stateToken) {
         if (empty($stateToken)) {
-            throw new Gdn_UserException(t('Invalid state token supplied.'), 403);
+            throw new Gdn_UserException(t('State token not found.'), 403);
         }
 
         $storedStateTokenData = null;


### PR DESCRIPTION
Ref. #9120

Presently when connecting using OAuth2 we pass, store and retrieve a state token. If no state token is passed back, we give the error "Invalid State Token" which is misleading since it is not there at all. This PR fixes this problem.