### PR TITLE
Add additional styling options for tabs and frames

### DIFF
--- a/applications/dashboard/src/scripts/forms/DashboardFormList.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardFormList.tsx
@@ -7,7 +7,14 @@ import React from "react";
 import classNames from "classnames";
 import { dashboardFormListClasses } from "@dashboard/forms/DashboardFormListStyles";
 
-export function DashboardFormList(props: { children: React.ReactNode }) {
+export function DashboardFormList(props: { children: React.ReactNode; isBlurred?: boolean }) {
     const classes = dashboardFormListClasses();
-    return <ul className={classNames(classes.root)}>{props.children}</ul>;
+    return (
+        <ul
+            className={classNames(classes.root, props.isBlurred && "foggy")}
+            aria-hidden={props.isBlurred ? true : false}
+        >
+            {props.children}
+        </ul>
+    );
 }

--- a/library/src/scripts/layout/frame/FrameBody.tsx
+++ b/library/src/scripts/layout/frame/FrameBody.tsx
@@ -33,3 +33,14 @@ export default class FrameBody extends React.PureComponent<IFrameBodyProps> {
         );
     }
 }
+
+interface IContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+    children?: React.ReactNode;
+}
+/**
+ * Container to apply paddings inside of a frame body.
+ */
+export function FrameBodyContainer(props: IContainerProps) {
+    const classes = frameBodyClasses();
+    return <div {...props} className={classNames(props.className, classes.framePaddings)} />;
+}

--- a/library/src/scripts/layout/frame/FrameHeader.tsx
+++ b/library/src/scripts/layout/frame/FrameHeader.tsx
@@ -22,6 +22,7 @@ export interface IFrameHeaderProps extends ICommonHeadingProps {
     srOnlyTitle?: boolean;
     titleID?: string;
     children?: React.ReactNode;
+    borderless?: boolean;
 }
 
 /**
@@ -62,7 +63,14 @@ export default class FrameHeader extends React.PureComponent<IFrameHeaderProps> 
         }
 
         return (
-            <header className={classNames("frameHeader", this.props.className, classes.root)}>
+            <header
+                className={classNames(
+                    "frameHeader",
+                    this.props.className,
+                    classes.root,
+                    this.props.borderless && classes.rootBorderLess,
+                )}
+            >
                 <Heading
                     id={this.props.titleID}
                     title={this.props.title}

--- a/library/src/scripts/layout/frame/frameBodyStyles.ts
+++ b/library/src/scripts/layout/frame/frameBodyStyles.ts
@@ -44,6 +44,13 @@ export const frameBodyClasses = useThemeCache(() => {
         },
     });
 
+    const framePaddings = style("framePaddings", {
+        ...paddings({
+            left: vars.spacing.padding,
+            right: vars.spacing.padding,
+        }),
+    });
+
     const noContentMessage = style("noContentMessage", {
         ...paddings({
             top: vars.header.spacing * 2,
@@ -65,6 +72,7 @@ export const frameBodyClasses = useThemeCache(() => {
     });
     return {
         root,
+        framePaddings,
         noContentMessage,
         contents,
     };

--- a/library/src/scripts/layout/frame/frameHeaderStyles.ts
+++ b/library/src/scripts/layout/frame/frameHeaderStyles.ts
@@ -39,6 +39,10 @@ export const frameHeaderClasses = useThemeCache(() => {
         },
     });
 
+    const rootBorderLess = style("rootBorderless", {
+        borderBottom: "none",
+    });
+
     const rootMinimal = style("rootMinimal", {
         display: "block",
     });
@@ -151,6 +155,7 @@ export const frameHeaderClasses = useThemeCache(() => {
         closeMinimal,
         root,
         rootMinimal,
+        rootBorderLess,
         backButton,
         heading,
         left,

--- a/library/src/scripts/sectioning/TabStyles.ts
+++ b/library/src/scripts/sectioning/TabStyles.ts
@@ -5,11 +5,22 @@
 
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
-import { colorOut, unit, fonts, paddings, borders, negative, srOnly, IFont } from "@library/styles/styleHelpers";
+import {
+    colorOut,
+    unit,
+    fonts,
+    paddings,
+    borders,
+    negative,
+    srOnly,
+    IFont,
+    sticky,
+    extendItemContainer,
+} from "@library/styles/styleHelpers";
 import { userSelect } from "@library/styles/styleHelpers";
 import { layoutVariables } from "@library/layout/panelLayoutStyles";
 import { formElementsVariables } from "@library/forms/formElementStyles";
-import { percent, viewHeight } from "csx";
+import { percent, viewHeight, calc } from "csx";
 
 export const tabsVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -71,16 +82,22 @@ export const tabClasses = useThemeCache(() => {
 
     const tabList = style("tabList", {
         display: "flex",
-        width: percent(100),
+        // Offset for the outer borders.
+        ...extendItemContainer(globalVariables().border.width),
         justifyContent: "space-between",
         alignItems: "stretch",
+        background: colorOut(vars.colors.bg),
+        ...sticky(),
+        top: 0,
+        zIndex: 1,
     });
+
     const tab = style(
         "tab",
         {
             ...userSelect(),
             position: "relative",
-            width: percent(25),
+            flex: 1,
             fontWeight: globalVars.fonts.weights.semiBold,
             textAlign: "center",
             border: "1px solid #bfcbd8",


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1576

- Add blurred/disabled style for DashboardFormList
- Tabs are now sticky positioned and extend their width to account for their border (allowing them to be used in all modals, not just full screen ones)
- Tabs now flex grow to be of equal size rather than a fixed 25%.
- Frame header now was an option to omit it's top border.
- Add `<FrameBodyContainer />` to pad self-padded frames.