### PR TITLE
Split sections: discussion and article in user menu

### DIFF
--- a/library/Vanilla/Models/DraftModel.php
+++ b/library/Vanilla/Models/DraftModel.php
@@ -43,4 +43,22 @@ class DraftModel extends PipelineModel {
         $jsonProcessor->setFields(["attributes"]);
         $this->addPipelineProcessor($jsonProcessor);
     }
+
+    /**
+     * Get draft count for particular user
+     *
+     * @param int $userID
+     * @return int
+     */
+    public function draftsCount(int $userID): int {
+
+        $countRecord = $this->sql()
+            ->from($this->getTable())
+            ->select('*', 'COUNT', 'draftCount')
+            ->where('insertUserID', $userID)
+            ->groupBy('insertUserID')
+            ->get()->nextRow(DATASET_TYPE_ARRAY);
+
+         return $countRecord['draftCount'];
+    }
 }

--- a/library/src/scripts/flyouts/dropDownStyles.ts
+++ b/library/src/scripts/flyouts/dropDownStyles.ts
@@ -72,8 +72,8 @@ export const dropDownVariables = useThemeCache(() => {
 
     const sectionTitle = makeThemeVars("sectionTitle", {
         padding: {
-            top: 6,
-            bottom: 6,
+            top: 0,
+            bottom: 0,
         },
     });
 

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
@@ -43,7 +43,11 @@ function UserDropDownContents(props: IProps) {
             <DropDownItemLink to="/profile/edit" name={t("Edit Profile")} />
             <DropDownSection title={t("Articles")}>
                 <Permission permission="articles.add">
-                    <DropDownItemLinkWithCount to="/kb/drafts" name={t("Drafts")} count={getCountByName("ArticleDrafts")} />
+                    <DropDownItemLinkWithCount
+                        to="/kb/drafts"
+                        name={t("Drafts")}
+                        count={getCountByName("ArticleDrafts")}
+                    />
                 </Permission>
             </DropDownSection>
             <DropDownSection title={t("Discussions")}>

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
@@ -102,7 +102,7 @@ interface IExtraDropDownProps {
  */
 UserDropDownContents.registerBeforeUserDropDown = (component: React.ComponentType<IExtraDropDownProps>) => {
     UserDropDownContents.extraUserDropDownComponents.push(component);
-}
+};
 
 interface IOwnProps {
     className?: string;

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
@@ -50,7 +50,7 @@ function UserDropDownContents(props: IProps) {
                     name={t("Bookmarks")}
                     count={getCountByName("Bookmarks")}
                 />
-                <Permission permission="Discussions.Add">
+                <Permission permission="discussions.add">
                     <DropDownItemLinkWithCount to="/drafts" name={t("Drafts")} count={getCountByName("Drafts")} />
                 </Permission>
                 <DropDownItemLinkWithCount

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
@@ -41,15 +41,9 @@ function UserDropDownContents(props: IProps) {
             <DropDownUserCard className="userDropDown-userCard" />
             <DropDownItemSeparator />
             <DropDownItemLink to="/profile/edit" name={t("Edit Profile")} />
-            <Permission permission="articles.add">
-                <DropDownSection title={t("Articles")}>
-                    <DropDownItemLinkWithCount
-                        to="/kb/drafts"
-                        name={t("Drafts")}
-                        count={getCountByName("ArticleDrafts")}
-                    />
-                </DropDownSection>
-            </Permission>
+            {UserDropDownContents.extraUserDropDownComponents.map((ComponentName, index) => {
+                return <ComponentName key={index} getCountByName={getCountByName} />;
+            })}
             <DropDownSection title={t("Discussions")}>
                 <DropDownItemLinkWithCount
                     to={"/discussions/bookmarked"}
@@ -91,6 +85,23 @@ function UserDropDownContents(props: IProps) {
             <DropDownItemLink to={`/entry/signout?target=${window.location.href}`} name={t("Sign Out")} />
         </div>
     );
+}
+
+/** Hold the extra user dropdown menu components before rendering. */
+UserDropDownContents.extraUserDropDownComponents = [];
+
+interface IExtraDropDownProps {
+    getCountByName: (name: string) => number;
+}
+
+/**
+ * Register an extra component to be rendered before the user dropdown menu.
+ * This will only affect larger screen sizes.
+ *
+ * @param component The component class to be render.
+ */
+UserDropDownContents.registerBeforeUserDropDown = (component: React.ComponentType<IExtraDropDownProps>) => {
+    UserDropDownContents.extraUserDropDownComponents.push(component);
 }
 
 interface IOwnProps {

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
@@ -41,15 +41,15 @@ function UserDropDownContents(props: IProps) {
             <DropDownUserCard className="userDropDown-userCard" />
             <DropDownItemSeparator />
             <DropDownItemLink to="/profile/edit" name={t("Edit Profile")} />
-            <DropDownSection title={t("Articles")}>
-                <Permission permission="articles.add">
+            <Permission permission="articles.add">
+                <DropDownSection title={t("Articles")}>
                     <DropDownItemLinkWithCount
                         to="/kb/drafts"
                         name={t("Drafts")}
                         count={getCountByName("ArticleDrafts")}
                     />
-                </Permission>
-            </DropDownSection>
+                </DropDownSection>
+            </Permission>
             <DropDownSection title={t("Discussions")}>
                 <DropDownItemLinkWithCount
                     to={"/discussions/bookmarked"}

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
@@ -41,14 +41,19 @@ function UserDropDownContents(props: IProps) {
             <DropDownUserCard className="userDropDown-userCard" />
             <DropDownItemSeparator />
             <DropDownItemLink to="/profile/edit" name={t("Edit Profile")} />
+            <DropDownSection title={t("Articles")}>
+                <Permission permission="articles.add">
+                    <DropDownItemLinkWithCount to="/kb/drafts" name={t("Drafts")} count={getCountByName("ArticleDrafts")} />
+                </Permission>
+            </DropDownSection>
             <DropDownSection title={t("Discussions")}>
                 <DropDownItemLinkWithCount
                     to={"/discussions/bookmarked"}
                     name={t("Bookmarks")}
                     count={getCountByName("Bookmarks")}
                 />
-                <Permission permission="articles.add">
-                    <DropDownItemLinkWithCount to="/kb/drafts" name={t("Drafts")} count={getCountByName("Drafts")} />
+                <Permission permission="Discussions.Add">
+                    <DropDownItemLinkWithCount to="/drafts" name={t("Drafts")} count={getCountByName("Drafts")} />
                 </Permission>
                 <DropDownItemLinkWithCount
                     to="/discussions/mine"


### PR DESCRIPTION
Add section `Articles` with menu item `Drafts` with proper implemented link to `/kb/drafts/` and counter.

Update section `Discussion` with proper link for discussions drafts `/drafts` and counter.

Closes: #9713
