### PR TITLE
Fix Attributes JSON encoding for special data types

### DIFF
--- a/library/Garden/JsonFilterTrait.php
+++ b/library/Garden/JsonFilterTrait.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Garden;
+
+
+trait JsonFilterTrait {
+    /**
+     * Prepare data for json_encode
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    private function jsonFilter($value) {
+        $fn = function (&$value, $key = '', $parentKey = '') use (&$fn) {
+            if (is_array($value)) {
+                array_walk($value, function (&$childValue, $childKey) use ($fn, $key) {
+                    $fn($childValue, $childKey, $key);
+                });
+            } elseif ($value instanceof \DateTimeInterface) {
+                $value = $value->format(\DateTime::RFC3339);
+            } elseif (is_string($value)) {
+                // Only attempt to unpack as an IP address if this field or its parent matches the IP field naming scheme.
+                $isIPField = ($this->stringEndsWith($key, 'IPAddress', true) || $this->stringEndsWith($parentKey, 'IPAddresses', true));
+                if ($isIPField && ($ip = $this->ipDecode($value)) !== null) {
+                    $value = $ip;
+                }
+            }
+        };
+
+        if (is_array($value)) {
+            array_walk($value, $fn);
+        } else {
+            $fn($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Checks whether or not string A ends with string B.
+     *
+     * @param string $haystack The main string to check.
+     * @param string $needle The substring to check against.
+     * @param bool $caseInsensitive Whether or not the comparison should be case insensitive.
+     * @param bool $trim Whether or not to trim $B off of $A if it is found.
+     * @return bool|string Returns true/false unless $trim is true.
+     */
+    private function stringEndsWith($haystack, $needle, $caseInsensitive = false, $trim = false) {
+        if (strlen($haystack) < strlen($needle)) {
+            return $trim ? $haystack : false;
+        } elseif (strlen($needle) == 0) {
+            if ($trim) {
+                return $haystack;
+            }
+            return true;
+        } else {
+            $result = substr_compare($haystack, $needle, -strlen($needle), strlen($needle), $caseInsensitive) == 0;
+            if ($trim) {
+                $result = $result ? substr($haystack, 0, -strlen($needle)) : $haystack;
+            }
+            return $result;
+        }
+    }
+
+    /**
+     * Decode a packed IP address to its human-readable form.
+     *
+     * @param string $packedIP A string representing a packed IP address.
+     * @return string|null A human-readable representation of the provided IP address.
+     */
+    private function ipDecode($packedIP) {
+        if (filter_var($packedIP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6)) {
+            // If it's already a valid IP address, don't bother unpacking it.
+            $result = $packedIP;
+        } elseif ($iP = @inet_ntop($packedIP)) {
+            $result = $iP;
+        } else {
+            $result = null;
+        }
+
+        return $result;
+    }
+}

--- a/library/Garden/JsonFilterTrait.php
+++ b/library/Garden/JsonFilterTrait.php
@@ -7,7 +7,9 @@
 
 namespace Garden;
 
