### PR TITLE
Tweak codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -22,7 +22,7 @@ parsers:
       macro: no
 
 comment:
-  layout: "reach,diff,flags,tree"
+  layout: "diff,flags,tree"
   behavior: default
   require_changes: no
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,7 +7,9 @@ coverage:
   range: "70...100"
 
   status:
-    project: yes
+    project:
+      default:
+        informational: true
     patch: yes
     changes: no
 
@@ -26,3 +28,5 @@ comment:
 
 ignore:
   - "**/views/**/*.php"
+  - "**/settings/**.*.php"
+  - "**/conf/**/*.php"


### PR DESCRIPTION
- Sets codecov config to informative mode. This means PRs will not fail for missing a status. Once we've got our config down, we can change this if we want.
- Add a couple config directories to the coverage exclusions.
- Removes confusing graph from the pull request comment.