### PR TITLE
Prevent [deleted user] from appearing in activities

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3826,6 +3826,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
 
         // Remove activities
         $this->getDelete('Activity', ['InsertUserID' => $userID], $content);
+        $this->getDelete('Activity', ['ActivityUserID' => $userID], $content);
 
         // Remove activity comments.
         $this->getDelete('ActivityComment', ['InsertUserID' => $userID], $content);

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1513,20 +1513,21 @@ if (!function_exists('_formatStringCallback')) {
                                     continue;
                                 }
 
+                                $separator = '';
                                 if ($i == $count - 1) {
-                                    $result .= ' '.t('sep and', 'and').' ';
+                                    $separator = ' '.t('sep and', 'and').' ';
                                 } elseif ($i > 0) {
-                                    $result .= ', ';
+                                    $separator = ', ';
                                 }
 
                                 $special = [-1 => t('everyone'), -2 => t('moderators'), -3 => t('administrators')];
                                 if (isset($special[$iD])) {
-                                    $result .= $special[$iD];
+                                    $result .= $separator.$special[$iD];
                                 } else {
                                     $user = Gdn::userModel()->getID($iD);
-                                    if ($user) {
+                                    if ($user && $user->Deleted == 0) {
                                         $user->Name = formatUsername($user, $format, $contextUserID);
-                                        $result .= userAnchor($user);
+                                        $result .= $separator.userAnchor($user);
                                     }
                                 }
                             }


### PR DESCRIPTION
When deleting newly registered users (e.g. spam registrations), [deleted user] appears heavily in the activity feed which looks unprofessional.

The reason for this is that when a users content is deleted, it is queried by InsertUserID which doesn't cover all of the users activity.
Especially the "USER hat joined." activity type can have InsertUserID == null (no session present) or the ID of the admin creating the profile for the user.
This fixes that by also deleting by ActivityUserID (which has an index).

Note that this will delete grouped activities where the ActivityUserID happens to belong to the user being deleted.
But this is already the case when InsertUserID == ActivityUserID (grouped activities do not appear on user feeds anyway if the userID is not ActivityUserID).
So this just makes the behaviour more consistent.

Because of those grouped activities (which contain the UserIDs in the JSON "Data" field that can hardly be queried), the second part of this fix involves ignoring deleted users when building activity headlines.
