### PR TITLE
Add UserProviderInterface & MockUserProvider

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1201,8 +1201,9 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
                 }
 
                 if ($options['asFragments'] ?? false) {
-                    setValue($destination, $row, UserFragmentSchema::normalizeUserFragment($user));
+                    $user =  UserFragmentSchema::normalizeUserFragment($user);
                 }
+                setValue($destination, $row, $user);
             }
         };
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -258,6 +258,9 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->rule('Gdn_Model')
     ->setShared(true)
 
+    ->rule(Contracts\Models\UserProviderInterface::class)
+    ->setClass(UserModel::class)
+
     ->rule(Gdn_Validation::class)
     ->addCall('addRule', ['BodyFormat', new Reference(\Vanilla\BodyFormatValidator::class)])
 

--- a/library/Vanilla/Contracts/Models/FragmentProviderInterface.php
+++ b/library/Vanilla/Contracts/Models/FragmentProviderInterface.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Contracts\Models;
+
+/**
+ * Interface representing a generic fragment provider.
+ */
+interface FragmentProviderInterface {
+    /**
+     * Get a single fragment by it's ID.
+     *
+     * @param int $id The ID to lookup.
+     * @param bool $useUnknownFallback Whether or not to use the unknown fragment as a fallback.
+     * @return array
+     */
+    public function getFragmentByID(int $id, bool $useUnknownFallback = false): array;
+
+    /**
+     * Populate records with fragments based on various ID fields.
+     *
+     * @param array $records The records to populate.
+     * @param array $columnNames The column names to check for. These should end with `ID`.
+     *        The resulting values will be populated on a field without the ID suffix.
+     */
+    public function expandFragments(array &$records, array $columnNames): void;
+
+    /**
+     * Return an array of keys that can be used to generate some record.
+     *
+     * @return string[]
+     */
+    public function getAllowedGeneratedRecordKeys(): array;
+
+    /**
+     * Get a fragment representing when a record isn't found.
+     *
+     * @param string $key A key representing some generated record.
+     *
+     * @return array
+     */
+    public function getGeneratedFragment(string $key): array;
+}

--- a/library/Vanilla/Contracts/Models/UserProviderInterface.php
+++ b/library/Vanilla/Contracts/Models/UserProviderInterface.php
@@ -8,32 +8,7 @@
 namespace Vanilla\Contracts\Models;
 
 /**
- * Class for modelling user expansion.
+ * Interface for modelling user expansion.
  */
