### PR TITLE
Fix excerpt rendering with empty conversations

### DIFF
--- a/applications/conversations/openapi/conversations.yml
+++ b/applications/conversations/openapi/conversations.yml
@@ -277,6 +277,8 @@ components:
       type: array
     ConversationPost:
       properties:
+        name:
+          type: string
         participantUserIDs:
           description: List of userID of the participants.
           items:
@@ -284,4 +286,5 @@ components:
           type: array
       required:
       - participantUserIDs
+      - name
       type: object

--- a/applications/conversations/views/messages/conversations.php
+++ b/applications/conversations/views/messages/conversations.php
@@ -32,10 +32,11 @@ foreach ($this->data('Conversations') as $Conversation) {
     $CssClass .= ' '.($Conversation->CountNewMessages <= 0 ? 'Read' : 'Unread');
 
     $JumpToItem = $Conversation->CountMessages - $Conversation->CountNewMessages;
-    $Message = (sliceString(Gdn::formatService()->renderExcerpt($Conversation->LastBody, $Conversation->LastFormat), 100));
 
-    if (stringIsNullOrEmpty(trim($Message))) {
+    if (stringIsNullOrEmpty(trim($Conversation->LastBody))) {
         $Message = t('Blank Message');
+    } else {
+        $Message = (sliceString(Gdn::formatService()->renderExcerpt($Conversation->LastBody, $Conversation->LastFormat), 100));
     }
 
     $this->EventArguments['Conversation'] = $Conversation;


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/866

- The conversations page was calling `FormatService::renderExcerpt()`, which does not allow null parameters, even when it had no message.
  - I've moved the check for an empty message before rendering the excerpt.
- Fixed a missing parameter in the POST endpoint's OpenApi definition.