### PR TITLE
Add missing invitation target placeholder & description

### DIFF
--- a/applications/dashboard/views/settings/registration.php
+++ b/applications/dashboard/views/settings/registration.php
@@ -73,9 +73,12 @@ echo $this->Form->errors(); ?>
 <div id="InvitationTarget" class="form-group">
     <div class="label-wrap">
         <?php echo $this->Form->label('Invitation target', 'Garden.Registration.InviteTarget'); ?>
+        <div class="info">
+            <?php echo t('Users will be redirected to this URL after accepting an invitation. It can be a full URL or a path to redirect within the site.'); ?>
+        </div>
     </div>
     <div class="input-wrap invite-url-code">
-        <?php echo $this->Form->textBox('Garden.Registration.InviteTarget', ['value' => $this->InviteTarget]); ?>
+        <?php echo $this->Form->textBox('Garden.Registration.InviteTarget', ['value' => $this->InviteTarget, 'placeholder' => 'https://']); ?>
     </div>
 </div>
 <div id="InvitationExpiration" class="form-group">

--- a/applications/dashboard/views/settings/registration.php
+++ b/applications/dashboard/views/settings/registration.php
@@ -74,7 +74,7 @@ echo $this->Form->errors(); ?>
     <div class="label-wrap">
         <?php echo $this->Form->label('Invitation target', 'Garden.Registration.InviteTarget'); ?>
         <div class="info">
-            <?php echo t('Users will be redirected to this URL after accepting an invitation. It can be a full URL or a path to redirect within the site.'); ?>
+            <?php echo t('Users will be redirected to this URL after accepting an invitation.', "Users will be redirected to this URL after accepting an invitation. It can be a full URL or a path to redirect within the site."); ?>
         </div>
     </div>
     <div class="input-wrap invite-url-code">


### PR DESCRIPTION
closes https://github.com/vanilla/vanilla/issues/9273

This PR adds a description and a placeholder for "Invitation Target" under "/dashboard/settings/registration".
![Screen Shot 2019-09-30 at 12 52 54 PM](https://user-images.githubusercontent.com/31856281/65899212-3fab7b80-e381-11e9-8782-b986f60f311d.png)

### To test
Go to /dashboard/settings/registration
Change registration method to "Invitation" 

I'll add the translation key in a separate PR.

