### PR TITLE
Add ability to make Chromatic optional in build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ aliases:
 
                 # Run code sniffer on the diffed files.
                 ./.circleci/scripts/diff-standards.sh $CUSTOM_TARGET_BRANCH
+
 jobs:
     frontend_setup:
         executor: core/node
@@ -182,12 +183,27 @@ jobs:
         steps:
             - core/checkout
             - run: yarn audit
+    chromatic_test:
+        executor: core/node
+        steps:
+            - run:
+                command: |
+                    if [ -z "$CHROMATIC_APP_CODE" ]; then
+                        echo "No Chromatic app code detected. Exiting."
+                        circleci-agent step halt
+                    else
+                        echo "Chromatic app code detected. Proceeding..."
+                    fi
+                name: "Conditionally perform Chromatic test"
+            - checkout
+            - chromatic/load-node-modules
+            - chromatic/test-exit-cleanly-on-changes
 
 workflows:
     version: 2
     commit:
         jobs:
-            - chromatic/test:
+            - chromatic_test:
                 filters:
                     branches:
                         ignore: master


### PR DESCRIPTION
Vanilla's [Chromatic](https://www.chromaticqa.com) job runs every time there's a build. Forked repositories do not contain the necessary environmental variable (`CHROMATIC_APP_CODE`) required to perform this job, so builds based on those forks fail.

The build has been updated to check for the Chromatic app code in the environment to determine whether or not Chromatic tests should be run. If no Chromatic app code is detected, those tests should be skipped.

Making this happen required essentially wrapping the existing `chromatic/test` job in a custom `chromatic_test` job and putting in a conditional stop. The `core/checkout` step was not compatible with this method. [Yarn errors were triggered](https://app.circleci.com/jobs/github/vanilla/vanilla/21961) unless `checkout` was used, instead.