### PR TITLE
Fix activity URL generation when no route is specified

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -194,7 +194,12 @@ class ActivityModel extends Gdn_Model {
         }
 
 
-        $row['Url'] = externalUrl($row['Route']);
+        if (!empty($row['Route'])) {
+            $row['Url'] = externalUrl($row['Route']);
+        } else {
+            $id = $row['ActivityID'];
+            $row['Url'] = Gdn::request()->url("/activity/item/$id", true);
+        }
 
         if ($row['HeadlineFormat']) {
             $row['Headline'] = formatString($row['HeadlineFormat'], $row);


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/791

This PR adds a fallback URL to activity if no route is specified. This URL is the single item activity view, `/activity/item/:id`.

