### PR TITLE
Fix bad type cast in Config::splitConfigKey() & add logging

### DIFF
--- a/library/Vanilla/Utility/Deprecation.php
+++ b/library/Vanilla/Utility/Deprecation.php
@@ -14,6 +14,7 @@ use Garden\StaticCacheConfigTrait;
  */
 class Deprecation {
     use StaticCacheConfigTrait;
+
     protected static $calls = [];
 
     /**
@@ -43,12 +44,102 @@ class Deprecation {
         if (self::c('Garden.Log.Deprecation', true)) {
             $info = debug_backtrace()[1];
             if (!key_exists($info['function'], self::$calls)) {
-                $fileName = str_replace(PATH_ROOT, '', $info['file']);
+                $fileName = self::extractFileNameFromFrame($info);
                 $message = 'Deprecated function '.$info['function'].' called from '.$fileName.' at line : '.$info['line'];
-                trigger_error($message, E_USER_DEPRECATED);
-                error_log($message, E_USER_ERROR);
+                self::logErrorMessage($message);
                 self::$calls[$info['function']] = true;
             }
         }
+    }
+
+    /**
+     * Log information about an unsupported parameter value.
+     *
+     * @param string $paramName The parameter name.
+     * @param mixed $value The value of the parameter.
+     * @param string $reason An additional explanation of why the value is invalid.
+     *
+     * @return void
+     */
+    public static function unsupportedParam(string $paramName, $value, string $reason = "") {
+        // Set Garden.Log.Deprecation to false to disable log output
+        if (self::c('Garden.Log.Deprecation', true)) {
+            $stack = debug_backtrace();
+
+            $message = "Method received unsupported parameter type.\n" . $paramName . ": " . json_encode($value);
+            if ($reason) {
+                $message .= "\n" . $reason;
+            }
+            $message .= self::formatBackTrace($stack);
+            self::logErrorMessage($message);
+        }
+    }
+
+    /**
+     * Log an error message.
+     *
+     * @param string $message
+     *
+     * @throws \Exception If called while debug mode is enabled.
+     */
+    private static function logErrorMessage(string $message) {
+        trigger_error($message, E_USER_DEPRECATED);
+        error_log($message, E_USER_ERROR);
+
+        if (self::c('Debug', false)) {
+            throw new \Exception($message);
+        }
+    }
+
+    /**
+     * Format a backtrace for logging.
+     *
+     * @param array $backtrace
+     * @return string
+     */
+    private static function formatBackTrace(array $backtrace): string {
+        $errorMessage = "";
+        $stackDepth = self::c('Garden.Log.StackDepth', 3);
+
+        for ($i = 0; $i < $stackDepth; $i++) {
+            $frame = next($backtrace);
+            if (false === $frame) {
+                break;
+            }
+
+            $methodName = self::extractMethodNameFromFrame($frame);
+            $fileName = self::extractFileNameFromFrame($frame);
+
+            $errorMessage .= "\nMETHOD ==> " . $methodName;
+            $errorMessage .= "\n  FILE ==> " . $fileName . ':' . $frame['line'];
+            $errorMessage .= "\n";
+        }
+
+        return $errorMessage;
+    }
+
+    /**
+     * Extract a nice printable method from a backtrace frame.
+     *
+     * @param array $frame
+     * @return string
+     */
+    private static function extractMethodNameFromFrame(array $frame): string {
+        $methodName = $frame['function'] . '()';
+        if ($frame['class']) {
+            $methodName = $frame['class'] . $frame['type'] . $methodName;
+        }
+
+        return $methodName;
+    }
+
+    /**
+     * Get a nicely trimmed filename from a stack frame.
+     *
+     * @param array $frame
+     * @return string
+     */
+    private static function extractFileNameFromFrame(array $frame): string {
+        return str_replace(PATH_ROOT, '', $frame['file']);
     }
 }

--- a/library/core/class.configuration.php
+++ b/library/core/class.configuration.php
@@ -9,6 +9,8 @@
  * @since 2.0
  */
 
+use Vanilla\Utility\Deprecation;
+
 /**
  * The Configuration class can be used to load configuration arrays from files,
  * retrieve settings from the arrays, assign new values to the arrays, and save
@@ -362,7 +364,13 @@ class Gdn_Configuration extends Gdn_Pluggable implements \Vanilla\Contracts\Conf
             return $this->Data;
         }
 
-        $keys = $this->splitConfigKey($name);
+        if (!is_string($name)) {
+            Deprecation::unsupportedParam('$name', $name, "Only string parameters are allowed.");
+        } elseif (strlen($name) === 0) {
+            Deprecation::unsupportedParam("$name", $name, "Empty config keys may lead to undefined behaviour.");
+        }
+
+        $keys = $this->splitConfigKey((string) $name);
         $keyCount = count($keys);
 
         $value = $this->Data;


### PR DESCRIPTION
- Adds some additional logging utility `unsupportedParam()`
  - Shows message, param, and stack trace.
  - Stack depth is configurable.
- Throws an error if debug is enabled.
- Fixes some undefined behaviour when splitting string keys in `Gdn_Configuration::get($name)`. Name is not guaranteed to be a string but `splitConfigKeys` requires one. A type cast and logging has been added.