### PR TITLE
Add pluggable search filter context provider

### DIFF
--- a/library/src/scripts/AppContext.tsx
+++ b/library/src/scripts/AppContext.tsx
@@ -17,6 +17,7 @@ import classNames from "classnames";
 import { style } from "typestyle";
 import { percent } from "csx";
 import { LocaleProvider } from "@vanilla/i18n";
+import { SearchFilterContextProvider } from "@library/contexts/SearchFilterContext";
 
 interface IProps {
     children: React.ReactNode;
@@ -49,9 +50,11 @@ export function AppContext(props: IProps) {
                             variablesOnly={props.variablesOnly}
                         >
                             <FontSizeCalculatorProvider>
-                                <ScrollOffsetProvider scrollWatchingEnabled={false}>
-                                    <DeviceProvider>{props.children}</DeviceProvider>
-                                </ScrollOffsetProvider>
+                                <SearchFilterContextProvider>
+                                    <ScrollOffsetProvider scrollWatchingEnabled={false}>
+                                        <DeviceProvider>{props.children}</DeviceProvider>
+                                    </ScrollOffsetProvider>
+                                </SearchFilterContextProvider>
                             </FontSizeCalculatorProvider>
                         </ThemeProvider>
                     </LiveAnnouncer>

--- a/library/src/scripts/contexts/SearchFilterContext.tsx
+++ b/library/src/scripts/contexts/SearchFilterContext.tsx
@@ -1,0 +1,96 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React, { useContext, useState } from "react";
+
+interface IQueryValues {
+    [key: string]: any;
+}
+
+interface ISearchFilterContextValue {
+    /**
+     * Get all of the DOM elements for selecting query values for a search domain.
+     * @param domain The search domain to get values for.
+     */
+    getFilterComponentsForDomain(domain: string): React.ReactNode;
+
+    /**
+     * Get all of the parameters to filter a search for.
+     * @param domain The search domain to get parameters for.
+     */
+    getQueryValuesForDomain(domain: string): IQueryValues;
+
+    /**
+     * Get all of the parameters to filter a search for.
+     * @param domain The search domain to get parameters for.
+     */
+    updateQueryValuesForDomain(domain: string, values: IQueryValues): void;
+}
+
+const EMPTY_QUERY_VALUES = {};
+
+const SearchFilterContext = React.createContext<ISearchFilterContextValue>({
+    getFilterComponentsForDomain: () => null,
+    getQueryValuesForDomain: () => EMPTY_QUERY_VALUES,
+    updateQueryValuesForDomain: () => {},
+});
+
+interface IProps {
+    children?: React.ReactNode;
+}
+
+export function SearchFilterContextProvider(props: IProps) {
+    let [queryValuesByDomain, setQueryValuesByDomain] = useState<{ [domain: string]: IQueryValues }>({});
+
+    return (
+        <SearchFilterContext.Provider
+            value={{
+                getFilterComponentsForDomain: (domain: string) => {
+                    return SearchFilterContextProvider.extraFilters.map((extraFilter, i) => {
+                        if (extraFilter.searchDomain === domain) {
+                            return <React.Fragment key={i}>{extraFilter.filterNode}</React.Fragment>;
+                        } else {
+                            return null;
+                        }
+                    });
+                },
+                getQueryValuesForDomain: (domain: string) => {
+                    const existingValues = queryValuesByDomain[domain] || EMPTY_QUERY_VALUES;
+                    return existingValues;
+                },
+                updateQueryValuesForDomain: (domain: string, newValues: IQueryValues) => {
+                    const existingValues = queryValuesByDomain[domain] || EMPTY_QUERY_VALUES;
+                    setQueryValuesByDomain({
+                        ...queryValuesByDomain,
+                        [domain]: {
+                            ...existingValues,
+                            ...newValues,
+                        },
+                    });
+                },
+            }}
+        >
+            {props.children}
+        </SearchFilterContext.Provider>
+    );
+}
+
+export function useSearchFilters() {
+    return useContext(SearchFilterContext);
+}
+
+interface IExtraFilter {
+    searchDomain: string;
+    filterNode: React.ReactNode;
+}
+
+SearchFilterContextProvider.extraFilters = [] as IExtraFilter[];
+
+SearchFilterContextProvider.addSearchFilter = (domain: string, filterNode: React.ReactNode) => {
+    SearchFilterContextProvider.extraFilters.push({
+        searchDomain: domain,
+        filterNode,
+    });
+};

--- a/library/src/scripts/forms/select/SelectOne.tsx
+++ b/library/src/scripts/forms/select/SelectOne.tsx
@@ -36,10 +36,7 @@ export interface ISelectOneProps {
     noOptionsMessage?: (props: OptionProps<any>) => JSX.Element | null;
     isLoading?: boolean;
     inputClassName?: string;
-}
-
-interface IState {
-    focus: boolean;
+    isClearable?: boolean;
 }
 
 /**
@@ -82,7 +79,7 @@ export default function SelectOne(props: ISelectOneProps) {
                     inputId={inputID}
                     onChange={props.onChange}
                     onInputChange={props.onInputChange}
-                    isClearable={true}
+                    isClearable={props.isClearable}
                     isDisabled={disabled}
                     classNamePrefix={prefix}
                     className={classNames(prefix, className)}
@@ -105,6 +102,10 @@ export default function SelectOne(props: ISelectOneProps) {
         </div>
     );
 }
+
+SelectOne.defaultProps = {
+    isClearable: true,
+};
 
 /**
  * Hook to create react-select override props.


### PR DESCRIPTION
- Adds a pluggable context search context provider to be used in https://github.com/vanilla/multisite/pull/297
- Provider holds different query params and components per search domain.
- Set up the context provider in it's core.
- Update `<SelectOne />` to propagate an `isClearable` prop to the underlying select.