### PR TITLE
Fix panel scrolling issues

### DIFF
--- a/library/src/scripts/Router.tsx
+++ b/library/src/scripts/Router.tsx
@@ -24,7 +24,10 @@ export function Router(props: IProps) {
 
     useEffect(() => {
         if (onRouteChange) {
-            const unregister = history.listen(() => onRouteChange(history));
+            const unregister = history.listen(() => {
+                window.scrollTo(0, 0);
+                onRouteChange(history);
+            });
             // Return the cleanup function.
             return unregister;
         }

--- a/library/src/scripts/layout/panelAreaStyles.ts
+++ b/library/src/scripts/layout/panelAreaStyles.ts
@@ -52,7 +52,7 @@ export const panelAreaClasses = useThemeCache(() => {
         }),
     );
 
-    const overflowFull = (offset: number) =>
+    const overflowFull = useThemeCache((offset: number) =>
         style("overflowFull", {
             height: calc(`100vh - ${unit(offset)}`),
             overflow: "auto",
@@ -61,13 +61,14 @@ export const panelAreaClasses = useThemeCache(() => {
             paddingBottom: 50,
             paddingTop: 50,
             marginTop: -50,
-        });
+        }),
+    );
 
     const areaOverlay = style("areaOverlay", {
         position: "relative",
     });
 
-    const areaOverlayBefore = (color?: ColorHelper, side?: "left" | "right") => {
+    const areaOverlayBefore = useThemeCache((color?: ColorHelper, side?: "left" | "right") => {
         let gradientColor = color ?? globalVars.mainColors.bg;
 
         return style("areaOverlayBefore", {
@@ -80,8 +81,9 @@ export const panelAreaClasses = useThemeCache(() => {
             background: linearGradient("to top", colorOut(gradientColor.fade(0))!, colorOut(gradientColor)!),
             width: percent(100),
         });
-    };
-    const areaOverlayAfter = (color?: ColorHelper, side?: "left" | "right") => {
+    });
+
+    const areaOverlayAfter = useThemeCache((color?: ColorHelper, side?: "left" | "right") => {
         let gradientColor = color ?? globalVars.mainColors.bg;
 
         return style("areaOverlayAfter", {
@@ -94,7 +96,7 @@ export const panelAreaClasses = useThemeCache(() => {
             background: linearGradient("to bottom", colorOut(gradientColor.fade(0))!, colorOut(gradientColor)!),
             width: percent(100),
         });
-    };
+    });
 
     return { root, overflowFull, areaOverlayBefore, areaOverlayAfter, areaOverlay };
 });

--- a/library/src/scripts/layout/panelLayoutStyles.ts
+++ b/library/src/scripts/layout/panelLayoutStyles.ts
@@ -76,13 +76,14 @@ export const layoutVariables = useThemeCache(() => {
     const panelLayoutSpacing = makeThemeVars("panelLayoutSpacing", {
         margin: {
             top: 0,
-            bottom: 50,
+            bottom: 0,
         },
         padding: {
             top: gutter.halfSize * 1.5,
         },
         extraPadding: {
             top: 32,
+            bottom: 32,
             noBreadcrumbs: {},
             mobile: {
                 noBreadcrumbs: {
@@ -307,6 +308,7 @@ export const panelLayoutClasses = useThemeCache(() => {
         flexGrow: 1,
         width: percent(100),
         maxWidth: percent(100),
+        paddingBottom: unit(vars.panelLayoutSpacing.extraPadding.bottom),
         ...mediaQueries.oneColumnDown(paddings({ left: important(0), right: important(0) })),
     });
 

--- a/library/src/scripts/navigation/breadcrumbsStyles.ts
+++ b/library/src/scripts/navigation/breadcrumbsStyles.ts
@@ -49,6 +49,7 @@ export const breadcrumbsClasses = useThemeCache(() => {
         flexDirection: "row",
         justifyContent: "flex-start",
         flexWrap: "wrap",
+        minHeight: px(16),
     });
 
     const separator = style("separator", {


### PR DESCRIPTION
Fixes https://github.com/vanilla/knowledge/issues/1475

- Fix paddings and offsets in the panel layout
- Bottom margin converted to an inner padding. Height was adjusted for consistency
- Scroll to the top on history URL change (this used to happen automatically in chrome, but was removed in a recent chrome update).
- Add a min-height to breadcrumbs to prevent 1px off error when displaying loader
- Add min-height to breadcrumbs
- Add a little extra theme caching for functions called that create classes. This prevents the classes from being recreated over and over again if they have the same parameters.