### PR TITLE
Added new media query for title bar only

### DIFF
--- a/library/src/scripts/AppContext.tsx
+++ b/library/src/scripts/AppContext.tsx
@@ -19,6 +19,7 @@ import { percent } from "csx";
 import { LocaleProvider, ContentTranslationProvider } from "@vanilla/i18n";
 import { SearchFilterContextProvider } from "@library/contexts/SearchFilterContext";
 import { SearchContextProvider } from "@library/contexts/SearchContext";
+import { TitleBarDeviceProvider } from "@library/layout/TitleBarContext";
 
 interface IProps {
     children: React.ReactNode;
@@ -54,7 +55,9 @@ export function AppContext(props: IProps) {
                                 <FontSizeCalculatorProvider>
                                     <SearchFilterContextProvider>
                                         <ScrollOffsetProvider scrollWatchingEnabled={false}>
-                                            <DeviceProvider>{props.children}</DeviceProvider>
+                                            <TitleBarDeviceProvider>
+                                                <DeviceProvider>{props.children}</DeviceProvider>
+                                            </TitleBarDeviceProvider>
                                         </ScrollOffsetProvider>
                                     </SearchFilterContextProvider>
                                 </FontSizeCalculatorProvider>

--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -16,7 +16,6 @@ import MobileDropDown from "@library/headers/pieces/MobileDropDown";
 import { titleBarClasses, titleBarVariables } from "@library/headers/titleBarStyles";
 import Container from "@library/layout/components/Container";
 import ConditionalWrap from "@library/layout/ConditionalWrap";
-import { withDevice, IDeviceProps, Devices } from "@library/layout/DeviceContext";
 import FlexSpacer from "@library/layout/FlexSpacer";
 import { ScrollOffsetContext, HashOffsetReporter } from "@library/layout/ScrollOffsetContext";
 import BackLink from "@library/routing/links/BackLink";
@@ -37,8 +36,9 @@ import DropDown from "@library/flyouts/DropDown";
 import Hamburger from "@library/flyouts/Hamburger";
 import { hamburgerClasses } from "@library/flyouts/hamburgerStyles";
 import { styleFactory } from "@library/styles/styleUtils";
+import { ITitleBarDeviceProps, TitleBarDevices, withTitleBarDevice } from "@library/layout/TitleBarContext";
 
-interface IProps extends IDeviceProps, IInjectableUserState, IWithPagesProps {
+interface IProps extends ITitleBarDeviceProps, IInjectableUserState, IWithPagesProps {
     container?: Element; // Element containing header. Should be the default most if not all of the time.
     className?: string;
     title?: string; // Needed for mobile flyouts
@@ -89,10 +89,10 @@ export class TitleBar extends React.Component<IProps, IState> {
     };
     public render() {
         const { isFixed, hamburger } = this.props;
-        const isMobile = this.props.device === Devices.MOBILE || this.props.device === Devices.XS;
+        const isCompact = this.props.device === TitleBarDevices.COMPACT;
         const classes = titleBarClasses();
-        const showMobileDropDown = isMobile && !this.state.openSearch && this.props.title;
-        const showHamburger = isMobile && !this.state.openSearch && !!hamburger;
+        const showMobileDropDown = isCompact && !this.state.openSearch && this.props.title;
+        const showHamburger = isCompact && !this.state.openSearch && !!hamburger;
         const classesMeBox = meBoxClasses();
 
         const containerElement = this.props.container || document.getElementById("titleBar")!;
@@ -103,7 +103,7 @@ export class TitleBar extends React.Component<IProps, IState> {
                     <PanelWidgetHorizontalPadding>
                         <div className={classNames("titleBar-bar", classes.bar)}>
                             {!this.state.openSearch &&
-                                isMobile &&
+                                isCompact &&
                                 (this.props.useMobileBackButton ? (
                                     <BackLink
                                         className={classNames(
@@ -116,14 +116,14 @@ export class TitleBar extends React.Component<IProps, IState> {
                                 ) : (
                                     !hamburger && <FlexSpacer className="pageHeading-leftSpacer" />
                                 ))}
-                            {!isMobile && (
+                            {!isCompact && (
                                 <HeaderLogo
                                     className={classNames("titleBar-logoContainer", classes.logoContainer)}
                                     logoClassName="titleBar-logo"
                                     logoType={LogoType.DESKTOP}
                                 />
                             )}
-                            {!this.state.openSearch && !isMobile && (
+                            {!this.state.openSearch && !isCompact && (
                                 <TitleBarNav
                                     {...dummyNavigationData()}
                                     className={classNames("titleBar-nav", classes.nav)}
@@ -181,7 +181,7 @@ export class TitleBar extends React.Component<IProps, IState> {
                                     )}
                                     cancelContentClassName="meBox-buttonContent"
                                     buttonClass={classNames(classes.button, {
-                                        [classes.buttonOffset]: !isMobile && this.isGuest,
+                                        [classes.buttonOffset]: !isCompact && this.isGuest,
                                     })}
                                     showingSuggestions={this.state.showingSuggestions}
                                     onOpenSuggestions={this.setOpenSuggestions}
@@ -192,7 +192,7 @@ export class TitleBar extends React.Component<IProps, IState> {
                                     )}
                                     clearButtonClass={classes.clearButtonClass}
                                 />
-                                {isMobile ? this.renderMobileMeBox() : this.renderDesktopMeBox()}
+                                {isCompact ? this.renderMobileMeBox() : this.renderDesktopMeBox()}
                             </ConditionalWrap>
                         </div>
                     </PanelWidgetHorizontalPadding>
@@ -322,4 +322,4 @@ export class TitleBar extends React.Component<IProps, IState> {
 }
 
 const withRedux = connect(mapUsersStoreState);
-export default withRedux(withPages(withDevice(TitleBar)));
+export default withRedux(withPages(withTitleBarDevice(TitleBar)));

--- a/library/src/scripts/headers/TitleBarHome.tsx
+++ b/library/src/scripts/headers/TitleBarHome.tsx
@@ -7,18 +7,18 @@
 import React from "react";
 import TitleBar from "@library/headers/TitleBar";
 import TitleBarMobileHome from "@library/headers/pieces/TitleBarMobileHome";
-import { withDevice, IDeviceProps, Devices } from "@library/layout/DeviceContext";
+import { ITitleBarDeviceProps, TitleBarDevices, withTitleBarDevice } from "@library/layout/TitleBarContext";
 
-interface IProps extends IDeviceProps {}
+interface IProps extends ITitleBarDeviceProps {}
 
 /**
  * Implements Vanilla Header component. Note that this component uses a react portal.
  */
 export class TitleBarHome extends React.Component<IProps> {
     public render() {
-        const isMobile = this.props.device === Devices.MOBILE || this.props.device === Devices.XS;
-        return isMobile ? <TitleBarMobileHome /> : <TitleBar useMobileBackButton={false} />;
+        const isCompact = this.props.device === TitleBarDevices.COMPACT;
+        return isCompact ? <TitleBarMobileHome /> : <TitleBar useMobileBackButton={false} />;
     }
 }
 
-export default withDevice(TitleBarHome);
+export default withTitleBarDevice(TitleBarHome);

--- a/library/src/scripts/headers/titleBarNavStyles.ts
+++ b/library/src/scripts/headers/titleBarNavStyles.ts
@@ -57,7 +57,7 @@ const titleBarNavClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const titleBarVars = titleBarVariables();
     const vars = titleBarNavigationVariables();
-    const mediaQueries = layoutVariables().mediaQueries();
+    const mediaQueries = titleBarVars.mediaQueries();
     const flex = flexHelper();
     const style = styleFactory("titleBarNav");
 
@@ -67,7 +67,7 @@ const titleBarNavClasses = useThemeCache(() => {
             position: "relative",
             height: unit(titleBarVars.sizing.height),
         },
-        mediaQueries.oneColumnDown({
+        mediaQueries.compact({
             height: unit(titleBarVars.sizing.mobile.height),
         }),
     );
@@ -81,7 +81,7 @@ const titleBarNavClasses = useThemeCache(() => {
             height: unit(titleBarVars.sizing.height),
             ...paddings(vars.padding),
         },
-        mediaQueries.oneColumnDown({
+        mediaQueries.compact({
             height: px(titleBarVars.sizing.mobile.height),
             justifyContent: "center",
             width: percent(100),

--- a/library/src/scripts/headers/titleBarStyles.ts
+++ b/library/src/scripts/headers/titleBarStyles.ts
@@ -31,6 +31,7 @@ import { IButtonType } from "@library/forms/styleHelperButtonInterface";
 import { buttonClasses, buttonResetMixin, ButtonTypes } from "@library/forms/buttonStyles";
 import generateButtonClass from "@library/forms/styleHelperButtonGenerator";
 import classNames from "classnames";
+import { media } from "typestyle";
 
 enum TitleBarBorderType {
     BORDER = "border",
@@ -192,6 +193,35 @@ export const titleBarVariables = useThemeCache(() => {
         tablet: {},
     });
 
+    const breakpoints = makeThemeVars("breakpoints", {
+        compact: 850,
+    });
+
+    const mediaQueries = () => {
+        const full = (styles: NestedCSSProperties, useMinWidth: boolean = true) => {
+            return media(
+                {
+                    minWidth: px(breakpoints.compact + 1),
+                },
+                styles,
+            );
+        };
+
+        const compact = (styles: NestedCSSProperties) => {
+            return media(
+                {
+                    maxWidth: px(breakpoints.compact),
+                },
+                styles,
+            );
+        };
+
+        return {
+            full,
+            compact,
+        };
+    };
+
     return {
         border,
         sizing,
@@ -210,6 +240,8 @@ export const titleBarVariables = useThemeCache(() => {
         meBox,
         bottomRow,
         logo,
+        mediaQueries,
+        breakpoints,
     };
 });
 
@@ -218,7 +250,7 @@ export const titleBarClasses = useThemeCache(() => {
     const vars = titleBarVariables();
     const formElementVars = formElementsVariables();
     const headerColors = vars.colors;
-    const mediaQueries = layoutVariables().mediaQueries();
+    const mediaQueries = vars.mediaQueries();
     const flex = flexHelper();
     const style = styleFactory("titleBar");
 
@@ -273,7 +305,7 @@ export const titleBarClasses = useThemeCache(() => {
                 },
             },
         },
-        ...mediaQueries.oneColumnDown({
+        ...mediaQueries.compact({
             height: px(vars.sizing.mobile.height),
         }).$nest,
     });
@@ -283,7 +315,7 @@ export const titleBarClasses = useThemeCache(() => {
         {
             height: px(vars.sizing.height),
         },
-        mediaQueries.oneColumnDown({
+        mediaQueries.compact({
             height: px(vars.sizing.mobile.height),
         }),
     );
@@ -303,7 +335,7 @@ export const titleBarClasses = useThemeCache(() => {
                 },
             },
         },
-        mediaQueries.oneColumnDown({ height: px(vars.sizing.mobile.height) }),
+        mediaQueries.compact({ height: px(vars.sizing.mobile.height) }),
     );
 
     const logoContainer = style(
@@ -328,7 +360,7 @@ export const titleBarClasses = useThemeCache(() => {
                 },
             },
         },
-        mediaQueries.oneColumnDown({
+        mediaQueries.compact({
             height: px(vars.sizing.mobile.height),
             marginRight: unit(0),
         }),
@@ -350,7 +382,7 @@ export const titleBarClasses = useThemeCache(() => {
             height: px(vars.sizing.height),
             color: "inherit",
         },
-        mediaQueries.oneColumnDown({ height: px(vars.sizing.mobile.height) }),
+        mediaQueries.compact({ height: px(vars.sizing.mobile.height) }),
     );
 
     const locales = style(
@@ -370,7 +402,7 @@ export const titleBarClasses = useThemeCache(() => {
                 },
             },
         },
-        mediaQueries.oneColumnDown({ height: px(vars.sizing.mobile.height) }),
+        mediaQueries.compact({ height: px(vars.sizing.mobile.height) }),
     );
 
     const messages = style("messages", {
@@ -399,7 +431,7 @@ export const titleBarClasses = useThemeCache(() => {
                 },
             },
         },
-        mediaQueries.oneColumnDown({ height: px(vars.sizing.mobile.height) }),
+        mediaQueries.compact({ height: px(vars.sizing.mobile.height) }),
     );
 
     const compactSearchResults = style("compactSearchResults", {
@@ -437,7 +469,7 @@ export const titleBarClasses = useThemeCache(() => {
             margin: `0 ${px(vars.sizing.spacer / 2)}`,
             borderRadius: px(vars.button.borderRadius),
         },
-        mediaQueries.oneColumnDown({
+        mediaQueries.compact({
             fontSize: px(vars.button.mobile.fontSize),
         }),
     );
@@ -447,7 +479,7 @@ export const titleBarClasses = useThemeCache(() => {
         {
             height: px(vars.sizing.height),
         },
-        mediaQueries.oneColumnDown({
+        mediaQueries.compact({
             height: px(vars.sizing.mobile.height),
         }),
     );
@@ -522,7 +554,7 @@ export const titleBarClasses = useThemeCache(() => {
                 },
             },
         },
-        mediaQueries.oneColumnDown({
+        mediaQueries.compact({
             height: px(vars.sizing.mobile.height),
             width: px(vars.sizing.mobile.width),
             minWidth: px(vars.sizing.mobile.width),
@@ -611,7 +643,7 @@ export const titleBarClasses = useThemeCache(() => {
             alignItems: "center",
             flexBasis: vars.endElements.flexBasis,
         },
-        mediaQueries.oneColumnDown({
+        mediaQueries.compact({
             flexShrink: 1,
             flexBasis: px(vars.endElements.mobile.flexBasis),
             height: px(vars.sizing.mobile.height),
@@ -624,7 +656,7 @@ export const titleBarClasses = useThemeCache(() => {
             ...flex.middleLeft(),
             flexBasis: vars.endElements.flexBasis,
         },
-        mediaQueries.oneColumnDown({
+        mediaQueries.compact({
             flexShrink: 1,
             flexBasis: px(vars.endElements.mobile.flexBasis),
         }),

--- a/library/src/scripts/layout/TitleBarContext.tsx
+++ b/library/src/scripts/layout/TitleBarContext.tsx
@@ -1,0 +1,81 @@
+/*
+ * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { Optionalize } from "@library/@types/utils";
+import { layoutVariables } from "@library/layout/panelLayoutStyles";
+import throttle from "lodash/throttle";
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { titleBarVariables } from "@library/headers/titleBarStyles";
+
+export enum TitleBarDevices {
+    COMPACT = "compact",
+    FULL = "full",
+}
+
+export interface ITitleBarDeviceProps {
+    device: TitleBarDevices;
+}
+
+const TitleBarDeviceContext = React.createContext<TitleBarDevices>(TitleBarDevices.FULL);
+export default TitleBarDeviceContext;
+
+export function useDevice() {
+    const device = useContext(TitleBarDeviceContext);
+    return device;
+}
+
+interface IProps {
+    children: React.ReactNode;
+}
+
+export function TitleBarDeviceProvider(props: IProps) {
+    const calculateDevice = useCallback(() => {
+        // const breakpoints = layoutVariables().panelLayoutBreakPoints;
+        const breakpoints = titleBarVariables().breakpoints;
+        const width = document.body.clientWidth;
+        if (width <= breakpoints.compact) {
+            return TitleBarDevices.COMPACT;
+        } else {
+            return TitleBarDevices.FULL;
+        }
+    }, []);
+    const [device, setDevice] = useState<TitleBarDevices>(calculateDevice());
+
+    useEffect(() => {
+        const throttledUpdate = throttle(() => {
+            setDevice(calculateDevice);
+        }, 100);
+        window.addEventListener("resize", throttledUpdate);
+        return () => {
+            window.removeEventListener("resize", throttledUpdate);
+        };
+    }, [calculateDevice, setDevice]);
+
+    return <TitleBarDeviceContext.Provider value={device}>{props.children}</TitleBarDeviceContext.Provider>;
+}
+
+/**
+ * HOC to inject DeviceContext as props.
+ *
+ * @param WrappedComponent - The component to wrap
+ */
+export function withTitleBarDevice<T extends ITitleBarDeviceProps = ITitleBarDeviceProps>(
+    WrappedComponent: React.ComponentType<T>,
+) {
+    const displayName = WrappedComponent.displayName || WrappedComponent.name || "Component";
+    const ComponentWithDevice = (props: Optionalize<T, ITitleBarDeviceProps>) => {
+        return (
+            <TitleBarDeviceContext.Consumer>
+                {context => {
+                    // https://github.com/Microsoft/TypeScript/issues/28938
+                    return <WrappedComponent device={context} {...(props as T)} />;
+                }}
+            </TitleBarDeviceContext.Consumer>
+        );
+    };
+    ComponentWithDevice.displayName = `withDevice(${displayName})`;
+    return ComponentWithDevice;
+}

--- a/library/src/scripts/layout/TitleBarContext.tsx
+++ b/library/src/scripts/layout/TitleBarContext.tsx
@@ -76,6 +76,6 @@ export function withTitleBarDevice<T extends ITitleBarDeviceProps = ITitleBarDev
             </TitleBarDeviceContext.Consumer>
         );
     };
-    ComponentWithDevice.displayName = `withDevice(${displayName})`;
+    ComponentWithDevice.displayName = `useTitleBarDevice(${displayName})`;
     return ComponentWithDevice;
 }


### PR DESCRIPTION
This PR add a new context for the title bar only. It doesn't really make sense to be using the media queries for the layout for the title bar. Their layouts have nothing in common.

I do have an idea for a much better way to implement the title bar's breakpoints, but I won't have time this sprint. 