### PR TITLE
Rename FallbackUrlSetter to FallbackBackUrlSetter

### DIFF
--- a/library/src/scripts/routing/links/BackRoutingProvider.tsx
+++ b/library/src/scripts/routing/links/BackRoutingProvider.tsx
@@ -103,7 +103,7 @@ export function useBackRouting() {
 /**
  * Component version of `useFallbackBackUrl`.
  */
-export function FallbackUrlSetter(props: { url: string }) {
+export function FallbackBackUrlSetter(props: { url: string }) {
     useFallbackBackUrl(props.url);
     return <React.Fragment />;
 }


### PR DESCRIPTION
This was actually just added in https://github.com/vanilla/vanilla/pull/9606 but had an inconsistent name.

I forgot to push the commit before merging.

Blocking https://github.com/vanilla/knowledge/pull/1358