### PR TITLE
Fix some lint errors and code coverage

### DIFF
--- a/library/Garden/ArrayContainer.php
+++ b/library/Garden/ArrayContainer.php
@@ -44,8 +44,7 @@ class ArrayContainer extends \ArrayObject implements ContainerInterface {
      *
      * @param string $id Identifier of the entry to look for.
      *
-     * @throws NotFoundException  No entry was found for this identifier.
-     * @throws ContainerException Error while retrieving the entry.
+     * @throws ContainerNotFoundException  No entry was found for this identifier.
      *
      * @return mixed Entry.
      */

--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -115,7 +115,6 @@ class Addon implements Contracts\AddonInterface {
 
         // Fix issues with the plugin that can be fixed.
         $this->check(true);
-
     }
 
     /**
@@ -166,7 +165,7 @@ class Addon implements Contracts\AddonInterface {
                     }
                 }
             }
-            
+
             return $info;
         }
 
@@ -476,7 +475,6 @@ class Addon implements Contracts\AddonInterface {
                     if (strcasecmp(substr($className, -6), 'plugin') === 0
                         || strcasecmp(substr($className, -5), 'hooks') === 0
                     ) {
-
                         if (empty($this->special['plugin'])) {
                             $this->special['plugin'] = $namespace.$className;
                         } else {
@@ -756,7 +754,6 @@ class Addon implements Contracts\AddonInterface {
         if ($rawKey !== $subdir
             && in_array($this->getType(), [static::TYPE_LOCALE, static::TYPE_THEME])
         ) {
-
             $issues['key-subdir-mismatch'] = "The addon key must match its subdirectory name ($rawKey vs. $subdir).";
         }
 
@@ -922,6 +919,7 @@ class Addon implements Contracts\AddonInterface {
      *
      * @param string $version The version to check.
      * @param string $requirement The version requirement.
+     * @return bool Returns **true** if the version checks out or **false** otherwise.
      */
     public static function checkVersion($version, $requirement) {
         // Split the version up on operator boundaries.
@@ -1259,7 +1257,7 @@ class Addon implements Contracts\AddonInterface {
         $classInfo = self::parseFullyQualifiedClass($fullClassName);
         $key = strtolower($classInfo['className']);
         if (array_key_exists($key, $this->classes)) {
-            foreach($this->classes[$key] as $classData) {
+            foreach ($this->classes[$key] as $classData) {
                 if (strtolower($classInfo['namespace']) === strtolower($classData['namespace'])) {
                     $path = $this->path($classData['path'], $relative);
                     return $path;

--- a/library/core/class.autoloader.php
+++ b/library/core/class.autoloader.php
@@ -14,6 +14,8 @@
  * classes into scope as needed.
  *
  * This is a static class that hooks into the SPL autoloader.
+ * @deprecated
+ * @codeCoverageIgnore
  */
 class Gdn_Autoloader {
     const CONTEXT_APPLICATION = 'application';

--- a/library/core/functions.deprecated.php
+++ b/library/core/functions.deprecated.php
@@ -917,6 +917,23 @@ if (!function_exists('viewLocation')) {
     }
 }
 
+if (!function_exists('TagFullName')) {
+    /**
+     * Return the full name of a tag row.
+     *
+     * @param array|object $row
+     * @return mixed
+     * @deprecated
+     */
+    function tagFullName($row) {
+        $result = val('FullName', $row);
+        if (!$result) {
+            $result = val('Name', $row);
+        }
+        return $result;
+    }
+}
+
 if (!function_exists('\Gdn::config()->touch')) {
     /**
      * Make sure the config has a setting.

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -195,7 +195,9 @@ if (!function_exists('arrayReplaceConfig')) {
         $result = array_replace($default, $override);
 
         foreach ($result as $key => &$value) {
-            if (is_array($value) && isset($default[$key]) && isset($override[$key]) && is_array($default[$key]) && !isset($value[0]) && !isset($default[$key][0])) {
+            if (is_array($value) && isset($default[$key]) && isset($override[$key]) &&
+                is_array($default[$key]) && !isset($value[0]) && !isset($default[$key][0])
+            ) {
                 $value = arrayReplaceConfig($default[$key], $override[$key]);
             }
         }
@@ -310,7 +312,6 @@ if (!function_exists('attribute')) {
 
             if (is_array($val) && strpos($attribute, 'data-') === 0) {
                 $val = json_encode($val);
-
             }
 
             if ($val != '' && $attribute != 'Standard') {
@@ -1015,7 +1016,9 @@ if (!function_exists('htmlEntityDecode')) {
         $string = html_entity_decode($string, $quote_style, $charset);
         $string = str_ireplace('&apos;', "'", $string);
         $string = preg_replace_callback('/&#x([0-9a-fA-F]+);/i', "chr_utf8_callback", $string);
-        $string = preg_replace_callback('/&#([0-9]+);/', function($matches) { return chr_utf8($matches[1]); }, $string);
+        $string = preg_replace_callback('/&#([0-9]+);/', function ($matches) {
+            return chr_utf8($matches[1]);
+        }, $string);
         return $string;
     }
 
@@ -1508,12 +1511,16 @@ if (!function_exists('betterRandomString')) {
         if (function_exists('openssl_random_pseudo_bytes')) {
             $randomChars = unpack('C*', openssl_random_pseudo_bytes($length, $cryptoStrong));
         } elseif (function_exists('mcrypt_create_iv')) {
+            // @codeCoverageIgnoreStart
             $randomChars = unpack('C*', mcrypt_create_iv($length));
             $cryptoStrong = true;
+            // @codeCoverageIgnoreEnd
         } else {
+            // @codeCoverageIgnoreStart
             for ($i = 0; $i < $length; $i++) {
                 $randomChars[] = mt_rand();
             }
+            // @codeCoverageIgnoreEnd
         }
 
         $string = '';
@@ -1523,7 +1530,9 @@ if (!function_exists('betterRandomString')) {
         }
 
         if (!$cryptoStrong) {
+            // @codeCoverageIgnoreStart
             Logger::log(Logger::WARNING, 'Random number generation is not cryptographically strong.');
+            // @codeCoverageIgnoreEnd
         }
 
         return $string;
@@ -1649,10 +1658,9 @@ if (!function_exists('safeGlob')) {
     /**
      * A version of {@link glob()} that always returns an array.
      *
-     * @param string        $pattern    The glob pattern.
-     * @param array[string] $extensions An array of file extensions to whitelist.
-     *
-     * @return array[string] Returns an array of paths that match the glob.
+     * @param string $pattern The glob pattern.
+     * @param string[] $extensions An array of file extensions to whitelist.
+     * @return string[] Returns an array of paths that match the glob.
      */
     function safeGlob($pattern, $extensions = []) {
         $result = glob($pattern, GLOB_NOSORT);
@@ -1730,12 +1738,13 @@ if (!function_exists('sliceParagraph')) {
      * The purpose of this function is to provide a string that is reasonably easy to consume by a human.
      *
      * @param string $string The string to slice.
-     * @param int|array $limits Either int $maxLength or array($maxLength, $minLength); whereas $maxLength The maximum length of the string; $minLength The intended minimum length of the string (slice on sentence if paragraph is too short).
+     * @param int|array $limits Either int $maxLength or array($maxLength, $minLength); whereas $maxLength The maximum length of the string;
+     * $minLength The intended minimum length of the string (slice on sentence if paragraph is too short).
      * @param string $suffix The suffix if the string must be sliced mid-sentence.
      * @return string
      */
     function sliceParagraph($string, $limits = 500, $suffix = '…') {
-        if(is_int($limits)) {
+        if (is_int($limits)) {
             $limits = [$limits, 32];
         }
         list($maxLength, $minLength) = $limits;
@@ -1801,8 +1810,10 @@ if (!function_exists('sliceString')) {
         if (function_exists('mb_strimwidth')) {
             return mb_strimwidth($string, 0, $length, $suffix, 'utf-8');
         } else {
+            // @codeCoverageIgnoreStart
             $trim = substr($string, 0, $length);
             return $trim.((strlen($trim) != strlen($string)) ? $suffix : '');
+            // @codeCoverageIgnoreEnd
         }
     }
 }
@@ -1898,8 +1909,9 @@ if (!function_exists('touchValue')) {
      * Set the value on an object/array if it doesn't already exist.
      *
      * @param string $key The key or property name of the value.
-     * @param mixed &$collection The array or object to set.
+     * @param mixed $collection The array or object to set.
      * @param mixed $default The value to set.
+     * @return mixed Returns the existing or new value in the collection.
      */
     function touchValue($key, &$collection, $default) {
         if (is_array($collection) && !array_key_exists($key, $collection)) {
@@ -2044,7 +2056,7 @@ if (!function_exists('walkAllRecursive')) {
         $currentDepth = 0;
         $maxDepth = 128;
 
-        $walker = function(&$input, $callback, $parent = null) use (&$walker, &$currentDepth, $maxDepth) {
+        $walker = function (&$input, $callback, $parent = null) use (&$walker, &$currentDepth, $maxDepth) {
             $currentDepth++;
 
             if ($currentDepth > $maxDepth) {
@@ -2073,7 +2085,7 @@ if (!function_exists('ipEncodeRecursive')) {
      * @return array|object
      */
     function ipEncodeRecursive($input) {
-        walkAllRecursive($input, function(&$val, $key = null, $parent = null) {
+        walkAllRecursive($input, function (&$val, $key = null, $parent = null) {
             if (is_string($val)) {
                 if (stringEndsWith($key, 'IPAddress', true) || stringEndsWith($parent, 'IPAddresses', true) || $key === 'IP') {
                     $val = ipEncode($val);
@@ -2092,7 +2104,7 @@ if (!function_exists('ipDecodeRecursive')) {
      * @return array|object
      */
     function ipDecodeRecursive($input) {
-        walkAllRecursive($input, function(&$val, $key = null, $parent = null) {
+        walkAllRecursive($input, function (&$val, $key = null, $parent = null) {
             if (is_string($val)) {
                 if (stringEndsWith($key, 'IPAddress', true) || stringEndsWith($parent, 'IPAddresses', true) || $key === 'IP') {
                     $val = ipDecode($val);
@@ -2100,21 +2112,5 @@ if (!function_exists('ipDecodeRecursive')) {
             }
         });
         return $input;
-    }
-}
-
-if (!function_exists('TagFullName')) {
-    /**
-     *
-     *
-     * @param $row
-     * @return mixed
-     */
-    function tagFullName($row) {
-        $result = val('FullName', $row);
-        if (!$result) {
-            $result = val('Name', $row);
-        }
-        return $result;
     }
 }


### PR DESCRIPTION
Now that our code coverage of functions.general.php is in good shape I’ve added some ignore directives for areas that we just can’t hit.

In doing that I wanted to clean up some lint errors because I find it easier to not introduce new ones if an entire file is in a clean state.

Our old `Gdn_Autoloader` class has not been used for some time so I’m marking it as deprecated.