### PR TITLE
Fix some post 2019.013 bugs

### DIFF
--- a/library/src/scripts/routing/PageLoader.tsx
+++ b/library/src/scripts/routing/PageLoader.tsx
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
+import React, { useLayoutEffect } from "react";
 import { LoadStatus } from "@library/@types/api/core";
 import Loader from "@library/loaders/Loader";
 
@@ -15,17 +15,21 @@ interface IProps {
 /**
  * A class for handling an ILoadable and display error, loading, or children.
  */
-export default class PageLoader extends React.PureComponent<IProps, {}> {
-    public render(): React.ReactNode {
-        switch (this.props.status) {
-            case LoadStatus.SUCCESS:
-                document.body.classList.remove("isLoading");
-                return this.props.children;
-            case LoadStatus.LOADING:
-                document.body.classList.add("isLoading");
-                return <Loader />;
-            default:
-                return null;
+const PageLoader: React.FC<IProps> = (props: IProps) => {
+    const { status } = props;
+    useLayoutEffect(() => {
+        if (status === LoadStatus.LOADING) {
+            document.body.classList.add("isLoading");
+        } else {
+            document.body.classList.remove("isLoading");
         }
+    }, [status]);
+
+    if (status === LoadStatus.LOADING) {
+        return <Loader />;
+    } else {
+        return <>{props.children}</>;
     }
-}
+};
+
+export default PageLoader;

--- a/library/src/scripts/splash/splashStyles.ts
+++ b/library/src/scripts/splash/splashStyles.ts
@@ -277,10 +277,7 @@ export const splashClasses = useThemeCache((styleOverwrite = {}) => {
             width: percent(100),
             height: percent(100),
             ...background(finalBackground),
-            opacity:
-                (!url || url === splashFallbackBG) && vars.outerBackground.fallbackImage === splashFallbackBG
-                    ? 0.4
-                    : undefined,
+            opacity: finalBackground.image === splashFallbackBG ? 0.4 : undefined,
         });
     };
 


### PR DESCRIPTION
2 bugs popped up after deploying the latest release.

- Pages weren't scrolling.
- Opacity detection on the splash background caused the background color to bleed in.