### PR TITLE
Don’t allow classes for serialized routes

### DIFF
--- a/library/core/class.router.php
+++ b/library/core/class.router.php
@@ -246,7 +246,10 @@ class Gdn_Router extends Gdn_Pluggable {
      */
     private function _parseRoute($destination) {
         // If Destination is a serialized array
-        if (is_string($destination) && ($decoded = @unserialize($destination, ['allowed_classes' => false])) !== false) {
+        if (is_string($destination) &&
+            substr($destination, 0, 2) === 'a:' && // only serialized arrays
+            ($decoded = @unserialize($destination, ['allowed_classes' => false])) !== false // no classes
+        ) {
             $destination = $decoded;
         }
 

--- a/library/core/class.router.php
+++ b/library/core/class.router.php
@@ -246,7 +246,7 @@ class Gdn_Router extends Gdn_Pluggable {
      */
     private function _parseRoute($destination) {
         // If Destination is a serialized array
-        if (is_string($destination) && ($decoded = @unserialize($destination)) !== false) {
+        if (is_string($destination) && ($decoded = @unserialize($destination, ['allowed_classes' => false])) !== false) {
             $destination = $decoded;
         }
 

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -232,35 +232,4 @@ abstract class AbstractAPIv2Test extends TestCase {
             $this->api()->setUserID($userID);
         }
     }
-
-    /**
-     * Run a callback with the following config and restore the config after.
-     *
-     * @param array $config The config to set.
-     * @param callable $callback The code to run.
-     * @return mixed Returns the result of the callback.
-     */
-    protected function runWithConfig(array $config, callable $callback) {
-        /* @var \Gdn_Configuration $c */
-        $c = $this->container()->get(\Gdn_Configuration::class);
-
-        // Create a backup of the config.
-        $bak = [];
-        foreach ($config as $key => $value) {
-            $bak[$key] = $c->get($key, null);
-        }
-
-        try {
-            foreach ($config as $key => $value) {
-                $c->set($key, $value);
-            }
-
-            $r = $callback();
-            return $r;
-        } finally {
-            foreach ($bak as $key => $value) {
-                $c->set($key, $value);
-            }
-        }
-    }
 }

--- a/tests/BootstrapTrait.php
+++ b/tests/BootstrapTrait.php
@@ -73,4 +73,35 @@ trait BootstrapTrait {
     protected static function bootstrap() {
         return self::$bootstrap;
     }
+
+    /**
+     * Run a callback with the following config and restore the config after.
+     *
+     * @param array $config The config to set.
+     * @param callable $callback The code to run.
+     * @return mixed Returns the result of the callback.
+     */
+    protected function runWithConfig(array $config, callable $callback) {
+        /* @var \Gdn_Configuration $c */
+        $c = $this->container()->get(\Gdn_Configuration::class);
+
+        // Create a backup of the config.
+        $bak = [];
+        foreach ($config as $key => $value) {
+            $bak[$key] = $c->get($key, null);
+        }
+
+        try {
+            foreach ($config as $key => $value) {
+                $c->set($key, $value, true, false);
+            }
+
+            $r = $callback();
+            return $r;
+        } finally {
+            foreach ($bak as $key => $value) {
+                $c->set($key, $value, true, false);
+            }
+        }
+    }
 }

--- a/tests/Library/Core/RouterTest.php
+++ b/tests/Library/Core/RouterTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use VanillaTests\SharedBootstrapTestCase;
+
+/**
+ * Basic tests for `Gdn_Router`.
+ */
+class RouterTest extends SharedBootstrapTestCase {
+    /**
+     * @var \Gdn_Router
+     */
+    private $router;
+
+    /**
+     * @var callable
+     */
+    private $parseRoute;
+
+    /**
+     * Basic setup.
+     */
+    public function setUp() {
+        parent::setUp();
+
+        // New up a router without default routes to load.
+        $this->runWithConfig(['Routes' => []], function () {
+            $this->router = new \Gdn_Router();
+        });
+
+        $this->parseRoute = \Closure::bind(function ($destination) {
+            /* @var \Gdn_Router $this */
+            $r = $this->_parseRoute($destination);
+            return $r;
+        }, $this->router, $this->router);
+    }
+
+    /**
+     * Test `Gdn_Router::_parseRoute()`.
+     *
+     * @param mixed $destination
+     * @param array|mixed $expected
+     * @dataProvider provideSavedRoutes
+     */
+    public function testParseRoute($destination, $expected): void {
+        $parsed = $this->parseRoute($destination);
+        $this->assertEquals($expected, $parsed);
+    }
+
+    /**
+     * Provide some routes to parse.
+     *
+     * @return array
+     */
+    public function provideSavedRoutes(): array {
+        $default = ['Destination' => 'discussions', 'Type' => 'Internal'];
+        $raw = array_values($default);
+
+        $r = [
+            'default' => [$raw, $default],
+            'serialized' => [serialize($raw), $default],
+            'string' => [$default['Destination'], $default],
+            'one element' => [[$default['Destination']], $default],
+        ];
+
+        return $r;
+    }
+
+    /**
+     * Lift the private access of `Gdn_Router::_parseRoute()` for testing.
+     *
+     * @param mixed $destination
+     * @return mixed
+     */
+    protected function parseRoute($destination) {
+        return call_user_func($this->parseRoute, $destination);
+    }
+}


### PR DESCRIPTION
Routes haven’t been stored as serialized arrays since I think 2016, but we have this BC code in there. I am at least hardening it to not allow objects.