### PR TITLE
Restore the user’s session after running the structure

### DIFF
--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -656,6 +656,7 @@ class UpdateModel extends Gdn_Model {
     public function runStructure($captureOnly = false) {
         $this->saveStatus(self::STATUS_RUNNING);
 
+        $userID = Gdn::session()->UserID;
         try {
             $r = $this->runStructureInternal($captureOnly);
             $this->saveStatus(self::STATUS_SUCCESS);
@@ -663,6 +664,12 @@ class UpdateModel extends Gdn_Model {
         } catch (\Throwable $ex) {
             $this->saveStatus(self::STATUS_ERROR, $ex->getMessage());
             throw $ex;
+        } finally {
+            if ($userID && $userID !== Gdn::session()->UserID) {
+                Gdn::session()->start($userID, false, false);
+            } elseif (!$userID) {
+                Gdn::session()->end();
+            }
         }
     }
 


### PR DESCRIPTION
Since the structure now runs as system, the session should be restored for requests that don’t end after the update.