### PR TITLE
Use FormatService::renderHtml() on AbstractApiController

### DIFF
--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -47,7 +47,7 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller implements 
      */
     public function formatField(array &$row, $field, $format) {
         if (array_key_exists($field, $row)) {
-            $row[$field] = Gdn_Format::to($row[$field], $format) ?: '<!-- empty -->';
+            $row[$field] = \Gdn::formatService()->renderHTML($row[$field], $format) ?: '<!-- empty -->';
         }
     }
 


### PR DESCRIPTION
Call FormatService::renderHtml instead of deprecated Gdn_Format::to 

same as https://github.com/vanilla/vanilla/pull/9163