### PR TITLE
Add static designation support for assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ lerna-debug.log
 git-diff.txt
 phpcs-diff.json
 phpunit.xml.dist
+.phpunit.result.cache

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,0 @@
-C:37:"PHPUnit\Runner\DefaultTestResultCache":121:{a:2:{s:7:"defects";a:0:{}s:5:"times";a:1:{s:61:"VanillaTests\Library\Vanilla\Web\Asset\AssetsTest::testStatic";d:0.063;}}}

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,0 +1,1 @@
+C:37:"PHPUnit\Runner\DefaultTestResultCache":121:{a:2:{s:7:"defects";a:0:{}s:5:"times";a:1:{s:61:"VanillaTests\Library\Vanilla\Web\Asset\AssetsTest::testStatic";d:0.063;}}}

--- a/applications/dashboard/controllers/api/LocalesApiController.php
+++ b/applications/dashboard/controllers/api/LocalesApiController.php
@@ -139,13 +139,6 @@ class LocalesApiController extends Controller {
     public function index_translations(string $locale, array $query = []) {
         $this->permission();
 
-        $in = $this->schema([
-            'etag:s?' => 'Whether or not output is cached.'
-        ], 'in');
-        $out = $this->schema([':o'], 'out');
-
-        $query = $in->validate($query);
-
         $this->locale->set($locale);
 
         // Don't bother validating the translations since they are a free-form array.
@@ -155,10 +148,7 @@ class LocalesApiController extends Controller {
             $translations = (object)[];
         }
         $r = new Data($translations);
-        if (!empty($query['etag'])) {
-            $r->setHeader('Cache-Control', 'public, max-age=604800');
-        }
-
+        $r->setHeader('Cache-Control', 'public, max-age=1800');
         return $r;
     }
 

--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -76,7 +76,7 @@ if (!class_exists('HeadModule', false)) {
         /**
          * Adds a "link" tag to the head containing a reference to a stylesheet.
          * By default a stylesheet is considered as a static-asset
-         * 
+         *
          * @param string $hRef Location of the stylesheet relative to the web root (if an absolute path with http:// is provided, it will use the HRef as provided). ie. /themes/default/css/layout.css or http://url.com/layout.css
          * @param string $media Type media for the stylesheet. ie. "screen", "print", etc.
          * @param bool $addVersion Whether to append version number as query string.
@@ -144,7 +144,7 @@ if (!class_exists('HeadModule', false)) {
         /**
          * Adds a "script" tag to the head.
          * By default a script is considered as a static-asset
-         * 
+         *
          * @param string $src The location of the script relative to the web root. ie. "/js/jquery.js"
          * @param string $type The type of script being added. ie. "text/javascript"
          * @param bool $addVersion Whether to append version number as query string.

--- a/applications/dashboard/modules/class.headmodule.php
+++ b/applications/dashboard/modules/class.headmodule.php
@@ -54,6 +54,8 @@ if (!class_exists('HeadModule', false)) {
         /** @var \Vanilla\Web\Asset\AssetPreloadModel */
         private $assetPreloadModel;
 
+        /** @var Garden\EventManager */
+        protected $eventManager;
         /**
          *
          *
@@ -68,11 +70,13 @@ if (!class_exists('HeadModule', false)) {
             parent::__construct($sender);
             // Workaround beacuse we can't do parameter injection.
             $this->assetPreloadModel = \Gdn::getContainer()->get(\Vanilla\Web\Asset\AssetPreloadModel::class);
+            $this->eventManager = \Gdn::getContainer()->get(Garden\EventManager::class);
         }
 
         /**
          * Adds a "link" tag to the head containing a reference to a stylesheet.
-         *
+         * By default a stylesheet is considered as a static-asset
+         * 
          * @param string $hRef Location of the stylesheet relative to the web root (if an absolute path with http:// is provided, it will use the HRef as provided). ie. /themes/default/css/layout.css or http://url.com/layout.css
          * @param string $media Type media for the stylesheet. ie. "screen", "print", etc.
          * @param bool $addVersion Whether to append version number as query string.
@@ -82,7 +86,9 @@ if (!class_exists('HeadModule', false)) {
             $properties = [
                 'rel' => 'stylesheet',
                 'href' => asset($hRef, false, $addVersion),
-                'media' => $media];
+                'media' => $media,
+                'static' => $options['static'] ?? true,
+            ];
 
             // Use same underscore convention as AddScript
             if (is_array($options)) {
@@ -137,7 +143,8 @@ if (!class_exists('HeadModule', false)) {
 
         /**
          * Adds a "script" tag to the head.
-         *
+         * By default a script is considered as a static-asset
+         * 
          * @param string $src The location of the script relative to the web root. ie. "/js/jquery.js"
          * @param string $type The type of script being added. ie. "text/javascript"
          * @param bool $addVersion Whether to append version number as query string.
@@ -163,6 +170,7 @@ if (!class_exists('HeadModule', false)) {
             $attributes = [];
             if ($src) {
                 $attributes['src'] = asset($src, false, $addVersion);
+                $attributes['static'] = $options['static'] ?? true;
             }
             if ($type !== 'text/javascript') {
                 // Not needed in HTML5
@@ -514,12 +522,10 @@ if (!class_exists('HeadModule', false)) {
 
             $this->fireEvent('BeforeToString');
 
-            $tags = $this->_Tags;
-
             // Make sure that css loads before js (for jquery)
             usort($this->_Tags, ['HeadModule', 'TagCmp']); // "link" comes before "script"
 
-            $tags2 = $this->_Tags;
+            $this->eventManager->fireArray('HeadTagsBeforeRender', [&$this->_Tags]);
 
             // Start with the title.
             $head = '<title>'.Gdn_Format::text($this->title())."</title>\n";

--- a/build/entries/public-path.ts
+++ b/build/entries/public-path.ts
@@ -8,7 +8,7 @@
  * @license GPL-2.0-only
  */
 
-import { assetUrl } from "@library/utility/appUtils";
+import { assetUrl, getMeta } from "@library/utility/appUtils";
 
 /**
  * This needs to be a free variable.
@@ -21,4 +21,4 @@ import { assetUrl } from "@library/utility/appUtils";
  * @see https://github.com/webpack/webpack/issues/2776#issuecomment-233208623
  */
 // @ts-ignore: Cannot find variable warning. See comment aboe.
-__webpack_public_path__ = assetUrl("/dist/" + __BUILD__SECTION__ + "/");
+__webpack_public_path__ = assetUrl(getMeta("context.staticPathFolder") + "/dist/" + __BUILD__SECTION__ + "/");

--- a/build/scripts/configs/makeBaseConfig.ts
+++ b/build/scripts/configs/makeBaseConfig.ts
@@ -163,7 +163,7 @@ ${chalk.green(aliases)}`;
     if (options.mode === BuildMode.PRODUCTION) {
         config.plugins.push(
             new MiniCssExtractPlugin({
-                filename: "[name].min.css",
+                filename: "[name].min.css?[chunkhash]",
             }),
         );
     }

--- a/library/Vanilla/Contracts/Web/AssetInterface.php
+++ b/library/Vanilla/Contracts/Web/AssetInterface.php
@@ -12,6 +12,15 @@ namespace Vanilla\Contracts\Web;
  */
 interface AssetInterface {
     /**
+     * It tells if the asset is static or not
+     * Static means that the asset is inmutable during the build's lifecycle
+     * The value can be used for Caching purposes
+     *
+     * @return bool
+     */
+    public function isStatic(): bool;
+
+    /**
      * Get the full web ready URL of the asset.
      *
      * @return string

--- a/library/Vanilla/Models/SiteMeta.php
+++ b/library/Vanilla/Models/SiteMeta.php
@@ -11,6 +11,7 @@ use Garden\Web\RequestInterface;
 use Vanilla\Contracts;
 use Vanilla\Addon;
 use Vanilla\Site\SiteSectionModel;
+use Vanilla\Web\Asset\DeploymentCacheBuster;
 
 /**
  * A class for gathering particular data about the site.
@@ -71,18 +72,26 @@ class SiteMeta implements \JsonSerializable {
     /** @var string */
     private $orgName;
 
+    /** @var string */
+    private $cacheBuster;
+
+    /** @var string */
+    private $staticPathFolder = '';
+
     /**
      * SiteMeta constructor.
      *
      * @param RequestInterface $request The request to gather data from.
      * @param Contracts\ConfigurationInterface $config The configuration object.
      * @param SiteSectionModel $siteSectionModel
+     * @param DeploymentCacheBuster $deploymentCacheBuster
      * @param Contracts\AddonInterface $activeTheme
      */
     public function __construct(
         RequestInterface $request,
         Contracts\ConfigurationInterface $config,
         SiteSectionModel $siteSectionModel,
+        DeploymentCacheBuster $deploymentCacheBuster,
         ?Contracts\AddonInterface $activeTheme = null
     ) {
         $this->host = $request->getHost();
@@ -113,6 +122,9 @@ class SiteMeta implements \JsonSerializable {
 
         // localization
         $this->localeKey = $this->currentSiteSection->getContentLocale();
+
+        // DeploymentCacheBuster
+        $this->cacheBuster = $deploymentCacheBuster->value();
 
         // Theming
         $this->activeTheme = $activeTheme;
@@ -150,6 +162,8 @@ class SiteMeta implements \JsonSerializable {
                 'assetPath' => $this->assetPath,
                 'debug' => $this->debugModeEnabled,
                 'translationDebug' => $this->translationDebugModeEnabled,
+                'cacheBuster' => $this->cacheBuster,
+                'staticPathFolder' => $this->staticPathFolder,
             ],
             'ui' => [
                 'siteName' => $this->siteTitle,
@@ -273,5 +287,12 @@ class SiteMeta implements \JsonSerializable {
      */
     public function getMobileAddressBarColor(): ?string {
         return $this->mobileAddressBarColor;
+    }
+
+    /**
+     * @param string $staticPathFolder
+     */
+    public function setStaticPathFolder(string $staticPathFolder) {
+        $this->staticPathFolder = $staticPathFolder;
     }
 }

--- a/library/Vanilla/Web/Asset/ExternalAsset.php
+++ b/library/Vanilla/Web/Asset/ExternalAsset.php
@@ -30,4 +30,12 @@ class ExternalAsset implements AssetInterface {
     public function getWebPath(): string {
         return $this->url;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function isStatic(): bool
+    {
+        return false;
+    }
 }

--- a/library/Vanilla/Web/Asset/ExternalAsset.php
+++ b/library/Vanilla/Web/Asset/ExternalAsset.php
@@ -34,8 +34,7 @@ class ExternalAsset implements AssetInterface {
     /**
      * @inheritdoc
      */
-    public function isStatic(): bool
-    {
+    public function isStatic(): bool {
         return false;
     }
 }

--- a/library/Vanilla/Web/Asset/HotBuildAsset.php
+++ b/library/Vanilla/Web/Asset/HotBuildAsset.php
@@ -41,4 +41,12 @@ class HotBuildAsset implements Contracts\Web\AssetInterface {
     public function getWebPath(): string {
         return "http://$this->ip:3030/$this->section-hot-bundle.js";
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function isStatic(): bool
+    {
+        return false;
+    }
 }

--- a/library/Vanilla/Web/Asset/HotBuildAsset.php
+++ b/library/Vanilla/Web/Asset/HotBuildAsset.php
@@ -45,8 +45,7 @@ class HotBuildAsset implements Contracts\Web\AssetInterface {
     /**
      * @inheritdoc
      */
-    public function isStatic(): bool
-    {
+    public function isStatic(): bool {
         return false;
     }
 }

--- a/library/Vanilla/Web/Asset/LegacyAssetModel.php
+++ b/library/Vanilla/Web/Asset/LegacyAssetModel.php
@@ -111,7 +111,7 @@ class LegacyAssetModel extends Gdn_Model {
         // Include theme customizations last so that they override everything else.
         switch ($basename) {
             case 'style':
-                $this->addCssFile(asset('/applications/dashboard/design/style-compat.css', true), false, ['Sort' => -9.999]);
+                $this->addCssFile(asset('/applications/dashboard/design/style-compat.css', false), false, ['Sort' => -9.999]);
                 $this->addCssFile('custom.css', false, ['Sort' => 1000]);
 
                 if (Gdn::controller()->Theme && Gdn::controller()->ThemeOptions) {

--- a/library/Vanilla/Web/Asset/LocaleAsset.php
+++ b/library/Vanilla/Web/Asset/LocaleAsset.php
@@ -33,7 +33,7 @@ class LocaleAsset extends SiteAsset {
      * @inheritdoc
      */
     public function getWebPath(): string {
-        return self::makeAssetPath(
+        return $this->makeAssetPath(
             '/api/v2/locales',
             $this->localeKey,
             'translations.js'

--- a/library/Vanilla/Web/Asset/PolyfillAsset.php
+++ b/library/Vanilla/Web/Asset/PolyfillAsset.php
@@ -18,4 +18,11 @@ class PolyfillAsset extends SiteAsset {
     public function getWebPath(): string {
         return $this->makeAssetPath('dist', 'polyfills.min.js');
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function isStatic(): bool {
+        return true;
+    }
 }

--- a/library/Vanilla/Web/Asset/SiteAsset.php
+++ b/library/Vanilla/Web/Asset/SiteAsset.php
@@ -54,24 +54,6 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
     }
 
     /**
-     * Create a web-root url, not an asset URL. This is useful for application level resources like ones created from
-     * API endpoints.
-     *
-     * @param string[] $pieces The pieces to join together.
-     *
-     * @return string The relative web path.
-     */
-    protected function makeWebPath(string ...$pieces): string {
-        $path = self::joinWebPath(
-            '/',
-            $this->request->getRoot(),
-            ...$pieces
-        );
-
-        return $this->addCacheBuster($path);
-    }
-
-    /**
      * Add a cache busting query parameter if one is available.
      *
      * @param string $url The URL to modify.

--- a/library/Vanilla/Web/Asset/SiteAsset.php
+++ b/library/Vanilla/Web/Asset/SiteAsset.php
@@ -129,8 +129,9 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
     }
 
     /**
-     * @inheritDoc
      * The default behaviour is to be non-static
+     *
+     * @inheritDoc
      *
      * @return bool
      */

--- a/library/Vanilla/Web/Asset/SiteAsset.php
+++ b/library/Vanilla/Web/Asset/SiteAsset.php
@@ -40,7 +40,7 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
     /**
      * Utility function for calculating a relative asset URL
      *
-     * @param string ...$pieces The pieces of the web path.
+     * @param string[] $pieces The pieces of the web path.
      * @return string The relative web path.
      */
     protected function makeAssetPath(string ...$pieces): string {
@@ -57,7 +57,7 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
      * Create a web-root url, not an asset URL. This is useful for application level resources like ones created from
      * API endpoints.
      *
-     * @param string ...$pieces The pieces to join together.
+     * @param string[] $pieces The pieces to join together.
      *
      * @return string The relative web path.
      */
@@ -88,7 +88,7 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
     /**
      * Utility for joining together path pieces with a `/` (such as a web url).
      *
-     * @param string ...$pieces The pieces of the url.
+     * @param string[] $pieces The pieces of the url.
      * @return string A joined version of the pieces with no duplicate `/`s
      */
     public static function joinWebPath(string ...$pieces): string {
@@ -130,7 +130,6 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
 
     /**
      * @inheritDoc
-     *
      * The default behaviour is to be non-static
      *
      * @return bool

--- a/library/Vanilla/Web/Asset/SiteAsset.php
+++ b/library/Vanilla/Web/Asset/SiteAsset.php
@@ -38,14 +38,14 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
     abstract public function getWebPath(): string;
 
     /**
-     * Utility function for calculating a full asset URL w/the domain of site, and the asset root.
+     * Utility function for calculating a relative asset URL
      *
-     * @param string[] $pieces The pieces of the web path.
-     * @return string The full web path.
+     * @param string ...$pieces The pieces of the web path.
+     * @return string The relative web path.
      */
     protected function makeAssetPath(string ...$pieces): string {
         $path = self::joinWebPath(
-            $this->request->urlDomain(),
+            '/',
             $this->request->getAssetRoot(),
             ...$pieces
         );
@@ -57,13 +57,13 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
      * Create a web-root url, not an asset URL. This is useful for application level resources like ones created from
      * API endpoints.
      *
-     * @param string[] $pieces The pieces to join together.
+     * @param string ...$pieces The pieces to join together.
      *
-     * @return string
+     * @return string The relative web path.
      */
     protected function makeWebPath(string ...$pieces): string {
         $path = self::joinWebPath(
-            $this->request->urlDomain(),
+            '/',
             $this->request->getRoot(),
             ...$pieces
         );
@@ -88,7 +88,7 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
     /**
      * Utility for joining together path pieces with a `/` (such as a web url).
      *
-     * @param string[] $pieces The pieces of the url.
+     * @param string ...$pieces The pieces of the url.
      * @return string A joined version of the pieces with no duplicate `/`s
      */
     public static function joinWebPath(string ...$pieces): string {
@@ -126,5 +126,16 @@ abstract class SiteAsset implements Contracts\Web\AssetInterface {
         }
 
         return rtrim($path, $joiner);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * The default behaviour is to be non-static
+     *
+     * @return bool
+     */
+    public function isStatic(): bool {
+        return false;
     }
 }

--- a/library/Vanilla/Web/Asset/ThemeScriptAsset.php
+++ b/library/Vanilla/Web/Asset/ThemeScriptAsset.php
@@ -8,7 +8,6 @@
 namespace Vanilla\Web\Asset;
 
 use Garden\Web\RequestInterface;
-use Vanilla\Contracts;
 
 /**
  * An asset representing a script containing data for a particular locale.
@@ -34,10 +33,18 @@ class ThemeScriptAsset extends SiteAsset {
      * @inheritdoc
      */
     public function getWebPath(): string {
-        return self::makeWebPath(
+
+        return $this->makeWebPath(
             '/api/v2/themes',
             $this->themeKey,
             '/assets/javascript.js'
         );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isStatic(): bool {
+        return true;
     }
 }

--- a/library/Vanilla/Web/Asset/ThemeScriptAsset.php
+++ b/library/Vanilla/Web/Asset/ThemeScriptAsset.php
@@ -33,8 +33,7 @@ class ThemeScriptAsset extends SiteAsset {
      * @inheritdoc
      */
     public function getWebPath(): string {
-
-        return $this->makeWebPath(
+        return $this->makeAssetPath(
             '/api/v2/themes',
             $this->themeKey,
             '/assets/javascript.js'

--- a/library/Vanilla/Web/Asset/WebpackAsset.php
+++ b/library/Vanilla/Web/Asset/WebpackAsset.php
@@ -93,11 +93,4 @@ class WebpackAsset extends SiteAsset {
     public function setFsRoot(string $assetRoot) {
         $this->fsRoot = $assetRoot;
     }
-
-    /**
-     * @inheritdoc
-     */
-    public function isStatic(): bool {
-        return true;
-    }
 }

--- a/library/Vanilla/Web/Asset/WebpackAsset.php
+++ b/library/Vanilla/Web/Asset/WebpackAsset.php
@@ -8,7 +8,6 @@
 namespace Vanilla\Web\Asset;
 
 use Garden\Web\RequestInterface;
-use Vanilla\Contracts;
 
 /**
  * An asset representing a file created by the webpack build process.
@@ -93,5 +92,12 @@ class WebpackAsset extends SiteAsset {
      */
     public function setFsRoot(string $assetRoot) {
         $this->fsRoot = $assetRoot;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isStatic(): bool {
+        return true;
     }
 }

--- a/library/Vanilla/Web/Asset/WebpackAsset.php
+++ b/library/Vanilla/Web/Asset/WebpackAsset.php
@@ -93,4 +93,11 @@ class WebpackAsset extends SiteAsset {
     public function setFsRoot(string $assetRoot) {
         $this->fsRoot = $assetRoot;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function isStatic(): bool {
+        return true;
+    }
 }

--- a/library/Vanilla/Web/Page.php
+++ b/library/Vanilla/Web/Page.php
@@ -7,6 +7,7 @@
 
 namespace Vanilla\Web;
 
+use Garden\EventManager;
 use Garden\Web\Exception\HttpException;
 use Gdn_Upload;
 use Garden\CustomExceptionHandler;
@@ -108,6 +109,9 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
     /** @var AssetPreloadModel */
     protected $preloadModel;
 
+    /** @var EventManager */
+    protected $eventManager;
+
     /**
      * Dependendency Injection.
      *
@@ -118,6 +122,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
      * @param BreadcrumbModel $breadcrumbModel
      * @param ContentSecurityPolicyModel $cspModel
      * @param AssetPreloadModel $preloadModel
+     * @param EventManager $eventManager
      */
     public function setDependencies(
         SiteMeta $siteMeta,
@@ -126,7 +131,8 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
         WebpackAssetProvider $assetProvider,
         BreadcrumbModel $breadcrumbModel,
         ContentSecurityPolicyModel $cspModel,
-        AssetPreloadModel $preloadModel
+        AssetPreloadModel $preloadModel,
+        EventManager $eventManager
     ) {
         $this->siteMeta = $siteMeta;
         $this->request = $request;
@@ -135,6 +141,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
         $this->breadcrumbModel = $breadcrumbModel;
         $this->cspModel = $cspModel;
         $this->preloadModel = $preloadModel;
+        $this->eventManager = $eventManager;
 
         if ($mobileAddressBarColor = $this->siteMeta->getMobileAddressBarColor()) {
             $this->addMetaTag(["name" => "theme-color", "content" => $mobileAddressBarColor]);
@@ -185,6 +192,9 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
             'favIcon' => $this->siteMeta->getFavIcon(),
             'jsonLD' => $this->getJsonLDScriptContent(),
         ];
+
+        $this->eventManager->fireArray('BeforeRenderMasterView', [&$viewData]);
+
         $viewContent = $this->renderTwig('resources/views/default-master.twig', $viewData);
 
         return new Data($viewContent, $this->statusCode);

--- a/library/Vanilla/Web/ThemedPage.php
+++ b/library/Vanilla/Web/ThemedPage.php
@@ -6,18 +6,13 @@
 
 namespace Vanilla\Web;
 
-use Garden\Web\Data;
-use Garden\Web\Exception\ServerException;
+use Garden\EventManager;
 use Vanilla\Models\SiteMeta;
 use Vanilla\Models\ThemePreloadProvider;
 use Vanilla\Navigation\BreadcrumbModel;
-use Vanilla\Theme\JavascriptAsset;
-use Vanilla\Theme\JsonAsset;
 use Vanilla\Web\Asset\AssetPreloadModel;
 use Vanilla\Web\Asset\WebpackAssetProvider;
 use Vanilla\Web\ContentSecurityPolicy\ContentSecurityPolicyModel;
-use Vanilla\Web\JsInterpop\ReduxAction;
-use Vanilla\Theme\FontsAsset;
 
 /**
  * A Web\Page that makes use of custom theme data from the theming API.
@@ -38,9 +33,10 @@ abstract class ThemedPage extends Page {
         BreadcrumbModel $breadcrumbModel,
         ContentSecurityPolicyModel $cspModel,
         AssetPreloadModel $preloadModel,
-        ThemePreloadProvider $themeProvider = null // Default required to conform to interface
+        ThemePreloadProvider $themeProvider = null, // Default required to conform to interface
+        EventManager $eventManager
     ) {
-        parent::setDependencies($siteMeta, $request, $session, $assetProvider, $breadcrumbModel, $cspModel, $preloadModel);
+        parent::setDependencies($siteMeta, $request, $session, $assetProvider, $breadcrumbModel, $cspModel, $preloadModel, $eventManager);
         $this->themeProvider = $themeProvider;
         $this->initAssets();
     }

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -2067,7 +2067,11 @@ class Gdn_Controller extends Gdn_Pluggable {
         $this->registerReduxActionProvider($themeProvider);
         $themeScript = $themeProvider->getThemeScript();
         if ($themeScript !== null) {
-            $this->Head->addScript($themeScript->getWebPath());
+            $this->Head->addScript($themeScript->getWebPath(),
+                'text/javascript',
+                true,
+                ['static' => $themeScript->isStatic()]
+            );
         }
     }
 
@@ -2086,7 +2090,11 @@ class Gdn_Controller extends Gdn_Pluggable {
         $section = $this->MasterView === 'admin' ? 'admin' : 'forum';
         $jsAssets = $webpackAssetProvider->getScripts($section);
         foreach ($jsAssets as $asset) {
-            $this->Head->addScript($asset->getWebPath(), 'text/javascript', false, ['defer' => 'defer']);
+            $this->Head->addScript($asset->getWebPath(),
+            'text/javascript',
+            false,
+            ['defer' => 'defer', 'static' => $asset->isStatic()]
+        );
         }
 
         // The the built stylesheets

--- a/library/core/class.controller.php
+++ b/library/core/class.controller.php
@@ -2067,7 +2067,8 @@ class Gdn_Controller extends Gdn_Pluggable {
         $this->registerReduxActionProvider($themeProvider);
         $themeScript = $themeProvider->getThemeScript();
         if ($themeScript !== null) {
-            $this->Head->addScript($themeScript->getWebPath(),
+            $this->Head->addScript(
+                $themeScript->getWebPath(),
                 'text/javascript',
                 true,
                 ['static' => $themeScript->isStatic()]
@@ -2090,11 +2091,12 @@ class Gdn_Controller extends Gdn_Pluggable {
         $section = $this->MasterView === 'admin' ? 'admin' : 'forum';
         $jsAssets = $webpackAssetProvider->getScripts($section);
         foreach ($jsAssets as $asset) {
-            $this->Head->addScript($asset->getWebPath(),
-            'text/javascript',
-            false,
-            ['defer' => 'defer', 'static' => $asset->isStatic()]
-        );
+            $this->Head->addScript(
+                $asset->getWebPath(),
+                'text/javascript',
+                false,
+                ['defer' => 'defer', 'static' => $asset->isStatic()]
+            );
         }
 
         // The the built stylesheets

--- a/library/core/class.gdn.php
+++ b/library/core/class.gdn.php
@@ -70,9 +70,6 @@ class Gdn {
      */
     private static $container;
 
-    /** @var Gdn_Configuration  */
-    protected static $_Config = null;
-
     /** @var boolean Whether or not Gdn::FactoryInstall should overwrite existing objects. */
     protected static $_FactoryOverwrite = true;
 
@@ -142,10 +139,8 @@ class Gdn {
      * @return Gdn_Configuration|mixed The configuration setting.
      */
     public static function config($name = false, $default = false) {
-        if (self::$_Config === null) {
-            self::$_Config = static::getContainer()->get(self::AliasConfig);
-        }
-        $config = self::$_Config;
+        $config = static::getContainer()->get(self::AliasConfig);;
+
         if ($name === false) {
             $result = $config;
         } else {
@@ -582,7 +577,6 @@ class Gdn {
         /**
          * Reset all of the cached objects that are fetched from the container.
          */
-        self::$_Config = null;
         self::$_FactoryOverwrite = true;
         self::$_Locale = null;
         self::$_Request = null;

--- a/library/core/class.gdn.php
+++ b/library/core/class.gdn.php
@@ -139,7 +139,7 @@ class Gdn {
      * @return Gdn_Configuration|mixed The configuration setting.
      */
     public static function config($name = false, $default = false) {
-        $config = static::getContainer()->get(self::AliasConfig);;
+        $config = static::getContainer()->get(self::AliasConfig);
 
         if ($name === false) {
             $result = $config;

--- a/tests/Library/Vanilla/Web/Asset/AssetsTest.php
+++ b/tests/Library/Vanilla/Web/Asset/AssetsTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Web\Asset;
+
+use Vanilla\Web\Asset\ExternalAsset;
+use Vanilla\Web\Asset\HotBuildAsset;
+use Vanilla\Web\Asset\LocaleAsset;
+use Vanilla\Web\Asset\PolyfillAsset;
+use VanillaTests\Fixtures\Request;
+use VanillaTests\MinimalContainerTestCase;
+
+/**
+ * Tests for various assets.
+ */
+class AssetsTest extends MinimalContainerTestCase {
+
+    /**
+     * Tests for the site asset.
+     */
+    public function testStatic() {
+        $polyfill = new PolyfillAsset(new Request());
+        $this->assertTrue($polyfill->isStatic());
+
+        $locale = new LocaleAsset(new Request(), "en");
+        $this->assertFalse($locale->isStatic());
+
+        $external = new ExternalAsset("http://test.com/script.js");
+        $this->assertFalse($external->isStatic());
+
+        $hotBuild = new HotBuildAsset("test");
+        $this->assertFalse($hotBuild->isStatic());
+    }
+}

--- a/tests/Library/Vanilla/Web/Asset/WebpackAssetProviderTest.php
+++ b/tests/Library/Vanilla/Web/Asset/WebpackAssetProviderTest.php
@@ -69,7 +69,7 @@ class WebpackAssetProviderTest extends TestCase {
         $scripts = $provider->getScripts('someSection');
         $this->assertInstanceOf(LocaleAsset::class, $scripts[0]);
         $this->assertEquals(
-            'http://example.com/api/v2/locales/en/translations.js',
+            '/api/v2/locales/en/translations.js',
             $scripts[0]->getWebPath(),
             "Creates a valid API js file"
         );
@@ -78,7 +78,7 @@ class WebpackAssetProviderTest extends TestCase {
         $provider->setCacheBusterKey($buster);
         $scripts = $provider->getScripts('someSection');
         $this->assertEquals(
-            "http://example.com/api/v2/locales/en/translations.js?h=$buster",
+            "/api/v2/locales/en/translations.js?h=$buster",
             $scripts[0]->getWebPath(),
             "Uses the cache buster key"
         );
@@ -117,7 +117,7 @@ class WebpackAssetProviderTest extends TestCase {
         $provider->setFsRoot($fileSystem->url());
         $buster = 'buster12345';
         $provider->setCacheBusterKey($buster);
-        $root = 'http://example.com/dist/test/';
+        $root = '/dist/test/';
         $addonRoot = $root . 'addons/';
 
         // Stylesheets

--- a/tests/Library/Vanilla/Web/Asset/WebpackAssetTest.php
+++ b/tests/Library/Vanilla/Web/Asset/WebpackAssetTest.php
@@ -59,6 +59,20 @@ class WebpackAssetTest extends TestCase {
     }
 
     /**
+     * Test our static property.
+     */
+    public function testStatic() {
+        $asset = new WebpackAsset(
+            new Request(),
+            ".min.js",
+            "test",
+            "asset"
+        );
+
+        $this->assertTrue($asset->isStatic());
+    }
+
+    /**
      * Test that web patches are properly generated.
      *
      * @param Request $req

--- a/tests/Library/Vanilla/Web/Asset/WebpackAssetTest.php
+++ b/tests/Library/Vanilla/Web/Asset/WebpackAssetTest.php
@@ -84,19 +84,19 @@ class WebpackAssetTest extends TestCase {
     public function webPathProvider(): array {
         return [
             [
-                (new Request()),
+                (new Request())->setHost("http://example.com"),
                 "",
-                "http://example.com/dist/testSec/test.min.js",
+                "/dist/testSec/test.min.js",
             ],
             [
-                (new Request())->setAssetRoot("/someRoot"),
+                (new Request())->setHost("http://example.com")->setAssetRoot("/someRoot"),
                 "",
-                "http://example.com/someRoot/dist/testSec/test.min.js",
+                "/someRoot/dist/testSec/test.min.js",
             ],
             [
                 (new Request())->setHost("me.com"),
                 "cacheBuster",
-                "http://me.com/dist/testSec/test.min.js?h=cacheBuster",
+                "/dist/testSec/test.min.js?h=cacheBuster",
             ],
             [
                 (new Request())->setHost("me.com")
@@ -104,7 +104,7 @@ class WebpackAssetTest extends TestCase {
                     ->setRoot("/root-should-be-ignored")
                     ->setAssetRoot("/assetRoot"),
                 "cacheBuster",
-                "http://me.com/assetRoot/dist/testSec/test.min.js?h=cacheBuster",
+                "/assetRoot/dist/testSec/test.min.js?h=cacheBuster",
             ],
         ];
     }


### PR DESCRIPTION
Required KB subclass update here https://github.com/vanilla/knowledge/pull/1429

Adds support for static-asset handling. It allows better handling of Cache header

#### library/Vanilla/Contracts/Web/AssetInterface.php
+ Adds method `isStatic(): bool` to the interface

#### library/Vanilla/Web/Asset/SiteAsset.php
+ Implements default isStatic as false
+ `makeAssetPath` and `makeWebPath` now handle path as relative
+ fix small phpdocs

#### library/Vanilla/Web/Asset/ExternalAsset.php
+ Implements isStatic as false

#### library/Vanilla/Web/Asset/PolyfillAsset.php 
+ Implements isStatic as true

#### library/Vanilla/Web/Asset/LegacyAssetModel.php
+ fix `style-compat.css` path as relative

#### library/Vanilla/Web/Asset/LocaleAsset.php
+ fix  `self` usage for `$this`

#### library/Vanilla/Web/Asset/ThemeScriptAsset.php 
+ Implements isStatic as true
+ fix  `self` usage for `$this`

#### library/Vanilla/Web/Asset/WebpackAsset.php 
+ Implements isStatic as true

#### library/Vanilla/Web/Page.php
+ Adds EventManager as a dependency
+ Fires a new Event `BeforeRenderMasterView` before rendering the Twig template

#### library/Vanilla/Web/ThemedPage.php
+ Adds EventManager as a dependency
+ Removes some unused imports

#### applications/dashboard/modules/class.headmodule.php
+ `addScript` and `addCss` methods assume that a new added asset is static unless the asset is added with `$options['static'] = false`
+ A new event called `HeadTagsBeforeRender` is fired to allow manipulation of the tags before rendering.

#### library/core/class.controller.php 
+ adds `static` option when head->addScript is used

#### library/Vanilla/Models/SiteMeta.php
+ Adds `cacheBuster` and `staticPathFolder` properties
+ Fixes a small issue with getLogo returning null

#### build/entries/public-path.ts
+ Adds support for meta `context.staticPathFolder`

#### build/scripts/configs/makeBaseConfig.ts
+ Adds missing `chunkhash`

#### applications/dashboard/controllers/api/LocalesApiController.php
+ fix an apparently broken functionality regarding `Cache-Control` header. The new header is set to `1800` seconds (half an hour)

#### library/core/class.gdn.php
+ remove a static reference to the Gdn_Configuration object
+ The configuration object is taken from the container when needed.
+ This resolves an issue when the configuration object needs to be decorated or reimplemented in the container