### PR TITLE
Fire AfterRegister event only if a UserID is present

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2031,7 +2031,7 @@ class UserModel extends Gdn_Model {
                 break;
         }
 
-        if ($userID) {
+        if ($userID && is_numeric($userID)) {
             $this->EventArguments['UserID'] = $userID;
             $this->fireEvent('AfterRegister');
         }


### PR DESCRIPTION
The UserID value may also be UserModel::REDIRECT_APPROVE, which is a string, see #9390
Event handlers usually want to act on an actual UserID.

This does not fix the non-strongly-typed return issue present throughout UserModel, as UsersApiController depends on UserModel::insertForBasic sometimes returning UserModel::REDIRECT_APPROVE.