### PR TITLE
Fix options not being passed to visible colour picker form input

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -371,7 +371,10 @@ class Gdn_Form extends Gdn_Pluggable {
      * @return string The form element for a color picker.
      */
     public function color($fieldName, $options = []) {
-        Gdn::controller()->addJsFile('colorpicker.js', 'dashboard');
+        $controller = Gdn::controller();
+        if ($controller) {
+            $controller->addJsFile('colorpicker.js', 'dashboard');
+        }
 
         $valueAttributes['class'] = 'js-color-picker-value color-picker-value Hidden';
         $textAttributes['class'] = 'js-color-picker-text color-picker-text';

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -393,7 +393,7 @@ class Gdn_Form extends Gdn_Pluggable {
 
         return '<div id="'.$this->escapeFieldName($fieldName).'" class="'.$cssClass.'"'.$dataAttribute.'>'
         .$this->input($fieldName, 'text', $valueAttributes)
-        .$this->input($fieldName.'-text', 'text', $textAttributes)
+        .$this->input($fieldName.'-text', 'text', $options + $textAttributes)
         .'<span class="js-color-picker-preview color-picker-preview"></span>'
         .$this->input($fieldName.'-color', 'color', $colorAttributes)
         .'</div>';

--- a/tests/Library/Core/FormTest.php
+++ b/tests/Library/Core/FormTest.php
@@ -7,11 +7,11 @@
 
 namespace VanillaTests\Library\Core;
 
-use VanillaTests\SharedBootstrapTestCase;
+use VanillaTests\MinimalContainerTestCase;
 use Gdn;
 use Gdn_Form;
 
-class FormTest extends SharedBootstrapTestCase {
+class FormTest extends MinimalContainerTestCase {
     /**
      * Setup a dummy request because {@link Gdn_Form} needs it.
      */
@@ -30,6 +30,16 @@ class FormTest extends SharedBootstrapTestCase {
 
         $input = $frm->textBox('foo');
         $this->assertSame('<input type="text" id="Form_foo" name="foo" value="" class="form-control" />', $input);
+    }
+
+    /**
+     * Test that placeholders can be applied to color inputs.
+     */
+    public function testColorInputPlaceholder() {
+        $frm = new Gdn_Form('', 'bootstrap');
+        $input = $frm->color('test', ['placeholder' => 'My placeholder!']);
+
+        $this->assertStringContainsString('placeholder="My placeholder!"', $input);
     }
 
     /**

--- a/tests/Library/Core/FormTest.php
+++ b/tests/Library/Core/FormTest.php
@@ -11,6 +11,9 @@ use VanillaTests\MinimalContainerTestCase;
 use Gdn;
 use Gdn_Form;
 
+/**
+ * Tests for Gdn_Form.
+ */
 class FormTest extends MinimalContainerTestCase {
     /**
      * Setup a dummy request because {@link Gdn_Form} needs it.


### PR DESCRIPTION
Our `Gdn_Form::color()` creates a visible text input and some hidden ones, along with a color chooser.

We weren't passing the full options to visible input though, so it was no possible to set certain attributes on it, such as `placeholder`.