### PR TITLE
Backport: Add class to prevent self scraping and apply to the e…

### DIFF
--- a/library/Vanilla/Models/UserFragmentSchema.php
+++ b/library/Vanilla/Models/UserFragmentSchema.php
@@ -8,6 +8,7 @@
 namespace Vanilla\Models;
 
 use Garden\Schema\Schema;
+use Vanilla\ApiUtils;
 
 /**
  * Schema to validate shape of some media upload metadata.
@@ -24,5 +25,21 @@ class UserFragmentSchema extends Schema {
             'photoUrl:s', // The URL of the user\'s avatar picture.
             'dateLastActive:dt|n', // Time the user was last active.
         ]));
+    }
+
+    /**
+     * Normalize a user from the DB into a user fragment.
+     *
+     * @param array $dbRecord
+     * @return array
+     */
+    public static function normalizeUserFragment(array $dbRecord) {
+        if (array_key_exists('Photo', $dbRecord)) {
+            $photo = userPhotoUrl($dbRecord);
+            $dbRecord['PhotoUrl'] = $photo;
+        }
+
+        $schemaRecord = ApiUtils::convertOutputKeys($dbRecord);
+        return $schemaRecord;
     }
 }

--- a/library/Vanilla/Web/RequestValidator.php
+++ b/library/Vanilla/Web/RequestValidator.php
@@ -31,14 +31,15 @@ class RequestValidator {
      * Ensure the request is not of a particular type.
      *
      * @param string $requestMethod The method of the request, Eg. POST, PATCH, GET. See Gdn_Request constants.
-     * @param string|null $message The message to print in the exception.
+     * @param string $extraMessage Additional message content to add to the exception.
      *
      * @throws ClientException If the request method doesn't match.
      *
      */
-    public function blockRequestType(string $requestMethod, ?string $message = null) {
-        if ($message === null) {
-            $message = "Request method $requestMethod is not allowed.";
+    public function blockRequestType(string $requestMethod, string $extraMessage = "") {
+        $message = "Request method $requestMethod is not allowed.";
+        if ($extraMessage !== "") {
+            $message .= '\n' . $extraMessage;
         }
 
         if ($this->request->getMethod() === $requestMethod) {

--- a/library/Vanilla/Web/RequestValidator.php
+++ b/library/Vanilla/Web/RequestValidator.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Web;
+
+use Garden\Web\Exception\ClientException;
+use Garden\Web\RequestInterface;
+
+/**
+ * Class for validating various things about a request.
+ */
+class RequestValidator {
+
+    /** @var RequestInterface */
+    private $request;
+
+    /**
+     * DI.
+     *
+     * @param RequestInterface $request
+     */
+    public function __construct(RequestInterface $request) {
+        $this->request = $request;
+    }
+
+    /**
+     * Ensure the request is not of a particular type.
+     *
+     * @param string $requestMethod The method of the request, Eg. POST, PATCH, GET. See Gdn_Request constants.
+     * @param string|null $message The message to print in the exception.
+     *
+     * @throws ClientException If the request method doesn't match.
+     *
+     */
+    public function blockRequestType(string $requestMethod, ?string $message = null) {
+        if ($message === null) {
+            $message = "Request method $requestMethod is not allowed.";
+        }
+
+        if ($this->request->getMethod() === $requestMethod) {
+            throw new ClientException($message, 400);
+        }
+    }
+}

--- a/tests/Library/Vanilla/PageScraperTest.php
+++ b/tests/Library/Vanilla/PageScraperTest.php
@@ -25,7 +25,7 @@ class PageScraperTest extends SharedBootstrapTestCase {
      */
     private function pageScraper() {
         // Create the test instance. Register the metadata handlers.
-        $pageScraper = new LocalFilePageScraper(new HttpRequest());
+        $pageScraper = self::container()->get(LocalFilePageScraper::class);
         $pageScraper->setHtmlDir(self::HTML_DIR);
         $pageScraper->registerMetadataParser(new OpenGraphParser());
         $pageScraper->registerMetadataParser(new JsonLDParser());

--- a/tests/fixtures/src/MockPageScraper.php
+++ b/tests/fixtures/src/MockPageScraper.php
@@ -8,6 +8,7 @@ namespace VanillaTests\Fixtures;
 
 use Exception;
 use Garden\Http\HttpRequest;
+use Vanilla\Web\RequestValidator;
 
 /**
  * A PageScraper class, limited to local files.
@@ -20,9 +21,10 @@ class MockPageScraper extends \Vanilla\PageScraper {
      * Stub out unnecessary param in constructor.
      */
     public function __construct() {
-        // Stub in an empty request. We won't need it.
+        // Stub in args. We won't need them.
+        $validator = \Gdn::getContainer()->get(RequestValidator::class);
         $httpRequest = new HttpRequest();
-        parent::__construct($httpRequest);
+        parent::__construct($httpRequest, $validator);
     }
 
     /**


### PR DESCRIPTION
Backporting #9242 to `release/2019.012`

> **Breaking the infinite loop**
>
> I've left plenty of inline comments here I think, but the _TL;DR_ is if the embed service was used in a get request (or the page scraper), and someone pointed the scraper to that page, then the site would take itself out pretty quickly in an infinite loop.
>
> I've created a utility to check the request type and throw an exception and applied that to the page scraper and embed service.
>
> Note this breaks the reporting plugin which was recently updating to use the `EmbedService` in a get request (on accident).
>
> I've created an update to the reporting plugin as well to fix this.
>
> **Utility**
>
> I've also added a utility for normalizing user fragments (from outside of the API controller). This is useful for when an embed must be constructed manually to avoid this loop.