### PR TITLE
Add PSR-14 events for discussion write operations

### DIFF
--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -6,6 +6,8 @@
  */
 
 use Garden\Schema\Schema;
+use Vanilla\Community\Schemas\CategoryFragmentSchema;
+use Vanilla\Community\Schemas\PostFragmentSchema;
 use Vanilla\Formatting\FormatFieldTrait;
 use Vanilla\Utility\ModelUtils;
 
@@ -49,11 +51,7 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller implements 
      */
     public function getCategoryFragmentSchema() {
         if ($this->categoryFragmentSchema === null) {
-            $this->categoryFragmentSchema = $this->schema([
-                'categoryID:i' => 'The ID of the category.',
-                'name:s' => 'The name of the category.',
-                'url:s' => 'Full URL to the category.',
-            ], 'CategoryFragment');
+            $this->categoryFragmentSchema = $this->schema(new CategoryFragmentSchema(), 'CategoryFragment');
         }
         return $this->categoryFragmentSchema;
     }
@@ -79,16 +77,7 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller implements 
      */
     public function getPostFragmentSchema() {
         if ($this->postFragmentSchema === null) {
-            $this->postFragmentSchema = $this->schema([
-                'discussionID:i?' => 'The discussion ID of the post.',
-                'commentID:i?' => 'The comment ID of the post, if any.',
-                'name:s' => 'The title of the post.',
-                'body:s?' => 'The HTML body of the post.',
-                'url:s' => 'The URL of the post.',
-                'dateInserted:dt' => 'The date of the post.',
-                'insertUserID:i' => 'The author of the post.',
-                'insertUser?' => $this->getUserFragmentSchema(),
-            ], 'PostFragment');
+            $this->postFragmentSchema = $this->schema(new PostFragmentSchema(), 'PostFragment');
         }
         return $this->postFragmentSchema;
     }

--- a/applications/dashboard/controllers/api/AbstractApiController.php
+++ b/applications/dashboard/controllers/api/AbstractApiController.php
@@ -6,11 +6,15 @@
  */
 
 use Garden\Schema\Schema;
+use Vanilla\Formatting\FormatFieldTrait;
+use Vanilla\Utility\ModelUtils;
 
 /**
  * Base API controller for APIv2.
  */
 abstract class AbstractApiController extends \Vanilla\Web\Controller implements \Vanilla\InjectableInterface {
+
+    use FormatFieldTrait;
 
     /** @var Schema */
     private $categoryFragmentSchema;
@@ -36,19 +40,6 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller implements 
             return $valid;
         });
         return $result;
-    }
-
-    /**
-     * Format a specific field.
-     *
-     * @param array $row An array representing a database row.
-     * @param string $field The field name.
-     * @param string $format The source format.
-     */
-    public function formatField(array &$row, $field, $format) {
-        if (array_key_exists($field, $row)) {
-            $row[$field] = \Gdn::formatService()->renderHTML($row[$field], $format) ?: '<!-- empty -->';
-        }
     }
 
     /**
@@ -110,13 +101,7 @@ abstract class AbstractApiController extends \Vanilla\Web\Controller implements 
      * @return bool
      */
     public function isExpandField($field, $expand) {
-        $result = false;
-        if ($expand === true) {
-            // A boolean true allows everything.
-            $result = true;
-        } elseif (is_array($expand)) {
-            $result = !empty(array_intersect([\Vanilla\ApiUtils::EXPAND_ALL, 'true', '1', $field], $expand));
-        }
+        $result = ModelUtils::isExpandOption($field, $expand);
         return $result;
     }
 

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1163,6 +1163,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
                     'name' => 'guest',
                     'email' => 'guest@example.com',
                     'photoUrl' => self::getDefaultAvatarUrl(),
+                    'dateLastActive' => null,
                 ];
             case self::GENERATED_FRAGMENT_KEY_UNKNOWN:
                 return $unknownFragment;

--- a/applications/vanilla/Events/DiscussionEvent.php
+++ b/applications/vanilla/Events/DiscussionEvent.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Community\Events;
+
+use Garden\Events\ResourceEvent;
+
+/**
+ * Represent a discussion resource event.
+ */
+class DiscussionEvent extends ResourceEvent {
+}

--- a/applications/vanilla/Schemas/CategoryFragmentSchema.php
+++ b/applications/vanilla/Schemas/CategoryFragmentSchema.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Community\Schemas;
+
+use Garden\Schema\Schema;
+
+/**
+ * Schema for minimal category fields.
+ */
+class CategoryFragmentSchema extends Schema {
+    /**
+     * Setup new schema.
+     */
+    public function __construct() {
+        parent::__construct($this->parseInternal([
+            'categoryID:i' => 'The ID of the category.',
+            'name:s' => 'The name of the category.',
+            'url:s' => 'Full URL to the category.',
+        ]));
+    }
+}

