### PR TITLE
Add a poor man’s autoload-dev to tests

### DIFF
--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -58,3 +58,12 @@ Gdn::setContainer(new NullContainer());
 require_once PATH_LIBRARY_CORE.'/functions.validation.php';
 
 require_once PATH_LIBRARY_CORE.'/functions.render.php';
+
+// Include test utilities.
+$utilityFiles = array_merge(
+    glob(PATH_ROOT.'/plugins/*/tests/Utils/*.php'),
+    glob(PATH_ROOT.'/applications/*/tests/Utils/*.php'),
+);
+foreach ($utilityFiles as $file) {
+    require_once $file;
+}

--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -62,7 +62,7 @@ require_once PATH_LIBRARY_CORE.'/functions.render.php';
 // Include test utilities.
 $utilityFiles = array_merge(
     glob(PATH_ROOT.'/plugins/*/tests/Utils/*.php'),
-    glob(PATH_ROOT.'/applications/*/tests/Utils/*.php'),
+    glob(PATH_ROOT.'/applications/*/tests/Utils/*.php')
 );
 foreach ($utilityFiles as $file) {
     require_once $file;


### PR DESCRIPTION
This change allows addons that run through our core test harness to add files within their `/tests/Utils` directory and have them included for tests. The intention is for them to add classes and traits that can be helpful for tests.

I thought of this while noticing a lot of copy/pasted code in some tests in other repos. I realized they really had no way to not do that since they have no `autoload-dev`.

This is a bit kludgey, but I figure that’s not the worst since this is *just* for tests.

Do you want to know what I specifically have in mind for this? Well, approve this PR and then stay tuned.