### PR TITLE
Add email logging

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1044,7 +1044,7 @@ class ActivityModel extends Gdn_Model {
         $subject = $options['EmailSubject'] ?: Gdn_Format::plainText($activity['Headline']);
 
         // Build the email to send.
-        $email = new Gdn_Email();
+        $email = Gdn::getContainer()->get(Gdn_Email::class);
         $email->subject(sprintf(
             t('[%1$s] %2$s'),
             c('Garden.Title'),

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1044,7 +1044,7 @@ class ActivityModel extends Gdn_Model {
         $subject = $options['EmailSubject'] ?: Gdn_Format::plainText($activity['Headline']);
 
         // Build the email to send.
-        $email = Gdn::getContainer()->get(Gdn_Email::class);
+        $email = new Gdn_Email();
         $email->subject(sprintf(
             t('[%1$s] %2$s'),
             c('Garden.Title'),

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -365,7 +365,7 @@ class Gdn_Email extends Gdn_Pluggable implements LoggerAwareInterface{
         }
         // Set $Configuration['PhpMailer']['Debug'] to true to activate phpmailer logs.
         if (c('PhpMailer.Debug') === true) {
-            $payLoad = $this->PhpMailer->getSentMIMEMessage();
+            $payload = $this->PhpMailer->getSentMIMEMessage();
             $this->logger->info(
                 'Email Payload',
                 ['event' => 'Debug email',
@@ -376,14 +376,14 @@ class Gdn_Email extends Gdn_Pluggable implements LoggerAwareInterface{
                     'method' => Gdn::request()->requestMethod(),
                     'domain' => rtrim(url('/', true), '/'),
                     'path' => Gdn::request()->path(),
-                    'Charset' => $this->PhpMailer->CharSet,
-                    'ContentType' => $this->PhpMailer->ContentType,
-                    'From' => $this->PhpMailer->From,
-                    'FromName' => $this->PhpMailer->FromName,
-                    'Sender' => $this->PhpMailer->Sender,
-                    'Subject' => $this->PhpMailer->Subject,
-                    'Body' => $this->PhpMailer->Body,
-                    'PayLoad' => $payLoad
+                    'charset' => $this->PhpMailer->CharSet,
+                    'contentType' => $this->PhpMailer->ContentType,
+                    'from' => $this->PhpMailer->From,
+                    'fromName' => $this->PhpMailer->FromName,
+                    'sender' => $this->PhpMailer->Sender,
+                    'subject' => $this->PhpMailer->Subject,
+                    'body' => $this->PhpMailer->Body,
+                    'payload' => $payload
                 ]
             );
         }

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -5,6 +5,7 @@
  */
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+
 /**
  * Email layer abstraction
  *
@@ -16,6 +17,7 @@ use Psr\Log\LoggerAwareTrait;
  * @since 2.0
  */
 class Gdn_Email extends Gdn_Pluggable implements LoggerAwareInterface{
+
     use LoggerAwareTrait;
 
     /** Error: The email was not attempted to be sent.. */

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -16,7 +16,7 @@ use Psr\Log\LoggerAwareTrait;
  * @package Core
  * @since 2.0
  */
-class Gdn_Email extends Gdn_Pluggable implements LoggerAwareInterface{
+class Gdn_Email extends Gdn_Pluggable implements LoggerAwareInterface {
 
     use LoggerAwareTrait;
 


### PR DESCRIPTION
related https://github.com/vanilla/support/issues/757
This PR adds email logging. 

### To activate email logging

- Enable DB Logger
- Set $Configuration['Garden']['Email']['Debug'] = true


