### PR TITLE
add formatFieldInterface to use with a container rule

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -12,6 +12,7 @@ use Garden\Schema\Schema;
 use Vanilla\Attributes;
 use Vanilla\Community\Events\DiscussionEvent;
 use Vanilla\Community\Schemas\PostFragmentSchema;
+use Vanilla\Contracts\Formatting\FormatFieldInterface;
 use Vanilla\Exception\PermissionException;
 use Vanilla\Formatting\FormatService;
 use Vanilla\Formatting\FormatFieldTrait;
@@ -24,7 +25,7 @@ use Vanilla\Utility\ModelUtils;
 /**
  * Manages discussions data.
  */
-class DiscussionModel extends Gdn_Model {
+class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
 
     use StaticInitializer;
 

--- a/library/Vanilla/Contracts/Formatting/FormatFieldInterface.php
+++ b/library/Vanilla/Contracts/Formatting/FormatFieldInterface.php
@@ -7,6 +7,11 @@
 
 namespace Vanilla\Contracts\Formatting;
 
+/**
+ * Interface FormatFieldInterface
+ *
+ * @package Vanilla\Contracts\Formatting
+ */
 interface FormatFieldInterface {
 
     /**

--- a/library/Vanilla/Contracts/Formatting/FormatFieldInterface.php
+++ b/library/Vanilla/Contracts/Formatting/FormatFieldInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Dani M <dani.m@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Contracts\Formatting;
+
+interface FormatFieldInterface {
+
+    /**
+     * Enable/disable field formatting.
+     *
+     * @param bool $doFieldFormatting Enable/disable formatting.
+     */
+    public function enableFieldFormatting(bool $doFieldFormatting);
+
+    /**
+     * Format a specific field.
+     *
+     * @param array $row An array representing a database row.
+     * @param string $field The field name.
+     * @param string $format The source format.
+     */
+    public function formatField(array &$row, $field, $format);
+}

--- a/library/Vanilla/Formatting/FormatFieldTrait.php
+++ b/library/Vanilla/Formatting/FormatFieldTrait.php
@@ -10,6 +10,10 @@ namespace Vanilla\Formatting;
  * Add basic field formatting with fallback render result.
  */
 trait FormatFieldTrait {
+
+    /** @var bool */
+    private $doFieldFormatting = true;
+
     /**
      * Format a specific field.
      *
@@ -18,8 +22,17 @@ trait FormatFieldTrait {
      * @param string $format The source format.
      */
     public function formatField(array &$row, $field, $format) {
-        if (array_key_exists($field, $row)) {
+        if ($this->doFieldFormatting && array_key_exists($field, $row)) {
             $row[$field] = \Gdn::formatService()->renderHTML($row[$field], $format) ?: '<!-- empty -->';
         }
+    }
+
+    /**
+     * Enable/disable field formatting.
+     *
+     * @param bool $doFieldFormatting Enable/disable field formatting.
+     */
+    public function enableFieldFormatting(bool $doFieldFormatting) {
+        $this->doFieldFormatting = $doFieldFormatting;
     }
 }


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1425

This PR adds FormatFieldInterface that has [formatFieldTTrait ](https://github.com/vanilla/vanilla/blob/578ccf1ac33fb6da5d0d0caec460db75bb10e0e6/library/Vanilla/Formatting/FormatFieldTrait.php#L19)method signatures. This will allow us to use it with the container.(Container does not support using traits).

