### PR TITLE
Tweak the ban rule search text

### DIFF
--- a/applications/dashboard/modules/class.userbanmodule.php
+++ b/applications/dashboard/modules/class.userbanmodule.php
@@ -50,7 +50,7 @@ class UserBanModule extends GDN_Module {
 
             // Add a link to identify the corresponding ban rule.
             if ($bit === 2) {
-                $text = sprintf(t('Find the corresponding ban rule for %s'), val('Name', $user));
+                $text = t('Find the matching ban rule(s).');
                 $reasons[$bit] .= ' '.anchor($text, 'settings/bans/find/'.$userID);
             }
         }


### PR DESCRIPTION
I would rather expand strings as little as possible because it hinders localization and can introduce XSS more easily. Also, we use “corresponding” here and “matching” in the dashboard which is inconsistent.