### PR TITLE
[Apiv2] Discussions: add discussion title before validating schema ou…

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -582,6 +582,7 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         foreach ($rows as &$currentRow) {
+            $currentRow['Name'] = !empty($currentRow['Name']) ? $currentRow['Name'] : '--Empty--';
             $currentRow = $this->normalizeOutput($currentRow, $query['expand']);
         }
         $this->expandLastCommentBody($rows, $query['expand']);


### PR DESCRIPTION
closes https://github.com/vanilla/vanilla/issues/8713

### Details

When an imported discussion does not have a title, api/v2/discussion fails with the following error:
<img width="365" alt="Screen Shot 2019-11-20 at 12 16 56 PM" src="https://user-images.githubusercontent.com/31856281/69261495-aa15b680-0b8f-11ea-8003-e1b4b64411e7.png">
we are doing the validation here [DiscussionsApiController.php#L588](https://github.com/vanilla/vanilla/blob/81535af8c0c7507afb754a5579a72cb4960781af/applications/vanilla/controllers/api/DiscussionsApiController.php#L588)

