### PR TITLE
Allow image transparency when resizing images using GD

### DIFF
--- a/library/Vanilla/ImageResizer.php
+++ b/library/Vanilla/ImageResizer.php
@@ -120,6 +120,11 @@ class ImageResizer {
             }
 
             $destImage = imagecreatetruecolor($resize['width'], $resize['height']);
+            if ($srcType === IMAGETYPE_PNG || $srcType === IMAGETYPE_ICO) {
+                // Set image transparency on target if necessary
+                imagealphablending($destImage, false);
+                imagesavealpha($destImage, true);
+            }
 
             imagecopyresampled(
                 $destImage,
@@ -343,7 +348,6 @@ class ImageResizer {
                 break;
             case IMAGETYPE_PNG:
                 $r = imagecreatefrompng($path);
-                imagealphablending($r, true);
                 break;
             default:
                 $ext = $this->extFromImageType($type);


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/9927

PNGs and ICO files need to have additional properties applied to the **destination** image in order for for them to save properly with transparency.

Unfortunately, even though so some other code in `Gdn_Upload` was applying these properties, using `imagecreatetruecolor()` creates a _**new image**_ and requires the properties to be set again.