### PR TITLE
Remove extra parenthese & fix dependency order

### DIFF
--- a/library/Vanilla/Web/ThemedPage.php
+++ b/library/Vanilla/Web/ThemedPage.php
@@ -33,8 +33,8 @@ abstract class ThemedPage extends Page {
         BreadcrumbModel $breadcrumbModel,
         ContentSecurityPolicyModel $cspModel,
         AssetPreloadModel $preloadModel,
-        ThemePreloadProvider $themeProvider = null, // Default required to conform to interface
-        EventManager $eventManager
+        EventManager $eventManager,
+        ThemePreloadProvider $themeProvider = null // Default required to conform to interface
     ) {
         parent::setDependencies($siteMeta, $request, $session, $assetProvider, $breadcrumbModel, $cspModel, $preloadModel, $eventManager);
         $this->themeProvider = $themeProvider;

--- a/library/src/scripts/flyouts/DropDown.tsx
+++ b/library/src/scripts/flyouts/DropDown.tsx
@@ -135,7 +135,6 @@ export default function DropDown(props: IProps) {
                                 )}
                                 {openAsModal && (
                                     <SmartAlign>
-                                        (
                                         <Heading
                                             title={title}
                                             className={classNames(


### PR DESCRIPTION
This was rendering as a literal parenthese in the dropdown.

Likely leftover from some merge conflict.

Additionally fixed some dependency order that's breaking https://app.circleci.com/jobs/github/vanilla/knowledge/8520