### PR TITLE
Fix rich editor embed render error handling

### DIFF
--- a/library/src/scripts/embeddedContent/EmbedErrorBoundary.tsx
+++ b/library/src/scripts/embeddedContent/EmbedErrorBoundary.tsx
@@ -1,0 +1,37 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { EmbedRenderError } from "@library/embeddedContent/EmbedRenderError";
+
+interface IProps {
+    url: string;
+    children: React.ReactNode;
+}
+
+interface IState {
+    error: Error | null;
+}
+
+/**
+ * Error boundary for catching rendering errors from embeds.
+ */
+export class EmbedErrorBoundary extends React.PureComponent<IProps, IState> {
+    public state: IState = {
+        error: null,
+    };
+
+    public render() {
+        if (this.state.error) {
+            return <EmbedRenderError url={this.props.url} />;
+        } else {
+            return this.props.children;
+        }
+    }
+
+    public componentDidCatch(error: Error) {
+        this.setState({ error });
+    }
+}

--- a/library/src/scripts/embeddedContent/EmbedRenderError.tsx
+++ b/library/src/scripts/embeddedContent/EmbedRenderError.tsx
@@ -1,0 +1,34 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { WarningIcon } from "@library/icons/common";
+import { t } from "@library/utility/appUtils";
+import { embedErrorClasses } from "@library/embeddedContent/embedErrorStyles";
+import SmartLink from "@library/routing/links/SmartLink";
+import { FOCUS_CLASS } from "@library/embeddedContent/embedService";
+import classNames from "classnames";
+
+interface IProps {
+    url: string;
+}
+
+export function EmbedRenderError(props: IProps) {
+    const warningTitle = t("This embed could not be loaded in your browser.");
+    const classes = embedErrorClasses();
+    const helpUrl =
+        "https://success.vanillaforums.com/kb/articles/13-rich-editor#what-causes-the-warning-icon-while-inserting-a-rich-embed";
+
+    return (
+        <div className={classes.renderErrorRoot}>
+            <SmartLink tabIndex={-1} to={props.url} rel="nofollow" className={classNames(FOCUS_CLASS)}>
+                {props.url}
+            </SmartLink>
+            <SmartLink className={classes.renderErrorIconLink} to={helpUrl}>
+                <WarningIcon warningMessage={warningTitle} />
+            </SmartLink>
+        </div>
+    );
+}

