### PR TITLE
Fix locale asset not being include in hot build

### DIFF
--- a/library/Vanilla/Web/Asset/WebpackAssetProvider.php
+++ b/library/Vanilla/Web/Asset/WebpackAssetProvider.php
@@ -118,7 +118,8 @@ class WebpackAssetProvider {
 
         // Return early with the hot build if that flag is enabled.
         if ($this->hotReloadEnabled) {
-            return [new HotBuildAsset($section, $this->hotReloadIP)];
+            $scripts[] = new HotBuildAsset($section, $this->hotReloadIP);
+            return $scripts;
         }
 
         // A couple of required assets.
@@ -133,7 +134,6 @@ class WebpackAssetProvider {
 
         // Grab all of the addon based assets.
         foreach ($this->addonProvider->getEnabled() as $addon) {
-
             // See if we have a common bundle
             $commonAsset = new WebpackAddonAsset(
                 $this->request,


### PR DESCRIPTION
The locales asset is critical for development a multilingual feature, but do to some sloppy logic here it wasn't being include when the hot build was enabled.

I've fixed that.