### PR TITLE
Fix Signin and Register buttons when Googlesignin is default method

### DIFF
--- a/plugins/googlesignin/class.googlesignin.plugin.php
+++ b/plugins/googlesignin/class.googlesignin.plugin.php
@@ -94,7 +94,7 @@ class GoogleSignInPlugin extends Gdn_OAuth2 {
             $sender->Form->validateRule('AssociationSecret', 'ValidateRequired', t('You must provide a Secret'));
 
             // To satisfy the AuthenticationProviderModel, create a BaseUrl.
-            $baseUrl = $this->getBaseUrl($form->getValue('AuthorizeUrl'));
+            $baseUrl = $this->getBaseUrl(self::AUTHORIZE_URL);
 
             if ($baseUrl) {
                 $form->setFormValue('BaseUrl', $baseUrl);

--- a/plugins/googlesignin/class.googlesignin.plugin.php
+++ b/plugins/googlesignin/class.googlesignin.plugin.php
@@ -99,6 +99,7 @@ class GoogleSignInPlugin extends Gdn_OAuth2 {
             if ($baseUrl) {
                 $form->setFormValue('BaseUrl', $baseUrl);
                 $form->setFormValue('SignInUrl', $baseUrl); // kludge for default provider
+                $form->setFormValue('RegisterUrl', $baseUrl); // kludge for default provider
             }
             if ($form->save()) {
                 $sender->informMessage(t('Saved'));


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/437

The issue was described as Keystone related but it actually happens in the `GoogleSignInPlugin` class.

To test the issue first make sure you have "Google SignIn" enabled and configured.
