### PR TITLE
Fix permission check when using quotes

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2986,6 +2986,24 @@ class DiscussionModel extends Gdn_Model {
     }
 
     /**
+     * Tests whether a user/admin has permission to view a specific discussion.
+     *
+     * @param object $discussion
+     * @return bool whether the user can view a discussion.
+     */
+    public function canViewDiscussion($discussion): bool {
+        $canViewDiscussion = true;
+        $session = $this->sessionInterface;
+        $userID = $session->UserID;
+        $canView = $this->canView($discussion, $userID);
+        $isModerator = $session->checkRankedPermission('Garden.Moderation.Manage');
+        if (!$canView && !$isModerator) {
+            $canViewDiscussion = false;
+        }
+        return $canViewDiscussion;
+    }
+
+    /**
      * Tests whether a user has permission for a discussion by checking category-specific permissions.
      *
      * Fires an event that can override the calculated permission.

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2992,13 +2992,13 @@ class DiscussionModel extends Gdn_Model {
      * @return bool whether the user can view a discussion.
      */
     public function canViewDiscussion($discussion): bool {
-        $canViewDiscussion = true;
+        $canViewDiscussion = false;
         $session = $this->sessionInterface;
         $userID = $session->UserID;
         $canView = $this->canView($discussion, $userID);
         $isModerator = $session->checkRankedPermission('Garden.Moderation.Manage');
-        if (!$canView && !$isModerator) {
-            $canViewDiscussion = false;
+        if ($canView || $isModerator) {
+            $canViewDiscussion = true;
         }
         return $canViewDiscussion;
     }


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/195#issuecomment-576496613

When member level users quote inside a group, they are being caught by 'Vanilla.Discussions.View' permission on the 'Social Groups' category.

This PR overrides that permission.

### To Test

- Create a group/discussion (with group view permission revoked for members)
- as a member, quote a comment.