### PR TITLE
[Backport 2019.018] Fix background image default breaking with assetUrl subdirectory

### DIFF
--- a/library/src/scripts/styles/styleHelpersBackgroundStyling.ts
+++ b/library/src/scripts/styles/styleHelpersBackgroundStyling.ts
@@ -41,7 +41,7 @@ export const getBackgroundImage = (image?: BackgroundImageProperty, fallbackImag
         return themeAsset(workingImage.substr(1, workingImage.length - 1));
     }
 
-    if (workingImage.startsWith('"data:image/')) {
+    if (workingImage.startsWith("data:image/")) {
         return workingImage;
     }
 


### PR DESCRIPTION
Backport #9815