### PR TITLE
Add answer and poll to search type docs

### DIFF
--- a/applications/dashboard/openapi/search.yml
+++ b/applications/dashboard/openapi/search.yml
@@ -34,7 +34,9 @@ paths:
             - discussion
             - comment
             - question
+            - answer
             - group
+            - poll
             type: string
           type: array
         style: form


### PR DESCRIPTION
Addressing https://github.com/vanilla/support/issues/894#issuecomment-544541309
I know it's not ideal to put these here, but we already have groups in this spot.

On top of that this endpoint doesn't even belong to dashboard, but I'll leave that for another PR.