### PR TITLE
Remove enter handler hack and fix quill handler

### DIFF
--- a/plugins/rich-editor/package.json
+++ b/plugins/rich-editor/package.json
@@ -14,6 +14,6 @@
         "@vanilla/library": "^3.0.1",
         "@vanilla/react-utils": "^3.0.1",
         "@vanilla/utils": "^3.0.1",
-        "quill": "https://github.com/vanilla/quill.git#1.3.7"
+        "quill": "https://github.com/vanilla/quill.git#1.3.10"
     }
 }

--- a/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
+++ b/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
@@ -56,28 +56,6 @@ export default class VanillaTheme extends ThemeBase {
     }
 
     /**
-     * Override to ensure we get a public update event after the enter key is pressed.
-     * Prevents a "lagging" paragraph menu that doesn't listen to silent events.
-     */
-    public init() {
-        super.init();
-
-        const keyboard = this.quill.getModule("keyboard") as KeyboardModule;
-        keyboard.addBinding(
-            {
-                key: KeyboardModule.keys.ENTER,
-            },
-            {},
-            () => {
-                const selection = this.quill.getSelection();
-                selection.index += 1;
-                this.quill.setSelection(selection, Quill.sources.USER);
-                return true;
-            },
-        );
-    }
-
-    /**
      * Apply a hacky method of tracking the last good selection in quill.
      *
      * This should be handled properly after forking.

--- a/yarn.lock
+++ b/yarn.lock
@@ -15227,9 +15227,9 @@ quill-delta@^3.6.2:
     extend "^3.0.2"
     fast-diff "1.1.2"
 
-"quill@https://github.com/vanilla/quill.git#1.3.7":
-  version "1.3.7"
-  resolved "https://github.com/vanilla/quill.git#d4eafda13c49ba43fc3152abdc4afd37d46eb153"
+"quill@https://github.com/vanilla/quill.git#1.3.10":
+  version "1.3.10"
+  resolved "https://github.com/vanilla/quill.git#b43ef4105ae8c02008cfec24e0eca1dc503cca73"
   dependencies:
     clone "^2.1.1"
     deep-equal "^1.0.1"


### PR DESCRIPTION
Removes the hacky keyboard handler from https://github.com/vanilla/vanilla/pull/9706

and bumps the quill version to include the change in https://github.com/vanilla/quill/commit/b43ef4105ae8c02008cfec24e0eca1dc503cca73

I skipped straight to `1.3.10` as a number because of some previous failed attempts to make yarn understand `1.3.8` and `1.3.9`.