### PR TITLE
Fix encoded discussion name in quotes

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -382,6 +382,7 @@ class DiscussionsApiController extends AbstractApiController {
 
         $isRich = $discussion['Format'] === 'Rich';
         $discussion['bodyRaw'] = $isRich ? json_decode($discussion['Body'], true) : $discussion['Body'];
+        $discussion = $this->discussionModel->fixRow($discussion);
 
         $this->userModel->expandUsers($discussion, ['InsertUserID']);
         $result = $out->validate($discussion);


### PR DESCRIPTION
This is a patch to ensure that discussion names don't display html entities when using the quoting functionality.  There's a been a history of discussion names not being displayed correctly and at the moment no elegant solution has been proposed.

note: this has been tested to ensure it doesn't open up any xss vulnerabilities, but should be tested by any reviewers.

closes https://github.com/vanilla/vanilla/issues/9837