### PR TITLE
Remove val() call from ProfileExtender view

### DIFF
--- a/plugins/ProfileExtender/views/helper_functions.php
+++ b/plugins/ProfileExtender/views/helper_functions.php
@@ -11,7 +11,7 @@ if (!function_exists('extendedProfileFields')) {
     function extendedProfileFields($profileFields, $allFields, $magicLabels = []) {
         foreach ($profileFields as $name => $value) {
             // Skip empty and hidden fields.
-            if (!$value || !val('OnProfile', $allFields[$name])) {
+            if (!$value || !($allFields[$name]['OnProfile'] ?? false)) {
                 continue;
             }
 


### PR DESCRIPTION
This also fixes various "Undefined index" notices since `$allFields` includes user properties which do not have a `OnProfile` key set.