### PR TITLE
Fix Vanilla\Web\Page error handling with redux preloads

### DIFF
--- a/library/Vanilla/Web/JsInterpop/ReduxActionPreloadTrait.php
+++ b/library/Vanilla/Web/JsInterpop/ReduxActionPreloadTrait.php
@@ -47,7 +47,11 @@ trait ReduxActionPreloadTrait {
     protected function getReduxActionsAsJsVariable(): PhpAsJsVariable {
         // Apply all extra providers.
         foreach ($this->actionProviders as $provider) {
-            $this->reduxActions = array_merge($this->reduxActions, $provider->createActions());
+            try {
+                $this->reduxActions = array_merge($this->reduxActions, $provider->createActions());
+            } catch (\Exception $e) {
+                $this->reduxActions[] = new ReduxErrorAction($e);
+            }
         }
 
         return new PhpAsJsVariable('__ACTIONS__', $this->reduxActions);

--- a/library/Vanilla/Web/Page.php
+++ b/library/Vanilla/Web/Page.php
@@ -363,7 +363,10 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
         $this->addReduxAction(new ReduxErrorAction($e))
             ->setSeoTitle($e->getMessage())
             ->addMetaTag('robots', ['name' => 'robots', 'content' => 'noindex'])
-            ->setSeoContent('resources/views/error.twig', ['error' => $e])
+            ->setSeoContent('resources/views/error.twig', [
+                'errorMessage' => $e->getMessage(),
+                'errorCode' => $e->getCode()
+            ])
         ;
 
         return $this->render();

--- a/resources/views/error.twig
+++ b/resources/views/error.twig
@@ -1,3 +1,3 @@
 <main>
-    <h1>{{ error.status }} - {{ error.message }}</h1>
+    <h1>{{ errorCode }} - {{ errorMessage }}</h1>
 </main>


### PR DESCRIPTION
Closes https://github.com/vanilla/knowledge/issues/1153

- Fixes a twig template error in the error SEO view.
- Catches exceptions in `ReduxActionPreloadTrait` and converts them to a `ReduxErrorAction`.