### PR TITLE
Backport: Fix notifications not being sent to participating users

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -617,9 +617,10 @@ class CommentModel extends Gdn_Model {
             ],
             "participated" => [
                 "notifyUserIDs" => array_column(
-                    $discussionModel->getParticipatedUsers($discussionID),
+                    $discussionModel->getParticipatedUsers($discussionID)->resultArray(),
                     "UserID"
-                ),                "options" => ['CheckRecord' => true],
+                ),
+                "options" => ['CheckRecord' => true],
                 "preference" => "ParticipateComment",
             ],
         ];


### PR DESCRIPTION
Backporting #9406 to `release/2019.014`

> Some parts of `CommentModel` were refactored in #9329 for the sake of preparing the notifications routine for improvements. Part of that refactoring caused "participating" users not to receive notifications, when they had explicitly opted into them. This was due to treating the result of `DiscussionModel::getParticipatedUsers` like an array, instead of an instance of `Gdn_Dataset`. This has been corrected.
>
> A minor formatting issue has also been corrected.