### PR TITLE
Fixed bug where the theme's logo was not overwritable

### DIFF
--- a/library/Vanilla/Models/FsThemeProvider.php
+++ b/library/Vanilla/Models/FsThemeProvider.php
@@ -197,16 +197,18 @@ class FsThemeProvider implements ThemeProviderInterface {
             "logo" => "Garden.Logo",
             "mobileLogo" => "Garden.MobileLogo",
         ];
+        $foundLogo = false;
         foreach ($logos as $logoName => $logoConfig) {
             if ($logo = $this->config->get($logoConfig)) {
                 $logoUrl = Gdn_Upload::url($logo);
                 $res["assets"][$logoName] = new ImageAsset($logoUrl);
+                $foundLogo = true;
             }
         }
 
 
         // Check theme for default.
-        if (!$logo) {
+        if (!$foundLogo) {
             if (valr("assets.variables", $res)) {
                 $themeVars = json_decode($res['assets']['variables']->getData(), true);
                 $desktopLogo = valr("titleBar.logo.desktop.url", $themeVars);


### PR DESCRIPTION
If you set a logo in a theme:

```
"titleBar": {
    "logo": {
        "desktop": {
            "url": "/addons/themes/lavendermoon/design/knowShare.png"
        },
        "mobile": {
             "url": "/addons/themes/lavendermoon/design/knowShare.png"
        }
    },
}
```
It's only supposed to be taken if there is no logo set through the dashboard. The theme always took precedence. I updated the logic to allow the overwrite.