### PR TITLE
Fix chromatic not working with squash merges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,15 @@
 version: 2.1
 orbs:
     core: vanilla/core@2
-    chromatic: wave/chromatic@1.0.1
     codecov: codecov/codecov@1.0.5
 aliases:
     - &run_yarn
         run:
             name: Install Yarn Packages
             command: |
-                cd ~/workspace/repo
+                if [ -d ~/workspace/repo ]; then
+                    cd ~/workspace/repo
+                fi
                 yarn install --pure-lockfile
                 yarn install-all
     - &attach_workspace
@@ -229,8 +230,28 @@ jobs:
                     fi
                 name: "Conditionally perform Chromatic test"
             - checkout
-            - chromatic/load-node-modules
-            - chromatic/test-exit-cleanly-on-changes
+            - *run_yarn
+            - run:
+                command: yarn chromatic test --exit-zero-on-changes
+                name: Chromatic - accept all changes
+    chromatic_run_accept_all:
+        executor: core/node
+        steps:
+            - run:
+                command: |
+                    if [ -z "$CHROMATIC_APP_CODE" ]; then
+                        echo "No Chromatic app code detected. Exiting."
+                        circleci-agent step halt
+                    else
+                        echo "Chromatic app code detected. Proceeding..."
+                    fi
+                name: "Conditionally perform Chromatic test"
+            - checkout
+            - *run_yarn
+            - run:
+                command: yarn chromatic test --auto-accept-changes
+                name: Chromatic - accept all changes
+
 
 workflows:
     version: 2
@@ -240,7 +261,7 @@ workflows:
                 filters:
                     branches:
                         ignore: master
-            - chromatic/run-and-accept-all:
+            - chromatic_run_accept_all:
                 filters:
                     branches:
                         only: master


### PR DESCRIPTION
Old accepted stories keep appearing in new PRs. This seems to be the cause of 2 things.

- The old version of orb 1.0.1 that we're using passes the wrong flag (`--accept-all` instead of `--auto-accept-changes`). Unfortunately the only version that passes the correct flag doesn't support using a secure environment variable for configuring chromatic.
- Manual PR approvals don't work with squash merges, because the "approved" commit never makes it master branch. Instead a new unapproved change is applied. Talking to CircleCI support, the proper solution is to add `--auto-accept-changes` when calling chromatic.

It came to my attention that the orb we are using is not actually an official chromatic one, because they currently don't have one. I've passed along the feature request through their support channel.

In the meantime I replaced this chromatic orb with by just running the command in a simple way.

@initvector After this you should be able to re-enable squash-merging on this repo.