### PR TITLE
Upgrade to Garden Container 2.0

### DIFF
--- a/applications/dashboard/models/SwaggerModel.php
+++ b/applications/dashboard/models/SwaggerModel.php
@@ -12,7 +12,7 @@ use Garden\Web\Dispatcher;
 use Garden\Web\Exception\ServerException;
 use Garden\Web\RequestInterface;
 use Garden\Web\ResourceRoute;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use ReflectionClass;
 use ReflectionMethod;
 use Vanilla\AddonManager;

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -31,9 +31,13 @@ if (!class_exists('Gdn')) {
 $dic = new Container();
 Gdn::setContainer($dic);
 
-$dic->setInstance('Garden\Container\Container', $dic)
-    ->rule('Interop\Container\ContainerInterface')
-    ->setAliasOf('Garden\Container\Container')
+$dic->setInstance(Garden\Container\Container::class, $dic)
+    ->rule(\Psr\Container\ContainerInterface::class)
+    ->setAliasOf(Garden\Container\Container::class)
+
+    ->rule(\Interop\Container\ContainerInterface::class)
+    ->setClass(\Vanilla\InteropContainer::class)
+    ->setShared(true)
 
     ->rule(InjectableInterface::class)
     ->addCall('setDependencies')

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "smarty/smarty": "~3.1",
         "symfony/yaml": "^3.2",
         "tburry/pquery": "~1.1",
-        "vanilla/garden-container": "^1.3.4",
+        "vanilla/garden-container": "^2.0",
         "vanilla/garden-http": "~2.0",
         "vanilla/garden-schema": "~1.0",
         "vanilla/garden-password": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "857489d11d82cd4b48f14ed687efae7f",
+    "content-hash": "8a4320fa486e5e3a572512769c7e5677",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -737,21 +737,21 @@
         },
         {
             "name": "vanilla/garden-container",
-            "version": "v1.5.1",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vanilla/garden-container.git",
-                "reference": "b718c9b4c1040643620922b3ac988dadc38f3b87"
+                "reference": "25f213022d41292c69425573c9bac98d9deb703e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vanilla/garden-container/zipball/b718c9b4c1040643620922b3ac988dadc38f3b87",
-                "reference": "b718c9b4c1040643620922b3ac988dadc38f3b87",
+                "url": "https://api.github.com/repos/vanilla/garden-container/zipball/25f213022d41292c69425573c9bac98d9deb703e",
+                "reference": "25f213022d41292c69425573c9bac98d9deb703e",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
-                "php": ">=5.6.0"
+                "php": ">=5.6.0",
+                "psr/container": "^1.0"
             },
             "type": "library",
             "autoload": {
@@ -770,7 +770,7 @@
                 }
             ],
             "description": "A dependency injection container.",
