### PR TITLE
Fix category dropdown options when moving a reported discussion using a checkbox

### DIFF
--- a/applications/vanilla/Events/UserEvent.php
+++ b/applications/vanilla/Events/UserEvent.php
@@ -1,9 +1,0 @@
-<?php
-
-
-namespace Vanilla\Community\Events;
-
-
-class UserEvent {
-
-}

--- a/applications/vanilla/Events/UserEvent.php
+++ b/applications/vanilla/Events/UserEvent.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace Vanilla\Community\Events;
+
+
+class UserEvent {
+
+}

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -370,13 +370,13 @@ class ModerationController extends VanillaController {
 
         // Check for edit permissions on each discussion
         $AllowedDiscussions = [];
-        $DiscussionData = $DiscussionModel->SQL->select('DiscussionID, Name, DateLastComment, CategoryID, CountComments')->from('Discussion')->whereIn('DiscussionID', $DiscussionIDs)->get();
+        $DiscussionData = $DiscussionModel->SQL->select('DiscussionID, Name, Type, DateLastComment, CategoryID, CountComments')->from('Discussion')->whereIn('DiscussionID', $DiscussionIDs)->get();
 
         $DiscussionData = Gdn_DataSet::index($DiscussionData->resultArray(), ['DiscussionID']);
         foreach ($DiscussionData as $DiscussionID => $Discussion) {
             $Category = CategoryModel::categories($Discussion['CategoryID']);
-            if ($Category['Type'] === 'Reporting' && !array_key_exists('DiscussionType', $this->Data)) {
-                $this->setData('DiscussionType', 'Report');
+            if (!array_key_exists('DiscussionType', $this->Data) && !is_null($Discussion['Type'])) {
+                $this->setData('DiscussionType', $Discussion['Type']);
                 $this->setData('CategoryID', $Category['CategoryID']);
             }
             if ($Category && $Category['PermsDiscussionsEdit']) {

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -375,6 +375,10 @@ class ModerationController extends VanillaController {
         $DiscussionData = Gdn_DataSet::index($DiscussionData->resultArray(), ['DiscussionID']);
         foreach ($DiscussionData as $DiscussionID => $Discussion) {
             $Category = CategoryModel::categories($Discussion['CategoryID']);
+            if ($Category['Type'] === 'Reporting' && !array_key_exists('DiscussionType', $this->Data)) {
+                $this->setData('DiscussionType', 'Report');
+                $this->setData('CategoryID', $Category['CategoryID']);
+            }
             if ($Category && $Category['PermsDiscussionsEdit']) {
                 $AllowedDiscussions[] = $DiscussionID;
             }

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -370,7 +370,9 @@ class ModerationController extends VanillaController {
 
         // Check for edit permissions on each discussion
         $AllowedDiscussions = [];
-        $DiscussionData = $DiscussionModel->SQL->select('DiscussionID, Name, Type, DateLastComment, CategoryID, CountComments')->from('Discussion')->whereIn('DiscussionID', $DiscussionIDs)->get();
+        $DiscussionData = $DiscussionModel->SQL
+            ->select('DiscussionID, Name, Type, DateLastComment, CategoryID, CountComments')
+            ->from('Discussion')->whereIn('DiscussionID', $DiscussionIDs)->get();
 
         $DiscussionData = Gdn_DataSet::index($DiscussionData->resultArray(), ['DiscussionID']);
         foreach ($DiscussionData as $DiscussionID => $Discussion) {


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1443

Moving a post out for reported posts is not currently allowed. In the drop-down menu, the only available option is 'Reported Posts' category. However, this is not the case when selecting the discussion with a checkbox. then moving it.

**Changes**

I've set the CategoryID and DiscussionType on the Data array similar to what we're doing when moving a discussion with the cog wheel.

### To Test

- Move a discussion using the cog wheel, you should have Reported Posts as the only available option

<img width="251" alt="Screen Shot 2020-02-25 at 12 33 54 PM" src="https://user-images.githubusercontent.com/31856281/75271981-1cb7b300-57cb-11ea-97cd-ff7236ffd8e1.png">

- Move a discussion using the checkbox 
- Confirm that you have a similar behaviour.
