### PR TITLE
Make the controller throw a ServerException rather than a generic Exception

### DIFF
--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -12,6 +12,7 @@ use Garden\Schema\Schema;
 use Garden\Schema\Validation;
 use Garden\Schema\ValidationException;
 use Garden\Web\Exception\HttpException;
+use Garden\Web\Exception\ServerException;
 use Gdn_Locale as LocaleInterface;
 use Gdn_Session as SessionInterface;
 use Gdn_Upload as Upload;
@@ -80,7 +81,7 @@ abstract class Controller implements InjectableInterface {
      */
     public function permission($permission = null, $id = null) {
         if (!$this->session instanceof SessionInterface) {
-            throw new \Exception("Session not available.", 500);
+            throw new ServerException("Session not available.", 500);
         }
         $permissions = (array)$permission;
 


### PR DESCRIPTION
Currently, the `Vanilla\Web\Controller` throws a generic `Exception` when the session hasn’t been injected. If you are using PHPStorm then this riddles subclasses with a tonne of code inspection warnings which makes code hygiene quite difficult.

This change proposes to change the exception type to our general HTTP level `ServerException`. It’s the same code, but can then be ignored in your project settings. This makes sense because we generally expect `HttpException` subclasses to throw their exceptions up to the dispatcher.