### PR TITLE
Fix banner image legacy fallback

### DIFF
--- a/library/SmartyPlugins/function.hero_image_link.php
+++ b/library/SmartyPlugins/function.hero_image_link.php
@@ -6,6 +6,8 @@
  * @since 1.0
  */
 
+use Vanilla\Dashboard\Models\BannerImageModel;
+
 /**
  * Get the hero image for the page.
  *
@@ -16,5 +18,5 @@
  * @deprecated 4.0
  */
 function smarty_function_hero_image_link($params, &$smarty) {
-    return smarty_function_banner_image_url($params, $smarty);
+    return BannerImageModel::getCurrentBannerImageLink();
 }


### PR DESCRIPTION
Fixes a bug preventing the legacy smarty banner image call from working.

For whatever reason calling smarty function from another smarty function gives an error.