### PR TITLE
Fix header link corruption in JsonView

### DIFF
--- a/library/Vanilla/Web/JsonView.php
+++ b/library/Vanilla/Web/JsonView.php
@@ -15,12 +15,6 @@ use Garden\Web\Data;
  */
 class JsonView implements ViewInterface {
     /**
-     * JsonView constructor.
-     */
-    public function __construct() {
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function render(Data $data) {

--- a/library/Vanilla/Web/JsonView.php
+++ b/library/Vanilla/Web/JsonView.php
@@ -14,17 +14,10 @@ use Garden\Web\Data;
  * Class JsonView
  */
 class JsonView implements ViewInterface {
-
-    /** @var WebLinking */
-    private $webLinking;
-
     /**
      * JsonView constructor.
-     *
-     * @param WebLinking $webLinking
      */
-    public function __construct(WebLinking $webLinking) {
-        $this->webLinking = $webLinking;
+    public function __construct() {
     }
 
     /**
@@ -35,23 +28,23 @@ class JsonView implements ViewInterface {
 
         // Handle pagination.
         if ($paging) {
+            $links = new WebLinking();
             $hasPageCount = isset($paging['pageCount']);
 
             $firstPageUrl = str_replace('%s', 1, $paging['urlFormat']);
-            $this->webLinking->addLink('first', $firstPageUrl);
+            $links->addLink('first', $firstPageUrl);
             if ($paging['page'] > 1) {
                 $prevPageUrl = $paging['page'] > 2 ? str_replace('%s', $paging['page'] - 1, $paging['urlFormat']) : $firstPageUrl;
-                $this->webLinking->addLink('prev', $prevPageUrl);
+                $links->addLink('prev', $prevPageUrl);
             }
             if (($paging['more'] ?? false) || ($hasPageCount && $paging['page'] < $paging['pageCount'])) {
-                $this->webLinking->addLink('next', str_replace('%s', $paging['page'] + 1, $paging['urlFormat']));
+                $links->addLink('next', str_replace('%s', $paging['page'] + 1, $paging['urlFormat']));
             }
             if ($hasPageCount) {
-                $this->webLinking->addLink('last', str_replace('%s', $paging['pageCount'], $paging['urlFormat']));
+                $links->addLink('last', str_replace('%s', $paging['pageCount'], $paging['urlFormat']));
             }
+            $links->setHeader($data);
         }
-
-        $data->setHeader('Link', $this->webLinking->getLinkHeaderValue());
 
         echo $data->render();
     }

--- a/library/Vanilla/Web/WebLinking.php
+++ b/library/Vanilla/Web/WebLinking.php
@@ -7,6 +7,8 @@
 
 namespace Vanilla\Web;
 
+use Garden\Web\Data;
+
 /**
  * Class WebLinking
  */
@@ -99,5 +101,20 @@ class WebLinking {
     public function clear() {
         $this->links = [];
         return $this;
+    }
+
+    /**
+     * A convenience function for setting a link heaer.
+     *
+     * @param Data $data
+     */
+    public function setHeader(Data $data) {
+        $link = $data->getHeader('Link');
+        if (empty($link)) {
+            $link = $this->getLinkHeaderValue();
+        } else {
+            $link .= ', '.$this->getLinkHeaderValue();
+        }
+        $data->setHeader('Link', $link);
     }
 }


### PR DESCRIPTION
I noticed some tests failing because the WebLinking is a property of JsonView and doesn’t get cleared from test to test. This wasn’t the intent of view objects as they are meant to me more view renderers.

This fix just makes the web linking a convenience object within the render.

The change isn’t without risk since there is the possibility that other functionality depends on adding links to the header via the web linking property. If we find anything like that I would rather they add link headers directly to the response rather than polluting the renderer.