### PR TITLE
Extract post notifications into dedicated methods

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -536,6 +536,150 @@ class CommentModel extends Gdn_Model {
     }
 
     /**
+     * Notify users of a new comment.
+     *
+     * @param array $comment
+     * @param array $discussion
+     */
+    private function notifyNewComment(?array $comment, ?array $discussion) {
+        if ($comment === null || $discussion === null) {
+            return;
+        }
+
+        $commentID = $comment["CommentID"] ?? null;
+        $discussionID = $discussion["DiscussionID"] ?? null;
+        $categoryID = $discussion["CategoryID"] ?? null;
+
+        if ($commentID === null || $discussionID === null || $categoryID === null) {
+            return;
+        }
+
+        $category = CategoryModel::categories($categoryID);
+        if ($category === null) {
+            return;
+        }
+
+        $body = $comment["Body"] ?? null;
+        $discussionUserID = $discussion["InsertUserID"] ?? null;
+        $format = $comment["Format"] ?? null;
+
+        // Prepare the notification queue.
+        $data = [
+            "ActivityType" => "Comment",
+            "ActivityUserID" => $comment["InsertUserID"] ?? null,
+            "HeadlineFormat" => t(
+                "HeadlineFormat.Comment",
+                '{ActivityUserID,user} commented on <a href="{Url,html}">{Data.Name,text}</a>'
+            ),
+            "RecordType" => "Comment",
+            "RecordID" => $commentID,
+            "Route" => "/discussion/comment/{$commentID}#Comment_{$commentID}",
+            "Data" => [
+                "Name" => $discussion["Name"] ?? null,
+                "Category" => $category["Name"] ?? null,
+            ]
+        ];
+
+        // Allow simple fulltext notifications
+        if (c("Vanilla.Activity.ShowCommentBody", false)) {
+            $data["Story"] = $comment["Body"] ?? null;
+            $data["Format"] = $comment["Format"] ?? null;
+        }
+
+        // Pass generic activity to events.
+        $this->EventArguments["Activity"] = $data;
+
+        /** @var ActivityModel $activityModel */
+        $activityModel = Gdn::getContainer()->get(ActivityModel::class);
+        /** @var DiscussionModel $discussionModel */
+        $discussionModel = Gdn::getContainer()->get(DiscussionModel::class);
+
+        $notificationGroups = [
+            "bookmark" => [
+                "notifyUserIDs" => array_column(
+                    $discussionModel->getBookmarkUsers($discussionID)->resultArray(),
+                    "UserID"
+                ),
+                "options" => ['CheckRecord' => true],
+                "preference" => "BookmarkComment",
+            ],
+            "mention" => [
+                "headlineFormat" => t(
+                    "HeadlineFormat.Mention",
+                    '{ActivityUserID,user} mentioned you in <a href="{Url,html}">{Data.Name,text}</a>'
+                ),
+                "notifyUserIDs" => [],
+                "preference" => "Mention",
+            ],
+            "mine" => [
+                "notifyUserIDs" => [$discussionUserID],
+                "preference" => "DiscussionComment",
+            ],
+            "participated" => [
+                "notifyUserIDs" => array_column(
+                    $discussionModel->getParticipatedUsers($discussionID),
+                    "UserID"
+                ),                "options" => ['CheckRecord' => true],
+                "preference" => "ParticipateComment",
+            ],
+        ];
+
+        $mentions = [];
+        if (is_string($body) && is_string($format)) {
+            $mentions = Gdn::formatService()->parseMentions($body, $format);
+            /** @var UserModel $userModel */
+            $userModel = Gdn::getContainer()->get(UserModel::class);
+
+            foreach ($mentions as $mentionName) {
+                $mentionUser = $userModel->getByUsername($mentionName);
+                if ($mentionUser) {
+                    $notificationGroups["mention"]["notifyUserIDs"][] = $mentionUser->UserID ?? null;
+                }
+            }
+        }
+
+        foreach ($notificationGroups as $group => $groupData) {
+            $headlineFormat = $groupData["headlineFormat"] ?? $data["HeadlineFormat"];
+            $notifyUserIDs = $groupData["notifyUserIDs"] ?? [];
+            $preference = $groupData["preference"] ?? false;
+            $options = $groupData["options"] ?? [];
+
+            foreach ($notifyUserIDs as $notifyUserID) {
+                if ($notifyUserID === null) {
+                    continue;
+                }
+
+                // Check user can still see the discussion.
+                if (!$discussionModel->canView($discussion, $notifyUserID)) {
+                    continue;
+                }
+
+                $notification = $data;
+                $notification["HeadlineFormat"] = $headlineFormat;
+                $notification["NotifyUserID"] = $notifyUserID;
+                $notification["Data"]["Reason"] = $group;
+                $activityModel->queue($notification, $preference, $options);
+            }
+        }
+
+        // Record advanced notifications.
+        $advancedActivity = $data;
+        $advancedActivity["Data"]["Reason"] = "advanced";
+        $this->recordAdvancedNotications($activityModel, $advancedActivity, $discussion);
+
+        // Throw an event for users to add their own events.
+        $this->EventArguments["Comment"] = $comment;
+        $this->EventArguments["Discussion"] = $discussion;
+        $this->EventArguments["NotifiedUsers"] = array_keys(ActivityModel::$Queue);
+        $this->EventArguments["MentionedUsers"] = $mentions;
+        $this->EventArguments["ActivityModel"] = $activityModel;
+        $this->fireEvent("BeforeNotification");
+
+        // Send all notifications.
+        $activityModel->saveQueue();
+    }
+
+    /**
      * Set the order of the comments or return current order.
      *
      * Getter/setter for $this->_OrderBy.
@@ -1171,7 +1315,6 @@ class CommentModel extends Gdn_Model {
      */
     public function save2($CommentID, $Insert, $CheckExisting = true, $IncUser = false) {
         $Session = Gdn::session();
-        $discussionModel = new DiscussionModel();
 
         // Load comment data
         $Fields = $this->getID($CommentID, DATASET_TYPE_ARRAY);
@@ -1206,111 +1349,10 @@ class CommentModel extends Gdn_Model {
             if ($Discussion->CategoryID > 0) {
                 CategoryModel::instance()->incrementLastComment($Fields);
             }
-
-            // Prepare the notification queue.
-            $ActivityModel = new ActivityModel();
-            $HeadlineFormat = t('HeadlineFormat.Comment', '{ActivityUserID,user} commented on <a href="{Url,html}">{Data.Name,text}</a>');
-            $Category = CategoryModel::categories($Discussion->CategoryID);
-            $Activity = [
-                'ActivityType' => 'Comment',
-                'ActivityUserID' => $Fields['InsertUserID'],
-                'HeadlineFormat' => $HeadlineFormat,
-                'RecordType' => 'Comment',
-                'RecordID' => $CommentID,
-                'Route' => "/discussion/comment/$CommentID#Comment_$CommentID",
-                'Data' => [
-                    'Name' => $Discussion->Name,
-                    'Category' => val('Name', $Category),
-                ]
-            ];
-
-            // Allow simple fulltext notifications
-            if (c('Vanilla.Activity.ShowCommentBody', false)) {
-                $Activity['Story'] = val('Body', $Fields);
-                $Activity['Format'] = val('Format', $Fields);
-            }
-
-            // Pass generic activity to events.
-            $this->EventArguments['Activity'] = $Activity;
-
-
-            // Notify users who have bookmarked the discussion.
-            $BookmarkData = $DiscussionModel->getBookmarkUsers($DiscussionID);
-            foreach ($BookmarkData->result() as $Bookmark) {
-                // Check user can still see the discussion.
-                if (!$discussionModel->canView($Discussion, $Bookmark->UserID)) {
-                    continue;
-                }
-
-                $Activity['NotifyUserID'] = $Bookmark->UserID;
-                $Activity['Data']['Reason'] = 'bookmark';
-                $ActivityModel->queue($Activity, 'BookmarkComment', ['CheckRecord' => true]);
-            }
-
-            // Notify users who have participated in the discussion.
-            $ParticipatedData = $DiscussionModel->getParticipatedUsers($DiscussionID);
-            foreach ($ParticipatedData->result() as $UserRow) {
-                if (!$discussionModel->canView($Discussion, $UserRow->UserID)) {
-                    continue;
-                }
-
-                $Activity['NotifyUserID'] = $UserRow->UserID;
-                $Activity['Data']['Reason'] = 'participated';
-                $ActivityModel->queue($Activity, 'ParticipateComment', ['CheckRecord' => true]);
-            }
-
-            // Record user-comment activity.
-            if ($Discussion != false) {
-                $InsertUserID = val('InsertUserID', $Discussion);
-                // Check user can still see the discussion.
-                if ($discussionModel->canView($Discussion, $InsertUserID)) {
-                    $Activity['NotifyUserID'] = $InsertUserID;
-                    $Activity['Data']['Reason'] = 'mine';
-                    $ActivityModel->queue($Activity, 'DiscussionComment');
-                }
-            }
-
-            // Record advanced notifications.
-            if ($Discussion !== false) {
-                $Activity['Data']['Reason'] = 'advanced';
-                $this->recordAdvancedNotications($ActivityModel, $Activity, $Discussion);
-            }
-
-            // Notify any users who were mentioned in the comment.
-            $Usernames = Gdn::formatService()->parseMentions($Fields['Body'], $Fields['Format']);
-
-            $userModel = Gdn::userModel();
-            foreach ($Usernames as $i => $Username) {
-                $User = $userModel->getByUsername($Username);
-                if (!$User) {
-                    unset($Usernames[$i]);
-                    continue;
-                }
-
-                // Check user can still see the discussion.
-                if (!$discussionModel->canView($Discussion, $User->UserID)) {
-                    continue;
-                }
-
-                $HeadlineFormatBak = $Activity['HeadlineFormat'];
-                $Activity['HeadlineFormat'] = t('HeadlineFormat.Mention', '{ActivityUserID,user} mentioned you in <a href="{Url,html}">{Data.Name,text}</a>');
-                $Activity['NotifyUserID'] = $User->UserID;
-                $Activity['Data']['Reason'] = 'mention';
-                $ActivityModel->queue($Activity, 'Mention');
-                $Activity['HeadlineFormat'] = $HeadlineFormatBak;
-            }
-            unset($Activity['Data']['Reason']);
-
-            // Throw an event for users to add their own events.
-            $this->EventArguments['Comment'] = $Fields;
-            $this->EventArguments['Discussion'] = $Discussion;
-            $this->EventArguments['NotifiedUsers'] = array_keys(ActivityModel::$Queue);
-            $this->EventArguments['MentionedUsers'] = $Usernames;
-            $this->EventArguments['ActivityModel'] = $ActivityModel;
-            $this->fireEvent('BeforeNotification');
-
-            // Send all notifications.
-            $ActivityModel->saveQueue();
+            $this->notifyNewComment(
+                $Fields ? (array)$Fields : null,
+                $Discussion ? (array)$Discussion : null
+            );
         }
     }
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -687,7 +687,7 @@ class CommentModel extends Gdn_Model {
      * @since 2.0.0
      * @access public
      *
-     * @param mixed Field name(s) to order results by. May be a string or array of strings.
+     * @param mixed $value Field name(s) to order results by. May be a string or array of strings.
      * @return array $this->_OrderBy (optionally).
      */
     public function orderBy($value = null) {

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2198,83 +2198,8 @@ class DiscussionModel extends Gdn_Model {
                     $formPostValues['IsNewDiscussion'] = true;
                     $formPostValues['DiscussionID'] = $discussionID;
 
-                    // Do data prep.
-                    $discussionName = val('Name', $fields, '');
-                    $story = val('Body', $fields, '');
-                    $notifiedUsers = [];
-
-                    $userModel = Gdn::userModel();
-                    $activityModel = new ActivityModel();
-
-                    if (val('Type', $formPostValues)) {
-                        $code = 'HeadlineFormat.Discussion.'.$formPostValues['Type'];
-                    } else {
-                        $code = 'HeadlineFormat.Discussion';
-                    }
-
-                    $headlineFormat = t($code, '{ActivityUserID,user} started a new discussion: <a href="{Url,html}">{Data.Name,text}</a>');
-                    $category = CategoryModel::categories(val('CategoryID', $fields));
-                    $activity = [
-                        'ActivityType' => 'Discussion',
-                        'ActivityUserID' => $fields['InsertUserID'],
-                        'HeadlineFormat' => $headlineFormat,
-                        'RecordType' => 'Discussion',
-                        'RecordID' => $discussionID,
-                        'Route' => discussionUrl($fields, '', '/'),
-                        'Data' => [
-                            'Name' => $discussionName,
-                            'Category' => val('Name', $category)
-                        ]
-                    ];
-
-                    // Allow simple fulltext notifications
-                    if (c('Vanilla.Activity.ShowDiscussionBody', false)) {
-                        $activity['Story'] = $story;
-                    }
-
-                    // Notify all of the users that were mentioned in the discussion.
-                    $usernames = Gdn::formatService()->parseMentions($fields['Body'], $discussionName . ' ' . $story);
-
-                    // Use our generic Activity for events, not mentions
-                    $this->EventArguments['Activity'] = $activity;
-
-                    // Notify everyone that has advanced notifications.
-                    if (!c('Vanilla.QueueNotifications')) {
-                        try {
-                            $fields['DiscussionID'] = $discussionID;
-                            $this->notifyNewDiscussion($fields, $activityModel, $activity);
-                        } catch (Exception $ex) {
-                            throw $ex;
-                        }
-                    }
-
-                    // Notifications for mentions
-                    foreach ($usernames as $username) {
-                        $user = $userModel->getByUsername($username);
-                        if (!$user) {
-                            continue;
-                        }
-
-                        // Check user can still see the discussion.
-                        if (!$this->canView($fields, $user->UserID)) {
-                            continue;
-                        }
-
-                        $activity['HeadlineFormat'] = t('HeadlineFormat.Mention', '{ActivityUserID,user} mentioned you in <a href="{Url,html}">{Data.Name,text}</a>');
-
-                        $activity['NotifyUserID'] = val('UserID', $user);
-                        $activityModel->queue($activity, 'Mention');
-                    }
-
-                    // Throw an event for users to add their own events.
-                    $this->EventArguments['Discussion'] = $fields;
-                    $this->EventArguments['NotifiedUsers'] = $notifiedUsers;
-                    $this->EventArguments['MentionedUsers'] = $usernames;
-                    $this->EventArguments['ActivityModel'] = $activityModel;
-                    $this->fireEvent('BeforeNotification');
-
-                    // Send all notifications.
-                    $activityModel->saveQueue();
+                    $discussion = $this->getID($discussionID, DATASET_TYPE_ARRAY);
+                    $this->notifyNewDiscussion($discussion);
                 }
 
                 // Get CategoryID of this discussion
@@ -2308,62 +2233,169 @@ class DiscussionModel extends Gdn_Model {
      * @param ActivityModel $activityModel
      * @param array $activity
      */
-    public function notifyNewDiscussion($discussion, $activityModel, $activity) {
+    public function notifyNewDiscussion($discussion, $activityModel = null, $activity = []) {
         if (is_numeric($discussion)) {
-            $discussion = $this->getID($discussion);
+            $discussion = $this->getID($discussion, DATASET_TYPE_ARRAY);
         }
 
-        $categoryID = val('CategoryID', $discussion);
-
-        // Figure out the category that governs this notification preference.
-        $i = 0;
-        $category = CategoryModel::categories($categoryID);
-        if (!$category) {
+        if (!is_array($discussion)) {
             return;
         }
+        $body = $discussion["Body"] ?? null;
+        $categoryID = $discussion["CategoryID"] ?? null;
+        $discussionID = $discussion["DiscussionID"] ?? null;
+        $format = $discussion["Format"] ?? null;
+        $insertUserID = $discussion["InsertUserID"] ?? null;
+        $name = $discussion["Name"] ?? null;
+        $type = $discussion["Type"] ?? null;
 
-        while ($category['Depth'] > 2 && $i < 20) {
-            if (!$category || $category['Archived']) {
+        $discussionCategory = CategoryModel::categories($categoryID);
+        if ($discussionCategory === null) {
+            return;
+        }
+        $categoryName = $discussionCategory["Name"] ?? null;
+
+        /** @var ActivityModel $activityModel */
+        $activityModel = Gdn::getContainer()->get(ActivityModel::class);
+
+        if ($type) {
+            $code = "HeadlineFormat.Discussion.{$type}";
+        } else {
+            $code = "HeadlineFormat.Discussion";
+        }
+
+        $data = [
+            "ActivityType" => "Discussion",
+            "ActivityUserID" => $insertUserID,
+            "HeadlineFormat" => t(
+                $code,
+                '{ActivityUserID,user} started a new discussion: <a href="{Url,html}">{Data.Name,text}</a>'
+            ),
+            "RecordType" => "Discussion",
+            "RecordID" => $discussionID,
+            "Route" => discussionUrl($discussion, "", "/"),
+            "Data" => [
+                "Name" => $name,
+                "Category" => $categoryName,
+            ]
+        ];
+
+        // Allow simple fulltext notifications
+        if (c("Vanilla.Activity.ShowDiscussionBody", false)) {
+            $data["Story"] = $body;
+            $data["Format"] = $format;
+        }
+
+        // Notify all of the users that were mentioned in the discussion.
+        $mentions = [];
+        if (is_string($body) && is_string($format)) {
+            $mentions = Gdn::formatService()->parseMentions($body, $format);
+            /** @var UserModel $userModel */
+            $userModel = Gdn::getContainer()->get(UserModel::class);
+
+            foreach ($mentions as $mentionName) {
+                $mentionUser = $userModel->getByUsername($mentionName);
+                if (!$mentionUser) {
+                    continue;
+                }
+
+                // Check user can still see the discussion.
+                if (!$this->canView($discussion, $mentionUser->UserID)) {
+                    continue;
+                }
+
+                $activity = $data;
+                $activity["HeadlineFormat"] = t(
+                    "HeadlineFormat.Mention",
+                    '{ActivityUserID,user} mentioned you in <a href="{Url,html}">{Data.Name,text}</a>'
+                );
+                $activity["NotifyUserID"] = $mentionUser->UserID;
+                $activityModel->queue($activity, "Mention");
+            }
+        }
+
+        $this->EventArguments["Activity"] = $data;
+
+        // Notify everyone that has advanced notifications.
+        if (!c("Vanilla.QueueNotifications")) {
+            $advancedActivity = $data;
+            $advancedActivity["Data"]["Reason"] = "advanced";
+            $this->recordAdvancedNotications($activityModel, $advancedActivity, $discussion);
+        }
+
+        // Throw an event for users to add their own events.
+        $this->EventArguments["Discussion"] = $discussion;
+        $this->EventArguments["NotifiedUsers"] = array_keys(ActivityModel::$Queue);
+        $this->EventArguments["MentionedUsers"] = $mentions;
+        $this->EventArguments["ActivityModel"] = $activityModel;
+        $this->fireEvent("BeforeNotification");
+
+        // Send all notifications.
+        $activityModel->saveQueue();
+    }
+
+    /**
+     * Record advanced notifications for users.
+     *
+     * @param ActivityModel $activityModel
+     * @param array $activity
+     * @param array $discussion
+     */
+    private function recordAdvancedNotications(ActivityModel $activityModel, array $activity, array $discussion) {
+        $categoryID = $discussion["CategoryID"] ?? null;
+        $insertUserID = $discussion["InsertUserID"] ?? null;
+
+        // Figure out the category that governs this notification preference.
+        $category = CategoryModel::categories($categoryID);
+        if ($category === null) {
+            return;
+        }
+        $i = 0;
+        while ($category["Depth"] > 2 && $i < 20) {
+            if (!$category || $category["Archived"]) {
                 return;
             }
             $i++;
-            $category = CategoryModel::categories($category['ParentCategoryID']);
+            $category = CategoryModel::categories($category["ParentCategoryID"]);
         }
 
         // Grab all of the users that need to be notified.
         $data = $this->SQL
-            ->whereIn('Name', ['Preferences.Email.NewDiscussion.'.$category['CategoryID'], 'Preferences.Popup.NewDiscussion.'.$category['CategoryID']])
-            ->get('UserMeta')->resultArray();
+            ->whereIn("Name", [
+                "Preferences.Email.NewDiscussion.{$category['CategoryID']}",
+                "Preferences.Popup.NewDiscussion.{$category['CategoryID']}",
+            ])
+            ->get("UserMeta")
+            ->resultArray();
 
         $notifyUsers = [];
         foreach ($data as $row) {
-            if (!$row['Value']) {
+            if (!$row["Value"]) {
                 continue;
             }
 
-            $userID = $row['UserID'];
+            $userID = $row["UserID"];
             // Check user can still see the discussion.
             if (!$this->canView($discussion, $userID)) {
                 continue;
             }
 
-            $name = $row['Name'];
-            if (strpos($name, '.Email.') !== false) {
-                $notifyUsers[$userID]['Emailed'] = ActivityModel::SENT_PENDING;
-            } elseif (strpos($name, '.Popup.') !== false) {
-                $notifyUsers[$userID]['Notified'] = ActivityModel::SENT_PENDING;
+            $name = $row["Name"];
+            if (strpos($name, ".Email.") !== false) {
+                $notifyUsers[$userID]["Emailed"] = ActivityModel::SENT_PENDING;
+            } elseif (strpos($name, ".Popup.") !== false) {
+                $notifyUsers[$userID]["Notified"] = ActivityModel::SENT_PENDING;
             }
         }
 
-        $insertUserID = val('InsertUserID', $discussion);
         foreach ($notifyUsers as $userID => $prefs) {
             if ($userID == $insertUserID) {
                 continue;
             }
 
-            $activity['NotifyUserID'] = $userID;
-            $activity['Emailed'] = val('Emailed', $prefs, false);
-            $activity['Notified'] = val('Notified', $prefs, false);
+            $activity["NotifyUserID"] = $userID;
+            $activity["Emailed"] = $prefs["Emailed"] ?? false;
+            $activity["Notified"] = $prefs["Notified"] ?? false;
             $activityModel->queue($activity);
         }
     }


### PR DESCRIPTION
Vanilla's notification system is beginning to undergo an overhaul. Instead of doing this in one giant leap, we're taking small incremental steps. This particular step moves notification logic outside post save methods and into dedicated methods on the model. This is done so that when the new notification system is introduced, changes can confidently be made without affecting the rest of the record's save routine. For the sake of simplifying future updates, the process behind generating notifications has been normalized between the comment and discussion models. Previously, each had their own way of handling notifications.

No functional changes have been introduced. Notifications should function the same as they currently do.

Closes #9285 