### PR TITLE
Improve batch email compatibility with email addons

### DIFF
--- a/applications/dashboard/models/ActivityEmail.php
+++ b/applications/dashboard/models/ActivityEmail.php
@@ -19,14 +19,14 @@ class ActivityEmail {
     /** @var string */
     private $actionText;
 
-    /** @var string */
-    private $actionUrl;
-
     /** @var int */
     private $activityTypeID;
 
     /** @var string */
     private $body = "";
+
+    /** @var string */
+    private $internalRoute;
 
     /** @var string[] */
     private $recipients = [];
@@ -68,15 +68,6 @@ class ActivityEmail {
     }
 
     /**
-     * Get the call to action URL for this email.
-     *
-     * @return string|null
-     */
-    public function getActionUrl(): ?string {
-        return $this->actionUrl;
-    }
-
-    /**
      * Return all associated activity IDs.
      *
      * @return array
@@ -101,6 +92,15 @@ class ActivityEmail {
      */
     public function getBody(): string {
         return $this->body;
+    }
+
+    /**
+     * Get the internal route behind the call to action for this email.
+     *
+     * @return string|null
+     */
+    public function getInternalRoute(): ?string {
+        return $this->internalRoute;
     }
 
     /**
@@ -144,10 +144,10 @@ class ActivityEmail {
      */
     public function reset() {
         $this->actionText = null;
-        $this->actionUrl = null;
         $this->activityIDs = [];
         $this->activityTypeID = null;
         $this->body = "";
+        $this->internalRoute = null;
         $this->recipients = [];
         $this->recordID = null;
         $this->recordType = null;
@@ -164,12 +164,12 @@ class ActivityEmail {
     }
 
     /**
-     * Set the call to action URL for this email.
+     * Set the route behind the call to action for this email.
      *
-     * @param string|null $actionUrl
+     * @param string|null $internalRoute
      */
-    public function setActionUrl(?string $actionUrl) {
-        $this->actionUrl = $actionUrl;
+    public function setInternalRoute(?string $internalRoute) {
+        $this->internalRoute = $internalRoute;
     }
 
     /**

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -2076,6 +2076,7 @@ class ActivityModel extends Gdn_Model {
             ],
             "Email" => $email,
             "Route" => $route,
+            "UserAuthorized" => true, // Let anything hooking in know we've already authorized user access to the resources.
         ];
 
         $batchOffset = 0;

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1990,8 +1990,8 @@ class ActivityModel extends Gdn_Model {
             $activityEmail->setBody($body);
             $activityEmail->setSubject($subject);
             $activityEmail->setActionText($activity["ActionText"] ?? t("Check it out"));
-            $activityEmail->setActionUrl(externalUrl(val('Route', $activity) == '' ? '/' : val('Route', $activity)));
             $activityEmail->setActivityTypeID($activity["ActivityTypeID"] ?? null);
+            $activityEmail->setInternalRoute($activity["Route"] ?? "");
             $activityEmail->setRecordID($activity["RecordID"] ?? null);
             $activityEmail->setRecordType($activity["RecordType"] ?? null);
             static::$emailQueue[$key] = $activityEmail;
@@ -2066,13 +2066,16 @@ class ActivityModel extends Gdn_Model {
         $recipients = $activityEmail->getRecipients();
 
         $activityType = static::getActivityType($activityEmail->getActivityTypeID());
+        $route = $activityEmail->getInternalRoute() ?? "/";
         $notification = [
             "Activity" => [
                 "ActivityType" => $activityType["Name"] ?? null,
                 "RecordID" => $activityEmail->getRecordID(),
                 "RecordType" => $activityEmail->getRecordType(),
+                "Route" => $route,
             ],
             "Email" => $email,
+            "Route" => $route,
         ];
 
         $batchOffset = 0;
@@ -2085,8 +2088,9 @@ class ActivityModel extends Gdn_Model {
                 $email->bcc($address, $name ?? "");
             }
 
+            $actionUrl = externalUrl($route);
             $emailTemplate = $email->getEmailTemplate()
-                ->setButton($activityEmail->getActionUrl(), $activityEmail->getActionText())
+                ->setButton($actionUrl, $activityEmail->getActionText())
                 ->setTitle($activityEmail->getSubject());
             if ($message = $activityEmail->getBody()) {
                 $emailTemplate->setMessage($message, true);


### PR DESCRIPTION
For the sake of improving compatibility with some existing email addon capabilities, the following changes have been made:

1. Update `ActivityEmail` to use an internal route versus an external URL.
1. Add a user-authentication hint (UserAuthorized) to the `BeforeSendNotification` event fired by `ActivityModel::sendActivityEmail`. This is done to allow addons to know they can skip per-user notification checking. If a user notification has been queued up using `ActivityEmail`, they should already been authorized.