### PR TITLE
Deprecate markString()

### DIFF
--- a/library/core/functions.deprecated.php
+++ b/library/core/functions.deprecated.php
@@ -565,6 +565,42 @@ if (!function_exists('parseUrl')) {
     }
 }
 
+if (!function_exists('markString')) {
+    /**
+     * Wrap occurrences of {@link $needle} in {@link $haystack} with `<mark>` tags.
+     *
+     * This method explodes {@link $needle} on spaces and returns {@link $haystack} with replacements.
+     *
+     * @param string|array $needle The strings to search for in {@link $haystack}.
+     * @param string $haystack The string to search for replacements.
+     * @return string Returns a marked version of {@link $haystack}.
+     * @deprecated
+     */
+    function markString($needle, $haystack) {
+        if (!$needle) {
+            return $haystack;
+        }
+        if (!is_array($needle)) {
+            $needle = explode(' ', $needle);
+        }
+
+        foreach ($needle as $n) {
+            if (strlen($n) <= 2 && preg_match('`^\w+$`', $n)) {
+                $word = '\b';
+            } else {
+                $word = '';
+            }
+
+            $haystack = preg_replace(
+                '#(?!<.*?)('.$word.preg_quote($n, '#').$word.')(?![^<>]*?>)#i',
+                '<mark>\1</mark>',
+                $haystack
+            );
+        }
+        return $haystack;
+    }
+}
+
 if (!function_exists('prepareArray')) {
     /**
      * Makes sure that the key in question exists and is of the specified type, by default also an array.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2160,41 +2160,6 @@ if (!function_exists('isWritable')) {
     }
 }
 
-if (!function_exists('markString')) {
-    /**
-     * Wrap occurrences of {@link $needle} in {@link $haystack} with `<mark>` tags.
-     *
-     * This method explodes {@link $needle} on spaces and returns {@link $haystack} with replacements.
-     *
-     * @param string|array $needle The strings to search for in {@link $haystack}.
-     * @param string $haystack The string to search for replacements.
-     * @return string Returns a marked version of {@link $haystack}.
-     */
-    function markString($needle, $haystack) {
-        if (!$needle) {
-            return $haystack;
-        }
-        if (!is_array($needle)) {
-            $needle = explode(' ', $needle);
-        }
-
-        foreach ($needle as $n) {
-            if (strlen($n) <= 2 && preg_match('`^\w+$`', $n)) {
-                $word = '\b';
-            } else {
-                $word = '';
-            }
-
-            $haystack = preg_replace(
-                '#(?!<.*?)('.$word.preg_quote($n, '#').$word.')(?![^<>]*?>)#i',
-                '<mark>\1</mark>',
-                $haystack
-            );
-        }
-        return $haystack;
-    }
-}
-
 if (!function_exists('joinRecords')) {
     /**
      * Join external records to an array.

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1296,10 +1296,9 @@ if (!function_exists('searchExcerpt')) {
      * @param string $plainText
      * @param array|string $searchTerms
      * @param int $length
-     * @param bool $mark
      * @return string
      */
-    function searchExcerpt($plainText, $searchTerms, $length = 200, $mark = true) {
+    function searchExcerpt($plainText, $searchTerms, $length = 200) {
         if (empty($searchTerms)) {
             return substrWord($plainText, 0, $length);
         }
@@ -1325,11 +1324,7 @@ if (!function_exists('searchExcerpt')) {
                 if (($pos = mb_stripos($line, $term)) !== false) {
                     $line = substrWord($line, $term, $length);
 
-                    if ($mark) {
-                        return markString($searchTerms, $line);
-                    } else {
-                        return $line;
-                    }
+                    return $line;
                 }
             }
         }


### PR DESCRIPTION
We currently use `markString()` to add `<mark>` tags to search results. This presents a few issues:

1. The function only works on plain text, but is not documented as such. It ends up being called incorrectly.
2. We don’t often use plain text at all. Usually, when we say plain text we mean text that has passed through `htmlspecialchars()`. Currently, `markString()` has several edge case bugs with html entities.
3. Since we won’t always use plaintext it will make our functionality appear inconsistent.
4. I suspect there are also hidden XSS vulnerabilities waiting to be uncovered in this function too. We must remain vigilant.