### PR TITLE
Fix asset loading bugs

### DIFF
--- a/build/scripts/utility/EntryModel.ts
+++ b/build/scripts/utility/EntryModel.ts
@@ -134,7 +134,7 @@ export default class EntryModel {
         names = names
             .filter(name => name.match(EntryModel.TS_REGEX))
             .map(name => name.replace(EntryModel.TS_REGEX, ""))
-            .filter(name => name !== "bootstrap");
+            .filter(name => name !== "bootstrap" && name !== "common");
 
         names = Array.from(new Set(names));
 

--- a/build/scripts/utility/EntryModel.ts
+++ b/build/scripts/utility/EntryModel.ts
@@ -40,7 +40,17 @@ interface IAddon {
  */
 export default class EntryModel {
     /** Regex to match typescript files. */
-    private static TS_REGEX = /\.tsx?$/;
+    private static readonly TS_REGEX = /\.tsx?$/;
+
+    /** Name of the section defined from having a "bootstrap.ts(x?) file in entries. " */
+    private static readonly BOOTSTRAP_SECTION_NAME = "bootstrap";
+
+    /** Name of the section defined from having a "common.ts(x?) file in entries. " */
+    private static readonly COMMON_SECTION_NAME = "common";
+
+    /**
+     * These 2 sections are special cases are included in all sections. They are not their own sections by themselves. */
+    private excludedSections = [EntryModel.BOOTSTRAP_SECTION_NAME, EntryModel.COMMON_SECTION_NAME];
 
     /** The addons that are being built. */
     private buildAddons: {
@@ -134,7 +144,8 @@ export default class EntryModel {
         names = names
             .filter(name => name.match(EntryModel.TS_REGEX))
             .map(name => name.replace(EntryModel.TS_REGEX, ""))
-            .filter(name => name !== "bootstrap" && name !== "common");
+            // Filter out unwanted sections (special cases).
+            .filter(name => !this.excludedSections.includes(name));
 
         names = Array.from(new Set(names));
 

--- a/library/Vanilla/Web/Asset/LocaleAsset.php
+++ b/library/Vanilla/Web/Asset/LocaleAsset.php
@@ -33,7 +33,7 @@ class LocaleAsset extends SiteAsset {
      * @inheritdoc
      */
     public function getWebPath(): string {
-        return self::makeWebPath(
+        return self::makeAssetPath(
             '/api/v2/locales',
             $this->localeKey,
             'translations.js'

--- a/library/Vanilla/Web/Asset/WebpackAddonAsset.php
+++ b/library/Vanilla/Web/Asset/WebpackAddonAsset.php
@@ -23,15 +23,27 @@ class WebpackAddonAsset extends WebpackAsset {
      * @see https://docs.vanillaforums.com/developer/tools/building-frontend/#site-sections
      * @param Contracts\AddonInterface $addon The addon to get an asset for.
      * @param string $cacheBustingKey A string for busting the cache.
+     * @param bool $isCommonChunk Whether to check append common to the path.
      */
     public function __construct(
         RequestInterface $request,
         string $extension,
         string $section,
         Contracts\AddonInterface $addon,
-        $cacheBustingKey = ""
+        $cacheBustingKey = "",
+        bool $isCommonChunk = false
     ) {
-        parent::__construct($request, $extension, $section, $addon->getKey(), $cacheBustingKey);
+        $assetName = $addon->getKey();
+        if ($isCommonChunk) {
+            $assetName .= "-common";
+        }
+        parent::__construct(
+            $request,
+            $extension,
+            $section,
+            $assetName,
+            $cacheBustingKey
+        );
         $this->fileSubpath = $section . DS . 'addons';
         $this->webSubpath = $section . '/' . 'addons';
     }

--- a/library/Vanilla/Web/Asset/WebpackAssetProvider.php
+++ b/library/Vanilla/Web/Asset/WebpackAssetProvider.php
@@ -133,6 +133,22 @@ class WebpackAssetProvider {
 
         // Grab all of the addon based assets.
         foreach ($this->addonProvider->getEnabled() as $addon) {
+
+            // See if we have a common bundle
+            $commonAsset = new WebpackAddonAsset(
+                $this->request,
+                WebpackAsset::SCRIPT_EXTENSION,
+                $section,
+                $addon,
+                $this->cacheBustingKey,
+                true
+            );
+            $commonAsset->setFsRoot($this->fsRoot);
+
+            if ($commonAsset->existsOnFs()) {
+                $scripts[] = $commonAsset;
+            }
+
             $asset = new WebpackAddonAsset(
                 $this->request,
                 WebpackAsset::SCRIPT_EXTENSION,


### PR DESCRIPTION
- A new common asset is now possible on a per-addon basis (starting with https://github.com/vanilla/vanilla/pull/9246 and [used in multisite](https://github.com/vanilla/multisite/tree/master/plugins/subcommunities/src/scripts/entries)). Make sure these get loaded by the asset provider.
- Prevent `common` from being recognized as it's own section.
- Fix locale asset loading with subcommunities (API endpoints shouldn't have a subcommunity slug).