### PR TITLE
Centralize PHP version checks

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -387,13 +387,13 @@ class DashboardHooks extends Gdn_Plugin {
      */
     public function settingsController_render_before($sender) {
         // Set this in your config to dismiss our upgrade warnings. Not recommended.
-        if (c('Vanilla.WarnedMeToUpgrade') === 'PHP 7.0') {
+        if (c('Vanilla.WarnedMeToUpgrade') === ENVIRONMENT_PHP_NEXT_VERSION) {
             return;
         }
 
         $phpVersion = phpversion();
-        if (version_compare($phpVersion, '7.1') < 0) {
-            $upgradeMessage = ['Content' => 'We recommend using at least PHP 7.1. Support for PHP '.htmlspecialchars($phpVersion).' may be dropped in upcoming releases.', 'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'];
+        if (version_compare($phpVersion, ENVIRONMENT_PHP_NEXT_VERSION) < 0) {
+            $upgradeMessage = ['Content' => 'We recommend using at least PHP '.ENVIRONMENT_PHP_NEXT_VERSION.'. Support for PHP '.htmlspecialchars($phpVersion).' may be dropped in upcoming releases.', 'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'];
             $messageModule = new MessageModule($sender, $upgradeMessage);
             $sender->addModule($messageModule);
         }

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -387,13 +387,19 @@ class DashboardHooks extends Gdn_Plugin {
      */
     public function settingsController_render_before($sender) {
         // Set this in your config to dismiss our upgrade warnings. Not recommended.
-        if (c('Vanilla.WarnedMeToUpgrade') === ENVIRONMENT_PHP_NEXT_VERSION) {
+        $warning = c('Vanilla.WarnedMeToUpgrade');
+        if ($warning && version_compare(ENVIRONMENT_PHP_NEXT_VERSION, $warning) <= 0) {
             return;
         }
 
         $phpVersion = phpversion();
         if (version_compare($phpVersion, ENVIRONMENT_PHP_NEXT_VERSION) < 0) {
-            $upgradeMessage = ['Content' => 'We recommend using at least PHP '.ENVIRONMENT_PHP_NEXT_VERSION.'. Support for PHP '.htmlspecialchars($phpVersion).' may be dropped in upcoming releases.', 'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'];
+            $versionStr = htmlspecialchars($phpVersion);
+
+            $upgradeMessage = [
+                'Content' => 'We recommend using at least PHP '.ENVIRONMENT_PHP_NEXT_VERSION.'. Support for PHP '.$versionStr.' may be dropped in upcoming releases.',
+                'AssetTarget' => 'Content', 'CssClass' => 'WarningMessage'
+            ];
             $messageModule = new MessageModule($sender, $upgradeMessage);
             $sender->addModule($messageModule);
         }

--- a/conf/constants.php
+++ b/conf/constants.php
@@ -65,9 +65,6 @@ define('TRACE_ERROR', 'Error');
 define('TRACE_WARNING', 'Warning');
 define('TRACE_NOTICE', 'Notice');
 
-// Environment
-define('ENVIRONMENT_PHP_VERSION', '7.1');
-
 if (!defined('E_USER_DEPRECATED')) {
     define('E_USER_DEPRECATED', E_USER_WARNING);
 }

--- a/environment.php
+++ b/environment.php
@@ -7,8 +7,12 @@
  * @license GPL-2.0-only
  */
 
-if (PHP_VERSION_ID < 70100) {
-    die('Vanilla requires PHP 7.1 or greater.');
+// Environment
+define('ENVIRONMENT_PHP_VERSION', '7.1');
+define('ENVIRONMENT_PHP_NEXT_VERSION', '7.2');
+
+if (version_compare(phpversion(), ENVIRONMENT_PHP_VERSION) < 0) {
+    die('Vanilla requires PHP '.ENVIRONMENT_PHP_VERSION.' or greater.');
 }
 
 // Define the constants we need to get going.

--- a/library/Vanilla/Models/InstallModel.php
+++ b/library/Vanilla/Models/InstallModel.php
@@ -167,8 +167,8 @@ class InstallModel {
             throw new ValidationException($validation);
         }
 
-        if (PHP_VERSION_ID < 70000) {
-            $validation->addError('', 'PHP {version} or higher is required.', ['version' => '7.0']);
+        if (version_compare(phpversion(), ENVIRONMENT_PHP_VERSION) < 0) {
+            $validation->addError('', 'PHP {version} or higher is required.', ['version' => ENVIRONMENT_PHP_VERSION]);
         }
 
         if (!class_exists(\PDO::class)) {


### PR DESCRIPTION
In anticipation of the most wonderful time of the year when we upgrade our version requirements, I’m trying to consolidate the places that need to be updated to as few files as possible.

This change:

1. Moves our version requirement to the earliest version check in `environment.php`.
2. Makes use of the constants whenever version checking.
3. The dashboard warning has different logic now. It makes use of a new `ENVIRONMENT_PHP_NEXT_VERSION` constant to warn people when they are below the next version of PHP.