### PR TITLE
add group discussion permission-override to comments api

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -340,6 +340,9 @@ class CommentsApiController extends AbstractApiController {
         $out = $this->schema([':a' => $this->commentSchema()], 'out');
 
         $query = $in->validate($query);
+        if (isset($query['discussionID'])) {
+            $this->getEventManager()->fireFilter('commentsApiController_getFilters', $this, $query['discussionID'], $query);
+        }
         $where = ApiUtils::queryToFilters($in, $query);
 
         list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);


### PR DESCRIPTION
related https://github.com/vanilla/internal/pull/2031
closes https://github.com/vanilla/support/issues/777
### Details

When creating a comment inside a discussion inside a group and then trying to get the discussion's comment using api/v2/
with api/v2/comments?discussionID= you get this permission error.

<img width="613" alt="Screen Shot 2019-10-22 at 1 58 44 PM" src="https://user-images.githubusercontent.com/31856281/67315192-155a6300-f4d4-11e9-8b23-b54e172f71dc.png">

The reason this works for /discussion and not /comment is because

We're overriding group permissions when making an api/v2/discussions call, we check if the user can view the group then we set 'Vanilla.Discussions.View' on the category. However, we haven't implemented that for /comments

It could be a feature request to do the same for /comments. We will have to discuss it with Todd.

### Hooking into the discussionApiController
[class.hooks.php#L955](https://github.com/vanilla/internal/blob/master/applications/groups/settings/class.hooks.php#L955)
### Overriding Permission

[class.groupmodel.php#L1299](https://github.com/vanilla/internal/blob/master/applications/groups/models/class.groupmodel.php#L1299)

### To Test

Create a discussion inside a group, add a few comments
run this api call: /api/v2/comment?discussionID=?

### The Fix

In commentAPIController::Index() i called commentsApiController_getFilters and then created a hook in class.hooks.php in the referenced PR.
