### PR TITLE
Update tests Bootstrap with SearchRecordTypesProvider init

### DIFF
--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -33,16 +33,6 @@ class VanillaHooks implements Gdn_IPlugin {
         $dic->rule(\Vanilla\Menu\CounterModel::class)
             ->addCall('addProvider', [new Reference(\Vanilla\Forum\Menu\UserCounterProvider::class)])
         ;
-
-        $dic
-            ->rule(SearchRecordTypeProviderInterface::class)
-            ->setClass(SearchRecordTypeProvider::class)
-            ->addCall('setType', [new SearchRecordTypeDiscussion()])
-            ->addCall('setType', [new SearchRecordTypeComment()])
-            ->addCall('addProviderGroup', [SearchRecordTypeDiscussion::PROVIDER_GROUP])
-            ->addAlias('SearchRecordTypeProvider')
-            ->setShared(true)
-        ;
     }
 
     /**

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -14,6 +14,10 @@ use Vanilla\Utility\ContainerUtils;
 use \Vanilla\Formatting\Formats;
 use Firebase\JWT\JWT;
 use Vanilla\Web\TwigEnhancer;
+use Vanilla\Contracts\Search\SearchRecordTypeProviderInterface;
+use Vanilla\Models\SearchRecordTypeComment;
+use Vanilla\Models\SearchRecordTypeDiscussion;
+use Vanilla\Models\SearchRecordTypeProvider;
 
 if (!defined('APPLICATION')) exit();
 /**
@@ -262,6 +266,14 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->rule(\Vanilla\Models\AuthenticatorModel::class)
     ->setShared(true)
     ->addCall('registerAuthenticatorClass', [\Vanilla\Authenticator\PasswordAuthenticator::class])
+
+    ->rule(SearchRecordTypeProviderInterface::class)
+    ->setClass(SearchRecordTypeProvider::class)
+    ->addCall('setType', [new SearchRecordTypeDiscussion()])
+    ->addCall('setType', [new SearchRecordTypeComment()])
+    ->addCall('addProviderGroup', [SearchRecordTypeDiscussion::PROVIDER_GROUP])
+    ->addAlias('SearchRecordTypeProvider')
+    ->setShared(true)
 
     ->rule(SearchModel::class)
     ->setShared(true)

--- a/library/Vanilla/Models/SearchRecordTypeComment.php
+++ b/library/Vanilla/Models/SearchRecordTypeComment.php
@@ -5,14 +5,14 @@
  * @license GPL-2.0-only
  */
 
