### PR TITLE
Add code coverage reporting for to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,7 @@ jobs:
             - *run_php_lint
     php_72_tests:
         executor: core/php72
+        resource_class: large
         steps: &php_unit_test_steps
             - *attach_workspace
             - run:
@@ -172,10 +173,9 @@ jobs:
             - *upload_coverage
             - store_test_results:
                 path: ~/phpunit
-            - store_artifacts:
-                path: ~/phpunit
     php_72_integration:
         executor: core/php72
+        resource_class: large
         steps: &php_integration_test_steps
             - *attach_workspace
             - core/prepare_php_tests
@@ -200,6 +200,8 @@ jobs:
                         --log-junit ~/phpunit/models-junit.xml \
                         --coverage-clover=models-coverage.xml
             - *upload_coverage
+            - store_test_results:
+                path: ~/phpunit
     php_73_lint:
         executor: core/php73
         steps: *php_lint_steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ aliases:
     - &attach_workspace
         attach_workspace:
             at: ~/workspace
+    - &prepare_coverage
+        run:
+            name: Prepare Coverage
+            command: mkdir ~/phpunit
     - &upload_coverage
         run:
             name: Upload Coverage
@@ -144,6 +148,7 @@ jobs:
                     cd ~/workspace/repo
                     cp ./.circleci/scripts/templates/vanilla/conf/bootstrap.before.php ./conf/bootstrap.before.php
             - core/prepare_php_tests
+            - *prepare_coverage
             - run:
                 name: Library Tests
                 command: |
@@ -152,6 +157,7 @@ jobs:
                         -c phpunit.xml.dist \
                         --exclude-group=ignore \
                         --testsuite="Library" \
+                        --log-junit ~/phpunit/library-junit.xml \
                         --coverage-clover=library-coverage.xml
             - run:
                 name: APIv2 Tests
@@ -161,17 +167,13 @@ jobs:
                         -c phpunit.xml.dist \
                         --exclude-group=ignore \
                         --testsuite="APIv2" \
+                        --log-junit ~/phpunit/apiv2-junit.xml \
                         --coverage-clover=apiv2-coverage.xml
-            - run:
-                name: Models Tests
-                command: |
-                    cd ~/workspace/repo
-                    ./vendor/bin/phpunit \
-                        -c phpunit.xml.dist \
-                        --exclude-group=ignore \
-                        --testsuite="Models" \
-                        --coverage-clover=models-coverage.xml
             - *upload_coverage
+            - store_test_results:
+                path: ~/phpunit
+            - store_artifacts:
+                path: ~/phpunit
     php_72_integration:
         executor: core/php72
         steps: &php_integration_test_steps
@@ -187,6 +189,16 @@ jobs:
                         --exclude-group=ignore \
                         --testsuite="APIv0" \
                         --coverage-clover=apiv0-coverage.xml
+            - run:
+                name: Models Tests
+                command: |
+                    cd ~/workspace/repo
+                    ./vendor/bin/phpunit \
+                        -c phpunit.xml.dist \
+                        --exclude-group=ignore \
+                        --testsuite="Models" \
+                        --log-junit ~/phpunit/models-junit.xml \
+                        --coverage-clover=models-coverage.xml
             - *upload_coverage
     php_73_lint:
         executor: core/php73

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,10 @@ aliases:
         run:
             name: Upload Coverage
             command: |
+                cd ~/workspace/repo
                 curl -s https://codecov.io/bash | bash -s -- \
                     -s "$HOME/workspace/repo" \
-                    -y "$HOME/workspace/repo/.codecov.yml"\
+                    -y ".codecov.yml"\
                     -Z || echo 'Codecov upload failed'
     - &run_composer
         run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
     core: vanilla/core@2.1.0
     chromatic: wave/chromatic@1.0.1
+    codecov: codecov/codecov@1.0.5
 aliases:
     - &run_yarn
         run:
@@ -13,6 +14,14 @@ aliases:
     - &attach_workspace
         attach_workspace:
             at: ~/workspace
+    - &upload_coverage
+        run:
+            name: Upload Coverage
+            command: |
+                curl -s https://codecov.io/bash | bash -s -- \
+                    -s "$HOME/workspace/repo" \
+                    -y "$HOME/workspace/repo/.codecov.yml"\
+                    -Z || echo 'Codecov upload failed'
     - &run_composer
         run:
             name: Install Composer Packages
