### PR TITLE
add getFilters to comments api

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -171,6 +171,9 @@ class CommentsApiController extends AbstractApiController {
         $query = $in->validate($query);
 
         $comment = $this->commentByID($id);
+        if (isset($comment['DiscussionID'])) {
+            $this->getEventManager()->fireFilter('commentsApiController_getFilters', $this, $comment['DiscussionID'], $query);
+        }
         if ($comment['InsertUserID'] !== $this->getSession()->UserID) {
             $discussion = $this->discussionByID($comment['DiscussionID']);
             $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $discussion['CategoryID']);


### PR DESCRIPTION
related https://github.com/vanilla/vanilla/pull/9454

similar to the referenced issue, api/v2/comments/commentid would also return a 'Vanilla.Discussions.View' permission error.

This PR calls commentsApiController_getFilters to update the 'Social Groups' category permission.

### To Test

api call api/v2/comments/commentid