### PR TITLE
Fix polluted SchemaFactory dependencies in tests

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -28,6 +28,7 @@ use Vanilla\Formatting\FormatService;
 use Vanilla\InjectableInterface;
 use Vanilla\Models\AuthenticatorModel;
 use Vanilla\Models\SSOModel;
+use Vanilla\SchemaFactory;
 use Vanilla\Site\SiteSectionModel;
 use Vanilla\Web\UASniffer;
 use Vanilla\Theme\ThemeFeatures;
@@ -512,6 +513,9 @@ class Bootstrap {
         if (class_exists(\CategoryModel::class)) {
             \CategoryModel::$Categories = null;
         }
+
+        SchemaFactory::setContainer(null);
+        SchemaFactory::setEventManager(null);
 
         unset($GLOBALS['dic']);
         Gdn::setContainer(new NullContainer());


### PR DESCRIPTION
`SchemaFactory` has some static properties set that were persisting between test suites. This was causing errors, so the properties will now be reset as part of the testing cleanup routine.