### PR TITLE
Ensure filtering </br> tags don't break formatting

### DIFF
--- a/tests/fixtures/formats/bbcode/carriage-returns/input.txt
+++ b/tests/fixtures/formats/bbcode/carriage-returns/input.txt
@@ -1,0 +1,5 @@
+Line 1[br]
+Line 2[br]
+Line 3[br][br]
+Line 4[br][br]
+Line 5

--- a/tests/fixtures/formats/bbcode/carriage-returns/output.html
+++ b/tests/fixtures/formats/bbcode/carriage-returns/output.html
@@ -1,0 +1,8 @@
+Line 1<br>
+<br> Line 2<br>
+<br> Line 3<br>
+<br>
+<br> Line 4<br>
+<br>
+<br> Line 5<br>
+

--- a/tests/fixtures/formats/bbcode/carriage-returns/output.txt
+++ b/tests/fixtures/formats/bbcode/carriage-returns/output.txt
@@ -1,0 +1,12 @@
+Line 1
+
+Line 2
+
+Line 3
+
+
+Line 4
+
+
+Line 5
+

--- a/tests/fixtures/formats/bbcode/code-block-formatting/input.txt
+++ b/tests/fixtures/formats/bbcode/code-block-formatting/input.txt
@@ -1,0 +1,8 @@
+[code]
+<body>
+line 1
+<br></br>
+line 2
+<br></br>
+</body>
+[/code]

--- a/tests/fixtures/formats/bbcode/code-block-formatting/output.html
+++ b/tests/fixtures/formats/bbcode/code-block-formatting/output.html
@@ -1,0 +1,1 @@
+<pre class="code codeBlock" spellcheck=false>&lt;body&gt;line 1&lt;br&gt;&lt;/br&gt;line 2&lt;br&gt;&lt;/br&gt;&lt;/body&gt;</pre>

--- a/tests/fixtures/formats/bbcode/code-block-formatting/output.txt
+++ b/tests/fixtures/formats/bbcode/code-block-formatting/output.txt
@@ -1,0 +1,1 @@
+<body>line 1<br></br>line 2<br></br></body>


### PR DESCRIPTION
Add testing for bbcode to ensure that formatting isn't broken when we filter closing <br> tags.

closes https://github.com/vanilla/support/issues/1106
