### PR TITLE
Fix some formatting and embed tests

### DIFF
--- a/library/Vanilla/BodyFormatValidator.php
+++ b/library/Vanilla/BodyFormatValidator.php
@@ -42,7 +42,9 @@ class BodyFormatValidator {
         } catch (FormattingException $e) {
             $result = new Invalid($e->getMessage());
         } catch (FormatterNotFoundException $e) {
-            $result = new Invalid($e->getMessage());
+            // For backwards compatibility unknown formatters are allowed in this validator.
+            // The old models handle their own format validation where necessary.
+            return $value;
         }
 
         return $result;

--- a/library/Vanilla/BodyFormatValidator.php
+++ b/library/Vanilla/BodyFormatValidator.php
@@ -44,6 +44,13 @@ class BodyFormatValidator {
         } catch (FormatterNotFoundException $e) {
             // For backwards compatibility unknown formatters are allowed in this validator.
             // The old models handle their own format validation where necessary.
+            trigger_error(
+                "Could not validate format $format. A formatter was not found."
+                . "This is currently a warning, but may be an exception in the future.\n"
+                . "To fix this, implement `Vanilla\Contracts\Formatting\FormatInterface` for $format "
+                . "and register it with the `Vanilla\Formatting\FormatService`",
+                E_USER_WARNING
+            );
             return $value;
         }
 

