### PR TITLE
Fix editor mounting

### DIFF
--- a/packages/vanilla-react-utils/src/mounting.tsx
+++ b/packages/vanilla-react-utils/src/mounting.tsx
@@ -10,6 +10,7 @@ import { ReactElement } from "react";
 
 export interface IComponentMountOptions {
     overwrite?: boolean;
+    clearContents?: boolean;
 }
 
 interface IPortal {
@@ -87,6 +88,10 @@ export function mountReact(
 ) {
     let mountPoint = target;
     let cleanupContainer: HTMLElement | undefined;
+    if (options?.clearContents) {
+        target.innerHTML = "";
+    }
+
     if (options && options.overwrite) {
         const container = document.createElement("span");
         cleanupContainer = container;

--- a/plugins/rich-editor/src/scripts/mountEditor.tsx
+++ b/plugins/rich-editor/src/scripts/mountEditor.tsx
@@ -25,9 +25,14 @@ export default function mountEditor(containerSelector: string | Element) {
     const initialFormat = bodybox.getAttribute("format");
 
     if (initialFormat === "Rich" || initialFormat === "rich") {
-        mountReact(<ForumEditor legacyTextArea={bodybox as HTMLInputElement} />, container, () => {
-            container.classList.remove("isDisabled");
-        });
+        mountReact(
+            <ForumEditor legacyTextArea={bodybox as HTMLInputElement} />,
+            container,
+            () => {
+                container.classList.remove("isDisabled");
+            },
+            { clearContents: true },
+        );
     } else {
         throw new Error(`Unsupported initial editor format ${initialFormat}`);
     }


### PR DESCRIPTION
Add a new mounting option to cleanout the contents of the target before mounting.

This is best used when mounting over placeholders.
