### PR TITLE
Implement locale utilities using /api/v2/locales endpoint in @vanilla/i18n package

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -5,6 +5,7 @@
     "dependencies": {
         "@vanilla/dom-utils": "^3.0.1",
         "@vanilla/react-utils": "^3.0.1",
-        "@vanilla/utils": "^3.0.1"
+        "@vanilla/utils": "^3.0.1",
+        "@vanilla/i18n": "^3.0.1"
     }
 }

--- a/library/src/scripts/AppContext.tsx
+++ b/library/src/scripts/AppContext.tsx
@@ -16,6 +16,7 @@ import { inheritHeightClass } from "@library/styles/styleHelpers";
 import classNames from "classnames";
 import { style } from "typestyle";
 import { percent } from "csx";
+import { LocaleProvider } from "@vanilla/i18n";
 
 interface IProps {
     children: React.ReactNode;
@@ -39,20 +40,22 @@ export function AppContext(props: IProps) {
         <div className={classNames("js-appContext", rootStyle, inheritHeightClass())}>
             {/* A wrapper div is required or will cause error when no routes match or in hot reload */}
             <Provider store={store}>
-                <LiveAnnouncer>
-                    <ThemeProvider
-                        disabled={props.noTheme}
-                        errorComponent={props.errorComponent || null}
-                        themeKey={getMeta("ui.themeKey", "keystone")}
-                        variablesOnly={props.variablesOnly}
-                    >
-                        <FontSizeCalculatorProvider>
-                            <ScrollOffsetProvider scrollWatchingEnabled={false}>
-                                <DeviceProvider>{props.children}</DeviceProvider>
-                            </ScrollOffsetProvider>
-                        </FontSizeCalculatorProvider>
-                    </ThemeProvider>
-                </LiveAnnouncer>
+                <LocaleProvider>
+                    <LiveAnnouncer>
+                        <ThemeProvider
+                            disabled={props.noTheme}
+                            errorComponent={props.errorComponent || null}
+                            themeKey={getMeta("ui.themeKey", "keystone")}
+                            variablesOnly={props.variablesOnly}
+                        >
+                            <FontSizeCalculatorProvider>
+                                <ScrollOffsetProvider scrollWatchingEnabled={false}>
+                                    <DeviceProvider>{props.children}</DeviceProvider>
+                                </ScrollOffsetProvider>
+                            </FontSizeCalculatorProvider>
+                        </ThemeProvider>
+                    </LiveAnnouncer>
+                </LocaleProvider>
             </Provider>
         </div>
     );

--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -14,10 +14,13 @@ import { onPageView } from "@library/pageViews/pageViewTracking";
 import { History } from "history";
 import { _mountComponents } from "@library/utility/componentRegistry";
 import { blotCSS } from "@rich-editor/quill/components/blotStyles";
+import { bootstrapLocales } from "@library/locales/localeBootstrap";
 
 // Inject the debug flag into the utility.
 const debugValue = getMeta("context.debug", getMeta("debug", false));
 debug(debugValue);
+
+bootstrapLocales();
 
 // Export the API to the global object.
 gdn.apiv2 = apiv2;

--- a/library/src/scripts/locales/localeActions.ts
+++ b/library/src/scripts/locales/localeActions.ts
@@ -1,0 +1,32 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { ILocale } from "@vanilla/i18n";
+import { actionCreatorFactory } from "typescript-fsa";
+import { IApiError, LoadStatus } from "@library/@types/api/core";
+import { bindThunkAction } from "@library/redux/ReduxActions";
+import apiv2 from "@library/apiv2";
+import getStore from "@library/redux/getStore";
+
+const createAction = actionCreatorFactory("@@locales");
+export const getAllLocalesACs = createAction.async<{}, ILocale[], IApiError>("GET_ALL");
+
+/**
+ * Thunk for fetching locales.
+ */
+export function fetchLocalesFromApi(force?: boolean): Promise<ILocale[]> {
+    const { dispatch, getState } = getStore();
+
+    const localeLoadable = getState().locales.locales;
+    if (!force && localeLoadable.status === LoadStatus.SUCCESS) {
+        return Promise.resolve(localeLoadable.data!);
+    }
+
+    const apiThunk = bindThunkAction(getAllLocalesACs, async () => {
+        const response = await apiv2.get(`/locales`);
+        return response.data;
+    })();
+    return apiThunk(dispatch, getState, {});
+}

--- a/library/src/scripts/locales/localeBootstrap.ts
+++ b/library/src/scripts/locales/localeBootstrap.ts
@@ -1,0 +1,19 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { fetchLocalesFromApi } from "@library/locales/localeActions";
+import { setCurrentLocale, loadLocales } from "@vanilla/i18n";
+import { getMeta } from "@library/utility/appUtils";
+
+export async function bootstrapLocales() {
+    // Fetch the current locale from meta.
+    const currentLocaleValue = getMeta("ui.localeKey", getMeta("ui.locale", null));
+    setCurrentLocale(currentLocaleValue);
+
+    // Register the redux reducer for locales and attempt to fetch them.
+    // They may already be preloaded.
+    const locales = await fetchLocalesFromApi();
+    loadLocales(locales);
+}

--- a/library/src/scripts/locales/localeReducer.ts
+++ b/library/src/scripts/locales/localeReducer.ts
@@ -1,0 +1,38 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { produce } from "immer";
+import { reducerWithInitialState } from "typescript-fsa-reducers";
+import { ILocale } from "@vanilla/i18n";
+import { ILoadable, LoadStatus } from "@library/@types/api/core";
+import { getAllLocalesACs } from "@library/locales/localeActions";
+
+export interface ILocaleState {
+    locales: ILoadable<ILocale[]>;
+}
+
+const DEFAULT_LOCALE_STATE = {
+    locales: {
+        status: LoadStatus.PENDING,
+    },
+};
+
+export const localeReducer = produce(
+    reducerWithInitialState<ILocaleState>(DEFAULT_LOCALE_STATE)
+        .case(getAllLocalesACs.started, (nextState, payload) => {
+            nextState.locales.status = LoadStatus.LOADING;
+            return nextState;
+        })
+        .case(getAllLocalesACs.done, (nextState, payload) => {
+            nextState.locales.status = LoadStatus.SUCCESS;
+            nextState.locales.data = payload.result;
+            return nextState;
+        })
+        .case(getAllLocalesACs.failed, (nextState, payload) => {
+            nextState.locales.status = LoadStatus.ERROR;
+            nextState.locales.error = payload.error;
+            return nextState;
+        }),
+);

--- a/library/src/scripts/redux/reducerRegistry.ts
+++ b/library/src/scripts/redux/reducerRegistry.ts
@@ -10,6 +10,7 @@
 import { IThemeState, themeReducer } from "@library/theming/themeReducer";
 import { IUsersStoreState, usersReducer } from "@library/features/users/userModel";
 import { Reducer, ReducersMapObject, combineReducers } from "redux";
+import { ILocaleState, localeReducer } from "@library/locales/localeReducer";
 import getStore from "@library/redux/getStore";
 
 const dynamicReducers = {};
@@ -21,6 +22,7 @@ export function registerReducer(name: string, reducer: Reducer) {
 
 export interface ICoreStoreState extends IUsersStoreState {
     theme: IThemeState;
+    locales: ILocaleState;
 }
 
 export function getReducers(): ReducersMapObject<any, any> {
@@ -28,6 +30,7 @@ export function getReducers(): ReducersMapObject<any, any> {
         // We have a few static reducers.
         users: usersReducer,
         theme: themeReducer,
+        locales: localeReducer,
         ...dynamicReducers,
     };
 }

--- a/library/src/scripts/utility/appUtils.test.ts
+++ b/library/src/scripts/utility/appUtils.test.ts
@@ -38,22 +38,6 @@ describe("metaDataFunctions", () => {
     });
 });
 
