### PR TITLE
Adds database connection smoothness

### DIFF
--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -159,6 +159,9 @@ class Gdn_Database {
      * `$timeoutAt` holds the timestamps at which no more retries are done. It's static as it's a fixed amount of time
      * we are willing to wait during the whole request processing time (Otherwise, waiting time could be accumulative in cases)
      *
+     * Beware that in the theoretical "worst" case scenario we wait for up to (SmoothTimeoutMillis +  SmoothWaitMaxMillis - 1),
+     * 5749ms for the defaults values.
+     *
      * @param $dsn
      * @param $user
      * @param $password

--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -181,7 +181,6 @@ class Gdn_Database {
                 $pDO->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
                 return $pDO;
-
             } catch (Exception $ex) {
                 if ($ex instanceof PDOException &&
                     microtime(true) < $timeoutAt &&

--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -182,7 +182,8 @@ class Gdn_Database {
             } catch (Exception $ex) {
                 if ($ex instanceof PDOException &&
                     microtime(true) < $timeoutAt &&
-                    ($ex->getCode() === 1203 || $ex->getCode() === 1040 || $ex->getCode() === 1226)) {
+                    in_array($ex->getCode(), [1203, 1040, 1226])
+                ) {
                     /*
                      * https://dev.mysql.com/doc/refman/5.7/en/server-error-reference.html
                      * ---


### PR DESCRIPTION
Add supports for database connection smoothness.

In the case that the connection cannot be done because a resources limit is reached (max connections, max user connections, user limits) we loop up to `SmoothTimeoutMillis` milliseconds and we retry the connection.

Every try sleeps for a random amount of time between SmoothWaitMinMillis & SmoothWaitMaxMillis and then attempts a new connection.

The defaults value are:
SmoothTimeoutMillis = 5000
SmoothWaitMinMillis = 250
SmoothWaitMaxMillis = 750
These values can be overwritten via Gdn::config('Database')

In the `query` method, the connection to the database was moved outside of the retry loop. Otherwise, the connection smoothness would be also influenced by the retry configuration.