### PR TITLE
Filter out '\r\n' (new-line) characters from Wysiwyg content

### DIFF
--- a/library/Vanilla/Formatting/Formats/WysiwygFormat.php
+++ b/library/Vanilla/Formatting/Formats/WysiwygFormat.php
@@ -21,52 +21,25 @@ class WysiwygFormat extends HtmlFormat {
 
     const ALT_FORMAT_KEY = "raw";
 
-    /** @var HtmlSanitizer */
-    private $htmlSanitizer;
-
-    /** @var HtmlEnhancer */
-    private $htmlEnhancer;
-
-    /** @var HtmlPlainTextConverter */
-    private $plainTextConverter;
-
     /**
-     * Constructor for dependency Injection.
+     * Constructor for dependency Injection
      *
-     * @param HtmlSanitizer $htmlSanitizer
-     * @param HtmlEnhancer $htmlEnhancer
-     * @param HtmlPlainTextConverter $plainTextConverter
+     * @inheritdoc
      */
     public function __construct(
         HtmlSanitizer $htmlSanitizer,
         HtmlEnhancer $htmlEnhancer,
         HtmlPlainTextConverter $plainTextConverter
     ) {
-        $this->htmlSanitizer = $htmlSanitizer;
-        $this->htmlEnhancer = $htmlEnhancer;
-        $this->plainTextConverter = $plainTextConverter;
-
         parent::__construct($htmlSanitizer, $htmlEnhancer, $plainTextConverter, false);
     }
-
 
     /**
      * @inheritdoc
      */
     public function renderHtml(string $content, bool $enhance = true): string {
-        $result = $this->htmlSanitizer->filter($content);
-
-        $result = FormatUtil::replaceButProtectCodeBlocks('/\\\r\\\n/', '', $result);
-
-        $result = $this->legacySpoilers($result);
-
-        if ($enhance) {
-            $result = $this->htmlEnhancer->enhance($result);
-        }
-
-        $result = self::cleanupEmbeds($result);
-
-        return $result;
+        $result = FormatUtil::replaceButProtectCodeBlocks('/\\\r\\\n/', '', $content);
+        return parent::renderHtml($result, $enhance);
     }
 
     /**

--- a/tests/fixtures/formats/wysiwyg/remove-carriage-returns/input.html
+++ b/tests/fixtures/formats/wysiwyg/remove-carriage-returns/input.html
@@ -1,0 +1,1 @@
+<div>Random: let's\r\n replace all the \r\ncarriages\r\n because they are annoying.</div>

--- a/tests/fixtures/formats/wysiwyg/remove-carriage-returns/output.html
+++ b/tests/fixtures/formats/wysiwyg/remove-carriage-returns/output.html
@@ -1,0 +1,1 @@
+<div>Random: let's replace all the carriages because they are annoying.</div>

--- a/tests/fixtures/formats/wysiwyg/remove-carriage-returns/output.txt
+++ b/tests/fixtures/formats/wysiwyg/remove-carriage-returns/output.txt
@@ -1,0 +1,1 @@
+Random: let's replace all the carriages because they are annoying.


### PR DESCRIPTION
So content in contains`\r\n` characters  which isn't parsed out by the Wysiwyg format, causing the content to be rendered incorrectly.

relates to https://github.com/vanilla/support/issues/1033

blocks https://github.com/vanilla/internal/pull/2097