### PR TITLE
Make limitToSuffix check case insensitive in PermissionModel::isGlobalPermission

### DIFF
--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -895,7 +895,7 @@ class PermissionModel extends Gdn_Model {
         if (!($value & 2)) {
             return false;
         }
-        if (!empty($limitToSuffix) && substr($permissionName, -strlen($limitToSuffix)) != $limitToSuffix) {
+        if (!empty($limitToSuffix) && strtolower(substr($permissionName, -strlen($limitToSuffix))) != strtolower($limitToSuffix)) {
             return false;
         }
         if ($index = strpos($permissionName, '.')) {


### PR DESCRIPTION
Permissions in vanilla can be upper or lower case.  In this case if this check would fail based on casing of the $permissionName and the $limitToSuffix parameter.  For example `plugin.manage.view` ===`View` would return false and not be listed as a Global permission.

Related to https://github.com/vanilla/knowledge/issues/1319

