### PR TITLE
Set Google+ plugin to hidden

### DIFF
--- a/plugins/GooglePlus/addon.json
+++ b/plugins/GooglePlus/addon.json
@@ -5,7 +5,7 @@
     "mobileFriendly": true,
     "settingsUrl": "/dashboard/social/googleplus",
     "settingsPermission": "Garden.Settings.Manage",
-    "hidden": false,
+    "hidden": true,
     "socialConnect": true,
     "requiresRegistration": false,
     "icon": "google_social_connect.png",

--- a/tests/APIv2/AddonsTest.php
+++ b/tests/APIv2/AddonsTest.php
@@ -14,7 +14,7 @@ class AddonsTest extends AbstractAPIv2Test {
     private $coreAddons = [
         'conversations', // applications
         'allviewed', 'emojiextender', 'facebook', 'flagging',
-        'googleplus', 'googleprettify', 'gravatar', 'indexphotos', 'profileextender', 'quotes',
+        'googleprettify', 'gravatar', 'indexphotos', 'profileextender', 'quotes',
         'splitmerge', 'stopforumspam', 'twitter', 'vanillainthisdiscussion', 'vanillastats', 'editor', 'oauth2',
         'recaptcha', 'stubcontent', 'vanillicon', 'googlesignin'// plugins
     ];
@@ -24,7 +24,7 @@ class AddonsTest extends AbstractAPIv2Test {
     ];
 
     private $hiddenAddons = [
-        'dashboard', 'vanilla', 'gettingstarted'
+        'dashboard', 'vanilla', 'gettingstarted', 'googleplus'
     ];
 
     /**


### PR DESCRIPTION
This PR set Google+ plugin to hidden as requested in https://github.com/vanilla/vanilla-patches/issues/642