### PR TITLE
Remove Gdn_SQLDriver::whereNotIn workarounds

### DIFF
--- a/applications/dashboard/models/class.messagemodel.php
+++ b/applications/dashboard/models/class.messagemodel.php
@@ -137,9 +137,6 @@ class MessageModel extends Gdn_Model {
     public function getMessagesForLocation($Location, $Exceptions = ['[Base]'], $CategoryID = null) {
         $Session = Gdn::session();
         $Prefs = $Session->getPreference('DismissedMessages', []);
-        if (count($Prefs) == 0) {
-            $Prefs[] = 0;
-        }
 
         $category = null;
         if (!empty($CategoryID)) {

--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -580,9 +580,7 @@ class PermissionModel extends Gdn_Model {
                     $disabledWhere[] = $tableName;
                 }
             }
-            if (count($disabledWhere) > 0) {
-                $sQL->whereNotIn('JunctionTable', $disabledWhere);
-            }
+            $sQL->whereNotIn('JunctionTable', $disabledWhere);
         }
 
         $data = $sQL->get()->resultArray();

--- a/library/Vanilla/Formatting/UpdateMediaTrait.php
+++ b/library/Vanilla/Formatting/UpdateMediaTrait.php
@@ -41,14 +41,9 @@ trait UpdateMediaTrait {
             ->update($mediaModel->Name)
             ->set("Active", 0)
             ->where("ForeignID", $foreignID)
-            ->where("ForeignTable", $foreignTable);
-
-        /** @see https://github.com/vanilla/vanilla/issues/2969 */
-        if (!empty($currentMediaIDs)) {
-            $mediaModel->SQL->whereNotIn("MediaID", $currentMediaIDs);
-        }
-
-        $mediaModel->SQL->put();
+            ->where("ForeignTable", $foreignTable)
+            ->whereNotIn("MediaID", $currentMediaIDs)
+            ->put();
     }
 
     /**


### PR DESCRIPTION
Thanks to #9439 some workarounds from the past can now finally be removed.