### PR TITLE
Validate user fragment

### DIFF
--- a/applications/conversations/controllers/api/ConversationsApiController.php
+++ b/applications/conversations/controllers/api/ConversationsApiController.php
@@ -449,7 +449,6 @@ class ConversationsApiController extends AbstractApiController {
             false
         );
         $data = array_values($conversationMembers);
-
         $this->userModel->expandUsers($data, ['UserID']);
         $data = array_map([$this, 'normalizeParticipantOutput'], $data);
 
@@ -576,7 +575,7 @@ class ConversationsApiController extends AbstractApiController {
         if (isset($dbRecord["User"]) && is_array($dbRecord["User"])) {
             $dbRecord["User"] = array_intersect_key(
                 $dbRecord["User"],
-                array_flip(["UserID", "Name", "PhotoUrl", "DateLastActive"])
+                array_flip(["userID", "name", "photoUrl", "dateLastActive"])
             );
         } elseif (isset($dbRecord["UserID"]) && isset($dbRecord["Name"])) {
             $dbRecord['User'] = [

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1234,7 +1234,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
                         // Add an alias to Photo. Currently only used in API calls.
                         setValue('PhotoUrl', $user, $photo);
                     } else {
-                        $user = self::getUnknownFragment();
+                        $user = $this->getGeneratedFragment(self::GENERATED_FRAGMENT_KEY_UNKNOWN);
                     }
                 }
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1141,6 +1141,13 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
     /**
      * @inheritdoc
      */
+    public function expandFragments(array &$records, array $columnNames): void {
+        $this->expandUsers($records, $columnNames);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getAllowedGeneratedRecordKeys(): array {
         return [self::GENERATED_FRAGMENT_KEY_GUEST, self::GENERATED_FRAGMENT_KEY_UNKNOWN];
     }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1189,7 +1189,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
      * @param array $options Additional options. Passed to filter event.
      *        [bool asFragments] - Expand as user fragments.
      */
-    public function expandUsers(array &$rows, array $columns, array $options = []) {
+    public function expandUsers(array &$rows, array $columns) {
         // How are we supposed to lookup users by column if we don't have any columns?
         if (count($rows) === 0 || count($columns) === 0) {
             return;
@@ -1245,9 +1245,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
                     }
                 }
 
-                if ($options['asFragments'] ?? false) {
-                    $user =  UserFragmentSchema::normalizeUserFragment($user);
-                }
+                $user =  UserFragmentSchema::normalizeUserFragment($user);
                 setValue($destination, $row, $user);
             }
         };
@@ -1259,15 +1257,6 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
             foreach ($rows as &$row) {
                 $populate($row);
             }
-        }
-
-        // Don't bother addons with whether or not this is a single row. Pack and unpack it here, as necessary.
-        if ($single) {
-            $rows = [$rows];
-        }
-        $rows = $this->eventManager->fireFilter('userModel_expandUsers', $rows, $options);
-        if ($single) {
-            $rows = reset($rows);
         }
     }
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1558,7 +1558,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
         $record = $this->getID($id, DATASET_TYPE_ARRAY);
         if ($record === false) {
             if ($useUnknownFallback) {
-                return $this->getUnknownFragment();
+                $record = $this->getGeneratedFragment(self::GENERATED_FRAGMENT_KEY_UNKNOWN);
             } else {
                 throw new NoResultsException("No user found for ID: " . $id);
             }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1251,6 +1251,15 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
                 $populate($row);
             }
         }
+
+        // Don't bother addons with whether or not this is a single row. Pack and unpack it here, as necessary.
+        if ($single) {
+            $rows = [$rows];
+        }
+
+        if ($single) {
+            $rows = reset($rows);
+        }
     }
 
     /**

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1251,15 +1251,6 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
                 $populate($row);
             }
         }
-
-        // Don't bother addons with whether or not this is a single row. Pack and unpack it here, as necessary.
-        if ($single) {
-            $rows = [$rows];
-        }
-
-        if ($single) {
-            $rows = reset($rows);
-        }
     }
 
     /**

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1154,6 +1154,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
             'name' => 'unknown',
             'email' => 'unknown@example.com',
             'photoUrl' => self::getDefaultAvatarUrl(),
+            'dateLastActive' => time(0),
         ];
         switch ($key) {
             case self::GENERATED_FRAGMENT_KEY_GUEST:
@@ -1233,11 +1234,9 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
                         setValue('Photo', $user, $photo);
                         // Add an alias to Photo. Currently only used in API calls.
                         setValue('PhotoUrl', $user, $photo);
-                    } else {
-                        $user = $this->getGeneratedFragment(self::GENERATED_FRAGMENT_KEY_UNKNOWN);
                     }
                 }
-
+                $user = !empty($user) ? $user : $this->getGeneratedFragment(self::GENERATED_FRAGMENT_KEY_UNKNOWN);
                 $user =  UserFragmentSchema::normalizeUserFragment($user);
                 setValue($destination, $row, $user);
             }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1142,7 +1142,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
      * @inheritdoc
      */
     public function expandFragments(array &$records, array $columnNames): void {
-        $this->expandUsers($records, $columnNames, ['asFragments' => true]);
+        $this->expandUsers($records, $columnNames);
     }
 
     /**

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1141,13 +1141,6 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
     /**
      * @inheritdoc
      */
