### PR TITLE
Add some frame style fixes in the dashboard and make ILoadable more flexible

### DIFF
--- a/library/src/scripts/@types/api/core.ts
+++ b/library/src/scripts/@types/api/core.ts
@@ -14,9 +14,9 @@ export enum LoadStatus {
     ERROR = "ERROR",
 }
 
-export interface ILoadable<T> {
+export interface ILoadable<T, E = IApiError> {
     status: LoadStatus;
-    error?: IApiError;
+    error?: E;
     data?: T;
 }
 

--- a/library/src/scripts/content/userContentStyles.ts
+++ b/library/src/scripts/content/userContentStyles.ts
@@ -138,6 +138,7 @@ export const userContentClasses = useThemeCache(() => {
         ["& ol"]: {
             listStylePosition: "inside",
             margin: `0 0 1em 3em`,
+            padding: 0,
             $nest: {
                 [`& li`]: {
                     listStyle: "decimal",
@@ -169,6 +170,7 @@ export const userContentClasses = useThemeCache(() => {
             listStylePosition: "inside",
             listStyle: "disc",
             margin: `1em 0 1em 2em`,
+            padding: 0,
             $nest: {
                 [`& li`]: {
                     listStyle: "none",

--- a/library/src/scripts/layout/frame/frameBodyStyles.ts
+++ b/library/src/scripts/layout/frame/frameBodyStyles.ts
@@ -5,7 +5,7 @@
  */
 
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { paddings, unit } from "@library/styles/styleHelpers";
+import { paddings, unit, importantUnit } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { frameVariables } from "@library/layout/frame/frameStyles";
 import { inputBlockClasses } from "@library/forms/InputBlockStyles";
@@ -57,6 +57,7 @@ export const frameBodyClasses = useThemeCache(() => {
             bottom: vars.spacing.padding,
             left: 0,
         }),
+        fontSize: importantUnit(globalVars.fonts.size.medium),
         minHeight: unit(50),
     });
     return {


### PR DESCRIPTION
Blocking https://github.com/vanilla/multisite/pull/262

- Fixes some conflicts with the `FrameBody` styles in the dashboard.
- Add a padding reset to user content styles (dashboard doesn't provide one).
- Add an additional generic value to `ILoadable` to allow specifying the error type.