### PR TITLE
Fix SchemaFactory not firing events on schema objects

### DIFF
--- a/library/Vanilla/SchemaFactory.php
+++ b/library/Vanilla/SchemaFactory.php
@@ -95,11 +95,13 @@ final class SchemaFactory {
         // Allow the schema ID to be set or overwritten.
         if (!empty($id)) {
             $result->setID($id);
+        } elseif ($schemaID = $schema->getID()) {
+            $id = $schemaID;
         }
 
-        if ($schemaID = $schema->getID()) {
+        if ($id) {
             // Fire an event for schema modification.
-            self::getEventManager()->fire("{$schemaID}Schema_init", $result);
+            self::getEventManager()->fire("{$id}Schema_init", $result);
         }
 
         return $result;


### PR DESCRIPTION
A typo in `SchemaFactory::prepare` caused an event to not be dispatched when expected. The bug is fixed here by checking the proper variable and tests have been implemented to protect against regressions of the behavior.