### PR TITLE
Fix titlebar styles in IE11

### DIFF
--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -96,13 +96,6 @@ export class TitleBar extends React.Component<IProps, IState> {
         const classesMeBox = meBoxClasses();
 
         const containerElement = this.props.container || document.getElementById("titleBar")!;
-        containerElement.classList.value = classNames(
-            "titleBar",
-            classes.root,
-            this.props.className,
-            { [classes.isFixed]: isFixed },
-            this.context.offsetClass,
-        );
 
         return ReactDOM.createPortal(
             <HashOffsetReporter>
@@ -212,6 +205,18 @@ export class TitleBar extends React.Component<IProps, IState> {
     public componentDidMount() {
         const titleBarVars = titleBarVariables();
         this.context.setScrollOffset(titleBarVars.sizing.height);
+        const { isFixed } = this.props;
+        const classes = titleBarClasses();
+
+        const containerElement = this.props.container || document.getElementById("titleBar")!;
+        containerElement.className = classNames(
+            "titleBar",
+            classes.root,
+            this.props.className,
+            { [classes.isFixed]: isFixed },
+            this.context.offsetClass,
+            containerElement.className,
+        );
     }
 
     public componentWillUnmount() {

--- a/library/src/scripts/headers/titleBarNavStyles.ts
+++ b/library/src/scripts/headers/titleBarNavStyles.ts
@@ -53,7 +53,7 @@ export const titleBarNavigationVariables = useThemeCache(() => {
     };
 });
 
-export default function titleBarNavClasses() {
+const titleBarNavClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const titleBarVars = titleBarVariables();
     const vars = titleBarNavigationVariables();
@@ -132,6 +132,10 @@ export default function titleBarNavClasses() {
 
     const linkContent = style("linkContent", {
         position: "relative",
+        display: "flex",
+        alignItems: "center",
+        minHeight: unit(vars.item.size),
+        height: 0, // IE11 Fix.
     });
 
     const firstItem = style("lastItem", {
@@ -152,4 +156,6 @@ export default function titleBarNavClasses() {
         lastItem,
         firstItem,
     };
-}
+});
+
+export default titleBarNavClasses;


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/9213

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/1770056/70483935-2711bd00-1ab8-11ea-9de4-2e0b86997556.png)|![image](https://user-images.githubusercontent.com/1770056/70483834-d39f6f00-1ab7-11ea-9b64-116fea9e9c6c.png)|

- Fixes missing theme cache around titlebarNav styles.
- Fixes titlebar background color not getting applied in IE11
- Fixes alignment of titlbarnav links in IE11.