### PR TITLE
Translate "roles" into "Roles" when passing roles over SSO.

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -503,6 +503,8 @@ class EntryController extends Gdn_Controller {
         }
 
         $isTrustedProvider = $this->data('Trusted');
+        $saveRoles = false;
+        $saveRolesRegister = false;
 
         // Check if we need to sync roles
         if (($isTrustedProvider || c('Garden.SSO.SyncRoles'))) {
@@ -535,9 +537,6 @@ class EntryController extends Gdn_Controller {
 
                 $this->Form->setFormValue('RoleID', $roleIDs);
             }
-        } else {
-            $saveRoles = false;
-            $saveRolesRegister = false;
         }
 
         $userModel = Gdn::userModel();

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -505,25 +505,36 @@ class EntryController extends Gdn_Controller {
         $isTrustedProvider = $this->data('Trusted');
 
         // Check if we need to sync roles
-        if (($isTrustedProvider || c('Garden.SSO.SyncRoles')) && $this->Form->getFormValue('Roles', null) !== null) {
-            $saveRoles = $saveRolesRegister = true;
-
-            // Translate the role names to IDs.
+        if (($isTrustedProvider || c('Garden.SSO.SyncRoles'))) {
             $roles = $this->Form->getFormValue('Roles', null);
-            $roles = RoleModel::getByName($roles);
-            $roleIDs = array_keys($roles);
 
-            // Ensure user has at least one role.
-            if (empty($roleIDs)) {
-                $roleIDs = $this->UserModel->newUserRoleIDs();
+            // Allow the roles index to be lower case.
+            // This feature was requested and approved here https://github.com/vanillaforums/estimates/issues/886
+            $loweredRoles = $this->Form->getFormValue('roles', null);
+            if ($roles === null && $loweredRoles !== null) {
+                $this->Form->setFormValue('Roles', $loweredRoles);
+                $roles = $loweredRoles;
             }
 
-            // Allow role syncing to only happen on first connect.
-            if (c('Garden.SSO.SyncRolesBehavior') === 'register') {
-                $saveRoles = false;
-            }
+            if ($roles !== null) {
+                $saveRoles = $saveRolesRegister = true;
 
-            $this->Form->setFormValue('RoleID', $roleIDs);
+                // Translate the role names to IDs.
+                $roles = RoleModel::getByName($roles);
+                $roleIDs = array_keys($roles);
+
+                // Ensure user has at least one role.
+                if (empty($roleIDs)) {
+                    $roleIDs = $this->UserModel->newUserRoleIDs();
+                }
+
+                // Allow role syncing to only happen on first connect.
+                if (c('Garden.SSO.SyncRolesBehavior') === 'register') {
+                    $saveRoles = false;
+                }
+
+                $this->Form->setFormValue('RoleID', $roleIDs);
+            }
         } else {
             $saveRoles = false;
             $saveRolesRegister = false;


### PR DESCRIPTION
# SSO roles adjustments

A client is currently unable to pass roles via SSO because Vanilla's SSO is using "Roles" and does not accept "roles" (in lower case).

I initially hid this feature behind a feature flag, however, I felt it was a bit extreme. In this change, I am also making sure that "roles" does not take over "Roles" if both are set.

Estimate request: https://github.com/vanillaforums/estimates/issues/886
Project: https://github.com/vanillaforums/sonicwall/issues/10

## Requirements

To test this change, you will need to have SSO setup locally. I followed the directives from both repositories below.

https://github.com/vanilla/vanilla-docker
https://github.com/vanilla/stub-sso-providers
