### PR TITLE
Prevent editor crash with mention inside of inline code

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/utility.ts
+++ b/plugins/rich-editor/src/scripts/quill/utility.ts
@@ -13,6 +13,7 @@ import FocusableEmbedBlot from "@rich-editor/quill/blots/abstract/FocusableEmbed
 import BlockBlot from "quill/blots/block";
 import CodeBlockBlot from "@rich-editor/quill/blots/blocks/CodeBlockBlot";
 import { logDebug } from "@vanilla/utils";
+import CodeBlot from "@rich-editor/quill/blots/inline/CodeBlot";
 
 interface IBoundary {
     start: number;
@@ -295,7 +296,10 @@ export function getMentionRange(quill: Quill, currentSelection: RangeStatic | nu
         return null;
     }
 
-    if (rangeContainsBlot(quill, CodeBlockBlot, currentSelection)) {
+    if (
+        rangeContainsBlot(quill, CodeBlockBlot, currentSelection) ||
+        rangeContainsBlot(quill, CodeBlot, currentSelection)
+    ) {
         return null;
     }
 


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/9189

Rich editor was crashing while creating a mention inside of an inline code formats. We already restrict mentions inside of block code formats, so I've added an additional restriction there.