### PR TITLE
Backport: Fix html double-encoding in Promoted Content Module 

### DIFF
--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -93,7 +93,7 @@ if (!function_exists('WritePromotedContent')):
                 class="Title"><?php echo anchor(htmlspecialchars(sliceString($content['Name'], $sender->TitleLimit), false), $contentURL, 'DiscussionLink'); ?></div>
             <div class="Body">
                 <?php
-                $linkContent = Gdn_Format::excerpt($content['Body'], $content['Format']);
+                $linkContent = Gdn::formatService()->renderExcerpt($content['Body'], $content['Format']);
                 $trimmedLinkContent = sliceString($linkContent, $sender->BodyLimit);
 
                 echo anchor(htmlspecialchars($trimmedLinkContent), $contentURL, 'BodyLink');


### PR DESCRIPTION
Backport https://github.com/vanilla/vanilla/pull/10080

Closes vanilla/support#723.

This fixes double html encoding in of content in the Promoted Content Module.