### PR TITLE
Apply a max-height to code blocks

### DIFF
--- a/library/src/scripts/content/userContentStyles.ts
+++ b/library/src/scripts/content/userContentStyles.ts
@@ -61,6 +61,7 @@ export const userContentVariables = useThemeCache(() => {
         lineHeight: 1.45,
         fg: blocks.fg,
         bg: blocks.bg,
+        maxHeight: 500,
     });
 
     const list = makeThemeVars("list", {
@@ -291,6 +292,8 @@ export const userContentClasses = useThemeCache(() => {
                 left: vars.codeBlock.paddingHorizontal,
                 right: vars.codeBlock.paddingHorizontal,
             }),
+            maxHeight: unit(vars.codeBlock.maxHeight),
+            overflow: "auto",
         },
     };
 

--- a/plugins/rich-editor/src/scripts/quill/components/codeBlockStyles.ts
+++ b/plugins/rich-editor/src/scripts/quill/components/codeBlockStyles.ts
@@ -11,6 +11,7 @@ import { colorOut, modifyColorBasedOnLightness } from "@library/styles/styleHelp
 import { em, percent } from "csx";
 import { paddings } from "@library/styles/styleHelpersfPadding";
 import { userContentVariables } from "@library/content/userContentStyles";
+import { unit } from "@library/styles/styleHelpers";
 
 export const codeBlockVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -53,6 +54,7 @@ export const codeBlockVariables = useThemeCache(() => {
         paddings: {
             all: globalVars.userContent.font.sizes.default,
         },
+        maxHeight: variablesUserContent.codeBlock.maxHeight,
     });
 
     return {
@@ -100,6 +102,8 @@ export const codeBlockCSS = useThemeCache(() => {
                 borderRadius: vars.block.border.radius,
                 color: colorOut(vars.block.fg),
                 backgroundColor: colorOut(vars.block.bg),
+                maxHeight: unit(vars.block.maxHeight),
+                overflow: "auto",
             },
         },
     });


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/8314

- Applies a max-height to code blocks w/ overflow scrolling. The variable defaults to 600, which seems to be a sane maximum.
- This max-height is similar to what Github uses.
- The code block styles seem to be split into 2 places. Not sure what's up with that. I applied to both. @slafleche Maybe you can clarify?