### PR TITLE
Add lastPost.body expansion to /api/v2/discussions endpoints

### DIFF
--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -92,6 +92,7 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller implements 
                 'discussionID:i?' => 'The discussion ID of the post.',
                 'commentID:i?' => 'The comment ID of the post, if any.',
                 'name:s' => 'The title of the post.',
+                'body:s?' => 'The HTML body of the post.',
                 'url:s' => 'The URL of the post.',
                 'dateInserted:dt' => 'The date of the post.',
                 'insertUserID:i' => 'The author of the post.',

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -40,21 +40,27 @@ class DiscussionsApiController extends AbstractApiController {
     /** @var UserModel */
     private $userModel;
 
+    /** @var CommentModel */
+    private $commentModel;
+
     /**
      * DiscussionsApiController constructor.
      *
      * @param DiscussionModel $discussionModel
      * @param UserModel $userModel
      * @param CategoryModel $categoryModel
+     * @param CommentModel $commentModel
      */
     public function __construct(
         DiscussionModel $discussionModel,
         UserModel $userModel,
-        CategoryModel $categoryModel
+        CategoryModel $categoryModel,
+        CommentModel $commentModel
     ) {
         $this->categoryModel = $categoryModel;
         $this->discussionModel = $discussionModel;
         $this->userModel = $userModel;
+        $this->commentModel = $commentModel;
     }
 
     /**
@@ -79,7 +85,7 @@ class DiscussionsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand?' => ApiUtils::getExpandDefinition(['insertUser', 'lastUser', 'lastPost'])
+            'expand?' => ApiUtils::getExpandDefinition(['insertUser', 'lastUser', 'lastPost', 'lastPost.body', 'lastPost.insertUser'])
         ], 'in')->setDescription('Get a list of the current user\'s bookmarked discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
@@ -94,13 +100,14 @@ class DiscussionsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID']),
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID', 'lastPost.insertUser' => 'LastUserID']),
             ['expand' => $query['expand']]
         );
 
         foreach ($rows as &$currentRow) {
-            $currentRow = $this->normalizeOutput($currentRow);
+            $currentRow = $this->normalizeOutput($currentRow, $query['expand'] ?? []);
         }
+        $this->expandLastCommentBody($rows, $query['expand']);
 
         $result = $out->validate($rows);
 
@@ -251,7 +258,7 @@ class DiscussionsApiController extends AbstractApiController {
 
         $this->idParamSchema();
         $in = $this->schema([
-            'expand?' => ApiUtils::getExpandDefinition([]) // Allow addons to expand additional fields.
+            'expand?' => ApiUtils::getExpandDefinition(['lastPost', 'lastPost.body', 'lastPost.insertUser']) // Allow addons to expand additional fields.
         ], ['DiscussionGet', 'in'])->setDescription('Get a discussion.');
         $out = $this->schema($this->discussionSchema(), 'out');
 
@@ -268,6 +275,8 @@ class DiscussionsApiController extends AbstractApiController {
 
         $this->userModel->expandUsers($row, ['InsertUserID', 'LastUserID'], ['expand' => true]);
         $row = $this->normalizeOutput($row, $query["expand"] ?? []);
+        $rows = [&$row];
+        $this->expandLastCommentBody($rows, $query['expand'] ?? []);
 
         $result = $out->validate($row);
 
@@ -304,7 +313,6 @@ class DiscussionsApiController extends AbstractApiController {
             $lastPost = [
                 'discussionID' => $dbRecord['DiscussionID'],
                 'dateInserted' => $dbRecord['DateLastComment'],
-                'insertUser' => $dbRecord['LastUser'],
                 "insertUserID" => $dbRecord["LastUserID"],
             ];
             if ($dbRecord['LastCommentID']) {
@@ -314,6 +322,13 @@ class DiscussionsApiController extends AbstractApiController {
             } else {
                 $lastPost['name'] = $dbRecord['Name'];
                 $lastPost['url'] = $dbRecord['Url'];
+            }
+
+            if ($this->isExpandField('lastPost.insertUser', $expand) || $this->isExpandField('lastUser', $expand) && array_key_exists('LastUser', $dbRecord)) {
+                $lastPost['insertUser'] = $dbRecord['LastUser'];
+                if (!$this->isExpandField('lastUser', $expand)) {
+                    unset($dbRecord['LastUser']);
+                }
             }
 
             $dbRecord['lastPost'] = $lastPost;
@@ -503,7 +518,7 @@ class DiscussionsApiController extends AbstractApiController {
                     'field' => 'd.InsertUserID',
                 ],
             ],
-            'expand?' => ApiUtils::getExpandDefinition(['category', 'insertUser', 'lastUser', 'lastPost'])
+            'expand?' => ApiUtils::getExpandDefinition(['category', 'insertUser', 'lastUser', 'lastPost', 'lastPost.body', 'lastPost.insertUser'])
         ], ['DiscussionIndex', 'in'])->setDescription('List discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
@@ -545,7 +560,7 @@ class DiscussionsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID']),
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID', 'lastPost.insertUser' => 'LastUserID']),
             ['expand' => $query['expand']]
         );
         if ($this->isExpandField('category', $query['expand'])) {
@@ -555,6 +570,7 @@ class DiscussionsApiController extends AbstractApiController {
         foreach ($rows as &$currentRow) {
             $currentRow = $this->normalizeOutput($currentRow, $query['expand']);
         }
+        $this->expandLastCommentBody($rows, $query['expand']);
 
         $result = $out->validate($rows, true);
 
@@ -735,6 +751,41 @@ class DiscussionsApiController extends AbstractApiController {
         if (!empty($attributes['CanonicalUrl'] ?? '')) {
             unset($attributes['CanonicalUrl']);
             $this->discussionModel->setProperty($id, 'Attributes', dbencode($attributes));
+        }
+    }
+
+    /**
+     * Expand the body of the last comment.
+     *
+     * @param array $rows
+     * @param array|bool $expand
+     */
+    private function expandLastCommentBody(array &$rows, $expand): void {
+        if (!$this->isExpandField('lastPost', $expand) || !$this->isExpandField('lastPost.body', $expand)) {
+            return;
+        }
+
+        $commentIDs = [];
+        foreach ($rows as $row) {
+            $id = $row['lastPost']['commentID'] ?? null;
+            if (is_int($id)) {
+                $commentIDs[] = $id;
+            }
+        }
+        if (!empty($commentIDs)) {
+            $comments = $this->commentModel->getWhere(['commentID' => $commentIDs], '', 'asc', count($commentIDs))->resultArray();
+            $comments = array_column($comments, null, 'CommentID');
+        } else {
+            $comments = [];
+        }
+
+        foreach ($rows as &$row) {
+            $id = $row['lastPost']['commentID'] ?? null;
+            if (isset($comments[$id])) {
+                $row['lastPost']['body'] = \Gdn::formatService()->renderHTML($comments[$id]['Body'], $comments[$id]['Format']);
+            } else {
+                $row['lastPost']['body'] = $row['body'];
+            }
         }
     }
 }

