### PR TITLE
Fix IE11 polyfills not loading consistently

### DIFF
--- a/library/Vanilla/Web/Asset/InlinePolyfillContent.js.twig
+++ b/library/Vanilla/Web/Asset/InlinePolyfillContent.js.twig
@@ -1,0 +1,29 @@
+{%- autoescape false -%}
+var supportsAllFeatures =
+    window.Promise &&
+    window.fetch &&
+    window.Symbol &&
+    window.CustomEvent &&
+    Element.prototype.remove &&
+    Element.prototype.closest &&
+    window.NodeList &&
+    NodeList.prototype.forEach
+;
+
+if (!supportsAllFeatures) {
+    {{ debugModeLiteral }} && console.log("Older browser detected. Initiating polyfills.");
+    var head = document.getElementsByTagName('head')[0];
+    var script = document.createElement('script');
+    script.src = "{{ polyfillAsset.getWebPath() }}";
+
+    {#
+    // Without this script execution order is inconsistent.
+    // IE11 does not seem to respect https://html.spec.whatwg.org/multipage/scripting.html#script-processing-src-sync
+    // Which means we HAVE to set the element, even if it should be defaulted.
+    #}
+    script.async = false;
+    head.appendChild(script);
+} else {
+    {{ debugModeLiteral }} && console.log("Modern browser detected. No polyfills necessary");
+}
+{%- endautoescape -%}


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/1001

The HTML5 script loading spec states the following

> The script's type is "classic", and the element has a src attribute, and the element does not have an async attribute, and the element does not have the "non-blocking" flag set:
> Add the element to the end of the list of scripts that will execute in order as soon as possible associated with the node document of the script element at the time the prepare a script algorithm started.
> ...

Unfortunately IE11 does not comply with the spec as it is worded, and instead is treating it as async, which means it gets loaded whenever the browsers gets a chance.

Sometimes that is immediately (like when the script is cached). Other times it takes some time causing errors.

## The changes

- Set the async attribute to false on the script being loaded.
- Convert the inline polyfill content to be a twig js template.
