### PR TITLE
Add Scheduler to Vanilla's testing bootstrap

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -317,7 +317,7 @@ class Bootstrap {
             ->setShared(true)
 
             ->rule(Vanilla\Scheduler\SchedulerInterface::class)
-            ->setClass(Vanilla\Scheduler\DummyScheduler::class)
+            ->setClass(VanillaTests\Fixtures\Scheduler\InstantScheduler::class)
             ->addCall('addDriver', [Vanilla\Scheduler\Driver\LocalDriver::class])
             ->addCall('setDispatchEventName', ['SchedulerDispatch'])
             ->addCall('setDispatchedEventName', ['SchedulerDispatched'])

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -315,6 +315,13 @@ class Bootstrap {
             ->rule('HtmlFormatter')
             ->setClass(\VanillaHtmlFormatter::class)
             ->setShared(true)
+
+            ->rule(Vanilla\Scheduler\SchedulerInterface::class)
+            ->setClass(Vanilla\Scheduler\DummyScheduler::class)
+            ->addCall('addDriver', [Vanilla\Scheduler\Driver\LocalDriver::class])
+            ->addCall('setDispatchEventName', ['SchedulerDispatch'])
+            ->addCall('setDispatchedEventName', ['SchedulerDispatched'])
+            ->setShared(true)
             ;
     }
 

--- a/tests/fixtures/src/Scheduler/InstantScheduler.php
+++ b/tests/fixtures/src/Scheduler/InstantScheduler.php
@@ -27,6 +27,7 @@ class InstantScheduler extends DummyScheduler {
     public function addJob(string $jobType, $message = [], JobPriority $jobPriority = null, int $delay = null): TrackingSlipInterface {
         $result = parent::addJob($jobType, $message, $jobPriority, $delay);
         $this->dispatchAll();
+        $this->trackingSlips = [];
         return $result;
     }
 }

--- a/tests/fixtures/src/Scheduler/InstantScheduler.php
+++ b/tests/fixtures/src/Scheduler/InstantScheduler.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures\Scheduler;
+
+use Vanilla\Scheduler\DummyScheduler;
+use Vanilla\Scheduler\Job\JobPriority;
+use Vanilla\Scheduler\TrackingSlipInterface;
+
+/**
+ * Class InstantScheduler
+ */
+class InstantScheduler extends DummyScheduler {
+
+    /**
+     * Add a new Job to the queue and immediately execute it.
+     *
+     * @param string $jobType
+     * @param array $message
+     * @param JobPriority|null $jobPriority
+     * @param int|null $delay
+     * @return TrackingSlipInterface
+     */
+    public function addJob(string $jobType, $message = [], JobPriority $jobPriority = null, int $delay = null): TrackingSlipInterface {
+        $result = parent::addJob($jobType, $message, $jobPriority, $delay);
+        $this->dispatchAll();
+        return $result;
+    }
+}


### PR DESCRIPTION
If tests in Vanilla happen to touch any code that makes use of the scheduler, it will currently fail. This is due to the scheduler not being properly configured in the test bootstrap. That is resolved with this update.