### PR TITLE
Fix PHP 7.4 deprecation warnings

### DIFF
--- a/library/core/functions.deprecated.php
+++ b/library/core/functions.deprecated.php
@@ -848,26 +848,6 @@ if (!function_exists('safeRedirect')) {
     }
 }
 
-if (!function_exists('trueStripSlashes')) {
-    if (get_magic_quotes_gpc()) {
-        /**
-         * @deprecated
-         */
-        function trueStripSlashes($string) {
-            \Vanilla\Utility\Deprecation::log();
-            return stripslashes($string);
-        }
-    } else {
-        /**
-         * @deprecated
-         */
-        function trueStripSlashes($string) {
-            \Vanilla\Utility\Deprecation::log();
-            return $string;
-        }
-    }
-}
-
 if (!function_exists('viewLocation')) {
     /**
      * Get the path of a view.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -2137,7 +2137,7 @@ if (!function_exists('isWritable')) {
      * @return bool Returns true if {@link $path} is writable or false otherwise.
      */
     function isWritable($path) {
-        if ($path{strlen($path) - 1} == DS) {
+        if (substr($path, -1) === DS) {
             // Recursively return a temporary file path
             return isWritable($path.uniqid(mt_rand()).'.tmp');
         } elseif (is_dir($path)) {


### PR DESCRIPTION
- There was an invalud `{}` string access in functions.general.
- Our deprecated `trueStripSlashes()` calls a now deprecated `get_magic_quotes_gpc()`. I checked all of our source code and this function can safely be removed.