### PR TITLE
Fix theme reset from getting applied to old themes

### DIFF
--- a/applications/dashboard/src/scripts/entries/forum.tsx
+++ b/applications/dashboard/src/scripts/entries/forum.tsx
@@ -22,6 +22,7 @@ import { TitleBarHamburger } from "@library/headers/TitleBarHamburger";
 import { authReducer } from "@dashboard/auth/authReducer";
 import { compatibilityStyles } from "@dashboard/compatibilityStyles";
 import { applyCompatibilityIcons } from "@dashboard/compatibilityStyles/compatibilityIcons";
+import { fullBackgroundCompat } from "@vanilla/library/src/scripts/layout/Backgrounds";
 
 initAllUserContent();
 onContent(convertAllUserContent);
@@ -46,6 +47,7 @@ addComponent("App", () => (
 addComponent("title-bar-hamburger", TitleBarHamburger);
 
 if (getMeta("themeFeatures.DataDrivenForumColors", false)) {
+    fullBackgroundCompat();
     compatibilityStyles();
     applyCompatibilityIcons();
 }

--- a/library/src/scripts/theming/ThemeProvider.tsx
+++ b/library/src/scripts/theming/ThemeProvider.tsx
@@ -14,7 +14,7 @@ import { prepareShadowRoot } from "@vanilla/dom-utils";
 import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { loadThemeFonts } from "./loadThemeFonts";
-import { Backgrounds, BackgroundsProvider, fullBackgroundCompat } from "@library/layout/Backgrounds";
+import { Backgrounds, BackgroundsProvider } from "@library/layout/Backgrounds";
 import { BrowserRouter } from "react-router-dom";
 
 interface IProps {
@@ -71,7 +71,6 @@ export const ThemeProvider: React.FC<IProps> = (props: IProps) => {
     }, [assets, disabled, setTopOffset, variablesOnly, getAssets, themeKey]);
 
     if (props.disabled || props.variablesOnly) {
-        fullBackgroundCompat();
         return <>{props.children}</>;
     }
 


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/1337
Fixes https://github.com/vanilla/support/issues/1338
Fixes https://github.com/vanilla/support/issues/1339

We were not doing a proper check before applying the compatibility backgrounds styles. These should only be applied in the forum, when the proper theme feature flag is applied.