### PR TITLE
Fix Users' Own Comments Appearing to them as New

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1264,10 +1264,10 @@ class CommentModel extends Gdn_Model {
         // discussion author.
         $this->updateUser($Fields['InsertUserID'], $IncUser && $Insert);
 
-        // Mark the user as participated.
+        // Mark the user as participated and update DateLastViewed.
         $this->SQL->replace(
             'UserDiscussion',
-            ['Participated' => 1],
+            ['Participated' => 1, 'DateLastViewed' => $Fields['DateInserted']],
             ['DiscussionID' => $DiscussionID, 'UserID' => val('InsertUserID', $Fields)]
         );
 


### PR DESCRIPTION
After vanilla/vanilla#9944, we're calculating whether there are new comments based on dates rather than comment counts. This caused a user's own comment to discussions display as new to that user. This PR fixes that problem by updating the DateLastViewed field in the user_discussion table whenever a user makes a comment.

### TO TEST
1. Before checking out branch, make a comment on a discussion. 
1. Go to Discussions page and verify that the discussion displays as new.
1. Checkout branch, repeat steps 1 and 2, and verify that the discussion doesn't display as new.