### PR TITLE
Add ability to add link tags to Vanilla\Web\Page

### DIFF
--- a/library/Vanilla/Site/SiteSectionModel.php
+++ b/library/Vanilla/Site/SiteSectionModel.php
@@ -17,7 +17,7 @@ use Vanilla\Contracts\Site\SiteSectionProviderInterface;
  */
 class SiteSectionModel {
     /** @var SiteSectionProviderInterface[] $providers */
-    private $providers;
+    private $providers = [];
 
     /** @var SiteSectionInterface[] $siteSections */
     private $siteSections;

--- a/library/Vanilla/Web/Page.php
+++ b/library/Vanilla/Web/Page.php
@@ -54,6 +54,9 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
     /** @var array */
     private $metaTags = [];
 
+    /** @var array */
+    private $linkTags = [];
+
     /** @var AssetInterface[] */
     protected $scripts = [];
 
@@ -185,6 +188,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
             'inlineStyles' => $this->inlineStyles,
             'seoContent' => $this->seoContent,
             'metaTags' => $this->metaTags,
+            'linkTags' => $this->linkTags,
             'header' => $this->headerHtml,
             'footer' => $this->footerHtml,
             'preloadModel' => $this->preloadModel,
@@ -248,6 +252,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
 
         if ($this->canonicalUrl) {
             $this->addOpenGraphTag('og:url', $this->canonicalUrl);
+            $this->addLinkTag(['rel' => 'canonical', 'href' => $this->canonicalUrl]);
         }
 
         // Twitter specific tags
@@ -381,6 +386,19 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
         }
 
         $this->seoContent = $this->renderTwig($viewPathOrView, $viewData);
+
+        return $this;
+    }
+
+    /**
+     * Set page link tag attributes.
+     *
+     * @param array $attributes Array of attributes to set for tag.
+     *
+     * @return $this Own instance for chaining.
+     */
+    protected function addLinkTag(array $attributes): self {
+        $this->linkTags[] = $attributes;
 
         return $this;
     }

--- a/library/Vanilla/Web/Page.php
+++ b/library/Vanilla/Web/Page.php
@@ -397,7 +397,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
      *
      * @return $this Own instance for chaining.
      */
-    protected function addLinkTag(array $attributes): self {
+    public function addLinkTag(array $attributes): self {
         $this->linkTags[] = $attributes;
 
         return $this;
@@ -410,7 +410,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
      *
      * @return $this Own instance for chaining.
      */
-    protected function addMetaTag(array $attributes): self {
+    public function addMetaTag(array $attributes): self {
         $this->metaTags[] = $attributes;
 
         return $this;
@@ -423,7 +423,7 @@ abstract class Page implements InjectableInterface, CustomExceptionHandler {
      * @param string $content
      * @return $this
      */
-    protected function addOpenGraphTag(string $property, string $content): self {
+    public function addOpenGraphTag(string $property, string $content): self {
         return $this->addMetaTag(['property' => $property, 'content' => $content]);
     }
 

--- a/resources/views/default-master.twig
+++ b/resources/views/default-master.twig
@@ -10,6 +10,10 @@
             <meta{% for attribute,value in meta %} {{ attribute }}="{{ value }}"{% endfor %} />
         {% endfor %}
 
+        {% for link in linkTags -%}
+            <link{% for attribute,value in link %} {{ attribute }}="{{ value }}"{% endfor %} />
+        {% endfor %}
+
         {% if favIcon -%}
             <link rel="shortcut icon" href="{{ favIcon }}" type="image/x-icon" />
         {% endif %}
@@ -35,10 +39,6 @@
         {% endfor -%}
 
         {{ preloadModel.renderHtml()|raw }}
-
-        {%- if canonicalUrl -%}
-            <link rel="canonical" href="{{ canonicalUrl }}"/>
-        {%- endif -%}
 
         <noscript>
             <style>

--- a/tests/Library/Vanilla/Web/PageTest.php
+++ b/tests/Library/Vanilla/Web/PageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace VanillaTests\Library\Vanilla\Web;
+
+use VanillaTests\Fixtures\PageFixture;
+use VanillaTests\MinimalContainerTestCase;
+
+/**
+ * Tests of Vanilla's base page class.
+ */
+class PageTest extends MinimalContainerTestCase {
+
+    /**
+     * Test that links get added properly.
+     */
+    public function testLinkTags() {
+        /** @var PageFixture $fixture */
+        $fixture = self::container()->get(PageFixture::class);
+
+        $fixture->addLinkTag(['rel' => 'isLink']);
+        $fixture->addMetaTag(['type' => 'isMeta']);
+        $fixture->addOpenGraphTag('og:isOg', 'ogContent');
+
+        $result = $fixture->render()->getData();
+
+        $dom = new \DOMDocument();
+        @$dom->loadHTML($result);
+
+        $xpath = new \DOMXPath($dom);
+        $head = $xpath->query('head')->item(0);
+
+        // Link tag
+        $link = $xpath->query("//link[@rel='isLink']", $head);
+        $this->assertEquals(1, $link->count());
+
+        // Meta tags
+        $meta = $xpath->query("//meta[@type='isMeta']", $head);
+        $this->assertEquals(1, $meta->count());
+
+        $meta = $xpath->query("//meta[@property='og:isOg']", $head);
+        $this->assertEquals(1, $meta->count());
+    }
+}

--- a/tests/Library/Vanilla/Web/PageTest.php
+++ b/tests/Library/Vanilla/Web/PageTest.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
 
 namespace VanillaTests\Library\Vanilla\Web;
 

--- a/tests/MinimalContainerTestCase.php
+++ b/tests/MinimalContainerTestCase.php
@@ -21,6 +21,7 @@ use Vanilla\Formatting\FormatService;
 use Vanilla\Formatting\Quill\Parser;
 use Vanilla\InjectableInterface;
 use Vanilla\Site\SingleSiteSectionProvider;
+use Vanilla\Utility\ContainerUtils;
 use VanillaTests\Fixtures\MockAddonProvider;
 use VanillaTests\Fixtures\MockConfig;
 use VanillaTests\Fixtures\MockHttpClient;
@@ -91,6 +92,12 @@ class MinimalContainerTestCase extends TestCase {
             ->rule(MockLocale::class)
             ->setAliasOf(LocaleInterface::class)
             ->setShared(true)
+
+            ->rule(\Vanilla\Web\Asset\DeploymentCacheBuster::class)
+            ->setShared(true)
+            ->setConstructorArgs([
+                'deploymentTime' => null,
+            ])
 
             // Prevent real HTTP requests.
             ->rule(HttpClient::class)

--- a/tests/fixtures/src/PageFixture.php
+++ b/tests/fixtures/src/PageFixture.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures;
+
+use Vanilla\Web\Page;
+
+/**
+ * Fixture for testing the page class.
+ */
+class PageFixture extends Page {
+
+    /**
+     * @inheritdoc
+     */
+    public function initialize() {
+        return;
+    }
+}


### PR DESCRIPTION
Blocking https://github.com/vanilla/knowledge/pull/1450

- Allows setting `link` tags in addition to `meta` tags on `Vanilla\Web\Page`.

Additionally I've added some test coverage in this repo over `Vanilla\Web\Page`.