### PR TITLE
Filter emojis when parsing Image Urls in HtmlFormatter

### DIFF
--- a/library/Vanilla/Formatting/FormatService.php
+++ b/library/Vanilla/Formatting/FormatService.php
@@ -38,7 +38,7 @@ class FormatService {
      * Format a particular string.
      *
      * @param string $content The content to render.
-     * @param string $format The format of the content.
+     * @param string|null $format The format of the content.
      *
      * @return string
      *
@@ -56,11 +56,11 @@ class FormatService {
      * Render a safe, sanitized, short version of some content.
      *
      * @param string $content The content to render.
-     * @param string $format The format of the content.
+     * @param string|null $format The format of the content.
      *
      * @return string
      */
-    public function renderExcerpt(string $content, ?string $format ): string {
+    public function renderExcerpt(string $content, ?string $format): string {
         return $this
             ->getFormatter($format)
             ->renderExcerpt($content);
@@ -70,7 +70,7 @@ class FormatService {
      * Render a plain text version of some content.
      *
      * @param string $content The content to render.
-     * @param string $format The format of the content.
+     * @param string|null $format The format of the content.
      *
      * @return string
      */
@@ -84,7 +84,7 @@ class FormatService {
      * Render a version of the content suitable to be quoted in other content.
      *
      * @param string $content The raw content to render.
-     * @param string $format The format of the content.
+     * @param string|null $format The format of the content.
      *
      * @return string
      */
@@ -98,7 +98,7 @@ class FormatService {
      * Parse attachment data from a message.
      *
      * @param string $content The content the parse.
-     * @param string $format The format of the content.
+     * @param string|null $format The format of the content.
      *
      * @return Attachment[]
      */
@@ -112,7 +112,7 @@ class FormatService {
      * Parse images out of the post contents.
      *
      * @param string $content
-     * @param string $format The format of the content.
+     * @param string|null $format The format of the content.
      *
      * @return string[]
      */
@@ -126,7 +126,7 @@ class FormatService {
      * Parse out a list of headings from the post contents.
      *
      * @param string $content The raw content to parse.
-     * @param string $format The format of the content.
+     * @param string|null $format The format of the content.
      *
      * @return Heading[]
      */
@@ -140,7 +140,7 @@ class FormatService {
      * Parse out a list of usernames mentioned in the post contents.
      *
      * @param string $content The content the parse.
-     * @param string $format The format of the content.
+     * @param string|null $format The format of the content.
      *
      * @return string[] A list of usernames.
      */

--- a/library/Vanilla/Formatting/FormatService.php
+++ b/library/Vanilla/Formatting/FormatService.php
@@ -28,7 +28,7 @@ class FormatService {
      *
      * @return string
      */
-    public function renderHTML(string $content, string $format): string {
+    public function renderHTML(string $content, ?string $format): string {
         return $this
             ->getFormatter($format)
             ->renderHTML($content);
@@ -45,7 +45,7 @@ class FormatService {
      * @throws FormattingException If the post content wasn't valid and couldn't be filtered.
      * @throws FormatterNotFoundException If the format doesn't have a match.
      */
-    public function filter(string $content, string $format): string {
+    public function filter(string $content, ?string $format): string {
         return $this
             ->getFormatter($format, true)
             ->filter($content);
@@ -60,7 +60,7 @@ class FormatService {
      *
      * @return string
      */
-    public function renderExcerpt(string $content, string $format): string {
+    public function renderExcerpt(string $content, ?string $format ): string {
         return $this
             ->getFormatter($format)
             ->renderExcerpt($content);
@@ -74,7 +74,7 @@ class FormatService {
      *
      * @return string
      */
-    public function renderPlainText(string $content, string $format): string {
+    public function renderPlainText(string $content, ?string $format): string {
         return $this
             ->getFormatter($format)
             ->renderPlainText($content);
@@ -88,7 +88,7 @@ class FormatService {
      *
      * @return string
      */
-    public function renderQuote(string $content, string $format): string {
+    public function renderQuote(string $content, ?string $format): string {
         return $this
             ->getFormatter($format)
             ->renderQuote($content);
@@ -102,7 +102,7 @@ class FormatService {
      *
      * @return Attachment[]
      */
-    public function parseAttachments(string $content, string $format): array {
+    public function parseAttachments(string $content, ?string $format): array {
         return $this
             ->getFormatter($format)
             ->parseAttachments($content);
@@ -116,7 +116,7 @@ class FormatService {
      *
      * @return string[]
      */
-    public function parseImageUrls(string $content, string $format): array {
+    public function parseImageUrls(string $content, ?string $format): array {
         return $this
             ->getFormatter($format)
             ->parseImageUrls($content);
@@ -130,7 +130,7 @@ class FormatService {
      *
      * @return Heading[]
      */
-    public function parseHeadings(string $content, string $format): array {
+    public function parseHeadings(string $content, ?string $format): array {
         return $this
             ->getFormatter($format)
             ->parseHeadings($content);
@@ -144,7 +144,7 @@ class FormatService {
      *
      * @return string[] A list of usernames.
      */
-    public function parseMentions(string $content, string $format): array {
+    public function parseMentions(string $content, ?string $format): array {
         return $this
             ->getFormatter($format)
             ->parseMentions($content);
@@ -193,8 +193,8 @@ class FormatService {
      * @return FormatInterface
      * @throws FormatterNotFoundException If $throw === true &&  the formatter that was requested could not be found.
      */
-    private function getFormatter(string $formatKey, $throw = false): FormatInterface {
-        $formatKey = strtolower($formatKey);
+    private function getFormatter(?string $formatKey, $throw = false): FormatInterface {
+        $formatKey = strtolower($formatKey) ?? null;
         $format = $this->formats[$formatKey] ?? null;
         $errorMessage = "Unable to find a formatter for the formatKey $formatKey.";
         if (!$format) {

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -185,6 +185,9 @@ class HtmlFormat extends BaseFormat {
         /** @var \DOMNode $domImages */
         foreach ($domImages as $domImage) {
             $src = $domImage->getAttribute('src');
+            if (preg_match("/emoji/", $src)) {
+                continue;
+            }
             if ($src) {
                 $imageUrls[] = $src;
             }

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -184,8 +184,9 @@ class HtmlFormat extends BaseFormat {
 
         /** @var \DOMNode $domImages */
         foreach ($domImages as $domImage) {
+            $domImageClass = $domImage->getAttribute('class');
             $src = $domImage->getAttribute('src');
-            if (preg_match("/emoji/", $src)) {
+            if ($domImageClass === 'emoji') {
                 continue;
             }
             if ($src) {

--- a/tests/Library/Vanilla/Formatting/Formats/AbstractFormatTestCase.php
+++ b/tests/Library/Vanilla/Formatting/Formats/AbstractFormatTestCase.php
@@ -8,6 +8,7 @@
 namespace VanillaTests\Library\Vanilla\Formatting\Formats;
 
 use Vanilla\Contracts\Formatting\FormatInterface;
+use Vanilla\Formatting\FormatService;
 use VanillaTests\MinimalContainerTestCase;
 use VanillaTests\Fixtures\Formatting\FormatFixture;
 use VanillaTests\Library\Vanilla\Formatting\AssertsFixtureRenderingTrait;
@@ -214,6 +215,15 @@ abstract class AbstractFormatTestCase extends MinimalContainerTestCase {
             $expectedOutput,
             $format->parseMentions($input)
         );
+    }
+
+    /**
+     * Test parseImageUrls when the format is null.
+     */
+    public function testParseImageUrlsNullFormat() {
+        $formatService =  self::container()->get(FormatService::class);
+        $result = $formatService->parseImageUrls('test content', null);
+        $this->assertEquals([], $result, 'NotFoundFormat::parseImageUrl returns an empty array');
     }
 
     /**


### PR DESCRIPTION
Filters out emoji images when parsing image urls.

closes vanilla/support#1236
related to https://github.com/vanilla/support/issues/1236