### PR TITLE
Add dashboard image upload in react

### DIFF
--- a/applications/dashboard/src/scripts/forms/0-SimpleForm.story.tsx
+++ b/applications/dashboard/src/scripts/forms/0-SimpleForm.story.tsx
@@ -14,7 +14,6 @@ import React, { useState } from "react";
 import { DashboardSelect } from "@dashboard/forms/DashboardSelect";
 import { IComboBoxOption } from "@library/features/search/SearchBar";
 import { DashboardImageUploadGroup } from "@dashboard/forms/DashboardImageUploadGroup";
-import { IUploadedMedia } from "@library/apiv2";
 
 const formsStory = storiesOf("Dashboard/Forms", module).addDecorator(dashboardCssDecorator);
 

--- a/applications/dashboard/src/scripts/forms/0-SimpleForm.story.tsx
+++ b/applications/dashboard/src/scripts/forms/0-SimpleForm.story.tsx
@@ -13,12 +13,15 @@ import { storiesOf } from "@storybook/react";
 import React, { useState } from "react";
 import { DashboardSelect } from "@dashboard/forms/DashboardSelect";
 import { IComboBoxOption } from "@library/features/search/SearchBar";
+import { DashboardImageUploadGroup } from "@dashboard/forms/DashboardImageUploadGroup";
+import { IUploadedMedia } from "@library/apiv2";
 
 const formsStory = storiesOf("Dashboard/Forms", module).addDecorator(dashboardCssDecorator);
 
 formsStory.add("FormGroup", () =>
     (() => {
         const [dropdownValue, setDropdownValue] = useState<IComboBoxOption | null>(null);
+        const [image, setImage] = useState<string | null>(null);
 
         return (
             <StoryContent>
@@ -59,6 +62,17 @@ formsStory.add("FormGroup", () =>
                                 onChange={setDropdownValue}
                             />
                         </DashboardFormGroup>
+                        <DashboardImageUploadGroup
+                            value={image}
+                            onChange={setImage}
+                            imageUploader={() => {
+                                // Always returns null for the story.
+                                // Stubbed out because we may not have a real API available.
+                                return Promise.resolve(null) as any;
+                            }}
+                            label="Image Upload"
+                            description="An image upload can have a description. Ideally it should describe things like the expected image dimensions"
+                        />
                     </ul>
                 </form>
                 <StoryHeading depth={1}>Label Variants</StoryHeading>

--- a/applications/dashboard/src/scripts/forms/DashboardFormGroup.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardFormGroup.tsx
@@ -12,6 +12,7 @@ import classNames from "classnames";
 interface IProps {
     label: string;
     description?: React.ReactNode;
+    afterDescription?: React.ReactNode;
     labelType?: DashboardLabelType;
     tag?: keyof JSX.IntrinsicElements;
     children: React.ReactNode;

--- a/applications/dashboard/src/scripts/forms/DashboardFormLabel.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardFormLabel.tsx
@@ -9,6 +9,7 @@ import { useFormGroup } from "@dashboard/forms/DashboardFormGroup";
 interface IProps {
     label: string;
     description?: React.ReactNode;
+    afterDescription?: React.ReactNode;
     labelType?: DashboardLabelType;
 }
 
@@ -27,6 +28,7 @@ export const DashboardFormLabel: React.FC<IProps> = (props: IProps) => {
         <div className={rootClass} id={labelID}>
             {props.label && <label htmlFor={inputID}>{props.label}</label>}
             {props.description && <div className="info">{props.description}</div>}
+            {props.afterDescription}
         </div>
     );
 };

--- a/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
@@ -1,0 +1,67 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React, { useState, useEffect, useRef } from "react";
+import { useFormGroup } from "@dashboard/forms/DashboardFormGroup";
+import classNames from "classnames";
+import { DashboardLabelType } from "@dashboard/forms/DashboardFormLabel";
+import { t } from "@vanilla/i18n";
+import { IUploadedMedia, uploadFile } from "@library/apiv2";
+
+interface IProps {
+    value: string | null; // The image url
+    onChange: (newUrl: string) => void;
+    onImagePreview?: (tempImageUrl: string) => void;
+    className?: string;
+    placeholder?: string;
+    imageUploader?: typeof uploadFile;
+}
+
+export function DashboardImageUpload(props: IProps) {
+    const { inputID, labelType } = useFormGroup();
+    const imageUploader = props.imageUploader || uploadFile;
+    const [name, setName] = useState<string | null>(null);
+
+    // Used for stashing the URL we just uploaded so we don't wipe out our name in the next step.
+    const valueRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (valueRef.current !== props.value) {
+            setName(null);
+        }
+    }, [props.value]);
+
+    const classes = classNames("form-control", props.className);
+    const rootClass = labelType === DashboardLabelType.WIDE ? "input-wrap-right" : "input-wrap";
+
+    return (
+        <div className={rootClass}>
+            <label className="file-upload">
+                <input
+                    type="file"
+                    id={inputID}
+                    className={classes}
+                    onChange={async event => {
+                        const file = event.target.files && event.target.files[0];
+                        if (!file) {
+                            return;
+                        }
+
+                        setName(file.name);
+                        const tempUrl = URL.createObjectURL(file);
+                        props.onImagePreview && props.onImagePreview(tempUrl);
+
+                        // Upload the image.
+                        const uploaded = await imageUploader(file);
+                        valueRef.current = uploaded.url;
+                        props.onChange(uploaded.url);
+                    }}
+                />
+                <span className="file-upload-choose">{name || props.placeholder || t("Choose")}</span>
+                <span className="file-upload-browse">{t("Browse")}</span>
+            </label>
+        </div>
+    );
+}

--- a/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
@@ -8,7 +8,7 @@ import { useFormGroup } from "@dashboard/forms/DashboardFormGroup";
 import classNames from "classnames";
 import { DashboardLabelType } from "@dashboard/forms/DashboardFormLabel";
 import { t } from "@vanilla/i18n";
-import { IUploadedMedia, uploadFile } from "@library/apiv2";
+import { uploadFile } from "@library/apiv2";
 
 interface IProps {
     value: string | null; // The image url

--- a/applications/dashboard/src/scripts/forms/DashboardImageUploadGroup.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardImageUploadGroup.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState } from "react";
-import { IUploadedMedia, uploadFile } from "@library/apiv2";
+import { uploadFile } from "@library/apiv2";
 import { DashboardFormGroup } from "@dashboard/forms/DashboardFormGroup";
 import { DashboardImageUpload } from "@dashboard/forms/DashboardImageUpload";
 import Button from "@library/forms/Button";
@@ -13,7 +13,7 @@ import { t } from "@vanilla/i18n";
 
 interface IProps {
     value: string | null; // The image url
-    onChange: (newUrl: string) => void;
+    onChange: (newUrl: string | null) => void;
     label: string;
     description?: React.ReactNode;
     imageUploader?: typeof uploadFile;

--- a/applications/dashboard/src/scripts/forms/DashboardImageUploadGroup.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardImageUploadGroup.tsx
@@ -1,0 +1,59 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React, { useState } from "react";
+import { IUploadedMedia, uploadFile } from "@library/apiv2";
+import { DashboardFormGroup } from "@dashboard/forms/DashboardFormGroup";
+import { DashboardImageUpload } from "@dashboard/forms/DashboardImageUpload";
+import Button from "@library/forms/Button";
+import { ButtonTypes } from "@library/forms/buttonStyles";
+import { t } from "@vanilla/i18n";
+
+interface IProps {
+    value: string | null; // The image url
+    onChange: (newUrl: string) => void;
+    label: string;
+    description?: React.ReactNode;
+    imageUploader?: typeof uploadFile;
+}
+
+export function DashboardImageUploadGroup(props: IProps) {
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const [originalValue] = useState(props.value);
+
+    const imagePreviewSrc = previewUrl || props.value;
+
+    return (
+        <DashboardFormGroup
+            label={props.label}
+            description={props.description}
+            afterDescription={
+                imagePreviewSrc && (
+                    <>
+                        <div>{<img src={imagePreviewSrc} />}</div>
+                        <div>
+                            <Button
+                                baseClass={ButtonTypes.TEXT_PRIMARY}
+                                onClick={() => {
+                                    setPreviewUrl(null);
+                                    props.onChange(originalValue);
+                                }}
+                            >
+                                {t("Undo")}
+                            </Button>
+                        </div>
+                    </>
+                )
+            }
+        >
+            <DashboardImageUpload
+                value={props.value}
+                onChange={props.onChange}
+                onImagePreview={setPreviewUrl}
+                imageUploader={props.imageUploader}
+            />
+        </DashboardFormGroup>
+    );
+}

--- a/library/src/scripts/apiv2.ts
+++ b/library/src/scripts/apiv2.ts
@@ -44,26 +44,12 @@ export function createTrackableRequest(
     };
 }
 
-export interface IUploadedMedia {
-    mediaID: 0;
-    url: string;
-    dateInserted: string;
-    insertUserID: number;
-    name: string;
-    size: number;
-    type: string; // Mime type
-    foreignID: number | null;
-    foreignType: string | null;
-    height: number | null;
-    width: number | null;
-}
-
 /**
  * Upload an image using Vanilla's API v2.
  *
  * @param file - The file to upload.
  */
-export async function uploadFile(file: File, requestConfig: AxiosRequestConfig = {}): Promise<IUploadedMedia> {
+export async function uploadFile(file: File, requestConfig: AxiosRequestConfig = {}) {
     let allowedExtensions = getMeta("upload.allowedExtensions", []) as string[];
     allowedExtensions = allowedExtensions.map((ext: string) => ext.toLowerCase());
     const maxSize = getMeta("upload.maxSize", 0);

--- a/library/src/scripts/apiv2.ts
+++ b/library/src/scripts/apiv2.ts
@@ -43,12 +43,27 @@ export function createTrackableRequest(
         return requestFunction(onUploadProgress);
     };
 }
+
+export interface IUploadedMedia {
+    mediaID: 0;
+    url: string;
+    dateInserted: string;
+    insertUserID: number;
+    name: string;
+    size: number;
+    type: string; // Mime type
+    foreignID: number | null;
+    foreignType: string | null;
+    height: number | null;
+    width: number | null;
+}
+
 /**
  * Upload an image using Vanilla's API v2.
  *
  * @param file - The file to upload.
  */
-export async function uploadFile(file: File, requestConfig: AxiosRequestConfig = {}) {
+export async function uploadFile(file: File, requestConfig: AxiosRequestConfig = {}): Promise<IUploadedMedia> {
     let allowedExtensions = getMeta("upload.allowedExtensions", []) as string[];
     allowedExtensions = allowedExtensions.map((ext: string) => ext.toLowerCase());
     const maxSize = getMeta("upload.maxSize", 0);

--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -375,12 +375,14 @@ export const buttonUtilityClasses = useThemeCache(() => {
     });
 
     const buttonAsTextPrimary = style("asTextPrimary", asTextStyles, {
-        color: colorOut(globalVars.mainColors.primary),
         $nest: {
-            "&:not(.focus-visible)": {
+            "&&": {
+                color: colorOut(globalVars.mainColors.primary),
+            },
+            "&&:not(.focus-visible)": {
                 outline: 0,
             },
-            "&:hover, &:focus, &:active": {
+            "&&:hover, &&:focus, &&:active": {
                 color: colorOut(globalVars.mainColors.secondary),
             },
         },


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/issues/1337

- Adds a react image upload for the dashboard.
- This relies on existing dashboard styles.
- Image upload displays an image preview.
- Image upload has an "undo" action to revert to the old image.
- Images are uploaded through the `/media` API endpoint.
- Works purely by URL. Form value is a URL, and a URL is returned. This means when initializing an existing form, the name will not present. This is also a limitation of our non-react dashboard image upload.
- Adds the image upload to the storybook.

## Screenshot

![image](https://user-images.githubusercontent.com/1770056/68413858-1db1cf80-015d-11ea-97c3-fa4988239fac.png)
