### PR TITLE
Backport: Fix updating email addresses when not allowed .

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -391,6 +391,14 @@ class ProfileController extends Gdn_Controller {
         // Decide if we can *see* email
         $this->setData('_CanViewPersonalInfo', Gdn::session()->UserID == val('UserID', $user) || checkPermission('Garden.PersonalInfo.View') || checkPermission('Garden.Users.Edit'));
 
+        // Decide if there will be a Titles field.
+        $canAddEditTitle = c('Garden.Profile.Titles', false);
+        $this->setData('_CanAddEditTitle', $canAddEditTitle);
+
+        // Decide if there will be Locations field.
+        $canAddEditLocations = c('Garden.Profile.Locations', false);
+        $this->setData('_CanAddEditLocation', $canAddEditLocations);
+
         // Define gender dropdown options
         $this->GenderOptions = [
             'u' => t('Unspecified'),
@@ -431,6 +439,11 @@ class ProfileController extends Gdn_Controller {
             // This field cannot be updated from here.
             $this->Form->removeFormValue('Password');
 
+            // If someone tries to update the email without permission, send back the original email to the form.
+            if (!$canEditEmail) {
+                $this->Form->setFormValue("Email", $user['Email']);
+            }
+
             if (!$canEditUsername) {
                 $this->Form->setFormValue("Name", $user['Name']);
             } else {
@@ -438,6 +451,15 @@ class ProfileController extends Gdn_Controller {
                 Gdn::userModel()->Validation->applyRule('Name', 'Username', $usernameError);
             }
 
+            // Do not accept Title updates if the user isn't allowed.
+            if (!$canAddEditTitle) {
+                $this->Form->removeFormValue('Title');
+            }
+
+            // Do not accept Location updates if the user isn't allowed.
+            if (!$canAddEditLocations) {
+                $this->Form->removeFormValue('Location');
+            }
             // API
             // These options become available when POSTing as a user with Garden.Settings.Manage permissions
 
@@ -499,11 +521,6 @@ class ProfileController extends Gdn_Controller {
 
                 $this->informMessage(sprite('Check', 'InformSprite').t('Your changes have been saved.'), 'Dismissable AutoDismiss HasSprite');
             }
-
-            if (!$canEditEmail) {
-                $this->Form->setFormValue("Email", $user['Email']);
-            }
-
         }
 
         $this->title(t('Edit Profile'));
@@ -1195,7 +1212,7 @@ class ProfileController extends Gdn_Controller {
         $this->permission('Garden.SignIn.Allow');
 
         // If users are registering with SSO, don't bother with this form.
-        if (c('Garden.Registration.Method') == 'Connect') {
+        if (!is_object(Gdn::session()->User) || (c('Garden.Registration.Method') === 'Connect' && (Gdn::session()->User->HashMethod ?? '') !== 'Vanilla')) {
             Gdn::dispatcher()->dispatch('DefaultPermission');
             exit();
         }

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -1286,7 +1286,7 @@ class Gdn_Controller extends Gdn_Pluggable {
 
         // ...and have a proper password.
         $user = Gdn::userModel()->getID(Gdn::session()->UserID);
-        if (val('HashMethod', $user) == 'Random') {
+        if (val('HashMethod', $user) === 'Random') {
             return;
         }
 


### PR DESCRIPTION
This is a backport of https://github.com/vanilla/vanilla-patches/pull/645

In the Edit Profile page you can add any of the possible form values that are not displayed or are disabled and submit them. The model does not filter them. This will filter out the values in the controller on submission.

The controller already handles this with the Name field.