### PR TITLE
Gdn_Session: Fix hash_equals notice

### DIFF
--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -693,8 +693,10 @@ class Gdn_Session {
              * We are not doing `!empty()` first because that would skip hash_equals and would then enable a possible timing attack.
              */
             // Make sure we're testing a string.
-            $stringToTest = $this->_TransientKey ?: '';
-            $isCorrectHash = (hash_equals($stringToTest, $foreignKey) && !empty($this->_TransientKey));
+            $knownString = $this->_TransientKey ?: '';
+            $userString = $foreignKey ?: '';
+
+            $isCorrectHash = (hash_equals($knownString, $userString) && !empty($this->_TransientKey));
 
             // Checking the postback here is a kludge, but is absolutely necessary until we can test the ValidatePostBack more.
             $return = ($forceValid && Gdn::request()->isPostBack()) || $isCorrectHash;


### PR DESCRIPTION
#9265 did not fully fix the warning

The `$foreignKey` passed into `validateTransientKey()` may be `false`, especially when coming from a function like `val()`:
https://github.com/vanilla/vanilla/blob/666558094c9dbdbf1ad3ee9d5fb3e34767912e54/applications/vanilla/controllers/class.moderationcontroller.php#L48
The above code should probably not use $_POST directly, but why not make sure both arguments of hash_equals are always a string.

Changed the variable names to reflect the arguments of [hash_equals](https://www.php.net/manual/en/function.hash-equals.php) for clarity.