### PR TITLE
Fix plain text emails rendering with HTML tags

### DIFF
--- a/applications/dashboard/library/class.emailtemplate.php
+++ b/applications/dashboard/library/class.emailtemplate.php
@@ -4,6 +4,7 @@
  * @license GPL-2.0-only
  */
 
+use Vanilla\Formatting\Formats\WysiwygFormat;
 use Vanilla\Web\Asset\LegacyAssetModel;
 
 /**
@@ -508,6 +509,8 @@ class EmailTemplate extends Gdn_Pluggable implements Gdn_IEmailTemplate {
      * @return string A plaintext email.
      */
     protected function plainTextEmail() {
+        $formatService = Gdn::formatService();
+
         $email = [
             'banner' => val('alt', $this->image).' '.val('link', $this->image),
             'title' => $this->getTitle(),
@@ -521,13 +524,19 @@ class EmailTemplate extends Gdn_Pluggable implements Gdn_IEmailTemplate {
             if (!$val) {
                 unset($email[$key]);
             } else {
+                // Add some additional padding, where necessary, to improve the appearance of plain-text messages.
                 if ($key == 'message') {
                     $email[$key] = "<br>$val<br>";
+                } elseif ($key == "banner") {
+                    $email["banner"] = "{$val}<br>";
                 }
             }
         }
 
-        return Gdn_Format::plainText(Gdn_Format::text(implode('<br>', $email), false));
+        $body = implode("<br>", $email);
+        // Treat the HTML as WYSIWYG for the format's preferred handling of breaks/newlines.
+        $result = $formatService->renderPlainText($body, WysiwygFormat::FORMAT_KEY);
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Vanilla's plain text emails have been rendering with HTML tags since the recent formatting service improvements were introduced. `EmailTemplate` has been updated to generate HTML that is then converted to plain text using the new formatting service before. This ensures the message is rendering consistently without HTML, as expected.

### Recommended Testing

1. Visit the email settings page of the Vanilla dashboard. Ensure HTML email is **off**.
1. Send a test email.
1. Verify the email you receive is a plain text message with no visible HTML tags. The formatting of the message should also separate all relevant portions onto their own newlines (e.g. the title and the message should be separated by at least one new line).

Closes vanilla/support#719