### PR TITLE
Improve min length validation and fix rich rendering with empty bodies

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1041,8 +1041,7 @@ class CommentModel extends Gdn_Model {
         }
         $minCommentLength = c('Vanilla.Comment.MinLength');
         if ($minCommentLength && is_numeric($minCommentLength)) {
-            $this->Validation->setSchemaProperty('Body', 'MinLength', $minCommentLength);
-            $this->Validation->addRule('MinTextLength', 'function:ValidateMinTextLength');
+            $this->Validation->setSchemaProperty('Body', 'MinTextLength', $minCommentLength);
             $this->Validation->applyRule('Body', 'MinTextLength');
         }
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1957,9 +1957,16 @@ class DiscussionModel extends Gdn_Model {
             $this->Validation->addRule('MeAction', 'function:ValidateMeAction');
             $this->Validation->applyRule('Body', 'MeAction');
             $maxCommentLength = Gdn::config('Vanilla.Comment.MaxLength');
+
             if (is_numeric($maxCommentLength) && $maxCommentLength > 0) {
                 $this->Validation->setSchemaProperty('Body', 'Length', $maxCommentLength);
                 $this->Validation->applyRule('Body', 'Length');
+            }
+
+            // Add min length if body is required.
+            if (Gdn::config('Vanilla.DiscussionBody.Required', true)) {
+                $this->Validation->setSchemaProperty('Body', 'MinTextLength', 1);
+                $this->Validation->applyRule('Body', 'MinTextLength');
             }
         }
 

--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -19,6 +19,11 @@ use Vanilla\Formatting\Quill\Blots\AbstractBlot;
  */
 class Parser {
 
+    /** @var array Represents the operations of an "empty" body. */
+    const SINGLE_NEWLINE_CONTENTS = [[
+        'insert' => "\n",
+    ]];
+
     const PARSE_MODE_NORMAL = "normal";
     const PARSE_MODE_QUOTE = "quote";
 
@@ -142,12 +147,42 @@ class Parser {
      * @throws FormattingException If valid operations could not be produced.
      */
     public static function jsonToOperations(string $json): array {
+        // Ensure that empty posts still get some body content.
+        // This will ensure that they will render/validate correctly where empty is allowed
+        // And that empty bodies by properly caught in length validation.
+        if (empty($json)) {
+            return self::SINGLE_NEWLINE_CONTENTS;
+        }
         $operations = json_decode($json, true);
 
+        $errMessage = "JSON could not be converted into quill operations.\n $json";
         if (json_last_error() !== JSON_ERROR_NONE || !is_array($operations)) {
-            throw new FormattingException("JSON could not be converted into quill operations.\n $json");
+            throw new FormattingException($errMessage);
         }
+
+        // Also normalizing an empty array to have at least 1 operation.
+        if (empty($operations)) {
+            return self::SINGLE_NEWLINE_CONTENTS;
+        }
+
+        if (!self::areArrayKeysSequentialInts($operations)) {
+            throw new FormattingException($errMessage);
+        }
+
         return $operations;
+    }
+
+    /**
+     * Determine if an array is sequential (IE. not assosciative).
+     *
+     * @param array $arr
+     * @return bool
+     */
+    private static function areArrayKeysSequentialInts(array &$arr): bool {
+        for (reset($arr), $base = 0; key($arr) === $base++;) {
+            next($arr);
+        }
+        return is_null(key($arr));
     }
 
     /**

--- a/library/core/class.validation.php
+++ b/library/core/class.validation.php
@@ -93,6 +93,7 @@ class Gdn_Validation {
         $this->addRule('Time', 'function:ValidateTime', true);
         $this->addRule('Timestamp', 'function:ValidateDate');
         $this->addRule('Length', 'function:ValidateLength');
+        $this->addRule('MinTextLength', 'function:validateMinTextLength');
         $this->addRule('Enum', 'function:ValidateEnum');
         $this->addRule('MinimumAge', 'function:ValidateMinimumAge');
         $this->addRule('Captcha', 'function:ValidateCaptcha');

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -599,16 +599,17 @@ if (!function_exists('validateMinTextLength')) {
      * @param mixed $value The value to validate.
      * @param object $field The field meta information.
      * @param array $post The full posted data.
-     * @return bool|string Returns true if teh value is valid or an error string otherwise.
+     * @return bool|string Returns true if the value is valid or an error string otherwise.
      */
     function validateMinTextLength($value, $field, $post) {
         if (isset($post['Format'])) {
-            $value = Gdn_Format::to($value, $post['Format']);
+            $value = Gdn::formatService()->renderPlainText($value, $post['Format']);
         }
 
         $value = html_entity_decode(trim(strip_tags($value)));
-        $minLength = getValue('MinLength', $field, 0);
 
+        // We need to check both values for backwards compatibility.
+        $minLength = $field->MinLength ?? $field->MinTextLength ?? 0;
         if (function_exists('mb_strlen')) {
             $diff = $minLength - mb_strlen($value, 'UTF-8');
         } else {


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7290
Closes https://github.com/vanilla/support/issues/691

- Updates the Rich parser to be more robust when given empty values.
  - Does better and validation and throws a `FormattingException` when given more types of bad values.
  - Falls back to some default value when given "empty" values.
- Add tests for `Quill\Parser::jsonToOperations()`. Also added some missing docblocks in that test file.
- Doing this further exposed https://github.com/vanilla/support/issues/691 so I fixed that too.
  - Apply min length validation to Discussions.
  - Improve min length validation to properly work on plaintext instead of just stripping tags.

## Discussion Comment Tests

Relevant configuration options that affect this are `Vanilla.Comments.MinLength`, and `Vanilla.DiscussionBody.Required`.