### PR TITLE
Add index endpoint to the locales API

### DIFF
--- a/applications/dashboard/controllers/api/LocalesApiController.php
+++ b/applications/dashboard/controllers/api/LocalesApiController.php
@@ -5,21 +5,18 @@
  * @license GPL-2.0-only
  */
 
-use Garden\Container\Container;
 use Garden\Schema\Schema;
 use Garden\Web\Data;
-use Vanilla\Addon;
-use Vanilla\ApiUtils;
-use Vanilla\Contracts\AddonProviderInterface;
 use Vanilla\Web\Controller;
 
 /**
  * Endpoint for getting translations.
  */
 class LocalesApiController extends Controller {
-    /**
-     * @var \Gdn_Locale
-     */
+
+    const GET_ALL_REDUX_KEY = "@@locales/GET_ALL_DONE";
+
+    /** @var \Gdn_Locale */
     private $locale;
 
     /** @var LocaleModel */

--- a/applications/dashboard/controllers/api/LocalesApiController.php
+++ b/applications/dashboard/controllers/api/LocalesApiController.php
@@ -6,7 +6,11 @@
  */
 
 use Garden\Container\Container;
+use Garden\Schema\Schema;
 use Garden\Web\Data;
+use Vanilla\Addon;
+use Vanilla\ApiUtils;
+use Vanilla\Contracts\AddonProviderInterface;
 use Vanilla\Web\Controller;
 
 /**
@@ -18,13 +22,98 @@ class LocalesApiController extends Controller {
      */
     private $locale;
 
+    /** @var LocaleModel */
+    private $localeModel;
+
     /**
      * LocalesApiController constructor.
      *
      * @param \Gdn_Locale $locale
+     * @param LocaleModel $localeModel
      */
-    public function __construct(\Gdn_Locale $locale) {
+    public function __construct(\Gdn_Locale $locale, LocaleModel $localeModel) {
         $this->locale = $locale;
+        $this->localeModel = $localeModel;
+    }
+
+    public function index() {
+        $out = $this->schema([":a" => $this->localeSchema()], 'out');
+        $enabled = $this->getEnabledLocales();
+        $this->expandDisplayNames($enabled, array_column($enabled, 'localeKey'));
+        $locales = $out->validate($enabled);
+
+        return $locales;
+    }
+
+    /**
+     * @return Schema
+     */
+    private function localeSchema() {
+        return Schema::parse([
+            'localeID:s',
+            'localeKey:s',
+            'regionalKey:s',
+            'displayNames:o',
+        ]);
+    }
+
+    /**
+     * Get all enabled locales of the site.
+     *
+     * @return array[]
+     */
+    private function getEnabledLocales(): array {
+        $locales = [];
+        $locales += $this->localeModel->enabledLocalePacks(true);
+        $result = [[
+            'localeID' => 'en',
+            'localeKey' => 'en',
+            'regionalKey' => 'en',
+        ]];
+        foreach ($locales as $localeID => $locale) {
+            $result[] = [
+                'localeID' => $localeID,
+                'localeKey' => substr($locale['Locale'], 0, 2),
+                'regionalKey' => $locale['Locale'],
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Expand display names for the locales.
+     *
+     * @param array $rows
+     * @param array $locales
+     */
+    public function expandDisplayNames(array &$rows, array $locales) {
+        if (count($rows) === 0) {
+            return;
+        }
+        reset($rows);
+        $single = is_string(key($rows));
+
+        $populate = function (array &$row, array $locales) {
+            $displayNames = [];
+            foreach ($locales as $locale) {
+                $displayName = \Locale::getDisplayLanguage($row["localeKey"], $locale);
+
+                // Standardize capitalization
+                $displayName = mb_convert_case($displayName, MB_CASE_TITLE);
+
+                $displayNames[$locale] = $displayName;
+            }
+            $row['displayNames'] = $displayNames;
+        };
+
+        if ($single) {
+            $populate($rows, $locales);
+        } else {
+            foreach ($rows as &$row) {
+                $populate($row, $locales);
+            }
+        }
     }
 
     /**

--- a/applications/dashboard/controllers/api/LocalesApiController.php
+++ b/applications/dashboard/controllers/api/LocalesApiController.php
@@ -36,7 +36,13 @@ class LocalesApiController extends Controller {
         $this->localeModel = $localeModel;
     }
 
-    public function index() {
+    /**
+     * Get all enabled locales for the site.
+     *
+     * @return array
+     */
+    public function index(): array {
+        $this->permission();
         $out = $this->schema([":a" => $this->localeSchema()], 'out');
         $enabled = $this->getEnabledLocales();
         $this->expandDisplayNames($enabled, array_column($enabled, 'localeKey'));

--- a/applications/dashboard/openapi/locales.yml
+++ b/applications/dashboard/openapi/locales.yml
@@ -87,8 +87,8 @@ components:
           type: object
           description: Translatable names of the
           example: {
-            en: French,
-            fr: Français,
-            de: Französisch,
+            "en": "French",
+            "fr": "Français",
+            "de": "Französisch",
           }
       type: object

--- a/applications/dashboard/openapi/locales.yml
+++ b/applications/dashboard/openapi/locales.yml
@@ -1,6 +1,19 @@
 openapi: 3.0.2
-info:
 paths:
+  '/locales':
+    get:
+      summary: Get all enabled locales on the site.
+      tags:
+        - Locales
+      responses:
+        '200':
+          description: A list of enabled locales
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Locale'
   '/locales/translations/{locale}':
     get:
       summary: Get all of the application's translation strings.
@@ -54,3 +67,28 @@ components:
         Whether or not output is cached.
       schema:
         type: string
+  schemas:
+    Locale:
+      properties:
+        localeID:
+          description: The key of the locale addon.
+          minLength: 1
+          type: string
+          example: vf_fr_CA,
+        localeKey:
+          description: The normalized key of the locale without any regional modifier.
+          type: string
+          example: fr
+        regionalKey:
+          description: The normalized key of the locale with a regional modifier if it exists.
+          type: string
+          example: fr_CA
+        displayNames:
+          type: object
+          description: Translatable names of the
+          example: {
+            en: French,
+            fr: Français,
+            de: Französisch,
+          }
+      type: object

--- a/applications/dashboard/openapi/locales.yml
+++ b/applications/dashboard/openapi/locales.yml
@@ -1,4 +1,5 @@
 openapi: 3.0.2
+info:
 paths:
   '/locales':
     get:

--- a/applications/dashboard/openapi/locales.yml
+++ b/applications/dashboard/openapi/locales.yml
@@ -86,9 +86,5 @@ components:
         displayNames:
           type: object
           description: Translatable names of the
-          example: {
-            "en": "French",
-            "fr": "Français",
-            "de": "Französisch",
-          }
+          example: { "en": "French", "fr": "Français", "de": "Französisch" }
       type: object

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,10 +9,12 @@ use Vanilla\Formatting\Html\HtmlEnhancer;
 use Vanilla\Formatting\Html\HtmlSanitizer;
 use Vanilla\InjectableInterface;
 use Vanilla\Contracts;
+use Vanilla\Models\LocalePreloadProvider;
 use Vanilla\Site\SingleSiteSectionProvider;
 use Vanilla\Utility\ContainerUtils;
 use \Vanilla\Formatting\Formats;
 use Firebase\JWT\JWT;
+use Vanilla\Web\Page;
 use Vanilla\Web\TwigEnhancer;
 
 if (!defined('APPLICATION')) exit();
@@ -366,6 +368,14 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->addCall('setDispatchEventName', ['SchedulerDispatch'])
     ->addCall('setDispatchedEventName', ['SchedulerDispatched'])
     ->setShared(true)
+
+    // Controller data preloading
+    ->rule(Page::class)
+    ->setInherit(true)
+    ->addCall('registerReduxActionProvider', ['provider' => new Reference(LocalePreloadProvider::class)])
+    ->rule(Gdn_Controller::class)
+    ->setInherit(true)
+    ->addCall('registerReduxActionProvider', ['provider' => new Reference(LocalePreloadProvider::class)])
 ;
 
 // Run through the bootstrap with dependencies.

--- a/library/Vanilla/Models/LocalePreloadProvider.php
+++ b/library/Vanilla/Models/LocalePreloadProvider.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models;
+
+use Garden\Web\Data;
+use Vanilla\Web\JsInterpop\ReduxAction;
+use Vanilla\Web\JsInterpop\ReduxActionProviderInterface;
+
+/**
+ * Page preloader for locale information.
+ */
+class LocalePreloadProvider implements ReduxActionProviderInterface {
+
+    /** @var \LocalesApiController */
+    private $localesApi;
+
+    /**
+     * DI.
+     *
+     * @param \LocalesApiController $localesApi
+     */
+    public function __construct(\LocalesApiController $localesApi) {
+        $this->localesApi = $localesApi;
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function createActions(): array {
+        $locales = $this->localesApi->index();
+
+        return [
+            new ReduxAction(
+                \LocalesApiController::GET_ALL_REDUX_KEY,
+                Data::box($locales),
+                []
+            ),
+        ];
+    }
+}


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/issues/1240 and https://github.com/vanilla/knowledge/issues/1233

## Changes

- Adds an index endpoint to the `/api/v2/locales` endpoint.
  - Lists all enabled locales and their translations.
- This API endpoint will remove the need for the expand `locales` param on the [subcommunities API](https://github.com/vanilla/multisite/blob/master/plugins/subcommunities/controllers/Api/SubcommunitiesApiController.php#L181-L202) these names are required even when that plugin is disabled.