### PR TITLE
Add deferment of post notifications

### DIFF
--- a/applications/dashboard/library/Jobs/ExecuteActivityQueue.php
+++ b/applications/dashboard/library/Jobs/ExecuteActivityQueue.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+use Vanilla\Scheduler\Job\JobExecutionStatus;
+use Vanilla\Scheduler\Job\JobPriority;
+
+/**
+ * Execute the activity queue.
+ */
+class ExecuteActivityQueue implements Vanilla\Scheduler\Job\LocalJobInterface {
+
+    /**
+     * Execute all queued up items in the ActivityModel queue.
+     */
+    public function run(): JobExecutionStatus {
+        /** @var \ActivityModel $activityModel */
+        $activityModel = \Gdn::getContainer()->get(\ActivityModel::class);
+        $activityModel->saveQueue();
+        return JobExecutionStatus::complete();
+    }
+
+    /**
+     * Set job Message
+     *
+     * @param array $message
+     */
+    public function setMessage(array $message) {
+    }
+
+    /**
+     * Set job priority
+     *
+     * @param JobPriority $priority
+     * @return void
+     */
+    public function setPriority(JobPriority $priority) {
+    }
+
+    /**
+     * Set job execution delay
+     *
+     * @param int $seconds
+     * @return void
+     */
+    public function setDelay(int $seconds) {
+    }
+}

--- a/applications/dashboard/library/Jobs/ExecuteActivityQueue.php
+++ b/applications/dashboard/library/Jobs/ExecuteActivityQueue.php
@@ -12,13 +12,23 @@ use Vanilla\Scheduler\Job\JobPriority;
  */
 class ExecuteActivityQueue implements Vanilla\Scheduler\Job\LocalJobInterface {
 
+    /** @var ActivityModel */
+    private $activityModel;
+
+    /**
+     * Initial job setup.
+     *
+     * @param ActivityModel $activityModel
+     */
+    public function __construct(ActivityModel $activityModel) {
+        $this->activityModel = $activityModel;
+    }
+
     /**
      * Execute all queued up items in the ActivityModel queue.
      */
     public function run(): JobExecutionStatus {
-        /** @var \ActivityModel $activityModel */
-        $activityModel = \Gdn::getContainer()->get(\ActivityModel::class);
-        $activityModel->saveQueue();
+        $this->activityModel->saveQueue();
         return JobExecutionStatus::complete();
     }
 

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -675,10 +675,15 @@ class CommentModel extends Gdn_Model {
         $this->EventArguments["ActivityModel"] = $activityModel;
         $this->fireEvent("BeforeNotification");
 
-        // Queue sending notifications.
-        /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */
-        $scheduler = Gdn::getContainer()->get(Vanilla\Scheduler\SchedulerInterface::class);
-        $scheduler->addJob(ExecuteActivityQueue::class);
+        if (\Vanilla\FeatureFlagHelper::featureEnabled("deferredNotifications")) {
+            // Queue sending notifications.
+            /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */
+            $scheduler = Gdn::getContainer()->get(Vanilla\Scheduler\SchedulerInterface::class);
+            $scheduler->addJob(ExecuteActivityQueue::class);
+        } else {
+            // Send all notifications.
+            $activityModel->saveQueue();
+        }
     }
 
     /**

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -8,10 +8,10 @@
  * @since 2.0
  */
 
- use Vanilla\Formatting\FormatService;
- use Vanilla\Formatting\UpdateMediaTrait;
+use Vanilla\Formatting\FormatService;
+use Vanilla\Formatting\UpdateMediaTrait;
 
- /**
+/**
  * Manages discussion comments data.
  */
 class CommentModel extends Gdn_Model {
@@ -675,8 +675,10 @@ class CommentModel extends Gdn_Model {
         $this->EventArguments["ActivityModel"] = $activityModel;
         $this->fireEvent("BeforeNotification");
 
-        // Send all notifications.
-        $activityModel->saveQueue();
+        // Queue sending notifications.
+        /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */
+        $scheduler = Gdn::getContainer()->get(Vanilla\Scheduler\SchedulerInterface::class);
+        $scheduler->addJob(ExecuteActivityQueue::class);
     }
 
     /**

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2330,10 +2330,15 @@ class DiscussionModel extends Gdn_Model {
         $this->EventArguments["ActivityModel"] = $activityModel;
         $this->fireEvent("BeforeNotification");
 
-        // Queue sending notifications.
-        /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */
-        $scheduler = Gdn::getContainer()->get(Vanilla\Scheduler\SchedulerInterface::class);
-        $scheduler->addJob(ExecuteActivityQueue::class);
+        if (\Vanilla\FeatureFlagHelper::featureEnabled("deferredNotifications")) {
+            // Queue sending notifications.
+            /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */
+            $scheduler = Gdn::getContainer()->get(Vanilla\Scheduler\SchedulerInterface::class);
+            $scheduler->addJob(ExecuteActivityQueue::class);
+        } else {
+            // Send all notifications.
+            $activityModel->saveQueue();
+        }
     }
 
     /**

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2330,8 +2330,10 @@ class DiscussionModel extends Gdn_Model {
         $this->EventArguments["ActivityModel"] = $activityModel;
         $this->fireEvent("BeforeNotification");
 
-        // Send all notifications.
-        $activityModel->saveQueue();
+        // Queue sending notifications.
+        /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */
+        $scheduler = Gdn::getContainer()->get(Vanilla\Scheduler\SchedulerInterface::class);
+        $scheduler->addJob(ExecuteActivityQueue::class);
     }
 
     /**


### PR DESCRIPTION
Post notifications are currently queued up and sent in the middle of the request, after the post has been saved and before the post is rendered. This update moves executing of the `ActivityModel` queue, which includes post notifications, to the local scheduler. This scheduler processes its own queue after the response has been sent to the client. The intent is to remove sending notifications as a blocking operation for responses.

This is the first use of the scheduler, introduced into Vanilla via #9290.

### Testing

Make sure you've enabled the deferredNotifications feature flag in your config (`Feature.deferredNotifications.Enabled` set to `true`).

The only functional change here should be the order in which notifications are sent. To test, you can add a high-interval [`sleep`](https://www.php.net/sleep) call to the start of the `run` method of `ExecuteActivityQueue`, then create a discussion you expect to receive a notification for. You should notice the server's response is received before the expected completion of the `sleep` call. Alternatively, you can debug the code and add a breakpoint in the same method. Leave execution paused while you verify the response has been received as expected by the browser.

Closes #9286