### PR TITLE
Make nested list rendering for RichFormat more robust

### DIFF
--- a/library/Vanilla/Formatting/Quill/BlotGroupCollection.php
+++ b/library/Vanilla/Formatting/Quill/BlotGroupCollection.php
@@ -46,6 +46,10 @@ class BlotGroupCollection implements \IteratorAggregate {
     private $prevOp;
 
     // ITERABLE IMPLEMENTATION
+
+    /**
+     * @inheritdoc
+     */
     public function getIterator() {
         return new \ArrayIterator($this->groups);
     }
@@ -95,6 +99,9 @@ class BlotGroupCollection implements \IteratorAggregate {
 
         if ($prevGroup && $prevGroup->canNest($currentGroup)) {
             $prevGroup->nestGroup($currentGroup);
+        } elseif ($prevGroup && $prevGroup->canMerge($currentGroup)) {
+            // Merge the current group into the previous one.
+            $prevGroup->pushBlots($currentGroup->getBlotsAndGroups());
         } else {
             $this->groups[] = $this->inProgressGroup;
         }

--- a/library/Vanilla/Formatting/Quill/Blots/AbstractBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/AbstractBlot.php
@@ -9,6 +9,7 @@ namespace Vanilla\Formatting\Quill\Blots;
 
 use Vanilla\Formatting\Quill\BlotGroup;
 use Vanilla\Formatting\Quill\Parser;
+use Vanilla\Formatting\Quill\Nesting\NestableItemInterface;
 
 /**
  * All blots extend AbstractBlot. Even formats. Blots map lightly to quill blots.
@@ -16,7 +17,7 @@ use Vanilla\Formatting\Quill\Parser;
  * This is pretty bare-bones so you likely want to extend TextBlot or AbstractFormat instead.
  * See https://github.com/quilljs/parchment#blots for an explanation of the JS implementation of quill (parchment) blots.
  */
-abstract class AbstractBlot {
+abstract class AbstractBlot implements NestableItemInterface {
 
     /** @var string */
     protected $parseMode;
@@ -136,9 +137,7 @@ abstract class AbstractBlot {
     }
 
     /**
-     * Get the nesting depth of the blot.
-     *
-     * @return int
+     * @inheritdoc
      */
     public function getNestingDepth(): int {
         return 0;

--- a/library/Vanilla/Formatting/Quill/Blots/Lines/ListLineTerminatorBlot.php
+++ b/library/Vanilla/Formatting/Quill/Blots/Lines/ListLineTerminatorBlot.php
@@ -8,16 +8,23 @@
 namespace Vanilla\Formatting\Quill\Blots\Lines;
 
 use Vanilla\Formatting\Quill\BlotGroup;
+use Vanilla\Formatting\Quill\Nesting\InvalidNestingException;
+use Vanilla\Formatting\Quill\Nesting\NestableItemInterface;
+use Vanilla\Formatting\Quill\Nesting\NestingParentInterface;
+use Vanilla\Formatting\Quill\Nesting\NestingParentRendererInterface;
 
 /**
  * A blot to represent a list line terminator.
  */
-class ListLineTerminatorBlot extends AbstractLineTerminatorBlot {
+class ListLineTerminatorBlot extends AbstractLineTerminatorBlot implements NestingParentRendererInterface {
 
     const LIST_TYPE_BULLET = "bullet";
     const LIST_TYPE_ORDERED = "ordered";
     const LIST_TYPE_UNRECOGNIZED = "unrecognized list value";
     const LIST_TYPES = [self::LIST_TYPE_BULLET, self::LIST_TYPE_ORDERED];
+
+    /** @var array BlotGroup[] */
+    private $nestedGroups = [];
 
     /**
      * @inheritdoc
@@ -26,7 +33,6 @@ class ListLineTerminatorBlot extends AbstractLineTerminatorBlot {
         $value = self::normalizeValue($operation ?? []);
         return in_array($value['type'], self::LIST_TYPES, true);
     }
-
 
     /**
      * Get a normalized value from the blot.
@@ -54,6 +60,84 @@ class ListLineTerminatorBlot extends AbstractLineTerminatorBlot {
         ];
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function renderNestedGroups(): string {
+        $result = '';
+
+        // Prepend our nested groups before the terminators.
+        foreach ($this->nestedGroups as $group) {
+            $result .= $group->render();
+        }
+        return $result;
+    }
+
+    /**
+     * Get the target parent to nest in.
+     * This will either be this instance or own of the nested groups.
+     *
+     * @param NestableItemInterface $nestable
+     *
+     * @return NestingParentInterface
+     */
+    private function getTargetNestingParent(NestableItemInterface $nestable): ?NestingParentInterface {
+        if ($nestable->getNestingDepth() === $this->getNestingDepth() + 1) {
+            return $this;
+        } else {
+            $lastIndex = count($this->nestedGroups) - 1;
+            $lastNestedItem = $this->nestedGroups[$lastIndex] ?? null;
+            if ($lastNestedItem !== null && $nestable->getNestingDepth() === $lastNestedItem->getNestingDepth() + 1) {
+                return $lastNestedItem;
+            } else {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function nestGroup(BlotGroup $blotGroup): void {
+        if (!$this->canNest($blotGroup)) {
+            throw new InvalidNestingException();
+        }
+
+        $targetGroup = $this->getTargetNestingParent($blotGroup);
+        if ($targetGroup === null) {
+            throw new InvalidNestingException();
+        } elseif ($targetGroup === $this) {
+            // Protect against recursion.
+            $lastNestedIndex = count($this->nestedGroups) - 1;
+
+            /** @var BlotGroup|null $lastNestedGroup */
+            $lastNestedGroup = $this->nestedGroups[$lastNestedIndex] ?? null;
+
+            if ($lastNestedGroup && $lastNestedGroup->canMerge($blotGroup)) {
+                $lastNestedGroup->pushBlots($blotGroup->getBlotsAndGroups());
+            } else {
+                $this->nestedGroups[] = $blotGroup;
+            }
+        } else {
+            $targetGroup->nestGroup($blotGroup);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function canNest(BlotGroup $blotGroup): bool {
+        $mainBlot = $blotGroup->getMainBlot();
+        $targetNestingParent = $this->getTargetNestingParent($blotGroup);
+        return $targetNestingParent && $targetNestingParent->getNestingDepth() + 1 === $mainBlot->getNestingDepth();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getNestedGroups(): array {
+        return $this->nestedGroups;
+    }
 
     /**
      * @inheritdoc

--- a/library/Vanilla/Formatting/Quill/Nesting/InvalidNestingException.php
+++ b/library/Vanilla/Formatting/Quill/Nesting/InvalidNestingException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting\Quill\Nesting;
+
+/**
+ * Exception to throw when a blot is nested improperly.
+ */
+class InvalidNestingException extends \Exception {
+}

--- a/library/Vanilla/Formatting/Quill/Nesting/NestableItemInterface.php
+++ b/library/Vanilla/Formatting/Quill/Nesting/NestableItemInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting\Quill\Nesting;
+
+/**
+ * Interface for representing items that can be nested.
+ */
+interface NestableItemInterface {
+    /**
+     * Get the current nesting depth of the item.
+     *
+     * @return int
+     */
+    public function getNestingDepth(): int;
+}

--- a/library/Vanilla/Formatting/Quill/Nesting/NestingParentInterface.php
+++ b/library/Vanilla/Formatting/Quill/Nesting/NestingParentInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting\Quill\Nesting;
+
+use Vanilla\Formatting\Quill\BlotGroup;
+
+/**
+ * Interface representing a an item that can contain nestable items.
+ */
+interface NestingParentInterface {
+
+    /**
+     * The group to nest.
+     *
+     * @param BlotGroup $blotGroup
+     *
+     * @return void
+     * @throws InvalidNestingException If the group can't be nested. Be sure to call ::canNest().
+     */
+    public function nestGroup(BlotGroup $blotGroup): void;
+
+    /**
+     * Determine if a blot group can be nested inside of the parent.
+     *
+     * @param BlotGroup $blotGroup
+     * @return bool
+     */
+    public function canNest(BlotGroup $blotGroup): bool;
+}

--- a/library/Vanilla/Formatting/Quill/Nesting/NestingParentRendererInterface.php
+++ b/library/Vanilla/Formatting/Quill/Nesting/NestingParentRendererInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting\Quill\Nesting;
+
+use Vanilla\Formatting\Quill\BlotGroup;
+
+/**
+ * Interface representing a an item that can contain nestable items.
+ */
+interface NestingParentRendererInterface extends NestingParentInterface {
+    /**
+     * Render nested groups.
+     *
+     * @return string HTML of the rendered groups.
+     */
+    public function renderNestedGroups(): string;
+
+    /**
+     * Get all of the nested blot groups.
+     *
+     * @return BlotGroup[]
+     */
+    public function getNestedGroups(): array;
+}

--- a/tests/fixtures/formats/rich/lists/input.json
+++ b/tests/fixtures/formats/rich/lists/input.json
@@ -1,50 +1,179 @@
 [
-    { "insert": "Bulleted 1" },
-    { "attributes": { "list": "bullet" }, "insert": "\n" },
-    { "insert": "Bulleted 2" },
-    { "attributes": { "list": {
-        "type":"bullet",
-        "depth": 0
-    }}, "insert": "\n" },    { "insert": "Bulleted 2.1 (indented 1)" },
-    { "attributes": { "list": {
-        "type":"bullet",
-        "depth": 1
-    }}, "insert": "\n" },
-    { "insert": "Bulleted 2.1.1 (indented 2)" },
-    { "attributes": { "list": {
-        "type":"bullet",
-        "depth": 2
-    }}, "insert": "\n" },
-    { "insert": "Bulleted 2.2 (indented 1)" },
-    { "attributes": { "list": {
-        "type":"bullet",
-        "depth": 1
-    }}, "insert": "\n" },
-    { "insert": "Bulleted 3" },
-    { "attributes": { "list": {
-        "type":"bullet",
-        "depth": 0
-    }}, "insert": "\n" },
-
-
-    { "insert": "\nNumbered 1" },
-    { "attributes": { "list": {
-        "type":"ordered",
-        "depth": 0
-    }}, "insert": "\n" },
-    { "insert": "Numbered 2" },
-    { "attributes": { "list": {
-        "type":"ordered",
-        "depth": 0
-    }}, "insert": "\n" },
-    { "insert": "Numbered 2.1 (indented 1)" },
-    { "attributes": { "list": {
-        "type":"ordered",
-        "depth": 1
-    }}, "insert": "\n" },
-    { "insert": "Numbered 2.1.1 (indented 2)" },
-    { "attributes": { "list": {
-        "type":"ordered",
-        "depth": 2
-    }}, "insert": "\n" }
+    {
+        "insert": "Bulleted 1"
+    },
+    {
+        "attributes": {
+            "list": "bullet"
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Bulleted 2"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "bullet",
+                "depth": 0
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Bulleted 2.1 (indented 1)"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "bullet",
+                "depth": 1
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Bulleted 2.1.1 (indented 2)"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "bullet",
+                "depth": 2
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Bulleted 2.2 (indented 1)"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "bullet",
+                "depth": 1
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Bulleted 3"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "bullet",
+                "depth": 0
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "\nNumbered 1"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "ordered",
+                "depth": 0
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Numbered 2"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "ordered",
+                "depth": 0
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Numbered 2.1 (indented 1)"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "ordered",
+                "depth": 1
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Numbered 2.1.1 (indented 2)"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "ordered",
+                "depth": 2
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "\nMixed 1"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "ordered",
+                "depth": 0
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Mixed 2"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "ordered",
+                "depth": 0
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Mixed 2.1 (indented 1)"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "bullet",
+                "depth": 1
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Mixed 2.2 (indented 1)"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "bullet",
+                "depth": 1
+            }
+        },
+        "insert": "\n"
+    },
+    {
+        "insert": "Mixed 3"
+    },
+    {
+        "attributes": {
+            "list": {
+                "type": "ordered",
+                "depth": 0
+            }
+        },
+        "insert": "\n"
+    }
 ]

--- a/tests/fixtures/formats/rich/lists/output.html
+++ b/tests/fixtures/formats/rich/lists/output.html
@@ -10,8 +10,6 @@
             <li>Bulleted 2.2 (indented 1)</li>
         </ul>
     </li>
-</ul>
-<ul>
     <li>Bulleted 3</li>
 </ul>
 <p>
@@ -28,4 +26,17 @@
             </li>
         </ol>
     </li>
+</ol>
+<p>
+    <br>
+</p>
+<ol>
+    <li>Mixed 1</li>
+    <li>Mixed 2
+        <ul>
+            <li>Mixed 2.1 (indented 1)</li>
+            <li>Mixed 2.2 (indented 1)</li>
+        </ul>
+    </li>
+    <li>Mixed 3</li>
 </ol>

--- a/tests/fixtures/formats/rich/lists/output.txt
+++ b/tests/fixtures/formats/rich/lists/output.txt
@@ -1,6 +1,17 @@
 Bulleted 1
 Bulleted 2
+Bulleted 2.1 (indented 1)
+Bulleted 2.1.1 (indented 2)
+Bulleted 2.2 (indented 1)
 Bulleted 3
 
 Numbered 1
 Numbered 2
+Numbered 2.1 (indented 1)
+Numbered 2.1.1 (indented 2)
+
+Mixed 1
+Mixed 2
+Mixed 2.1 (indented 1)
+Mixed 2.2 (indented 1)
+Mixed 3


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/9216

- Adds improved test cases related to nested lists for the rich renderer.
- Adds new interfaces related to nesting blots and groups. `NestableItemInterface`, `NestingParentInterface`, and `NestingParentRendererInterface`.
- Nested items now live on the `Blot` instead of the `BlotGroup`. This is so that order of blots can be preserved. Previously all nested items would render at the end of their group. In some use cases they can actually be rendered in the middle.
- Ensure `RichFormat::renderPlainText` renders nested list items.
- Add methods for merging groups together.