### PR TITLE
Update prettier to 1.19.1

### DIFF
--- a/applications/dashboard/src/scripts/pages/authenticate/SignInPage.tsx
+++ b/applications/dashboard/src/scripts/pages/authenticate/SignInPage.tsx
@@ -86,7 +86,4 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(SignInPage);
+export default connect(mapStateToProps, mapDispatchToProps)(SignInPage);

--- a/applications/dashboard/src/scripts/pages/authenticate/components/PasswordForm.tsx
+++ b/applications/dashboard/src/scripts/pages/authenticate/components/PasswordForm.tsx
@@ -204,8 +204,5 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-const withRedux = connect(
-    mapStateToProps,
-    mapDispatchToProps,
-);
+const withRedux = connect(mapStateToProps, mapDispatchToProps);
 export default withRedux(withRouter(PasswordForm));

--- a/applications/dashboard/src/scripts/pages/recoverPassword/RecoverPasswordPage.tsx
+++ b/applications/dashboard/src/scripts/pages/recoverPassword/RecoverPasswordPage.tsx
@@ -150,9 +150,6 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-const withRedux = connect(
-    mapStateToProps,
-    mapDispatchToProps,
-);
+const withRedux = connect(mapStateToProps, mapDispatchToProps);
 
 export default withRedux(RecoverPasswordPage);

--- a/applications/vanilla/src/scripts/forms/CommunityCategoryInput.tsx
+++ b/applications/vanilla/src/scripts/forms/CommunityCategoryInput.tsx
@@ -63,9 +63,6 @@ function mapDispatchToProps(dispatch: any) {
     };
 }
 
-const withRedux = connect(
-    mapStateToProps,
-    mapDispatchToProps,
-);
+const withRedux = connect(mapStateToProps, mapDispatchToProps);
 
 export default withRedux(CommunityCategoryInput);

--- a/library/src/scripts/@types/api/users.ts
+++ b/library/src/scripts/@types/api/users.ts
@@ -31,7 +31,7 @@ export interface IUserRoles {
         {
             roleID: number;
             name: string;
-        }
+        },
     ];
 }
 

--- a/library/src/scripts/content/Translate.tsx
+++ b/library/src/scripts/content/Translate.tsx
@@ -112,9 +112,7 @@ export default class Translate extends React.Component<IProps> {
      */
     private logIDNotFound(id) {
         this.props.errorHandler!(
-            `A translation interpolation value #${id} was not provided for source string ${
-                this.props.source
-            }. \nThe translated value of source is ${this.translatedSource}.`,
+            `A translation interpolation value #${id} was not provided for source string ${this.props.source}. \nThe translated value of source is ${this.translatedSource}.`,
         );
     }
 }

--- a/library/src/scripts/contexts/SearchContext.tsx
+++ b/library/src/scripts/contexts/SearchContext.tsx
@@ -35,7 +35,7 @@ export function withSearch<T extends IWithSearchProps = IWithSearchProps>(Wrappe
                 <SearchContext.Consumer>
                     {context => {
                         // https://github.com/Microsoft/TypeScript/issues/28938
-                        return <WrappedComponent {...context} {...this.props as T} />;
+                        return <WrappedComponent {...context} {...(this.props as T)} />;
                     }}
                 </SearchContext.Consumer>
             );

--- a/library/src/scripts/contexts/TabContext.tsx
+++ b/library/src/scripts/contexts/TabContext.tsx
@@ -31,7 +31,7 @@ export function withTabs<T extends ITabProps = ITabProps>(WrappedComponent: Reac
                 <TabContext.Consumer>
                     {context => {
                         // https://github.com/Microsoft/TypeScript/issues/28938
-                        return <WrappedComponent {...context} {...this.props as T} />;
+                        return <WrappedComponent {...context} {...(this.props as T)} />;
                     }}
                 </TabContext.Consumer>
             );

