### PR TITLE
Remove unneeded versions and just use the environment version

### DIFF
--- a/applications/conversations/settings/structure.php
+++ b/applications/conversations/settings/structure.php
@@ -173,7 +173,3 @@ $PermissionModel->define([
     'Conversations.Moderation.Manage' => 0,
     'Conversations.Conversations.Add' => 'Garden.Profiles.Edit',
 ]);
-
-// Set current Conversations.Version
-$appInfo = json_decode(file_get_contents(PATH_APPLICATIONS.DS.'conversations'.DS.'addon.json'), true);
-saveToConfig('Conversations.Version', val('version', $appInfo, 'Undefined'));

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -489,7 +489,3 @@ foreach ($users as $user) {
             ->put();
     }
 }
-
-// Set current Vanilla.Version
-$appInfo = json_decode(file_get_contents(PATH_APPLICATIONS.DS.'vanilla'.DS.'addon.json'), true);
-saveToConfig('Vanilla.Version', val('version', $appInfo, 'Undefined'));

--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -424,7 +424,7 @@ class ProxyRequest {
         curl_setopt($handler, CURLOPT_HEADER, false);
         curl_setopt($handler, CURLINFO_HEADER_OUT, true);
         curl_setopt($handler, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($handler, CURLOPT_USERAGENT, val('HTTP_USER_AGENT', $_SERVER, 'Vanilla/'.c('Vanilla.Version')));
+        curl_setopt($handler, CURLOPT_USERAGENT, val('HTTP_USER_AGENT', $_SERVER, 'Vanilla/'.APPLICATION_VERSION));
         curl_setopt($handler, CURLOPT_CONNECTTIMEOUT, $connectTimeout);
         curl_setopt($handler, CURLOPT_HEADERFUNCTION, [$this, 'CurlHeader']);
         curl_setopt($handler, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);


### PR DESCRIPTION
The versions in the addon.jsons are never updated, and had only 1 usage.

I've switched the curl wrapper to use the environment version, which should be more up-to-date, and remove this extra step of saving versions into the config.