### PR TITLE
Fix embeds double rendering

### DIFF
--- a/library/src/scripts/embeddedContent/embedService.tsx
+++ b/library/src/scripts/embeddedContent/embedService.tsx
@@ -113,6 +113,7 @@ export async function mountEmbed(mountPoint: HTMLElement, data: IBaseEmbedProps,
             </EmbedErrorBoundary>,
             mountPoint,
             !isAsync ? onMountComplete : undefined,
+            { bypassPortalManager: true },
         );
     });
 }

--- a/packages/vanilla-react-utils/src/mounting.tsx
+++ b/packages/vanilla-react-utils/src/mounting.tsx
@@ -11,6 +11,7 @@ import { ReactElement } from "react";
 export interface IComponentMountOptions {
     overwrite?: boolean;
     clearContents?: boolean;
+    bypassPortalManager?: boolean;
 }
 
 interface IPortal {
@@ -86,6 +87,11 @@ export function mountReact(
     callback?: () => void,
     options?: IComponentMountOptions,
 ) {
+    if (options?.bypassPortalManager) {
+        ReactDOM.render(<PortalContext>{component}</PortalContext>, target, callback);
+        return;
+    }
+
     let mountPoint = target;
     let cleanupContainer: HTMLElement | undefined;
     if (options?.clearContents) {


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/10053

Due to their odd integration with quill blots, the embed contents cannot work in the shared portal system, and needs independant renders.

I've added a flag to bypass the shared portal rendering and applied to the embeds.
