### PR TITLE
Correct empty discussion titles at the model level

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1011,11 +1011,15 @@ class DiscussionModel extends Gdn_Model {
         }
     }
 
+    /**
+     * Massage the data on a discussion row.
+     *
+     * @param object $discussion
+     * @throws Exception
+     */
     public function calculate(&$discussion) {
-
-
         // Fix up output
-        $discussion->Name = htmlspecialchars($discussion->Name);
+        $discussion->Name = htmlspecialchars(trim($discussion->Name) ?: t('(Untitled)'));
         $discussion->Attributes = dbdecode($discussion->Attributes);
         $discussion->Url = discussionUrl($discussion);
         $discussion->CanonicalUrl = $discussion->Attributes['CanonicalUrl'] ?? $discussion->Url;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1015,7 +1015,6 @@ class DiscussionModel extends Gdn_Model {
      * Massage the data on a discussion row.
      *
      * @param object $discussion
-     * @throws Exception
      */
     public function calculate(&$discussion) {
         // Fix up output

--- a/applications/vanilla/views/discussions/helper_functions.php
+++ b/applications/vanilla/views/discussions/helper_functions.php
@@ -136,10 +136,6 @@ if (!function_exists('WriteDiscussion')) :
         $sender->fireEvent('BeforeDiscussionName');
 
         $discussionName = $discussion->Name;
-        // If there are no word character detected in the title treat it as if it is blank.
-        if (!preg_match('/\w/u', $discussionName)) {
-            $discussionName = t('Blank Discussion Topic');
-        }
         $sender->EventArguments['DiscussionName'] = &$discussionName;
 
         static $firstDiscussion = true;

--- a/applications/vanilla/views/discussions/table_functions.php
+++ b/applications/vanilla/views/discussions/table_functions.php
@@ -62,10 +62,6 @@ if (!function_exists('writeDiscussionRow')) :
         $sender->fireEvent('BeforeDiscussionName');
 
         $discussionName = $discussion->Name;
-        // If there are no word character detected in the title treat it as if it is blank.
-        if (!preg_match('/\w/u', $discussionName)) {
-            $discussionName = t('Blank Discussion Topic');
-        }
         $sender->EventArguments['DiscussionName'] = &$discussionName;
 
         static $firstDiscussion = true;

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -270,4 +270,18 @@ class DiscussionsTest extends AbstractResourceTest {
         $this->assertArrayHasKey('insertUser', $row['lastPost']);
         $this->assertArrayNotHasKey('lastUser', $row);
     }
+
+    /**
+     * The API should not fail when the discussion title/body is empty.
+     */
+    public function testEmptyDiscussionTitle() {
+        $row = $this->testPost();
+
+        /* @var \Gdn_SQLDriver $sql */
+        $sql = self::container()->get(\Gdn_SQLDriver::class);
+        $sql->put('Discussion', ['Name' => '', 'Body' => ''], ['DiscussionID' => $row['discussionID']]);
+
+        $discussion = $this->api()->get("$this->baseUrl/{$row['discussionID']}")->getBody();
+        $this->assertNotEmpty($discussion['name']);
+    }
 }


### PR DESCRIPTION
The discussions APIv2 was failing with empty discussion titles. This fix is primarily for that defect, but also includes the enhancement to correct the title at the model level so that other code that may benefit from it.

This change also renames the translation for untitled discussions to a simple “(Untitled)” that is more generic for other types of data.