### PR TITLE
Fix $.morepager on profile/comments

### DIFF
--- a/applications/vanilla/js/discussions.js
+++ b/applications/vanilla/js/discussions.js
@@ -10,7 +10,7 @@ jQuery(document).ready(function($) {
         });
 
         // profile/discussions paging
-        $('.Section-Profile .Discussions .MorePager').morepager({
+        $('.Section-Profile .Discussions .MorePager, .Section-Profile .Comments .MorePager').morepager({
             pagerInContainer: true,
             afterPageLoaded: function() {
                 $(document).trigger('DiscussionPagingComplete');

--- a/applications/vanilla/views/discussion/profile.php
+++ b/applications/vanilla/views/discussion/profile.php
@@ -2,7 +2,7 @@
 
 echo '<div class="DataListWrap">';
 echo '<h2 class="H">'.t('Comments').'</h2>';
-echo '<ul class="DataList SearchResults">';
+echo '<ul class="DataList Comments">';
 
 if (sizeof($this->data('Comments'))) {
     echo $this->fetchView('profilecomments', 'Discussion', 'Vanilla');


### PR DESCRIPTION
This make the "more" pager work the same way on profile/comments as it does on profile/discussions.
Fixes #5651

This was partly introduced in #5557 by the more restrictive selector, but the CSS class of the profile/comments `.Datalist` has always been wrong.