### PR TITLE
Implement ApplicationInterface and ApplicationProviderInterface toget…

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -80,6 +80,9 @@ class DashboardHooks extends Gdn_Plugin {
             ->addCall('addProvider', [new Reference(ActivityCounterProvider::class)])
             ->addCall('addProvider', [new Reference(LogCounterProvider::class)])
             ->addCall('addProvider', [new Reference(RoleCounterProvider::class)])
+
+            ->rule(\Vanilla\Contracts\Site\ApplicationProviderInterface::class)
+            ->addCall('add', [new \Vanilla\Site\Application('vanilla', ['api', 'entry', 'sso', 'utility'])])
         ;
     }
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -70,6 +70,11 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->setClass(SingleSiteSectionProvider::class)
     ->setShared(true)
 
+    // Site applications
+    ->rule(\Vanilla\Contracts\Site\ApplicationProviderInterface::class)
+    ->setClass(\Vanilla\Site\ApplicationProvider::class)
+    ->setShared(true)
+
     // AddonManager
     ->rule(Vanilla\AddonManager::class)
     ->setShared(true)

--- a/library/Vanilla/Contracts/Site/ApplicationInterface.php
+++ b/library/Vanilla/Contracts/Site/ApplicationInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Contracts\Site;
+
+/**
+ * Interface representing application.
+ */
+interface ApplicationInterface {
+    /**
+     * Get the application name.
+     *
+     * @return string
+     */
+    public function getName(): string;
+
+    /**
+     * Get the list of reserved slugs managed by this application only.
+     *
+     * @return string[]
+     */
+    public function getReservedSlugs(): array;
+}

--- a/library/Vanilla/Contracts/Site/ApplicationProviderInterface.php
+++ b/library/Vanilla/Contracts/Site/ApplicationProviderInterface.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Contracts\Site;
+
+/**
+ * Provider for applications.
+ */
+interface ApplicationProviderInterface {
+    /**
+     * Returns all applications of the site.
+     *
+     * @return ApplicationInterface[]
+     */
+    public function getAll(): array;
+
+    /**
+     * Returns all application reserved slugs.
+     *
+     * @return string[]
+     */
+    public function getReservedSlugs(): array;
+
+    /**
+     * Register an application.
+     *
+     * @param ApplicationInterface $application
+     * @return $this
+     */
+    public function add(ApplicationInterface $application): self;
+}

--- a/library/Vanilla/Site/Application.php
+++ b/library/Vanilla/Site/Application.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Site;
+
+use Vanilla\Contracts\Site\ApplicationInterface;
+
+/**
+ * Class Application
+ * @package Vanilla\Site
+ */
+class Application implements ApplicationInterface {
+    /**
+     * @var string
+     */
+    private $name = '';
+
+    /**
+     * @var array List of reserved root slugs managed by app
+     */
+    private $reservedSlugs = [];
+
+    public function __construct(string $name, array $reservedSlugs) {
+        $this->name = $name;
+        $this->reservedSlugs = $reservedSlugs;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getName(): string {
+        return $this->name;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getReservedSlugs(): array {
+        return $this->reservedSlugs;
+    }
+}

--- a/library/Vanilla/Site/ApplicationProvider.php
+++ b/library/Vanilla/Site/ApplicationProvider.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Site;
+
+use Vanilla\Contracts\Site\ApplicationInterface;
+use Vanilla\Contracts\Site\ApplicationProviderInterface;
+
+/**
+ * Class for dealing with applications of a site.
+ *
+ * @see ApplicationProviderInterface
+ */
+class ApplicationProvider implements ApplicationProviderInterface {
+
+    /** @var ApplicationInterface[] */
+    private $apps;
+
+    /**
+     * @inheritdoc
+     */
+    public function getAll(): array {
+        return $this->apps;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getReservedSlugs(): array {
+        $reservedSlugs = [];
+        foreach ($this->apps as $app) {
+            $reservedSlugs = array_merge($reservedSlugs, $app->getReservedSlugs());
+        }
+        return $reservedSlugs;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function add(ApplicationInterface $application): ApplicationProviderInterface {
+        $this->apps[] = $application;
+        return $this;
+    }
+}


### PR DESCRIPTION
Introduce `ApplicationInterface` and `ApplicationProviderInterface` together with their default implementations `Application` and `ApplicationProvider`

Those interfaces will allow to provide some information about apps installed to plugins which require that information.

For example to provide reserved root slugs which do not require to be redirected to default site section (site section agnostic endpoints).