### PR TITLE
Decrease stale.yml to 1 year

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 730
+daysUntilStale: 365
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale


### PR DESCRIPTION
It turns out we didn’t really have any stale issues older than 2 years. Right now there are about 2 pages of stale issues older than a year.