### PR TITLE
Update categories page to load a CategoryID from the current site section

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -8,6 +8,9 @@
  * @since 2.0
  */
 
+use Vanilla\Contracts\Site\SiteSectionInterface;
+use Vanilla\Site\SiteSectionModel;
+
 /**
  * Handles displaying categories via /categoris endpoint.
  */
@@ -260,6 +263,12 @@ class CategoriesController extends VanillaController {
      * @param int $offset Number of discussions to skip.
      */
     public function index($categoryIdentifier = '', $page = '0') {
+        if (!$categoryIdentifier) {
+            /** @var SiteSectionInterface $siteSection */
+            $siteSection = Gdn::getContainer()->get(SiteSectionModel::class)->getCurrentSiteSection();
+            $categoryIdentifier = $siteSection->getAttributes()['CategoryID'] ?? '';
+        }
+
         // Figure out which category layout to choose (Defined on "Homepage" settings page).
         $layout = c('Vanilla.Categories.Layout');
 

--- a/library/Vanilla/Contracts/Site/SiteSectionInterface.php
+++ b/library/Vanilla/Contracts/Site/SiteSectionInterface.php
@@ -86,4 +86,11 @@ interface SiteSectionInterface extends \JsonSerializable {
      * @return array
      */
     public function setApplication(string $app, bool $enable);
+
+    /**
+     * Get attributes assosciated with the site section.
+     *
+     * @return array
+     */
+    public function getAttributes(): array;
 }

--- a/library/Vanilla/Site/DefaultSiteSection.php
+++ b/library/Vanilla/Site/DefaultSiteSection.php
@@ -116,4 +116,11 @@ class DefaultSiteSection implements SiteSectionInterface {
     public function setApplication(string $app, bool $enable = true) {
         $this->apps[$app] = $enable;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAttributes(): array {
+        return [];
+    }
 }

--- a/tests/fixtures/src/MockSiteSection.php
+++ b/tests/fixtures/src/MockSiteSection.php
@@ -129,4 +129,11 @@ class MockSiteSection implements SiteSectionInterface {
     public function setApplication(string $app, bool $enable = true) {
         $this->apps[$app] = $enable;
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAttributes(): array {
+        return [];
+    }
 }


### PR DESCRIPTION
Related to https://github.com/vanilla/support/issues/1411

- When no ID is provided to the categories controller index, check the site section and see if it has a contextual ID in it's attributes.
- Add attributes method to site section interface.