### PR TITLE
Do not add #latest anchor when AutoOffset is disabled

### DIFF
--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -108,7 +108,7 @@ if (!function_exists('writeComment')) :
 
                 <?php
                 // Write a stub for the latest comment so it's easy to link to it from outside.
-                if ($currentOffset == Gdn::controller()->data('_LatestItem')) {
+                if ($currentOffset == Gdn::controller()->data('_LatestItem') && c('Vanilla.Comments.AutoOffset')) {
                     echo '<span id="latest"></span>';
                 }
                 ?>

--- a/applications/vanilla/views/discussion/helper_functions.php
+++ b/applications/vanilla/views/discussion/helper_functions.php
@@ -108,7 +108,7 @@ if (!function_exists('writeComment')) :
 
                 <?php
                 // Write a stub for the latest comment so it's easy to link to it from outside.
-                if ($currentOffset == Gdn::controller()->data('_LatestItem') && c('Vanilla.Comments.AutoOffset')) {
+                if ($currentOffset == Gdn::controller()->data('_LatestItem') && Gdn::config('Vanilla.Comments.AutoOffset')) {
                     echo '<span id="latest"></span>';
                 }
                 ?>


### PR DESCRIPTION
fixes #2469 

While i appreciate closing off stale issues, this just came up recently:
https://open.vanillaforums.com/discussion/comment/258777/#Comment_258777
With the suggested fix of inserting JS to remove the anchor.

So why not fix what (for the time being) is still a feature.