### PR TITLE
prefix akismet host with ssl

### DIFF
--- a/plugins/Akismet/class.socketwriteread.php
+++ b/plugins/Akismet/class.socketwriteread.php
@@ -60,7 +60,7 @@ class SocketWriteRead {
     public function send() {
         $this->response = '';
 
-        $fs = fsockopen($this->host, $this->port, $this->errorNumber, $this->errorString, 3);
+        $fs = fsockopen('ssl://' . $this->host, $this->port, $this->errorNumber, $this->errorString, 3);
 
         if ($this->errorNumber != 0) {
             throw new Exception('Error connecting to host: ' . $this->host . ' Error number: ' . $this->errorNumber . ' Error message: ' . $this->errorString);


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1393

we recently upgrade akismet to use port 443 https://github.com/vanilla/vanilla/pull/9864
but we didn't prefix the host in  fscoketopen with 'ssl://'

### To Test
[Get a dev akismet api key](https://akismet.com/account)
![Screen Shot 2020-02-18 at 1 19 23 PM](https://user-images.githubusercontent.com/31856281/74765331-57f93580-5251-11ea-9ec2-c18aa49ad0bc.png)
You can debug this locally to test if your key passes validation.


Ref. https://akismet.com/development/api/#verify-key