### PR TITLE
Fix frontend URL generation when site is served in a subdirectory

### DIFF
--- a/library/Vanilla/OpenAPIBuilder.php
+++ b/library/Vanilla/OpenAPIBuilder.php
@@ -105,7 +105,7 @@ class OpenAPIBuilder {
         // Fix the server URL.
         $openApi['servers'] = [
             [
-                'url' => $this->request->urlDomain(true) . $this->request->getRoot() . '/api/v2',
+                'url' => $this->request->urlDomain(true) . $this->request->getAssetRoot() . '/api/v2',
             ]
         ];
 

--- a/library/Vanilla/OpenAPIBuilder.php
+++ b/library/Vanilla/OpenAPIBuilder.php
@@ -7,6 +7,7 @@
 
 namespace Vanilla;
 
+use Garden\Web\RequestInterface;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -26,15 +27,20 @@ class OpenAPIBuilder {
      */
     private $cachePath;
 
+    /** @var RequestInterface */
+    private $request;
+
     /**
      * OpenAPIBuilder constructor.
      *
      * @param AddonManager $addonManager The addon manager used to get a list of addons to combine.
+     * @param RequestInterface $request The request to use for the URL base path.
      * @param string $cachePath The path to cache the built OpenAPI spec.
      */
-    public function __construct(AddonManager $addonManager, string $cachePath = '') {
+    public function __construct(AddonManager $addonManager, RequestInterface $request, string $cachePath = '') {
         $this->addonManager = $addonManager;
         $this->cachePath = $cachePath ?: PATH_CACHE.'/openapi.php';
+        $this->request = $request;
     }
 
     /**
@@ -81,7 +87,29 @@ class OpenAPIBuilder {
         }
 
         $result = require $this->cachePath;
+
+        // Reapply URL even after pulling from cache.
+        // A site may be accessed from multiple URLs and share the same cache.
+        $result = $this->applyCorrectApiBaseUrl($result);
         return $result;
+    }
+
+
+    /**
+     * Apply the correct server root to the OpenAPI definition.
+     *
+     * @param array $openApi A built OpenAPI definition.
+     * @return array The modified OpenAPI definition
+     */
+    private function applyCorrectApiBaseUrl(array $openApi): array {
+        // Fix the server URL.
+        $openApi['servers'] = [
+            [
+                'url' => $this->request->urlDomain(true) . $this->request->getRoot() . '/api/v2',
+            ]
+        ];
+
+        return $openApi;
     }
 
     /**
@@ -137,7 +165,9 @@ class OpenAPIBuilder {
 
         $result = [
             'openapi' => '3.0.2',
-            'info' => []
+            'info' => [],
+            'paths' => [],
+            'components' => [],
         ];
         $results = [];
 
@@ -171,6 +201,8 @@ class OpenAPIBuilder {
         foreach ($result['components'] as $key => $_) {
             ksort($result['components'][$key]);
         }
+
+        $result = $this->applyCorrectApiBaseUrl($result);
 
         return $result;
     }

--- a/library/Vanilla/OpenAPIBuilder.php
+++ b/library/Vanilla/OpenAPIBuilder.php
@@ -90,18 +90,18 @@ class OpenAPIBuilder {
 
         // Reapply URL even after pulling from cache.
         // A site may be accessed from multiple URLs and share the same cache.
-        $result = $this->applyCorrectApiBaseUrl($result);
+        $result = $this->applyRequestBasedApiBasePath($result);
         return $result;
     }
 
 
     /**
-     * Apply the correct server root to the OpenAPI definition.
+     * Apply the request specific server root to the OpenAPI definition.
      *
      * @param array $openApi A built OpenAPI definition.
      * @return array The modified OpenAPI definition
      */
-    private function applyCorrectApiBaseUrl(array $openApi): array {
+    private function applyRequestBasedApiBasePath(array $openApi): array {
         // Fix the server URL.
         $openApi['servers'] = [
             [
@@ -202,7 +202,7 @@ class OpenAPIBuilder {
             ksort($result['components'][$key]);
         }
 
-        $result = $this->applyCorrectApiBaseUrl($result);
+        $result = $this->applyRequestBasedApiBasePath($result);
 
         return $result;
     }

--- a/library/src/scripts/navigation/SiteNav.tsx
+++ b/library/src/scripts/navigation/SiteNav.tsx
@@ -41,18 +41,16 @@ export class SiteNav extends React.Component<IProps> {
         const content = hasChildren
             ? children.map((child, i) => {
                   return (
-                      <>
-                          <SiteNavNode
-                              {...child}
-                              collapsible={collapsible}
-                              activeRecord={activeRecord}
-                              key={child.recordType + child.recordID}
-                              titleID={this.titleID}
-                              depth={0}
-                              onItemHover={onItemHover}
-                              clickableCategoryLabels={!!this.props.clickableCategoryLabels}
-                          />
-                      </>
+                      <SiteNavNode
+                          {...child}
+                          collapsible={collapsible}
+                          activeRecord={activeRecord}
+                          key={child.recordType + child.recordID}
+                          titleID={this.titleID}
+                          depth={0}
+                          onItemHover={onItemHover}
+                          clickableCategoryLabels={!!this.props.clickableCategoryLabels}
+                      />
                   );
               })
             : null;

--- a/library/src/scripts/routing/RouteHandler.tsx
+++ b/library/src/scripts/routing/RouteHandler.tsx
@@ -10,6 +10,7 @@ import Loadable, { LoadableComponent } from "react-loadable";
 import Loader from "@library/loaders/Loader";
 import { Hoverable } from "@vanilla/react-utils";
 import SmartLink from "@library/routing/links/SmartLink";
+import { formatUrl } from "@library/utility/appUtils";
 
 type LoadFunction = () => Promise<any>;
 
@@ -26,10 +27,12 @@ export default class RouteHandler<GeneratorProps> {
     /** Key to identify the route. Components with the same key share the same instance. */
     private key: string;
 
+    public url: (data: GeneratorProps) => string;
+
     public constructor(
         componentPromise: LoadFunction,
         public path: string | string[],
-        public url: (data: GeneratorProps) => string,
+        url: (data: GeneratorProps) => string,
         loadingComponent: React.ReactNode = Loader,
         key?: string,
     ) {
@@ -37,6 +40,7 @@ export default class RouteHandler<GeneratorProps> {
             loading: loadingComponent as any,
             loader: componentPromise,
         });
+        this.url = (data: GeneratorProps) => formatUrl(url(data), true);
         const finalPath = Array.isArray(path) ? path : [path];
         this.key = key || finalPath.join("-");
         this.route = <Route exact path={path} component={this.loadable} key={this.key} />;

--- a/library/src/scripts/routing/RouteHandler.tsx
+++ b/library/src/scripts/routing/RouteHandler.tsx
@@ -9,6 +9,7 @@ import { Omit } from "@library/@types/utils";
 import Loadable, { LoadableComponent } from "react-loadable";
 import Loader from "@library/loaders/Loader";
 import { Hoverable } from "@vanilla/react-utils";
+import SmartLink from "@library/routing/links/SmartLink";
 
 type LoadFunction = () => Promise<any>;
 
@@ -49,7 +50,7 @@ export default class RouteHandler<GeneratorProps> {
     public Link = (props: Omit<NavLinkProps, "to"> & { data: GeneratorProps }) => {
         return (
             <Hoverable duration={50} onHover={this.preload}>
-                {provided => <NavLink {...provided} {...props} to={this.url(props.data)} />}
+                {provided => <SmartLink {...provided} {...props} to={this.url(props.data)} />}
             </Hoverable>
         );
     };

--- a/library/src/scripts/utility/appUtils.tsx
+++ b/library/src/scripts/utility/appUtils.tsx
@@ -234,5 +234,5 @@ export function removeOnContent(callback: (event: CustomEvent) => void) {
  */
 export function makeProfileUrl(username: string) {
     const userPath = `/profile/${encodeURIComponent(username)}`;
-    return formatUrl(userPath);
+    return formatUrl(userPath, true);
 }

--- a/tests/Library/Vanilla/OpenAPIBuilderTest.php
+++ b/tests/Library/Vanilla/OpenAPIBuilderTest.php
@@ -25,7 +25,7 @@ class OpenAPIBuilderTest extends TestCase {
     public function testApiPathGeneration() {
         $addonManager = new AddonManager();
         $request = new Request();
-        $request->setRoot('root');
+        $request->setAssetRoot('root');
         $request->setHost('testhost.com');
         $request->setScheme('https');
         $builder = new OpenAPIBuilder($addonManager, $request);

--- a/tests/Library/Vanilla/OpenAPIBuilderTest.php
+++ b/tests/Library/Vanilla/OpenAPIBuilderTest.php
@@ -11,11 +11,31 @@ use PHPUnit\Framework\TestCase;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
 use Vanilla\OpenAPIBuilder;
+use VanillaTests\Fixtures\MockAddonProvider;
+use VanillaTests\Fixtures\Request;
 
 /**
  * Test Vanilla's OpenAPI build.
  */
 class OpenAPIBuilderTest extends TestCase {
+
+    /**
+     * Test that we generate a proper base path.
+     */
+    public function testApiPathGeneration() {
+        $addonManager = new AddonManager();
+        $request = new Request();
+        $request->setRoot('root');
+        $request->setHost('testhost.com');
+        $request->setScheme('https');
+        $builder = new OpenAPIBuilder($addonManager, $request);
+        $data = $builder->generateFullOpenAPI();
+        $this->assertEquals(
+            'https://testhost.com/root/api/v2',
+            $data['servers'][0]['url'],
+            'Generated API base was incorrect'
+        );
+    }
 
     /**
      * The OpenAPI build should validate against the OpenAPI spec.
@@ -29,7 +49,9 @@ class OpenAPIBuilderTest extends TestCase {
             ],
             PATH_ROOT.'/tests/cache/open-api-builder/vanilla-manager'
         );
-        $builder = new OpenAPIBuilder($am);
+
+        $request = new Request();
+        $builder = new OpenAPIBuilder($am, $request);
 
         $data = $builder->generateFullOpenAPI();
         $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/tests/fixtures/src/Request.php
+++ b/tests/fixtures/src/Request.php
@@ -176,7 +176,7 @@ class Request implements RequestInterface {
      */
     public function setRoot($root) {
         $root = trim($root, '/');
-        $root = $root ? '' : "/$root";
+        $root = $root ? "/$root" : '';
         $this->root = $root;
 
         return $this;


### PR DESCRIPTION
Goes with https://github.com/vanilla/knowledge/pull/1202

Fixes https://github.com/vanilla/internal/issues/1970
Fixes https://github.com/vanilla/support/issues/781
Fixes https://github.com/vanilla/support/issues/551
Fixes https://github.com/vanilla/multisite/issues/219

- Format full URLs in `makeProfileUrl()`.
- Use `<SmartLink />` in `RouteHandler`.
- Have `RouteHandler` wrap it's URLs in `formatUrl()` -> This change required a fix in KB https://github.com/vanilla/knowledge/pull/1202
- Fix a react warning in SiteNav caused by having an unneeded fragment wrapper.
- Fix generation of the OpenApi URL when site is served from a subdirectory (test added).
- Fix our PHP request test fixture having backwards logic about setting a site root.

## Testing

@tburry has a WIP PR that lets you serve your site out of `vanilla.localhost/dev` instead of `dev.vanilla.localhost` here https://github.com/vanilla/vanilla-docker/pull/60
It's pretty useful for testing this and is what I used.