### PR TITLE
Update comment and discussion embed factories to support site sections

### DIFF
--- a/library/Vanilla/EmbeddedContent/AbstractEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/AbstractEmbedFactory.php
@@ -62,7 +62,7 @@ abstract class AbstractEmbedFactory implements EmbedCreatorInterface {
             $pathMatches = $this->canHandleEmptyPaths;
         } else {
             $regex = $this->getSupportedPathRegex($domain);
-            $pathMatches = (bool) preg_match($regex, $path);
+            $pathMatches = preg_match($regex, $path) === 1;
         }
 
         return $schemeMatches && $pathMatches && $domainMatches;

--- a/library/Vanilla/EmbeddedContent/AbstractEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/AbstractEmbedFactory.php
@@ -61,7 +61,8 @@ abstract class AbstractEmbedFactory implements EmbedCreatorInterface {
         if ($path === null) {
             $pathMatches = $this->canHandleEmptyPaths;
         } else {
-            $pathMatches = (bool) preg_match($this->getSupportedPathRegex($domain), $path);
+            $regex = $this->getSupportedPathRegex($domain);
+            $pathMatches = (bool) preg_match($regex, $path);
         }
 
         return $schemeMatches && $pathMatches && $domainMatches;

--- a/library/Vanilla/EmbeddedContent/Factories/AbstractOwnSiteEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/AbstractOwnSiteEmbedFactory.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\EmbeddedContent\Factories;
+
+use Garden\Web\Exception\NotFoundException;
+use Garden\Web\RequestInterface;
+use Vanilla\Contracts\Site\SiteSectionProviderInterface;
+use Vanilla\EmbeddedContent\AbstractEmbed;
+use Vanilla\EmbeddedContent\AbstractEmbedFactory;
+use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
+use Vanilla\Web\Asset\SiteAsset;
+
+/**
+ * Embed factory with utilities for matching our own site.
+ */
+abstract class AbstractOwnSiteEmbedFactory extends AbstractEmbedFactory {
+
+    /** @var RequestInterface */
+    private $request;
+
+    /** @var string[] */
+    private $allowedSiteSectionSlugs = [];
+
+    /**
+     * DI
+     *
+     * @param RequestInterface $request
+     * @param SiteSectionProviderInterface $siteSectionProvider
+     */
+    public function __construct(
+        RequestInterface $request,
+        SiteSectionProviderInterface $siteSectionProvider
+    ) {
+        $this->request = $request;
+
+        foreach ($siteSectionProvider->getAll() as $siteSection) {
+            if ($siteSection->getBasePath() !== '') {
+                $this->allowedSiteSectionSlugs[] = $siteSection->getBasePath();
+            }
+        }
+    }
+
+    /**
+     * @return array
+     */
+    protected function getSupportedDomains(): array {
+        return [
+            $this->request->getHost(),
+        ];
+    }
+
+    /**
+     * Get a regex representing the root of the site w/ all allowable site sections and siteRoot.
+     */
+    protected function getRegexRoot(): string {
+        $siteSectionRegex = count($this->allowedSiteSectionSlugs) > 0 ?
+            '(' . implode('|', $this->allowedSiteSectionSlugs) . ')'
+            : '';
+        $root = $this->request->getAssetRoot() . $siteSectionRegex;
+
+        // Escape slashes.
+        $root = str_replace('/', '\/', $root);
+        return $root;
+    }
+}

--- a/library/Vanilla/EmbeddedContent/Factories/CommentEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/CommentEmbedFactory.php
@@ -9,18 +9,14 @@ namespace Vanilla\EmbeddedContent\Factories;
 
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\RequestInterface;
+use Vanilla\Contracts\Site\SiteSectionProviderInterface;
 use Vanilla\EmbeddedContent\AbstractEmbed;
-use Vanilla\EmbeddedContent\AbstractEmbedFactory;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
-use Vanilla\Web\Asset\SiteAsset;
 
 /**
  * Quote embed factory for comments.
  */
-class CommentEmbedFactory extends AbstractEmbedFactory {
-
-    /** @var RequestInterface */
-    private $request;
+final class CommentEmbedFactory extends AbstractOwnSiteEmbedFactory {
 
     /** @var \CommentsApiController */
     private $commentApi;
@@ -29,31 +25,24 @@ class CommentEmbedFactory extends AbstractEmbedFactory {
      * DI
      *
      * @param RequestInterface $request
+     * @param SiteSectionProviderInterface $siteSectionProvider
      * @param \CommentsApiController $commentApi
      */
-    public function __construct(RequestInterface $request, \CommentsApiController $commentApi) {
-        $this->request = $request;
+    public function __construct(
+        RequestInterface $request,
+        SiteSectionProviderInterface $siteSectionProvider,
+        \CommentsApiController $commentApi
+    ) {
+        parent::__construct($request, $siteSectionProvider);
         $this->commentApi = $commentApi;
-    }
-
-    /**
-     * @return array
-     */
-    protected function getSupportedDomains(): array {
-        return [
-            $this->request->getHost(),
-        ];
     }
 
     /**
      * @inheritdoc
      */
     protected function getSupportedPathRegex(string $domain = ''): string {
-        // We need ot be sure to the proper web root here.
-        $root = SiteAsset::joinWebPath($this->request->getRoot(), '/discussion/comment');
-        $root = str_replace('/', '\/', $root);
-
-        return "/$root\/(?<commentID>\d+)/i";
+        $regexRoot = $this->getRegexRoot();
+        return "/^$regexRoot\/discussion\/comment\/(?<commentID>\d+)/i";
     }
 
     /**

--- a/library/Vanilla/EmbeddedContent/Factories/CommentEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/CommentEmbedFactory.php
@@ -9,9 +9,9 @@ namespace Vanilla\EmbeddedContent\Factories;
 
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\RequestInterface;
-use Vanilla\Contracts\Site\SiteSectionProviderInterface;
 use Vanilla\EmbeddedContent\AbstractEmbed;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
+use Vanilla\Site\SiteSectionModel;
 
 /**
  * Quote embed factory for comments.
@@ -25,15 +25,15 @@ final class CommentEmbedFactory extends AbstractOwnSiteEmbedFactory {
      * DI
      *
      * @param RequestInterface $request
-     * @param SiteSectionProviderInterface $siteSectionProvider
+     * @param SiteSectionModel $siteSectionModel
      * @param \CommentsApiController $commentApi
      */
     public function __construct(
         RequestInterface $request,
-        SiteSectionProviderInterface $siteSectionProvider,
+        SiteSectionModel $siteSectionModel,
         \CommentsApiController $commentApi
     ) {
-        parent::__construct($request, $siteSectionProvider);
+        parent::__construct($request, $siteSectionModel);
         $this->commentApi = $commentApi;
     }
 
@@ -49,7 +49,8 @@ final class CommentEmbedFactory extends AbstractOwnSiteEmbedFactory {
      * @inheritdoc
      */
     public function createEmbedForUrl(string $url): AbstractEmbed {
-        preg_match($this->getSupportedPathRegex(), $url, $matches);
+        $path = parse_url($url, PHP_URL_PATH);
+        preg_match($this->getSupportedPathRegex(), $path, $matches);
         $id = $matches['commentID'] ?? null;
 
         if ($id === null) {

--- a/library/Vanilla/EmbeddedContent/Factories/DiscussionEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/DiscussionEmbedFactory.php
@@ -9,6 +9,7 @@ namespace Vanilla\EmbeddedContent\Factories;
 
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\RequestInterface;
+use Vanilla\Contracts\Site\SiteSectionProviderInterface;
 use Vanilla\EmbeddedContent\AbstractEmbed;
 use Vanilla\EmbeddedContent\AbstractEmbedFactory;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
@@ -17,10 +18,7 @@ use Vanilla\Web\Asset\SiteAsset;
 /**
  * Quote embed factory for comments.
  */
-class DiscussionEmbedFactory extends AbstractEmbedFactory {
-
-    /** @var RequestInterface */
-    private $request;
+class DiscussionEmbedFactory extends AbstractOwnSiteEmbedFactory {
 
     /** @var \DiscussionsApiController */
     private $discussionApi;
@@ -29,32 +27,24 @@ class DiscussionEmbedFactory extends AbstractEmbedFactory {
      * DI
      *
      * @param RequestInterface $request
+     * @param SiteSectionProviderInterface $siteSectionProvider
      * @param \DiscussionsApiController $discussionApi
      */
-    public function __construct(RequestInterface $request, \DiscussionsApiController $discussionApi) {
-        $this->request = $request;
+    public function __construct(
+        RequestInterface $request,
+        SiteSectionProviderInterface $siteSectionProvider,
+        \DiscussionsApiController $discussionApi
+    ) {
+        parent::__construct($request, $siteSectionProvider);
         $this->discussionApi = $discussionApi;
-    }
-
-    /**
-     * @return array
-     */
-    protected function getSupportedDomains(): array {
-        return [
-            $this->request->getHost(),
-        ];
     }
 
     /**
      * @inheritdoc
      */
     protected function getSupportedPathRegex(string $domain = ''): string {
-        // We need ot be sure to the proper web root here.
-        $root = SiteAsset::joinWebPath($this->request->getRoot(), '/discussion');
-        $root = str_replace('/', '\/', $root);
-
-        $regex = "/$root\/(?<discussionID>\d+)/i";
-        return $regex;
+        $regexRoot = $this->getRegexRoot();
+        return "/^$regexRoot\/discussion\/(?<commentID>\d+)/i";
     }
 
     /**

--- a/library/Vanilla/EmbeddedContent/Factories/DiscussionEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/DiscussionEmbedFactory.php
@@ -13,6 +13,7 @@ use Vanilla\Contracts\Site\SiteSectionProviderInterface;
 use Vanilla\EmbeddedContent\AbstractEmbed;
 use Vanilla\EmbeddedContent\AbstractEmbedFactory;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
+use Vanilla\Site\SiteSectionModel;
 use Vanilla\Web\Asset\SiteAsset;
 
 /**
@@ -27,15 +28,15 @@ class DiscussionEmbedFactory extends AbstractOwnSiteEmbedFactory {
      * DI
      *
      * @param RequestInterface $request
-     * @param SiteSectionProviderInterface $siteSectionProvider
+     * @param SiteSectionModel $siteSectionModel
      * @param \DiscussionsApiController $discussionApi
      */
     public function __construct(
         RequestInterface $request,
-        SiteSectionProviderInterface $siteSectionProvider,
+        SiteSectionModel $siteSectionModel,
         \DiscussionsApiController $discussionApi
     ) {
-        parent::__construct($request, $siteSectionProvider);
+        parent::__construct($request, $siteSectionModel);
         $this->discussionApi = $discussionApi;
     }
 
@@ -44,14 +45,15 @@ class DiscussionEmbedFactory extends AbstractOwnSiteEmbedFactory {
      */
     protected function getSupportedPathRegex(string $domain = ''): string {
         $regexRoot = $this->getRegexRoot();
-        return "/^$regexRoot\/discussion\/(?<commentID>\d+)/i";
+        return "/^$regexRoot\/discussion\/(?<discussionID>\d+)/i";
     }
 
     /**
      * @inheritdoc
      */
     public function createEmbedForUrl(string $url): AbstractEmbed {
-        preg_match($this->getSupportedPathRegex(), $url, $matches);
+        $path = parse_url($url, PHP_URL_PATH);
+        preg_match($this->getSupportedPathRegex(), $path, $matches);
         $id = $matches['discussionID'] ?? null;
 
         if ($id === null) {

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/CommentEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/CommentEmbedFactoryTest.php
@@ -11,6 +11,7 @@ use Garden\Web\RequestInterface;
 use Vanilla\Contracts\Site\SiteSectionInterface;
 use Vanilla\EmbeddedContent\Factories\CommentEmbedFactory;
 use Vanilla\Site\DefaultSiteSection;
+use Vanilla\Site\SiteSectionModel;
 use VanillaTests\APIv2\AbstractAPIv2Test;
 use VanillaTests\Fixtures\MockConfig;
 use VanillaTests\Fixtures\MockSiteSection;
@@ -39,8 +40,10 @@ class CommentEmbedFactoryTest extends AbstractAPIv2Test {
 
         $sectionProvider = new MockSiteSectionProvider(new DefaultSiteSection(new MockConfig()));
         $sectionProvider->addSiteSections($siteSections);
+        $sectionModel = new SiteSectionModel(new MockConfig());
+        $sectionModel->addProvider($sectionProvider);
 
-        $factory = new CommentEmbedFactory($request, $sectionProvider, $commentsApi);
+        $factory = new CommentEmbedFactory($request, $sectionModel, $commentsApi);
 
         $this->assertEquals($isSupported, $factory->canHandleUrl($urlToTest));
     }

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/CommentEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/CommentEmbedFactoryTest.php
@@ -8,53 +8,93 @@
 namespace VanillaTests\Library\EmbeddedContent\Factories;
 
 use Garden\Web\RequestInterface;
+use Vanilla\Contracts\Site\SiteSectionInterface;
 use Vanilla\EmbeddedContent\Factories\CommentEmbedFactory;
+use Vanilla\Site\DefaultSiteSection;
 use VanillaTests\APIv2\AbstractAPIv2Test;
+use VanillaTests\Fixtures\MockConfig;
+use VanillaTests\Fixtures\MockSiteSection;
+use VanillaTests\Fixtures\MockSiteSectionProvider;
 
 /**
  * Tests for the comment/quote embed.
  */
 class CommentEmbedFactoryTest extends AbstractAPIv2Test {
 
-    /** @var CommentEmbedFactory */
-    private $factory;
-
-    /** @var \CommentsApiController */
-    private $commentsApi;
-
     /**
-     * Set the factory and client.
+     * Test that all domain types are supported.
+     *
+     * @param string $urlToTest
+     * @param bool $isSupported
+     * @param string $customRoot
+     * @param SiteSectionInterface[] $siteSections
+     * @dataProvider supportedDomainsProvider
      */
-    public function setUp() {
-        parent::setUp();
-        $this->commentsApi = $this->createMock(\CommentsApiController::class);
+    public function testSupportedDomains(string $urlToTest, bool $isSupported, string $customRoot = '', array $siteSections = []) {
+        $commentsApi = $this->createMock(\CommentsApiController::class);
+
+        /** @var RequestInterface $request */
         $request = self::container()->get(RequestInterface::class);
-        $this->factory = new CommentEmbedFactory($request, $this->commentsApi);
-    }
+        $request->setAssetRoot($customRoot);
 
+        $sectionProvider = new MockSiteSectionProvider(new DefaultSiteSection(new MockConfig()));
+        $sectionProvider->addSiteSections($siteSections);
 
-    /**
-     * Test that all giphy domain types are supported.
-     */
-    public function testSupportedDomains() {
-        foreach ($this->supportedDomainsProvider() as [$urlToTest, $isSupported, $message]) {
-            $this->assertEquals($this->factory->canHandleUrl($urlToTest), $isSupported, $message);
-        }
+        $factory = new CommentEmbedFactory($request, $sectionProvider, $commentsApi);
+
+        $this->assertEquals($isSupported, $factory->canHandleUrl($urlToTest));
     }
 
     /**
      * @return array
      */
     public function supportedDomainsProvider(): array {
+        $bootstrapBase = 'http://vanilla.test';
         return [
             // Allowed
-            [static::bootstrap()->getBaseUrl() . '/discussion/comment/41342', true, "It should match a proper URL"],
+            'Correct' => [
+                $bootstrapBase . '/discussion/comment/41342',
+                true
+            ],
             // Not allowed
-            ['http://vanilla.test' . '/discussion/comment/41342', false, "It should match a proper URL"],
-            ['https://otherdomain.com' . '/discussion/comment/41342', false, "It should fail on a bad domain."],
-            [static::bootstrap()->getBaseUrl() . '/discussions/comments/41342', false, "It should fail on a bad path 1."],
-            [static::bootstrap()->getBaseUrl() . '/discussion/41342', false, "It should fail on a bad path 2"],
-            [static::bootstrap()->getBaseUrl() . '/discussion/comment/asdfads', false, "It should fail on a bad ID."],
+            'Correct webroot' => [
+                $bootstrapBase . '/actual-root/discussion/comment/41342',
+                true,
+                '/actual-root'
+            ],
+            'Correct section' => [
+                $bootstrapBase . '/actual-root/actual-section/discussion/comment/41342',
+                true,
+                '/actual-root',
+                [new MockSiteSection('test', 'en', '/actual-section', 'test1', 'test1')]
+            ],
+            // Not allowed
+            'Wrong webroot' => [
+                $bootstrapBase . '/wrong-root/discussion/comment/41342',
+                false,
+                '/actual-root'
+            ],
+            'Wrong section' => [
+                $bootstrapBase . '/actual-root/actual-section/discussion/comment/41342',
+                false,
+                '/actual-root',
+            ],
+            'wrong host' => [
+                'https://otherdomain.com/discussion/comment/41342',
+                false
+            ],
+            'wrong url (typo)' => [
+                $bootstrapBase . '/discussions/comments/41342',
+                false
+            ],
+            'Wrong url (discussion)' => [
+                $bootstrapBase . '/discussion/41342',
+                false
+            ],
+            'bad ID' => [
+                $bootstrapBase . '/discussion/comment/asdfads',
+                false
+            ],
         ];
     }
 }

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/DiscussionEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/DiscussionEmbedFactoryTest.php
@@ -11,6 +11,7 @@ use Garden\Web\RequestInterface;
 use Vanilla\Contracts\Site\SiteSectionInterface;
 use Vanilla\EmbeddedContent\Factories\DiscussionEmbedFactory;
 use Vanilla\Site\DefaultSiteSection;
+use Vanilla\Site\SiteSectionModel;
 use VanillaTests\APIv2\AbstractAPIv2Test;
 use VanillaTests\Fixtures\MockConfig;
 use VanillaTests\Fixtures\MockSiteSection;
@@ -39,8 +40,10 @@ class DiscussionEmbedFactoryTest extends AbstractAPIv2Test {
 
         $sectionProvider = new MockSiteSectionProvider(new DefaultSiteSection(new MockConfig()));
         $sectionProvider->addSiteSections($siteSections);
+        $sectionModel = new SiteSectionModel(new MockConfig());
+        $sectionModel->addProvider($sectionProvider);
 
-        $factory = new DiscussionEmbedFactory($request, $sectionProvider, $discussionApi);
+        $factory = new DiscussionEmbedFactory($request, $sectionModel, $discussionApi);
 
         $this->assertEquals($isSupported, $factory->canHandleUrl($urlToTest));
     }

--- a/tests/fixtures/src/MockSiteSection.php
+++ b/tests/fixtures/src/MockSiteSection.php
@@ -4,7 +4,7 @@
  * @license GPL-2.0-only
  */
 
-namespace VanillaTests\fixtures;
+namespace VanillaTests\Fixtures;
 
 use Vanilla\Contracts\Site\SiteSectionInterface;
 use Vanilla\Site\SiteSectionSchema;


### PR DESCRIPTION
Requires https://github.com/vanilla/multisite/pull/301 to actually work

- Updates `CommentsEmbedFactory` and it's tests.
  - To support site sections.
  - Tests now use a data provider.
- Updates `DiscussionEmbedFactory` and it's tests.
  - To support site sections.
  - Tests now use a data provider.

**Expected**

`/api/v2/media/scrape` now works on discussions/comment URLs that have a site section in them.