### PR TITLE
Fix notifications rendering with null format

### DIFF
--- a/applications/dashboard/controllers/class.notificationscontroller.php
+++ b/applications/dashboard/controllers/class.notificationscontroller.php
@@ -8,6 +8,8 @@
  * @since 2.0
  */
 
+use Vanilla\Formatting\Formats\HtmlFormat;
+
 /**
  * Handle /notifications endpoint.
  */
@@ -90,7 +92,11 @@ class NotificationsController extends Gdn_Controller {
             } else {
                 $userPhoto = '';
             }
-            $excerpt = Gdn_Format::excerpt($activity['Story'], $activity['Format']);
+
+            $excerpt = '';
+            $story = $activity['Story'] ?? null;
+            $format = $activity['Format'] ?? HtmlFormat::FORMAT_KEY;
+            $excerpt = $story ? Gdn::formatService()->renderExcerpt($story, $format) : $excerpt;
             $activityClass = ' Activity-'.$activity['ActivityType'];
 
             $sender->informMessage(

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -840,6 +840,7 @@ class Gdn_Format {
      * @deprecated 3.2 FormatService::renderPlainText
      */
     public static function plainText($body, $format = 'Html') {
+        $format = $format ?? Formats\HtmlFormat::FORMAT_KEY;
         $plainText = Gdn::formatService()->renderPlainText((string) $body, (string) $format);
 
         // Even though this shouldn't be sanitized here (it should be sanitized in the view layer)
@@ -867,6 +868,7 @@ class Gdn_Format {
      * @deprecated 3.2 FormatService::renderExcerpt
      */
     public static function excerpt($body, $format = 'Html', $collapse = false) {
+        $format = $format ?? Formats\HtmlFormat::FORMAT_KEY;
         $plainText = Gdn::formatService()->renderExcerpt((string) $body, (string) $format);
 
         // Even though this shouldn't be sanitized here (it should be sanitized in the view layer)


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/703
Cleanup from https://github.com/vanilla/vanilla/pull/8980

Prior to https://github.com/vanilla/vanilla/pull/8980 `Gdn_Format::plainText()` and `Gdn_Format::excerpt()` redirected their format through `Gdn_Format::to()` which has explicit null handling.

During the refactoring this was removed causing "No formatter is installed for format" messages if a `null` format was was passed https://github.com/vanilla/support/issues/703

I've added handling of null to these 2 methods, and updated the 1 call-site that was unknowingly passing in null. This both fixes the proper cause of https://github.com/vanilla/support/issues/703 and addresses other potential backwards compatibility issues if there is some other call site doing this.