### PR TITLE
Get rid of forcing tables to MyISAM when FULLTEXT key is used (rebased)

### DIFF
--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -202,89 +202,7 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
      * Creates the table defined with $this->table() and $this->column().
      */
     protected function _create() {
-        $primaryKey = [];
-        $uniqueKey = [];
-        $fullTextKey = [];
-        $indexes = [];
-        $keys = '';
-        $sql = '';
-        $tableName = Gdn_Format::alphaNumeric($this->_TableName);
-
-        foreach ($this->_Columns as $columnName => $column) {
-            if ($sql != '') {
-                $sql .= ',';
-            }
-
-            $sql .= "\n".$this->_defineColumn($column);
-
-            $columnKeyTypes = (array)$column->KeyType;
-
-            foreach ($columnKeyTypes as $columnKeyType) {
-                $keyTypeParts = explode('.', $columnKeyType, 2);
-                $columnKeyType = $keyTypeParts[0];
-                $indexGroup = val(1, $keyTypeParts, '');
-
-                if ($columnKeyType == 'primary') {
-                    $primaryKey[] = $columnName;
-                } elseif ($columnKeyType == 'key') {
-                    $indexes['FK'][$indexGroup][] = $columnName;
-                } elseif ($columnKeyType == 'index') {
-                    $indexes['IX'][$indexGroup][] = $columnName;
-                } elseif ($columnKeyType == 'unique') {
-                    $uniqueKey[] = $columnName;
-                } elseif ($columnKeyType == 'fulltext') {
-                    $fullTextKey[] = $columnName;
-                }
-            }
-        }
-        // Build primary keys
-        if (count($primaryKey) > 0) {
-            $keys .= ",\nprimary key (`".implode('`, `', $primaryKey)."`)";
-        }
-        // Build unique keys.
-        if (count($uniqueKey) > 0) {
-            $keys .= ",\nunique index `UX_{$tableName}` (`".implode('`, `', $uniqueKey)."`)";
-        }
-        // Build full text index.
-        if (count($fullTextKey) > 0) {
-            $keys .= ",\nfulltext index `TX_{$tableName}` (`".implode('`, `', $fullTextKey)."`)";
-        }
-        // Build the rest of the keys.
-        foreach ($indexes as $indexType => $indexGroups) {
-            $createString = val($indexType, ['FK' => 'key', 'IX' => 'index']);
-            foreach ($indexGroups as $indexGroup => $columnNames) {
-                if (!$indexGroup) {
-                    foreach ($columnNames as $columnName) {
-                        $keys .= ",\n{$createString} `{$indexType}_{$tableName}_{$columnName}` (`{$columnName}`)";
-                    }
-                } else {
-                    $keys .= ",\n{$createString} `{$indexType}_{$tableName}_{$indexGroup}` (`".implode('`, `', $columnNames).'`)';
-                }
-            }
-        }
-
-        $sql = 'create table `'.$this->_DatabasePrefix.$tableName.'` ('
-            .$sql
-            .$keys
-            ."\n)";
-
-        $forceDatabaseEngine = Gdn::config('Database.ForceStorageEngine');
-        if ($forceDatabaseEngine && !$this->_TableStorageEngine) {
-            $this->_TableStorageEngine = $forceDatabaseEngine;
-        }
-        if ($this->_TableStorageEngine) {
-            $sql .= ' engine='.$this->_TableStorageEngine;
-        }
-
-        if ($this->_CharacterEncoding !== false && $this->_CharacterEncoding != '') {
-            $sql .= ' default character set '.$this->_CharacterEncoding;
-        }
-
-        if (array_key_exists('Collate', $this->Database->ExtendedProperties)) {
-            $sql .= ' collate '.$this->Database->ExtendedProperties['Collate'];
-        }
-
-        $sql .= ';';
+        $sql = $this->getCreateTable();
 
         $result = $this->executeQuery($sql);
         $this->reset();
@@ -782,5 +700,92 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         } else {
             return "'".str_replace("'", "''", $value)."'";
         }
