### PR TITLE
Add `imageUploadReact` to `Gdn_Form`

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -501,20 +501,20 @@ class SettingsController extends DashboardController {
                 'Description' => t("OrgDescription", "Your organization name is used for SEO microdata and JSON+LD"),
             ],
             'Garden.Logo' => [
-                'LabelCode' => t('Banner Logo'),
-                'Control' => 'imageupload',
-                'Description' => t('LogoDescription', 'The banner logo appears at the top of your site. Some themes may not display this logo.'),
-                'Options' => [
-                    'RemoveConfirmText' => sprintf(t('Are you sure you want to delete your %s?'), t('banner logo'))
-                ]
+                'Label' => t('Banner Logo'),
+                'Control' => 'imageUploadReact',
+                'Description' => t(
+                    'LogoDescription',
+                    'The banner logo appears at the top of your site. Some themes may not display this logo.'
+                ),
             ],
             'Garden.MobileLogo' => [
-                'LabelCode' => t('Mobile Banner Logo'),
-                'Control' => 'imageupload',
-                'Description' => t('MobileLogoDescription', 'The mobile banner logo appears at the top of your site. Some themes may not display this logo.'),
-                'Options' => [
-                    'RemoveConfirmText' => sprintf(t('Are you sure you want to delete your %s?'), t('mobile banner logo'))
-                ]
+                'Label' => t('Mobile Banner Logo'),
+                'Control' => 'imageUploadReact',
+                'Description' => t(
+                    'MobileLogoDescription',
+                    'The mobile banner logo appears at the top of your site. Some themes may not display this logo.'
+                ),
             ],
             'Garden.FavIcon' => [
                 'LabelCode' => t('Favicon'),
@@ -528,8 +528,6 @@ class SettingsController extends DashboardController {
                     'RemoveConfirmText' => sprintf(t('Are you sure you want to delete your %s?'), t('favicon'))
                 ]
             ],
-
-
             'Garden.TouchIcon' => [
                 'LabelCode' => t('Touch Icon'),
                 'Control' => 'imageupload',
@@ -542,14 +540,15 @@ class SettingsController extends DashboardController {
                     'RemoveConfirmText' => sprintf(t('Are you sure you want to delete your %s?'), t('Touch Icon'))
                 ]
             ],
