### PR TITLE
fix adding required user fields when approving a post from moderation

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1129,8 +1129,11 @@ class CommentModel extends Gdn_Model {
             if (!$insert || !$this->checkUserSpamming(Gdn::session()->UserID, $this->floodGate)) {
                 $fields = $this->Validation->schemaValidationFields();
                 unset($fields[$this->PrimaryKey]);
+                $comment = $this->getID($commentID, DATASET_TYPE_ARRAY);
+                $insertUserID = $comment['InsertUserID'] ?? null;
+                $dateInserted = $comment['DateInserted'] ?? null;
 
-                $commentData = $commentID ? array_merge($fields, ['CommentID' => $commentID]) : $fields;
+                $commentData = $commentID ? array_merge($fields, ['CommentID' => $commentID, 'InsertUserID' => $insertUserID, 'DateInserted' => $dateInserted]) : $fields;
                 // Check for spam
                 $spam = SpamModel::isSpam('Comment', $commentData);
                 if ($spam) {

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1129,9 +1129,14 @@ class CommentModel extends Gdn_Model {
             if (!$insert || !$this->checkUserSpamming(Gdn::session()->UserID, $this->floodGate)) {
                 $fields = $this->Validation->schemaValidationFields();
                 unset($fields[$this->PrimaryKey]);
-                $comment = $this->getID($commentID, DATASET_TYPE_ARRAY);
-                $insertUserID = $comment['InsertUserID'] ?? null;
-                $dateInserted = $comment['DateInserted'] ?? null;
+                if (!isset($fields['InsertUserID']) || !isset($fields['DateInserted'])) {
+                    $comment = $this->getID($commentID, DATASET_TYPE_ARRAY);
+                    $insertUserID = $comment['InsertUserID'] ?? null;
+                    $dateInserted = $comment['DateInserted'] ?? null;
+                } else {
+                    $insertUserID = $fields['InsertUserID'];
+                    $dateInserted = $fields['DateInserted'];
+                }
 
                 $commentData = $commentID ? array_merge($fields, ['CommentID' => $commentID, 'InsertUserID' => $insertUserID, 'DateInserted' => $dateInserted]) : $fields;
                 // Check for spam

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1184,7 +1184,7 @@ class DiscussionModel extends Gdn_Model {
      */
     public function calculateCommentReadData(
         int $discussionCommentCount,
-        string $discussionLastCommentDate,
+        ?string $discussionLastCommentDate,
         ?int $userReadComments,
         ?string $userLastReadDate
     ): array {
@@ -1216,7 +1216,9 @@ class DiscussionModel extends Gdn_Model {
         // If the discussion has no comments and read status is false or both user categories are null,
         // set unread comments to true unless the discussion is archived (in which case, we don't want it showing up as new).
         if (($discussionCommentCount === 0 && !$isRead) | ($userReadComments === null && $userLastReadDate === null)) {
-            $this->isArchived($discussionLastCommentDate->format(MYSQL_DATE_FORMAT)) ? $unreadCommentCount = 0 : $unreadCommentCount = true;
+            if (!is_null($discussionLastCommentDate)) {
+                $this->isArchived($discussionLastCommentDate->format(MYSQL_DATE_FORMAT)) ? $unreadCommentCount = 0 : $unreadCommentCount = true;
+            }
         }
 
         return [$isRead, $unreadCommentCount];

--- a/tests/Models/DiscussionModelTest.php
+++ b/tests/Models/DiscussionModelTest.php
@@ -464,6 +464,13 @@ class DiscussionModelTest extends TestCase {
      */
     public function provideTestCalculateCommentReadData() {
         $r = [
+            'discussionLastCommentDateIsNull' => [
+                10,
+                null,
+                null,
+                '2020-01-09 16:22:42',
+                [true, 0],
+            ],
             'userReadCommentIsNullWithReadDate' => [
                 10,
                 '2019-12-02 21:55:40',


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1309

### Issue 

When a post gets sent to moderation after being edited->saved, the post is missing InsertUserID and DateInserted.

### Details
whenever a plugin hooks into https://github.com/vanilla/vanilla/blob/03eba20c06cf9678556c4b87cc964f5ee1fdfb86/applications/vanilla/models/class.commentmodel.php#L1148, $commentData is missing InsertUserID and DateInserted. If a post goes to moderation and then it gets approved, the post gets overwritten here https://github.com/vanilla/vanilla/blob/cb23d99019c198ea2f7aeeb903f8a93eaa615b07/applications/dashboard/models/class.logmodel.php#L967 with the missing information.

There is also another bug that was introduced in https://github.com/vanilla/vanilla/pull/9944 when creating a discussion, if a discussion gets sent to moderation before being posted(doesn't have any comment DateLastComment is usually null https://github.com/vanilla/vanilla/blob/03eba20c06cf9678556c4b87cc964f5ee1fdfb86/applications/vanilla/models/class.discussionmodel.php#L1140 I set that paramter as optional.


### To test

Test posting comments and discussion, you can use this plugin https://github.com/vanillaforums/niantic/tree/master/plugins/nianticimagemoderation to send a post to moderation if it has an image
create a comment. edit it, add an image
as a mod approve the post, notice the fields InsertUserID and DateInserted.
Do the same as a discussion
