### PR TITLE
Backport: Fix session stash not having an ID.

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -826,6 +826,7 @@ class Gdn_Session {
 
             // Save the session information to the database.
             $sessionID = $sessionModel->insert($session);
+            $session['SessionID'] = $sessionID;
             trace("Inserting session stash $sessionID");
 
             // Save a session cookie.


### PR DESCRIPTION
Recent changes made to Session Stash feature created a subtle bug by not putting the sessionID back into the session array. This PR will put it back.

The code before was like this:

```
      if (!$session) {
            $sessionID = betterRandomString(32);

            $session = [
                'SessionID' => $sessionID,
                'UserID' => Gdn::session()->UserID,
                'DateInserted' => Gdn_Format::toDateTime(),
                'Attributes' => [],
            ];

            // Save the session information to the database.
            $sessionModel->insert($session);
```
We would generate a SessionID and insert it into the DB and then return the $session array. Now we use the SessionModel which returns the SessionID, but we aren't putting that sessionID back into the $session array before returning it.

This PR will fix it.
