### PR TITLE
Remove unused`<Splash />` property & fix PHP notice

### DIFF
--- a/library/Vanilla/Web/LegacyTwigViewHandler.php
+++ b/library/Vanilla/Web/LegacyTwigViewHandler.php
@@ -24,7 +24,7 @@ class LegacyTwigViewHandler implements LegacyViewHandlerInterface {
     public function render($path, $controller) {
         // Extra data to merge into the controllers data for every render.
         $extraData = [
-            'form' => $controller->Form ? new TwigFormWrapper($controller->Form) : null,
+            'form' => isset($controller->Form) ? new TwigFormWrapper($controller->Form) : null,
             'category' => $controller->Category ?? null,
             'discussion' => $controller->Discussion ?? null,
             'pluggable' => $controller instanceof \Gdn_Pluggable ? $controller : null,

--- a/library/src/scripts/splash/Splash.tsx
+++ b/library/src/scripts/splash/Splash.tsx
@@ -34,7 +34,6 @@ interface IProps extends IDeviceProps {
     action?: React.ReactNode;
     title?: string; // Often the message to display isn't the real H1
     className?: string;
-    outerBackgroundImage?: string;
     styleOverwrite?: ISplashStyleOverwrite;
 }
 

--- a/library/src/scripts/splash/Splash.tsx
+++ b/library/src/scripts/splash/Splash.tsx
@@ -42,12 +42,11 @@ interface IProps extends IDeviceProps {
  */
 export class Splash extends React.Component<IProps> {
     public render() {
-        const { action, className } = this.props;
-        const styleOverwrite = this.props.styleOverwrite ? this.props.styleOverwrite : ({} as ISplashStyleOverwrite);
+        const { action, className, title } = this.props;
+        const styleOverwrite = this.props.styleOverwrite || {};
 
         const classes = splashClasses(styleOverwrite);
-        const title = this.props.title;
-        const vars = splashVariables({});
+        const vars = splashVariables(styleOverwrite);
 
         return (
             <div className={classNames(className, classes.root)}>


### PR DESCRIPTION
The `outerBackgroundImage` prop was not being used in the component. This occurred during the refactor to use `styleOverwrite`.

This led to the prop not being updated in the help center home page here causing this bug. https://github.com/vanilla/knowledge/issues/1186

- Clean up `<Splash />` style overwrite (and remove unused prop).
- Fix a random PHP notice I found.
- Actual bug fix in this PR https://github.com/vanilla/knowledge/pull/1187