### PR TITLE
Fix case sensitivity of build output

### DIFF
--- a/build/scripts/utility/EntryModel.ts
+++ b/build/scripts/utility/EntryModel.ts
@@ -88,13 +88,13 @@ export default class EntryModel {
         for (const entryDir of this.entryDirs) {
             const commonEntry = await this.lookupEntry(entryDir, "common");
             if (commonEntry !== null) {
-                const addonName = path.basename(commonEntry.addonPath);
+                const addonName = path.basename(commonEntry.addonPath).toLowerCase();
                 entries[`addons/${addonName}-common`] = [PUBLIC_PATH_SOURCE_FILE, commonEntry.entryPath];
             }
 
             const entry = await this.lookupEntry(entryDir, section);
             if (entry !== null) {
-                const addonName = path.basename(entry.addonPath);
+                const addonName = path.basename(entry.addonPath).toLowerCase();
                 entries[`addons/${addonName}`] = [PUBLIC_PATH_SOURCE_FILE, entry.entryPath];
             }
         }
@@ -211,11 +211,11 @@ export default class EntryModel {
         // Filter only the enabled addons for a development build.
         if (this.options.mode === BuildMode.DEVELOPMENT) {
             addonKeyList = addonKeyList.filter(addonPath => {
-                const addonKey = path.basename(addonPath);
+                const addonKey = path.basename(addonPath).toLowerCase();
 
                 // Check if we have a case-insensitive addon key match.
                 return this.options.enabledAddonKeys.some(val => {
-                    if (val.toLowerCase() === addonKey.toLowerCase()) {
+                    if (val.toLowerCase() === addonKey) {
                         return true;
                     }
                     return false;


### PR DESCRIPTION
Our addon manager lowercases addon keys. This can lead to issues when loading our scripts in our webpack asset model, because we have to check if a file exists on the system. On case-sensitive systems this leads to addon assets not loading.

See https://github.com/vanilla/vanilla/blob/e0ff3c5d7fbf31e59686ef5ec6840036b4d6a1d5/library/Vanilla/Addon.php#L765

I'm essentially mimicking this my lowercasing the frontend assets too.