### PR TITLE
Fix missing event args

### DIFF
--- a/library/core/class.bbcode.php
+++ b/library/core/class.bbcode.php
@@ -330,7 +330,8 @@ class BBCode extends Gdn_Pluggable {
                 $commentIDList[] = $controller->Comment->CommentID;
             }
 
-            $this->eventManager->fire('BBCode_BeforePreloadDiscussionMedia');
+            // Empty array needed for backwards compatibility args.
+            $this->eventManager->fire('BBCode_BeforePreloadDiscussionMedia', $this, []);
 
             $mediaQuery = Gdn::sql()
                 ->select('m.*')

--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -247,7 +247,7 @@ class Emoji {
             $this->enabled = false;
         }
 
-        $eventManager->fire('Emoji_Init', $this);
+        $eventManager->fire('Emoji_Init', $this, []); // Empty $argrs array needed for backwards compatibility.
 
         // Add emoji to definition list for whole site. This used to be in the
         // advanced editor plugin, but since moving atmentions to core, had to


### PR DESCRIPTION
https://github.com/vanilla/vanilla/pull/8980 updated some deprecated event firings to use the event manager. Unfortunately a couple did not properly pass the arguments array.

This is fixed in this PR.