### PR TITLE
Move timezone test setup out of DateTime test and into global test setup

### DIFF
--- a/tests/Library/Vanilla/Formatting/DateTimeFormatterTest.php
+++ b/tests/Library/Vanilla/Formatting/DateTimeFormatterTest.php
@@ -35,8 +35,6 @@ class DateTimeFormatterTest extends MinimalContainerTestCase {
     /**
      * Test the HTML formatting.
      * This test needs a separate process because of the time zone setting.
-     *
-     * @runInSeparateProcess
      */
     public function testFormatDateHtml() {
         $actual = self::getFormatter()->formatDate(self::NOW, true);

--- a/tests/Library/Vanilla/Formatting/DateTimeFormatterTest.php
+++ b/tests/Library/Vanilla/Formatting/DateTimeFormatterTest.php
@@ -22,17 +22,6 @@ class DateTimeFormatterTest extends MinimalContainerTestCase {
     // Saturday, July 27, 2015 12:00:01 AM
     const NOW = 1437955201;
 
-    public $runTestInSeparateProcess = true;
-    public $preserveGlobalState = false;
-
-    /**
-     * Configure a standard timezone.
-     */
-    public function setUp() {
-        parent::setUp();
-        date_default_timezone_set("UTC");
-    }
-
     /**
      * @return DateTimeFormatter
      */

--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -1,6 +1,14 @@
 <?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
 
 use VanillaTests\NullContainer;
+
+// Use consistent timezone for all tests.
+date_default_timezone_set("UTC");
+
 error_reporting(E_ALL);
 // Alias classes for some limited PHPUnit v5 compatibility with v6.
 $classCompatibility = [


### PR DESCRIPTION
This test was set to be isolated to not effect timezone behaviour of other tests in a non-deterministic way.

Unfortunately this massively slows down this suite of tests, so I've opted instead to just move the timezone setting to the phpunit test setup to it applies to all tests evenly, in any order.