### PR TITLE
Deprecate Gdn_Request::withURI() to start working towards PSR-7 support

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1173,12 +1173,12 @@ class EntryController extends Gdn_Controller {
             // Try to grab the authenticator data
             $payload = $authenticator->getHandshake();
             if ($payload === false) {
-                Gdn::request()->withURI('dashboard/entry/auth/password');
+                Gdn::request()->setURI('dashboard/entry/auth/password');
 
                 return Gdn::dispatcher()->dispatch();
             }
         } catch (Exception $e) {
-            Gdn::request()->withURI('/entry/signin');
+            Gdn::request()->setURI('/entry/signin');
 
             return Gdn::dispatcher()->dispatch();
         }

--- a/library/core/class.dispatcher.php
+++ b/library/core/class.dispatcher.php
@@ -236,7 +236,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
     public function dispatch($importRequest = null, $permanent = true) {
 
         if ($importRequest && is_string($importRequest)) {
-            $importRequest = Gdn_Request::create()->fromEnvironment()->withURI($importRequest);
+            $importRequest = Gdn_Request::create()->fromEnvironment()->setURI($importRequest);
         }
 
         if (is_a($importRequest, 'Gdn_Request') && $permanent) {
@@ -252,7 +252,7 @@ class Gdn_Dispatcher extends Gdn_Pluggable {
 
         // If we're in update mode and aren't explicitly prevented from blocking, block.
         if (inMaintenanceMode() && $this->getCanBlock($request) > self::BLOCK_NEVER) {
-            $request->withURI(Gdn::router()->getDestination('UpdateMode'));
+            $request->setURI(Gdn::router()->getDestination('UpdateMode'));
         }
 
         // Check for URL rewrites.

--- a/library/core/class.gdn.php
+++ b/library/core/class.gdn.php
@@ -70,22 +70,22 @@ class Gdn {
      */
     private static $container;
 
-    /** @var object  */
+    /** @var Gdn_Configuration  */
     protected static $_Config = null;
 
     /** @var boolean Whether or not Gdn::FactoryInstall should overwrite existing objects. */
     protected static $_FactoryOverwrite = true;
 
-    /** @var object  */
+    /** @var Gdn_Locale  */
     protected static $_Locale = null;
 
-    /** @var object  */
+    /** @var Gdn_Request  */
     protected static $_Request = null;
 
-    /** @var object  */
+    /** @var Gdn_PluginManager  */
     protected static $_PluginManager = null;
 
-    /** @var object  */
+    /** @var Gdn_Session  */
     protected static $_Session = null;
 
     /**
@@ -426,7 +426,7 @@ class Gdn {
         $request = self::$_Request; //self::factory(self::AliasRequest);
         if (!is_null($newRequest)) {
             if (is_string($newRequest)) {
-                $request->withURI($newRequest);
+                $request->setURI($newRequest);
             } elseif (is_object($newRequest))
                 $request->fromImport($newRequest);
         }

--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -292,7 +292,7 @@ class Gdn_Request implements RequestInterface {
      * @return Gdn_Request
      */
     public function fromEnvironment() {
-        $this->withURI()
+        $this->setURI()
             ->withArgs(self::INPUT_GET, self::INPUT_POST, self::INPUT_SERVER, self::INPUT_FILES, self::INPUT_COOKIES);
 
         return $this;
@@ -303,9 +303,9 @@ class Gdn_Request implements RequestInterface {
      *
      * This method allows one method to import the raw information of another request
      *
-     * @param $newRequest New Request from which to import environment and arguments.
+     * @param Gdn_Request $newRequest New Request from which to import environment and arguments.
      * @flow chain
-     * @return Gdn_Request
+     * @return $this
      */
     public function fromImport($newRequest) {
         // Import Environment
@@ -1848,14 +1848,26 @@ class Gdn_Request implements RequestInterface {
     }
 
     /**
-     * Chainable URI Setter, source is a simple string
+     * Set the URI of the request.
      *
-     * @param $uri optional URI to set as as replacement for the REQUEST_URI superglobal value
-     * @flow chain
-     * @return Gdn_Request
+     * @param string $uri Optional URI to set as as replacement for the REQUEST_URI super global value.
+     * @return $this
      */
-    public function withURI($uri = null) {
+    public function setURI($uri = null) {
         $this->_environmentElement('URI', $uri);
         return $this;
+    }
+
+    /**
+     * WARNING: This method is being temporarily deprecated so that we can later change its signature to match the PSR-7
+     * `ServerRequestInterface`. DO NOT MAKE CALLS TO THIS METHOD.
+     *
+     * @param string $uri
+     * @return $this
+     * @deprecated
+     */
+    public function withURI($uri = null) {
+        deprecated('Gdn_Request::withURI()', 'Gdn_Request::setURI()');
+        return $this->setURI($uri);
     }
 }


### PR DESCRIPTION
I did a test to see how far off our request class is from the PSR-7 `ServerRequestInterface` and it turns out that `withURI()` is the only method that has a signature mismatch.

I am temporarily deprecating the method now to give us time to update our other code without having to do too much coordination.