### PR TITLE
Fix gdn & global scope issues in bootstrap

### DIFF
--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -8,7 +8,6 @@
 import { onContent, getMeta, _executeReady } from "@library/utility/appUtils";
 import { logDebug, logError, debug } from "@vanilla/utils";
 import { translationDebug } from "@vanilla/i18n";
-import gdn from "@library/gdn";
 import apiv2 from "@library/apiv2";
 import { mountInputs } from "@library/forms/mountInputs";
 import { onPageView } from "@library/pageViews/pageViewTracking";
@@ -17,7 +16,7 @@ import { _mountComponents } from "@library/utility/componentRegistry";
 import { blotCSS } from "@rich-editor/quill/components/blotStyles";
 import { bootstrapLocales } from "@library/locales/localeBootstrap";
 
-if (!gdn.getMeta("featureFlags.useFocusVisible.Enabled", true)) {
+if (!getMeta("featureFlags.useFocusVisible.Enabled", true)) {
     document.body.classList.add("hasNativeFocus");
 }
 
@@ -31,7 +30,7 @@ translationDebug(translationDebugValue);
 bootstrapLocales();
 
 // Export the API to the global object.
-gdn.apiv2 = apiv2;
+window.gdn.apiv2 = apiv2;
 
 // Record the page view.
 onPageView((params: { history: History }) => {


### PR DESCRIPTION
A `gdn.getMeta()` is exposed, but not on the imported Gdn object here.

I've cleared up the scoping issues that were causing the bootstrap to emit a module error.