### PR TITLE
Expose quill parser format and blot classes

### DIFF
--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -312,4 +312,40 @@ class Parser {
             $lastOp["insert"] = preg_replace('/\s+$/', "\n", $lastOp["insert"]);
         }
     }
+
+    /**
+     * Get all registered blot classes.
+     *
+     * @return array
+     */
+    public function getBlotClasses(): array {
+        return $this->blotClasses;
+    }
+
+    /**
+     * Replace all registered blot classes.
+     *
+     * @param array
+     */
+    public function setBlotClasses(array $blotClasses) {
+        $this->blotClasses = $blotClasses;
+    }
+
+    /**
+     * Get all registered format classes.
+     *
+     * @return array
+     */
+    public function getFormatClasses(): array {
+        return $this->formatClasses;
+    }
+
+    /**
+     * Replace all registered format classes.
+     *
+     * @param array
+     */
+    public function setFormatClasses(array $formatClasses) {
+        $this->formatClasses = $formatClasses;
+    }
 }

--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -314,38 +314,71 @@ class Parser {
     }
 
     /**
-     * Get all registered blot classes.
+     * Replace a registered blot class.
      *
-     * @return array
+     * @return bool
      */
-    public function getBlotClasses(): array {
-        return $this->blotClasses;
+    public function replaceBlot(string $newBlotClass, string $existingBlotClass): bool {
+        $key = array_search($existingBlotClass, $this->blotClasses);
+
+        if ($key !== false) {
+            $this->blotClasses[$key] = $newBlotClass;
+
+            return true;
+        }
+
+        return false;
     }
 
     /**
-     * Replace all registered blot classes.
+     * Remove a registered blot class.
      *
-     * @param array
+     * @return bool
      */
-    public function setBlotClasses(array $blotClasses) {
-        $this->blotClasses = $blotClasses;
+    public function removeBlot(string $existingBlotClass): bool {
+        $key = array_search($existingBlotClass, $this->blotClasses);
+
+        if ($key !== false) {
+            unset($this->blotClasses[$key]);
+
+            return true;
+        }
+
+        return false;
     }
 
     /**
-     * Get all registered format classes.
+     * Replace a registered format class.
      *
-     * @return array
+     * @return bool
      */
-    public function getFormatClasses(): array {
-        return $this->formatClasses;
+    public function replaceFormat(string $newFormatClass, string $existingFormatClass): bool {
+        $key = array_search($existingFormatClass, $this->formatClasses);
+
+        if ($key !== false) {
+            $this->formatClasses[$key] = $newFormatClass;
+
+            return true;
+        }
+
+        return false;
     }
 
     /**
-     * Replace all registered format classes.
+     * Remove a registered format class.
      *
-     * @param array
+     * @return bool
      */
-    public function setFormatClasses(array $formatClasses) {
-        $this->formatClasses = $formatClasses;
+    public function removeFormat(string $existingFormatClass): bool {
+        $key = array_search($existingFormatClass, $this->formatClasses);
+
+        if ($key !== false) {
+            unset($this->formatClasses[$key]);
+
+            return true;
+        }
+
+        return false;
     }
+
 }

--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -363,7 +363,6 @@ class Parser {
             throw new \Exception($newFormatClass . " should be a subclass of " . $existingFormatClass);
         }
 
-
         $key = array_search($existingFormatClass, $this->formatClasses);
 
         if ($key !== false) {

--- a/library/Vanilla/Formatting/Quill/Parser.php
+++ b/library/Vanilla/Formatting/Quill/Parser.php
@@ -317,8 +317,13 @@ class Parser {
      * Replace a registered blot class.
      *
      * @return bool
+     * @throws \Exception If the replacement class isn't a subclass of the existing blot class.
      */
     public function replaceBlot(string $newBlotClass, string $existingBlotClass): bool {
+       if (!is_subclass_of($newBlotClass, $existingBlotClass)) {
+            throw new \Exception($newBlotClass . " should be a subclass of " . $existingBlotClass);
+        }
+
         $key = array_search($existingBlotClass, $this->blotClasses);
 
         if ($key !== false) {
@@ -351,8 +356,14 @@ class Parser {
      * Replace a registered format class.
      *
      * @return bool
+     * @throws \Exception If the replacement class isn't a subclass of the existing format class.
      */
     public function replaceFormat(string $newFormatClass, string $existingFormatClass): bool {
+        if (!is_subclass_of($newFormatClass, $existingFormatClass)) {
+            throw new \Exception($newFormatClass . " should be a subclass of " . $existingFormatClass);
+        }
+
+
         $key = array_search($existingFormatClass, $this->formatClasses);
 
         if ($key !== false) {


### PR DESCRIPTION
I hit a roadblock, trying to modify a quill format like this:

    public function container_init(\Garden\Container\Container $dic) {
        $dic
            ->rule(\Vanilla\Formatting\Quill\Parser::class)
            ->addCall('addFormat', [\Bleistivt\Formats\ImprovedLink::class]);
    }

This only lets me add a format to the end of the chain, which will then be wrapped in the old format I am actually trying to overwrite.
(I currently have to use reflection to do this instead.)

For real extensibility (e.g. setting the precedence as well), formatClasses and blotClasses would have to be exposed.
