### PR TITLE
Touch all feature flag config values

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -1026,3 +1026,11 @@ if ($config->get("Robots.Rules") === false && $sitemapsRobotsRules = $config->ge
     $config->set("Robots.Rules", $sitemapsRobotsRules);
     $config->remove("Sitemap.Robots.Rules");
 }
+
+// Set feature flag defaults into the config
+// So in a future update the can be safely changed for new sites.
+$config->touch('Feature.DeferredLegacyScripts.Enabled', false);
+$config->touch('Feature.AuthenticationAPI.Enabled', false);
+$config->touch('Feature.discussionSiteMaps.Enabled', false);
+$config->touch('Feature.Import.Enabled', false);
+$config->touch('Feature.updateTokens.Enabled', false);


### PR DESCRIPTION
This will enable us to change the default value of one of these in the future so that it only affects new sites.

- Writes all current core feature flags into a site config on structure.
- Cleans up the ending section of the dashboard structure file to be a bit cleaner.