### PR TITLE
Change log deleted record url

### DIFF
--- a/applications/dashboard/views/log/table.php
+++ b/applications/dashboard/views/log/table.php
@@ -38,7 +38,6 @@ include $this->fetchViewLocation('helper_functions');
                 } elseif ($Row['Operation'] === 'Delete') {
                     switch (strtolower($Row['RecordType'])) {
                         case 'comment':
-                            $Url = "/discussion/{$Row['ParentRecordID']}/x/p1";
                             $Url = "/log/filter?recordType=comment&recordID={$Row['RecordID']}";
                     }
                 }

--- a/applications/dashboard/views/log/table.php
+++ b/applications/dashboard/views/log/table.php
@@ -39,6 +39,7 @@ include $this->fetchViewLocation('helper_functions');
                     switch (strtolower($Row['RecordType'])) {
                         case 'comment':
                             $Url = "/discussion/{$Row['ParentRecordID']}/x/p1";
+                            $Url = "/log/filter?recordType=comment&recordID={$Row['RecordID']}";
                     }
                 }
 


### PR DESCRIPTION
Issue reported here: https://github.com/vanillaforums/mse/issues/64#issuecomment-578261937

During implementation, I think there was one step missing, where mods/admins could click on the record link and it would take the user to the record's "change history".