### PR TITLE
Fix analytics events firing incorrectly

### DIFF
--- a/library/src/scripts/Router.tsx
+++ b/library/src/scripts/Router.tsx
@@ -12,6 +12,7 @@ import NotFoundPage from "@library/routing/NotFoundPage";
 import { BackRoutingProvider } from "@library/routing/links/BackRoutingProvider";
 import { BackgroundsProvider } from "./layout/Backgrounds";
 import { SplashContextProvider } from "@library/splash/SplashContext";
+import { initPageViewTracking } from "@library/pageViews/pageViewTracking";
 
 interface IProps {
     disableDynamicRouting?: boolean;
@@ -23,6 +24,10 @@ export function Router(props: IProps) {
     const { onRouteChange } = props;
     const history = useMemo(() => createBrowserHistory({ basename: formatUrl("") }), []);
     const [previousPath, setPreviousPath] = useState(window.location.pathname);
+
+    useEffect(() => {
+        initPageViewTracking(history);
+    }, [history]);
 
     useEffect(() => {
         if (onRouteChange) {

--- a/library/src/scripts/Router.tsx
+++ b/library/src/scripts/Router.tsx
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import React, { useMemo, useEffect } from "react";
+import React, { useMemo, useEffect, useState } from "react";
 import { LinkContextProvider } from "@library/routing/links/LinkContextProvider";
 import { Router as ReactRouter, Switch, Route } from "react-router-dom";
 import { formatUrl } from "@library/utility/appUtils";
@@ -22,17 +22,21 @@ interface IProps {
 export function Router(props: IProps) {
     const { onRouteChange } = props;
     const history = useMemo(() => createBrowserHistory({ basename: formatUrl("") }), []);
+    const [previousPath, setPreviousPath] = useState(window.location.pathname);
 
     useEffect(() => {
         if (onRouteChange) {
             const unregister = history.listen(() => {
-                window.scrollTo(0, 0);
-                onRouteChange(history);
+                if (previousPath !== window.location.pathname) {
+                    window.scrollTo(0, 0);
+                    onRouteChange(history);
+                    setPreviousPath(window.location.pathname);
+                }
             });
             // Return the cleanup function.
             return unregister;
         }
-    }, [history, onRouteChange]);
+    }, [history, onRouteChange, previousPath]);
 
     let routes = (
         <Switch>

--- a/library/src/scripts/Router.tsx
+++ b/library/src/scripts/Router.tsx
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import React, { useMemo, useEffect, useState } from "react";
+import React, { useMemo, useEffect, useState, useCallback } from "react";
 import { LinkContextProvider } from "@library/routing/links/LinkContextProvider";
 import { Router as ReactRouter, Switch, Route } from "react-router-dom";
 import { formatUrl } from "@library/utility/appUtils";
@@ -12,7 +12,7 @@ import NotFoundPage from "@library/routing/NotFoundPage";
 import { BackRoutingProvider } from "@library/routing/links/BackRoutingProvider";
 import { BackgroundsProvider } from "./layout/Backgrounds";
 import { SplashContextProvider } from "@library/splash/SplashContext";
-import { initPageViewTracking } from "@library/pageViews/pageViewTracking";
+import { initPageViewTracking, usePageChangeListener } from "@library/pageViews/pageViewTracking";
 
 interface IProps {
     disableDynamicRouting?: boolean;
@@ -23,25 +23,17 @@ interface IProps {
 export function Router(props: IProps) {
     const { onRouteChange } = props;
     const history = useMemo(() => createBrowserHistory({ basename: formatUrl("") }), []);
-    const [previousPath, setPreviousPath] = useState(window.location.pathname);
 
     useEffect(() => {
         initPageViewTracking(history);
     }, [history]);
 
-    useEffect(() => {
-        if (onRouteChange) {
-            const unregister = history.listen(() => {
-                if (previousPath !== window.location.pathname) {
-                    window.scrollTo(0, 0);
-                    onRouteChange(history);
-                    setPreviousPath(window.location.pathname);
-                }
-            });
-            // Return the cleanup function.
-            return unregister;
-        }
-    }, [history, onRouteChange, previousPath]);
+    const pageChangeHandler = useCallback(() => {
+        window.scrollTo(0, 0);
+        onRouteChange?.(history);
+    }, [history, onRouteChange]);
+
+    usePageChangeListener(pageChangeHandler);
 
     let routes = (
         <Switch>

--- a/library/src/scripts/analytics/AnalyticsData.tsx
+++ b/library/src/scripts/analytics/AnalyticsData.tsx
@@ -18,7 +18,9 @@ export const AnalyticsData: FC<IProps> = (props: IProps) => {
 
     useEffect(() => {
         document.dispatchEvent(new CustomEvent("pageViewWithContext", { detail: data }));
-    }, [uniqueKey, data]);
+        // Setting data here will cause the analytics event to fired far to often.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [uniqueKey]);
     return <>{null}</>;
 };
 

--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -34,9 +34,12 @@ window.gdn.apiv2 = apiv2;
 
 // Record the page view.
 onPageView((params: { history: History }) => {
-    void apiv2.post("/tick").then(() => {
-        window.dispatchEvent(new CustomEvent("analyticsTick"));
-    });
+    // Low priority so put a slight delay so other network requests run first.
+    setTimeout(() => {
+        void apiv2.post("/tick").then(() => {
+            window.dispatchEvent(new CustomEvent("analyticsTick"));
+        });
+    }, 50);
 });
 
 logDebug("Bootstrapping");

--- a/library/src/scripts/pageViews/pageViewTracking.spec.ts
+++ b/library/src/scripts/pageViews/pageViewTracking.spec.ts
@@ -22,4 +22,18 @@ describe("pageViewTracking", () => {
         history.push("/test1");
         expect(spy.callCount).eq(5, "Further page views are tracked.");
     });
+
+    it("can ignores changes in the hash", () => {
+        const history = createMemoryHistory();
+        const spy = sinon.spy();
+        onPageView(spy);
+        initPageViewTracking(history);
+
+        expect(spy.callCount).eq(1, "the initalization tracks a page view.");
+        history.push("/path2");
+        history.push("/path2#testasd");
+        history.push("/path2#90148");
+        expect(spy.callCount).eq(2, "the hash is ignored");
+        ``;
+    });
 });

--- a/library/src/scripts/pageViews/pageViewTracking.spec.ts
+++ b/library/src/scripts/pageViews/pageViewTracking.spec.ts
@@ -16,6 +16,7 @@ describe("pageViewTracking", () => {
         initPageViewTracking(history);
 
         expect(spy.callCount).eq(1, "the initalization tracks a page view.");
+        expect(spy.args[0][0]).eq(history, "the history object is passed to handlers");
         history.push("/test1");
         history.push("/test3");
         history.push("/test4");
@@ -34,6 +35,5 @@ describe("pageViewTracking", () => {
         history.push("/path2#testasd");
         history.push("/path2#90148");
         expect(spy.callCount).eq(2, "the hash is ignored");
-        ``;
     });
 });

--- a/library/src/scripts/pageViews/pageViewTracking.ts
+++ b/library/src/scripts/pageViews/pageViewTracking.ts
@@ -17,6 +17,20 @@ export function onPageView(handler: PageViewHandler) {
     handlers.push(handler);
 }
 
+export function registerTick() {}
+
+window.onPageView = onPageView;
+
+let previousPath: string | null = null;
+
+function getPreviousPath() {
+    return previousPath;
+}
+
+function setPreviousPath(path: string) {
+    previousPath = path;
+}
+
 /**
  * Initialize tracking of the page history and fire the handlers for the current page.
  */
@@ -26,5 +40,11 @@ export function initPageViewTracking(history: History) {
     };
 
     callHandlers();
-    history.listen(callHandlers);
+    history.listen(() => {
+        if (getPreviousPath() !== history.location.pathname) {
+            callHandlers();
+        }
+
+        setPreviousPath(history.location.pathname);
+    });
 }


### PR DESCRIPTION
- Fixes `pageViewWithContext` firing too often.
  - Fired even when hash changed.
  - Was firing any time data object changed. Should only have been firing when the uniqueKey changed. As a result every article preload while looking at the article page triggered a page view.
- Fixes `onPageView` handlers never being called (registration was missing).
- Refactor onPageView to handle unregistering events by using built-in JS event system.
- Adds additional unit tests for page views.
- Expose the `onPageView` event so that it can be used by customers in a javascript theme asset.