### PR TITLE
Add API format tests and fixes

### DIFF
--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -359,7 +359,7 @@ class MessagesApiController extends AbstractApiController {
                 Schema::parse([
                     'conversationID',
                     'body',
-                    'format:s?' => 'The input format of the record.',
+                    'format' => new \Vanilla\Models\FormatSchema(),
                 ])->add($this->fullSchema()),
                 'MessagePost'
             );

--- a/applications/conversations/openapi/messages.yml
+++ b/applications/conversations/openapi/messages.yml
@@ -130,8 +130,7 @@ components:
           description: The ID of the conversation.
           type: integer
         format:
-          description: The input format of the record.
-          type: string
+          $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/Format'
       required:
       - conversationID
       - body

--- a/applications/dashboard/openapi/rich.yml
+++ b/applications/dashboard/openapi/rich.yml
@@ -14,9 +14,7 @@ paths:
                   minLength: 1
                   type: string
                 format:
-                  description: The format to be used for rendering the text.
-                  minLength: 1
-                  type: string
+                  $ref: 'schemas.yml#/components/schemas/Format'
               required:
               - body
               - format

--- a/applications/dashboard/openapi/schemas.yml
+++ b/applications/dashboard/openapi/schemas.yml
@@ -3,6 +3,18 @@ info:
 paths:
 components:
   schemas:
+    Format:
+      description: The format of the body used to convert it to HTML.
+      type: string
+      enum:
+        - rich
+        - markdown
+        - text
+        - textex
+        - wysiwyg
+        - bbcode
+        - display
+      example: markdown
     RoleFragment:
       type: object
       properties:

--- a/applications/dashboard/openapi/schemas.yml
+++ b/applications/dashboard/openapi/schemas.yml
@@ -13,7 +13,6 @@ components:
         - textex
         - wysiwyg
         - bbcode
