### PR TITLE
Convert some PHP views into twig

### DIFF
--- a/applications/dashboard/views/components/dashboardSymbol.twig
+++ b/applications/dashboard/views/components/dashboardSymbol.twig
@@ -1,0 +1,14 @@
+{#
+    /**
+    * Render SVG icons in the dashboard. Icon must exist in applications/dashboard/views/symbols.php
+    *
+    * @param string $name The name of the icon to render. Must be set in applications/dashboard/views/symbols.php.
+    * @param string $class If set, overrides any 'class' attribute in the $attr param.
+    * @param string $alt Alt text for the symbol The default 'alt' attribute will be set to $name.
+    */
+#}
+
+
+<svg class="{{ classNames('icon', 'icon-svg', params.class ?? null) }}" viewBox="0 0 17 17">
+    <use xlink:href="#{{ params.name }}" ></use>
+</svg>

--- a/applications/dashboard/views/components/heading.twig
+++ b/applications/dashboard/views/components/heading.twig
@@ -1,0 +1,26 @@
+{#
+    /**
+     * Formats a h1 header block for the dashboard. Only to be used once on a page as the h1 header.
+     * Handles url-ifying. Adds an optional button or return link.
+     *
+     * @param {string} title
+     * @param {string} returnUrl (optional) A URL to use for a back button.
+     * @param {string} buttonHtml (optional) Pre-sanitized HTML button button content to apply.
+     */
+#}
+{% from "@dashboard/components/macros.twig" import dashboardSymbol %}
+<header class="header-block">
+    <div class="title-block">
+        {% if params.returnUrl is defined %}
+            <a href="{{ url(params.returnUrl) }}" class="btn btn-icon btn-return" aria-label="Return">
+                {{ dashboardSymbol({ name: 'chevron-left' }) }}
+            </a>
+        {% endif %}
+        <h1>{{ params.title }}</h1>
+    </div>
+    {% if params.buttonHtml is defined and params.buttonHtml is not empty %}
+        <div class="btn-container">
+            {{ params.buttonHtml|raw }}
+        </div>
+    {% endif %}
+</header>

--- a/applications/dashboard/views/components/macros.twig
+++ b/applications/dashboard/views/components/macros.twig
@@ -1,0 +1,14 @@
+{#
+    /**
+     * All dashboard twig components available as macros.
+     */
+#}
+
+{% macro heading(params) %}
+    {% include "@dashboard/components/heading.twig" %}
+{% endmacro heading %}
+
+{% macro dashboardSymbol(params) %}
+    {% include "@dashboard/components/dashboardSymbol.twig" %}
+{% endmacro dashboardSymbol %}
+

--- a/applications/vanilla/views/vanillasettings/addcategory.php
+++ b/applications/vanilla/views/vanillasettings/addcategory.php
@@ -1,3 +1,3 @@
 <?php
 deprecated('addCategory', 'editCategory', 'October 2016');
-include($this->fetchViewLocation('editcategory', 'vanillasettings', 'vanilla'));
+echo $this->fetchView('editcategory', 'vanillasettings', 'vanilla');

--- a/applications/vanilla/views/vanillasettings/editcategory.twig
+++ b/applications/vanilla/views/vanillasettings/editcategory.twig
@@ -1,0 +1,118 @@
+
+{% from "@dashboard/components/macros.twig" import heading %}
+
+{{ helpAsset(
+    sprintf(t('About %s'), t('Categories')),
+    t(
+        'Categories are used to organize discussions.',
+        'Categories allow you to organize your discussions.'
+    )
+) }}
+
+{{
+  heading({
+    title: Title,
+    returnUrl: '/vanilla/settings/categories'
+  })
+}}
+{{ form.open({'enctype': 'multipart/form-data'})}}
+{{ form.errors()}}
+{{ form.hidden('ParentCategoryID')}}
+<ul>
+    <li class="form-group">
+        <div class="label-wrap">
+            {{ form.label('Category', 'Name')}}
+        </div>
+        <div class="input-wrap">
+            {{ form.textBox('Name')}}
+        </div>
+    </li>
+    <li class="form-group">
+        <div class="label-wrap">
+            <strong>{{ t('Category Url:') }}</strong>
+        </div>
+        <div id="UrlCode" class="input-wrap category-url-code">
+            <div class="category-url">
+                {{ url('/categories', true) }}
+                {{- '/' -}}
+                <span>{{ form.getValue('UrlCode') }}</span>
+            </div>
+            {{ form.textBox('UrlCode')}}
+            {{ form.getValue('UrlCode') ? '/' : '' }}
+            <a class="Edit btn btn-link" href="#">{{ t('edit') }}</a>
+            <a class="Save btn btn-primary" href="#">{{ t('OK') }}</a>
+        </div>
+    </li>
+    <li class="form-group">
+        <div class="label-wrap">
+            {{ form.label('Description', 'Description') }}
+        </div>
+        <div class="input-wrap">
+            {{ form.textBox('Description', {'MultiLine': true }) }}
+        </div>
+    </li>
+    <li class="form-group">
+        <div class="label-wrap">
+            {{ form.label('Css Class', 'CssClass') }}
+        </div>
+        <div class="input-wrap">
+            {{ form.textBox('CssClass', {'MultiLine': false}) }}
+        </div>
+    </li>
+    {{ form.imageUploadPreview(
+        'Photo',
+        t('Photo'),
+        '',
+        'vanilla/settings/deletecategoryphoto/' ~ category.CategoryID
+    ) }}
+
+    {#
+        // Extended fields may be defined through some addon.
+     #}
+    {% if _ExtendedFields is defined %}
+        {{ form.simple(_ExtendedFields, []) }}
+    {% endif %}
+    <li class="form-group">
+        <div class="label-wrap">
+            {{ form.label('Display As', 'DisplayAs') }}
+        </div>
+        <div class="input-wrap">
+            {{ form.dropDown('DisplayAs', DisplayAsOptions, {'Wrap': true}) }}
+        </div>
+    </li>
+    <li class="form-group">
+        {{ form.toggle('HideAllDiscussions', 'Hide from the recent discussions page.') }}
+    </li>
+    {% if Operation is same as('Edit') %}
+        <li class="form-group">
+            {{ form.toggle('Archived', 'This category is archived.') }}
+        </li>
+    {% endif %}
+    {{ firePluggableEchoEvent(pluggable, 'afterCategorySettings') }}
+    {% if PermissionData|length > 0 %}
+        <li id="Permissions" class="form-group">
+            {{ form.toggle('CustomPermissions', 'This category has custom permissions.') }}
+        </li>
+    {% endif %}
+</ul>
+<div class="CategoryPermissions">
+
+{% if DiscussionTypes|length > 1 %}
+    <div class="P DiscussionTypes form-group">
+        <div class="label-wrap">
+            {{ form.label('Discussion Types') }}
+        </div>
+        <div class="checkbox-list input-wrap">
+            {% for type, row in DiscussionTypes %}
+                {{ form.checkBox('AllowedDiscussionTypes[]', row.Plural ?: type, {value: type}) }}
+            {% endfor %}
+        </div>
+    </div>
+{% endif %}
+
+{{ form.simple(_PermissionFields, []) }}
+
+<div class="padded">{{ t('Check all permissions that apply for each role') }}</div>
+{{ form.checkBoxGridGroups(PermissionData, 'Permission') }}
+</div>
+{{ form.close('Save') }}

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -9,6 +9,7 @@
  */
 
 use Vanilla\Formatting\Formats;
+use Vanilla\Web\TwigStaticRenderer;
 
 if (!function_exists('alternate')) {
     /**
@@ -46,6 +47,10 @@ if (!function_exists('dashboardSymbol')) {
      * @param string $class If set, overrides any 'class' attribute in the $attr param.
      * @param array $attr The dashboard symbol attributes. The default 'alt' attribute will be set to $name.
      * @return string An HTML-formatted string to render svg icons.
+     *
+     * @deprecated 3.3 Use @dashboard/components/dashboardSymbol.twig or the dashboardSymbol mixin.
+     * This does not render out to the new twig symbol version because of it currently allows all attributes.
+     * We want to work with a whitelist going forward so we can't shim this to the new one and keep compatibility.
      */
     function dashboardSymbol($name, $class = '', array $attr = []) {
         if (empty($attr['alt'])) {
@@ -147,20 +152,14 @@ if (!function_exists('heading')) {
                 $buttonsString .= ' <a '.attribute($buttonAttributes).' href="'.url($buttonUrl).'">'.$buttonText.'</a>';
             }
         }
-        $buttonsString = '<div class="btn-container">'.$buttonsString.'</div>';
 
-        $title = '<h1>'.$title.'</h1>';
-
-        if ($returnUrl !== '') {
-            $title = '<div class="title-block">
-                <a class="btn btn-icon btn-return" aria-label="Return" href="'.url($returnUrl).'">'.
-                    dashboardSymbol('chevron-left').'
-                </a>
-                '.$title.'
-            </div>';
-        }
-
-        return '<header class="header-block">'.$title.$buttonsString.'</header>';
+        return TwigStaticRenderer::renderTwig('@dashboard/components/heading.twig', [
+            'params' => [
+                'title' => $title,
+                'returnUrl' => $returnUrl,
+                'buttonHtml' => $buttonsString,
+            ]
+        ]);
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/9253

## Converted views

- 2 functions from `functions.render.php`
  - `dashboardSymbol()` - Creates a twig alternative. Unfortunately this one could not be replaced because it was far too open in the attributes it allowed to be set.
  - `heading()` - Replaces part of the function.
- The `editcategories` view.
- Updates the `addcategories` view which exists from some compatibility reasons to properly use a renderer when rendering the editcategories view.