### PR TITLE
Fix BBcode spacing issue

### DIFF
--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -403,9 +403,8 @@ HTML;
         // The DOM Document added starting body and ending tags. We need to remove them.
         $htmlBodyString = preg_replace('/^<body>/', '', $htmlBodyString);
         $htmlBodyString = preg_replace('/<\/body>$/', '', $htmlBodyString);
-
+        // saveXML adds closing <br> tags, which breaks formatting.
         $htmlBodyString = preg_replace('/<\/br>/', '', $htmlBodyString);
-
 
         return $htmlBodyString;
     }

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -398,7 +398,7 @@ HTML;
         self::cleanupInlineCodeBlocks($inlineCodeBlocks);
 
         $content = $dom->getElementsByTagName('body');
-        $htmlBodyString = @$dom->saveXML($content[0], LIBXML_NOEMPTYTAG);
+        $htmlBodyString = @$dom->saveXML($content[0]);
 
         // The DOM Document added starting body and ending tags. We need to remove them.
         $htmlBodyString = preg_replace('/^<body>/', '', $htmlBodyString);

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -398,11 +398,14 @@ HTML;
         self::cleanupInlineCodeBlocks($inlineCodeBlocks);
 
         $content = $dom->getElementsByTagName('body');
-        $htmlBodyString = @$dom->saveXML($content[0]);
+        $htmlBodyString = @$dom->saveXML($content[0], LIBXML_NOEMPTYTAG);
 
         // The DOM Document added starting body and ending tags. We need to remove them.
         $htmlBodyString = preg_replace('/^<body>/', '', $htmlBodyString);
         $htmlBodyString = preg_replace('/<\/body>$/', '', $htmlBodyString);
+
+        $htmlBodyString = preg_replace('/<\/br>/', '', $htmlBodyString);
+
 
         return $htmlBodyString;
     }


### PR DESCRIPTION
~Removes the LIBXML_NOEMPTYTAG from HtmlFormat::cleanupEmbeds.  This was causing and extra <br> to appended to the body content causing formatting issues.  Tests will be written ensure this doesn't occur.~

~https://www.php.net/manual/en/libxml.constants.php~
~` LIBXML_NOEMPTYTAG (integer) Expand empty tags (e.g. <br/> to <br></br>)`~

filter out `</br>` from content, this breaks formatting.

closes https://github.com/vanilla/support/issues/1106

