### PR TITLE
Remove ReduxReducer instance initial state requirement

### DIFF
--- a/library/src/scripts/redux/ReduxReducer.ts
+++ b/library/src/scripts/redux/ReduxReducer.ts
@@ -11,11 +11,6 @@ import { IAction } from "@library/redux/ReduxActions";
  */
 export default abstract class ReduxReducer<S> {
     /**
-     * The initial state of the object.
-     */
-    public abstract readonly initialState: S;
-
-    /**
      * The reducer function for redux.
      */
     public abstract reducer: (state: S, action: IAction<any>) => S;


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/pull/1158

The instance property of this class for initial state was a bit of a mistake.

- This always needs to be defined as a constant anyways so the initializer was unnecessary. 
- It's not possible to have an `static abstract` property in typescript, so I had to remove it rather than make it static.