### PR TITLE
Fix debug mode template errors in category settings view

### DIFF
--- a/applications/vanilla/views/vanillasettings/editcategory.twig
+++ b/applications/vanilla/views/vanillasettings/editcategory.twig
@@ -63,7 +63,7 @@ dashboardHeading({
         'Photo',
         t('Photo'),
         '',
-        'vanilla/settings/deletecategoryphoto/' ~ category.CategoryID
+        category.CategoryID !== null ? 'vanilla/settings/deletecategoryphoto/' ~ category.CategoryID : ''
     ) }}
 
     {#
@@ -110,7 +110,9 @@ dashboardHeading({
         </div>
     {% endif %}
 
+    {% if _PermissionFields is defined %}
     {{ form.simple(_PermissionFields, []) }}
+    {% endif %}
 
     <div class="padded">{{ t('Check all permissions that apply for each role') }}</div>
     {{ form.checkBoxGridGroups(PermissionData, 'Permission') }}


### PR DESCRIPTION
There were some errors in this page in debug mode (mostly due to undefined varaible access).

These were not errors with debug mode off.

I've fixed them so the template now renders properly in debug mode.

## To Test

Go to the category add page in the dashboard with debug mode on.