-        - display
       example: markdown
     RoleFragment:
       type: object

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -79,7 +79,7 @@ class CommentsApiController extends AbstractApiController {
             $this->commentPostSchema = $this->schema(
                 Schema::parse([
                     'body',
-                    'format:s' => 'The input format of the comment.',
+                    'format:s' => new \Vanilla\Models\FormatSchema(),
                     'discussionID'
                 ])->add($this->fullSchema()),
                 'CommentPost'

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -79,7 +79,7 @@ class CommentsApiController extends AbstractApiController {
             $this->commentPostSchema = $this->schema(
                 Schema::parse([
                     'body',
-                    'format:s' => new \Vanilla\Models\FormatSchema(),
+                    'format' => new \Vanilla\Models\FormatSchema(),
                     'discussionID'
                 ])->add($this->fullSchema()),
                 'CommentPost'
@@ -236,7 +236,7 @@ class CommentsApiController extends AbstractApiController {
             'dateUpdated:dt|n' => 'When the comment was last updated.',
             'insertUser' => $this->getUserFragmentSchema(),
             'url:s' => 'The full URL to the comment.',
-            'format:s' => 'The original format of the comment',
+            'format' => new \Vanilla\Models\FormatSchema(true),
         ]);
     }
 
@@ -254,7 +254,7 @@ class CommentsApiController extends AbstractApiController {
             'commentID',
             'discussionID',
             'body',
-            'format:s' => 'The input format of the comment.',
+            'format' => new \Vanilla\Models\FormatSchema(true),
         ])
             ->add($this->fullSchema()), 'out')
             ->addFilter('', [\Vanilla\Formatting\Formats\RichFormat::class, 'editBodyFilter']);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -160,7 +160,7 @@ class DiscussionsApiController extends AbstractApiController {
                 Schema::parse([
                     'name',
                     'body',
-                    'format:s' => new \Vanilla\Models\FormatSchema(),
+                    'format' => new \Vanilla\Models\FormatSchema(),
                     'categoryID',
                     'closed?',
                     'sink?',
@@ -402,7 +402,7 @@ class DiscussionsApiController extends AbstractApiController {
             'dateUpdated:dt|n' => 'When the discussion was last updated.',
             'insertUser' => $this->getUserFragmentSchema(),
             'url:s' => 'The full URL to the discussion.',
-            'format:s' => 'The original format of the discussion',
+            'format' => new \Vanilla\Models\FormatSchema(true),
         ]);
     }
 
@@ -422,7 +422,7 @@ class DiscussionsApiController extends AbstractApiController {
                 'discussionID',
                 'name',
                 'body',
-                'format:s' => 'The input format of the discussion.',
+                'format' => new \Vanilla\Models\FormatSchema(true),
                 'categoryID',
                 'sink',
                 'closed',

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -160,7 +160,7 @@ class DiscussionsApiController extends AbstractApiController {
                 Schema::parse([
                     'name',
                     'body',
-                    'format:s' => 'The input format of the discussion.',
+                    'format:s' => new \Vanilla\Models\FormatSchema(),
                     'categoryID',
                     'closed?',
                     'sink?',

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1273,11 +1273,11 @@ class CommentModel extends Gdn_Model {
                     $this->fireEvent('AfterSaveComment');
                 }
             }
-        }
 
         // Update discussion's comment count.
         if (isset($formPostValues['DiscussionID'])) {
             $this->updateCommentCount($formPostValues['DiscussionID'], ['Slave' => false]);
+            }
         }
 
         return $commentID;

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1274,9 +1274,9 @@ class CommentModel extends Gdn_Model {
                 }
             }
 
-        // Update discussion's comment count.
-        if (isset($formPostValues['DiscussionID'])) {
-            $this->updateCommentCount($formPostValues['DiscussionID'], ['Slave' => false]);
+            // Update discussion's comment count.
+            if (isset($formPostValues['DiscussionID'])) {
+                $this->updateCommentCount($formPostValues['DiscussionID'], ['Slave' => false]);
             }
         }
 

--- a/applications/vanilla/openapi/comments.yml
+++ b/applications/vanilla/openapi/comments.yml
@@ -261,9 +261,7 @@ paths:
                     description: The ID of the discussion.
                     type: integer
                   format:
-                    description: The input format of the comment.
-                    minLength: 1
-                    type: string
+                    $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/Format'
                 required:
                 - commentID
                 - discussionID
@@ -322,9 +320,7 @@ paths:
                     nullable: true
                     type: string
                   format:
-                    description: The original format of the comment
-                    minLength: 1
-                    type: string
+                    $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/Format'
                   insertUser:
                     $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/UserFragment'
                   url:
@@ -630,9 +626,7 @@ components:
           description: The ID of the discussion.
           type: integer
         format:
-          description: The input format of the comment.
-          minLength: 1
-          type: string
+          $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/Format'
       required:
       - body
       - format

--- a/applications/vanilla/openapi/discussions.yml
+++ b/applications/vanilla/openapi/discussions.yml
@@ -516,9 +516,7 @@ paths:
                     description: The ID of the discussion.
                     type: integer
                   format:
-                    description: The original format of the discussion
-                    minLength: 1
-                    type: string
+                    $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/Format'
                   insertUser:
                     $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/UserFragment'
                   name:
@@ -990,9 +988,7 @@ components:
           description: The ID of the discussion.
           type: integer
         format:
-          description: The input format of the discussion.
-          minLength: 1
-          type: string
+          $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/Format'
         groupID:
           x-addon: groups
           description: The group the discussion is in.
@@ -1042,9 +1038,7 @@ components:
           description: Whether the discussion is closed or open.
           type: boolean
         format:
-          description: The input format of the discussion.
-          minLength: 1
-          type: string
+          $ref: '../../dashboard/openapi/schemas.yml#/components/schemas/Format'
         groupID:
           x-addon: groups
           description: The group the discussion is in.

--- a/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/QuoteEmbed.php
@@ -11,6 +11,7 @@ use Vanilla\EmbeddedContent\AbstractEmbed;
 use Vanilla\EmbeddedContent\EmbedUtils;
 use Vanilla\Formatting\Formats\RichFormat;
 use Vanilla\Formatting\FormatService;
+use Vanilla\Models\FormatSchema;
 use Vanilla\Models\UserFragmentSchema;
 use Vanilla\Utility\InstanceValidatorSchema;
 
@@ -136,7 +137,7 @@ class QuoteEmbed extends AbstractEmbed {
             'body:s', // The body is need currnetly during edit mode,
             // to prevent needing extra server roundtrips to render them.
             'bodyRaw:s|a', // Raw body is the source of truth for the embed.
-            'format:s',
+            'format' => new FormatSchema(true),
             'dateInserted:dt',
             'insertUser' => new UserFragmentSchema(),
             'displayOptions' => new InstanceValidatorSchema(QuoteEmbedDisplayOptions::class),

--- a/library/Vanilla/Models/FormatSchema.php
+++ b/library/Vanilla/Models/FormatSchema.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models;
+
+use Garden\Schema\Schema;
+use Garden\Schema\ValidationField;
+
+/**
+ * A utility class for format schemas.
+ */
+class FormatSchema extends Schema {
+    /**
+     * FormatSchema constructor.
+     *
+     * @param bool $deprecated Include deprecated formats.
+     */
+    public function __construct(bool $deprecated = false) {
+        $formats = ['rich', 'markdown', 'text', 'textex', 'wysiwyg', 'bbcode'];
+        if ($deprecated) {
+            $formats[] = 'html';
+        }
+
+        parent::__construct([
+            'enum' => $formats,
+        ]);
+        $this->addFilter('', function ($value, ValidationField $field) {
+            return strtolower($value);
+        });
+    }
+}

--- a/library/Vanilla/Models/FormatSchema.php
+++ b/library/Vanilla/Models/FormatSchema.php
@@ -26,10 +26,14 @@ class FormatSchema extends Schema {
         }
 
         parent::__construct([
+            'type' => 'string',
             'enum' => $formats,
         ]);
         $this->addFilter('', function ($value, ValidationField $field) {
-            return strtolower($value);
+            if (is_string($value)) {
+                return strtolower($value);
+            }
+            return $value;
         });
     }
 }

--- a/plugins/rich-editor/controllers/api/RichApiController.php
+++ b/plugins/rich-editor/controllers/api/RichApiController.php
@@ -34,7 +34,7 @@ class RichApiController extends AbstractApiController {
 
         $in = $this->schema([
             'body:s' => 'Raw post text to render as a rich post quote.',
-            'format:s' => 'The format to be used for rendering the text.',
+            'format' => new \Vanilla\Models\FormatSchema(true),
         ], 'in')->setDescription('Create a rich-compatible HTML representation of a string for quoting.');
         $out = $this->schema([
             'quote:s' => 'A quoted representation of the text, rendered as HTML.',


### PR DESCRIPTION
Currently, our app supports only a subset of formats, but some API endpoints don't check against formats. This PR adds some base tests for formats and makes fixes where appropriate.

Note: I've intentionally left some of the formats we will allow (html, ipb) out of the OpenAPI docs because I want to consider them deprecated.