### PR TITLE
Allow it to be specified if the back button is allowed in the titlebar

### DIFF
--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -41,6 +41,7 @@ interface IProps extends IDeviceProps, IInjectableUserState, IWithPagesProps {
     title?: string; // Needed for mobile flyouts
     mobileDropDownContent?: React.ReactNode; // Needed for mobile flyouts
     isFixed?: boolean;
+    useMobileBackButton?: boolean;
 }
 
 interface IState {
@@ -73,6 +74,7 @@ export class TitleBar extends React.Component<IProps, IState> {
     public static defaultProps: Partial<IProps> = {
         mobileDropDownContent: null,
         isFixed: true,
+        useMobileBackButton: true,
     };
 
     public state = {
@@ -110,17 +112,20 @@ export class TitleBar extends React.Component<IProps, IState> {
                 <Container>
                     <PanelWidgetHorizontalPadding>
                         <div className={classNames("titleBar-bar", classes.bar)}>
-                            {!this.state.openSearch && isMobile && (
-                                <BackLink
-                                    className={classNames(
-                                        "titleBar-leftFlexBasis",
-                                        "titleBar-backLink",
-                                        classes.leftFlexBasis,
-                                    )}
-                                    linkClassName={classes.button}
-                                    fallbackElement={<FlexSpacer className="pageHeading-leftSpacer" />}
-                                />
-                            )}
+                            {!this.state.openSearch &&
+                                isMobile &&
+                                (this.props.useMobileBackButton ? (
+                                    <BackLink
+                                        className={classNames(
+                                            "titleBar-leftFlexBasis",
+                                            "titleBar-backLink",
+                                            classes.leftFlexBasis,
+                                        )}
+                                        linkClassName={classes.button}
+                                    />
+                                ) : (
+                                    <FlexSpacer className="pageHeading-leftSpacer" />
+                                ))}
                             {!isMobile && (
                                 <HeaderLogo
                                     className={classNames("titleBar-logoContainer", classes.logoContainer)}

--- a/library/src/scripts/headers/TitleBarHome.tsx
+++ b/library/src/scripts/headers/TitleBarHome.tsx
@@ -17,7 +17,7 @@ interface IProps extends IDeviceProps {}
 export class TitleBarHome extends React.Component<IProps> {
     public render() {
         const isMobile = this.props.device === Devices.MOBILE || this.props.device === Devices.XS;
-        return isMobile ? <TitleBarMobileHome /> : <TitleBar />;
+        return isMobile ? <TitleBarMobileHome /> : <TitleBar useMobileBackButton={false} />;
     }
 }
 

--- a/library/src/scripts/layout/PageHeading.tsx
+++ b/library/src/scripts/layout/PageHeading.tsx
@@ -42,7 +42,7 @@ export function PageHeading(props: IPageHeading) {
     return (
         <div className={classNames(classes.root, className)}>
             <div className={classes.main}>
-                {includeBackLink && <BackLink fallbackElement={null} className={linkClasses.inHeading(fontSize)} />}
+                {includeBackLink && <BackLink className={linkClasses.inHeading(fontSize)} />}
                 <ConditionalWrap condition={!!actions} className={classes.titleWrap}>
                     <Heading titleRef={ref} depth={1} title={title} className={headingClassName}>
                         {children}

--- a/library/src/scripts/routing/links/BackLink.tsx
+++ b/library/src/scripts/routing/links/BackLink.tsx
@@ -23,9 +23,6 @@ interface IProps {
     /** The URL to navigate to if we can't do a dynamic browser back navigation. */
     fallbackUrl?: string;
 
-    /** A component to render if we can't do a dynamic browser back navigation. */
-    fallbackElement?: React.ReactNode;
-
     /** An action to if the component is clicked */
     onClick?: (e: React.MouseEvent) => void;
 
@@ -51,7 +48,6 @@ interface IProps {
  * Render priority:
  * - Render a button w/ the provided click handler.
  * - Render a button that navigates back using (dynamic routing, uses real browser history back & preserves scroll).
- * - Render the provided fallbackElement if we can't navigate back.
  * - Render the a link to one of the following if we can't navigate back.
  *   - The `fallbackUrl` prop.
  *   - The site homepage.
@@ -99,8 +95,6 @@ export default function BackLink(props: IProps) {
                 {content}
             </Button>
         );
-    } else if (props.fallbackElement) {
-        return <>{props.fallbackElement}</>;
     } else {
         content = (
             <a


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1379


The behaviour of `fallbackElement` w/ `<BackLink />` changed in https://github.com/vanilla/vanilla/pull/9606. Unfortunately it was still very confusing and misleading, since we __always__ set a backlink now.

I've done the following:

- Remove the prop from `<BackLink />` entirely.
- Remove the usage from `<PageHeading />` it already has it's own `includeBackLink`  prop to control this.
- Remove the usage in `<TitleBar />` and add a `useMobileBackButton` prop, defaulting to true on `<TitleBar />`.