### PR TITLE
Fix conversation popin w/ Empty message

### DIFF
--- a/applications/conversations/views/messages/popin.php
+++ b/applications/conversations/views/messages/popin.php
@@ -26,7 +26,9 @@
                 <div class="ItemContent">
                     <b class="Subject"><?php echo anchor(htmlspecialchars($Subject), "/messages/{$Row['ConversationID']}#Message_{$Row['LastMessageID']}"); ?></b>
                     <?php
-                    $Excerpt = sliceString(Gdn::formatService()->renderExcerpt($Row['LastBody'], $Row['LastFormat']), 80);
+                    $Excerpt = isset($Row['LastBody'])
+                        ? sliceString(Gdn::formatService()->renderExcerpt($Row['LastBody'], $Row['LastFormat']), 80)
+                        : t('Blank Message');
                     echo wrap(nl2br(htmlspecialchars($Excerpt)), 'div', ['class' => 'Excerpt']);
                     ?>
                     <div class="Meta">


### PR DESCRIPTION
We had a fatal error here because `renderExcerpt()` requires a string as the first parameter.

This is a similar fix to what we did on the actual conversations page in https://github.com/vanilla/vanilla/pull/9396