-    public function expandFragments(array &$records, array $columnNames): void {
-        $this->expandUsers($records, $columnNames);
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function getAllowedGeneratedRecordKeys(): array {
         return [self::GENERATED_FRAGMENT_KEY_GUEST, self::GENERATED_FRAGMENT_KEY_UNKNOWN];
     }

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -179,7 +179,7 @@ class CommentsApiController extends AbstractApiController {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $discussion['CategoryID']);
         }
 
-        $this->userModel->expandUsers($comment, ['InsertUserID'], ['expand' => true]);
+        $this->userModel->expandUsers($comment, ['InsertUserID']);
         $comment = $this->normalizeOutput($comment);
         $result = $out->validate($comment);
 
@@ -218,7 +218,7 @@ class CommentsApiController extends AbstractApiController {
         $isRich = $comment['Format'] === 'Rich';
         $comment['bodyRaw'] = $isRich ? json_decode($comment['Body'], true) : $comment['Body'];
 
-        $this->userModel->expandUsers($comment, ['InsertUserID'], ['expand' => true]);
+        $this->userModel->expandUsers($comment, ['InsertUserID']);
         $result = $out->validate($comment);
         return $result;
     }
@@ -358,8 +358,7 @@ class CommentsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID']),
-            ['expand' => $query['expand']]
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID'])
         );
 
         foreach ($rows as &$currentRow) {
@@ -435,7 +434,7 @@ class CommentsApiController extends AbstractApiController {
         $this->commentModel->save($commentData);
         $this->validateModel($this->commentModel);
         $row = $this->commentByID($id);
-        $this->userModel->expandUsers($row, ['InsertUserID'], ['expand' => true]);
+        $this->userModel->expandUsers($row, ['InsertUserID']);
         $row = $this->normalizeOutput($row);
 
         $result = $out->validate($row);
@@ -465,7 +464,7 @@ class CommentsApiController extends AbstractApiController {
             throw new ServerException('Unable to insert comment.', 500);
         }
         $row = $this->commentByID($id);
-        $this->userModel->expandUsers($row, ['InsertUserID'], ['expand' => true]);
+        $this->userModel->expandUsers($row, ['InsertUserID']);
         $row = $this->normalizeOutput($row);
 
         $result = $out->validate($row);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -274,7 +274,7 @@ class DiscussionsApiController extends AbstractApiController {
 
         $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $row['CategoryID']);
 
-        $this->userModel->expandUsers($row, ['InsertUserID', 'LastUserID'], ['expand' => true]);
+        $this->userModel->expandUsers($row, ['InsertUserID', 'LastUserID']);
         $row = $this->normalizeOutput($row, $query["expand"] ?? []);
         $rows = [&$row];
         $this->expandLastCommentBody($rows, $query['expand'] ?? []);
@@ -384,7 +384,7 @@ class DiscussionsApiController extends AbstractApiController {
         $isRich = $discussion['Format'] === 'Rich';
         $discussion['bodyRaw'] = $isRich ? json_decode($discussion['Body'], true) : $discussion['Body'];
 
-        $this->userModel->expandUsers($discussion, ['InsertUserID'], ['expand' => true]);
+        $this->userModel->expandUsers($discussion, ['InsertUserID']);
         $result = $out->validate($discussion);
         return $result;
     }
@@ -574,8 +574,7 @@ class DiscussionsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID', 'lastPost.insertUser' => 'LastUserID']),
-            ['expand' => $query['expand']]
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID', 'lastPost.insertUser' => 'LastUserID'])
         );
         if ($this->isExpandField('category', $query['expand'])) {
             $this->categoryModel->expandCategories($rows);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -100,8 +100,7 @@ class DiscussionsApiController extends AbstractApiController {
         // Expand associated rows.
         $this->userModel->expandUsers(
             $rows,
-            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID', 'lastPost.insertUser' => 'LastUserID']),
-            ['expand' => $query['expand']]
+            $this->resolveExpandFields($query, ['insertUser' => 'InsertUserID', 'lastUser' => 'LastUserID', 'lastPost.insertUser' => 'LastUserID'])
         );
 
         foreach ($rows as &$currentRow) {

--- a/library/Vanilla/Contracts/Models/FragmentProviderInterface.php
+++ b/library/Vanilla/Contracts/Models/FragmentProviderInterface.php
@@ -21,15 +21,6 @@ interface FragmentProviderInterface {
     public function getFragmentByID(int $id, bool $useUnknownFallback = false): array;
 
     /**
-     * Populate records with fragments based on various ID fields.
-     *
-     * @param array $records The records to populate.
-     * @param array $columnNames The column names to check for. These should end with `ID`.
-     *        The resulting values will be populated on a field without the ID suffix.
-     */
-    public function expandFragments(array &$records, array $columnNames): void;
-
-    /**
      * Return an array of keys that can be used to generate some record.
      *
      * @return string[]

--- a/library/Vanilla/Contracts/Models/UserProviderInterface.php
+++ b/library/Vanilla/Contracts/Models/UserProviderInterface.php
@@ -11,12 +11,4 @@ namespace Vanilla\Contracts\Models;
  * Interface for modelling user expansion.
  */
 interface UserProviderInterface extends FragmentProviderInterface {
-    /**
-     * Populate records with fragments based on various ID fields.
-     *
-     * @param array $records The records to populate.
-     * @param array $columnNames The column names to check for. These should end with `ID`.
-     *        The resulting values will be populated on a field without the ID suffix.
-     */
-    public function expandUsers(array &$records, array $columnNames): void;
 }

--- a/library/Vanilla/Contracts/Models/UserProviderInterface.php
+++ b/library/Vanilla/Contracts/Models/UserProviderInterface.php
@@ -11,4 +11,12 @@ namespace Vanilla\Contracts\Models;
  * Interface for modelling user expansion.
  */
 interface UserProviderInterface extends FragmentProviderInterface {
+    /**
+     * Populate records with fragments based on various ID fields.
+     *
+     * @param array $records The records to populate.
+     * @param array $columnNames The column names to check for. These should end with `ID`.
+     *        The resulting values will be populated on a field without the ID suffix.
+     */
+    public function expandUsers(array &$records, array $columnNames): void;
 }

--- a/tests/Models/UserModelExpandUserFragmentTest.php
+++ b/tests/Models/UserModelExpandUserFragmentTest.php
@@ -42,7 +42,7 @@ class UserModelExpandUserFragmentTest extends TestCase {
     /**
      * Get a new model for each test.
      */
-    public function setUp() {
+    protected function setUp() {
         parent::setUp();
 
         $this->model = $this->container()->get(\UserModel::class);

--- a/tests/Models/UserModelExpandUserFragmentTest.php
+++ b/tests/Models/UserModelExpandUserFragmentTest.php
@@ -42,7 +42,7 @@ class UserModelExpandUserFragmentTest extends TestCase {
     /**
      * Get a new model for each test.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         parent::setUp();
 
         $this->model = $this->container()->get(\UserModel::class);

--- a/tests/Models/UserModelExpandUserFragmentTest.php
+++ b/tests/Models/UserModelExpandUserFragmentTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @author Alexander Kim <alexander.k@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Models;
+
+use PHPUnit\Framework\TestCase;
+use VanillaTests\ExpectErrorTrait;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Some basic tests for the `UserModel`.
+ */
+class UserModelExpandUserFragmentTest extends TestCase {
+    use SiteTestTrait, ExpectErrorTrait;
+
+    /**
+     * @var \UserModel
+     */
+    private $model;
+
+    const VALID_FRAGMENT_FIELDS = [
+        'userID',
+        'name',
+        'photoUrl',
+        'dateLastActive'
+    ];
+
+    const INVALID_FRAGMENT_FIELDS = [
+        'email',
+        'password',
+        'hashMethod',
+        'updateIPAddress',
+        'insertIPAddress',
+        'lastIPAddress',
+        'permissions'
+    ];
+
+    /**
+     * Get a new model for each test.
+     */
+    public function setUp() {
+        parent::setUp();
+
+        $this->model = $this->container()->get(\UserModel::class);
+    }
+
+    /**
+     * Test UserModel->expandUsers method
+     */
+    public function testExpandUsers() {
+        $name = uniqid('User');
+        $user = [
+            'name' => $name,
+            'email' => $name.'@mail.com',
+            'Password' => 'test',
+            'HashMethod' => 'text',
+            'DateInserted' => date("Y-m-d H:i:s")
+        ];
+        $userID = (int)$this->model->SQL->insert($this->model->Name, $user);
+        $this->assertGreaterThan(0, $userID);
+
+        $userRecord = $this->model->getByUsername($name);
+        $this->assertEquals($userID, $userRecord->UserID);
+
+        $rows = [
+            ['insertUser' => $userID],
+            ['insertUser' => $userID*1000],
+        ];
+        $this->model->expandUsers($rows, ['insertUser']);
+        $this->assertEquals(2, count($rows));
+        $both = 0;
+        foreach ($rows as $row) {
+            foreach (self::VALID_FRAGMENT_FIELDS as $validField) {
+                $this->assertArrayHasKey($validField, $row['insertUser']);
+            }
+            foreach (self::INVALID_FRAGMENT_FIELDS as $invalidField) {
+                $this->assertArrayNotHasKey($invalidField, $row['insertUser']);
+            }
+            if ($row['insertUser']['userID'] === $userID) {
+                //existing user
+                $this->assertEquals($name, $row['insertUser']['name']);
+                $both += 10;
+            } else {
+                //unknown user
+                $this->assertEquals(\UserModel::GENERATED_FRAGMENT_KEY_UNKNOWN, $row['insertUser']['name']);
+                $both += 1;
+            }
+        }
+        $this->assertEquals(11, $both);
+    }
+
+    /**
+     * Test UserModel->getFragmnetById method
+     */
+    public function testGetFragmentById() {
+        $name = uniqid('User');
+        $user = [
+            'name' => $name,
+            'email' => $name.'@mail.com',
+            'Password' => 'test',
+            'HashMethod' => 'text',
+            'DateInserted' => date("Y-m-d H:i:s")
+        ];
+        $userID = (int)$this->model->SQL->insert($this->model->Name, $user);
+        $this->assertGreaterThan(0, $userID);
+
+        // existing user fragment
+        $userRecord = $this->model->getByUsername($name);
+        $this->assertEquals($userID, $userRecord->UserID);
+
+        $row = $this->model->getFragmentByID($userID);
+
+        foreach (self::VALID_FRAGMENT_FIELDS as $validField) {
+            $this->assertArrayHasKey($validField, $row);
+        }
+        foreach (self::INVALID_FRAGMENT_FIELDS as $invalidField) {
+            $this->assertArrayNotHasKey($invalidField, $row);
+        }
+        $this->assertEquals($userID, $row['userID']);
+        $this->assertEquals($name, $row['name']);
+
+        // unknown user fragment
+        $row = $this->model->getFragmentByID(0, true);
+
+        foreach (self::VALID_FRAGMENT_FIELDS as $validField) {
+            $this->assertArrayHasKey($validField, $row);
+        }
+        foreach (self::INVALID_FRAGMENT_FIELDS as $invalidField) {
+            $this->assertArrayNotHasKey($invalidField, $row);
+        }
+        $this->assertEquals(\UserModel::UNKNOWN_USER_ID, $row['userID']);
+        $this->assertEquals(\UserModel::GENERATED_FRAGMENT_KEY_UNKNOWN, $row['name']);
+    }
+}

--- a/tests/fixtures/src/Models/MockUserProvider.php
+++ b/tests/fixtures/src/Models/MockUserProvider.php
@@ -38,7 +38,7 @@ class MockUserProvider implements UserProviderInterface {
     /**
      * @inheritdoc
      */
-    public function expandFragments(array &$records, array $columnNames): void {
+    public function expandUsers(array &$records, array $columnNames): void {
         foreach ($columnNames as $column) {
             $noIDName = str_replace('ID', '', $column);
             foreach ($records as $record) {


### PR DESCRIPTION
Revert changes introduced: https://github.com/vanilla/vanilla/pull/6867

Seem that `$options` parameter and event `userModel_expandUsers ` were never used.

Closes: https://github.com/vanilla/support/issues/1122

Closes: https://github.com/vanilla/vanilla-patches/issues/667