### PR TITLE
Remove logging for empty config keys

### DIFF
--- a/library/core/class.configuration.php
+++ b/library/core/class.configuration.php
@@ -366,8 +366,6 @@ class Gdn_Configuration extends Gdn_Pluggable implements \Vanilla\Contracts\Conf
 
         if (!is_string($name)) {
             Deprecation::unsupportedParam('$name', $name, "Only string parameters are allowed.");
-        } elseif (strlen($name) === 0) {
-            Deprecation::unsupportedParam("$name", $name, "Empty config keys may lead to undefined behaviour.");
         }
 
         $keys = $this->splitConfigKey((string) $name);

--- a/tests/Library/Core/GdnConfigurationTest.php
+++ b/tests/Library/Core/GdnConfigurationTest.php
@@ -27,7 +27,7 @@ class GdnConfigurationTest extends TestCase {
         $config = new \Gdn_Configuration();
         $config->loadArray($configData, "test");
 
-        $this->assertEquals($expectedResult, $config->configKeyExists($keyToCheck));
+        $this->assertSame($expectedResult, $config->configKeyExists($keyToCheck));
     }
 
     /**
@@ -78,7 +78,7 @@ class GdnConfigurationTest extends TestCase {
         $config = new \Gdn_Configuration();
         $config->loadArray($configData, "test");
 
-        $this->assertEquals($expectedResult, $config->get($keyToCheck));
+        $this->assertSame($expectedResult, $config->get($keyToCheck));
     }
 
     /**
@@ -108,9 +108,14 @@ class GdnConfigurationTest extends TestCase {
                 'Nested.Value',
                 "",
             ],
-            "Value is undefined" =>[
+            "Value is undefined" => [
                 [],
                 'Nested.Value',
+                false,
+            ],
+            "Value is empty string" => [
+                [],
+                "",
                 false,
             ],
         ];


### PR DESCRIPTION
It turns out `Gdn_Locale` uses a `Gdn_Locale` internally and `""` is definitely a valid value to pass in.

I've added a test and removed the logged warning that this is "undefined" behaviour potentially.