### PR TITLE
Use https with spam detectors

### DIFF
--- a/plugins/Akismet/class.akismet.php
+++ b/plugins/Akismet/class.akismet.php
@@ -103,7 +103,7 @@ class Akismet {
         $this->wordPressAPIKey = $wordPressAPIKey;
 
         // Set some default values
-        $this->apiPort = 80;
+        $this->apiPort = 443;
         $this->akismetServer = 'rest.akismet.com';
         $this->akismetVersion = '1.1';
 

--- a/plugins/StopForumSpam/class.stopforumspam.plugin.php
+++ b/plugins/StopForumSpam/class.stopforumspam.plugin.php
@@ -56,14 +56,14 @@ class StopForumSpamPlugin extends Gdn_Plugin {
 
         $get['f'] = 'json';
 
-        $url = "http://www.stopforumspam.com/api?".http_build_query($get);
+        $url = "https://www.stopforumspam.com/api?".http_build_query($get);
 
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_TIMEOUT, 4);
         curl_setopt($curl, CURLOPT_FAILONERROR, 1);
-        
+
         $resultString = CurlWrapper::curlExec($curl, false);
         curl_close($curl);
 


### PR DESCRIPTION
Changed stopforumspam and akismet plugins to use https rather than http.

Tested each plugin on localhost.

Closes issue [https://github.com/vanilla/vanilla/issues/9744](url)
Closes issue [https://github.com/vanilla/vanilla/issues/9745](url)