--- a/applications/vanilla/Schemas/PostFragmentSchema.php
+++ b/applications/vanilla/Schemas/PostFragmentSchema.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Community\Schemas;
+
+use Garden\Schema\Schema;
+use Vanilla\ExtensibleSchemasTrait;
+use Vanilla\Models\UserFragmentSchema;
+
+/**
+ * Schema for minimal post fields.
+ */
+class PostFragmentSchema extends Schema {
+
+    use ExtensibleSchemasTrait;
+
+    /**
+     * Setup new schema.
+     */
+    public function __construct() {
+        parent::__construct($this->parseInternal([
+            'discussionID:i?' => 'The discussion ID of the post.',
+            'commentID:i?' => 'The comment ID of the post, if any.',
+            'name:s' => 'The title of the post.',
+            'body:s?' => 'The HTML body of the post.',
+            'url:s' => 'The URL of the post.',
+            'dateInserted:dt' => 'The date of the post.',
+            'insertUserID:i' => 'The author of the post.',
+            'insertUser?' => $this->extensibleSchema(new UserFragmentSchema(), "UserFragment"),
+        ]));
+    }
+}

--- a/applications/vanilla/Schemas/PostFragmentSchema.php
+++ b/applications/vanilla/Schemas/PostFragmentSchema.php
@@ -7,15 +7,13 @@
 namespace Vanilla\Community\Schemas;
 
 use Garden\Schema\Schema;
-use Vanilla\ExtensibleSchemasTrait;
 use Vanilla\Models\UserFragmentSchema;
