### PR TITLE
Use setProperty instead of setField to announce discussions

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -573,7 +573,7 @@ class DiscussionController extends VanillaController {
                 $this->DiscussionModel->getAnnouncementCacheKey(val('CategoryID', $discussion))
             ];
             $this->DiscussionModel->SQL->cache($cacheKeys);
-            $this->DiscussionModel->setField($discussionID, 'Announce', (int)$this->Form->getFormValue('Announce', 0));
+            $this->DiscussionModel->setProperty($discussionID, 'Announce', (int)$this->Form->getFormValue('Announce', 0));
 
             if ($target) {
                 $this->setRedirectTo($target);


### PR DESCRIPTION
A change was made recently to use setField in the announce function of the DiscussionController. This tweak ended up breaking announcements.

This PR revert the change made in https://github.com/vanilla/vanilla/pull/9353 to use setProperty instead of setField 

Issue: https://github.com/vanilla/support/issues/890
