### PR TITLE
Add original filename support to API controller uploads

### DIFF
--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -243,7 +243,7 @@ abstract class Controller implements InjectableInterface {
         $result = $this->upload->saveAs(
             $upload->getFile(),
             $target,
-            [],
+            ["OriginalFilename" => $upload->getClientFilename()],
             $copy
         );
         return $result;


### PR DESCRIPTION
When invoking `Vanilla\Web\Controller::saveUpload`, a call is made to `Gdn_Upload::saveAs`. One of the possible options to this call is the client's original filename. It is not currently used, which means upload-handling addons cannot carry forward the original filename. This update should address that.