### PR TITLE
Backport: Fix confusing message and workflow in SSO connections.

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -707,11 +707,6 @@ class EntryController extends Gdn_Controller {
                 );
             }
 
-            // Pre-populate our ConnectName field with the passed name if we couldn't match it.
-            if (!isset($nameFound) && !$isPostBack) {
-                $this->Form->setFormValue('ConnectName', $this->Form->getFormValue('Name'));
-            }
-
             // Block connecting to an existing user if it's disallowed.
             if (!$allowConnect) {
                 // Make sure photo of existing user doesn't show on the form.

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -123,7 +123,7 @@ if (!$hasUserID) {
                     if (count($ExistingUsers) >= 1 && !$NoConnectName){
                         echo $this->Form->label('Username', 'ConnectName');
                         echo \Gdn::translate('ConnectWithExistingUser', 'One or more users with your name already exist, would you like to connect as them?');
-                        $connectNameMessage = (!$allowConnect) ? '' : ' <span class="FinePrint">('.\Gdn::translate('Requires a password').')</span>';
+                        $connectNameMessage = (!$allowConnect) ? '' : ' <span class="FinePrint">'.\Gdn::translate('Requires a password').'</span>';
                         foreach ($ExistingUsers as $Row) {
                             echo wrap($this->Form->radio('UserSelect', $Row['Name'] . $connectNameMessage, ['value' => $Row['UserID'], 'class' => 'existingConnectName']), 'div');
                         }

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -123,7 +123,7 @@ if (!$hasUserID) {
                     if (count($ExistingUsers) >= 1 && !$NoConnectName){
                         echo $this->Form->label('Username', 'ConnectName');
                         echo \Gdn::translate('ConnectWithExistingUser', 'One or more users with your name already exist, would you like to connect as them?');
-                        $connectNameMessage = (!$allowConnect) ? '' : \Gdn::translate(' <span class="FinePrint">(Requires a password)</span>');
+                        $connectNameMessage = (!$allowConnect) ? '' : ' <span class="FinePrint">('.\Gdn::translate('Requires a password').')</span>';
                         foreach ($ExistingUsers as $Row) {
                             echo wrap($this->Form->radio('UserSelect', $Row['Name'] . $connectNameMessage, ['value' => $Row['UserID'], 'class' => 'existingConnectName']), 'div');
                         }

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -123,7 +123,7 @@ if (!$hasUserID) {
                     if (count($ExistingUsers) >= 1 && !$NoConnectName){
                         echo $this->Form->label('Username', 'ConnectName');
                         echo \Gdn::translate('ConnectWithExistingUser', 'One or more users with your name already exist, would you like to connect as them?');
-                        $connectNameMessage = (!$allowConnect) ? '' : ' <span class="FinePrint">'.\Gdn::translate('Requires a password').'</span>';
+                        $connectNameMessage = (!$allowConnect) ? '' : ' <span class="FinePrint">'.\Gdn::translate('(Requires a password.)').'</span>';
                         foreach ($ExistingUsers as $Row) {
                             echo wrap($this->Form->radio('UserSelect', $Row['Name'] . $connectNameMessage, ['value' => $Row['UserID'], 'class' => 'existingConnectName']), 'div');
                         }

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -122,8 +122,7 @@ if (!$hasUserID) {
                     // Found User's Name in GDN_User.
                     if (count($ExistingUsers) >= 1 && !$NoConnectName){
                         echo $this->Form->label('Username', 'ConnectName');
-                        $connectInstructions = \Gdn::translate('One or more users with your name already exist, would you like to connect as them?');
-                        echo $connectInstructions;
+                        echo \Gdn::translate('ConnectWithExistingUser', 'One or more users with your name already exist, would you like to connect as them?');
                         $connectNameMessage = (!$allowConnect) ? '' : \Gdn::translate(' <span class="FinePrint">(Requires a password)</span>');
                         foreach ($ExistingUsers as $Row) {
                             echo wrap($this->Form->radio('UserSelect', $Row['Name'] . $connectNameMessage, ['value' => $Row['UserID'], 'class' => 'existingConnectName']), 'div');

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -101,14 +101,14 @@ if (!$hasUserID) {
                     echo $this->Form->textBox('Email');
                     ?>
                 </li>
-                <?php endif; ?>
+        <?php endif; ?>
 
-                <?php
-                    $PasswordMessage = t('ConnectLeaveBlank', 'Leave blank unless connecting to an existing account.');
-                    if ($displayConnectName && !$this->data('HideName')) : ?>
+        <?php if ($displayConnectName && !$this->data('HideName')) : ?>
+
                 <li>
                     <?php
 
+                    // One User was found in GDN_User based on the Email.
                     if (count($ExistingUsers) == 1 && $NoConnectName) {
                         $PasswordMessage = t('ConnectExistingPassword', 'Enter your existing account password.');
                         $Row = reset($ExistingUsers);
@@ -117,24 +117,33 @@ if (!$hasUserID) {
                         wrap(sprintf(t('ConnectRegisteredName', 'Your registered username: <strong>%s</strong>'), htmlspecialchars($Row['Name'])), 'div', ['class' => 'ExistingUsername']);
                         $this->addDefinition('NoConnectName', true);
                         echo $this->Form->hidden('UserSelect', ['Value' => $Row['UserID']]);
-                    } else {
-                        echo $this->Form->label('Username', 'ConnectName');
-                        echo '<div class="FinePrint">', t('ConnectChooseName', 'Choose a name to identify yourself on the site.'), '</div>';
+                    }
 
-                        if (count($ExistingUsers) > 0) {
+                    // Found User's Name in GDN_User.
+                    if (count($ExistingUsers) >= 1 && !$NoConnectName){
+                        echo $this->Form->label('Username', 'ConnectName');
+                        if (count($ExistingUsers) > 0 && !$NoConnectName) {
+                            $connectInstructions = (count($ExistingUsers) > 1) ? \Gdn::translate('If you created one of these users, log in as them. If not choose a new name.') :  \Gdn::translate('If you created this user, log in as them. If not choose a new name.');
+                            echo $connectInstructions;
+                            $connectNameMessage = (!$allowConnect) ? '' : \Gdn::translate(' <span class="FinePrint">(Requires a password)</span>');
                             foreach ($ExistingUsers as $Row) {
-                                echo wrap($this->Form->radio('UserSelect', $Row['Name'], ['value' => $Row['UserID']]), 'div');
+                                echo wrap($this->Form->radio('UserSelect', $Row['Name'] . $connectNameMessage, ['value' => $Row['UserID'], 'class' => 'existingConnectName']), 'div');
                             }
-                            echo wrap($this->Form->radio('UserSelect', t('Other'), ['value' => 'other']), 'div');
+                            $connectChooseName = ' <span class="FinePrint">('.\Gdn::translate('ConnectChooseName', 'Choose a name to identify yourself on the site.').')</span>';
+                            echo wrap($this->Form->radio('UserSelect', 'Other'.$connectChooseName, ['value' => 'other']), 'div');
+                            echo $this->Form->textbox('ConnectName');
                         }
                     }
 
-                    if (!$NoConnectName) {
+                    // No Name was passed over SSO and...
+                    // No Users were found in GDN_User
+                    if (count($ExistingUsers) === 0 && !$NoConnectName) {
+                        echo \Gdn::translate('ConnectChooseName', 'Choose a name to identify yourself on the site.');
                         echo $this->Form->textbox('ConnectName');
                     }
                     ?>
                 </li>
-                <?php endif; ?>
+        <?php endif; ?>
 
                 <?php $this->fireEvent('RegisterBeforePassword'); ?>
 

--- a/applications/dashboard/views/entry/connect.php
+++ b/applications/dashboard/views/entry/connect.php
@@ -122,17 +122,15 @@ if (!$hasUserID) {
                     // Found User's Name in GDN_User.
                     if (count($ExistingUsers) >= 1 && !$NoConnectName){
                         echo $this->Form->label('Username', 'ConnectName');
-                        if (count($ExistingUsers) > 0 && !$NoConnectName) {
-                            $connectInstructions = (count($ExistingUsers) > 1) ? \Gdn::translate('If you created one of these users, log in as them. If not choose a new name.') :  \Gdn::translate('If you created this user, log in as them. If not choose a new name.');
-                            echo $connectInstructions;
-                            $connectNameMessage = (!$allowConnect) ? '' : \Gdn::translate(' <span class="FinePrint">(Requires a password)</span>');
-                            foreach ($ExistingUsers as $Row) {
-                                echo wrap($this->Form->radio('UserSelect', $Row['Name'] . $connectNameMessage, ['value' => $Row['UserID'], 'class' => 'existingConnectName']), 'div');
-                            }
-                            $connectChooseName = ' <span class="FinePrint">('.\Gdn::translate('ConnectChooseName', 'Choose a name to identify yourself on the site.').')</span>';
-                            echo wrap($this->Form->radio('UserSelect', 'Other'.$connectChooseName, ['value' => 'other']), 'div');
-                            echo $this->Form->textbox('ConnectName');
+                        $connectInstructions = \Gdn::translate('One or more users with your name already exist, would you like to connect as them?');
+                        echo $connectInstructions;
+                        $connectNameMessage = (!$allowConnect) ? '' : \Gdn::translate(' <span class="FinePrint">(Requires a password)</span>');
+                        foreach ($ExistingUsers as $Row) {
+                            echo wrap($this->Form->radio('UserSelect', $Row['Name'] . $connectNameMessage, ['value' => $Row['UserID'], 'class' => 'existingConnectName']), 'div');
                         }
+                        $connectChooseName = ' <span class="FinePrint">('.\Gdn::translate('ConnectChooseName', 'Choose a name to identify yourself on the site.').')</span>';
+                        echo wrap($this->Form->radio('UserSelect', 'Other'.$connectChooseName, ['value' => 'other']), 'div');
+                        echo $this->Form->textbox('ConnectName');
                     }
 
                     // No Name was passed over SSO and...


### PR DESCRIPTION
Backport https://github.com/vanilla/vanilla/pull/9721

After discovering a bug in which user's could not input a different user name than the one that was passed over SSO (see https://github.com/vanilla/support/issues/906) we decided to revisit the workflow of the Connect page. This PR will change a little bit of the wording and clean up the logic of the Connect method in the Entry Controller. 

This PR will: 
 - Create 3 distinct code blocks for the 3 distinct scenarios of connection (Name exists, Email exists, create a new User).
 - Change some of the wording on the Connect page. (see images below).
 - Not overwrite the ConnectName with the Name passed over SSO (which was causing the bug to allow user's to change their name if it existed.

## Before:
<img width="813" alt="Screen Shot 2019-11-28 at 4 41 19 PM" src="https://user-images.githubusercontent.com/2651070/69832876-948f3500-11fe-11ea-9c5a-56a98aed6d03.png">

## After
<img width="830" alt="Screen Shot 2019-11-28 at 4 39 50 PM" src="https://user-images.githubusercontent.com/2651070/69832890-a53fab00-11fe-11ea-8979-713ad95cc21f.png">
