### PR TITLE
Fix chromatic on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
     core: vanilla/core@2
-    chromatic: wave/chromatic@1.0.1
+    chromatic: wave/chromatic@1.2.0
     codecov: codecov/codecov@1.0.5
 aliases:
     - &run_yarn


### PR DESCRIPTION
Chromatic has been failing on master branch.

https://app.circleci.com/jobs/github/vanilla/vanilla/32911/parallel-runs/0/steps/0-105

This PR attempts to fix it by bumping our orb version.