### PR TITLE
Fix emoji suggestions not displaying

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -28,19 +28,36 @@ class DashboardHooks extends Gdn_Plugin {
     /** @var \Vanilla\AddonManager */
     private $addonManager;
 
+    /** @var Emoji */
+    private $emoji;
+
     /**
      * Constructor for DI.
      *
      * @param \Vanilla\AddonManager $addonManager
      * @param Contracts\ConfigurationInterface $config
+     * @param Emoji $emoji
      */
-    public function __construct(\Vanilla\AddonManager $addonManager, Contracts\ConfigurationInterface $config) {
+    public function __construct(\Vanilla\AddonManager $addonManager, Contracts\ConfigurationInterface $config, Emoji $emoji) {
         parent::__construct();
         $this->addonManager = $addonManager;
         $this->mobileThemeKey = $config->get('Garden.MobileTheme');
         $this->desktopThemeKey = $config->get('Garden.Theme');
+        $this->emoji = $emoji;
     }
 
+    /**
+     * Add emoji config to a controller's JavaScript definitions object.
+     *
+     * @param Gdn_Controller $controller
+     */
+    private function addEmojiDefinitions(Gdn_Controller $controller) {
+        if ($this->emoji->isEnabled() === false) {
+            return;
+        }
+
+        $controller->addDefinition("emoji", $this->emoji->getWebConfig());
+    }
 
     /**
      * Install the formatter to the container.
@@ -255,12 +272,13 @@ class DashboardHooks extends Gdn_Plugin {
             $sender->addDefinition('TagHint', t('TagHint', 'Start to type...'));
         }
 
-
-
         // Add symbols.
         if ($sender->deliveryMethod() === DELIVERY_METHOD_XHTML) {
             $sender->addAsset('Symbols', $sender->fetchView('symbols', '', 'Dashboard'));
         }
+
+        // Add emoji.
+        $this->addEmojiDefinitions($sender);
     }
 
     /**

--- a/library/core/class.emoji.php
+++ b/library/core/class.emoji.php
@@ -248,36 +248,6 @@ class Emoji {
         }
 
         $eventManager->fire('Emoji_Init', $this, []); // Empty $argrs array needed for backwards compatibility.
-
-        // Add emoji to definition list for whole site. This used to be in the
-        // advanced editor plugin, but since moving atmentions to core, had to
-        // make sure they were still being added. This will make sure that
-        // emoji autosuggest works. Note: emoji will not be core yet, so the only
-        // way that this gets called is by the editor when it instantiates. Core
-        // does not instantiate this class anywhere, so there will not be any
-        // suggestions for emoji yet, but keep here for whenever Advanced Editor
-        // is running.
-        $c = Gdn::controller();
-        if ($c && $this->enabled) {
-            $emojis = $this->getEmoji();
-            $emojiAssetPath = $this->getAssetPath();
-            $emoji = [];
-
-            foreach ($emojis as $name => $data) {
-                $emoji[] = [
-                    "name" => "".$name."",
-                    "url" => asset($emojiAssetPath.'/'.$data, true)
-                ];
-            }
-
-            $emoji = [
-                'assetPath' => asset($this->getAssetPath(), true),
-                'format' => $this->getFormat(),
-                'emoji' => $this->getEmoji()
-            ];
-
-            $c->addDefinition('emoji', $emoji);
-        }
     }
 
     /**
@@ -336,6 +306,30 @@ class Emoji {
      */
     public function getArchive() {
         return $this->archive;
+    }
+
+    /**
+     * Get an emoji config array with essential information for rendering emoji in the browser.
+     *
+     * @return array
+     */
+    public function getWebConfig(): array {
+        $result = [
+            "assetPath" => asset($this->getAssetPath(), true),
+            "format" => $this->getFormat(),
+            "emoji" => $this->getEmoji()
+        ];
+
+        return $result;
+    }
+
+    /**
+     * Are emoji enabled?
+     *
+     * @return boolean
+     */
+    public function isEnabled(): bool {
+        return (bool)$this->enabled;
     }
 
     /**


### PR DESCRIPTION
Emoji suggestions are currently broken. Typing a colon should trigger the emoji suggestion menu in a default install of Vanilla. This is not happening due to [recent revisions to Vanilla's formatting](https://github.com/vanilla/vanilla/pull/8980). Vanilla started instantiating the `Emoji` class earlier for DI. The `Emoji` class had code in it to add its config to the controller's definitions whenever it was instantiated. Since we started instantiating it earlier, there is no controller available at the time.

Having the controller definitions added at the time the class is instantiated is weird. Adding the config to the controller has been moved to `base_render_before` in the Dashboard hooks file. This should be in a place where it's always available and only added when needed.

### Recommended Testing
1. Navigate to the new discussion form.
1. Enter a single colon (:).
1. Observe the emoji suggestions menu is displayed.
1. Type characters to update the suggestions.
1. Click a suggestion to insert it in the content and dismiss the menu.