### PR TITLE
Fix editor syntax highlighting moving cursor and spiking CPU

### DIFF
--- a/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
+++ b/plugins/rich-editor/src/scripts/editor/EditorContent.tsx
@@ -149,8 +149,11 @@ function useInitialValue() {
 
     useEffect(() => {
         if (quill && initialValue && initialValue.length > 0) {
-            if (prevInitialValue !== initialValue && prevReinitialize !== reinitialize) {
+            const initializeChangedToTrue = !prevReinitialize && reinitialize;
+            if (prevInitialValue !== initialValue && initializeChangedToTrue) {
                 quill.setContents(initialValue);
+                quill.setSelection(0, 0);
+                quill.history.clear();
             }
         }
     }, [quill, initialValue, reinitialize, prevInitialValue, prevReinitialize]);
@@ -347,20 +350,14 @@ function useUpdateHandler() {
             if (!quill) {
                 return;
             }
-            if (onChange && type === Quill.events.TEXT_CHANGE && source !== Quill.sources.SILENT) {
+            if (source === Quill.sources.SILENT) {
+                return;
+            }
+            if (onChange && type === Quill.events.TEXT_CHANGE) {
                 onChange(getOperations());
             }
 
-            let shouldDispatch = false;
-            if (type === Quill.events.SELECTION_CHANGE) {
-                shouldDispatch = true;
-            } else if (source !== Quill.sources.SILENT) {
-                shouldDispatch = true;
-            }
-
-            if (shouldDispatch) {
-                updateSelection(quill.getSelection());
-            }
+            updateSelection(quill.getSelection());
         };
         return throttle(updateFn, 1000 / 60); // Throttle to 60 FPS.
     }, [quill, onChange, getOperations, updateSelection]);

--- a/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
+++ b/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
@@ -110,10 +110,15 @@ export default class KeyboardBindings {
      */
     public handleCodeBlockEnter = (range: RangeStatic) => {
         const [line] = this.quill.getLine(range.index);
+        if (!(line instanceof CodeBlockBlot)) {
+            return;
+        }
 
         const { textContent } = line.domNode;
-        const currentLineIsEmpty = /\n\n\n$/.test(textContent);
-        if (!currentLineIsEmpty) {
+        const codeEndsWithNewlines = /\n\n\n$/.test(textContent ?? "");
+        const endOfLine = line.offset(this.quill.scroll) + line.length() - 1;
+
+        if (!codeEndsWithNewlines || range.index !== endOfLine) {
             return true;
         }
 

--- a/plugins/rich-editor/src/scripts/quill/SyntaxModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/SyntaxModule.ts
@@ -4,41 +4,100 @@
  * @license GPL-2.0-only
  */
 
-import BaseSyntaxModule from "quill/modules/syntax";
 import Quill from "quill/core";
 import CodeBlockBlot from "@rich-editor/quill/blots/blocks/CodeBlockBlot";
+import { CodeToken } from "quill/modules/syntax";
+import Module from "quill/core/module";
+import throttle from "lodash/throttle";
 
 /**
- * Override the core syntax module to register our own code block.
+ * Module that triggers syntax highlighting in code blocks.
+ * The actual code block highlighting logic lives in CodeBlockBlot.
+ *
+ * We use this instead of the built-in quill 1.x syntax module for the following reasons:
+ *
+ * - Only trigger on text change instead of constantly in a loop.
+ * - Throttle highlights for performance reasons.
+ * - Ensure we don't jump the cursor position around while highlighting.
+ *
+ * Maybe some of this won't be necessary once we are on the quill 2.x branch.
  */
-export default class SyntaxModule extends BaseSyntaxModule {
+export default class SyntaxModule extends Module {
+    /** The throttle duration for the highlighting. */
+    public static THROTTLE_DURATION = 500; // milliseconds
+
+    /**
+     * Register our code blots with quill.
+     */
     public static register() {
-        super.register();
+        Quill.register(CodeToken, true);
         Quill.register(CodeBlockBlot, true);
     }
 
     /**
-     * Overridden to ensure quill has focus before resetting the selection
-     * because quill selection does not always get moved away from quill when focus moves.
-     *
-     * For example opening the paragraph menu retains selection, but the setSelection at the end here
-     * would clear remove focus from the paragraph menu.
-     *
-     * Check if this needs to be removed with Quill 2.0.
+     * @inheritdoc
      */
-    public highlight() {
-        if ((this.quill as any).selection.composing) {
-            return;
-        }
-        this.quill.update(Quill.sources.USER);
-        const range = this.quill.getSelection();
-        const hasFocus = this.quill.hasFocus();
-        (this.quill as any).scroll.descendants(CodeBlockBlot).forEach(code => {
-            code.highlight(this.options.highlight);
-        });
-        this.quill.update(Quill.sources.SILENT);
-        if (range != null && hasFocus) {
-            this.quill.setSelection(range, Quill.sources.SILENT);
-        }
+    public constructor(public quill: Quill, options) {
+        super(quill, options);
+        this.setupEventHandler();
     }
+
+    /**
+     * Setup the text event handler that triggers changes.
+     */
+    private setupEventHandler() {
+        this.quill.on("text-change", () => {
+            requestAnimationFrame(() => {
+                this.highlight();
+            });
+        });
+    }
+
+    /**
+     * Apply syntax highlighting to code blots.
+     *
+     * This method is throttled to only occur on the trailing edge of THROTTLE_DURATION
+     * The reasoning for only the trailing edge is that ideally we don't want to cause
+     * any initial lag spike while the user is editing a code block.
+     *
+     * - Update quill (ensure all operations are persisted).
+     * - Saves the existing selection.
+     * - Bails out if there are no code blocks.
+     * - Gets all the code blots.
+     * - Writes out all the code blocks w/ highlighting.
+     * - Update quill again (silently this time).
+     * - Silently put the cursor back because the highlighting might have moved it.
+     */
+    public highlight = throttle(
+        () => {
+            if ((this.quill as any).selection.composing) {
+                return;
+            }
+            this.quill.update(Quill.sources.USER);
+            const selection = this.quill.getSelection();
+            const codeBlocks = (this.quill.scroll.descendants(
+                blot => blot instanceof CodeBlockBlot,
+                0,
+                this.quill.scroll.length() - 1,
+            ) as any) as CodeBlockBlot[];
+
+            if (codeBlocks.length === 0) {
+                return; // Nothing to do here.
+            }
+
+            codeBlocks.forEach(code => {
+                code.highlight();
+            });
+            this.quill.update(Quill.sources.SILENT);
+            const hasFocus = this.quill.hasFocus();
+            if (selection && hasFocus) {
+                this.quill.setSelection(selection, Quill.sources.SILENT);
+            }
+        },
+        SyntaxModule.THROTTLE_DURATION,
+        {
+            leading: false,
+            trailing: true,
+        },
+    );
 }

--- a/plugins/rich-editor/src/scripts/quill/blots/blocks/CodeBlockBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/blocks/CodeBlockBlot.ts
@@ -6,7 +6,7 @@
 
 import BaseCodeBlock from "quill/formats/code";
 import { CodeBlock } from "quill/modules/syntax";
-import { highlightText } from "@library/content/code";
+import { highlightTextSync } from "@library/content/code";
 
 export default class CodeBlockBlot extends CodeBlock {
     public static create(value) {
@@ -26,11 +26,15 @@ export default class CodeBlockBlot extends CodeBlock {
         let text = this.domNode.textContent;
         if (text && this.cachedText !== text) {
             if (text.trim().length > 0 || this.cachedText == null) {
-                highlightText(text).then(result => {
+                const result = highlightTextSync(text);
+                if (result !== null) {
                     this.domNode.innerHTML = result;
                     this.domNode.normalize();
                     this.attach();
-                });
+                } else {
+                    // Highlighter loads asynchonrously but we need to return synchrously.
+                    // Do nothing because the highlighter isn't loaded yet.
+                }
             }
             this.cachedText = text;
         }


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/9440
Fixes https://github.com/vanilla/knowledge/issues/1347

There were a few issues causing the cursor to jump around and CPU usage to spike.

1. When initializing a synchronized editor `useInitialValue()` was re-initializing too often due to some faulty logic. Additionally it was not clearing history or setting the initial selection. This could cause the selection to jump when first editing a code block.

2. `SyntaxModule` has some logic to preserve the selection after a highlight. Unfortunately we made `highlightText` asynchronous for a dynamic import. This method **has to work synchronously**.
    - If we awaited the async value we would likely be setting back the old selection value or content.

3. Our editor UI synchronizer was listening to `Quill.sources.SILENT` events. This was a mistake, because being silent, they should not cause any UI updates.

## The fixes

- Update `useInitialValue()` to clear history, and reset only when the `reinitialize` value has changed from `false|undefined` -> `true` (or starts as true).
- Create a synchronous highlighter function `highlightTextSync()`.
    - Uses an already downloaded highlightJS to highlight code synchronously.
    - Starts loading highlightJS if it's not loaded yet.
    - Returns null if the library is not loaded.
- Update `CodeBlockBlot.highlight()` to have a synchronous control flow.
    - Makes no changes while the highlight function returns null.
- Update the editor UI synchronizer to ignore silent updates.


## Testing

1. Load up rich editor on the forum or knowledge base.
2. Create a code block.
3. Start putting a bunch of text in it.
4. Nothing should "jump around".

I also did some testing in firefox to make sure https://github.com/vanilla/vanilla/issues/9440 was resolved.