### PR TITLE
All home widget to be styled as nav links

### DIFF
--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -65,7 +65,11 @@ export default function Banner(props: IProps) {
                     <div className={classes.contentContainer}>
                         <div className={classes.titleWrap}>
                             <FlexSpacer className={classes.titleFlexSpacer} />
-                            {title && <Heading title={title} className={classes.title} />}
+                            {title && (
+                                <Heading className={classes.title} depth={1} isLarge>
+                                    {title}
+                                </Heading>
+                            )}
                             <div className={classNames(classes.text, classes.titleFlexSpacer)}>{action}</div>
                         </div>
                         {!options.hideDesciption && description && (

--- a/library/src/scripts/content/TruncatedText.tsx
+++ b/library/src/scripts/content/TruncatedText.tsx
@@ -81,10 +81,10 @@ const TruncatedText = React.memo(function TruncatedText(_props: IProps) {
 
     let { children } = props;
     if (props.maxCharCount && typeof children === "string") {
-        const newChildren = children.slice(0, props.maxCharCount);
+        let newChildren = children.slice(0, props.maxCharCount);
 
         if (newChildren.length < children.length) {
-            children += "…";
+            newChildren += "…";
         }
 
         children = newChildren;
@@ -92,7 +92,7 @@ const TruncatedText = React.memo(function TruncatedText(_props: IProps) {
 
     return (
         <Tag className={props.className} ref={ref}>
-            {props.children}
+            {children}
         </Tag>
     );
 });

--- a/library/src/scripts/flyouts/dropDownStyles.ts
+++ b/library/src/scripts/flyouts/dropDownStyles.ts
@@ -301,13 +301,15 @@ export const dropDownClasses = useThemeCache(() => {
     });
 
     const sectionHeading = style("sectionHeading", {
-        color: colorOut(globalVars.meta.text.color),
-        fontSize: unit(globalVars.fonts.size.small),
-        textTransform: "uppercase",
-        textAlign: "center",
-        fontWeight: globalVars.fonts.weights.semiBold,
-        ...(paddings(vars.sectionTitle.padding) as NestedCSSProperties),
         $nest: {
+            "&&": {
+                color: colorOut(globalVars.meta.text.color),
+                fontSize: unit(globalVars.fonts.size.small),
+                textTransform: "uppercase",
+                textAlign: "center",
+                fontWeight: globalVars.fonts.weights.semiBold,
+                ...(paddings(vars.sectionTitle.padding) as NestedCSSProperties),
+            },
             [`& + .${sectionContents} li:first-child`]: { paddingTop: unit(vars.spacer.margin.vertical) },
         },
     });

--- a/library/src/scripts/homeWidget/HomeWidget.story.tsx
+++ b/library/src/scripts/homeWidget/HomeWidget.story.tsx
@@ -16,6 +16,7 @@ import { color } from "csx";
 import { storyWithConfig } from "@library/storybook/StoryContext";
 import { HomeWidget } from "@library/homeWidget/HomeWidget";
 import { ButtonTypes } from "@library/forms/buttonStyles";
+import { StandardNavLinksStory } from "@library/navigation/navLinksWithHeadings.story";
 
 export default {
     title: "Home Widget",
@@ -237,6 +238,54 @@ export function Items() {
         </div>
     );
 }
+
+export const AsNavLinks = storyWithConfig({ useWrappers: false }, () => {
+    return (
+        <div>
+            <StandardNavLinksStory />
+            <HomeWidget
+                itemData={STANDARD_5_ITEMS}
+                title="As Navigation Links"
+                maxItemCount={4}
+                containerOptions={{
+                    borderType: "navLinks",
+                    maxColumnCount: 2,
+                    viewAll: { to: "#", position: "bottom" },
+                }}
+            />
+        </div>
+    );
+});
+
+export const AsNavLinksFullBg = storyWithConfig({ useWrappers: false }, () => {
+    return (
+        <div>
+            <StandardNavLinksStory />
+            <HomeWidget
+                itemData={STANDARD_5_ITEMS}
+                title="As Navigation Links"
+                maxItemCount={3}
+                itemOptions={{
+                    contentType: HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE,
+                }}
+                containerOptions={{
+                    viewAll: { to: "#" },
+                    outerBackground: {
+                        color: color("#F8F8F8"),
+                    },
+                }}
+            />
+        </div>
+    );
+});
+
+AsNavLinks.story = {
+    parameters: {
+        chromatic: {
+            viewports: [500, 1200],
+        },
+    },
+};
 
 function ContainerWithOptionsAndImage(props: Omit<IHomeWidgetContainerProps, "children">) {
     return (

--- a/library/src/scripts/homeWidget/HomeWidget.story.tsx
+++ b/library/src/scripts/homeWidget/HomeWidget.story.tsx
@@ -249,6 +249,16 @@ export const AsNavLinks = storyWithConfig({ useWrappers: false }, () => {
                 maxItemCount={4}
                 containerOptions={{
                     borderType: "navLinks",
+                    maxColumnCount: 1,
+                    viewAll: { to: "#", position: "bottom" },
+                }}
+            />
+            <HomeWidget
+                itemData={STANDARD_5_ITEMS}
+                title="As Navigation Links"
+                maxItemCount={4}
+                containerOptions={{
+                    borderType: "navLinks",
                     maxColumnCount: 2,
                     viewAll: { to: "#", position: "bottom" },
                 }}

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -156,7 +156,6 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
 
     const root = style({
         ...background(vars.options.outerBackground ?? {}),
-        ...paddings(vars.spacing.padding),
     });
 
     // For navLinks style only.
@@ -168,6 +167,10 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
         }),
         ...(vars.options.borderType === "navLinks" ? {} : extendItemContainer(vars.itemSpacing.horizontal)),
     };
+
+    const verticalContainer = style("verticalContainer", {
+        ...paddings(vars.spacing.padding),
+    });
 
     const container = style("container", {
         $nest: {
@@ -281,7 +284,7 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
         $nest: {
             "&&": {
                 ...margins({
-                    horizontal: vars.itemSpacing.horizontal,
+                    horizontal: vars.options.borderType === "navLinks" ? 0 : vars.itemSpacing.horizontal,
                 }),
             },
             "&:first-child": {
@@ -304,6 +307,7 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
     return {
         root,
         separator,
+        verticalContainer,
         container,
         content,
         borderedContent,

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -284,7 +284,7 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
         $nest: {
             "&&": {
                 ...margins({
-                    horizontal: vars.options.borderType === "navLinks" ? 0 : vars.itemSpacing.horizontal,
+                    horizontal: vars.options.borderType === "navLinks" ? 0 : vars.gridItem.padding.horizontal,
                 }),
             },
             "&:first-child": {

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -100,11 +100,13 @@ export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHo
     const mobileNavPaddings = navLinksVariables().item.paddingMobile;
 
     const bottomMultiplier = options.viewAll.position === "bottom" ? 1.5 : 2;
+    const needsSpacing =
+        options.outerBackground.color || options.outerBackground.image || options.borderType === "navLinks";
     const spacing = makeVars("spacing", {
         padding: {
             ...EMPTY_SPACING,
-            top: globalVars.gutter.size * 2,
-            bottom: globalVars.gutter.size * bottomMultiplier,
+            top: needsSpacing ? globalVars.gutter.size * 2 : 0,
+            bottom: needsSpacing ? globalVars.gutter.size * bottomMultiplier : 0,
         },
     });
 

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -99,7 +99,16 @@ export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHo
     const navPaddings = navLinksVariables().item.padding;
     const mobileNavPaddings = navLinksVariables().item.paddingMobile;
 
+    const bottomMultiplier = options.viewAll.position === "bottom" ? 1.5 : 2;
     const spacing = makeVars("spacing", {
+        padding: {
+            ...EMPTY_SPACING,
+            top: globalVars.gutter.size * 2,
+            bottom: globalVars.gutter.size * bottomMultiplier,
+        },
+    });
+
+    const itemSpacing = makeVars("itemSpacing", {
         ...EMPTY_SPACING,
         horizontal: options.borderType === "navLinks" ? navPaddings.horizontal : globalVars.gutter.size,
         vertical: globalVars.gutter.size,
@@ -109,14 +118,14 @@ export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHo
         },
     });
 
-    const horizontalSpacing = spacing.horizontal / 2; // Cut in half to account for grid item spacing.
-    const horizontalSpacingMobile = spacing.mobile.horizontal / 2; // Cut in half to account for grid item spacing.
+    const horizontalSpacing = itemSpacing.horizontal / 2; // Cut in half to account for grid item spacing.
+    const horizontalSpacingMobile = itemSpacing.mobile.horizontal / 2; // Cut in half to account for grid item spacing.
 
     const grid = makeVars("grid", {
         padding: {
             ...EMPTY_SPACING,
             horizontal: horizontalSpacing,
-            vertical: spacing.vertical,
+            vertical: itemSpacing.vertical,
         },
         paddingMobile: {
             horizontal: horizontalSpacingMobile,
@@ -127,7 +136,7 @@ export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHo
         padding: {
             ...EMPTY_SPACING,
             horizontal: horizontalSpacing,
-            vertical: spacing.vertical,
+            vertical: itemSpacing.vertical,
         },
         paddingMobile: {
             ...EMPTY_SPACING,
@@ -135,9 +144,9 @@ export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHo
         },
     });
 
-    const mobileMediaQuery = layoutVariables().mediaQueries().oneColumn;
+    const mobileMediaQuery = layoutVariables().mediaQueries().oneColumnDown;
 
-    return { options, spacing, title, grid, gridItem, mobileMediaQuery };
+    return { options, spacing, itemSpacing, title, grid, gridItem, mobileMediaQuery };
 });
 
 export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHomeWidgetContainerOptions) => {
@@ -147,18 +156,17 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
 
     const root = style({
         ...background(vars.options.outerBackground ?? {}),
+        ...paddings(vars.spacing.padding),
     });
 
     // For navLinks style only.
-    const separator = style("separator", {
-        marginBottom: vars.spacing.vertical * 2,
-    });
+    const separator = style("separator", {});
 
     const contentMixin: NestedCSSProperties = {
         ...paddings({
-            vertical: vars.spacing.vertical,
+            vertical: vars.itemSpacing.vertical,
         }),
-        ...(vars.options.borderType === "navLinks" ? {} : extendItemContainer(vars.spacing.horizontal)),
+        ...(vars.options.borderType === "navLinks" ? {} : extendItemContainer(vars.itemSpacing.horizontal)),
     };
 
     const container = style("container", {
@@ -176,7 +184,7 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
         ...contentMixin,
         ...paddings({
             top: 0,
-            horizontal: vars.spacing.horizontal,
+            horizontal: vars.itemSpacing.horizontal,
         }),
     });
 
@@ -273,7 +281,7 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
         $nest: {
             "&&": {
                 ...margins({
-                    horizontal: vars.spacing.horizontal,
+                    horizontal: vars.itemSpacing.horizontal,
                 }),
             },
             "&:first-child": {
@@ -285,7 +293,7 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
     const viewAllContent = style("viewAllContent", {
         ...contentMixin,
         paddingTop: 0,
-        marginTop: -vars.spacing.vertical,
+        marginTop: -vars.itemSpacing.vertical,
         $nest: {
             [`.${borderedContent} + &`]: {
                 marginTop: 0,

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
@@ -17,6 +17,7 @@ import LinkAsButton from "@library/routing/LinkAsButton";
 import { ButtonTypes } from "@library/forms/buttonStyles";
 import { t } from "@vanilla/i18n";
 import Container from "@library/layout/components/Container";
+import { navLinksClasses } from "@library/navigation/navLinksStyles";
 
 export interface IHomeWidgetContainerProps {
     options?: IHomeWidgetContainerOptions;
@@ -53,7 +54,7 @@ export function HomeWidgetContainer(props: IHomeWidgetContainerProps) {
         </div>
     );
 
-    const gridHasBorder = options.borderType !== BorderType.NONE;
+    const gridHasBorder = [BorderType.BORDER, BorderType.SHADOW].includes(options.borderType as BorderType);
 
     const viewAllButton = props.options?.viewAll?.to && (
         <LinkAsButton
@@ -69,9 +70,16 @@ export function HomeWidgetContainer(props: IHomeWidgetContainerProps) {
         <div className={classes.root}>
             <Container fullGutter>
                 <div className={classes.container}>
+                    {options.borderType === "navLinks" && (
+                        <hr className={classNames(navLinksClasses().separator, classes.separator)}></hr>
+                    )}
                     <div className={classes.content}>
                         <div className={classes.viewAllContainer}>
-                            {props.title && <Heading className={classes.title}>{props.title}</Heading>}
+                            {props.title && (
+                                <Heading className={classes.title} renderAsDepth={1}>
+                                    {props.title}
+                                </Heading>
+                            )}
                             {options.viewAll.position === "top" && viewAllButton}
                         </div>
                         {!gridHasBorder && grid}

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.tsx
@@ -73,23 +73,25 @@ export function HomeWidgetContainer(props: IHomeWidgetContainerProps) {
                     {options.borderType === "navLinks" && (
                         <hr className={classNames(navLinksClasses().separator, classes.separator)}></hr>
                     )}
-                    <div className={classes.content}>
-                        <div className={classes.viewAllContainer}>
-                            {props.title && (
-                                <Heading className={classes.title} renderAsDepth={1}>
-                                    {props.title}
-                                </Heading>
-                            )}
-                            {options.viewAll.position === "top" && viewAllButton}
+                    <div className={classes.verticalContainer}>
+                        <div className={classes.content}>
+                            <div className={classes.viewAllContainer}>
+                                {props.title && (
+                                    <Heading className={classes.title} renderAsDepth={1}>
+                                        {props.title}
+                                    </Heading>
+                                )}
+                                {options.viewAll.position === "top" && viewAllButton}
+                            </div>
+                            {!gridHasBorder && grid}
                         </div>
-                        {!gridHasBorder && grid}
+                        {gridHasBorder && <div className={classes.borderedContent}>{grid}</div>}
+                        {viewAllButton && options.viewAll.position === "bottom" && (
+                            <div className={classes.viewAllContent}>
+                                <div className={classes.viewAllContainer}>{viewAllButton}</div>{" "}
+                            </div>
+                        )}
                     </div>
-                    {gridHasBorder && <div className={classes.borderedContent}>{grid}</div>}
-                    {viewAllButton && options.viewAll.position === "bottom" && (
-                        <div className={classes.viewAllContent}>
-                            <div className={classes.viewAllContainer}>{viewAllButton}</div>{" "}
-                        </div>
-                    )}
                 </div>
             </Container>
         </div>

--- a/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
@@ -63,7 +63,7 @@ export const homeWidgetItemVariables = useThemeCache((optionOverrides?: IHomeWid
         "options",
         {
             ...options,
-            borderType: hasImage ? BorderType.SHADOW : BorderType.NONE,
+            borderType: hasImage ? BorderType.SHADOW : options.borderType,
         },
         optionOverrides,
     );
@@ -187,5 +187,9 @@ export const homeWidgetItemClasses = useThemeCache((optionOverrides?: IHomeWidge
         objectPosition: "center center",
     });
 
-    return { root, name, content, imageContainer, image };
+    const description = style("description", {
+        lineHeight: globalVars.lineHeights.base,
+    });
+
+    return { root, name, content, imageContainer, image, description };
 });

--- a/library/src/scripts/homeWidget/HomeWidgetItem.tsx
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.tsx
@@ -47,7 +47,7 @@ export function HomeWidgetItem(props: IHomeWidgetItemProps) {
                     HomeWidgetItemContentType.TITLE_DESCRIPTION,
                     HomeWidgetItemContentType.TITLE_DESCRIPTION_IMAGE,
                 ].includes(options.contentType) && (
-                    <TruncatedText maxCharCount={160} tag={"div"}>
+                    <TruncatedText maxCharCount={160} tag={"div"} className={classes.description}>
                         {props.description}
                     </TruncatedText>
                 )}

--- a/library/src/scripts/layout/Heading.tsx
+++ b/library/src/scripts/layout/Heading.tsx
@@ -13,44 +13,45 @@ export interface ICommonHeadingProps {
     depth?: 1 | 2 | 3 | 4 | 5 | 6;
     renderAsDepth?: 1 | 2 | 3 | 4 | 5 | 6;
     className?: string;
-    title: React.ReactNode;
+    title?: React.ReactNode;
 }
 
-export interface IHeadingProps extends ICommonHeadingProps {
+export interface IHeadingProps extends ICommonHeadingProps, Omit<React.HTMLAttributes<HTMLHeadingElement>, "title"> {
+    isLarge?: boolean;
     children?: React.ReactNode;
-    titleRef: React.RefObject<HTMLHeadingElement>;
 }
 
 /**
  * A component representing a element.
  */
-export default class Heading extends React.Component<IHeadingProps> {
-    public static defaultProps: Partial<IHeadingProps> = {
-        depth: 2,
-    };
+const Heading = React.forwardRef<HTMLHeadingElement, IHeadingProps>(function Heading(props: IHeadingProps, ref) {
+    const { children, title, depth, renderAsDepth, className, isLarge, ...restProps } = props;
+    const finalDepth = depth ?? 2;
+    const finalRenderDepth = renderAsDepth ?? finalDepth;
 
-    private get renderAsDepth(): number {
-        return this.props.renderAsDepth ? this.props.renderAsDepth : this.props.depth!;
-    }
+    const Tag = `h${finalDepth}` as "h1";
+    const classes = typographyClasses();
 
-    public render() {
-        const { children, title } = this.props;
-        const Tag = `h${this.props.depth}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-        const classesTypography = typographyClasses();
+    return (
+        <Tag
+            {...restProps}
+            ref={ref}
+            className={classNames(
+                "heading",
+                `heading-${finalRenderDepth}`,
+                {
+                    [classes.pageTitle]: finalRenderDepth === 1,
+                    [classes.largeTitle]: isLarge,
+                    [classes.subTitle]: finalRenderDepth === 2,
+                    [classes.componentSubTitle]: finalRenderDepth >= 3,
+                },
 
-        return (
-            <Tag
-                id={this.props.id}
-                ref={this.props.titleRef}
-                className={classNames(
-                    "heading",
-                    `heading-${this.renderAsDepth}`,
-                    { [`${classesTypography.pageTitle}`]: this.renderAsDepth === 1 },
-                    this.props.className,
-                )}
-            >
-                {children ? children : title}
-            </Tag>
-        );
-    }
-}
+                className,
+            )}
+        >
+            {children ?? title}
+        </Tag>
+    );
+});
+
+export default Heading;

--- a/library/src/scripts/layout/PageHeading.tsx
+++ b/library/src/scripts/layout/PageHeading.tsx
@@ -30,10 +30,6 @@ interface IPageHeading {
 
 export function PageHeading(props: IPageHeading) {
     const { includeBackLink = true, actions, children, headingClassName, title, className } = props;
-
-    // public context!: React.ContextType<typeof LineHeightCalculatorContext>;
-    // public titleRef: React.RefObject<HTMLHeadingElement>;
-    const ref = useRef<HTMLHeadingElement>(null);
     const { fontSize } = useFontSizeCalculator();
 
     const classes = pageHeadingClasses();
@@ -44,7 +40,7 @@ export function PageHeading(props: IPageHeading) {
             <div className={classes.main}>
                 {includeBackLink && <BackLink className={linkClasses.inHeading(fontSize)} />}
                 <ConditionalWrap condition={!!actions} className={classes.titleWrap}>
-                    <Heading titleRef={ref} depth={1} title={title} className={headingClassName}>
+                    <Heading depth={1} title={title} className={headingClassName}>
                         {children}
                     </Heading>
                 </ConditionalWrap>

--- a/library/src/scripts/layout/components/Container.tsx
+++ b/library/src/scripts/layout/components/Container.tsx
@@ -14,6 +14,7 @@ export interface IContainer {
     tag?: keyof JSX.IntrinsicElements;
     fullGutter?: boolean; // Use when a component wants a full mobile/desktop gutter.
     // Useful for components that don't provide their own padding.
+    narrow?: boolean;
 }
 
 /*
@@ -34,6 +35,7 @@ export default class Container extends React.Component<IContainer> {
                         classes.root,
                         this.props.className,
                         this.props.fullGutter && classes.fullGutter,
+                        this.props.narrow && "isNarrow",
                     )}
                 >
                     {this.props.children}

--- a/library/src/scripts/layout/components/containerStyles.ts
+++ b/library/src/scripts/layout/components/containerStyles.ts
@@ -67,6 +67,12 @@ export const containerMainStyles = (): NestedCSSProperties => {
         marginLeft: "auto",
         marginRight: "auto",
         ...paddings(vars.spacing.padding),
+
+        $nest: {
+            "&.isNarrow": {
+                maxWidth: vars.sizing.narrowContentSize,
+            },
+        },
     };
 };
 

--- a/library/src/scripts/layout/heading.story.tsx
+++ b/library/src/scripts/layout/heading.story.tsx
@@ -22,15 +22,21 @@ story.add("Headings", () => {
         <StoryContent>
             <StoryHeading depth={1}>Headings</StoryHeading>
             <StoryParagraph>Headings can get the style of any depth, but semantically be different</StoryParagraph>
-            <Heading depth={1} renderAsDepth={1} title={"True H1"} />
+            <Heading depth={1} renderAsDepth={1}>
+                True H1
+            </Heading>
             <StoryParagraph>Page Title style</StoryParagraph>
-            <Heading depth={3} renderAsDepth={1} title={"H3 with the style of an H1"} />
+            <Heading depth={3} renderAsDepth={1}>
+                H3 with the style of an H1
+            </Heading>
             <StoryParagraph>
                 The styles are independent from the markup, so you can use any heading that is most semantic.
             </StoryParagraph>
-            <Heading depth={2} title={"Sub Title"} className={classesTypography.subTitle} />
+            <Heading depth={2}>Sub Title</Heading>
             <StoryParagraph>Mostly sub headings in panels</StoryParagraph>
-            <Heading depth={2} title={"Component sub title"} className={classesTypography.componentSubTitle} />
+            <Heading depth={2} renderAsDepth={3}>
+                Component sub title
+            </Heading>
             <StoryParagraph>Sub headings in components</StoryParagraph>
         </StoryContent>
     );

--- a/library/src/scripts/navigation/NavLinks.tsx
+++ b/library/src/scripts/navigation/NavLinks.tsx
@@ -13,6 +13,7 @@ import SmartLink from "@library/routing/links/SmartLink";
 import ScreenReaderContent from "@library/layout/ScreenReaderContent";
 import { navLinksClasses } from "@library/navigation/navLinksStyles";
 import Translate from "@library/content/Translate";
+import Container from "@library/layout/components/Container";
 
 interface IProps {
     classNames?: string;

--- a/library/src/scripts/navigation/NavLinksWithHeadings.tsx
+++ b/library/src/scripts/navigation/NavLinksWithHeadings.tsx
@@ -62,7 +62,7 @@ export default class NavLinksWithHeadings extends Component<IProps> {
             });
 
             return (
-                <Container fullGutter>
+                <Container fullGutter narrow>
                     <nav
                         className={classNames("navLinksWithHeadings", this.props.classNames, classes.linksWithHeadings)}
                     >

--- a/library/src/scripts/navigation/NavLinksWithHeadings.tsx
+++ b/library/src/scripts/navigation/NavLinksWithHeadings.tsx
@@ -13,6 +13,7 @@ import ScreenReaderContent from "@library/layout/ScreenReaderContent";
 import { navLinksClasses } from "@library/navigation/navLinksStyles";
 import { ILinkListData } from "@library/@types/api/core";
 import NavLinks from "@library/navigation/NavLinks";
+import Container from "@library/layout/components/Container";
 
 interface IProps {
     title: string; // For accessibility, title of group
@@ -61,13 +62,17 @@ export default class NavLinksWithHeadings extends Component<IProps> {
             });
 
             return (
-                <nav className={classNames("navLinksWithHeadings", this.props.classNames, classes.linksWithHeadings)}>
-                    <ScreenReaderContent>
-                        <Heading title={this.props.title} depth={this.props.depth} />
-                    </ScreenReaderContent>
-                    {groupedContent}
-                    {ungroupedContent}
-                </nav>
+                <Container fullGutter>
+                    <nav
+                        className={classNames("navLinksWithHeadings", this.props.classNames, classes.linksWithHeadings)}
+                    >
+                        <ScreenReaderContent>
+                            <Heading title={this.props.title} depth={this.props.depth} />
+                        </ScreenReaderContent>
+                        {groupedContent}
+                        {ungroupedContent}
+                    </nav>
+                </Container>
             );
         } else {
             return null;

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -5,11 +5,23 @@
  */
 
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { colorOut, margins, paddings, setAllLinkColors, unit, fonts } from "@library/styles/styleHelpers";
+import {
+    colorOut,
+    margins,
+    paddings,
+    setAllLinkColors,
+    unit,
+    fonts,
+    extendItemContainer,
+    EMPTY_FONTS,
+    singleBorder,
+    EMPTY_SPACING,
+} from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { percent, px } from "csx";
 import { media } from "typestyle";
 import { NestedCSSProperties } from "typestyle/lib/types";
+import { containerVariables } from "@library/layout/components/containerStyles";
 
 export const navLinksVariables = useThemeCache(() => {
     const makeThemeVars = variableFactory("navLinks");
@@ -17,7 +29,7 @@ export const navLinksVariables = useThemeCache(() => {
 
     const linksWithHeadings = makeThemeVars("linksWithHeadings", {
         paddings: {
-            all: 20,
+            // all: 20,
         },
         mobile: {
             paddings: {
@@ -28,19 +40,34 @@ export const navLinksVariables = useThemeCache(() => {
 
     const item = makeThemeVars("item", {
         fontSize: globalVars.fonts.size.large,
+        padding: {
+            ...EMPTY_SPACING,
+            vertical: 24,
+            horizontal: containerVariables().spacing.paddingFull.horizontal,
+        },
+        paddingMobile: {
+            ...EMPTY_SPACING,
+            horizontal: 0,
+        },
     });
 
     const title = makeThemeVars("title", {
-        fontSize: globalVars.fonts.size.title,
-        fontWeight: globalVars.fonts.weights.semiBold,
-        lineHeight: globalVars.lineHeights.condensed,
+        font: {
+            ...EMPTY_FONTS,
+            size: globalVars.fonts.size.title,
+            weight: globalVars.fonts.weights.bold,
+            lineHeight: globalVars.lineHeights.condensed,
+        },
         maxWidth: percent(100),
         margins: {
-            bottom: 8,
+            bottom: globalVars.gutter.size,
         },
         mobile: {
-            fontSize: globalVars.fonts.size.large,
-            fontWeight: globalVars.fonts.weights.bold,
+            font: {
+                ...EMPTY_FONTS,
+                fontSize: globalVars.fonts.size.large,
+                fontWeight: globalVars.fonts.weights.bold,
+            },
         },
     });
 
@@ -73,17 +100,7 @@ export const navLinksVariables = useThemeCache(() => {
     });
 
     const spacing = makeThemeVars("spacing", {
-        paddings: {
-            vertical: 34,
-            horizontal: 40,
-        },
         margin: 6,
-        mobile: {
-            paddings: {
-                vertical: 22,
-                horizontal: 8,
-            },
-        },
     });
 
     const columns = makeThemeVars("columns", {
@@ -128,7 +145,7 @@ export const navLinksClasses = useThemeCache(() => {
 
     const root = style(
         {
-            ...paddings(vars.spacing.paddings),
+            ...paddings(vars.item.padding),
             display: "flex",
             flexDirection: "column",
             maxWidth: percent(100),
@@ -136,7 +153,7 @@ export const navLinksClasses = useThemeCache(() => {
         },
         mediaQueries.oneColumn({
             width: percent(100),
-            ...paddings(vars.spacing.mobile.paddings),
+            ...paddings(vars.item.paddingMobile),
         }),
     );
 
@@ -157,16 +174,11 @@ export const navLinksClasses = useThemeCache(() => {
         "title",
         {
             display: "block",
-            fontSize: unit(vars.title.fontSize),
-            lineHeight: globalVars.lineHeights.condensed,
-            fontWeight: globalVars.fonts.weights.semiBold,
+            ...fonts(vars.title.font),
             maxWidth: percent(100),
             ...margins(vars.title.margins),
         },
-        mediaQueries.oneColumn({
-            fontSize: unit(vars.title.mobile.fontSize),
-            fontWeight: vars.title.mobile.fontWeight,
-        }),
+        mediaQueries.oneColumn(fonts(vars.title.mobile.font)),
     );
 
     const linkColors = setAllLinkColors({
@@ -216,6 +228,7 @@ export const navLinksClasses = useThemeCache(() => {
         "linksWithHeadings",
         {
             ...paddings(vars.linksWithHeadings.paddings),
+            ...extendItemContainer(vars.item.padding.horizontal),
             display: "flex",
             flexWrap: "wrap",
             alignItems: "stretch",
@@ -223,15 +236,22 @@ export const navLinksClasses = useThemeCache(() => {
         },
         mediaQueries.oneColumn({
             ...paddings(vars.linksWithHeadings.mobile.paddings),
+            ...extendItemContainer(vars.item.paddingMobile.horizontal),
         }),
     );
 
-    const separator = style("separator", {
-        display: "block",
-        width: percent(100),
-        height: unit(vars.separator.height),
-        backgroundColor: colorOut(vars.separator.bg),
-    });
+    const separator = style(
+        "separator",
+        {
+            display: "block",
+            width: percent(100),
+            height: unit(vars.separator.height),
+
+            // Has to be a border and not a BG, because sometimes chrome rounds it's height to 0.99px and it disappears.
+            borderBottom: singleBorder({ color: vars.separator.bg }),
+        },
+        mediaQueries.oneColumn(margins({ horizontal: vars.item.paddingMobile.horizontal })),
+    );
 
     const separatorOdd = style(
         "separatorOdd",

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -29,12 +29,7 @@ export const navLinksVariables = useThemeCache(() => {
 
     const linksWithHeadings = makeThemeVars("linksWithHeadings", {
         paddings: {
-            // all: 20,
-        },
-        mobile: {
-            paddings: {
-                all: 0,
-            },
+            vertical: globalVars.gutter.size * 1.5,
         },
     });
 
@@ -89,12 +84,7 @@ export const navLinksVariables = useThemeCache(() => {
             top: "auto",
         },
         paddings: {
-            top: 20,
-        },
-        mobile: {
-            paddings: {
-                top: 8,
-            },
+            top: globalVars.gutter.size,
         },
         $nest: viewAllLinkColors.nested,
     });
@@ -170,16 +160,17 @@ export const navLinksClasses = useThemeCache(() => {
         marginBottom: unit(vars.spacing.margin),
     });
 
-    const title = style(
-        "title",
-        {
-            display: "block",
-            ...fonts(vars.title.font),
-            maxWidth: percent(100),
-            ...margins(vars.title.margins),
+    const title = style("title", {
+        $nest: {
+            "&&": {
+                display: "block",
+                ...fonts(vars.title.font),
+                maxWidth: percent(100),
+                ...margins(vars.title.margins),
+                ...mediaQueries.oneColumn(fonts(vars.title.mobile.font)),
+            },
         },
-        mediaQueries.oneColumn(fonts(vars.title.mobile.font)),
-    );
+    });
 
     const linkColors = setAllLinkColors({
         default: globalVars.mainColors.fg,
@@ -196,18 +187,12 @@ export const navLinksClasses = useThemeCache(() => {
         $nest: linkColors.nested as NestedCSSProperties,
     } as NestedCSSProperties);
 
-    const viewAllItem = style(
-        "viewAllItem",
-        {
-            display: "block",
-            fontSize: unit(vars.item.fontSize),
-            ...margins(vars.viewAll.margins),
-            ...paddings(vars.viewAll.paddings),
-        },
-        mediaQueries.oneColumn({
-            ...paddings(vars.viewAll.mobile.paddings),
-        }),
-    );
+    const viewAllItem = style("viewAllItem", {
+        display: "block",
+        fontSize: unit(vars.item.fontSize),
+        ...margins(vars.viewAll.margins),
+        ...paddings(vars.viewAll.paddings),
+    });
 
     const viewAllLinkColors = setAllLinkColors({
         default: globalVars.mainColors.primary,
@@ -235,7 +220,6 @@ export const navLinksClasses = useThemeCache(() => {
             justifyContent: "space-between",
         },
         mediaQueries.oneColumn({
-            ...paddings(vars.linksWithHeadings.mobile.paddings),
             ...extendItemContainer(vars.item.paddingMobile.horizontal),
         }),
     );
@@ -245,10 +229,9 @@ export const navLinksClasses = useThemeCache(() => {
         {
             display: "block",
             width: percent(100),
-            height: unit(vars.separator.height),
 
             // Has to be a border and not a BG, because sometimes chrome rounds it's height to 0.99px and it disappears.
-            borderBottom: singleBorder({ color: vars.separator.bg }),
+            borderBottom: singleBorder({ color: vars.separator.bg, width: vars.separator.height }),
         },
         mediaQueries.oneColumn(margins({ horizontal: vars.item.paddingMobile.horizontal })),
     );
@@ -256,7 +239,6 @@ export const navLinksClasses = useThemeCache(() => {
     const separatorOdd = style(
         "separatorOdd",
         {
-            $unique: true,
             display: "none",
         },
         mediaQueries.oneColumn({

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -27,22 +27,22 @@ export const navLinksVariables = useThemeCache(() => {
     const makeThemeVars = variableFactory("navLinks");
     const globalVars = globalVariables();
 
-    const linksWithHeadings = makeThemeVars("linksWithHeadings", {
-        paddings: {
-            vertical: globalVars.gutter.size * 1.5,
-        },
-    });
-
     const item = makeThemeVars("item", {
         fontSize: globalVars.fonts.size.large,
         padding: {
             ...EMPTY_SPACING,
-            vertical: 24,
+            vertical: globalVars.spacer.size * 2,
             horizontal: containerVariables().spacing.paddingFull.horizontal,
         },
         paddingMobile: {
             ...EMPTY_SPACING,
             horizontal: 0,
+        },
+    });
+
+    const linksWithHeadings = makeThemeVars("linksWithHeadings", {
+        paddings: {
+            horizontal: item.padding.horizontal / 2,
         },
     });
 
@@ -135,7 +135,10 @@ export const navLinksClasses = useThemeCache(() => {
 
     const root = style(
         {
-            ...paddings(vars.item.padding),
+            ...paddings({
+                ...vars.item.padding,
+                horizontal: vars.item.padding.horizontal / 2,
+            }),
             display: "flex",
             flexDirection: "column",
             maxWidth: percent(100),
@@ -143,7 +146,10 @@ export const navLinksClasses = useThemeCache(() => {
         },
         mediaQueries.oneColumn({
             width: percent(100),
-            ...paddings(vars.item.paddingMobile),
+            ...paddings({
+                ...vars.item.paddingMobile,
+                horizontal: vars.item.paddingMobile.horizontal / 2,
+            }),
         }),
     );
 

--- a/library/src/scripts/navigation/navLinksWithHeadings.story.tsx
+++ b/library/src/scripts/navigation/navLinksWithHeadings.story.tsx
@@ -4,30 +4,28 @@
  * @license GPL-2.0-only
  */
 
-import { StoryHeading } from "@library/storybook/StoryHeading";
-import { storiesOf } from "@storybook/react";
-import React from "react";
-import { StoryContent } from "@library/storybook/StoryContent";
-import { t } from "@library/utility/appUtils";
-import NextPrevious from "@library/navigation/NextPrevious";
-import NavLinksWithHeadings from "@library/navigation/NavLinksWithHeadings";
+import NavLinksWithHeadingsComponent from "@library/navigation/NavLinksWithHeadings";
 import { navLinksWithHeadingsData } from "@library/navigation/navLinksWithHeadings.storyData";
+import { t } from "@library/utility/appUtils";
+import React from "react";
 
-const story = storiesOf("Navigation", module);
+export default {
+    title: "NavLinksWithHeadings",
+};
 
-const data = navLinksWithHeadingsData;
-
-story.add("Nav Links with Headings", () => {
+export function StandardNavLinksStory() {
     return (
-        <StoryContent>
-            <NavLinksWithHeadings
-                title={t("Browse Articles by Category")}
-                accessibleViewAllMessage={t(`View all articles from category: "<0/>".`)}
-                {...data}
-                depth={2}
-                ungroupedTitle={t("Other Articles")}
-                ungroupedViewAllUrl={data.ungroupedViewAllUrl}
-            />
-        </StoryContent>
+        <NavLinksWithHeadingsComponent
+            title={t("Browse Articles by Category")}
+            accessibleViewAllMessage={t(`View all articles from category: "<0/>".`)}
+            {...navLinksWithHeadingsData}
+            depth={2}
+            ungroupedTitle={t("Other Articles")}
+            ungroupedViewAllUrl={navLinksWithHeadingsData.ungroupedViewAllUrl}
+        />
     );
-});
+}
+
+StandardNavLinksStory.story = {
+    name: "Standard",
+};

--- a/library/src/scripts/storybook/StoryContext.tsx
+++ b/library/src/scripts/storybook/StoryContext.tsx
@@ -58,7 +58,7 @@ export function useStoryConfig(value: Partial<IContext>) {
     return context.refreshKey;
 }
 
-export function storyWithConfig(config: Partial<IContext>, Component: React.ComponentType) {
+export function storyWithConfig(config: Partial<IContext>, Component: React.ComponentType): any {
     const HookWrapper = () => {
         const refreshKey = useStoryConfig(config);
         return <Component key={refreshKey} />;


### PR DESCRIPTION
Working Towards https://github.com/vanilla/knowledge/issues/1516

This PR adjusts a lot of spacing in the nav links and home widget in order to accomplish the styles in the following mockups:

- https://zpl.io/bJxP9kJ
- https://zpl.io/VY7jG9L
- https://zpl.io/bAQgWL6

In order to accomplish this I've needed to adjust the CSS on a few components.

- Refactor `<Heading />` component as discussed with @slafleche. It now applies default sizes to all heading levels, not just level 1s. `displayDepth` is still respected.
- Refactor spacing & margins & fonts in `<NavLinksWithHeadings />`.
  - Uses "half" size gutters with extended outside instead of double width gutters. This made the sizing much easier to port to home widget.
  - Add new smaller width option to to `<Container />`
  - Apply `<Container />` to `NavLinks`
  - Update font weights/sizes in nav links to conform to mockups.
- Add new borderType to `IHomeWidgetContainerOptions`: `navLinks`
  - Applies nav links paddings and sizing.
- Adjust spacing and margins of HomeWidget to match mockups.


