### PR TITLE
Backport: Fix IE11 polyfills not loading consistently

### DIFF
--- a/library/Vanilla/Web/Asset/InlinePolyfillContent.js.twig
+++ b/library/Vanilla/Web/Asset/InlinePolyfillContent.js.twig
@@ -1,0 +1,29 @@
+{%- autoescape false -%}
+var supportsAllFeatures =
+    window.Promise &&
+    window.fetch &&
+    window.Symbol &&
+    window.CustomEvent &&
+    Element.prototype.remove &&
+    Element.prototype.closest &&
+    window.NodeList &&
+    NodeList.prototype.forEach
+;
+
+if (!supportsAllFeatures) {
+    {{ debugModeLiteral }} && console.log("Older browser detected. Initiating polyfills.");
+    var head = document.getElementsByTagName('head')[0];
+    var script = document.createElement('script');
+    script.src = "{{ polyfillAsset.getWebPath() }}";
+
+    {#
+    // Without this script execution order is inconsistent.
+    // IE11 does not seem to respect https://html.spec.whatwg.org/multipage/scripting.html#script-processing-src-sync
+    // Which means we HAVE to set the element, even if it should be defaulted.
+    #}
+    script.async = false;
+    head.appendChild(script);
+} else {
+    {{ debugModeLiteral }} && console.log("Modern browser detected. No polyfills necessary");
+}
+{%- endautoescape -%}


### PR DESCRIPTION
Backporting #9672 to `release/2019.017`.

> [...]
> ## The changes
>
> - Set the async attribute to false on the script being loaded.
> - Convert the inline polyfill content to be a twig js template.