### PR TITLE
Fix breadcrumb scrolling issue

### DIFF
--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -209,7 +209,7 @@ export class TitleBar extends React.Component<IProps, IState> {
         const titleBarVars = titleBarVariables();
         this.context.setScrollOffset(titleBarVars.sizing.height);
         if (this.containerElement) {
-            this.containerElement.classList.value = this.containerClasses;
+            this.containerElement.setAttribute("class", this.containerClasses);
         }
     }
 

--- a/library/src/scripts/navigation/breadcrumbsStyles.ts
+++ b/library/src/scripts/navigation/breadcrumbsStyles.ts
@@ -10,8 +10,19 @@ import { styleFactory, useThemeCache, variableFactory } from "@library/styles/st
 import { px, em } from "csx";
 import { colorOut, margins, paddings, singleLineEllipsis, unit, userSelect } from "@library/styles/styleHelpers";
 
+export const breadcrumbsVariables = useThemeCache(() => {
+    const makeVariables = variableFactory("breadcrumbs");
+
+    const sizing = makeVariables("sizing", {
+        minHeight: 16,
+    });
+
+    return { sizing };
+});
+
 export const breadcrumbsClasses = useThemeCache(() => {
     const globalVars = globalVariables();
+    const vars = breadcrumbsVariables();
     const style = styleFactory("breadcrumbs");
 
     const link = style("link", {
@@ -49,7 +60,7 @@ export const breadcrumbsClasses = useThemeCache(() => {
         flexDirection: "row",
         justifyContent: "flex-start",
         flexWrap: "wrap",
-        minHeight: px(16),
+        minHeight: unit(vars.sizing.minHeight),
     });
 
     const separator = style("separator", {
@@ -74,6 +85,7 @@ export const breadcrumbsClasses = useThemeCache(() => {
     const breadcrumb = style("breadcrumb", {
         display: "inline-flex",
         lineHeight: 1,
+        minHeight: unit(vars.sizing.minHeight),
     });
 
     const current = style("current", {


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/1133

- The breadcrumbs had a 1 pixel overflow. I couldn't really figure out why it was happening, but it had also been causing issues for the panel layout, which I resolved with a min-height on the list in https://github.com/vanilla/vanilla/pull/9922
- I also noticed while testing in IE11 that the titlebar background class wasn't being applied. Changing the way we applied it fixed the issue