### PR TITLE
Demo Feedback - Checkbox/Radio button groups, token click target

### DIFF
--- a/library/src/scripts/embeddedContent/FormElements.story.tsx
+++ b/library/src/scripts/embeddedContent/FormElements.story.tsx
@@ -23,6 +23,8 @@ import { uniqueIDFromPrefix } from "@library/utility/idUtils";
 import RadioButton from "@library/forms/RadioButton";
 import { inputBlockClasses } from "@library/forms/InputBlockStyles";
 import "@library/forms/datePicker.scss";
+import RadioButtonGroup from "@library/forms/RadioButtonGroup";
+import CheckboxGroup from "@library/forms/CheckboxGroup";
 
 const story = storiesOf("Form Elements", module);
 
@@ -55,16 +57,21 @@ story.add("Inputs", () => {
             <StoryHeading depth={1}>Form Elements</StoryHeading>
             <StoryHeading>Checkbox</StoryHeading>
             <Checkbox label={t("Simple Checkbox")} />
-            <StoryHeading>Radio Buttons - In Group</StoryHeading>
-
-            <InputBlock label={"Gaggle of radio buttons"}>
+            <StoryHeading>Checkboxes - In a Group</StoryHeading>
+            <CheckboxGroup label={"A sleuth of check boxes"}>
+                <Checkbox label={t("Option A")} />
+                <Checkbox label={t("Option B")} />
+                <Checkbox label={t("Option C")} />
+                <Checkbox label={t("Option D")} />
+            </CheckboxGroup>
+            <StoryHeading>Radio Buttons - In a Group</StoryHeading>
+            <RadioButtonGroup label={"Gaggle of radio buttons"}>
                 <RadioButton label={"Option A"} name={radioButtonGroup1} />
                 <RadioButton label={"Option B"} name={radioButtonGroup1} />
                 <RadioButton label={"Option C"} name={radioButtonGroup1} />
                 <RadioButton label={"Option D"} name={radioButtonGroup1} />
                 <RadioButton label={"Option E"} name={radioButtonGroup1} />
-            </InputBlock>
-
+            </RadioButtonGroup>
             <StoryHeading>InputBlock</StoryHeading>
             <StoryParagraph>Helper component to add label to various inputs</StoryParagraph>
             <InputBlock label={"Example of label that can be used for any input"}>
@@ -89,7 +96,6 @@ story.add("Inputs", () => {
                 <RadioTab label={t("Tab A")} position="left" data={"Tab A"} />
                 <RadioTab label={t("Tab B")} position="right" data={"Tab B"} />
             </RadioTabs>
-
             <StoryHeading>Tokens Input</StoryHeading>
             <MultiUserInput
                 onChange={handleUserChange}
@@ -112,10 +118,8 @@ story.add("Inputs", () => {
                     },
                 ]}
             />
-
             <StoryHeading>DropDown with search</StoryHeading>
             <StoryExampleDropDownSearch onChange={doNothing} />
-
             <StoryHeading>Date Range</StoryHeading>
             <DateRange onStartChange={doNothing} onEndChange={doNothing} start={undefined} end={undefined} />
         </StoryContent>

--- a/library/src/scripts/features/users/MultiUserInput.tsx
+++ b/library/src/scripts/features/users/MultiUserInput.tsx
@@ -19,6 +19,7 @@ interface IProps extends IInjectableSuggestionsProps {
     suggestionActions: UserSuggestionActions;
     onChange: (users: IComboBoxOption[]) => void;
     value: IComboBoxOption[];
+    className?: string;
 }
 
 /**
@@ -45,6 +46,7 @@ export class MultiUserInput extends React.Component<IProps> {
                 onChange={this.props.onChange}
                 value={this.props.value}
                 onInputChange={this.onInputChange}
+                className={this.props.className}
             />
         );
     }

--- a/library/src/scripts/forms/Checkbox.tsx
+++ b/library/src/scripts/forms/Checkbox.tsx
@@ -24,9 +24,9 @@ export default function CheckBox(props: IProps) {
     const classes = checkRadioClasses();
 
     return (
-        <label id={labelID} className={classNames("checkbox", props.className, classes.root)}>
+        <label id={labelID} className={classNames(props.className, classes.root)}>
             <input
-                className={classNames("checkbox-input", classes.input)}
+                className={classes.input}
                 aria-labelledby={labelID}
                 type="checkbox"
                 onChange={props.onChange}
@@ -34,10 +34,10 @@ export default function CheckBox(props: IProps) {
                 disabled={props.disabled}
                 tabIndex={0}
             />
-            <span className={classNames("checkbox-box", classes.iconContainer)} aria-hidden="true">
-                <span className={classNames("checkbox-state", classes.state)}>
+            <span className={classes.iconContainer} aria-hidden="true">
+                <span className={classes.state}>
                     <svg
-                        className={classNames("checkbox-icon checkbox-checkIcon", classes.checkIcon)}
+                        className={classNames(classes.checkIcon)}
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 10 10"
                     >
@@ -50,7 +50,7 @@ export default function CheckBox(props: IProps) {
                 </span>
             </span>
             {props.label && (
-                <span id={labelID} className={classNames("checkbox-label", classes.label)}>
+                <span id={labelID} className={classes.label}>
                     {props.label}
                 </span>
             )}

--- a/library/src/scripts/forms/CheckboxGroup.tsx
+++ b/library/src/scripts/forms/CheckboxGroup.tsx
@@ -1,0 +1,22 @@
+/*
+ * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { checkRadioClasses } from "@library/forms/checkRadioStyles";
+import InputBlock, { IInputBlockProps } from "@library/forms/InputBlock";
+import classNames from "classnames";
+
+export interface ICheckboxGroup extends IInputBlockProps {}
+
+export default class CheckboxGroup extends React.Component<ICheckboxGroup> {
+    public render() {
+        return (
+            <InputBlock {...this.props} legend={true}>
+                {this.props.children}
+            </InputBlock>
+        );
+    }
+}

--- a/library/src/scripts/forms/InputBlock.tsx
+++ b/library/src/scripts/forms/InputBlock.tsx
@@ -26,8 +26,10 @@ type CallbackChildren = (props: ICallbackProps) => React.ReactNode;
 
 export interface IInputBlockProps extends IOptionalComponentID {
     label?: ReactNode;
+    legend?: boolean;
     children: React.ReactNode | CallbackChildren;
     className?: string;
+    wrapClassName?: string;
     labelClassName?: string;
     noteAfterInput?: string;
     labelNote?: string;
@@ -56,6 +58,7 @@ export default class InputBlock extends React.Component<IInputBlockProps, IState
     }
 
     public render() {
+        const { label, legend } = this.props;
         const classesInputBlock = inputBlockClasses();
         const componentClasses = classNames(
             this.props.baseClass === InputTextBlockBaseClass.STANDARD ? classesInputBlock.root : "",
@@ -72,23 +75,30 @@ export default class InputBlock extends React.Component<IInputBlockProps, IState
             children = this.props.children;
         }
 
-        const Tag = this.props.label ? "label" : "div";
+        const OuterTag = label ? (legend ? "fieldset" : "label") : "div";
+        const LabelTag = label && legend ? "legend" : "span";
 
         return (
-            <Tag className={componentClasses}>
+            <OuterTag className={componentClasses}>
                 {this.props.label && (
                     <span id={this.labelID} className={classesInputBlock.labelAndDescription}>
-                        <span className={classNames(classesInputBlock.labelText, this.props.labelClassName)}>
+                        <LabelTag className={classNames(classesInputBlock.labelText, this.props.labelClassName)}>
                             {this.props.label}
-                        </span>
+                        </LabelTag>
                         <Paragraph className={classesInputBlock.labelNote}>{this.props.labelNote}</Paragraph>
                     </span>
                 )}
 
-                <span className={classesInputBlock.inputWrap}>{children}</span>
+                <span
+                    className={classNames(classesInputBlock.inputWrap, this.props.wrapClassName, [
+                        classesInputBlock.fieldsetGroup,
+                    ])}
+                >
+                    {children}
+                </span>
                 <Paragraph className={classesInputBlock.labelNote}>{this.props.noteAfterInput}</Paragraph>
                 <ErrorMessages id={this.errorID} errors={this.props.errors} />
-            </Tag>
+            </OuterTag>
         );
     }
 

--- a/library/src/scripts/forms/InputBlockStyles.tsx
+++ b/library/src/scripts/forms/InputBlockStyles.tsx
@@ -92,6 +92,11 @@ export const inputBlockClasses = useThemeCache(() => {
         marginBottom: unit(formElementVars.spacing.margin / 2),
     });
 
+    const sectionTitle = style("sectionTitle", {
+        fontWeight: globalVars.fonts.weights.semiBold,
+        lineHeight: globalVars.lineHeights.base,
+    });
+
     const fieldsetGroup = style("fieldsetGroup", {
         marginTop: unit(formElementVars.spacing.margin),
     });
@@ -105,6 +110,7 @@ export const inputBlockClasses = useThemeCache(() => {
         labelText,
         inputWrap,
         labelAndDescription,
+        sectionTitle,
         fieldsetGroup,
     };
 });

--- a/library/src/scripts/forms/InputBlockStyles.tsx
+++ b/library/src/scripts/forms/InputBlockStyles.tsx
@@ -24,17 +24,14 @@ export const inputBlockClasses = useThemeCache(() => {
     const vars = inputBlockVariables();
     const formElementVars = formElementsVariables();
 
-    const inputText = style("inputText", {});
-    const inputWrap = style("inputWrap", {
-        $nest: {
-            "& + .checkbox": {
-                marginTop: unit(6),
-            },
-            "& + .radioButton": {
-                marginTop: unit(6),
-            },
-        },
+    const inputText = style("inputText", {
+        display: "block",
     });
+
+    const inputWrap = style("inputWrap", {
+        display: "block",
+    });
+
     const labelAndDescription = style("labelAndDescription", {
         display: "block",
         width: percent(100),
@@ -92,13 +89,11 @@ export const inputBlockClasses = useThemeCache(() => {
         display: "block",
         fontWeight: globalVars.fonts.weights.semiBold,
         fontSize: unit(globalVars.fonts.size.medium),
-        marginBottom: unit(6),
+        marginBottom: unit(formElementVars.spacing.margin / 2),
     });
 
-    const sectionTitle = style("sectionTitle", {
-        fontWeight: globalVars.fonts.weights.semiBold,
-        lineHeight: globalVars.lineHeights.base,
-        marginBottom: unit(formElementVars.spacing.margin / 2),
+    const fieldsetGroup = style("fieldsetGroup", {
+        marginTop: unit(formElementVars.spacing.margin),
     });
 
     return {
@@ -110,6 +105,6 @@ export const inputBlockClasses = useThemeCache(() => {
         labelText,
         inputWrap,
         labelAndDescription,
-        sectionTitle,
+        fieldsetGroup,
     };
 });

--- a/library/src/scripts/forms/RadioButton.tsx
+++ b/library/src/scripts/forms/RadioButton.tsx
@@ -32,9 +32,9 @@ export default function RadioButton(props: IProps) {
     const classes = checkRadioClasses();
 
     return (
-        <label className={classNames("radioButton", classes.root)}>
+        <label className={classNames(classes.root, props.className)}>
             <input
-                className={classNames("radioButton-input", classes.input)}
+                className={classes.input}
                 onChange={props.onChange}
                 aria-disabled={props.disabled}
                 name={props.name}
@@ -43,16 +43,16 @@ export default function RadioButton(props: IProps) {
                 checked={props.checked}
                 tabIndex={0}
             />
-            <span className={classNames("radioButton-disk", classes.iconContainer, classes.disk)}>
-                <span className={classNames("checkbox-state", classes.state)}>
-                    <svg className={classNames(classes.diskIcon, "radioButton-icon", "radioButton-diskIcon")}>
+            <span aria-hidden={true} className={classNames(classes.iconContainer, classes.disk)}>
+                <span className={classes.state}>
+                    <svg className={classes.diskIcon}>
                         <title>{t("Radio Button")}</title>
                         <circle fill="currentColor" cx="3" cy="3" r="3" />
                     </svg>
                 </span>
             </span>
             {props.label && (
-                <span id={labelID} className={classNames("radioButton-label", classes.label)}>
+                <span id={labelID} className={classes.label}>
                     {props.label}
                 </span>
             )}

--- a/library/src/scripts/forms/RadioButtonGroup.tsx
+++ b/library/src/scripts/forms/RadioButtonGroup.tsx
@@ -1,0 +1,22 @@
+/*
+ * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { checkRadioClasses } from "@library/forms/checkRadioStyles";
+import InputBlock, { IInputBlockProps } from "@library/forms/InputBlock";
+import classNames from "classnames";
+
+export interface IRadioButtonGroup extends IInputBlockProps {}
+
+export default class RadioButtonGroup extends React.Component<IRadioButtonGroup> {
+    public render() {
+        return (
+            <InputBlock {...this.props} legend={true}>
+                {this.props.children}
+            </InputBlock>
+        );
+    }
+}

--- a/library/src/scripts/forms/checkRadioStyles.ts
+++ b/library/src/scripts/forms/checkRadioStyles.ts
@@ -221,15 +221,19 @@ export const checkRadioClasses = useThemeCache(() => {
                             },
                         },
                     },
-                    "& .radioButton-disk, & .checkbox-box": {
+                    [`& ${iconContainer}`]: {
                         backgroundColor: vars.main.hover.bg.toString(),
                     },
                 },
             },
-            "& + .radioButton, & + .checkbox": {
-                marginTop: px(12),
+            [`& + &`]: {
+                marginTop: px(globalVars.spacer.size / 2),
             },
         },
+    });
+
+    const group = style("group", {
+        marginTop: unit(globalVars.spacer.size / 2),
     });
 
     return {
@@ -243,5 +247,6 @@ export const checkRadioClasses = useThemeCache(() => {
         state,
         diskIcon,
         input,
+        group,
     };
 });

--- a/library/src/scripts/forms/select/SelectOne.tsx
+++ b/library/src/scripts/forms/select/SelectOne.tsx
@@ -98,7 +98,7 @@ export default class SelectOne extends React.Component<ISelectOneProps, IState> 
         });
         const classesInputBlock = inputBlockClasses();
         return (
-            <div className={this.props.className}>
+            <div className={classNames(classesInputBlock.root, this.props.className)}>
                 <label htmlFor={this.inputID} className={classesInputBlock.labelAndDescription}>
                     <span className={classNames(classesInputBlock.labelText, this.props.label)}>
                         {this.props.label}

--- a/library/src/scripts/forms/select/tokensStyles.ts
+++ b/library/src/scripts/forms/select/tokensStyles.ts
@@ -55,6 +55,10 @@ export const tokensClasses = useThemeCache(() => {
                 },
             },
             ".tokens__value-container": {
+                display: "flex",
+                flexWrap: "wrap",
+                alignItems: "center",
+                justifyContent: "flexStart",
                 minHeight: unit(formElVars.sizing.height),
                 paddingTop: 0,
                 paddingRight: px(12),
@@ -63,6 +67,20 @@ export const tokensClasses = useThemeCache(() => {
                 $nest: {
                     "&.tokens__value-container--has-value": {
                         padding: px(3),
+                    },
+                    "& .tokens__multi-value + div:not(.tokens__multi-value)": {
+                        display: "flex",
+                        flexWrap: "wrap",
+                        alignItems: "center",
+                        justifyContent: "flexStart",
+                        flexGrow: 1,
+                    },
+                    ".tokens__input": {
+                        flexGrow: 1,
+                    },
+                    input: {
+                        width: percent(100),
+                        minWidth: unit(45),
                     },
                 },
             },


### PR DESCRIPTION
Created RadioButtonGroup and CheckboxGroup components. They wrap inputBlock to add appropriate markup and styles.

Got rid of all SASS classes on radio buttons and checkboxes.

Fixed input spacing in advanced search (KB). Some elements didn't have the proper class and were too tight.

Fixed bug with token input. After inputting the first element, the text input would be super small ( 1 or 2 pixels wide). Making it difficult to click back and continue adding text. I also gave a minimum width for the input so it won't ever be too small up against the edge if the tokens happen to take almost a full line.

Companion PR: https://github.com/vanilla/knowledge/pull/1131
