### PR TITLE
Fix sign-in link generation sometimes redirecting back to entry pages

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1734,6 +1734,10 @@ if (!function_exists('signInUrl')) {
             }
         }
 
+        if ($target = '/entry/autosignedout') {
+            $target = '/';
+        }
+
         return '/entry/signin'.($target ? '?Target='.urlencode($target) : '');
     }
 }

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1734,7 +1734,7 @@ if (!function_exists('signInUrl')) {
             }
         }
 
-        if ($target = '/entry/autosignedout') {
+        if (strpos($target, 'entry') === 0) {
             $target = '';
         }
 

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1735,7 +1735,7 @@ if (!function_exists('signInUrl')) {
         }
 
         if ($target = '/entry/autosignedout') {
-            $target = '/';
+            $target = '';
         }
 
         return '/entry/signin'.($target ? '?Target='.urlencode($target) : '');

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1734,7 +1734,7 @@ if (!function_exists('signInUrl')) {
             }
         }
 
-        if (strpos($target, 'entry') === 0) {
+        if (strpos($target, 'entry/') === 0) {
             $target = '';
         }
 

--- a/tests/Library/Core/SignInUrlTest.php
+++ b/tests/Library/Core/SignInUrlTest.php
@@ -14,7 +14,7 @@ use VanillaTests\SiteTestTrait;
 /**
  * Tests for signInUrl()
  */
-class SignInUrlTest extends TestCase{
+class SignInUrlTest extends TestCase {
 
     use SiteTestTrait {
         SiteTestTrait::setUpBeforeClass as siteSetUpBeforeClass;

--- a/tests/Library/Core/SignInUrlTest.php
+++ b/tests/Library/Core/SignInUrlTest.php
@@ -7,44 +7,36 @@
 
 namespace VanillaTests\Library\Core;
 
-use Gdn_Configuration;
 use PHPUnit\Framework\TestCase;
-use VanillaTests\SiteTestTrait;
 
 /**
  * Tests for signInUrl()
  */
 class SignInUrlTest extends TestCase {
 
-    use SiteTestTrait {
-        SiteTestTrait::setUpBeforeClass as siteSetUpBeforeClass;
-    }
-
     /**
-     * @inheritdoc
+     * Test target parameter.
+     *
+     * @param string $target
+     * @param string $expected
+     * @dataProvider provideSignInUrls
      */
-    public static function setUpBeforeClass(): void {
-        self::siteSetUpBeforeClass();
-
-        /** @var Gdn_Configuration $config */
-        $config = self::container()->get(Gdn_Configuration::class);
-    }
-
-    /**
-     * Test where target starts with 'entry'.
-     */
-    public function testSignInUrlWithEntryTarget() {
-        $expected = '/entry/signin';
-        $actual = signInUrl('entry/autosignedout');
+    public function testSignInUrlTarget(string $target, string $expected): void {
+        $actual = signInUrl($target);
         $this->assertSame($expected, $actual);
     }
 
     /**
-     * Test where target doesn't contain 'entry'.
+     * Provide targets for verifying signInUrl handling.
+     *
+     * @return array
      */
-    public function testSignInUrlWithNoEntry() {
-        $expected = '/entry/signin?Target=foo';
-        $actual = signInUrl('foo');
-        $this->assertSame($expected, $actual);
+    public function provideSignInUrlTargets(): array {
+        $result = [
+            ["foo", "/entry/signin?Target=foo"],
+            ["entry/register", "/entry/signin"],
+            ["discussion/1/the-word-entry-is-in-this-discussion-name", "/entry/signin?Target=discussion%2F1%2Fthe-word-entry-is-in-this-discussion-name"],
+        ];
+        return $result;
     }
 }

--- a/tests/Library/Core/SignInUrlTest.php
+++ b/tests/Library/Core/SignInUrlTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @author Richard Flynn <richard.flynn@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use Gdn_Configuration;
+use PHPUnit\Framework\TestCase;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Tests for signInUrl()
+ */
+class SignInUrlTest extends TestCase{
+
+    use SiteTestTrait {
+        SiteTestTrait::setUpBeforeClass as siteSetUpBeforeClass;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function setUpBeforeClass(): void {
+        self::siteSetUpBeforeClass();
+
+        /** @var Gdn_Configuration $config */
+        $config = self::container()->get(Gdn_Configuration::class);
+    }
+
+    /**
+     * Test where target starts with 'entry'.
+     */
+    public function testSignInUrlWithEntryTarget() {
+        $expected = '/entry/signin';
+        $actual = signInUrl('entry/autosignedout');
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test where target doesn't contain 'entry'.
+     */
+    public function testSignInUrlWithNoEntry() {
+        $expected = '/entry/signin?Target=foo';
+        $actual = signInUrl('foo');
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Library/Core/SignInUrlTest.php
+++ b/tests/Library/Core/SignInUrlTest.php
@@ -8,18 +8,21 @@
 namespace VanillaTests\Library\Core;
 
 use PHPUnit\Framework\TestCase;
+use VanillaTests\SiteTestTrait;
 
 /**
  * Tests for signInUrl()
  */
 class SignInUrlTest extends TestCase {
 
+    use SiteTestTrait;
+
     /**
      * Test target parameter.
      *
      * @param string $target
      * @param string $expected
-     * @dataProvider provideSignInUrls
+     * @dataProvider provideSignInUrlTargets
      */
     public function testSignInUrlTarget(string $target, string $expected): void {
         $actual = signInUrl($target);


### PR DESCRIPTION
Closes vanilla/support#1450.

This fixes an issue where users who are signed out with autosignout sign back in, they are redirected to the the same "You have been signed out" page. This PR redirects users to the home page.

TO TEST
1. Enable the autosignout plugin and set the minutes to 1.
1. After you are signed out, sign back in.
1. Verify that you are redirected to the home page rather than the "You have been signed out" page.