### PR TITLE
Remove some compatibility functions that are no longer needed

### DIFF
--- a/library/core/functions.compatibility.php
+++ b/library/core/functions.compatibility.php
@@ -11,115 +11,6 @@
  * @since 2.2
  */
 
-/**
- * This file is part of the array_column library
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- *
- * @copyright Copyright (c) 2013 Ben Ramsey <http://benramsey.com>
- * @license http://opensource.org/licenses/MIT MIT
- */
-
-if (!function_exists('array_column')) {
-    /**
-     * Returns the values from a single column of the input array, identified by the $columnKey.
-     *
-     * Optionally, you may provide an $indexKey to index the values in the returned
-     * array by the values from the $indexKey column in the input array.
-     *
-     * @param array $input A multi-dimensional array (record set) from which to pull a column of values.
-     * @param mixed $columnKey The column of values to return. This value may be the integer key of the column you wish
-     * to retrieve, or it may be the string key name for an associative array.
-     * @param mixed $indexKey The column to use as the index/keys for the returned array. This value may be the integer
-     * key of the column, or it may be the string key name.
-     * @return array
-     */
-    function array_column($input = null, $columnKey = null, $indexKey = null) {
-        // Using func_get_args() in order to check for proper number of
-        // parameters and trigger errors exactly as the built-in array_column()
-        // does in PHP 5.5.
-        $argc = func_num_args();
-        $params = func_get_args();
-
-        if ($argc < 2) {
-            trigger_error("array_column() expects at least 2 parameters, {$argc} given", E_USER_WARNING);
-            return null;
-        }
-
-        if (!is_array($params[0])) {
-            trigger_error(
-                'array_column() expects parameter 1 to be array, '.gettype($params[0]).' given',
-                E_USER_WARNING
-            );
-            return null;
-        }
-
-        if (!is_int($params[1])
-            && !is_float($params[1])
-            && !is_string($params[1])
-            && $params[1] !== null
-            && !(is_object($params[1]) && method_exists($params[1], '__toString'))
-        ) {
-            trigger_error('array_column(): The column key should be either a string or an integer', E_USER_WARNING);
-            return false;
-        }
-
-        if (isset($params[2])
-            && !is_int($params[2])
-            && !is_float($params[2])
-            && !is_string($params[2])
-            && !(is_object($params[2]) && method_exists($params[2], '__toString'))
-        ) {
-            trigger_error('array_column(): The index key should be either a string or an integer', E_USER_WARNING);
-            return false;
-        }
-
-        $paramsInput = $params[0];
-        $paramsColumnKey = ($params[1] !== null) ? (string)$params[1] : null;
-
-        $paramsIndexKey = null;
-        if (isset($params[2])) {
-            if (is_float($params[2]) || is_int($params[2])) {
-                $paramsIndexKey = (int)$params[2];
-            } else {
-                $paramsIndexKey = (string)$params[2];
-            }
-        }
-
-        $resultArray = [];
-
-        foreach ($paramsInput as $row) {
-            $key = $value = null;
-            $keySet = $valueSet = false;
-
-            if ($paramsIndexKey !== null && array_key_exists($paramsIndexKey, $row)) {
-                $keySet = true;
-                $key = (string)$row[$paramsIndexKey];
-            }
-
-            if ($paramsColumnKey === null) {
-                $valueSet = true;
-                $value = $row;
-            } elseif (is_array($row) && array_key_exists($paramsColumnKey, $row)) {
-                $valueSet = true;
-                $value = $row[$paramsColumnKey];
-            }
-
-            if ($valueSet) {
-                if ($keySet) {
-                    $resultArray[$key] = $value;
-                } else {
-                    $resultArray[] = $value;
-                }
-            }
-
-        }
-
-        return $resultArray;
-    }
-}
-
 if (!function_exists('apc_fetch') && function_exists('apcu_fetch')) {
     /**
      * Fetch a stored variable from the cache.
@@ -176,32 +67,6 @@ if (!function_exists('getallheaders')) {
 if (!function_exists('gzopen') && function_exists('gzopen64')) {
     function gzopen($filename, $mode, $use_include_path = 0) {
         return gzopen64($filename, $mode, $use_include_path);
-    }
-}
-
-if (!function_exists('hash_equals')) {
-    /**
-     * Determine whether or not two strings are equal in a time that is independent of partial matches.
-     *
-     * This snippet prevents HMAC Timing attacks (http://codahale.com/a-lesson-in-timing-attacks/).
-     * Thanks to Eric Karulf (ekarulf @ github) for this fix.
-     *
-     * @param string $known_string The string of known length to compare against.
-     * @param string $user_string The user-supplied string.
-     * @return bool Returns **true** when the two strings are equal, **false** otherwise.
-     * @see http://php.net/manual/en/function.hash-equals.php
-     */
-    function hash_equals($known_string, $user_string) {
-        if (strlen($known_string) !== strlen($user_string)) {
-            return false;
-        }
-
-        $result = 0;
-        for ($i = strlen($known_string) - 1; $i >= 0; $i--) {
-            $result |= ord($known_string[$i]) ^ ord($user_string[$i]);
-        }
-
-        return 0 === $result;
     }
 }
 
@@ -339,28 +204,6 @@ if (!function_exists('is_id')) {
      */
     function is_id($val) {
         return is_numeric($val);
-    }
-}
-
-if (!function_exists('parse_ini_string')) {
-    /**
-     * The parse_ini_string function is not supported until PHP 5.3.0, and we currently support PHP 5.2.0.
-     *
-     * @param string $ini The INI string to parse.
-     * @return array Returns the array representation of the INI string.
-     */
-    function parse_ini_string($ini) {
-        $lines = explode("\n", $ini);
-        $result = [];
-        foreach ($lines as $line) {
-            $parts = explode('=', $line, 2);
-            if (count($parts) == 1) {
-                $result[trim($parts[0])] = '';
-            } elseif (count($parts) >= 2) {
-                $result[trim($parts[0])] = trim($parts[1]);
-            }
-        }
-        return $result;
     }
 }
 


### PR DESCRIPTION
We have a few really old compatibility functions that haven't been necessary for several years. This code removes them.

- `array_column()`: PHP 5.5+.
- `hash_equals()`: PHP 5.6+
- `parse_ini_string()`: PHP 5.3+ haha