### PR TITLE
Add minimum length validation rule for the original post of a discussion

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2080,16 +2080,22 @@ class DiscussionModel extends Gdn_Model {
             $this->Validation->addRule('MeAction', 'function:ValidateMeAction');
             $this->Validation->applyRule('Body', 'MeAction');
             $maxCommentLength = Gdn::config('Vanilla.Comment.MaxLength');
+            $minCommentLength = Gdn::config('Vanilla.Comment.MinLength');
 
             if (is_numeric($maxCommentLength) && $maxCommentLength > 0) {
                 $this->Validation->setSchemaProperty('Body', 'Length', $maxCommentLength);
                 $this->Validation->applyRule('Body', 'Length');
             }
 
-            // Add min length if body is required.
-            if (Gdn::config('Vanilla.DiscussionBody.Required', true)) {
-                $this->Validation->setSchemaProperty('Body', 'MinTextLength', 1);
+            if ($minCommentLength && is_numeric($minCommentLength)) {
+                $this->Validation->setSchemaProperty('Body', 'MinTextLength', $minCommentLength);
                 $this->Validation->applyRule('Body', 'MinTextLength');
+            } else {
+                // Add min length if body is required.
+                if (Gdn::config('Vanilla.DiscussionBody.Required', true)) {
+                    $this->Validation->setSchemaProperty('Body', 'MinTextLength', 1);
+                    $this->Validation->applyRule('Body', 'MinTextLength');
+                }
             }
         }
 

--- a/applications/vanilla/views/vanillasettings/posting.php
+++ b/applications/vanilla/views/vanillasettings/posting.php
@@ -168,8 +168,8 @@ specify the same one as above. If users report issues with mobile editing, this 
     </div>
     <div class="form-group">
         <div class="label-wrap">
-        <?php echo $form->label('Max Comment Length', 'Vanilla.Comment.MaxLength'); ?>
-        <div class="info"><?php echo t("It is a good idea to keep the maximum number of characters allowed in a comment down to a reasonable size."); ?></div>
+        <?php echo $form->label('Max Post Length', 'Vanilla.Comment.MaxLength'); ?>
+        <div class="info"><?php echo t("It is a good idea to keep the maximum number of characters allowed in a post down to a reasonable size."); ?></div>
         </div>
         <div class="input-wrap">
         <?php echo $form->textBox('Vanilla.Comment.MaxLength', ['class' => 'InputBox SmallInput']); ?>
@@ -177,8 +177,8 @@ specify the same one as above. If users report issues with mobile editing, this 
     </div>
     <div class="form-group">
         <div class="label-wrap">
-        <?php echo $form->label('Min Comment Length', 'Vanilla.Comment.MinLength'); ?>
-        <div class="info"><?php echo t("You can specify a minimum comment length to discourage short comments."); ?></div>
+        <?php echo $form->label('Min Post Length', 'Vanilla.Comment.MinLength'); ?>
+        <div class="info"><?php echo t("You can specify a minimum post length to discourage short posts."); ?></div>
         </div>
         <div class="input-wrap">
         <?php echo $form->textBox('Vanilla.Comment.MinLength', ['class' => 'InputBox SmallInput']); ?>


### PR DESCRIPTION
Closes vanilla/support#343

The minimum length configuration setting previously applied to comments, but not the original post of a discussion. Since users expect that that setting would apply to the original post as well as comments, this fix implements that.

### TO TEST
1. On master, set a minimum post length and start a discussion where the body is shorter than the min.
1. Observe that the discussion passes validation.
1. Checkout branch, repeat steps 1 and 2, and verify that the 'This discussion is x characters too short' error message displays.