### PR TITLE
Fix tests sometimes throwing NullContainer exceptions

### DIFF
--- a/tests/Library/Core/GdnConfigurationTest.php
+++ b/tests/Library/Core/GdnConfigurationTest.php
@@ -15,6 +15,17 @@ use PHPUnit\Framework\TestCase;
 class GdnConfigurationTest extends TestCase {
 
     /**
+     * Get a new configuration instance to test.
+     *
+     * @return \Gdn_Configuration
+     */
+    private function config(): \Gdn_Configuration {
+        $config = new \Gdn_Configuration();
+        $config->autoSave(false);
+        return $config;
+    }
+
+    /**
      * Test if some configuraton key exists.
      *
      * @param array $configData
@@ -24,7 +35,7 @@ class GdnConfigurationTest extends TestCase {
      * @dataProvider provideConfigKeyExistsData
      */
     public function testConfigKeyExists(array $configData, string $keyToCheck, bool $expectedResult) {
-        $config = new \Gdn_Configuration();
+        $config = $this->config();
         $config->loadArray($configData, "test");
 
         $this->assertSame($expectedResult, $config->configKeyExists($keyToCheck));
@@ -75,7 +86,7 @@ class GdnConfigurationTest extends TestCase {
      * @dataProvider provideConfigGetData
      */
     public function testConfigGet(array $configData, string $keyToCheck, $expectedResult) {
-        $config = new \Gdn_Configuration();
+        $config = $this->config();
         $config->loadArray($configData, "test");
 
         $this->assertSame($expectedResult, $config->get($keyToCheck));
@@ -126,7 +137,7 @@ class GdnConfigurationTest extends TestCase {
      */
     public function testTouchConfig() {
         // Quick check with falsy value.
-        $config = new \Gdn_Configuration();
+        $config = $this->config();
         $config->loadArray(["Nested" => ["Value" => false]], "test");
         $config->touch("Nested.Value", "myValue");
 


### PR DESCRIPTION
The `GdnConfigurationTest` test case creates instances of `Gdn_Configuration`. By default, this class will attempt to save its data, if necessary, [as part of its `__destruct` routine](https://www.php.net/__destruct#language.oop5.decon.destructor). Saving the config involves firing an event ("BeforeSave"), which requires retrieving the plug-in manager from the container. If an instance of `Gdn_Configuration` has its `__destruct` routine invoked when the container has not been properly configured, such as during library tests, a fatal error will be generated.

The fix here is simple: avoid trying to auto-save the config as part of `__destruct`. This is a matter of setting the instance's `autosave` property to `false`. The relevant library tests have been updated to do so.