### PR TITLE
Add a check for  record ownership before testing view permission when joining records

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2280,7 +2280,8 @@ if (!function_exists('joinRecords')) {
 
             $record = $joinData[$recordType][$iD];
 
-            if ($checkCategoryPermission && $allowedCats !== true) {
+            // Make sure the user is not the owner of the record before unsetting record values.
+            if ($checkCategoryPermission && $allowedCats !== true && $record['InsertUserID'] !==  Gdn::session()->UserID) {
                 // Check to see if the user has permission to view this record.
                 $categoryID = getValue('CategoryID', $record, -1);
                 if (!in_array($categoryID, $allowedCats)) {


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/547

### Details

in https://github.com/vanilla/vanilla/blob/a9b799697ff7242913eab6179ebc0c8f38bb6232/library/core/functions.general.php#L2284 when Joining records, I added a condition to skip checking of view permissions on the category if the record being tested is owned by the user.

Testing details are in the referenced support ticket.