### PR TITLE
Fix SiteMeta::getLogo() method to return nullable string

### DIFF
--- a/library/Vanilla/Models/SiteMeta.php
+++ b/library/Vanilla/Models/SiteMeta.php
@@ -257,7 +257,7 @@ class SiteMeta implements \JsonSerializable {
     /**
      * @return string
      */
-    public function getLogo(): string {
+    public function getLogo(): ?string {
         return $this->logo;
     }
 


### PR DESCRIPTION
Some pages fail to load and return json error message instead when site logo is not set.

This patch fixes this issue.