### PR TITLE
Relax DateTimeFormatter::dateTmeToTimesStamp()

### DIFF
--- a/library/Vanilla/Formatting/DateTimeFormatter.php
+++ b/library/Vanilla/Formatting/DateTimeFormatter.php
@@ -218,14 +218,18 @@ class DateTimeFormatter {
      * @param string $dateTime The Mysql-formatted datetime to convert to a timestamp. Should be in one
      * of the following formats: YYYY-MM-DD or YYYY-MM-DD HH:MM:SS.
      * @param mixed $fallback The value to return if the value couldn't be properly converted.
-     * @return int A timestamp or now if it couldn't be parsed properly.
+     * @param mixed $emptyFallback The fallback for an empty value. If not supplied then the `$fallback` will be used.
+     * @return int|null A timestamp or now if it couldn't be parsed properly.
      */
-    public static function dateTimeToTimeStamp(?string $dateTime = '', $fallback = null): int {
-        if (($testTime = strtotime($dateTime)) !== false) {
+    public static function dateTimeToTimeStamp(?string $dateTime, $fallback = false, $emptyFallback = false): ?int {
+        if (empty($dateTime)) {
+            $emptyFallback = $emptyFallback !== false ? $emptyFallback : $fallback;
+            return $emptyFallback !== false ? $emptyFallback : time();
+        } elseif (($testTime = strtotime($dateTime)) !== false) {
             return $testTime;
         } else {
-            $fallback = $fallback ?? time();
-            trigger_error(__FUNCTION__ . 'called with bad input ' . $dateTime, E_USER_WARNING);
+            $fallback = $fallback !== false ? $fallback : time();
+            trigger_error(__FUNCTION__ . 'called with bad input ' . $dateTime, E_USER_NOTICE);
             return $fallback;
         }
     }

--- a/tests/Library/Vanilla/Formatting/DateTimeFormatterTest.php
+++ b/tests/Library/Vanilla/Formatting/DateTimeFormatterTest.php
@@ -171,10 +171,10 @@ class DateTimeFormatterTest extends MinimalContainerTestCase {
         if ($isNotice) {
             $this->expectNotice();
         }
-        $now = time();
         $actual = DateTimeFormatter::dateTimeToTimeStamp($timestamp);
         if ($expected === self::NOW) {
             // This is a bit of a kludge because the test may take longer than a second.
+            $now = time();
             $this->assertGreaterThanOrEqual($now, $actual);
             $this->assertLessThanOrEqual($now + 10, $actual);
         } else {


### PR DESCRIPTION
- Trigger notices instead of warnings.
- Add a third parameter for empty/null fallbacks.
- Allow the method to return null instead of just an integer.

Closes #9489