### PR TITLE
Fix header logo link in TitleBar

### DIFF
--- a/library/src/scripts/headers/mebox/pieces/HeaderLogo.tsx
+++ b/library/src/scripts/headers/mebox/pieces/HeaderLogo.tsx
@@ -24,7 +24,7 @@ export interface IHeaderLogo {
  */
 export default class HeaderLogo extends React.Component<IHeaderLogo> {
     public static defaultProps: Partial<IHeaderLogo> = {
-        to: formatUrl("/"),
+        to: "/",
     };
 
     public render() {


### PR DESCRIPTION
- `<SmartLink />` (used to render the link) automatically adds the sitesection `baseUrl` to link. There's no need to do it twice with `formatUrl`.