--- a/library/src/scripts/embeddedContent/EmbedRenderError.tsx
+++ b/library/src/scripts/embeddedContent/EmbedRenderError.tsx
@@ -22,8 +22,8 @@ export function EmbedRenderError(props: IProps) {
         "https://success.vanillaforums.com/kb/articles/13-rich-editor#what-causes-the-warning-icon-while-inserting-a-rich-embed";
 
     return (
-        <div className={classes.renderErrorRoot}>
-            <SmartLink tabIndex={-1} to={props.url} rel="nofollow" className={classNames(FOCUS_CLASS)}>
+        <div className={classNames(FOCUS_CLASS, classes.renderErrorRoot, "embedLinkLoader-link")} tabIndex={-1}>
+            <SmartLink to={props.url} rel="nofollow">
                 {props.url}
             </SmartLink>
             <SmartLink className={classes.renderErrorIconLink} to={helpUrl}>

--- a/library/src/scripts/embeddedContent/GettyImagesEmbed.tsx
+++ b/library/src/scripts/embeddedContent/GettyImagesEmbed.tsx
@@ -8,6 +8,7 @@ import { EmbedContainer } from "@library/embeddedContent/EmbedContainer";
 import { EmbedContent } from "@library/embeddedContent/EmbedContent";
 import { IBaseEmbedProps } from "@library/embeddedContent/embedService";
 import React, { useEffect } from "react";
+import { useThrowError } from "@vanilla/react-utils";
 
 interface IProps extends IBaseEmbedProps {
     height: number;
@@ -23,8 +24,10 @@ interface IProps extends IBaseEmbedProps {
  * A class for rendering Getty Images embeds.
  */
 export function GettyImagesEmbed(props: IProps): JSX.Element {
+    const throwError = useThrowError();
+
     useEffect(() => {
-        void convertGettyEmbeds();
+        void convertGettyEmbeds().catch(throwError);
     });
 
     return (

--- a/library/src/scripts/embeddedContent/GettyImagesEmbed.tsx
+++ b/library/src/scripts/embeddedContent/GettyImagesEmbed.tsx
@@ -4,10 +4,9 @@
  */
 
 import { ensureScript } from "@vanilla/dom-utils";
-import { EmbedContainer } from "@library/embeddedContent/EmbedContainer";
 import { EmbedContent } from "@library/embeddedContent/EmbedContent";
 import { IBaseEmbedProps } from "@library/embeddedContent/embedService";
-import React, { useEffect } from "react";
+import React, { useLayoutEffect } from "react";
 import { useThrowError } from "@vanilla/react-utils";
 
 interface IProps extends IBaseEmbedProps {
@@ -26,7 +25,7 @@ interface IProps extends IBaseEmbedProps {
 export function GettyImagesEmbed(props: IProps): JSX.Element {
     const throwError = useThrowError();
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         void convertGettyEmbeds().catch(throwError);
     });
 

--- a/library/src/scripts/embeddedContent/ImgurEmbed.tsx
+++ b/library/src/scripts/embeddedContent/ImgurEmbed.tsx
@@ -4,10 +4,9 @@
  */
 
 import { ensureScript } from "@vanilla/dom-utils";
-import { EmbedContainer } from "@library/embeddedContent/EmbedContainer";
 import { EmbedContent } from "@library/embeddedContent/EmbedContent";
 import { IBaseEmbedProps } from "@library/embeddedContent/embedService";
-import React, { useEffect } from "react";
+import React, { useLayoutEffect } from "react";
 import { useThrowError } from "@vanilla/react-utils";
 
 interface IProps extends IBaseEmbedProps {
@@ -23,7 +22,7 @@ interface IProps extends IBaseEmbedProps {
 export function ImgurEmbed(props: IProps): JSX.Element {
     const throwError = useThrowError();
 
-    useEffect(() => {
+    useLayoutEffect(() => {
         void convertImgurEmbeds().catch(throwError);
     });
 

--- a/library/src/scripts/embeddedContent/ImgurEmbed.tsx
+++ b/library/src/scripts/embeddedContent/ImgurEmbed.tsx
@@ -8,6 +8,7 @@ import { EmbedContainer } from "@library/embeddedContent/EmbedContainer";
 import { EmbedContent } from "@library/embeddedContent/EmbedContent";
 import { IBaseEmbedProps } from "@library/embeddedContent/embedService";
 import React, { useEffect } from "react";
+import { useThrowError } from "@vanilla/react-utils";
 
 interface IProps extends IBaseEmbedProps {
     height: number;
@@ -20,8 +21,10 @@ interface IProps extends IBaseEmbedProps {
  * A class for rendering Imgur embeds.
  */
 export function ImgurEmbed(props: IProps): JSX.Element {
+    const throwError = useThrowError();
+
     useEffect(() => {
-        void convertImgurEmbeds();
+        void convertImgurEmbeds().catch(throwError);
     });
 
     return (

--- a/library/src/scripts/embeddedContent/InstagramEmbed.tsx
+++ b/library/src/scripts/embeddedContent/InstagramEmbed.tsx
@@ -8,6 +8,7 @@ import { EmbedContent } from "@library/embeddedContent/EmbedContent";
 import { IBaseEmbedProps } from "@library/embeddedContent/embedService";
 import React, { useEffect } from "react";
 import { ensureScript } from "@vanilla/dom-utils";
+import { useThrowError } from "@vanilla/react-utils";
 
 interface IProps extends IBaseEmbedProps {
     version: number;
@@ -21,8 +22,9 @@ interface IProps extends IBaseEmbedProps {
  * A class for rendering Instagram embeds.
  */
 export function InstagramEmbed(props: IProps): JSX.Element {
+    const throwError = useThrowError();
     useEffect(() => {
-        void convertInstagramEmbeds();
+        void convertInstagramEmbeds().catch(throwError);
     });
 
     const permaLink = `https://www.instagram.com/p/${props.postID}`;

--- a/library/src/scripts/embeddedContent/InstagramEmbed.tsx
+++ b/library/src/scripts/embeddedContent/InstagramEmbed.tsx
@@ -6,7 +6,7 @@
 import { EmbedContainer } from "@library/embeddedContent/EmbedContainer";
 import { EmbedContent } from "@library/embeddedContent/EmbedContent";
 import { IBaseEmbedProps } from "@library/embeddedContent/embedService";
-import React, { useEffect } from "react";
+import React, { useEffect, useLayoutEffect } from "react";
 import { ensureScript } from "@vanilla/dom-utils";
 import { useThrowError } from "@vanilla/react-utils";
 
@@ -23,7 +23,7 @@ interface IProps extends IBaseEmbedProps {
  */
 export function InstagramEmbed(props: IProps): JSX.Element {
     const throwError = useThrowError();
-    useEffect(() => {
+    useLayoutEffect(() => {
         void convertInstagramEmbeds().catch(throwError);
     });
 

--- a/library/src/scripts/embeddedContent/embedErrorStyles.ts
+++ b/library/src/scripts/embeddedContent/embedErrorStyles.ts
@@ -1,0 +1,23 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { useThemeCache, styleFactory } from "@library/styles/styleUtils";
+import { flexHelper } from "@library/styles/styleHelpers";
+import { px } from "csx";
+
+export const embedErrorClasses = useThemeCache(() => {
+    const style = styleFactory("embedError");
+    const renderErrorRoot = style("renderErrorRoot", {
+        display: "block",
+        textAlign: "left",
+    });
+
+    const renderErrorIconLink = style("renderErrorIconLink", {
+        paddingLeft: px(4),
+        verticalAlign: "middle",
+    });
+
+    return { renderErrorRoot, renderErrorIconLink };
+});

--- a/library/src/scripts/embeddedContent/embedService.tsx
+++ b/library/src/scripts/embeddedContent/embedService.tsx
@@ -20,6 +20,7 @@ import { onContent } from "@library/utility/appUtils";
 import { logWarning } from "@vanilla/utils";
 import React from "react";
 import Quill from "quill/core";
+import { EmbedErrorBoundary } from "@library/embeddedContent/EmbedErrorBoundary";
 
 export const FOCUS_CLASS = "embed-focusableElement";
 
@@ -76,7 +77,9 @@ export async function mountEmbed(mountPoint: HTMLElement, data: IBaseEmbedProps,
         const onMountComplete = () => resolve();
         // If the component is flagged as async, then it will confirm when the render is complete.
         mountReact(
-            <EmbedClass {...data} inEditor={inEditor} onRenderComplete={isAsync ? onMountComplete : undefined} />,
+            <EmbedErrorBoundary url={data.url}>
+                <EmbedClass {...data} inEditor={inEditor} onRenderComplete={isAsync ? onMountComplete : undefined} />
+            </EmbedErrorBoundary>,
             mountPoint,
             !isAsync ? onMountComplete : undefined,
         );

--- a/library/src/scripts/icons/common.tsx
+++ b/library/src/scripts/icons/common.tsx
@@ -218,6 +218,28 @@ export function NewFolderIcon(props: { className?: string; title?: string }) {
     );
 }
 
+export function WarningIcon(props: { className?: string; warningMessage: string }) {
+    const classes = iconClasses();
+
+    return (
+        <svg
+            className={classNames(classes.warning, props.className)}
+            aria-label={props.warningMessage}
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 16 16"
+        >
+            <title>{props.warningMessage}</title>
+            <circle cx="8" cy="8" r="8" style={currentColorFill} />
+            <circle cx="8" cy="8" r="7.5" style={{ fill: "none", stroke: "#000", strokeOpacity: 0.122 }} />
+            <path
+                d="M11,10.4V8h2v2.4L12.8,13H11.3Zm0,4h2v2H11Z"
+                transform="translate(-4 -4)"
+                style={{ fill: "#fff" }}
+            />
+        </svg>
+    );
+}
+
 export function CategoryIcon(props: { className?: string }) {
     const title = t("Folder");
     const classes = iconClasses();

--- a/library/src/scripts/icons/iconClasses.ts
+++ b/library/src/scripts/icons/iconClasses.ts
@@ -5,7 +5,8 @@
 
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { em } from "csx";
-import { margins, unit } from "@library/styles/styleHelpers";
+import { margins, unit, colorOut } from "@library/styles/styleHelpers";
+import { globalVariables } from "@library/styles/globalStyleVars";
 
 export const iconVariables = useThemeCache(() => {
     const themeVars = variableFactory("defaultIconSizes");
@@ -38,6 +39,12 @@ export const iconVariables = useThemeCache(() => {
     const compact = themeVars("compact", {
         width: 12,
         height: 12,
+    });
+
+    const warning = themeVars("warning", {
+        width: 16,
+        height: 16,
+        color: "#f5af15",
     });
 
     const settings = themeVars("settings", {
@@ -114,6 +121,7 @@ export const iconVariables = useThemeCache(() => {
         vanillaLogo,
         compact,
         settings,
+        warning,
         search,
         notifications,
         messages,
@@ -167,6 +175,12 @@ export const iconClasses = useThemeCache(() => {
     const settings = style("settings", {
         width: unit(vars.settings.width),
         height: unit(vars.settings.height),
+    });
+
+    const warning = style("warning", {
+        width: unit(vars.warning.width),
+        height: unit(vars.warning.height),
+        color: colorOut(vars.warning.color),
     });
 
     const search = style("search", {
@@ -238,6 +252,7 @@ export const iconClasses = useThemeCache(() => {
     return {
         standard,
         newFolder,
+        warning,
         fileType,
         attachmentError,
         vanillaLogo,

--- a/packages/vanilla-react-utils/src/index.ts
+++ b/packages/vanilla-react-utils/src/index.ts
@@ -10,3 +10,4 @@ export * from "./useFocusWatcher";
 export * from "./useMeasure";
 export * from "./useLastValue";
 export * from "./useTabKeyboardHandler";
+export * from "./useThrowError";

--- a/packages/vanilla-react-utils/src/useThrowError.ts
+++ b/packages/vanilla-react-utils/src/useThrowError.ts
@@ -1,0 +1,21 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { useState } from "react";
+
+/**
+ * Return a throw function for use inside of custom hooks & useEffect.
+ *
+ * This needed because throwing inside of `useEffect` does not propagate up to error boundaries.
+ * @see https://github.com/facebook/react/issues/11334
+ */
+export function useThrowError(): (err: Error) => void {
+    const [error, setError] = useState<Error | null>(null);
+    if (error) {
+        throw error;
+    }
+
+    return setError;
+}


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/7606

The main issue here is that our error handling was at the Blot level, but react was catching the errors before they ever got there. What I've done is:

- Create an `EmbedRenderError` component. This displays the link error.
- Create an `EmbedErrorBoundary` component. This catches the errors thrown in react.
- A new react utility `useThrowError` to make throwing errors from inside of `useEffect` hooks work.
- Update `TwitterEmbed`, `GettyEmbed`, `ImgurEmbed`, and `Instagram` to properly throw an error (previously getting caught in hook, now `useThrowError()` is used.)