### PR TITLE
Add Psr\SimpleCache support to the app

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -54,10 +54,14 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->setConstructorArgs([null, null])
 
     // Cache
-    ->rule('Gdn_Cache')
+    ->rule(\Gdn_Cache::class)
     ->setShared(true)
-    ->setFactory(['Gdn_Cache', 'initialize'])
+    ->setFactory([\Gdn_Cache::class, 'initialize'])
     ->addAlias('Cache')
+
+    ->rule(\Psr\SimpleCache\CacheInterface::class)
+    ->setShared(true)
+    ->setFactory([\Vanilla\Adapters\SimpleCacheAdapter::class, 'fromGdnCache'])
 
     // Configuration
     ->rule('Gdn_Configuration')

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,9 @@
         "vanilla/nbbc": "~2.1",
         "vanilla/safecurl": "~0.9",
         "vanilla/vanilla-connect": "~0.0",
-        "twig/twig": "^2.5"
+        "twig/twig": "^2.5",
+        "psr/simple-cache": "^1.0",
+        "symfony/cache": "^3.4"
     },
     "require-dev": {
         "exussum12/coverage-checker": "~0.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7fc0a1883fc32a13c4ae8f9ab9abd2a1",
+    "content-hash": "e608d15898ebde87f745f45a80bee1fc",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -292,6 +292,52 @@
             "time": "2018-11-15T22:32:31+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -388,6 +434,54 @@
             "time": "2018-11-20T15:27:04+00:00"
         },
         {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
             "name": "ralouphie/mimey",
             "version": "2.1.0",
             "source": {
@@ -479,6 +573,132 @@
                 "templating"
             ],
             "time": "2018-09-12T20:54:16+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "v3.4.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "5c7bd827617fcb9b13e04e423c31c0fb0bcf0160"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/5c7bd827617fcb9b13e04e423c31c0fb0bcf0160",
+                "reference": "5c7bd827617fcb9b13e04e423c31c0fb0bcf0160",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/cache": "~1.0",
+                "psr/log": "~1.0",
+                "psr/simple-cache": "^1.0",
+                "symfony/polyfill-apcu": "~1.1"
+            },
+            "conflict": {
+                "symfony/var-dumper": "<3.3"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "~1.6",
+                "doctrine/dbal": "~2.4",
+                "predis/predis": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Cache component with PSR-6, PSR-16, and tags",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "time": "2019-09-29T21:19:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-apcu",
+            "version": "v1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-apcu.git",
+                "reference": "71ce80635d5dcd67772b4dda00b86068595f64d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-apcu/zipball/71ce80635d5dcd67772b4dda00b86068595f64d5",
+                "reference": "71ce80635d5dcd67772b4dda00b86068595f64d5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Apcu\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting apcu_* functions to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "apcu",
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/library/Vanilla/Adapters/SimpleCacheAdapter.php
+++ b/library/Vanilla/Adapters/SimpleCacheAdapter.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Adapters;
+
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Simple\MemcachedCache;
+use Symfony\Component\Cache\Simple\NullCache;
+
+/**
+ * Adapt SimpleCache from Gdn_Cache.
+ *
+ * This is a backwards-compatibility class so that we can use a standards-based cache class in new code.
+ */
+class SimpleCacheAdapter {
+    public static function fromGdnCache(\Gdn_Cache $cache): CacheInterface {
+        switch (get_class($cache)) {
+            case \Gdn_Memcached::class:
+                /* @var \Gdn_Memcached $cache */
+                $result = new MemcachedCache($cache->getMemcached());
+                break;
+            default:
+                $result = new NullCache();
+        }
+        return $result;
+    }
+}

--- a/library/core/class.memcached.php
+++ b/library/core/class.memcached.php
@@ -849,6 +849,15 @@ class Gdn_Memcached extends Gdn_Cache {
     public function resultMessage() {
         return $this->memcache->getResultMessage();
     }
+
+    /**
+     * Get the driver instance for this cache.
+     *
+     * @return Memcached
+     */
+    public function getMemcached(): \Memcached {
+        return $this->memcache;
+    }
 }
 
 /**

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -103,6 +103,10 @@ class Bootstrap {
             ->setAliasOf(NullCache::class)
             ->addAlias('Cache')
 
+            ->rule(\Psr\SimpleCache\CacheInterface::class)
+            ->setShared(true)
+            ->setFactory([\Vanilla\Adapters\SimpleCacheAdapter::class, 'fromGdnCache'])
+
             // Configuration
             ->rule(ConfigurationInterface::class)
             ->setClass(\Gdn_Configuration::class)

--- a/tests/Library/Vanilla/Adapters/AdaptersTest.php
+++ b/tests/Library/Vanilla/Adapters/AdaptersTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Adapters;
+
+use Psr\SimpleCache\CacheInterface;
+use VanillaTests\SharedBootstrapTestCase;
+
+/**
+ * Basic integration smoke tests for adapters.
+ */
+class AdaptersTest extends SharedBootstrapTestCase {
+
+    /**
+     * Smoke test the simple cache adapter.
+     */
+    public function testSimpleCacheContainer() {
+        $cache = static::container()->get(CacheInterface::class);
+
+        $this->assertInstanceOf(CacheInterface::class, $cache);
+    }
+}


### PR DESCRIPTION
This PR adds PSR caching support to Vanilla. There is a simple adapter class that acts as a container factory.

closes #9519.