+use Vanilla\SchemaFactory;
 
 /**
  * Schema for minimal post fields.
  */
 class PostFragmentSchema extends Schema {
-
-    use ExtensibleSchemasTrait;
 
     /**
      * Setup new schema.
@@ -29,7 +27,7 @@ class PostFragmentSchema extends Schema {
             'url:s' => 'The URL of the post.',
             'dateInserted:dt' => 'The date of the post.',
             'insertUserID:i' => 'The author of the post.',
-            'insertUser?' => $this->extensibleSchema(new UserFragmentSchema(), "UserFragment"),
+            'insertUser?' => SchemaFactory::parse(new UserFragmentSchema(), "UserFragment"),
         ]));
     }
 }

--- a/applications/vanilla/Schemas/PostFragmentSchema.php
+++ b/applications/vanilla/Schemas/PostFragmentSchema.php
@@ -27,7 +27,7 @@ class PostFragmentSchema extends Schema {
             'url:s' => 'The URL of the post.',
             'dateInserted:dt' => 'The date of the post.',
             'insertUserID:i' => 'The author of the post.',
-            'insertUser?' => SchemaFactory::parse(new UserFragmentSchema(), "UserFragment"),
+            'insertUser?' => SchemaFactory::get(UserFragmentSchema::class, "UserFragment"),
         ]));
     }
 }

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -217,7 +217,7 @@ class DiscussionsApiController extends AbstractApiController {
             ->schema()
             ->merge($this->discussionModel->userDiscussionSchema())
             ->merge(Schema::parse([
-                'category?' => SchemaFactory::parse(new CategoryFragmentSchema(), 'CategoryFragment'),
+                'category?' => SchemaFactory::get(CategoryFragmentSchema::class, 'CategoryFragment'),
             ]));
         return $result;
     }

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -11,6 +11,7 @@ use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\DateFilterSchema;
 use Vanilla\ApiUtils;
+use Vanilla\Community\Schemas\CategoryFragmentSchema;
 use Vanilla\Formatting\Formats\RichFormat;
 
 /**
@@ -211,7 +212,13 @@ class DiscussionsApiController extends AbstractApiController {
      * @return Schema Returns a schema object.
      */
     protected function fullSchema() {
-        return $this->discussionModel->schema();
+        $result = $this->discussionModel
+            ->schema()
+            ->merge($this->discussionModel->userDiscussionSchema())
+            ->merge(Schema::parse([
+                'category?' => $this->extensibleSchema(new CategoryFragmentSchema(), 'CategoryFragment'),
+            ]));
+        return $result;
     }
 
     /**

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -13,6 +13,7 @@ use Vanilla\DateFilterSchema;
 use Vanilla\ApiUtils;
 use Vanilla\Community\Schemas\CategoryFragmentSchema;
 use Vanilla\Formatting\Formats\RichFormat;
+use Vanilla\SchemaFactory;
 
 /**
  * API Controller for the `/discussions` resource.
@@ -216,7 +217,7 @@ class DiscussionsApiController extends AbstractApiController {
             ->schema()
             ->merge($this->discussionModel->userDiscussionSchema())
             ->merge(Schema::parse([
-                'category?' => $this->extensibleSchema(new CategoryFragmentSchema(), 'CategoryFragment'),
+                'category?' => SchemaFactory::parse(new CategoryFragmentSchema(), 'CategoryFragment'),
             ]));
         return $result;
     }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -10,16 +10,14 @@
 
 use Garden\EventManager;
 use Garden\Schema\Schema;
-use Vanilla\ExtensibleSchemasTrait;
 use Vanilla\Forum\Navigation\ForumCategoryRecordType;
 use Vanilla\Navigation\BreadcrumbModel;
+use Vanilla\SchemaFactory;
 
 /**
  * Manages discussion categories' data.
  */
 class CategoryModel extends Gdn_Model {
-
-    use ExtensibleSchemasTrait;
 
     /** Cache key. */
     const CACHE_KEY = 'Categories';
@@ -3709,7 +3707,7 @@ SQL;
      * @return Schema Returns a schema.
      */
     public function fragmentSchema(): Schema {
-        $result = $this->extensibleSchema([
+        $result = SchemaFactory::parse([
             'categoryID:i' => 'The ID of the category.',
             'name:s' => 'The name of the category.',
             'url:s' => 'Full URL to the category.',

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -9,6 +9,8 @@
  */
 
 use Garden\EventManager;
+use Garden\Schema\Schema;
+use Vanilla\ExtensibleSchemasTrait;
 use Vanilla\Forum\Navigation\ForumCategoryRecordType;
 use Vanilla\Navigation\BreadcrumbModel;
 
@@ -16,6 +18,8 @@ use Vanilla\Navigation\BreadcrumbModel;
  * Manages discussion categories' data.
  */
 class CategoryModel extends Gdn_Model {
+
+    use ExtensibleSchemasTrait;
 
     /** Cache key. */
     const CACHE_KEY = 'Categories';
@@ -3697,5 +3701,19 @@ SQL;
             $targetID = val('CategoryID', $current);
             self::instance()->setField($targetID, ['LastCategoryID' => $categoryID]);
         }
+    }
+
+    /**
+     * Get the schema for categories joined to records.
+     *
+     * @return Schema Returns a schema.
+     */
+    public function fragmentSchema(): Schema {
+        $result = $this->extensibleSchema([
+            'categoryID:i' => 'The ID of the category.',
+            'name:s' => 'The name of the category.',
+            'url:s' => 'Full URL to the category.',
+        ], 'CategoryFragment');
+        return $result;
     }
 }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -30,7 +30,7 @@ class DiscussionModel extends Gdn_Model {
 
     use \Vanilla\FloodControlTrait;
 
-    use FormatfieldTrait;
+    use FormatFieldTrait;
 
     use UpdateMediaTrait;
 
@@ -2268,7 +2268,7 @@ class DiscussionModel extends Gdn_Model {
                     (array)$discussion,
                     $insert ? DiscussionEvent::ACTION_INSERT : DiscussionEvent::ACTION_UPDATE
                 );
-                $this->eventManager->dispatch($discussionEvent);
+                $this->getEventManager()->dispatch($discussionEvent);
 
                 // Fire an event that the discussion was saved.
                 $this->EventArguments['FormPostValues'] = $formPostValues;
@@ -2972,7 +2972,7 @@ class DiscussionModel extends Gdn_Model {
         $dataObject = (object)$data;
         $this->calculate($dataObject);
         $discussionEvent = $this->eventFromRow((array)$dataObject, DiscussionEvent::ACTION_DELETE);
-        $this->eventManager->dispatch($discussionEvent);
+        $this->getEventManager()->dispatch($discussionEvent);
 
         return true;
     }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3600,8 +3600,8 @@ class DiscussionModel extends Gdn_Model {
             'dateUpdated:dt|n' => 'When the discussion was last updated.',
             'dateLastComment:dt|n' => 'When the last comment was posted.',
             'insertUserID:i' => 'The user that created the discussion.',
-            'insertUser?' => SchemaFactory::parse(new UserFragmentSchema(), "UserFragment"),
-            'lastUser?' => SchemaFactory::parse(new UserFragmentSchema(), "UserFragment"),
+            'insertUser?' => SchemaFactory::get(UserFragmentSchema::class, "UserFragment"),
+            'lastUser?' => SchemaFactory::get(UserFragmentSchema::class, "UserFragment"),
             'pinned:b?' => 'Whether or not the discussion has been pinned.',
             'pinLocation:s|n' => [
                 'enum' => ['category', 'recent'],
@@ -3616,7 +3616,7 @@ class DiscussionModel extends Gdn_Model {
             'score:i|n' => 'Total points associated with this post.',
             'url:s?' => 'The full URL to the discussion.',
             'canonicalUrl:s' => 'The full canonical URL to the discussion.',
-            'lastPost?' => SchemaFactory::parse(new PostFragmentSchema(), "PostFragment"),
+            'lastPost?' => SchemaFactory::get(PostFragmentSchema::class, "PostFragment"),
         ]);
         return $result;
     }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2306,6 +2306,7 @@ class DiscussionModel extends Gdn_Model {
     }
 
     /**
+     * Notify users of new discussions.
      *
      * @param int|array|stdClass $discussion
      * @param ActivityModel $activityModel
@@ -3602,7 +3603,9 @@ class DiscussionModel extends Gdn_Model {
             'pinned:b?' => 'Whether or not the discussion has been pinned.',
             'pinLocation:s|n' => [
                 'enum' => ['category', 'recent'],
-                'description' => 'The location for the discussion, if pinned. "category" are pinned to their own category. "recent" are pinned to the recent discussions list, as well as their own category.'
+                'description' => 'The location for the discussion, if pinned. '
+                    . '"category" are pinned to their own category. '
+                    . '"recent" are pinned to the recent discussions list, as well as their own category.',
             ],
             'closed:b' => 'Whether the discussion is closed or open.',
             'sink:b' => 'Whether or not the discussion has been sunk.',

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2972,7 +2972,9 @@ class DiscussionModel extends Gdn_Model {
             $this->setUserBookmarkCount($user->UserID);
         }
 
-        $discussionEvent = $this->eventFromRow($data, DiscussionEvent::ACTION_DELETE);
+        $dataObject = (object)$data;
+        $this->calculate($dataObject);
+        $discussionEvent = $this->eventFromRow((array)$dataObject, DiscussionEvent::ACTION_DELETE);
         Gdn::getContainer()->get(EventManager::class)->dispatch($discussionEvent);
 
         return true;
@@ -3501,7 +3503,7 @@ class DiscussionModel extends Gdn_Model {
         $this->formatField($row, "Body", $row["Format"]);
         $row['Attributes'] = new Attributes($row['Attributes']);
 
-        if (isset($row["Bookmarked"])) {
+        if (array_key_exists("Bookmarked", $row)) {
             $row["Bookmarked"] = (bool)$row["Bookmarked"];
         }
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -13,11 +13,11 @@ use Vanilla\Attributes;
 use Vanilla\Community\Events\DiscussionEvent;
 use Vanilla\Community\Schemas\PostFragmentSchema;
 use Vanilla\Exception\PermissionException;
-use Vanilla\ExtensibleSchemasTrait;
 use Vanilla\Formatting\FormatService;
 use Vanilla\Formatting\FormatFieldTrait;
 use Vanilla\Formatting\UpdateMediaTrait;
 use Vanilla\Models\UserFragmentSchema;
+use Vanilla\SchemaFactory;
 use Vanilla\Utility\CamelCaseScheme;
 use Vanilla\Utility\ModelUtils;
 
@@ -25,8 +25,6 @@ use Vanilla\Utility\ModelUtils;
  * Manages discussions data.
  */
 class DiscussionModel extends Gdn_Model {
-
-    use ExtensibleSchemasTrait;
 
     use StaticInitializer;
 
@@ -3602,8 +3600,8 @@ class DiscussionModel extends Gdn_Model {
             'dateUpdated:dt|n' => 'When the discussion was last updated.',
             'dateLastComment:dt|n' => 'When the last comment was posted.',
             'insertUserID:i' => 'The user that created the discussion.',
-            'insertUser?' => $this->extensibleSchema(new UserFragmentSchema(), "UserFragment"),
-            'lastUser?' => $this->extensibleSchema(new UserFragmentSchema(), "UserFragment"),
+            'insertUser?' => SchemaFactory::parse(new UserFragmentSchema(), "UserFragment"),
+            'lastUser?' => SchemaFactory::parse(new UserFragmentSchema(), "UserFragment"),
             'pinned:b?' => 'Whether or not the discussion has been pinned.',
             'pinLocation:s|n' => [
                 'enum' => ['category', 'recent'],
@@ -3618,7 +3616,7 @@ class DiscussionModel extends Gdn_Model {
             'score:i|n' => 'Total points associated with this post.',
             'url:s?' => 'The full URL to the discussion.',
             'canonicalUrl:s' => 'The full canonical URL to the discussion.',
-            'lastPost?' => $this->extensibleSchema(new PostFragmentSchema(), "PostFragment"),
+            'lastPost?' => SchemaFactory::parse(new PostFragmentSchema(), "PostFragment"),
         ]);
         return $result;
     }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3497,10 +3497,13 @@ class DiscussionModel extends Gdn_Model {
      */
     public function normalizeRow(array $row, $expand = []): array {
         $row['Announce'] = (bool)$row['Announce'];
-        $row['Bookmarked'] = (bool)$row['Bookmarked'];
         $row['Url'] = discussionUrl($row);
         $this->formatField($row, "Body", $row["Format"]);
         $row['Attributes'] = new Attributes($row['Attributes']);
+
+        if (isset($row["Bookmarked"])) {
+            $row["Bookmarked"] = (bool)$row["Bookmarked"];
+        }
 
         if (ModelUtils::isExpandOption('lastPost', $expand)) {
             $lastPost = [

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -8,7 +8,6 @@
  * @since 2.0
  */
 
-use Garden\EventManager;
 use Garden\Schema\Schema;
 use Vanilla\Attributes;
 use Vanilla\Community\Events\DiscussionEvent;
@@ -2271,7 +2270,7 @@ class DiscussionModel extends Gdn_Model {
                     (array)$discussion,
                     $insert ? DiscussionEvent::ACTION_INSERT : DiscussionEvent::ACTION_UPDATE
                 );
-                Gdn::getContainer()->get(EventManager::class)->dispatch($discussionEvent);
+                $this->eventManager->dispatch($discussionEvent);
 
                 // Fire an event that the discussion was saved.
                 $this->EventArguments['FormPostValues'] = $formPostValues;
@@ -2975,7 +2974,7 @@ class DiscussionModel extends Gdn_Model {
         $dataObject = (object)$data;
         $this->calculate($dataObject);
         $discussionEvent = $this->eventFromRow((array)$dataObject, DiscussionEvent::ACTION_DELETE);
-        Gdn::getContainer()->get(EventManager::class)->dispatch($discussionEvent);
+        $this->eventManager->dispatch($discussionEvent);
 
         return true;
     }

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -14,8 +14,12 @@ use Vanilla\Utility\CapitalCaseScheme;
 
 class ApiUtils {
 
-    // Expand field value to indicate expanding all fields.
-    const EXPAND_ALL = "all";
+    /**
+     * Expand field value to indicate expanding all fields.
+     *
+     * @deprecated
+     */
+    const EXPAND_ALL = \Vanilla\Utility\ModelUtils::EXPAND_ALL;
 
     /**
      * Convert array keys for functions that aren't compatible with camelCase.

--- a/library/Vanilla/ExtensibleSchemasTrait.php
+++ b/library/Vanilla/ExtensibleSchemasTrait.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla;
+
+use Garden\EventManager;
+use Garden\Schema\Schema;
+
+trait ExtensibleSchemasTrait {
+
+    /**
+     * Create a schema, allowing for extension via events.
+     *
+     * @param array|Schema $schema
+     * @param string|array $type
+     * @return Schema
+     */
+    public function extensibleSchema($schema, $type): Schema {
+        /** @var EventManager */
+        $eventManager = \Gdn::getContainer()->get(EventManager::class);
+
+        $id = '';
+        if (is_array($type)) {
+            $origType = $type;
+            list($id, $type) = $origType;
+        } elseif (!in_array($type, ['in', 'out'], true)) {
+            $id = $type;
+            $type = '';
+        }
+
+        // Figure out the name.
+        if (is_array($schema)) {
+            $schema = Schema::parse($schema);
+        } elseif ($schema instanceof Schema) {
+            $schema = clone $schema;
+        }
+
+        // Fire an event for schema modification.
+        if (!empty($id)) {
+            // The type is a specific type of schema.
+            $schema->setID($id);
+
+            $eventManager->fire("{$id}Schema_init", $schema);
+        }
+
+        return $schema;
+    }
+}

--- a/library/Vanilla/Formatting/FormatFieldTrait.php
+++ b/library/Vanilla/Formatting/FormatFieldTrait.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting;
+
+/**
+ * Add basic field formatting with fallback render result.
+ */
+trait FormatFieldTrait {
+    /**
+     * Format a specific field.
+     *
+     * @param array $row An array representing a database row.
+     * @param string $field The field name.
+     * @param string $format The source format.
+     */
+    public function formatField(array &$row, $field, $format) {
+        if (array_key_exists($field, $row)) {
+            $row[$field] = \Gdn::formatService()->renderHTML($row[$field], $format) ?: '<!-- empty -->';
+        }
+    }
+}

--- a/library/Vanilla/SchemaFactory.php
+++ b/library/Vanilla/SchemaFactory.php
@@ -8,8 +8,29 @@ namespace Vanilla;
 
 use Garden\EventManager;
 use Garden\Schema\Schema;
+use Gdn;
 
-trait ExtensibleSchemasTrait {
+/**
+ * Factory for schema objects.
+ */
+class SchemaFactory {
+
+    /** @var EventManager */
+    private static $eventManager;
+
+    /**
+     * Get the configured event manager instance.
+     *
+     * @return EventManager
+     */
+    private static function getEventManager(): EventManager {
+        if (!isset(self::$eventManager)) {
+            /** @var EventManager */
+            $eventManager = Gdn::getContainer()->get(EventManager::class);
+            self::setEventManager($eventManager);
+        }
+        return self::$eventManager;
+    }
 
     /**
      * Create a schema, allowing for extension via events.
@@ -18,10 +39,7 @@ trait ExtensibleSchemasTrait {
      * @param string|array $type
      * @return Schema
      */
-    public function extensibleSchema($schema, $type): Schema {
-        /** @var EventManager */
-        $eventManager = \Gdn::getContainer()->get(EventManager::class);
-
+    public static function parse($schema, $type): Schema {
         $id = '';
         if (is_array($type)) {
             $origType = $type;
@@ -43,9 +61,19 @@ trait ExtensibleSchemasTrait {
             // The type is a specific type of schema.
             $schema->setID($id);
 
-            $eventManager->fire("{$id}Schema_init", $schema);
+            self::getEventManager()->fire("{$id}Schema_init", $schema);
         }
 
         return $schema;
+    }
+
+    /**
+     * Set the event manager instance.
+     *
+     * @param EventManager $eventManager
+     * @return void
+     */
+    private static function setEventManager(EventManager $eventManager): void {
+        self::$eventManager = $eventManager;
     }
 }

--- a/library/Vanilla/SchemaFactory.php
+++ b/library/Vanilla/SchemaFactory.php
@@ -73,7 +73,7 @@ class SchemaFactory {
      * @param EventManager $eventManager
      * @return void
      */
-    public static function setEventManager(EventManager $eventManager): void {
+    public static function setEventManager(?EventManager $eventManager): void {
         self::$eventManager = $eventManager;
     }
 }

--- a/library/Vanilla/SchemaFactory.php
+++ b/library/Vanilla/SchemaFactory.php
@@ -23,7 +23,7 @@ class SchemaFactory {
      *
      * @return EventManager
      */
-    private static function getEventManager(): EventManager {
+    public static function getEventManager(): EventManager {
         if (!isset(self::$eventManager)) {
             /** @var EventManager */
             $eventManager = Gdn::getContainer()->get(EventManager::class);
@@ -73,7 +73,7 @@ class SchemaFactory {
      * @param EventManager $eventManager
      * @return void
      */
-    private static function setEventManager(EventManager $eventManager): void {
+    public static function setEventManager(EventManager $eventManager): void {
         self::$eventManager = $eventManager;
     }
 }

--- a/library/Vanilla/Utility/ModelUtils.php
+++ b/library/Vanilla/Utility/ModelUtils.php
@@ -17,6 +17,27 @@ use Gdn_Validation;
  */
 class ModelUtils {
 
+    // Expand field value to indicate expanding all fields.
+    public const EXPAND_ALL = "all";
+
+    /**
+     * Given an array of expand options, determine if a value matches any of them.
+     *
+     * @param string $value The field name to search for.
+     * @param array|bool $options An array of fields to expand, or true for all.
+     * @return bool
+     */
+    public static function isExpandOption(string $value, $options): bool {
+        $result = false;
+        if ($options === true) {
+            // A boolean true allows everything.
+            $result = true;
+        } elseif (is_array($options)) {
+            $result = !empty(array_intersect([self::EXPAND_ALL, 'true', '1', $value], $options));
+        }
+        return $result;
+    }
+
     /**
      * Convert a Garden Schema validation exception into a Gdn_Validation instance.
      *

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -17,8 +17,8 @@ use Gdn_Locale as LocaleInterface;
 use Gdn_Session as SessionInterface;
 use Gdn_Upload as Upload;
 use Vanilla\Exception\PermissionException;
-use Vanilla\ExtensibleSchemasTrait;
 use Vanilla\InjectableInterface;
+use Vanilla\SchemaFactory;
 use Vanilla\UploadedFile;
 use Vanilla\Utility\ModelUtils;
 
@@ -26,8 +26,6 @@ use Vanilla\Utility\ModelUtils;
  * The controller base class.
  */
 abstract class Controller implements InjectableInterface {
-
-    use ExtensibleSchemasTrait;
 
     /**
      * @var SessionInterface
@@ -116,7 +114,7 @@ abstract class Controller implements InjectableInterface {
      * @return Schema Returns a schema object.
      */
     public function schema($schema, $type = 'in') {
-        $schema = $this->extensibleSchema($schema, $type);
+        $schema = SchemaFactory::parse($schema, $type);
 
         // Fire a generic schema event for documentation.
         if (!empty($type)) {

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -17,6 +17,7 @@ use Gdn_Locale as LocaleInterface;
 use Gdn_Session as SessionInterface;
 use Gdn_Upload as Upload;
 use Vanilla\Exception\PermissionException;
+use Vanilla\ExtensibleSchemasTrait;
 use Vanilla\InjectableInterface;
 use Vanilla\UploadedFile;
 use Vanilla\Utility\ModelUtils;
@@ -25,6 +26,9 @@ use Vanilla\Utility\ModelUtils;
  * The controller base class.
  */
 abstract class Controller implements InjectableInterface {
+
+    use ExtensibleSchemasTrait;
+
     /**
      * @var SessionInterface
      */
@@ -112,29 +116,7 @@ abstract class Controller implements InjectableInterface {
      * @return Schema Returns a schema object.
      */
     public function schema($schema, $type = 'in') {
-        $id = '';
-        if (is_array($type)) {
-            $origType = $type;
-            list($id, $type) = $origType;
-        } elseif (!in_array($type, ['in', 'out'], true)) {
-            $id = $type;
-            $type = '';
-        }
-
-        // Figure out the name.
-        if (is_array($schema)) {
-            $schema = Schema::parse($schema);
-        } elseif ($schema instanceof Schema) {
-            $schema = clone $schema;
-        }
-
-        // Fire an event for schema modification.
-        if (!empty($id)) {
-            // The type is a specific type of schema.
-            $schema->setID($id);
-
-            $this->eventManager->fire("{$id}Schema_init", $schema);
-        }
+        $schema = $this->extensibleSchema($schema, $type);
 
         // Fire a generic schema event for documentation.
         if (!empty($type)) {

--- a/library/Vanilla/Web/Controller.php
+++ b/library/Vanilla/Web/Controller.php
@@ -114,7 +114,22 @@ abstract class Controller implements InjectableInterface {
      * @return Schema Returns a schema object.
      */
     public function schema($schema, $type = 'in') {
-        $schema = SchemaFactory::parse($schema, $type);
+        if (is_array($type)) {
+            $origType = $type;
+            list($id, $type) = $origType;
+        } elseif (!in_array($type, ['in', 'out'], true)) {
+            $id = $type;
+            $type = '';
+        }
+
+        if (empty($id) || !is_string($id)) {
+            $id = null;
+        }
+        if (is_array($schema)) {
+            $schema = SchemaFactory::parse($schema, $id);
+        } else {
+            $schema = SchemaFactory::prepare($schema, $id);
+        }
 
         // Fire a generic schema event for documentation.
         if (!empty($type)) {

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -39,7 +39,7 @@ class Gdn_Model extends Gdn_Pluggable {
     public $DateUpdated = 'DateUpdated';
 
     /** @var EventManager */
-    protected $eventManager;
+    private $eventManager;
 
     /**
      * @var array The fields that should be filtered out via {@link Gdn_Model::filterForm()}.
@@ -151,6 +151,15 @@ class Gdn_Model extends Gdn_Pluggable {
      * A overridable function called before the various get queries.
      */
     protected function _beforeGet() {
+    }
+
+    /**
+     * Get the configured event mnager instance.
+     *
+     * @return EventManager
+     */
+    public function getEventManager(): EventManager {
+        return $this->eventManager;
     }
 
     /**

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -9,6 +9,8 @@
  * @since 2.0
  */
 
+use Garden\EventManager;
+
 /**
  * Model base class.
  *
@@ -35,6 +37,9 @@ class Gdn_Model extends Gdn_Pluggable {
      * field will be automatically filled by the model if it exists.
      */
     public $DateUpdated = 'DateUpdated';
+
+    /** @var EventManager */
+    protected $eventManager;
 
     /**
      * @var array The fields that should be filtered out via {@link Gdn_Model::filterForm()}.
@@ -121,6 +126,8 @@ class Gdn_Model extends Gdn_Pluggable {
             'TransientKey' => 0,
             'hpt' => 0
         ];
+
+        $this->eventManager = Gdn::getContainer()->get(EventManager::class);
 
         parent::__construct();
     }

--- a/tests/Library/Vanilla/SchemaFactoryTest.php
+++ b/tests/Library/Vanilla/SchemaFactoryTest.php
@@ -38,13 +38,6 @@ class SchemaFactoryTest extends TestCase {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    protected function setUp(): void {
-        SchemaFactory::setEventManager($this->container()->get(EventManager::class));
-    }
-
-    /**
      * Verify the expected events are dispatched when the schema is created.
      *
      * @param array|string $type
@@ -64,6 +57,20 @@ class SchemaFactoryTest extends TestCase {
 
         SchemaFactory::parse(["stringField:s"], $type);
         $this->assertTrue($dispatched);
+    }
+
+    /**
+     * Verify the event manager will automatically be retrieved when not explicitly set.
+     *
+     * @return void
+     */
+    public function testGetEventManagerDefault(): void {
+        // Unset the existing event manager.
+        SchemaFactory::setEventManager(null);
+        $this->assertSame(
+            $this->container()->get(EventManager::class),
+            SchemaFactory::getEventManager()
+        );
     }
 
     /**

--- a/tests/Library/Vanilla/SchemaFactoryTest.php
+++ b/tests/Library/Vanilla/SchemaFactoryTest.php
@@ -62,7 +62,8 @@ class SchemaFactoryTest extends TestCase {
     /**
      * Verify the expected events are dispatched when the schema is retrieved from the container.
      *
-     * @param array|string $type
+     * @param string $class
+     * @param string $id
      * @param string $event
      * @return void
      * @dataProvider provideGetEvents
@@ -84,12 +85,12 @@ class SchemaFactoryTest extends TestCase {
     /**
      * Verify the expected events are dispatched when the schema is parsed from an array.
      *
-     * @param array|string $type
+     * @param string $id
      * @param string $event
      * @return void
      * @dataProvider provideParseEvents
      */
-    public function testParseEventDispatched($type, string $event): void {
+    public function testParseEventDispatched(string $id, string $event): void {
         // Start with a clean slate.
         $eventManager = new EventManager($this->container());
         SchemaFactory::setEventManager($eventManager);
@@ -99,7 +100,7 @@ class SchemaFactoryTest extends TestCase {
             $dispatched = true;
         });
 
-        SchemaFactory::parse(["stringField:s"], $type);
+        SchemaFactory::parse(["stringField:s"], $id);
         $this->assertTrue($dispatched);
     }
 

--- a/tests/Library/Vanilla/SchemaFactoryTest.php
+++ b/tests/Library/Vanilla/SchemaFactoryTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla;
+
+use Garden\EventManager;
+use PHPUnit\Framework\TestCase;
+use Vanilla\SchemaFactory;
+use VanillaTests\BootstrapTrait;
+
+/**
+ * Verify basic capabilities of SchemaFactory.
+ */
+class SchemaFactoryTest extends TestCase {
+
+    use BootstrapTrait;
+
+    /**
+     * Provide type prameters to verify the associated events are properly dispatched.
+     *
+     * @return array
+     */
+    public function provideTypesForEvents(): array {
+        $types = [
+            "array" => [
+                ["ExampleA", "in"],
+                "ExampleASchema_init",
+            ],
+            "string" => [
+                "ExampleB",
+                "ExampleBSchema_init",
+            ],
+        ];
+        return $types;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp(): void {
+        SchemaFactory::setEventManager($this->container()->get(EventManager::class));
+    }
+
+    /**
+     * Verify the expected events are dispatched when the schema is created.
+     *
+     * @param array|string $type
+     * @param string $event
+     * @return void
+     * @dataProvider provideTypesForEvents
+     */
+    public function testEventDispatched($type, string $event): void {
+        // Start with a clean slate.
+        $eventManager = new EventManager($this->container());
+        SchemaFactory::setEventManager($eventManager);
+
+        $dispatched = false;
+        $eventManager->bind($event, function () use (&$dispatched) {
+            $dispatched = true;
+        });
+
+        SchemaFactory::parse(["stringField:s"], $type);
+        $this->assertTrue($dispatched);
+    }
+
+    /**
+     * Test configuring the event manager dependency.
+     *
+     * @return void
+     */
+    public function testSetEventManager(): void {
+        $eventManager = new EventManager($this->container());
+        SchemaFactory::setEventManager($eventManager);
+        $this->assertSame($eventManager, SchemaFactory::getEventManager());
+    }
+}

--- a/tests/Models/DiscussionModelTest.php
+++ b/tests/Models/DiscussionModelTest.php
@@ -7,10 +7,11 @@
 
 namespace VanillaTests\Models;
 
-
 use DiscussionModel;
+use Garden\EventManager;
 use Gdn;
 use PHPUnit\Framework\TestCase;
+use Vanilla\Community\Events\DiscussionEvent;
 use VanillaTests\ExpectErrorTrait;
 use VanillaTests\SiteTestTrait;
 
@@ -19,6 +20,9 @@ use VanillaTests\SiteTestTrait;
  */
 class DiscussionModelTest extends TestCase {
     use SiteTestTrait, ExpectErrorTrait;
+
+    /** @var DiscussionEvent */
+    private $lastEvent;
 
     /**
      * @var \DiscussionModel
@@ -36,6 +40,17 @@ class DiscussionModelTest extends TestCase {
     private $session;
 
     /**
+     * A test listener that increments the counter.
+     *
+     * @param TestEvent $e
+     * @return TestEvent
+     */
+    public function handleDiscussionEvent(DiscussionEvent $e): DiscussionEvent {
+        $this->lastEvent = $e;
+        return $e;
+    }
+
+    /**
      * Get a new model for each test.
      */
     public function setUp(): void {
@@ -44,6 +59,14 @@ class DiscussionModelTest extends TestCase {
         $this->model = $this->container()->get(\DiscussionModel::class);
         $this->now = new \DateTimeImmutable();
         $this->session = Gdn::session();
+
+        // Make event testing a little easier.
+        $this->container()->setInstance(self::class, $this);
+        $this->lastEvent = null;
+        /** @var EventManager */
+        $eventManager = $this->container()->get(EventManager::class);
+        $eventManager->unbindClass(self::class);
+        $eventManager->addListenerMethod(self::class, "handleDiscussionEvent");
     }
 
     /**
@@ -207,5 +230,57 @@ class DiscussionModelTest extends TestCase {
         $actual = DiscussionModel::canClose($discussion);
         $expected = true;
         $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Verify delete event dispatched during deletion.
+     *
+     * @return void
+     */
+    public function testDeleteEventDispatched(): void {
+        $discussionID = $this->model->save([
+            "Name" => __FUNCTION__,
+            "Body" => "Hello world.",
+            "Format" => "markdown",
+        ]);
+        $this->model->deleteID($discussionID);
+
+        $this->assertInstanceOf(DiscussionEvent::class, $this->lastEvent);
+        $this->assertEquals(DiscussionEvent::ACTION_DELETE, $this->lastEvent->getAction());
+    }
+
+    /**
+     * Verify insert event dispatched during save.
+     *
+     * @return void
+     */
+    public function testSaveInsertEventDispatched(): void {
+        $this->model->save([
+            "Name" => __FUNCTION__,
+            "Body" => "Hello world.",
+            "Format" => "markdown",
+        ]);
+        $this->assertInstanceOf(DiscussionEvent::class, $this->lastEvent);
+        $this->assertEquals(DiscussionEvent::ACTION_INSERT, $this->lastEvent->getAction());
+    }
+
+    /**
+     * Verify update event dispatched during save.
+     *
+     * @return void
+     */
+    public function testSaveUpdateEventDispatched(): void {
+        $discussionID = $this->model->save([
+            "Name" => __FUNCTION__,
+            "Body" => "Hello world.",
+            "Format" => "markdown",
+        ]);
+        $this->model->save([
+            "DiscussionID" => $discussionID,
+            "Body" => "Hello again, world.",
+        ]);
+
+        $this->assertInstanceOf(DiscussionEvent::class, $this->lastEvent);
+        $this->assertEquals(DiscussionEvent::ACTION_UPDATE, $this->lastEvent->getAction());
     }
 }


### PR DESCRIPTION
This update introduces [PSR-14-style events](https://www.php-fig.org/psr/psr-14/) for discussion-write operations (insert, update, delete). To ensure discussion event data shared the same shape as Vanilla's public API v2, some refactoring has been done to allow the code to be more easily shared between models and controllers. That refactoring represents the bulk of the changed lines here. Mostly, the individual lines of code have been unaltered as they were moved from one area to another. Original methods have been left in place, but use new methods internally, to ensure backwards compatibility. Tests have been added for the newer functionality, including verifying events have been dispatched.

Relates to vanilla/internal#2142