### PR TITLE
Fixing narrow width always being applied to .Content

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/forumLayoutStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/forumLayoutStyles.ts
@@ -112,13 +112,14 @@ export const forumLayoutCSS = () => {
 
     cssOut(
         `.Container, body.Section-Event.NoPanel .Frame-content > .Container`,
-        containerMainStyles() as NestedCSSProperties,
         mediaQueries.xs({
             ...paddings({
                 horizontal: globalVars.gutter.half,
             }),
         }),
     );
+
+    cssOut(`body.Section-Event.NoPanel .Frame-content > .Container`, containerMainStyles() as NestedCSSProperties);
 
     cssOut(
         `.Frame-row`,

--- a/library/src/scripts/layout/components/widgetContainerStyles.ts
+++ b/library/src/scripts/layout/components/widgetContainerStyles.ts
@@ -17,7 +17,11 @@ export const widgetContainerClasses = useThemeCache(() => {
         position: "relative",
         maxWidth: percent(100),
         margin: "auto",
-        width: unit(vars.sizing.narrowContentSize),
+        $nest: {
+            "&.isNarrow": {
+                maxWidth: vars.sizing.narrowContentSize,
+            },
+        },
     });
 
     return {


### PR DESCRIPTION
Fixing bad CSS selector applying narrow width to .Content unconditionally. 

Closes: https://github.com/vanilla/vanilla/issues/10112