### PR TITLE
Fix the user preloader typo

### DIFF
--- a/library/Vanilla/Models/CurrentUserPreloadProvider.php
+++ b/library/Vanilla/Models/CurrentUserPreloadProvider.php
@@ -33,7 +33,7 @@ class CurrentUserPreloadProvider implements ReduxActionProviderInterface {
      * @inheritdoc
      */
     public function createActions(): array {
-        $user = $this->usersApi->index([]);
+        $user = $this->usersApi->get_me([]);
 
         return [
             new ReduxAction(\UsersApiController::ME_ACTION_CONSTANT, Data::box($user), [])


### PR DESCRIPTION
Fixes a mistake from https://github.com/vanilla/vanilla/pull/9670/ and uses a more scoped, less permissioned endpoint.
