### PR TITLE
Fix getting the permissions for a category with an invalid permission category ID

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2527,8 +2527,10 @@ class CategoryModel extends Gdn_Model {
      * @since 2.2
      */
     public static function permissionCategory($category) {
-        if (empty($category) || empty(((object)$category->PermissionCategoryID))) {
-            return self::categories(-1);
+        if (!is_integer($category)) {
+            if (empty($category) || empty(((object)$category->PermissionCategoryID))) {
+                return self::categories(-1);
+            }
         }
 
         if (!is_array($category) && !is_object($category)) {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2534,10 +2534,13 @@ class CategoryModel extends Gdn_Model {
         if (!is_array($category) && !is_object($category)) {
             $category = self::categories($category);
         }
-
         $category = self::categories(val('PermissionCategoryID', $category));
+
         // Ensure all of our values are processed properly.
-        self::calculate($category);
+        if (isset($category)) {
+            self::calculate($category);
+        }
+
         return $category;
     }
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2527,7 +2527,7 @@ class CategoryModel extends Gdn_Model {
      * @since 2.2
      */
     public static function permissionCategory($category) {
-        if (empty($category) || empty($category['PermissionCategoryID'])) {
+        if (empty($category) || empty(((object)$category->PermissionCategoryID))) {
             return self::categories(-1);
         }
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2527,17 +2527,19 @@ class CategoryModel extends Gdn_Model {
      * @since 2.2
      */
     public static function permissionCategory($category) {
-        if (!is_integer($category)) {
-            if (empty($category) || empty(((object)$category->PermissionCategoryID))) {
-                return self::categories(-1);
-            }
+        if (empty($category)) {
+            return self::categories(-1);
         }
 
         if (!is_array($category) && !is_object($category)) {
             $category = self::categories($category);
         }
+        
         $permissionCategory = self::categories(val('PermissionCategoryID', $category));
-
+        if (empty($permissionCategory)) {
+            return self::categories(-1);
+        }
+        
         // Ensure all of our values are processed properly.
         self::calculate($permissionCategory);
         return $permissionCategory;

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -2527,21 +2527,18 @@ class CategoryModel extends Gdn_Model {
      * @since 2.2
      */
     public static function permissionCategory($category) {
-        if (empty($category)) {
+        if (empty($category) || empty($category['PermissionCategoryID'])) {
             return self::categories(-1);
         }
 
         if (!is_array($category) && !is_object($category)) {
             $category = self::categories($category);
         }
-        $category = self::categories(val('PermissionCategoryID', $category));
+        $permissionCategory = self::categories(val('PermissionCategoryID', $category));
 
         // Ensure all of our values are processed properly.
-        if (isset($category)) {
-            self::calculate($category);
-        }
-
-        return $category;
+        self::calculate($permissionCategory);
+        return $permissionCategory;
     }
 
     /**


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1234

### Details
 in [class.categorymodel.php#L2540](https://github.com/vanilla/vanilla/blob/92bfca055e907b38d30f65a1512b7a3307246f86/applications/vanilla/models/class.categorymodel.php#L2540)

we are calling self::calculate($category); without checking if we have a category returned from  `$category = self::categories(val('PermissionCategoryID', $category)); `this is resulting in a fatal error when categoryModel::Calculate is called that requires $category to be an array
![Screen Shot 2020-01-07 at 5 53 32 PM](https://user-images.githubusercontent.com/31856281/71936149-a3aac080-3176-11ea-8feb-5b5a9276222a.png)



