### PR TITLE
Backport: Fix comment watch status in visited discussions

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -861,6 +861,18 @@ class CommentModel extends Gdn_Model {
                     ]
                 );
             }
+        } else {
+            // Insert watch data.
+            $this->SQL->options('Ignore', true);
+            $this->SQL->insert(
+                'UserDiscussion',
+                [
+                    'UserID' => $userID,
+                    'DiscussionID' => $discussion->DiscussionID,
+                    'CountComments' => $countWatch,
+                    'DateLastViewed' => Gdn_Format::toDateTime()
+                ]
+            );
         }
 
         /**

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -8,6 +8,7 @@
  * @since 2.0
  */
 
+use Vanilla\Formatting\DateTimeFormatter;
 use Vanilla\Formatting\FormatService;
 use Vanilla\Formatting\UpdateMediaTrait;
 
@@ -870,7 +871,7 @@ class CommentModel extends Gdn_Model {
                     'UserID' => $userID,
                     'DiscussionID' => $discussion->DiscussionID,
                     'CountComments' => $countWatch,
-                    'DateLastViewed' => Gdn_Format::toDateTime()
+                    'DateLastViewed' => DateTimeFormatter::timeStampToDateTime(time())
                 ]
             );
         }

--- a/tests/Models/CommentModelTest.php
+++ b/tests/Models/CommentModelTest.php
@@ -60,4 +60,52 @@ class CommentModelTest extends SharedBootstrapTestCase {
         $row = $result->firstRow(DATASET_TYPE_ARRAY);
         $this->assertEquals($commentID, $row['CommentID']);
     }
+
+    /**
+     * Test inserting and updating a user's watch status of comments in a discussion.
+     *
+     * @return void
+     */
+    public function testSetWatch(): void {
+        $commentModel = new CommentModel();
+        $discussionModel = new DiscussionModel();
+
+        $countComments = 5;
+        $discussion = [
+            "CategoryID" => 1,
+            "Name" => "Comment Watch Test",
+            "Body" => "foo bar baz",
+            "Format" => "Text",
+            "CountComments" => $countComments,
+            "InsertUserID" => 1,
+        ];
+
+        // Confirm the initial state, so changes are easy to detect.
+        $discussionID = $discussionModel->save($discussion);
+        $discussion = $discussionModel->getID($discussionID);
+        $this->assertNull(
+            $discussion->CountCommentWatch,
+            "Initial comment watch status not null."
+        );
+
+        // Create a comment watch status.
+        $commentModel->setWatch($discussion, 10, 0, $discussion->CountComments);
+        $discussionFirstVisit = $discussionModel->getID($discussionID);
+        $this->assertSame(
+            $discussionFirstVisit->CountComments,
+            $discussionFirstVisit->CountCommentWatch,
+            "Creating new comment watch status failed."
+        );
+
+        // Update an existing comment watch status.
+        $updatedCountComments = $countComments + 1;
+        $discussionModel->setField($discussionID, "CountComments", $updatedCountComments);
+        $commentModel->setWatch($discussionFirstVisit, 10, 0, $updatedCountComments);
+        $discussionSecondVisit = $discussionModel->getID($discussionID);
+        $this->assertSame(
+            $discussionSecondVisit->CountComments,
+            $discussionSecondVisit->CountCommentWatch,
+            "Updating comment watch status failed."
+        );
+    }
 }


### PR DESCRIPTION
Backporting #9723

> Since #9488, visiting a new discussion fails to create a new "watch" status. This status is used by Vanilla to determine which discussions have new content since the user last viewed them. Existing "watch" status records are still being updated. Only new discussion "watch" statuses are being missed. This was caused by mistakenly removing the insert routine for these statuses, along with the archiving code it was adjacent to.
>
> The code for inserting new discussion "watch" statuses has been restored and a simple (yet verbose) test has been added to ensure the relevant records continue to be added and updated.