### PR TITLE
Add message component to storybook

### DIFF
--- a/library/src/scripts/messages/message.story.tsx
+++ b/library/src/scripts/messages/message.story.tsx
@@ -1,0 +1,106 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { StoryHeading } from "@library/storybook/StoryHeading";
+import { storiesOf } from "@storybook/react";
+import React, { useEffect, useState } from "react";
+import { StoryContent } from "@library/storybook/StoryContent";
+//import { LinkEmbed } from "@library/embeddedContent/LinkEmbed";
+import Message from "@library/messages/Message";
+import { AttachmentErrorIcon } from "@library/icons/fileTypes";
+import { messagesClasses } from "@library/messages/messageStyles";
+import Translate from "@library/content/Translate";
+import { WarningIcon } from "@library/icons/common";
+import classNames from "classnames";
+import { t } from "@library/utility/appUtils";
+
+const story = storiesOf("Messages", module);
+
+// tslint:disable:jsx-use-translation-function
+
+const shortMessage = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+`;
+const message = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce blandit lorem ac dui porta, scelerisque placerat felis finibus.`;
+const longMessage = `
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce blandit lorem ac dui porta, scelerisque placerat felis finibus. Fusce vitae porttitor augue. Integer sagittis justo vitae nibh aliquet, a viverra ipsum laoreet. Interdum et malesuada fames ac ante ipsum primis in faucibus.
+`;
+
+story.add("Message", () => {
+    const classesMessages = messagesClasses();
+    const [shortMessageFlag, setShortMessageFlag] = useState(true);
+    const [longMessageFlag, setLongMessageFlag] = useState(true);
+    const [fixedMessageFlag, setFixedMessageFlag] = useState(true);
+    const _shortMessage = shortMessageFlag && (
+        <Message
+            contents={
+                <div className={classesMessages.content}>
+                    <AttachmentErrorIcon
+                        className={classNames(classesMessages.messageIcon, classesMessages.errorIcon)}
+                    />
+                    <div>
+                        <Translate source={shortMessage} />
+                    </div>
+                </div>
+            }
+            onConfirm={() => {
+                setShortMessageFlag(false);
+            }}
+            stringContents={t(shortMessage)}
+        />
+    );
+    const _longMessage = longMessageFlag && (
+        <Message
+            contents={
+                <div className={classesMessages.content}>
+                    <WarningIcon className={classNames(classesMessages.messageIcon)} />
+                    <div>
+                        <Translate source={longMessage} />
+                    </div>
+                </div>
+            }
+            onConfirm={() => {
+                setLongMessageFlag(false);
+            }}
+            confirmText={t("Cancel")}
+            stringContents={t(longMessage)}
+        />
+    );
+    const _fixedMessage = fixedMessageFlag && (
+        <Message
+            isFixed={true}
+            contents={
+                <div className={classesMessages.content}>
+                    <AttachmentErrorIcon
+                        className={classNames(classesMessages.messageIcon, classesMessages.errorIcon)}
+                    />
+                    <div>
+                        <Translate source={message} />
+                    </div>
+                </div>
+            }
+            onConfirm={() => {
+                setFixedMessageFlag(false);
+            }}
+            stringContents={t(message)}
+        />
+    );
+    return (
+        <>
+            {_fixedMessage}
+            <StoryContent>
+                <StoryHeading>Short message</StoryHeading>
+                {_shortMessage}
+                <StoryHeading>Long message</StoryHeading>
+                {_longMessage}
+                <div
+                    style={{
+                        height: 450,
+                    }}
+                ></div>
+            </StoryContent>
+        </>
+    );
+});

--- a/library/src/scripts/messages/message.story.tsx
+++ b/library/src/scripts/messages/message.story.tsx
@@ -15,14 +15,14 @@ import Translate from "@library/content/Translate";
 import { WarningIcon } from "@library/icons/common";
 import classNames from "classnames";
 import { t } from "@library/utility/appUtils";
+import SmartLink from "@library/routing/links/SmartLink";
 
 const story = storiesOf("Messages", module);
-
-// tslint:disable:jsx-use-translation-function
 
 const shortMessage = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 `;
+
 const message = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce blandit lorem ac dui porta, scelerisque placerat felis finibus.`;
 const longMessage = `
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce blandit lorem ac dui porta, scelerisque placerat felis finibus. Fusce vitae porttitor augue. Integer sagittis justo vitae nibh aliquet, a viverra ipsum laoreet. Interdum et malesuada fames ac ante ipsum primis in faucibus.
@@ -68,6 +68,27 @@ story.add("Message", () => {
             stringContents={t(longMessage)}
         />
     );
+
+    const _messageWithLink = (
+        <Message
+            contents={
+                <div className={classesMessages.content}>
+                    <WarningIcon className={classNames(classesMessages.messageIcon)} />
+                    <div>
+                        <Translate
+                            source="Lorem ipsum dolor sit amet, consectetur adipiscing elit, <0>visit site</0>."
+                            c0={content => <SmartLink to="http://www.google.com">{content}</SmartLink>}
+                        />
+                    </div>
+                </div>
+            }
+            onConfirm={() => {
+                setLongMessageFlag(false);
+            }}
+            //confirmText={t("Cancel")}
+            stringContents={t("Lorem ipsum dolor sit amet, consectetur adipiscing elit, visit site.")}
+        />
+    );
     const _fixedMessage = fixedMessageFlag && (
         <Message
             isFixed={true}
@@ -91,10 +112,17 @@ story.add("Message", () => {
         <>
             {_fixedMessage}
             <StoryContent>
+                <div
+                    style={{
+                        height: 50,
+                    }}
+                ></div>
                 <StoryHeading>Short message</StoryHeading>
                 {_shortMessage}
                 <StoryHeading>Long message</StoryHeading>
                 {_longMessage}
+                <StoryHeading>Message with link</StoryHeading>
+                {_messageWithLink}
                 <div
                     style={{
                         height: 450,

--- a/library/src/scripts/messages/message.story.tsx
+++ b/library/src/scripts/messages/message.story.tsx
@@ -5,9 +5,8 @@
 
 import { StoryHeading } from "@library/storybook/StoryHeading";
 import { storiesOf } from "@storybook/react";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { StoryContent } from "@library/storybook/StoryContent";
-//import { LinkEmbed } from "@library/embeddedContent/LinkEmbed";
 import Message from "@library/messages/Message";
 import { AttachmentErrorIcon } from "@library/icons/fileTypes";
 import { messagesClasses } from "@library/messages/messageStyles";
@@ -85,7 +84,6 @@ story.add("Message", () => {
             onConfirm={() => {
                 setLongMessageFlag(false);
             }}
-            //confirmText={t("Cancel")}
             stringContents={t("Lorem ipsum dolor sit amet, consectetur adipiscing elit, visit site.")}
         />
     );


### PR DESCRIPTION
Fix - https://github.com/vanilla/knowledge/issues/1371
This PR is for  - Add message variations in storybook

- messages with full width.
- sticky message with fixed position.
- short message and long message with icons and buttons.
- message with link.


