### PR TITLE
Added config setting to bypass js-focus-visible plugin

### DIFF
--- a/applications/dashboard/design/admin.css
+++ b/applications/dashboard/design/admin.css
@@ -10664,7 +10664,7 @@ em {
   font-style: italic;
 }
 
-.js-focus-visible :focus:not(.focus-visible) {
+body.js-focus-visible:not(.hasNativeFocus) :focus:not(.focus-visible) {
   outline: none;
 }
 

--- a/applications/dashboard/design/style-compat.css
+++ b/applications/dashboard/design/style-compat.css
@@ -200,7 +200,7 @@ em {
   font-style: italic;
 }
 
-.js-focus-visible :focus:not(.focus-visible) {
+body.js-focus-visible:not(.hasNativeFocus) :focus:not(.focus-visible) {
   outline: none;
 }
 

--- a/applications/dashboard/scss/compatibility/_scaffolding.scss
+++ b/applications/dashboard/scss/compatibility/_scaffolding.scss
@@ -6,6 +6,6 @@ em {
     font-style: italic;
 }
 
-.js-focus-visible :focus:not(.focus-visible) {
+body.js-focus-visible:not(.hasNativeFocus) :focus:not(.focus-visible) {
     outline: none;
 }

--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -17,7 +17,7 @@ import { _mountComponents } from "@library/utility/componentRegistry";
 import { blotCSS } from "@rich-editor/quill/components/blotStyles";
 import { bootstrapLocales } from "@library/locales/localeBootstrap";
 
-if (!gdn.getMeta("Feature.UseFocusVisible.Enabled", true)) {
+if (!gdn.getMeta("featureFlags.useFocusVisible.Enabled", true)) {
     document.body.classList.add("hasNativeFocus");
 }
 

--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -17,6 +17,10 @@ import { _mountComponents } from "@library/utility/componentRegistry";
 import { blotCSS } from "@rich-editor/quill/components/blotStyles";
 import { bootstrapLocales } from "@library/locales/localeBootstrap";
 
+if (gdn.getMeta("Feature.UseFocusVisible.Enabled", true)) {
+    document.body.classList.add("hasNativeFocus");
+}
+
 // Inject the debug flag into the utility.
 const debugValue = getMeta("context.debug", getMeta("debug", false));
 debug(debugValue);

--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -17,7 +17,7 @@ import { _mountComponents } from "@library/utility/componentRegistry";
 import { blotCSS } from "@rich-editor/quill/components/blotStyles";
 import { bootstrapLocales } from "@library/locales/localeBootstrap";
 
-if (gdn.getMeta("Feature.UseFocusVisible.Enabled", true)) {
+if (!gdn.getMeta("Feature.UseFocusVisible.Enabled", true)) {
     document.body.classList.add("hasNativeFocus");
 }
 

--- a/library/src/scss/utility/_scaffolding.scss
+++ b/library/src/scss/utility/_scaffolding.scss
@@ -117,7 +117,7 @@ fieldset {
     border: 0;
 }
 
-.js-focus-visible :focus:not(.focus-visible) {
+body.js-focus-visible:not(.hasNativeFocus) :focus:not(.focus-visible) {
     outline: none;
 }
 


### PR DESCRIPTION
Added config (true by default) to use the focus visible plugin. Some clients may not want this style and it can now be bypassed with a config.

Note that there are more styles in our core theme that is problematic. For the moment if a client wants it, they will need to style the outline. They can do a feature request to remove the core styles. It's not so easy, since we need to worry about backwards compatibility. 

@irina-vanillaforums 