### PR TITLE
Add a recursion guard in Gdn_Format::to()

### DIFF
--- a/tests/Library/Core/FormatTest.php
+++ b/tests/Library/Core/FormatTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use PHPUnit\Framework\TestCase;
+use VanillaTests\BootstrapTrait;
+
+/**
+ * Tests for the `Gdn_Format` class.
+ */
+class FormatTest extends TestCase {
+    use BootstrapTrait;
+
+    /**
+     * Test formatting an object that references itself.
+     */
+    public function testObjectFormatWithRecursiveReference() {
+        $obj = new \stdClass();
+        $obj->foo = '>';
+        $obj->bar = $obj;
+
+        $actual = \Gdn_Format::to($obj, 'display');
+
+        $this->assertEquals('&gt;', $actual->foo);
+        $this->assertSame($actual, $actual->bar);
+    }
+
+    /**
+     * Test formatting an object with circular references.
+     */
+    public function testObjectFormatWithCircularReferences() {
+        $a = new \stdClass();
+        $a->foo = '>';
+        $a->bar = new \stdClass();
+        $a->bar->baz = '<';
+        $a->bar->qux = $a;
+
+        $actual = \Gdn_Format::to($a, 'display');
+
+        $this->assertEquals('&gt;', $actual->foo);
+        $this->assertEquals('&lt;', $actual->bar->baz);
+        $this->assertSame($actual, $actual->bar->qux);
+    }
+
+    /**
+     * Test formatting a recursive array.
+     */
+    public function testArrayFormatWithRecursiveReference() {
+        $a = [
+            'foo' => '>'
+        ];
+        $a['bar'] = &$a;
+
+        $actual = \Gdn_Format::to($a, 'display');
+
+        $this->assertEquals('&gt;', $a['foo']);
+    }
+
+    /**
+     * Formatting an array should not modify the original array.
+     */
+    public function testArrayNonCorruption() {
+        $a = ['>'];
+
+        $actual = \Gdn_Format::to($a, 'display');
+
+        $this->assertEquals(['&gt;'], $actual);
+        $this->assertEquals(['>'], $a);
+    }
+
+    /**
+     * An object listed twice inside an array should only format once.
+     */
+    public function testNoDoubleFormat() {
+        $a = new \stdClass();
+        $a->foo = '<';
+
+        $arr = [$a, $a];
+
+        $actual = \Gdn_Format::to($arr, 'display');
+        $this->assertEquals('&lt;', $actual[0]->foo);
+    }
+}


### PR DESCRIPTION
We have an ill-advised use of `Gdn_Format::to()` where we allow arrays or objects to be passed and the class will format everything in them. Although the practice is heavily discouraged, we still support it.

There is a problem with self-referencing objects or arrays where `Gdn_Format::to()` will infinitely recurse when formatting in that case. This fix puts a guard against infinite recursion by keeping track of the objects and arrays that have already been formatted and not re-formatting them.

This also adds core support for the “display” format as a sanitized format. That’s our version of `htmlspecialchars()` with some extra processing. I think that’s an okay thing to do, but am asking reviewers to check it out.

Closes https://github.com/vanilla/support/issues/316.