### PR TITLE
Fix Stub Content re-adding content by re-enforcing the check for Garden.Installed

### DIFF
--- a/plugins/stubcontent/class.stubcontent.plugin.php
+++ b/plugins/stubcontent/class.stubcontent.plugin.php
@@ -243,7 +243,7 @@ class StubContentPlugin extends Gdn_Plugin {
                     if ($rowID) {
                         $receipt = $this->createReceipt($content, $rowID);
                     } else {
-                        Logger::event("stubcontent-insertfailed", "Failed to insert {type} ({content}): {error}", [
+                        Logger::event("stubcontent-insertfailed", Logger::WARNING, "Failed to insert {type} ({content}): {error}", [
                             'type' => $content['type'],
                             'content' => $contentID,
                             'error' => print_r($model->validationResults(), true)
@@ -255,7 +255,7 @@ class StubContentPlugin extends Gdn_Plugin {
                         $errors[] = "missing role: {$roleTag}";
                     }
 
-                    Logger::event("stubcontent-insertfailed", "Failed to insert {type} ({content}): {error}", [
+                    Logger::event("stubcontent-insertfailed", Logger::WARNING, "Failed to insert {type} ({content}): {error}", [
                         'type' => $content['type'],
                         'content' => $contentID,
                         'error' => print_r($errors, true)
@@ -306,7 +306,7 @@ class StubContentPlugin extends Gdn_Plugin {
                     if ($rowID) {
                         $receipt = $this->createReceipt($content, $rowID);
                     } else {
-                        Logger::event("stubcontent-insertfailed", "Failed to insert {type} ({content}): {error}", [
+                        Logger::event("stubcontent-insertfailed", Logger::WARNING, "Failed to insert {type} ({content}): {error}", [
                             'type' => $content['type'],
                             'content' => $contentID,
                             'error' => print_r($model->validationResults(), true)
@@ -321,7 +321,7 @@ class StubContentPlugin extends Gdn_Plugin {
                         $errors[] = "missing category: {$categoryTag}";
                     }
 
-                    Logger::event("stubcontent-insertfailed", "Failed to insert {type} ({content}): {error}", [
+                    Logger::event("stubcontent-insertfailed", Logger::WARNING, "Failed to insert {type} ({content}): {error}", [
                         'type' => $content['type'],
                         'content' => $contentID,
                         'error' => print_r($errors, true)
@@ -369,7 +369,7 @@ class StubContentPlugin extends Gdn_Plugin {
                     if ($rowID) {
                         $receipt = $this->createReceipt($content, $rowID);
                     } else {
-                        Logger::event("stubcontent-insertfailed", "Failed to insert {type} ({content}): {error}", [
+                        Logger::event("stubcontent-insertfailed", Logger::WARNING, "Failed to insert {type} ({content}): {error}", [
                             'type' => $content['type'],
                             'content' => $contentID,
                             'error' => print_r($model->validationResults(), true)
@@ -384,7 +384,7 @@ class StubContentPlugin extends Gdn_Plugin {
                         $errors[] = "missing parent: {$parentTag}";
                     }
 
-                    Logger::event("stubcontent-insertfailed", "Failed to insert {type} ({content}): {error}", [
+                    Logger::event("stubcontent-insertfailed", Logger::WARNING, "Failed to insert {type} ({content}): {error}", [
                         'type' => $content['type'],
                         'content' => $contentID,
                         'error' => print_r($errors, true)
@@ -407,7 +407,7 @@ class StubContentPlugin extends Gdn_Plugin {
                 if ($rowID) {
                     $receipt = $this->createReceipt($content, $rowID);
                 } else {
-                    Logger::event("stubcontent-insertfailed", "Failed to insert {type} ({content}): {error}", [
+                    Logger::event("stubcontent-insertfailed", Logger::WARNING, "Failed to insert {type} ({content}): {error}", [
                         'type' => $content['type'],
                         'content' => $contentID,
                         'error' => print_r($model->validationResults(), true)

--- a/plugins/stubcontent/class.stubcontent.plugin.php
+++ b/plugins/stubcontent/class.stubcontent.plugin.php
@@ -201,7 +201,7 @@ class StubContentPlugin extends Gdn_Plugin {
     public function insertContent($content) {
 
         // Don't affect installed forums
-        if (c('Garden.Installed', false) === true) {
+        if (!empty(c('Garden.Installed', false))) {
             return;
         }
 

--- a/plugins/stubcontent/class.stubcontent.plugin.php
+++ b/plugins/stubcontent/class.stubcontent.plugin.php
@@ -201,7 +201,7 @@ class StubContentPlugin extends Gdn_Plugin {
     public function insertContent($content) {
 
         // Don't affect installed forums
-        if (!empty(c('Garden.Installed', false))) {
+        if (c('Garden.Installed', false) == true) {
             return;
         }
 

--- a/plugins/stubcontent/class.stubcontent.plugin.php
+++ b/plugins/stubcontent/class.stubcontent.plugin.php
@@ -201,7 +201,7 @@ class StubContentPlugin extends Gdn_Plugin {
     public function insertContent($content) {
 
         // Don't affect installed forums
-        if (c('Garden.Installed', false) == true) {
+        if (c('Garden.Installed', false)) {
             return;
         }
 


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1412

The issue happens because **Stub Content** checks for the config `Garden.Installed` before adding the content, and all those communities (for whatever reason I couldn't find why) have this config set to `'1'` instead of `true`.

I've made a fix which reenforces this check so it doesn't happen again.