### PR TITLE
Backport: Remove E_WARNING from error reporting

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
  */
 
 // Report and track all errors.
-error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_WARNING | E_USER_WARNING | E_RECOVERABLE_ERROR);
+error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_USER_WARNING | E_RECOVERABLE_ERROR);
 ini_set('display_errors', 0);
 ini_set('track_errors', 1);
 


### PR DESCRIPTION
Backporting #9266 to `release/2019.012`.

> TOO LOUD!!!