### PR TITLE
Remove ‘on’ from display date.

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -118,7 +118,6 @@ if (!function_exists('MostRecentString')):
             $r .= ' ';
 
             $r .= '<span class="MostRecentOn">';
-            $r .= t('on').' ';
             $r .= anchor(
                 Gdn_Format::date($row['LastDateInserted'], 'html'),
                 $row['LastUrl'],


### PR DESCRIPTION
This closes https://github.com/vanilla/support/issues/30

When displaying the most recent post in date in a Category in the Categories view we have tried to give it some natural language display by adding the word "on" before the date. This works when the date is a full date with a day, month and year (e.g. "Most recent: Exciting changes coming up in the NFL. by Patrick Kelly **on September 12, 2019**") but it doesn't work if the post just happened (e.g. "Most recent: Exciting changes coming up in the NFL. by Patrick Kelly **on 12:45pm**").

This will also make it more translatable from one language to another.

## Testing

Make sure your categories display is 'modern'.