### PR TITLE
Add SearchRecordTypeProvider to core Vanilla namespace

### DIFF
--- a/applications/vanilla/models/SearchRecords/SearchRecordTypeComment.php
+++ b/applications/vanilla/models/SearchRecords/SearchRecordTypeComment.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models\SearchRecords;
+
+use Vanilla\Contracts\Search\SearchRecordTypeInterface;
+use Vanilla\Contracts\Search\SearchRecordTypeTrait;
+
+/**
+ * Class SearchRecordTypeComment
+ * @package Vanilla\AdvancedSearch\Models
+ */
+class SearchRecordTypeComment implements SearchRecordTypeInterface {
+    use SearchRecordTypeTrait;
+
+    const PROVIDER_GROUP = 'advanced';
+
+    const TYPE = 'comment';
+
+    const API_TYPE_KEY = 'comment';
+
+    const SUB_KEY = 'c';
+
+    const CHECKBOX_LABEL = 'comments';
+
+    const SPHINX_DTYPE = 100;
+
+    const SPHINX_INDEX = 'Comment';
+
+    const GUID_OFFSET = 2;
+
+    const GUID_MULTIPLIER = 10;
+
+    /**
+     * @inheritdoc
+     */
+    public function getDocuments(array $IDs, \SearchModel $searchModel): array {
+        $result = $searchModel->getComments($IDs);
+        foreach ($result as &$record) {
+            $record['guid'] = $record['PrimaryID'] * self::GUID_MULTIPLIER + self::GUID_OFFSET;
+        }
+        return $result;
+    }
+}

--- a/applications/vanilla/models/SearchRecords/SearchRecordTypeDiscussion.php
+++ b/applications/vanilla/models/SearchRecords/SearchRecordTypeDiscussion.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models\SearchRecords;
+
+use Vanilla\Contracts\Search\SearchRecordTypeInterface;
+use Vanilla\Contracts\Search\SearchRecordTypeTrait;
+
+/**
+ * Class SearchRecordTypeDiscussion
+ * @package Vanilla\AdvancedSearch\Models
+ */
+class SearchRecordTypeDiscussion implements SearchRecordTypeInterface {
+    use SearchRecordTypeTrait;
+
+    const PROVIDER_GROUP = 'advanced';
+
+    const TYPE = 'discussion';
+
+    const API_TYPE_KEY = 'discussion';
+
+    const SUB_KEY = 'd';
+
+    const CHECKBOX_LABEL = 'discussions';
+
+    const SPHINX_DTYPE = 0;
+
+    const SPHINX_INDEX = 'Discussion';
+
+    const GUID_OFFSET = 1;
+
+    const GUID_MULTIPLIER = 10;
+
+    /**
+     * @inheritdoc
+     */
+    public function getDocuments(array $IDs, \SearchModel $searchModel): array {
+        $result = $searchModel->getDiscussions($IDs);
+        foreach ($result as &$record) {
+            $record['guid'] = $record['PrimaryID'] * self::GUID_MULTIPLIER + self::GUID_OFFSET;
+        }
+        return $result;
+    }
+}

--- a/applications/vanilla/models/SearchRecords/SearchRecordTypeProvider.php
+++ b/applications/vanilla/models/SearchRecords/SearchRecordTypeProvider.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models\SearchRecords;
+
+use Vanilla\Contracts\Search\SearchRecordTypeInterface;
+use Vanilla\Contracts\Search\SearchRecordTypeProviderInterface;
+
+/**
+ * Class SearchRecordTypeProvider
+ * @package Vanilla\AdvancedSearch\Models
+ */
+class SearchRecordTypeProvider implements SearchRecordTypeProviderInterface {
+    /** @var $searchRecordTypes SearchRecordTypeInterface[] */
+    private $types = [];
+
+    /** @var $providerGroups string[] */
+    private $providerGroups = [];
+
+    /**
+     * @inheritdoc
+     */
+    public function getAll(): array {
+        $res = [];
+        foreach ($this->types as $recordType) {
+            if (in_array($recordType->getProviderGroup(), $this->providerGroups)) {
+                $res[] = $recordType;
+            }
+        }
+        return $res;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setType(SearchRecordTypeInterface $recordType) {
+        $this->types[] = $recordType;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getType(string $typeKey): ?SearchRecordTypeInterface {
+        $result = null;
+        foreach ($this->types as $type) {
+            if ($type->getKey() === $typeKey) {
+                $result = $type;
+                break;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getByDType(int $dtype): ?SearchRecordTypeInterface {
+        $result = null;
+        foreach ($this->types as $recordType) {
+            if (in_array($recordType->getProviderGroup(), $this->providerGroups)) {
+                if ($dtype === $recordType->getDType()) {
+                    $result = $recordType;
+                    break;
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function addProviderGroup(string $providerGroup) {
+        $this->providerGroups[] = $providerGroup;
+    }
+}

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -10,6 +10,10 @@
 
 use Garden\Container\Container;
 use Garden\Container\Reference;
+use Vanilla\Contracts\Search\SearchRecordTypeProviderInterface;
+use Vanilla\Models\SearchRecords\SearchRecordTypeComment;
+use Vanilla\Models\SearchRecords\SearchRecordTypeDiscussion;
+use Vanilla\Models\SearchRecords\SearchRecordTypeProvider;
 
 /**
  * Vanilla's event handlers.
@@ -28,6 +32,16 @@ class VanillaHooks implements Gdn_IPlugin {
 
         $dic->rule(\Vanilla\Menu\CounterModel::class)
             ->addCall('addProvider', [new Reference(\Vanilla\Forum\Menu\UserCounterProvider::class)])
+        ;
+
+        $dic
+            ->rule(SearchRecordTypeProviderInterface::class)
+            ->setClass(SearchRecordTypeProvider::class)
+            ->addCall('setType', [new SearchRecordTypeDiscussion()])
+            ->addCall('setType', [new SearchRecordTypeComment()])
+            ->addCall('addProviderGroup', [SearchRecordTypeDiscussion::PROVIDER_GROUP])
+            ->addAlias('SearchRecordTypeProvider')
+            ->setShared(true)
         ;
     }
 


### PR DESCRIPTION
Move `SearchRecordTypeProvider` together with `SearchRecordTypeDiscussion` and `SearchRecordTypeComment` to the core forum application Vanilla namespace

Relates to : https://github.com/vanilla/internal/issues/2003