-namespace Vanilla\Models\SearchRecords;
+namespace Vanilla\Models;
 
 use Vanilla\Contracts\Search\SearchRecordTypeInterface;
 use Vanilla\Contracts\Search\SearchRecordTypeTrait;
 
 /**
  * Class SearchRecordTypeComment
- * @package Vanilla\AdvancedSearch\Models
+ * @package Vanilla\Models
  */
 class SearchRecordTypeComment implements SearchRecordTypeInterface {
     use SearchRecordTypeTrait;

--- a/library/Vanilla/Models/SearchRecordTypeDiscussion.php
+++ b/library/Vanilla/Models/SearchRecordTypeDiscussion.php
@@ -5,14 +5,14 @@
  * @license GPL-2.0-only
  */
 
-namespace Vanilla\Models\SearchRecords;
+namespace Vanilla\Models;
 
 use Vanilla\Contracts\Search\SearchRecordTypeInterface;
 use Vanilla\Contracts\Search\SearchRecordTypeTrait;
 
 /**
  * Class SearchRecordTypeDiscussion
- * @package Vanilla\AdvancedSearch\Models
+ * @package Vanilla\Models
  */
 class SearchRecordTypeDiscussion implements SearchRecordTypeInterface {
     use SearchRecordTypeTrait;

--- a/library/Vanilla/Models/SearchRecordTypeProvider.php
+++ b/library/Vanilla/Models/SearchRecordTypeProvider.php
@@ -5,14 +5,14 @@
  * @license GPL-2.0-only
  */
 
-namespace Vanilla\Models\SearchRecords;
+namespace Vanilla\Models;
 
 use Vanilla\Contracts\Search\SearchRecordTypeInterface;
 use Vanilla\Contracts\Search\SearchRecordTypeProviderInterface;
 
 /**
  * Class SearchRecordTypeProvider
- * @package Vanilla\AdvancedSearch\Models
+ * @package Vanilla\Models
  */
 class SearchRecordTypeProvider implements SearchRecordTypeProviderInterface {
     /** @var $searchRecordTypes SearchRecordTypeInterface[] */

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -28,6 +28,10 @@ use VanillaTests\Fixtures\Authenticator\MockAuthenticator;
 use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 use VanillaTests\Fixtures\NullCache;
 use Vanilla\Utility\ContainerUtils;
+use Vanilla\Contracts\Search\SearchRecordTypeProviderInterface;
+use Vanilla\Models\SearchRecords\SearchRecordTypeComment;
+use Vanilla\Models\SearchRecords\SearchRecordTypeDiscussion;
+use Vanilla\Models\SearchRecords\SearchRecordTypeProvider;
 
 /**
  * Run bootstrap code for Vanilla tests.
@@ -223,6 +227,14 @@ class Bootstrap {
             ->addCall('registerAuthenticatorClass', [MockSSOAuthenticator::class])
 
             ->rule(SearchModel::class)
+            ->setShared(true)
+
+            ->rule(SearchRecordTypeProviderInterface::class)
+            ->setClass(SearchRecordTypeProvider::class)
+            ->addCall('setType', [new SearchRecordTypeDiscussion()])
+            ->addCall('setType', [new SearchRecordTypeComment()])
+            ->addCall('addProviderGroup', [SearchRecordTypeDiscussion::PROVIDER_GROUP])
+            ->addAlias('SearchRecordTypeProvider')
             ->setShared(true)
 
             ->rule(SSOModel::class)

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -29,9 +29,9 @@ use VanillaTests\Fixtures\Authenticator\MockSSOAuthenticator;
 use VanillaTests\Fixtures\NullCache;
 use Vanilla\Utility\ContainerUtils;
 use Vanilla\Contracts\Search\SearchRecordTypeProviderInterface;
-use Vanilla\Models\SearchRecords\SearchRecordTypeComment;
-use Vanilla\Models\SearchRecords\SearchRecordTypeDiscussion;
-use Vanilla\Models\SearchRecords\SearchRecordTypeProvider;
+use Vanilla\Models\SearchRecordTypeComment;
+use Vanilla\Models\SearchRecordTypeDiscussion;
+use Vanilla\Models\SearchRecordTypeProvider;
 
 /**
  * Run bootstrap code for Vanilla tests.

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -226,15 +226,15 @@ class Bootstrap {
             ->addCall('registerAuthenticatorClass', [MockAuthenticator::class])
             ->addCall('registerAuthenticatorClass', [MockSSOAuthenticator::class])
 
-            ->rule(SearchModel::class)
-            ->setShared(true)
-
             ->rule(SearchRecordTypeProviderInterface::class)
             ->setClass(SearchRecordTypeProvider::class)
             ->addCall('setType', [new SearchRecordTypeDiscussion()])
             ->addCall('setType', [new SearchRecordTypeComment()])
             ->addCall('addProviderGroup', [SearchRecordTypeDiscussion::PROVIDER_GROUP])
             ->addAlias('SearchRecordTypeProvider')
+            ->setShared(true)
+
+            ->rule(SearchModel::class)
             ->setShared(true)
 
             ->rule(SSOModel::class)


### PR DESCRIPTION
Init searchRecordType related classes for test container in Bootstrap,

Vanilla app hooks does not work for some reason

Relates to: https://github.com/vanilla/internal/issues/2003