+    }
+
+    /**
+     * Generate the DDL for creating a table.
+     *
+     * @return string Returns a DDL statement.
+     */
+    final protected function getCreateTable(): string {
+        $primaryKey = [];
+        $uniqueKey = [];
+        $fullTextKey = [];
+        $indexes = [];
+        $keys = '';
+        $sql = '';
+        $tableName = Gdn_Format::alphaNumeric($this->_TableName);
+
+        foreach ($this->_Columns as $columnName => $column) {
+            if ($sql != '') {
+                $sql .= ',';
+            }
+
+            $sql .= "\n" . $this->_defineColumn($column);
+
+            $columnKeyTypes = (array)$column->KeyType;
+
+            foreach ($columnKeyTypes as $columnKeyType) {
+                $keyTypeParts = explode('.', $columnKeyType, 2);
+                $columnKeyType = $keyTypeParts[0];
+                $indexGroup = val(1, $keyTypeParts, '');
+
+                if ($columnKeyType == 'primary') {
+                    $primaryKey[] = $columnName;
+                } elseif ($columnKeyType == 'key') {
+                    $indexes['FK'][$indexGroup][] = $columnName;
+                } elseif ($columnKeyType == 'index') {
+                    $indexes['IX'][$indexGroup][] = $columnName;
+                } elseif ($columnKeyType == 'unique') {
+                    $uniqueKey[] = $columnName;
+                } elseif ($columnKeyType == 'fulltext') {
+                    $fullTextKey[] = $columnName;
+                }
+            }
+        }
+        // Build primary keys
+        if (count($primaryKey) > 0) {
+            $keys .= ",\nprimary key (`" . implode('`, `', $primaryKey) . "`)";
+        }
+        // Build unique keys.
+        if (count($uniqueKey) > 0) {
+            $keys .= ",\nunique index `UX_{$tableName}` (`" . implode('`, `', $uniqueKey) . "`)";
+        }
+        // Build full text index.
+        if (count($fullTextKey) > 0) {
+            $keys .= ",\nfulltext index `TX_{$tableName}` (`" . implode('`, `', $fullTextKey) . "`)";
+        }
+        // Build the rest of the keys.
+        foreach ($indexes as $indexType => $indexGroups) {
+            $createString = val($indexType, ['FK' => 'key', 'IX' => 'index']);
+            foreach ($indexGroups as $indexGroup => $columnNames) {
+                if (!$indexGroup) {
+                    foreach ($columnNames as $columnName) {
+                        $keys .= ",\n{$createString} `{$indexType}_{$tableName}_{$columnName}` (`{$columnName}`)";
+                    }
+                } else {
+                    $keys .= ",\n{$createString} `{$indexType}_{$tableName}_{$indexGroup}` (`" . implode('`, `', $columnNames) . '`)';
+                }
+            }
+        }
+
+        $sql = 'create table `' . $this->_DatabasePrefix . $tableName . '` ('
+            . $sql
+            . $keys
+            . "\n)";
+
+        $engine = ($this->_TableStorageEngine ?: Gdn::config('Database.ForceStorageEngine', Gdn::config('Database.DefaultStorageEngine'))) ?: 'innodb';
+        $sql .= ' engine=' . $engine;
+
+        if ($this->_CharacterEncoding !== false && $this->_CharacterEncoding != '') {
+            $sql .= ' default character set ' . $this->_CharacterEncoding;
+        }
+
+        if (array_key_exists('Collate', $this->Database->ExtendedProperties)) {
+            $sql .= ' collate ' . $this->Database->ExtendedProperties['Collate'];
+        }
+
+        $sql .= ';';
+        return $sql;
     }
 }

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -226,14 +226,15 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
 
                 if ($columnKeyType == 'primary') {
                     $primaryKey[] = $columnName;
-                } elseif ($columnKeyType == 'key')
+                } elseif ($columnKeyType == 'key') {
                     $indexes['FK'][$indexGroup][] = $columnName;
-                elseif ($columnKeyType == 'index')
+                } elseif ($columnKeyType == 'index') {
                     $indexes['IX'][$indexGroup][] = $columnName;
-                elseif ($columnKeyType == 'unique')
+                } elseif ($columnKeyType == 'unique') {
                     $uniqueKey[] = $columnName;
-                elseif ($columnKeyType == 'fulltext')
+                } elseif ($columnKeyType == 'fulltext') {
                     $fullTextKey[] = $columnName;
+                }
             }
         }
         // Build primary keys

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -267,7 +267,6 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
             .$keys
             ."\n)";
 
