### PR TITLE
Backport: Add state token to OAuth2 registrations

### DIFF
--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,1 +1,0 @@
-Deny from all

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,0 +1,1 @@
+Deny from all

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -453,7 +453,7 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
      * @return string Returns the sign-in URL.
      */
     final protected function realRegisterUri($state = []) {
-        $r = $this->generateAuthorizeUriWithStateToken($state, $this->provider()['RegisterUrl']);
+        $r = $this->generateAuthorizeUriWithStateToken($this->provider()['RegisterUrl'], $state);
         return $r;
     }
 
@@ -465,18 +465,18 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
      * @return string Endpoint of the provider.
      */
     protected function realAuthorizeUri(array $state = []): string {
-        $r = $this->generateAuthorizeUriWithStateToken($state, $this->provider()['AuthorizeUrl']);
+        $r = $this->generateAuthorizeUriWithStateToken($this->provider()['AuthorizeUrl'], $state);
         return $r;
     }
 
     /**
      * Add the state other needed params to the Authorize or Register URL.
      *
-     * @param array $state Data that will be sent to the provider containing, for example, the target URL.
      * @param string $uri Either a RegisterURL or an AuthorizeURL.
+     * @param array $state Data that will be sent to the provider containing, for example, the target URL.
      * @return string The URI of the provider's registration or authorization page with the state token attached.
      */
-    final protected function generateAuthorizeUriWithStateToken(array $state, string $uri = ''): string {
+    final protected function generateAuthorizeUriWithStateToken(string $uri, array $state): string {
         $provider = $this->provider();
         $redirect_uri = '/entry/' . $this->getProviderKey();
         $response_type = c('OAuth2.ResponseType', 'code');

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -831,8 +831,8 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
     /**
      * Redirect to provider's signin page if this is the default behaviour.
      *
-     * @param EntryController $sender.
-     * @param EntryController $args.
+     * @param EntryController $sender Entry Controller object.
+     * @param EntryController $args Array of Event Arguments from the Entry Controller.
      *
      * @return mixed|bool Return null if not configured.
      */
@@ -849,8 +849,8 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
     /**
      * Inject a sign-in icon into the ME menu.
      *
-     * @param Gdn_Controller $sender.
-     * @param Gdn_Controller $args.
+     * @param Gdn_Controller $sender Controller object that executes the page the button will be on..
+     * @param Gdn_Controller $args Array of arguments from the host controller.
      */
     public function base_beforeSignInButton_handler($sender, $args) {
         if (!$this->isConfigured() || $this->isDefault()) {

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -447,43 +447,42 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
     }
 
     /**
-     * Return the URL that sign-in buttons should use.
+     * Return the URL where the browser should be sent with all the necessary params to begin the authorization process.
      *
      * @param array $state Optionally provide an array of variables to be sent to the provider.
      * @return string Returns the sign-in URL.
      */
     final protected function realRegisterUri($state = []) {
-        $r = $this->generateAuthorizeUriWithStateToken($state, $this->provider()['RegisterUrl']);
+        $r = $this->generateAuthorizeUriWithStateToken($this->provider()['RegisterUrl'], $state);
         return $r;
     }
 
     /**
-     * Create the URI that can return an authorization.
+     * Return the URL where the browser should be sent with all the necessary params to begin the registration process.
      *
      * @param array $state Optionally provide an array of variables to be sent to the provider.
      *
      * @return string Endpoint of the provider.
      */
     protected function realAuthorizeUri(array $state = []): string {
-        $r = $this->generateAuthorizeUriWithStateToken($state, $this->provider()['AuthorizeUrl']);
+        $r = $this->generateAuthorizeUriWithStateToken( $this->provider()['AuthorizeUrl'], $state);
         return $r;
     }
 
     /**
-     * @param array $state
-     * @param string $baseUri
-     * @return string
+     * Add the state other needed params to the Authorize or Register URL.
+     *
+     * @param string $uri Either a RegisterURL or an AuthorizeURL.
+     * @param array $state Data that will be sent to the provider containing, for example, the target URL.
+     * @return string The URI of the provider's registration or authorization page with the state token attached.
      */
-    final protected function generateAuthorizeUriWithStateToken(array $state, string $baseUri = ''): string {
+    final protected function generateAuthorizeUriWithStateToken(string $uri = '', array $state): string {
         $provider = $this->provider();
-
-        $uri = $baseUri;
-        unset($state['context']);
         $redirect_uri = '/entry/' . $this->getProviderKey();
-        $reponse_type = c('OAuth2.ResponseType', 'code');
+        $response_type = c('OAuth2.ResponseType', 'code');
 
         $defaultParams = [
-            'response_type' => $reponse_type,
+            'response_type' => $response_type,
             'client_id' => val('AssociationKey', $provider),
             'redirect_uri' => url($redirect_uri, true),
             'scope' => val('AcceptedScope', $provider)

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -453,7 +453,7 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
      * @return string Returns the sign-in URL.
      */
     final protected function realRegisterUri($state = []) {
-        $r = $this->generateAuthorizeUriWithStateToken($this->provider()['RegisterUrl'], $state);
+        $r = $this->generateAuthorizeUriWithStateToken($state, $this->provider()['RegisterUrl']);
         return $r;
     }
 
@@ -465,18 +465,18 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
      * @return string Endpoint of the provider.
      */
     protected function realAuthorizeUri(array $state = []): string {
-        $r = $this->generateAuthorizeUriWithStateToken( $this->provider()['AuthorizeUrl'], $state);
+        $r = $this->generateAuthorizeUriWithStateToken($state, $this->provider()['AuthorizeUrl']);
         return $r;
     }
 
     /**
      * Add the state other needed params to the Authorize or Register URL.
      *
-     * @param string $uri Either a RegisterURL or an AuthorizeURL.
      * @param array $state Data that will be sent to the provider containing, for example, the target URL.
+     * @param string $uri Either a RegisterURL or an AuthorizeURL.
      * @return string The URI of the provider's registration or authorization page with the state token attached.
      */
-    final protected function generateAuthorizeUriWithStateToken(string $uri = '', array $state): string {
+    final protected function generateAuthorizeUriWithStateToken(array $state, string $uri = ''): string {
         $provider = $this->provider();
         $redirect_uri = '/entry/' . $this->getProviderKey();
         $response_type = c('OAuth2.ResponseType', 'code');


### PR DESCRIPTION
This is a backport of https://github.com/vanilla/vanilla/pull/9634

We have recently added the State Token to Authorization request. Most OAuth2 providers do not use a separate URL for users to register so we weren't adding the Token to the Registration request.

However, some customers do have a register button and would like to return the user back to the forum after registering them. This requires a State Token. This PR will modify the Registration URL by passing it through the same authorization redirect endpoint as the Authorization URL to generate and save the State Token and attach it to the request.