### PR TITLE
Fix dropdown styles and improve DropDown storybook entry.

### DIFF
--- a/library/src/scripts/embeddedContent/StoryExampleDropDown.tsx
+++ b/library/src/scripts/embeddedContent/StoryExampleDropDown.tsx
@@ -24,67 +24,66 @@ import { MeBoxItemType } from "@library/headers/mebox/pieces/MeBoxDropDownItem";
 
 interface IProps extends Omit<IStoryTileAndTextProps, "children"> {
     flyoutType: FlyoutType;
+    defaultsOpen?: boolean;
 }
 
 export function StoryExampleDropDown(props: IProps) {
-    const device = useDevice();
+    const [isVisible, setVisible] = useState(!!props.defaultsOpen);
 
     return (
-        <DeviceProvider>
-            <DropDown
-                name={t("Article Options")}
-                renderLeft={true}
-                flyoutType={props.flyoutType}
-                openAsModal={device === Devices.MOBILE || device === Devices.XS}
-            >
-                <InsertUpdateMetas
-                    dateInserted={"2019-03-06 21:21:18"}
-                    dateUpdated={"2019-03-06 21:21:18"}
-                    insertUser={{
-                        userID: 1,
-                        name: "test",
-                        photoUrl: "test",
-                        dateLastActive: null,
-                    }}
-                    updateUser={{
-                        userID: 1,
-                        name: "test",
-                        photoUrl: "test",
-                        dateLastActive: null,
-                    }}
+        <DropDown
+            name={t("Article Options")}
+            flyoutType={props.flyoutType}
+            isVisible={isVisible}
+            onVisibilityChange={setVisible}
+        >
+            <InsertUpdateMetas
+                dateInserted={"2019-03-06 21:21:18"}
+                dateUpdated={"2019-03-06 21:21:18"}
+                insertUser={{
+                    userID: 1,
+                    name: "test",
+                    photoUrl: "test",
+                    dateLastActive: null,
+                }}
+                updateUser={{
+                    userID: 1,
+                    name: "test",
+                    photoUrl: "test",
+                    dateLastActive: null,
+                }}
+            />
+            <DropDownItemSeparator />
+            <DropDownItemLink name={t("Link 1")} to={"#"} />
+            <DropDownItemLink name={t("Link 2")} to={"#"} />
+            <DropDownItemLink name={t("Link 3")} to={"#"} />
+            <DropDownSection title={"Section Title"}>
+                <MeBoxDropDownItemList
+                    emptyMessage={t("You do not have any notifications yet.")}
+                    className="headerDropDown-notifications"
+                    type={MeBoxItemType.NOTIFICATION}
+                    data={[
+                        {
+                            type: MeBoxItemType.NOTIFICATION,
+                            message: "Sample message",
+                            photo: null,
+                            recordID: 1,
+                            timestamp: "2019-03-06 21:21:18",
+                            to: "#",
+                            unread: true,
+                        },
+                        {
+                            type: MeBoxItemType.NOTIFICATION,
+                            message: "Sample message",
+                            photo: null,
+                            recordID: 1,
+                            timestamp: "2019-03-06 21:21:18",
+                            to: "#",
+                            unread: false,
+                        },
+                    ]}
                 />
-                <DropDownItemSeparator />
-                <DropDownItemLink name={t("Link 1")} to={"#"} />
-                <DropDownItemLink name={t("Link 2")} to={"#"} />
-                <DropDownItemLink name={t("Link 3")} to={"#"} />
-                <DropDownSection title={"Section Title"}>
-                    <MeBoxDropDownItemList
-                        emptyMessage={t("You do not have any notifications yet.")}
-                        className="headerDropDown-notifications"
-                        type={MeBoxItemType.NOTIFICATION}
-                        data={[
-                            {
-                                type: MeBoxItemType.NOTIFICATION,
-                                message: "Sample message",
-                                photo: null,
-                                recordID: 1,
-                                timestamp: "2019-03-06 21:21:18",
-                                to: "#",
-                                unread: true,
-                            },
-                            {
-                                type: MeBoxItemType.NOTIFICATION,
-                                message: "Sample message",
-                                photo: null,
-                                recordID: 1,
-                                timestamp: "2019-03-06 21:21:18",
-                                to: "#",
-                                unread: false,
-                            },
-                        ]}
-                    />
-                </DropDownSection>
-            </DropDown>
-        </DeviceProvider>
+            </DropDownSection>
+        </DropDown>
     );
 }

