### PR TITLE
Fix DummyScheduler not running child jobs

### DIFF
--- a/library/Vanilla/Scheduler/DummyScheduler.php
+++ b/library/Vanilla/Scheduler/DummyScheduler.php
@@ -268,7 +268,7 @@ class DummyScheduler implements SchedulerInterface {
      * @return void
      */
     protected function dispatchAll() {
-        foreach ($this->trackingSlips as $trackingSlip) {
+        foreach ($this->generateTrackingSlips() as $trackingSlip) {
             try {
                 $jobInterface = $trackingSlip->getJobInterface();
                 $driverSlip = $trackingSlip->getDriverSlip();
@@ -288,6 +288,23 @@ class DummyScheduler implements SchedulerInterface {
         if ($this->dispatchedEventName != null) {
             $this->eventManager->fire($this->dispatchedEventName, $this->trackingSlips);
         }
+    }
+
+    /**
+     * Tracking slip generator.
+     */
+    private function generateTrackingSlips() {
+        // Ensure we're starting at the start.
+        reset($this->trackingSlips);
+        while (($key = key($this->trackingSlips)) !== null) {
+            // Get the value. Advance the internal pointer.
+            $slip = $this->trackingSlips[$key];
+            next($this->trackingSlips);
+
+            yield $slip;
+        }
+        // Reset the internal pointer to hopefully avoid unexpected behavior.
+        reset($this->trackingSlips);
     }
 
     /**

--- a/tests/Library/Vanilla/Scheduler/SchedulerTest.php
+++ b/tests/Library/Vanilla/Scheduler/SchedulerTest.php
@@ -170,6 +170,32 @@ final class SchedulerTest extends \PHPUnit\Framework\TestCase {
     }
 
     /**
+     * Test dispatching with a single job in the queue that would create a children
+     */
+    public function testDispatchedWithOneJobOneChildren() {
+        /** @var $container \Garden\Container\Container */
+        $container = $this->getNewContainer();
+
+        /** @var $eventManager \Garden\EventManager */
+        $eventManager = $container->get(\Garden\EventManager::class);
+
+        /* @var $dummyScheduler \Vanilla\Scheduler\SchedulerInterface */
+        $dummyScheduler = $container->get(\Vanilla\Scheduler\SchedulerInterface::class);
+
+        $dummyScheduler->addJob(\VanillaTests\Fixtures\Scheduler\ParentJob::class);
+
+        $eventManager->bind(self::DISPATCHED_EVENT, function ($trackingSlips) {
+            /** @var $trackingSlips \Vanilla\Scheduler\TrackingSlip[] */
+            $this->assertTrue(count($trackingSlips) == 2);
+            $complete = \Vanilla\Scheduler\Job\JobExecutionStatus::complete();
+            $this->assertTrue($trackingSlips[0]->getStatus()->is($complete));
+            $this->assertTrue($trackingSlips[1]->getStatus()->is($complete));
+        });
+
+        $eventManager->fire(self::DISPATCH_EVENT);
+    }
+
+    /**
      * Test dispatching a single job, resulting in failure.
      */
     public function testDispatchedWithOneFailedJob() {

--- a/tests/fixtures/src/Scheduler/ParentJob.php
+++ b/tests/fixtures/src/Scheduler/ParentJob.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @author Eduardo Garcia Julia <eduardo.garciajulia@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Fixtures\Scheduler;
+
+use Psr\Log\LoggerInterface;
+use Vanilla\Scheduler\Job\JobExecutionStatus;
+use Vanilla\Scheduler\Job\JobPriority;
+use Vanilla\Scheduler\Job\LocalJobInterface;
+use Vanilla\Scheduler\SchedulerInterface;
+
+/**
+ * Class ParentJob.
+ */
+class ParentJob implements LocalJobInterface {
+
+    /** @var LoggerInterface */
+    protected $logger;
+
+    /** @var SchedulerInterface */
+    protected $scheduler;
+
+    /** @var array */
+    protected $message;
+
+    /**
+     * EchoJob constructor.
+     *
+     * @param LoggerInterface $logger
+     * @param SchedulerInterface $scheduler
+     */
+    public function __construct(LoggerInterface $logger, SchedulerInterface $scheduler) {
+        $this->logger = $logger;
+        $this->scheduler = $scheduler;
+    }
+
+    /**
+     * Set the message.
+     *
+     * @param array $message
+     */
+    public function setMessage(array $message) {
+        $this->message = $message;
+    }
+
+    /**
+     * Run the job.
+     *
+     * @return JobExecutionStatus
+     */
+    public function run(): JobExecutionStatus {
+        $this->logger->info(get_class($this)." :: Creating ChildJob");
+        $this->scheduler->addJob(\VanillaTests\Fixtures\Scheduler\EchoJob::class);
+        return JobExecutionStatus::complete();
+    }
+
+    /**
+     * Set the priority.
+     *
+     * @param JobPriority $priority
+     */
+    public function setPriority(JobPriority $priority) {
+        // void method. It doesn't make any sense set a priority for a LocalJob
+    }
+
+    /**
+     * Set the delay.
+     *
+     * @param integer $seconds
+     */
+    public function setDelay(int $seconds) {
+        // void method. It doesn't make any sense set a delay for a LocalJob
+    }
+}


### PR DESCRIPTION
`DummyScheduler::dispatchAll` currently executes its jobs by running a `foreach` on its internal tracking slips array. Since `foreach` runs on a copy of the array by default, any new jobs queued up during execution of the queue will be ignored.

This update adds a simple [generator function](https://www.php.net/manual/en/language.generators.syntax.php) to `DummyScheduler` for accessing the internal tracking slips array in way that will allow iteration to include new items.