### PR TITLE
Fix styling for messaging

### DIFF
--- a/library/src/scripts/forms/select/SelectBox.tsx
+++ b/library/src/scripts/forms/select/SelectBox.tsx
@@ -17,7 +17,7 @@ import React, { useState, useRef } from "react";
 
 export interface ISelectBoxItem {
     value: string;
-    name: string;
+    name?: string;
     content?: React.ReactNode;
     className?: string;
     icon?: React.ReactNode;

--- a/library/src/scripts/messages/Message.tsx
+++ b/library/src/scripts/messages/Message.tsx
@@ -12,6 +12,7 @@ import { messagesClasses } from "@library/messages/messageStyles";
 import Button from "@library/forms/Button";
 import Container from "@library/layout/components/Container";
 import { ButtonTypes } from "@library/forms/buttonStyles";
+import ButtonLoader from "@library/loaders/ButtonLoader";
 
 export interface IMessageProps {
     className?: string;
@@ -24,6 +25,9 @@ export interface IMessageProps {
     cancelText?: React.ReactNode;
     isFixed?: boolean;
     isContained?: boolean;
+    title?: string;
+    isActionLoading?: boolean;
+    noIcon?: boolean;
 }
 
 export default function Message(props: IMessageProps) {
@@ -33,26 +37,32 @@ export default function Message(props: IMessageProps) {
     const InnerWrapper = props.isContained ? Container : React.Fragment;
     const OuterWrapper = props.isFixed ? Container : React.Fragment;
 
+    const contents = props.contents || props.stringContents;
+
     return (
         <>
             <div className={classNames(classes.root, props.className, { [classes.fixed]: props.isFixed })}>
                 <OuterWrapper>
                     <div
-                        className={classNames(classes.wrap, props.className, {
+                        className={classNames(classes.wrap(props.noIcon), props.className, {
                             [classes.noPadding]: props.isContained,
                             [classes.fixed]: props.isContained,
                         })}
                     >
                         <InnerWrapper className={classes.innerWrapper}>
-                            <div className={classes.message}>{props.contents || props.stringContents}</div>
+                            <div className={classes.message}>
+                                {props.title && <h2 className={classes.title}>{props.title}</h2>}
+                                {contents && <p className={classes.text}>{contents}</p>}
+                            </div>
 
                             {props.onConfirm && (
                                 <Button
                                     baseClass={ButtonTypes.TEXT_PRIMARY}
                                     onClick={props.onConfirm}
                                     className={classes.actionButton}
+                                    disabled={!!props.isActionLoading}
                                 >
-                                    {props.confirmText || t("OK")}
+                                    {props.isActionLoading ? <ButtonLoader /> : props.confirmText || t("OK")}
                                 </Button>
                             )}
                             {props.onCancel && (
@@ -60,8 +70,9 @@ export default function Message(props: IMessageProps) {
                                     baseClass={ButtonTypes.TEXT}
                                     onClick={props.onCancel}
                                     className={classes.actionButton}
+                                    disabled={!!props.isActionLoading}
                                 >
-                                    {props.cancelText || t("Cancel")}
+                                    {props.isActionLoading ? <ButtonLoader /> : props.cancelText || t("Cancel")}
                                 </Button>
                             )}
                         </InnerWrapper>

--- a/library/src/scripts/messages/messageStyles.ts
+++ b/library/src/scripts/messages/messageStyles.ts
@@ -54,7 +54,7 @@ export const messagesVariables = useThemeCache(() => {
         font: {
             color: colors.fg,
             size: globalVars.fonts.size.medium,
-            weight: globalVars.fonts.weights.semiBold as FontWeightProperty,
+            weight: globalVars.fonts.weights.normal as FontWeightProperty,
         },
     });
 
@@ -86,22 +86,26 @@ export const messagesClasses = useThemeCache(() => {
     const titleBarVars = titleBarVariables();
     const shadows = shadowHelper();
 
-    const wrap = style("wrap", {
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "flex-start",
-        flexWrap: "nowrap",
-        minHeight: unit(vars.sizing.minHeight),
-
-        width: percent(100),
-
-        margin: "auto",
-        color: colorOut(vars.colors.fg),
-        ...paddings({
-            ...vars.spacing.padding,
-            right: vars.spacing.padding.right,
-        }),
-    });
+    const wrap = (noIcon?: boolean) => {
+        const padding = noIcon
+            ? {
+                  vertical: vars.spacing.padding.vertical,
+                  left: vars.spacing.padding.right,
+                  right: vars.spacing.padding.right,
+              }
+            : { ...vars.spacing.padding, right: vars.spacing.padding.right };
+        return style("wrap", {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-start",
+            flexWrap: "nowrap",
+            minHeight: unit(vars.sizing.minHeight),
+            width: percent(100),
+            margin: "auto",
+            color: colorOut(vars.colors.fg),
+            ...paddings(padding),
+        });
+    };
 
     // Fixed wrapper
     const fixed = style("fixed", {
@@ -146,27 +150,27 @@ export const messagesClasses = useThemeCache(() => {
         },
     });
 
-    const root = style(
-        {
-            width: percent(100),
-            backgroundColor: colorOut(vars.colors.bg),
-            ...shadowOrBorderBasedOnLightness(
-                globalVars.body.backgroundImage.color,
-                borders({
-                    color: globalVars.mainColors.fg,
-                }),
-                shadows.embed(),
-            ),
+    const root = style({
+        width: percent(100),
+        backgroundColor: colorOut(vars.colors.bg),
+        ...shadowOrBorderBasedOnLightness(
+            globalVars.body.backgroundImage.color,
+            borders({
+                color: globalVars.mainColors.fg,
+            }),
+            shadows.embed(),
+        ),
+        ...margins({ horizontal: "auto" }),
+        $nest: {
+            "& + &": {
+                marginTop: unit(globalVars.spacer.size / 2),
+            },
         },
-        margins({ horizontal: "auto" }),
-    );
+    });
 
     const message = style("message", {
         ...userSelect(),
         ...fonts(vars.text.font),
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "flexStart",
         width: percent(100),
         flex: 1,
     });
@@ -227,6 +231,22 @@ export const messagesClasses = useThemeCache(() => {
 
     const confirm = style("confirm", {});
 
+    const main = style("title", {});
+
+    const text = style("text", {
+        ...fonts(vars.text.font),
+    });
+
+    const title = style("title", {
+        ...fonts(vars.text.font),
+        fontWeight: globalVars.fonts.weights.bold,
+        $nest: {
+            [`& + .${text}`]: {
+                marginTop: unit(6),
+            },
+        },
+    });
+
     return {
         root,
         wrap,
@@ -241,5 +261,8 @@ export const messagesClasses = useThemeCache(() => {
         errorIcon,
         noPadding,
         messageWrapper,
+        main,
+        text,
+        title,
     };
 });


### PR DESCRIPTION
This PR fixes wording issues for both the "other locales" dropdown and for error messages. See https://github.com/vanilla/knowledge/issues/1370




Requires: https://github.com/vanilla/vanilla/pull/9684

For: https://github.com/vanilla/knowledge/issues/1370

Companion PR: https://github.com/vanilla/knowledge/pull/1398