@@ -138,12 +147,30 @@ jobs:
                 name: Library Tests
                 command: |
                     cd ~/workspace/repo
-                    ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="Library"
+                    ./vendor/bin/phpunit \
+                        -c phpunit.xml.dist \
+                        --exclude-group=ignore \
+                        --testsuite="Library" \
+                        --coverage-clover=library-coverage.xml
             - run:
                 name: APIv2 Tests
                 command: |
                     cd ~/workspace/repo
-                    ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="APIv2"
+                    ./vendor/bin/phpunit \
+                        -c phpunit.xml.dist \
+                        --exclude-group=ignore \
+                        --testsuite="APIv2" \
+                        --coverage-clover=apiv2-coverage.xml
+            - run:
+                name: Models Tests
+                command: |
+                    cd ~/workspace/repo
+                    ./vendor/bin/phpunit \
+                        -c phpunit.xml.dist \
+                        --exclude-group=ignore \
+                        --testsuite="Models" \
+                        --coverage-clover=models-coverage.xml
+            - *upload_coverage
     php_72_integration:
         executor: core/php72
         steps: &php_integration_test_steps
@@ -154,12 +181,12 @@ jobs:
                 name: APIv0 Tests
                 command: |
                     cd ~/workspace/repo
-                    ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="APIv0"
-            - run:
-                name: Models Tests
-                command: |
-                    cd ~/workspace/repo
-                    ./vendor/bin/phpunit -c phpunit.xml.dist --exclude-group=ignore --testsuite="Models"
+                    ./vendor/bin/phpunit \
+                        -c phpunit.xml.dist \
+                        --exclude-group=ignore \
+                        --testsuite="APIv0" \
+                        --coverage-clover=apiv0-coverage.xml
+            - *upload_coverage
     php_73_lint:
         executor: core/php73
         steps: *php_lint_steps

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no
+
+ignore:
+  - "**/views/**/*.php"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![](https://img.shields.io/github/license/vanilla/vanilla.svg)](https://github.com/vanilla/vanilla/blob/master/LICENSE)
 [![CircleCI](https://circleci.com/gh/vanilla/vanilla/tree/master.svg?style=svg)](https://circleci.com/gh/vanilla/vanilla/tree/master)
+[![codecov](https://codecov.io/gh/vanilla/vanilla/branch/master/graph/badge.svg)](https://codecov.io/gh/vanilla/vanilla)
 ![](https://img.shields.io/github/commits-since/vanilla/vanilla/Vanilla_3.3.svg)
 
 ## Howdy, Stranger!
@@ -66,12 +67,12 @@ Our open source release branches are named by version number, e.g. `release/3.3`
 
 The `release/VERSION+BUILD` branches are production-ready branches for our cloud product but are not yet vetted for open source release (alternate platforms & configurations).
 
-|                     | Active Release |
-| ------------------- | -------------- |
-| **Version**         | `3.3`          |
+|                     | Active Release  |
+| ------------------- | --------------- |
+| **Version**         | `3.3`           |
 | **Initial Release** | 28 October 2019 |
 | **Last Updated**    | 28 October 2019 |
-| **EOL**             | Next release   |
+| **EOL**             | Next release    |
 
 Refer to the [OSS changelog](https://docs.vanillaforums.com/developer/changelog/) and the [Vanilla Cloud changelog](https://docs.vanillaforums.com/help/releases/) to track active changes between releases.
 


### PR DESCRIPTION
Working towards https://github.com/vanilla/vanilla/issues/9714

- Adds code coverage setup for https://codecov.io w/ CircleCI.
- Adds CircleCI coverage tracking.
- Increases the resource class size for our PHP tests to help offset the increased time  of tracking coverage.

The reports have started to appear in Codecov, but it looks like it can't actually generate any comparisons until the master branch contains the coverage reporting config file.

I will make followup PRs to tweak this setup once I can see it running.

- Codecov uses the clover coverage files.
- CircleCI uses the junit files.

## Example Report

![image](https://user-images.githubusercontent.com/1770056/70020864-832a8d80-155c-11ea-8895-ee6480ced853.png)
