### PR TITLE
Fix banner overflow

### DIFF
--- a/library/src/scripts/banner/banner.story.tsx
+++ b/library/src/scripts/banner/banner.story.tsx
@@ -15,6 +15,8 @@ import Banner from "@library/banner/Banner";
 import { SearchBarButtonType } from "@library/headers/mebox/pieces/compactSearchStyles";
 import { DeviceProvider } from "@library/layout/DeviceContext";
 import { BannerAlignment } from "@library/banner/bannerStyles";
+import { globalVariables } from "@library/styles/globalStyleVars";
+import { layoutVariables } from "@library/layout/panelLayoutStyles";
 
 export default {
     title: "Banner",
@@ -200,3 +202,72 @@ export const ImageAsElement = storyWithConfig(
     },
     () => <StoryBanner title="Image as Element - (With Left Alignment)" />,
 );
+
+(ImageAsElement as any).story = {
+    parameters: {
+        chromatic: {
+            viewports: [1400, globalVariables().content.width, layoutVariables().panelLayoutBreakPoints.oneColumn, 400],
+        },
+    },
+};
+
+export const ImageAsElementWide = storyWithConfig(
+    {
+        useWrappers: false,
+        themeVars: {
+            global: {
+                mainColors: {
+                    primary: color("#111111"),
+                },
+                body: {
+                    backgroundImage: {
+                        color: color("#efefef"),
+                    },
+                },
+                content: {
+                    width: 1350,
+                },
+            },
+            banner: {
+                options: {
+                    alignment: BannerAlignment.LEFT,
+                },
+                colors: {
+                    bg: "#fff",
+                    contrast: "#111111",
+                },
+                outerBackground: {
+                    color: "#FFF6F5",
+                    image: "linear-gradient(215.7deg, #FFFDFC 16.08%, #FFF6F5 63.71%), #C4C4C4",
+                },
+                description: {
+                    font: {
+                        color: "#323232",
+                    },
+                },
+                imageElement: {
+                    image:
+                        "https://user-images.githubusercontent.com/1770056/73629535-7fc98600-4621-11ea-8f0b-06b21dbd59e3.png",
+                },
+                searchButtonOptions: {
+                    type: SearchBarButtonType.NONE,
+                },
+                spacing: {
+                    padding: {
+                        top: 87,
+                        bottom: 87,
+                    },
+                },
+            },
+        },
+    },
+    () => <StoryBanner title="Image as Element - (With Left Alignment)" />,
+);
+
+(ImageAsElementWide as any).story = {
+    parameters: {
+        chromatic: {
+            viewports: [1450, 1350, layoutVariables().panelLayoutBreakPoints.oneColumn, 400],
+        },
+    },
+};

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -33,6 +33,7 @@ import { compactSearchVariables, SearchBarButtonType } from "@library/headers/me
 import { margins, paddings } from "@library/styles/styleHelpersSpacing";
 import { IButtonType } from "@library/forms/styleHelperButtonInterface";
 import { media } from "typestyle";
