### PR TITLE
[Backport] Fix touch config from overriding falsy values & fix excerpt rendering on empty conversations

### DIFF
--- a/applications/conversations/openapi/conversations.yml
+++ b/applications/conversations/openapi/conversations.yml
@@ -277,6 +277,8 @@ components:
       type: array
     ConversationPost:
       properties:
+        name:
+          type: string
         participantUserIDs:
           description: List of userID of the participants.
           items:
@@ -284,4 +286,5 @@ components:
           type: array
       required:
       - participantUserIDs
+      - name
       type: object

--- a/applications/conversations/views/messages/conversations.php
+++ b/applications/conversations/views/messages/conversations.php
@@ -32,10 +32,11 @@ foreach ($this->data('Conversations') as $Conversation) {
     $CssClass .= ' '.($Conversation->CountNewMessages <= 0 ? 'Read' : 'Unread');
 
     $JumpToItem = $Conversation->CountMessages - $Conversation->CountNewMessages;
-    $Message = (sliceString(Gdn::formatService()->renderExcerpt($Conversation->LastBody, $Conversation->LastFormat), 100));
 
-    if (stringIsNullOrEmpty(trim($Message))) {
+    if (stringIsNullOrEmpty(trim($Conversation->LastBody))) {
         $Message = t('Blank Message');
+    } else {
+        $Message = (sliceString(Gdn::formatService()->renderExcerpt($Conversation->LastBody, $Conversation->LastFormat), 100));
     }
 
     $this->EventArguments['Conversation'] = $Conversation;

--- a/tests/Library/Core/GdnConfigurationTest.php
+++ b/tests/Library/Core/GdnConfigurationTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for Gdn_Configuration.
+ */
+class GdnConfigurationTest extends TestCase {
+
+    /**
+     * Test if some configuraton key exists.
+     *
+     * @param array $configData
+     * @param string $keyToCheck
+     * @param bool $expectedResult
+     *
+     * @dataProvider provideConfigKeyExistsData
+     */
+    public function testConfigKeyExists(array $configData, string $keyToCheck, bool $expectedResult) {
+        $config = new \Gdn_Configuration();
+        $config->loadArray($configData, "test");
+
+        $this->assertEquals($expectedResult, $config->configKeyExists($keyToCheck));
+    }
+
+    /**
+     * Provide test cases.
+     *
+     * @return array
+     */
+    public function provideConfigKeyExistsData(): array {
+        return [
+            "Value is false" => [
+                ["Nested" => ["Value" => false]],
+                'Nested.Value',
+                true,
+            ],
+            "Value is falsy number" => [
+                ["Nested" => ["Value" => 0]],
+                'Nested.Value',
+                true,
+            ],
+            "Value is falsy array" => [
+                ["Nested" => ["Value" => []]],
+                'Nested.Value',
+                true,
+            ],
+            "Value is falsy string" => [
+                ["Nested" => ["Value" => ""]],
+                'Nested.Value',
+                true,
+            ],
+            "Value is undefined" =>[
+                [],
+                'Nested.Value',
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * Test if some configuraton key exists.
+     *
+     * @param array $configData
+     * @param string $keyToCheck
+     * @param bool $expectedResult
+     *
+     * @dataProvider provideConfigGetData
+     */
+    public function testConfigGet(array $configData, string $keyToCheck, $expectedResult) {
+        $config = new \Gdn_Configuration();
+        $config->loadArray($configData, "test");
+
+        $this->assertEquals($expectedResult, $config->get($keyToCheck));
+    }
+
+    /**
+     * Provide test cases.
+     *
+     * @return array
+     */
+    public function provideConfigGetData(): array {
+        return [
+            "Value is false" => [
+                ["Nested" => ["Value" => false]],
+                'Nested.Value',
+                false,
+            ],
+            "Value is falsy number" => [
+                ["Nested" => ["Value" => 0]],
+                'Nested.Value',
+                0,
+            ],
+            "Value is falsy array" => [
+                ["Nested" => ["Value" => []]],
+                'Nested.Value',
+                [],
+            ],
+            "Value is falsy string" => [
+                ["Nested" => ["Value" => ""]],
+                'Nested.Value',
+                "",
+            ],
+            "Value is undefined" =>[
+                [],
+                'Nested.Value',
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * Test the touch config method.
+     */
+    public function testTouchConfig() {
+        // Quick check with falsy value.
+        $config = new \Gdn_Configuration();
+        $config->loadArray(["Nested" => ["Value" => false]], "test");
+        $config->touch("Nested.Value", "myValue");
+
+        $this->assertEquals(false, $config->get("Nested.Value"));
+
+        // Actually touching a value.
+        $config->touch("Other.Value", "myValue");
+
+        $this->assertEquals("myValue", $config->get("Other.Value"));
+    }
+}


### PR DESCRIPTION
Backport #9388 Ticket https://github.com/vanilla/support/issues/850
Backport https://github.com/vanilla/vanilla/pull/9396 Ticket https://github.com/vanilla/support/issues/866