### PR TITLE
Merge pull request #10005 from vanilla/fix/theming-reset

### DIFF
--- a/applications/dashboard/src/scripts/entries/admin.tsx
+++ b/applications/dashboard/src/scripts/entries/admin.tsx
@@ -12,7 +12,7 @@ import { addComponent, disableComponentTheming } from "@library/utility/componen
 import { DashboardImageUploadGroup } from "@dashboard/forms/DashboardImageUploadGroup";
 import { mountReact } from "@vanilla/react-utils/src";
 import { ErrorPage } from "@library/errorPages/ErrorComponent";
-import { Backgrounds } from "@vanilla/library/src/scripts/layout/Backgrounds";
+import "@library/theming/reset";
 
 addComponent("imageUploadGroup", DashboardImageUploadGroup, { overwrite: true });
 

--- a/library/src/scripts/layout/Backgrounds.tsx
+++ b/library/src/scripts/layout/Backgrounds.tsx
@@ -7,8 +7,6 @@
 import React, { ReactNode, useContext, useEffect, useState } from "react";
 import { fullBackgroundClasses, bodyCSS } from "@library/layout/bodyStyles";
 import { useHistory } from "react-router";
-import { LoadStatus } from "@library/@types/api/core";
-import "@library/theming/reset";
 
 interface IProps {
     isHomePage?: boolean;


### PR DESCRIPTION
The theme reset was being applied through `<Backgrounds />` which applies to everywhere (through `<ThemeProvider />`). This reset could cause issues with older themes if this went out to production in its current state.

- Move the reset to apply to the dashboard only.
- Reset is applied in the knowledge base here. https://github.com/vanilla/knowledge/pull/1494