### PR TITLE
Adjust getSimpleUrl method of Gdn_Request with assetRoot

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -1673,7 +1673,8 @@ class Gdn_Request implements RequestInterface {
     public function getSimpleUrl(string $uri = ''): string {
         $scheme = $this->getScheme();
         $hostAndPort = $this->getHostAndPort();
-        return "{$scheme}://{$hostAndPort}{$uri}";
+        $assetRoot = $this->getAssetRoot();
+        return "{$scheme}://{$hostAndPort}{$assetRoot}{$uri}";
     }
 
     /**

--- a/tests/fixtures/src/MockSiteSectionProvider.php
+++ b/tests/fixtures/src/MockSiteSectionProvider.php
@@ -15,7 +15,7 @@ use Vanilla\Contracts\Site\SiteSectionProviderInterface;
 class MockSiteSectionProvider implements SiteSectionProviderInterface {
 
     /**
-     * @var array $siteSections
+     * @var SiteSectionInterface[] $siteSections
      */
     private $siteSections = [];
 
@@ -72,6 +72,7 @@ class MockSiteSectionProvider implements SiteSectionProviderInterface {
      * @inheritdoc
      */
     public function getCurrentSiteSection(): SiteSectionInterface {
+        return $this->siteSections[0];
     }
 
     /**


### PR DESCRIPTION
Adjust `getSimpleUrl` method of `Gdn_Request` with `assetRoot` (when set)

Relates to: https://github.com/vanilla/vanilla/pull/9432 , https://github.com/vanilla/knowledge/pull/1299 

Closes: https://github.com/vanilla/vanilla/issues/9410 
