### PR TITLE
Remove Garden.Archive.Exclude functionality

### DIFF
--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -158,8 +158,19 @@ class VanillaSettingsController extends Gdn_Controller {
         if ($this->Form->authenticatedPostBack() === false) {
             $this->Form->setData($configurationModel->Data);
         } else {
-            // Define some validation rules for the fields being saved
-            $configurationModel->Validation->applyRule('Vanilla.Archive.Date', 'Date');
+            // Define some validation rules for the fields being saved.
+            $configurationModel->Validation->addRule('dateish', function ($value) {
+                if (empty($value)) {
+                    return $value;
+                }
+                try {
+                    $dt = new \DateTimeImmutable($value, new \DateTimeZone('UTC'));
+                    return $value;
+                } catch (\Exception $ex) {
+                    return new \Vanilla\Invalid('%s is not a valid date string.');
+                }
+            });
+            $configurationModel->Validation->applyRule('Vanilla.Archive.Date', 'dateish');
 
             // Grab old config values to check for an update.
             $archiveDateBak = Gdn::config('Vanilla.Archive.Date');

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -149,7 +149,6 @@ class VanillaSettingsController extends Gdn_Controller {
         $configurationModel = new Gdn_ConfigurationModel($validation);
         $configurationModel->setField([
             'Vanilla.Archive.Date',
-            'Vanilla.Archive.Exclude'
         ]);
 
         // Set the model on the form.
@@ -164,18 +163,10 @@ class VanillaSettingsController extends Gdn_Controller {
 
             // Grab old config values to check for an update.
             $archiveDateBak = Gdn::config('Vanilla.Archive.Date');
-            $archiveExcludeBak = (bool)Gdn::config('Vanilla.Archive.Exclude');
 
             // Save new settings
             $saved = $this->Form->save();
             if ($saved !== false) {
-                $archiveDate = Gdn::config('Vanilla.Archive.Date');
-                $archiveExclude = (bool)Gdn::config('Vanilla.Archive.Exclude');
-
-                if ($archiveExclude != $archiveExcludeBak || ($archiveExclude && $archiveDate != $archiveDateBak)) {
-                    $discussionModel = new DiscussionModel();
-                    $discussionModel->updateDiscussionCount('All');
-                }
                 $this->informMessage(t("Your changes have been saved."));
             }
         }

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -865,25 +865,6 @@ class CommentModel extends Gdn_Model {
                     ]
                 );
             }
-
-        } else {
-            // Make sure the discussion isn't archived.
-            $archiveDate = Gdn::config('Vanilla.Archive.Date', false);
-            if (!$archiveDate || (Gdn_Format::toTimestamp($discussion->DateLastComment) > Gdn_Format::toTimestamp($archiveDate))) {
-                $newComments = true;
-
-                // Insert watch data.
-                $this->SQL->options('Ignore', true);
-                $this->SQL->insert(
-                    'UserDiscussion',
-                    [
-                        'UserID' => $userID,
-                        'DiscussionID' => $discussion->DiscussionID,
-                        'CountComments' => $countWatch,
-                        'DateLastViewed' => Gdn_Format::toDateTime()
-                    ]
-                );
-            }
         }
 
         /**

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -480,8 +480,6 @@ class DiscussionModel extends Gdn_Model {
                 ->select('d.Announce', '', 'IsAnnounce');
         }
 
-        $this->addArchiveWhere($this->SQL);
-
         if ($offset !== false && $limit !== false) {
             $this->SQL->limit($limit, $offset);
         }
@@ -868,9 +866,6 @@ class DiscussionModel extends Gdn_Model {
                 ->select('d.Announce', '', 'IsAnnounce');
         }
 
-        $this->addArchiveWhere($this->SQL);
-
-
         $this->SQL->limit($limit, $offset);
 
         $this->EventArguments['SortField'] = c('Vanilla.Discussions.SortField', 'd.DateLastComment');
@@ -1120,23 +1115,11 @@ class DiscussionModel extends Gdn_Model {
     /**
      * Add SQL Where to account for archive date.
      *
-     * @since 2.0.0
-     * @access public
-     *
-     * @param object $sql Gdn_SQLDriver
+     * @param Gdn_SQLDriver $sql
+     * @deprecated
      */
     public function addArchiveWhere($sql = null) {
-        if (is_null($sql)) {
-            $sql = $this->SQL;
-        }
-
-        $exclude = Gdn::config('Vanilla.Archive.Exclude');
-        if ($exclude) {
-            $archiveDate = Gdn::config('Vanilla.Archive.Date');
-            if ($archiveDate) {
-                $sql->where('d.DateLastComment >', $archiveDate);
-            }
-        }
+        deprecated('DiscussionModel::addArchiveWhere()');
     }
 
 
