### PR TITLE
Fix subheading spacing and error message tilles

### DIFF
--- a/applications/dashboard/design/admin.css
+++ b/applications/dashboard/design/admin.css
@@ -9674,7 +9674,7 @@ ul {
   color: #0291db;
 }
 
-.subheading {
+.subheading.subheading {
   display: block;
   margin-left: -18px;
   margin-right: -18px;

--- a/applications/dashboard/scss/src/_type.scss
+++ b/applications/dashboard/scss/src/_type.scss
@@ -255,7 +255,7 @@
 //
 // Styleguide 1.6.
 
-.subheading {
+.subheading.subheading {
   @include full-border(block, false, true);
   @include has-top-border;
   padding-top: $spacer;

--- a/library/src/scripts/errorPages/CoreErrorMessages.tsx
+++ b/library/src/scripts/errorPages/CoreErrorMessages.tsx
@@ -107,6 +107,8 @@ export function getErrorCode(errorMessageProps: IErrorMessageProps) {
         return errorMessageProps.apiError.response.status;
     } else if (errorMessageProps.error && errorMessageProps.error.status) {
         return errorMessageProps.error.status;
+    } else if (errorMessageProps.defaultError) {
+        return errorMessageProps.defaultError;
     } else {
         return errorMessageProps.defaultError;
     }


### PR DESCRIPTION
- Fixes style specificity for subheadings.
- Fixes core error messages not respecting the `defaultError` code.