### PR TITLE
Add email setting translation strings

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -930,20 +930,24 @@ class SettingsController extends DashboardController {
                 ]
             ],
             'Garden.EmailTemplate.TextColor' => [
-                'Control' => 'color'
+                'LabelCode' => 'Text Color',
+                'Control' => 'color',
             ],
             'Garden.EmailTemplate.BackgroundColor' => [
-                'Control' => 'color'
+                'LabelCode' => 'Background Color',
+                'Control' => 'color',
             ],
             'Garden.EmailTemplate.ContainerBackgroundColor' => [
                 'Control' => 'color',
-                'LabelCode' => 'Page Color'
+                'LabelCode' => 'Page Color',
             ],
             'Garden.EmailTemplate.ButtonTextColor' => [
-                'Control' => 'color'
+                'LabelCode' => 'Button Text Color',
+                'Control' => 'color',
             ],
             'Garden.EmailTemplate.ButtonBackgroundColor' => [
-                'Control' => 'color'
+                'LabelCode' => 'Button Background Color',
+                'Control' => 'color',
             ],
         ]);
 


### PR DESCRIPTION
The translations are complete, but the codes aren’t being used.