### PR TITLE
IE 11 - Bumped up specificity and fixed CSS prop for logo

### DIFF
--- a/packages/vanilla-polyfill/index.js
+++ b/packages/vanilla-polyfill/index.js
@@ -8,6 +8,8 @@
  * @license GPL-2.0-only
  */
 
+"use strict";
+
 import "core-js/stable";
 import "@webcomponents/webcomponentsjs";
 
@@ -112,3 +114,63 @@ function polyfillStringNormalize() {
         return this;
     }
 }
+
+
+/**
+ * Polyfill "append" for ie11.
+ */
+
+// Source: https://github.com/jserz/js_piece/blob/master/DOM/ParentNode/append()/append().md
+(function (arr) {
+    arr.forEach(function (item) {
+        if (item.hasOwnProperty('append')) {
+            return;
+        }
+        Object.defineProperty(item, 'append', {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: function append() {
+                var argArr = Array.prototype.slice.call(arguments),
+                    docFrag = document.createDocumentFragment();
+
+                argArr.forEach(function (argItem) {
+                    var isNode = argItem instanceof Node;
+                    docFrag.appendChild(isNode ? argItem : document.createTextNode(String(argItem)));
+                });
+
+                this.appendChild(docFrag);
+            }
+        });
+    });
+})([Element.prototype, Document.prototype, DocumentFragment.prototype]);
+
+/**
+ * Polyfill "prepend" for ie11.
+ */
+// Source: https://github.com/jserz/js_piece/blob/master/DOM/ParentNode/prepend()/prepend().md
+
+(function (arr) {
+    arr.forEach(function (item) {
+        if (item.hasOwnProperty('prepend')) {
+            return;
+        }
+        Object.defineProperty(item, 'prepend', {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: function prepend() {
+                var argArr = Array.prototype.slice.call(arguments),
+                    docFrag = document.createDocumentFragment();
+
+                argArr.forEach(function (argItem) {
+                    var isNode = argItem instanceof Node;
+                    docFrag.appendChild(isNode ? argItem : document.createTextNode(String(argItem)));
+                });
+
+                this.insertBefore(docFrag, this.firstChild);
+            }
+        });
+    });
+})([Element.prototype, Document.prototype, DocumentFragment.prototype]);
+

--- a/themes/theme-boilerplate/src/scss/sections/_header.scss
+++ b/themes/theme-boilerplate/src/scss/sections/_header.scss
@@ -156,7 +156,7 @@
 
 // IE 11 specific bug
 @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
-    .Header-logo img {
-        max-height: unset;
+    .Header .Header-logo img {
+        max-height: initial;
     }
 }


### PR DESCRIPTION
Bumps up specificity and fixes bad value for CSS logo style.

Added missing polyfills for append/prepend.

Fixes bugs for https://github.com/vanilla/support/issues/1190

