### PR TITLE
Backport: Track errors related to the state token.

### DIFF
--- a/library/core/helpers/class.ssoutils.php
+++ b/library/core/helpers/class.ssoutils.php
@@ -158,36 +158,37 @@ class SsoUtils {
      */
     protected function isStateTokenValid($stateTokenData, $stateToken, $source = '') {
         $loggingContext = [
+            'source' => $source,
             'event' => 'state_token_errors',
             'timestamp' => time(),
         ];
         // Validate expected data.
         if (!is_array($stateTokenData)) {
-            $this->logger->error('Missing stateTokenData', ['source' => $source] + $loggingContext);
+            $this->logger->error('Missing stateTokenData', $loggingContext);
             return false;
         }
 
         // Validate it contains a stateToken.
         if (empty($stateTokenData['stateToken'])) {
-            $this->logger->error('Missing stateToken from stateToken Array', ['source' => $source, 'stateTokenData' => $stateTokenData] + $loggingContext);
+            $this->logger->error('Missing stateToken from stateToken Array', ['stateTokenData' => $stateTokenData] + $loggingContext);
             return false;
         }
 
         // Validate if exp exists.
         if (empty($stateTokenData['exp'])) {
-            $this->logger->error('Missing Expiry from stateTokenArray', ['source' => $source, 'stateTokenData' => $stateTokenData] + $loggingContext);
+            $this->logger->error('Missing Expiry from stateTokenArray', ['stateTokenData' => $stateTokenData] + $loggingContext);
             return false;
         }
 
         // Check for expiration.
         if ($stateTokenData['exp'] < time()) {
-            $this->logger->error('StateToken Expired', ['source' => $source, 'stateTokenExp' => $stateTokenData['exp'], 'time' => time()] + $loggingContext);
+            $this->logger->error('StateToken Expired', ['stateTokenExp' => $stateTokenData['exp'], 'time' => time()] + $loggingContext);
             return false;
         }
 
         // Check the token.
         if ($stateToken !== $stateTokenData['stateToken']) {
-            $this->logger->error('StateTokens do not match.', ['source' => $source, 'StoredStateToken' => $stateTokenData['stateToken'], 'RecievedStateToken' => $stateToken] + $loggingContext);
+            $this->logger->error('StateTokens do not match.', ['StoredStateToken' => $stateTokenData['stateToken'], 'RecievedStateToken' => $stateToken] + $loggingContext);
             return false;
         }
 

--- a/library/core/helpers/class.ssoutils.php
+++ b/library/core/helpers/class.ssoutils.php
@@ -157,33 +157,37 @@ class SsoUtils {
      * @return bool true if the data is valid and false otherwise.
      */
     protected function isStateTokenValid($stateTokenData, $stateToken, $source = '') {
+        $loggingContext = [
+            'event' => 'state_token_errors',
+            'timestamp' => time(),
+        ];
         // Validate expected data.
         if (!is_array($stateTokenData)) {
-            $this->logger->error('Missing stateTokenData', ['source' => $source]);
+            $this->logger->error('Missing stateTokenData', ['source' => $source] + $loggingContext);
             return false;
         }
 
         // Validate it contains a stateToken.
         if (empty($stateTokenData['stateToken'])) {
-            $this->logger->error('Missing stateToken from stateToken Array', ['source' => $source, 'stateTokenData' => $stateTokenData]);
+            $this->logger->error('Missing stateToken from stateToken Array', ['source' => $source, 'stateTokenData' => $stateTokenData] + $loggingContext);
             return false;
         }
 
         // Validate if exp exists.
         if (empty($stateTokenData['exp'])) {
-            $this->logger->error('Missing Expiry from stateTokenArray', ['source' => $source, 'stateTokenData' => $stateTokenData]);
+            $this->logger->error('Missing Expiry from stateTokenArray', ['source' => $source, 'stateTokenData' => $stateTokenData] + $loggingContext);
             return false;
         }
 
         // Check for expiration.
         if ($stateTokenData['exp'] < time()) {
-            $this->logger->error('StateToken Expired', ['source' => $source, 'stateTokenExp' => $stateTokenData['exp'], 'time' => time()]);
+            $this->logger->error('StateToken Expired', ['source' => $source, 'stateTokenExp' => $stateTokenData['exp'], 'time' => time()] + $loggingContext);
             return false;
         }
 
         // Check the token.
         if ($stateToken !== $stateTokenData['stateToken']) {
-            $this->logger->error('StateTokens do not match.', ['source' => $source, 'StoredStateToken' => $stateTokenData['stateToken'], 'RecievedStateToken' => $stateToken]);
+            $this->logger->error('StateTokens do not match.', ['source' => $source, 'StoredStateToken' => $stateTokenData['stateToken'], 'RecievedStateToken' => $stateToken] + $loggingContext);
             return false;
         }
 

--- a/library/core/helpers/class.ssoutils.php
+++ b/library/core/helpers/class.ssoutils.php
@@ -48,6 +48,9 @@ class SsoUtils {
         $this->cookieName = $config->get('Garden.Cookie.Name', 'Vanilla').'-ssostatetoken';
         $this->cookieSalt = $config->get('Garden.Cookie.Salt');
         $this->session = $session;
+        if ($logger === null) {
+            $logger = Gdn::getContainer()->get(\Psr\Log\LoggerInterface::class);
+        }
         $this->logger = $logger;
 
         if (!$this->cookieSalt) {


### PR DESCRIPTION
Backport: https://github.com/vanilla/vanilla/pull/9356

It became apparent that this PR was necessary when debugging a customer's SSO when the State token failed to verify. It is not a good practice to expose the details of every error when it comes to user authentication for fear of giving hackers too much knowledge. This PR uses the Logger class to update the Event Log with details of why a State token has failed to be verified.