### PR TITLE
Use dynamicPath from infra context for notifications and analytics requests.

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -823,7 +823,7 @@ jQuery(document).ready(function($) {
 
     gdn.stats = function() {
         // Call directly back to the deployment and invoke the stats handler
-        var StatsURL = gdn.url('settings/analyticstick.json');
+        var StatsURL = gdn.url(gdn.getMeta('context')["dynamicPathFolder"] + '/settings/analyticstick.json');
         var SendData = {
             'TransientKey': gdn.definition('TransientKey'),
             'Path': gdn.definition('Path'),
@@ -1082,7 +1082,7 @@ jQuery(document).ready(function($) {
 
         $.ajax({
             type: "POST",
-            url: gdn.url('/notifications/inform'),
+            url: gdn.url(gdn.getMeta('context')["dynamicPathFolder"] + '/notifications/inform'),
             data: {
                 'TransientKey': gdn.definition('TransientKey'),
                 'Path': gdn.definition('Path'),

--- a/library/Vanilla/Models/SiteMeta.php
+++ b/library/Vanilla/Models/SiteMeta.php
@@ -78,6 +78,9 @@ class SiteMeta implements \JsonSerializable {
     /** @var string */
     private $staticPathFolder = '';
 
+    /** @var string */
+    private $dynamicPathFolder = '';
+
     /**
      * SiteMeta constructor.
      *
@@ -164,6 +167,7 @@ class SiteMeta implements \JsonSerializable {
                 'translationDebug' => $this->translationDebugModeEnabled,
                 'cacheBuster' => $this->cacheBuster,
                 'staticPathFolder' => $this->staticPathFolder,
+                'dynamicPathFolder' => $this->dynamicPathFolder,
             ],
             'ui' => [
                 'siteName' => $this->siteTitle,
@@ -295,4 +299,12 @@ class SiteMeta implements \JsonSerializable {
     public function setStaticPathFolder(string $staticPathFolder) {
         $this->staticPathFolder = $staticPathFolder;
     }
+
+    /**
+     * @param string $dynamicPathFolder
+     */
+    public function setDynamicPathFolder(string $dynamicPathFolder) {
+        $this->dynamicPathFolder = $dynamicPathFolder;
+    }
+
 }


### PR DESCRIPTION
Issue https://github.com/vanilla/dev-inter-ops/issues/41

The PR adds a new SiteMeta parameter called `dynamicPathFolder` and it usage into js/global.js
It allows `url-path` manipulation for the endpoints `/settings/analyticstick.json` and `/notifications/inform`