### PR TITLE
Fix merge tags HTML

### DIFF
--- a/applications/dashboard/views/settings/tags.php
+++ b/applications/dashboard/views/settings/tags.php
@@ -18,9 +18,11 @@ echo $this->Form->errors();
             ?>
         </li>
         <?php if ($this->data('MergeTagVisible')): ?>
-            <li>
+            <li class="form-group">
                 <?php
-                echo $this->Form->checkBox('MergeTag', 'Merge this tag with the existing one');
+                echo '<div class="label-wrap"></div><div class="input-wrap">'.
+                    $this->Form->checkBox('MergeTag', 'Merge this tag with the existing one').
+                    '</div>';
                 ?>
             </li>
         <?php endif; ?>


### PR DESCRIPTION
The merge checkbox wasn’t properly wrapped for the new dashboard. If you want to test this, do the following:

1. Have at least two tags.
2. Edit one and rename it to be the same as another tag.
3. Hit save. The checkbox should appear.

Closes https://github.com/vanilla/support/issues/102.