@@ -2450,8 +2433,6 @@ class DiscussionModel extends Gdn_Model {
                 ->select('d.CountComments', 'sum', 'CountComments')
                 ->from('Discussion d')
                 ->where('d.CategoryID', $categoryID);
-
-            $this->addArchiveWhere();
 
             $data = $this->SQL->get()->firstRow();
             $countDiscussions = (int)getValue('CountDiscussions', $data, 0);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3417,17 +3417,17 @@ class DiscussionModel extends Gdn_Model {
     /**
      * Determine whether or not the discussion is archived based on its last comment date.
      *
-     * @param string|null $DateLastComment
+     * @param string|null $dateLastComment
      * @return bool
      */
-    public function isArchived($DateLastComment): bool {
-        if (empty($DateLastComment) || $this->getArchiveDate() === null) {
+    public function isArchived($dateLastComment): bool {
+        if (empty($dateLastComment) || $this->getArchiveDate() === null) {
             return false;
         }
         try {
-            $dt = new DateTimeImmutable($DateLastComment, $this->getArchiveDate()->getTimezone());
+            $dt = new DateTimeImmutable($dateLastComment, $this->getArchiveDate()->getTimezone());
         } catch (\Exception $ex) {
-            trigger_error($ex->getMessage(), E_USER_WARNING);
+            trigger_error('DiscussionModel::isArchived() got an invalid dateLastComment.', E_USER_WARNING);
             return false;
         }
         if ($dt < $this->getArchiveDate()) {

--- a/applications/vanilla/views/vanillasettings/archive.php
+++ b/applications/vanilla/views/vanillasettings/archive.php
@@ -18,12 +18,5 @@ echo $this->Form->errors();
             ?>
         </div>
     </li>
-    <li class="form-group">
-        <div class="input-wrap no-label">
-            <?php
-            echo $this->Form->checkBox('Vanilla.Archive.Exclude', 'Exclude archived discussions from the discussions list');
-            ?>
-        </div>
-    </li>
 </ul>
 <?php echo $this->Form->close('Save'); ?>

--- a/applications/vanilla/views/vanillasettings/archive.php
+++ b/applications/vanilla/views/vanillasettings/archive.php
@@ -14,7 +14,7 @@ echo $this->Form->errors();
         </div>
         <div class="input-wrap">
             <?php
-            echo $this->Form->calendar('Vanilla.Archive.Date', ['placeholder' => t('YYYY-mm-dd')]);
+            echo $this->Form->calendar('Vanilla.Archive.Date', ['placeholder' => t('Ex: 2009-01-01, 6 months, 1 year')]);
             ?>
         </div>
     </li>

--- a/library/core/class.configurationmodel.php
+++ b/library/core/class.configurationmodel.php
@@ -26,7 +26,7 @@ class Gdn_ConfigurationModel {
      */
     public $Name;
 
-    /** @var object An object that is used to manage and execute data integrity rules on this object. */
+    /** @var Gdn_Validation An object that is used to manage and execute data integrity rules on this object. */
     public $Validation;
 
     /** @var object The actual array of data being worked on. */

--- a/tests/ExpectErrorTrait.php
+++ b/tests/ExpectErrorTrait.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests;
+
+/**
+ * Allows a test case to expect an error to occur.
+ */
+trait ExpectErrorTrait {
+    /**
+     * Run code that expects an error.
+     *
+     * This method is intended to test functions that have non-fatal errors. By using `expectError` you can assert that
+     * test has an error, and at the same time test its return type.
+     *
+     * @param callable $test The test to run.
+     * @param callable $onError An optional event handler to inspect the error thrown.
+     */
+    protected function expectError(callable $test, ?callable $onError = null): void {
+        try {
+            $hasError = false;
+
+            set_error_handler(function ($errorNumber, $message, $file, $line, $arguments) use ($onError, &$hasError) {
+                $ex = new \ErrorException($message, $errorNumber, $errorNumber, $file, $line);
+
+                $hasError = true;
+                if (is_callable($onError)) {
+                    $onError($ex);
+                }
+            });
+            $test();
+            if (!$hasError) {
+                $this->fail("An expected error never occurred.");
+            }
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * A higher order function that asserts an error is a specific number.
+     *
+     * @param int $number One of the error constants.
+     * @return callable Returns a callback that can be passed to higher order functions.
+     */
+    static function assertErrorNumber(int $number): callable {
+        return function(\Throwable $ex) use ($number) {
+            if ($number !== $ex->getCode()) {
+                $this->fail("Failed asserting the error number: $number.");
+            }
+        };
+    }
+}

--- a/tests/ExpectErrorTrait.php
+++ b/tests/ExpectErrorTrait.php
@@ -47,8 +47,8 @@ trait ExpectErrorTrait {
      * @param int $number One of the error constants.
      * @return callable Returns a callback that can be passed to higher order functions.
      */
-    static function assertErrorNumber(int $number): callable {
-        return function(\Throwable $ex) use ($number) {
+    public static function assertErrorNumber(int $number): callable {
+        return function (\Throwable $ex) use ($number) {
             if ($number !== $ex->getCode()) {
                 $this->fail("Failed asserting the error number: $number.");
             }

--- a/tests/Models/DiscussionModelTest.php
+++ b/tests/Models/DiscussionModelTest.php
@@ -91,7 +91,7 @@ class DiscussionModelTest extends TestCase {
     public function testIsArchivedInvalidDate() {
         $this->model->setArchiveDate('2019-10-26');
 
-        $this->expectError(function() {
+        $this->expectError(function () {
             $actual = $this->model->isArchived('fldjsjs');
             $this->assertFalse($actual);
         }, self::assertErrorNumber(E_USER_WARNING));

--- a/tests/Models/DiscussionModelTest.php
+++ b/tests/Models/DiscussionModelTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Models;
+
+use PHPUnit\Framework\Error\Warning;
+use PHPUnit\Framework\TestCase;
+use VanillaTests\ExpectErrorTrait;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Some basic tests for the `DiscussionModel`.
+ */
+class DiscussionModelTest extends TestCase {
+    use SiteTestTrait, ExpectErrorTrait;
+
+    /**
+     * @var \DiscussionModel
+     */
+    private $model;
+
+    /**
+     * @var \DateTimeImmutable
+     */
+    private $now;
+
+    /**
+     * Get a new model for each test.
+     */
+    public function setUp() {
+        parent::setUp();
+
+        $this->model = $this->container()->get(\DiscussionModel::class);
+        $this->now = new \DateTimeImmutable();
+    }
+
+    /**
+     * An empty archive date should be null.
+     */
+    public function testArchiveDateEmpty() {
+        $this->model->setArchiveDate('');
+        $this->assertNull($this->model->getArchiveDate());
+    }
+
+    /**
+     * A date expression is valid.
+     */
+    public function testDayInPast() {
+        $this->model->setArchiveDate('-3 days');
+        $this->assertLessThan($this->now, $this->model->getArchiveDate());
+    }
+
+    /**
+     * A future date expression gets flipped to the past.
+     */
+    public function testDayFlippedToPast() {
+        $this->model->setArchiveDate('3 days');
+        $this->assertLessThan($this->now, $this->model->getArchiveDate());
+    }
+
+    /**
+     * An invalid archive date should throw an exception.
+     *
+     * @expectedException \Exception
+     */
+    public function testInvalidArchiveDate() {
+        $this->model->setArchiveDate('dnsfids');
+    }
+
+    /**
+     * Test `DiscussionModel::isArchived()`.
+     *
+     * @param string $archiveDate
+     * @param string|null $dateLastComment
+     * @param bool $expected
+     * @dataProvider provideIsArchivedTests
+     */
+    public function testIsArchived(string $archiveDate, ?string $dateLastComment, bool $expected) {
+        $this->model->setArchiveDate($archiveDate);
+        $actual = $this->model->isArchived($dateLastComment);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * An invalid date should return a warning.
+     */
+    public function testIsArchivedInvalidDate() {
+        $this->model->setArchiveDate('2019-10-26');
+
+        $this->expectError(function() {
+            $actual = $this->model->isArchived('fldjsjs');
+            $this->assertFalse($actual);
+        }, self::assertErrorNumber(E_USER_WARNING));
+    }
+
+    /**
+     * Provide some tests for `DiscussionModel::isArchived()`.
+     *
+     * @return array
+     */
+    public function provideIsArchivedTests(): array {
+        $r = [
+            ['2000-01-01', '2019-10-26', false],
+            ['2000-01-01', '1999-12-31', true],
+            ['2001-01-01', '2001-01-01', false],
+            ['', '1999-01-01', false],
+            ['2001-01-01', null, false],
+        ];
+
+        return $r;
+    }
+}


### PR DESCRIPTION
We haven’t officially supported archiving for some time. We can’t remove archive date functionality at this time, but we can remove the filtering which is more bug prone anyway.

Closes #5294.
Closes #5206.
Closes #2894.
Closes #3870.

With respect to the archive dates, I extended it to allow for date expressions since that would be the most common use-case anyway.