### PR TITLE
Use setField instead of setProperty to announce discussions

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -573,7 +573,7 @@ class DiscussionController extends VanillaController {
                 $this->DiscussionModel->getAnnouncementCacheKey(val('CategoryID', $discussion))
             ];
             $this->DiscussionModel->SQL->cache($cacheKeys);
-            $this->DiscussionModel->setProperty($discussionID, 'Announce', (int)$this->Form->getFormValue('Announce', 0));
+            $this->DiscussionModel->setField($discussionID, 'Announce', (int)$this->Form->getFormValue('Announce', 0));
 
             if ($target) {
                 $this->setRedirectTo($target);


### PR DESCRIPTION
The `setField` function from the discussion model is a wrapper for `Gdn_Model::setField` which fires the `AfterSetField` event.

By replacing the `setProperty` call by `setField`, it is possible to hook into the AfterSetField event after a discussion is announced (or un-announced). Both functions are used to update an existing records and produce the same results.