### PR TITLE
Backport: Fix fatal error when rendering unknown format

### DIFF
--- a/library/Vanilla/Formatting/Formats/NotFoundFormat.php
+++ b/library/Vanilla/Formatting/Formats/NotFoundFormat.php
@@ -86,6 +86,13 @@ class NotFoundFormat implements FormatInterface {
     }
 
     /**
+     * @inheritDoc
+     */
+    public function parseImageUrls(): array {
+        return [];
+    }
+
+    /**
      * @inheritdoc
      */
     public function parseMentions(string $content): array {


### PR DESCRIPTION
Backporting #9625 

> `FormatInterface` was updated with #9554. Most of core Vanilla's formats seem to have been updated, with the exception of `NotFoundFormat`. The method is added here.