### PR TITLE
PHPmas 7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,15 +169,6 @@ jobs:
     php_73_integration:
         executor: core/php73
         steps: *php_integration_test_steps
-    php_71_lint:
-        executor: core/php71
-        steps: *php_lint_steps
-    php_71_tests:
-        executor: core/php71
-        steps: *php_unit_test_steps
-    php_71_integration:
-        executor: core/php71
-        steps: *php_integration_test_steps
     dependency_audit:
         executor: core/php72
         steps:
@@ -246,19 +237,12 @@ workflows:
             - dependency_audit
             # PHP and serverside
             - php_setup
-            - php_71_lint
             - php_72_lint
             - php_73_lint
-            - php_71_integration:
-                requires:
-                    - php_setup
             - php_72_integration:
                 requires:
                     - php_setup
             - php_73_integration:
-                requires:
-                    - php_setup
-            - php_71_tests:
                 requires:
                     - php_setup
             - php_72_tests:

--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     ],
     "config": {
         "platform": {
-            "php": "7.1"
+            "php": "7.2"
         }
     },
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "ext-pdo": "*",
         "ext-json": "*",
         "ext-fileinfo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e190c94c1fdbbc725c788c52b20649ea",
+    "content-hash": "503bbde6f99847c7bf6a4ed799f1da94",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -78,6 +78,7 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
@@ -1483,8 +1484,8 @@
             "authors": [
                 {
                     "name": "Frank Kleine",
-                    "role": "Developer",
-                    "homepage": "http://frankkleine.de/"
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
                 }
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
@@ -3505,13 +3506,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1.0",
+        "php": ">=7.2.0",
         "ext-pdo": "*",
         "ext-json": "*",
         "ext-fileinfo": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1"
+        "php": "7.2"
     }
 }

--- a/environment.php
+++ b/environment.php
@@ -22,7 +22,7 @@ if (!defined('APPLICATION')) {
 if (!defined('APPLICATION_VERSION')) {
     // Rules for the versioning
     // {OSS version}-{Cloud release version}-{? SNAPSHOT if it's a dev build}
-    define('APPLICATION_VERSION', '3.5-2019.018-SNAPSHOT');
+    define('APPLICATION_VERSION', '4.0-2019.018-SNAPSHOT');
 }
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);

--- a/environment.php
+++ b/environment.php
@@ -8,8 +8,8 @@
  */
 
 // Environment
-define('ENVIRONMENT_PHP_VERSION', '7.1');
-define('ENVIRONMENT_PHP_NEXT_VERSION', '7.2');
+define('ENVIRONMENT_PHP_VERSION', '7.2');
+define('ENVIRONMENT_PHP_NEXT_VERSION', '7.3');
 
 if (version_compare(phpversion(), ENVIRONMENT_PHP_VERSION) < 0) {
     die('Vanilla requires PHP '.ENVIRONMENT_PHP_VERSION.' or greater.');


### PR DESCRIPTION
PHPmas has to come a bit early this year because I want to bring in the psr-14 event dispatcher which is PHP 7.2+. See #9559.

Due to an [earlier PR](https://github.com/vanilla/vanilla/pull/9485) I’m hoping this is all that is needed for the version bump.