### PR TITLE
Fix "new" tags on discussions created after category has been marked read

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1146,7 +1146,8 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
         } else {
             // If the category was marked explicitly read at some point, see if that applies here
             if ($category && !is_null($category['DateMarkedRead'])) {
-                // If the discussion was created after the category was marked read and hasn't been viewed, reset DateLastViewed to null
+                // If the discussion was created after the category was marked read and it hasn't been viewed,
+                // leave CountCountCommentWatch and DateLastViewed null.
                 if (!is_null($discussion->CountCommentWatch)) {
                     // If it's not a newly created discussion, set DateLastViewed to whichever is most recent.
                     $discussion->DateLastViewed = self::maxDate($discussion->DateLastViewed, $category['DateMarkedRead']);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1146,9 +1146,10 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
         } else {
             // If the category was marked explicitly read at some point, see if that applies here
             if ($category && !is_null($category['DateMarkedRead'])) {
-                // If the discussion was created after the category was marked read and it hasn't been viewed,
-                // leave CountCountCommentWatch and DateLastViewed null.
-                if (!is_null($discussion->CountCommentWatch)) {
+                // If the discussion hasn't been viewed or was created after the category was marked read,
+                // leave CountCountCommentWatch and DateLastViewed null. Otherwise, calculate the correct DateLastViewed.
+                if (!is_null($discussion->DateLastViewed) |
+                    self::maxDate($category['DateMarkedRead'], $discussion->DateInserted) === $category['DateMarkedRead']) {
                     // If it's not a newly created discussion, set DateLastViewed to whichever is most recent.
                     $discussion->DateLastViewed = self::maxDate($discussion->DateLastViewed, $category['DateMarkedRead']);
                 }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1148,7 +1148,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
             if ($category && !is_null($category['DateMarkedRead'])) {
                 // If the discussion hasn't been viewed or was created after the category was marked read,
                 // leave CountCountCommentWatch and DateLastViewed null. Otherwise, calculate the correct DateLastViewed.
-                if (!is_null($discussion->DateLastViewed) |
+                if (!is_null($discussion->DateLastViewed) ||
                     self::maxDate($category['DateMarkedRead'], $discussion->DateInserted) === $category['DateMarkedRead']) {
                     // If it's not a newly created discussion, set DateLastViewed to whichever is most recent.
                     $discussion->DateLastViewed = self::maxDate($discussion->DateLastViewed, $category['DateMarkedRead']);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1147,9 +1147,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
             // If the category was marked explicitly read at some point, see if that applies here
             if ($category && !is_null($category['DateMarkedRead'])) {
                 // If the discussion was created after the category was marked read and hasn't been viewed, reset DateLastViewed to null
-                if ($category['DateMarkedRead'] <= $discussion->DateInserted && is_null($discussion->CountCommentWatch)) {
-                    $discussion->DateLastViewed = null;
-                } else {
+                if (!is_null($discussion->CountCommentWatch)) {
                     // If it's not a newly created discussion, set DateLastViewed to whichever is most recent.
                     $discussion->DateLastViewed = self::maxDate($discussion->DateLastViewed, $category['DateMarkedRead']);
                 }
@@ -1258,6 +1256,32 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
         $result = null;
 
         if ($dateOne < $dateTwo) {
+            $result = $dateTwo;
+        } elseif (empty($dateOne) && empty($dateTwo)) {
+            $result = null;
+            return $result;
+        } else {
+            $result = $dateOne;
+        }
+
+        $maxDate = $result->format(MYSQL_DATE_FORMAT);
+        return $maxDate;
+    }
+
+    /**
+     * Decide which of two dates is older.
+     *
+     * @param string|null $dateOne
+     * @param string|null $dateTwo
+     * @return string|null Returns the older of two dates.
+     * @throws Exception Emits Exception in case of an error.
+     */
+    public static function minDate(?string $dateOne, ?string $dateTwo): ?string {
+        $dateOne = self::forceDateTime($dateOne);
+        $dateTwo = self::forceDateTime($dateTwo);
+        $result = null;
+
+        if ($dateOne > $dateTwo) {
             $result = $dateTwo;
         } elseif (empty($dateOne) && empty($dateTwo)) {
             $result = null;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1144,12 +1144,14 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
             $discussion->Read = false;
             $discussion->CountUnreadComments = true;
         } else {
+            // If the category was marked explicitly read at some point, see if that applies here
             if ($category && !is_null($category['DateMarkedRead'])) {
-                // If the category was marked explicitly read at some point, see if that applies here
-                $discussion->DateLastViewed = self::maxDate($discussion->DateLastViewed, $category['DateMarkedRead']);
                 // If the discussion was created after the category was marked read and hasn't been viewed, reset DateLastViewed to null
                 if ($category['DateMarkedRead'] <= $discussion->DateInserted && is_null($discussion->CountCommentWatch)) {
                     $discussion->DateLastViewed = null;
+                } else {
+                    // If it's not a newly created discussion, set DateLastViewed to whichever is most recent.
+                    $discussion->DateLastViewed = self::maxDate($discussion->DateLastViewed, $category['DateMarkedRead']);
                 }
             }
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1147,7 +1147,12 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
             if ($category && !is_null($category['DateMarkedRead'])) {
                 // If the category was marked explicitly read at some point, see if that applies here
                 $discussion->DateLastViewed = self::maxDate($discussion->DateLastViewed, $category['DateMarkedRead']);
+                // If the discussion was created after the category was marked read, reset DateLastViewed to null
+                if ($category['DateMarkedRead'] <= $discussion->DateInserted) {
+                    $discussion->DateLastViewed = null;
+                }
             }
+
             list($read, $count) = $this->calculateCommentReadData(
                 $discussion->CountComments,
                 $discussion->DateLastComment,

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1147,8 +1147,8 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
             if ($category && !is_null($category['DateMarkedRead'])) {
                 // If the category was marked explicitly read at some point, see if that applies here
                 $discussion->DateLastViewed = self::maxDate($discussion->DateLastViewed, $category['DateMarkedRead']);
-                // If the discussion was created after the category was marked read, reset DateLastViewed to null
-                if ($category['DateMarkedRead'] <= $discussion->DateInserted) {
+                // If the discussion was created after the category was marked read and hasn't been viewed, reset DateLastViewed to null
+                if ($category['DateMarkedRead'] <= $discussion->DateInserted && is_null($discussion->CountCommentWatch)) {
                     $discussion->DateLastViewed = null;
                 }
             }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1269,32 +1269,6 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
     }
 
     /**
-     * Decide which of two dates is older.
-     *
-     * @param string|null $dateOne
-     * @param string|null $dateTwo
-     * @return string|null Returns the older of two dates.
-     * @throws Exception Emits Exception in case of an error.
-     */
-    public static function minDate(?string $dateOne, ?string $dateTwo): ?string {
-        $dateOne = self::forceDateTime($dateOne);
-        $dateTwo = self::forceDateTime($dateTwo);
-        $result = null;
-
-        if ($dateOne > $dateTwo) {
-            $result = $dateTwo;
-        } elseif (empty($dateOne) && empty($dateTwo)) {
-            $result = null;
-            return $result;
-        } else {
-            $result = $dateOne;
-        }
-
-        $maxDate = $result->format(MYSQL_DATE_FORMAT);
-        return $maxDate;
-    }
-
-    /**
      * Add SQL Where to account for archive date.
      *
      * @param Gdn_SQLDriver $sql

--- a/tests/Models/DiscussionModelTest.php
+++ b/tests/Models/DiscussionModelTest.php
@@ -720,22 +720,46 @@ class DiscussionModelTest extends TestCase {
      */
     public function provideMarkedRead(): array {
         $result = [
-            "Category has not been marked read." => [
-                "2010-01-01-16:22:42",
-                "2019-01-09 16:22:42",
-                null,
-                "2019-01-09 16:22:42",
+            "Discussion unread, category unread" => [
+                "2020-01-01 00:00:00", // Discussion.DateInserted
+                null, // Discussion.DateLastViewed
+                null, // Category.DateMarkedRead
+                null, // Expected value.
             ],
-            "Category was marked read after discussion was created." => [
-                "2010-01-01-16:22:42",
-                "2020-01-09 16:22:42",
-                "2019-01-09 16:22:42",
-                "2020-01-09 16:22:42",
-            ],
-            "Discussion was created after the category was marked read." => [
-                "2020-03-02 16:22:42",
+            "Discussion read, category unread." => [
+                "2020-01-01 00:00:00",
+                "2020-01-08 00:00:00",
                 null,
-                "2020-01-09 16:22:42",
+                "2020-01-08 00:00:00",
+            ],
+            "Discussion read, category read more recently." => [
+                "2020-01-01 00:00:00",
+                "2020-01-08 00:00:00",
+                "2020-01-10 00:00:00",
+                "2020-01-10 00:00:00",
+            ],
+            "Discussion read, category read prior." => [
+                "2020-01-01 00:00:00",
+                "2020-01-22 00:00:00",
+                "2020-01-08 00:00:00",
+                "2020-01-22 00:00:00",
+            ],
+            "Discussion read, category read before discussion created." => [
+                "2020-01-01 00:00:00",
+                "2020-01-08 00:00:00",
+                "2019-12-25 00:00:00",
+                "2020-01-08 00:00:00",
+            ],
+            "Discussion unread, category read after discussion created." => [
+                "2020-01-01 00:00:00",
+                null,
+                "2020-01-15 00:00:00",
+                "2020-01-15 00:00:00",
+            ],
+            "Discussion unread, category read before discussion created." => [
+                "2020-01-22 00:00:00",
+                null,
+                "2020-01-15 00:00:00",
                 null,
             ],
         ];

--- a/tests/Models/DiscussionModelTest.php
+++ b/tests/Models/DiscussionModelTest.php
@@ -12,7 +12,6 @@ use DiscussionModel;
 use Garden\EventManager;
 use Gdn;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use Vanilla\Community\Events\DiscussionEvent;
 use VanillaTests\ExpectErrorTrait;
 use VanillaTests\SiteTestTrait;
@@ -42,11 +41,6 @@ class DiscussionModelTest extends TestCase {
     private $session;
 
     /**
-     * @var \CategoryModel
-     */
-    private $category;
-
-    /**
      * A test listener that increments the counter.
      *
      * @param TestEvent $e
@@ -64,7 +58,6 @@ class DiscussionModelTest extends TestCase {
         parent::setUp();
 
         $this->model = $this->container()->get(\DiscussionModel::class);
-        $this->category = $this->container()->get(\CategoryModel::class);
         $this->now = new \DateTimeImmutable();
         $this->session = Gdn::session();
         $this->backupSession();
@@ -673,6 +666,7 @@ class DiscussionModelTest extends TestCase {
     /**
      * Test calculate() with various category marked read discussion dates.
      *
+     * @param string $discussionInserted
      * @param string|null $discussionMarkedRead
      * @param string|null $categoryMarkedRead
      * @param string|null $expected


### PR DESCRIPTION
Closes vanilla/support#1481.

This PR fixes a bug where discussions created after a category has been marked read would display the number of unread comments, even though the user had never viewed the discussion. With this fix, the 'new' tag displays without a number, as it should.

### TO TEST

1. As user A, mark a category as read.
1. As user B, create a new discussion in that category and add a comment to that discussion.
1. As user A, refresh the page and ensure that discussion's tag is 'new' and not '1 new'