### PR TITLE
Improve error handling in new controllers

### DIFF
--- a/library/Vanilla/Web/JsInterpop/ReduxErrorAction.php
+++ b/library/Vanilla/Web/JsInterpop/ReduxErrorAction.php
@@ -8,6 +8,7 @@
 namespace Vanilla\Web\JsInterpop;
 
 use Garden\Web\Data;
+use Garden\Web\Exception\HttpException;
 
 /**
  * A redux error action to render a frontend error page.
@@ -20,7 +21,16 @@ class ReduxErrorAction extends ReduxAction {
      * @param \Throwable $throwable The exception to create the error for.
      */
     public function __construct(\Throwable $throwable) {
-        parent::__construct(self::ACTION_TYPE, new Data($throwable));
+        $data = [
+            'message' => $throwable->getMessage(),
+            'status' => $throwable->getCode(),
+        ];
+
+        if ($throwable instanceof HttpException) {
+            $data['description'] = $throwable->getDescription();
+        }
+
+        parent::__construct(self::ACTION_TYPE, new Data($data));
     }
 
     /**

--- a/library/Vanilla/Web/Page.php
+++ b/library/Vanilla/Web/Page.php
@@ -7,6 +7,7 @@
 
 namespace Vanilla\Web;
 
+use Garden\Web\Exception\HttpException;
 use Gdn_Upload;
 use Garden\CustomExceptionHandler;
 use Garden\Web\Data;
@@ -355,14 +356,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
      * @inheritdoc
      */
     public function hasExceptionHandler(\Throwable $e): bool {
-        switch ($e->getCode()) {
-            case 404:
-            case 403:
-                return true;
-                break;
-            default:
-                return false;
-        }
+        return $e instanceof HttpException;
     }
 
     /**

--- a/library/Vanilla/Web/Page.php
+++ b/library/Vanilla/Web/Page.php
@@ -147,6 +147,17 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
      * @return Data Data object for global dispatcher.
      */
     public function render(): Data {
+        return $this->renderMasterView();
+    }
+
+    /**
+     * Render the page content and wrap it in a data object for the dispatcher.
+     *
+     * This method is kept private so that it can be called internally for error pages without being overridden.
+     *
+     * @return Data Data object for global dispatcher.
+     */
+    private function renderMasterView(): Data {
         $this->validateSeo();
 
         $this->inlineScripts[] = new PhpAsJsVariable('gdn', [
@@ -369,7 +380,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
             ])
         ;
 
-        return $this->render();
+        return $this->renderMasterView();
     }
 
     /**


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1216
Used in https://github.com/vanilla/knowledge/pull/1296

- Update the `Vanilla\Web\Page::handleException()` to only call rendering of the base master view & not the overridden full rendering. Handling an exception should be as short & container a process as possible.
- Update the `Vanilla\Web\Page::hasExceptionHandler()` to handle all `Vanilla\Web\HttpExceptions`.
- Update `ReduxErrorAction` to not pass null values of description. The frontend has it's own fallback descriptions that will display if the value is undefined.