### PR TITLE
Add Keystone as default mobile theme

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -116,7 +116,7 @@ $Configuration['Garden']['Thumbnail']['Size'] = 200;
 
 // Appearance.
 $Configuration['Garden']['Theme'] = 'keystone';
-$Configuration['Garden']['MobileTheme'] = 'mobile';
+$Configuration['Garden']['MobileTheme'] = 'keystone';
 $Configuration['Garden']['Menu']['Sort'] = ['Dashboard', 'Discussions', 'Questions', 'Activity', 'Applicants', 'Conversations', 'User'];
 $Configuration['Garden']['ThemeOptions']['Styles']['Key'] = 'Default';
 $Configuration['Garden']['ThemeOptions']['Styles']['Value'] = '%s_default';

--- a/tests/APIv2/AddonsTest.php
+++ b/tests/APIv2/AddonsTest.php
@@ -110,7 +110,7 @@ class AddonsTest extends AbstractAPIv2Test {
         $this->assertEquals('keystone-theme', $desktop['addonID']);
 
         $mobile = $this->api()->get('/addons', ['type' => 'theme', 'enabled' => true, 'themeType' => 'mobile'])[0];
-        $this->assertEquals('mobile-theme', $mobile['addonID']);
+        $this->assertEquals('keystone-theme', $mobile['addonID']);
 
         // Set the desktop and mobile theme.
         $this->api()->patch('/addons/bittersweet-theme', ['enabled' => true, 'themeType' => 'desktop']);


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1438

Mobile theme default config was set to `mobile` instead of `keystone`.