### PR TITLE
Fix array access in CommentModel::setWatch

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -902,7 +902,7 @@ class CommentModel extends Gdn_Model {
             return;
         }
         $wheres = ['CategoryID' => $categoryID];
-        $dateMarkedRead = $category->DateMarkedRead ?? null;
+        $dateMarkedRead = $category['DateMarkedRead'];
         if ($dateMarkedRead) {
             $wheres['DateLastComment>'] = $dateMarkedRead;
         }


### PR DESCRIPTION
There used to be this notice in the discussion view:

    Trying to get property 'DateMarkedRead' of non-object

This was fixed here, but not correctly:
https://github.com/vanilla/vanilla/commit/dceb535e408fc268f29f15ad9dff2582547e2398

CategoryModel::categories() always returns categories as an array, thus the null coalescing operator is not needed and was just masking the actual error.
