### PR TITLE
Fix new discussion submit returning during redirect

### DIFF
--- a/applications/vanilla/js/post.js
+++ b/applications/vanilla/js/post.js
@@ -117,6 +117,7 @@ jQuery(document).ready(function($) {
             error: function(XMLHttpRequest, textStatus, errorThrown) {
                 $('div.Popup').remove();
                 $.popup({}, XMLHttpRequest.responseText);
+                gdn.enable(btn);
             },
             success: function(json) {
                 // Remove any old popups if not saving as a draft
@@ -136,6 +137,7 @@ jQuery(document).ready(function($) {
                 if (json.FormSaved == false) {
                     $(frm).prepend(json.ErrorMessages);
                     json.ErrorMessages = null;
+                    gdn.enable(btn);
                 } else if (preview) {
                     // Reveal the "Edit" button and hide this one
                     $(btn).hide();
@@ -143,6 +145,7 @@ jQuery(document).ready(function($) {
 
                     $(frm).find('.bodybox-wrap .TextBoxWrapper').hide().after(json.Data);
                     $(frm).trigger('PreviewLoaded', [frm]);
+                    gdn.enable(btn);
                 } else if (!draft) {
                     if (json.RedirectTo) {
                         $(frm).triggerHandler('complete');
@@ -159,12 +162,11 @@ jQuery(document).ready(function($) {
                             contentContainer.html(json.Data);
                             $(frm).replaceWith(contentContainer);
                         }
+
+                        gdn.enable(btn);
                     }
                 }
                 gdn.inform(json);
-            },
-            complete: function(XMLHttpRequest, textStatus) {
-                gdn.enable(btn);
             }
         });
         $(frm).triggerHandler('submit');


### PR DESCRIPTION
When submitting a new discussion, the form submission button is disabled, then re-enabled before the page fully redirects the user to their new discussion. This can present a confusion experience for the user. It is caused by the "complete" handler for the AJAX request, which always runs when the new-discussion form is submitted. This handler always re-enables the submit button.

The button will now only be enabled in certain circumstances that warrant it (basically everything it was doing before, minus the redirect).

### Testing
1. Create a new discussion with valid values. When clicking the submit button, notice it goes from enabled to disabled and back to enabled, before you are redirected to your new discussion.
1. Checkout this branch.
1. Repeat step one. The submit button should go from enabled to disabled and stay that way. You will be redirected to your new discussion.
1. Try creating a new discussion with invalid values. The submit button should be re-enabled after the errors are reported, allowing you to correct the values and submit again.