### PR TITLE
Improve SiteSection and MockSiteSectionProvider for tests

### DIFF
--- a/library/Vanilla/Models/SiteMeta.php
+++ b/library/Vanilla/Models/SiteMeta.php
@@ -9,7 +9,6 @@ namespace Vanilla\Models;
 
 use Garden\Web\RequestInterface;
 use Vanilla\Contracts;
-use Vanilla\FeatureFlagHelper;
 use Vanilla\Addon;
 
 /**
@@ -38,6 +37,9 @@ class SiteMeta implements \JsonSerializable {
     /** @var int */
     private $maxUploadSize;
 
+    /** @var int */
+    private $maxUploads;
+
     /** @var string */
     private $localeKey;
 
@@ -61,16 +63,14 @@ class SiteMeta implements \JsonSerializable {
      *
      * @param RequestInterface $request The request to gather data from.
      * @param Contracts\ConfigurationInterface $config The configuration object.
-     * @param \Gdn_Locale $locale
-     * @param Addon $activeTheme
      * @param Contracts\Site\SiteSectionProviderInterface $siteSectionProvider
+     * @param Contracts\AddonInterface $activeTheme
      */
     public function __construct(
         RequestInterface $request,
         Contracts\ConfigurationInterface $config,
-        \Gdn_Locale $locale,
-        Addon $activeTheme,
-        Contracts\Site\SiteSectionProviderInterface $siteSectionProvider
+        Contracts\Site\SiteSectionProviderInterface $siteSectionProvider,
+        ?Contracts\AddonInterface $activeTheme = null
     ) {
         $this->host = $request->getHost();
 
@@ -96,7 +96,7 @@ class SiteMeta implements \JsonSerializable {
         $this->maxUploads = (int)$config->get('Garden.Upload.maxFileUploads', ini_get('max_file_uploads'));
 
         // localization
-        $this->localeKey = $locale->current();
+        $this->localeKey = $this->currentSiteSection->getContentLocale();
 
         // Theming
         $this->activeTheme = $activeTheme;
@@ -141,13 +141,6 @@ class SiteMeta implements \JsonSerializable {
             'featureFlags' => $this->featureFlags,
             'siteSection' => $this->currentSiteSection,
         ];
-    }
-
-    /**
-     * @return Contracts\Site\SiteSectionInterface
-     */
-    public function getCurrentSiteSection(): Contracts\Site\SiteSectionInterface {
-        return $this->currentSiteSection;
     }
 
     /**
@@ -209,7 +202,7 @@ class SiteMeta implements \JsonSerializable {
     /**
      * @return Addon
      */
-    public function getActiveTheme(): Addon {
+    public function getActiveTheme(): ?Contracts\AddonInterface {
         return $this->activeTheme;
     }
 

--- a/library/Vanilla/Models/ThemePreloadProvider.php
+++ b/library/Vanilla/Models/ThemePreloadProvider.php
@@ -8,7 +8,6 @@
 namespace Vanilla\Models;
 
 use Garden\Web\Data;
-use Garden\Web\Exception\NotFoundException;
 use Garden\Web\RequestInterface;
 use Vanilla\Web\Asset\DeploymentCacheBuster;
 use Vanilla\Web\Asset\ThemeScriptAsset;
@@ -88,6 +87,11 @@ class ThemePreloadProvider implements ReduxActionProviderInterface {
      */
     public function getThemeData(): ?array {
         if (!$this->themeData) {
+            $theme = $this->siteMeta->getActiveTheme();
+            if ($theme === null) {
+                $this->themeData = null;
+                return null;
+            }
             $themeKey = $this->siteMeta->getActiveTheme()->getKey();
             try {
                 $this->themeData = $this->themesApi->get($themeKey);

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -115,6 +115,9 @@ class Bootstrap {
 
             // Site sections
             ->rule(\Vanilla\Contracts\Site\SiteSectionProviderInterface::class)
+            ->setFactory(function () {
+                return MockSiteSectionProvider::fromLocales();
+            })
             ->setClass(MockSiteSectionProvider::class)
             ->setShared(true)
 

--- a/tests/fixtures/src/MockSiteSectionProvider.php
+++ b/tests/fixtures/src/MockSiteSectionProvider.php
@@ -8,6 +8,7 @@ namespace VanillaTests\Fixtures;
 
 use Vanilla\Contracts\Site\SiteSectionInterface;
 use Vanilla\Contracts\Site\SiteSectionProviderInterface;
+use Vanilla\Site\DefaultSiteSection;
 
 /**
  * Mock site-section-provider.
@@ -19,11 +20,24 @@ class MockSiteSectionProvider implements SiteSectionProviderInterface {
      */
     private $siteSections = [];
 
+    /** @var SiteSectionInterface */
+    private $currentSiteSection;
+
     /**
      * MockSiteSectionProvider constructor.
+     *
+     * @param DefaultSiteSection $defaultSiteSection
      */
-    public function __construct() {
-        $this->siteSections = self::fromLocales();
+    public function __construct(DefaultSiteSection $defaultSiteSection) {
+        $this->siteSections = array_merge([$defaultSiteSection]);
+        $this->currentSiteSection = $defaultSiteSection;
+    }
+
+    /**
+     * @param SiteSectionInterface[] $siteSections
+     */
+    public function addSiteSections(array $siteSections) {
+        $this->siteSections = array_merge($this->siteSections, $siteSections);
     }
 
 
@@ -54,25 +68,56 @@ class MockSiteSectionProvider implements SiteSectionProviderInterface {
      * @inheritdoc
      */
     public function getByID(int $id): ?SiteSectionInterface {
+        foreach ($this->siteSections as $section) {
+            if ($section->getSectionID() === $id) {
+                return $section;
+            }
+        }
+
+        return null;
     }
 
     /**
      * @inheritdoc
      */
     public function getByBasePath(string $basePath): ?SiteSectionInterface {
+        foreach ($this->siteSections as $section) {
+            if ($section->getBasePath() === $basePath) {
+                return $section;
+            }
+        }
+
+        return null;
     }
 
     /**
      * @inheritdoc
      */
     public function getForLocale(string $localeKey): array {
+        $sections = [];
+
+        /** @var SiteSectionInterface $section */
+        foreach ($this->siteSections as $section) {
+            if ($section->getContentLocale() === $localeKey) {
+                $sections[] = $section;
+            }
+        }
+
+        return $sections;
     }
 
     /**
      * @inheritdoc
      */
     public function getCurrentSiteSection(): SiteSectionInterface {
-        return $this->siteSections[0];
+        return $this->currentSiteSection;
+    }
+
+    /**
+     * @param SiteSectionInterface $currentSiteSection
+     */
+    public function setCurrentSiteSection(SiteSectionInterface $currentSiteSection): void {
+        $this->currentSiteSection = $currentSiteSection;
     }
 
     /**
@@ -80,10 +125,9 @@ class MockSiteSectionProvider implements SiteSectionProviderInterface {
      *
      * @param array $locales
      *
-     * @return array
+     * @return MockSiteSectionProvider
      */
-    public static function fromLocales(array $locales = ["en", "fr", "es", "ru"]): array {
-
+    public static function fromLocales(array $locales = ["en", "fr", "es", "ru"]): MockSiteSectionProvider {
         $siteSections = [];
 
         foreach ($locales as $locale) {
@@ -104,6 +148,9 @@ class MockSiteSectionProvider implements SiteSectionProviderInterface {
             );
         }
 
-        return $siteSections;
+        /** @var MockSiteSectionProvider $provider */
+        $provider = \Gdn::getContainer()->get(MockSiteSectionProvider::class);
+        $provider->addSiteSections($siteSections);
+        return $provider;
     }
 }


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/pull/1296

**SiteMeta**

- No longer requires a `Gdn_Locale`. It pulls it's locale from the current site section.
- No longer requires a theme. The theme can now be null (common in a test or partiality initialized site.) `ThemePreloadProvider` now has some handling of a null theme value as well.

**MockSiteSectionProvider**

- `MockSiteSectionProvider::fromLocales()` now returns a full provider instance. It is no longer called automatically in the constructor. This allows other tests to use their own site sections. `Bootstrap` has been updated to accommodate this.
- It now uses the default site section.
- Added methods for pushing extra site sections.
- Implement `getForLocale()`, `getByBasePath`, `getForID()`.