### PR TITLE
Fix - calculate height for nav in theme editor

### DIFF
--- a/library/src/scripts/sectioning/TabStyles.ts
+++ b/library/src/scripts/sectioning/TabStyles.ts
@@ -9,7 +9,7 @@ import { colorOut, unit, fonts, paddings, borders, negative, srOnly, IFont } fro
 import { userSelect } from "@library/styles/styleHelpers";
 import { layoutVariables } from "@library/layout/panelLayoutStyles";
 import { formElementsVariables } from "@library/forms/formElementStyles";
-import { percent, viewHeight } from "csx";
+import { percent, viewHeight, calc } from "csx";
 
 export const tabsVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -30,6 +30,10 @@ export const tabsVariables = useThemeCache(() => {
         },
     });
 
+    const navHeight = makeVars("navHeight", {
+        height: 48
+    })
+
     const border = makeVars("border", {
         width: globalVars.border.width,
         color: globalVars.border.color,
@@ -43,6 +47,7 @@ export const tabsVariables = useThemeCache(() => {
     return {
         colors,
         border,
+        navHeight
     };
 });
 
@@ -57,7 +62,9 @@ export const tabClasses = useThemeCache(() => {
         display: "flex",
         flexDirection: "column",
         justifyContent: "stretch",
-        height: viewHeight(90),
+        height: calc(
+            `${percent(100)} - ${unit(vars.navHeight.height)}`,
+        ),
     });
 
     const tabsHandles = style("tabsHandles", {
@@ -120,6 +127,7 @@ export const tabClasses = useThemeCache(() => {
         flexGrow: 1,
         height: percent(100),
         flexDirection: "column",
+        position: "relative"
     });
 
     const panel = style("panel", {

--- a/library/src/scripts/sectioning/TabStyles.ts
+++ b/library/src/scripts/sectioning/TabStyles.ts
@@ -8,11 +8,13 @@ import { styleFactory, useThemeCache, variableFactory } from "@library/styles/st
 import { colorOut, unit, fonts, paddings, borders, negative, srOnly, IFont } from "@library/styles/styleHelpers";
 import { userSelect } from "@library/styles/styleHelpers";
 import { layoutVariables } from "@library/layout/panelLayoutStyles";
+import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { formElementsVariables } from "@library/forms/formElementStyles";
 import { percent, viewHeight, calc } from "csx";
 
 export const tabsVariables = useThemeCache(() => {
     const globalVars = globalVariables();
+    const titlebarVars = titleBarVariables();
     const makeVars = variableFactory("onlineTabs");
 
     const colors = makeVars("colors", {
@@ -31,7 +33,7 @@ export const tabsVariables = useThemeCache(() => {
     });
 
     const navHeight = makeVars("navHeight", {
-        height: 48
+        height: titlebarVars.sizing.height
     })
 
     const border = makeVars("border", {

--- a/library/src/scripts/sectioning/TabStyles.ts
+++ b/library/src/scripts/sectioning/TabStyles.ts
@@ -33,8 +33,8 @@ export const tabsVariables = useThemeCache(() => {
     });
 
     const navHeight = makeVars("navHeight", {
-        height: titlebarVars.sizing.height
-    })
+        height: titlebarVars.sizing.height,
+    });
 
     const border = makeVars("border", {
         width: globalVars.border.width,
@@ -49,7 +49,7 @@ export const tabsVariables = useThemeCache(() => {
     return {
         colors,
         border,
-        navHeight
+        navHeight,
     };
 });
 
@@ -64,9 +64,7 @@ export const tabClasses = useThemeCache(() => {
         display: "flex",
         flexDirection: "column",
         justifyContent: "stretch",
-        height: calc(
-            `${percent(100)} - ${unit(vars.navHeight.height)}`,
-        ),
+        height: calc(`${percent(100)} - ${unit(vars.navHeight.height)}`),
     });
 
     const tabsHandles = style("tabsHandles", {
@@ -129,7 +127,7 @@ export const tabClasses = useThemeCache(() => {
         flexGrow: 1,
         height: percent(100),
         flexDirection: "column",
-        position: "relative"
+        position: "relative",
     });
 
     const panel = style("panel", {


### PR DESCRIPTION
require : https://github.com/vanilla/internal/pull/2254

Fix: set height using calc() for tabs in theme editor page.
