### PR TITLE
Fix mention crash and add tests

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/utility.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/utility.test.ts
@@ -194,6 +194,20 @@ describe("getMentionRange", () => {
         quill.setSelection(selection);
         expect(getMentionRange(quill, selection)).to.eq(null);
     });
+
+    it("Returns null if we are inside of a inline code", () => {
+        quill.setContents([OpUtils.code("@Somebody")]);
+        const selection = { index: 3, length: 0 };
+        quill.setSelection(selection);
+        expect(getMentionRange(quill, selection)).to.eq(null);
+    });
+
+    it("Returns null if we are inside of a link", () => {
+        quill.setContents([OpUtils.link("http://test.com", "@Somebody")]);
+        const selection = { index: 3, length: 0 };
+        quill.setSelection(selection);
+        expect(getMentionRange(quill, selection)).to.eq(null);
+    });
 });
 
 describe("getIDForQuill()", () => {

--- a/plugins/rich-editor/src/scripts/quill/utility.ts
+++ b/plugins/rich-editor/src/scripts/quill/utility.ts
@@ -278,6 +278,8 @@ export function getBlotAtIndex<T extends Blot>(
 
 const MIN_MENTION_LENGTH = 1;
 
+const EXCLUDED_MENTION_BLOTS = [CodeBlockBlot, CodeBlot, Link];
+
 /**
  * Get the range of text to convert to a mention.
  *
@@ -297,12 +299,10 @@ export function getMentionRange(quill: Quill, currentSelection: RangeStatic | nu
         return null;
     }
 
-    if (
-        rangeContainsBlot(quill, CodeBlockBlot, currentSelection) ||
-        rangeContainsBlot(quill, CodeBlot, currentSelection) ||
-        rangeContainsBlot(quill, Link, currentSelection)
-    ) {
-        return null;
+    for (const excludedBlot of EXCLUDED_MENTION_BLOTS) {
+        if (rangeContainsBlot(quill, excludedBlot, currentSelection)) {
+            return null;
+        }
     }
 
     // Get details about our current leaf (likely a TextBlot).

--- a/plugins/rich-editor/src/scripts/quill/utility.ts
+++ b/plugins/rich-editor/src/scripts/quill/utility.ts
@@ -14,6 +14,7 @@ import BlockBlot from "quill/blots/block";
 import CodeBlockBlot from "@rich-editor/quill/blots/blocks/CodeBlockBlot";
 import { logDebug } from "@vanilla/utils";
 import CodeBlot from "@rich-editor/quill/blots/inline/CodeBlot";
+import Link from "quill/formats/link";
 
 interface IBoundary {
     start: number;
@@ -298,7 +299,8 @@ export function getMentionRange(quill: Quill, currentSelection: RangeStatic | nu
 
     if (
         rangeContainsBlot(quill, CodeBlockBlot, currentSelection) ||
-        rangeContainsBlot(quill, CodeBlot, currentSelection)
+        rangeContainsBlot(quill, CodeBlot, currentSelection) ||
+        rangeContainsBlot(quill, Link, currentSelection)
     ) {
         return null;
     }


### PR DESCRIPTION
Fixes https://github.com/vanilla/knowledge/issues/1171

- Adds failing test.
- Fixes the test by excluding links when trying to get a mention range.

It's illegal to try and insert a link (mention) inside of another link. We already have a few excluded blots for mentions, so I've added link to the list