### PR TITLE
Fix list embed rendering issue

### DIFF
--- a/library/Vanilla/Formatting/Quill/BlotGroupCollection.php
+++ b/library/Vanilla/Formatting/Quill/BlotGroupCollection.php
@@ -130,12 +130,13 @@ class BlotGroupCollection implements \IteratorAggregate {
                 continue;
             }
 
+            if (($this->inProgressBlot->shouldClearCurrentGroup($this->inProgressGroup))) {
+                // Ask the blot if it should close the current group.
+                $this->clearBlotGroup();
+            }
+
             // Ask the blot if it should close the current group.
             if ($this->inProgressBlot instanceof AbstractLineTerminatorBlot) {
-                if (($this->inProgressBlot->shouldClearCurrentGroup($this->inProgressGroup))) {
-                    $this->clearBlotGroup();
-                }
-
                 // Clear the line because we we had line terminator.
                 $this->clearLine();
             }

--- a/tests/Library/Vanilla/Formatting/Formats/RichFormatTest.php
+++ b/tests/Library/Vanilla/Formatting/Formats/RichFormatTest.php
@@ -8,6 +8,8 @@
 namespace VanillaTests\Library\Vanilla\Formatting\Formats;
 
 use Vanilla\Contracts\Formatting\FormatInterface;
+use Vanilla\EmbeddedContent\Embeds\ImageEmbed;
+use Vanilla\EmbeddedContent\EmbedService;
 use Vanilla\Formatting\Formats\RichFormat;
 use Vanilla\Formatting\Quill\Parser;
 use VanillaTests\Fixtures\Formatting\FormatFixtureFactory;
@@ -22,7 +24,9 @@ class RichFormatTest extends AbstractFormatTestCase {
      */
     protected function prepareFormatter(): FormatInterface {
         self::container()->rule(Parser::class)
-            ->addCall('addCoreBlotsAndFormats');
+            ->addCall('addCoreBlotsAndFormats')
+            ->rule(EmbedService::class)
+            ->addCall('registerEmbed', [ImageEmbed::class, ImageEmbed::TYPE]);
         return self::container()->get(RichFormat::class);
     }
 

--- a/tests/fixtures/formats/rich/list-embed/input.json
+++ b/tests/fixtures/formats/rich/list-embed/input.json
@@ -1,0 +1,20 @@
+[
+    { "insert": "List Item" },
+    { "attributes": { "list": { "depth": 0, "type": "bullet" } }, "insert": "\n" },
+    {
+        "insert": {
+            "embed-external": {
+                "data": {
+                    "url": "https://us.v-cdn.net/6030677/uploads/698/E2G3E1MAL7AD.png",
+                    "name": "image.png",
+                    "type": "image/png",
+                    "size": 48779,
+                    "width": 746,
+                    "height": 682,
+                    "embedType": "image"
+                },
+                "loaderData": { "type": "image" }
+            }
+        }
+    }
+]

--- a/tests/fixtures/formats/rich/list-embed/output.html
+++ b/tests/fixtures/formats/rich/list-embed/output.html
@@ -1,0 +1,10 @@
+<ul>
+    <li>List Item</li>
+</ul>
+<div class="embedExternal embedImage">
+    <div class="embedExternal-content">
+        <a class="embedImage-link" href="https://us.v-cdn.net/6030677/uploads/698/E2G3E1MAL7AD.png" rel="nofollow noopener" target="_blank">
+            <img alt="image.png" class="embedImage-img" src="https://us.v-cdn.net/6030677/uploads/698/E2G3E1MAL7AD.png">
+        </a>
+    </div>
+</div>


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/9324

- Adds minimal failing test case.
- Fixes some parsing logic in the blot group collection. Blots that don't extend `AbstractLineTerminatorBlot` can still clear a group w/ their `shouldClearCurrentGroup()` method. In this case our embed blot needs to clear the current group.
- Since this test case requires an image embed, I needed to register the image embed with the embed service in the test setup.