### PR TITLE
Add afterSave as props to IContentTranslatorProps 

### DIFF
--- a/packages/vanilla-i18n/src/ContentTranslator.tsx
+++ b/packages/vanilla-i18n/src/ContentTranslator.tsx
@@ -14,7 +14,7 @@ export interface IContentTranslatorProps {
     title: string;
     sourceLocale?: string | null;
     activeLocale?: string | null; // for organizecategories
-    renderNavigationData?: () => void;
+    afterSave?: () => void;
 }
 
 // Subtypes

--- a/packages/vanilla-i18n/src/ContentTranslator.tsx
+++ b/packages/vanilla-i18n/src/ContentTranslator.tsx
@@ -14,6 +14,7 @@ export interface IContentTranslatorProps {
     title: string;
     sourceLocale?: string | null;
     activeLocale?: string | null; // for organizecategories
+    renderNavigationData?: () => void;
 }
 
 // Subtypes


### PR DESCRIPTION
Fix: https://github.com/vanilla/knowledge/issues/1372

Add afterSave() as props to IContentTranslatorProps to get navigationFlat data after saving translations for organize categories page.

Requires: 
https://github.com/vanilla/knowledge/pull/1432,
https://github.com/vanilla/internal/pull/2127