### PR TITLE
Allow truly dynamic redux reducers

### DIFF
--- a/library/src/scripts/redux/getStore.ts
+++ b/library/src/scripts/redux/getStore.ts
@@ -4,7 +4,7 @@
  */
 
 import { createStore, compose, applyMiddleware, combineReducers, Store, AnyAction } from "redux";
-import { getReducers, getReducersReady } from "@library/redux/reducerRegistry";
+import { getReducers, ICoreStoreState } from "@library/redux/reducerRegistry";
 import thunk from "redux-thunk";
 
 // There may be an initial state to import.
@@ -30,7 +30,7 @@ const enhancer = composeEnhancers(applyMiddleware(...middleware));
 // Build the store, add devtools extension support if it's available.
 let store;
 
-export default function getStore<S>(): Store<S> {
+export default function getStore<S = ICoreStoreState>(): Store<S, any> {
     if (store === undefined) {
         // Get our reducers.
         const reducer = combineReducers(getReducers());
@@ -41,12 +41,4 @@ export default function getStore<S>(): Store<S> {
     }
 
     return store;
-}
-
-export function getDeferredStoreState<S, T>(fallback: T): S | T {
-    if (getReducersReady()) {
-        return getStore<S>().getState();
-    } else {
-        return fallback;
-    }
 }

--- a/library/src/scripts/redux/reducerRegistry.ts
+++ b/library/src/scripts/redux/reducerRegistry.ts
@@ -7,47 +7,31 @@
  * @license GPL-2.0-only
  */
 
-import { onReady } from "@library/utility/appUtils";
 import { IThemeState, themeReducer } from "@library/theming/themeReducer";
 import { IUsersStoreState, usersReducer } from "@library/features/users/userModel";
-import { logError } from "@vanilla/utils";
-import { Reducer, ReducersMapObject } from "redux";
+import { Reducer, ReducersMapObject, combineReducers } from "redux";
+import { ILocaleState, localeReducer } from "@library/locales/localeReducer";
+import getStore from "@library/redux/getStore";
 
-let haveGot = false;
-let wasReadyCalled = false;
-const reducers = {};
-
-onReady(() => {
-    wasReadyCalled = true;
-});
+const dynamicReducers = {};
 
 export function registerReducer(name: string, reducer: Reducer) {
-    if (haveGot) {
-        logError("Cannot register reducer %s after reducers applied to the store.", name);
-    } else {
-        reducers[name] = reducer;
-    }
+    dynamicReducers[name] = reducer;
+    getStore().replaceReducer(combineReducers(getReducers()));
 }
 
 export interface ICoreStoreState extends IUsersStoreState {
     theme: IThemeState;
-}
-
-export function getReducersReady(): boolean {
-    return haveGot;
+    locales: ILocaleState;
 }
 
 export function getReducers(): ReducersMapObject<any, any> {
-    haveGot = true;
-
-    if (!wasReadyCalled) {
-        logError("getReducers() was called before onReady");
-    }
-
     return {
+        // We have a few static reducers.
         users: usersReducer,
         theme: themeReducer,
-        ...reducers,
+        locales: localeReducer,
+        ...dynamicReducers,
     };
 }
 

--- a/library/src/scripts/redux/reducerRegistry.ts
+++ b/library/src/scripts/redux/reducerRegistry.ts
@@ -10,7 +10,6 @@
 import { IThemeState, themeReducer } from "@library/theming/themeReducer";
 import { IUsersStoreState, usersReducer } from "@library/features/users/userModel";
 import { Reducer, ReducersMapObject, combineReducers } from "redux";
-import { ILocaleState, localeReducer } from "@library/locales/localeReducer";
 import getStore from "@library/redux/getStore";
 
 const dynamicReducers = {};
@@ -22,7 +21,6 @@ export function registerReducer(name: string, reducer: Reducer) {
 
 export interface ICoreStoreState extends IUsersStoreState {
     theme: IThemeState;
-    locales: ILocaleState;
 }
 
 export function getReducers(): ReducersMapObject<any, any> {
@@ -30,7 +28,6 @@ export function getReducers(): ReducersMapObject<any, any> {
         // We have a few static reducers.
         users: usersReducer,
         theme: themeReducer,
-        locales: localeReducer,
         ...dynamicReducers,
     };
 }

--- a/library/src/scripts/styles/styleUtils.ts
+++ b/library/src/scripts/styles/styleUtils.ts
@@ -6,9 +6,8 @@
 
 import { NestedCSSProperties } from "typestyle/lib/types";
 import { style } from "typestyle";
-import { getDeferredStoreState } from "@library/redux/getStore";
+import getStore from "@library/redux/getStore";
 import { getMeta } from "@library/utility/appUtils";
-import { ICoreStoreState } from "@library/redux/reducerRegistry";
 import memoize from "lodash/memoize";
 import merge from "lodash/merge";
 import { color } from "csx";
@@ -71,9 +70,9 @@ export function styleFactory(componentName: string) {
  */
 export function useThemeCache<Cb>(callback: Cb): Cb {
     const makeCacheKey = (...args) => {
-        const storeState = getDeferredStoreState<ICoreStoreState, null>(null);
+        const storeState = getStore().getState();
         const themeKey = getMeta("ui.themeKey", "default");
-        const status = storeState ? storeState.theme.assets.status : "not loaded yet";
+        const status = storeState.theme.assets.status;
         const cacheKey = themeKey + status;
         return cacheKey + JSON.stringify(args);
     };

--- a/library/src/scripts/theming/getThemeVariables.ts
+++ b/library/src/scripts/theming/getThemeVariables.ts
@@ -3,11 +3,10 @@
  * @license GPL-2.0-only
  */
 
-import { getDeferredStoreState } from "@library/redux/getStore";
-import { ICoreStoreState } from "@library/redux/reducerRegistry";
+import getStore from "@library/redux/getStore";
 
 export function getThemeVariables() {
-    const state = getDeferredStoreState<ICoreStoreState, null>(null);
+    const state = getStore().getState();
     if (state !== null) {
         const assets = state.theme.assets.data || {};
         const variables = assets.variables ? assets.variables.data : {};

--- a/library/src/scripts/theming/loadThemeFonts.ts
+++ b/library/src/scripts/theming/loadThemeFonts.ts
@@ -3,8 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import { getDeferredStoreState } from "@library/redux/getStore";
-import { ICoreStoreState } from "@library/redux/reducerRegistry";
+import getStore from "@library/redux/getStore";
 import WebFont from "webfontloader";
 
 const defaultFontConfig: WebFont.Config = {
@@ -14,25 +13,23 @@ const defaultFontConfig: WebFont.Config = {
 };
 
 export function loadThemeFonts() {
-    const state = getDeferredStoreState<ICoreStoreState, null>(null);
-    if (state !== null) {
-        const assets = state.theme.assets.data || {};
-        const { fonts } = assets;
+    const state = getStore().getState();
+    const assets = state.theme.assets.data || {};
+    const { fonts } = assets;
 
-        if (fonts && fonts.length > 0) {
-            const webFontConfig: WebFont.Config = {
-                custom: {
-                    families: fonts.map(font => font.name),
-                    urls: fonts.map(font => font.url),
-                },
-            };
+    if (fonts && fonts.length > 0) {
+        const webFontConfig: WebFont.Config = {
+            custom: {
+                families: fonts.map(font => font.name),
+                urls: fonts.map(font => font.url),
+            },
+        };
 
-            if (webFontConfig.custom && webFontConfig.custom.urls && webFontConfig.custom.urls.length > 0) {
-                WebFont.load(webFontConfig);
-            }
-        } else {
-            // If the theme has no font config of its own, load the default.
-            WebFont.load(defaultFontConfig);
+        if (webFontConfig.custom && webFontConfig.custom.urls && webFontConfig.custom.urls.length > 0) {
+            WebFont.load(webFontConfig);
         }
+    } else {
+        // If the theme has no font config of its own, load the default.
+        WebFont.load(defaultFontConfig);
     }
 }


### PR DESCRIPTION
## Context

Historically we have been very picky about the order/when redux reducers are configured.

The previous rule, which was enforced in the code was that you were not allowed to register a reducer after the store had been fetched.

There is no longer any need for this. With the latest version of redux (which we are using), the store provides a `replaceReducer` that lets us add extra reducers at any time.

## The PR

- I've remove all checks that the store has already been fetched/onReady called.
- Remove `getDeferredStoreState()` which is no longer necessary. Usages have been fixed.
- Update our reducer registrations to replace reducers including all dynamic reducers. This is implemented similar to [this example from the redux documentation](https://redux.js.org/recipes/code-splitting#defining-an-injectreducer-function)