### PR TITLE
Fix date grammar on category list

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -95,8 +95,8 @@ endif;
 if (!function_exists('MostRecentString')):
     function mostRecentString($row, $options = []) {
         $options = (array)$options + [
-            'user' => true,
-            'date' => true,
+            'showUser' => true,
+            'showDate' => true,
         ];
 
         if (!$row['LastTitle']) {
@@ -112,7 +112,7 @@ if (!function_exists('MostRecentString')):
             $row['LastUrl'],
             'LatestPostTitle');
 
-        if ($options['user'] && val('LastName', $row)) {
+        if ($options['showUser'] && val('LastName', $row)) {
             $r .= ' ';
 
             $r .= '<span class="MostRecentBy">'.t('by').' ';
@@ -120,7 +120,7 @@ if (!function_exists('MostRecentString')):
             $r .= '</span>';
         }
 
-        if ($options['date'] && val('LastDateInserted', $row)) {
+        if ($options['showDate'] && val('LastDateInserted', $row)) {
             $r .= ' ';
 
             $r .= '<span class="MostRecentOn"><span class="CommentDate">';
@@ -206,7 +206,7 @@ if (!function_exists('writeListItem')):
 
                         <?php if (val('LastTitle', $category) != '') : ?>
                             <span class="MItem LastDiscussionTitle">
-                                <?php echo mostRecentString($category, ['date' => false]); ?>
+                                <?php echo mostRecentString($category, ['showDate' => false]); ?>
                             </span>
                             <span class="MItem LastCommentDate">
                                 <?php echo Gdn_Format::date(val('LastDateInserted', $category)); ?>

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -93,9 +93,15 @@ if (!function_exists('getOptions')):
 endif;
 
 if (!function_exists('MostRecentString')):
-    function mostRecentString($row) {
-        if (!$row['LastTitle'])
+    function mostRecentString($row, $options = []) {
+        $options = (array)$options + [
+            'user' => true,
+            'date' => true,
+        ];
+
+        if (!$row['LastTitle']) {
             return '';
+        }
 
         $r = '';
 
@@ -106,7 +112,7 @@ if (!function_exists('MostRecentString')):
             $row['LastUrl'],
             'LatestPostTitle');
 
-        if (val('LastName', $row)) {
+        if ($options['user'] && val('LastName', $row)) {
             $r .= ' ';
 
             $r .= '<span class="MostRecentBy">'.t('by').' ';
@@ -114,16 +120,12 @@ if (!function_exists('MostRecentString')):
             $r .= '</span>';
         }
 
-        if (val('LastDateInserted', $row)) {
+        if ($options['date'] && val('LastDateInserted', $row)) {
             $r .= ' ';
 
-            $r .= '<span class="MostRecentOn">';
-            $r .= t('on').' ';
-            $r .= anchor(
-                Gdn_Format::date($row['LastDateInserted'], 'html'),
-                $row['LastUrl'],
-                'CommentDate');
-            $r .= '</span>';
+            $r .= '<span class="MostRecentOn"><span class="CommentDate">';
+            $r .= Gdn_Format::date($row['LastDateInserted'], 'html');
+            $r .= '</span></span>';
         }
 
         $r .= '</span>';
@@ -204,7 +206,7 @@ if (!function_exists('writeListItem')):
 
                         <?php if (val('LastTitle', $category) != '') : ?>
                             <span class="MItem LastDiscussionTitle">
-                                <?php echo mostRecentString($category); ?>
+                                <?php echo mostRecentString($category, ['date' => false]); ?>
                             </span>
                             <span class="MItem LastCommentDate">
                                 <?php echo Gdn_Format::date(val('LastDateInserted', $category)); ?>


### PR DESCRIPTION
Two things:

- The most recent date used “most recent by user on date”. If the date is formatted as just a time then it should be “at”. This would be very tedious to determine with localization so I opted just to remove the word “on” entirely.
- The category list displays the date twice. I added an option to remove it from the string.

Closes https://github.com/vanilla/support/issues/30.
Closes #7252.