--- a/library/src/scripts/features/search/SearchOption.tsx
+++ b/library/src/scripts/features/search/SearchOption.tsx
@@ -39,7 +39,7 @@ export default function SearchOption(props: IProps) {
         return (
             <li className="suggestedTextInput-item">
                 <SmartLink
-                    {...innerProps as any}
+                    {...(innerProps as any)}
                     // We want to use the SmarkLink clickHandler, not the innerProps one from the SearchBar.
                     // The innerProps click handler will trigger a search event (goes to search page).
                     // The SmartLink will navigate to the result itself.

--- a/library/src/scripts/features/users/MultiUserInput.tsx
+++ b/library/src/scripts/features/users/MultiUserInput.tsx
@@ -59,11 +59,8 @@ export class MultiUserInput extends React.Component<IProps> {
     };
 }
 
-const withRedux = connect(
-    UserSuggestionModel.mapStateToProps,
-    dispatch => ({
-        suggestionActions: new UserSuggestionActions(dispatch, apiv2),
-    }),
-);
+const withRedux = connect(UserSuggestionModel.mapStateToProps, dispatch => ({
+    suggestionActions: new UserSuggestionActions(dispatch, apiv2),
+}));
 
 export default withRedux(MultiUserInput);

--- a/library/src/scripts/features/users/Permission.tsx
+++ b/library/src/scripts/features/users/Permission.tsx
@@ -84,9 +84,6 @@ function mapDispatchToProps(dispatch) {
     };
 }
 
-const withRedux = connect(
-    mapUsersStoreState,
-    mapDispatchToProps,
-);
+const withRedux = connect(mapUsersStoreState, mapDispatchToProps);
 
 export default withRedux(Permission);

