### PR TITLE
Prepare new banner variables for use in custom themes

### DIFF
--- a/applications/dashboard/src/scripts/forms/DashboardFormSubheading.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardFormSubheading.tsx
@@ -1,0 +1,17 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import classNames from "classnames";
+
+interface IProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function DashboardFormSubheading(props: IProps) {
+    return (
+        <li>
+            <h2 {...props} className={classNames("subheading", props.className)}></h2>
+        </li>
+    );
+}

--- a/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
@@ -11,6 +11,8 @@ import { t } from "@vanilla/i18n";
 import { uploadFile } from "@library/apiv2";
 import { IFieldError } from "@library/@types/api/core";
 import ErrorMessages from "@library/forms/ErrorMessages";
+import ButtonLoader from "@vanilla/library/src/scripts/loaders/ButtonLoader";
+import { ButtonTypes } from "@vanilla/library/src/scripts/forms/buttonStyles";
 
 interface IProps {
     value: string | null; // The image url
@@ -26,6 +28,7 @@ interface IProps {
 export function DashboardImageUpload(props: IProps) {
     const { inputID, labelType } = useFormGroup();
     const imageUploader = props.imageUploader || uploadFile;
+    const [isLoading, setIsLoading] = useState(false);
     const [name, setName] = useState<string | null>(null);
     const [uploadError, setUploadError] = useState<Error | null>(null);
 
@@ -57,6 +60,7 @@ export function DashboardImageUpload(props: IProps) {
                             return;
                         }
 
+                        setIsLoading(true);
                         setName(file.name);
                         const tempUrl = URL.createObjectURL(file);
                         props.onImagePreview && props.onImagePreview(tempUrl);
@@ -67,13 +71,17 @@ export function DashboardImageUpload(props: IProps) {
                             const uploaded = await imageUploader(file);
                             valueRef.current = uploaded.url;
                             props.onChange(uploaded.url);
+                            setIsLoading(false);
                         } catch (e) {
                             setUploadError(e);
+                            setIsLoading(false);
                         }
                     }}
                 />
                 <span className="file-upload-choose">{name || fallbackName || props.placeholder || t("Choose")}</span>
-                <span className="file-upload-browse">{t("Browse")}</span>
+                <span className="file-upload-browse">
+                    {isLoading ? <ButtonLoader buttonType={ButtonTypes.DASHBOARD_PRIMARY} /> : t("Browse")}
+                </span>
             </label>
             {props.errors && <ErrorMessages errors={props.errors} />}
             {uploadError && (

--- a/library/Vanilla/Theme/ThemeFeatures.php
+++ b/library/Vanilla/Theme/ThemeFeatures.php
@@ -27,13 +27,14 @@ class ThemeFeatures {
         'SharedMasterView' => false,
         'ProfileHeader' => false,
         'DataDrivenTheme' => false,
+        'DisableKludgedVars' => false,
     ];
 
     /**
      * Constuctor.
      *
      * @param ConfigurationInterface $config
-     * @param Addon|null $theme
+     * @param ThemeModel $themeModel
      */
     public function __construct(ConfigurationInterface $config, ThemeModel $themeModel) {
         $this->config = $config;
@@ -51,6 +52,14 @@ class ThemeFeatures {
             'NewFlyouts' => $this->config->get('Feature.NewFlyouts.Enabled'),
         ];
         $themeValues = $this->theme->getInfoValue('Features', []);
+        if ($themeValues['DataDrivenTheme'] ?? false) {
+            // Data driven themes automatically enables other theme features.
+            $themeValues['DisableKludgedVars'] = true;
+            $themeValues['ProfileHeader'] = true;
+            $themeValues['SharedMasterView'] = true;
+            $themeValues['NewFlyouts'] = true;
+        }
+
         return array_merge(self::FEATURE_DEFAULTS, $configValues, $themeValues);
     }
 
@@ -80,5 +89,12 @@ class ThemeFeatures {
      */
     public function useDataDrivenTheme(): bool {
         return (bool) $this->allFeatures()['DataDrivenTheme'];
+    }
+
+    /**
+     * @return bool
+     */
+    public function disableKludgedVars(): bool {
+        return (bool) $this->allFeatures()['DisableKludgedVars'];
     }
 }

--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -27,7 +27,8 @@ interface IProps {
     title?: string; // Often the message to display isn't the real H1
     description?: React.ReactNode;
     className?: string;
-    image?: string;
+    backgroundImage?: string;
+    contentImage?: string;
 }
 
 /**
@@ -45,8 +46,8 @@ export default function Banner(props: IProps) {
     const vars = bannerVariables();
     const { options } = vars;
 
-    const isImageBg = vars.options.imageType === "background";
-    const imageSrc = assetUrl(props.image ?? vars.outerBackground.image ?? "");
+    let imageElementSrc = props.contentImage || vars.imageElement.image || null;
+    imageElementSrc = imageElementSrc ? assetUrl(imageElementSrc) : null;
 
     return (
         <div
@@ -55,46 +56,52 @@ export default function Banner(props: IProps) {
                 [classesTitleBar.negativeSpacer]: varsTitleBar.fullBleed.enabled,
             })}
         >
-            <div className={classNames(classes.outerBackground(props.image ?? undefined))}>
-                {!props.image && !vars.outerBackground.image && <DefaultBannerBg />}
+            <div className={classNames(classes.outerBackground(props.backgroundImage ?? undefined))}>
+                {!props.backgroundImage && !vars.outerBackground.image && <DefaultBannerBg />}
             </div>
-            {vars.backgrounds.useOverlay && isImageBg && <div className={classes.backgroundOverlay} />}
+            {vars.backgrounds.useOverlay && <div className={classes.backgroundOverlay} />}
             <Container>
-                {options.imageType === "element" && <img className={classes.imageElement} src={imageSrc}></img>}
-                <div className={classes.innerContainer}>
-                    <PanelWidgetHorizontalPadding className={classes.widget}>
-                        <div className={classes.titleWrap}>
-                            <FlexSpacer className={classes.titleFlexSpacer} />
-                            {title && <Heading title={title} className={classes.title} />}
-                            <div className={classNames(classes.text, classes.titleFlexSpacer)}>{action}</div>
+                <PanelWidgetHorizontalPadding>
+                    <div className={imageElementSrc ? classes.imagePositioner : ""}>
+                        <div className={classes.contentContainer}>
+                            <div className={classes.titleWrap}>
+                                <FlexSpacer className={classes.titleFlexSpacer} />
+                                {title && <Heading title={title} className={classes.title} />}
+                                <div className={classNames(classes.text, classes.titleFlexSpacer)}>{action}</div>
+                            </div>
+                            {!options.hideDesciption && description && (
+                                <div className={classes.descriptionWrap}>
+                                    <p className={classNames(classes.description, classes.text)}>{description}</p>
+                                </div>
+                            )}
+                            {!options.hideSearch && (
+                                <div className={classes.searchContainer}>
+                                    <IndependentSearch
+                                        buttonClass={classes.searchButton}
+                                        buttonBaseClass={ButtonTypes.CUSTOM}
+                                        isLarge={true}
+                                        placeholder={t("Search")}
+                                        inputClass={classes.input}
+                                        iconClass={classes.icon}
+                                        buttonLoaderClassName={classes.buttonLoader}
+                                        hideSearchButton={
+                                            device === Devices.MOBILE ||
+                                            device === Devices.XS ||
+                                            vars.searchButtonOptions.type === SearchBarButtonType.NONE
+                                        }
+                                        contentClass={classes.content}
+                                        valueContainerClasses={classes.valueContainer}
+                                    />
+                                </div>
+                            )}
                         </div>
-                        {!options.hideDesciption && description && (
-                            <div className={classes.descriptionWrap}>
-                                <p className={classNames(classes.description, classes.text)}>{description}</p>
+                        {imageElementSrc && (
+                            <div className={classes.imageElementContainer}>
+                                <img className={classes.imageElement} src={imageElementSrc}></img>
                             </div>
                         )}
-                        {!options.hideSearch && (
-                            <div className={classes.searchContainer}>
-                                <IndependentSearch
-                                    buttonClass={classes.searchButton}
-                                    buttonBaseClass={ButtonTypes.CUSTOM}
-                                    isLarge={true}
-                                    placeholder={t("Search")}
-                                    inputClass={classes.input}
-                                    iconClass={classes.icon}
-                                    buttonLoaderClassName={classes.buttonLoader}
-                                    hideSearchButton={
-                                        device === Devices.MOBILE ||
-                                        device === Devices.XS ||
-                                        vars.searchButtonOptions.type === SearchBarButtonType.NONE
-                                    }
-                                    contentClass={classes.content}
-                                    valueContainerClasses={classes.valueContainer}
-                                />
-                            </div>
-                        )}
-                    </PanelWidgetHorizontalPadding>
-                </div>
+                    </div>
+                </PanelWidgetHorizontalPadding>
             </Container>
         </div>
     );

--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -38,7 +38,7 @@ export default function Banner(props: IProps) {
     const device = useDevice();
     const ref = useBannerContainerDivRef();
 
-    const { action, className, title, description } = props;
+    const { action, className, title } = props;
 
     const varsTitleBar = titleBarVariables();
     const classesTitleBar = titleBarClasses();
@@ -48,6 +48,7 @@ export default function Banner(props: IProps) {
 
     let imageElementSrc = props.contentImage || vars.imageElement.image || null;
     imageElementSrc = imageElementSrc ? assetUrl(imageElementSrc) : null;
+    const description = props.description ?? vars.description.text;
 
     return (
         <div

--- a/library/src/scripts/banner/banner.story.tsx
+++ b/library/src/scripts/banner/banner.story.tsx
@@ -14,6 +14,7 @@ import { color } from "csx";
 import Banner from "@library/banner/Banner";
 import { SearchBarButtonType } from "@library/headers/mebox/pieces/compactSearchStyles";
 import { DeviceProvider } from "@library/layout/DeviceContext";
+import { BannerAlignment } from "@library/banner/bannerStyles";
 
 export default {
     title: "Banner",
@@ -104,7 +105,7 @@ export const LeftAligned = storyWithConfig(
         themeVars: {
             banner: {
                 options: {
-                    alignment: "left",
+                    alignment: BannerAlignment.LEFT,
                 },
             },
         },
@@ -165,23 +166,25 @@ export const ImageAsElement = storyWithConfig(
                 },
             },
             banner: {
+                options: {
+                    alignment: BannerAlignment.LEFT,
+                },
                 colors: {
                     bg: "#fff",
                     contrast: "#111111",
                 },
                 outerBackground: {
                     color: "#FFF6F5",
-                    image:
-                        "https://user-images.githubusercontent.com/1770056/73575470-438dfe00-4446-11ea-8db7-c3d36da2b3cb.png",
+                    image: "linear-gradient(215.7deg, #FFFDFC 16.08%, #FFF6F5 63.71%), #C4C4C4",
                 },
                 description: {
                     font: {
                         color: "#323232",
                     },
                 },
-                options: {
-                    alignment: "left",
-                    imageType: "element",
+                imageElement: {
+                    image:
+                        "https://user-images.githubusercontent.com/1770056/73629535-7fc98600-4621-11ea-8f0b-06b21dbd59e3.png",
                 },
                 searchButtonOptions: {
                     type: SearchBarButtonType.NONE,
@@ -191,9 +194,6 @@ export const ImageAsElement = storyWithConfig(
                         top: 87,
                         bottom: 87,
                     },
-                },
-                searchBar: {
-                    sizing: { maxWidth: 400 },
                 },
             },
         },

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -154,6 +154,7 @@ export const bannerVariables = useThemeCache(() => {
     });
 
     const description = makeThemeVars("description", {
+        text: undefined as string | undefined,
         font: {
             ...textMixin,
             color: colors.contrast,

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -23,6 +23,7 @@ import {
     EMPTY_SPACING,
     borders,
     IButtonStates,
+    EMPTY_BACKGROUND,
 } from "@library/styles/styleHelpers";
 import { NestedCSSProperties, TLength } from "typestyle/lib/types";
 import { widgetVariables } from "@library/styles/widgetStyleVars";
@@ -31,17 +32,21 @@ import { layoutVariables } from "@library/layout/panelLayoutStyles";
 import { compactSearchVariables, SearchBarButtonType } from "@library/headers/mebox/pieces/compactSearchStyles";
 import { margins, paddings } from "@library/styles/styleHelpersSpacing";
 import { IButtonType } from "@library/forms/styleHelperButtonInterface";
+import { media } from "typestyle";
+
+export enum BannerAlignment {
+    LEFT = "left",
+    CENTER = "center",
+}
 
 export const bannerVariables = useThemeCache(() => {
     const makeThemeVars = variableFactory(["banner", "splash"]);
     const globalVars = globalVariables();
     const widgetVars = widgetVariables();
     const formElVars = formElementsVariables();
-    const layoutVars = layoutVariables();
 
     const options = makeThemeVars("options", {
-        alignment: "center" as "left" | "center",
-        imageType: "background" as "background" | "element",
+        alignment: BannerAlignment.CENTER,
         hideDesciption: false,
         hideSearch: false,
     });
@@ -85,7 +90,9 @@ export const bannerVariables = useThemeCache(() => {
     });
 
     const imageElement = makeThemeVars("imageElement", {
-        width: percent(60),
+        image: undefined as string | undefined,
+        minWidth: 600,
+        disappearingWidth: 500,
         padding: {
             ...EMPTY_SPACING,
             all: globalVars.gutter.size,
@@ -93,11 +100,10 @@ export const bannerVariables = useThemeCache(() => {
     });
 
     const outerBackground = makeThemeVars("outerBackground", {
+        ...EMPTY_BACKGROUND,
         color: colors.primary.lighten("12%"),
         backgroundPosition: "50% 50%",
         backgroundSize: "cover",
-        image: undefined as undefined | string,
-        fallbackImage: undefined as undefined | string,
     });
 
     const innerBackground = makeThemeVars("innerBackground", {
@@ -173,7 +179,7 @@ export const bannerVariables = useThemeCache(() => {
 
     const searchBar = makeThemeVars("searchBar", {
         sizing: {
-            maxWidth: options.alignment === "left" ? layoutVars.contentSizes.full / 2 : 705,
+            maxWidth: 705,
         },
         font: {
             color: colors.fg,
@@ -314,7 +320,6 @@ export const bannerClasses = useThemeCache(() => {
     const mediaQueries = layoutVariables().mediaQueries();
 
     const isCentered = vars.options.alignment === "center";
-    const isImageBg = vars.options.imageType === "background";
     const searchButton = style("searchButton", generateButtonStyleProperties(vars.searchButton), { left: -1 });
 
     const valueContainer = style("valueContainer", {
@@ -334,6 +339,7 @@ export const bannerClasses = useThemeCache(() => {
     const root = style({
         position: "relative",
         backgroundColor: colorOut(vars.outerBackground.color),
+        overflow: "hidden",
     });
 
     const outerBackground = (url?: string) => {
@@ -342,11 +348,6 @@ export const bannerClasses = useThemeCache(() => {
             ...vars.outerBackground,
             image: finalUrl,
         };
-
-        if (vars.options.imageType !== "background") {
-            delete finalVars.image;
-            delete finalVars.fallbackImage;
-        }
 
         return style("outerBackground", {
             ...centeredBackgroundProps(),
@@ -370,12 +371,19 @@ export const bannerClasses = useThemeCache(() => {
         background: colorOut(vars.backgrounds.overlayColor),
     });
 
-    const innerContainer = style(
-        "innerContainer",
+    const contentContainer = style(
+        "contentContainer",
         {
             ...paddings(vars.spacing.padding),
             backgroundColor: vars.innerBackground.bg,
+            minWidth: 500,
         },
+        media(
+            { maxWidth: 500 },
+            {
+                minWidth: "initial",
+            },
+        ),
         mediaQueries.oneColumnDown({
             ...paddings(vars.spacing.paddingMobile),
         }),
@@ -470,10 +478,6 @@ export const bannerClasses = useThemeCache(() => {
         },
     });
 
-    const widget = style("widget", {
-        display: "block",
-    });
-
     const descriptionWrap = style("descriptionWrap", { ...margins(vars.description.margins), ...textWrapMixin });
 
     const description = style("description", {
@@ -492,29 +496,44 @@ export const bannerClasses = useThemeCache(() => {
         },
     });
 
+    const imagePositioner = style("imagePositioner", {
+        display: "flex",
+        flexDirection: "row",
+        flexWrap: "nowrap",
+        alignItems: "center",
+    });
+
+    const imageElementContainer = style(
+        "imageElementContainer",
+        {
+            alignSelf: "stretch",
+            minWidth: unit(vars.imageElement.minWidth),
+            flexGrow: 1,
+            position: "relative",
+        },
+        media(
+            { maxWidth: 500 },
+            {
+                display: "none",
+            },
+        ),
+    );
+
     const imageElement = style(
         "imageElement",
         {
-            position: "absolute",
-            top: 0,
-            right: 0,
-            bottom: 0,
-            width: unit(vars.imageElement.width),
-            height: percent(100),
+            ...absolutePosition.fullSizeOfParent(),
             objectFit: "contain",
             ...paddings(vars.imageElement.padding),
             objectPosition: "100% 50%",
         },
-        mediaQueries.oneColumnDown({
-            display: "none",
-        }),
+        mediaQueries.oneColumnDown({ objectPosition: "0% 100%" }),
     );
 
     return {
-        widget,
         root,
         outerBackground,
-        innerContainer,
+        contentContainer,
         text,
         icon,
         defaultBannerSVG,
@@ -531,6 +550,8 @@ export const bannerClasses = useThemeCache(() => {
         content,
         valueContainer,
         backgroundOverlay,
+        imageElementContainer,
         imageElement,
+        imagePositioner,
     };
 });

--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -15,6 +15,7 @@ import {
     spinnerLoader,
     unit,
     userSelect,
+    spinnerLoaderAnimationProperties,
 } from "@library/styles/styleHelpers";
 import { NestedCSSProperties } from "typestyle/lib/types";
 import { DEBUG_STYLES, styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
@@ -429,7 +430,7 @@ export const buttonUtilityClasses = useThemeCache(() => {
     };
 });
 
-export const buttonLoaderClasses = (buttonType?: ButtonTypes) => {
+export const buttonLoaderClasses = useThemeCache((buttonType?: ButtonTypes) => {
     const globalVars = globalVariables();
     const flexUtils = flexHelper();
     const style = styleFactory("buttonLoader");
@@ -448,22 +449,23 @@ export const buttonLoaderClasses = (buttonType?: ButtonTypes) => {
             break;
     }
 
-    const root = (alignment: "left" | "center" = "center") =>
+    const root = useThemeCache((alignment: "left" | "center" = "center") =>
         style({
             ...(alignment === "center" ? flexUtils.middle() : flexUtils.middleLeft),
             padding: unit(4),
             height: percent(100),
             width: percent(100),
-            $nest: {
-                "&:after": spinnerLoader({
-                    color: spinnerColor,
-                    dimensions: 20,
-                }),
-                "&:hover:after": spinnerLoader({
-                    color: stateSpinnerColor,
-                    dimensions: 20,
-                }),
+        }),
+    );
+
+    const reducedPadding = style("reducedPadding", {
+        $nest: {
+            "&&": {
+                padding: unit(3),
             },
-        });
-    return { root };
-};
+        },
+    });
+
+    const svg = style("svg", spinnerLoaderAnimationProperties());
+    return { root, svg, reducedPadding };
+});

--- a/library/src/scripts/icons/common.tsx
+++ b/library/src/scripts/icons/common.tsx
@@ -695,3 +695,35 @@ export function PlusIcon(props: { className?: string; title?: string }) {
         </svg>
     );
 }
+
+export function LoaderIcon(props: { className?: string }) {
+    return (
+        <svg
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            width="18px"
+            height="18px"
+            viewBox="0 0 18 18"
+            version="1.1"
+            className={props.className}
+        >
+            <title>{t("Loader")}</title>
+            <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+                <g id="Artboard" fill="currentColor">
+                    <g id="Loader">
+                        <path
+                            d="M9,0 C13.9705627,0 18,4.02943725 18,9 C18,13.9705627 13.9705627,18 9,18 C4.07738737,18 0,13.97 0,9 C0,8.99144674 1,8.99144674 3,9 C3,12.3137085 5.6862915,15 9,15 C12.3137085,15 15,12.3137085 15,9 C15,5.6862915 12.3137085,3 9,3 L9,0 Z"
+                            id="Path"
+                            opacity="0.3"
+                        ></path>
+                        <path
+                            d="M9,5.1159077e-13 C9,5 4.97,9 1.42108547e-14,9 C1.42108547e-14,9 1.42108547e-14,6 1.42108547e-14,6 C3.31,6 5.95313475,3.31 6,5.1159077e-13 C6,5.1159077e-13 9,5.1159077e-13 9,5.1159077e-13 Z"
+                            id="Path"
+                            transform="translate(4.500000, 4.500000) rotate(180.000000) translate(-4.500000, -4.500000) "
+                        ></path>
+                    </g>
+                </g>
+            </g>
+        </svg>
+    );
+}

--- a/library/src/scripts/loaders/ButtonLoader.tsx
+++ b/library/src/scripts/loaders/ButtonLoader.tsx
@@ -5,10 +5,11 @@
  */
 
 import React from "react";
-import classNames from "classnames";
 import { t } from "@library/utility/appUtils";
 import { buttonLoaderClasses, ButtonTypes } from "@library/forms/buttonStyles";
 import ScreenReaderContent from "@library/layout/ScreenReaderContent";
+import { LoaderIcon } from "@library/icons/common";
+import classNames from "classnames";
 
 interface IProps {
     className?: string;
@@ -19,17 +20,17 @@ interface IProps {
 /**
  * A smart loading component. Takes up the full page and only displays in certain scenarios.
  */
-export default class ButtonLoader extends React.Component<IProps> {
-    public render() {
-        const classes = buttonLoaderClasses(this.props.buttonType ? this.props.buttonType : undefined);
-        return (
-            <React.Fragment>
-                <div
-                    className={classNames(classes.root(this.props.alignLeft ? "left" : "center"), this.props.className)}
-                    aria-hidden="true"
-                />
-                <ScreenReaderContent>{t("Loading")}</ScreenReaderContent>
-            </React.Fragment>
-        );
-    }
+export default function ButtonLoader(props: IProps) {
+    const classes = buttonLoaderClasses();
+    return (
+        <span
+            className={classNames(
+                classes.root(props.alignLeft ? "left" : "center"),
+                props.buttonType?.startsWith("dashboard") && classes.reducedPadding,
+            )}
+        >
+            <LoaderIcon className={classes.svg} />
+            <ScreenReaderContent>{t("Loading")}</ScreenReaderContent>
+        </span>
+    );
 }

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -99,7 +99,7 @@ export const globalVariables = useThemeCache(() => {
     });
 
     const linkColorDefault = mainColors.secondary;
-    const linkColorState = emphasizeLightness(colorPrimary, constants.linkStateColorEmphasis, true);
+    const linkColorState = emphasizeLightness(linkColorDefault, constants.linkStateColorEmphasis, true);
 
     const links = makeThemeVars("links", {
         colors: {

--- a/library/src/scripts/styles/styleHelpersSpinner.ts
+++ b/library/src/scripts/styles/styleHelpersSpinner.ts
@@ -9,6 +9,7 @@ import { ColorHelper, deg, percent, quote } from "csx";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { ContentProperty, DisplayProperty, PositionProperty } from "csstype";
 import { debugHelper, defaultTransition, unit } from "@library/styles/styleHelpers";
+import { NestedCSSProperties } from "typestyle/lib/types";
 
 const spinnerOffset = 73;
 const spinnerLoaderAnimation = keyframes({
@@ -24,6 +25,18 @@ export interface ISpinnerProps {
     speed?: string;
 }
 
+const DEFAULT_SPEED = "0.7s";
+
+export function spinnerLoaderAnimationProperties(): NestedCSSProperties {
+    return {
+        ...defaultTransition("opacity"),
+        animationName: spinnerLoaderAnimation,
+        animationDuration: DEFAULT_SPEED,
+        animationIterationCount: "infinite",
+        animationTimingFunction: "ease-in-out",
+    };
+}
+
 export const spinnerLoader = (props: ISpinnerProps) => {
     const debug = debugHelper("spinnerLoader");
     const globalVars = globalVariables();
@@ -31,14 +44,12 @@ export const spinnerLoader = (props: ISpinnerProps) => {
         color: props.color || globalVars.mainColors.primary,
         size: props.size || 18,
         thickness: props.thickness || 3,
-        speed: "0.7s",
         ...props,
     };
     return {
         ...debug.name("spinner"),
         position: "relative" as PositionProperty,
         content: quote("") as ContentProperty,
-        ...defaultTransition("opacity"),
         display: "block" as DisplayProperty,
         width: unit(spinnerVars.size),
         height: unit(spinnerVars.size),
@@ -48,10 +59,6 @@ export const spinnerLoader = (props: ISpinnerProps) => {
         borderBottom: `${unit(spinnerVars.thickness)} solid ${spinnerVars.color.fade(0.3).toString()}`,
         borderLeft: `${unit(spinnerVars.thickness)} solid ${spinnerVars.color.fade(0.3).toString()}`,
         transform: "translateZ(0)",
-        animation: `spillerLoader ${spinnerVars.speed} infinite ease-in-out`,
-        animationName: spinnerLoaderAnimation,
-        animationDuration: spinnerVars.speed,
-        animationIterationCount: "infinite",
-        animationTimingFunction: "ease-in-out",
+        ...spinnerLoaderAnimationProperties(),
     };
 };


### PR DESCRIPTION
_**See [Changed Chromatic Diffs Here](https://www.chromaticqa.com/build?appId=5d5eba16c782b600204ba187&number=2033)**_

KB side of the PR https://github.com/vanilla/knowledge/pull/1501

## Adjustments to Banner

Closes https://github.com/vanilla/knowledge/issues/1480

After discussion w/ Todd there were a few changes that needed to be made with the Banner.

- Responsiveness of the component needs some improvement.
  - Content image and text now have fixed min-widths, and content image will be pushed off the screen as it shrinks. Variable breakpoint to make it disappear entirely has been added.
- Allow backgroundImage and contentImage to exist at the same time.
  - Rename the props of the new banner `contentImage`.
  - Rename the existing `image` props to `backgroundImage`.
  - Story is updated with linear-gradient as the background image.

## Theme Features Changes

- Add a new theme feature `DisableKludgedVars`
  - Automatically enabled by `DataDrivenTheme`
  - Disables many kludged variables in knowledge base that were often conflicting with custom theme.

## Improved Dashboard Forms

Closes https://github.com/vanilla/vanilla/issues/9943

- Image upload now displays a loader.
- `<ButtonLoader />` refactored to use an SVG. This means it can inherit color and no longer needs to have the outer button manage all of it's button states.
  - Makes button loader work in dashboard image uploads.
- Add a form subheading component.