### PR TITLE
Fix creation of vendor licenses when dist directory doesn't exist

### DIFF
--- a/library/setup/ComposerHelper.php
+++ b/library/setup/ComposerHelper.php
@@ -108,7 +108,11 @@ class ComposerHelper {
         passthru('yarn install --pure-lockfile --ignore-engines', $installReturn);
 
         // Generate our vendor license file.
-        $licensePath = $vanillaRoot . "/dist/VENDOR_LICENSES.txt";
+        $distDir = $vanillaRoot . '/dist';
+        $licensePath = $distDir . '/VENDOR_LICENSES.txt';
+        if (!file_exists($distDir)) {
+            mkdir($distDir);
+        }
         printf("\nGererating Vendor Licenses for build\n");
         passthru("yarn licenses generate-disclaimer --prod --ignore-engines > $licensePath");
 


### PR DESCRIPTION
Reported by ops.

The `dist` directory is current created by the build if it doesn't exist, but on infra this step runs before the build.

That means on a fresh data server with no dist directory created this part of the build will fail.