### PR TITLE
Allow body parameter to be optional for link embeds

### DIFF
--- a/library/Vanilla/EmbeddedContent/Embeds/LinkEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/LinkEmbed.php
@@ -28,7 +28,7 @@ class LinkEmbed extends AbstractEmbed {
      */
     protected function schema(): Schema {
         return Schema::parse([
-            'body:s',
+            'body:s?',
             'photoUrl:s?',
         ]);
     }

--- a/library/src/scripts/embeddedContent/LinkEmbed.tsx
+++ b/library/src/scripts/embeddedContent/LinkEmbed.tsx
@@ -15,7 +15,7 @@ import { EmbedContent } from "@library/embeddedContent/EmbedContent";
 
 interface IProps extends IBaseEmbedProps {
     photoUrl?: string;
-    body: string;
+    body?: string;
 }
 
 export function LinkEmbed(props: IProps) {


### PR DESCRIPTION
Currently the link embed schema requires the body to parameter.  A link embed's body is built with the content attribute of the page, if that's an empty string it will cause the media scrape to fail and throw a 422 error code.  This relaxes the schema and makes the body parameter optional.

closes vanilla/vanilla#9049
