### PR TITLE
Fix device detection for multiple device types

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3926,19 +3926,40 @@ if (!function_exists('userAgentType')) {
             $type = $value;
         }
 
+        if (defined('TESTMODE_ENABLED') && constant('TESTMODE_ENABLED')) {
+            $type = null;
+        }
+
         if ($type !== null) {
             return $type;
         }
 
+        // A function to make sure the type is one of our supported types.
+        $validateType = function (string $type): string {
+            $validTypes = ['desktop', 'tablet', 'app', 'mobile'];
+
+            if (in_array($type, $validTypes)) {
+                return $type;
+            } else {
+                // There is no exact match so look for a partial match.
+                foreach ($validTypes as $validType) {
+                    if (strpos($type, $validType) !== false) {
+                        return $validType;
+                    }
+                }
+            }
+            return 'desktop';
+        };
+
         // Try and get the user agent type from the header if it was set from the server, varnish, etc.
         $type = strtolower(val('HTTP_X_UA_DEVICE', $_SERVER, ''));
         if ($type) {
-            return $type;
+            return $validateType($type);
         }
 
         // See if there is an override in the cookie.
         if ($type = val('X-UA-Device-Force', $_COOKIE)) {
-            return $type;
+            return $validateType($type);
         }
 
         // Now we will have to figure out the type based on the user agent and other things.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3916,18 +3916,17 @@ if (!function_exists('userAgentType')) {
      * This method checks the user agent to try and determine the type of device making the current request.
      * It also checks for a special X-UA-Device header that a server module can set to more quickly determine the device.
      *
-     * @param string|null $value The new value to set. This should be one of desktop, mobile, tablet, or app.
+     * @param string|null|false $value The new value to set or **false** to clear. This should be one of desktop, mobile, tablet, or app.
      * @return string Returns one of desktop, mobile, tablet, or app.
      */
     function userAgentType($value = null) {
         static $type = null;
 
-        if ($value !== null) {
-            $type = $value;
-        }
-
-        if (defined('TESTMODE_ENABLED') && constant('TESTMODE_ENABLED')) {
+        if ($value === false) {
             $type = null;
+            return null;
+        } elseif ($value !== null) {
+            $type = $value;
         }
 
         if ($type !== null) {

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -3924,7 +3924,7 @@ if (!function_exists('userAgentType')) {
 
         if ($value === false) {
             $type = null;
-            return null;
+            return '';
         } elseif ($value !== null) {
             $type = $value;
         }

--- a/tests/Library/Core/UserAgentTypeTest.php
+++ b/tests/Library/Core/UserAgentTypeTest.php
@@ -18,6 +18,14 @@ class UserAgentTypeTest extends TestCase {
     const COOKIE_NAME = 'X-UA-Device-Force';
 
     /**
+     * Clean up before each test.
+     */
+    public function setUp() {
+        parent::setUp();
+        userAgentType(false);
+    }
+
+    /**
      * Clean up the user agent cache at the end of each test.
      */
     public function tearDown() {

--- a/tests/Library/Core/UserAgentTypeTest.php
+++ b/tests/Library/Core/UserAgentTypeTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the user agent type.
+ * @backupGlobals enabled
+ */
+class UserAgentTypeTest extends TestCase {
+    const HEADER_NAME = 'HTTP_X_UA_DEVICE';
+    const COOKIE_NAME = 'X-UA-Device-Force';
+
+    /**
+     * Test device detection from the header.
+     *
+     * @param string $value
+     * @param string $expected
+     * @dataProvider provideForceValues
+     */
+    public function testHeaderForce(string $value, string $expected) {
+        $_SERVER[self::HEADER_NAME] = $value;
+
+        $actual = userAgentType();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test device detection from a forced cookie.
+     *
+     * @param string $value
+     * @param string $expected
+     * @dataProvider provideForceValues
+     */
+    public function testCookieForce(string $value, string $expected) {
+        $_COOKIE[self::COOKIE_NAME] = $value;
+
+        $actual = userAgentType();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test device detection from the user agent.
+     *
+     * @param string $agent
+     * @param string $expected
+     * @dataProvider provideUserAgents
+     */
+    public function testUserAgentDetect(string $agent, string $expected) {
+        $_SERVER['HTTP_USER_AGENT'] = $agent;
+
+        $actual = userAgentType();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Provide user agent header tests.
+     *
+     * @return array
+     */
+    public function provideForceValues(): array {
+        $r = [
+            ['mobile', 'mobile'],
+            ['desktop', 'desktop'],
+            ['tablet', 'tablet'],
+            ['app', 'app'],
+            ['unknown', 'desktop'],
+            ['mobile;tablet', 'tablet'],
+        ];
+
+        return array_column($r, null, 0);
+    }
+
+    /**
+     * Provide some sample user agents.
+     *
+     * This isn't an exhaustive list.
+     *
+     * @return array
+     */
+    public function provideUserAgents(): array {
+        $r = [
+            [
+                'Mozilla/5.0 (Linux; Android 8.1.0; Pixel 2 Build/OPM2.171026.006.G1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36',
+                'mobile',
+            ],
+            [
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1',
+                'mobile',
+            ],
+            [
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.120 Safari/537.36',
+                'desktop',
+            ],
+        ];
+
+        return $r;
+    }
+}

--- a/tests/Library/Core/UserAgentTypeTest.php
+++ b/tests/Library/Core/UserAgentTypeTest.php
@@ -17,6 +17,9 @@ class UserAgentTypeTest extends TestCase {
     const HEADER_NAME = 'HTTP_X_UA_DEVICE';
     const COOKIE_NAME = 'X-UA-Device-Force';
 
+    /**
+     * Clean up the user agent cache at the end of each test.
+     */
     public function tearDown() {
         parent::tearDown();
         userAgentType(false);

--- a/tests/Library/Core/UserAgentTypeTest.php
+++ b/tests/Library/Core/UserAgentTypeTest.php
@@ -17,6 +17,11 @@ class UserAgentTypeTest extends TestCase {
     const HEADER_NAME = 'HTTP_X_UA_DEVICE';
     const COOKIE_NAME = 'X-UA-Device-Force';
 
+    public function tearDown() {
+        parent::tearDown();
+        userAgentType(false);
+    }
+
     /**
      * Test device detection from the header.
      *


### PR DESCRIPTION
The device detection library we use can return a string of “mobile;tablet”. In the past, we’ve modified that to return just “tablet”. This seems to be prone to regressions so I’m hardening the detection on the app-side.

Closes https://github.com/vanilla/support/issues/58.