### PR TITLE
Fix heading rendering and add tests

### DIFF
--- a/applications/dashboard/views/components/dashboardHeading.twig
+++ b/applications/dashboard/views/components/dashboardHeading.twig
@@ -11,14 +11,14 @@
 {% from "@dashboard/components/macros.twig" import dashboardSymbol %}
 <header class="header-block">
     <div class="title-block">
-        {% if params.returnUrl is defined %}
+        {% if params.returnUrl|default(false) %}
             <a href="{{ url(params.returnUrl) }}" class="btn btn-icon btn-return" aria-label="Return">
                 {{ dashboardSymbol({ name: 'chevron-left' }) }}
             </a>
         {% endif %}
         <h1>{{ params.title }}</h1>
     </div>
-    {% if params.buttons is defined %}
+    {% if params.buttons|default(false) %}
         <div class="btn-container">
             {{ params.buttons }}
         </div>

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -161,9 +161,9 @@ if (!function_exists('heading')) {
 
         return TwigStaticRenderer::renderTwigStatic('@dashboard/components/dashboardHeading.twig', [
             'params' => [
-                'title' => $title,
-                'returnUrl' => $returnUrl,
-                'buttons' => new \Twig\Markup($buttonsString, 'utf-8'),
+                'title' => new \Twig\Markup($title, 'utf-8'),
+                'returnUrl' => $returnUrl ?: null,
+                'buttons' => $buttonsString ? new \Twig\Markup($buttonsString, 'utf-8') : null,
             ]
         ]);
     }

--- a/tests/Library/Core/RenderFunctionsTest.php
+++ b/tests/Library/Core/RenderFunctionsTest.php
@@ -120,4 +120,66 @@ class RenderFunctionsTest extends TestCase {
             ],
         ];
     }
+
+    /**
+     * Tests for the heading function.
+     *
+     * @param array $params
+     * @param string $expectedHtml
+     *
+     * @dataProvider provideHeadingArgs
+     */
+    public function testDashboardHeading(array $params, string $expectedHtml) {
+        $actual = heading(...$params);
+        $this->assertHtmlStringEqualsHtmlString($expectedHtml, $actual);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideHeadingArgs(): array {
+        return [
+            'simple title' => [
+                ["Hello! <dont-escape-me></dont-escape-me> me once"],
+                "
+                <header class=header-block>
+                    <div class=title-block>
+                    <h1>Hello!<dont-escape-me></dont-escape-me> me once</h1></div>
+                </header>",
+            ],
+            'title with return' => [
+                [
+                    'Hello',
+                    '',
+                    '',
+                    '',
+                    'https://test.com/back',
+                ],
+                "<header class=header-block>
+                    <div class=title-block>
+                        <a aria-label=Return class='btn btn-icon btn-return' href=https://test.com/back><SVG /></a>
+                        <h1>Hello</h1>
+                    </div>
+                </header>"
+            ],
+            'with buttons' => [
+                [
+                    'Hello',
+                    'button',
+                    'http://test.com/button',
+                    ['data-test' => 'test'],
+                    'https://test.com/back',
+                ],
+                "<header class=header-block>
+                    <div class=title-block>
+                        <a aria-label=Return class='btn btn-icon btn-return' href=https://test.com/back><SVG /></a>
+                        <h1>Hello</h1>
+                    </div>
+                    <div class=btn-container>
+                        <a class='btn btn-primary' data-test=test href=http://test.com/button>button</a>
+                    </div>
+                </header>"
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
Followup to https://github.com/vanilla/vanilla/pull/9314

During routine testing a notice a couple issues with the refactoring:

- The back arrow and button container was always appearing (I've switch the if statement in the template to fix this).
- The title wasn't being unnecessarily escaped. In the previous implementation, the title could container HTML (see the `/settings/swagger` page for an example).

I've fixed these and added some rendering tests for the old `heading()` function.