### PR TITLE
Add support for images in webp format to AdvancedEditor

### DIFF
--- a/plugins/editor/js/editor.js
+++ b/plugins/editor/js/editor.js
@@ -1244,7 +1244,7 @@
                 // Match image URLs
                 var imageUrl = e.target.value;
                 // Doesn't have to be perfect, because URL can still not exist.
-                var imageUrlRegex = /(?:\/\/)(?:.+)(\/)(.*\.(?:jpe?g|gif|png))(?:\?([^#]*))?(?:#(.*))?/i;
+                var imageUrlRegex = /(?:\/\/)(?:.+)(\/)(.*\.(?:jpe?g|gif|png|webp))(?:\?([^#]*))?(?:#(.*))?/i;
                 if (imageUrlRegex.test(imageUrl)) {
 
                     editorInstance.focus();


### PR DESCRIPTION
AdvancedEditor doesn't insert images with `webp` extension. The format should be supported.

https://developers.google.com/speed/webp/
