### PR TITLE
Enhance Panel Layout and add to Storybook

### DIFF
--- a/build/.storybook/config.js
+++ b/build/.storybook/config.js
@@ -15,23 +15,7 @@ import { unit } from '@library/styles/styleHelpers';
 import { layoutVariables } from '@library/layout/panelLayoutStyles';
 import 'storybook-chromatic';
 
-/**
- * Utility for importing everything from a wepback require.context
- * https://webpack.js.org/guides/dependency-management/#context-module-api
- */
-function importAll(r) {
-    r.keys().forEach(r);
-}
-
 require('../../library/src/scripts/storybookConfig');
-
-function loadStories() {
-    const storyFiles = require.context(
-        '../..',
-        true,
-        /^(?!.*(?:\/node_modules\/|\/vendor\/$)).*\.story\.tsx?$/);
-    importAll(storyFiles);
-}
 
 addParameters({
     chromatic: {
@@ -96,5 +80,9 @@ addParameters({
 });
 
 // Load Stories
-configure(loadStories, module);
+const storyFiles = require.context(
+    '../..',
+    true,
+    /^(?!.*(?:\/node_modules\/|\/vendor\/$)).*\.story\.tsx?$/);
+configure(storyFiles, module);
 

--- a/library/src/scripts/AppContext.tsx
+++ b/library/src/scripts/AppContext.tsx
@@ -46,22 +46,22 @@ export function AppContext(props: IProps) {
                 <SearchContextProvider>
                     <ContentTranslationProvider>
                         <LiveAnnouncer>
-                            <ThemeProvider
-                                disabled={props.noTheme}
-                                errorComponent={props.errorComponent || null}
-                                themeKey={getMeta("ui.themeKey", "keystone")}
-                                variablesOnly={props.variablesOnly}
-                            >
-                                <FontSizeCalculatorProvider>
-                                    <SearchFilterContextProvider>
-                                        <ScrollOffsetProvider scrollWatchingEnabled={false}>
+                            <ScrollOffsetProvider scrollWatchingEnabled={false}>
+                                <ThemeProvider
+                                    disabled={props.noTheme}
+                                    errorComponent={props.errorComponent || null}
+                                    themeKey={getMeta("ui.themeKey", "keystone")}
+                                    variablesOnly={props.variablesOnly}
+                                >
+                                    <FontSizeCalculatorProvider>
+                                        <SearchFilterContextProvider>
                                             <TitleBarDeviceProvider>
                                                 <DeviceProvider>{props.children}</DeviceProvider>
                                             </TitleBarDeviceProvider>
-                                        </ScrollOffsetProvider>
-                                    </SearchFilterContextProvider>
-                                </FontSizeCalculatorProvider>
-                            </ThemeProvider>
+                                        </SearchFilterContextProvider>
+                                    </FontSizeCalculatorProvider>
+                                </ThemeProvider>
+                            </ScrollOffsetProvider>
                         </LiveAnnouncer>
                     </ContentTranslationProvider>
                 </SearchContextProvider>

--- a/library/src/scripts/__tests__/testStoreState.ts
+++ b/library/src/scripts/__tests__/testStoreState.ts
@@ -1,7 +1,13 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
 import { DeepPartial } from "redux";
 import { ICoreStoreState } from "@library/redux/reducerRegistry";
 import merge from "lodash/merge";
 import { INITIAL_USERS_STATE, INITIAL_THEMES_STATE, INITIAL_LOCALE_STATE } from "@library/features/users/userModel";
+import getStore, { resetActionAC } from "@library/redux/getStore";
 
 const DEFAULT_STATE: ICoreStoreState = {
     users: INITIAL_USERS_STATE,
@@ -10,5 +16,11 @@ const DEFAULT_STATE: ICoreStoreState = {
 };
 
 export function testStoreState(state: DeepPartial<ICoreStoreState>) {
-    return merge(DEFAULT_STATE, state);
+    return merge({}, DEFAULT_STATE, state);
+}
+
+export function resetStoreState(state: DeepPartial<ICoreStoreState>) {
+    const store = getStore();
+    console.log("resetting redux state", state);
+    store.dispatch(resetActionAC(testStoreState(state)));
 }

--- a/library/src/scripts/content/CollapsableContent.tsx
+++ b/library/src/scripts/content/CollapsableContent.tsx
@@ -68,7 +68,7 @@ export function CollapsableContent(props: IProps) {
                 ref.current?.appendChild(node);
             });
         }
-    }, []); // eslint-ignore-line
+    }, [domNodesToAttach]); // eslint-ignore-line
 
     useLayoutEffect(() => {
         nextTick(() => {

--- a/library/src/scripts/layout/PanelLayout.story.tsx
+++ b/library/src/scripts/layout/PanelLayout.story.tsx
@@ -1,0 +1,120 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import PanelLayout, { PanelWidget } from "@library/layout/PanelLayout";
+import { DeviceProvider } from "@library/layout/DeviceContext";
+import Container from "@library/layout/components/Container";
+import { layoutVariables } from "@library/layout/panelLayoutStyles";
+
+export default {
+    title: "PanelLayout",
+    params: {
+        chromatic: {
+            viewports: Object.values(layoutVariables().panelLayoutBreakPoints),
+        },
+    },
+};
+
+const smallIpsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse ac arcu massa. Cras lobortis orci turpis, non viverra ex laoreet a. Sed dolor nisi, condimentum tincidunt gravida nec, pellentesque at felis. Phasellus vitae efficitur nibh, at ultricies tortor. Curabitur mauris lectus, luctus non est sit amet, elementum consectetur augue. Nullam non erat at tellus tincidunt ultricies quis non mi. Quisque vestibulum, nibh a sodales porta, neque diam iaculis lorem, in interdum tortor erat ut eros. Suspendisse magna lorem, euismod at bibendum id, semper non massa. Sed tempus orci dignissim molestie tempus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Nam eget dolor ut ex consequat egestas quis eget sem. Nulla sit amet orci porta, feugiat nisl scelerisque, ultrices lorem. Suspendisse potenti. Cras et arcu vitae libero congue porta et vel orci. Morbi tincidunt massa et euismod sodales. Aliquam vel massa facilisis, volutpat massa sit amet, laoreet risus.`;
+const largeIpsum = smallIpsum + smallIpsum + smallIpsum + smallIpsum + smallIpsum;
+
+const DummyPanel = (props: { bg?: string; children?: React.ReactNode }) => {
+    return (
+        <PanelWidget>
+            <div style={{ background: props.bg || "#444", color: "white", padding: 12 }}>{props.children}</div>
+        </PanelWidget>
+    );
+};
+
+export const LargeContent = () => {
+    return (
+        <DeviceProvider>
+            <Container>
+                <PanelLayout
+                    leftTop={<DummyPanel>Left Top</DummyPanel>}
+                    leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
+                    middleTop={<DummyPanel>Middle Top</DummyPanel>}
+                    middleBottom={<DummyPanel>Middle Bottom{largeIpsum}</DummyPanel>}
+                    rightTop={<DummyPanel>Right Top</DummyPanel>}
+                    rightBottom={<DummyPanel>Right bottom</DummyPanel>}
+                ></PanelLayout>
+            </Container>
+        </DeviceProvider>
+    );
+};
+
+export const LargeLeftPanel = () => {
+    return (
+        <DeviceProvider>
+            <Container>
+                <PanelLayout
+                    leftTop={<DummyPanel>Left Top {largeIpsum}</DummyPanel>}
+                    leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
+                    middleTop={<DummyPanel>Middle Top</DummyPanel>}
+                    middleBottom={<DummyPanel>Middle Bottom</DummyPanel>}
+                    rightTop={<DummyPanel>Right Top</DummyPanel>}
+                    rightBottom={<DummyPanel>Right bottom</DummyPanel>}
+                ></PanelLayout>
+            </Container>
+        </DeviceProvider>
+    );
+};
+
+export const LargeRightTopPanel = () => {
+    return (
+        <DeviceProvider>
+            <Container>
+                <PanelLayout
+                    leftTop={<DummyPanel>Left Top</DummyPanel>}
+                    leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
+                    middleTop={<DummyPanel>Middle Top</DummyPanel>}
+                    middleBottom={<DummyPanel>Middle Bottom</DummyPanel>}
+                    rightTop={<DummyPanel>Right Top {largeIpsum}</DummyPanel>}
+                    rightBottom={<DummyPanel>Right bottom</DummyPanel>}
+                ></PanelLayout>
+            </Container>
+        </DeviceProvider>
+    );
+};
+
+export const LargeRightBottomPanel = () => {
+    return (
+        <DeviceProvider>
+            <Container>
+                <PanelLayout
+                    leftTop={<DummyPanel>Left Top</DummyPanel>}
+                    leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
+                    middleTop={<DummyPanel>Middle Top</DummyPanel>}
+                    middleBottom={
+                        <DummyPanel>
+                            Middle Bottom{smallIpsum}
+                            {smallIpsum}
+                        </DummyPanel>
+                    }
+                    rightTop={<DummyPanel>Right Top</DummyPanel>}
+                    rightBottom={<DummyPanel>Right bottom {largeIpsum}</DummyPanel>}
+                ></PanelLayout>
+            </Container>
+        </DeviceProvider>
+    );
+};
+
+export const LargeEverything = () => {
+    return (
+        <DeviceProvider>
+            <Container>
+                <PanelLayout
+                    leftTop={<DummyPanel>Left Top{largeIpsum}</DummyPanel>}
+                    leftBottom={<DummyPanel>Left Bottom{largeIpsum}</DummyPanel>}
+                    middleTop={<DummyPanel>Middle Top{largeIpsum}</DummyPanel>}
+                    middleBottom={<DummyPanel>Middle Bottom{largeIpsum}</DummyPanel>}
+                    rightTop={<DummyPanel>Right Top{largeIpsum}</DummyPanel>}
+                    rightBottom={<DummyPanel>Right bottom {largeIpsum}</DummyPanel>}
+                ></PanelLayout>
+            </Container>
+        </DeviceProvider>
+    );
+};

--- a/library/src/scripts/layout/PanelLayout.story.tsx
+++ b/library/src/scripts/layout/PanelLayout.story.tsx
@@ -6,8 +6,8 @@
 import React from "react";
 import PanelLayout, { PanelWidget } from "@library/layout/PanelLayout";
 import { DeviceProvider } from "@library/layout/DeviceContext";
-import Container from "@library/layout/components/Container";
 import { layoutVariables } from "@library/layout/panelLayoutStyles";
+import { useStoryConfig, NO_WRAPPER_CONFIG, storyWithConfig } from "@library/storybook/StoryContext";
 
 export default {
     title: "PanelLayout",
@@ -29,92 +29,103 @@ const DummyPanel = (props: { bg?: string; children?: React.ReactNode }) => {
     );
 };
 
-export const LargeContent = () => {
+export const SimplePanels = storyWithConfig(NO_WRAPPER_CONFIG, () => {
     return (
         <DeviceProvider>
-            <Container>
-                <PanelLayout
-                    leftTop={<DummyPanel>Left Top</DummyPanel>}
-                    leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
-                    middleTop={<DummyPanel>Middle Top</DummyPanel>}
-                    middleBottom={<DummyPanel>Middle Bottom{largeIpsum}</DummyPanel>}
-                    rightTop={<DummyPanel>Right Top</DummyPanel>}
-                    rightBottom={<DummyPanel>Right bottom</DummyPanel>}
-                ></PanelLayout>
-            </Container>
+            <PanelLayout
+                leftTop={<DummyPanel>Left Top{largeIpsum}</DummyPanel>}
+                middleTop={<DummyPanel>Middle Top</DummyPanel>}
+                middleBottom={<DummyPanel>Middle Bottom{largeIpsum}</DummyPanel>}
+                rightTop={<DummyPanel>Right Top{largeIpsum}</DummyPanel>}
+            ></PanelLayout>
         </DeviceProvider>
     );
-};
+});
 
-export const LargeLeftPanel = () => {
+export const LargeContent = storyWithConfig(NO_WRAPPER_CONFIG, () => {
     return (
         <DeviceProvider>
-            <Container>
-                <PanelLayout
-                    leftTop={<DummyPanel>Left Top {largeIpsum}</DummyPanel>}
-                    leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
-                    middleTop={<DummyPanel>Middle Top</DummyPanel>}
-                    middleBottom={<DummyPanel>Middle Bottom</DummyPanel>}
-                    rightTop={<DummyPanel>Right Top</DummyPanel>}
-                    rightBottom={<DummyPanel>Right bottom</DummyPanel>}
-                ></PanelLayout>
-            </Container>
+            <PanelLayout
+                leftTop={<DummyPanel>Left Top</DummyPanel>}
+                leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
+                middleTop={<DummyPanel>Middle Top</DummyPanel>}
+                middleBottom={<DummyPanel>Middle Bottom{largeIpsum}</DummyPanel>}
+                rightTop={<DummyPanel>Right Top</DummyPanel>}
+                rightBottom={<DummyPanel>Right bottom</DummyPanel>}
+            ></PanelLayout>
         </DeviceProvider>
     );
-};
+});
 
-export const LargeRightTopPanel = () => {
-    return (
-        <DeviceProvider>
-            <Container>
-                <PanelLayout
-                    leftTop={<DummyPanel>Left Top</DummyPanel>}
-                    leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
-                    middleTop={<DummyPanel>Middle Top</DummyPanel>}
-                    middleBottom={<DummyPanel>Middle Bottom</DummyPanel>}
-                    rightTop={<DummyPanel>Right Top {largeIpsum}</DummyPanel>}
-                    rightBottom={<DummyPanel>Right bottom</DummyPanel>}
-                ></PanelLayout>
-            </Container>
-        </DeviceProvider>
-    );
-};
+export const LargeLeftPanel = storyWithConfig(NO_WRAPPER_CONFIG, () => {
+    useStoryConfig(NO_WRAPPER_CONFIG);
 
-export const LargeRightBottomPanel = () => {
     return (
         <DeviceProvider>
-            <Container>
-                <PanelLayout
-                    leftTop={<DummyPanel>Left Top</DummyPanel>}
-                    leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
-                    middleTop={<DummyPanel>Middle Top</DummyPanel>}
-                    middleBottom={
-                        <DummyPanel>
-                            Middle Bottom{smallIpsum}
-                            {smallIpsum}
-                        </DummyPanel>
-                    }
-                    rightTop={<DummyPanel>Right Top</DummyPanel>}
-                    rightBottom={<DummyPanel>Right bottom {largeIpsum}</DummyPanel>}
-                ></PanelLayout>
-            </Container>
+            <PanelLayout
+                leftTop={<DummyPanel>Left Top {largeIpsum}</DummyPanel>}
+                leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
+                middleTop={<DummyPanel>Middle Top</DummyPanel>}
+                middleBottom={<DummyPanel>Middle Bottom</DummyPanel>}
+                rightTop={<DummyPanel>Right Top</DummyPanel>}
+                rightBottom={<DummyPanel>Right bottom</DummyPanel>}
+            ></PanelLayout>
         </DeviceProvider>
     );
-};
+});
 
-export const LargeEverything = () => {
+export const LargeRightTopPanel = storyWithConfig(NO_WRAPPER_CONFIG, () => {
+    useStoryConfig(NO_WRAPPER_CONFIG);
+
     return (
         <DeviceProvider>
-            <Container>
-                <PanelLayout
-                    leftTop={<DummyPanel>Left Top{largeIpsum}</DummyPanel>}
-                    leftBottom={<DummyPanel>Left Bottom{largeIpsum}</DummyPanel>}
-                    middleTop={<DummyPanel>Middle Top{largeIpsum}</DummyPanel>}
-                    middleBottom={<DummyPanel>Middle Bottom{largeIpsum}</DummyPanel>}
-                    rightTop={<DummyPanel>Right Top{largeIpsum}</DummyPanel>}
-                    rightBottom={<DummyPanel>Right bottom {largeIpsum}</DummyPanel>}
-                ></PanelLayout>
-            </Container>
+            <PanelLayout
+                leftTop={<DummyPanel>Left Top</DummyPanel>}
+                leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
+                middleTop={<DummyPanel>Middle Top</DummyPanel>}
+                middleBottom={<DummyPanel>Middle Bottom</DummyPanel>}
+                rightTop={<DummyPanel>Right Top {largeIpsum}</DummyPanel>}
+                rightBottom={<DummyPanel>Right bottom</DummyPanel>}
+            ></PanelLayout>
         </DeviceProvider>
     );
-};
+});
+
+export const LargeRightBottomPanel = storyWithConfig(NO_WRAPPER_CONFIG, () => {
+    useStoryConfig(NO_WRAPPER_CONFIG);
+
+    return (
+        <DeviceProvider>
+            <PanelLayout
+                leftTop={<DummyPanel>Left Top</DummyPanel>}
+                leftBottom={<DummyPanel>Left Bottom</DummyPanel>}
+                middleTop={<DummyPanel>Middle Top</DummyPanel>}
+                middleBottom={
+                    <DummyPanel>
+                        Middle Bottom{smallIpsum}
+                        {smallIpsum}
+                    </DummyPanel>
+                }
+                rightTop={<DummyPanel>Right Top</DummyPanel>}
+                rightBottom={<DummyPanel>Right bottom {largeIpsum}</DummyPanel>}
+            ></PanelLayout>
+        </DeviceProvider>
+    );
+});
+
+export const LargeEverything = storyWithConfig(NO_WRAPPER_CONFIG, () => {
+    useStoryConfig(NO_WRAPPER_CONFIG);
+
+    return (
+        <DeviceProvider>
+            <PanelLayout
+                leftTop={<DummyPanel>Left Top{largeIpsum}</DummyPanel>}
+                leftBottom={<DummyPanel>Left Bottom{largeIpsum}</DummyPanel>}
+                middleTop={<DummyPanel>Middle Top{largeIpsum}</DummyPanel>}
+                middleBottom={<DummyPanel>Middle Bottom{largeIpsum}</DummyPanel>}
+                rightTop={<DummyPanel>Right Top{largeIpsum}</DummyPanel>}
+                rightBottom={<DummyPanel>Right bottom {largeIpsum}</DummyPanel>}
+            ></PanelLayout>
+        </DeviceProvider>
+    );
+});

--- a/library/src/scripts/layout/PanelLayout.story.tsx
+++ b/library/src/scripts/layout/PanelLayout.story.tsx
@@ -58,8 +58,6 @@ export const LargeContent = storyWithConfig(NO_WRAPPER_CONFIG, () => {
 });
 
 export const LargeLeftPanel = storyWithConfig(NO_WRAPPER_CONFIG, () => {
-    useStoryConfig(NO_WRAPPER_CONFIG);
-
     return (
         <DeviceProvider>
             <PanelLayout
@@ -75,8 +73,6 @@ export const LargeLeftPanel = storyWithConfig(NO_WRAPPER_CONFIG, () => {
 });
 
 export const LargeRightTopPanel = storyWithConfig(NO_WRAPPER_CONFIG, () => {
-    useStoryConfig(NO_WRAPPER_CONFIG);
-
     return (
         <DeviceProvider>
             <PanelLayout
@@ -92,8 +88,6 @@ export const LargeRightTopPanel = storyWithConfig(NO_WRAPPER_CONFIG, () => {
 });
 
 export const LargeRightBottomPanel = storyWithConfig(NO_WRAPPER_CONFIG, () => {
-    useStoryConfig(NO_WRAPPER_CONFIG);
-
     return (
         <DeviceProvider>
             <PanelLayout
@@ -114,8 +108,6 @@ export const LargeRightBottomPanel = storyWithConfig(NO_WRAPPER_CONFIG, () => {
 });
 
 export const LargeEverything = storyWithConfig(NO_WRAPPER_CONFIG, () => {
-    useStoryConfig(NO_WRAPPER_CONFIG);
-
     return (
         <DeviceProvider>
             <PanelLayout
@@ -129,3 +121,31 @@ export const LargeEverything = storyWithConfig(NO_WRAPPER_CONFIG, () => {
         </DeviceProvider>
     );
 });
+
+export const DarkMode = storyWithConfig(
+    {
+        ...NO_WRAPPER_CONFIG,
+        themeVars: {
+            global: {
+                mainColors: {
+                    bg: "#333",
+                    fg: "#fff",
+                },
+            },
+        },
+    },
+    () => {
+        return (
+            <DeviceProvider>
+                <PanelLayout
+                    leftTop={<DummyPanel>Left Top{largeIpsum}</DummyPanel>}
+                    leftBottom={<DummyPanel>Left Bottom{largeIpsum}</DummyPanel>}
+                    middleTop={<DummyPanel>Middle Top{largeIpsum}</DummyPanel>}
+                    middleBottom={<DummyPanel>Middle Bottom{largeIpsum}</DummyPanel>}
+                    rightTop={<DummyPanel>Right Top{largeIpsum}</DummyPanel>}
+                    rightBottom={<DummyPanel>Right bottom {largeIpsum}</DummyPanel>}
+                ></PanelLayout>
+            </DeviceProvider>
+        );
+    },
+);

--- a/library/src/scripts/layout/PanelLayout.tsx
+++ b/library/src/scripts/layout/PanelLayout.tsx
@@ -3,16 +3,18 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
-import classNames from "classnames";
-import { Devices, IDeviceProps, withDevice } from "@library/layout/DeviceContext";
-import { ScrollOffsetContext } from "@library/layout/ScrollOffsetContext";
-import { inheritHeightClass } from "@library/styles/styleHelpers";
-import { panelLayoutClasses } from "@library/layout/panelLayoutStyles";
+import { Devices, useDevice } from "@library/layout/DeviceContext";
 import { panelAreaClasses } from "@library/layout/panelAreaStyles";
+import { panelLayoutClasses } from "@library/layout/panelLayoutStyles";
 import { panelWidgetClasses } from "@library/layout/panelWidgetStyles";
+import { useScrollOffset } from "@library/layout/ScrollOffsetContext";
+import { inheritHeightClass } from "@library/styles/styleHelpers";
+import classNames from "classnames";
+import React, { useRef, useState, useEffect, useLayoutEffect } from "react";
+import { style } from "typestyle";
+import { useMeasure } from "@vanilla/react-utils";
 
-interface IProps extends IDeviceProps {
+interface IProps {
     className?: string;
     toggleMobileMenu?: (isOpen: boolean) => void;
     contentTag?: keyof JSX.IntrinsicElements;
@@ -58,127 +60,154 @@ interface IProps extends IDeviceProps {
  * | MiddleBottom |
  * | RightBottom  |
  */
-class PanelLayout extends React.Component<IProps> {
-    public static contextType = ScrollOffsetContext;
-    public context!: React.ContextType<typeof ScrollOffsetContext>;
+export default function PanelLayout(props: IProps) {
+    const { topPadding, className, growMiddleBottom, isFixed, ...childComponents } = props;
 
-    public static defaultProps: Partial<IProps> = {
-        contentTag: "div",
-        growMiddleBottom: false,
-        topPadding: true,
-        isFixed: true,
-    };
+    const { offsetClass, topOffset } = useScrollOffset();
+    const device = useDevice();
+    const sidePanelRef = useRef<HTMLDivElement | null>(null);
+    const sidePanelMeasure = useMeasure(sidePanelRef);
+    const overflowOffset = sidePanelMeasure.top - topOffset;
 
-    public render() {
-        const { topPadding, className, growMiddleBottom, device, isFixed, ...childComponents } = this.props;
+    const panelOffsetClass = style({ top: overflowOffset });
 
-        // Calculate some rendering variables.
-        const isMobile = device === Devices.MOBILE || device === Devices.XS;
-        const isTablet = device === Devices.TABLET;
-        const isFullWidth = [Devices.DESKTOP, Devices.NO_BLEED].includes(device); // This compoment doesn't care about the no bleed, it's the same as desktop
-        const shouldRenderLeftPanel: boolean = !isMobile && (!!childComponents.leftTop || !!childComponents.leftBottom);
-        const shouldRenderRightPanel: boolean = isFullWidth || (isTablet && !shouldRenderLeftPanel);
-        const classes = panelLayoutClasses();
+    // Calculate some rendering variables.
+    const isMobile = device === Devices.MOBILE || device === Devices.XS;
+    const isTablet = device === Devices.TABLET;
+    const isFullWidth = [Devices.DESKTOP, Devices.NO_BLEED].includes(device); // This compoment doesn't care about the no bleed, it's the same as desktop
+    const shouldRenderLeftPanel: boolean = !isMobile && (!!childComponents.leftTop || !!childComponents.leftBottom);
+    const shouldRenderRightPanel: boolean = isFullWidth || (isTablet && !shouldRenderLeftPanel);
+    const classes = panelLayoutClasses();
 
-        // Determine the classes we want to display.
-        const panelClasses = classNames(
-            classes.root,
-            { noLeftPanel: !shouldRenderLeftPanel },
-            { noRightPanel: !shouldRenderRightPanel },
-            { noBreadcrumbs: !childComponents.breadcrumbs },
-            className,
-            { hasTopPadding: topPadding },
-            growMiddleBottom ? inheritHeightClass() : "",
-        );
+    // Determine the classes we want to display.
+    const panelClasses = classNames(
+        classes.root,
+        { noLeftPanel: !shouldRenderLeftPanel },
+        { noRightPanel: !shouldRenderRightPanel },
+        { noBreadcrumbs: !childComponents.breadcrumbs },
+        className,
+        { hasTopPadding: topPadding },
+        growMiddleBottom ? inheritHeightClass() : "",
+    );
 
-        // If applicable, set semantic tag, like "article"
-        const ContentTag = this.props.contentTag as "div";
+    // If applicable, set semantic tag, like "article"
+    const ContentTag = props.contentTag as "div";
 
-        return (
-            <div className={panelClasses}>
-                {childComponents.breadcrumbs && (
-                    <div className={classNames(classes.container, classes.breadcrumbsContainer)}>
-                        {shouldRenderLeftPanel && (
-                            <Panel className={classNames(classes.leftColumn)} ariaHidden={true} />
-                        )}
-                        <PanelAreaHorizontalPadding
-                            className={classNames(classes.middleColumnMaxWidth, {
-                                hasAdjacentPanel: shouldRenderLeftPanel,
-                            })}
-                        >
-                            <PanelWidgetHorizontalPadding>{childComponents.breadcrumbs}</PanelWidgetHorizontalPadding>
-                        </PanelAreaHorizontalPadding>
-                    </div>
-                )}
-
-                <main className={classNames(classes.main, this.props.growMiddleBottom ? inheritHeightClass() : "")}>
-                    <div
-                        className={classNames(
-                            classes.container,
-                            this.props.growMiddleBottom ? inheritHeightClass() : "",
-                        )}
+    return (
+        <div className={panelClasses}>
+            {childComponents.breadcrumbs && (
+                <div className={classNames(classes.container, classes.breadcrumbsContainer)}>
+                    {shouldRenderLeftPanel && <Panel className={classNames(classes.leftColumn)} ariaHidden={true} />}
+                    <PanelAreaHorizontalPadding
+                        className={classNames(classes.middleColumnMaxWidth, {
+                            hasAdjacentPanel: shouldRenderLeftPanel,
+                        })}
                     >
-                        {!isMobile && shouldRenderLeftPanel && (
-                            <Panel
-                                className={classNames(classes.leftColumn, this.context.offsetClass, {
-                                    [classes.isSticky]: isFixed,
-                                })}
-                                tag="aside"
-                            >
-                                {childComponents.leftTop && <PanelArea>{childComponents.leftTop}</PanelArea>}
-                                {childComponents.leftBottom && <PanelArea>{childComponents.leftBottom}</PanelArea>}
-                            </Panel>
-                        )}
+                        <PanelWidgetHorizontalPadding>{childComponents.breadcrumbs}</PanelWidgetHorizontalPadding>
+                    </PanelAreaHorizontalPadding>
+                </div>
+            )}
 
-                        <ContentTag
-                            className={classNames(classes.content, classes.middleColumnMaxWidth, {
-                                hasAdjacentPanel: shouldRenderLeftPanel || shouldRenderRightPanel,
-                                hasTwoAdjacentPanels: shouldRenderLeftPanel && shouldRenderRightPanel,
+            <main className={classNames(classes.main, props.growMiddleBottom ? inheritHeightClass() : "")}>
+                <div className={classNames(classes.container, props.growMiddleBottom ? inheritHeightClass() : "")}>
+                    {!isMobile && shouldRenderLeftPanel && (
+                        <Panel
+                            innerRef={sidePanelRef}
+                            className={classNames(classes.leftColumn, offsetClass, panelOffsetClass, {
+                                [classes.isSticky]: isFixed,
+                            })}
+                            tag="aside"
+                        >
+                            {childComponents.leftTop && (
+                                <PanelArea>
+                                    <PanelOverflow
+                                        offset={overflowOffset}
+                                        overflowSizing={props.leftBottom ? "half" : "full"}
+                                    >
+                                        {childComponents.leftTop}
+                                    </PanelOverflow>
+                                </PanelArea>
+                            )}
+                            {childComponents.leftBottom && (
+                                <PanelArea>
+                                    <PanelOverflow
+                                        offset={overflowOffset}
+                                        overflowSizing={props.leftTop ? "half" : "full"}
+                                    >
+                                        {childComponents.leftBottom}
+                                    </PanelOverflow>
+                                </PanelArea>
+                            )}
+                        </Panel>
+                    )}
+
+                    <ContentTag
+                        className={classNames(classes.content, classes.middleColumnMaxWidth, {
+                            hasAdjacentPanel: shouldRenderLeftPanel || shouldRenderRightPanel,
+                            hasTwoAdjacentPanels: shouldRenderLeftPanel && shouldRenderRightPanel,
+                        })}
+                    >
+                        <Panel
+                            className={classNames(
+                                classes.middleColumn,
+                                props.growMiddleBottom ? inheritHeightClass() : "",
+                            )}
+                        >
+                            {childComponents.middleTop && <PanelArea>{childComponents.middleTop}</PanelArea>}
+                            {!shouldRenderLeftPanel && childComponents.leftTop && (
+                                <PanelArea tag="aside">{childComponents.leftTop}</PanelArea>
+                            )}
+                            {!shouldRenderRightPanel && childComponents.rightTop && (
+                                <PanelArea tag="aside">{childComponents.rightTop}</PanelArea>
+                            )}
+                            <PanelArea className={classNames(props.growMiddleBottom ? inheritHeightClass() : "")}>
+                                {childComponents.middleBottom}
+                            </PanelArea>
+                            {!shouldRenderRightPanel && childComponents.rightBottom && (
+                                <PanelArea tag="aside">{childComponents.rightBottom}</PanelArea>
+                            )}
+                        </Panel>
+                    </ContentTag>
+                    {shouldRenderRightPanel && (
+                        <Panel
+                            className={classNames(classes.rightColumn, offsetClass, panelOffsetClass, {
+                                [classes.isSticky]: isFixed,
                             })}
                         >
-                            <Panel
-                                className={classNames(
-                                    classes.middleColumn,
-                                    this.props.growMiddleBottom ? inheritHeightClass() : "",
-                                )}
-                            >
-                                {childComponents.middleTop && <PanelArea>{childComponents.middleTop}</PanelArea>}
-                                {!shouldRenderLeftPanel && childComponents.leftTop && (
-                                    <PanelArea tag="aside">{childComponents.leftTop}</PanelArea>
-                                )}
-                                {!shouldRenderRightPanel && childComponents.rightTop && (
-                                    <PanelArea tag="aside">{childComponents.rightTop}</PanelArea>
-                                )}
-                                <PanelArea
-                                    className={classNames(this.props.growMiddleBottom ? inheritHeightClass() : "")}
-                                >
-                                    {childComponents.middleBottom}
+                            {childComponents.rightTop && (
+                                <PanelArea tag="aside">
+                                    <PanelOverflow
+                                        offset={overflowOffset}
+                                        overflowSizing={props.rightBottom ? "half" : "full"}
+                                    >
+                                        {childComponents.rightTop}
+                                    </PanelOverflow>
                                 </PanelArea>
-                                {!shouldRenderRightPanel && childComponents.rightBottom && (
-                                    <PanelArea tag="aside">{childComponents.rightBottom}</PanelArea>
-                                )}
-                            </Panel>
-                        </ContentTag>
-                        {shouldRenderRightPanel && (
-                            <Panel
-                                className={classNames(classes.rightColumn, this.context.offsetClass, {
-                                    [classes.isSticky]: isFixed,
-                                })}
-                            >
-                                {childComponents.rightTop && (
-                                    <PanelArea tag="aside">{childComponents.rightTop}</PanelArea>
-                                )}
-                                {childComponents.rightBottom && (
-                                    <PanelArea tag="aside">{childComponents.rightBottom}</PanelArea>
-                                )}
-                            </Panel>
-                        )}
-                    </div>
-                </main>
-            </div>
-        );
-    }
+                            )}
+                            {childComponents.rightBottom && (
+                                <PanelArea tag="aside">
+                                    <PanelOverflow
+                                        offset={overflowOffset}
+                                        overflowSizing={props.rightTop ? "half" : "full"}
+                                    >
+                                        {childComponents.rightBottom}
+                                    </PanelOverflow>
+                                </PanelArea>
+                            )}
+                        </Panel>
+                    )}
+                </div>
+            </main>
+        </div>
+    );
 }
+
+PanelLayout.defaultProps = {
+    contentTag: "div",
+    growMiddleBottom: false,
+    topPadding: true,
+    isFixed: true,
+};
 
 // Simple container components.
 interface IContainerProps {
@@ -199,10 +228,33 @@ export function Panel(props: IContainerProps) {
     );
 }
 
-export function PanelArea(props: IContainerProps) {
-    const Tag = props.tag || "div";
+export function PanelOverflow(props: IContainerProps & { overflowSizing: "half" | "full"; offset: number }) {
     const classes = panelAreaClasses();
-    return <Tag className={classNames(classes.root, props.className)}>{props.children}</Tag>;
+    return (
+        <div className={classes.areaOverlay}>
+            <div className={classes.areaOverlayBefore}></div>
+            <div
+                ref={props.innerRef}
+                className={classNames(props.className, {
+                    [classes.overflowHalf(props.offset)]: props.overflowSizing === "half",
+                    [classes.overflowFull(props.offset)]: props.overflowSizing === "full",
+                })}
+            >
+                {props.children}
+            </div>
+            <div className={classes.areaOverlayAfter}></div>
+        </div>
+    );
+}
+
+export function PanelArea(props: IContainerProps) {
+    const Tag = (props.tag as "div") || "div";
+    const classes = panelAreaClasses();
+    return (
+        <Tag ref={props.innerRef} className={classNames(classes.root, props.className)}>
+            {props.children}
+        </Tag>
+    );
 }
 
 export function PanelAreaHorizontalPadding(props: IContainerProps) {
@@ -225,5 +277,3 @@ export function PanelWidgetHorizontalPadding(props: IContainerProps) {
     const classes = panelWidgetClasses();
     return <div className={classNames(classes.root, "hasNoVerticalPadding", props.className)}>{props.children}</div>;
 }
-
-export default withDevice(PanelLayout);

--- a/library/src/scripts/layout/PanelLayout.tsx
+++ b/library/src/scripts/layout/PanelLayout.tsx
@@ -9,10 +9,10 @@ import { panelLayoutClasses } from "@library/layout/panelLayoutStyles";
 import { panelWidgetClasses } from "@library/layout/panelWidgetStyles";
 import { useScrollOffset } from "@library/layout/ScrollOffsetContext";
 import { inheritHeightClass } from "@library/styles/styleHelpers";
-import classNames from "classnames";
-import React, { useRef, useState, useEffect, useLayoutEffect } from "react";
-import { style } from "typestyle";
 import { useMeasure } from "@vanilla/react-utils";
+import classNames from "classnames";
+import React, { useMemo, useRef } from "react";
+import { style } from "typestyle";
 
 interface IProps {
     className?: string;
@@ -65,11 +65,12 @@ export default function PanelLayout(props: IProps) {
 
     const { offsetClass, topOffset } = useScrollOffset();
     const device = useDevice();
-    const sidePanelRef = useRef<HTMLDivElement | null>(null);
-    const sidePanelMeasure = useMeasure(sidePanelRef);
+    const panelRef = useRef<HTMLDivElement | null>(null);
+    const sidePanelMeasure = useMeasure(panelRef);
     const overflowOffset = sidePanelMeasure.top - topOffset;
 
-    const panelOffsetClass = style({ top: overflowOffset });
+    console.log("render panel", overflowOffset, sidePanelMeasure);
+    const panelOffsetClass = useMemo(() => style({ top: overflowOffset }), [overflowOffset]);
 
     // Calculate some rendering variables.
     const isMobile = device === Devices.MOBILE || device === Devices.XS;
@@ -109,10 +110,12 @@ export default function PanelLayout(props: IProps) {
             )}
 
             <main className={classNames(classes.main, props.growMiddleBottom ? inheritHeightClass() : "")}>
-                <div className={classNames(classes.container, props.growMiddleBottom ? inheritHeightClass() : "")}>
+                <div
+                    ref={panelRef}
+                    className={classNames(classes.container, props.growMiddleBottom ? inheritHeightClass() : "")}
+                >
                     {!isMobile && shouldRenderLeftPanel && (
                         <Panel
-                            innerRef={sidePanelRef}
                             className={classNames(classes.leftColumn, offsetClass, panelOffsetClass, {
                                 [classes.isSticky]: isFixed,
                             })}

--- a/library/src/scripts/layout/PanelLayout.tsx
+++ b/library/src/scripts/layout/PanelLayout.tsx
@@ -118,26 +118,10 @@ export default function PanelLayout(props: IProps) {
                             })}
                             tag="aside"
                         >
-                            {childComponents.leftTop && (
-                                <PanelArea>
-                                    <PanelOverflow
-                                        offset={overflowOffset}
-                                        overflowSizing={props.leftBottom ? "half" : "full"}
-                                    >
-                                        {childComponents.leftTop}
-                                    </PanelOverflow>
-                                </PanelArea>
-                            )}
-                            {childComponents.leftBottom && (
-                                <PanelArea>
-                                    <PanelOverflow
-                                        offset={overflowOffset}
-                                        overflowSizing={props.leftTop ? "half" : "full"}
-                                    >
-                                        {childComponents.leftBottom}
-                                    </PanelOverflow>
-                                </PanelArea>
-                            )}
+                            <PanelOverflow offset={overflowOffset}>
+                                {childComponents.leftTop && <PanelArea>{childComponents.leftTop}</PanelArea>}
+                                {childComponents.leftBottom && <PanelArea>{childComponents.leftBottom}</PanelArea>}
+                            </PanelOverflow>
                         </Panel>
                     )}
 
@@ -174,26 +158,14 @@ export default function PanelLayout(props: IProps) {
                                 [classes.isSticky]: isFixed,
                             })}
                         >
-                            {childComponents.rightTop && (
-                                <PanelArea tag="aside">
-                                    <PanelOverflow
-                                        offset={overflowOffset}
-                                        overflowSizing={props.rightBottom ? "half" : "full"}
-                                    >
-                                        {childComponents.rightTop}
-                                    </PanelOverflow>
-                                </PanelArea>
-                            )}
-                            {childComponents.rightBottom && (
-                                <PanelArea tag="aside">
-                                    <PanelOverflow
-                                        offset={overflowOffset}
-                                        overflowSizing={props.rightTop ? "half" : "full"}
-                                    >
-                                        {childComponents.rightBottom}
-                                    </PanelOverflow>
-                                </PanelArea>
-                            )}
+                            <PanelOverflow offset={overflowOffset}>
+                                {childComponents.rightTop && (
+                                    <PanelArea tag="aside">{childComponents.rightTop}</PanelArea>
+                                )}
+                                {childComponents.rightBottom && (
+                                    <PanelArea tag="aside">{childComponents.rightBottom}</PanelArea>
+                                )}
+                            </PanelOverflow>
                         </Panel>
                     )}
                 </div>
@@ -228,18 +200,12 @@ export function Panel(props: IContainerProps) {
     );
 }
 
-export function PanelOverflow(props: IContainerProps & { overflowSizing: "half" | "full"; offset: number }) {
+export function PanelOverflow(props: IContainerProps & { offset: number }) {
     const classes = panelAreaClasses();
     return (
         <div className={classes.areaOverlay}>
             <div className={classes.areaOverlayBefore}></div>
-            <div
-                ref={props.innerRef}
-                className={classNames(props.className, {
-                    [classes.overflowHalf(props.offset)]: props.overflowSizing === "half",
-                    [classes.overflowFull(props.offset)]: props.overflowSizing === "full",
-                })}
-            >
+            <div ref={props.innerRef} className={classNames(props.className, classes.overflowFull(props.offset))}>
                 {props.children}
             </div>
             <div className={classes.areaOverlayAfter}></div>

--- a/library/src/scripts/layout/ScrollOffsetContext.tsx
+++ b/library/src/scripts/layout/ScrollOffsetContext.tsx
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import React, { useContext } from "react";
+import React, { useContext, useDebugValue } from "react";
 import { logWarning } from "@vanilla/utils";
 import { style } from "typestyle";
 
@@ -17,6 +17,8 @@ interface IContextParams {
     getCalcedHashOffset(): number;
     hashOffsetRef: React.RefObject<HTMLDivElement>;
     temporarilyDisabledWatching: (duration: number) => void;
+    topOffset: number;
+    setTopOffset(pixels: number): void;
 }
 
 export const ScrollOffsetContext = React.createContext<IContextParams>({
@@ -27,6 +29,10 @@ export const ScrollOffsetContext = React.createContext<IContextParams>({
         logWarning("Reset scroll offset called, but a proper provider was not configured.");
     },
     scrollOffset: null,
+    topOffset: 0,
+    setTopOffset: (pixels: number) => {
+        logWarning("Set scroll offset called, but a proper provider was not configured.");
+    },
     getCalcedHashOffset: () => 0,
     temporarilyDisabledWatching: () => {
         logWarning("Attempted to disable watching but a proper provider was not configured.");
@@ -48,6 +54,7 @@ interface IProps {
 
 interface IState {
     scrollOffset: number;
+    topOffset: number;
     isScrolledOff: boolean;
     hashOffset: number;
     isWatchingEnabled: boolean;
@@ -67,6 +74,7 @@ interface IState {
 export class ScrollOffsetProvider extends React.Component<IProps, IState> {
     public state: IState = {
         scrollOffset: 0,
+        topOffset: 0,
         isScrolledOff: false,
         hashOffset: 0,
         isWatchingEnabled: true,
@@ -95,6 +103,8 @@ export class ScrollOffsetProvider extends React.Component<IProps, IState> {
                     setScrollOffset: this.setScrollOffset,
                     resetScrollOffset: this.resetScrollOffset,
                     scrollOffset: isScrolledOff && scrollWatchingEnabled ? scrollOffset : 0,
+                    topOffset: this.state.topOffset,
+                    setTopOffset: this.setTopOffset,
                     offsetClass: scrollWatchingEnabled ? offsetClass : "",
                     getCalcedHashOffset: this.getCalcedHashOffset,
                     hashOffsetRef: this.hashOffsetRef,
@@ -179,6 +189,13 @@ export class ScrollOffsetProvider extends React.Component<IProps, IState> {
         this.setState({ scrollOffset: offset });
     };
 
+    /**
+     * Set the value items will be translated by.
+     */
+    private setTopOffset: ScollOffsetSetter = offset => {
+        this.setState({ topOffset: offset });
+    };
+
     private getCalcedHashOffset = (): number => {
         const offsetElement = this.hashOffsetRef.current;
         if (!offsetElement) {
@@ -191,7 +208,9 @@ export class ScrollOffsetProvider extends React.Component<IProps, IState> {
 }
 
 export function useScrollOffset() {
-    return useContext(ScrollOffsetContext);
+    const value = useContext(ScrollOffsetContext);
+    useDebugValue(value);
+    return value;
 }
 
 /**

--- a/library/src/scripts/layout/bodyStyles.ts
+++ b/library/src/scripts/layout/bodyStyles.ts
@@ -6,11 +6,12 @@
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { percent, viewHeight } from "csx";
-import { cssRule } from "typestyle";
+import { cssRule, forceRenderStyles } from "typestyle";
 import { colorOut, background, fontFamilyWithDefaults, margins, paddings, fonts } from "@library/styles/styleHelpers";
 
 export const bodyCSS = useThemeCache(() => {
     const globalVars = globalVariables();
+    console.log("body css", globalVars);
     cssRule("html", {
         "-ms-overflow-style": "-ms-autohiding-scrollbar",
     });
@@ -25,6 +26,7 @@ export const bodyCSS = useThemeCache(() => {
         wordBreak: "break-word",
         overscrollBehavior: "none", // For IE -> https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior
         height: percent(100),
+        $unique: true, // This doesn't refresh without this for some reason.
     });
 
     cssRule("*", {

--- a/library/src/scripts/layout/panelAreaStyles.ts
+++ b/library/src/scripts/layout/panelAreaStyles.ts
@@ -54,14 +54,16 @@ export const panelAreaClasses = useThemeCache(() => {
 
     const overflowHalf = (offset: number) =>
         style("overflowHalf", {
-            maxHeight: calc(`50vh - ${unit(globalVars.gutter.size)}`),
+            maxHeight: calc(`50vh - ${unit(offset / 2)}`),
             overflow: "auto",
+            minHeight: 100,
         });
     const overflowFull = (offset: number) =>
         style("overflowFull", {
             maxHeight: calc(`100vh - ${unit(offset)}`),
             overflow: "auto",
             position: "relative",
+            minHeight: 100,
             paddingBottom: 50,
             paddingTop: 50,
             marginTop: -50,

--- a/library/src/scripts/layout/panelAreaStyles.ts
+++ b/library/src/scripts/layout/panelAreaStyles.ts
@@ -52,16 +52,14 @@ export const panelAreaClasses = useThemeCache(() => {
         }),
     );
 
-    const { margin } = layoutVars.panelLayoutSpacing;
-    const totalMargin = margin.top + margin.bottom;
     const overflowHalf = (offset: number) =>
         style("overflowHalf", {
-            maxHeight: calc(`50vh - ${unit(globalVars.gutter.size + totalMargin)}`),
+            maxHeight: calc(`50vh - ${unit(globalVars.gutter.size)}`),
             overflow: "auto",
         });
     const overflowFull = (offset: number) =>
         style("overflowFull", {
-            maxHeight: calc(`100vh - ${unit(totalMargin + offset)}`),
+            maxHeight: calc(`100vh - ${unit(offset)}`),
             overflow: "auto",
             position: "relative",
             paddingBottom: 50,

--- a/library/src/scripts/layout/panelAreaStyles.ts
+++ b/library/src/scripts/layout/panelAreaStyles.ts
@@ -4,17 +4,18 @@
  * @license GPL-2.0-only
  */
 
-import { color, percent } from "csx";
+import { color, percent, calc, linearGradient } from "csx";
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { layoutVariables } from "@library/layout/panelLayoutStyles";
 import { lineHeightAdjustment } from "@library/styles/textUtils";
 import { panelWidgetClasses } from "@library/layout/panelWidgetStyles";
-import { paddings } from "@library/styles/styleHelpers";
+import { paddings, unit, colorOut } from "@library/styles/styleHelpers";
 import { NestedCSSSelectors } from "typestyle/lib/types";
 
 export const panelAreaClasses = useThemeCache(() => {
     const globalVars = globalVariables();
+    const layoutVars = layoutVariables();
     const vars = layoutVariables();
     const mediaQueries = vars.mediaQueries();
     const style = styleFactory("panelArea");
@@ -51,5 +52,52 @@ export const panelAreaClasses = useThemeCache(() => {
         }),
     );
 
-    return { root };
+    const { margin } = layoutVars.panelLayoutSpacing;
+    const totalMargin = margin.top + margin.bottom;
+    const overflowHalf = (offset: number) =>
+        style("overflowHalf", {
+            maxHeight: calc(`50vh - ${unit(globalVars.gutter.size + totalMargin)}`),
+            overflow: "auto",
+        });
+    const overflowFull = (offset: number) =>
+        style("overflowFull", {
+            maxHeight: calc(`100vh - ${unit(totalMargin + offset)}`),
+            overflow: "auto",
+            position: "relative",
+            paddingBottom: 50,
+            paddingTop: 50,
+            marginTop: -50,
+        });
+
+    const areaOverlay = style("areaOverlay", {});
+
+    const areaOverlayBefore = style("areaOverlayBefore", {
+        zIndex: 3,
+        top: 0,
+        left: 0,
+        right: 0,
+        position: "absolute",
+        height: 50,
+        marginTop: -50,
+        background: linearGradient(
+            "to top",
+            colorOut(globalVars.mainColors.bg.fade(0))!,
+            colorOut(globalVars.mainColors.bg)!,
+        ),
+    });
+    const areaOverlayAfter = style("areaOverlayAfter", {
+        zIndex: 1,
+        bottom: 0,
+        left: 0,
+        right: 0,
+        position: "absolute",
+        height: 50,
+        background: linearGradient(
+            "to bottom",
+            colorOut(globalVars.mainColors.bg.fade(0))!,
+            colorOut(globalVars.mainColors.bg)!,
+        ),
+    });
+
+    return { root, overflowHalf, overflowFull, areaOverlayBefore, areaOverlayAfter, areaOverlay };
 });

--- a/library/src/scripts/layout/panelAreaStyles.ts
+++ b/library/src/scripts/layout/panelAreaStyles.ts
@@ -52,12 +52,6 @@ export const panelAreaClasses = useThemeCache(() => {
         }),
     );
 
-    const overflowHalf = (offset: number) =>
-        style("overflowHalf", {
-            maxHeight: calc(`50vh - ${unit(offset / 2)}`),
-            overflow: "auto",
-            minHeight: 100,
-        });
     const overflowFull = (offset: number) =>
         style("overflowFull", {
             maxHeight: calc(`100vh - ${unit(offset)}`),
@@ -99,5 +93,5 @@ export const panelAreaClasses = useThemeCache(() => {
         ),
     });
 
-    return { root, overflowHalf, overflowFull, areaOverlayBefore, areaOverlayAfter, areaOverlay };
+    return { root, overflowFull, areaOverlayBefore, areaOverlayAfter, areaOverlay };
 });

--- a/library/src/scripts/layout/panelLayoutStyles.ts
+++ b/library/src/scripts/layout/panelLayoutStyles.ts
@@ -191,7 +191,6 @@ export const panelLayoutClasses = useThemeCache(() => {
     const style = styleFactory("panelLayout");
     const classesPanelArea = panelAreaClasses();
     const classesPanelList = panelListClasses();
-    const titleBarVars = titleBarVariables();
 
     const main = style("main", {
         minHeight: viewHeight(20),
@@ -324,6 +323,7 @@ export const panelLayoutClasses = useThemeCache(() => {
         {
             ...sticky(),
             height: percent(100),
+            $unique: true,
         },
         mediaQueries.oneColumnDown({
             position: "relative",

--- a/library/src/scripts/layout/panelLayoutStyles.ts
+++ b/library/src/scripts/layout/panelLayoutStyles.ts
@@ -317,7 +317,6 @@ export const panelLayoutClasses = useThemeCache(() => {
         "isSticky",
         {
             ...sticky(),
-            top: titleBarVars.sizing.height * 2,
             height: percent(100),
         },
         mediaQueries.oneColumnDown({
@@ -334,7 +333,7 @@ export const panelLayoutClasses = useThemeCache(() => {
     });
 
     const breadcrumbsContainer = style("breadcrumbs", {
-        marginBottom: unit(10),
+        paddingBottom: unit(10),
     });
 
     return {

--- a/library/src/scripts/layout/panelLayoutStyles.ts
+++ b/library/src/scripts/layout/panelLayoutStyles.ts
@@ -16,7 +16,12 @@ import { panelAreaClasses } from "@library/layout/panelAreaStyles";
 import { NestedCSSProperties } from "typestyle/lib/types";
 
 export const layoutVariables = useThemeCache(() => {
+    const globalVars = globalVariables();
     const makeThemeVars = variableFactory("globalVariables");
+
+    const colors = makeThemeVars("colors", {
+        leftColumnBg: globalVars.mainColors.bg,
+    });
 
     // Important variables that will be used to calculate other variables
     const foundationalWidths = makeThemeVars("foundationalWidths", {
@@ -167,6 +172,7 @@ export const layoutVariables = useThemeCache(() => {
     };
 
     return {
+        colors,
         foundationalWidths,
         gutter,
         panel,

--- a/library/src/scripts/redux/ReduxActions.ts
+++ b/library/src/scripts/redux/ReduxActions.ts
@@ -11,6 +11,9 @@ import { ThunkDispatch, ThunkAction } from "redux-thunk";
 import { AnyAction } from "redux";
 import { AsyncActionCreators } from "typescript-fsa";
 import { ICoreStoreState } from "@library/redux/reducerRegistry";
+import { useDispatch } from "react-redux";
+import { useMemo, useDebugValue } from "react";
+import apiv2 from "@library/apiv2";
 
 /**
  * Base class for creating redux actions.
@@ -203,6 +206,20 @@ export default class ReduxActions<S extends ICoreStoreState = ICoreStoreState> {
             return getState();
         });
     }
+}
+
+type ReduxActionConstructor<T extends ICoreStoreState, R extends ReduxActions<T>> = {
+    new (dispatch: any, api: AxiosInstance): R;
+};
+export function useReduxActions<T extends ICoreStoreState, R extends ReduxActions<T>>(
+    actionClass: ReduxActionConstructor<T, R>,
+): R {
+    const dispatch = useDispatch();
+    const actions = useMemo(() => {
+        return new actionClass(dispatch, apiv2);
+    }, [dispatch, actionClass]);
+    useDebugValue(actions);
+    return actions;
 }
 
 // Redux FSA

--- a/library/src/scripts/redux/getStore.ts
+++ b/library/src/scripts/redux/getStore.ts
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import { createStore, compose, applyMiddleware, combineReducers, Store, AnyAction, DeepPartial } from "redux";
+import { createStore, compose, applyMiddleware, combineReducers, Store, AnyAction, DeepPartial, Action } from "redux";
 import { getReducers, ICoreStoreState } from "@library/redux/reducerRegistry";
 import thunk from "redux-thunk";
 
@@ -33,10 +33,29 @@ export function resetStore() {
     store = undefined;
 }
 
+export const resetActionAC = (newState: ICoreStoreState) => {
+    return {
+        type: "@@store/RESET",
+        payload: newState,
+    };
+};
+
+function createRootReducer() {
+    const appReducer = combineReducers(getReducers());
+
+    return (state, action) => {
+        if (action.type === "@@store/RESET") {
+            return action.payload;
+        } else {
+            return appReducer(state, action);
+        }
+    };
+}
+
 export default function getStore<S = ICoreStoreState>(initialState?: DeepPartial<S>, force?: boolean): Store<S, any> {
     if (store === undefined || force) {
         // Get our reducers.
-        const reducer = combineReducers(getReducers());
+        const reducer = createRootReducer();
         store = createStore(reducer, initialState || {}, enhancer);
 
         // Dispatch initial actions returned from the server.

--- a/library/src/scripts/storybook/StoryContext.tsx
+++ b/library/src/scripts/storybook/StoryContext.tsx
@@ -1,0 +1,94 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import Backgrounds from "@library/layout/Backgrounds";
+import getStore from "@library/redux/getStore";
+import { ICoreStoreState } from "@library/redux/reducerRegistry";
+import { storyBookClasses } from "@library/storybook/StoryBookStyles";
+import { ThemeProvider } from "@library/theming/ThemeProvider";
+import { blotCSS } from "@rich-editor/quill/components/blotStyles";
+import React, { useContext, useState, useEffect, useLayoutEffect, useMemo, useCallback } from "react";
+import { Provider } from "react-redux";
+import { DeepPartial } from "redux";
+import "../../scss/_base.scss";
+import isEqual from "lodash/isEqual";
+
+const errorMessage = "There was an error fetching the theme.";
+
+function ErrorComponent() {
+    return <p>{errorMessage}</p>;
+}
+
+interface IContext {
+    storeState?: DeepPartial<ICoreStoreState>;
+    useWrappers?: boolean;
+}
+
+const StoryContext = React.createContext<IContext & { updateContext: (value: Partial<IContext>) => void }>({
+    updateContext: () => {},
+});
+
+export const NO_WRAPPER_CONFIG = {
+    useWrappers: false,
+};
+
+export function useStoryConfig(value: Partial<IContext>) {
+    const context = useContext(StoryContext);
+    useLayoutEffect(() => {
+        context.updateContext(value);
+    }, [context, value]);
+}
+
+export function storyWithConfig(config: Partial<IContext>, Component: React.ComponentType) {
+    const HookWrapper = () => {
+        useStoryConfig(config);
+        return <Component />;
+    };
+
+    const StoryCaller = () => {
+        return <HookWrapper />;
+    };
+
+    return StoryCaller;
+}
+
+export function StoryContextProvider(props: { children?: React.ReactNode }) {
+    const [contextState, setContextState] = useState<IContext>({
+        useWrappers: true,
+    });
+    const updateContext = useCallback(
+        (value: Partial<IContext>) => {
+            const newState = { ...contextState, ...value };
+            if (!isEqual(newState, contextState)) {
+                setContextState({ ...contextState, ...value });
+            }
+        },
+        [setContextState, contextState],
+    );
+    const content = (
+        <>
+            <Backgrounds />
+            {props.children}
+        </>
+    );
+
+    const classes = storyBookClasses();
+    blotCSS();
+    return (
+        <StoryContext.Provider value={{ ...contextState, updateContext }}>
+            <Provider store={getStore()}>
+                <ThemeProvider errorComponent={<ErrorComponent />} themeKey="theme-variables-dark">
+                    {contextState.useWrappers ? (
+                        <div className={classes.containerOuter}>
+                            <div className={classes.containerInner}>{content}</div>
+                        </div>
+                    ) : (
+                        content
+                    )}
+                </ThemeProvider>
+            </Provider>
+        </StoryContext.Provider>
+    );
+}

--- a/library/src/scripts/storybookConfig.tsx
+++ b/library/src/scripts/storybookConfig.tsx
@@ -3,37 +3,8 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
+import { StoryContextProvider } from "@library/storybook/StoryContext";
 import { addDecorator } from "@storybook/react";
-import Backgrounds from "@library/layout/Backgrounds";
-import { ThemeProvider } from "@library/theming/ThemeProvider";
-import { Provider } from "react-redux";
-import getStore from "@library/redux/getStore";
-import { ensureScript } from "@vanilla/dom-utils";
-import "../scss/_base.scss";
-import { storyBookClasses } from "@library/storybook/StoryBookStyles";
-import { blotCSS } from "@rich-editor/quill/components/blotStyles";
+import React from "react";
 
-const errorMessage = "There was an error fetching the theme.";
-
-const Error = () => <p>{errorMessage}</p>;
-const styleDecorator = storyFn => {
-    const classes = storyBookClasses();
-    blotCSS();
-    return (
-        <>
-            <Provider store={getStore()}>
-                <ThemeProvider errorComponent={<Error />} themeKey="theme-variables-dark">
-                    <div className={classes.containerOuter}>
-                        <div className={classes.containerInner}>
-                            <Backgrounds />
-                            {storyFn()}
-                        </div>
-                    </div>
-                </ThemeProvider>
-            </Provider>
-        </>
-    );
-};
-
-addDecorator(styleDecorator);
+addDecorator(storyFn => <StoryContextProvider>{storyFn()}</StoryContextProvider>);

--- a/library/src/scripts/styles/styleUtils.ts
+++ b/library/src/scripts/styles/styleUtils.ts
@@ -11,7 +11,7 @@ import { getMeta } from "@library/utility/appUtils";
 import memoize from "lodash/memoize";
 import merge from "lodash/merge";
 import { color } from "csx";
-import { logDebug, logWarning } from "@vanilla/utils";
+import { logDebug, logWarning, hashString } from "@vanilla/utils";
 import { getThemeVariables } from "@library/theming/getThemeVariables";
 
 export const DEBUG_STYLES = Symbol.for("Debug");
@@ -67,6 +67,13 @@ export function styleFactory(componentName: string) {
     return styleCreator;
 }
 
+let themeUniqueness = hashString(Math.random().toString());
+
+export function clearThemeCache() {
+    themeUniqueness = hashString(Math.random().toString());
+    return themeUniqueness;
+}
+
 /**
  * Wrap a callback so that it will only run once with a particular set of global theme variables.
  *
@@ -77,8 +84,9 @@ export function useThemeCache<Cb>(callback: Cb): Cb {
         const storeState = getStore().getState();
         const themeKey = getMeta("ui.themeKey", "default");
         const status = storeState.theme.assets.status;
-        const cacheKey = themeKey + status;
-        return cacheKey + JSON.stringify(args);
+        const cacheKey = themeKey + status + themeUniqueness;
+        const result = cacheKey + JSON.stringify(args);
+        return result;
     };
     return memoize(callback as any, makeCacheKey);
 }

--- a/library/src/scripts/theming/ThemeProvider.tsx
+++ b/library/src/scripts/theming/ThemeProvider.tsx
@@ -5,81 +5,19 @@
 
 import { LoadStatus } from "@library/@types/api/core";
 import apiv2 from "@library/apiv2";
-import Backgrounds from "@library/layout/Backgrounds";
 import { inputClasses } from "@library/forms/inputStyles";
+import Backgrounds from "@library/layout/Backgrounds";
+import { useScrollOffset } from "@library/layout/ScrollOffsetContext";
 import Loader from "@library/loaders/Loader";
-import { prepareShadowRoot } from "@vanilla/dom-utils";
 import { ICoreStoreState } from "@library/redux/reducerRegistry";
+import { useReduxActions } from "@library/redux/ReduxActions";
 import ThemeActions from "@library/theming/ThemeActions";
-import { IThemeVariables } from "@library/theming/themeReducer";
-import React, { Children } from "react";
-import { connect } from "react-redux";
+import { prepareShadowRoot } from "@vanilla/dom-utils";
+import React, { useEffect } from "react";
+import { useSelector } from "react-redux";
 import { loadThemeFonts } from "./loadThemeFonts";
 
-export interface IWithThemeProps {
-    theme: IThemeVariables;
-}
-
-class BaseThemeProvider extends React.Component<IProps> {
-    public render() {
-        const { assets } = this.props;
-        if (this.props.disabled) {
-            return this.props.children;
-        }
-        if (this.props)
-            switch (assets.status) {
-                case LoadStatus.PENDING:
-                case LoadStatus.LOADING:
-                    return <Loader />;
-                case LoadStatus.ERROR:
-                    return this.props.errorComponent;
-            }
-
-        if (!assets.data) {
-            return null;
-        }
-
-        if (this.props.variablesOnly) {
-            return this.props.children;
-        }
-
-        // Apply kludged input text styling everywhere.
-        inputClasses().applyInputCSSRules();
-
-        return (
-            <>
-                <Backgrounds />
-                {this.props.children}
-            </>
-        );
-    }
-
-    public componentDidMount() {
-        if (this.props.disabled) {
-            return;
-        }
-        void this.props.requestData();
-
-        const themeHeader = document.getElementById("themeHeader");
-        const themeFooter = document.getElementById("themeFooter");
-
-        if (themeHeader) {
-            prepareShadowRoot(themeHeader, true);
-        }
-
-        if (themeFooter) {
-            prepareShadowRoot(themeFooter, true);
-        }
-
-        if (this.props.variablesOnly) {
-            return;
-        }
-
-        loadThemeFonts();
-    }
-}
-
-interface IOwnProps {
+interface IProps {
     children: React.ReactNode;
     themeKey: string;
     errorComponent: React.ReactNode;
@@ -87,19 +25,80 @@ interface IOwnProps {
     disabled?: boolean;
 }
 
-type IProps = IOwnProps & ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchToProps>;
+export function ThemeProvider(props: IProps) {
+    const { themeKey, disabled, variablesOnly } = props;
+    const { getAssets } = useReduxActions(ThemeActions);
+    const { assets } = useSelector((state: ICoreStoreState) => state.theme);
+    const { setTopOffset } = useScrollOffset();
 
-function mapStateToProps(state: ICoreStoreState, ownProps: IOwnProps) {
-    return {
-        assets: state.theme.assets,
-    };
+    useEffect(() => {
+        if (disabled) {
+            return;
+        }
+
+        if (assets.status === LoadStatus.PENDING) {
+            void getAssets(themeKey);
+            return;
+        }
+
+        if (assets.data) {
+            let themeHeader = document.getElementById("themeHeader");
+            const themeFooter = document.getElementById("themeFooter");
+
+            if (themeHeader) {
+                themeHeader = prepareShadowRoot(themeHeader, true);
+                console.log("Measure theme header", themeHeader, themeHeader.getBoundingClientRect());
+                // For some reason the measurements are not applied immediately to the header
+                // Waiting 1 tick works though.
+                setTopOffset(themeHeader.getBoundingClientRect().height);
+            }
+
+            if (themeFooter) {
+                prepareShadowRoot(themeFooter, true);
+            }
+
+            if (variablesOnly) {
+                return;
+            }
+
+            loadThemeFonts();
+        }
+    }, [assets, disabled, setTopOffset, variablesOnly, getAssets, themeKey]);
+
+    if (props.disabled) {
+        return props.children;
+    }
+    if (props)
+        switch (assets.status) {
+            case LoadStatus.PENDING:
+            case LoadStatus.LOADING:
+                return <Loader />;
+            case LoadStatus.ERROR:
+                return props.errorComponent;
+        }
+
+    if (!assets.data) {
+        return null;
+    }
+
+    if (props.variablesOnly) {
+        return props.children;
+    }
+
+    // Apply kludged input text styling everywhere.
+    inputClasses().applyInputCSSRules();
+
+    return (
+        <>
+            <Backgrounds />
+            {props.children}
+        </>
+    );
 }
 
-function mapDispatchToProps(dispatch: any, ownProps: IOwnProps) {
+function mapDispatchToProps(dispatch: any, ownProps: IProps) {
     const themeActions = new ThemeActions(dispatch, apiv2);
     return {
         requestData: () => themeActions.getAssets(ownProps.themeKey),
     };
 }
-
-export const ThemeProvider = connect(mapStateToProps, mapDispatchToProps)(BaseThemeProvider);

--- a/library/src/scripts/theming/ThemeProvider.tsx
+++ b/library/src/scripts/theming/ThemeProvider.tsx
@@ -13,7 +13,7 @@ import { ICoreStoreState } from "@library/redux/reducerRegistry";
 import { useReduxActions } from "@library/redux/ReduxActions";
 import ThemeActions from "@library/theming/ThemeActions";
 import { prepareShadowRoot } from "@vanilla/dom-utils";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { loadThemeFonts } from "./loadThemeFonts";
 
@@ -31,12 +31,19 @@ export const ThemeProvider: React.FC<IProps> = (props: IProps) => {
     const { assets } = useSelector((state: ICoreStoreState) => state.theme);
     const { setTopOffset } = useScrollOffset();
 
+    const [ownThemeKey, setThemeKey] = useState({});
+    // Trigger a state re-render when the theme key changes
+    useEffect(() => {
+        setThemeKey(themeKey);
+    }, [themeKey, setThemeKey]);
+
     useEffect(() => {
         if (disabled) {
             return;
         }
 
         if (assets.status === LoadStatus.PENDING) {
+            console.log("fetch assets");
             void getAssets(themeKey);
             return;
         }
@@ -65,7 +72,7 @@ export const ThemeProvider: React.FC<IProps> = (props: IProps) => {
     }, [assets, disabled, setTopOffset, variablesOnly, getAssets, themeKey]);
 
     if (props.disabled || props.variablesOnly) {
-        return <>props.children</>;
+        return <>{props.children}</>;
     }
 
     if ([LoadStatus.PENDING, LoadStatus.LOADING].includes(assets.status)) {
@@ -73,7 +80,7 @@ export const ThemeProvider: React.FC<IProps> = (props: IProps) => {
     }
 
     if (assets.status === LoadStatus.ERROR) {
-        return <>props.errorComponent</>;
+        return <>{props.errorComponent}</>;
     }
 
     if (!assets.data) {

--- a/packages/vanilla-dom-utils/src/shadowDom.tsx
+++ b/packages/vanilla-dom-utils/src/shadowDom.tsx
@@ -13,7 +13,11 @@ import { browserEscapesNoScript, unescapeHTML } from "./sanitization";
  *      Particularly useful for when the initial content is inside of a <noscript /> tag.
  * @param newElementTag
  */
-export function prepareShadowRoot(element: HTMLElement, cloneElement: boolean = false, newElementTag = "div") {
+export function prepareShadowRoot(
+    element: HTMLElement,
+    cloneElement: boolean = false,
+    newElementTag = "div",
+): HTMLElement {
     let html = element.innerHTML;
     // This is likely a noscript tag.
     if (browserEscapesNoScript()) {
@@ -39,4 +43,5 @@ export function prepareShadowRoot(element: HTMLElement, cloneElement: boolean = 
 
     const shadowHeader = element.attachShadow({ mode: "open" });
     shadowHeader.innerHTML = html;
+    return element;
 }


### PR DESCRIPTION
Closes https://github.com/vanilla/knowledge/issues/1434

## Still todo

- [x] Apply scroll overlay indicators.
- [x] Add variations into storybook.
- [x] Use real calculated values.
- [x] Make sure things still work on mobile.

## Storybook housekeeping

- Update our storybook config to allow the new story format. [Component Story Format](https://storybook.js.org/docs/formats/component-story-format/)
- Add a new storybook utility `storyWithConfig()` that makes it easier to:
  - Make a story use a specific redux state.
  - Opt out of the outer storybook wrappers.
  - Make a story use some particular theming variables.

## Panel Layout changes

- Panel layout is now in storybook.
- Side panels are now scrollable separate from the main page content.
  - Customer request https://github.com/vanilla/knowledge/issues/1434
  - I implemented a similar scrolling system previously for our dashboard https://github.com/vanilla/vanilla/pull/8490
  - Linear gradients are used to show that some content is not visible (similar to our collapsable content).
- Actual top sticky position is calculated using a ref instead of some guessed hardcoded value.
  - Some extra context values were added so this now accounts for customer theme header height as well.
