### PR TITLE
Fix header and footer called in opposite methods

### DIFF
--- a/library/Vanilla/Models/ThemePreloadProvider.php
+++ b/library/Vanilla/Models/ThemePreloadProvider.php
@@ -165,7 +165,7 @@ class ThemePreloadProvider implements ReduxActionProviderInterface {
         if (!$themeData) {
             return '';
         }
-        return $this->getThemeInlineCss() . ($themeData['assets']['header'] ?? '');
+        return $this->getThemeInlineCss() . ($themeData['assets']['footer'] ?? '');
     }
 
     /**
@@ -178,6 +178,6 @@ class ThemePreloadProvider implements ReduxActionProviderInterface {
         if (!$themeData) {
             return '';
         }
-        return $this->getThemeInlineCss() . ($themeData['assets']['footer'] ?? '');
+        return $this->getThemeInlineCss() . ($themeData['assets']['header'] ?? '');
     }
 }


### PR DESCRIPTION
There is kind "typo" in our code in ThemePreloadProvider `header` and `footer` data are mixed up