### PR TITLE
Rich Editor Placeholder Alignment

### DIFF
--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -25,6 +25,7 @@ const DEFAULT_CONTENT = [{ insert: "\n" }];
 interface IProps {
     legacyTextArea?: HTMLInputElement | HTMLTextAreaElement;
     placeholder?: string;
+    placeholderClassName?: string;
 }
 
 /**
@@ -37,7 +38,7 @@ export default function EditorContent(props: IProps) {
     useQuillInstance(quillMountRef);
     useLegacyTextAreaSync(props.legacyTextArea);
     useDebugPasteListener(props.legacyTextArea);
-    useQuillAttributeSync(props.placeholder);
+    useQuillAttributeSync(props.placeholder, props.placeholderClassName);
     useLoadStatus();
     useInitialValue();
     useOperationsQueue();
@@ -91,13 +92,13 @@ export function useQuillInstance(mountRef: React.RefObject<HTMLDivElement>, extr
 /**
  * Apply our CSS classes/styles and other attributes to quill's root. (Not a react component).
  */
-function useQuillAttributeSync(placeholder?: string) {
+function useQuillAttributeSync(placeholder?: string, placeholderClass?: string) {
     const { legacyMode, quill } = useEditor();
     const classesRichEditor = richEditorClasses(legacyMode);
     const classesUserContent = userContentClasses();
     const quillRootClasses = useMemo(
         () =>
-            classNames("richEditor-text", "userContent", classesRichEditor.text, {
+            classNames("richEditor-text", "userContent", placeholderClass, classesRichEditor.text, {
                 // These classes shouln't be applied until the forum is converted to the new styles.
                 [classesUserContent.root]: !legacyMode,
             }),

--- a/plugins/rich-editor/src/scripts/editor/richEditorStyles.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorStyles.ts
@@ -12,11 +12,9 @@ import {
     srOnly,
     unit,
     userSelect,
-    sticky,
     pointerEvents,
-    allButtonStates,
     borders,
-    negative,
+    paddings,
 } from "@library/styles/styleHelpers";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
@@ -316,7 +314,10 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
     const embedBar = style("embedBar", {
         display: "block",
         width: percent(100),
-        padding: unit(vars.embedMenu.padding),
+        ...paddings({
+            horizontal: (vars.menuButton.size - globalVars.icon.sizes.small) / 2,
+            vertical: vars.embedMenu.padding,
+        }),
         background: legacyMode ? undefined : colorOut(vars.colors.bg),
     });
 
@@ -393,6 +394,14 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
         marginTop: unit((vars.menuButton.size - vars.iconWrap.width) / -2 + 1),
     });
 
+    const placeholder = style("placeholder", {
+        $nest: {
+            "&&&:before": {
+                margin: 0,
+            },
+        },
+    });
+
     return {
         root,
         menuBar,
@@ -418,5 +427,6 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
         iconWrap,
         flyoutOffset,
         emojiGroup,
+        placeholder,
     };
 });

--- a/plugins/rich-editor/src/scripts/editor/richEditorVariables.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorVariables.ts
@@ -66,7 +66,7 @@ export const richEditorVariables = useThemeCache(() => {
     });
 
     const pilcrow = makeThemeVars("pilcrow", {
-        offset: 9,
+        offset: 0,
         fontSize: 14,
         animation: {
             duration: ".3s",


### PR DESCRIPTION
The pilcrow icon and the placeholder were not aligned with the text. This PR fixes that issue.

Companion PR: https://github.com/vanilla/knowledge/pull/1309