### PR TITLE
Fix discussions api call when a discussion format is BBCode

### DIFF
--- a/library/core/class.bbcode.php
+++ b/library/core/class.bbcode.php
@@ -311,6 +311,9 @@ class BBCode extends Gdn_Pluggable {
     public function media() {
         if ($this->media === null) {
             $controller = Gdn::controller();
+            if (!$controller instanceof Gdn_Controller) {
+                return;
+            }
             $commentIDList = [];
             $comments = $controller->data('Comments');
             $discussionID = $controller->data('Discussion.DiscussionID');


### PR DESCRIPTION
related https://github.com/vanilla/support/issues/607

### Details

When a discussion format is 'BBCode', a call to api/v2/discussions would return 'Call to a member function data() on null'

### Reason

In [class.bbcode.php#L313](https://github.com/vanilla/vanilla/blob/9e0cf71d1b574c390b0d32c5c5b76999746405aa/library/core/class.bbcode.php#L313) $controller is null, we're trying to access data() on null.

### To Test

Run an api call to api/v2/discussions with a discussion format of 'BBCode'