### PR TITLE
Use $(document).on() for discussions admin toggles

### DIFF
--- a/applications/vanilla/js/discussions.js
+++ b/applications/vanilla/js/discussions.js
@@ -23,14 +23,14 @@ jQuery(document).ready(function($) {
     }
 
     /* Discussion Checkboxes */
-    $('.AdminCheck [name="Toggle"]').click(function() {
+    $(document).on('click', '.AdminCheck [name="Toggle"]', function() {
         if ($(this).prop('checked')) {
             $('.DataList .AdminCheck :checkbox, tbody .AdminCheck :checkbox').prop('checked', true).change();
         } else {
             $('.DataList .AdminCheck :checkbox, tbody .AdminCheck :checkbox').prop('checked', false).change();
         }
     });
-    $('.AdminCheck :checkbox').click(function() {
+    $(document).on('click', '.AdminCheck :checkbox', function() {
         // retrieve all checked ids
         var checkIDs = $('.DataList .AdminCheck :checkbox, tbody .AdminCheck :checkbox');
         var aCheckIDs = new Array();


### PR DESCRIPTION
This will ensure the checkboxes still work if content is delivered via AJAX.

Closes #9532.