### PR TITLE
Prevent useless user preference queries

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -5229,8 +5229,10 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
         }
 
         $user = $this->getID($userID);
-        $preferences = val('Preferences', $user, []);
-        $landingPages = val('DashboardNav.SectionLandingPages', $preferences, []);
+        $preferences = $user->Preferences ?? [];
+        $landingPages = $preferences['DashboardNav.SectionLandingPages'] ?? [];
+        $sectionPreference = $preferences['DashboardNav.DashboardLandingPage'] ?: '';
+        $sectionReset = false;
 
         // Run through the user's saved landing page per section and if the url matches the passed url,
         // remove that preference.
@@ -5238,13 +5240,16 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
             $url = strtolower(trim($url, '/'));
             $landingPage = strtolower(trim($landingPage, '/'));
             if ($url == $landingPage || stringEndsWith($url, $landingPage)) {
+                $sectionReset = true;
                 unset($landingPages[$section]);
             }
         }
 
-        $this->savePreference($userID, 'DashboardNav.SectionLandingPages', $landingPages);
+        if ($sectionReset) {
+            $this->savePreference($userID, 'DashboardNav.SectionLandingPages', $landingPages);
+        }
 
-        if ($resetSectionPreference) {
+        if ($resetSectionPreference && $sectionPreference !== '') {
             $this->savePreference($userID, 'DashboardNav.DashboardLandingPage', '');
         }
     }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -5231,7 +5231,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
         $user = $this->getID($userID);
         $preferences = $user->Preferences ?? [];
         $landingPages = $preferences['DashboardNav.SectionLandingPages'] ?? [];
-        $sectionPreference = $preferences['DashboardNav.DashboardLandingPage'] ?: '';
+        $sectionPreference = $preferences['DashboardNav.DashboardLandingPage'] ?? '';
         $sectionReset = false;
 
         // Run through the user's saved landing page per section and if the url matches the passed url,


### PR DESCRIPTION
Whenever a signed in user visits a page that is the controllers `index()` with non-empty arguments (e.g. a standard discussion page like /discussion/123/slug), `UserModel::clearSectionNavigationPreference()` is called.

This is because the user may have been redirected from a falsely set `DashboardNav.DashboardLandingPage` in their preferences. This logic is flawed, but since with the current architecture there is not way to "test" a dispatch to a particular route, it is probably the best that can be done.
See #4497 and #4734 for reference.

Unfortunately `clearSectionNavigationPreference()` calls `saveToSerializedColumn()` twice leading to 2 entirely useless and duplicated write queries on the user table even if there is no actual change in the data. 

This PR checks for an actual change in the preference data to prevent those queries.

