### PR TITLE
Optimize search query when 'union all' is in use

### DIFF
--- a/applications/dashboard/models/class.searchmodel.php
+++ b/applications/dashboard/models/class.searchmodel.php
@@ -142,6 +142,8 @@ class SearchModel extends Gdn_Model {
         $this->_SearchMode = $searchMode;
 
         $this->EventArguments['Search'] = $search;
+        $this->EventArguments['Limit'] = $limit;
+        $this->EventArguments['Offset'] = $offset;
         $this->fireEvent('Search');
 
         if (count($this->_SearchSql) == 0) {

--- a/applications/vanilla/models/class.vanillasearchmodel.php
+++ b/applications/vanilla/models/class.vanillasearchmodel.php
@@ -117,9 +117,9 @@ class VanillaSearchModel extends Gdn_Model {
             ->join('Discussion d', 'd.DiscussionID = c.DiscussionID')
             ->orderBy('c.DateInserted', 'desc')
         ;
-         if ($searchModel->EventArguments['Limit'] ?? false) {
-             $this->SQL->limit($searchModel->EventArguments['Limit'] + $searchModel->EventArguments['Offset'] ?? 0);
-         }
+        if ($searchModel->EventArguments['Limit'] ?? false) {
+            $this->SQL->limit($searchModel->EventArguments['Limit'] + $searchModel->EventArguments['Offset'] ?? 0);
+        }
 
         if ($addMatch) {
             // Generate query

--- a/applications/vanilla/models/class.vanillasearchmodel.php
+++ b/applications/vanilla/models/class.vanillasearchmodel.php
@@ -65,11 +65,16 @@ class VanillaSearchModel extends Gdn_Model {
             ->select('d.DateInserted')
             ->select('d.InsertUserID as UserID')
             ->select("'Discussion'", '', 'RecordType')
-            ->from('Discussion d');
+            ->from('Discussion d')
+            ->orderBy('d.DateInserted', 'desc')
+        ;
 
         if ($addMatch) {
-            // Execute query.
-            $result = $this->SQL->getSelect();
+            // Generate query.
+            if ($searchModel->EventArguments['Limit'] ?? false) {
+                $this->SQL->limit($searchModel->EventArguments['Limit'] + $searchModel->EventArguments['Offset'] ?? 0);
+            }
+            $result = '( '.$this->SQL->getSelect().' )';
 
             // Unset SQL
             $this->SQL->reset();
@@ -109,12 +114,16 @@ class VanillaSearchModel extends Gdn_Model {
             ->select('c.InsertUserID as UserID')
             ->select("'Comment'", '', 'RecordType')
             ->from('Comment c')
-            ->join('Discussion d', 'd.DiscussionID = c.DiscussionID');
+            ->join('Discussion d', 'd.DiscussionID = c.DiscussionID')
+            ->orderBy('c.DateInserted', 'desc')
+        ;
 
         if ($addMatch) {
-            // Exectute query
-            $result = $this->SQL->getSelect();
-
+            // Generate query
+            if ($searchModel->EventArguments['Limit'] ?? false) {
+                $this->SQL->limit($searchModel->EventArguments['Limit'] + $searchModel->EventArguments['Offset'] ?? 0);
+            }
+            $result = '( '.$this->SQL->getSelect().' )';
             // Unset SQL
             $this->SQL->reset();
         } else {

--- a/applications/vanilla/models/class.vanillasearchmodel.php
+++ b/applications/vanilla/models/class.vanillasearchmodel.php
@@ -68,12 +68,12 @@ class VanillaSearchModel extends Gdn_Model {
             ->from('Discussion d')
             ->orderBy('d.DateInserted', 'desc')
         ;
+        if ($searchModel->EventArguments['Limit'] ?? false) {
+            $this->SQL->limit($searchModel->EventArguments['Limit'] + $searchModel->EventArguments['Offset'] ?? 0);
+        }
 
         if ($addMatch) {
             // Generate query.
-            if ($searchModel->EventArguments['Limit'] ?? false) {
-                $this->SQL->limit($searchModel->EventArguments['Limit'] + $searchModel->EventArguments['Offset'] ?? 0);
-            }
             $result = '( '.$this->SQL->getSelect().' )';
 
             // Unset SQL
@@ -117,12 +117,12 @@ class VanillaSearchModel extends Gdn_Model {
             ->join('Discussion d', 'd.DiscussionID = c.DiscussionID')
             ->orderBy('c.DateInserted', 'desc')
         ;
+         if ($searchModel->EventArguments['Limit'] ?? false) {
+             $this->SQL->limit($searchModel->EventArguments['Limit'] + $searchModel->EventArguments['Offset'] ?? 0);
+         }
 
         if ($addMatch) {
             // Generate query
-            if ($searchModel->EventArguments['Limit'] ?? false) {
-                $this->SQL->limit($searchModel->EventArguments['Limit'] + $searchModel->EventArguments['Offset'] ?? 0);
-            }
             $result = '( '.$this->SQL->getSelect().' )';
             // Unset SQL
             $this->SQL->reset();


### PR DESCRIPTION
Closes

Search model generates sql query like:

```
select *
from (
select d.DiscussionID as `PrimaryID`, d.Name as `Title`, d.Body as `Summary`, d.Format as `Format`, d.CategoryID as `CategoryID`, d.Score as `Score`, concat('/discussion/', d.DiscussionID) as `Url`, d.DateInserted as `DateInserted`, d.InsertUserID as `UserID`, 'Discussion' as `RecordType`, d.Type as `Type`
from `GDN_Discussion` `d`
where (d.Name like '%some text to search%'
  or d.Body like '%some text to search%')
 and `CategoryID` in (...)
union all
select c.CommentID as `PrimaryID`, d.Name as `Title`, c.Body as `Summary`, c.Format as `Format`, d.CategoryID as `CategoryID`, c.Score as `Score`, concat('/discussion/comment/', c.CommentID, '/#Comment_', c.CommentID) as `Url`, c.DateInserted as `DateInserted`, c.InsertUserID as `UserID`, 'Comment' as `RecordType`, null as `Type`
from `GDN_Comment` `c`
join `GDN_Discussion` `d` on d.DiscussionID = c.DiscussionID
where c.Body like '%some text to search%'
 and `CategoryID` in (...)
) s
order by `s`.`DateInserted` desc
limit 10 offset 100
```

That is very slow because we do not apply `LIMIT` to subqueries. And on top of that we apply `ORDER BY` to the huge result record set returned by `UNION ALL` which has no indexes since it is not a real table but just temporary table structure in memory.

Changes provided transform this query to:
```
select *
from (
( select d.DiscussionID as `PrimaryID`, d.Name as `Title`, d.Body as `Summary`, d.Format as `Format`, d.CategoryID as `CategoryID`, d.Score as `Score`, concat('/discussion/', d.DiscussionID) as `Url`, d.DateInserted as `DateInserted`, d.InsertUserID as `UserID`, 'Discussion' as `RecordType`, d.Type as `Type`
from `GDN_Discussion` `d`
where (d.Name like '%some text to search%'
  or d.Body like '%some text to search%')
 and `CategoryID` in (...)
order by `d`.`DateInserted` desc
limit 110 )
union all
( select c.CommentID as `PrimaryID`, d.Name as `Title`, c.Body as `Summary`, c.Format as `Format`, d.CategoryID as `CategoryID`, c.Score as `Score`, concat('/discussion/comment/', c.CommentID, '/#Comment_', c.CommentID) as `Url`, c.DateInserted as `DateInserted`, c.InsertUserID as `UserID`, 'Comment' as `RecordType`, null as `Type`
from `GDN_Comment` `c`
join `GDN_Discussion` `d` on d.DiscussionID = c.DiscussionID
where c.Body like '%some text to search%'
 and `CategoryID` in (...)
order by `c`.`DateInserted` desc
limit 110 )
) s
order by `s`.`DateInserted` desc
limit 10 offset 100
```

Which is not the absolutely the best, especially when it comes to the page 1000 or 10 000.
But it still respect pagination principle and search results should be equivalent to the result returned by previous implementation.

On my localhost with ~1.5 M comments and ~2M discussions performance is 400x - 1500x times better for first 100 pages.