### PR TITLE
Make <Message /> component padding more flexible

### DIFF
--- a/library/src/scripts/messages/Message.tsx
+++ b/library/src/scripts/messages/Message.tsx
@@ -23,14 +23,17 @@ export interface IMessageProps {
     onCancel?: () => void;
     cancelText?: React.ReactNode;
     isFixed?: boolean;
+    noContainer?: boolean;
 }
 
 export default function Message(props: IMessageProps) {
     const classes = messagesClasses();
+
+    const WrapperElement = props.noContainer ? React.Fragment : Container;
     return (
         <>
             <div className={classNames(classes.root, props.className, { [classes.fixed]: props.isFixed })}>
-                <Container>
+                <WrapperElement>
                     <div className={classNames(classes.wrap)}>
                         <div className={classes.message}>{props.contents || props.stringContents}</div>
                         {props.onConfirm && (
@@ -52,7 +55,7 @@ export default function Message(props: IMessageProps) {
                             </Button>
                         )}
                     </div>
-                </Container>
+                </WrapperElement>
             </div>
             {/* Does not visually render, but sends message to screen reader users*/}
             <LiveMessage clearOnUnmount={!!props.clearOnUnmount} message={props.stringContents} aria-live="assertive" />

--- a/library/src/scripts/messages/Message.tsx
+++ b/library/src/scripts/messages/Message.tsx
@@ -23,13 +23,13 @@ export interface IMessageProps {
     onCancel?: () => void;
     cancelText?: React.ReactNode;
     isFixed?: boolean;
-    noContainer?: boolean;
 }
 
 export default function Message(props: IMessageProps) {
     const classes = messagesClasses();
 
-    const WrapperElement = props.noContainer ? React.Fragment : Container;
+    // When fixed we need to apply an extra layer for padding.
+    const WrapperElement = props.isFixed ? Container : React.Fragment;
     return (
         <>
             <div className={classNames(classes.root, props.className, { [classes.fixed]: props.isFixed })}>


### PR DESCRIPTION
This PR removes the `<Container />` padding from the `<Message />` component by default. It is still needed for the fixed version however.

Other components are now free to specify their own padding. This is to prevent issue with double padding. https://github.com/vanilla/knowledge/pull/1140 required to place the container in a couple places that need it now.

For example:

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/1770056/62953733-0c566280-bdbc-11e9-8f44-3d873bae96a5.png)|![image](https://user-images.githubusercontent.com/1770056/62953648-e466ff00-bdbb-11e9-9d8b-a9e94822061c.png)|
|![image](https://user-images.githubusercontent.com/1770056/62953776-2001c900-bdbc-11e9-8783-c4a2f881ad6a.png)|![image](https://user-images.githubusercontent.com/1770056/62953798-2abc5e00-bdbc-11e9-879b-4ef6a0ea4f69.png)|

