### PR TITLE
Sanitize variables during smarty debug

### DIFF
--- a/applications/dashboard/views/debug.tpl
+++ b/applications/dashboard/views/debug.tpl
@@ -1,0 +1,27 @@
+{capture name='_smarty_debug' assign=debug_output}
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+    <head>
+        <title>Debug Console</title>
+        <style type="text/css">
+            {literal}
+            body, h1, h2, h3, td, th, p {
+                font-family: sans-serif;
+                margin: 1em;
+                padding: 0;
+            }
+            {/literal}
+        </style>
+    </head>
+    <body>
+    {literal}{debug} has been disabled, use {debug_vars} instead.{/literal}
+    </body>
+    </html>
+{/capture}
+<script type="text/javascript">
+    {$id = '__Smarty__'}
+    {if $display_mode}{$id = "$offset$template_name"|md5}{/if}
+    _smarty_console = window.open("", "console{$id}", "width=1024,height=600,left={$offset},top={$offset},resizable,scrollbars=yes");
+    _smarty_console.document.write("{$debug_output|escape:'javascript' nofilter}");
+    _smarty_console.document.close();
+</script>

--- a/applications/dashboard/views/debug_vars.tpl
+++ b/applications/dashboard/views/debug_vars.tpl
@@ -1,0 +1,136 @@
+{capture name='_smarty_debug' assign=debug_output}
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+    <head>
+        <title>Smarty Debug Console</title>
+        <style type="text/css">
+            {literal}
+            body, h1, h2, h3, td, th, p {
+                font-family: sans-serif;
+                font-weight: normal;
+                font-size: 0.9em;
+                padding: 0;
+            }
+
+            h1 {
+                margin: 0;
+                text-align: left;
+                padding: 8px;
+                color: black;
+                font-weight: bold;
+                font-size: 1.2em;
+            }
+
+            h2 {
+                color: white;
+                text-align: left;
+                font-weight: bold;
+                padding: 2px;
+                border-top: 1px solid black;
+            }
+            h3 {
+                text-align: left;
+                font-weight: bold;
+                color: #333434;
+                font-size: 0.7em;
+                padding: 0;
+                margin: 0 0 8px;
+            }
+
+            body {
+                margin: 0;
+            }
+
+            p {
+                margin: 0;
+                font-style: italic;
+                text-align: center;
+            }
+
+            table {
+                width: 100%;
+                border-spacing: 0;
+            }
+
+            th, td {
+                font-family: monospace;
+                vertical-align: top;
+                text-align: left;
+                padding: 12px;
+            }
+
+            th {
+                text-transform: uppercase;
+            }
+
+            td {
+                color: green;
+            }
+
+            .odd {
+                background-color: #eeeeee;
+            }
+
+            .even {
+                background-color: #fafafa;
+            }
+
+            .exectime {
+                font-size: 0.8em;
+                font-style: italic;
+            }
+
+            #bold div {
+                color: black;
+                font-weight: bold;
+            }
+            #blue h3 {
+                color: blue;
+            }
+            #normal div {
+                color: black;
+                font-weight: normal;
+            }
+            #table_assigned_vars th {
+                color: #333434;
+                font-weight: bold;
+            }
+
+            #table_config_vars th {
+                color: maroon;
+            }
+
+            {/literal}
+        </style>
+    </head>
+    <body>
+
+    <h1>Debug Console</h1>
+
+    <table id="table_assigned_vars">
+        <thead>
+            <tr>
+                <th>Variable</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+        {foreach $assigned_vars as $vars}
+            <tr class="{if $vars@iteration % 2 eq 0}odd{else}even{/if}">
+                <td>${$vars@key}
+                    {if isset($vars['nocache'])}<b>Nocache</b><br />{/if}
+                </td>
+                <td>{$vars['value']|debug_print_var:10:80 nofilter}</td>
+         {/foreach}
+        </tbody>
+    </table>
+    </body>
+    </html>
+{/capture}
+<script type="text/javascript">
+    {$id = '__Smarty__'}
+    {if $display_mode}{$id = "$offset$template_name"|md5}{/if}
+    _smarty_console = window.open("", "console{$id}", "width=1024,height=600,left={$offset},top={$offset},resizable,scrollbars=yes");
+    _smarty_console.document.write("{$debug_output|escape:'javascript' nofilter}");
+    _smarty_console.document.close();
+</script>

--- a/tests/Library/Core/SmartyTest.php
+++ b/tests/Library/Core/SmartyTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the `Gdn_Smarty` class.
+ */
+class SmartyTest extends TestCase {
+    /**
+     * Some keys should be removed.
+     */
+    public function testSanitizeRemove() {
+        $arr = ['Password' => 'a', 'AccessToken' => 'a', 'Fingerprint' => 'a', 'Updatetoken' => 'a'];
+        $actual = \Gdn_Smarty::sanitizeVariables($arr);
+        $this->assertEmpty($actual);
+    }
+
+    /**
+     * Some keys should be obscured.
+     */
+    public function testSanitizeObscure() {
+        $arr = [
+            'insertipaddress' => 'a',
+            'updateipaddress' => 'a',
+            'lastipaddress' => 'a',
+            'allipaddresses' => 'a',
+            'dateofbirth' => 'a',
+            'hashmethod' => 'a',
+            'email' => 'a',
+            'firstemail' => 'a',
+            'lastemail' => 'a',
+        ];
+
+        $actual = \Gdn_Smarty::sanitizeVariables($arr);
+
+        foreach ($actual as $key => $value) {
+            $this->assertSame('***OBSCURED***', $value);
+        }
+    }
+
+    /**
+     * Arrays should sanitize recursively.
+     */
+    public function testArrayRecurse() {
+        $arr = [
+            'a' => [
+                'b' => 'c',
+                'password' => 'foo',
+                'lastEmail' => 'bar',
+            ],
+        ];
+
+        $expected = [
+            'a' => [
+                'b' => 'c',
+                'lastEmail' => '***OBSCURED***',
+            ],
+        ];
+
+        $actual = \Gdn_Smarty::sanitizeVariables($arr);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * A nested object should be sanitized, but not change the original object.
+     */
+    public function testStdClass() {
+        $arr = [
+            'a' => (object)[
+                'b' => 'c',
+                'password' => 'foo',
+            ],
+        ];
+
+        $actual = \Gdn_Smarty::sanitizeVariables($arr);
+        $this->assertSame('foo', $arr['a']->password);
+        $this->assertInstanceOf(\stdClass::class, $actual['a']);
+        $this->assertNotTrue(isset($actual['a']->password));
+    }
+}


### PR DESCRIPTION
The smarty `{debug}` function outputs useful information for debugging. However, if this function is accidentally left on then sensitive information will leak.

This PR does the following:

- Effectively disables the `{debug}` function by overriding its template to give a deprecation notice. This was done because I couldn’t find a way to change its behavior.
- Adds another `{debug_vars}` function that does some basic sanitization of variables before rendering them. It uses a modified version of the built in smarty debug console that has some nicer styling and only outputs assigned variables.

Closes https://github.com/vanilla/vanilla-patches/issues/661