### PR TITLE
Add slight rendering delay for chromatic

### DIFF
--- a/build/.storybook/config.js
+++ b/build/.storybook/config.js
@@ -34,7 +34,9 @@ function loadStories() {
     importAll(storyFiles);
 }
 
-
+addParameters({
+    chromatic: { delay: 1000 } // Add a slight delay to ensure everything has rendered properly.
+})
 
 addDecorator(checkA11y);
 addDecorator(withA11y);


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/9248

- Adds a slight rendering delay to chromatic to help prevent false positives.
- I found this from an example in the storybook docs: https://github.com/storybookjs/storybook/pull/5943/files