--- a/library/src/scripts/forms/select/overwrites.tsx
+++ b/library/src/scripts/forms/select/overwrites.tsx
@@ -141,7 +141,7 @@ export function SelectOption(props: OptionProps<any>) {
     return (
         <li className="suggestedTextInput-item">
             <button
-                {...props.innerProps as any}
+                {...(props.innerProps as any)}
                 type="button"
                 className={classNames("suggestedTextInput-option", {
                     isSelected,

--- a/library/src/scripts/headers/mebox/pieces/MessagesContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/MessagesContents.tsx
@@ -171,7 +171,4 @@ function mapDispatchToProps(dispatch) {
 }
 
 // Connect Redux to the React component.
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(withDevice(MessagesContents));
+export default connect(mapStateToProps, mapDispatchToProps)(withDevice(MessagesContents));

--- a/library/src/scripts/headers/mebox/pieces/NotificationsContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/NotificationsContents.tsx
@@ -181,7 +181,4 @@ function mapStateToProps(state: INotificationsStoreState) {
 }
 
 // Connect Redux to the React component.
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(withDevice(NotificationsContents));
+export default connect(mapStateToProps, mapDispatchToProps)(withDevice(NotificationsContents));

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
@@ -105,7 +105,4 @@ function mapDispatchToProps(dispatch: any) {
     };
 }
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(UserDropDownContents);
+export default connect(mapStateToProps, mapDispatchToProps)(UserDropDownContents);

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContext.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContext.tsx
@@ -108,7 +108,4 @@ function mapDispatchToProps(dispatch: any) {
     };
 }
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(UserDropDownContents);
+export default connect(mapStateToProps, mapDispatchToProps)(UserDropDownContents);

--- a/library/src/scripts/headers/mebox/pieces/UserDropdown.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropdown.tsx
@@ -85,7 +85,4 @@ function mapDispatchToProps(dispatch: any) {
     };
 }
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(UserDropDown);
+export default connect(mapStateToProps, mapDispatchToProps)(UserDropDown);

--- a/library/src/scripts/layout/DeviceContext.tsx
+++ b/library/src/scripts/layout/DeviceContext.tsx
@@ -76,7 +76,7 @@ export function withDevice<T extends IDeviceProps = IDeviceProps>(WrappedCompone
             <DeviceContext.Consumer>
                 {context => {
                     // https://github.com/Microsoft/TypeScript/issues/28938
-                    return <WrappedComponent device={context} {...props as T} />;
+                    return <WrappedComponent device={context} {...(props as T)} />;
                 }}
             </DeviceContext.Consumer>
         );

--- a/library/src/scripts/routing/PagesContext.tsx
+++ b/library/src/scripts/routing/PagesContext.tsx
@@ -43,7 +43,7 @@ export function withPages<T extends IWithPagesProps = IWithPagesProps>(WrappedCo
                 <PageContext.Consumer>
                     {context => {
                         // https://github.com/Microsoft/TypeScript/issues/28938
-                        return <WrappedComponent {...context} {...this.props as T} />;
+                        return <WrappedComponent {...context} {...(this.props as T)} />;
                     }}
                 </PageContext.Consumer>
             );

--- a/library/src/scripts/styles/textUtils.ts
+++ b/library/src/scripts/styles/textUtils.ts
@@ -86,18 +86,10 @@ export function defaultHyphenation() {
         "-webkit-hyphenate-limit-before": vars.minimumCharactersBeforeBreak,
         "-webkit-hyphenate-limit-after": vars.minimumCharactersAfterBreak,
         /* current proposal */
-        "-moz-hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${
-            vars.minimumCharactersAfterBreak
-        }` /* not yet supported */,
-        "-webkit-hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${
-            vars.minimumCharactersAfterBreak
-        }` /* not yet supported */,
-        "-ms-hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${
-            vars.minimumCharactersAfterBreak
-        }`,
-        "hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${
-            vars.minimumCharactersAfterBreak
-        }`,
+        "-moz-hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${vars.minimumCharactersAfterBreak}` /* not yet supported */,
+        "-webkit-hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${vars.minimumCharactersAfterBreak}` /* not yet supported */,
+        "-ms-hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${vars.minimumCharactersAfterBreak}`,
+        "hyphenate-limit-chars": `${vars.minimumCharactersToHyphenate} ${vars.minimumCharactersBeforeBreak} ${vars.minimumCharactersAfterBreak}`,
         // Maximum consecutive lines to have hyphenation
         "-ms-hyphenate-limit-lines": vars.maximumConsecutiveBrokenLines,
         "-webkit-hyphenate-limit-lines": vars.maximumConsecutiveBrokenLines,

--- a/library/src/scripts/theming/ThemeProvider.tsx
+++ b/library/src/scripts/theming/ThemeProvider.tsx
@@ -102,7 +102,4 @@ function mapDispatchToProps(dispatch: any, ownProps: IOwnProps) {
     };
 }
 
-export const ThemeProvider = connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(BaseThemeProvider);
+export const ThemeProvider = connect(mapStateToProps, mapDispatchToProps)(BaseThemeProvider);

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
         "mocha": "^6.1.4",
         "optimize-css-assets-webpack-plugin": "^5.0.1",
         "postcss-loader": "^3.0.0",
-        "prettier": "1.19.0",
+        "prettier": "1.19.1",
         "prettier-webpack-plugin": "^1.2.0",
         "prop-types": "^15.7.2",
         "raw-loader": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
         "mocha": "^6.1.4",
         "optimize-css-assets-webpack-plugin": "^5.0.1",
         "postcss-loader": "^3.0.0",
-        "prettier": "1.17.0",
+        "prettier": "1.19.0",
         "prettier-webpack-plugin": "^1.2.0",
         "prop-types": "^15.7.2",
         "raw-loader": "^2.0.0",

