### PR TITLE
Add fix rows method to discussion model

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3388,7 +3388,7 @@ class DiscussionModel extends Gdn_Model {
      * DiscussionModel::calculate applies htmlspecialchars to discussion name which could conflict when
      * data is encoded on the view.  As result characters will display in their entity codes.  Removing the
      * htmlspecialchars in the calculate method could result in several XSS vulnerabilities in Vanilla.  This
-     * method is a utility method avoid dencoding data where it's not necessary.
+     * method is a utility method to avoid encoding data where it's not necessary.
      *
      * @param array $data The discussion record to fix.
      * @return array

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3385,15 +3385,18 @@ class DiscussionModel extends Gdn_Model {
     /**
      * Method to prevent encoding data twice.
      *
-     * @param array $data
+     * DiscussionModel::calculate applies htmlspecialchars to discussion name which could conflict when
+     * data is encoded on the view.  As result characters will display in their entity codes.  Removing the
+     * htmlspecialchars in the calculate method could result in several XSS vulnerabilities in Vanilla.  This
+     * method is a utility method avoid dencoding data where it's not necessary.
+     *
+     * @param array $data The discussion record to fix.
      * @return array
      */
-    public function fixRows(array $data):array {
-
+    public function fixRows(array $data): array {
         if (array_key_exists('Name', $data)) {
             $data['Name'] = htmlspecialchars_decode($data['Name']);
         }
-
         return $data;
     }
 }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3381,4 +3381,19 @@ class DiscussionModel extends Gdn_Model {
             }
         }
     }
+
+    /**
+     * Method to prevent encoding data twice.
+     *
+     * @param array $data
+     * @return array
+     */
+    public function fixRows(array $data):array {
+
+        if (array_key_exists('Name', $data)) {
+            $data['Name'] = htmlspecialchars_decode($data['Name']);
+        }
+
+        return $data;
+    }
 }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3390,13 +3390,13 @@ class DiscussionModel extends Gdn_Model {
      * htmlspecialchars in the calculate method could result in several XSS vulnerabilities in Vanilla.  This
      * method is a utility method to avoid encoding data where it's not necessary.
      *
-     * @param array $data The discussion record to fix.
+     * @param array $row The discussion record to fix.
      * @return array
      */
-    public function fixRows(array $data): array {
-        if (array_key_exists('Name', $data)) {
-            $data['Name'] = htmlspecialchars_decode($data['Name']);
+    public function fixRow(array $row): array {
+        if (array_key_exists('Name', $row)) {
+            $row['Name'] = htmlspecialchars_decode($row['Name']);
         }
-        return $data;
+        return $row;
     }
 }


### PR DESCRIPTION
Adding a utility method to the DiscussionModel to be used to prevent double encoding data.

Blocking https://github.com/vanilla/internal/pull/1995