### PR TITLE
strip out &nbsp; from end of mentions

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -1015,7 +1015,7 @@ class Gdn_Format {
 
             // Unquoted mention.
             if (!$mention && !empty($str)) {
-                $parts2 = preg_split('`([\s.,;?!:\'])`', $str, 2, PREG_SPLIT_DELIM_CAPTURE);
+                $parts2 = preg_split('`&nbsp;|([\s.,;?!:\'])`', $str, 2, PREG_SPLIT_DELIM_CAPTURE);
                 $mention = $parts2[0];
                 $suffix = val(1, $parts2, '') . val(2, $parts2, '');
             }


### PR DESCRIPTION
Closes vanilla/support#1400

This fixes a problem when using wysiwyg with the advanced editor. If there were two spaces after an '@mention', '&nbsp;' would be appended to the name. This fix strips out the '&nbsp;'.

### To Test
1. Make sure advanced editor is enabled and set to WYSIWYG.
1. Add a mention with two spaces after it.
1. Verify that '&nbsp;' is not appended to the name.