### PR TITLE
Fix editor paragraph direction

### DIFF
--- a/plugins/rich-editor/src/scripts/editor/richEditorStyles.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorStyles.ts
@@ -124,6 +124,7 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
         position: "relative",
         width: unit(vars.menuButton.size * 4),
         overflow: "hidden",
+        zIndex: 1,
     });
 
     const menuBarToggles = style("menuBarToggles", {

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
@@ -53,6 +53,10 @@ interface IState {
     rovingTabIndex: number; // https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_roving_tabindex
 }
 
+// With some effort we could probably calculate this value.
+// For now this is good enough.
+const APPROXIMATE_MAX_MENU_HEIGHT = 170;
+
 // Implements the paragraph menubar
 export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState> {
     private quill: Quill;
@@ -280,7 +284,9 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
             classes.position,
             classes.menuBar,
             classesDropDown.likeDropDownContent,
-            this.props.renderAbove || (scrollBounds.height >= 170 && scrollBounds.height - bounds.bottom <= 170)
+            this.props.renderAbove ||
+                (scrollBounds.height >= APPROXIMATE_MAX_MENU_HEIGHT &&
+                    scrollBounds.height - bounds.bottom <= APPROXIMATE_MAX_MENU_HEIGHT)
                 ? "isUp"
                 : "isDown",
         );

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
@@ -280,7 +280,9 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
             classes.position,
             classes.menuBar,
             classesDropDown.likeDropDownContent,
-            this.props.renderAbove || scrollBounds.height - bounds.bottom <= 170 ? "isUp" : "isDown",
+            this.props.renderAbove || (scrollBounds.height >= 170 && scrollBounds.height - bounds.bottom <= 170)
+                ? "isUp"
+                : "isDown",
         );
     }
 


### PR DESCRIPTION
Closes https://github.com/vanilla/knowledge/issues/1137

The direction selection was missing some minimum height check that would cause it to always display the menu in the wrong direction if the the scroll-bounds were particularly short.

I also added a z-index on this menubar so that it would stay above the bottom border when opening on mobile.