-interface UserProviderInterface {
-
-    /**
-     * Get a single user fragment by it's ID.
-     *
-     * @param int $id The ID to lookup.
-     * @param bool $useUnknownFallback Whether or not to use the unknown fragment as a fallback.
-     * @return array
-     */
-    public function getFragmentByID(int $id, bool $useUnknownFallback = false): array;
-
-    /**
-     * Populate records with user fragments based on various ID fields.
-     *
-     * @param array $records The records to populate.
-     * @param array $columnNames The column names to check for. These should end with `ID`.
-     *        The resulting values will be populated on a field without the ID suffix.
-     */
-    public function expandUserFragments(array &$records, array $columnNames): void;
-
-    /**
-     * Get a fragment representing an unkown user.
-     *
-     * @return array
-     */
-    public function getUnknownFragment(): array;
+interface UserProviderInterface extends FragmentProviderInterface {
 }

--- a/library/Vanilla/Contracts/Models/UserProviderInterface.php
+++ b/library/Vanilla/Contracts/Models/UserProviderInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Contracts\Models;
+
+/**
+ * Class for modelling user expansion.
+ */
+interface UserProviderInterface {
+
+    /**
+     * Get a single user fragment by it's ID.
+     *
+     * @param int $id The ID to lookup.
+     * @param bool $useUnknownFallback Whether or not to use the unknown fragment as a fallback.
+     * @return array
+     */
+    public function getFragmentByID(int $id, bool $useUnknownFallback = false): array;
+
+    /**
+     * Populate records with user fragments based on various ID fields.
+     *
+     * @param array $records The records to populate.
+     * @param array $columnNames The column names to check for. These should end with `ID`.
+     *        The resulting values will be populated on a field without the ID suffix.
+     */
+    public function expandUserFragments(array &$records, array $columnNames): void;
+
+    /**
+     * Get a fragment representing an unkown user.
+     *
+     * @return array
+     */
+    public function getUnknownFragment(): array;
+}

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -190,6 +190,9 @@ class Bootstrap {
             ->addAlias('MySQLDriver')
             ->addAlias(Gdn::AliasSqlDriver)
 
+            ->rule(\Vanilla\Contracts\Models\UserProviderInterface::class)
+            ->setClass(\UserModel::class)
+
             // Locale
             ->rule(\Gdn_Locale::class)
             ->setShared(true)

--- a/tests/MinimalContainerTestCase.php
+++ b/tests/MinimalContainerTestCase.php
@@ -16,6 +16,7 @@ use Vanilla\AddonManager;
 use Vanilla\Contracts\AddonProviderInterface;
 use Vanilla\Contracts\ConfigurationInterface;
 use Vanilla\Contracts\LocaleInterface;
+use Vanilla\Contracts\Models\UserProviderInterface;
 use Vanilla\Formatting\FormatService;
 use Vanilla\InjectableInterface;
 use Vanilla\Site\SingleSiteSectionProvider;
@@ -23,6 +24,7 @@ use VanillaTests\Fixtures\MockAddonProvider;
 use VanillaTests\Fixtures\MockConfig;
 use VanillaTests\Fixtures\MockHttpClient;
 use VanillaTests\Fixtures\MockLocale;
+use VanillaTests\Fixtures\Models\MockUserProvider;
 use VanillaTests\Fixtures\NullCache;
 
 /**
@@ -106,6 +108,10 @@ class MinimalContainerTestCase extends TestCase {
             ->setShared(true)
             ->addAlias(Gdn::AliasRequest)
             ->addAlias(RequestInterface::class)
+
+            ->rule(UserProviderInterface::class)
+            ->setClass(MockUserProvider::class)
+            ->setShared(true)
         ;
     }
 
@@ -179,6 +185,12 @@ class MinimalContainerTestCase extends TestCase {
         $_SERVER['HTTPS'] = parse_url($baseUrl, PHP_URL_SCHEME) === 'https';
     }
 
+    /**
+     * @return MockUserProvider
+     */
+    protected function getMockUserProvider(): MockUserProvider {
+        return self::container()->get(UserProviderInterface::class);
+    }
 
     /**
      * Reset the container.

--- a/tests/fixtures/src/Models/MockUserProvider.php
+++ b/tests/fixtures/src/Models/MockUserProvider.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures\Models;
+
+use Vanilla\Contracts\Models\UserProviderInterface;
+use Vanilla\Exception\Database\NoResultsException;
+
+/**
+ * Mock user provider that can be configured for some users.
+ */
+class MockUserProvider implements UserProviderInterface {
+
+    private $currentID = 1;
+
+    private $usersByID = [];
+
+    /**
+     * @inheritdoc
+     */
+    public function getFragmentByID(int $id, bool $useUnknownFallback = false): array {
+        $user = $this->usersByID[$id] ?? null;
+        if (!$user) {
+            if ($useUnknownFallback) {
+                return $this->getUnknownFragment();
+            } else {
+                throw new NoResultsException('No user found for ID ' . $id);
+            }
+        }
+
+        return $user;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function expandUserFragments(array &$records, array $columnNames): void {
+        foreach ($columnNames as $column) {
+            $noIDName = str_replace('ID', '', $column);
+            foreach ($records as $record) {
+                $record[$noIDName] = $this->getFragmentByID($record[$column], true);
+            }
+        }
+    }
+
+    /**
+     * Create a mock user, add it, and return it.
+     *
+     * @param string|null $label
+     * @return array
+     */
+    public function addMockUser(string $label = null) {
+        $record = [
+            'userID' => $this->currentID,
+            'name' => 'user' . $this->currentID,
+            'email' => 'user' . $this->currentID . '@example.com',
+            'photoUrl' => 'image.png',
+        ];
+
+        if ($label) {
+            $record['label'] = $label;
+        }
+
+        $this->usersByID[$this->currentID] = $record;
+        $this->currentID++;
+        return $record;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUnknownFragment(): array {
+        return [
+            'userID' => 0,
+            'name' => 'unknown',
+            'email' => 'unknown@example.com',
+            'photoUrl' => 'unknown.png',
+        ];
+    }
+}

--- a/tests/fixtures/src/Models/MockUserProvider.php
+++ b/tests/fixtures/src/Models/MockUserProvider.php
@@ -38,7 +38,7 @@ class MockUserProvider implements UserProviderInterface {
     /**
      * @inheritdoc
      */
-    public function expandUserFragments(array &$records, array $columnNames): void {
+    public function expandFragments(array &$records, array $columnNames): void {
         foreach ($columnNames as $column) {
             $noIDName = str_replace('ID', '', $column);
             foreach ($records as $record) {
@@ -46,6 +46,15 @@ class MockUserProvider implements UserProviderInterface {
             }
         }
     }
+
+    /**
+     * All values are supported.
+     * @return array
+     */
+    public function getAllowedGeneratedRecordKeys(): array {
+        return [];
+    }
+
 
     /**
      * Create a mock user, add it, and return it.
@@ -73,12 +82,12 @@ class MockUserProvider implements UserProviderInterface {
     /**
      * @inheritdoc
      */
-    public function getUnknownFragment(): array {
+    public function getGeneratedFragment(string $key): array {
         return [
             'userID' => 0,
-            'name' => 'unknown',
-            'email' => 'unknown@example.com',
-            'photoUrl' => 'unknown.png',
+            'name' => $key,
+            'email' => $key . '@example.com',
+            'photoUrl' => $key . '.png',
         ];
     }
 }

--- a/tests/fixtures/src/Models/MockUserProvider.php
+++ b/tests/fixtures/src/Models/MockUserProvider.php
@@ -57,7 +57,7 @@ class MockUserProvider implements UserProviderInterface {
         $record = [
             'userID' => $this->currentID,
             'name' => 'user' . $this->currentID,
-            'email' => 'user' . $this->currentID . '@example.com',
+            'dateLastActive' => null,
             'photoUrl' => 'image.png',
         ];
 


### PR DESCRIPTION
## Why?

With this new mock, we can now write unit tests against stuff that depends on user record/expansion without needing the a real DB for the actual `UserModel`.

## What is it?

- Add `Contracts\Models\UserProviderInterface`
  - Expands users.
  - Get user fragments by ID.
- Update `\UserModel` to implement this interface.
  - These are **new methods** that call out to old ones & do a little cleanup. The new methods don't have weird/unneeded parameters like the base user model, and doesn't have any 
  - Main application `bootstrap.php` and the test `Bootstrap` class have been updated with a definition for the interface/implementation.
- Add's a `MockUserProvider` that is configurable with fake users. No DB connection.
  - Configured automatically in the container setup of `MinimalContainerTestCase`