### PR TITLE
Add full regular expression patterns support for username validation

### DIFF
--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -281,6 +281,8 @@ if (!function_exists('validateUsername')) {
         $validateUsernameRegex = validateUsernameRegex($isPartialRegex);
 
         if ($isPartialRegex) {
+            // Unescape the delimiters and escape them again to prevent double escaping.
+            $validateUsernameRegex = str_replace('`', '\\`', str_replace('\\`', '`', $validateUsernameRegex));
             $validateUsernameRegex = "`^({$validateUsernameRegex})?$`siu";
         }
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -247,6 +247,13 @@ if (!function_exists('validateUsernameRegex')) {
         static $validateUsernameRegex;
 
         if (is_null($validateUsernameRegex)) {
+            // Get the full regular expression from the configuration file.
+            $validateUsernameRegex = c('Garden.User.ValidationRegexPattern');
+
+            if ($validateUsernameRegex) {
+                return $validateUsernameRegex;
+            }
+
             // Set our default ValidationRegex based on Unicode support.
             // Unicode includes Numbers, Letters, Marks, & Connector punctuation.
             $defaultPattern = (unicodeRegexSupport()) ? '\p{N}\p{L}\p{M}\p{Pc}' : '\w';
@@ -258,7 +265,7 @@ if (!function_exists('validateUsernameRegex')) {
             );
         }
 
-        return $validateUsernameRegex;
+        return "/^({$validateUsernameRegex})?$/siu";
     }
 }
 
