### PR TITLE
Refactor tryRecalculate lock condition

### DIFF
--- a/applications/dashboard/modules/class.sitetotalsmodule.php
+++ b/applications/dashboard/modules/class.sitetotalsmodule.php
@@ -79,10 +79,8 @@ class SiteTotalsModule extends Gdn_Module {
     private function tryRecalculate():bool {
         $lock = Gdn::cache()->get(self::LOCK_KEY);
 
-        if ($lock === Gdn_Cache::CACHEOP_SUCCESS) { //already locked
-            return false;
-        } else {
-            $added = Gdn::cache()->add(self::LOCK_KEY, mt_rand(0, 999999), [Gdn_Cache::FEATURE_EXPIRY => self::LOCK_INTERVAL]);
+        if ($lock === Gdn_Cache::CACHEOP_FAILURE) { //already locked
+            $added = Gdn::cache()->add(self::LOCK_KEY, mt_rand(1, 999999), [Gdn_Cache::FEATURE_EXPIRY => self::LOCK_INTERVAL]);
 
             if ($added) {
                 /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */


### PR DESCRIPTION
`tryRecalculate` had a bug where it was trying to match with `true` but if the `mt_rand(0, 999999)` returns `0` it would fail.