### PR TITLE
Display categories with no discussions on "Mixed" layout

### DIFF
--- a/applications/vanilla/views/categories/discussions.php
+++ b/applications/vanilla/views/categories/discussions.php
@@ -36,7 +36,38 @@ $ViewLocation = $this->fetchViewLocation('discussions', 'discussions');
 
                 </div>
 
-            <?php endif; ?>
+            <?php else:
+
+                if ($Category->CountCategories > 0) { ?>
+
+                    <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">
+                        <?php echo getOptions($Category); ?>
+                        <h2 class="H">
+                            <?php
+                                echo anchor(htmlspecialchars($Category->Name), categoryUrl($Category));
+                                Gdn::controller()->EventArguments['Category'] = $Category;
+                                Gdn::controller()->fireEvent('AfterCategoryTitle');
+                            ?>
+                        </h2>
+                    </div>
+
+                <?php } else { ?>
+
+                    <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">
+                        <?php echo getOptions($Category); ?>
+                        <h2 class="H">
+                            <?php
+                                echo anchor(htmlspecialchars($Category->Name), categoryUrl($Category));
+                                Gdn::controller()->EventArguments['Category'] = $Category;
+                                Gdn::controller()->fireEvent('AfterCategoryTitle');
+                            ?>
+                        </h2>
+                        <div class="Empty"><?php echo t('No discussions were found.'); ?></div>
+                    </div>
+
+                <?php }
+
+            endif; ?>
 
         <?php endforeach; ?>
     <?php else: ?>

--- a/applications/vanilla/views/categories/discussions.php
+++ b/applications/vanilla/views/categories/discussions.php
@@ -40,11 +40,8 @@ $ViewLocation = $this->fetchViewLocation('discussions', 'discussions');
                     <div class="Empty"><?php echo t('No discussions were found.'); ?></div>
                 <?php endif; ?>
             </div>
-
         <?php endforeach; ?>
-    <?php else:
-        if ($Category->DisplayAs === "Discussions") : ?>
-            <div class="Empty"><?php echo t('No discussions were found.'); ?></div>
-        <?php endif; ?>
+    <?php else: ?>
+        <div class="Empty"><?php echo t('No categories were found.'); ?></div>
     <?php endif; ?>
 </div>

--- a/applications/vanilla/views/categories/discussions.php
+++ b/applications/vanilla/views/categories/discussions.php
@@ -11,19 +11,21 @@ $ViewLocation = $this->fetchViewLocation('discussions', 'discussions');
             if ($Category->CategoryID <= 0)
                 continue;
 
-            $this->Category = $Category;
-            $this->DiscussionData = $this->CategoryDiscussionData[$Category->CategoryID];
+                $this->Category = $Category;
+                $this->DiscussionData = $this->CategoryDiscussionData[$Category->CategoryID];
+            ?>
 
-            if ($this->DiscussionData->numRows() > 0) : ?>
-
-                <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">
-                    <?php echo getOptions($Category); ?>
-                    <h2 class="H"><?php
+            <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">
+                <?php echo getOptions($Category); ?>
+                <h2 class="H">
+                    <?php
                         echo anchor(htmlspecialchars($Category->Name), categoryUrl($Category));
                         Gdn::controller()->EventArguments['Category'] = $Category;
                         Gdn::controller()->fireEvent('AfterCategoryTitle');
-                        ?></h2>
+                    ?>
+                </h2>
 
+                <?php if ($this->DiscussionData->numRows() > 0) : ?>
                     <ul class="DataList Discussions">
                         <?php include($this->fetchViewLocation('discussions', 'discussions')); ?>
                     </ul>
@@ -34,43 +36,15 @@ $ViewLocation = $this->fetchViewLocation('discussions', 'discussions');
                         </div>
                     <?php endif; ?>
 
-                </div>
-
-            <?php else:
-
-                if ($Category->CountCategories > 0) { ?>
-
-                    <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">
-                        <?php echo getOptions($Category); ?>
-                        <h2 class="H">
-                            <?php
-                                echo anchor(htmlspecialchars($Category->Name), categoryUrl($Category));
-                                Gdn::controller()->EventArguments['Category'] = $Category;
-                                Gdn::controller()->fireEvent('AfterCategoryTitle');
-                            ?>
-                        </h2>
-                    </div>
-
-                <?php } else { ?>
-
-                    <div class="CategoryBox Category-<?php echo $Category->UrlCode; ?>">
-                        <?php echo getOptions($Category); ?>
-                        <h2 class="H">
-                            <?php
-                                echo anchor(htmlspecialchars($Category->Name), categoryUrl($Category));
-                                Gdn::controller()->EventArguments['Category'] = $Category;
-                                Gdn::controller()->fireEvent('AfterCategoryTitle');
-                            ?>
-                        </h2>
-                        <div class="Empty"><?php echo t('No discussions were found.'); ?></div>
-                    </div>
-
-                <?php }
-
-            endif; ?>
+                <?php else: ?>
+                    <div class="Empty"><?php echo t('No discussions were found.'); ?></div>
+                <?php endif; ?>
+            </div>
 
         <?php endforeach; ?>
-    <?php else: ?>
-        <div class="Empty"><?php echo t('No categories were found.'); ?></div>
+    <?php else:
+        if ($Category->DisplayAs === "Discussions") : ?>
+            <div class="Empty"><?php echo t('No discussions were found.'); ?></div>
+        <?php endif; ?>
     <?php endif; ?>
 </div>


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/275

The issue It's not keystone related actually, it's just how this view works (disable the theme and you will see the same behavior).

The view doesn't render categories who have no discussions. Since you can't add discussions to categories type "Nested", it ignores them: https://github.com/vanilla/vanilla/blob/9dda0f328015a74cd88a3a54f0a66ad5addd76e8/applications/vanilla/views/categories/discussions.php#L17

**Notes:** The view seems to flat the category tree when rendering so I've just followed the same logic.
