### PR TITLE
Fix call to time() in user model

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1154,7 +1154,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
             'name' => 'unknown',
             'email' => 'unknown@example.com',
             'photoUrl' => self::getDefaultAvatarUrl(),
-            'dateLastActive' => time(0),
+            'dateLastActive' => time(),
         ];
         switch ($key) {
             case self::GENERATED_FRAGMENT_KEY_GUEST:


### PR DESCRIPTION
The `time()` function does not take any arguments and supplying one causes issues in later versions of PHP. Basically, this was fixing a typo.