### PR TITLE
Rich-editor: remove '*' as a Inline trigger for markdown marcos

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
@@ -290,9 +290,8 @@ export default class MarkdownModule {
         {
             name: "bold",
             type: MarkdownMacroType.INLINE,
-            pattern: /(\*{2})(.*?)\*{2}\1/g,
+            pattern: /(?:\*|_){2}(.+?)(?:\*|_){2}$/g,
             handler: (text, selection, pattern, lineStart) => {
-                console.log("bold" + text);
                 const match = pattern.exec(text);
                 if (!match) {
                     return;
@@ -307,7 +306,7 @@ export default class MarkdownModule {
 
                 this.quill.deleteText(startIndex, annotatedText.length);
                 this.quill.insertText(startIndex, matchedText, { bold: true });
-                this.quill.format("bold: ", false);
+                this.quill.format("bold", false);
             },
         },
         {
@@ -315,17 +314,15 @@ export default class MarkdownModule {
             type: MarkdownMacroType.INLINE,
             pattern: /(?:\*|_){1}(.+?)(?:\*|_){1}$/g,
             handler: (text, selection, pattern, lineStart) => {
-                console.log("italic: " + text);
                 const match = pattern.exec(text);
                 if (!match) {
                     return;
                 }
-
                 const annotatedText = match[0];
                 const matchedText = match[1];
                 const startIndex = lineStart + match.index;
 
-                if (text.match(/^([*_ \n]+)$/g) || text.match(/\*(.*?)\*/g)) {
+                if (text.match(/^([*_ \n]+)$/g)) {
                     return;
                 }
 

--- a/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
@@ -36,7 +36,6 @@ export enum MarkdownInlineTriggers {
     ESCLAME_INVERT = "¡",
     QUOTE = '"',
     APOSTOPH = "'",
-    STAR = "*",
     COLON = ":",
     SEMI_COLON = ";",
 }
@@ -291,8 +290,9 @@ export default class MarkdownModule {
         {
             name: "bold",
             type: MarkdownMacroType.INLINE,
-            pattern: /(?:\*|_){2}(.+?)(?:\*|_){2}$/g,
+            pattern: /(\*{2})(.*?)\*{2}\1/g,
             handler: (text, selection, pattern, lineStart) => {
+                console.log("bold" + text);
                 const match = pattern.exec(text);
                 if (!match) {
                     return;
@@ -307,7 +307,7 @@ export default class MarkdownModule {
 
                 this.quill.deleteText(startIndex, annotatedText.length);
                 this.quill.insertText(startIndex, matchedText, { bold: true });
-                this.quill.format("bold", false);
+                this.quill.format("bold: ", false);
             },
         },
         {
@@ -315,15 +315,17 @@ export default class MarkdownModule {
             type: MarkdownMacroType.INLINE,
             pattern: /(?:\*|_){1}(.+?)(?:\*|_){1}$/g,
             handler: (text, selection, pattern, lineStart) => {
+                console.log("italic: " + text);
                 const match = pattern.exec(text);
                 if (!match) {
                     return;
                 }
+
                 const annotatedText = match[0];
                 const matchedText = match[1];
                 const startIndex = lineStart + match.index;
 
-                if (text.match(/^([*_ \n]+)$/g)) {
+                if (text.match(/^([*_ \n]+)$/g) || text.match(/\*(.*?)\*/g)) {
                     return;
                 }
 


### PR DESCRIPTION
When triggering inline markdown macros in the rich-editor, the `*` would immediately trigger _italic_ fonts instead of continuing reading for potential  __bold__ markup.  This removes `*`'s as trigger character so that user can continue typing before the marco is trigger.

`**test**` would result in \*_test_\* 

closes https://github.com/vanilla/knowledge/issues/1346