### PR TITLE
Fix background image default breaking with assetUrl subdirectory

### DIFF
--- a/library/src/scripts/styles/styleHelpersBackgroundStyling.ts
+++ b/library/src/scripts/styles/styleHelpersBackgroundStyling.ts
@@ -41,7 +41,7 @@ export const getBackgroundImage = (image?: BackgroundImageProperty, fallbackImag
         return themeAsset(workingImage.substr(1, workingImage.length - 1));
     }
 
-    if (workingImage.startsWith('"data:image/')) {
+    if (workingImage.startsWith("data:image/")) {
         return workingImage;
     }
 


### PR DESCRIPTION
Fix typo when checking for image background for theme images.

This would cause our default `data:filter` SVG thing we use in the hero banner to break on sites with a different asset path (eg. hub/node or local subdirectory `vanilla.localhost/dev`).