### PR TITLE
Apply more case-insensitive format checks for rich

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -10,6 +10,7 @@ use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\DateFilterSchema;
 use Vanilla\ApiUtils;
+use Vanilla\Formatting\Formats\RichFormat;
 
 /**
  * API Controller for the `/comments` resource.
@@ -215,7 +216,7 @@ class CommentsApiController extends AbstractApiController {
         }
 
         $comment['Url'] = commentUrl($comment);
-        $isRich = $comment['Format'] === 'Rich';
+        $isRich = strcasecmp($comment['Format'], RichFormat::FORMAT_KEY) === 0;
         $comment['bodyRaw'] = $isRich ? json_decode($comment['Body'], true) : $comment['Body'];
 
         $this->userModel->expandUsers($comment, ['InsertUserID']);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -11,6 +11,7 @@ use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\DateFilterSchema;
 use Vanilla\ApiUtils;
+use Vanilla\Formatting\Formats\RichFormat;
 
 /**
  * API Controller for the `/discussions` resource.
@@ -380,7 +381,7 @@ class DiscussionsApiController extends AbstractApiController {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $discussion['CategoryID']);
         }
 
-        $isRich = $discussion['Format'] === 'Rich';
+        $isRich = strcasecmp($$discussion['Format'], RichFormat::FORMAT_KEY) === 0;
         $discussion['bodyRaw'] = $isRich ? json_decode($discussion['Body'], true) : $discussion['Body'];
 
         $this->userModel->expandUsers($discussion, ['InsertUserID']);

--- a/plugins/rich-editor/RichEditorPlugin.php
+++ b/plugins/rich-editor/RichEditorPlugin.php
@@ -1,4 +1,7 @@
 <?php
+
+use Vanilla\Formatting\Formats\RichFormat;
+
 /**
  * @author Adam (charrondev) Charron <adam.c@vanillaforums.com>
  * @copyright 2009-2019 Vanilla Forums Inc.
@@ -7,7 +10,7 @@
 
 class RichEditorPlugin extends Gdn_Plugin {
 
-    const FORMAT_NAME = "Rich";
+    const FORMAT_NAME = RichFormat::FORMAT_KEY;
     const QUOTE_CONFIG_ENABLE = "RichEditor.Quote.Enable";
 
     /** @var integer */
@@ -25,8 +28,8 @@ class RichEditorPlugin extends Gdn_Plugin {
      * {@inheritDoc}
      */
     public function setup() {
-        saveToConfig('Garden.InputFormatter', self::FORMAT_NAME);
-        saveToConfig('Garden.MobileInputFormatter', self::FORMAT_NAME);
+        saveToConfig('Garden.InputFormatter', RichFormat::FORMAT_KEY);
+        saveToConfig('Garden.MobileInputFormatter', RichFormat::FORMAT_KEY);
         saveToConfig(self::QUOTE_CONFIG_ENABLE, true);
         saveToConfig('EnabledPlugins.Quotes', false);
     }
@@ -52,13 +55,13 @@ class RichEditorPlugin extends Gdn_Plugin {
      */
     public function isFormRich(Gdn_Form $form): bool {
         $data = $form->formData();
-        $format = $data['Format'] ?? 'Rich';
+        $format = $data['Format'] ?? null;
 
-        return $format === self::FORMAT_NAME;
+        return strcasecmp($format, RichFormat::FORMAT_KEY) === 0;
     }
 
     public function isInputFormatterRich(): bool {
-        return Gdn_Format::defaultFormat() === "Rich";
+        return strcasecmp(Gdn_Format::defaultFormat(), RichFormat::FORMAT_KEY) === 0;
     }
 
     /**
@@ -69,7 +72,7 @@ class RichEditorPlugin extends Gdn_Plugin {
      * @return string[] Additional post formats.
      */
     public function getPostFormats_handler(array $postFormats): array {
-        $postFormats[] = self::FORMAT_NAME;
+        $postFormats[] = RichFormat::FORMAT_KEY;
         return $postFormats;
     }
 

--- a/plugins/rich-editor/RichEditorPlugin.php
+++ b/plugins/rich-editor/RichEditorPlugin.php
@@ -1,13 +1,15 @@
 <?php
-
-use Vanilla\Formatting\Formats\RichFormat;
-
 /**
  * @author Adam (charrondev) Charron <adam.c@vanillaforums.com>
  * @copyright 2009-2019 Vanilla Forums Inc.
  * @license GPL-2.0-only
  */
 
+use Vanilla\Formatting\Formats\RichFormat;
+
+/**
+ * Plugin class for the Rich Editor.
+ */
 class RichEditorPlugin extends Gdn_Plugin {
 
     const FORMAT_NAME = RichFormat::FORMAT_KEY;

--- a/plugins/rich-editor/src/scripts/entries/admin.ts
+++ b/plugins/rich-editor/src/scripts/entries/admin.ts
@@ -21,7 +21,7 @@ function handleRichEditorInputFormatterOptions() {
 
 function updateRichFormValues(inputFormatter: string) {
     const richFormGroups = document.querySelectorAll(".js-richFormGroup");
-    if (inputFormatter === "Rich") {
+    if (inputFormatter === "Rich" || inputFormatter === "rich") {
         richFormGroups.forEach(group => {
             group.classList.remove("Hidden");
         });

--- a/plugins/rich-editor/src/scripts/mountEditor.tsx
+++ b/plugins/rich-editor/src/scripts/mountEditor.tsx
@@ -22,9 +22,9 @@ export default function mountEditor(containerSelector: string | Element) {
         throw new Error("Could not find the BodyBox to mount editor to.");
     }
 
-    const initialFormat = bodybox.getAttribute("format") || "Rich";
+    const initialFormat = bodybox.getAttribute("format");
 
-    if (initialFormat === "Rich") {
+    if (initialFormat === "Rich" || initialFormat === "rich") {
         mountReact(<ForumEditor legacyTextArea={bodybox as HTMLInputElement} />, container, () => {
             container.classList.remove("isDisabled");
         });


### PR DESCRIPTION
With https://success.vanillaforums.com/kb/articles/144-release-2020-001#api-v2 going out we are likely to begin seeing more lowercase usages of Rich throughout existing parts of the application.

Unfortunately not everything was:

- Using the constant.
- Doing a case-insensitive comparison.

I've updated some case-sensitive checks to now be case-insensitive & used the constant in a few places it wasn't in use.