### PR TITLE
Exclude deleted users from format strings

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1515,20 +1515,20 @@ if (!function_exists('_formatStringCallback')) {
                                     continue;
                                 }
 
+                                $separator = '';
                                 if ($i == $count - 1) {
-                                    $result .= ' '.t('sep and', 'and').' ';
+                                    $separator = ' '.t('sep and', 'and').' ';
                                 } elseif ($i > 0) {
-                                    $result .= ', ';
+                                    $separator = ', ';
                                 }
-
                                 $special = [-1 => t('everyone'), -2 => t('moderators'), -3 => t('administrators')];
                                 if (isset($special[$iD])) {
-                                    $result .= $special[$iD];
+                                    $result .= $separator.$special[$iD];
                                 } else {
                                     $user = Gdn::userModel()->getID($iD);
-                                    if ($user) {
+                                    if ($user && $user->Deleted == 0) {
                                         $user->Name = formatUsername($user, $format, $contextUserID);
-                                        $result .= userAnchor($user);
+                                        $result .= $separator.userAnchor($user);
                                     }
                                 }
                             }


### PR DESCRIPTION
Less intrusive version of #9533

This is mainly used in activitiy headlines, where "[deleted user] has joined" shouldn't really appear.