### PR TITLE
Fix IE11 bugs in Rich Editor

### DIFF
--- a/library/src/scripts/layout/frame/frameStyles.ts
+++ b/library/src/scripts/layout/frame/frameStyles.ts
@@ -85,7 +85,7 @@ export const frameClasses = useThemeCache(() => {
         minHeight: 0, // https://bugs.chromium.org/p/chromium/issues/detail?id=927066
         $nest: {
             [`.${bodyWrap}`]: {
-                flex: 1,
+                flex: "1 0 auto",
                 overflowY: "auto",
             },
         },

--- a/packages/vanilla-polyfill/index.js
+++ b/packages/vanilla-polyfill/index.js
@@ -14,6 +14,7 @@ import "@webcomponents/webcomponentsjs";
 polyfillClosest();
 polyfillRemove();
 polyfillCustomEvent();
+polyfillStringNormalize();
 
 /**
  * Polyfill Element.closest() on IE 9+.
@@ -96,4 +97,18 @@ function polyfillCustomEvent() {
     CustomEvent.prototype = window.Event.prototype;
 
     window.CustomEvent = CustomEvent;
+}
+
+/**
+ * A library like unorm would be a lot more robust but is huge!
+ * Users of older browsers just don't get full string normalization.
+ */
+function polyfillStringNormalize() {
+    if (typeof String.prototype.normalize === "function") {
+        return;
+    }
+
+    String.prototype.normalize = function () {
+        return this;
+    }
 }

--- a/plugins/rich-editor/src/scripts/editor/richEditorStyles.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorStyles.ts
@@ -24,7 +24,7 @@ import { formElementsVariables } from "@library/forms/formElementStyles";
 import { NestedCSSProperties } from "typestyle/lib/types";
 import { buttonResetMixin } from "@library/forms/buttonStyles";
 
-export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: boolean) => {
+export const richEditorClasses = useThemeCache((legacyMode: boolean) => {
     const globalVars = globalVariables();
     const style = styleFactory("richEditor");
     const vars = richEditorVariables();
@@ -95,7 +95,7 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
         marginLeft: unit(-globalVars.gutter.quarter + (!legacyMode ? -(globalVars.gutter.size + 6) : 0)),
         transform: `translateX(-100%) translateY(-50%)`,
         height: unit(vars.paragraphMenuHandle.size),
-        width: unit(globalVars.icon.sizes.default),
+        width: unit(vars.paragraphMenuHandle.size),
         animationName: vars.pilcrow.animation.name,
         animationDuration: vars.pilcrow.animation.duration,
         animationTimingFunction: vars.pilcrow.animation.timing,
@@ -368,9 +368,11 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean, mobile?: bo
     });
 
     const position = style("position", {
-        position: "absolute",
-        left: calc(`50% - ${unit(vars.spacing.paddingLeft / 2)}`),
         $nest: {
+            "&&": {
+                position: "absolute",
+                left: calc(`50% - ${unit(vars.spacing.paddingLeft / 2)}`),
+            },
             "&.isUp": {
                 bottom: calc(`50% + ${unit(vars.spacing.paddingRight / 2 - formVars.border.width)}`),
             },

--- a/plugins/rich-editor/src/scripts/editor/richEditorStyles.ts
+++ b/plugins/rich-editor/src/scripts/editor/richEditorStyles.ts
@@ -315,7 +315,7 @@ export const richEditorClasses = useThemeCache((legacyMode: boolean) => {
         display: "block",
         width: percent(100),
         ...paddings({
-            horizontal: (vars.menuButton.size - globalVars.icon.sizes.small) / 2,
+            horizontal: legacyMode ? 0 : (vars.menuButton.size - globalVars.icon.sizes.small) / 2,
             vertical: vars.embedMenu.padding,
         }),
         background: legacyMode ? undefined : colorOut(vars.colors.bg),

--- a/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
+++ b/plugins/rich-editor/src/scripts/menuBar/paragraph/ParagraphMenusBarToggle.tsx
@@ -161,11 +161,7 @@ export class ParagraphMenusBarToggle extends React.PureComponent<IProps, IState>
                 </button>
                 <div
                     id={this.menuID}
-                    className={classNames(
-                        this.dropDownClasses,
-                        classes.menuBar,
-                        this.isMenuVisible ? "" : style(srOnly()),
-                    )}
+                    className={classNames(this.dropDownClasses, this.isMenuVisible ? "" : style(srOnly()))}
                     style={this.toolbarStyles}
                     role="menu"
                 >


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/9141
Fixes https://github.com/vanilla/support/issues/536


- Adds a stub method for `String.prototype.normalize` to prevent an IE11 crash.
- Fix the vertical flex rule used in `frameBody` to be IE11 compatible.
- Fixed a specificity error on master preventing the paragraph menu from appearing.
- Fixed some duplicate CSS classes being applied where they didn't need to be.
- Fix the paragraph menu icon not being the correct width.
- Remove extra paddings from the embed toolbar in legacy mode.