### PR TITLE
Remove grace period from the deployment cache buster

### DIFF
--- a/library/Vanilla/Web/Asset/DeploymentCacheBuster.php
+++ b/library/Vanilla/Web/Asset/DeploymentCacheBuster.php
@@ -9,56 +9,19 @@ namespace Vanilla\Web\Asset;
 
 /**
  * A cache buster that works based on the last deployment time.
- *
- * Settings the config value `Garden.Deployed` to the current unix timestamp on a deploy
- * will allow this cache buster to work properly.
- *
- * The grace period here is prevent the following scenario:
- *
- * 1. Browser A requests pageY
- * 2. Servers 1 & 2 deploy.
- * 3. Server 1 returns pageY which has a scriptZ using the new cache-buster. Deploy is completed on server1.
- * 4. Browser A requests scriptZ.
- * 5. Load-balancer sends the request to Server 2. Server 2 is not finished deploying.
- * 6. Server2 serves the old scriptZ with the new cache-buster.
- * 7. Caching server caches this results.
- * 8. Users B-Z all receive the old asset with the new cache buster.
- *
- * The grace period adds a step:
- * 7a. After the grace period has elapsed,
- *     increment the timestamp for the grace period by the duration of the grace period.
- *
- * EVENTUALLY (after the grace period has completed) we get a fresh start and everything should be consistent.
- * In the intermediary time it is possible a user gets served an old script.
+ * If that deployment time is not available it will fall back to the application version.
  */
 class DeploymentCacheBuster {
 
-    /**
-     * The number of seconds to wait after a deploy before switching the cache buster.
-     */
-    const GRACE_PERIOD = 90;
-
-    /** @var \DateTimeInterface */
-    private $currentTime;
-
     /** @var int|null */
     private $deploymentTime;
-
-    /** @var int|null */
-    private $gracedDeploymentTime;
-
     /**
      * DeploymentCacheBuster constructor.
      *
-     * @param \DateTimeInterface $currentTime
      * @param int|null $deploymentTime
      */
-    public function __construct(\DateTimeInterface $currentTime, $deploymentTime) {
-        $this->currentTime = $currentTime;
+    public function __construct($deploymentTime) {
         $this->deploymentTime = $deploymentTime;
-        if ($this->deploymentTime) {
-            $this->gracedDeploymentTime = $this->deploymentTime + self::GRACE_PERIOD;
-        }
     }
 
     /**
@@ -71,9 +34,7 @@ class DeploymentCacheBuster {
      */
     public function value(): string {
         if ($this->deploymentTime) {
-            $isBeyondGracePeriod = $this->currentTime->getTimestamp() >= $this->gracedDeploymentTime;
-            $deploymentTime = $isBeyondGracePeriod ? $this->gracedDeploymentTime : $this->deploymentTime;
-            $result = dechex($deploymentTime);
+            $result = dechex($this->deploymentTime);
         } else {
             $result = APPLICATION_VERSION;
         }

--- a/tests/Library/Vanilla/Web/Asset/DeploymentCacheBusterTest.php
+++ b/tests/Library/Vanilla/Web/Asset/DeploymentCacheBusterTest.php
@@ -20,7 +20,6 @@ class DeploymentCacheBusterTest extends TestCase {
      */
     public function testFallback() {
         $buster = new DeploymentCacheBuster(
-            new \DateTimeImmutable(1000),
             null
         );
 
@@ -32,39 +31,20 @@ class DeploymentCacheBusterTest extends TestCase {
      */
     public function testValue() {
         $firstValue = (new DeploymentCacheBuster(
-            new \DateTimeImmutable(1000),
             900
         ))->value();
         $secondValue = (new DeploymentCacheBuster(
-            new \DateTimeImmutable(1000),
             900
         ))->value();
         $this->assertEquals($firstValue, $secondValue, "Busters should be consistent between each other");
 
         $thirdValue = (new DeploymentCacheBuster(
-            new \DateTimeImmutable(1000),
             500
         ))->value();
         $this->assertNotEquals(
             $secondValue,
             $thirdValue,
             "Busters created at different times should have different values"
-        );
-
-        $deployTime = 900;
-        $beforeGracePeriodEllapsed = (new DeploymentCacheBuster(
-            new \DateTimeImmutable('@' . ($deployTime + DeploymentCacheBuster::GRACE_PERIOD - 1)),
-            $deployTime
-        ))->value();
-        $afterGracePeriodEllapsed = (new DeploymentCacheBuster(
-            new \DateTimeImmutable('@' . ($deployTime + DeploymentCacheBuster::GRACE_PERIOD + 1)),
-            $deployTime
-        ))->value();
-
-        $this->assertNotEquals(
-            $beforeGracePeriodEllapsed,
-            $afterGracePeriodEllapsed,
-            "The buster should change after the grace period."
         );
     }
 
@@ -73,7 +53,6 @@ class DeploymentCacheBusterTest extends TestCase {
      */
     public function testConsistentValue() {
         $buster = new DeploymentCacheBuster(
-            new \DateTimeImmutable(1000),
             500
         );
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/718

After some recent deployment and discussion with ops, it seems the incrementing behaviour of our grace period increases the chance of conflict in our shared cache bucket.

So with that said, this behaviour is being removed at the insistence of @DaazKu.