### PR TITLE
Fix output buffer corruption during tests

### DIFF
--- a/library/Vanilla/Scheduler/DummyScheduler.php
+++ b/library/Vanilla/Scheduler/DummyScheduler.php
@@ -155,7 +155,6 @@ class DummyScheduler implements SchedulerInterface {
             }
 
             if ($this->getFinalizeRequest()) {
-
                 // Finish Flushes all response data to the client
                 // so that job payloads can run without affecting the browser experience
                 session_write_close();

--- a/tests/Library/Vanilla/Scheduler/SchedulerTest.php
+++ b/tests/Library/Vanilla/Scheduler/SchedulerTest.php
@@ -276,6 +276,7 @@ final class SchedulerTest extends \PHPUnit\Framework\TestCase {
             ->setShared(true)
             ->rule(\Vanilla\Scheduler\SchedulerInterface::class)
             ->setClass(\Vanilla\Scheduler\DummyScheduler::class)
+            ->addCall('setFinalizeRequest', [false])
             ->setShared(true)
         ;
 


### PR DESCRIPTION
The job scheduler tests were always failing on my local host due to PHPUnit’s strict checking of output buffering. This change adds an option to the DummyScheduler to not flush buffers.