### PR TITLE
Set the error reporting to include E_USER_WARNING

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  */
 
 // Report and track all errors.
-error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);
+error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_WARNING | E_USER_WARNING | E_RECOVERABLE_ERROR);
 ini_set('display_errors', 0);
 ini_set('track_errors', 1);
 


### PR DESCRIPTION
I want to be able to trigger warnings for some things that we plan to change in the future, but are uncertain of the production implications.

This change will send E_WARNING and E_USER_WARNING errors to the log rather than discarding them.

**Note: I added E_WARNING to the list of warnings we report because it seems like the right thing to do, but that may end up being too noisy. I feel like I remember some really dumb things escalating to E_WARNING in PHP, but I just can't remember what.**