### PR TITLE
Fixed border radius issue for splash's search

### DIFF
--- a/library/src/scripts/features/search/SearchBar.tsx
+++ b/library/src/scripts/features/search/SearchBar.tsx
@@ -280,6 +280,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                                 {
                                     [classes.compoundValueContainer]: !this.props.hideSearchButton,
                                     isLarge: this.props.isBigInput,
+                                    noSearchButton: !!this.props.hideSearchButton,
                                 },
                             )}
                         >

--- a/library/src/scripts/features/search/searchBarStyles.ts
+++ b/library/src/scripts/features/search/searchBarStyles.ts
@@ -7,7 +7,7 @@
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { formElementsVariables } from "@library/forms/formElementStyles";
-import { borderRadii, borders, colorOut, unit, paddings } from "@library/styles/styleHelpers";
+import { borderRadii, borders, colorOut, unit, paddings, importantUnit } from "@library/styles/styleHelpers";
 import { calc, important, percent, px } from "csx";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { buttonClasses, buttonVariables } from "@library/forms/buttonStyles";
@@ -217,7 +217,6 @@ export const searchBarClasses = useThemeCache(() => {
     const valueContainer = style("valueContainer", {
         display: "flex",
         alignItems: "center",
-        borderRight: 0,
         paddingTop: 0,
         paddingBottom: 0,
         paddingRight: 0,
@@ -236,6 +235,11 @@ export const searchBarClasses = useThemeCache(() => {
                 alignItems: "center",
                 justifyContent: "flex-start",
                 paddingLeft: unit(vars.searchIcon.gap),
+            },
+            "&.noSearchButton": {
+                ...borderRadii({
+                    right: importantUnit(vars.border.radius),
+                }),
             },
         },
     });


### PR DESCRIPTION
On mobile, the search button was hidden, but the border radius was not applied to the right side of the input.

Closes: https://github.com/vanilla/vanilla/issues/9252