### PR TITLE
Fix getAssetRoot deprecation warning

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -109,7 +109,7 @@ class Gdn_Request implements RequestInterface {
             $this->setAssetRoot($assetRoot);
             return $assetRoot;
         } else {
-            deprecated(__FUNCTION__, "addAssetRoot");
+            deprecated(__FUNCTION__, "getAssetRoot");
             $result = $this->getAssetRoot();
         }
         return $result;


### PR DESCRIPTION
It suggests you use "addAssetRoot" which doesn't exist.