### PR TITLE
Fix editor paragraph menu tabs only appearing when open/active

### DIFF
--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/tabs/ParagraphMenuBarTab.tsx
@@ -60,34 +60,30 @@ export default class ParagraphMenuBarTab extends React.PureComponent<IProps> {
 
     public render() {
         const { className, isMenuVisible, icon } = this.props;
-        if (this.props.open) {
-            const classes = richEditorClasses(this.props.legacyMode);
+        const classes = richEditorClasses(this.props.legacyMode);
 
-            // If the roving index matches my index, or no roving index is set and we're on the first tab
-            return (
-                <div id={this.componentID} ref={this.selfRef} className={classNames(className)}>
-                    <button
-                        type="button"
-                        role="menuitem"
-                        id={this.buttonID}
-                        aria-label={this.props.accessibleButtonLabel}
-                        title={this.props.accessibleButtonLabel}
-                        aria-controls={this.menuID}
-                        aria-expanded={isMenuVisible}
-                        aria-haspopup="menu"
-                        onClick={this.handleClick}
-                        className={classNames(classes.button, this.props.open ? classes.topLevelButtonActive : "")}
-                        tabIndex={this.props.tabIndex}
-                        ref={this.toggleButtonRef}
-                    >
-                        <IconForButtonWrap icon={icon} />
-                        <ScreenReaderContent>{this.props.accessibleButtonLabel}</ScreenReaderContent>
-                    </button>
-                </div>
-            );
-        } else {
-            return null;
-        }
+        // If the roving index matches my index, or no roving index is set and we're on the first tab
+        return (
+            <div id={this.componentID} ref={this.selfRef} className={classNames(className)}>
+                <button
+                    type="button"
+                    role="menuitem"
+                    id={this.buttonID}
+                    aria-label={this.props.accessibleButtonLabel}
+                    title={this.props.accessibleButtonLabel}
+                    aria-controls={this.menuID}
+                    aria-expanded={isMenuVisible}
+                    aria-haspopup="menu"
+                    onClick={this.handleClick}
+                    className={classNames(classes.button, this.props.open ? classes.topLevelButtonActive : "")}
+                    tabIndex={this.props.tabIndex}
+                    ref={this.toggleButtonRef}
+                >
+                    <IconForButtonWrap icon={icon} />
+                    <ScreenReaderContent>{this.props.accessibleButtonLabel}</ScreenReaderContent>
+                </button>
+            </div>
+        );
     }
 
     public componentDidMount() {


### PR DESCRIPTION
Fixes https://github.com/vanilla/knowledge/issues/1376
Fixes https://github.com/vanilla/support/issues/1054

In the recent typescript update the conditional here was flagged as being incorrect. https://github.com/vanilla/vanilla/commit/9dab47625eb1d35a2a81d17a488acbce5ee4648d#diff-865586e0184f5855dca1fd1863126621R63

Eg. `if (open)` always was true because `open` is global function on the window.

I guess I didn't think critically enough because I just updated it to be `this.props.open` instead. Unfortunately that totally breaks the logic of component. As the previous behaviour intended, this should __always__ be visible, and should not ever be null, so I removed the conditional altogether.

I've opened this tech debt issue to get this component into storybook so regressions like this don't happen again. https://github.com/vanilla/vanilla/issues/9631