### PR TITLE
Advanced Editor: Remove redundant link title

### DIFF
--- a/plugins/editor/js/buttonbarplus.js
+++ b/plugins/editor/js/buttonbarplus.js
@@ -771,7 +771,7 @@
                                         : GuessText;
 
                                     $(TextArea).focus();
-                                    $(TextArea).replaceSelectedText('[' + CurrentSelectText + '](' + val + ' "' + CurrentSelectText + '")', 'select');
+                                    $(TextArea).replaceSelectedText('[' + CurrentSelectText + '](' + val + ')', 'select');
 
                                     // Close dropdowns
                                     $('.editor-dialog-fire-close').trigger('mouseup.fireclose');


### PR DESCRIPTION
This changes Advanced Editors markdown so that when hyperlinking a selected piece of text, the link is created without the optional and always redundant (in the case of this editor) title. This makes the generated markdown easier to understand.

fixes #5806