--- a/packages/vanilla-eslint-config/index.js
+++ b/packages/vanilla-eslint-config/index.js
@@ -32,6 +32,7 @@ module.exports = {
         "no-case-declarations": "off",
         "prefer-const": "off",
         "require-atomic-updates": "off",
+        "react/prop-types": "off", // We use typescript
 
         // We have typescript for these.
         "no-undef": "off",

--- a/packages/vanilla-eslint-config/package.json
+++ b/packages/vanilla-eslint-config/package.json
@@ -10,11 +10,11 @@
         "@typescript-eslint/eslint-plugin": "^2.6.1",
         "@typescript-eslint/parser": "^2.6.1",
         "eslint": "^6.6.0",
-        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-prettier": "^6.5.0",
         "eslint-plugin-import": "^2.17.3",
         "eslint-plugin-jsx-a11y": "^6.2.1",
         "eslint-plugin-lodash": "^6.0.0",
         "eslint-plugin-react": "^7.13.0",
-        "eslint-plugin-react-hooks": "^1.6.0"
+        "eslint-plugin-react-hooks": "^2.2.0"
     }
 }

--- a/packages/vanilla-eslint-config/package.json
+++ b/packages/vanilla-eslint-config/package.json
@@ -15,6 +15,6 @@
         "eslint-plugin-jsx-a11y": "^6.2.1",
         "eslint-plugin-lodash": "^6.0.0",
         "eslint-plugin-react": "^7.13.0",
-        "eslint-plugin-react-hooks": "^2.2.0"
+        "eslint-plugin-react-hooks": "^1.6.0"
     }
 }

--- a/packages/vanilla-react-utils/src/index.ts
+++ b/packages/vanilla-react-utils/src/index.ts
@@ -11,3 +11,4 @@ export * from "./useMeasure";
 export * from "./useLastValue";
 export * from "./useTabKeyboardHandler";
 export * from "./useThrowError";
+export * from "./useDefaultProps";

--- a/packages/vanilla-react-utils/src/index.ts
+++ b/packages/vanilla-react-utils/src/index.ts
@@ -11,4 +11,3 @@ export * from "./useMeasure";
 export * from "./useLastValue";
 export * from "./useTabKeyboardHandler";
 export * from "./useThrowError";
-export * from "./useDefaultProps";

--- a/plugins/rich-editor/src/scripts/editor/withEditor.tsx
+++ b/plugins/rich-editor/src/scripts/editor/withEditor.tsx
@@ -18,7 +18,7 @@ export function withEditor<T extends IWithEditorProps = IWithEditorProps>(Wrappe
     function ComponentWithEditor(props: Omitted) {
         const context = useEditor();
         const content = useEditorContents();
-        return <WrappedComponent {...context} {...content} {...props as T} />;
+        return <WrappedComponent {...context} {...content} {...(props as T)} />;
     }
     ComponentWithEditor.displayName = WrappedComponent.displayName || WrappedComponent.name || "Component";
     return ComponentWithEditor as React.ComponentType<Omitted>;

--- a/plugins/rich-editor/src/scripts/toolbars/MentionToolbar.tsx
+++ b/plugins/rich-editor/src/scripts/toolbars/MentionToolbar.tsx
@@ -355,11 +355,8 @@ export class MentionToolbar extends React.Component<IProps, IMentionState> {
     };
 }
 
-const withRedux = connect(
-    UserSuggestionModel.mapStateToProps,
-    dispatch => ({
-        suggestionActions: new UserSuggestionActions(dispatch, apiv2),
-    }),
-);
+const withRedux = connect(UserSuggestionModel.mapStateToProps, dispatch => ({
+    suggestionActions: new UserSuggestionActions(dispatch, apiv2),
+}));
 
 export default withRedux(withEditor(MentionToolbar));

--- a/yarn.lock
+++ b/yarn.lock
@@ -14883,10 +14883,10 @@ prettier-webpack-plugin@^1.2.0:
   resolved "https://registry.yarnpkg.com/prettier-webpack-plugin/-/prettier-webpack-plugin-1.2.0.tgz#4a5635f054741160936c7f509f0a9b1f928e5550"
   integrity sha512-icoIPxDpOo/q7SUCHSW152dCr83z7QS/6s2V3phweKu1bfJcXSObVAq/Z8OeSX7ykuXrcV2UpZbfljRI2rIOMg==
 
