### PR TITLE
Add PSR-14 event dispatcher support to Vanilla

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -137,7 +137,7 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
 
     // EventManager
     ->rule(\Garden\EventManager::class)
-    ->addAlias(\Vanilla\Contracts\Addons\EventListenerAddonInterface::class)
+    ->addAlias(\Vanilla\Contracts\Addons\EventListenerConfigInterface::class)
     ->addAlias(\Psr\EventDispatcher\EventDispatcherInterface::class)
     ->addAlias(\Psr\EventDispatcher\ListenerProviderInterface::class)
     ->setShared(true)

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -137,6 +137,9 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
 
     // EventManager
     ->rule(\Garden\EventManager::class)
+    ->addAlias(\Vanilla\Contracts\Addons\EventListenerAddonInterface::class)
+    ->addAlias(\Psr\EventDispatcher\EventDispatcherInterface::class)
+    ->addAlias(\Psr\EventDispatcher\ListenerProviderInterface::class)
     ->setShared(true)
 
     // Locale

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,9 @@
         "vanilla/nbbc": "~2.1",
         "vanilla/safecurl": "~0.9",
         "vanilla/vanilla-connect": "~0.0",
-        "twig/twig": "^2.5"
+        "twig/twig": "^2.5",
+        "psr/event-dispatcher": "^1.0",
+        "fig/event-dispatcher-util": "^1.1"
     },
     "require-dev": {
         "exussum12/coverage-checker": "~0.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d17a7c45aff843d50cf5b1cfd05e0f79",
+    "content-hash": "d052a1a69f7af1504a1bcf9df0e7fb82",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -80,6 +80,57 @@
             "homepage": "https://github.com/container-interop/container-interop",
             "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "fig/event-dispatcher-util",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher-util.git",
+                "reference": "29725c77467dddf637d08579e63b28a14209dbff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher-util/zipball/29725c77467dddf637d08579e63b28a14209dbff",
+                "reference": "29725c77467dddf637d08579e63b28a14209dbff",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.2",
+                "psr/event-dispatcher": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fig\\EventDispatcher\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                },
+                {
+                    "name": "Larry Garfield",
+                    "email": "larry@garfieldtech.com",
+                    "homepage": "https://www.garfieldtech.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Useful utility classes and traits for implementing the PSR events standard",
+            "homepage": "https://github.com/php-fig/event-dispatcher-util",
+            "keywords": [
+                "events",
+                "psr-14"
+            ],
+            "time": "2019-04-03T18:45:35+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -340,6 +391,52 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "psr/log",
@@ -2344,12 +2441,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "40fb2c205dd261ab6bb42ec29545934f0db7026f"
+                "reference": "e4ee2c8e4ccd908debc64069faf023c684a76760"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/40fb2c205dd261ab6bb42ec29545934f0db7026f",
-                "reference": "40fb2c205dd261ab6bb42ec29545934f0db7026f",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/e4ee2c8e4ccd908debc64069faf023c684a76760",
+                "reference": "e4ee2c8e4ccd908debc64069faf023c684a76760",
                 "shasum": ""
             },
             "conflict": {
@@ -2452,7 +2549,7 @@
                 "silverstripe/userforms": "<3",
                 "simple-updates/phpwhois": "<=1",
                 "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
-                "simplesamlphp/simplesamlphp": "<1.17.3",
+                "simplesamlphp/simplesamlphp": "<1.17.8",
                 "simplesamlphp/simplesamlphp-module-infocard": "<1.0.1",
                 "slim/slim": "<2.6",
                 "smarty/smarty": "<3.1.33",
@@ -2554,7 +2651,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-11-19T14:18:57+00:00"
+            "time": "2019-12-02T13:03:15+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3308,8 +3405,8 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -461,7 +461,7 @@ class EventManager implements EventDispatcherInterface, ListenerProviderInterfac
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function dispatch(object $event) {
         foreach ($this->getListenersForEvent($event) as $listener) {
@@ -474,7 +474,7 @@ class EventManager implements EventDispatcherInterface, ListenerProviderInterfac
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getListenersForEvent(object $event): iterable {
         $class = new \ReflectionClass($event);
@@ -486,7 +486,7 @@ class EventManager implements EventDispatcherInterface, ListenerProviderInterfac
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function addListenerMethod(string $class, string $method): EventListenerConfigInterface {
         $method = new \ReflectionMethod($class, $method);

--- a/library/Garden/EventManager.php
+++ b/library/Garden/EventManager.php
@@ -8,6 +8,10 @@
 namespace Garden;
 
 use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+use Vanilla\Contracts\Addons\EventListenerConfigInterface;
 
 /**
  * Contains methods for binding and firing to events.
@@ -15,7 +19,7 @@ use Psr\Container\ContainerInterface;
  * Addons can create callbacks that bind to events which are called throughout the code to allow extension of the
  * application and framework.
  */
-class EventManager {
+class EventManager implements EventDispatcherInterface, ListenerProviderInterface, EventListenerConfigInterface {
     const PRIORITY_LOW = 10;
     const PRIORITY_NORMAL = 100;
     const PRIORITY_HIGH = 1000;
@@ -457,11 +461,42 @@ class EventManager {
     }
 
     /**
-     * For debugging.
-     *
-     * @return array
+     * @inheritDoc
      */
-//    public function dumpAllHandlers() {
-//        return $this->handlers;
-//    }
+    public function dispatch(object $event) {
+        foreach ($this->getListenersForEvent($event) as $listener) {
+            $event = $listener($event);
+            if ($event instanceof StoppableEventInterface && $event->isPropagationStopped()) {
+                return $event;
+            }
+        }
+        return $event;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getListenersForEvent(object $event): iterable {
+        $class = new \ReflectionClass($event);
+
+        do {
+            $handlers = $this->getHandlers($class->getName());
+            yield from $handlers;
+        } while ($class = $class->getParentClass());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addListenerMethod(string $class, string $method): EventListenerConfigInterface {
+        $method = new \ReflectionMethod($class, $method);
+        $params = $method->getParameters();
+        if (count($params) === 0 || null === $rType = $params[0]->getType()) {
+            throw new \InvalidArgumentException('Listeners must declare an object type they can accept.');
+        }
+        $type = $rType->getName();
+
+        $this->bindLazy($type, $class, $method->getName());
+        return $this;
+    }
 }

--- a/library/Vanilla/Contracts/Addons/EventListenerConfigInterface.php
+++ b/library/Vanilla/Contracts/Addons/EventListenerConfigInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Contracts\Addons;
+
+/**
+ * A collection of event listeners that can be configured by addons.
+ */
+interface EventListenerConfigInterface {
+    /**
+     * Add a class method as an event listener.
+     *
+     * The class must be defined as a string class name rather than an object to enable caching optimization. The class
+     * instance will usually be retrieved from a container.
+     *
+     * Reflection is used to determine the event being subscribed to so make sure the method has the appropriate type hint.
+     *
+     * @param string $class The name of the class that contains the listener.
+     * @param string $method The name of the method within the class.
+     * @return $this
+     */
+    public function addListenerMethod(string $class, string $method): self;
+}

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -11,12 +11,16 @@ use Garden\Container\Container;
 use Garden\Container\Reference;
 use Garden\Web\RequestInterface;
 use Gdn;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Vanilla\Addon;
 use Vanilla\AddonManager;
 use Vanilla\Authenticator\PasswordAuthenticator;
 use Vanilla\Contracts\AddonProviderInterface;
+use Vanilla\Contracts\Addons\EventListenerAddonInterface;
+use Vanilla\Contracts\Addons\EventListenerConfigInterface;
 use Vanilla\Contracts\ConfigurationInterface;
 use Vanilla\Contracts\LocaleInterface;
 use Vanilla\Contracts\Site\SiteSectionProviderInterface;
@@ -179,6 +183,9 @@ class Bootstrap {
 
             // EventManager
             ->rule(\Garden\EventManager::class)
+            ->addAlias(EventListenerConfigInterface::class)
+            ->addAlias(EventDispatcherInterface::class)
+            ->addAlias(ListenerProviderInterface::class)
             ->setShared(true)
 
             ->rule(InjectableInterface::class)

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -19,7 +19,6 @@ use Vanilla\Addon;
 use Vanilla\AddonManager;
 use Vanilla\Authenticator\PasswordAuthenticator;
 use Vanilla\Contracts\AddonProviderInterface;
-use Vanilla\Contracts\Addons\EventListenerAddonInterface;
 use Vanilla\Contracts\Addons\EventListenerConfigInterface;
 use Vanilla\Contracts\ConfigurationInterface;
 use Vanilla\Contracts\LocaleInterface;

--- a/tests/Library/Garden/EventManagerPsrTest.php
+++ b/tests/Library/Garden/EventManagerPsrTest.php
@@ -97,16 +97,24 @@ class EventManagerPsrTest extends TestCase {
         $this->assertSame(3, $this->testEventChild->getNum());
     }
 
+    /**
+     * An event handler without a type hint should fail.
+     */
     public function testBadEventHandler() {
         $this->expectException(\InvalidArgumentException::class);
         $this->config->addListenerMethod(self::class, 'badListener');
     }
 
+    /**
+     * A bad event listener.
+     */
     public function badListener() {
         //
     }
 
     /**
+     * A test listener that increments the counter.
+     *
      * @param TestEvent $e
      * @return TestEvent
      */
@@ -115,12 +123,24 @@ class EventManagerPsrTest extends TestCase {
         return $e;
     }
 
+    /**
+     * A test listener that increments twice.
+     *
+     * @param TestEventChild $e
+     * @return TestEventChild
+     */
     public function incEventChild(TestEventChild $e): TestEventChild {
         $e->incNum();
         $e->incNum();
         return $e;
     }
 
+    /**
+     * An event listener that stops propagation.
+     *
+     * @param TestEvent $e
+     * @return TestEvent
+     */
     public function incEventStop(TestEvent $e): TestEvent {
         $e->incNum();
         $e->stopPropagation();

--- a/tests/Library/Garden/EventManagerPsrTest.php
+++ b/tests/Library/Garden/EventManagerPsrTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Garden;
+
+use Garden\EventManager;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use Vanilla\Contracts\Addons\EventListenerConfigInterface;
+use VanillaTests\BootstrapTrait;
+use VanillaTests\Fixtures\TestEvent;
+use VanillaTests\Fixtures\TestEventChild;
+
+/**
+ * Tests for the event manager's PSR integration.
+ */
+class EventManagerPsrTest extends TestCase {
+    use BootstrapTrait;
+
+    /**
+     * @var EventListenerConfigInterface
+     */
+    private $config;
+    /**
+     * @var ListenerProviderInterface
+     */
+    private $provider;
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $events;
+    /**
+     * @var TestEventChild
+     */
+    private $testEventChild;
+    /**
+     * @var TestEvent
+     */
+    private $testEvent;
+
+    /**
+     * @var EventManager
+     */
+    private $eventManager;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->container()->setInstance(self::class, $this);
+        $this->eventManager = new EventManager($this->container());
+        $this->config = $this->eventManager;
+        $this->provider = $this->eventManager;
+        $this->events = $this->eventManager;
+
+        $this->testEvent = new TestEvent();
+        $this->testEventChild = new TestEventChild();
+    }
+
+    /**
+     * Test a basic dispatch.
+     */
+    public function testConfigDispatch() {
+        $this->config->addListenerMethod(self::class, 'incEvent');
+        $this->config->addListenerMethod(self::class, 'incEvent');
+
+        $this->events->dispatch($this->testEvent);
+        $this->assertSame(2, $this->testEvent->getNum());
+    }
+
+    /**
+     * Events should be able to stop propagation.
+     */
+    public function testStopPropagation() {
+        $this->config->addListenerMethod(self::class, 'incEventStop');
+        $this->config->addListenerMethod(self::class, 'incEvent');
+
+        $this->events->dispatch($this->testEvent);
+        $this->assertSame(1, $this->testEvent->getNum());
+    }
+
+    /**
+     * A child event should be handled by it's parent listener too.
+     */
+    public function testEventInheritance() {
+        $this->config->addListenerMethod(self::class, 'incEvent');
+        $this->config->addListenerMethod(self::class, 'incEventChild');
+
+        $this->events->dispatch($this->testEventChild);
+        $this->assertSame(3, $this->testEventChild->getNum());
+    }
+
+    public function testBadEventHandler() {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->config->addListenerMethod(self::class, 'badListener');
+    }
+
+    public function badListener() {
+        //
+    }
+
+    /**
+     * @param TestEvent $e
+     * @return TestEvent
+     */
+    public function incEvent(TestEvent $e): TestEvent {
+        $e->incNum();
+        return $e;
+    }
+
+    public function incEventChild(TestEventChild $e): TestEventChild {
+        $e->incNum();
+        $e->incNum();
+        return $e;
+    }
+
+    public function incEventStop(TestEvent $e): TestEvent {
+        $e->incNum();
+        $e->stopPropagation();
+        return $e;
+    }
+}

--- a/tests/fixtures/src/TestEvent.php
+++ b/tests/fixtures/src/TestEvent.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+
+/**
+ * A test event for PSR event tests.
+ */
+class TestEvent implements StoppableEventInterface {
+
+    private $stopPropagation = false;
+
+    private $num = 0;
+
+    /**
+     * Increment the number.
+     */
+    public function incNum() {
+        $this->num++;
+    }
+
+    /**
+     * Get the number.
+     *
+     * @return int
+     */
+    public function getNum(): int {
+        return $this->num;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isPropagationStopped(): bool {
+        return $this->stopPropagation;
+    }
+
+    /**
+     * Set the stop propagation property.
+     *
+     * @param bool $stop
+     */
+    public function stopPropagation() {
+        $this->stopPropagation = true;
+    }
+}

--- a/tests/fixtures/src/TestEvent.php
+++ b/tests/fixtures/src/TestEvent.php
@@ -43,8 +43,6 @@ class TestEvent implements StoppableEventInterface {
 
     /**
      * Set the stop propagation property.
-     *
-     * @param bool $stop
      */
     public function stopPropagation() {
         $this->stopPropagation = true;

--- a/tests/fixtures/src/TestEventChild.php
+++ b/tests/fixtures/src/TestEventChild.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures;
+
+/**
+ * Class TestEventChild
+ */
+class TestEventChild extends TestEvent {
+
+}


### PR DESCRIPTION
This PR introduces PSR-14 event dispatching and listening to the app for more structured events.

The `EventManager` now supports the two main interfaces: `EventDispatcherInterface ` and `ListenerProviderInterface `. I've also added an internal interface to configure listeners: `EventListenerAddonInterface `.

The idea is for addons to inject only the interfaces they need so we know the functionality they are using. Addons can use the `EventListenerAddonInterface` in their bootstraps to configure event listeners.

Closes #9559