### PR TITLE
Backport: Fix formatting always counting against post character limits (#10095)

### DIFF
--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -1093,8 +1093,8 @@ class CommentModel extends Gdn_Model {
         $this->Validation->applyRule('Body', 'MeAction');
         $maxCommentLength = Gdn::config('Vanilla.Comment.MaxLength');
         if (is_numeric($maxCommentLength) && $maxCommentLength > 0) {
-            $this->Validation->setSchemaProperty('Body', 'Length', $maxCommentLength);
-            $this->Validation->applyRule('Body', 'Length');
+            $this->Validation->setSchemaProperty('Body', 'maxPlainTextLength', $maxCommentLength);
+            $this->Validation->applyRule('Body', 'plainTextLength');
         }
         $minCommentLength = c('Vanilla.Comment.MinLength');
         if ($minCommentLength && is_numeric($minCommentLength)) {

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2096,8 +2096,8 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
             $minCommentLength = Gdn::config('Vanilla.Comment.MinLength');
 
             if (is_numeric($maxCommentLength) && $maxCommentLength > 0) {
-                $this->Validation->setSchemaProperty('Body', 'Length', $maxCommentLength);
-                $this->Validation->applyRule('Body', 'Length');
+                $this->Validation->setSchemaProperty('Body', 'maxPlainTextLength', $maxCommentLength);
+                $this->Validation->applyRule('Body', 'plainTextLength');
             }
 
             if ($minCommentLength && is_numeric($minCommentLength)) {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -292,6 +292,9 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->rule(Gdn_Validation::class)
     ->addCall('addRule', ['BodyFormat', new Reference(\Vanilla\BodyFormatValidator::class)])
 
+    ->rule(Gdn_Validation::class)
+    ->addCall('addRule', ['plainTextLength', new Reference(\Vanilla\PlainTextLengthValidator::class)])
+
     ->rule(\Vanilla\Models\AuthenticatorModel::class)
     ->setShared(true)
     ->addCall('registerAuthenticatorClass', [\Vanilla\Authenticator\PasswordAuthenticator::class])

--- a/library/Vanilla/Contracts/Formatting/FormatInterface.php
+++ b/library/Vanilla/Contracts/Formatting/FormatInterface.php
@@ -44,7 +44,15 @@ interface FormatInterface {
     public function renderPlainText(string $content): string;
 
     /**
-     * Render a version of the content suitable to be quoted in other content.
+     * Calculate the length of content with formatting and metadata removed.
+     *
+     * @param string $content
+     * @return int
+     */
+    public function getPlainTextLength(string $content): int;
+
+    /**
+     * Render a version of the content   suitable to be quoted in other content.
      *
      * @param string $content The raw content to render.
      *

--- a/library/Vanilla/Formatting/BaseFormat.php
+++ b/library/Vanilla/Formatting/BaseFormat.php
@@ -42,4 +42,11 @@ abstract class BaseFormat implements FormatInterface {
     public function renderQuote(string $content): string {
         return $this->renderHTML($content);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPlainTextLength(string $content): int {
+        return mb_strlen($this->renderPlainText($content), 'UTF-8');
+    }
 }

--- a/library/Vanilla/Formatting/FormatService.php
+++ b/library/Vanilla/Formatting/FormatService.php
@@ -81,6 +81,20 @@ class FormatService {
     }
 
     /**
+     * Get the length of content with all formatting removed.
+     *
+     * @param string $content The content to render.
+     * @param string|null $format The format of the content.
+     *
+     * @return int The number of visible characters in $content.
+     */
+    public function getPlainTextLength(string $content, ?string $format): int {
+        return $this
+            ->getFormatter($format)
+            ->getPlainTextLength($content);
+    }
+
+    /**
      * Render a version of the content suitable to be quoted in other content.
      *
      * @param string $content The raw content to render.

--- a/library/Vanilla/Formatting/Formats/NotFoundFormat.php
+++ b/library/Vanilla/Formatting/Formats/NotFoundFormat.php
@@ -60,6 +60,13 @@ class NotFoundFormat implements FormatInterface {
     /**
      * @inheritdoc
      */
+    public function getPlainTextLength(string $content): int {
+        return 0;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function renderQuote(string $content): string {
         return $this->renderHTML($content);
     }

--- a/library/Vanilla/PlainTextLengthValidator.php
+++ b/library/Vanilla/PlainTextLengthValidator.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @author Patrick Kelly <patrick.k@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla;
+
+use Vanilla\Invalid;
+use Vanilla\Formatting\FormatService;
+use Vanilla\Contracts\LocaleInterface;
+
+/*
+ * Validates the Body field length by stripping any formatting code.
+ */
+class PlainTextLengthValidator {
+
+    /** @var LocaleInterface */
+    private $locale;
+
+    /** @var FormatService */
+    private $formatService;
+
+    /**
+     * PlainTextLengthValidator constructor.
+     *
+     * @param FormatService $formatService Service to apply a formatter.
+     * @param LocaleInterface $locale For translating error messages.
+     */
+    public function __construct(FormatService $formatService, LocaleInterface $locale) {
+        $this->locale = $locale;
+        $this->formatService = $formatService;
+    }
+
+    /**
+     * Validate content length by stripping most meta-data and formatting.
+     *
+     * @param string $value User input content.
+     * @param object $field Properties of field where content is found.
+     * @param array $post POST array.
+     * @return mixed Either an Invalid Object or the value.
+     */
+    private function validate($value, $field, $post) {
+        $format = $post['Format'] ?? '';
+        if (!$format) {
+            $noFormatError = $this->locale->translate('%s Not Found');
+            return new Invalid(sprintf($noFormatError, 'Format'));
+        }
+
+        $maxPlainTextLength = $field->maxPlainTextLength ?? null;
+        if (!is_numeric($maxPlainTextLength)) {
+            throw new \InvalidArgumentException("Invalid max plain-text length specified in field schema.");
+        }
+
+        $plainTextLength = $this->formatService->getPlainTextLength($value, $format);
+        if ($plainTextLength <= $maxPlainTextLength) {
+            return $value;
+        } else {
+            $validationMessage = $this->locale->translate('ValidateLength' ?? '');
+            $fieldName = $this->locale->translate($field->Name ?? '');
+            $diff = $plainTextLength - $maxPlainTextLength;
+            return new Invalid(sprintf($validationMessage, $fieldName, abs($diff)));
+        }
+    }
+
+    /**
+     * Execute validate function for visible text validator.
+     *
+     * @param string $value User input content.
+     * @param object $field Properties of field where content is found.
+     * @param array $row POST array.
+     * @return mixed Either an Invalid Object or the value.
+     */
+    public function __invoke($value, $field, $row = []) {
+        return $this->validate($value, $field, $row);
+    }
+}

--- a/tests/Library/Vanilla/PlainTextLengthValidatorTest.php
+++ b/tests/Library/Vanilla/PlainTextLengthValidatorTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla;
+
+use Vanilla\Invalid;
+use Vanilla\PlainTextLengthValidator;
+use VanillaTests\MinimalContainerTestCase;
+
+/**
+ * Tests for PlainTextLengthValidator class.
+ */
+class PlainTextLengthValidatorTest extends MinimalContainerTestCase {
+
+    /** @var int Number of characters to test for. */
+    const TEST_MAX_COMMENT_LENGTH = 10;
+
+    /**
+     * Test the PlainTextLengthValidator Class
+     *
+     * @param array $post Testable POST array.
+     * @param bool $isValid Expected result of the validator.
+     *
+     * @dataProvider providePostContent
+     */
+    public function testPlainTextLengthValidator(array $post, bool $isValid) {
+        $validator = $this->container()->get(PlainTextLengthValidator::class);
+        $field = (object)[
+            'Name' => 'Body',
+            'maxPlainTextLength' => self::TEST_MAX_COMMENT_LENGTH,
+        ];
+        $result = $validator($post['Body'] ?? '', $field, $post);
+        $actual = !($result instanceof Invalid);
+        $this->assertEquals($isValid, $actual);
+    }
+
+    /**
+     * Provide formatted text to test counting text length with formatting stripped out.
+     *
+     * @return array Formatted posts with expected validation results (true or false).
+     */
+    public static function providePostContent() {
+        return [
+            'Empty Body' => [
+                [
+                    'Body' => '',
+                    'Format' => 'markdown',
+                ],
+                true,
+            ],
+            'Empty Format' => [
+                [
+                    'Body' => 'Word up!',
+                    'Format' => '',
+                ],
+                false,
+            ],
+            'Short Plain' => [
+                [
+                    'Body' => 'Word Up',
+                    'Format' => 'markdown',
+                ],
+                true,
+            ],
+            'Short Formatted' => [
+                [
+                    'Body' => '**Word** *Up*',
+                    'Format' => 'markdown',
+                ],
+                true,
+            ],
+            'Long Markdown' => [
+                [
+                    'Body' => '**Many** Words *Up*',
+                    'Format' => 'markdown',
+                ],
+                false,
+            ],
+            'Short Rich' => [
+                [
+                    'Body' => '[{"insert":"Word "},{"attributes":{"link":"https:\/\/up.org"},"insert":"Up"},{"insert":"\n"}]',
+                    'Format' => 'rich',
+                ],
+                true,
+            ],
+            'Long Rich' => [
+                [
+                    'Body' => '[{"insert":"Many words"},{"attributes":{"link":"https:\/\/up.org"},"insert":"Up"}]',
+                    'Format' => 'rich',
+                ],
+                false,
+            ],
+            'Short WYSYWIG' => [
+                [
+                    'Body' => '<p>Word<span class="Test"><a rel="nofollow" href="https://up.org">up</a></span></p>',
+                    'Format' => 'wysiwyg',
+                ],
+                true,
+            ],
+            'Long WYSYWIG' => [
+                [
+                    'Body' => '<p>Many words<span class="Test"><a rel="nofollow" href="https://up.org">up</a></span></p>',
+                    'Format' => 'wysiwyg',
+                ],
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Backport #10095 
Closed issues: vanilla/support#1439 and vanilla/support#1396
* Add a validation function that validates Rich Text on the length of visible text.

* Create validation methods for visible content lengths for different formats.

 - Simplify the validateRawLength validation function.
 - Create an interface for it in the FormatInterface.
 - Create a call to the getVisibleTextLength() function in the Format Service.
 - Create corresponding functions in HtmlFormat, RichFormat and TextFormat classes.

* Add getVisibleTextLength() to NotFoundFormat class.

* Output the correct format in NotFoundFormat.

* Fix type-hinting.

* Use `mb_strlen` to count string length. Fix validation function.

* Add test case.

* Starting creating tests.

* Create fixtures to test text counting.

* Add fixtures, fix linting.

* Fix Rich test.

* Add a callable function to validate raw length.

* Add RawLength validation function to Validation class.

* Move tests, rename validation function to `visibleTextLength`, create VisibleTextLengthValidator class.

* Refactor, fix tests.

* Add doc blocks.

* More formatting.

* More formatting.

* Add a missing space.

* Remove unused line

* Remove unused methods, start creating test for VisibleTextLengthValidator class.

* Move test for VisibleTextValidator into its own class.

* Punctuation.

* Remove unused ‘use’.

* Add docblocks.

* Changes to Provider. Validate for missing formats. General tightening up.

* Add getters and setters, remove unused code.

* Fix getter and setter.

* Stop setting the max length in the constructor.

* Fix formatting.

* Remove extra @param line in docblock.

* Tidying up plain text length validation

Co-authored-by: Ryan <initvector@users.noreply.github.com>