### PR TITLE
Add callback scheduled job

### DIFF
--- a/library/Vanilla/Scheduler/Job/CallbackJob.php
+++ b/library/Vanilla/Scheduler/Job/CallbackJob.php
@@ -17,8 +17,14 @@ class CallbackJob implements LocalJobInterface {
     /** @var callable */
     private $callback;
 
+    /** @var int */
+    private $delay;
+
     /** @var array */
     private $parameters = [];
+
+    /** @var JobPriority */
+    private $priority;
 
     /**
      * Execute the configured callback function.
@@ -59,6 +65,7 @@ class CallbackJob implements LocalJobInterface {
      * @return void
      */
     public function setPriority(JobPriority $priority) {
+        $this->priority = $priority;
     }
 
     /**
@@ -68,5 +75,6 @@ class CallbackJob implements LocalJobInterface {
      * @return void
      */
     public function setDelay(int $seconds) {
+        $this->delay = $seconds;
     }
 }

--- a/library/Vanilla/Scheduler/Job/CallbackJob.php
+++ b/library/Vanilla/Scheduler/Job/CallbackJob.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Scheduler\Job;
+
+use Vanilla\Scheduler\Job\JobExecutionStatus;
+use Vanilla\Scheduler\Job\JobPriority;
+
+/**
+ * Execute a callback as a job.
+ */
+class CallbackJob implements LocalJobInterface {
+
+    /** @var callable */
+    private $callback;
+
+    /** @var array */
+    private $parameters = [];
+
+    /**
+     * Execute the configured callback function.
+     */
+    public function run(): JobExecutionStatus {
+        try {
+            call_user_func_array($this->callback, $this->parameters);
+        } catch (\Exception $e) {
+            return JobExecutionStatus::error();
+        }
+        return JobExecutionStatus::complete();
+    }
+
+    /**
+     * Set job Message
+     *
+     * @param array $message
+     */
+    public function setMessage(array $message) {
+        $callback = $message["callback"] ?? null;
+        $parameters = $message["parameters"] ?? [];
+
+        if (is_callable($callback) === false) {
+            throw new \Exception("Invalid callback configuration for " . __CLASS__);
+        }
+        $this->callback = $callback;
+
+        if (!is_array($parameters)) {
+            throw new \Exception("Invalid parameter configuration for " . __CLASS__);
+        }
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * Set job priority
+     *
+     * @param JobPriority $priority
+     * @return void
+     */
+    public function setPriority(JobPriority $priority) {
+    }
+
+    /**
+     * Set job execution delay
+     *
+     * @param int $seconds
+     * @return void
+     */
+    public function setDelay(int $seconds) {
+    }
+}


### PR DESCRIPTION
A new type of scheduled job has been added, allowing for a simple callback to be executed at end of the request.

### Example Usage
```php
$scheduler->addJob(
    Vanilla\Scheduler\Job\CallbackJob::class,
    [
        "callback" => "implode",
        "parameters" => ["one", "two", "three"],
    ]
);
```

Any valid [`callable` in PHP](https://www.php.net/manual/en/language.types.callable.php) can be provided as the callback. The parameters array will be passed to the callable with each element representing a separate parameter to the function/method.