-            "time": "2017-05-05T17:46:16+00:00"
+            "time": "2018-08-13T20:13:16+00:00"
         },
         {
             "name": "vanilla/garden-http",

--- a/library/Garden/ArrayContainer.php
+++ b/library/Garden/ArrayContainer.php
@@ -8,7 +8,7 @@
 namespace Garden;
 
 use Garden\Exception\ContainerNotFoundException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * A basic container that stores its objects in an array.

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -7,7 +7,7 @@
 
 namespace Garden;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Contains methods for binding and firing to events.

--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -13,7 +13,7 @@ use Garden\Schema\ValidationException;
 use Garden\Web\Exception\HttpException;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\Pass;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Vanilla\Permissions;
 use Garden\CustomExceptionHandler;
 

--- a/library/Garden/Web/ResourceRoute.php
+++ b/library/Garden/Web/ResourceRoute.php
@@ -8,7 +8,7 @@
 namespace Garden\Web;
 
 use Garden\ClassLocator;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Maps requests to controllers using RESTful URLs.

--- a/library/Vanilla/InteropContainer.php
+++ b/library/Vanilla/InteropContainer.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPLv2
+ */
+
+namespace Vanilla;
+
+use Interop\Container\ContainerInterface as InteropContainerInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Adapts a PSR container to an interop container.
+ */
+class InteropContainer implements InteropContainerInterface {
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * InteropContainer constructor.
+     *
+     * @param ContainerInterface $container The container to adapt to.
+     */
+    public function __construct(ContainerInterface $container) {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id) {
+        return $this->container->get($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id) {
+        return $this->container->has($id);
+    }
+
+}

--- a/library/Vanilla/InteropContainer.php
+++ b/library/Vanilla/InteropContainer.php
@@ -41,5 +41,4 @@ class InteropContainer implements InteropContainerInterface {
     public function has($id) {
         return $this->container->has($id);
     }
-
 }

--- a/library/Vanilla/Models/InstallModel.php
+++ b/library/Vanilla/Models/InstallModel.php
@@ -10,7 +10,7 @@ namespace Vanilla\Models;
 use Garden\Schema\Schema;
 use Garden\Schema\Validation;
 use Garden\Schema\ValidationException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use PDO;
 
 /**

--- a/library/core/class.gdn.php
+++ b/library/core/class.gdn.php
@@ -545,8 +545,12 @@ class Gdn {
         if (self::$container === null) {
             $dic = new Garden\Container\Container();
 
-            $dic->setInstance('Garden\Container\Container', $dic)
-                ->setInstance('Interop\Container\ContainerInterface', $dic);
+            $dic->setInstance(\Garden\Container\Container::class, $dic)
+                ->setInstance(\Psr\Container\ContainerInterface::class, $dic)
+
+                ->rule(\Interop\Container\ContainerInterface::class)
+                ->setClass(\Vanilla\InteropContainer::class)
+            ;
 
             self::$container = $dic;
         }

--- a/library/core/class.pluginmanager.php
+++ b/library/core/class.pluginmanager.php
@@ -11,7 +11,7 @@
  * @since 2.0
  */
 use Garden\EventManager;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
 

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -11,7 +11,6 @@ use Garden\Container\Container;
 use Garden\Container\Reference;
 use Garden\Web\RequestInterface;
 use Gdn;
-use Interop\Container\ContainerInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Vanilla\Addon;
@@ -72,8 +71,11 @@ class Bootstrap {
             ->setInstance('@baseUrl', $this->getBaseUrl())
             ->setInstance(Container::class, $container)
 
-            ->rule(ContainerInterface::class)
+            ->rule(\Psr\Container\ContainerInterface::class)
             ->setAliasOf(Container::class)
+
+            ->rule(\Interop\Container\ContainerInterface::class)
+            ->setClass(\Vanilla\InteropContainer::class)
 
             // Base classes that want to support DI without polluting their constructor implement this.
             ->rule(InjectableInterface::class)

--- a/tests/Library/Vanilla/VanillaClassLocatorTest.php
+++ b/tests/Library/Vanilla/VanillaClassLocatorTest.php
@@ -8,7 +8,6 @@ namespace VanillaTests\Library\Vanilla;
 
 use Deeply\Nested\Namespaced\Fixture\NamespacedPlugin;
 use Garden\Container\Container;
-use Interop\Container\ContainerInterface;
 use Garden\EventManager;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
@@ -21,7 +20,10 @@ class VanillaClassLocatorTest extends ClassLocatorTest {
 
     public function testFindMethodWithOverride() {
         $container = new Container();
-        $container->setInstance(ContainerInterface::class, $container)
+        $container
+            ->setInstance(Container::class, $container)
+            ->setInstance(\Psr\Container\ContainerInterface::class, $container)
+
             ->defaultRule()
             ->setShared(true)
             ->rule(EventManager::class)

--- a/tests/TestInstallModel.php
+++ b/tests/TestInstallModel.php
@@ -7,7 +7,7 @@
 
 namespace VanillaTests;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Vanilla\Models\AddonModel;
 use Vanilla\Models\InstallModel;
 

--- a/tests/fixtures/src/Container.php
+++ b/tests/fixtures/src/Container.php
@@ -8,9 +8,9 @@
 namespace VanillaTests\Fixtures;
 
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\Exception\ContainerException;
+use Psr\Container\Exception\NotFoundException;
 
 /**
  * A basic container for unit testing.


### PR DESCRIPTION
Garden container updates to PSR container which is the same interface as interop container, but with a different name. This presents a challenge in upgrading. I’ve added an adaption object so that we can slowly move other dependencies over to the new PSR container.

The work on this PR was fairly easy with just the adapter class (`InteropContainer`). However, changing container usage throughout the app to PSR container proved to be a bit more difficult as sometimes missing a single item in a dependency would cause site crashing errors. Some care should be taken when removing the interop container from other repos.

Closes #8853.