### PR TITLE
Backport: Fixing adding GET params to existing URLs in OAuth2.

### DIFF
--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -81,6 +81,20 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
 
 
     /**
+     * Add a query to a URL without checking if there is already a query attached.
+     *
+     * @param string $uri The URL with or without a query string already attached.
+     * @param array $get Array of key/value pairs to be passed as GET params.
+     * @return string URL with or without param string attached.
+     */
+    public static function concatUriQueryString(string $uri, array $get = []): string {
+        if (!$get) {
+            return $uri;
+        }
+        return $uri . (strpos($uri, '?') !== false ? '&' : '?') . http_build_query($get);
+    }
+
+    /**
      * Setup
      */
     public function setup() {
@@ -496,8 +510,7 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
         if (array_key_exists('Prompt', $provider) && isset($provider['Prompt'])) {
             $get['prompt'] = $provider['Prompt'];
         }
-
-        return $uri . '?' . http_build_query($get);
+        return self::concatUriQueryString($uri, $get);
     }
 
     /**


### PR DESCRIPTION
This is a backport of https://github.com/vanilla/vanilla/pull/9748

We have a customer whose Register URL in OAuth2 connection has query parameters attached to it which makes for double '?' when we add our GET parameters.

This PR will create a static public method (so we can use it elsewhere) that will add an array of queries to an existing URL regardless of if the URL already has parameters.