### PR TITLE
Fix post contents displaying in popup notifications

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1520,7 +1520,7 @@ class ActivityModel extends Gdn_Model {
     }
 
     /**
-     *
+     * Save an activity.
      *
      * @param array $data
      * @param bool $preference

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1538,7 +1538,6 @@ class ActivityModel extends Gdn_Model {
         unset($data["Ext"]);
         $emailFields = $extraFields["Email"] ?? [];
 
-
         if ($activity['ActivityUserID'] == $activity['NotifyUserID'] && !val('Force', $options)) {
             trace('Skipping activity because it would notify the user of something they did.');
 

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1500,11 +1500,11 @@ class ActivityModel extends Gdn_Model {
     }
 
     /**
-     * Extract the excerpt for a story.
+     * Set the story for an activity to an excerpt of the original.
      *
      * @param array $activity
      * @param int $length
-     * @return void
+     * @return array
      */
     public function setStoryExcerpt(array $activity, int $length = self::DEFAULT_EXCERPT_LENGTH): array {
         if (!isset($activity["Story"]) || !isset($activity["Format"])) {

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -1629,8 +1629,10 @@ class ActivityModel extends Gdn_Model {
 
         $delete = false;
         if ($activity['Emailed'] == self::SENT_PENDING && !$queueEmail) {
-            $this->email($emailFields + $activity, $options);
-            $delete = val('_Delete', $activity);
+            $emailActivity = $emailFields + $activity;
+            $this->email($emailActivity, $options);
+            $delete = val('_Delete', $emailActivity);
+            $activity["Emailed"] = $emailActivity["Emailed"];
         }
 
         $activityData = $activity['Data'];

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -10,7 +10,6 @@
 
 use Psr\Log\LoggerInterface;
 use Vanilla\Dashboard\Models\ActivityEmail;
-use Vanilla\Formatting\Formats\HtmlFormat;
 use Vanilla\Formatting\Formats\TextFormat;
 
 /**

--- a/applications/vanilla/controllers/class.vanillasettingscontroller.php
+++ b/applications/vanilla/controllers/class.vanillasettingscontroller.php
@@ -72,8 +72,8 @@ class VanillaSettingsController extends Gdn_Controller {
             'Plugins.editor.ForceWysiwyg',
             'ImageUpload.Limits.Enabled',
             'ImageUpload.Limits.Width',
-            'ImageUpload.Limits.Height'
-
+            'ImageUpload.Limits.Height',
+            'Vanilla.Email.FullPost',
         ]);
 
         // Fire an filter event gather extra form HTML for specific format items.

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -564,11 +564,20 @@ class CommentModel extends Gdn_Model {
         $discussionUserID = $discussion["InsertUserID"] ?? null;
         $format = $comment["Format"] ?? null;
 
+        $fullPost = c('Vanilla.Activity.FullPost');
+        if ($fullPost) {
+            $story = $comment["Body"] ?? null;
+            $storyFormat = $comment["Format"] ?? null;
+        } else {
+            $story = Gdn::formatService()->renderExcerpt($comment["Body"] ?? "", $comment["Format"] ?? "");
+            $storyFormat = \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY;
+        }
+
         // Prepare the notification queue.
         $data = [
             "ActivityType" => "Comment",
             "ActivityUserID" => $comment["InsertUserID"] ?? null,
-            "Format" => $comment["Format"] ?? null,
+            "Format" => $storyFormat,
             "HeadlineFormat" => t(
                 "HeadlineFormat.Comment",
                 '{ActivityUserID,user} commented on <a href="{Url,html}">{Data.Name,text}</a>'
@@ -576,7 +585,7 @@ class CommentModel extends Gdn_Model {
             "RecordType" => "Comment",
             "RecordID" => $commentID,
             "Route" => "/discussion/comment/{$commentID}#Comment_{$commentID}",
-            "Story" => $comment["Body"] ?? null,
+            "Story" => $story,
             "Data" => [
                 "Name" => $discussion["Name"] ?? null,
                 "Category" => $category["Name"] ?? null,

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2245,6 +2245,15 @@ class DiscussionModel extends Gdn_Model {
         $name = $discussion["Name"] ?? null;
         $type = $discussion["Type"] ?? null;
 
+        $fullPost = c('Vanilla.Activity.FullPost');
+        if ($fullPost) {
+            $story = $discussion["Body"] ?? null;
+            $storyFormat = $discussion["Format"] ?? null;
+        } else {
+            $story = Gdn::formatService()->renderExcerpt($discussion["Body"] ?? "", $discussion["Format"] ?? "");
+            $storyFormat = \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY;
+        }
+
         $discussionCategory = CategoryModel::categories($categoryID);
         if ($discussionCategory === null) {
             return;
@@ -2263,7 +2272,7 @@ class DiscussionModel extends Gdn_Model {
         $data = [
             "ActivityType" => "Discussion",
             "ActivityUserID" => $insertUserID,
-            "Format" => $format ?? null,
+            "Format" => $storyFormat,
             "HeadlineFormat" => t(
                 $code,
                 '{ActivityUserID,user} started a new discussion: <a href="{Url,html}">{Data.Name,text}</a>'
@@ -2271,7 +2280,7 @@ class DiscussionModel extends Gdn_Model {
             "RecordType" => "Discussion",
             "RecordID" => $discussionID,
             "Route" => discussionUrl($discussion, "", "/"),
-            "Story" => $body ?? null,
+            "Story" => $story,
             "Data" => [
                 "Name" => $name,
                 "Category" => $categoryName,

--- a/applications/vanilla/views/vanillasettings/posting.php
+++ b/applications/vanilla/views/vanillasettings/posting.php
@@ -184,4 +184,14 @@ specify the same one as above. If users report issues with mobile editing, this 
         <?php echo $form->textBox('Vanilla.Comment.MinLength', ['class' => 'InputBox SmallInput']); ?>
         </div>
     </div>
+    <div class="form-group">
+        <?php
+        echo $form->toggle(
+            "Vanilla.Email.FullPost",
+            "Include full post in email notifications",
+            [],
+            "If enabled, the full content of posts will be sent in email notifications to users."
+        );
+        ?>
+    </div>
 <?php echo $form->close('Save'); ?>


### PR DESCRIPTION
Creating a notification as the result of some comment or discussion activity can potentially cause an excerpt of the post to display in popup notifications. This is caused by the post content automatically being included as the notification activity's `Story`.

To fix this, we're creating a separate story for emails that will only be temporarily attached to the activity data. Notification popups will no longer display post content. Email notifications will continue to display post content, but now have the option of displaying the full post or a 160-character excerpt.

### Testing

Please try the following with `deferredNotifications` enabled and disabled.

1. Configure User A's notification preferences to be emailed when someone comments on their discussion, as well as also receiving a popup notification.
1. Create a discussion as User A.
1. Comment on the discussion as User B.
  1. As User A, you should receive a popup notification that User B has commented on your post. No post content should be displayed in the popup.
  1. User A should also receive an email **with an excerpt of the post**.
1. Visit posting settings in the Vanilla dashboard. Enable the "Include full post in email notifications" toggle.
1. Repeat steps 1-3.
  1. As User A, you should receive a popup notification that User B has commented on your post. No post content should be displayed in the popup.
  1. User A should also receive an email **with the full text of the post**.