### PR TITLE
Fix missing style-compat.css in sub-communities.

### DIFF
--- a/library/Vanilla/Web/Asset/LegacyAssetModel.php
+++ b/library/Vanilla/Web/Asset/LegacyAssetModel.php
@@ -111,7 +111,7 @@ class LegacyAssetModel extends Gdn_Model {
         // Include theme customizations last so that they override everything else.
         switch ($basename) {
             case 'style':
-                $this->addCssFile(asset('/applications/dashboard/design/style-compat.css', false), false, ['Sort' => -9.999]);
+                $this->addCssFile('style-compat.css', 'dashboard', ['Sort' => -9.999]);
                 $this->addCssFile('custom.css', false, ['Sort' => 1000]);
 
                 if (Gdn::controller()->Theme && Gdn::controller()->ThemeOptions) {


### PR DESCRIPTION
This PR will close https://github.com/vanilla/support/issues/1194

Recent changes made the calling of the style-compat.css not work in subfolders (subcommunities). This PR will address it correctly. The most obvious result of this was extremely large category follow icons on pages.