### PR TITLE
Fix reset password link in login form error message

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -2297,6 +2297,8 @@ PASSWORDMETER;
                     '## '.$error->getFile().'('.$error->getLine().")".$fileSuffix."\n".
                     htmlspecialchars($error->getTraceAsString()).
                     '</pre>';
+            } elseif ($error instanceof \Gdn_SanitizedUserException) {
+                $errorCode = '@'.$error->getMessage();
             } else {
                 $errorCode = '@'.htmlspecialchars(strip_tags($error->getMessage()));
             }


### PR DESCRIPTION
The strip tags behavior should not happen when a developer explicitly adds a sanitized exception.

Closes https://github.com/vanilla/support/issues/1126.