### PR TITLE
Fix convert to discussion being broken

### DIFF
--- a/applications/dashboard/src/scripts/entries/common.tsx
+++ b/applications/dashboard/src/scripts/entries/common.tsx
@@ -8,20 +8,22 @@ import { onReady } from "@library/utility/appUtils";
 import { addComponent } from "@library/utility/componentRegistry";
 import Toast from "@library/features/toaster/Toast";
 import { ThemePreviewToast } from "@library/features/toaster/themePreview/ThemePreviewToast";
-import { mountModal } from "@library/modal/Modal";
 import { themePreviewToastReducer } from "@library/features/toaster/themePreview/ThemePreviewToastReducer";
 import { registerReducer } from "@library/redux/reducerRegistry";
 import { AppContext } from "@library/AppContext";
+import { mountPortal } from "@vanilla/react-utils";
+
+const PREVIEW_CONTAINER = "previewContainer";
 
 // Routing
 
 registerReducer("themePreviewToaster", themePreviewToastReducer);
 addComponent("toaster", Toast);
 onReady(() => {
-    const themePreviewContainer = document.body;
-    mountModal(
+    mountPortal(
         <AppContext noWrap noTheme>
             <ThemePreviewToast />
         </AppContext>,
+        PREVIEW_CONTAINER,
     );
 });

--- a/library/src/scripts/embeddedContent/embedService.tsx
+++ b/library/src/scripts/embeddedContent/embedService.tsx
@@ -24,7 +24,6 @@ import { EmbedErrorBoundary } from "@library/embeddedContent/EmbedErrorBoundary"
 import { useUniqueID, uniqueIDFromPrefix } from "@library/utility/idUtils";
 import { visibility } from "@library/styles/styleHelpers";
 import ScreenReaderContent from "@library/layout/ScreenReaderContent";
-import { mountModal } from "@library/modal/Modal";
 
 export const FOCUS_CLASS = "embed-focusableElement";
 export const EMBED_DESCRIPTION_ID = uniqueIDFromPrefix("embed-description");

--- a/library/src/scripts/modal/Modal.tsx
+++ b/library/src/scripts/modal/Modal.tsx
@@ -10,6 +10,7 @@ import { logWarning, debug } from "@vanilla/utils";
 import React, { ReactElement } from "react";
 import ReactDOM from "react-dom";
 import { TabHandler } from "@vanilla/dom-utils";
+import { mountPortal } from "@vanilla/react-utils";
 
 interface IProps {
     className?: string;
@@ -37,28 +38,12 @@ export const MODAL_CONTAINER_ID = "modals";
 export const PAGE_CONTAINER_ID = "page";
 
 /**
- * Mount a modal with ReactDOM. This is only needed at the top level context.
+ * Mount a modal from a top level context.
  *
  * If you are already in a react context, just use `<Modal />`.
- * Note: Using this will clear any other modals mounted with this component.
- *
- * @param element The <Modal /> element to render.
  */
-export function mountModal(element: ReactElement<any>) {
-    // Ensure we have our modal container.
-    let modals = document.getElementById(MODAL_CONTAINER_ID);
-    if (!modals) {
-        modals = document.createElement("div");
-        modals.id = MODAL_CONTAINER_ID;
-        document.body.appendChild(modals);
-    } else {
-        ReactDOM.unmountComponentAtNode(modals);
-    }
-
-    ReactDOM.render(
-        element,
-        modals, // Who cares where we go. This is a portal anyways.
-    );
+export function mountModal(node: ReactElement<any>) {
+    return mountPortal(node, MODAL_CONTAINER_ID);
 }
 
 /**
@@ -88,7 +73,7 @@ export default class Modal extends React.Component<IProps, IState> {
             return null;
         }
 
-        const portal = ReactDOM.createPortal(
+        return mountPortal(
             <>
                 <ModalView
                     onDestroyed={this.handleDestroyed}
@@ -107,9 +92,9 @@ export default class Modal extends React.Component<IProps, IState> {
                 </ModalView>
                 {this.props.afterContent}
             </>,
-            this.getModalContainer(),
+            MODAL_CONTAINER_ID,
+            true,
         );
-        return portal;
     }
 
     /**
@@ -188,16 +173,6 @@ Please wrap your primary content area with the ID "${PAGE_CONTAINER_ID}" so it c
         }
 
         this.closeFocusElement?.focus();
-    }
-
-    private getModalContainer(): HTMLElement {
-        let container = document.getElementById(MODAL_CONTAINER_ID)!;
-        if (container === null) {
-            container = document.createElement("div");
-            container.id = MODAL_CONTAINER_ID;
-            document.body.appendChild(container);
-        }
-        return container;
     }
 
     private getPageContainer(): HTMLElement | null {

--- a/packages/vanilla-react-utils/src/mounting.spec.tsx
+++ b/packages/vanilla-react-utils/src/mounting.spec.tsx
@@ -1,0 +1,47 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { mountPortal } from "./mounting";
+
+function HelloWorld(props: { id: string }) {
+    return <div className="helloworld" id={props.id}></div>;
+}
+
+function PortalWorld(props: { id: string; contentID: string }) {
+    return (
+        <div className="portal" id={props.id}>
+            <HelloWorld id={props.contentID} />
+        </div>
+    );
+}
+
+describe("mountPortal", () => {
+    it("can create it's own container", async () => {
+        document.body.innerHTML = "<div></div>";
+        await mountPortal(<HelloWorld id={"world1-item"} />, "world1-cont");
+        expect(document.getElementById("world1-cont")).toBeDefined();
+        expect(document.getElementById("world1-item")).toBeDefined();
+    });
+
+    it("can override an existing container", async () => {
+        document.body.innerHTML = "<div></div>";
+        await mountPortal(<HelloWorld id={"world1-item"} />, "world1-cont");
+        await mountPortal(<HelloWorld id={"world1-item2"} />, "world1-cont");
+        expect(document.getElementById("world1-cont")).toBeDefined();
+        expect(document.getElementById("world1-item")).toBeNull();
+        expect(document.getElementById("world1-item2")).toBeDefined();
+    });
+
+    it("can be used as a portal to override existing containers", async () => {
+        document.body.innerHTML = "<div></div>";
+        await mountPortal(<HelloWorld id={"world1-item"} />, "world1-cont");
+        await mountPortal(<PortalWorld id={"world1-portal"} contentID={"world1-item2"} />, "world1-cont");
+        expect(document.getElementById("world1-cont")).toBeDefined();
+        expect(document.getElementById("world1-item")).toBeNull();
+        expect(document.getElementById("world1-portal")).toBeDefined();
+        expect(document.getElementById("world1-item2")).toBeDefined();
+    });
+});

--- a/packages/vanilla-react-utils/src/mounting.ts
+++ b/packages/vanilla-react-utils/src/mounting.ts
@@ -77,6 +77,8 @@ export function mountPortal(element: ReactElement<any>, containerID: string, asP
     if (asPortal) {
         return ReactDOM.createPortal(element, container);
     } else {
-        ReactDOM.render(element, container);
+        return new Promise(resolve => {
+            ReactDOM.render(element, container, () => resolve());
+        });
     }
 }

--- a/packages/vanilla-react-utils/src/mounting.ts
+++ b/packages/vanilla-react-utils/src/mounting.ts
@@ -5,6 +5,7 @@
 
 import ReactDOM from "react-dom";
 import { forceRenderStyles } from "typestyle";
+import { ReactElement } from "react";
 
 export interface IComponentMountOptions {
     overwrite?: boolean;
@@ -50,4 +51,32 @@ export function mountReact(
         forceRenderStyles();
         callback && callback();
     });
+}
+
+/**
+ * Mount a modal with ReactDOM. This is only needed at the top level context.
+ *
+ * If you are already in a react context, just use `<Modal />`.
+ * Note: Using this will clear any other modals mounted with this component.
+ *
+ * @param element The <Modal /> element to render.
+ * @param containerID The container to render the modal into. Defaults to modal container.
+ * @param asPortal Whether or not we should render as a portal or a render.
+ */
+export function mountPortal(element: ReactElement<any>, containerID: string, asPortal: boolean = false) {
+    // Ensure we have our modal container.
+    let container = document.getElementById(containerID);
+    if (!container) {
+        container = document.createElement("div");
+        container.id = containerID;
+        document.body.appendChild(container);
+    } else {
+        ReactDOM.unmountComponentAtNode(container);
+    }
+
+    if (asPortal) {
+        return ReactDOM.createPortal(element, container);
+    } else {
+        ReactDOM.render(element, container);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/1354

_Note: Reproducing this issues requires a production build. To run one quickly, disable hot reload config, and run `yarn build --debug`_

- When we added the theme preview card, we used mountModal.
- mountModal tries takes over the entire modal container.
- The actual Modal component did not have the unmounting behaviour of mountModal, so it would try to render into the container before clearing it.
- This caused a fatal react error, because react does not automatically call `unmountComponentAtNode` when using `React.createPortal`
- This never showed up in developer builds because the load order of modules is not the same.

The fix

- Extract a new function mountPortal, that cleans up the mounting container and attaches to the end of the document.
- Update Modal to use mountPortal (now cleans the container properly).
- Update theme preview card to use mountPortal.
- Render the preview card into a different portal container so that it doesn't get unmounted by a knowledge modal.
