### PR TITLE
Fix markdown macro issues and link scroll jumping issues

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/ClipboardModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/ClipboardModule.ts
@@ -58,46 +58,6 @@ export default class ClipboardModule extends ClipboardBase {
     }
 
     /**
-     * @override
-     * Override the paste handler to
-     * - Prevent jumping on paste.
-     * - Ensure current selection is deleted before a paste.
-     */
-    public onPaste(e: Event) {
-        if (e.defaultPrevented || !(this.quill as any).isEnabled()) {
-            return;
-        }
-        const range = this.quill.getSelection();
-        const container = this.quill.root.closest(`.${EDITOR_SCROLL_CONTAINER_CLASS}`);
-
-        // Get our scroll positions
-        const scrollTop = document.documentElement!.scrollTop || document.body.scrollTop;
-        const containerTop = container ? container.scrollTop : 0;
-        this.container.focus();
-        this.quill.selection.update(Quill.sources.SILENT);
-
-        // Delete text if any is currently selected.
-        if (range.length) {
-            this.quill.deleteText(range.index, range.length, Quill.sources.SILENT);
-        }
-
-        // Settimeout so that the paste goes into `this.container`.
-        setImmediate(() => {
-            // Insert the pasted content.
-            const delta = new Delta().retain(range.index).concat(this.convert());
-            this.quill.updateContents(delta, Quill.sources.USER);
-
-            // Fix our selection & scroll position.
-            this.quill.setSelection(delta.length(), 0, Quill.sources.SILENT);
-            document.documentElement!.scrollTop = document.body.scrollTop = scrollTop;
-            if (container) {
-                container.scrollTop = containerTop;
-            }
-            this.quill.focus();
-        });
-    }
-
-    /**
      * A matcher for img tags. Converts `<img />` into an external embed (type image).
      */
     public imageMatcher = (node: HTMLImageElement, delta: DeltaStatic) => {

--- a/plugins/rich-editor/src/scripts/quill/MarkdownModule.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/MarkdownModule.test.ts
@@ -41,7 +41,8 @@ describe("NewLineClickInsertionModule", () => {
             code: true,
         },
         type: MarkdownMacroType.INLINE,
-        trailingCharacter: " ",
+        trailingCharacter: "", // The space is actually inserted by quill automatically. No need for an extra
+    });
     });
 
     testInlineFormat({

--- a/plugins/rich-editor/src/scripts/quill/MarkdownModule.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/MarkdownModule.test.ts
@@ -43,7 +43,6 @@ describe("NewLineClickInsertionModule", () => {
         type: MarkdownMacroType.INLINE,
         trailingCharacter: "", // The space is actually inserted by quill automatically. No need for an extra
     });
-    });
 
     testInlineFormat({
         name: "italic *",

--- a/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/MarkdownModule.ts
@@ -378,7 +378,6 @@ export default class MarkdownModule {
                 this.quill.deleteText(startIndex, annotatedText.length);
                 this.quill.insertText(startIndex, matchedText, { [CodeBlot.blotName]: true });
                 this.quill.format(CodeBlot.blotName, false);
-                this.quill.insertText(this.quill.getSelection().index, " ");
             },
         },
     ];

--- a/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
+++ b/plugins/rich-editor/src/scripts/quill/VanillaTheme.ts
@@ -33,6 +33,7 @@ export default class VanillaTheme extends ThemeBase {
 
         super(quill, themeOptions);
         this.applyLastSelectionHack();
+        this.applyFocusFixHack();
 
         this.quill.root.classList.add(classesRichEditor.text);
         this.quill.root.classList.add("richEditor-text");
@@ -53,6 +54,22 @@ export default class VanillaTheme extends ThemeBase {
 
         // Create the newline insertion module.
         void new NewLineClickInsertionModule(this.quill);
+    }
+
+    /**
+     * Quill has a bad habit of scrolling the document on focus.
+     * We are monkey patching over it to pass some extra arguments to the build in focus method.
+     */
+    private applyFocusFixHack() {
+        const { root } = this.quill.selection;
+        const initialFocus: typeof HTMLElement.prototype.focus = root.focus;
+
+        root.focus = function(options = {}) {
+            initialFocus.call(root, {
+                ...options,
+                preventScroll: true,
+            });
+        };
     }
 
     /**

--- a/plugins/rich-editor/src/scripts/toolbars/InlineToolbar.tsx
+++ b/plugins/rich-editor/src/scripts/toolbars/InlineToolbar.tsx
@@ -167,19 +167,9 @@ export class InlineToolbar extends React.PureComponent<IProps, IState> {
      */
     public componentDidMount() {
         this.quill.root.addEventListener("keydown", this.escFunction, false);
+        this.quill.root.addEventListener("keydown", this.commandKHandler, false);
         this.focusWatcher = new FocusWatcher(this.selfRef.current!, this.handleFocusChange);
         this.focusWatcher.start();
-
-        // Add a key binding for the link popup.
-        const keyboard: Keyboard = this.quill.getModule("keyboard");
-        keyboard.addBinding(
-            {
-                key: "k",
-                metaKey: true,
-            },
-            {},
-            this.commandKHandler,
-        );
     }
 
     /**
@@ -187,6 +177,7 @@ export class InlineToolbar extends React.PureComponent<IProps, IState> {
      */
     public componentWillUnmount() {
         this.quill.root.removeEventListener("keydown", this.escFunction, false);
+        this.quill.root.removeEventListener("keydown", this.commandKHandler, false);
         this.focusWatcher.stop();
     }
 
@@ -200,7 +191,15 @@ export class InlineToolbar extends React.PureComponent<IProps, IState> {
     /**
      * Handle create-link keyboard shortcut.
      */
-    private commandKHandler = () => {
+    private commandKHandler = (e: KeyboardEvent) => {
+        if (e.key !== "k" || !e.metaKey) {
+            return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+
         const { lastGoodSelection } = this.props;
         const inCodeBlock = rangeContainsBlot(this.quill, CodeBlockBlot, lastGoodSelection);
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/9912
Fixes https://github.com/vanilla/vanilla/issues/9914

- Fixes the double space inserted after an inline markdown macro. https://github.com/vanilla/vanilla/issues/9912
- Fix scroll jumping when creating a link https://github.com/vanilla/vanilla/issues/9914