### PR TITLE
Fix panel layout overflows and stickiness

### DIFF
--- a/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
@@ -27,6 +27,7 @@ export function DashboardImageUpload(props: IProps) {
     const { inputID, labelType } = useFormGroup();
     const imageUploader = props.imageUploader || uploadFile;
     const [name, setName] = useState<string | null>(null);
+    const [uploadError, setUploadError] = useState<Error | null>(null);
 
     // Used for stashing the URL we just uploaded so we don't wipe out our name in the next step.
     const valueRef = useRef<string | null>(null);
@@ -61,15 +62,23 @@ export function DashboardImageUpload(props: IProps) {
                         props.onImagePreview && props.onImagePreview(tempUrl);
 
                         // Upload the image.
-                        const uploaded = await imageUploader(file);
-                        valueRef.current = uploaded.url;
-                        props.onChange(uploaded.url);
+                        try {
+                            setUploadError(null);
+                            const uploaded = await imageUploader(file);
+                            valueRef.current = uploaded.url;
+                            props.onChange(uploaded.url);
+                        } catch (e) {
+                            setUploadError(e);
+                        }
                     }}
                 />
                 <span className="file-upload-choose">{name || fallbackName || props.placeholder || t("Choose")}</span>
                 <span className="file-upload-browse">{t("Browse")}</span>
             </label>
             {props.errors && <ErrorMessages errors={props.errors} />}
+            {uploadError && (
+                <ErrorMessages errors={[{ message: uploadError.message, code: "UploadError", field: "" }]} />
+            )}
         </div>
     );
 }

--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -81,6 +81,9 @@ export const buttonVariables = useThemeCache(() => {
             color: globalVars.mainColors.fg,
         },
         hover: {
+            borders: {
+                color: globalVars.mainColors.primary,
+            },
             colors: {
                 bg: globalVars.mainColors.primary,
             },
@@ -89,6 +92,9 @@ export const buttonVariables = useThemeCache(() => {
             },
         },
         active: {
+            borders: {
+                color: globalVars.mainColors.primary,
+            },
             colors: {
                 bg: globalVars.mainColors.primary,
             },
@@ -97,6 +103,9 @@ export const buttonVariables = useThemeCache(() => {
             },
         },
         focus: {
+            borders: {
+                color: globalVars.mainColors.primary,
+            },
             colors: {
                 bg: globalVars.mainColors.primary,
             },
@@ -105,6 +114,9 @@ export const buttonVariables = useThemeCache(() => {
             },
         },
         focusAccessible: {
+            borders: {
+                color: globalVars.mainColors.primary,
+            },
             colors: {
                 bg: globalVars.mainColors.primary,
             },

--- a/library/src/scripts/layout/bodyStyles.ts
+++ b/library/src/scripts/layout/bodyStyles.ts
@@ -87,10 +87,6 @@ export const bodyCSS = useThemeCache(() => {
             display: "none",
         },
     );
-
-    cssRule("#app", {
-        overflowX: "hidden",
-    });
 });
 
 export const fullBackgroundClasses = useThemeCache((isRootPage = false) => {

--- a/library/src/scripts/layout/panelAreaStyles.ts
+++ b/library/src/scripts/layout/panelAreaStyles.ts
@@ -76,6 +76,8 @@ export const panelAreaClasses = useThemeCache(() => {
             left: 0,
             right: 0,
             position: "absolute",
+            height: 50,
+            background: linearGradient("to top", colorOut(gradientColor.fade(0))!, colorOut(gradientColor)!),
             width: percent(100),
         });
     };

--- a/library/src/scripts/layout/panelAreaStyles.ts
+++ b/library/src/scripts/layout/panelAreaStyles.ts
@@ -54,7 +54,7 @@ export const panelAreaClasses = useThemeCache(() => {
 
     const overflowFull = (offset: number) =>
         style("overflowFull", {
-            maxHeight: calc(`100vh - ${unit(offset)}`),
+            height: calc(`100vh - ${unit(offset)}`),
             overflow: "auto",
             position: "relative",
             minHeight: 100,

--- a/library/src/scripts/layout/panelLayoutStyles.ts
+++ b/library/src/scripts/layout/panelLayoutStyles.ts
@@ -290,7 +290,6 @@ export const panelLayoutClasses = useThemeCache(() => {
         width: unit(vars.panel.paddedWidth),
         flexBasis: unit(vars.panel.paddedWidth),
         minWidth: unit(vars.panel.paddedWidth),
-        transform: translateY(`${unit(vars.panelLayoutSpacing.offset.left)}`),
         paddingRight: unit(offset),
     });
 
@@ -300,7 +299,6 @@ export const panelLayoutClasses = useThemeCache(() => {
         flexBasis: unit(vars.panel.paddedWidth),
         minWidth: unit(vars.panel.paddedWidth),
         overflow: "initial",
-        transform: translateY(`${unit(vars.panelLayoutSpacing.offset.right)}`),
         paddingLeft: unit(offset),
     });
 

--- a/library/src/scripts/theming/themeCardStyles.ts
+++ b/library/src/scripts/theming/themeCardStyles.ts
@@ -4,7 +4,7 @@
  */
 
 import { percent, color, rgba } from "csx";
-import { unit, paddings, defaultTransition } from "@library/styles/styleHelpers";
+import { unit, paddings, defaultTransition, flexHelper } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { globalVariables } from "@library/styles/globalStyleVars";
 
@@ -162,13 +162,18 @@ export const themeCardClasses = useThemeCache(() => {
     const actionButtons = style("actionButtons", {
         textAlign: "center",
         margin: "44px 0",
+        ...flexHelper().middle(),
+        flexDirection: "column",
     });
     const overlay = style("overlay", {
         position: "absolute",
         top: 0,
         left: 0,
+        bottom: 0,
+        right: 0,
         backgroundColor: "rgba(103, 105, 109, 0.8)",
         opacity: 0,
+        ...flexHelper().middle(),
         ...defaultTransition("opacity"),
     });
     const wrapper = style("wrapper", {});


### PR DESCRIPTION
- Fix panel layout sometimes clipping dropdowns inside of them.
- Fix panel layout having weird top offset @slafleche Not really sure why these were added, but they break the layout calculations I was doing.
- Fix active/hover/focus border color for primary buttons. I consulted with @ElisaAlmeida for this.
- Fix layout issue in the theme preview card