### PR TITLE
Fix issue where paragraph menu can lag in the editor

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
+++ b/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
@@ -11,6 +11,7 @@ import KeyboardBindings from "@rich-editor/quill/KeyboardBindings";
 import { richEditorClasses } from "@rich-editor/editor/richEditorStyles";
 import MarkdownModule from "@rich-editor/quill/MarkdownModule";
 import NewLineClickInsertionModule from "./NewLineClickInsertionModule";
+import KeyboardModule from "quill/modules/keyboard";
 
 export default class VanillaTheme extends ThemeBase {
     /** The previous selection */
@@ -52,6 +53,28 @@ export default class VanillaTheme extends ThemeBase {
 
         // Create the newline insertion module.
         void new NewLineClickInsertionModule(this.quill);
+    }
+
+    /**
+     * Override to ensure we get a public update event after the enter key is pressed.
+     * Prevents a "lagging" paragraph menu that doesn't listen to silent events.
+     */
+    public init() {
+        super.init();
+
+        const keyboard = this.quill.getModule("keyboard") as KeyboardModule;
+        keyboard.addBinding(
+            {
+                key: KeyboardModule.keys.ENTER,
+            },
+            {},
+            () => {
+                const selection = this.quill.getSelection();
+                selection.index += 1;
+                this.quill.setSelection(selection, Quill.sources.USER);
+                return true;
+            },
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/9705

This is notable bug in quill we are working around https://github.com/quilljs/quill/blob/1.3.7/modules/keyboard.js#L409

This event is silent, because they aren't handling some edge case. One of these days we'll need to fix it, but this makes sure we always update our location when hitting enter.