### PR TITLE
Remove dependencies from AddonManager

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -352,11 +352,7 @@ class AddonManager implements Contracts\AddonProviderInterface {
                 } elseif (!array_key_exists($key, $addons)) {
                     $addons[$key] = $addon;
                 } else {
-                    \Logger::error('Duplicate addon: {key}', [
-                        'key' => $key,
-                        'event' => 'duplicate_addon'
-                    ]);
-                    throw new \Exception("Duplicate addon: {$key}");
+                    throw new \Exception("Duplicate addon: {$key}", 500);
                 }
             } catch (\Exception $ex) {
                 $exceptionMessage = $ex->getMessage();
@@ -402,10 +398,7 @@ class AddonManager implements Contracts\AddonProviderInterface {
                 } elseif (!array_key_exists($basename, $result)) {
                     $result[$basename] = substr($path, $strlen);
                 } else {
-                    \Logger::error('Duplicate addon: {basename}', [
-                        'basename' => $basename,
-                        'event' => 'duplicate_addon'
-                    ]);
+                    trigger_error("Duplicate addon: $basename", E_USER_WARNING);
                 }
             }
         }

--- a/tests/Library/Vanilla/AddonManagerTest.php
+++ b/tests/Library/Vanilla/AddonManagerTest.php
@@ -7,7 +7,6 @@
 
 namespace VanillaTests\Library\Vanilla;
 
-use VanillaTests\SharedBootstrapTestCase;
 use Test\OldApplication\Controllers\Api\NewApiController;
 use Test\OldApplication\Controllers\ArchiveController;
 use Test\OldApplication\Controllers\HiddenController;
@@ -17,6 +16,7 @@ use Test\OldApplication\arbitraryLowercase;
 use Vanilla\AddonManager;
 use Vanilla\Addon;
 use VanillaTests\Fixtures\TestAddonManager;
+use VanillaTests\SharedBootstrapTestCase;
 
 /**
  * Tests for the AddonManager
@@ -30,6 +30,7 @@ class AddonManagerTest extends SharedBootstrapTestCase {
      */
     public static function setUpBeforeClass() {
         \Gdn_FileSystem::removeFolder(PATH_ROOT.'/tests/cache/am');
+        parent::setUpBeforeClass();
     }
 
     /**


### PR DESCRIPTION
The calls to the static `Logger` methods sneaks a dependency into the AddonManger and was causing certain tests to fail.