### PR TITLE
Fix canonical URLs on entry controller

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1032,6 +1032,7 @@ class EntryController extends Gdn_Controller {
      * @return string Rendered XHTML template.
      */
     public function signIn($method = false, $arg1 = false) {
+        $this->canonicalUrl(url('/entry/signin', true));
         if (!$this->Request->isPostBack()) {
             $this->checkOverride('SignIn', $this->target());
         }
@@ -1781,6 +1782,7 @@ class EntryController extends Gdn_Controller {
      * @since 2.0.0
      */
     public function passwordRequest() {
+        $this->canonicalUrl(url('/entry/passwordrequest', true));
         if (!$this->UserModel->isEmailUnique() && $this->UserModel->isNameUnique()) {
             Gdn::locale()->setTranslation('Email', t('Username'));
         }

--- a/applications/dashboard/controllers/class.homecontroller.php
+++ b/applications/dashboard/controllers/class.homecontroller.php
@@ -169,6 +169,7 @@ class HomeController extends Gdn_Controller {
      * @access public
      */
     public function termsOfService() {
+        $this->canonicalUrl(url('/home/termsofservices', true));
         $this->render();
     }
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/1130

This PR sets some canonical URLs to match their commonly linked to versions throughout the application.

It sets the following as canonical URLs on their methods.

- /entry/signin
- /home/termsofservice
- /entry/passwordrequest

I could have updated the method names, because PHP is case-insensitive with those,  but I didn't want to leave behind a bunch of methods that were cased incorrectly.