### PR TITLE
Fix typo in messages/all view

### DIFF
--- a/applications/conversations/views/messages/all.php
+++ b/applications/conversations/views/messages/all.php
@@ -21,7 +21,7 @@ echo '</div>';
     <div class="DataListWrap">
         <ul class="Condensed DataList Conversations">
             <?php
-            if (count($this->data('Conversations') > 0)):
+            if (count($this->data('Conversations')) > 0):
                 $ViewLocation = $this->fetchViewLocation('conversations');
                 include $ViewLocation;
             else:


### PR DESCRIPTION
Found an old typo in messages/all, where it tries to count a boolean.
`count(): Parameter must be an array or an object that implements Countable`