### PR TITLE
Fix overzealous event propagation stopping in dropdown content

### DIFF
--- a/library/src/scripts/flyouts/DropDownContents.tsx
+++ b/library/src/scripts/flyouts/DropDownContents.tsx
@@ -87,9 +87,5 @@ export default class DropDownContents extends React.Component<IProps> {
 
     private doNothing = (e: React.MouseEvent) => {
         e.stopPropagation();
-        e.preventDefault();
-        e.nativeEvent.stopImmediatePropagation();
-        e.nativeEvent.stopPropagation();
-        e.nativeEvent.preventDefault();
     };
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/knowledge/issues/1165

I added this while attempting to fix some focus stealing issue in contenteditable. It turns out the real solution is what I put in a few lines above this.

I've gone and tested and the alt text UI (that this was added for as a I tested it) and this fixes it.