### PR TITLE
Prevent duplicate mounting of theme provider

### DIFF
--- a/applications/dashboard/src/scripts/entries/forum.tsx
+++ b/applications/dashboard/src/scripts/entries/forum.tsx
@@ -41,18 +41,19 @@ Router.addRoutes([
 
 applySharedPortalContext(props => {
     return (
-        <AppContext variablesOnly={!getMeta("themeFeatures.DataDrivenTheme", false)} errorComponent={ErrorPage}>
+        <AppContext
+            variablesOnly={
+                !getMeta("themeFeatures.DataDrivenTheme", false) && !getMeta("themeFeatures.SharedMasterView", false)
+            }
+            errorComponent={ErrorPage}
+        >
             {props.children}
         </AppContext>
     );
 });
 
 // Routing
-addComponent("App", () => (
-    <AppContext variablesOnly>
-        <Router disableDynamicRouting />
-    </AppContext>
-));
+addComponent("App", () => <Router disableDynamicRouting />);
 
 addComponent("title-bar-hamburger", TitleBarHamburger);
 

--- a/library/src/scripts/theming/ThemeProvider.tsx
+++ b/library/src/scripts/theming/ThemeProvider.tsx
@@ -25,6 +25,8 @@ interface IProps {
     disabled?: boolean;
 }
 
+let hasMounted = false;
+
 export const ThemeProvider: React.FC<IProps> = (props: IProps) => {
     const { themeKey, disabled, variablesOnly } = props;
     const { getAssets } = useReduxActions(ThemeActions);
@@ -47,7 +49,8 @@ export const ThemeProvider: React.FC<IProps> = (props: IProps) => {
             return;
         }
 
-        if (assets.data) {
+        if (assets.data && !hasMounted) {
+            hasMounted = true;
             let themeHeader = document.getElementById("themeHeader");
             const themeFooter = document.getElementById("themeFooter");
 


### PR DESCRIPTION
If the theme provider was mounted twice it would delete the theme header and footer.

I've added some checks to prevent it from double mounting, and an removed an unnecssary app context.