### PR TITLE
Add insertUser to /search spec and fix the UserFragment schema docs

### DIFF
--- a/applications/dashboard/openapi/schemas.yml
+++ b/applications/dashboard/openapi/schemas.yml
@@ -19,33 +19,24 @@ components:
     UserFragment:
       type: object
       properties:
+        userID:
+          description: The ID of the user.
+          type: integer
+        name:
+          description: The username of the user.
+          minLength: 1
+          type: string
+        photoUrl:
+          description: The URL of the user's avatar picture.
+          minLength: 1
+          type: string
         dateLastActive:
           description: Time the user was last active.
           format: date-time
           nullable: true
           type: string
-        isAdmin:
-          type: boolean
-        name:
-          description: The username of the user.
-          minLength: 1
-          type: string
-        permissions:
-          description: Global permissions available to the current user.
-          items:
-            type: string
-          type: array
-        photoUrl:
-          description: The URL of the user's avatar picture.
-          minLength: 1
-          type: string
-        userID:
-          description: The ID of the user.
-          type: integer
       required:
       - userID
       - name
       - photoUrl
       - dateLastActive
-      - isAdmin
-      - permissions

--- a/applications/dashboard/openapi/search.yml
+++ b/applications/dashboard/openapi/search.yml
@@ -135,6 +135,18 @@ paths:
           default: 30
           maximum: 100
           minimum: 1
+      - description: >
+          Expand associated records using one or more valid field names. A
+          value of "all" will expand all expandable fields.
+        in: query
+        name: expand
+        schema:
+          items:
+            enum:
+            - insertUser
+            type: string
+          type: array
+        style: form
       responses:
         '200':
           content:
@@ -180,6 +192,8 @@ components:
         insertUserID:
           description: The user that created the record.
           type: integer
+        insertUser:
+          $ref: 'schemas.yml#/components/schemas/UserFragment'
         name:
           description: 'The title of the record. A comment would be "RE: {DiscussionTitle}".'
           minLength: 1

--- a/applications/dashboard/openapi/users.yml
+++ b/applications/dashboard/openapi/users.yml
@@ -164,7 +164,21 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '../dashboard/schemas.yml#/components/schemas/UserFragment'
+                allOf:
+                  - $ref: '../dashboard/schemas.yml#/components/schemas/UserFragment'
+                  - type: object
+                    properties:
+                      isAdmin:
+                        description: Whether or not the user is a global admin.
+                        type: boolean
+                      permissions:
+                        description: Global permissions available to the current user.
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - isAdmin
+                      - permissions
           description: Success
       tags:
       - Users


### PR DESCRIPTION
This is just for docs, but depends on functionality in another repo. It's probably the case that these docs should be moved, but if that's so then that should be done after a deploy cycle.

I also noticed an error in the `UserFragment` schema docs that doesn't agree with our default implementation. It's very possible some addon modifies `UserFragment`, but I would rather we don't *document* that because that doesn't seem like a wise course of action.