### PR TITLE
Fixing adding GET params to existing URLs in OAuth2.

### DIFF
--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -94,7 +94,7 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
      *
      * @param string $uri The URL with or without a query string already attached.
      * @param array $get Array of key/value pairs to be passed as GET params.
-     * @return string URL with
+     * @return string URL with or without param string attached.
      */
     public static function concatUriQueryString(string $uri, array $get = []): string {
         if (!$get) {

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -524,7 +524,7 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
             $get['prompt'] = $provider['Prompt'];
         }
 
-        return $uri . '?' . http_build_query($get);
+        return $uri.(strpos($uri, '?') !== false ? '&' : '?').http_build_query($get);
     }
 
     /**

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -91,7 +91,7 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
 
     /**
      * Add a query to a URL without checking if there is already a query attached.
-     * 
+     *
      * @param string $uri The URL with or without a query string already attached.
      * @param array $get Array of key/value pairs to be passed as GET params.
      * @return string URL with

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -90,6 +90,20 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
     }
 
     /**
+     * Add a query to a URL without checking if there is already a query attached.
+     * 
+     * @param string $uri The URL with or without a query string already attached.
+     * @param array $get Array of key/value pairs to be passed as GET params.
+     * @return string URL with
+     */
+    public static function concatUriQueryString(string $uri, array $get = []): string {
+        if (!$get) {
+            return $uri;
+        }
+        return $uri . (strpos($uri, '?') !== false ? '&' : '?') . http_build_query($get);
+    }
+
+    /**
      * Generate a container key from a provider type.
      *
      * @param string $providerType The provider type (Gdn_AuthenticationProvider.AuthenticationSchemeAlias).
@@ -523,8 +537,7 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
         if (array_key_exists('Prompt', $provider) && isset($provider['Prompt'])) {
             $get['prompt'] = $provider['Prompt'];
         }
-
-        return $uri.(strpos($uri, '?') !== false ? '&' : '?').http_build_query($get);
+        return self::concatUriQueryString($uri, $get);
     }
 
     /**


### PR DESCRIPTION
This PR is in response to this issue: https://github.com/vanilla/support/issues/1088

We have a customer whose Register URL in OAuth2 connection has query parameters attached to it which makes for double '?' when we add our GET parameters. 

This PR will create a static public method (so we can use it elsewhere) that will add an array of queries to an existing URL regardless of if the URL already has parameters.

## Testing

 - Turn on the OAuth2 plugin.
 - Configure the plugin so that the Register URL and the Authorize URL has a query parameter (e.g. `https://myauthserver.com/authorize?forward=true`).
 - Try to connect.
 - Observe borking.
 - Checkout this branch.
 - Now try to correct. 
 - It may still bork because of the extra parameters you passed but if the URL contains only one '?' then we are good.
