### PR TITLE
Fix a bug in twitter embed rendering

### DIFF
--- a/library/src/scripts/embeddedContent/TwitterEmbed.tsx
+++ b/library/src/scripts/embeddedContent/TwitterEmbed.tsx
@@ -115,13 +115,11 @@ export async function convertTwitterEmbeds() {
     const tweets = Array.from(document.querySelectorAll(".js-twitterCard"));
     if (tweets.length > 0) {
         await ensureScript(TWITTER_SCRIPT);
-        if (window.twttr) {
-            const promises = tweets.map(contentElement => {
-                return renderTweet(contentElement as HTMLElement);
-            });
+        const promises = tweets.map(contentElement => {
+            return renderTweet(contentElement as HTMLElement);
+        });
 
-            // Render all the pages twitter embeds at the same time.
-            await Promise.all(promises);
-        }
+        // Render all the pages twitter embeds at the same time.
+        await Promise.all(promises);
     }
 }

--- a/packages/vanilla-dom-utils/src/scripts.ts
+++ b/packages/vanilla-dom-utils/src/scripts.ts
@@ -16,15 +16,10 @@ export function ensureScript(scriptUrl: string): Promise<void> {
         if (rejectionCache.has(scriptUrl)) {
             reject(rejectionCache.get(scriptUrl));
         }
-        if (existingScript) {
-            if (loadEventCallbacks.has(existingScript)) {
-                // Add another resolveCallback into the weakmap.
-                const callbacks = loadEventCallbacks.get(existingScript);
-                callbacks && callbacks.push(resolve);
-            } else {
-                // Script is already loaded. Resolve immediately.
-                resolve();
-            }
+        if (existingScript && loadEventCallbacks.has(existingScript)) {
+            // Add another resolveCallback into the weakmap.
+            const callbacks = loadEventCallbacks.get(existingScript);
+            callbacks && callbacks.push(resolve);
         } else {
             // The script doesn't exist. Lets create it.
             const head = document.getElementsByTagName("head")[0];


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/660

`ensureScript` was resolving immediately if it saw a script already in the header. Unfortunately just having the script existing there doesn't mean it is loaded and has executed.

- Updates `ensureScript` to always attach the `onload` and `onerror` handlers if it has not already.
- Updates `convertTwitterEmbeds()` to remove duplicated check for twitter library. The check in `renderTweet()` has error handling and logging which would have made this easier to track down.