### PR TITLE
Fixed logic in edit category template

### DIFF
--- a/applications/vanilla/views/vanillasettings/editcategory.twig
+++ b/applications/vanilla/views/vanillasettings/editcategory.twig
@@ -63,7 +63,7 @@ dashboardHeading({
         'Photo',
         t('Photo'),
         '',
-        category.CategoryID is not null ? 'vanilla/settings/deletecategoryphoto/' ~ category.CategoryID : ''
+        category.CategoryID is defined ? 'vanilla/settings/deletecategoryphoto/' ~ category.CategoryID : ''
     ) }}
 
     {#


### PR DESCRIPTION
Fixed logic in edit category template, it was crashing when creating a new category.