### PR TITLE
Remove expand parameters from the reactions specs

### DIFF
--- a/applications/vanilla/openapi/comments.yml
+++ b/applications/vanilla/openapi/comments.yml
@@ -354,19 +354,6 @@ paths:
         required: true
         schema:
           type: integer
-      - description: >
-          Expand associated records using one or more valid field names. A
-          value of "all" will expand all expandable fields.
-        in: query
-        name: expand
-        schema:
-          items:
-            enum:
-            - reactions
-            - all
-            type: string
-          type: array
-        style: form
       - description: |
           Filter to a specific reaction type by using its URL code.
         in: query

--- a/applications/vanilla/openapi/discussions.yml
+++ b/applications/vanilla/openapi/discussions.yml
@@ -553,19 +553,6 @@ paths:
         required: true
         schema:
           type: integer
-      - description: >
-          Expand associated records using one or more valid field names. A
-          value of "all" will expand all expandable fields.
-        in: query
-        name: expand
-        schema:
-          items:
-            enum:
-            - reactions
-            - all
-            type: string
-          type: array
-        style: form
       - description: Filter to a specific reaction type by using its URL code.
         in: query
         name: type


### PR DESCRIPTION
The reactions endpoints don’t use expand parameters so they should be in the spec.