### PR TITLE
Prevent formatTableName from adding redundant set of backticks by adding validation

### DIFF
--- a/library/database/class.mysqldriver.php
+++ b/library/database/class.mysqldriver.php
@@ -206,7 +206,11 @@ class Gdn_MySQLDriver extends Gdn_SQLDriver {
                 $databaseTable = '`'.str_replace('.', '`.`', $matches[1]).'`';
                 $table = str_replace($matches[1], $databaseTable, $table);
             } else {
-                $table = '`'.str_replace('.', '`.`', $table).'`';
+                $table = str_replace('.', '`.`', $table);
+
+                if (!preg_match('#^`.+`$#', $table, $matches)) {
+                    $table = "`$table`";
+                }
             }
         }
         return $table;


### PR DESCRIPTION
Here is more details on the problematic. https://github.com/vanilla/vanilla/issues/9311

## Description

The issue was that an additional set of backticks was wrapping table name when the database was added as a prefix. I think that the database name can only be found in "Forum Merge" queries, hence the reason why we never heard of this issue before.

Instead of instantly wrapping the table name, I added a validation that will prevent this addition if the table name is already escaped with backticks.

```php
$table = str_replace('.', '`.`', $table);

if (!preg_match('#^`.+`$#', $table, $matches)) {
    $table = "`$table`";
}
```

The regex is pretty straight forward, maybe there are better solutions to get over this problem.
