### PR TITLE
Add missing title on new pages

### DIFF
--- a/library/Vanilla/Web/MasterViewRenderer.php
+++ b/library/Vanilla/Web/MasterViewRenderer.php
@@ -60,6 +60,7 @@ class MasterViewRenderer {
             'seoContent' => new \Twig\Markup($page->getSeoContent(), 'utf-8'),
             'cssClasses' => 'isLoading',
             'pageHead' => $page->getHead()->renderHtml(),
+            'title' => $page->getSeoTitle(),
         ];
         $data = array_merge($viewData, $extraData, $this->getSharedData());
 

--- a/library/Vanilla/Web/PageHead.php
+++ b/library/Vanilla/Web/PageHead.php
@@ -153,14 +153,14 @@ final class PageHead implements PageHeadInterface {
     /**
      * @inheritdoc
      */
-    public function getSeoTitle(): string {
+    public function getSeoTitle(): ?string {
         return $this->seoTitle;
     }
 
     /**
      * @inheritdoc
      */
-    public function getSeoDescription(): string {
+    public function getSeoDescription(): ?string {
         return $this->seoDescription;
     }
 
@@ -174,7 +174,7 @@ final class PageHead implements PageHeadInterface {
     /**
      * @inheritdoc
      */
-    public function getCanonicalUrl(): string {
+    public function getCanonicalUrl(): ?string {
         return $this->canonicalUrl;
     }
 

--- a/library/Vanilla/Web/PageHeadInterface.php
+++ b/library/Vanilla/Web/PageHeadInterface.php
@@ -116,12 +116,12 @@ interface PageHeadInterface {
     /**
      * @return string
      */
-    public function getSeoTitle(): string;
+    public function getSeoTitle(): ?string;
 
     /**
      * @return string
      */
-    public function getSeoDescription(): string;
+    public function getSeoDescription(): ?string;
 
     /**
      * @return Breadcrumb[]|null
@@ -131,5 +131,5 @@ interface PageHeadInterface {
     /**
      * @return string
      */
-    public function getCanonicalUrl(): string;
+    public function getCanonicalUrl(): ?string;
 }

--- a/library/Vanilla/Web/PageHeadProxyTrait.php
+++ b/library/Vanilla/Web/PageHeadProxyTrait.php
@@ -117,14 +117,14 @@ trait PageHeadProxyTrait { // implements PageHeadInterface
     /**
      * @inheritdoc
      */
-    public function getSeoTitle(): string {
+    public function getSeoTitle(): ?string {
         return $this->proxy->getSeoTitle();
     }
 
     /**
      * @inheritdoc
      */
-    public function getSeoDescription(): string {
+    public function getSeoDescription(): ?string {
         return $this->proxy->getSeoDescription();
     }
 
@@ -138,7 +138,7 @@ trait PageHeadProxyTrait { // implements PageHeadInterface
     /**
      * @inheritdoc
      */
-    public function getCanonicalUrl(): string {
+    public function getCanonicalUrl(): ?string {
         return $this->proxy->getCanonicalUrl();
     }
 }


### PR DESCRIPTION
- Ensure title is always included in the new master view renderings.
- This fixes a crash in Debug mode on new pages.