-describe("translate", () => {
-    gdn.translations.foo = "bar";
-
-    it("Translates a string", () => {
-        expect(application.translate("foo")).eq("bar");
-    });
-
-    it("Returns the default string", () => {
-        expect(application.translate("baz", "bam")).eq("bam");
-    });
-
-    it("Falls back to the string code", () => {
-        expect(application.translate("moo")).eq("moo");
-    });
-});
-
 describe("formatUrl", () => {
     it("passes absolute URLs through directly", () => {
         const paths = ["https://test.com", "//test.com", "http://test.com"];

--- a/library/src/scripts/utility/appUtils.tsx
+++ b/library/src/scripts/utility/appUtils.tsx
@@ -5,14 +5,12 @@
  * @license GPL-2.0-only
  */
 
-import React, { ComponentClass } from "react";
-import ReactDOM from "react-dom";
 import gdn from "@library/gdn";
-import { RouteProps } from "react-router";
-import { logError, PromiseOrNormalCallback, logWarning } from "@vanilla/utils";
+import { PromiseOrNormalCallback } from "@vanilla/utils";
 import isUrl from "validator/lib/isURL";
-import { mountReact } from "@vanilla/react-utils";
-import { AppContext } from "@library/AppContext";
+
+// Re-exported for backwards compatibility
+export { t, translate } from "@vanilla/i18n";
 
 /**
  * Get a piece of metadata passed from the server.
@@ -63,32 +61,6 @@ export function setMeta(key: string, value: any) {
     }
     haystack[last] = value;
 }
-
-/**
- * Translate a string into the current locale.
- *
- * @param str - The string to translate.
- * @param defaultTranslation - The default translation to use.
- *
- * @returns Returns the translation or the default.
- */
-export function translate(str: string, defaultTranslation?: string): string {
-    // Codes that begin with @ are considered literals.
-    if (str.substr(0, 1) === "@") {
-        return str.substr(1);
-    }
-
-    if (gdn.translations[str] !== undefined) {
-        return gdn.translations[str];
-    }
-
-    return defaultTranslation !== undefined ? defaultTranslation : str;
-}
-
-/**
- * The t function is an alias for translate.
- */
-export const t = translate;
 
 /**
  * Determine if a string is an allowed URL.

--- a/packages/vanilla-i18n/package.json
+++ b/packages/vanilla-i18n/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "@vanilla/i18n",
+    "main": "./src/index.ts",
+    "module": "./src/index.ts",
+    "version": "3.0.1",
+    "dependencies": {},
+    "peerDependencies": {
+        "react": "^16.0.0",
+        "@vanilla/utils": "^3.0.1"
+    },
+    "devDependencies": {
+        "@vanilla/tsconfig": "^3.0.1"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/vanilla-i18n/src/LocaleDisplayer.tsx
+++ b/packages/vanilla-i18n/src/LocaleDisplayer.tsx
@@ -1,0 +1,43 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+import React from "react";
+import { useLocaleInfo } from "./LocaleProvider";
+import { translate } from "./translationStore";
+import { ILocale } from "./localeStore";
+
+interface IProps {
+    localeContent: string; // The locale key to translate into a full name.
+    displayLocale?: string; // The language to use for the display.
+}
+
+/**
+ * Component for displaying a locale translated into a different locale.
+ *
+ * Currently this relies on the subcommuntiies endpoint to provide all translations for active locale.s
+ */
+export function LocaleDisplayer(props: IProps) {
+    const { locales, currentLocale } = useLocaleInfo();
+    if (!currentLocale) {
+        return null;
+    }
+
+    let selectedLocale: ILocale | null = null;
+    for (const locale of locales) {
+        if (locale.localeKey === props.localeContent) {
+            selectedLocale = locale;
+        }
+    }
+
+    if (!selectedLocale) {
+        return <span lang={props.displayLocale}>Unknown Language {props.localeContent}</span>;
+    }
+
+    let fullLocaleName = selectedLocale.displayNames[props.displayLocale || currentLocale];
+    if (!fullLocaleName) {
+        fullLocaleName = translate(props.localeContent);
+    }
+
+    return <span lang={props.displayLocale}>{fullLocaleName}</span>;
+}

--- a/packages/vanilla-i18n/src/LocaleProvider.tsx
+++ b/packages/vanilla-i18n/src/LocaleProvider.tsx
@@ -1,0 +1,50 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React, { useState, useContext, useEffect } from "react";
+import { ILocale, getLocales, onLocaleChange, getCurrentLocale } from "./localeStore";
+import { logWarning } from "@vanilla/utils";
+
+const LocaleContext = React.createContext<{
+    locales: ILocale[];
+    currentLocale: string | null;
+}>({
+    locales: [],
+    currentLocale: null,
+});
+
+export function LocaleProvider(props: { children?: React.ReactNode }) {
+    const [locales, setLocales] = useState(getLocales());
+    const [currentLocale, setCurrentLocale] = useState(getCurrentLocale());
+
+    if (!currentLocale) {
+        logWarning("No locale loaded for <LocaleProvider />");
+    }
+
+    useEffect(() => {
+        setLocales(getLocales());
+        setCurrentLocale(getCurrentLocale());
+
+        onLocaleChange(() => {
+            setLocales(getLocales());
+            setCurrentLocale(getCurrentLocale());
+        });
+    }, [setLocales, setCurrentLocale]);
+
+    return (
+        <LocaleContext.Provider
+            value={{
+                locales,
+                currentLocale,
+            }}
+        >
+            {props.children}
+        </LocaleContext.Provider>
+    );
+}
+
+export function useLocaleInfo() {
+    return useContext(LocaleContext);
+}

--- a/packages/vanilla-i18n/src/index.ts
+++ b/packages/vanilla-i18n/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+export * from "./LocaleDisplayer";
+export * from "./localeStore";
+export * from "./translationStore";
+export * from "./LocaleProvider";

--- a/packages/vanilla-i18n/src/localeStore.ts
+++ b/packages/vanilla-i18n/src/localeStore.ts
@@ -1,0 +1,63 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+export interface ILocale {
+    localeID: string;
+    localeKey: string;
+    regionalKey: string;
+    displayNames: {
+        [localeKey: string]: string;
+    };
+}
+
+let currentLocale = "en";
+let localeStore: ILocale[] = [];
+let callbacks: Array<() => void> = [];
+
+/**
+ * Get the available locales.
+ */
+export function getLocales(): ILocale[] {
+    return localeStore;
+}
+
+/**
+ * Register a handler for if the locales change.
+ * @param callback
+ */
+export function onLocaleChange(callback: () => void) {
+    callbacks.push(callback);
+}
+
+/**
+ * Set the current locale.
+ */
+export function setCurrentLocale(localeKey: string) {
+    currentLocale = localeKey;
+    callbacks.forEach(callback => callback());
+}
+
+/**
+ * Get the current locale.
+ */
+export function getCurrentLocale() {
+    return currentLocale;
+}
+
+/**
+ * Load a group of locales.
+ */
+export function loadLocales(locales: ILocale[]) {
+    localeStore = [...localeStore, ...locales];
+    callbacks.forEach(callback => callback());
+}
+
+/**
+ * Clear the loaded locales.
+ */
+export function clearLocales() {
+    localeStore = [];
+    callbacks.forEach(callback => callback());
+}

--- a/packages/vanilla-i18n/src/translationStore.test.ts
+++ b/packages/vanilla-i18n/src/translationStore.test.ts
@@ -1,0 +1,31 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { loadTranslations, clearTranslations, translate } from "./translationStore";
+import { expect } from "chai";
+
+describe("translate", () => {
+    beforeEach(() => {
+        loadTranslations({
+            foo: "bar",
+        });
+    });
+
+    afterEach(() => {
+        clearTranslations();
+    });
+
+    it("Translates a string", () => {
+        expect(translate("foo")).eq("bar");
+    });
+
+    it("Returns the default string", () => {
+        expect(translate("baz", "bam")).eq("bam");
+    });
+
+    it("Falls back to the string code", () => {
+        expect(translate("moo")).eq("moo");
+    });
+});

--- a/packages/vanilla-i18n/src/translationStore.ts
+++ b/packages/vanilla-i18n/src/translationStore.ts
@@ -1,0 +1,50 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+interface ITranslations {
+    [key: string]: string;
+}
+
+let translationStore: ITranslations = {};
+
+/**
+ * Load a set of key value pairs as translation resources.
+ */
+export function loadTranslations(translations: ITranslations) {
+    translationStore = { ...translations };
+}
+
+/**
+ * Clear all translation resources.
+ */
+export function clearTranslations() {
+    translationStore = {};
+}
+
+/**
+ * Translate a string into the current locale.
+ *
+ * @param str - The string to translate.
+ * @param defaultTranslation - The default translation to use.
+ *
+ * @returns Returns the translation or the default.
+ */
+export function translate(str: string, defaultTranslation?: string): string {
+    // Codes that begin with @ are considered literals.
+    if (str.substr(0, 1) === "@") {
+        return str.substr(1);
+    }
+
+    if (translationStore[str] !== undefined) {
+        return translationStore[str];
+    }
+
+    return defaultTranslation !== undefined ? defaultTranslation : str;
+}
+
+/**
+ * The t function is an alias for translate.
+ */
+export const t = translate;

--- a/packages/vanilla-i18n/tsconfig.json
+++ b/packages/vanilla-i18n/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "@vanilla/tsconfig/base",
+    "compilerOptions": {}
+}


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/issues/1240

Companion PR to remove duplicate code from subcommunties https://github.com/vanilla/multisite/pull/280

We currently have most our localization stuff locked up into our subcommunities plugin. However we have parts of front-end that need to display available locales, even without using subcommunities. As a result I've decouple some stuff out of there and placed it the `@vanilla/i18n` package here.

Notably this package now includes:

- A locale context in React.
  - Provides utility method `useLocaleInfo()`. Returns available locales, display names, and the current locale.
- A `<LocaleDisplayer />` component for displaying a locale in the language of another given locale.

This package is configured in our bootstrapping & can fetch its data from the `/api/v2/locales` endpoint. This data is preloaded in all controllers starting with https://github.com/vanilla/vanilla/pull/9385