### PR TITLE
Re-apply store actions after registering reducers

### DIFF
--- a/library/src/scripts/redux/getStore.ts
+++ b/library/src/scripts/redux/getStore.ts
@@ -29,6 +29,10 @@ const enhancer = composeEnhancers(applyMiddleware(...middleware));
 // Build the store, add devtools extension support if it's available.
 let store;
 
+export function resetStore() {
+    store = undefined;
+}
+
 export default function getStore<S = ICoreStoreState>(initialState?: DeepPartial<S>, force?: boolean): Store<S, any> {
     if (store === undefined || force) {
         // Get our reducers.

--- a/library/src/scripts/redux/reducerRegistry.spec.ts
+++ b/library/src/scripts/redux/reducerRegistry.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import getStore, { resetStore } from "@library/redux/getStore";
+import { registerReducer, resetReducers } from "@library/redux/reducerRegistry";
+
+describe.only("reducerRegistry", () => {
+    afterEach(() => {
+        resetStore();
+        resetReducers();
+    });
+
+    it("handles custom reducers that were registered", () => {
+        const reducer1 = () => 1;
+        registerReducer("reducer1", reducer1);
+
+        const store = getStore();
+
+        const reducer2 = () => 2;
+        registerReducer("reducer2", reducer2);
+
+        const state = store.getState();
+        expect(state["reducer1"]).toEqual(1);
+        expect(state["reducer2"]).toEqual(2);
+    });
+
+    it.only("Can apply initial state", () => {
+        window.__ACTIONS__ = [
+            {
+                type: "update",
+            },
+        ];
+        const reducer1 = (state = "1before", action) => {
+            if (action.type === "update") {
+                return "updated1";
+            } else {
+                return state;
+            }
+        };
+        registerReducer("reducer1", reducer1);
+
+        const store = getStore<any>();
+
+        const reducer2 = (state = "2before", action) => {
+            if (action.type === "update") {
+                return "updated2";
+            } else {
+                return state;
+            }
+        };
+        registerReducer("reducer2", reducer2);
+
+        const state = store.getState();
+        expect(state["reducer1"]).toEqual("updated1");
+        expect(state["reducer2"]).toEqual("updated2");
+    });
+});

--- a/library/src/scripts/redux/reducerRegistry.ts
+++ b/library/src/scripts/redux/reducerRegistry.ts
@@ -15,11 +15,17 @@ import getStore from "@library/redux/getStore";
 import NotificationsModel from "@library/features/notifications/NotificationsModel";
 import ConversationsModel from "@library/features/conversations/ConversationsModel";
 
-const dynamicReducers = {};
+let dynamicReducers = {};
 
 export function registerReducer(name: string, reducer: Reducer) {
     dynamicReducers[name] = reducer;
-    getStore().replaceReducer(combineReducers(getReducers()));
+    const store = getStore();
+    store.replaceReducer(combineReducers(getReducers()));
+
+    const initialActions = window.__ACTIONS__ || [];
+
+    // Re-apply initial actions.
+    initialActions.forEach(store.dispatch);
 }
 
 export interface ICoreStoreState extends IUsersStoreState {
@@ -37,6 +43,10 @@ export function getReducers(): ReducersMapObject<any, any> {
         conversations: new ConversationsModel().reducer,
         ...dynamicReducers,
     };
+}
+
+export function resetReducers() {
+    dynamicReducers = {};
 }
 
 /**


### PR DESCRIPTION
Issue https://github.com/vanilla/knowledge/issues/1435

- Re-apply default actions when new reducers are registered.
- Adds unit tests for the reducerRegistry.