### PR TITLE
Prepare site section interface to allow expansion in API responses

### DIFF
--- a/applications/dashboard/src/scripts/tables/DashboardMediaItem.tsx
+++ b/applications/dashboard/src/scripts/tables/DashboardMediaItem.tsx
@@ -14,7 +14,7 @@ interface IProps {
 export function DashboardMediaItem(props: IProps) {
     return (
         <div className="media-sm">
-            {props.imgSrc && (
+            {props.imgSrc !== undefined && (
                 <div className="media-left">
                     <div className="media-image-wrap">
                         <img src={props.imgSrc} />

--- a/library/Vanilla/Contracts/Site/SiteSectionInterface.php
+++ b/library/Vanilla/Contracts/Site/SiteSectionInterface.php
@@ -12,7 +12,7 @@ namespace Vanilla\Contracts\Site;
  *
  * Through this mechanism content across the site may be separated and filtered.
  */
-interface SiteSectionInterface {
+interface SiteSectionInterface extends \JsonSerializable {
     /**
      * Get the base path for the section of the site.
      *
@@ -43,15 +43,14 @@ interface SiteSectionInterface {
     /**
      * Get the uniqueID representing the section.
      *
-     * @return int
+     * @return string
      */
-    public function getSectionID(): int;
-    
+    public function getSectionID(): string;
+
     /**
      * Get the section group that a section belongs.
      *
      * @return string
      */
     public function getSectionGroup(): string;
-
 }

--- a/library/Vanilla/Contracts/Site/SiteSectionProviderInterface.php
+++ b/library/Vanilla/Contracts/Site/SiteSectionProviderInterface.php
@@ -47,6 +47,14 @@ interface SiteSectionProviderInterface {
     public function getForLocale(string $localeKey): array;
 
     /**
+     * Get all site sections that match a particular locale.
+     *
+     * @param string $sectionGroupKey The name of the section group to check.
+     * @return SiteSectionInterface[]
+     */
+    public function getForSectionGroup(string $sectionGroupKey): array;
+
+    /**
      * Get the current site section for the request automatically if possible.
      *
      * @return SiteSectionInterface

--- a/library/Vanilla/Site/DefaultSiteSection.php
+++ b/library/Vanilla/Site/DefaultSiteSection.php
@@ -62,7 +62,7 @@ class DefaultSiteSection implements SiteSectionInterface {
     /**
      * @inheritdoc
      */
-    public function getSectionID(): int {
+    public function getSectionID(): string {
         return self::DEFAULT_ID;
     }
 
@@ -71,5 +71,12 @@ class DefaultSiteSection implements SiteSectionInterface {
      */
     public function getSectionGroup(): string {
         return self::DEFAULT_SECTION_GROUP;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function jsonSerialize() {
+        return SiteSectionSchema::toArray($this);
     }
 }

--- a/library/Vanilla/Site/SingleSiteSectionProvider.php
+++ b/library/Vanilla/Site/SingleSiteSectionProvider.php
@@ -32,6 +32,17 @@ class SingleSiteSectionProvider implements SiteSectionProviderInterface {
     /**
      * @inheritdoc
      */
+    public function getForSectionGroup(string $sectionGroupKey): array {
+        if ($sectionGroupKey === DefaultSiteSection::DEFAULT_SECTION_GROUP) {
+            return [$this->defaultSite];
+        } else {
+            return [];
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getAll(): array {
         return [$this->defaultSite];
     }

--- a/library/Vanilla/Site/SiteSectionSchema.php
+++ b/library/Vanilla/Site/SiteSectionSchema.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Site;
+
+use Vanilla\Contracts\Site\SiteSectionInterface;
+use Vanilla\Utility\InstanceValidatorSchema;
+
+/**
+ * Schema for validating a site section.
+ */
+class SiteSectionSchema extends InstanceValidatorSchema {
+
+    /**
+     * Configure the class.
+     */
+    public function __construct() {
+        parent::__construct(SiteSectionInterface::class);
+    }
+
+    /**
+     * Convert a site section into an array. Useful for API/JSON output.
+     *
+     * @param SiteSectionInterface $section
+     *
+     * @return array
+     */
+    public static function toArray(SiteSectionInterface $section): array {
+        return [
+            'basePath' => $section->getBasePath(),
+            'contentLocale' => $section->getContentLocale(),
+            'sectionGroup' => $section->getSectionGroup(),
+            'sectionID' => $section->getSectionID(),
+            'name' => $section->getSectionName(),
+        ];
+    }
+}

--- a/library/src/scripts/icons/common.tsx
+++ b/library/src/scripts/icons/common.tsx
@@ -542,7 +542,7 @@ export function DiscussionIcon(props: { className?: string; title?: string }) {
     );
 }
 
-export function AlertIcon(props: { className?: string; title?: string }) {
+export function AlertIcon(props: { className?: string; title?: string | null }) {
     const classes = iconClasses();
     return (
         <svg className={classNames(classes.alertIcon, props.className)} viewBox="0 0 24 24" aria-hidden="true">

--- a/tests/fixtures/src/MockSiteSection.php
+++ b/tests/fixtures/src/MockSiteSection.php
@@ -7,6 +7,7 @@
 namespace VanillaTests\fixtures;
 
 use Vanilla\Contracts\Site\SiteSectionInterface;
+use Vanilla\Site\SiteSectionSchema;
 
 /**
  * Mock site-section.
@@ -74,7 +75,7 @@ class MockSiteSection implements SiteSectionInterface {
     /**
      * @inheritdoc
      */
-    public function getSectionID(): int {
+    public function getSectionID(): string {
         return $this->sectionID;
     }
 
@@ -83,5 +84,12 @@ class MockSiteSection implements SiteSectionInterface {
      */
     public function getSectionGroup(): string {
         return $this->sectionGroup;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function jsonSerialize() {
+        return SiteSectionSchema::toArray($this);
     }
 }


### PR DESCRIPTION
- Updates the `SiteSectionInterface::getSectionID()` to return a string. `SubcomunitySiteSection::getSectionID()` was returning always a string which caused an error on access.
- Add `JsonSerialize` to the interface.
- Add a `SiteSectionSchema` with a utility for json serialization.
- Add a new provider interface method `getForSectionGroup()`.
- A couple minor tweaks in some frontend files.

Multisite PR to update interface implementations https://github.com/vanilla/multisite/pull/284