### PR TITLE
Insert logic to validate empty string where the default is not null

### DIFF
--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -63,11 +63,8 @@ if (!function_exists('ValidateRequired')) {
 
             // Checking for an Enum with an empty string.
             $hasEmptyEnum = false;
-            if ($field instanceof ArrayObject && $field->offsetExists('Enum')) {
-                $enum = $field->offsetGet('Enum');
-                if (is_array($enum) && in_array('', $enum, true)) {
-                    $hasEmptyEnum = true;
-                }
+            if (is_array($enum = val('Enum', $field, null))) {
+                $hasEmptyEnum = in_array('', $enum, true);
             }
 
             if ($value === '' && (val('Default', $field, null) === '' || $hasEmptyEnum)) {

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -63,7 +63,7 @@ if (!function_exists('ValidateRequired')) {
 
             // Checking for an Enum with an empty string.
             $hasEmptyEnum = false;
-            if ($field->offsetExists('Enum')) {
+            if ($field instanceof ArrayObject && $field->offsetExists('Enum')) {
                 $enum = $field->offsetGet('Enum');
                 if (is_array($enum) && in_array('', $enum, true)) {
                     $hasEmptyEnum = true;

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -58,8 +58,19 @@ if (!function_exists('ValidateRequired')) {
         }
 
         if (is_string($value)) {
-            // Empty strings should pass if the default value of the field is an empty string.
-            if ($value === '' && val('Default', $field, null) === '') {
+            // Empty strings should pass if the default value of the field is an empty string or one of the Enum
+            // values is an empty string.
+
+            // Checking for an Enum with an empty string.
+            $hasEmptyEnum = false;
+            if ($field->offsetExists('Enum')) {
+                $enum = $field->offsetGet('Enum');
+                if (is_array($enum) && in_array('', $enum, true)) {
+                    $hasEmptyEnum = true;
+                }
+            }
+
+            if ($value === '' && (val('Default', $field, null) === '' || $hasEmptyEnum)) {
                 return true;
             }
 

--- a/library/core/functions.validation.php
+++ b/library/core/functions.validation.php
@@ -13,7 +13,7 @@
  * are: (string) Name, (bool) PrimaryKey, (string) Type, (bool) AllowNull,
  * (string) Default, (int) Length, (array) Enum.
  *
- * @copyright 2009-2019 Vanilla Forums Inc.
+ * @copyright 2009-2020 Vanilla Forums Inc.
  * @license GPL-2.0-only
  * @package Core
  * @since 2.0

--- a/tests/Library/Core/ValidateRequiredTest.php
+++ b/tests/Library/Core/ValidateRequiredTest.php
@@ -27,7 +27,7 @@ class ValidateRequiredTest extends TestCase {
         $actual = validateRequired($testValue, $testField);
         $this->assertSame($expected, $actual);
     }
-    
+
     /**
      * Provide test data for {@link testValidateRequired()}
      *
@@ -35,44 +35,54 @@ class ValidateRequiredTest extends TestCase {
      */
     public function provideTestValidateRequiredArrays() {
         $r = [
-            'valueEmptyString' => [
-                '',
-                null,
-                false,
-            ],
-            'emptyStringDefaultAlsoEmptyString' => [
-                '',
-                ['Default' => ''],
-                true,
-            ],
-            'valueIsArray' => [
-                ['foo', 'bar'],
-                null,
-                true,
-            ],
-            'valueIsInt' => [
-                5,
-                null,
-                true,
-            ],
-            'valueIsString' => [
-                'fooBar',
-                null,
-                true,
-            ],
-            'valueIsBool' => [
-                true,
-                null,
-                false,
-            ],
+//            'valueEmptyString' => [
+//                '',
+//                null,
+//                false,
+//            ],
+//            'emptyStringDefaultAlsoEmptyString' => [
+//                '',
+//                ['Default' => ''],
+//                true,
+//            ],
+//            'valueIsArray' => [
+//                ['foo', 'bar'],
+//                null,
+//                true,
+//            ],
+//            'valueIsInt' => [
+//                5,
+//                null,
+//                true,
+//            ],
+//            'valueIsString' => [
+//                'fooBar',
+//                null,
+//                true,
+//            ],
+//            'valueIsBool' => [
+//                true,
+//                null,
+//                false,
+//            ],
             'valueIsEmptyStringFieldIsArrayObjectWithEnumTrue' => [
                 '',
-                new \ArrayObject(array('Enum' => array (
-                    0 => '',
-                    1 => 'declined',
-                    2 => 'given',
-                    3 => 'pending',
-                ))),
+                new \ArrayObject(['Enum' => [
+                    '',
+                    'declined',
+                    'given',
+                    'pending',
+                    ]], \ArrayObject::ARRAY_AS_PROPS),
+                true,
+            ],
+            'valueIsEmptyStringFieldIsArrayWithEnumTrue' => [
+                '',
+                ['Enum' => [
+                    '',
+                    'declined',
+                    'given',
+                    'pending',
+                ]],
                 true,
             ],
             'valueIsEmptyStringFieldIsArrayObjectWithEnumFalse' => [

--- a/tests/Library/Core/ValidateRequiredTest.php
+++ b/tests/Library/Core/ValidateRequiredTest.php
@@ -35,36 +35,36 @@ class ValidateRequiredTest extends TestCase {
      */
     public function provideTestValidateRequiredArrays() {
         $r = [
-//            'valueEmptyString' => [
-//                '',
-//                null,
-//                false,
-//            ],
-//            'emptyStringDefaultAlsoEmptyString' => [
-//                '',
-//                ['Default' => ''],
-//                true,
-//            ],
-//            'valueIsArray' => [
-//                ['foo', 'bar'],
-//                null,
-//                true,
-//            ],
-//            'valueIsInt' => [
-//                5,
-//                null,
-//                true,
-//            ],
-//            'valueIsString' => [
-//                'fooBar',
-//                null,
-//                true,
-//            ],
-//            'valueIsBool' => [
-//                true,
-//                null,
-//                false,
-//            ],
+            'valueEmptyString' => [
+                '',
+                null,
+                false,
+            ],
+            'emptyStringDefaultAlsoEmptyString' => [
+                '',
+                ['Default' => ''],
+                true,
+            ],
+            'valueIsArray' => [
+                ['foo', 'bar'],
+                null,
+                true,
+            ],
+            'valueIsInt' => [
+                5,
+                null,
+                true,
+            ],
+            'valueIsString' => [
+                'fooBar',
+                null,
+                true,
+            ],
+            'valueIsBool' => [
+                true,
+                null,
+                false,
+            ],
             'valueIsEmptyStringFieldIsArrayObjectWithEnumTrue' => [
                 '',
                 new \ArrayObject(['Enum' => [

--- a/tests/Library/Core/ValidateRequiredTest.php
+++ b/tests/Library/Core/ValidateRequiredTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @author Richard Flynn <richard.flynn@vanillaforums.com>
- * @copyright 2009-2019 Vanilla Forums Inc.
+ * @copyright 2009-2020 Vanilla Forums Inc.
  * @license GPL-2.0-only
  */
 
@@ -27,7 +27,7 @@ class ValidateRequiredTest extends TestCase {
         $actual = validateRequired($testValue, $testField);
         $this->assertSame($expected, $actual);
     }
-
+    
     /**
      * Provide test data for {@link testValidateRequired()}
      *
@@ -63,6 +63,26 @@ class ValidateRequiredTest extends TestCase {
             'valueIsBool' => [
                 true,
                 null,
+                false,
+            ],
+            'valueIsEmptyStringFieldIsArrayObjectWithEnumTrue' => [
+                '',
+                new \ArrayObject(array('Enum' => array (
+                    0 => '',
+                    1 => 'declined',
+                    2 => 'given',
+                    3 => 'pending',
+                ))),
+                true,
+            ],
+            'valueIsEmptyStringFieldIsArrayObjectWithEnumFalse' => [
+                '',
+                new \ArrayObject(array('Enum' => array (
+                    0 => 'foo',
+                    1 => 'declined',
+                    2 => 'given',
+                    3 => 'pending',
+                ))),
                 false,
             ],
         ];


### PR DESCRIPTION
Please make sure these points are completed:

Along with vanilla/internal#2197, this will close issue vanilla/support#1239

The updated comboBreaker data was not being saved to the db. 
Because the badge status was an empty string and didn't have a default value of null, it was not passing validation. This fix adds logic to validateRequired() in functions.validation that allows it to pass validation.

### To Test:
* Open the GDN_UserBadge table
* Give a user a badge
* Verify that the Attributes field for the comboBreaker badge (BadgeID = 3) updates with a new event
* Give that user 4 more badges
* Verify that the status field for the comboBreaker badge switches from NULL to given