### PR TITLE
fix - Uploaded image filename on dashboard category 

### DIFF
--- a/applications/dashboard/js/dashboard.js
+++ b/applications/dashboard/js/dashboard.js
@@ -1249,7 +1249,7 @@ $(document).on('contentLoad', function(e) {
             filename = filename.substring(12);
         }
         if (filename) {
-            $(this).parent().find('.file-upload-choose').html(filename);
+            $(this).parent().find('.file-upload-choose').text(filename);
         }
     });
 

--- a/applications/dashboard/js/src/main.js
+++ b/applications/dashboard/js/src/main.js
@@ -486,7 +486,7 @@
             filename = filename.substring(12);
         }
         if (filename) {
-            $(this).parent().find('.file-upload-choose').html(filename);
+            $(this).parent().find('.file-upload-choose').text(filename);
         }
     });
 


### PR DESCRIPTION
Issue -  https://github.com/vanilla/vanilla/issues/8878
This PR is to fix uploaded image name preview on dashboard category page. 

**Test**
Create an image file named `x<img src=x onerror=alert(document.cookie)>x.jpeg`
Go to the dashboard categories page.
Upload it as the category thumbnail.
Verify file name.