### PR TITLE
Add body to comment and discussion notifications

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -567,6 +567,7 @@ class CommentModel extends Gdn_Model {
         $data = [
             "ActivityType" => "Comment",
             "ActivityUserID" => $comment["InsertUserID"] ?? null,
+            "Format" => $comment["Format"] ?? null,
             "HeadlineFormat" => t(
                 "HeadlineFormat.Comment",
                 '{ActivityUserID,user} commented on <a href="{Url,html}">{Data.Name,text}</a>'
@@ -574,17 +575,12 @@ class CommentModel extends Gdn_Model {
             "RecordType" => "Comment",
             "RecordID" => $commentID,
             "Route" => "/discussion/comment/{$commentID}#Comment_{$commentID}",
+            "Story" => $comment["Body"] ?? null,
             "Data" => [
                 "Name" => $discussion["Name"] ?? null,
                 "Category" => $category["Name"] ?? null,
             ]
         ];
-
-        // Allow simple fulltext notifications
-        if (c("Vanilla.Activity.ShowCommentBody", false)) {
-            $data["Story"] = $comment["Body"] ?? null;
-            $data["Format"] = $comment["Format"] ?? null;
-        }
 
         // Pass generic activity to events.
         $this->EventArguments["Activity"] = $data;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2267,6 +2267,7 @@ class DiscussionModel extends Gdn_Model {
         $data = [
             "ActivityType" => "Discussion",
             "ActivityUserID" => $insertUserID,
+            "Format" => $format ?? null,
             "HeadlineFormat" => t(
                 $code,
                 '{ActivityUserID,user} started a new discussion: <a href="{Url,html}">{Data.Name,text}</a>'
@@ -2274,17 +2275,12 @@ class DiscussionModel extends Gdn_Model {
             "RecordType" => "Discussion",
             "RecordID" => $discussionID,
             "Route" => discussionUrl($discussion, "", "/"),
+            "Story" => $body ?? null,
             "Data" => [
                 "Name" => $name,
                 "Category" => $categoryName,
             ]
         ];
-
-        // Allow simple fulltext notifications
-        if (c("Vanilla.Activity.ShowDiscussionBody", false)) {
-            $data["Story"] = $body;
-            $data["Format"] = $format;
-        }
 
         // Notify all of the users that were mentioned in the discussion.
         $mentions = [];


### PR DESCRIPTION
Vanilla supports including post contents in comment and discussion notifications. This is currently optional, but moving forward with improvements to notifications, this will be required to give adequate context for email notifications.

Merging into a feature branch for batching email notifications.

Closes #9309