### PR TITLE
Remove legacy Vanilla notifications queueing

### DIFF
--- a/applications/vanilla/controllers/class.discussioncontroller.php
+++ b/applications/vanilla/controllers/class.discussioncontroller.php
@@ -214,11 +214,6 @@ class DiscussionController extends VanillaController {
             }
         }
 
-        // Queue notification.
-        if ($this->Request->get('new') && c('Vanilla.QueueNotifications')) {
-            $this->addDefinition('NotifyNewDiscussion', 1);
-        }
-
         // Make sure to set the user's discussion watch records if this is not an API request.
         if ($this->deliveryType() !== DELIVERY_TYPE_DATA) {
             $this->CommentModel->setWatch($this->Discussion, $Limit, $this->Offset, $this->Discussion->CountComments);

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -1002,58 +1002,6 @@ class PostController extends VanillaController {
         $this->CssClass = 'NoPanel';
     }
 
-    public function notifyNewDiscussion($discussionID) {
-        if (!c('Vanilla.QueueNotifications')) {
-            throw forbiddenException('NotifyNewDiscussion');
-        }
-
-        if (!$this->Request->isPostBack()) {
-            throw forbiddenException('GET');
-        }
-
-        // Grab the discussion.
-        $discussion = $this->DiscussionModel->getID($discussionID);
-        if (!$discussion) {
-            throw notFoundException('Discussion');
-        }
-
-        if (val('Notified', $discussion) != ActivityModel::SENT_PENDING) {
-            die('Not pending');
-        }
-
-        // Mark the notification as in progress.
-        $this->DiscussionModel->setField($discussionID, 'Notified', ActivityModel::SENT_INPROGRESS);
-
-        $discussionType = val('Type', $discussion);
-        if ($discussionType) {
-            $code = "HeadlineFormat.Discussion.{$discussionType}";
-        } else {
-            $code = 'HeadlineFormat.Discussion';
-        }
-
-        $headlineFormat = t($code, '{ActivityUserID,user} started a new discussion: <a href="{Url,html}">{Data.Name,text}</a>');
-        $category = CategoryModel::categories(val('CategoryID', $discussion));
-        $activity = [
-            'ActivityType' => 'Discussion',
-            'ActivityUserID' => $discussion->InsertUserID,
-            'HeadlineFormat' => $headlineFormat,
-            'RecordType' => 'Discussion',
-            'RecordID' => $discussionID,
-            'Route' => discussionUrl($discussion, '', '/'),
-            'Data' => [
-                'Name' => $discussion->Name,
-                'Category' => val('Name', $category)
-            ]
-        ];
-
-        $activityModel = new ActivityModel();
-        $this->DiscussionModel->notifyNewDiscussion($discussion, $activityModel, $activity);
-        $activityModel->saveQueue();
-        $this->DiscussionModel->setField($discussionID, 'Notified', ActivityModel::SENT_OK);
-
-        die('OK');
-    }
-
     /**
      * Pre-populate the form with values from the query string.
      *

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2144,10 +2144,6 @@ class DiscussionModel extends Gdn_Model {
                         $fields['Format'] = c('Garden.InputFormatter', '');
                     }
 
-                    if (c('Vanilla.QueueNotifications')) {
-                        $fields['Notified'] = ActivityModel::SENT_PENDING;
-                    }
-
                     // Check for approval
                     $approvalRequired = checkRestriction('Vanilla.Approval.Require');
                     if ($approvalRequired && !val('Verified', Gdn::session()->User)) {
@@ -2317,11 +2313,9 @@ class DiscussionModel extends Gdn_Model {
         $this->EventArguments["Activity"] = $data;
 
         // Notify everyone that has advanced notifications.
-        if (!c("Vanilla.QueueNotifications")) {
-            $advancedActivity = $data;
-            $advancedActivity["Data"]["Reason"] = "advanced";
-            $this->recordAdvancedNotications($activityModel, $advancedActivity, $discussion);
-        }
+        $advancedActivity = $data;
+        $advancedActivity["Data"]["Reason"] = "advanced";
+        $this->recordAdvancedNotications($activityModel, $advancedActivity, $discussion);
 
         // Throw an event for users to add their own events.
         $this->EventArguments["Discussion"] = $discussion;

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -147,10 +147,6 @@ $Construct
     ->column('RegardingID', 'int(11)', true, 'index');
 //->column('Source', 'varchar(20)', true)
 
-if (c('Vanilla.QueueNotifications')) {
-    $Construct->column('Notified', 'tinyint', ActivityModel::SENT_ARCHIVE);
-}
-
 $Construct
     ->set($Explicit, $Drop);
 


### PR DESCRIPTION
Many, many years ago, 181a6f6 introduced `Vanilla.QueueNotifications`. It was a way to offset the sending of notifications. It was used by (almost) no one. Today, we remove it from core.

All removed code is gated behind a truthy `Vanilla.QueueNotifications` config. I do not anticipate any collateral damage.