@@ -270,16 +277,9 @@ if (!function_exists('validateUsername')) {
      * @return bool Returns true if the value validates or false otherwise.
      */
     function validateUsername($value) {
-        $validationRegexPattern = c('Garden.User.ValidationRegexPattern');
-
-        if (!$validationRegexPattern) {
-            $validateUsernameRegex = validateUsernameRegex();
-            $validationRegexPattern = "/^({$validateUsernameRegex})?$/siu";
-        }
-
         return validateRegex(
             $value,
-            $validationRegexPattern
+            validateUsernameRegex()
         );
     }
 }

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -281,7 +281,7 @@ if (!function_exists('validateUsername')) {
         $validateUsernameRegex = validateUsernameRegex($isPartialRegex);
 
         if ($isPartialRegex) {
-            $validateUsernameRegex = "/^({$validateUsernameRegex})?$/siu";
+            $validateUsernameRegex = "`^({$validateUsernameRegex})?$`siu";
         }
 
         return validateRegex(

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -270,11 +270,16 @@ if (!function_exists('validateUsername')) {
      * @return bool Returns true if the value validates or false otherwise.
      */
     function validateUsername($value) {
-        $validateUsernameRegex = validateUsernameRegex();
+        $validationRegexPattern = c('Garden.User.ValidationRegexPattern');
+
+        if (!$validationRegexPattern) {
+            $validateUsernameRegex = validateUsernameRegex();
+            $validationRegexPattern = "/^({$validateUsernameRegex})?$/siu";
+        }
 
         return validateRegex(
             $value,
-            "/^({$validateUsernameRegex})?$/siu"
+            $validationRegexPattern
         );
     }
 }

--- a/tests/Library/Core/ValidateUsernameTest.php
+++ b/tests/Library/Core/ValidateUsernameTest.php
@@ -56,7 +56,7 @@ class ValidateUsernameTest extends SharedBootstrapTestCase {
     }
 
     /**
-     * Test some partial regex patterns.
+     * Test `Garden.User.ValidationRegex`.
      *
      * @param string $pattern The pattern to test.
      * @param string $username The username to test.
@@ -72,6 +72,8 @@ class ValidateUsernameTest extends SharedBootstrapTestCase {
     }
 
     /**
+     * Test `Garden.User.ValidationRegexPattern`.
+     *
      * @param string $pattern
      * @param string $username
      * @param bool $expected
@@ -82,6 +84,8 @@ class ValidateUsernameTest extends SharedBootstrapTestCase {
     }
 
     /**
+     * Test `Garden.User.ValidationLength`.
+     *
      * @param string $length
      * @param string $username
      * @param bool $expected
@@ -100,6 +104,7 @@ class ValidateUsernameTest extends SharedBootstrapTestCase {
         $r = [
             'valid' => ['^0-9', 'todd', true],
             'invalid' => ['^0-9', 'todd0', false],
+            'invalid slash' => ['^/', 'to/dd', false],
         ];
 
         return $r;

--- a/tests/Library/Core/ValidateUsernameTest.php
+++ b/tests/Library/Core/ValidateUsernameTest.php
@@ -115,7 +115,6 @@ class ValidateUsernameTest extends SharedBootstrapTestCase {
             'invalid slash' => ['^/', 'to/dd', false],
             'invalid unescaped backtick' => ['^`+', 'p`tches', false],
             'invalid escaped backtick' => ['^\\`+', 'p`tches', false],
-
         ];
 
         return $r;

--- a/tests/Library/Core/ValidateUsernameTest.php
+++ b/tests/Library/Core/ValidateUsernameTest.php
@@ -109,8 +109,13 @@ class ValidateUsernameTest extends SharedBootstrapTestCase {
     public function providePartialRegexTests(): array {
         $r = [
             'valid' => ['^0-9', 'todd', true],
+            'valid unescaped backtick' => ['^`', 'patches', true],
+            'valid escaped backtick' => ['^\\`', 'patches', true],
             'invalid' => ['^0-9', 'todd0', false],
             'invalid slash' => ['^/', 'to/dd', false],
+            'invalid unescaped backtick' => ['^`+', 'p`tches', false],
+            'invalid escaped backtick' => ['^\\`+', 'p`tches', false],
+
         ];
 
         return $r;

--- a/tests/Library/Core/ValidateUsernameTest.php
+++ b/tests/Library/Core/ValidateUsernameTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @author Patrick Desjardins <patrick.d@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use VanillaTests\SharedBootstrapTestCase;
+
+/**
+ * Tests for `validateUsername()` and `validateUsernameRegex()`.
+ */
+class ValidateUsernameTest extends SharedBootstrapTestCase {
+    protected const CONFIG_KEYS = [
+        'Garden.User'
+    ];
+
+    /**
+     * @var \Gdn_Configuration
+     */
+    private $config;
+
+    /**
+     * @var array
+     */
+    private $configBak;
+
+    /**
+     * Back up the config before each test.
+     */
+    public function setUp() {
+        parent::setUp();
+
+        /* @var \Gdn_Configuration $config */
+        $this->config = $this->container()->get(\Gdn_Configuration::class);
+
+        // Back up the config before each test.
+        $this->configBak = [];
+        foreach (self::CONFIG_KEYS as $key) {
+            $this->configBak[$key] = $this->config->get($key);
+        }
+    }
+
+    /**
+     * Restore the config after each test.
+     */
+    public function tearDown() {
+        parent::tearDown();
+
+        foreach ($this->configBak as $key => $value) {
+            $this->config->set($key, $value, true, false);
+        }
+    }
+
+    /**
+     * Test some partial regex patterns.
+     *
+     * @param string $pattern The pattern to test.
+     * @param string $username The username to test.
+     * @param bool $expected The expected result of `validateUsername()`.
+     * @dataProvider providePartialRegexTests
+     */
+    public function testValidationRegex(string $pattern, string $username, bool $expected): void {
+        $this->config->set('Garden.User.ValidationRegex', $pattern, true, false);
+        $this->config->set('Garden.User.ValidationLength', '{3,20}', true, false);
+
+        $actual = validateUsername($username);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $username
+     * @param bool $expected
+     * @dataProvider provideValidationRegexPatternTests
+     */
+    public function testValidationRegexPattern(string $pattern, string $username, bool $expected): void {
+        $this->fail('Not implemented');
+    }
+
+    /**
+     * @param string $length
+     * @param string $username
+     * @param bool $expected
+     * @dataProvider provideValidationLengthTests
+     */
+    public function testValidationLength(string $length, string $username, bool $expected) {
+        $this->fail('Not implemented');
+    }
+
+    /**
+     * Provide tests for partial regex configs.
+     *
+     * @return array
+     */
+    public function providePartialRegexTests(): array {
+        $r = [
+            'valid' => ['^0-9', 'todd', true],
+            'invalid' => ['^0-9', 'todd0', false],
+        ];
+
+        return $r;
+    }
+
+    /**
+     * Provide tests for full regex configs.
+     *
+     * @return array
+     */
+    public function provideValidationRegexPatternTests(): array {
+        $r = [
+            'valid' => ['`[tod]+`', 'todd', true],
+        ];
+
+        return $r;
+    }
+
+    /**
+     * Provide tests for full regex configs.
+     *
+     * @return array
+     */
+    public function provideValidationLengthTests(): array {
+        $r = [
+            'valid' => ['`{2,4}`', 'todd', true],
+        ];
+
+        return $r;
+    }
+}

--- a/tests/Library/Core/ValidateUsernameTest.php
+++ b/tests/Library/Core/ValidateUsernameTest.php
@@ -80,7 +80,10 @@ class ValidateUsernameTest extends SharedBootstrapTestCase {
      * @dataProvider provideValidationRegexPatternTests
      */
     public function testValidationRegexPattern(string $pattern, string $username, bool $expected): void {
-        $this->fail('Not implemented');
+        $this->config->set('Garden.User.ValidationRegexPattern', $pattern, true, false);
+
+        $actual = validateUsername($username);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -89,10 +92,13 @@ class ValidateUsernameTest extends SharedBootstrapTestCase {
      * @param string $length
      * @param string $username
      * @param bool $expected
-     * @dataProvider provideValidationLengthTests
+     * @dataProvider providePartialLengthTests
      */
     public function testValidationLength(string $length, string $username, bool $expected) {
-        $this->fail('Not implemented');
+        $this->config->set('Garden.User.ValidationLength', $length, true, false);
+
+        $actual = validateUsername($username);
+        $this->assertSame($expected, $actual);
     }
 
     /**
@@ -118,19 +124,21 @@ class ValidateUsernameTest extends SharedBootstrapTestCase {
     public function provideValidationRegexPatternTests(): array {
         $r = [
             'valid' => ['`[tod]+`', 'todd', true],
+            'invalid' => ['`(\w+){3,30}`', 'sh', false],
         ];
 
         return $r;
     }
 
     /**
-     * Provide tests for full regex configs.
+     * Provide tests for partial length regex configs.
      *
      * @return array
      */
-    public function provideValidationLengthTests(): array {
+    public function providePartialLengthTests(): array {
         $r = [
-            'valid' => ['`{2,4}`', 'todd', true],
+            'valid' => ['{2,4}', 'todd', true],
+            'invalid' => ['{3}', 'todd', false],
         ];
 
         return $r;


### PR DESCRIPTION
It is currently possible to add custom validation on usernames by adding the "ValidationRegex" and "ValidationLength" configs to the configuration file. The "ValidationRegex" is wrapped in a character class which makes the functionality very rigid.

For example, it is impossible to do negative look-around to prevent usernames from starting with a certain pattern.

The change was discussed in [this internal issue](https://github.com/vanillaforums/estimates/issues/708)

It will now be possible to add "ValidationRegexPattern" to your configuration file and write the full regular expression without any restrictions. This pattern will have priority on the other (ValidationRegex, ValidationLength) configurations.
