### PR TITLE
Add support for batch sending of notification emails

### DIFF
--- a/applications/dashboard/library/Jobs/ExecuteActivityQueue.php
+++ b/applications/dashboard/library/Jobs/ExecuteActivityQueue.php
@@ -28,7 +28,7 @@ class ExecuteActivityQueue implements Vanilla\Scheduler\Job\LocalJobInterface {
      * Execute all queued up items in the ActivityModel queue.
      */
     public function run(): JobExecutionStatus {
-        $this->activityModel->saveQueue();
+        $this->activityModel->saveQueue(true);
         return JobExecutionStatus::complete();
     }
 

--- a/applications/dashboard/models/ActivityEmail.php
+++ b/applications/dashboard/models/ActivityEmail.php
@@ -54,8 +54,8 @@ class ActivityEmail {
      *
      * @param string $email
      */
-    public function addRecipient(string $email) {
-        $this->recipients[] = $email;
+    public function addRecipient(string $email, ?string $name = null) {
+        $this->recipients[] = [$email, $name];
     }
 
     /**

--- a/applications/dashboard/models/ActivityEmail.php
+++ b/applications/dashboard/models/ActivityEmail.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+ namespace Vanilla\Dashboard\Models;
+
+/**
+  * Dumb data object representing an email notification for an activity.
+  *
+  * @internal This is a temporary class. Do not use. It will be removed in the near future.
+  */
+class ActivityEmail {
+
+    /** @var int[] */
+    private $activityIDs = [];
+
+    /** @var string */
+    private $actionText;
+
+    /** @var string */
+    private $actionUrl;
+
+    /** @var int */
+    private $activityTypeID;
+
+    /** @var string */
+    private $body = "";
+
+    /** @var string[] */
+    private $recipients = [];
+
+    /** @var int */
+    private $recordID;
+
+    /** @var string */
+    private $recordType;
+
+    /** @var string */
+    private $subject = "";
+
+    /**
+     * Add the ID of an activity associated with this email.
+     *
+     * @param integer $activityID
+     */
+    public function addActivityID(int $activityID) {
+        $this->activityIDs[] = $activityID;
+    }
+
+    /**
+     * Add an email address to the list of recipients.
+     *
+     * @param string $email
+     */
+    public function addRecipient(string $email) {
+        $this->recipients[] = $email;
+    }
+
+    /**
+     * Get the call to action text for this email.
+     *
+     * @return string|null
+     */
+    public function getActionText(): ?string {
+        return $this->actionText;
+    }
+
+    /**
+     * Get the call to action URL for this email.
+     *
+     * @return string|null
+     */
+    public function getActionUrl(): ?string {
+        return $this->actionUrl;
+    }
+
+    /**
+     * Return all associated activity IDs.
+     *
+     * @return array
+     */
+    public function getActivityIDs(): array {
+        return $this->activityIDs;
+    }
+
+    /**
+     * Get the activity type for this notification.
+     *
+     * @return integer
+     */
+    public function getActivityTypeID(): ?int {
+        return $this->activityTypeID;
+    }
+
+    /**
+     * Get the email body.
+     *
+     * @return string
+     */
+    public function getBody(): string {
+        return $this->body;
+    }
+
+    /**
+     * Get the currently-configured list of recipient email addresses.
+     *
+     * @return string[]
+     */
+    public function getRecipients(): array {
+        return $this->recipients;
+    }
+
+    /**
+     * Get the ID of the record associated with this notification.
+     *
+     * @return integer
+     */
+    public function getRecordID(): ?int {
+        return $this->recordID;
+    }
+
+    /**
+     * Get the type of record associated with this notification.
+     *
+     * @return string
+     */
+    public function getRecordType(): ?string {
+        return $this->recordType;
+    }
+
+    /**
+     * Get the email subject.
+     *
+     * @return string
+     */
+    public function getSubject(): string {
+        return $this->subject;
+    }
+
+    /**
+     * Reset to defaults.
+     */
+    public function reset() {
+        $this->actionText = null;
+        $this->actionUrl = null;
+        $this->activityIDs = [];
+        $this->activityTypeID = null;
+        $this->body = "";
+        $this->recipients = [];
+        $this->recordID = null;
+        $this->recordType = null;
+        $this->subject = "";
+    }
+
+    /**
+     * Set the call to action text for this email.
+     *
+     * @param string|null $actionText
+     */
+    public function setActionText(?string $actionText) {
+        $this->actionText = $actionText;
+    }
+
+    /**
+     * Set the call to action URL for this email.
+     *
+     * @param string|null $actionUrl
+     */
+    public function setActionUrl(?string $actionUrl) {
+        $this->actionUrl = $actionUrl;
+    }
+
+    /**
+     * Set the activity type for this notification.
+     *
+     * @param integer|null $activityTypeID
+     */
+    public function setActivityTypeID(?int $activityTypeID) {
+        $this->activityTypeID = $activityTypeID;
+    }
+
+    /**
+     * Set the email body.
+     *
+     * @param string $body
+     */
+    public function setBody(string $body) {
+        $this->body = $body;
+    }
+
+    /**
+     * Set the ID of the record associated with this notification.
+     *
+     * @param integer|null $recordID
+     */
+    public function setRecordID(?int $recordID) {
+        $this->recordID = $recordID;
+    }
+
+    /**
+     * Set the type of record associated with this notification.
+     *
+     * @param string|null $recordType
+     */
+    public function setRecordType(?string $recordType) {
+        $this->recordType = $recordType;
+    }
+
+    /**
+     * Set the email subject.
+     *
+     * @param string $subject
+     */
+    public function setSubject(string $subject) {
+        $this->subject = $subject;
+    }
+}

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -2078,7 +2078,7 @@ class ActivityModel extends Gdn_Model {
         $batchOffset = 0;
         while ($batch = array_slice($recipients, $batchOffset, $batchSize)) {
             $email->subject($activityEmail->getSubject());
-            $email->to($email->getDefaultFromAddress(), t("Notifications"));
+            $email->to($email->getNoReplyAddress(), t("Notifications Postmaster"));
 
             foreach ($batch as $recipient) {
                 [$address, $name] = $recipient;

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1117,7 +1117,8 @@ class ActivityModel extends Gdn_Model {
      * @return string
      */
     private function getEmailSubject(array $activity, array $options): string {
-        $result = $options["EmailSubject"] ?: Gdn_Format::plainText($activity["Headline"]);
+        $emailSubject = $options["EmailSubject"] ?? null;
+        $result = $emailSubject ?: Gdn_Format::plainText($activity["Headline"]);
         return $result;
     }
 

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -2005,7 +2005,14 @@ class ActivityModel extends Gdn_Model {
      */
     private function sendEmailQueue() {
         foreach (static::$emailQueue as $activityEmail) {
-            $this->sendActivityEmail($activityEmail);
+            try {
+                $this->sendActivityEmail($activityEmail);
+            } catch (Exception $e) {
+                $this->logger->error("An exception occurred while processing the notification email queue.", [
+                    "event" => "activity_email_failed",
+                    "exception" => $e,
+                ]);
+            }
         }
         static::$emailQueue = [];
     }

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -8,6 +8,8 @@
  * @since 2.0
  */
 
+use Vanilla\Dashboard\Models\ActivityEmail;
+
 /**
  * Activity data management.
  */
@@ -53,6 +55,9 @@ class ActivityModel extends Gdn_Model {
 
     /** @var int Limit on number of activity to combine. */
     public static $MaxMergeCount = 10;
+
+    /** @var ActivityEmail[] Emails pending sending. */
+    private static $emailQueue = [];
 
     /**
      * @var string The amount of time to delete logs after.
@@ -997,7 +1002,7 @@ class ActivityModel extends Gdn_Model {
      * @return bool
      * @throws Exception
      */
-    public function email(&$activity,  $options = []) {
+    public function email(&$activity, $options = []) {
         // The $options parameter used to be $noDelete bool, this is the backwards compat.
         if (is_bool($options)) {
             $options = ['NoDelete' => $options];
@@ -1025,11 +1030,66 @@ class ActivityModel extends Gdn_Model {
             return false;
         }
 
+        $activity["Headline"] = $this->getActivityHeadline($activity, $user);
+
+        // Build the email to send.
+        $email = new Gdn_Email();
+        $email->subject($this->getEmailSubjectFormatted($activity, $options));
+        $email->to($user);
+
+        $url = externalUrl(val('Route', $activity) == '' ? '/' : val('Route', $activity));
+
+        $emailTemplate = $email->getEmailTemplate()
+            ->setButton($url, val('ActionText', $activity, t('Check it out')))
+            ->setTitle($this->getEmailSubject($activity, $options));
+
+        if ($message = $this->getEmailMessage($activity)) {
+            $emailTemplate->setMessage($message, true);
+        }
+
+        $email->setEmailTemplate($emailTemplate);
+
+        // Fire an event for the notification.
+        $notification = ['ActivityID' => $activityID, 'User' => $user, 'Email' => $email, 'Route' => $activity['Route'], 'Story' => $activity['Story'], 'Headline' => $activity['Headline'], 'Activity' => $activity];
+        $this->EventArguments = $notification;
+        $this->fireEvent('BeforeSendNotification');
+
+        // Only send if the user is not banned
+        if (!val('Banned', $user)) {
+            $activity['Emailed'] = $this->sendEmail($email, $activity, $options);
+            if ($activity['Emailed'] === self::SENT_OK) {
+                // Delete the activity now that it has been emailed.
+                if (!$options['NoDelete'] && !$activity['Notified']) {
+                    if (val('ActivityID', $activity)) {
+                        $this->delete($activity['ActivityID']);
+                    } else {
+                        $activity['_Delete'] = true;
+                    }
+                }
+            }
+        } else {
+            $activity['Emailed'] = self::SENT_SKIPPED;
+        }
+
+        if ($activityID) {
+            // Save the emailed flag back to the activity.
+            $this->SQL->put('Activity', ['Emailed' => $emailed], ['ActivityID' => $activityID]);
+        }
+        return true;
+    }
+
+    /**
+     * Given an activity, generate a fully-formatted headline.
+     *
+     * @param array $activity
+     * @return string
+     */
+    private function getActivityHeadline(array $activity, array $user): string {
         // Format the activity headline based on the user being emailed.
         if (val('HeadlineFormat', $activity)) {
             $sessionUserID = Gdn::session()->UserID;
             Gdn::session()->UserID = $user['UserID'];
-            $activity['Headline'] = formatString($activity['HeadlineFormat'], $activity);
+            $result = formatString($activity['HeadlineFormat'], $activity);
             Gdn::session()->UserID = $sessionUserID;
         } else {
             if (!isset($activity['ActivityGender'])) {
@@ -1043,76 +1103,39 @@ class ActivityModel extends Gdn_Model {
                 $activity['ProfileHeadline'] = val('ProfileHeadline', $aT);
             }
 
-            $activity['Headline'] = Gdn_Format::activityHeadline($activity, '', $user['UserID']);
+            $result = Gdn_Format::activityHeadline($activity, '', $user['UserID']);
         }
 
-        $subject = $options['EmailSubject'] ?: Gdn_Format::plainText($activity['Headline']);
+        return $result;
+    }
 
-        // Build the email to send.
-        $email = new Gdn_Email();
-        $email->subject(sprintf(
-            t('[%1$s] %2$s'),
-            c('Garden.Title'),
+    /**
+     * Get the unformatted subject line for an activity email.
+     *
+     * @param array $activity
+     * @param array $options
+     * @return string
+     */
+    private function getEmailSubject(array $activity, array $options): string {
+        $result = $options["EmailSubject"] ?: Gdn_Format::plainText($activity["Headline"]);
+        return $result;
+    }
+
+    /**
+     * Get the subject line for an activity email, formatted per the activity data.
+     *
+     * @param array $activity
+     * @param array $options
+     * @return string
+     */
+    private function getEmailSubjectFormatted(array $activity, array $options): string {
+        $subject = $this->getEmailSubject($activity, $options);
+        $result = sprintf(
+            t("[%1\$s] %2\$s"),
+            c("Garden.Title"),
             $subject
-        ));
-        $email->to($user);
-
-        $url = externalUrl(val('Route', $activity) == '' ? '/' : val('Route', $activity));
-
-        $emailTemplate = $email->getEmailTemplate()
-            ->setButton($url, val('ActionText', $activity, t('Check it out')))
-            ->setTitle($subject);
-
-        if ($message = $this->getEmailMessage($activity)) {
-            $emailTemplate->setMessage($message, true);
-        }
-
-        $email->setEmailTemplate($emailTemplate);
-
-        // Fire an event for the notification.
-        $notification = ['ActivityID' => $activityID, 'User' => $user, 'Email' => $email, 'Route' => $activity['Route'], 'Story' => $activity['Story'], 'Headline' => $activity['Headline'], 'Activity' => $activity];
-        $this->EventArguments = $notification;
-        $this->fireEvent('BeforeSendNotification');
-
-        // Send the email.
-        try {
-            // Only send if the user is not banned
-            if (!val('Banned', $user)) {
-                $email->send();
-                $emailed = self::SENT_OK;
-            } else {
-                $emailed = self::SENT_SKIPPED;
-            }
-
-            // Delete the activity now that it has been emailed.
-            if (!$options['NoDelete'] && !$activity['Notified']) {
-                if (val('ActivityID', $activity)) {
-                    $this->delete($activity['ActivityID']);
-                } else {
-                    $activity['_Delete'] = true;
-                }
-            }
-        } catch (phpmailerException $pex) {
-            if ($pex->getCode() == PHPMailer::STOP_CRITICAL && !$email->PhpMailer->isServerError($pex)) {
-                $emailed = self::SENT_FAIL;
-            } else {
-                $emailed = self::SENT_ERROR;
-            }
-        } catch (Exception $ex) {
-            switch ($ex->getCode()) {
-                case Gdn_Email::ERR_SKIPPED:
-                    $emailed = self::SENT_SKIPPED;
-                    break;
-                default:
-                    $emailed = self::SENT_FAIL; // similar to http 5xx
-            }
-        }
-        $activity['Emailed'] = $emailed;
-        if ($activityID) {
-            // Save the emailed flag back to the activity.
-            $this->SQL->put('Activity', ['Emailed' => $emailed], ['ActivityID' => $activityID]);
-        }
-        return true;
+        );
+        return $result;
     }
 
     /**
@@ -1459,6 +1482,7 @@ class ActivityModel extends Gdn_Model {
         trace('ActivityModel->save()');
         $activity = $data;
         $this->_touch($activity);
+        $queueEmail = $options["QueueEmail"] ?? false;
 
         if ($activity['ActivityUserID'] == $activity['NotifyUserID'] && !val('Force', $options)) {
             trace('Skipping activity because it would notify the user of something they did.');
@@ -1550,7 +1574,7 @@ class ActivityModel extends Gdn_Model {
         }
 
         $delete = false;
-        if ($activity['Emailed'] == self::SENT_PENDING) {
+        if ($activity['Emailed'] == self::SENT_PENDING && !$queueEmail) {
             $this->email($activity, $options);
             $delete = val('_Delete', $activity);
         }
@@ -1610,6 +1634,7 @@ class ActivityModel extends Gdn_Model {
 
                 $activityID = $this->SQL->insert('Activity', $activity);
                 $activity['ActivityID'] = $activityID;
+                $this->queueEmail($activity, $options);
 
                 $this->prune();
             }
@@ -1797,18 +1822,24 @@ class ActivityModel extends Gdn_Model {
     }
 
     /**
+     * Save all queued activity rows.
      *
-     *
+     * @param bool $batchEmails Should emails be sent to multiple recipients when possible?
      * @return array
      */
-    public function saveQueue() {
+    public function saveQueue(bool $batchEmails = false) {
         $result = [];
-        foreach (self::$Queue as $userID => $activities) {
-            foreach ($activities as $activityType => $row) {
-                $result[] = $this->save($row[0], false, ['DisableFloodControl' => true] + $row[1]);
+        $options = [
+            "DisableFloodControl" => true,
+            "QueueEmail" => $batchEmails,
+        ];
+        foreach (self::$Queue as $activities) {
+            foreach ($activities as $row) {
+                $result[] = $this->save($row[0], false, $options + $row[1]);
             }
         }
         self::$Queue = [];
+        $this->sendEmailQueue();
         return $result;
     }
 
@@ -1895,5 +1926,152 @@ class ActivityModel extends Gdn_Model {
             ['DateUpdated <' => Gdn_Format::toDateTime($date->getTimestamp())],
             10
         );
+    }
+
+    /**
+     * Queue up an activity email notification.
+     *
+     * @param array $activity
+     * @param array $options
+     */
+    private function queueEmail(array $activity, array $options = []) {
+        $activityID = $activity["ActivityID"] ?? null;
+        $notifyUserID = $activity["NotifyUserID"] ?? null;
+        if (filter_var($activityID, FILTER_VALIDATE_INT) === false || filter_var($notifyUserID, FILTER_VALIDATE_INT) === false) {
+            return;
+        }
+
+        $user = Gdn::userModel()->getID($notifyUserID, DATASET_TYPE_ARRAY);
+        if (!is_array($user) || !array_key_exists("Email", $user)) {
+            return;
+        }
+
+        if (!array_key_exists("Banned", $user) || $user["Banned"]) {
+            return;
+        }
+
+        $address = $user["Email"] ?? null;
+        if (!is_string($address) || empty($address)) {
+            return;
+        }
+
+        $decodedData = false;
+        if (array_key_exists("Data", $activity) && is_string($activity["Data"])) {
+            $activity["Data"] = dbdecode($activity["Data"]);
+            $decodedData = true;
+        }
+        $activity["Headline"] = $this->getActivityHeadline($activity, $user);
+        $subject = $this->getEmailSubjectFormatted($activity, $options);
+        $body = $this->getEmailMessage($activity);
+        $key = implode(".", [
+            $activity["ActivityTypeID"],
+            $activity["RecordID"],
+            $activity["RecordType"],
+            md5($subject),
+            md5($body),
+        ]);
+        if ($decodedData === true && array_key_exists("Data", $activity) && is_array($activity["Data"])) {
+            $activity["Data"] = dbencode($activity["Data"]);
+        }
+
+        if (!array_key_exists($key, static::$emailQueue) || !(static::$emailQueue[$key] instanceof ActivityEmail)) {
+            $activityEmail = new ActivityEmail();
+            $activityEmail->setBody($body);
+            $activityEmail->setSubject($subject);
+            $activityEmail->setActionText($activity["ActionText"] ?? t("Check it out"));
+            $activityEmail->setActionUrl(externalUrl(val('Route', $activity) == '' ? '/' : val('Route', $activity)));
+            $activityEmail->setActivityTypeID($activity["ActivityTypeID"] ?? null);
+            $activityEmail->setRecordID($activity["RecordID"] ?? null);
+            $activityEmail->setRecordType($activity["RecordType"] ?? null);
+            static::$emailQueue[$key] = $activityEmail;
+        } else {
+            $activityEmail = &static::$emailQueue[$key];
+        }
+
+        $activityEmail->addActivityID($activityID);
+        $activityEmail->addRecipient($address);
+    }
+
+    /**
+     * Send any queued emails.
+     */
+    private function sendEmailQueue() {
+        foreach (static::$emailQueue as $activityEmail) {
+            $this->sendActivityEmail($activityEmail);
+        }
+        static::$emailQueue = [];
+    }
+
+    /**
+     * Invoke send on an instance of Gdn_Email and return its status.
+     *
+     * @param Gdn_Email $email
+     * @return integer
+     */
+    private function sendEmail(Gdn_Email $email): int {
+        // Send the email.
+        try {
+            $email->send();
+            return self::SENT_OK;
+        } catch (phpmailerException $pex) {
+            if ($pex->getCode() == PHPMailer::STOP_CRITICAL && !$email->PhpMailer->isServerError($pex)) {
+                return self::SENT_FAIL;
+            } else {
+                return self::SENT_ERROR;
+            }
+        } catch (Exception $ex) {
+            switch ($ex->getCode()) {
+                case Gdn_Email::ERR_SKIPPED:
+                    return self::SENT_SKIPPED;
+                default:
+                    return self::SENT_FAIL; // similar to http 5xx
+            }
+        }
+    }
+
+    /**
+     * Given an ActivityEmail instance, create and send the email it represents.
+     *
+     * @param ActivityEmail $activityEmail
+     */
+    private function sendActivityEmail(ActivityEmail $activityEmail) {
+        $batchSize = c("Garden.Email.BatchSize", 50);
+        $email = new Gdn_Email();
+        $recipients = $activityEmail->getRecipients();
+
+        $activityType = static::getActivityType($activityEmail->getActivityTypeID());
+        $notification = [
+            "Activity" => [
+                "ActivityType" => $activityType["Name"] ?? null,
+                "RecordID" => $activityEmail->getRecordID(),
+                "RecordType" => $activityEmail->getRecordType(),
+            ],
+            "Email" => $email,
+        ];
+
+        $batchOffset = 0;
+        while ($batch = array_slice($recipients, $batchOffset, $batchSize)) {
+            $email->subject($activityEmail->getSubject());
+            $email->to($email->getDefaultFromAddress(), t("Undisclosed Recipients"));
+
+            foreach ($batch as $recipient) {
+                $email->bcc($recipient);
+            }
+
+            $emailTemplate = $email->getEmailTemplate()
+                ->setButton($activityEmail->getActionUrl(), $activityEmail->getActionText())
+                ->setTitle($activityEmail->getSubject());
+            if ($message = $activityEmail->getBody()) {
+                $emailTemplate->setMessage($message, true);
+            }
+            $email->setEmailTemplate($emailTemplate);
+
+            $this->EventArguments = $notification;
+            $this->fireEvent("BeforeSendNotification");
+            $this->sendEmail($email);
+
+            $email->clear();
+            $batchOffset += $batchSize;
+        }
     }
 }

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1965,9 +1965,9 @@ class ActivityModel extends Gdn_Model {
         $subject = $this->getEmailSubjectFormatted($activity, $options);
         $body = $this->getEmailMessage($activity);
         $key = implode(".", [
-            $activity["ActivityTypeID"] ?? null,
-            $activity["RecordID"] ?? null,
-            $activity["RecordType"] ?? null,
+            $activity["ActivityTypeID"] ?? "",
+            $activity["RecordID"] ?? "",
+            $activity["RecordType"] ?? "",
             md5($subject),
             md5($body),
         ]);
@@ -2053,7 +2053,7 @@ class ActivityModel extends Gdn_Model {
         $batchOffset = 0;
         while ($batch = array_slice($recipients, $batchOffset, $batchSize)) {
             $email->subject($activityEmail->getSubject());
-            $email->to($email->getDefaultFromAddress(), t("Undisclosed Recipients"));
+            $email->to($email->getDefaultFromAddress(), t("Notifications"));
 
             foreach ($batch as $recipient) {
                 [$address, $name] = $recipient;

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1990,7 +1990,7 @@ class ActivityModel extends Gdn_Model {
         }
 
         $activityEmail->addActivityID($activityID);
-        $activityEmail->addRecipient($address);
+        $activityEmail->addRecipient($address, $user["Name"] ?? null);
     }
 
     /**
@@ -2056,7 +2056,8 @@ class ActivityModel extends Gdn_Model {
             $email->to($email->getDefaultFromAddress(), t("Undisclosed Recipients"));
 
             foreach ($batch as $recipient) {
-                $email->bcc($recipient);
+                [$address, $name] = $recipient;
+                $email->bcc($address, $name ?? "");
             }
 
             $emailTemplate = $email->getEmailTemplate()

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1965,9 +1965,9 @@ class ActivityModel extends Gdn_Model {
         $subject = $this->getEmailSubjectFormatted($activity, $options);
         $body = $this->getEmailMessage($activity);
         $key = implode(".", [
-            $activity["ActivityTypeID"],
-            $activity["RecordID"],
-            $activity["RecordType"],
+            $activity["ActivityTypeID"] ?? null,
+            $activity["RecordID"] ?? null,
+            $activity["RecordType"] ?? null,
             md5($subject),
             md5($body),
         ]);

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1642,7 +1642,10 @@ class ActivityModel extends Gdn_Model {
 
                 $activityID = $this->SQL->insert('Activity', $activity);
                 $activity['ActivityID'] = $activityID;
-                $this->queueEmail($activity, $options);
+
+                if ($activity['Emailed'] == self::SENT_PENDING) {
+                    $this->queueEmail($activity, $options);
+                }
 
                 $this->prune();
             }

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -187,8 +187,19 @@ class Gdn_Email extends Gdn_Pluggable implements LoggerAwareInterface {
     public function getDefaultFromAddress(): string {
         $result = c('Garden.Email.SupportAddress', '');
         if (!$result) {
-            $result = 'noreply@'.Gdn::request()->host();
+            $result = $this->getNoReplyAddress();
         }
+        return $result;
+    }
+
+    /**
+     * Get an address suitable for no-reply-style emails.
+     *
+     * @return string
+     */
+    public function getNoReplyAddress(): string {
+        $host = Gdn::request()->host();
+        $result = "noreply@{$host}";
         return $result;
     }
 

--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -180,6 +180,19 @@ class Gdn_Email extends Gdn_Pluggable implements LoggerAwareInterface {
     }
 
     /**
+     * Get the site's default from address.
+     *
+     * @return string
+     */
+    public function getDefaultFromAddress(): string {
+        $result = c('Garden.Email.SupportAddress', '');
+        if (!$result) {
+            $result = 'noreply@'.Gdn::request()->host();
+        }
+        return $result;
+    }
+
+    /**
      * Allows the explicit definition of the email's sender address & name.
      * Defaults to the applications Configuration 'SupportEmail' & 'SupportName' settings respectively.
      *
@@ -190,10 +203,7 @@ class Gdn_Email extends Gdn_Pluggable implements LoggerAwareInterface {
      */
     public function from($senderEmail = '', $senderName = '', $bOverrideSender = false) {
         if ($senderEmail == '') {
-            $senderEmail = c('Garden.Email.SupportAddress', '');
-            if (!$senderEmail) {
-                $senderEmail = 'noreply@'.Gdn::request()->host();
-            }
+            $senderEmail = $this->getDefaultFromAddress();
         }
 
         if ($senderName == '') {

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -446,7 +446,7 @@ class Gdn_Request implements RequestInterface {
         $port = $this->getPort();
 
         // Only append the port if it is non-standard.
-        if (($port == 80 && $this->getScheme() === 'http') || ($port == 443 && $this->getScheme() === 'https')) {
+        if ($port == 80 || $port == 443) {
             $port = '';
         } else {
             $port = ':'.$port;


### PR DESCRIPTION
Introducing sending notifications in fewer emails. Users having the same notification regarding the same record will be lumped into email messages as BCC recipients in batches. The default is fifty per message, but this is configurable via the `Garden.Email.BatchSize` key. Users are grouped on emails based on the notifications sharing the following: activity type, record type, record ID, subject and body. If all these align, emails are reused for up to X users.

This functionality is currently only implemented behind the `deferredNotifications` feature flag. You should need to enable this to see the batch-sending of notification emails. If you observe the behavior without this feature enabled, something has gone wrong. No functional changes should be observed in notifications when `deferredNotifications` is not enabled. Things should continue to function as they always have: one email per notification, per user. Additionally, since this feature only affects comments and discussions, you should only observe batch emails for those notifications.

This includes a sizable refactor of emailing in `ActivityModel`. Mostly, this involved moving functionality from large methods out into smaller private methods. Again, no functional changes should be observed here for the current notification email flow. These changes should only impact batch email sending.

**Please note: the changes here are only a stopgap until notification improvements are made in earnest. The only new class introduced here has documentation warning against its use. It is flagged as "internal" with messaging to discourage any additional use.**

### Recommended Testing
1. Ensure `Feature.deferredNotifications.Enabled` is set in your config.
1. Create a new discussion. Ensure activity on the new discussion will trigger email notifications to several users (e.g. bookmark notifications, participated notifications, etc.)
1. Make various comments on the discussion to trigger the assorted notifications for users.
1. You should observe emails being delivered to "Undisclosed Recipients". The recipients address should be hidden as BCC.
1. Try the above for discussion notifications.
1. Disable `Feature.deferredNotifications.Enabled`.
1. Repeat the steps above. Messages should still appear the same, but will be sent separately, one per-user.

It may be beneficial to put a breakpoint or two in `ActivityModel::sendActivityEmail` to see what is being sent and when.

Since `Garden.Email.BatchSize` is configurable, you can make small batches (e.g two-three users) to make it easier to verify functionality.

Closes #9310