### PR TITLE
Allow custom url schemes

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -137,7 +137,9 @@ $Configuration['Garden']['SignIn']['Popup'] = true; // Should the sign-in link p
 $Configuration['Garden']['InputFormatter'] = 'Rich'; // Html, BBCode, Markdown, Text, Rich
 $Configuration['Garden']['MobileInputFormatter'] = 'Rich';
 $Configuration['Garden']['Html']['AllowedElements'] = "a, abbr, acronym, address, area, audio, b, bdi, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, details, dfn, div, dl, dt, em, figure, figcaption, font, h1, h2, h3, h4, h5, h6, hgroup, hr, i, img, ins, kbd, li, map, mark, menu, meter, ol, p, pre, q, s, samp, small, span, strike, strong, sub, sup, summary, table, tbody, td, tfoot, th, thead, time, tr, tt, u, ul, var, video, wbr";
-$Configuration['Garden']['Html']['AllowedUrlSchemes'] = ['aim', 'feed', 'file', 'ftp', 'gopher', 'http', 'https', 'irc', 'mailto', 'news', 'nntp', 'rapidminer', 'sftp', 'ssh', 'telnet'];
+$Configuration['Garden']['Html']['AllowedUrlSchemes'] = [
+    'aim', 'feed', 'file', 'ftp', 'gopher', 'http', 'https', 'irc', 'mailto', 'news', 'nntp', 'rapidminer', 'sftp', 'ssh', 'telnet'
+];
 $Configuration['Garden']['Search']['Mode'] = 'boolean'; // matchboolean, match, boolean, like
 $Configuration['Garden']['EditContentTimeout'] = 3600; // -1 means no timeout. 0 means immediate timeout. > 0 is in seconds. 60 * 60 = 3600 (aka 1hr)
 $Configuration['Garden']['Format']['Mentions'] = true;

--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -137,6 +137,7 @@ $Configuration['Garden']['SignIn']['Popup'] = true; // Should the sign-in link p
 $Configuration['Garden']['InputFormatter'] = 'Rich'; // Html, BBCode, Markdown, Text, Rich
 $Configuration['Garden']['MobileInputFormatter'] = 'Rich';
 $Configuration['Garden']['Html']['AllowedElements'] = "a, abbr, acronym, address, area, audio, b, bdi, bdo, big, blockquote, br, caption, center, cite, code, col, colgroup, dd, del, details, dfn, div, dl, dt, em, figure, figcaption, font, h1, h2, h3, h4, h5, h6, hgroup, hr, i, img, ins, kbd, li, map, mark, menu, meter, ol, p, pre, q, s, samp, small, span, strike, strong, sub, sup, summary, table, tbody, td, tfoot, th, thead, time, tr, tt, u, ul, var, video, wbr";
+$Configuration['Garden']['Html']['AllowedUrlSchemes'] = ['aim', 'feed', 'file', 'ftp', 'gopher', 'http', 'https', 'irc', 'mailto', 'news', 'nntp', 'rapidminer', 'sftp', 'ssh', 'telnet'];
 $Configuration['Garden']['Search']['Mode'] = 'boolean'; // matchboolean, match, boolean, like
 $Configuration['Garden']['EditContentTimeout'] = 3600; // -1 means no timeout. 0 means immediate timeout. > 0 is in seconds. 60 * 60 = 3600 (aka 1hr)
 $Configuration['Garden']['Format']['Mentions'] = true;

--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -167,6 +167,7 @@ class VanillaHtmlFormatter {
      */
     public function format($html, $options = []) {
         $attributes = self::c('Garden.Html.BlockedAttributes', 'on*, target, download');
+        $schemes = implode(', ', self::c('Garden.Html.AllowedUrlSchemes'));
 
         $specOverrides = val('spec', $options, []);
         if (!is_array($specOverrides)) {
@@ -183,10 +184,7 @@ class VanillaHtmlFormatter {
             'direct_list_nest' => 1,
             'elements' => '*-applet-button-embed-fieldset-form-iframe-input-legend-link-object-optgroup-option-script-select-style-textarea',
             'keep_bad' => 0,
-            'schemes' => self::c(
-                'Garden.Html.CustomUrlSchemes',
-                'classid:clsid; href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, rapidminer, sftp, ssh, telnet; style: nil; *:file, http, https' // clsid allowed in class
-            ),
+            'schemes' => 'classid:clsid; href: '.$schemes.'; style: nil; *:file, http, https', // clsid allowed in class
             'unique_ids' => 1,
             'valid_xhtml' => 0
         ];

--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -5,11 +5,14 @@
  */
 
 use Vanilla\EmbeddedContent\LegacyEmbedReplacer;
+use Garden\StaticCacheConfigTrait;
 
 /**
  * Class VanillaHtmlFormatter
  */
 class VanillaHtmlFormatter {
+
+    use StaticCacheConfigTrait;
 
     /** @var array Classes users may have in their content. */
     protected $allowedClasses = [
@@ -163,7 +166,7 @@ class VanillaHtmlFormatter {
      * @return string Returns the filtered HTML.
      */
     public function format($html, $options = []) {
-        $attributes = c('Garden.Html.BlockedAttributes', 'on*, target, download');
+        $attributes = self::c('Garden.Html.BlockedAttributes', 'on*, target, download');
 
         $specOverrides = val('spec', $options, []);
         if (!is_array($specOverrides)) {
@@ -180,13 +183,16 @@ class VanillaHtmlFormatter {
             'direct_list_nest' => 1,
             'elements' => '*-applet-button-embed-fieldset-form-iframe-input-legend-link-object-optgroup-option-script-select-style-textarea',
             'keep_bad' => 0,
-            'schemes' => 'classid:clsid; href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, rapidminer, sftp, ssh, telnet; style: nil; *:file, http, https', // clsid allowed in class
+            'schemes' => self::c(
+                'Garden.Html.CustomUrlSchemes',
+                'classid:clsid; href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, rapidminer, sftp, ssh, telnet; style: nil; *:file, http, https' // clsid allowed in class
+            ),
             'unique_ids' => 1,
             'valid_xhtml' => 0
         ];
 
         // If we don't allow URL embeds, don't allow HTML media embeds, either.
-        if (c('Garden.Format.DisableUrlEmbeds')) {
+        if (self::c('Garden.Format.DisableUrlEmbeds')) {
             if (!array_key_exists('elements', $config) || !is_string($config['elements'])) {
                 $config['elements'] = '';
             }


### PR DESCRIPTION
I followed the suggestions of #7769

The only difference is, that `Garden.Html.CustomUrlSchemes` replaces the default config in my implementation. This is because afaik array configs are somewhat deprecated and because of HtmLawed's special scheme syntax which doesn't really map to an array. String concatenation would be another option.