-
             'Garden.ShareImage' => [
-                'LabelCode' => t('Share Image'),
-                'Control' => 'imageupload',
-                'Description' => t('ShareImageDescription', "When someone shares a link from your site we try and grab an image from the page. If there isn't an image on the page then we'll use this image instead. The image should be at least 50&times;50, but we recommend 200&times;200."),
-                'Options' => [
-                    'RemoveConfirmText' => sprintf(t('Are you sure you want to delete your %s?'), t('share image'))
-                ]
+                'Label' => t('Share Image'),
+                'Control' => 'imageUploadReact',
+                'Description' => t(
+                    'ShareImageDescription',
+                    "When someone shares a link from your site we try and grab an image from the page. "
+                    . "If there isn't an image on the page then we'll use this image instead. "
+                    . "The image should be at least 50×50, but we recommend 200×200."
+                ),
             ],
             'Garden.MobileAddressBarColor' => [
                 'LabelCode' => t('Mobile Address Bar Color'),

--- a/applications/dashboard/src/scripts/entries/admin.tsx
+++ b/applications/dashboard/src/scripts/entries/admin.tsx
@@ -10,6 +10,9 @@ import { onContent } from "@library/utility/appUtils";
 import { Router } from "@library/Router";
 import { AppContext } from "@library/AppContext";
 import { addComponent, disableComponentTheming } from "@library/utility/componentRegistry";
+import { DashboardImageUploadGroup } from "@dashboard/forms/DashboardImageUploadGroup";
+
+addComponent("imageUploadGroup", DashboardImageUploadGroup, { overwrite: true });
 
 disableComponentTheming();
 onContent(() => initAllUserContent());

--- a/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
@@ -40,6 +40,8 @@ export function DashboardImageUpload(props: IProps) {
     const classes = classNames("form-control", props.className);
     const rootClass = labelType === DashboardLabelType.WIDE ? "input-wrap-right" : "input-wrap";
 
+    const fallbackName = props.value?.substring(props.value?.lastIndexOf("/") + 1);
+
     return (
         <div className={rootClass}>
             <label className="file-upload">
@@ -64,7 +66,7 @@ export function DashboardImageUpload(props: IProps) {
                         props.onChange(uploaded.url);
                     }}
                 />
-                <span className="file-upload-choose">{name || props.placeholder || t("Choose")}</span>
+                <span className="file-upload-choose">{name || fallbackName || props.placeholder || t("Choose")}</span>
                 <span className="file-upload-browse">{t("Browse")}</span>
             </label>
             {props.errors && <ErrorMessages errors={props.errors} />}

--- a/applications/dashboard/src/scripts/forms/DashboardImageUploadGroup.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardImageUploadGroup.tsx
@@ -35,7 +35,6 @@ export function DashboardImageUploadGroup(props: IProps) {
     const [ownValue, ownOnChange] = useState<string | null>(props.initialValue || null);
     const [wantsDelete, setWantsDelete] = useState(false);
 
-    console.log(props);
     const value = props.value ?? ownValue;
     const onChange = props.onChange ?? ownOnChange;
 

--- a/applications/dashboard/views/modules/configuration.php
+++ b/applications/dashboard/views/modules/configuration.php
@@ -31,7 +31,8 @@ echo $Form->errors();
             continue;
         }
 
-        if ((strtolower($Row['Control'])) !== 'imageupload') {
+        $nowrapControls = ['imageupload', 'react', 'imageuploadreact'];
+        if (!in_array(strtolower($Row['Control']), $nowrapControls)) {
             if (val('no-grid', $Row['Options'])) {
                 echo "<li>\n  ";
             } else {
@@ -82,6 +83,16 @@ echo $Form->errors();
             case 'imageupload':
                 $removeUrl = 'asset/deleteconfigimage/'.urlencode($Row['Name']);
                 echo $Form->imageUploadPreview($Row['Name'], $LabelCode, $Description, $removeUrl, $Row['Options']);
+                break;
+            case 'react':
+                echo $Form->react($Row['Name'], $Row['Component']);
+                break;
+            case 'imageuploadreact':
+                echo $Form->imageUploadReact(
+                    $Row['Name'],
+                    $Row['Label'] ?? '',
+                    $Row['Description'] ?? ''
+                );
                 break;
             case 'color':
                 echo '<div class="label-wrap">';

--- a/library/Vanilla/Web/TwigFormWrapper.php
+++ b/library/Vanilla/Web/TwigFormWrapper.php
@@ -51,6 +51,7 @@ class TwigFormWrapper {
         'radio',
         'radioList',
         'imageUploadPreview',
+        'imageUploadReact',
         'date',
         'currentImage',
         'imageUpload',

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -1778,7 +1778,7 @@ class Gdn_Form extends Gdn_Pluggable {
         $value = $attributes['value'] ?? $this->getValue($fieldName);
         $props = $props + [
             'initialValue' => $value,
-            'fieldName'  => $fieldName,
+            'fieldName'  => $this->escapeFieldName($fieldName),
         ];
         $props = htmlspecialchars(json_encode($props), ENT_QUOTES);
 

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -784,7 +784,7 @@ class Gdn_Form extends Gdn_Pluggable {
      * @return string
      */
     public function imageUploadReact(string $fieldName, string $label = '', string $labelDescription = ''): string {
-        $value = $this->getValue($fieldName);
+        $value = $this->getValue($fieldName, null);
         if ($value) {
             $value = Gdn_Upload::url($value);
         }

--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -774,6 +774,30 @@ class Gdn_Form extends Gdn_Pluggable {
         return '<div class="input-wrap">'.$this->fileUpload($fieldName, $attributes).'</div>';
     }
 
+    /**
+     * A react based image uploader that uploads to the Media table.
+     *
+     * @param string $fieldName The form field name for the input.
+     * @param string $label The label.
+     * @param string $labelDescription The label description.
+     *
+     * @return string
+     */
+    public function imageUploadReact(string $fieldName, string $label = '', string $labelDescription = ''): string {
+        $value = $this->getValue($fieldName);
+        if ($value) {
+            $value = Gdn_Upload::url($value);
+        }
+        return $this->react(
+            $fieldName,
+            'imageUploadGroup',
+            [
+                'label' => $label,
+                'description' =>  $labelDescription,
+                'initialValue' => $value,
+            ]
+        );
+    }
 
     /**
      * Outputs the entire form group with both the label and input. Adds an image preview and a link to delete the
@@ -791,7 +815,6 @@ class Gdn_Form extends Gdn_Pluggable {
      *      'Tag' (string) The tag for the form-group. Defaults to li, but you may want a div or something.
      * @param array $attributes The html attributes to pass to the file upload function.
      * @return string
-
      */
     public function imageUploadPreview($fieldName, $label = '', $labelDescription = '', $removeUrl = '', $options = [], $attributes = []) {
 
@@ -1747,11 +1770,17 @@ class Gdn_Form extends Gdn_Pluggable {
      * @param string $fieldName The name of the field that is being hidden/posted with this input. It
      * should related directly to a field name in $this->_DataArray.
      * @param string $componentKey The key of the of the component registered in the frontend with addComponent.
+     * @param array $props Extra props to pass to the component.
+     *
      * @return string
      */
-    public function react(string $fieldName, string $componentKey) {
+    public function react(string $fieldName, string $componentKey, array $props = []) {
         $value = $attributes['value'] ?? $this->getValue($fieldName);
-        $props = htmlspecialchars(json_encode(['initialValue' => $value]));
+        $props = $props + [
+            'initialValue' => $value,
+            'fieldName'  => $fieldName,
+        ];
+        $props = htmlspecialchars(json_encode($props), ENT_QUOTES);
 
         return "<div data-react='$componentKey' data-props='$props'></div>";
     }
@@ -2997,6 +3026,9 @@ PASSWORDMETER;
 
             if (strtolower($row['Control']) === 'react') {
                 $result .= $this->react($row['Name'], $row['Component']);
+                continue;
+            } elseif (strtolower($row['Control']) === 'imageUploadReact') {
+                $result .= $this->imageUploadReact($row['Name'], $row['Label'], $row['Description'] ?? '');
                 continue;
             } elseif (strtolower($row['Control']) == 'callback' || strtolower($row['Control']) == 'imageuploadpreview') {
                 $itemWrap = '';

--- a/library/src/scripts/AppContext.tsx
+++ b/library/src/scripts/AppContext.tsx
@@ -24,6 +24,7 @@ interface IProps {
     children: React.ReactNode;
     variablesOnly?: boolean;
     noTheme?: boolean;
+    noWrap?: boolean;
     errorComponent?: React.ReactNode;
 }
 
@@ -38,33 +39,36 @@ export function AppContext(props: IProps) {
         width: percent(100),
     });
 
-    return (
-        <div className={classNames("js-appContext", rootStyle, inheritHeightClass())}>
-            {/* A wrapper div is required or will cause error when no routes match or in hot reload */}
-            <Provider store={store}>
-                <LocaleProvider>
-                    <SearchContextProvider>
-                        <ContentTranslationProvider>
-                            <LiveAnnouncer>
-                                <ThemeProvider
-                                    disabled={props.noTheme}
-                                    errorComponent={props.errorComponent || null}
-                                    themeKey={getMeta("ui.themeKey", "keystone")}
-                                    variablesOnly={props.variablesOnly}
-                                >
-                                    <FontSizeCalculatorProvider>
-                                        <SearchFilterContextProvider>
-                                            <ScrollOffsetProvider scrollWatchingEnabled={false}>
-                                                <DeviceProvider>{props.children}</DeviceProvider>
-                                            </ScrollOffsetProvider>
-                                        </SearchFilterContextProvider>
-                                    </FontSizeCalculatorProvider>
-                                </ThemeProvider>
-                            </LiveAnnouncer>
-                        </ContentTranslationProvider>
-                    </SearchContextProvider>
-                </LocaleProvider>
-            </Provider>
-        </div>
+    const content = (
+        <Provider store={store}>
+            <LocaleProvider>
+                <SearchContextProvider>
+                    <ContentTranslationProvider>
+                        <LiveAnnouncer>
+                            <ThemeProvider
+                                disabled={props.noTheme}
+                                errorComponent={props.errorComponent || null}
+                                themeKey={getMeta("ui.themeKey", "keystone")}
+                                variablesOnly={props.variablesOnly}
+                            >
+                                <FontSizeCalculatorProvider>
+                                    <SearchFilterContextProvider>
+                                        <ScrollOffsetProvider scrollWatchingEnabled={false}>
+                                            <DeviceProvider>{props.children}</DeviceProvider>
+                                        </ScrollOffsetProvider>
+                                    </SearchFilterContextProvider>
+                                </FontSizeCalculatorProvider>
+                            </ThemeProvider>
+                        </LiveAnnouncer>
+                    </ContentTranslationProvider>
+                </SearchContextProvider>
+            </LocaleProvider>
+        </Provider>
     );
+
+    if (props.noWrap) {
+        return content;
+    } else {
+        return <div className={classNames("js-appContext", rootStyle, inheritHeightClass())}>{content}</div>;
+    }
 }

--- a/library/src/scripts/utility/componentRegistry.tsx
+++ b/library/src/scripts/utility/componentRegistry.tsx
@@ -89,7 +89,7 @@ export function _mountComponents(parent: Element) {
 
         if (registeredComponent) {
             mountReact(
-                <AppContext variablesOnly noTheme={!useTheme}>
+                <AppContext variablesOnly noTheme={!useTheme} noWrap={registeredComponent?.mountOptions?.overwrite}>
                     <registeredComponent.Component {...props} contents={children} />
                 </AppContext>,
                 node,

--- a/tests/Library/Core/FormTest.php
+++ b/tests/Library/Core/FormTest.php
@@ -7,6 +7,7 @@
 
 namespace VanillaTests\Library\Core;
 
+use VanillaTests\Library\Vanilla\Formatting\HtmlNormalizeTrait;
 use VanillaTests\MinimalContainerTestCase;
 use Gdn;
 use Gdn_Form;
@@ -15,6 +16,9 @@ use Gdn_Form;
  * Tests for Gdn_Form.
  */
 class FormTest extends MinimalContainerTestCase {
+
+    use HtmlNormalizeTrait;
+
     /**
      * Setup a dummy request because {@link Gdn_Form} needs it.
      */
@@ -33,6 +37,30 @@ class FormTest extends MinimalContainerTestCase {
 
         $input = $frm->textBox('foo');
         $this->assertSame('<input type="text" id="Form_foo" name="foo" value="" class="form-control" />', $input);
+    }
+
+    /**
+     * Test the react image upload component.
+     */
+    public function testImageUploadReact() {
+        $frm = new Gdn_Form('', 'bootstrap');
+
+        $expected = "<div data-react='imageUploadGroup' data-props="
+            ."'{&quot;label&quot;:&quot;test label&quot;,&quot;description&quot;:&quot;test desc&quot;,"
+            ."&quot;initialValue&quot;:null,"
+            ."&quot;fieldName&quot;:&quot;test&quot;}'></div>";
+        $input = $frm->imageUploadReact('test', 'test label', 'test desc');
+        $this->assertHtmlStringEqualsHtmlString($expected, $input);
+
+        $frm->setData(['test' => '533ae319e87e04.jpg']);
+        $input = $frm->imageUploadReact('test', 'test label', 'test desc');
+
+        $expected = "<div data-react='imageUploadGroup' data-props="
+        ."'{&quot;label&quot;:&quot;test label&quot;,&quot;description&quot;:&quot;test desc&quot;,"
+        ."&quot;initialValue&quot;:&quot;http:\/\/vanilla.test\/minimal-container-test\/uploads\/533ae319e87e04.jpg&quot;,"
+        ."&quot;fieldName&quot;:&quot;test&quot;}'></div>";
+
+        $this->assertHtmlStringEqualsHtmlString($expected, $input);
     }
 
     /**

--- a/tests/MinimalContainerTestCase.php
+++ b/tests/MinimalContainerTestCase.php
@@ -51,6 +51,7 @@ class MinimalContainerTestCase extends TestCase {
      */
     private function configureContainer() {
         \Gdn::setContainer(new Container());
+
         self::container()
             ->rule(FormatService::class)
             ->setShared(true)
@@ -117,6 +118,11 @@ class MinimalContainerTestCase extends TestCase {
             ->rule(UserProviderInterface::class)
             ->setClass(MockUserProvider::class)
             ->setShared(true)
+
+            ->rule(\Gdn_PluginManager::class)
+            ->addAlias(\Gdn::AliasPluginManager)
+
+            ->setInstance(\Gdn_PluginManager::class, $this->createMock(\Gdn_PluginManager::class))
         ;
     }
 


### PR DESCRIPTION
Blocking https://github.com/vanilla/vanilla/pull/9797
Closes https://github.com/vanilla/vanilla/issues/9795

- No special endpoints needed. Uses `/api/v2/media`.
- Works in `Gdn_Form`
  - directly with `imageUploadReact`.
  - in twig.
  - in `ConfigurationModule`.
  - In `Gdn_Form::simple()`.
- Improves `DashboardImageUploadGroup`
  - Offers confirm dialogue while deleting (similar to old image upload in `Gdn_Form`). New translation strings here https://github.com/vanilla/locales/pull/241
  - Use the file name as a fallback when the image name is not available.