-
+/**
+ * Filters output before being JSON-encoded.
+ */
 trait JsonFilterTrait {
     /**
      * Prepare data for json_encode

--- a/library/Garden/Web/Data.php
+++ b/library/Garden/Web/Data.php
@@ -6,17 +6,16 @@
  */
 
 namespace Garden\Web;
+use Garden\JsonFilterTrait;
 use Traversable;
 
 use Garden\MetaTrait;
-use DateTime;
-use DateTimeInterface;
 
 /**
  * Represents the data in a web response.
  */
 class Data implements \JsonSerializable, \ArrayAccess, \Countable, \IteratorAggregate  {
-    use MetaTrait;
+    use MetaTrait, JsonFilterTrait;
 
     private $data;
 
@@ -258,57 +257,6 @@ class Data implements \JsonSerializable, \ArrayAccess, \Countable, \IteratorAggr
     }
 
     /**
-     * Decode a packed IP address to its human-readable form.
-     *
-     * @param string $packedIP A string representing a packed IP address.
-     * @return string|null A human-readable representation of the provided IP address.
-     */
-    private function ipDecode($packedIP) {
-        if (filter_var($packedIP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4|FILTER_FLAG_IPV6)) {
-            // If it's already a valid IP address, don't bother unpacking it.
-            $result = $packedIP;
-        } elseif ($iP = @inet_ntop($packedIP)) {
-            $result = $iP;
-        } else {
-            $result = null;
-        }
-
-        return $result;
-    }
-
-    /**
-     * Prepare data for json_encode
-     *
-     * @param mixed $value
-     * @return mixed
-     */
-    private function jsonFilter($value) {
-        $fn = function (&$value, $key = '', $parentKey = '') use (&$fn) {
-            if (is_array($value)) {
-                array_walk($value, function(&$childValue, $childKey) use ($fn, $key) {
-                    $fn($childValue, $childKey, $key);
-                });
-            } elseif ($value instanceof DateTimeInterface) {
-                $value = $value->format(DateTime::RFC3339);
-            } elseif (is_string($value)) {
-                // Only attempt to unpack as an IP address if this field or its parent matches the IP field naming scheme.
-                $isIPField = ($this->stringEndsWith($key, 'IPAddress', true) || $this->stringEndsWith($parentKey, 'IPAddresses', true));
-                if ($isIPField && ($ip = $this->ipDecode($value)) !== null) {
-                    $value = $ip;
-                }
-            }
-        };
-
-        if (is_array($value)) {
-            array_walk($value, $fn);
-        } else {
-            $fn($value);
-        }
-
-        return $value;
-    }
-
-    /**
      * Whether a offset exists.
      *
      * @param mixed $offset An offset to check for.
@@ -350,32 +298,6 @@ class Data implements \JsonSerializable, \ArrayAccess, \Countable, \IteratorAggr
      */
     public function offsetUnset($offset) {
         unset($this->data[$offset]);
-    }
-
-    /**
-     * Checks whether or not string A ends with string B.
-     *
-     * @param string $haystack The main string to check.
-     * @param string $needle The substring to check against.
-     * @param bool $caseInsensitive Whether or not the comparison should be case insensitive.
-     * @param bool $trim Whether or not to trim $B off of $A if it is found.
-     * @return bool|string Returns true/false unless $trim is true.
-     */
-    private function stringEndsWith($haystack, $needle, $caseInsensitive = false, $trim = false) {
-        if (strlen($haystack) < strlen($needle)) {
-            return $trim ? $haystack : false;
-        } elseif (strlen($needle) == 0) {
-            if ($trim) {
-                return $haystack;
-            }
-            return true;
-        } else {
-            $result = substr_compare($haystack, $needle, -strlen($needle), strlen($needle), $caseInsensitive) == 0;
-            if ($trim) {
-                $result = $result ? substr($haystack, 0, -strlen($needle)) : $haystack;
-            }
-            return $result;
-        }
     }
 
     /**

--- a/library/Vanilla/Attributes.php
+++ b/library/Vanilla/Attributes.php
@@ -7,10 +7,14 @@
 
 namespace Vanilla;
 
+use Garden\JsonFilterTrait;
+
 /**
  * A container for API attributes.
  */
 class Attributes extends \ArrayObject implements \JsonSerializable {
+    use JsonFilterTrait;
+
     /**
      * Attributes constructor.
      *
@@ -38,8 +42,9 @@ class Attributes extends \ArrayObject implements \JsonSerializable {
     public function jsonSerialize() {
         $r = $this->getArrayCopy();
         if (empty($r)) {
-            $r = (object)$r;
+            return (object)$r;
         }
+        $r = $this->jsonFilter($r);
         return $r;
     }
 }

--- a/tests/Library/Vanilla/AttributesTest.php
+++ b/tests/Library/Vanilla/AttributesTest.php
@@ -45,4 +45,13 @@ class AttributesTest extends SharedBootstrapTestCase {
         $attr = new Attributes(['a' => new Attributes()]);
         $this->assertEquals('{"a":{}}', json_encode($attr));
     }
+
+    /**
+     * Dates should properly encode within attributes.
+     */
+    public function testDateEncoding() {
+        $attr = new Attributes(['dt' => new \DateTimeImmutable('2019-09-22', new \DateTimeZone('Z'))]);
+        $actual = json_encode($attr);
+        $this->assertSame('{"dt":"2019-09-22T00:00:00+00:00"}', $actual);
+    }
 }


### PR DESCRIPTION
The `Attributes` class is meant to properly JSON encode object-like data, but was not handling date/time objects properly, nor IP addresses.

This fix grabs functionality from the `Data` class into a trait that can be used by both classes. I cut/pasted the methods into the traits rather than using a refactoring tool.