--- a/library/src/scripts/embeddedContent/StoryExampleDropDownMessages.tsx
+++ b/library/src/scripts/embeddedContent/StoryExampleDropDownMessages.tsx
@@ -307,7 +307,6 @@ export default class StoryExampleMessagesDropDown extends React.Component<IProps
             <DropDown
                 id={this.id}
                 name={t("Messages")}
-                renderLeft={true}
                 buttonClassName={classesHeader.button}
                 contentsClassName={classesHeader.dropDownContents}
                 buttonContents={<MessagesCount open={this.state.open} compact={false} />}

--- a/library/src/scripts/embeddedContent/StoryExampleDropDownNotifications.tsx
+++ b/library/src/scripts/embeddedContent/StoryExampleDropDownNotifications.tsx
@@ -27,64 +27,55 @@ interface IProps extends Omit<IStoryTileAndTextProps, "children"> {
 }
 
 export function StoryExampleDropDown(props: IProps) {
-    const device = useDevice();
-
     return (
-        <DeviceProvider>
-            <DropDown
-                name={t("Article Options")}
-                renderLeft={true}
-                flyoutType={props.flyoutType}
-                openAsModal={device === Devices.MOBILE || device === Devices.XS}
-            >
-                <InsertUpdateMetas
-                    dateInserted={"2019-03-06 21:21:18"}
-                    dateUpdated={"2019-03-06 21:21:18"}
-                    insertUser={{
-                        userID: 1,
-                        name: "test",
-                        photoUrl: "test",
-                        dateLastActive: null,
-                    }}
-                    updateUser={{
-                        userID: 1,
-                        name: "test",
-                        photoUrl: "test",
-                        dateLastActive: null,
-                    }}
+        <DropDown name={t("Article Options")} flyoutType={props.flyoutType}>
+            <InsertUpdateMetas
+                dateInserted={"2019-03-06 21:21:18"}
+                dateUpdated={"2019-03-06 21:21:18"}
+                insertUser={{
+                    userID: 1,
+                    name: "test",
+                    photoUrl: "test",
+                    dateLastActive: null,
+                }}
+                updateUser={{
+                    userID: 1,
+                    name: "test",
+                    photoUrl: "test",
+                    dateLastActive: null,
+                }}
+            />
+            <DropDownItemSeparator />
+            <DropDownItemLink name={t("Link 1")} to={"#"} />
+            <DropDownItemLink name={t("Link 2")} to={"#"} />
+            <DropDownItemLink name={t("Link 3")} to={"#"} />
+            <DropDownSection title={"Section Title"}>
+                <MeBoxDropDownItemList
+                    emptyMessage={t("You do not have any notifications yet.")}
+                    className="headerDropDown-notifications"
+                    type={MeBoxItemType.NOTIFICATION}
+                    data={[
+                        {
+                            type: MeBoxItemType.NOTIFICATION,
+                            message: "Sample message",
+                            photo: null,
+                            recordID: 1,
+                            timestamp: "2019-03-06 21:21:18",
+                            to: "#",
+                            unread: true,
+                        },
+                        {
+                            type: MeBoxItemType.NOTIFICATION,
+                            message: "Sample message",
+                            photo: null,
+                            recordID: 1,
+                            timestamp: "2019-03-06 21:21:18",
+                            to: "#",
+                            unread: false,
+                        },
+                    ]}
                 />
-                <DropDownItemSeparator />
-                <DropDownItemLink name={t("Link 1")} to={"#"} />
-                <DropDownItemLink name={t("Link 2")} to={"#"} />
-                <DropDownItemLink name={t("Link 3")} to={"#"} />
-                <DropDownSection title={"Section Title"}>
-                    <MeBoxDropDownItemList
-                        emptyMessage={t("You do not have any notifications yet.")}
-                        className="headerDropDown-notifications"
-                        type={MeBoxItemType.NOTIFICATION}
-                        data={[
-                            {
-                                type: MeBoxItemType.NOTIFICATION,
-                                message: "Sample message",
-                                photo: null,
-                                recordID: 1,
-                                timestamp: "2019-03-06 21:21:18",
-                                to: "#",
-                                unread: true,
-                            },
-                            {
-                                type: MeBoxItemType.NOTIFICATION,
-                                message: "Sample message",
-                                photo: null,
-                                recordID: 1,
-                                timestamp: "2019-03-06 21:21:18",
-                                to: "#",
-                                unread: false,
-                            },
-                        ]}
-                    />
-                </DropDownSection>
-            </DropDown>
-        </DeviceProvider>
+            </DropDownSection>
+        </DropDown>
     );
 }

