### PR TITLE
Fix double escaping in twig templates

### DIFF
--- a/library/Vanilla/Web/TwigRenderTrait.php
+++ b/library/Vanilla/Web/TwigRenderTrait.php
@@ -54,14 +54,14 @@ trait TwigRenderTrait {
      * @param string $path The view path.
      * @param array $data The data to render.
      *
-     * @return \Twig\Markup The rendered HTML in a twig wrapper. Casts to string to unwrap.
+     * @return string Rendered HTML.
      */
-    public function renderTwig(string $path, array $data): \Twig\Markup {
+    public function renderTwig(string $path, array $data): string {
         if (!$this->twig) {
             $this->twig = $this->prepareTwig();
         }
         // Ensure that we don't duplicate our root path in the path view.
         $path = str_replace(PATH_ROOT, '', $path);
-        return new \Twig\Markup($this->twig->render($path, $data), 'utf-8');
+        return $this->twig->render($path, $data);
     }
 }


### PR DESCRIPTION
Followup from https://github.com/vanilla/vanilla/pull/9281

This auto-wrapping was too overzealous. It totally breaks the top level template. Renders that want to mark their output as sanitized can manually wrap their string in `new \Twig\Markup()` (already used in a few different places.)