### PR TITLE
Fix empty comment draft button and autosave behaviour for rich editor (#9198)

### DIFF
--- a/applications/vanilla/js/autosave.js
+++ b/applications/vanilla/js/autosave.js
@@ -14,7 +14,7 @@ jQuery(document).ready(function($) {
                 undefined,
                 null,
                 '',
-                '[{"insert":"\n"}]',
+                '[{\"insert\":\"\\n\"}]',
                 lastVal
             ];
             if (!defaultValues.includes(currentVal)) {

--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -35,6 +35,12 @@ jQuery(document).ready(function($) {
         var inpDraftID = $(frm).find('input:hidden[name$=DraftID]');
         var type = 'Post';
         var preview = $(btn).hasClass('PreviewButton');
+        var defaultValues = [
+            undefined,
+            null,
+            '',
+            '[{\"insert\":\"\\n\"}]'
+        ];
         if (preview) {
             type = 'Preview';
             // If there is already a preview showing, kill processing.
@@ -44,9 +50,10 @@ jQuery(document).ready(function($) {
         }
         var draft = $(btn).hasClass('DraftButton');
         if (draft) {
+            var currentVal = $(textbox).val()
             type = 'Draft';
             // Don't save draft if string is empty
-            if (jQuery.trim($(textbox).val()) == '')
+            if (!defaultValues.includes(currentVal))
                 return false;
 
             if (draftSaving > 0)

--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -53,7 +53,7 @@ jQuery(document).ready(function($) {
             var currentVal = $(textbox).val()
             type = 'Draft';
             // Don't save draft if string is empty
-            if (!defaultValues.includes(currentVal))
+            if (defaultValues.includes(currentVal))
                 return false;
 
             if (draftSaving > 0)


### PR DESCRIPTION
This PR fixes two bugs related to saving drafts when the rich editor is enabled.

1. It fixes incorrect string escaping in autosave.js that causes it to never match rich editor "empty string" markup, and 
2. It aligns empty string matching in discussion.js with the same functionality in autosave.js to fix a bug where it was possible to save empty drafts when rich editor is in use.

When combined, these two bugs allow for empty comments to be autosaved, which quickly fills an active user's drafts index up with empty drafts.

## Testing

### Test structure

1. With rich editor enabled, carry out all tests below
2. With rich editor disabled, carry out only tests 1, 2, 4, and 5.

### Test 1

1. Write a comment and click 'save draft'
2. Confirm draft has been saved

### Test 2

1. With an empty comment, click 'save draft'
2. Confirm no draft saved

### Test 3

1. Write a comment and then delete it (this will put the textarea into a state where it definitely contains the rich editor markup for empty input)
2. Confirm no draft saved

### Test 4

1. Write a comment and wait (60 seconds by default)
2. Confirm draft was saved by autosave functionality

### Test 5

1. Write a comment and then blank it out and wait
2. Confirm autosave does not save the draft