--- a/library/src/scripts/embeddedContent/dropDowns.story.tsx
+++ b/library/src/scripts/embeddedContent/dropDowns.story.tsx
@@ -33,7 +33,12 @@ story.add(
             <StoryContent>
                 <StoryHeading depth={1}>Drop Down</StoryHeading>
                 <StoryParagraph>
-                    Note that these dropdowns are automatically transformed into modals with the `openAsModal` property.
+                    Note that these dropdowns are automatically transformed into modals on mobile, and will
+                    automatically determine the direction they need to open into.
+                </StoryParagraph>
+                <StoryParagraph>They can be forced into being a modal with the `openAsModal` prop.</StoryParagraph>
+                <StoryParagraph>
+                    They can be forced into a particular open direction with the `openDirection` prop.
                 </StoryParagraph>
                 <StoryTiles>
                     <StoryTileAndTextCompact>

--- a/library/src/scripts/embeddedContent/dropDowns.story.tsx
+++ b/library/src/scripts/embeddedContent/dropDowns.story.tsx
@@ -16,103 +16,47 @@ import { FlyoutType } from "@library/flyouts/DropDown";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import StoryExampleMessagesDropDown from "@library/embeddedContent/StoryExampleDropDownMessages";
 import StorybookExampleNotificationsDropDown from "@library/headers/mebox/pieces/StorybookExampleNotificationsDropDown";
+import { layoutVariables } from "@library/layout/panelLayoutStyles";
 
 const story = storiesOf("Components", module);
 
-// Radio as tabs
+story.add(
+    "Dropdowns",
+    () => {
+        const doNothing = () => {
+            return;
+        };
 
-const meBoxData = {
-    currentUser: {
-        status: "SUCCESS",
-        data: {
-            userID: 2,
-            name: "admin",
-            photoUrl: "https://dev.vanilla.localhost/applications/dashboard/design/images/defaulticon.png",
-            dateLastActive: "2019-08-21T12:43:58+00:00",
-            isAdmin: true,
-            countUnreadNotifications: 0,
-            permissions: [
-                "activity.delete",
-                "activity.view",
-                "advancedNotifications.allow",
-                "applicants.manage",
-                "approval.require",
-                "articles.add",
-                "articles.manage",
-                "badges.manage",
-                "badges.moderate",
-                "badges.view",
-                "bans.manage",
-                "community.manage",
-                "community.moderate",
-                "conversations.add",
-                "conversations.moderate",
-                "csil.report",
-                "curation.manage",
-                "customUpload.allow",
-                "email.view",
-                "features.add",
-                "flag.add",
-                "groups.add",
-                "groups.moderate",
-                "kb.view",
-                "logs.delete",
-                "personalInfo.view",
-                "pockets.manage",
-                "polls.add",
-                "profilePicture.edit",
-                "profiles.edit",
-                "profiles.view",
-                "reactions.negative.add",
-                "reactions.positive.add",
-                "settings.view",
-                "signIn.allow",
-                "site.manage",
-                "staff.allow",
-                "tags.add",
-                "tokens.add",
-                "uploads.add",
-                "uploads.add",
-                "users.add",
-                "users.delete",
-                "users.edit",
-            ],
+        const toolBarColors = titleBarVariables().colors;
+
+        return (
+            <StoryContent>
+                <StoryHeading depth={1}>Drop Down</StoryHeading>
+                <StoryParagraph>
+                    Note that these dropdowns are automatically transformed into modals with the `openAsModal` property.
+                </StoryParagraph>
+                <StoryTiles>
+                    <StoryTileAndTextCompact>
+                        <StoryExampleDropDown
+                            defaultsOpen={true}
+                            flyoutType={FlyoutType.LIST}
+                            title={"As List"}
+                            text={"Expects all chidren to be `<li/>`"}
+                        />
+                    </StoryTileAndTextCompact>
+                    <StoryTileAndTextCompact backgroundColor={toolBarColors.bg}>
+                        <StoryExampleMessagesDropDown />
+                    </StoryTileAndTextCompact>
+                    <StoryTileAndTextCompact backgroundColor={toolBarColors.bg}>
+                        <StorybookExampleNotificationsDropDown />
+                    </StoryTileAndTextCompact>
+                </StoryTiles>
+            </StoryContent>
+        );
+    },
+    {
+        chromatic: {
+            viewports: [layoutVariables().panelLayoutBreakPoints.noBleed, layoutVariables().panelLayoutBreakPoints.xs],
         },
     },
-    className: "titleBar-meBox",
-    buttonClassName: "titleBar-button_fhn7z8",
-    contentClassName: "titleBar-dropDownContents titleBar-dropDownContents_fto1o3a",
-};
-
-story.add("Dropdowns", () => {
-    const doNothing = () => {
-        return;
-    };
-
-    const toolBarColors = titleBarVariables().colors;
-
-    return (
-        <StoryContent>
-            <StoryHeading depth={1}>Drop Down</StoryHeading>
-            <StoryParagraph>
-                Note that these dropdowns can easily be transformed into modals on mobile by using the
-                &quot;openAsModal&quot; property.
-            </StoryParagraph>
-            <StoryTiles>
-                <StoryTileAndTextCompact>
-                    <StoryExampleDropDown
-                        flyoutType={FlyoutType.LIST}
-                        title={"As List"}
-                        text={"Expects all chidren to be `<li/>`"}
-                    />
-                </StoryTileAndTextCompact>
-                <StoryTileAndTextCompact backgroundColor={toolBarColors.bg}>
-                    <StoryExampleMessagesDropDown />
-                </StoryTileAndTextCompact>
-                <StoryTileAndTextCompact backgroundColor={toolBarColors.bg}>
-                    <StorybookExampleNotificationsDropDown />
-                </StoryTileAndTextCompact>
-            </StoryTiles>
-        </StoryContent>
-    );
-});
+);

--- a/library/src/scripts/layout/bodyStyles.ts
+++ b/library/src/scripts/layout/bodyStyles.ts
@@ -24,6 +24,7 @@ export const bodyCSS = useThemeCache(() => {
         }),
         wordBreak: "break-word",
         overscrollBehavior: "none", // For IE -> https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior
+        height: percent(100),
     });
 
     cssRule("*", {

--- a/library/src/scripts/layout/panelLayoutStyles.ts
+++ b/library/src/scripts/layout/panelLayoutStyles.ts
@@ -13,6 +13,7 @@ import { important } from "csx/lib/strings";
 import { panelListClasses } from "@library/layout/panelListStyles";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { panelAreaClasses } from "@library/layout/panelAreaStyles";
+import { NestedCSSProperties } from "typestyle/lib/types";
 
 export const layoutVariables = useThemeCache(() => {
     const makeThemeVars = variableFactory("globalVariables");
@@ -88,17 +89,17 @@ export const layoutVariables = useThemeCache(() => {
     });
 
     const mediaQueries = () => {
-        const noBleed = styles => {
+        const noBleed = (styles: NestedCSSProperties, useMinWidth: boolean = true) => {
             return media(
                 {
                     maxWidth: px(panelLayoutBreakPoints.noBleed),
-                    minWidth: px(panelLayoutBreakPoints.twoColumn + 1),
+                    minWidth: useMinWidth ? px(panelLayoutBreakPoints.twoColumn + 1) : undefined,
                 },
                 styles,
             );
         };
 
-        const noBleedDown = styles => {
+        const noBleedDown = (styles: NestedCSSProperties) => {
             return media(
                 {
                     maxWidth: px(panelLayoutBreakPoints.noBleed),
@@ -107,7 +108,7 @@ export const layoutVariables = useThemeCache(() => {
             );
         };
 
-        const twoColumnsDown = styles => {
+        const twoColumnsDown = (styles: NestedCSSProperties) => {
             return media(
                 {
                     maxWidth: px(panelLayoutBreakPoints.twoColumn),
@@ -116,27 +117,27 @@ export const layoutVariables = useThemeCache(() => {
             );
         };
 
-        const twoColumns = styles => {
+        const twoColumns = (styles: NestedCSSProperties, useMinWidth: boolean = true) => {
             return media(
                 {
                     maxWidth: px(panelLayoutBreakPoints.twoColumn),
-                    minWidth: px(panelLayoutBreakPoints.oneColumn + 1),
+                    minWidth: useMinWidth ? px(panelLayoutBreakPoints.oneColumn + 1) : undefined,
                 },
                 styles,
             );
         };
 
-        const oneColumn = styles => {
+        const oneColumn = (styles: NestedCSSProperties, useMinWidth: boolean = true) => {
             return media(
                 {
                     maxWidth: px(panelLayoutBreakPoints.oneColumn),
-                    minWidth: px(panelLayoutBreakPoints.xs + 1),
+                    minWidth: useMinWidth ? px(panelLayoutBreakPoints.xs + 1) : undefined,
                 },
                 styles,
             );
         };
 
-        const oneColumnDown = styles => {
+        const oneColumnDown = (styles: NestedCSSProperties) => {
             return media(
                 {
                     maxWidth: px(panelLayoutBreakPoints.oneColumn),
@@ -145,7 +146,7 @@ export const layoutVariables = useThemeCache(() => {
             );
         };
 
-        const xs = styles => {
+        const xs = (styles: NestedCSSProperties) => {
             return media(
                 {
                     maxWidth: px(panelLayoutBreakPoints.xs),

--- a/library/src/scripts/storybook/StoryBookStyles.ts
+++ b/library/src/scripts/storybook/StoryBookStyles.ts
@@ -19,6 +19,7 @@ import { lineHeightAdjustment } from "@library/styles/textUtils";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { InputTextBlockBaseClass } from "@library/forms/InputBlock";
 import { iconVariables } from "@library/icons/iconClasses";
+import { layoutVariables } from "@library/layout/panelLayoutStyles";
 
 export const storyBookVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -190,6 +191,16 @@ export const storyBookClasses = useThemeCache(() => {
         flexWrap: "wrap",
         width: calc(`100% + ${unit(vars.gaps.tile * 8)}`),
         transform: translateX(`-${unit(vars.gaps.tile * 4)}`),
+        ...layoutVariables()
+            .mediaQueries()
+            .oneColumn(
+                {
+                    display: "block",
+                    width: percent(100),
+                    transform: "none",
+                },
+                false,
+            ),
     });
 
     const tile = style("tile", {

--- a/library/src/scripts/storybook/StoryContent.tsx
+++ b/library/src/scripts/storybook/StoryContent.tsx
@@ -7,6 +7,7 @@
 import React, { useEffect } from "react";
 import { storyBookClasses } from "@library/storybook/StoryBookStyles";
 import { clearUniqueIDCache } from "@library/utility/idUtils";
+import { DeviceProvider } from "@library/layout/DeviceContext";
 
 export interface IStoryHeadingProps {
     depth?: number;
@@ -24,5 +25,9 @@ export function StoryContent(props: IStoryHeadingProps) {
     }, []);
 
     const classes = storyBookClasses();
-    return <div className={classes.content}>{props.children}</div>;
+    return (
+        <DeviceProvider>
+            <div className={classes.content}>{props.children}</div>
+        </DeviceProvider>
+    );
 }

--- a/library/src/scripts/styles/styleUtils.ts
+++ b/library/src/scripts/styles/styleUtils.ts
@@ -57,7 +57,11 @@ export function styleFactory(componentName: string) {
             logDebug(styleObjs);
         }
 
-        return style({ $debugName: debugName }, ...styleObjs);
+        const hasNestedStyles = !!objects.find(obj => typeof obj === "object" && "$nest" in obj);
+
+        // Applying $unique generally gives better consistency, but it can cause issues with nested styles.
+        // As a result we don't apply it if the class has any nested styles.
+        return style({ $debugName: debugName, $unique: !hasNestedStyles }, ...styleObjs);
     }
 
     return styleCreator;


### PR DESCRIPTION
Fixes https://github.com/vanilla/knowledge/issues/1385

**Note that this PR updates the storybook intentionally. Please review the changes and approve those if they make sense.**

- Fixes dropdown styles by applied the `$unique: true` value to its style. The order of selectors was inconsistently being rendered without that. This now automatically gets applied to all simple styles in the style factory.
- Updates the story for the dropdown.
  - Automatically opens the first dropdown item.
  - Run in mobile and desktop viewports.
- Improves storybook utilities
  - Adds better types for media queries.
  - Allow media queries to opt-out of the min-width.
  - Update `<StoryTiles />` to switch to a single column on smaller layout sizes.