### PR TITLE
Add basic class for simple resource events

### DIFF
--- a/library/Garden/Events/ResourceEvent.php
+++ b/library/Garden/Events/ResourceEvent.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Garden\Events;
+
+/**
+ * An event affecting a specific resource.
+ */
+abstract class ResourceEvent {
+
+    /** A resource has been removed. */
+    const ACTION_DELETE = "delete";
+
+    /** A resource has been created. */
+    const ACTION_INSERT = "insert";
+
+    /** An existing resource has been updated. */
+    const ACTION_UPDATE = "update";
+
+    /** @var string */
+    protected $action;
+
+    /** @var array */
+    protected $payload;
+
+    /** @var string */
+    protected $type;
+
+    /**
+     * Create the event.
+     *
+     * @param string $action
+     * @param array $payload
+     */
+    public function __construct(string $action, array $payload) {
+        $this->action = $action;
+        $this->payload = $payload;
+        $this->type = $this->typeFromClass();
+    }
+
+    /**
+     * Get the event action.
+     *
+     * @return string|null
+     */
+    public function getAction(): ?string {
+        return $this->action;
+    }
+
+    /**
+     * Get the event payload.
+     *
+     * @return array|null
+     */
+    public function getPayload(): ?array {
+        return $this->payload;
+    }
+
+    /**
+     * Get the event type.
+     *
+     * @return string|null
+     */
+    public function getType(): ?string {
+        return $this->type;
+    }
+
+    /**
+     * Derive the event type from the current class name.
+     *
+     * @return string
+     */
+    private function typeFromClass(): string {
+        $class = get_called_class();
+        if (($namespaceEnd = strrpos($class, '\\')) !== false) {
+            $baseName = substr($class, $namespaceEnd + 1);
+        } else {
+            $baseName = $class;
+        }
+        $type = lcfirst(preg_replace('/Event$/', '', $baseName));
+        return $type;
+    }
+}

--- a/library/Garden/Events/ResourceEvent.php
+++ b/library/Garden/Events/ResourceEvent.php
@@ -12,13 +12,13 @@ namespace Garden\Events;
 abstract class ResourceEvent {
 
     /** A resource has been removed. */
-    const ACTION_DELETE = "delete";
+    public const ACTION_DELETE = "delete";
 
     /** A resource has been created. */
-    const ACTION_INSERT = "insert";
+    public const ACTION_INSERT = "insert";
 
     /** An existing resource has been updated. */
-    const ACTION_UPDATE = "update";
+    public const ACTION_UPDATE = "update";
 
     /** @var string */
     protected $action;
@@ -44,9 +44,9 @@ abstract class ResourceEvent {
     /**
      * Get the event action.
      *
-     * @return string|null
+     * @return string
      */
-    public function getAction(): ?string {
+    public function getAction(): string {
         return $this->action;
     }
 
@@ -62,9 +62,9 @@ abstract class ResourceEvent {
     /**
      * Get the event type.
      *
-     * @return string|null
+     * @return string
      */
-    public function getType(): ?string {
+    public function getType(): string {
         return $this->type;
     }
 

--- a/tests/Library/Garden/Events/ResourceEventTest.php
+++ b/tests/Library/Garden/Events/ResourceEventTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Garden\Events;
+
+use PHPUnit\Framework\TestCase;
+use VanillaTests\Fixtures\Events\TestResourceEvent;
+
+/**
+ * Test capabilities of ResourceEvent data class.
+ */
+class ResourceEventTest extends TestCase {
+
+    /**
+     * Test setting the action.
+     *
+     * @return void
+     */
+    public function testSetAction(): void {
+        $resourceEvent = new TestResourceEvent(__FUNCTION__, []);
+        $this->assertEquals(__FUNCTION__, $resourceEvent->getAction());
+    }
+
+    /**
+     * Test setting the event payload.
+     *
+     * @return void
+     */
+    public function testSetPayload(): void {
+        $payload = ["foo" => "bar"];
+        $resourceEvent = new TestResourceEvent(__FUNCTION__, $payload);
+        $this->assertEquals($payload, $resourceEvent->getPayload());
+    }
+
+    /**
+     * Test deriving the type from the class name.
+     *
+     * @return void
+     */
+    public function testSetType(): void {
+        $resourceEvent = new TestResourceEvent(__FUNCTION__, []);
+        $this->assertEquals("testResource", $resourceEvent->getType());
+    }
+}

--- a/tests/fixtures/src/Events/TestResourceEvent.php
+++ b/tests/fixtures/src/Events/TestResourceEvent.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures\Events;
+
+use Garden\Events\ResourceEvent;
+
+/**
+ * Test implementation of ResourceEvent.
+ */
+class TestResourceEvent extends ResourceEvent {
+}


### PR DESCRIPTION
This update adds a very simple class that will be used for creating [PSR-14-style events](https://www.php-fig.org/psr/psr-14/) for basic resource operations (e.g. adding a discussion, deleting a comment, registering a user).