### PR TITLE
Add tests for CacheControlMiddleWare

### DIFF
--- a/library/Vanilla/Web/CacheControlMiddleware.php
+++ b/library/Vanilla/Web/CacheControlMiddleware.php
@@ -59,7 +59,7 @@ class CacheControlMiddleware {
     }
 
     /**
-     * Invoke the smart ID middleware on a request.
+     * Invoke the cache control middleware on a request.
      *
      * @param RequestInterface $request The incoming request.
      * @param callable $next The next middleware.

--- a/library/Vanilla/Web/CacheControlMiddleware.php
+++ b/library/Vanilla/Web/CacheControlMiddleware.php
@@ -76,7 +76,7 @@ class CacheControlMiddleware {
         }
 
         if ($response->getHeader('Cache-Control') !== self::NO_CACHE) {
-            // Unless we havy NO_CACHE set make sure to set the vary header.
+            // Unless we have NO_CACHE set make sure to set the vary header.
             $response->setHeader('Vary', self::VARY_COOKIE);
         }
 

--- a/tests/Library/Vanilla/Web/CacheControlMiddleWareTest.php
+++ b/tests/Library/Vanilla/Web/CacheControlMiddleWareTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @author Richard Flynn <richard.flynn@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Web;
+
+use PHPUnit\Framework\TestCase;
+use Vanilla\Web\CacheControlMiddleware;
+
+/**
+ * Test for functions of CacheControlMiddleWare
+ */
+
+class CacheControlMiddleWareTest extends TestCase {
+
+    /**
+     * Test getHttp10Headers() with max-time set to 0.
+     */
+    public function testGetHttp10HeadersWithMaxTimeZero() {
+        $actual = CacheControlMiddleware::getHttp10Headers('private, max-age=0, no-cache');
+        $expected = ['Expires' => 'Sat, 01 Jan 2000 00:00:00 GMT', 'Pragma' => 'no-cache'];
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getHttp10Headers() with max-time not set to zero.
+     */
+    public function testGetHttpHeadersWithMaxTimeGreaterThanZero() {
+        $actual = CacheControlMiddleware::getHttp10Headers('private, max-age=120');
+        $expected = ['Expires' => gmdate('D, d M Y H:i:s T', time() + 120)];
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test getHttpHeaders() with empty array.
+     */
+    public function testGetHttpHeadersWithEmptyArray() {
+        $actual = CacheControlMiddleware::getHttp10Headers('');
+        $expected = [];
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Library/Vanilla/Web/CacheControlMiddleWareTest.php
+++ b/tests/Library/Vanilla/Web/CacheControlMiddleWareTest.php
@@ -7,8 +7,12 @@
 
 namespace VanillaTests\Library\Vanilla\Web;
 
+use Garden\Web\Data;
+use Garden\Web\RequestInterface;
+use Gdn_Session;
 use PHPUnit\Framework\TestCase;
 use Vanilla\Web\CacheControlMiddleware;
+use VanillaTests\Fixtures\Request;
 
 /**
  * Test for functions of CacheControlMiddleWare
@@ -41,5 +45,102 @@ class CacheControlMiddleWareTest extends TestCase {
         $actual = CacheControlMiddleware::getHttp10Headers('');
         $expected = [];
         $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test __invoke().
+     *
+     * @param int $userID The userID code.
+     * @param array $headers Array of http headers.
+     * @param mixed $expected The expected result.
+     * @dataProvider provideTestInvokeArrays
+     */
+    public function testInvoke(int $userID, array $headers, $expected) {
+        $testSession = new Gdn_Session();
+        $testSession->UserID = $userID;
+        $testRequest = new Request('/', 'GET', [1, 2, 3]);
+        $testObject = new CacheControlMiddleware($testSession);
+        $modifiedObject = $testObject($testRequest, function (RequestInterface $request) use ($headers) {
+            $r = new Data([]);
+
+            foreach ($headers as $key => $value) {
+                $r->setHeader($key, $value);
+            }
+
+            return $r;
+        });
+        $actual = $modifiedObject->getHeaders();
+
+        if ($actual['Expires'] !== 'Sat, 01 Jan 2000 00:00:00 GMT') {
+            unset($actual['Expires']);
+        }
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Provide test data for testInvoke().
+     *
+     * @return array Returns an array of test data.
+     */
+    public function provideTestInvokeArrays() {
+        $r = [
+            'userIDZeroAndPublicCache' => [
+                0,
+                ['Cache-Control' => CacheControlMiddleware::PUBLIC_CACHE],
+                [
+                    'Cache-Control' => 'public, max-age=120',
+                    'Vary' => 'Accept-Encoding, Cookie',
+                ],
+            ],
+            'userIDZeroAndNoCache' => [
+                0,
+                ['Cache-Control' => CacheControlMiddleware::NO_CACHE],
+                [
+                    'Cache-Control' => 'private, no-cache, max-age=0, must-revalidate',
+                    'Expires' => 'Sat, 01 Jan 2000 00:00:00 GMT',
+                    'Pragma' => 'no-cache',
+                ],
+            ],
+            'userIDZeroAndNoCacheControlHeaderAtAll' => [
+                0,
+                ['Foo' => 'bar'],
+                [
+                    'Foo' => 'bar',
+                    'Cache-Control' => 'public, max-age=120',
+                    'Vary' => 'Accept-Encoding, Cookie'
+                ],
+            ],
+            'userID1AndPublicCache' => [
+                1,
+                ['Cache-Control' => CacheControlMiddleware::PUBLIC_CACHE],
+                [
+                    'Cache-Control' => 'public, max-age=120',
+                    'Vary' => 'Accept-Encoding, Cookie',
+                ],
+            ],
+            'userID1AndNoCache' => [
+                1,
+                ['Cache-Control' => CacheControlMiddleware::NO_CACHE],
+                [
+                    'Cache-Control' => 'private, no-cache, max-age=0, must-revalidate',
+                    'Expires' => 'Sat, 01 Jan 2000 00:00:00 GMT',
+                    'Pragma' => 'no-cache',
+                ],
+            ],
+            'userID1AndNoCacheControlHeaderAtAll' => [
+                1,
+                ['Foo' => 'bar'],
+                [
+                    'Foo' => 'bar',
+                    'Cache-Control' => 'private, no-cache, max-age=0, must-revalidate',
+                    'Expires' => 'Sat, 01 Jan 2000 00:00:00 GMT',
+                    'Pragma' => 'no-cache',
+                ],
+            ],
+
+        ];
+
+        return $r;
     }
 }


### PR DESCRIPTION
I added tests for the CacheControlMiddleWare methods (except for sendCacheControlHeaders()).

Partially addresses #9869