### PR TITLE
Implement home widget components and stories

### DIFF
--- a/build/.storybook/config.js
+++ b/build/.storybook/config.js
@@ -8,14 +8,14 @@
 
 'use strict';
 
+import { forceRenderStyles } from "typestyle";
 import { configure, addDecorator, addParameters } from '@storybook/react';
-import {checkA11y, withA11y} from '@storybook/addon-a11y';
+import { checkA11y, withA11y } from '@storybook/addon-a11y';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { unit } from '@library/styles/styleHelpers';
 import { layoutVariables } from '@library/layout/panelLayoutStyles';
 import 'storybook-chromatic';
-
-require('../../library/src/scripts/storybookConfig');
+const { applyStoryContext } = require('../../library/src/scripts/storybookConfig');
 
 addParameters({
     chromatic: {
@@ -93,3 +93,9 @@ const storyFiles = require.context(
     /^(?!.*(?:\/node_modules\/|\/vendor\/$)).*\.story\.tsx?$/);
 configure(storyFiles, module);
 
+applyStoryContext();
+
+module.hot?.accept(() => {
+    forceRenderStyles();
+    applyStoryContext();
+})

--- a/library/Vanilla/Formatting/BaseFormat.php
+++ b/library/Vanilla/Formatting/BaseFormat.php
@@ -14,7 +14,7 @@ use Vanilla\Contracts\Formatting\FormatInterface;
  */
 abstract class BaseFormat implements FormatInterface {
     /** @var int */
-    const EXCERPT_MAX_LENGTH = 325;
+    const EXCERPT_MAX_LENGTH = 160;
 
     /**
      * Implement rendering of excerpts based on the plain-text version of format.

--- a/library/Vanilla/Formatting/BaseFormat.php
+++ b/library/Vanilla/Formatting/BaseFormat.php
@@ -14,7 +14,7 @@ use Vanilla\Contracts\Formatting\FormatInterface;
  */
 abstract class BaseFormat implements FormatInterface {
     /** @var int */
-    const EXCERPT_MAX_LENGTH = 160;
+    const EXCERPT_MAX_LENGTH = 325;
 
     /**
      * Implement rendering of excerpts based on the plain-text version of format.

--- a/library/src/scripts/content/TruncatedText.tsx
+++ b/library/src/scripts/content/TruncatedText.tsx
@@ -16,6 +16,7 @@ interface IProps {
     useMaxHeight?: boolean;
     lines?: number;
     expand?: boolean;
+    maxCharCount?: number;
 }
 
 const TruncatedText = React.memo(function TruncatedText(_props: IProps) {
@@ -77,6 +78,17 @@ const TruncatedText = React.memo(function TruncatedText(_props: IProps) {
     }
 
     const Tag = (props.tag || "span") as "span";
+
+    let { children } = props;
+    if (props.maxCharCount && typeof children === "string") {
+        const newChildren = children.slice(0, props.maxCharCount);
+
+        if (newChildren.length < children.length) {
+            children += "…";
+        }
+
+        children = newChildren;
+    }
 
     return (
         <Tag className={props.className} ref={ref}>

--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -386,6 +386,7 @@ export const buttonUtilityClasses = useThemeCache(() => {
         textAlign: "left",
         lineHeight: globalVars.lineHeights.base,
         fontWeight: globalVars.fonts.weights.semiBold,
+        whiteSpace: "nowrap",
     };
 
     const buttonAsText = style("asText", asTextStyles, {

--- a/library/src/scripts/headers/titleBarStyles.ts
+++ b/library/src/scripts/headers/titleBarStyles.ts
@@ -20,6 +20,7 @@ import {
     pointerEvents,
     singleBorder,
     sticky,
+    BorderType,
 } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { ColorHelper, percent, px, quote, viewHeight, url, translate } from "csx";
@@ -32,12 +33,6 @@ import { buttonResetMixin, ButtonTypes } from "@library/forms/buttonStyles";
 import generateButtonClass from "@library/forms/styleHelperButtonGenerator";
 import { media } from "typestyle";
 import { LogoAlignment } from "./TitleBar";
-
-enum TitleBarBorderType {
-    BORDER = "border",
-    NONE = "none",
-    SHADOW = "shadow",
-}
 
 export const titleBarVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -74,7 +69,7 @@ export const titleBarVariables = useThemeCache(() => {
     });
 
     const border = makeThemeVars("border", {
-        type: TitleBarBorderType.NONE,
+        type: BorderType.NONE,
     });
 
     const buttonSize = globalVars.buttonIcon.size;
@@ -279,15 +274,15 @@ export const titleBarClasses = useThemeCache(() => {
 
     const getBorderVars = (): NestedCSSProperties => {
         switch (vars.border.type) {
-            case TitleBarBorderType.BORDER:
+            case BorderType.BORDER:
                 return {
                     borderBottom: singleBorder(),
                 };
-            case TitleBarBorderType.SHADOW:
+            case BorderType.SHADOW:
                 return {
                     boxShadow: shadowHelper().makeShadow(),
                 };
-            case TitleBarBorderType.NONE:
+            case BorderType.NONE:
             default:
                 return {};
         }

--- a/library/src/scripts/homeWidget/HomeWidget.story.tsx
+++ b/library/src/scripts/homeWidget/HomeWidget.story.tsx
@@ -1,0 +1,178 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { StoryHeading } from "@library/storybook/StoryHeading";
+import { HomeWidgetItem } from "@library/homeWidget/HomeWidgetItem";
+import { STORY_IPSUM_MEDIUM, STORY_IPSUM_SHORT, STORY_IMAGE } from "@library/storybook/storyData";
+import { HomeWidgetContainer, IHomeWidgetContainerProps } from "@library/homeWidget/HomeWidgetContainer";
+import { style } from "typestyle";
+import { HomeWidgetItemContentType } from "@library/homeWidget/HomeWidgetItem.styles";
+import { BorderType } from "@library/styles/styleHelpers";
+import { layoutVariables } from "@library/layout/panelLayoutStyles";
+
+export default {
+    title: "Home Widget",
+};
+
+export function ContainerTextOnly() {
+    return (
+        <div>
+            <ContainerWithOptions title="4 columns" options={{ maxColumnCount: 4 }} />
+            <ContainerWithOptions title="3 columns" options={{ maxColumnCount: 3 }} />
+            <ContainerWithOptions title="2 columns" options={{ maxColumnCount: 2 }} />
+            <ContainerWithOptions title="1 column" options={{ maxColumnCount: 1 }} />
+        </div>
+    );
+}
+
+export function ContainerWithImage() {
+    return (
+        <div>
+            <ContainerWithOptionsAndImage title="4 columns" options={{ maxColumnCount: 4 }} />
+            <ContainerWithOptionsAndImage title="3 columns" options={{ maxColumnCount: 3 }} />
+            <ContainerWithOptionsAndImage title="2 columns" options={{ maxColumnCount: 2 }} />
+        </div>
+    );
+}
+
+ContainerWithImage.story = {
+    parameters: {
+        chromatic: {
+            viewports: Object.values(layoutVariables().panelLayoutBreakPoints),
+        },
+    },
+};
+
+export function Items() {
+    return (
+        <div>
+            <StoryHeading>Title, Description</StoryHeading>
+            <ItemIn4Variants>
+                <HomeWidgetItem to="#" name="Hello Title" description={STORY_IPSUM_SHORT}></HomeWidgetItem>
+            </ItemIn4Variants>
+            <StoryHeading>Title, Description - Long</StoryHeading>
+            <ItemIn4Variants>
+                <HomeWidgetItem
+                    to="#"
+                    name="Hello Longer longer longer longer longer even longer"
+                    description={STORY_IPSUM_MEDIUM}
+                ></HomeWidgetItem>
+            </ItemIn4Variants>
+            <StoryHeading>Title, Description, Image</StoryHeading>
+            <ItemIn4Variants>
+                <HomeWidgetItem
+                    to="#"
+                    name="Hello Title with an Image"
+                    description={STORY_IPSUM_MEDIUM}
+                    imageUrl={STORY_IMAGE}
+                    options={{ contentType: HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE }}
+                ></HomeWidgetItem>
+            </ItemIn4Variants>
+            <StoryHeading>Missing Image</StoryHeading>
+            <ItemIn4Variants>
+                <HomeWidgetItem
+                    to="#"
+                    name="Hello Title with a missing Image"
+                    description={STORY_IPSUM_MEDIUM}
+                    options={{ contentType: HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE }}
+                ></HomeWidgetItem>
+            </ItemIn4Variants>
+        </div>
+    );
+}
+
+function ContainerWithOptionsAndImage(props: Omit<IHomeWidgetContainerProps, "children">) {
+    return (
+        <HomeWidgetContainer {...props}>
+            <DummyItem image />
+            <DummyItem image />
+            <DummyItem image />
+            <DummyItem image />
+            <DummyItem image />
+        </HomeWidgetContainer>
+    );
+}
+
+function ContainerWithOptions(props: Omit<IHomeWidgetContainerProps, "children">) {
+    return (
+        <HomeWidgetContainer {...props}>
+            <DummyItem />
+            <DummyItem />
+            <DummyItem />
+            <DummyItem />
+            <DummyItem />
+        </HomeWidgetContainer>
+    );
+}
+
+function DummyItem(props: { image?: boolean }) {
+    return (
+        <HomeWidgetItem
+            options={{
+                contentType: props.image
+                    ? HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE
+                    : HomeWidgetItemContentType.TITLE_DESCRIPTION,
+            }}
+            imageUrl={STORY_IMAGE}
+            to="#"
+            name="Hello Longer longer longer longer longer even longer"
+            description={STORY_IPSUM_MEDIUM}
+        ></HomeWidgetItem>
+    );
+}
+
+function ItemIn4Variants(props: { children: React.ReactElement }) {
+    const item1 = React.cloneElement(props.children, {
+        options: { ...props.children.props.options, borderType: BorderType.NONE },
+    });
+    const item2 = React.cloneElement(props.children, {
+        options: { ...props.children.props.options, borderType: BorderType.BORDER },
+    });
+    const item3 = React.cloneElement(props.children, {
+        options: { ...props.children.props.options, borderType: BorderType.SHADOW },
+    });
+    const item4 = React.cloneElement(props.children, {
+        options: {
+            ...props.children.props.options,
+            borderType: BorderType.SHADOW,
+            background: { image: "linear-gradient(215.7deg, #FCFEFF 16.08%, #fafdff 63.71%)" },
+        },
+    });
+    const itemContainer = style({
+        flex: 1,
+        marginRight: 24,
+        $nest: {
+            "&:last-child": {
+                marginRight: 0,
+            },
+        },
+    });
+
+    const root = style({
+        display: "flex",
+    });
+
+    return (
+        <div className={root}>
+            <div className={itemContainer}>
+                <StoryHeading>No border</StoryHeading>
+                {item1}
+            </div>
+            <div className={itemContainer}>
+                <StoryHeading>Border</StoryHeading>
+                {item2}
+            </div>
+            <div className={itemContainer}>
+                <StoryHeading>Shadow</StoryHeading>
+                {item3}
+            </div>
+            <div className={itemContainer}>
+                <StoryHeading>Custom BG</StoryHeading>
+                {item4}
+            </div>
+        </div>
+    );
+}

--- a/library/src/scripts/homeWidget/HomeWidget.story.tsx
+++ b/library/src/scripts/homeWidget/HomeWidget.story.tsx
@@ -73,6 +73,70 @@ export function ContainerItemEdgeCases() {
     );
 }
 
+export function NotEnoughItems() {
+    return (
+        <div>
+            <HomeWidget
+                itemData={[dummyItemProps()]}
+                title="Want 4, only 1 given"
+                containerOptions={{
+                    maxColumnCount: 4,
+                    viewAll: { to: "#", position: "top" },
+                }}
+            />
+            <HomeWidget
+                itemData={[dummyItemProps(), dummyItemProps()]}
+                title="Want 4, only 2 given"
+                containerOptions={{
+                    maxColumnCount: 4,
+                    viewAll: { to: "#", position: "top" },
+                }}
+            />
+            <HomeWidget
+                itemData={[dummyItemProps(), dummyItemProps(), dummyItemProps()]}
+                title="Want 4, only 3 given"
+                containerOptions={{
+                    maxColumnCount: 4,
+                    viewAll: { to: "#", position: "top" },
+                }}
+            />
+            <HomeWidget
+                itemData={[dummyItemProps()]}
+                title="Images - Want 4, only 1 given"
+                containerOptions={{
+                    maxColumnCount: 4,
+                    viewAll: { to: "#", position: "top" },
+                }}
+                itemOptions={{
+                    contentType: HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE,
+                }}
+            />
+            <HomeWidget
+                itemData={[dummyItemProps(), dummyItemProps()]}
+                title="Images - Want 4, only 2 given"
+                containerOptions={{
+                    maxColumnCount: 4,
+                    viewAll: { to: "#", position: "top" },
+                }}
+                itemOptions={{
+                    contentType: HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE,
+                }}
+            />
+            <HomeWidget
+                itemData={[dummyItemProps(), dummyItemProps(), dummyItemProps()]}
+                title="Images - Want 4, only 3 given"
+                containerOptions={{
+                    maxColumnCount: 4,
+                    viewAll: { to: "#", position: "top" },
+                }}
+                itemOptions={{
+                    contentType: HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE,
+                }}
+            />
+        </div>
+    );
+}
+
 export const ContainerBackgroundVariants = storyWithConfig({ useWrappers: false }, () => {
     return (
         <div>

--- a/library/src/scripts/homeWidget/HomeWidget.story.tsx
+++ b/library/src/scripts/homeWidget/HomeWidget.story.tsx
@@ -5,25 +5,30 @@
 
 import React from "react";
 import { StoryHeading } from "@library/storybook/StoryHeading";
-import { HomeWidgetItem } from "@library/homeWidget/HomeWidgetItem";
+import { HomeWidgetItem, IHomeWidgetItemProps } from "@library/homeWidget/HomeWidgetItem";
 import { STORY_IPSUM_MEDIUM, STORY_IPSUM_SHORT, STORY_IMAGE } from "@library/storybook/storyData";
 import { HomeWidgetContainer, IHomeWidgetContainerProps } from "@library/homeWidget/HomeWidgetContainer";
 import { style } from "typestyle";
 import { HomeWidgetItemContentType } from "@library/homeWidget/HomeWidgetItem.styles";
 import { BorderType } from "@library/styles/styleHelpers";
 import { layoutVariables } from "@library/layout/panelLayoutStyles";
+import { color } from "csx";
+import { storyWithConfig } from "@library/storybook/StoryContext";
+import { HomeWidget } from "@library/homeWidget/HomeWidget";
 
 export default {
     title: "Home Widget",
 };
 
+const STANDARD_5_ITEMS = [dummyItemProps(), dummyItemProps(), dummyItemProps(), dummyItemProps(), dummyItemProps()];
+
 export function ContainerTextOnly() {
     return (
         <div>
-            <ContainerWithOptions title="4 columns" options={{ maxColumnCount: 4 }} />
-            <ContainerWithOptions title="3 columns" options={{ maxColumnCount: 3 }} />
-            <ContainerWithOptions title="2 columns" options={{ maxColumnCount: 2 }} />
-            <ContainerWithOptions title="1 column" options={{ maxColumnCount: 1 }} />
+            <HomeWidget title="4 columns" itemData={STANDARD_5_ITEMS} containerOptions={{ maxColumnCount: 4 }} />
+            <HomeWidget title="3 columns" itemData={STANDARD_5_ITEMS} containerOptions={{ maxColumnCount: 3 }} />
+            <HomeWidget title="2 columns" itemData={STANDARD_5_ITEMS} containerOptions={{ maxColumnCount: 2 }} />
+            <HomeWidget title="1 column" itemData={STANDARD_5_ITEMS} containerOptions={{ maxColumnCount: 1 }} />
         </div>
     );
 }
@@ -39,6 +44,73 @@ export function ContainerWithImage() {
 }
 
 ContainerWithImage.story = {
+    parameters: {
+        chromatic: {
+            viewports: Object.values(layoutVariables().panelLayoutBreakPoints),
+        },
+    },
+};
+
+export function ContainerItemEdgeCases() {
+    return (
+        <div>
+            <HomeWidgetContainer title="Text only, varying heights">
+                <DummyItem />
+                <DummyItem shortTitle />
+                <DummyItem shortBody />
+                <DummyItem shortTitle />
+                <DummyItem />
+            </HomeWidgetContainer>
+            <HomeWidgetContainer title="Missing image, varying heights">
+                <DummyItem image />
+                <DummyItem image imageMissing />
+                <DummyItem image shortBody />
+                <DummyItem image shortTitle />
+                <DummyItem image />
+            </HomeWidgetContainer>
+        </div>
+    );
+}
+
+export const ContainerBackgroundVariants = storyWithConfig({ useWrappers: false }, () => {
+    return (
+        <div>
+            <HomeWidget
+                itemData={STANDARD_5_ITEMS}
+                title="Solid Outer BG"
+                containerOptions={{ maxColumnCount: 3, outerBackground: { color: color("#EBF6FD") } }}
+            />
+            <HomeWidget
+                itemData={STANDARD_5_ITEMS}
+                maxItemCount={4}
+                title="Outer BG w/ shadowed items"
+                containerOptions={{
+                    maxColumnCount: 2,
+                    outerBackground: { color: color("#f4f4f4") },
+                }}
+                itemOptions={{ borderType: BorderType.SHADOW }}
+            />
+            <HomeWidget
+                itemData={STANDARD_5_ITEMS}
+                maxItemCount={4}
+                title="Inner BG & shadow"
+                containerOptions={{
+                    maxColumnCount: 1,
+                    outerBackground: { image: "linear-gradient(215.7deg, #FAFEFF 16.08%, #f6fdff 63.71%)" },
+                    borderType: BorderType.SHADOW,
+                }}
+            />
+            <HomeWidget
+                itemData={STANDARD_5_ITEMS}
+                maxItemCount={4}
+                title="Solid Color"
+                containerOptions={{ maxColumnCount: 2 }}
+            />
+        </div>
+    );
+});
+
+(ContainerBackgroundVariants as any).story = {
     parameters: {
         chromatic: {
             viewports: Object.values(layoutVariables().panelLayoutBreakPoints),
@@ -96,32 +168,29 @@ function ContainerWithOptionsAndImage(props: Omit<IHomeWidgetContainerProps, "ch
     );
 }
 
-function ContainerWithOptions(props: Omit<IHomeWidgetContainerProps, "children">) {
-    return (
-        <HomeWidgetContainer {...props}>
-            <DummyItem />
-            <DummyItem />
-            <DummyItem />
-            <DummyItem />
-            <DummyItem />
-        </HomeWidgetContainer>
-    );
+interface IDummyItemProps {
+    image?: boolean;
+    imageMissing?: boolean;
+    shortTitle?: boolean;
+    shortBody?: boolean;
 }
 
-function DummyItem(props: { image?: boolean }) {
-    return (
-        <HomeWidgetItem
-            options={{
-                contentType: props.image
-                    ? HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE
-                    : HomeWidgetItemContentType.TITLE_DESCRIPTION,
-            }}
-            imageUrl={STORY_IMAGE}
-            to="#"
-            name="Hello Longer longer longer longer longer even longer"
-            description={STORY_IPSUM_MEDIUM}
-        ></HomeWidgetItem>
-    );
+function dummyItemProps(props?: IDummyItemProps): IHomeWidgetItemProps {
+    return {
+        options: {
+            contentType: props?.image
+                ? HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE
+                : HomeWidgetItemContentType.TITLE_DESCRIPTION,
+        },
+        imageUrl: props?.imageMissing ? undefined : STORY_IMAGE,
+        to: "#",
+        name: props?.shortTitle ? "Short Title" : "Hello Longer longer longer longer longer even longer",
+        description: props?.shortBody ? STORY_IPSUM_SHORT : STORY_IPSUM_MEDIUM,
+    };
+}
+
+function DummyItem(props: IDummyItemProps) {
+    return <HomeWidgetItem {...dummyItemProps(props)}></HomeWidgetItem>;
 }
 
 function ItemIn4Variants(props: { children: React.ReactElement }) {
@@ -143,6 +212,8 @@ function ItemIn4Variants(props: { children: React.ReactElement }) {
     });
     const itemContainer = style({
         flex: 1,
+        display: "flex",
+        flexDirection: "column",
         marginRight: 24,
         $nest: {
             "&:last-child": {

--- a/library/src/scripts/homeWidget/HomeWidget.story.tsx
+++ b/library/src/scripts/homeWidget/HomeWidget.story.tsx
@@ -15,6 +15,7 @@ import { layoutVariables } from "@library/layout/panelLayoutStyles";
 import { color } from "csx";
 import { storyWithConfig } from "@library/storybook/StoryContext";
 import { HomeWidget } from "@library/homeWidget/HomeWidget";
+import { ButtonTypes } from "@library/forms/buttonStyles";
 
 export default {
     title: "Home Widget",
@@ -78,7 +79,11 @@ export const ContainerBackgroundVariants = storyWithConfig({ useWrappers: false 
             <HomeWidget
                 itemData={STANDARD_5_ITEMS}
                 title="Solid Outer BG"
-                containerOptions={{ maxColumnCount: 3, outerBackground: { color: color("#EBF6FD") } }}
+                containerOptions={{
+                    maxColumnCount: 3,
+                    outerBackground: { color: color("#EBF6FD") },
+                    viewAll: { to: "#", position: "top" },
+                }}
             />
             <HomeWidget
                 itemData={STANDARD_5_ITEMS}
@@ -86,7 +91,11 @@ export const ContainerBackgroundVariants = storyWithConfig({ useWrappers: false 
                 title="Outer BG w/ shadowed items"
                 containerOptions={{
                     maxColumnCount: 2,
-                    outerBackground: { color: color("#f4f4f4") },
+                    outerBackground: {
+                        image:
+                            "linear-gradient(0deg, rgba(181,219,255,1) 0%, rgba(223,246,255,1) 37%, rgba(255,255,255,1) 100%)",
+                    },
+                    viewAll: { to: "#", displayType: ButtonTypes.TRANSPARENT },
                 }}
                 itemOptions={{ borderType: BorderType.SHADOW }}
             />
@@ -98,13 +107,14 @@ export const ContainerBackgroundVariants = storyWithConfig({ useWrappers: false 
                     maxColumnCount: 1,
                     outerBackground: { image: "linear-gradient(215.7deg, #FAFEFF 16.08%, #f6fdff 63.71%)" },
                     borderType: BorderType.SHADOW,
+                    viewAll: { to: "#", displayType: ButtonTypes.PRIMARY },
                 }}
             />
             <HomeWidget
                 itemData={STANDARD_5_ITEMS}
                 maxItemCount={4}
-                title="Solid Color"
-                containerOptions={{ maxColumnCount: 2 }}
+                title="Very Very Very Very Long Title with a top view all button, Very Very Very long"
+                containerOptions={{ maxColumnCount: 2, viewAll: { to: "#", position: "top" } }}
             />
         </div>
     );

--- a/library/src/scripts/homeWidget/HomeWidget.tsx
+++ b/library/src/scripts/homeWidget/HomeWidget.tsx
@@ -1,0 +1,16 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { IHomeWidgetItemOptions } from "@library/homeWidget/HomeWidgetItem.styles";
+import { IHomeWidgetContainerOptions } from "@library/homeWidget/HomeWidgetContainer.styles";
+
+export interface IHomeWidgetProps {
+    containerOptions: IHomeWidgetContainerOptions;
+    itemOptions: IHomeWidgetItemOptions;
+    maxItemCount?: number;
+}
+
+interface IProps {}

--- a/library/src/scripts/homeWidget/HomeWidget.tsx
+++ b/library/src/scripts/homeWidget/HomeWidget.tsx
@@ -6,11 +6,26 @@
 import React from "react";
 import { IHomeWidgetItemOptions } from "@library/homeWidget/HomeWidgetItem.styles";
 import { IHomeWidgetContainerOptions } from "@library/homeWidget/HomeWidgetContainer.styles";
+import { IHomeWidgetItemProps, HomeWidgetItem } from "@library/homeWidget/HomeWidgetItem";
+import { HomeWidgetContainer } from "@library/homeWidget/HomeWidgetContainer";
 
-export interface IHomeWidgetProps {
-    containerOptions: IHomeWidgetContainerOptions;
-    itemOptions: IHomeWidgetItemOptions;
+interface IProps {
+    // Options
+    containerOptions?: IHomeWidgetContainerOptions;
+    itemOptions?: IHomeWidgetItemOptions;
     maxItemCount?: number;
+
+    // Content
+    title?: string;
+    itemData: IHomeWidgetItemProps[];
 }
 
-interface IProps {}
+export function HomeWidget(props: IProps) {
+    return (
+        <HomeWidgetContainer options={props.containerOptions} title={props.title}>
+            {props.itemData.slice(0, props.maxItemCount ?? props.itemData.length - 1).map((item, i) => {
+                return <HomeWidgetItem key={i} {...item} options={props.itemOptions} />;
+            })}
+        </HomeWidgetContainer>
+    );
+}

--- a/library/src/scripts/homeWidget/HomeWidget.tsx
+++ b/library/src/scripts/homeWidget/HomeWidget.tsx
@@ -4,10 +4,19 @@
  */
 
 import React from "react";
-import { IHomeWidgetItemOptions } from "@library/homeWidget/HomeWidgetItem.styles";
-import { IHomeWidgetContainerOptions } from "@library/homeWidget/HomeWidgetContainer.styles";
+import {
+    IHomeWidgetItemOptions,
+    HomeWidgetItemContentType,
+    homeWidgetItemVariables,
+} from "@library/homeWidget/HomeWidgetItem.styles";
+import {
+    IHomeWidgetContainerOptions,
+    homeWidgetContainerVariables,
+    homeWidgetContainerClasses,
+} from "@library/homeWidget/HomeWidgetContainer.styles";
 import { IHomeWidgetItemProps, HomeWidgetItem } from "@library/homeWidget/HomeWidgetItem";
 import { HomeWidgetContainer } from "@library/homeWidget/HomeWidgetContainer";
+import { insertMediaClasses } from "@rich-editor/flyouts/pieces/insertMediaClasses";
 
 interface IProps {
     // Options
@@ -21,10 +30,31 @@ interface IProps {
 }
 
 export function HomeWidget(props: IProps) {
+    const itemOptions = homeWidgetItemVariables(props.itemOptions).options;
+    const containerOptions = homeWidgetContainerVariables(props.containerOptions).options;
+    const containerClasses = homeWidgetContainerClasses(props.containerOptions);
+
+    let items = props.itemData;
+
+    if (props.maxItemCount && items.length > props.maxItemCount) {
+        items = items.slice(0, props.maxItemCount);
+    }
+
+    let extraSpacerItemCount = 0;
+    if (
+        itemOptions.contentType === HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE &&
+        props.itemData.length < containerOptions.maxColumnCount
+    ) {
+        extraSpacerItemCount = containerOptions.maxColumnCount - props.itemData.length;
+    }
+
     return (
         <HomeWidgetContainer options={props.containerOptions} title={props.title}>
-            {props.itemData.slice(0, props.maxItemCount ?? props.itemData.length - 1).map((item, i) => {
+            {items.map((item, i) => {
                 return <HomeWidgetItem key={i} {...item} options={props.itemOptions} />;
+            })}
+            {[...new Array(extraSpacerItemCount)].map((_, i) => {
+                return <div key={"spacer-" + i} className={containerClasses.gridItemSpacer}></div>;
             })}
         </HomeWidgetContainer>
     );

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -164,9 +164,15 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
         borderStyling,
     );
 
-    const gridItem = style("gridItem", {
+    const itemMixin: NestedCSSProperties = {
         flex: 1,
         flexBasis: percent(100 / vars.options.maxColumnCount),
+    };
+
+    const gridItem = style("gridItem", itemMixin);
+
+    const gridItemSpacer = style("gridItemSpacer", {
+        ...itemMixin,
     });
 
     const gridItemContent = style("gridItemContent", {
@@ -233,6 +239,7 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
         viewAll,
         grid,
         gridItem,
+        gridItemSpacer,
         gridItemContent,
         gridItemWidthConstraint,
     };

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -21,14 +21,11 @@ import {
     borders,
 } from "@library/styles/styleHelpers";
 import { layoutVariables } from "@library/layout/panelLayoutStyles";
-import { percent } from "csx";
+import { percent, borderColor } from "csx";
 import { NestedCSSProperties } from "typestyle/lib/types";
 import { shadowHelper } from "@library/styles/shadowHelpers";
-
-export enum ViewAllDisplayType {
-    BUTTON_PRIMARY = "buttonPrimary",
-    LINK = "link",
-}
+import { cssRule } from "typestyle";
+import { ButtonTypes } from "@library/forms/buttonStyles";
 
 export interface IHomeWidgetContainerOptions {
     outerBackground?: IBackground;
@@ -42,7 +39,8 @@ export interface IHomeWidgetContainerOptions {
 interface IViewAll {
     position?: "top" | "bottom";
     to?: string;
-    displayType?: ViewAllDisplayType;
+    name?: string;
+    displayType?: ButtonTypes;
 }
 
 export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHomeWidgetContainerOptions) => {
@@ -62,8 +60,8 @@ export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHo
             borderType: BorderType.NONE,
             maxWidth: layoutVars.contentSizes.full,
             viewAll: {
-                position: "top",
-                displayType: ViewAllDisplayType.LINK,
+                position: "bottom" as "top" | "bottom",
+                displayType: ButtonTypes.TEXT_PRIMARY,
             },
             maxColumnCount: 3,
         },
@@ -182,12 +180,60 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
         }),
     );
 
+    const viewAllContainer = style("viewAllContainer", {
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+    });
+
     const title = style("title", {
+        flex: 1,
         ...fonts(vars.title.font),
         ...paddings({
             horizontal: vars.spacing.gutter,
         }),
     });
 
-    return { root, content, borderedContent, title, grid, gridItem, gridItemContent, gridItemWidthConstraint };
+    const viewAll = style("viewAll", {
+        $nest: {
+            "&&": {
+                ...margins({
+                    horizontal: vars.spacing.gutter,
+                }),
+            },
+            "&:first-child": {
+                marginLeft: "auto",
+            },
+        },
+    });
+
+    const viewAllContent = style("viewAllContent", {
+        ...contentMixin,
+        paddingTop: 0,
+        marginTop: -vars.spacing.gutter,
+        $nest: {
+            [`.${borderedContent} + &`]: {
+                marginTop: 0,
+                $nest: {
+                    [`& .${viewAll}`]: {
+                        marginRight: 0,
+                    },
+                },
+            },
+        },
+    });
+
+    return {
+        root,
+        content,
+        borderedContent,
+        viewAllContent,
+        title,
+        viewAllContainer,
+        viewAll,
+        grid,
+        gridItem,
+        gridItemContent,
+        gridItemWidthConstraint,
+    };
 });

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -1,0 +1,137 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { useThemeCache, variableFactory, styleFactory } from "@library/styles/styleUtils";
+import { globalVariables } from "@library/styles/globalStyleVars";
+import { CsxBackgroundOptions } from "csx/lib/types";
+import {
+    BorderType,
+    EMPTY_BACKGROUND,
+    IBackground,
+    unit,
+    background,
+    margins,
+    EMPTY_FONTS,
+    fonts,
+    paddings,
+} from "@library/styles/styleHelpers";
+import { layoutVariables } from "@library/layout/panelLayoutStyles";
+import { percent } from "csx";
+
+export enum ViewAllDisplayType {
+    BUTTON_PRIMARY = "buttonPrimary",
+    LINK = "link",
+}
+
+export interface IHomeWidgetContainerOptions {
+    outerBackground?: IBackground;
+    innerBackground?: IBackground;
+    borderType?: BorderType;
+    maxWidth?: number | string;
+    viewAll?: IViewAll;
+    maxColumnCount?: number;
+}
+
+interface IViewAll {
+    position?: "top" | "bottom";
+    to?: string;
+    displayType?: ViewAllDisplayType;
+}
+
+export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHomeWidgetContainerOptions) => {
+    const makeVars = variableFactory("homeWidgetContainer");
+    const globalVars = globalVariables();
+    const layoutVars = layoutVariables();
+
+    let options = makeVars(
+        "options",
+        {
+            outerBackground: {
+                ...EMPTY_BACKGROUND,
+            },
+            innerBackground: {
+                ...EMPTY_BACKGROUND,
+            },
+            borderType: BorderType.NONE,
+            maxWidth: layoutVars.contentSizes.full,
+            viewAll: {
+                position: "top",
+                displayType: ViewAllDisplayType.LINK,
+            },
+            maxColumnCount: 3,
+        },
+        optionOverrides,
+    );
+
+    options = makeVars(
+        "options",
+        {
+            ...options,
+            maxWidth: options.maxColumnCount <= 2 ? layoutVars.contentSizes.narrow : layoutVars.contentSizes.full,
+        },
+        optionOverrides,
+    );
+
+    const title = makeVars("title", {
+        font: {
+            ...EMPTY_FONTS,
+        },
+    });
+
+    const spacing = makeVars("spacing", {
+        gutter: globalVars.gutter.size,
+    });
+
+    return { options, spacing, title };
+});
+
+export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHomeWidgetContainerOptions) => {
+    const style = styleFactory("homeWidgetContainer");
+    const vars = homeWidgetContainerVariables(optionOverrides);
+
+    const root = style({
+        ...background(vars.options.outerBackground ?? {}),
+    });
+
+    const content = style("content", {
+        maxWidth: unit(vars.options.maxWidth),
+        ...margins({
+            vertical: 0,
+            horizontal: "auto",
+        }),
+    });
+
+    const grid = style("grid", {
+        display: "flex",
+        alignItems: "stretch",
+        justifyContent: "flex-start",
+        flexWrap: "wrap",
+        padding: unit(vars.spacing.gutter / 2),
+    });
+
+    const gridItem = style("gridItem", {
+        flex: 1,
+        flexBasis: percent(100 / vars.options.maxColumnCount),
+    });
+
+    const gridItemContent = style("gridItemContent", {
+        padding: unit(vars.spacing.gutter / 2),
+    });
+
+    const gridItemWidthConstraint = useThemeCache((maxWidth: number) =>
+        style("gridItemWidthConstraint", {
+            maxWidth: maxWidth > 0 ? maxWidth : "initial",
+        }),
+    );
+
+    const title = style("title", {
+        ...fonts(vars.title.font),
+        ...paddings({
+            horizontal: vars.spacing.gutter,
+        }),
+    });
+
+    return { root, content, title, grid, gridItem, gridItemContent, gridItemWidthConstraint };
+});

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
@@ -13,6 +13,9 @@ import { useMeasure } from "@vanilla/react-utils";
 import classNames from "classnames";
 import Heading from "@library/layout/Heading";
 import { BorderType } from "@library/styles/styleHelpers";
+import LinkAsButton from "@library/routing/LinkAsButton";
+import { ButtonTypes } from "@library/forms/buttonStyles";
+import { t } from "@vanilla/i18n";
 
 export interface IHomeWidgetContainerProps {
     options?: IHomeWidgetContainerOptions;
@@ -51,13 +54,31 @@ export function HomeWidgetContainer(props: IHomeWidgetContainerProps) {
 
     const gridHasBorder = options.borderType !== BorderType.NONE;
 
+    const viewAllButton = props.options?.viewAll?.to && (
+        <LinkAsButton
+            to={props.options?.viewAll?.to}
+            baseClass={options.viewAll.displayType}
+            className={classes.viewAll}
+        >
+            {props.options?.viewAll?.name ?? t("View All")}
+        </LinkAsButton>
+    );
+
     return (
         <div className={classes.root}>
             <div className={classes.content}>
-                {props.title && <Heading className={classes.title}>{props.title}</Heading>}
+                <div className={classes.viewAllContainer}>
+                    {props.title && <Heading className={classes.title}>{props.title}</Heading>}
+                    {options.viewAll.position === "top" && viewAllButton}
+                </div>
                 {!gridHasBorder && grid}
             </div>
             {gridHasBorder && <div className={classes.borderedContent}>{grid}</div>}
+            {viewAllButton && options.viewAll.position === "bottom" && (
+                <div className={classes.viewAllContent}>
+                    <div className={classes.viewAllContainer}>{viewAllButton}</div>{" "}
+                </div>
+            )}
         </div>
     );
 }

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
@@ -7,10 +7,12 @@ import React, { useRef } from "react";
 import {
     IHomeWidgetContainerOptions,
     homeWidgetContainerClasses,
+    homeWidgetContainerVariables,
 } from "@library/homeWidget/HomeWidgetContainer.styles";
 import { useMeasure } from "@vanilla/react-utils";
 import classNames from "classnames";
 import Heading from "@library/layout/Heading";
+import { BorderType } from "@library/styles/styleHelpers";
 
 export interface IHomeWidgetContainerProps {
     options?: IHomeWidgetContainerOptions;
@@ -19,35 +21,43 @@ export interface IHomeWidgetContainerProps {
 }
 
 export function HomeWidgetContainer(props: IHomeWidgetContainerProps) {
+    const options = homeWidgetContainerVariables(props.options).options;
     const classes = homeWidgetContainerClasses(props.options);
 
     const firstItemRef = useRef<HTMLDivElement | null>(null);
     const firstItemMeasure = useMeasure(firstItemRef);
 
+    const grid = (
+        <div className={classes.grid}>
+            {React.Children.map(props.children, (child, i) => {
+                return (
+                    <div
+                        ref={i === 0 ? firstItemRef : undefined}
+                        className={classNames(
+                            classes.gridItem,
+
+                            // Constrain grid items to the same max width in each row.
+                            // Workaround for flex-box limiations.
+                            i !== 0 && classes.gridItemWidthConstraint(firstItemMeasure.width),
+                        )}
+                        key={i}
+                    >
+                        <div className={classes.gridItemContent}>{child}</div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+
+    const gridHasBorder = options.borderType !== BorderType.NONE;
+
     return (
         <div className={classes.root}>
             <div className={classes.content}>
                 {props.title && <Heading className={classes.title}>{props.title}</Heading>}
-                <div className={classes.grid}>
-                    {React.Children.map(props.children, (child, i) => {
-                        return (
-                            <div
-                                ref={i === 0 ? firstItemRef : undefined}
-                                className={classNames(
-                                    classes.gridItem,
-
-                                    // Constrain grid items to the same max width in each row.
-                                    // Workaround for flex-box limiations.
-                                    i !== 0 && classes.gridItemWidthConstraint(firstItemMeasure.width),
-                                )}
-                                key={i}
-                            >
-                                <div className={classes.gridItemContent}>{child}</div>
-                            </div>
-                        );
-                    })}
-                </div>
+                {!gridHasBorder && grid}
             </div>
+            {gridHasBorder && <div className={classes.borderedContent}>{grid}</div>}
         </div>
     );
 }

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
@@ -1,0 +1,53 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React, { useRef } from "react";
+import {
+    IHomeWidgetContainerOptions,
+    homeWidgetContainerClasses,
+} from "@library/homeWidget/HomeWidgetContainer.styles";
+import { useMeasure } from "@vanilla/react-utils";
+import classNames from "classnames";
+import Heading from "@library/layout/Heading";
+
+export interface IHomeWidgetContainerProps {
+    options?: IHomeWidgetContainerOptions;
+    children: React.ReactNode;
+    title?: string;
+}
+
+export function HomeWidgetContainer(props: IHomeWidgetContainerProps) {
+    const classes = homeWidgetContainerClasses(props.options);
+
+    const firstItemRef = useRef<HTMLDivElement | null>(null);
+    const firstItemMeasure = useMeasure(firstItemRef);
+
+    return (
+        <div className={classes.root}>
+            <div className={classes.content}>
+                {props.title && <Heading className={classes.title}>{props.title}</Heading>}
+                <div className={classes.grid}>
+                    {React.Children.map(props.children, (child, i) => {
+                        return (
+                            <div
+                                ref={i === 0 ? firstItemRef : undefined}
+                                className={classNames(
+                                    classes.gridItem,
+
+                                    // Constrain grid items to the same max width in each row.
+                                    // Workaround for flex-box limiations.
+                                    i !== 0 && classes.gridItemWidthConstraint(firstItemMeasure.width),
+                                )}
+                                key={i}
+                            >
+                                <div className={classes.gridItemContent}>{child}</div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
@@ -1,0 +1,176 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { globalVariables } from "@library/styles/globalStyleVars";
+import { shadowHelper } from "@library/styles/shadowHelpers";
+import {
+    absolutePosition,
+    background,
+    borders,
+    BorderType,
+    colorOut,
+    EMPTY_BACKGROUND,
+    EMPTY_FONTS,
+    EMPTY_SPACING,
+    fonts,
+    IBackground,
+    linkStyleFallbacks,
+    paddings,
+    setAllLinkColors,
+    unit,
+} from "@library/styles/styleHelpers";
+import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
+import { percent } from "csx";
+import { NestedCSSProperties } from "typestyle/lib/types";
+
+export enum HomeWidgetItemContentType {
+    TITLE = "title",
+    TITLE_DESCRIPTION = "title-description",
+    TITLE_DESCRIPTION_IMAGE = "title-description-image",
+}
+
+export interface IHomeWidgetItemOptions {
+    borderType?: BorderType;
+    background?: IBackground;
+    contentType?: HomeWidgetItemContentType;
+    fg?: string;
+}
+
+export const homeWidgetItemVariables = useThemeCache((optionOverrides?: IHomeWidgetItemOptions) => {
+    const makeVars = variableFactory("homeWidgetItem");
+    const globalVars = globalVariables();
+
+    let options = makeVars(
+        "options",
+        {
+            contentType: HomeWidgetItemContentType.TITLE_DESCRIPTION,
+            borderType: BorderType.NONE,
+            background: {
+                ...EMPTY_BACKGROUND,
+            },
+            fg: globalVars.mainColors.fg,
+        },
+        optionOverrides,
+    );
+
+    const hasImage = options.contentType === HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE;
+
+    options = makeVars(
+        "options",
+        {
+            ...options,
+            borderType: hasImage ? BorderType.SHADOW : BorderType.NONE,
+        },
+        optionOverrides,
+    );
+
+    const sizing = makeVars("sizing", {
+        minWidth: 280,
+    });
+
+    const name = makeVars("name", {
+        font: {
+            ...EMPTY_FONTS,
+        },
+    });
+
+    const hasBorder = [BorderType.BORDER, BorderType.SHADOW].includes(options.borderType);
+
+    const spacing = makeVars("spacing", {
+        contentPadding: {
+            ...EMPTY_SPACING,
+            vertical: hasBorder || hasImage ? 24 : 0,
+            horizontal: hasBorder ? 16 : 0,
+        },
+    });
+
+    const image = makeVars("image", {
+        ratio: {
+            height: 10,
+            width: 16,
+        },
+        maxHeight: 250,
+    });
+
+    return { options, sizing, name, spacing, image };
+});
+
+export const homeWidgetItemClasses = useThemeCache((optionOverrides?: IHomeWidgetItemOptions) => {
+    const vars = homeWidgetItemVariables(optionOverrides);
+    const globalVars = globalVariables();
+    const style = styleFactory("homeWidgetItem");
+
+    const borderStyling: NestedCSSProperties = (() => {
+        switch (vars.options.borderType) {
+            case BorderType.NONE:
+                return {};
+            case BorderType.BORDER:
+                return {
+                    ...borders(),
+                    $nest: {
+                        "&:hover, &:focus": {
+                            ...borders({
+                                color: globalVars.border.colorHover,
+                            }),
+                        },
+                    },
+                };
+            case BorderType.SHADOW:
+                return {
+                    borderRadius: globalVars.border.radius,
+                    ...shadowHelper().embed(),
+                    $nest: {
+                        "&:hover, &:focus": {
+                            ...shadowHelper().embedHover(),
+                        },
+                    },
+                };
+        }
+    })();
+
+    const linkStyles = setAllLinkColors();
+
+    const name = style("name", {
+        color: colorOut(vars.options.fg),
+        ...fonts(vars.name.font),
+        ...linkStyleFallbacks,
+    });
+
+    const root = style(
+        {
+            display: "block",
+            ...background(vars.options.background),
+            color: colorOut(vars.options.fg),
+            overflow: "hidden",
+            minWidth: unit(vars.sizing.minWidth),
+            $nest: {
+                [`&:active .${name}`]: linkStyles.nested["&&:active"],
+                [`&:focus .${name}`]: linkStyles.nested["&&:focus"],
+                [`&:hover .${name}`]: linkStyles.nested["&&:hover"],
+            },
+        },
+        borderStyling,
+    );
+
+    const content = style("content", {}, paddings(vars.spacing.contentPadding));
+
+    const imageAspectRatio = percent((vars.image.ratio.height / vars.image.ratio.width) * 100);
+
+    const imageContainer = style("imageContainer", {
+        background: colorOut(globalVars.mixPrimaryAndBg(0.08)),
+        width: percent(100),
+        paddingTop: imageAspectRatio,
+        position: "relative",
+        maxHeight: unit(vars.image.maxHeight),
+    });
+
+    const image = style("image", {
+        ...absolutePosition.fullSizeOfParent(),
+        objectFit: "cover",
+        objectPosition: "center center",
+    });
+
+    return { root, name, content, imageContainer, image };
+});

--- a/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
@@ -24,6 +24,7 @@ import {
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { percent } from "csx";
 import { NestedCSSProperties } from "typestyle/lib/types";
+import { layoutVariables } from "@library/layout/panelLayoutStyles";
 
 export enum HomeWidgetItemContentType {
     TITLE = "title",
@@ -41,6 +42,7 @@ export interface IHomeWidgetItemOptions {
 export const homeWidgetItemVariables = useThemeCache((optionOverrides?: IHomeWidgetItemOptions) => {
     const makeVars = variableFactory("homeWidgetItem");
     const globalVars = globalVariables();
+    const layoutVars = layoutVariables();
 
     let options = makeVars(
         "options",
@@ -78,7 +80,7 @@ export const homeWidgetItemVariables = useThemeCache((optionOverrides?: IHomeWid
     );
 
     const sizing = makeVars("sizing", {
-        minWidth: 280,
+        minWidth: layoutVars.contentSizes.full / 4 - layoutVars.gutter.size * 5, // Min width allows 4 items to fit.
     });
 
     const name = makeVars("name", {

--- a/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
@@ -66,6 +66,17 @@ export const homeWidgetItemVariables = useThemeCache((optionOverrides?: IHomeWid
         optionOverrides,
     );
 
+    options = makeVars(
+        "options",
+        {
+            ...options,
+            background: {
+                color: options.borderType !== BorderType.NONE ? globalVars.mainColors.bg : undefined,
+            },
+        },
+        optionOverrides,
+    );
+
     const sizing = makeVars("sizing", {
         minWidth: 280,
     });
@@ -136,10 +147,12 @@ export const homeWidgetItemClasses = useThemeCache((optionOverrides?: IHomeWidge
         color: colorOut(vars.options.fg),
         ...fonts(vars.name.font),
         ...linkStyleFallbacks,
+        marginBottom: unit(globalVars.gutter.half),
     });
 
     const root = style(
         {
+            height: percent(100),
             display: "block",
             ...background(vars.options.background),
             color: colorOut(vars.options.fg),

--- a/library/src/scripts/homeWidget/HomeWidgetItem.tsx
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.tsx
@@ -48,7 +48,11 @@ export function HomeWidgetItem(props: IHomeWidgetItemProps) {
                 {[
                     HomeWidgetItemContentType.TITLE_DESCRIPTION,
                     HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE,
-                ].includes(options.contentType) && <TruncatedText tag={"div"}>{props.description}</TruncatedText>}
+                ].includes(options.contentType) && (
+                    <TruncatedText maxCharCount={160} tag={"div"}>
+                        {props.description}
+                    </TruncatedText>
+                )}
             </div>
         </SmartLink>
     );

--- a/library/src/scripts/homeWidget/HomeWidgetItem.tsx
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.tsx
@@ -1,0 +1,55 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { BorderType } from "@library/styles/styleHelpers";
+import { CsxBackgroundOptions } from "csx/lib/types";
+import {
+    IHomeWidgetItemOptions,
+    homeWidgetItemVariables,
+    homeWidgetItemClasses,
+    HomeWidgetItemContentType,
+} from "@library/homeWidget/HomeWidgetItem.styles";
+import SmartLink from "@library/routing/links/SmartLink";
+import { LocationDescriptor } from "history";
+import Heading from "@library/layout/Heading";
+import TruncatedText from "@library/content/TruncatedText";
+
+interface IProps {
+    // Content
+    to: LocationDescriptor;
+    imageUrl?: string;
+    name?: string;
+    description?: string;
+
+    // Layout options
+    options?: IHomeWidgetItemOptions;
+}
+
+export function HomeWidgetItem(props: IProps) {
+    const options = homeWidgetItemVariables(props.options).options;
+    const classes = homeWidgetItemClasses(props.options);
+
+    console.log("options", { options, propOptions: props.options });
+
+    return (
+        <SmartLink to={props.to} className={classes.root}>
+            {HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE === options.contentType && (
+                <div className={classes.imageContainer}>
+                    {props.imageUrl && <img className={classes.image} src={props.imageUrl} alt={props.name} />}
+                </div>
+            )}
+            <div className={classes.content}>
+                <Heading depth={3} className={classes.name}>
+                    {props.name}
+                </Heading>
+                {[
+                    HomeWidgetItemContentType.TITLE_DESCRIPTION,
+                    HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE,
+                ].includes(options.contentType) && <TruncatedText tag={"div"}>{props.description}</TruncatedText>}
+            </div>
+        </SmartLink>
+    );
+}

--- a/library/src/scripts/homeWidget/HomeWidgetItem.tsx
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.tsx
@@ -17,7 +17,7 @@ import { LocationDescriptor } from "history";
 import Heading from "@library/layout/Heading";
 import TruncatedText from "@library/content/TruncatedText";
 
-interface IProps {
+export interface IHomeWidgetItemProps {
     // Content
     to: LocationDescriptor;
     imageUrl?: string;
@@ -28,7 +28,7 @@ interface IProps {
     options?: IHomeWidgetItemOptions;
 }
 
-export function HomeWidgetItem(props: IProps) {
+export function HomeWidgetItem(props: IHomeWidgetItemProps) {
     const options = homeWidgetItemVariables(props.options).options;
     const classes = homeWidgetItemClasses(props.options);
 

--- a/library/src/scripts/layout/PanelLayout.story.tsx
+++ b/library/src/scripts/layout/PanelLayout.story.tsx
@@ -11,7 +11,7 @@ import { useStoryConfig, NO_WRAPPER_CONFIG, storyWithConfig } from "@library/sto
 
 export default {
     title: "PanelLayout",
-    params: {
+    parameters: {
         chromatic: {
             viewports: Object.values(layoutVariables().panelLayoutBreakPoints),
         },

--- a/library/src/scripts/result/Result.tsx
+++ b/library/src/scripts/result/Result.tsx
@@ -78,7 +78,7 @@ export default class Result extends React.Component<IResult> {
                             )}
                             {!!this.props.excerpt && (
                                 <Paragraph className={classNames("searchResult-excerpt", classes.excerpt)}>
-                                    <TruncatedText>{this.props.excerpt}</TruncatedText>
+                                    <TruncatedText maxCharCount={160}>{this.props.excerpt}</TruncatedText>
                                 </Paragraph>
                             )}
                         </div>

--- a/library/src/scripts/storybook/storyData.ts
+++ b/library/src/scripts/storybook/storyData.ts
@@ -1,0 +1,26 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { IUserFragment } from "@vanilla/library/src/scripts/@types/api/users";
+
+export const STORY_IMAGE =
+    "https://user-images.githubusercontent.com/1770056/74069119-5dda5580-49cb-11ea-883b-61b7463c8cfc.png";
+
+export const STORY_IPSUM_LONG =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+export const STORY_IPSUM_MEDIUM = STORY_IPSUM_LONG.slice(0, 160) + "…";
+
+export const STORY_IPSUM_SHORT = STORY_IPSUM_LONG.slice(0, 50) + "…";
+
+export const STORY_DATE = "2019-05-05T15:51:23+00:00";
+
+export const STORY_USER: IUserFragment = {
+    userID: 1,
+    name: "Joe",
+    dateLastActive: "2016-07-25 17:51:15",
+    photoUrl: "https://user-images.githubusercontent.com/1770056/74098133-6f625100-4ae2-11ea-8a9d-908d70030647.png",
+    label: "User Label",
+};

--- a/library/src/scripts/storybookConfig.tsx
+++ b/library/src/scripts/storybookConfig.tsx
@@ -7,4 +7,6 @@ import { StoryContextProvider } from "@library/storybook/StoryContext";
 import { addDecorator } from "@storybook/react";
 import React from "react";
 
-addDecorator(storyFn => <StoryContextProvider>{storyFn()}</StoryContextProvider>);
+export function applyStoryContext() {
+    addDecorator(storyFn => <StoryContextProvider>{storyFn()}</StoryContextProvider>);
+}

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -125,6 +125,7 @@ export const globalVariables = useThemeCache(() => {
 
     const border = makeThemeVars("border", {
         color: mixBgAndFg(0.15),
+        colorHover: mixBgAndFg(0.2),
         width: 1,
         style: "solid",
         radius: 6,

--- a/library/src/scripts/styles/styleHelpersBorders.ts
+++ b/library/src/scripts/styles/styleHelpersBorders.ts
@@ -14,6 +14,12 @@ import { ColorHelper } from "csx";
 import { getValueIfItExists } from "@library/forms/borderStylesCalculator";
 import produce from "immer";
 
+export enum BorderType {
+    BORDER = "border",
+    NONE = "none",
+    SHADOW = "shadow",
+}
+
 export interface ISimpleBorderStyle {
     color?: ColorValues | ColorHelper;
     width?: BorderWidthProperty<TLength>;

--- a/library/src/scripts/styles/styleUtils.ts
+++ b/library/src/scripts/styles/styleUtils.ts
@@ -133,14 +133,17 @@ export function variableFactory(componentNames: string | string[]) {
             return merge(prev, curr);
         }, {});
 
-    return function makeThemeVars<T extends object>(subElementName: string, declaredVars: T): T {
+    return function makeThemeVars<T extends object>(subElementName: string, declaredVars: T, overrides?: any): T {
         const customVars = componentThemeVars?.[subElementName] ?? null;
-        if (customVars === null) {
-            return declaredVars;
+        let result = declaredVars;
+        if (customVars != null) {
+            result = normalizeVariables(customVars, result);
         }
 
-        const normalized = normalizeVariables(customVars, declaredVars);
-        return normalized;
+        if (overrides != null) {
+            result = normalizeVariables(overrides, result);
+        }
+        return result;
     };
 }
 

--- a/packages/vanilla-react-utils/package.json
+++ b/packages/vanilla-react-utils/package.json
@@ -5,6 +5,7 @@
     "version": "3.0.1",
     "dependencies": {
         "@vanilla/dom-utils": "^3.0.1",
+        "lodash": "^4.17.11",
         "resize-observer-polyfill": "1.5.1"
     },
     "peerDependencies": {

--- a/packages/vanilla-react-utils/src/useMeasure.ts
+++ b/packages/vanilla-react-utils/src/useMeasure.ts
@@ -5,6 +5,7 @@
 
 import { RefObject, useState, useLayoutEffect } from "react";
 import ResizeObserver from "resize-observer-polyfill";
+import debounce from "lodash/debounce";
 
 // DOMRectReadOnly.fromRect()
 const EMPTY_RECT: DOMRect = {
@@ -53,9 +54,9 @@ export function useMeasure(ref: RefObject<HTMLElement | null>, adjustForScrollOf
             });
         };
 
-        const resizeListener = () => {
+        const resizeListener = debounce(() => {
             measure();
-        };
+        }, 100);
         window.addEventListener("resize", resizeListener);
 
         const ro = new ResizeObserver(measure);
@@ -66,6 +67,7 @@ export function useMeasure(ref: RefObject<HTMLElement | null>, adjustForScrollOf
         return () => {
             window.cancelAnimationFrame(animationFrameId!);
             ro.disconnect();
+            resizeListener.cancel();
             window.removeEventListener("resize", resizeListener);
         };
     }, [adjustForScrollOffset, ref]);


### PR DESCRIPTION
Closes https://github.com/vanilla/knowledge/issues/1489

## New Components and stories
___[See the stories.](https://www.chromaticqa.com/build?appId=5d5eba16c782b600204ba187&number=2104)___

- `<HomeWidgetContainer />` - Handle paddings, backgrounds, and grid.
- `<HomeWidgetItem />` - Handle view layout and option of individual items in a home widget.
- `<HomeWidget />` - Combine the previous 2 widgets with some extra capabilities.

### Stories

- [Text only items](https://www.chromaticqa.com/snapshot?appId=5d5eba16c782b600204ba187&id=5e408602475c230022c19aa7)
- [Image items](https://www.chromaticqa.com/component?appId=5d5eba16c782b600204ba187&name=Home%20Widget&buildNumber=2104&specName=Container%20With%20Image)
- [Edge Cases with item variance](https://www.chromaticqa.com/component?appId=5d5eba16c782b600204ba187&name=Home%20Widget&buildNumber=2104&specName=Container%20Item%20Edge%20Cases)
- [Not enough items being provided](https://www.chromaticqa.com/component?appId=5d5eba16c782b600204ba187&name=Home%20Widget&buildNumber=2104&specName=Not%20Enough%20Items)
- [Inner and outer background variants](https://www.chromaticqa.com/component?appId=5d5eba16c782b600204ba187&name=Home%20Widget&buildNumber=2104&specName=Container%20Background%20Variants)
- [Item style variations](https://www.chromaticqa.com/component?appId=5d5eba16c782b600204ba187&name=Home%20Widget&buildNumber=2104&specName=Items)

## Changes
- Update `<TruncateText />` to be able to use character length truncation in addition to line based truncation.
- Refactor truncate text to use the `useMeasure` hook for better performance during resizes.
- Add debouncing to `useMeasure` for better performance during resizes.
- Update storybook to properly re-apply global decorators during a hot reload.
- Add some core story dummy data.
- Move `BorderType` to the borders file.
- Simplify passing prop based overrides to `variableFactory()`.
- Fix PanelLayout mobile sizes not running in chromatic.