### PR TITLE
Fix API authentication by setting HTTP_AUTHORIZATION in .htaccess.dist

### DIFF
--- a/.htaccess.dist
+++ b/.htaccess.dist
@@ -46,10 +46,12 @@
     RewriteCond %{ENV:REDIRECT_X_PATH_INFO} (.+)
     RewriteRule ^index\.php - [E=X_REWRITE:1,E=!REDIRECT_X_REWRITE,E=X_PATH_INFO:%1,E=!REDIRECT_X_PATH_INFO,L]
     
-    ####
-    # Pass Authorization header to php environment variable to support API authentication
-    ####
-    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+    <IfModule mod_setenvif.c>
+        ####
+        # Pass Authorization header to php environment variable to support API authentication
+        ####
+        SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+    </IfModule>
 </IfModule>
 
 <IfModule mod_headers.c>

--- a/.htaccess.dist
+++ b/.htaccess.dist
@@ -45,6 +45,11 @@
     RewriteCond %{ENV:REDIRECT_X_REWRITE} .+
     RewriteCond %{ENV:REDIRECT_X_PATH_INFO} (.+)
     RewriteRule ^index\.php - [E=X_REWRITE:1,E=!REDIRECT_X_REWRITE,E=X_PATH_INFO:%1,E=!REDIRECT_X_PATH_INFO,L]
+    
+    ####
+    # Pass Authorization header to php environment variable to support API authentication
+    ####
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 </IfModule>
 
 <IfModule mod_headers.c>


### PR DESCRIPTION
Fixes #10091 

`$_SERVER['HTTP_AUTHORIZATION']` is empty by default, even when `Authorization` it's present in apache request headers. This passes the `Authorization` header to it, so [access token checking](https://github.com/vanilla/vanilla/blob/Vanilla_3.3/applications/dashboard/settings/class.hooks.php#L753) will work.

Feel free to disregard if there's a better way to address #10091.
