### PR TITLE
Optimize DiscussionModel query

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -860,7 +860,8 @@ class DiscussionModel extends Gdn_Model {
         $finalQuery = str_replace(
             '`'.$this->Database->DatabasePrefix.'_TBL_`',
             '('.$subQuery.')',
-            $outerQuery);
+            $outerQuery
+        );
 
         $data = $sql->query($finalQuery);
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -791,9 +791,8 @@ class DiscussionModel extends Gdn_Model {
         $sql = $this->SQL;
 
         // Build up the base query. Self-join for optimization.
-        $sql->select('d2.*')
+        $sql->select('d.DiscussionID')
             ->from('Discussion d')
-            ->join('Discussion d2', 'd.DiscussionID = d2.DiscussionID')
             ->limit($limit, $offset);
 
         foreach ($orderBy as $field => $direction) {
@@ -840,6 +839,12 @@ class DiscussionModel extends Gdn_Model {
             $safeWheres[$this->addFieldPrefix($key)] = $value;
         }
         $sql->where($safeWheres);
+        $subQuery = $sql->getSelect(true);
+
+        $sql->reset();
+        $sql->select('d2.*')
+            ->from('Discussion d2')
+            ->join('_TBL_ d', 'd.DiscussionID = d2.DiscussionID');
 
         // Add the UserDiscussion query.
         if (($userID = Gdn::session()->UserID) > 0) {
@@ -851,7 +856,13 @@ class DiscussionModel extends Gdn_Model {
                 ->select('w.Participated');
         }
 
-        $data = $sql->get();
+        $outerQuery = $sql->getSelect();
+        $finalQuery = str_replace(
+            '`'.$this->Database->DatabasePrefix.'_TBL_`',
+            '('.$subQuery.')',
+            $outerQuery);
+
+        $data = $sql->query($finalQuery);
 
         // Change discussions returned based on additional criteria
         $this->addDiscussionColumns($data);

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -188,13 +188,13 @@ $Construct->table('UserDiscussion');
 $ParticipatedExists = $Construct->columnExists('Participated');
 
 $Construct->column('UserID', 'int', false, 'primary')
-    ->column('DiscussionID', 'int', false, ['primary', 'key', 'index.bookmarked', 'index.participated'])
+    ->column('DiscussionID', 'int', false, ['primary', 'key'])
     ->column('Score', 'float', null)
     ->column('CountComments', 'int', '0')
     ->column('DateLastViewed', 'datetime', null)// null signals never
     ->column('Dismissed', 'tinyint(1)', '0')// relates to dismissed announcements
-    ->column('Bookmarked', 'tinyint(1)', '0', 'index.bookmarked')
-    ->column('Participated', 'tinyint(1)', '0', 'index.participated')// whether or not the user has participated in the discussion.
+    ->column('Bookmarked', 'tinyint(1)', '0')
+    ->column('Participated', 'tinyint(1)', '0')// whether or not the user has participated in the discussion.
     ->set($Explicit, $Drop);
 
 $Construct->table('Comment');

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -188,13 +188,13 @@ $Construct->table('UserDiscussion');
 $ParticipatedExists = $Construct->columnExists('Participated');
 
 $Construct->column('UserID', 'int', false, 'primary')
-    ->column('DiscussionID', 'int', false, ['primary', 'key'])
+    ->column('DiscussionID', 'int', false, ['primary', 'key', 'index.bookmarked', 'index.participated'])
     ->column('Score', 'float', null)
     ->column('CountComments', 'int', '0')
     ->column('DateLastViewed', 'datetime', null)// null signals never
-    ->column('Dismissed', 'tinyint(1)', '0', 'index')// relates to dismissed announcements
-    ->column('Bookmarked', 'tinyint(1)', '0', 'index')
-    ->column('Participated', 'tinyint(1)', '0', 'index')// whether or not the user has participated in the discussion.
+    ->column('Dismissed', 'tinyint(1)', '0')// relates to dismissed announcements
+    ->column('Bookmarked', 'tinyint(1)', '0', 'index.bookmarked')
+    ->column('Participated', 'tinyint(1)', '0', 'index.participated')// whether or not the user has participated in the discussion.
     ->set($Explicit, $Drop);
 
 $Construct->table('Comment');

--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -192,9 +192,9 @@ $Construct->column('UserID', 'int', false, 'primary')
     ->column('Score', 'float', null)
     ->column('CountComments', 'int', '0')
     ->column('DateLastViewed', 'datetime', null)// null signals never
-    ->column('Dismissed', 'tinyint(1)', '0')// relates to dismissed announcements
-    ->column('Bookmarked', 'tinyint(1)', '0')
-    ->column('Participated', 'tinyint(1)', '0')// whether or not the user has participated in the discussion.
+    ->column('Dismissed', 'tinyint(1)', '0', 'index')// relates to dismissed announcements
+    ->column('Bookmarked', 'tinyint(1)', '0', 'index')
+    ->column('Participated', 'tinyint(1)', '0', 'index')// whether or not the user has participated in the discussion.
     ->set($Explicit, $Drop);
 
 $Construct->table('Comment');

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -789,7 +789,7 @@ abstract class Gdn_SQLDriver {
      * object. This method should not be called directly; it is called by
      * $this->get() and $this->getWhere().
      */
-    public function getSelect() {
+    public function getSelect(bool $prepared = false) {
         // Close off any open query elements.
         $this->_endQuery();
 
@@ -875,6 +875,10 @@ abstract class Gdn_SQLDriver {
             $sql = $this->getLimit($sql, $this->_Limit, $this->_Offset);
         }
 
+        if ($prepared) {
+            $parameters = $this->calculateParameters($this->_NamedParameters);
+            $sql = $this->applyParameters($sql, $parameters);
+        }
         return $sql;
     }
 


### PR DESCRIPTION
Regularly our monitoring tool is reporting about slow queries like:  
```
select d2.*
from `GDN_Discussion` `d`
join `GDN_Discussion` `d2` on d.DiscussionID = d2.DiscussionID
where `d`.`CategoryID` = ?
order by `d`.`DateLastComment` desc
limit 248350, 50`
```
This is the query generated by DiscussionModel. There is a code fragment that does strange `join`:
```
        // Build up the base query. Self-join for optimization.
        $sql->select('d2.*')
            ->from('Discussion d')
            ->join('Discussion d2', 'd.DiscussionID = d2.DiscussionID')
            ->limit($limit, $offset);
```
In the comment it is written that this self-join was done with **optimization** in mind. In reality it does nothing. But there is a very well known technique to optimize deeply paginated query issue.
The point of that technique is to reduce number of columns returned by complex query till just primary id column, and then self-join table to get all data from the table.
In our case optimized query should look like:
```
SELECT d2.*
FROM `GDN_Discussion` `d2`
JOIN (
    SELECT DiscussionID
    FROM `GDN_Discussion` `d`
    WHERE `d`.`CategoryID` = ?
    ORDER BY `d`.`DateLastComment` DESC
    LIMIT 248350, 50`) d
ON d.DiscussionID = d2.DiscussionID
```

I've tested queries on my localhost and the performance of optimized version of query is better ~100x times.