--- a/applications/vanilla/openapi/discussions.yml
+++ b/applications/vanilla/openapi/discussions.yml
@@ -79,11 +79,13 @@ paths:
         schema:
           items:
             enum:
+            - all
             - category
             - insertUser
             - lastUser
             - lastPost
-            - all
+            - lastPost.body
+            - lastPost.insertUser
             - reactions
             type: string
           type: array
@@ -147,6 +149,8 @@ paths:
             - insertUser
             - lastUser
             - lastPost
+            - lastPost.body
+            - lastPost.insertUser
             - all
             type: string
           type: array
@@ -1073,29 +1077,32 @@ components:
       type: object
     PostFragment:
       properties:
-        commentID:
-          description: 'The comment ID of the post, if any.'
-          type: integer
-        dateInserted:
-          description: The date of the post.
-          format: date-time
-          type: string
         discussionID:
           description: The discussion ID of the post.
           type: integer
-        insertUser:
-          $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/UserFragment'
-        insertUserID:
-          description: The author of the post.
+        commentID:
+          description: 'The comment ID of the post, if any.'
           type: integer
         name:
           description: The title of the post.
           minLength: 1
           type: string
+        body:
+          description: The HTML formatted body of the post.
+          type: string
         url:
           description: The URL of the post.
           minLength: 1
           type: string
+        dateInserted:
+          description: The date of the post.
+          format: date-time
+          type: string
+        insertUser:
+          $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/UserFragment'
+        insertUserID:
+          description: The author of the post.
+          type: integer
       required:
       - name
       - url

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -209,4 +209,50 @@ class DiscussionsTest extends AbstractResourceTest {
     public function testIndexPrivateCommunity() {
         $this->runWithPrivateCommunity([$this, 'testIndex']);
     }
+
+    /**
+     * Test comment body expansion.
+     */
+    public function testExpandLastPostBody() {
+        $this->testPost();
+
+        // Test that the field is there.
+        $query = ['expand' => 'lastPost,lastPost.body'];
+        $rows = $this->api()->get($this->baseUrl, $query);
+        $this->assertArrayHasKey('body', $rows[0]['lastPost']);
+
+        // Comment on a discussions to see if it becomes the last post.
+        $comment = $this->api()->post("/comments", [
+            'discussionID' => $rows[0]['discussionID'],
+            'body' => 'hello',
+            'format' => 'markdown',
+        ]);
+
+        $rows = $this->api()->get($this->baseUrl, $query);
+        $this->assertSame($comment['commentID'], $rows[0]['lastPost']['commentID']);
+
+        // Individual discussions should expand too.
+        $discussion = $this->api()->get($this->baseUrl.'/'.$rows[0]['discussionID'], $query);
+        $this->assertArrayHasKey('body', $discussion['lastPost']);
+        $this->assertSame($comment['commentID'], $discussion['lastPost']['commentID']);
+    }
+
+    /**
+     * @requires testExpandLastPostBody
+     */
+    public function testExpandLastUser() {
+        $rows = $this->api()->get($this->baseUrl, ['expand' => 'lastPost,lastPost.insertUser']);
+        $this->assertArrayHasKey('insertUser', $rows[0]['lastPost']);
+        $this->assertArrayNotHasKey('lastUser', $rows[0]);
+
+        // Deprecated but should work for BC.
+        $rows = $this->api()->get($this->baseUrl, ['expand' => 'lastPost,lastUser']);
+        $this->assertArrayHasKey('insertUser', $rows[0]['lastPost']);
+        $this->assertArrayHasKey('lastUser', $rows[0]);
+
+        $url = $this->baseUrl.'/'.$rows[0]['discussionID'];
+        $row = $this->api()->get($url, ['expand' => 'lastPost,lastPost.insertUser']);
+        $this->assertArrayHasKey('insertUser', $row['lastPost']);
+        $this->assertArrayNotHasKey('lastUser', $row);
+    }
 }


### PR DESCRIPTION
This option allows body expansion to the discussions API. Because the body requires more queries and could add a significant amount of data to the result it is left as a parameter.

This PR also includes a slight fix to `lastUser` expansion. When this field is expanded it actually expands in two places which is not optimal. This functionality is kept for BC, but an additional `lastPost.insertUser` expansion parameter has been added for a lesser expansion.

Closes #9527.