-prettier@1.19.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.0.tgz#3bec4489d5eebcd52b95ddd2c22467b5c852fde1"
-  integrity sha512-GlAIjk6DjkNT6u/Bw5QCWrbzh9YlLKwwmJT//1YiCR3WDpZDnyss64aXHQZgF8VKeGlWnX6+tGsKSVxsZT/gtA==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 prettier@^1.16.4:
   version "1.18.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7782,10 +7782,10 @@ eslint-plugin-lodash@^6.0.0:
   dependencies:
     lodash "^4.17.15"
 
-eslint-plugin-react-hooks@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.2.0.tgz#078264e9e388da6929ace09d6abe92c85963aff4"
-  integrity sha512-jSlnBjV2cmyIeL555H/FbvuSbQ1AtpHjLMHuPrQnt1eVA6lX8yufdygh7AArI2m8ct7ChHGx2uOaCuxq2MUn6g==
+eslint-plugin-react-hooks@^1.6.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
+  integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
 
 eslint-plugin-react@^7.13.0:
   version "7.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7720,10 +7720,10 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz#c55c1fcac8ce4518aeb77906984e134d9eb5a4f0"
-  integrity sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==
+eslint-config-prettier@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.5.0.tgz#aaf9a495e2a816865e541bfdbb73a65cc162b3eb"
+  integrity sha512-cjXp8SbO9VFGW/Z7mbTydqS9to8Z58E5aYhj3e1+Hx7lS9s6gL5ILKNpCqZAFOVYRcSkWPFYljHrEh8QFEK5EQ==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -7782,10 +7782,10 @@ eslint-plugin-lodash@^6.0.0:
   dependencies:
     lodash "^4.17.15"
 
-eslint-plugin-react-hooks@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"
-  integrity sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==
+eslint-plugin-react-hooks@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.2.0.tgz#078264e9e388da6929ace09d6abe92c85963aff4"
+  integrity sha512-jSlnBjV2cmyIeL555H/FbvuSbQ1AtpHjLMHuPrQnt1eVA6lX8yufdygh7AArI2m8ct7ChHGx2uOaCuxq2MUn6g==
 
 eslint-plugin-react@^7.13.0:
   version "7.16.0"
@@ -14883,15 +14883,10 @@ prettier-webpack-plugin@^1.2.0:
   resolved "https://registry.yarnpkg.com/prettier-webpack-plugin/-/prettier-webpack-plugin-1.2.0.tgz#4a5635f054741160936c7f509f0a9b1f928e5550"
   integrity sha512-icoIPxDpOo/q7SUCHSW152dCr83z7QS/6s2V3phweKu1bfJcXSObVAq/Z8OeSX7ykuXrcV2UpZbfljRI2rIOMg==
 
-prettier@1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
-  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
-
-prettier@1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
-  integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==
+prettier@1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.0.tgz#3bec4489d5eebcd52b95ddd2c22467b5c852fde1"
+  integrity sha512-GlAIjk6DjkNT6u/Bw5QCWrbzh9YlLKwwmJT//1YiCR3WDpZDnyss64aXHQZgF8VKeGlWnX6+tGsKSVxsZT/gtA==
 
 prettier@^1.16.4:
   version "1.18.2"


### PR DESCRIPTION
**Why?**

- Prettier <= 1.19 breaks on nullish coalescing operators.

**Why are there changes?**

It looks like prettier 1.18 adjusted 2 things in how it formats stuff.

- HOC components will prefer to be on a single line when below the line length.
- Spreads w/ typecasts now get parantheses. Eg. `{(...thing as T)}` vs `{...thing as T}`