### PR TITLE
Improve focusing behaviour in modals

### DIFF
--- a/applications/dashboard/src/scripts/forms/DashboardSelect.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardSelect.tsx
@@ -11,6 +11,7 @@ import SelectOne, { IMenuPlacement } from "@library/forms/select/SelectOne";
 import { IComboBoxOption } from "@library/features/search/SearchBar";
 import { IFieldError } from "@library/@types/api/core";
 import ErrorMessages from "@library/forms/ErrorMessages";
+import Select from "react-select";
 
 interface IProps extends IMenuPlacement {
     options: IComboBoxOption[];
@@ -21,6 +22,7 @@ interface IProps extends IMenuPlacement {
     disabled?: boolean;
     isClearable?: boolean;
     errors?: IFieldError[];
+    selectRef?: React.RefObject<Select>;
 }
 
 export const DashboardSelect: React.FC<IProps> = (props: IProps) => {
@@ -39,6 +41,7 @@ export const DashboardSelect: React.FC<IProps> = (props: IProps) => {
                 disabled={props.disabled}
                 menuPlacement={props.menuPlacement}
                 isClearable={props.isClearable}
+                selectRef={props.selectRef}
             />
             {props.errors && <ErrorMessages errors={props.errors} />}
         </div>

--- a/library/src/scripts/forms/select/SelectOne.tsx
+++ b/library/src/scripts/forms/select/SelectOne.tsx
@@ -38,6 +38,7 @@ export interface ISelectOneProps extends IMenuPlacement {
     inputClassName?: string;
     isClearable?: boolean;
     describedBy?: string;
+    selectRef?: React.RefObject<Select>;
 }
 
 export enum MenuPlacement {
@@ -106,6 +107,7 @@ export default function SelectOne(props: ISelectOneProps) {
                     onFocus={() => setIsFocused(true)}
                     onBlur={() => setIsFocused(false)}
                     menuPlacement={props.menuPlacement ?? "auto"}
+                    ref={props.selectRef}
                 />
                 <Paragraph className={classesInputBlock.labelNote}>{props.noteAfterInput}</Paragraph>
                 <ErrorMessages id={errorID} errors={props.errors} />


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/pull/1388

- Update `<Modal />` to autodetect the `elementToFocusOnExit`. The prop will still be respected if passed though. This new default value is the last focused element before before we focus the first modal item.
- Update `<SelectOne />` and `<DashboardSelect />` to be able to pass a ref through.