### PR TITLE
Fix caching of temporary redirects

### DIFF
--- a/applications/dashboard/views/entry/signout.php
+++ b/applications/dashboard/views/entry/signout.php
@@ -15,11 +15,13 @@ $Session = Gdn::session();
                     <?php if ($Session->isValid()) { ?>
                         <p id="SignoutWrap">
                             <script>
-                                jQuery(document).ready(function($) {
-                                    var url = $('#SignoutLink').attr('href');
+                                document.addEventListener("DOMContentLoaded", function() {
+                                    var url = document.getElementById('SignoutLink').getAttribute('href');;
                                     if (url) {
-                                        $('#SignoutWrap').hide();
-                                        $('#LeavingWrap').show();
+                                        var signoutWrap = document.getElementById('SignoutWrap');
+                                        var leavingWrap = document.getElementById('LeavingWrap');
+                                        signoutWrap.style.display = "none"; // Hide
+                                        leavingWrap.style.display = "block"; // Show
                                         window.location.replace(url);
                                     }
                                 });

--- a/library/Vanilla/Web/CacheControlMiddleware.php
+++ b/library/Vanilla/Web/CacheControlMiddleware.php
@@ -74,6 +74,12 @@ class CacheControlMiddleware {
                 $this->session->isValid() || $request->getMethod() !== 'GET' ?  self::NO_CACHE : self::PUBLIC_CACHE
             );
         }
+
+        if ($response->getHeader('Cache-Control') !== self::NO_CACHE) {
+            // Unless we havy NO_CACHE set make sure to set the vary header.
+            $response->setHeader('Vary', self::VARY_COOKIE);
+        }
+
         foreach (static::getHttp10Headers($response->getHeader('Cache-Control')) as $key => $value) {
             $response->setHeader($key, $value);
         }

--- a/library/Vanilla/Web/CacheControlMiddleware.php
+++ b/library/Vanilla/Web/CacheControlMiddleware.php
@@ -87,9 +87,9 @@ class CacheControlMiddleware {
      * @param string $cacheControl The value of the cache control header.
      */
     public static function sendCacheControlHeaders(string $cacheControl) {
-        header("Cache-Control: $cacheControl");
+        safeHeader("Cache-Control: $cacheControl");
         foreach (static::getHttp10Headers($cacheControl) as $key => $value) {
-            header("$key: $value");
+            safeHeader("$key: $value");
         }
     }
 }

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -2107,10 +2107,9 @@ class Gdn_Controller extends Gdn_Pluggable {
                 safeHeader("$name: $value", true, $code);
             }
         }
+
         if (!empty($this->_Headers['Cache-Control'])) {
-            foreach (\Vanilla\Web\CacheControlMiddleware::getHttp10Headers($this->_Headers['Cache-Control']) as $key => $value) {
-                safeHeader("$key: $value", true);
-            }
+            \Vanilla\Web\CacheControlMiddleware::sendCacheControlHeaders($this->_Headers['Cache-Control']);
         }
 
         // Empty the collection after sending

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3058,10 +3058,9 @@ if (!function_exists('redirectTo')) {
             CacheControlMiddleware::sendCacheControlHeaders(CacheControlMiddleware::NO_CACHE);
         }
 
-        $controller = Gdn::controller();
-        if ($controller !== null
-            && in_array($controller->deliveryType(), [DELIVERY_TYPE_ASSET, DELIVERY_TYPE_VIEW], true)
-            && $controller->deliveryMethod() === DELIVERY_METHOD_JSON) {
+        if (Gdn::controller() !== null
+            && in_array(Gdn::controller()->deliveryType(), [DELIVERY_TYPE_ASSET, DELIVERY_TYPE_VIEW], true)
+            && Gdn::controller()->deliveryMethod() === DELIVERY_METHOD_JSON) {
             // This is a bit of a kludge, but it solves a perpetual gotcha when we switch full page forms to AJAX forms and forget about redirects.
             echo json_encode([
                 'FormSaved' => true,

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3054,22 +3054,11 @@ if (!function_exists('redirectTo')) {
         // This would cause http://evil.domain\@trusted.domain/ to be converted to http://evil.domain/@trusted.domain/
         $url = str_replace('\\', '%5c', $url);
 
-        $controller = Gdn::controller();
-
-        // Send any headers that were put together.
-        if ($controller !== null) {
-            if ($statusCode === 302) {
-                // 302 redirects are TEMPORARY and we don't want them cached by the browser.
-                $controller->setHeader('Cache-Control', CacheControlMiddleware::NO_CACHE);
-            }
-
-            // Send the headers the controller has collected so far.
-            $controller->sendHeaders();
-        } elseif ($statusCode === 302) {
-            // No controller, but we still shouldn't cache temporary redirects
-            safeHeader('Cache-Control', CacheControlMiddleware::NO_CACHE);
+        if ($statusCode === 302) {
+            CacheControlMiddleware::sendCacheControlHeaders(CacheControlMiddleware::NO_CACHE);
         }
 
+        $controller = Gdn::controller();
         if ($controller !== null
             && in_array($controller->deliveryType(), [DELIVERY_TYPE_ASSET, DELIVERY_TYPE_VIEW], true)
             && $controller->deliveryMethod() === DELIVERY_METHOD_JSON) {

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -8,6 +8,8 @@
  * @since 2.0
  */
 
+use Vanilla\Web\CacheControlMiddleware;
+
 if (!function_exists('absoluteSource')) {
     /**
      * Get the full url of a source path relative to a base url.
@@ -3052,9 +3054,25 @@ if (!function_exists('redirectTo')) {
         // This would cause http://evil.domain\@trusted.domain/ to be converted to http://evil.domain/@trusted.domain/
         $url = str_replace('\\', '%5c', $url);
 
-        if (Gdn::controller() !== null
-            && in_array(Gdn::controller()->deliveryType(), [DELIVERY_TYPE_ASSET, DELIVERY_TYPE_VIEW], true)
-            && Gdn::controller()->deliveryMethod() === DELIVERY_METHOD_JSON) {
+        $controller = Gdn::controller();
+
+        // Send any headers that were put together.
+        if ($controller !== null) {
+            if ($statusCode === 302) {
+                // 302 redirects are TEMPORARY and we don't want them cached by the browser.
+                $controller->setHeader('Cache-Control', CacheControlMiddleware::NO_CACHE);
+            }
+
+            // Send the headers the controller has collected so far.
+            $controller->sendHeaders();
+        } elseif ($statusCode === 302) {
+            // No controller, but we still shouldn't cache temporary redirects
+            safeHeader('Cache-Control', CacheControlMiddleware::NO_CACHE);
+        }
+
+        if ($controller !== null
+            && in_array($controller->deliveryType(), [DELIVERY_TYPE_ASSET, DELIVERY_TYPE_VIEW], true)
+            && $controller->deliveryMethod() === DELIVERY_METHOD_JSON) {
             // This is a bit of a kludge, but it solves a perpetual gotcha when we switch full page forms to AJAX forms and forget about redirects.
             echo json_encode([
                 'FormSaved' => true,


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/9374

302 redirects are temporary and should have no cache headers.

Upon investigation I found we were not actually sending any additional headers when return 302 redirects.

## `redirectTo()` changes

- Ensure `CacheControlMiddleware::NO_CACHE` is sent for 302 redirects.
- Make sure `safeHeader` is used in `CacheControlMiddleware`. Not really sure if there would be an issue without it, but I don't know all the contexts, `redirectTo()` might be called.

## Signout view

During testing I found the signout view actually doesn't work with `DeferredLegacyScripts` on. Updating this minor script to not rely on jquery fixes it though.

## CacheControlMiddleWare

- Update the middleware itself to send the vary header. This was causing pages using the new controller that redirect to signin to not invalidate properly after the cookie was set.