+import { containerVariables } from "@library/layout/components/containerStyles";
 
 export enum BannerAlignment {
     LEFT = "left",
@@ -87,6 +88,11 @@ export const bannerVariables = useThemeCache(() => {
 
     const backgrounds = makeThemeVars("backgrounds", {
         ...compactSearchVars.backgrounds,
+    });
+
+    const contentContainer = makeThemeVars("contentContainer", {
+        minWidth: 500,
+        padding: spacing.padding,
     });
 
     const imageElement = makeThemeVars("imageElement", {
@@ -299,6 +305,7 @@ export const bannerVariables = useThemeCache(() => {
         backgrounds,
         spacing,
         innerBackground,
+        contentContainer,
         text,
         title,
         description,
@@ -340,7 +347,6 @@ export const bannerClasses = useThemeCache(() => {
     const root = style({
         position: "relative",
         backgroundColor: colorOut(vars.outerBackground.color),
-        overflow: "hidden",
     });
 
     const outerBackground = (url?: string) => {
@@ -375,9 +381,9 @@ export const bannerClasses = useThemeCache(() => {
     const contentContainer = style(
         "contentContainer",
         {
-            ...paddings(vars.spacing.padding),
+            ...paddings(vars.contentContainer.padding),
             backgroundColor: vars.innerBackground.bg,
-            minWidth: 500,
+            minWidth: vars.contentContainer.minWidth,
         },
         media(
             { maxWidth: 500 },
@@ -504,14 +510,25 @@ export const bannerClasses = useThemeCache(() => {
         alignItems: "center",
     });
 
+    const makeImageMinWidth = (rootUnit, padding) =>
+        `${unit(rootUnit)} - ${unit(vars.contentContainer.minWidth)} - ${unit(
+            vars.contentContainer.padding.left ?? vars.contentContainer.padding.horizontal,
+        )} - ${unit(padding)}`;
+
     const imageElementContainer = style(
         "imageElementContainer",
         {
             alignSelf: "stretch",
-            minWidth: unit(vars.imageElement.minWidth),
+            minWidth: makeImageMinWidth(globalVars.content.width, containerVariables().spacing.padding.horizontal),
             flexGrow: 1,
             position: "relative",
         },
+        media(
+            { maxWidth: globalVars.content.width },
+            {
+                minWidth: makeImageMinWidth("100vw", containerVariables().spacing.padding.horizontal),
+            },
+        ),
         media(
             { maxWidth: 500 },
             {

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -91,7 +91,7 @@ export const bannerVariables = useThemeCache(() => {
     });
 
     const contentContainer = makeThemeVars("contentContainer", {
-        minWidth: 600,
+        minWidth: 550,
         padding: spacing.padding,
     });
 
@@ -387,7 +387,11 @@ export const bannerClasses = useThemeCache(() => {
             minWidth: vars.contentContainer.minWidth,
         },
         media(
-            { maxWidth: 500 },
+            {
+                maxWidth: calc(
+                    `${unit(vars.contentContainer.minWidth)} + ${unit(vars.contentContainer.padding.horizontal)} * 4`,
+                ),
+            },
             {
                 minWidth: "initial",
             },

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -91,13 +91,13 @@ export const bannerVariables = useThemeCache(() => {
     });
 
     const contentContainer = makeThemeVars("contentContainer", {
-        minWidth: 500,
+        minWidth: 600,
         padding: spacing.padding,
     });
 
     const imageElement = makeThemeVars("imageElement", {
         image: undefined as string | undefined,
-        minWidth: 600,
+        minWidth: 500,
         disappearingWidth: 500,
         padding: {
             ...EMPTY_SPACING,

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -8,7 +8,7 @@ import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { formElementsVariables } from "@library/forms/formElementStyles";
 import { BackgroundColorProperty, FontWeightProperty, PaddingProperty, TextShadowProperty } from "csstype";
-import { important, percent, px, quote, translateX, ColorHelper, url, rgba } from "csx";
+import { important, percent, px, quote, translateX, ColorHelper, url, rgba, calc } from "csx";
 import {
     centeredBackgroundProps,
     fonts,
@@ -102,6 +102,7 @@ export const bannerVariables = useThemeCache(() => {
         padding: {
             ...EMPTY_SPACING,
             all: globalVars.gutter.size,
+            right: 0,
         },
     });
 
@@ -511,9 +512,11 @@ export const bannerClasses = useThemeCache(() => {
     });
 
     const makeImageMinWidth = (rootUnit, padding) =>
-        `${unit(rootUnit)} - ${unit(vars.contentContainer.minWidth)} - ${unit(
-            vars.contentContainer.padding.left ?? vars.contentContainer.padding.horizontal,
-        )} - ${unit(padding)}`;
+        calc(
+            `${unit(rootUnit)} - ${unit(vars.contentContainer.minWidth)} - ${unit(
+                vars.contentContainer.padding.left ?? vars.contentContainer.padding.horizontal,
+            )} - ${unit(padding * 2)}`,
+        );
 
     const imageElementContainer = style(
         "imageElementContainer",
@@ -522,6 +525,7 @@ export const bannerClasses = useThemeCache(() => {
             minWidth: makeImageMinWidth(globalVars.content.width, containerVariables().spacing.padding.horizontal),
             flexGrow: 1,
             position: "relative",
+            overflow: "hidden",
         },
         media(
             { maxWidth: globalVars.content.width },
@@ -529,6 +533,11 @@ export const bannerClasses = useThemeCache(() => {
                 minWidth: makeImageMinWidth("100vw", containerVariables().spacing.padding.horizontal),
             },
         ),
+        layoutVariables()
+            .mediaQueries()
+            .oneColumnDown({
+                minWidth: makeImageMinWidth("100vw", containerVariables().spacing.paddingMobile.horizontal),
+            }),
         media(
             { maxWidth: 500 },
             {
@@ -540,12 +549,24 @@ export const bannerClasses = useThemeCache(() => {
     const imageElement = style(
         "imageElement",
         {
-            ...absolutePosition.fullSizeOfParent(),
-            objectFit: "contain",
+            ...absolutePosition.middleRightOfParent(),
+            minWidth: unit(vars.imageElement.minWidth),
             ...paddings(vars.imageElement.padding),
             objectPosition: "100% 50%",
+            objectFit: "contain",
+            marginLeft: "auto",
+            right: 0,
         },
-        mediaQueries.oneColumnDown({ objectPosition: "0% 100%" }),
+        media(
+            {
+                maxWidth: calc(
+                    `${unit(vars.imageElement.minWidth)} + ${unit(vars.contentContainer.minWidth)} + ${unit(
+                        vars.imageElement.padding.horizontal ?? vars.imageElement.padding.all,
+                    )}`,
+                ),
+            },
+            { right: "initial", objectPosition: "0% 50%" },
+        ),
     );
 
     return {

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -519,7 +519,7 @@ export const bannerClasses = useThemeCache(() => {
         calc(
             `${unit(rootUnit)} - ${unit(vars.contentContainer.minWidth)} - ${unit(
                 vars.contentContainer.padding.left ?? vars.contentContainer.padding.horizontal,
-            )} - ${unit(padding * 2)}`,
+            )} - ${unit(padding)}`,
         );
 
     const imageElementContainer = style(
@@ -566,7 +566,7 @@ export const bannerClasses = useThemeCache(() => {
                 maxWidth: calc(
                     `${unit(vars.imageElement.minWidth)} + ${unit(vars.contentContainer.minWidth)} + ${unit(
                         vars.imageElement.padding.horizontal ?? vars.imageElement.padding.all,
-                    )}`,
+                    )} * 2`,
                 ),
             },
             { right: "initial", objectPosition: "0% 50%" },

--- a/library/src/scripts/layout/components/containerStyles.ts
+++ b/library/src/scripts/layout/components/containerStyles.ts
@@ -20,6 +20,9 @@ export const containerVariables = useThemeCache(() => {
         padding: {
             horizontal: vars.gutter.size,
         },
+        paddingMobile: {
+            horizontal: 8,
+        },
     });
 
     const sizing = makeThemeVars("sizes", {
@@ -57,12 +60,11 @@ export const containerMainStyles = () => {
 export const containerClasses = useThemeCache(() => {
     const style = styleFactory("container");
     const mediaQueries = layoutVariables().mediaQueries();
+    const vars = containerVariables();
     const root = style(
         containerMainStyles() as NestedCSSProperties,
         mediaQueries.oneColumnDown({
-            ...paddings({
-                horizontal: 8,
-            }),
+            ...paddings(vars.spacing.paddingMobile),
         }),
     );
     return { root };


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/10066

Fixes banner image overflow cutting off the search results.

The new calculations are more complex but deliver the same behaviour as before. I've added additional stories and breakpoints for stories so due to the more complex behaviour.