### PR TITLE
Fix deleting posts from spam queue

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3059,11 +3059,12 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
             $this->setUserBookmarkCount($user->UserID);
         }
 
-        $dataObject = (object)$data;
-        $this->calculate($dataObject);
-        $discussionEvent = $this->eventFromRow((array)$dataObject, DiscussionEvent::ACTION_DELETE);
-        $this->getEventManager()->dispatch($discussionEvent);
-
+        if ($data) {
+            $dataObject = (object)$data;
+            $this->calculate($dataObject);
+            $discussionEvent = $this->eventFromRow((array)$dataObject, DiscussionEvent::ACTION_DELETE);
+            $this->getEventManager()->dispatch($discussionEvent);
+        }
         return true;
     }
 


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1459

When a post is marked as Spam and gets moved to the Spam queue, and an admin tries to delete that post, $data would be false https://github.com/vanilla/vanilla/blob/39d4c97c4a7806645c924373fb8bb5c0a4150f79/applications/vanilla/models/class.discussionmodel.php#L2980 discussion no longer exists in the discussion table.

### To Test

- Move a post to the Spam queue (you can edit the spam reaction and increase the points to get it to move to Spam immedietly) 
- Delete the post.