### PR TITLE
Fix save draft button when starting a new discussion

### DIFF
--- a/applications/vanilla/js/post.js
+++ b/applications/vanilla/js/post.js
@@ -167,6 +167,7 @@ jQuery(document).ready(function($) {
                     }
                 }
                 gdn.inform(json);
+                gdn.enable(btn);
             }
         });
         $(frm).triggerHandler('submit');


### PR DESCRIPTION
Closes vanilla/support#1289.

When starting a new discussion, the 'Save Draft' button was permanently disable after being clicked, meaning you could only save a draft one time. This fix re-enables the button so that users can save a draft as many times as they like.

### TO TEST

Start a new discussion, type something in the body, and click the "Save Draft" button. Verify that it's re-enabled and can be clicked again.