### PR TITLE
Added opacity property to background image options and fixed alignment issue with tiles

### DIFF
--- a/library/src/scripts/features/tiles/tilesStyles.ts
+++ b/library/src/scripts/features/tiles/tilesStyles.ts
@@ -83,7 +83,7 @@ export const tilesClasses = useThemeCache(() => {
                 display: "flex",
                 flexWrap: "wrap",
                 alignItems: "stretch",
-                justifyContent: isCentered ? "center" : "space-between",
+                justifyContent: isCentered ? "center" : "flex-start",
             },
             mediaQueries.oneColumnDown({
                 display: "block",

--- a/library/src/scripts/styles/styleHelpersBackgroundStyling.ts
+++ b/library/src/scripts/styles/styleHelpersBackgroundStyling.ts
@@ -11,6 +11,7 @@ import {
     BackgroundRepeatProperty,
     BackgroundSizeProperty,
     ObjectFitProperty,
+    OpacityProperty,
     PositionProperty,
 } from "csstype";
 import { percent, px, quote, url, viewHeight, viewWidth } from "csx";
@@ -27,6 +28,7 @@ export interface IBackground {
     size?: BackgroundSizeProperty<TLength>;
     image?: BackgroundImageProperty;
     fallbackImage?: BackgroundImageProperty;
+    opacity?: OpacityProperty;
 }
 
 export const getBackgroundImage = (image?: BackgroundImageProperty, fallbackImage?: BackgroundImageProperty) => {
@@ -59,6 +61,7 @@ export const background = (props: IBackground) => {
         backgroundRepeat: props.repeat || "no-repeat",
         backgroundSize: props.size || "cover",
         backgroundImage: image ? url(image) : undefined,
+        opacity: props.opacity ?? undefined,
     };
 };
 


### PR DESCRIPTION
Fixes 2 small bugs:
-  The left alignment wasn't working for tiles
- Added optional opacity property on background image to make it more subtle.