-
         $forceDatabaseEngine = Gdn::config('Database.ForceStorageEngine');
         if ($forceDatabaseEngine && !$this->_TableStorageEngine) {
             $this->_TableStorageEngine = $forceDatabaseEngine;

--- a/library/database/class.mysqlstructure.php
+++ b/library/database/class.mysqlstructure.php
@@ -210,11 +210,6 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
         $sql = '';
         $tableName = Gdn_Format::alphaNumeric($this->_TableName);
 
-        $forceDatabaseEngine = c('Database.ForceStorageEngine');
-        if ($forceDatabaseEngine && !$this->_TableStorageEngine) {
-            $this->_TableStorageEngine = $forceDatabaseEngine;
-        }
-
         foreach ($this->_Columns as $columnName => $column) {
             if ($sql != '') {
                 $sql .= ',';
@@ -272,28 +267,11 @@ class Gdn_MySQLStructure extends Gdn_DatabaseStructure {
             .$keys
             ."\n)";
 
-        // Check to see if there are any fulltext columns, otherwise use innodb.
-        if (!$this->_TableStorageEngine) {
-            $hasFulltext = false;
-            foreach ($this->_Columns as $column) {
-                $columnKeyTypes = (array)$column->KeyType;
-                array_map('strtolower', $columnKeyTypes);
-                if (in_array('fulltext', $columnKeyTypes)) {
-                    $hasFulltext = true;
-                    break;
-                }
-            }
-            if ($hasFulltext) {
-                $this->_TableStorageEngine = 'myisam';
-            } else {
-                $this->_TableStorageEngine = c('Database.DefaultStorageEngine', 'innodb');
-            }
 
-            if (!$this->hasEngine($this->_TableStorageEngine)) {
-                $this->_TableStorageEngine = 'myisam';
-            }
+        $forceDatabaseEngine = Gdn::config('Database.ForceStorageEngine');
+        if ($forceDatabaseEngine && !$this->_TableStorageEngine) {
+            $this->_TableStorageEngine = $forceDatabaseEngine;
         }
-
         if ($this->_TableStorageEngine) {
             $sql .= ' engine='.$this->_TableStorageEngine;
         }

--- a/tests/Library/Database/MySQLStructureTest.php
+++ b/tests/Library/Database/MySQLStructureTest.php
@@ -97,7 +97,9 @@ class MySQLStructureTest extends TestCase {
     /**
      * A forced engine should override the default.
      *
-     * @param string $expectedEngine
+     * @param array $config Config changes to run the test with.
+     * @param string $explicitEngine The engine to set on the `Gdn_MySQLStructure` class.
+     * @param string $expectedEngine The expected engine in the `create table` statement.
      * @dataProvider provideEngines
      */
     final private function doCollationTest(array $config, string $explicitEngine, string $expectedEngine): void {

--- a/tests/Library/Database/MySQLStructureTest.php
+++ b/tests/Library/Database/MySQLStructureTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Database;
+
+use PHPUnit\Framework\TestCase;
+use VanillaTests\Fixtures\TestMySQLStructure;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Tests for the `Gdn_MySQLStructure` class.
+ */
+class MySQLStructureTest extends TestCase {
+    use SiteTestTrait;
+
+    /**
+     * @var TestMySQLStructure
+     */
+    private $st;
+
+    /**
+     * Set up a fixture for use in tests.
+     */
+    public function setUp() {
+        parent::setUp();
+
+        $st = new TestMySQLStructure($this->container()->get(\Gdn_Database::class));
+        $this->st = $st;
+        $this->st->reset();
+    }
+
+    /**
+     * The default storage engine config should be applied to table creates.
+     *
+     * @param string $engine
+     * @dataProvider provideEngines
+     */
+    public function testDefaultCollation(string $engine): void {
+        $this->doCollationTest(
+            [
+                'Database.DefaultStorageEngine' => $engine,
+            ],
+            '',
+            $engine
+        );
+    }
+
+    /**
+     * The default storage engine should be innodb.
+     */
+    public function testDefaultCollationInnodb(): void {
+        $this->doCollationTest(
+            [],
+            '',
+            'innodb'
+        );
+    }
+
+    /**
+     * A forced engine should override the default.
+     *
+     * @param string $engine
+     * @dataProvider provideEngines
+     */
+    public function testForceCollation(string $engine): void {
+        $this->doCollationTest(
+            [
+                'Database.DefaultStorageEngine' => 'foo',
+                'Database.ForceStorageEngine' => $engine,
+            ],
+            '',
+            $engine
+        );
+    }
+
+    /**
+     * An explicitly set collation should override all configs.
+     *
+     * @param string $engine
+     * @dataProvider provideEngines
+     */
+    public function testExplicitCollation(string $engine): void {
+        $this->doCollationTest(
+            [
+                'Database.DefaultStorageEngine' => 'foo',
+                'Database.ForceStorageEngine' => 'foo',
+            ],
+            $engine,
+            $engine
+        );
+    }
+
+    /**
+     * A forced engine should override the default.
+     *
+     * @param string $expectedEngine
+     * @dataProvider provideEngines
+     */
+    final private function doCollationTest(array $config, string $explicitEngine, string $expectedEngine): void {
+        $this->runWithConfig($config, function () use ($explicitEngine, $expectedEngine) {
+            $this->st
+                ->table('testDefaultCollationISAM')
+                ->primaryKey('id')
+                ->column('name', 'varchar(50)');
+
+            if (!empty($explicitEngine)) {
+                $this->st->engine($explicitEngine, false);
+            }
+
+            $dml = $this->st->dumpCreateTable();
+            $expected = <<<EOT
+create table `GDN_testDefaultCollationISAM` (
+`id` int not null auto_increment,
+`name` varchar(50) not null,
+primary key (`id`)
+) engine=$expectedEngine default character set utf8mb4 collate utf8mb4_unicode_ci;
+EOT;
+
+            $this->assertEquals($expected, $dml);
+        });
+    }
+
+    /**
+     * Provide the database engines that we support.
+     *
+     * @return array
+     */
+    public function provideEngines(): array {
+        return [
+            'innodb' => ['innodb'],
+            'myisam' => ['myisam'],
+        ];
+    }
+}

--- a/tests/fixtures/TestMySQLStructure.php
+++ b/tests/fixtures/TestMySQLStructure.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures;
+
+/**
+ * A test version of `Gdn_MySQLStructure` for inspecting some protected methods.
+ */
+class TestMySQLStructure extends \Gdn_MySQLStructure {
+    /**
+     * Exposes the `Gdn_MySQLStructure::getCreateTable()` method.
+     *
+     * @return string
+     */
+    public function dumpCreateTable(): string {
+        return $this->getCreateTable();
+    }
+}


### PR DESCRIPTION
Vanilla always checked if a table had a FULLTEXT key in one row and forced that table to MyISAM. The minimum required MySQL version for Vanilla already supports fulltext keys for InnoDB tables, therefore that logic isn't needed any more.

The Gdn_MySqlStructure class had a helper function "_supportsFulltext. Under the assumption that this will always return `true`, I've deleted all code lines that became unnessecary.

This will close 
https://github.com/vanilla/vanilla/issues/5555
https://github.com/vanilla/vanilla/issues/6029