### PR TITLE
Add new components for creating custom loaders

### DIFF
--- a/library/src/scripts/layout/Heading.tsx
+++ b/library/src/scripts/layout/Heading.tsx
@@ -13,7 +13,7 @@ export interface ICommonHeadingProps {
     depth?: 1 | 2 | 3 | 4 | 5 | 6;
     renderAsDepth?: 1 | 2 | 3 | 4 | 5 | 6;
     className?: string;
-    title: string;
+    title: React.ReactNode;
 }
 
 export interface IHeadingProps extends ICommonHeadingProps {

--- a/library/src/scripts/layout/PageHeading.tsx
+++ b/library/src/scripts/layout/PageHeading.tsx
@@ -14,7 +14,7 @@ import { IWithFontSize, useFontSizeCalculator } from "@library/layout/pageHeadin
 import backLinkClasses from "@library/routing/links/backLinkStyles";
 
 interface IPageHeading {
-    title: string;
+    title: React.ReactNode;
     children?: React.ReactNode;
     className?: string;
     headingClassName?: string;

--- a/library/src/scripts/loaders/LoadingRectanges.story.tsx
+++ b/library/src/scripts/loaders/LoadingRectanges.story.tsx
@@ -1,0 +1,62 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { StoryContent } from "@library/storybook/StoryContent";
+import { LoadingRectange, LoadingSpacer } from "@library/loaders/LoadingRectangle";
+import { StoryHeading } from "@library/storybook/StoryHeading";
+import { StoryParagraph } from "@library/storybook/StoryParagraph";
+import { storyWithConfig } from "@library/storybook/StoryContext";
+
+export default {
+    title: "Loaders/LoadingRectange",
+};
+
+function LoadingRectangeStory() {
+    return (
+        <StoryContent>
+            <StoryHeading>Loaders</StoryHeading>
+            <StoryParagraph>Loaders default to 100% width and must take some pixel height.</StoryParagraph>
+            <div>
+                <LoadingRectange height={50} />
+                <LoadingSpacer height={20} />
+                <LoadingRectange height={14} width={"95%"} />
+                <LoadingSpacer height={12} />
+                <LoadingRectange height={14} width={"80%"} />
+                <LoadingSpacer height={12} />
+                <LoadingRectange height={14} width={"82%"} />
+                <LoadingSpacer height={12} />
+                <LoadingRectange height={14} width={"75%"} />
+                <LoadingSpacer height={12} />
+                <LoadingRectange height={14} width={"85%"} />
+            </div>
+            <StoryHeading>Grid</StoryHeading>
+            <StoryParagraph>The can be shaped hover you want</StoryParagraph>
+            <div>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                    <LoadingRectange style={{ borderRadius: 100, overflow: "hidden" }} height={100} width={100} />
+                    <LoadingRectange style={{ borderRadius: 12, overflow: "hidden" }} height={100} width={100} />
+                    <LoadingRectange style={{ borderRadius: 0, overflow: "hidden" }} height={100} width={100} />
+                </div>
+                <LoadingRectange style={{ margin: "24px auto" }} height={100} width={"50%"} />
+            </div>
+        </StoryContent>
+    );
+}
+
+export const Light = LoadingRectangeStory;
+export const Dark = storyWithConfig(
+    {
+        themeVars: {
+            global: {
+                mainColors: {
+                    bg: "#333",
+                    fg: "#fff",
+                },
+            },
+        },
+    },
+    LoadingRectangeStory,
+);

--- a/library/src/scripts/loaders/LoadingRectangle.tsx
+++ b/library/src/scripts/loaders/LoadingRectangle.tsx
@@ -1,0 +1,23 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React, { DetailedHTMLProps } from "react";
+import { loadingRectangeClass, loadingSpacerClass } from "@library/loaders/loadingRectangeStyles";
+import classNames from "classnames";
+
+interface IProps extends DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+    height: string | number;
+    width?: string | number;
+}
+
+export function LoadingRectange(props: IProps) {
+    return (
+        <div {...props} className={classNames(loadingRectangeClass(props.height, props.width), props.className)}></div>
+    );
+}
+
+export function LoadingSpacer(props: IProps) {
+    return <div {...props} className={classNames(loadingSpacerClass(props.height), props.className)}></div>;
+}

--- a/library/src/scripts/loaders/loadingRectangeStyles.ts
+++ b/library/src/scripts/loaders/loadingRectangeStyles.ts
@@ -1,0 +1,56 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { useThemeCache, styleFactory, variableFactory } from "@library/styles/styleUtils";
+import { rgba, percent, linearGradient } from "csx";
+import { globalVariables } from "@library/styles/globalStyleVars";
+import { colorOut, unit } from "@library/styles/styleHelpers";
+import { keyframes } from "typestyle";
+
+export const loadingRectangeVariables = useThemeCache(() => {
+    const makeVars = variableFactory("loadingRectatngle");
+
+    const colors = makeVars("colors", {
+        bg: linearGradient(
+            "to right",
+            globalVariables().mixBgAndFg(0.15),
+            globalVariables().mixBgAndFg(0.2),
+            globalVariables().mixBgAndFg(0.25),
+        ),
+    });
+
+    const loadingAnimation = keyframes({
+        "0%": { opacity: 0.8 },
+        "50%": { opacity: 1 },
+        "100%": { opacity: 0.8 },
+    });
+
+    return {
+        colors,
+        loadingAnimation,
+    };
+});
+
+const style = styleFactory("loadingRectangle");
+export const loadingRectangeClass = useThemeCache((height: string | number, width: string | number = "100%") => {
+    const vars = loadingRectangeVariables();
+    return style({
+        display: "block",
+        background: colorOut(vars.colors.bg),
+        height: unit(height),
+        width: unit(width),
+        animationName: vars.loadingAnimation,
+        animationDuration: "4s",
+        animationIterationCount: "infinite",
+    });
+});
+
+export const loadingSpacerClass = useThemeCache((height: string | number) => {
+    return style({
+        display: "block",
+        height: unit(height),
+        width: percent(100),
+    });
+});

--- a/library/src/scripts/navigation/BreadcrumbsLoader.tsx
+++ b/library/src/scripts/navigation/BreadcrumbsLoader.tsx
@@ -1,0 +1,54 @@
+/**
+ * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { LoadingRectange } from "@library/loaders/LoadingRectangle";
+import { breadcrumbsClasses } from "@library/navigation/breadcrumbsStyles";
+import { t } from "@library/utility/appUtils";
+import React from "react";
+
+export interface IProps {
+    crumbCount?: number;
+}
+
+/**
+ * A component representing a string of breadcrumbs. Passa n arrow crumb props as children.
+ */
+export default function BreadcrumbsLoader(props: IProps) {
+    const classes = breadcrumbsClasses();
+    const crumbCount = props.crumbCount ?? 2;
+
+    return (
+        <nav aria-label={t("Breadcrumb")} className={classes.root}>
+            <ol className={classes.list}>
+                {Array.from(Array(crumbCount)).map((_, index) => {
+                    const lastElement = index === crumbCount - 1;
+                    const crumbSeparator = ` `;
+                    return (
+                        <React.Fragment key={index}>
+                            <LoadingCrumb />
+                            {!lastElement && (
+                                <li aria-hidden={true} className={classes.separator}>
+                                    <span className={classes.separatorIcon}>{crumbSeparator}</span>
+                                </li>
+                            )}
+                        </React.Fragment>
+                    );
+                })}
+            </ol>
+        </nav>
+    );
+}
+
+function LoadingCrumb() {
+    const classes = breadcrumbsClasses();
+    return (
+        <li className={classes.breadcrumb}>
+            <span className={classes.link}>
+                <LoadingRectange height={12} width={100} />
+            </span>
+        </li>
+    );
+}

--- a/library/src/scripts/storybook/StoryContext.tsx
+++ b/library/src/scripts/storybook/StoryContext.tsx
@@ -79,7 +79,7 @@ export function StoryContextProvider(props: { children?: React.ReactNode }) {
                     assets: {
                         data: {
                             variables: {
-                                data: value.themeVars ?? {},
+                                data: (value.themeVars as any) ?? {},
                             },
                         },
                         status: LoadStatus.SUCCESS,
@@ -92,7 +92,6 @@ export function StoryContextProvider(props: { children?: React.ReactNode }) {
                 storeState: merge(value.storeState ?? {}, themeState),
             };
             if (!isEqual(newState, contextState)) {
-                console.log("uipdate to new state", newState);
                 setContextState(newState);
                 resetStoreState(newState.storeState);
                 setThemeKey(clearThemeCache().toString());

--- a/library/src/scripts/storybook/StoryContext.tsx
+++ b/library/src/scripts/storybook/StoryContext.tsx
@@ -18,6 +18,7 @@ import { LoadStatus } from "@library/@types/api/core";
 import { resetStoreState } from "@library/__tests__/testStoreState";
 import merge from "lodash/merge";
 import { Backgrounds } from "@library/layout/Backgrounds";
+import { globalVariables } from "@library/styles/globalStyleVars";
 
 const errorMessage = "There was an error fetching the theme.";
 
@@ -27,7 +28,10 @@ function ErrorComponent() {
 
 interface IContext {
     storeState?: DeepPartial<ICoreStoreState>;
-    themeVars?: any;
+    themeVars?: {
+        global: DeepPartial<ReturnType<typeof globalVariables>>;
+        [key: string]: any;
+    };
     useWrappers?: boolean;
     refreshKey?: string;
 }

--- a/library/src/scripts/styles/typographyStyles.ts
+++ b/library/src/scripts/styles/typographyStyles.ts
@@ -19,7 +19,9 @@ export const typographyClasses = useThemeCache(() => {
     const vars = containerVariables();
     const mediaQueries = layoutVariables().mediaQueries();
 
-    const largeTitle = style("largeTitle", {});
+    const largeTitle = style("largeTitle", {
+        width: percent(100),
+    });
 
     const pageTitle = style(
         "pageTitle",


### PR DESCRIPTION
**_This PR includes all of https://github.com/vanilla/vanilla/pull/9922. Once that is merged, I will retarget this PR._**

- Add some nice typing for storybook variables.
- Expand various heading components to allow a ReactNode for their contents (so you can put a loader in them).
- Add a new `<RectangleLoader />` and spacers. See the new stories that were added.