### PR TITLE
Fix HTML format tests

### DIFF
--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -69,7 +69,6 @@ class HtmlFormat extends BaseFormat {
     public function renderHtml(string $content, bool $enhance = true): string {
         $result = $this->htmlSanitizer->filter($content);
 
-
         if ($this->shouldCleanupLineBreaks) {
             $result = self::cleanupLineBreaks($result);
         }
@@ -81,7 +80,6 @@ class HtmlFormat extends BaseFormat {
         }
 
         $result = self::cleanupEmbeds($result);
-
 
         return $result;
     }
@@ -401,6 +399,11 @@ HTML;
 
         $content = $dom->getElementsByTagName('body');
         $htmlBodyString = @$dom->saveXML($content[0], LIBXML_NOEMPTYTAG);
+
+        // The DOM Document added starting body and ending tags. We need to remove them.
+        $htmlBodyString = preg_replace('/^<body>/', '', $htmlBodyString);
+        $htmlBodyString = preg_replace('/<\/body>$/', '', $htmlBodyString);
+
         return $htmlBodyString;
     }
 

--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -167,7 +167,7 @@ class VanillaHtmlFormatter {
      */
     public function format($html, $options = []) {
         $attributes = self::c('Garden.Html.BlockedAttributes', 'on*, target, download');
-        $schemes = implode(', ', self::c('Garden.Html.AllowedUrlSchemes'));
+        $schemes = implode(', ', self::c('Garden.Html.AllowedUrlSchemes', []));
 
         $specOverrides = val('spec', $options, []);
         if (!is_array($specOverrides)) {

--- a/tests/Library/Vanilla/Formatting/Formats/MarkdownFormatTest.php
+++ b/tests/Library/Vanilla/Formatting/Formats/MarkdownFormatTest.php
@@ -41,10 +41,10 @@ class MarkdownFormatTest extends AbstractFormatTestCase {
 > [/spoiler]
 EOT;
         $expected = <<<EOT
-<blockquote class="UserQuote"><div class="QuoteText">
-  <p>[spoiler]</p>
+<blockquote class="UserQuote blockquote"><div class="blockquote-content">
+  <p class="blockquote-line">[spoiler]</p>
   
-  <p>[/spoiler]</p>
+  <p class="blockquote-line">[/spoiler]</p>
 </div></blockquote>
 
 EOT;

--- a/tests/fixtures/formats/html/images/output.html
+++ b/tests/fixtures/formats/html/images/output.html
@@ -1,5 +1,5 @@
-<img alt="image" src="http://test.com">
+<img alt=image class="embedImage-img importedEmbed-img" src=http://test.com>
 <br>
-<img alt="image" src="http://test2.com">
+<img alt=image class="embedImage-img importedEmbed-img" src=http://test2.com>
 <br>
 <br>


### PR DESCRIPTION
- The imploding URL schemes actually had a default added in https://github.com/vanilla/vanilla/pull/9538, but we don't load the default when using our `MockConfig`. I added a non-fatal fallback if the config is not defined.
- We intentionally updated the way we rendered HTML, but the fixtures were added in a different PR so they were never run together. I've updated that fixture.