### PR TITLE
Escape route regex delimiter

### DIFF
--- a/library/core/class.router.php
+++ b/library/core/class.router.php
@@ -135,8 +135,8 @@ class Gdn_Router extends Gdn_Pluggable {
         foreach ($this->Routes as $route => $routeData) {
             // Check for wild-cards
             $route = str_replace(
-                [':alphanum', ':num'],
-                ['([0-9a-zA-Z-_]+)', '([0-9]+)'],
+                [':alphanum', ':num', '#'],
+                ['([0-9a-zA-Z-_]+)', '([0-9]+)', '\#'],
                 $route
             );
 


### PR DESCRIPTION
Routes with the # characters like `something#p1` were modifying the request.
Even if the route is "invalid" in the first place, delimiters should be escaped.