### PR TITLE
Fix forum classes being referenced in the core library

### DIFF
--- a/applications/vanilla/EmbeddedContent/Factories/CommentEmbedFactory.php
+++ b/applications/vanilla/EmbeddedContent/Factories/CommentEmbedFactory.php
@@ -5,39 +5,37 @@
  * @license GPL-2.0-only
  */
 
-namespace Vanilla\EmbeddedContent\Factories;
+namespace Vanilla\Forum\EmbeddedContent\Factories;
 
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\RequestInterface;
-use Vanilla\Contracts\Site\SiteSectionProviderInterface;
 use Vanilla\EmbeddedContent\AbstractEmbed;
-use Vanilla\EmbeddedContent\AbstractEmbedFactory;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
+use Vanilla\EmbeddedContent\Factories\AbstractOwnSiteEmbedFactory;
 use Vanilla\Site\SiteSectionModel;
-use Vanilla\Web\Asset\SiteAsset;
 
 /**
  * Quote embed factory for comments.
  */
-class DiscussionEmbedFactory extends AbstractOwnSiteEmbedFactory {
+final class CommentEmbedFactory extends AbstractOwnSiteEmbedFactory {
 
-    /** @var \DiscussionsApiController */
-    private $discussionApi;
+    /** @var \CommentsApiController */
+    private $commentApi;
 
     /**
      * DI
      *
      * @param RequestInterface $request
      * @param SiteSectionModel $siteSectionModel
-     * @param \DiscussionsApiController $discussionApi
+     * @param \CommentsApiController $commentApi
      */
     public function __construct(
         RequestInterface $request,
         SiteSectionModel $siteSectionModel,
-        \DiscussionsApiController $discussionApi
+        \CommentsApiController $commentApi
     ) {
         parent::__construct($request, $siteSectionModel);
-        $this->discussionApi = $discussionApi;
+        $this->commentApi = $commentApi;
     }
 
     /**
@@ -45,7 +43,7 @@ class DiscussionEmbedFactory extends AbstractOwnSiteEmbedFactory {
      */
     protected function getSupportedPathRegex(string $domain = ''): string {
         $regexRoot = $this->getRegexRoot();
-        return "/^$regexRoot\/discussion\/(?<discussionID>\d+)/i";
+        return "/^$regexRoot\/discussion\/comment\/(?<commentID>\d+)/i";
     }
 
     /**
@@ -54,16 +52,16 @@ class DiscussionEmbedFactory extends AbstractOwnSiteEmbedFactory {
     public function createEmbedForUrl(string $url): AbstractEmbed {
         $path = parse_url($url, PHP_URL_PATH);
         preg_match($this->getSupportedPathRegex(), $path, $matches);
-        $id = $matches['discussionID'] ?? null;
+        $id = $matches['commentID'] ?? null;
 
         if ($id === null) {
-            throw new NotFoundException('Discussion');
+            throw new NotFoundException('Comment');
         }
 
-        $discussion = $this->discussionApi->get_quote($id);
-        $data = $discussion + [
-                'embedType' => QuoteEmbed::TYPE,
-            ];
+        $comment = $this->commentApi->get_quote($id);
+        $data = $comment + [
+            'embedType' => QuoteEmbed::TYPE,
+        ];
         return new QuoteEmbed($data);
     }
 }

--- a/applications/vanilla/EmbeddedContent/Factories/DiscussionEmbedFactory.php
+++ b/applications/vanilla/EmbeddedContent/Factories/DiscussionEmbedFactory.php
@@ -5,36 +5,37 @@
  * @license GPL-2.0-only
  */
 
-namespace Vanilla\EmbeddedContent\Factories;
+namespace Vanilla\Forum\EmbeddedContent\Factories;
 
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\RequestInterface;
 use Vanilla\EmbeddedContent\AbstractEmbed;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
+use Vanilla\EmbeddedContent\Factories\AbstractOwnSiteEmbedFactory;
 use Vanilla\Site\SiteSectionModel;
 
 /**
  * Quote embed factory for comments.
  */
-final class CommentEmbedFactory extends AbstractOwnSiteEmbedFactory {
+class DiscussionEmbedFactory extends AbstractOwnSiteEmbedFactory {
 
-    /** @var \CommentsApiController */
-    private $commentApi;
+    /** @var \DiscussionsApiController */
+    private $discussionApi;
 
     /**
      * DI
      *
      * @param RequestInterface $request
      * @param SiteSectionModel $siteSectionModel
-     * @param \CommentsApiController $commentApi
+     * @param \DiscussionsApiController $discussionApi
      */
     public function __construct(
         RequestInterface $request,
         SiteSectionModel $siteSectionModel,
-        \CommentsApiController $commentApi
+        \DiscussionsApiController $discussionApi
     ) {
         parent::__construct($request, $siteSectionModel);
-        $this->commentApi = $commentApi;
+        $this->discussionApi = $discussionApi;
     }
 
     /**
@@ -42,7 +43,7 @@ final class CommentEmbedFactory extends AbstractOwnSiteEmbedFactory {
      */
     protected function getSupportedPathRegex(string $domain = ''): string {
         $regexRoot = $this->getRegexRoot();
-        return "/^$regexRoot\/discussion\/comment\/(?<commentID>\d+)/i";
+        return "/^$regexRoot\/discussion\/(?<discussionID>\d+)/i";
     }
 
     /**
@@ -51,16 +52,16 @@ final class CommentEmbedFactory extends AbstractOwnSiteEmbedFactory {
     public function createEmbedForUrl(string $url): AbstractEmbed {
         $path = parse_url($url, PHP_URL_PATH);
         preg_match($this->getSupportedPathRegex(), $path, $matches);
-        $id = $matches['commentID'] ?? null;
+        $id = $matches['discussionID'] ?? null;
 
         if ($id === null) {
-            throw new NotFoundException('Comment');
+            throw new NotFoundException('Discussion');
         }
 
-        $comment = $this->commentApi->get_quote($id);
-        $data = $comment + [
-            'embedType' => QuoteEmbed::TYPE,
-        ];
+        $discussion = $this->discussionApi->get_quote($id);
+        $data = $discussion + [
+                'embedType' => QuoteEmbed::TYPE,
+            ];
         return new QuoteEmbed($data);
     }
 }

--- a/applications/vanilla/bootstrap.php
+++ b/applications/vanilla/bootstrap.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+use Vanilla\EmbeddedContent\EmbedService;
+use Vanilla\Forum\EmbeddedContent\Factories\CommentEmbedFactory;
+use Vanilla\Forum\EmbeddedContent\Factories\DiscussionEmbedFactory;
+use \Garden\Container;
+
+Gdn::getContainer()
+    ->rule(EmbedService::class)
+    ->addCall('registerFactory', [
+        'embedFactory' => new Container\Reference(DiscussionEmbedFactory::class),
+        'priority' => EmbedService::PRIORITY_NORMAL
+    ])
+    ->addCall('registerFactory', [
+        'embedFactory' => new Container\Reference(CommentEmbedFactory::class),
+        'priority' => EmbedService::PRIORITY_NORMAL
+    ]);

--- a/applications/vanilla/tests/EmbeddedContent/Factories/CommentEmbedFactoryTest.php
+++ b/applications/vanilla/tests/EmbeddedContent/Factories/CommentEmbedFactoryTest.php
@@ -5,11 +5,11 @@
  * @license GPL-2.0-only
  */
 
-namespace VanillaTests\Library\EmbeddedContent\Factories;
+namespace VanillaTests\Forum\EmbeddedContent\Factories;
 
 use Garden\Web\RequestInterface;
 use Vanilla\Contracts\Site\SiteSectionInterface;
-use Vanilla\EmbeddedContent\Factories\DiscussionEmbedFactory;
+use Vanilla\Forum\EmbeddedContent\Factories\CommentEmbedFactory;
 use Vanilla\Site\DefaultSiteSection;
 use Vanilla\Site\SiteSectionModel;
 use VanillaTests\APIv2\AbstractAPIv2Test;
@@ -18,9 +18,9 @@ use VanillaTests\Fixtures\MockSiteSection;
 use VanillaTests\Fixtures\MockSiteSectionProvider;
 
 /**
- * Tests for the discussion/quote embed.
+ * Tests for the comment/quote embed.
  */
-class DiscussionEmbedFactoryTest extends AbstractAPIv2Test {
+class CommentEmbedFactoryTest extends AbstractAPIv2Test {
 
     /**
      * Test that all domain types are supported.
@@ -32,7 +32,7 @@ class DiscussionEmbedFactoryTest extends AbstractAPIv2Test {
      * @dataProvider supportedDomainsProvider
      */
     public function testSupportedDomains(string $urlToTest, bool $isSupported, string $customRoot = '', array $siteSections = []) {
-        $discussionApi = $this->createMock(\DiscussionsApiController::class);
+        $commentsApi = $this->createMock(\CommentsApiController::class);
 
         /** @var RequestInterface $request */
         $request = self::container()->get(RequestInterface::class);
@@ -43,7 +43,7 @@ class DiscussionEmbedFactoryTest extends AbstractAPIv2Test {
         $sectionModel = new SiteSectionModel(new MockConfig());
         $sectionModel->addProvider($sectionProvider);
 
-        $factory = new DiscussionEmbedFactory($request, $sectionModel, $discussionApi);
+        $factory = new CommentEmbedFactory($request, $sectionModel, $commentsApi);
 
         $this->assertEquals($isSupported, $factory->canHandleUrl($urlToTest));
     }
@@ -56,46 +56,46 @@ class DiscussionEmbedFactoryTest extends AbstractAPIv2Test {
         return [
             // Allowed
             'Correct' => [
-                $bootstrapBase . '/discussion/41342',
+                $bootstrapBase . '/discussion/comment/41342',
                 true
             ],
             // Not allowed
             'Correct webroot' => [
-                $bootstrapBase . '/actual-root/discussion/41342',
+                $bootstrapBase . '/actual-root/discussion/comment/41342',
                 true,
                 '/actual-root'
             ],
             'Correct section' => [
-                $bootstrapBase . '/actual-root/actual-section/discussion/41342',
+                $bootstrapBase . '/actual-root/actual-section/discussion/comment/41342',
                 true,
                 '/actual-root',
                 [new MockSiteSection('test', 'en', '/actual-section', 'test1', 'test1')]
             ],
             // Not allowed
             'Wrong webroot' => [
-                $bootstrapBase . '/wrong-root/discussion/41342',
+                $bootstrapBase . '/wrong-root/discussion/comment/41342',
                 false,
                 '/actual-root'
             ],
             'Wrong section' => [
-                $bootstrapBase . '/actual-root/actual-section/discussion/41342',
+                $bootstrapBase . '/actual-root/actual-section/discussion/comment/41342',
                 false,
                 '/actual-root',
             ],
             'wrong host' => [
-                'https://otherdomain.com/discussion/41342',
+                'https://otherdomain.com/discussion/comment/41342',
                 false
             ],
             'wrong url (typo)' => [
-                $bootstrapBase . '/discussions/41342',
+                $bootstrapBase . '/discussions/comments/41342',
                 false
             ],
-            'Wrong url (is a comment)' => [
-                $bootstrapBase . '/discussion/comment/41342',
+            'Wrong url (discussion)' => [
+                $bootstrapBase . '/discussion/41342',
                 false
             ],
             'bad ID' => [
-                $bootstrapBase . '/discussion/asdfads',
+                $bootstrapBase . '/discussion/comment/asdfads',
                 false
             ],
         ];

--- a/applications/vanilla/tests/EmbeddedContent/Factories/DiscussionEmbedFactoryTest.php
+++ b/applications/vanilla/tests/EmbeddedContent/Factories/DiscussionEmbedFactoryTest.php
@@ -5,11 +5,11 @@
  * @license GPL-2.0-only
  */
 
-namespace VanillaTests\Library\EmbeddedContent\Factories;
+namespace VanillaTests\Forum\EmbeddedContent\Factories;
 
 use Garden\Web\RequestInterface;
 use Vanilla\Contracts\Site\SiteSectionInterface;
-use Vanilla\EmbeddedContent\Factories\CommentEmbedFactory;
+use Vanilla\Forum\EmbeddedContent\Factories\DiscussionEmbedFactory;
 use Vanilla\Site\DefaultSiteSection;
 use Vanilla\Site\SiteSectionModel;
 use VanillaTests\APIv2\AbstractAPIv2Test;
@@ -18,9 +18,9 @@ use VanillaTests\Fixtures\MockSiteSection;
 use VanillaTests\Fixtures\MockSiteSectionProvider;
 
 /**
- * Tests for the comment/quote embed.
+ * Tests for the discussion/quote embed.
  */
-class CommentEmbedFactoryTest extends AbstractAPIv2Test {
+class DiscussionEmbedFactoryTest extends AbstractAPIv2Test {
 
     /**
      * Test that all domain types are supported.
@@ -32,7 +32,7 @@ class CommentEmbedFactoryTest extends AbstractAPIv2Test {
      * @dataProvider supportedDomainsProvider
      */
     public function testSupportedDomains(string $urlToTest, bool $isSupported, string $customRoot = '', array $siteSections = []) {
-        $commentsApi = $this->createMock(\CommentsApiController::class);
+        $discussionApi = $this->createMock(\DiscussionsApiController::class);
 
         /** @var RequestInterface $request */
         $request = self::container()->get(RequestInterface::class);
@@ -43,7 +43,7 @@ class CommentEmbedFactoryTest extends AbstractAPIv2Test {
         $sectionModel = new SiteSectionModel(new MockConfig());
         $sectionModel->addProvider($sectionProvider);
 
-        $factory = new CommentEmbedFactory($request, $sectionModel, $commentsApi);
+        $factory = new DiscussionEmbedFactory($request, $sectionModel, $discussionApi);
 
         $this->assertEquals($isSupported, $factory->canHandleUrl($urlToTest));
     }
@@ -56,46 +56,46 @@ class CommentEmbedFactoryTest extends AbstractAPIv2Test {
         return [
             // Allowed
             'Correct' => [
-                $bootstrapBase . '/discussion/comment/41342',
+                $bootstrapBase . '/discussion/41342',
                 true
             ],
             // Not allowed
             'Correct webroot' => [
-                $bootstrapBase . '/actual-root/discussion/comment/41342',
+                $bootstrapBase . '/actual-root/discussion/41342',
                 true,
                 '/actual-root'
             ],
             'Correct section' => [
-                $bootstrapBase . '/actual-root/actual-section/discussion/comment/41342',
+                $bootstrapBase . '/actual-root/actual-section/discussion/41342',
                 true,
                 '/actual-root',
                 [new MockSiteSection('test', 'en', '/actual-section', 'test1', 'test1')]
             ],
             // Not allowed
             'Wrong webroot' => [
-                $bootstrapBase . '/wrong-root/discussion/comment/41342',
+                $bootstrapBase . '/wrong-root/discussion/41342',
                 false,
                 '/actual-root'
             ],
             'Wrong section' => [
-                $bootstrapBase . '/actual-root/actual-section/discussion/comment/41342',
+                $bootstrapBase . '/actual-root/actual-section/discussion/41342',
                 false,
                 '/actual-root',
             ],
             'wrong host' => [
-                'https://otherdomain.com/discussion/comment/41342',
+                'https://otherdomain.com/discussion/41342',
                 false
             ],
             'wrong url (typo)' => [
-                $bootstrapBase . '/discussions/comments/41342',
+                $bootstrapBase . '/discussions/41342',
                 false
             ],
-            'Wrong url (discussion)' => [
-                $bootstrapBase . '/discussion/41342',
+            'Wrong url (is a comment)' => [
+                $bootstrapBase . '/discussion/comment/41342',
                 false
             ],
             'bad ID' => [
-                $bootstrapBase . '/discussion/comment/asdfads',
+                $bootstrapBase . '/discussion/asdfads',
                 false
             ],
         ];

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -343,10 +343,6 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->rule(\Emoji::class)
     ->setShared(true)
 
-    ->rule(Vanilla\Formatting\Embeds\EmbedManager::class)
-    ->addCall('addCoreEmbeds')
-    ->setShared(true)
-
     ->rule(\Vanilla\EmbeddedContent\EmbedService::class)
     ->addCall('addCoreEmbeds')
     ->setShared(true)

--- a/library/Vanilla/EmbeddedContent/EmbedService.php
+++ b/library/Vanilla/EmbeddedContent/EmbedService.php
@@ -8,8 +8,6 @@ namespace Vanilla\EmbeddedContent;
 
 use Garden\Container;
 use Garden\Schema\ValidationException;
-use Vanilla\Addon;
-use Vanilla\AddonManager;
 use Vanilla\EmbeddedContent\Embeds\CodePenEmbed;
 use Vanilla\EmbeddedContent\Embeds\ErrorEmbed;
 use Vanilla\EmbeddedContent\Embeds\FileEmbed;
@@ -189,14 +187,10 @@ class EmbedService implements EmbedCreatorInterface {
             ->registerEmbed(FileEmbed::class, FileEmbed::TYPE)
             // Internal Vanilla quote embed.
             ->registerEmbed(QuoteEmbed::class, QuoteEmbed::TYPE)
-            ->registerFilter($dic->get(QuoteEmbedFilter::class));
-
-        /* @var AddonManager $addonManager */
-        $addonManager = $dic->get(AddonManager::class);
-        if ($addonManager->isEnabled('vanilla', Addon::TYPE_ADDON)) {
-            $this->registerFactory($dic->get(DiscussionEmbedFactory::class));
-            $this->registerFactory($dic->get(CommentEmbedFactory::class));
-        }
+            ->registerFilter($dic->get(QuoteEmbedFilter::class))
+            ->registerFactory($dic->get(DiscussionEmbedFactory::class))
+            ->registerFactory($dic->get(CommentEmbedFactory::class))
+        ;
     }
 
     /**

--- a/library/Vanilla/EmbeddedContent/EmbedService.php
+++ b/library/Vanilla/EmbeddedContent/EmbedService.php
@@ -18,8 +18,6 @@ use Vanilla\EmbeddedContent\Embeds\LinkEmbed;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbedFilter;
 use Vanilla\EmbeddedContent\Factories\CodePenEmbedFactory;
-use Vanilla\EmbeddedContent\Factories\CommentEmbedFactory;
-use Vanilla\EmbeddedContent\Factories\DiscussionEmbedFactory;
 use Vanilla\EmbeddedContent\Factories\GiphyEmbedFactory;
 use Vanilla\EmbeddedContent\Factories\ImgurEmbedFactory;
 use Vanilla\EmbeddedContent\Factories\ScrapeEmbedFactory;
@@ -188,8 +186,6 @@ class EmbedService implements EmbedCreatorInterface {
             // Internal Vanilla quote embed.
             ->registerEmbed(QuoteEmbed::class, QuoteEmbed::TYPE)
             ->registerFilter($dic->get(QuoteEmbedFilter::class))
-            ->registerFactory($dic->get(DiscussionEmbedFactory::class))
-            ->registerFactory($dic->get(CommentEmbedFactory::class))
         ;
     }
 

--- a/library/Vanilla/EmbeddedContent/Factories/AbstractOwnSiteEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/AbstractOwnSiteEmbedFactory.php
@@ -61,7 +61,7 @@ abstract class AbstractOwnSiteEmbedFactory extends AbstractEmbedFactory {
             }
         }
         $siteSectionRegex = count($allowedSlugs) > 0 ?
-            '(' . implode('|', $allowedSlugs) . ')'
+            '(' . implode('|', $allowedSlugs) . ')?'
             : '';
         $root = $this->request->getAssetRoot() . $siteSectionRegex;
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/dev-inter-ops/issues/36

The Vanilla application is optional, so I've removed references to it from the `EmbedService`.

- `DiscussionEmbedFactory` and `CommentEmbedFactory` moved to `applications/vanilla`.
- Added a `bootstrap.php` file with registration of these factories only when the forum app is enabled.
- Moved the tests to the forum (vanilla) app.
- Removed a reference to the `EmbedManager` in the main bootstrap. This class doesn't exist anymore for a few releases, and was removed in favour of the `EmbedService`.