--- a/library/Vanilla/Formatting/FormatService.php
+++ b/library/Vanilla/Formatting/FormatService.php
@@ -43,10 +43,11 @@ class FormatService {
      * @return string
      *
      * @throws FormattingException If the post content wasn't valid and couldn't be filtered.
+     * @throws FormatterNotFoundException If the format doesn't have a match.
      */
     public function filter(string $content, string $format): string {
         return $this
-            ->getFormatter($format)
+            ->getFormatter($format, true)
             ->filter($content);
     }
 

--- a/library/Vanilla/Formatting/FormatService.php
+++ b/library/Vanilla/Formatting/FormatService.php
@@ -43,11 +43,10 @@ class FormatService {
      * @return string
      *
      * @throws FormattingException If the post content wasn't valid and couldn't be filtered.
-     * @throws FormatterNotFoundException If the format doesn't have a match.
      */
     public function filter(string $content, string $format): string {
         return $this
-            ->getFormatter($format, true)
+            ->getFormatter($format)
             ->filter($content);
     }
 

--- a/library/Vanilla/Formatting/Formats/NotFoundFormat.php
+++ b/library/Vanilla/Formatting/Formats/NotFoundFormat.php
@@ -68,9 +68,7 @@ class NotFoundFormat implements FormatInterface {
      * @inheritdoc
      */
     public function filter(string $content): string {
-        // For backwards compatibility with custom formats that haven't been updated yet
-        // We don't want to throw any exceptions if we don't recognize the format.
-        return $content;
+        throw new FormatterNotFoundException($this->getErrorMessage());
     }
 
     /**

--- a/library/Vanilla/Formatting/Formats/NotFoundFormat.php
+++ b/library/Vanilla/Formatting/Formats/NotFoundFormat.php
@@ -68,7 +68,9 @@ class NotFoundFormat implements FormatInterface {
      * @inheritdoc
      */
     public function filter(string $content): string {
-        throw new FormatterNotFoundException($this->getErrorMessage());
+        // For backwards compatibility with custom formats that haven't been updated yet
+        // We don't want to throw any exceptions if we don't recognize the format.
+        return $content;
     }
 
     /**

--- a/library/Vanilla/Formatting/Quill/Filterer.php
+++ b/library/Vanilla/Formatting/Quill/Filterer.php
@@ -9,6 +9,7 @@ namespace Vanilla\Formatting\Quill;
 
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
 use Vanilla\Formatting\Exception\FormattingException;
+use Vanilla\Formatting\Formats\RichFormat;
 
 /**
  * Class for filtering Rich content before it gets inserted into the database.
@@ -75,16 +76,18 @@ class Filterer {
             // Remove the rendered bodies. The raw bodies are the source of truth.
             $format = &$embedData['format'] ?? null;
             $bodyRaw = &$embedData['bodyRaw'] ?? null;
-            $type = &$embedData['type'] ?? null;
+            $type = $embedData['embedType'] ?? $embedData['type'] ?? null;
 
             if ($type !== QuoteEmbed::TYPE) {
                 // We only care about quote embeds specifically.
                 continue;
             }
 
+            $stringBodyRaw = $bodyRaw;
+
             // Remove nested external embed data. We don't want it rendered and this will prevent it from being
             // searched.
-            if ($format === 'Rich' && is_array($bodyRaw)) {
+            if (strtolower($format) === RichFormat::FORMAT_KEY && is_array($bodyRaw)) {
                 // Iterate through the nested embed.
                 foreach ($bodyRaw as $subInsertIndex => &$subInsertOp) {
                     $insert = &$subInsertOp['insert'];
@@ -97,10 +100,11 @@ class Filterer {
                         }
                     }
                 }
+                $stringBodyRaw = json_encode($bodyRaw);
             }
 
             // Finally render the new body to overwrite the previous HTML body.
-            $embedData['body'] = \Gdn::formatService()->renderQuote($bodyRaw, $format);
+            $embedData['body'] = \Gdn::formatService()->renderQuote($stringBodyRaw, $format);
         }
 
         return array_values($operations);

--- a/tests/Library/Vanilla/EmbeddedContent/AbstractEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/AbstractEmbedFactoryTest.php
@@ -14,7 +14,7 @@ use VanillaTests\Fixtures\EmbeddedContent\MockEmbedFactory;
 /**
  * Tests for the embed factory.
  */
-class AbstractEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class AbstractEmbedFactoryTest extends MinimalContainerTestCase {
 
     /**
      * @inheritdoc

--- a/tests/Library/Vanilla/EmbeddedContent/EmbedServiceTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/EmbedServiceTest.php
@@ -16,7 +16,7 @@ use VanillaTests\Fixtures\NullCache;
 /**
  * Tests for the EmbedService class.
  */
-class EmbedServiceTestMinimal extends MinimalContainerTestCase {
+class EmbedServiceTest extends MinimalContainerTestCase {
 
     /** @var EmbedService */
     private $embedService;

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/CodePenEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/CodePenEmbedTest.php
@@ -13,7 +13,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Validation logic test.
  */
-class CodePenEmbedTestMinimal extends MinimalContainerTestCase {
+class CodePenEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create code pen embed from the old data format that might still
      * live in the DB.

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/FileEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/FileEmbedTest.php
@@ -12,7 +12,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Validation logic test.
  */
-class FileEmbedTestMinimal extends MinimalContainerTestCase {
+class FileEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create file embed embed from the old data format that might still
      * live in the DB.
@@ -45,7 +45,7 @@ class FileEmbedTestMinimal extends MinimalContainerTestCase {
 JSON;
 
         $oldData = json_decode($oldDataJSON, true);
-        $dataEmbed = new FileEmbedTestMinimal($oldData);
-        $this->assertInstanceOf(FileEmbedTestMinimal::class, $dataEmbed);
+        $dataEmbed = new FileEmbedTest($oldData);
+        $this->assertInstanceOf(FileEmbedTest::class, $dataEmbed);
     }
 }

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/GettyImagesEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/GettyImagesEmbedTest.php
@@ -12,7 +12,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Verify embed class capabilities.
  */
-class GettyImagesEmbedTestMinimal extends MinimalContainerTestCase {
+class GettyImagesEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create an embed from legacy data that might still live in the DB.
      */

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/GiphyEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/GiphyEmbedTest.php
@@ -13,7 +13,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Validation logic test.
  */
-class GiphyEmbedTestMinimal extends MinimalContainerTestCase {
+class GiphyEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create giphy embed from the old data format that might still
      * live in the DB.

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/ImgurEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/ImgurEmbedTest.php
@@ -6,36 +6,35 @@
 
 namespace VanillaTests\Library\EmbeddedContent\Embeds;
 
-use Vanilla\EmbeddedContent\Embeds\InstagramEmbed;
+use Vanilla\EmbeddedContent\Embeds\ImgurEmbed;
 use VanillaTests\MinimalContainerTestCase;
 
 /**
  * Verify embed class capabilities.
  */
-class InstagramEmbedTestMinimal extends MinimalContainerTestCase {
+class ImgurEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create an embed from legacy data that might still live in the DB.
      */
     public function testLegacyDataFormat() {
         $legacyJSON = <<<JSON
 {
-    "url": "https://www.instagram.com/p/BTjnolqg4po/?taken-by=vanillaforums",
-    "type": "instagram",
+    "url": "https://imgur.com/gallery/arP2Otg",
+    "type": "imgur",
     "name": null,
     "body": null,
     "photoUrl": null,
     "height": null,
     "width": null,
     "attributes": {
-        "permaLink": "https://www.instagram.com/p/BTjnolqg4po",
-        "isCaptioned": true,
-        "versionNumber": "8"
+        "postID": "arP2Otg",
+        "isAlbum": false
     }
 }
 JSON;
 
         $data = json_decode($legacyJSON, true);
-        $embed = new InstagramEmbed($data);
-        $this->assertInstanceOf(InstagramEmbed::class, $embed);
+        $embed = new ImgurEmbed($data);
+        $this->assertInstanceOf(ImgurEmbed::class, $embed);
     }
 }

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/InstagramEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/InstagramEmbedTest.php
@@ -6,34 +6,36 @@
 
 namespace VanillaTests\Library\EmbeddedContent\Embeds;
 
-use Vanilla\EmbeddedContent\Embeds\TwitterEmbed;
+use Vanilla\EmbeddedContent\Embeds\InstagramEmbed;
 use VanillaTests\MinimalContainerTestCase;
 
 /**
  * Verify embed class capabilities.
  */
-class TwitterEmbedTestMinimal extends MinimalContainerTestCase {
+class InstagramEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create an embed from legacy data that might still live in the DB.
      */
     public function testLegacyDataFormat() {
         $legacyJSON = <<<JSON
 {
-    "url": "https://twitter.com/hootsuite/status/1009883861617135617",
-    "type": "twitter",
+    "url": "https://www.instagram.com/p/BTjnolqg4po/?taken-by=vanillaforums",
+    "type": "instagram",
     "name": null,
     "body": null,
     "photoUrl": null,
     "height": null,
     "width": null,
     "attributes": {
-        "statusID": "1009883861617135617"
+        "permaLink": "https://www.instagram.com/p/BTjnolqg4po",
+        "isCaptioned": true,
+        "versionNumber": "8"
     }
 }
 JSON;
 
         $data = json_decode($legacyJSON, true);
-        $embed = new TwitterEmbed($data);
-        $this->assertInstanceOf(TwitterEmbed::class, $embed);
+        $embed = new InstagramEmbed($data);
+        $this->assertInstanceOf(InstagramEmbed::class, $embed);
     }
 }

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/LinkEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/LinkEmbedTest.php
@@ -13,7 +13,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Test for the individual linkembed.
  */
-class LinkEmbedTestMinimal extends MinimalContainerTestCase {
+class LinkEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create giphy embed from the old data format that might still
      * live in the DB.

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/QuoteEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/QuoteEmbedTest.php
@@ -16,7 +16,7 @@ use VanillaTests\Fixtures\EmbeddedContent\LegacyEmbedFixtures;
 /**
  * Test for the individual linkembed.
  */
-class QuoteEmbedTestMinimal extends MinimalContainerTestCase {
+class QuoteEmbedTest extends MinimalContainerTestCase {
 
     /**
      * Setup.

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/SoundCloudEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/SoundCloudEmbedTest.php
@@ -12,7 +12,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Verify embed class capabilities.
  */
-class SoundCloudEmbedTestMinimal extends MinimalContainerTestCase {
+class SoundCloudEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create an embed from legacy data that might still live in the DB.
      */

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/TwitchEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/TwitchEmbedTest.php
@@ -12,7 +12,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Verify embed class capabilities.
  */
-class TwitchEmbedTestMinimal extends MinimalContainerTestCase {
+class TwitchEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create an embed from legacy data that might still live in the DB.
      */

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/TwitterEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/TwitterEmbedTest.php
@@ -6,35 +6,34 @@
 
 namespace VanillaTests\Library\EmbeddedContent\Embeds;
 
-use Vanilla\EmbeddedContent\Embeds\ImgurEmbed;
+use Vanilla\EmbeddedContent\Embeds\TwitterEmbed;
 use VanillaTests\MinimalContainerTestCase;
 
 /**
  * Verify embed class capabilities.
  */
-class ImgurEmbedTestMinimal extends MinimalContainerTestCase {
+class TwitterEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create an embed from legacy data that might still live in the DB.
      */
     public function testLegacyDataFormat() {
         $legacyJSON = <<<JSON
 {
-    "url": "https://imgur.com/gallery/arP2Otg",
-    "type": "imgur",
+    "url": "https://twitter.com/hootsuite/status/1009883861617135617",
+    "type": "twitter",
     "name": null,
     "body": null,
     "photoUrl": null,
     "height": null,
     "width": null,
     "attributes": {
-        "postID": "arP2Otg",
-        "isAlbum": false
+        "statusID": "1009883861617135617"
     }
 }
 JSON;
 
         $data = json_decode($legacyJSON, true);
-        $embed = new ImgurEmbed($data);
-        $this->assertInstanceOf(ImgurEmbed::class, $embed);
+        $embed = new TwitterEmbed($data);
+        $this->assertInstanceOf(TwitterEmbed::class, $embed);
     }
 }

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/VimeoEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/VimeoEmbedTest.php
@@ -12,7 +12,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Verify embed class capabilities.
  */
-class VimeoEmbedTestMinimal extends MinimalContainerTestCase {
+class VimeoEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create an embed from legacy data that might still live in the DB.
      */

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/WistiaEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/WistiaEmbedTest.php
@@ -12,7 +12,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Verify embed class capabilities.
  */
-class WistiaEmbedTestMinimal extends MinimalContainerTestCase {
+class WistiaEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create an embed from legacy data that might still live in the DB.
      */

--- a/tests/Library/Vanilla/EmbeddedContent/Embeds/YouTubeEmbedTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Embeds/YouTubeEmbedTest.php
@@ -12,7 +12,7 @@ use VanillaTests\MinimalContainerTestCase;
 /**
  * Verify embed class capabilities.
  */
-class YouTubeEmbedTestMinimal extends MinimalContainerTestCase {
+class YouTubeEmbedTest extends MinimalContainerTestCase {
     /**
      * Ensure we can create an embed from legacy data that might still live in the DB.
      */

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/CodePenEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/CodePenEmbedFactoryTest.php
@@ -8,17 +8,17 @@
 namespace VanillaTests\Library\EmbeddedContent\Factories;
 
 use Garden\Http\HttpResponse;
-use Vanilla\EmbeddedContent\Embeds\GiphyEmbed;
-use Vanilla\EmbeddedContent\Factories\GiphyEmbedFactory;
+use Vanilla\EmbeddedContent\Embeds\CodePenEmbed;
+use Vanilla\EmbeddedContent\Factories\CodePenEmbedFactory;
 use VanillaTests\MinimalContainerTestCase;
 use VanillaTests\Fixtures\MockHttpClient;
 
 /**
  * Tests for the giphy embed and factory.
  */
-class GiphyEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class CodePenEmbedFactoryTest extends MinimalContainerTestCase {
 
-    /** @var GiphyEmbedFactory */
+    /** @var CodePenEmbedFactory */
     private $factory;
 
     /** @var MockHttpClient */
@@ -30,7 +30,7 @@ class GiphyEmbedFactoryTestMinimal extends MinimalContainerTestCase {
     public function setUp() {
         parent::setUp();
         $this->httpClient = new MockHttpClient();
-        $this->factory = new GiphyEmbedFactory($this->httpClient);
+        $this->factory = new CodePenEmbedFactory($this->httpClient);
     }
 
 
@@ -49,9 +49,7 @@ class GiphyEmbedFactoryTestMinimal extends MinimalContainerTestCase {
      */
     public function supportedDomainsProvider(): array {
         return [
-            ['https://gph.is/291u1MC'],
-            ['https://giphy.com/gifs/howtogiphygifs-how-to-XatG8bioEwwVO'],
-            ['https://media.giphy.com/media/kW8mnYSNkUYKc/giphy.gif']
+            ['https://codepen.io/hiroshi_m/pen/YoKYVv'], // Only 1 image format.
         ];
     }
 
@@ -59,13 +57,14 @@ class GiphyEmbedFactoryTestMinimal extends MinimalContainerTestCase {
      * Test network request fetching and handling.
      */
     public function testCreateEmbedForUrl() {
-        $urlToCheck = 'https://giphy.com/gifs/howtogiphygifs-how-to-XatG8bioEwwVO';
-        $endpoint = GiphyEmbedFactory::OEMBED_URL_BASE . '?url=' . urlencode($urlToCheck);
+        $urlToCheck = 'https://codepen.io/hiroshi_m/pen/YoKYVv';
+        $endpoint = CodePenEmbedFactory::OEMBED_URL_BASE . '?url=' . urlencode($urlToCheck) . '&format=json';
 
-        $title = 'Hello title';
+        $name = 'Hello title';
         $width = 500;
         $height = 400;
-        $finalUrl = 'https://media.giphy.com/media/kW8mnYSNkUYKc/giphy.gif';
+        $frameSrc = 'https://codepen.io/hiroshi_m/embed/preview/YoKYVv?height=300';
+        $cpId = 'YoKYVv';
 
         $this->httpClient->addMockResponse(
             $endpoint,
@@ -74,31 +73,32 @@ class GiphyEmbedFactoryTestMinimal extends MinimalContainerTestCase {
                 'Content-Type: application/json',
                 json_encode([
                     'width' => $width,
-                    'title' => $title,
+                    'title' => $name,
                     'height' => $height,
-                    'url' => $finalUrl,
+                    'html' => "<iframe id='cp_embed_$cpId' src='$frameSrc'></iframe>",
                 ])
             )
         );
 
         // Check over the network.
-        $giphyEmbed = $this->factory->createEmbedForUrl($urlToCheck);
-        $embedData = $giphyEmbed->jsonSerialize();
+        $embed = $this->factory->createEmbedForUrl($urlToCheck);
+        $embedData = $embed->jsonSerialize();
         $this->assertEquals(
             [
                 'width' => $width,
-                'name' => $title,
+                'name' => $name,
                 'height' => $height,
                 'url' => $urlToCheck, // The original URL.
-                'embedType' => GiphyEmbed::TYPE,
-                'giphyID' => 'kW8mnYSNkUYKc',
+                'embedType' => CodePenEmbed::TYPE,
+                'codePenID' => $cpId,
+                'author' => 'hiroshi_m',
             ],
             $embedData,
-            'Data cna be fetched over the network to create the embed from a URL.'
+            'Data can be fetched over the network to create the embed from a URL.'
         );
 
         // Just verify that this doesn't throw an exception.
-        $dataEmbed = new GiphyEmbed($embedData);
-        $this->assertInstanceOf(GiphyEmbed::class, $dataEmbed);
+        $dataEmbed = new CodePenEmbed($embedData);
+        $this->assertInstanceOf(CodePenEmbed::class, $dataEmbed);
     }
 }

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/GettyImagesEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/GettyImagesEmbedFactoryTest.php
@@ -15,7 +15,7 @@ use VanillaTests\Fixtures\MockHttpClient;
 /**
  * Tests for the embed and factory.
  */
-class GettyImagesEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class GettyImagesEmbedFactoryTest extends MinimalContainerTestCase {
 
     /** @var GettyImagesEmbedFactory */
     private $factory;

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/GiphyEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/GiphyEmbedFactoryTest.php
@@ -8,17 +8,17 @@
 namespace VanillaTests\Library\EmbeddedContent\Factories;
 
 use Garden\Http\HttpResponse;
-use Vanilla\EmbeddedContent\Embeds\CodePenEmbed;
-use Vanilla\EmbeddedContent\Factories\CodePenEmbedFactory;
+use Vanilla\EmbeddedContent\Embeds\GiphyEmbed;
+use Vanilla\EmbeddedContent\Factories\GiphyEmbedFactory;
 use VanillaTests\MinimalContainerTestCase;
 use VanillaTests\Fixtures\MockHttpClient;
 
 /**
  * Tests for the giphy embed and factory.
  */
-class CodePenEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class GiphyEmbedFactoryTest extends MinimalContainerTestCase {
 
-    /** @var CodePenEmbedFactory */
+    /** @var GiphyEmbedFactory */
     private $factory;
 
     /** @var MockHttpClient */
@@ -30,7 +30,7 @@ class CodePenEmbedFactoryTestMinimal extends MinimalContainerTestCase {
     public function setUp() {
         parent::setUp();
         $this->httpClient = new MockHttpClient();
-        $this->factory = new CodePenEmbedFactory($this->httpClient);
+        $this->factory = new GiphyEmbedFactory($this->httpClient);
     }
 
 
@@ -49,7 +49,9 @@ class CodePenEmbedFactoryTestMinimal extends MinimalContainerTestCase {
      */
     public function supportedDomainsProvider(): array {
         return [
-            ['https://codepen.io/hiroshi_m/pen/YoKYVv'], // Only 1 image format.
+            ['https://gph.is/291u1MC'],
+            ['https://giphy.com/gifs/howtogiphygifs-how-to-XatG8bioEwwVO'],
+            ['https://media.giphy.com/media/kW8mnYSNkUYKc/giphy.gif']
         ];
     }
 
@@ -57,14 +59,13 @@ class CodePenEmbedFactoryTestMinimal extends MinimalContainerTestCase {
      * Test network request fetching and handling.
      */
     public function testCreateEmbedForUrl() {
-        $urlToCheck = 'https://codepen.io/hiroshi_m/pen/YoKYVv';
-        $endpoint = CodePenEmbedFactory::OEMBED_URL_BASE . '?url=' . urlencode($urlToCheck) . '&format=json';
+        $urlToCheck = 'https://giphy.com/gifs/howtogiphygifs-how-to-XatG8bioEwwVO';
+        $endpoint = GiphyEmbedFactory::OEMBED_URL_BASE . '?url=' . urlencode($urlToCheck);
 
-        $name = 'Hello title';
+        $title = 'Hello title';
         $width = 500;
         $height = 400;
-        $frameSrc = 'https://codepen.io/hiroshi_m/embed/preview/YoKYVv?height=300';
-        $cpId = 'YoKYVv';
+        $finalUrl = 'https://media.giphy.com/media/kW8mnYSNkUYKc/giphy.gif';
 
         $this->httpClient->addMockResponse(
             $endpoint,
@@ -73,32 +74,31 @@ class CodePenEmbedFactoryTestMinimal extends MinimalContainerTestCase {
                 'Content-Type: application/json',
                 json_encode([
                     'width' => $width,
-                    'title' => $name,
+                    'title' => $title,
                     'height' => $height,
-                    'html' => "<iframe id='cp_embed_$cpId' src='$frameSrc'></iframe>",
+                    'url' => $finalUrl,
                 ])
             )
         );
 
         // Check over the network.
-        $embed = $this->factory->createEmbedForUrl($urlToCheck);
-        $embedData = $embed->jsonSerialize();
+        $giphyEmbed = $this->factory->createEmbedForUrl($urlToCheck);
+        $embedData = $giphyEmbed->jsonSerialize();
         $this->assertEquals(
             [
                 'width' => $width,
-                'name' => $name,
+                'name' => $title,
                 'height' => $height,
                 'url' => $urlToCheck, // The original URL.
-                'embedType' => CodePenEmbed::TYPE,
-                'codePenID' => $cpId,
-                'author' => 'hiroshi_m',
+                'embedType' => GiphyEmbed::TYPE,
+                'giphyID' => 'kW8mnYSNkUYKc',
             ],
             $embedData,
-            'Data can be fetched over the network to create the embed from a URL.'
+            'Data cna be fetched over the network to create the embed from a URL.'
         );
 
         // Just verify that this doesn't throw an exception.
-        $dataEmbed = new CodePenEmbed($embedData);
-        $this->assertInstanceOf(CodePenEmbed::class, $dataEmbed);
+        $dataEmbed = new GiphyEmbed($embedData);
+        $this->assertInstanceOf(GiphyEmbed::class, $dataEmbed);
     }
 }

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/ImgurEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/ImgurEmbedFactoryTest.php
@@ -15,7 +15,7 @@ use VanillaTests\Fixtures\MockHttpClient;
 /**
  * Tests for the embed and factory.
  */
-class ImgurEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class ImgurEmbedFactoryTest extends MinimalContainerTestCase {
 
     /** @var ImgurEmbedFactory */
     private $factory;

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/InstagramEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/InstagramEmbedFactoryTest.php
@@ -15,7 +15,7 @@ use VanillaTests\Fixtures\MockHttpClient;
 /**
  * Tests for the embed and factory.
  */
-class InstagramEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class InstagramEmbedFactoryTest extends MinimalContainerTestCase {
 
     /** @var InstagramEmbedFactory */
     private $factory;

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/ScrapeEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/ScrapeEmbedFactoryTest.php
@@ -17,7 +17,7 @@ use VanillaTests\Fixtures\MockPageScraper;
 /**
  * Tests for the giphy embed and factory.
  */
-class ScrapeEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class ScrapeEmbedFactoryTest extends MinimalContainerTestCase {
 
     /** @var ScrapeEmbedFactory */
     private $factory;

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/SoundCloudEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/SoundCloudEmbedFactoryTest.php
@@ -15,7 +15,7 @@ use VanillaTests\Fixtures\MockHttpClient;
 /**
  * Tests for the embed and factory.
  */
-class SoundCloudEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class SoundCloudEmbedFactoryTest extends MinimalContainerTestCase {
 
     /** @var SoundCloudEmbedFactory */
     private $factory;

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/TwitchEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/TwitchEmbedFactoryTest.php
@@ -7,17 +7,17 @@
 namespace VanillaTests\Library\EmbeddedContent\Factories;
 
 use Garden\Http\HttpResponse;
-use Vanilla\EmbeddedContent\Embeds\WistiaEmbed;
-use Vanilla\EmbeddedContent\Factories\WistiaEmbedFactory;
+use Vanilla\EmbeddedContent\Embeds\TwitchEmbed;
+use Vanilla\EmbeddedContent\Factories\TwitchEmbedFactory;
 use VanillaTests\MinimalContainerTestCase;
 use VanillaTests\Fixtures\MockHttpClient;
 
 /**
  * Tests for the embed and factory.
  */
-class WistiaEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class TwitchEmbedFactoryTest extends MinimalContainerTestCase {
 
-    /** @var WistiaEmbedFactory */
+    /** @var TwitchEmbedFactory */
     private $factory;
 
     /** @var MockHttpClient */
@@ -29,7 +29,7 @@ class WistiaEmbedFactoryTestMinimal extends MinimalContainerTestCase {
     public function setUp() {
         parent::setUp();
         $this->httpClient = new MockHttpClient();
-        $this->factory = new WistiaEmbedFactory($this->httpClient);
+        $this->factory = new TwitchEmbedFactory($this->httpClient);
     }
 
     /**
@@ -47,8 +47,7 @@ class WistiaEmbedFactoryTestMinimal extends MinimalContainerTestCase {
      */
     public function supportedDomainsProvider(): array {
         return [
-            [ "https://dave.wistia.com/medias/0k5h1g1chs" ],
-            [ "https://dave.wi.st/medias/0k5h1g1chs" ],
+            [ "https://www.twitch.tv/videos/441409883" ]
         ];
     }
 
@@ -56,28 +55,31 @@ class WistiaEmbedFactoryTestMinimal extends MinimalContainerTestCase {
      * Test network request fetching and handling.
      */
     public function testCreateEmbedForUrl() {
-        $url = "https://dave.wistia.com/medias/0k5h1g1chs";
-        $videoID = "0k5h1g1chs";
-        $frameSrc = "https://fast.wistia.net/embed/iframe/0k5h1g1chs?autoPlay=1";
+        $url = "https://www.twitch.tv/videos/441409883";
+        $videoID = "441409883";
+        $frameSrc = "https://player.twitch.tv/?video=441409883";
 
         $oembedParams = http_build_query([ "url" => $url ]);
-        $oembedUrl = WistiaEmbedFactory::OEMBED_URL_BASE . "?" . $oembedParams;
+        $oembedUrl = TwitchEmbedFactory::OEMBED_URL_BASE . "?" . $oembedParams;
 
         // phpcs:disable Generic.Files.LineLength
         $data = [
-            "version" => "1.0",
+            "version" => 1,
             "type" => "video",
-            "html" => "<iframe src=\"https://fast.wistia.net/embed/iframe/0k5h1g1chs\" title=\"Lenny Delivers a Video - oEmbed glitch\" allowtransparency=\"true\" frameborder=\"0\" scrolling=\"no\" class=\"wistia_embed\" name=\"wistia_embed\" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width=\"960\" height=\"540\"></iframe>\n<script src=\"https://fast.wistia.net/assets/external/E-v1.js\" async></script>",
-            "width" => 960,
-            "height" => 540,
-            "provider_name" => "Wistia, Inc.",
-            "provider_url" => "https://wistia.com",
-            "title" => "Lenny Delivers a Video - oEmbed glitch",
-            "thumbnail_url" => "https://embed-ssl.wistia.com/deliveries/99f3aefb8d55eef2d16583886f610ebedd1c6734.jpg?image_crop_resized=960x540",
-            "thumbnail_width" => 960,
-            "thumbnail_height" => 540,
-            "player_color" => "54bbff",
-            "duration" => 40.264,
+            "twitch_type" => "vod",
+            "title" => "Movie Magic",
+            "author_name" => "Jerma985",
+            "author_url" => "https://www.twitch.tv/jerma985",
+            "provider_name" => "Twitch",
+            "provider_url" => "https://www.twitch.tv/",
+            "thumbnail_url" => "https://static-cdn.jtvnw.net/s3_vods/aa1bb413e849cf63b446_jerma985_34594404336_1230815694/thumb/thumb0-640x360.jpg",
+            "video_length" => 19593,
+            "created_at" => "2019-06-19T21:22:59Z",
+            "game" => "The Movies",
+            "html" => "<iframe src=\"https://player.twitch.tv/?%21branding=&amp;autoplay=false&amp;video=v441409883\" width=\"500\" height=\"281\" frameborder=\"0\" scrolling=\"no\" allowfullscreen></iframe>",
+            "width" => 500,
+            "height" => 281,
+            "request_url" => "https://www.twitch.tv/videos/441409883",
         ];
         // phpcs:enable Generic.Files.LineLength
 
@@ -98,9 +100,9 @@ class WistiaEmbedFactoryTestMinimal extends MinimalContainerTestCase {
                 "height" => $data["height"],
                 "width" => $data["width"],
                 "photoUrl" => $data["thumbnail_url"],
-                "videoID" => $videoID,
+                "twitchID" => "video:{$videoID}",
                 "url" => $url,
-                "embedType" => WistiaEmbed::TYPE,
+                "embedType" => TwitchEmbed::TYPE,
                 "name" => $data["title"],
                 "frameSrc" => $frameSrc,
             ],
@@ -109,7 +111,7 @@ class WistiaEmbedFactoryTestMinimal extends MinimalContainerTestCase {
         );
 
         // Just verify that this doesn't throw an exception.
-        $dataEmbed = new WistiaEmbed($embedData);
-        $this->assertInstanceOf(WistiaEmbed::class, $dataEmbed);
+        $dataEmbed = new TwitchEmbed($embedData);
+        $this->assertInstanceOf(TwitchEmbed::class, $dataEmbed);
     }
 }

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/TwitterEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/TwitterEmbedFactoryTest.php
@@ -14,7 +14,7 @@ use VanillaTests\Fixtures\MockHttpClient;
 /**
  * Tests for the embed and factory.
  */
-class TwitterEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class TwitterEmbedFactoryTest extends MinimalContainerTestCase {
 
     /** @var TwitterEmbedFactory */
     private $factory;

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/VimeoEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/VimeoEmbedFactoryTest.php
@@ -15,7 +15,7 @@ use VanillaTests\Fixtures\MockHttpClient;
 /**
  * Tests for the embed and factory.
  */
-class VimeoEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class VimeoEmbedFactoryTest extends MinimalContainerTestCase {
 
     /** @var VimeoEmbedFactory */
     private $factory;

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/WistiaEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/WistiaEmbedFactoryTest.php
@@ -7,17 +7,17 @@
 namespace VanillaTests\Library\EmbeddedContent\Factories;
 
 use Garden\Http\HttpResponse;
-use Vanilla\EmbeddedContent\Embeds\TwitchEmbed;
-use Vanilla\EmbeddedContent\Factories\TwitchEmbedFactory;
+use Vanilla\EmbeddedContent\Embeds\WistiaEmbed;
+use Vanilla\EmbeddedContent\Factories\WistiaEmbedFactory;
 use VanillaTests\MinimalContainerTestCase;
 use VanillaTests\Fixtures\MockHttpClient;
 
 /**
  * Tests for the embed and factory.
  */
-class TwitchEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class WistiaEmbedFactoryTest extends MinimalContainerTestCase {
 
-    /** @var TwitchEmbedFactory */
+    /** @var WistiaEmbedFactory */
     private $factory;
 
     /** @var MockHttpClient */
@@ -29,7 +29,7 @@ class TwitchEmbedFactoryTestMinimal extends MinimalContainerTestCase {
     public function setUp() {
         parent::setUp();
         $this->httpClient = new MockHttpClient();
-        $this->factory = new TwitchEmbedFactory($this->httpClient);
+        $this->factory = new WistiaEmbedFactory($this->httpClient);
     }
 
     /**
@@ -47,7 +47,8 @@ class TwitchEmbedFactoryTestMinimal extends MinimalContainerTestCase {
      */
     public function supportedDomainsProvider(): array {
         return [
-            [ "https://www.twitch.tv/videos/441409883" ]
+            [ "https://dave.wistia.com/medias/0k5h1g1chs" ],
+            [ "https://dave.wi.st/medias/0k5h1g1chs" ],
         ];
     }
 
@@ -55,31 +56,28 @@ class TwitchEmbedFactoryTestMinimal extends MinimalContainerTestCase {
      * Test network request fetching and handling.
      */
     public function testCreateEmbedForUrl() {
-        $url = "https://www.twitch.tv/videos/441409883";
-        $videoID = "441409883";
-        $frameSrc = "https://player.twitch.tv/?video=441409883";
+        $url = "https://dave.wistia.com/medias/0k5h1g1chs";
+        $videoID = "0k5h1g1chs";
+        $frameSrc = "https://fast.wistia.net/embed/iframe/0k5h1g1chs?autoPlay=1";
 
         $oembedParams = http_build_query([ "url" => $url ]);
-        $oembedUrl = TwitchEmbedFactory::OEMBED_URL_BASE . "?" . $oembedParams;
+        $oembedUrl = WistiaEmbedFactory::OEMBED_URL_BASE . "?" . $oembedParams;
 
         // phpcs:disable Generic.Files.LineLength
         $data = [
-            "version" => 1,
+            "version" => "1.0",
             "type" => "video",
-            "twitch_type" => "vod",
-            "title" => "Movie Magic",
-            "author_name" => "Jerma985",
-            "author_url" => "https://www.twitch.tv/jerma985",
-            "provider_name" => "Twitch",
-            "provider_url" => "https://www.twitch.tv/",
-            "thumbnail_url" => "https://static-cdn.jtvnw.net/s3_vods/aa1bb413e849cf63b446_jerma985_34594404336_1230815694/thumb/thumb0-640x360.jpg",
-            "video_length" => 19593,
-            "created_at" => "2019-06-19T21:22:59Z",
-            "game" => "The Movies",
-            "html" => "<iframe src=\"https://player.twitch.tv/?%21branding=&amp;autoplay=false&amp;video=v441409883\" width=\"500\" height=\"281\" frameborder=\"0\" scrolling=\"no\" allowfullscreen></iframe>",
-            "width" => 500,
-            "height" => 281,
-            "request_url" => "https://www.twitch.tv/videos/441409883",
+            "html" => "<iframe src=\"https://fast.wistia.net/embed/iframe/0k5h1g1chs\" title=\"Lenny Delivers a Video - oEmbed glitch\" allowtransparency=\"true\" frameborder=\"0\" scrolling=\"no\" class=\"wistia_embed\" name=\"wistia_embed\" allowfullscreen mozallowfullscreen webkitallowfullscreen oallowfullscreen msallowfullscreen width=\"960\" height=\"540\"></iframe>\n<script src=\"https://fast.wistia.net/assets/external/E-v1.js\" async></script>",
+            "width" => 960,
+            "height" => 540,
+            "provider_name" => "Wistia, Inc.",
+            "provider_url" => "https://wistia.com",
+            "title" => "Lenny Delivers a Video - oEmbed glitch",
+            "thumbnail_url" => "https://embed-ssl.wistia.com/deliveries/99f3aefb8d55eef2d16583886f610ebedd1c6734.jpg?image_crop_resized=960x540",
+            "thumbnail_width" => 960,
+            "thumbnail_height" => 540,
+            "player_color" => "54bbff",
+            "duration" => 40.264,
         ];
         // phpcs:enable Generic.Files.LineLength
 
@@ -100,9 +98,9 @@ class TwitchEmbedFactoryTestMinimal extends MinimalContainerTestCase {
                 "height" => $data["height"],
                 "width" => $data["width"],
                 "photoUrl" => $data["thumbnail_url"],
-                "twitchID" => "video:{$videoID}",
+                "videoID" => $videoID,
                 "url" => $url,
-                "embedType" => TwitchEmbed::TYPE,
+                "embedType" => WistiaEmbed::TYPE,
                 "name" => $data["title"],
                 "frameSrc" => $frameSrc,
             ],
@@ -111,7 +109,7 @@ class TwitchEmbedFactoryTestMinimal extends MinimalContainerTestCase {
         );
 
         // Just verify that this doesn't throw an exception.
-        $dataEmbed = new TwitchEmbed($embedData);
-        $this->assertInstanceOf(TwitchEmbed::class, $dataEmbed);
+        $dataEmbed = new WistiaEmbed($embedData);
+        $this->assertInstanceOf(WistiaEmbed::class, $dataEmbed);
     }
 }

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/YouTubeEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/YouTubeEmbedFactoryTest.php
@@ -15,7 +15,7 @@ use VanillaTests\Fixtures\MockHttpClient;
 /**
  * Tests for the embed and factory.
  */
-class YouTubeEmbedFactoryTestMinimal extends MinimalContainerTestCase {
+class YouTubeEmbedFactoryTest extends MinimalContainerTestCase {
 
     /** @var YouTubeEmbedFactory */
     private $factory;

--- a/tests/Library/Vanilla/Formatting/GdnFormatTest.php
+++ b/tests/Library/Vanilla/Formatting/GdnFormatTest.php
@@ -7,14 +7,13 @@
 
 namespace VanillaTests\Library\Vanilla\Formatting;
 
-use Vanilla\Formatting\Formats\RichFormat;
 use VanillaTests\MinimalContainerTestCase;
 use VanillaTests\Library\Vanilla\Formatting\AssertsFixtureRenderingTrait;
 
 /**
  * Unit tests for the Gdn_Format class.
  */
-class GdnFormatTestMinimal extends MinimalContainerTestCase {
+class GdnFormatTest extends MinimalContainerTestCase {
 
     use AssertsFixtureRenderingTrait;
 

--- a/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
+++ b/tests/Library/Vanilla/Formatting/Quill/FiltererTest.php
@@ -9,6 +9,7 @@ namespace VanillaTests\Library\Vanilla\Formatting\Quill;
 
 use PHPUnit\Framework\TestCase;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
+use Vanilla\Formatting\Formats\MarkdownFormat;
 use Vanilla\Formatting\Formats\RichFormat;
 use Vanilla\Formatting\Quill\Filterer;
 use VanillaTests\MinimalContainerTestCase;
@@ -20,7 +21,7 @@ use Vanilla\Formatting\Quill\Formats\Link;
 /**
  * General testing of Filterer.
  */
-class FiltererTestMinimal extends MinimalContainerTestCase {
+class FiltererTest extends MinimalContainerTestCase {
 
     /**
      * Assert that the filterer is validating json properly.
@@ -55,10 +56,10 @@ class FiltererTestMinimal extends MinimalContainerTestCase {
                 'insert' => [
                     'embed-external' => [
                         'data' => [
-                            'type' => QuoteEmbed::TYPE,
+                            'embedType' => QuoteEmbed::TYPE,
                             'body' => "Fake body contents, should be replaced.",
                             'bodyRaw' => 'Rendered Body',
-                            'format' => 'Markdown',
+                            'format' => MarkdownFormat::FORMAT_KEY,
                         ],
                     ],
                 ],
@@ -67,7 +68,7 @@ class FiltererTestMinimal extends MinimalContainerTestCase {
                 'insert' => [
                     'embed-external' => [
                         'data' => [
-                            'type' => QuoteEmbed::TYPE,
+                            'embedType' => QuoteEmbed::TYPE,
                             'format' => RichFormat::FORMAT_KEY,
                             'body' => '<div><script>alert("This should be replaced!")</script></div>',
                             'bodyRaw' => [
@@ -105,10 +106,10 @@ class FiltererTestMinimal extends MinimalContainerTestCase {
                 'insert' => [
                     'embed-external' => [
                         'data' => [
-                            'type' => QuoteEmbed::TYPE,
+                            'embedType' => QuoteEmbed::TYPE,
                             'body' => "<p>Rendered Body</p>\n",
                             'bodyRaw' => 'Rendered Body',
-                            'format' => 'Markdown',
+                            'format' => MarkdownFormat::FORMAT_KEY,
                         ],
                     ],
                 ],
@@ -117,9 +118,9 @@ class FiltererTestMinimal extends MinimalContainerTestCase {
                 'insert' => [
                     'embed-external' => [
                         'data' => [
-                            'type' => QuoteEmbed::TYPE,
-                            'format' => 'Rich',
-                            'body' => \Gdn::formatService()->renderQuote($expectedEmbedBodyRaw, RichFormat::FORMAT_KEY),
+                            'embedType' => QuoteEmbed::TYPE,
+                            'format' => RichFormat::FORMAT_KEY,
+                            'body' => \Gdn::formatService()->renderQuote(json_encode($expectedEmbedBodyRaw), RichFormat::FORMAT_KEY),
                             'bodyRaw' => $expectedEmbedBodyRaw,
                         ],
                     ],
@@ -127,7 +128,12 @@ class FiltererTestMinimal extends MinimalContainerTestCase {
             ],
         ];
 
-        $this->assertSame(json_encode($expected), $filterer->filter(json_encode($input)));
+        // Pretty print.
+        $actual =  json_encode(
+            json_decode($filterer->filter(json_encode($input)), true),
+            JSON_PRETTY_PRINT
+        );
+        $this->assertSame(json_encode($expected, JSON_PRETTY_PRINT), $actual);
     }
 
     /**
@@ -137,21 +143,21 @@ class FiltererTestMinimal extends MinimalContainerTestCase {
      */
     public function provideIO() {
         $loadingEmbed = <<<JSON
-   {  
-      "insert":{  
-         "embed-external":{  
-            "loaderData":{  
+   {
+      "insert":{
+         "embed-external":{
+            "loaderData":{
                "type":"file",
-               "file":{  
+               "file":{
 
                },
-               "progressEventEmitter":{  
-                  "listeners":[  
+               "progressEventEmitter":{
+                  "listeners":[
                      null
                   ]
                }
             },
-            "dataPromise":{  
+            "dataPromise":{
 
             }
          }

--- a/tests/fixtures/formats/text/mentions/output.txt
+++ b/tests/fixtures/formats/text/mentions/output.txt
@@ -1,0 +1,2 @@
+Line 1
+@mention1 @mention2 @!@#$%^&*( @@@inAts@@@

--- a/tests/fixtures/formats/textex/mentions/output.txt
+++ b/tests/fixtures/formats/textex/mentions/output.txt
@@ -1,0 +1,10 @@
+Line 1
+
+notmention@gmail.com
+
+@mention1 @mention2 @!@#$%^&*( @@@inAts@@@ end of line
+
+^^ Buggy https://github.com/vanilla/vanilla/issues/9134
+
+@"quotedMenti'on!#$%^&*("
+


### PR DESCRIPTION
Followup of https://github.com/vanilla/vanilla/pull/8980

There were a couple of lingering issues:


1. Some of the embed and rich tests had gotten misnamed during some refactoring. As a result they were not running. I've renamed them so they are now running.
2. The `FiltererTest` had some issues after addressing feedback that was never noticed, mostly relating to tightening of the `FormatInterface::renderQuote` signature.
3. `BodyFormatValidator` previously considered unknown formats as valid. https://github.com/vanilla/vanilla/pull/8980 had tightened it, but this has shown to be rather large BC break (See https://github.com/vanilla/internal/issues/1936). I've changed the behaviour to pass through and content a trigger an `E_USER_WARNING` instead for the old models using this validator).