### PR TITLE
Fix user availability search not working on connect registration

### DIFF
--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -5,17 +5,17 @@ jQuery(document).ready(function($) {
         $("#Register input[name=Email], body.register input[name=Email]").blur(function() {
             var email = $(this).val();
             if (email != "") {
-                var checkUrl = gdn.url("/user/emailavailable");
+                var checkUrl = gdn.url("/user/emailavailable.json");
                 $.ajax({
                     type: "GET",
                     url: checkUrl,
                     data: { email: email },
-                    dataType: "text",
+                    dataType: "json",
                     error: function(xhr) {
                         gdn.informError(xhr, true);
                     },
-                    success: function(text) {
-                        if (text == "FALSE") $("#EmailUnavailable").show();
+                    success: function(data) {
+                        if (data.Data === false) $("#EmailUnavailable").show();
                         else $("#EmailUnavailable").hide();
                     },
                 });
@@ -26,16 +26,17 @@ jQuery(document).ready(function($) {
         $("#Register input[name=Name], body.register input[name=Name]").blur(function() {
             var name = $(this).val();
             if (name != "") {
-                var checkUrl = gdn.url("/user/usernameavailable/" + encodeURIComponent(name));
+                var checkUrl = gdn.url("/user/usernameavailable.json");
                 $.ajax({
                     type: "GET",
                     url: checkUrl,
-                    dataType: "text",
+                    data: { name: name },
+                    dataType: "json",
                     error: function(xhr) {
                         gdn.informError(xhr, true);
                     },
-                    success: function(text) {
-                        if (text == "FALSE") $("#NameUnavailable").show();
+                    success: function(data) {
+                        if (data.Data === false) $("#NameUnavailable").show();
                         else $("#NameUnavailable").hide();
                     },
                 });
@@ -44,54 +45,56 @@ jQuery(document).ready(function($) {
     }
 
     var checkConnectName = function() {
-        // If config setting AllowConnect is set to false, hide the password and return.
-        if (!gdn.definition("AllowConnect", true)) {
-            $("#ConnectPassword").hide();
-            return;
-        }
-        if (gdn.definition("NoConnectName", false)) {
-            $("#ConnectPassword").show();
-            return;
-        }
-        var fineprint = $("#Form_ConnectName").siblings(".FinePrint");
-        var selectedName = $("input[name=UserSelect]:checked").val();
-        if (!selectedName || selectedName == "other") {
-            var name = $("#Form_ConnectName").val();
-            if (typeof name == "string" && name != "") {
-                var checkUrl = gdn.url("/user/usernameavailable/" + encodeURIComponent(name));
-                $.ajax({
-                    type: "GET",
-                    url: checkUrl,
-                    dataType: "text",
-                    error: function(xhr) {
-                        gdn.informError(xhr, true);
-                    },
-                    success: function(text) {
-                        if (text == "TRUE") {
-                            $("#ConnectPassword").hide();
-                            if (fineprint.length) {
-                                fineprint.html(gdn.definition("Choose a name to identify yourself on the site."));
-                            }
-                        } else {
-                            $("#ConnectPassword").show();
-                            if (fineprint.length) {
-                                fineprint.html(gdn.definition("Username already exists."));
-                            }
-                        }
-                    },
-                });
-            } else {
+            // If config setting AllowConnect is set to false, hide the password and return.
+            if (!gdn.definition("AllowConnect", true)) {
                 $("#ConnectPassword").hide();
+                return;
             }
-        } else {
-            $("#ConnectPassword").show();
-        }
+            if (gdn.definition("NoConnectName", false)) {
+                $("#ConnectPassword").show();
+                return;
+            }
+            var fineprint = $("#Form_ConnectName").siblings(".FinePrint");
+            var selectedName = $("input[name=UserSelect]:checked").val();
+            if (!selectedName || selectedName == "other") {
+                var name = $("#Form_ConnectName").val();
+                if (typeof name == "string" && name != "") {
+                    var checkUrl = gdn.url("/user/usernameavailable.json");
+                    $.ajax({
+                        type: "GET",
+                        url: checkUrl,
+                        data: { name: name },
+                        dataType: "json",
+                        error: function (xhr) {
+                            gdn.informError(xhr, true);
+                        },
+                        success: function (data) {
+                            if (data.Data === true) {
+                                $("#ConnectPassword").hide();
+                                if (fineprint.length) {
+                                    fineprint.html(gdn.definition("Choose a name to identify yourself on the site."));
+                                }
+                            } else {
+                                $("#ConnectPassword").show();
+                                if (fineprint.length) {
+                                    fineprint.html(gdn.definition("Username already exists."));
+                                }
+                            }
+                        },
+                    });
+                } else {
+                    $("#ConnectPassword").hide();
+                }
+            } else {
+                $("#ConnectPassword").show();
+            }
+      //  }
     };
-
-    checkConnectName();
-    $("#Form_ConnectName").keyup(checkConnectName);
-    $("input[name=UserSelect]").click(checkConnectName);
-
+    if (gdn.definition("userSearchAvailable", true)) {
+        checkConnectName();
+        $("#Form_ConnectName").keyup(checkConnectName);
+        $("input[name=UserSelect]").click(checkConnectName);
+    }
     // Check to see if passwords match
     $("input[name=PasswordMatch]").blur(function() {
         var $pwmatch = $(this);

--- a/applications/dashboard/js/entry.js
+++ b/applications/dashboard/js/entry.js
@@ -88,7 +88,6 @@ jQuery(document).ready(function($) {
             } else {
                 $("#ConnectPassword").show();
             }
-      //  }
     };
     if (gdn.definition("userSearchAvailable", true)) {
         checkConnectName();

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,1 +1,0 @@
-Deny from all

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -43,8 +43,8 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
         '#^plugin(/|$)#' => self::BLOCK_NEVER,
         '#^settings/analyticstick.json$#' => self::BLOCK_PERMISSION,
         '#^sso(/|$)#' => self::BLOCK_NEVER,
-        '#^user/emailavailable(/|$)#' => self::BLOCK_PERMISSION,
-        '#^user/usernameavailable(/|$)#' => self::BLOCK_PERMISSION,
+        '#^user/emailavailable(/|$|\.json)#' => self::BLOCK_PERMISSION,
+        '#^user/usernameavailable(/|$|\.json)#' => self::BLOCK_PERMISSION,
         '#^utility(/|$)#' => self::BLOCK_NEVER,
     ];
 


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/726
related https://github.com/vanilla/vanilla-patches/pull/592
### Details

When trying to connect over SSO with (Private-communities & Registration not set to basic) users cannot connect.
When inspecting the page, you'll notice this error:

<img width="686" alt="Screen Shot 2019-08-20 at 11 43 39 AM" src="https://user-images.githubusercontent.com/31856281/63381944-b0fe1480-c367-11e9-902d-2c2e70cb5e84.png">

We added this definition https://github.com/vanilla/vanilla/blob/46c27769344e83dd6752cc5bb2b76c765dae3357/applications/dashboard/controllers/class.entrycontroller.php#L79

https://github.com/vanilla/vanilla/blob/c120a36c1f901726f473f3f5bf27e72c1d2b641f/applications/dashboard/js/entry.js#L3

that's supposed to be turning off availability searches if the feature isn't available, but it isn't

 
### What Changed
In this PR we check if userSearchAvialable is true before we call checkConnectName();
 
Those availability checks are also updated to use "data" requests (e.g. /user/usernameavailable.json?name=f), instead of "regular" requests (e.g. /user/usernameavailable/f). When these requests fail, Its expect the exception message in the info popup.


### To Test

- Make sure you are not in a private community. Try using the /user/emailavailable and /user/usernameavailable endpoints while not signed in. Verify they function as expected.
- Enable private community and set your site's registration method to basic, if it isn't already.
- Try using /user/emailavailable and /user/usernameavaialble again. Verify they function normally.
- Change your site's registration method to invitation (or approval).
- Try using the /user/emailavailable and /user/usernameavailable endpoints again. They should now throw exceptions.
- Try using the site's regular registration form. You should not see any network requests to either /user/emailavailable or /user/usernameavailable while filling out the form.
- Disable private community and switch back to basic registration.
- Try using the site's regular registration form again. This time, you should see requests made to /user/emailavailable and /user/usernameavailable as you move from field to field in the form. Verify errors are displayed in the form, before you submit, if the username or email address are already taken on the site.

### Test using SSO

- set your community to private and registration to connect
- Using SSO provider, try connecting to the site.
- enter a username that already exists in the db (should get name already exists if private community is disabled)
- correct it and try with a new username

