### PR TITLE
Fix alt install tests

### DIFF
--- a/applications/dashboard/controllers/class.utilitycontroller.php
+++ b/applications/dashboard/controllers/class.utilitycontroller.php
@@ -292,6 +292,7 @@ class UtilityController extends DashboardController {
             $updateModel->runStructure();
             $this->setData('Success', true);
         } catch (Exception $ex) {
+            $this->statusCode(500);
             $this->setData('Success', false);
             $this->setData('Error', $ex->getMessage());
             if (debug()) {
@@ -363,9 +364,11 @@ class UtilityController extends DashboardController {
         $this->addJsFile('jquery.js');
         Gdn_Theme::section('Utility');
 
-        $this->setData('_isAdmin', Gdn::session()->checkPermission('Garden.Settings.Manager'));
-        $this->setData("form", $this->Form);
-        $this->setData("headerImage", asset("/applications/dashboard/design/images/vanilla_logo.png"));
+        if ($this->deliveryType() === DELIVERY_TYPE_ALL) {
+            $this->setData('_isAdmin', Gdn::session()->checkPermission('Garden.Settings.Manager'));
+            $this->setData("form", $this->Form);
+            $this->setData("headerImage", asset("/applications/dashboard/design/images/vanilla_logo.png"));
+        }
         $this->render($this->View, 'utility', 'dashboard');
     }
 
@@ -688,12 +691,14 @@ class UtilityController extends DashboardController {
             $updateModel->runStructure();
             $this->setData('Success', true);
         } catch (Exception $ex) {
+            $this->statusCode(500);
             $this->setData('Success', false);
             $this->setData('Error', $ex->getMessage());
 
             if (debug()) {
                 throw $ex;
             }
+            return false;
         }
         saveToConfig('Garden.Version', APPLICATION_VERSION);
 

--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -667,7 +667,7 @@ class UpdateModel extends Gdn_Model {
         } finally {
             if ($userID && $userID !== Gdn::session()->UserID) {
                 Gdn::session()->start($userID, false, false);
-            } elseif (!$userID) {
+            } elseif (!$userID && null !== c('Garden.Installed', false)) {
                 Gdn::session()->end();
             }
         }

--- a/applications/dashboard/models/class.updatemodel.php
+++ b/applications/dashboard/models/class.updatemodel.php
@@ -668,6 +668,8 @@ class UpdateModel extends Gdn_Model {
             if ($userID && $userID !== Gdn::session()->UserID) {
                 Gdn::session()->start($userID, false, false);
             } elseif (!$userID && null !== c('Garden.Installed', false)) {
+            // Vanilla has an alternate install method where this config value is set to null.
+            // When this using this alternate install method we don't have authenticators configured and can't end the session.
                 Gdn::session()->end();
             }
         }

--- a/tests/APIv0/AltTest.php
+++ b/tests/APIv0/AltTest.php
@@ -67,7 +67,7 @@ class AltTest extends SharedBootstrapTestCase {
         $config['Garden']['UpdateToken'] = $updateToken;
 
         $this->api()->saveToConfig($config);
-        $this->api()->post('/utility/update.json', ['updateToken' => $postUpdateToken]);
+        $r = $this->api()->post('/utility/update.json', ['updateToken' => $postUpdateToken])->getBody();
         $this->api()->saveToConfig(['Garden.Installed' => true]);
 
         // Do a simple get to make sure there isn't an error.


### PR DESCRIPTION
The test was failing due to our session restoring functionality during the alt install. That has been checked as a special case.

In addition to the fix I added 500 response codes when utility/update fails to hopefully help troubleshoot errors more. This should close #9144.