### PR TITLE
Update to allow post\patch endpoints to allow assets parameter to be array

### DIFF
--- a/applications/dashboard/controllers/api/ThemesApiSchemes.php
+++ b/applications/dashboard/controllers/api/ThemesApiSchemes.php
@@ -96,11 +96,11 @@ trait ThemesApiSchemes {
                     'description' => 'Parent theme template name.',
                 ],
                 'parentVersion:s' => [
-                   'description' => 'Parent theme template version/revision.',
+                    'description' => 'Parent theme template version/revision.',
                 ],
                 'assets?' => Schema::parse([
-                    "header:s?",
-                    "footer:s?",
+                    "header?" => $this->assetsPutArraySchema(),
+                    "footer?" => $this->assetsPutArraySchema(),
                     "variables:s?",
                     "fonts:s?",
                     "scripts:s?",
@@ -137,8 +137,8 @@ trait ThemesApiSchemes {
                     'description' => 'Parent theme template version/revision.',
                 ],
                 'assets?' => Schema::parse([
-                    "header:s?",
-                    "footer:s?",
+                    "header?" => $this->assetsPutArraySchema(),
+                    "footer?" => $this->assetsPutArraySchema(),
                     "variables:s?",
                     "fonts:s?",
                     "scripts:s?",
@@ -182,6 +182,19 @@ trait ThemesApiSchemes {
     private function assetsPutSchema(): Schema {
         $schema = Schema::parse([
             "data:s",
+        ])->setID('themeAssetsPutSchema');
+        return $schema;
+    }
+
+    /**
+     * PUT 'assets' schema
+     *
+     * @return Schema
+     */
+    private function assetsPutArraySchema(): Schema {
+        $schema = Schema::parse([
+            "data",
+            "type"
         ])->setID('themeAssetsPutSchema');
         return $schema;
     }

--- a/library/Vanilla/Models/ThemeModel.php
+++ b/library/Vanilla/Models/ThemeModel.php
@@ -305,12 +305,13 @@ class ThemeModel {
     /**
      * Basic input string validation function for html and json assets
      *
-     * @param string $data
+     * @param array $data
      * @param ValidationField $field
      * @return bool
      */
-    public static function validator(string $data, ValidationField $field) {
+    public static function validator(array $data, ValidationField $field) {
         $asset = self::ASSET_LIST[$field->getName()];
+        $data = $data['data'];
         switch ($asset['type']) {
             case 'html':
                 libxml_use_internal_errors(true);


### PR DESCRIPTION
This updates the POST\PATCH themes endpoints so that assets can be passed as an array or string. This lines up with the GET response.

required for https://github.com/vanilla/internal/pull/2184

related to https://github.com/vanilla/internal/issues/2140