### PR TITLE
Fix HTML being unnecessarily encoded in form error messages

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1140,9 +1140,6 @@ class EntryController extends Gdn_Controller {
                                 'Reason' => 'Password',
                             ]);
                         }
-                    } catch (Gdn_SanitizedUserException $ex) {
-                        $errorMessage = $ex->getMessage();
-                        $this->Form->addError($errorMessage);
                     } catch (Gdn_UserException $ex) {
                         $this->Form->addError($ex);
                     }


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1343

