### PR TITLE
Fix error in font loader when no fonts are loaded

### DIFF
--- a/library/src/scripts/theming/loadThemeFonts.ts
+++ b/library/src/scripts/theming/loadThemeFonts.ts
@@ -19,7 +19,7 @@ export function loadThemeFonts() {
         const assets = state.theme.assets.data || {};
         const { fonts } = assets;
 
-        if (fonts) {
+        if (fonts && fonts.length > 0) {
             const webFontConfig: WebFont.Config = {
                 custom: {
                     families: fonts.map(font => font.name),


### PR DESCRIPTION
I turned on one of the test themes I made for the KB and noticed it crashed when no fonts were defined. I added an extra check to avoid the crash.