### PR TITLE
Add tests for ApiFilterMiddleware

### DIFF
--- a/library/Vanilla/Web/ApiFilterMiddleware.php
+++ b/library/Vanilla/Web/ApiFilterMiddleware.php
@@ -77,4 +77,13 @@ class ApiFilterMiddleware {
             unset($this->blacklist[$key]);
         }
     }
+
+    /**
+     * Gets the array of blacklisted fields.
+     *
+     * @return array Returns an array of the blacklisted fields.
+     */
+    public function getBlacklistFields() {
+        return $this->blacklist;
+    }
 }

--- a/tests/Library/Vanilla/Web/ApiFilterMiddlewareTest.php
+++ b/tests/Library/Vanilla/Web/ApiFilterMiddlewareTest.php
@@ -10,6 +10,7 @@ namespace VanillaTests\Library\Vanilla\Web;
 use Garden\Web\Data;
 use Garden\Web\Exception\ServerException;
 use PHPUnit\Framework\TestCase;
+use ReflectionException;
 use Vanilla\Web\ApiFilterMiddleware;
 use VanillaTests\Fixtures\Request;
 
@@ -93,5 +94,52 @@ class ApiFilterMiddlewareTest extends TestCase {
             return new Data($testSuccessArray, ['request' => $request, 'api-allow' => ['InsertIPAddress']]);
         });
         $this->assertEquals($testSuccessArray, $response->getData());
+    }
+
+    /**
+     * Test getBlacklistFields method.
+     */
+    public function testGetBlacklist() {
+        $apiMiddleware = new ApiFilterMiddleware();
+        $actual = $apiMiddleware->getBlacklistFields();
+        $expected = ['password', 'email', 'insertipaddress', 'updateipaddress'];
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Set up function to call protected methods.
+     *
+     * @param object $testApiMiddleware Middleware object to test with.
+     * @param string $protectedMethod Protected method to test.
+     * @param array $testParameters Parameters to pass to $protectedMethod.
+     * @return mixed Returns the return value of the called function.
+     * @throws ReflectionException Throws exception.
+     */
+    public function invokeProtectedMethod(object &$testApiMiddleware, string $protectedMethod, array $testParameters) {
+        $reflectedApiMiddleware = new \ReflectionClass(get_class($testApiMiddleware));
+        $method = $reflectedApiMiddleware->getMethod($protectedMethod);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($testApiMiddleware, $testParameters);
+    }
+
+    /**
+     * Test addBlacklistField().
+     */
+    public function testAddBlacklistField() {
+        $apiMiddleware = new ApiFilterMiddleware();
+        $this->invokeProtectedMethod($apiMiddleware, 'addBlacklistField', ['topsecretinfo']);
+        $blacklistFields = $apiMiddleware->getBlacklistFields();
+        $this->assertContains('topsecretinfo', $blacklistFields);
+    }
+
+    /**
+     * Test removeBlacklistField().
+     */
+    public function testRemoveBlacklistField() {
+        $apiMiddleware = new ApiFilterMiddleware();
+        $this->invokeProtectedMethod($apiMiddleware, 'removeBlacklistField', ['email']);
+        $blacklistFields = $apiMiddleware->getBlacklistFields();
+        $this->assertNotContains('email', $blacklistFields);
     }
 }

--- a/tests/Library/Vanilla/Web/ApiFilterMiddlewareTest.php
+++ b/tests/Library/Vanilla/Web/ApiFilterMiddlewareTest.php
@@ -97,7 +97,7 @@ class ApiFilterMiddlewareTest extends TestCase {
     }
 
     /**
-     * Test getBlacklistFields method.
+     * Test getBlacklistFields().
      */
     public function testGetBlacklist() {
         $apiMiddleware = new ApiFilterMiddleware();


### PR DESCRIPTION
Added the getBlacklistFields() method to the ApiFilterMiddleware class as well as adding tests for the class methods. 

Partially addresses #9869 