### PR TITLE
Add navLinks placeholder

### DIFF
--- a/library/src/scripts/headers/ActionBar.tsx
+++ b/library/src/scripts/headers/ActionBar.tsx
@@ -34,6 +34,7 @@ interface IProps {
     selfPadded?: boolean;
     title?: React.ReactNode;
     fullWidth?: boolean;
+    backTitle?: string;
 }
 
 /**
@@ -60,7 +61,7 @@ export function ActionBar(props: IProps) {
     const content = (
         <ul className={classNames(classes.items)}>
             <li className={classNames(classes.item, "isPullLeft")} ref={backRef} style={minButtonSizeStyles}>
-                <BackLink title={t("Cancel")} visibleLabel={true} className={classes.backLink} />
+                <BackLink title={props.backTitle || t("Cancel")} visibleLabel={true} className={classes.backLink} />
             </li>
             {props.statusItem}
             {showMobileDropDown ? (

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -167,7 +167,9 @@ export const homeWidgetContainerClasses = useThemeCache((optionOverrides?: IHome
         ...paddings({
             vertical: vars.itemSpacing.vertical,
         }),
-        ...(vars.options.borderType === "navLinks" ? {} : extendItemContainer(vars.itemSpacing.horizontal)),
+        ...(vars.options.borderType === "navLinks"
+            ? extendItemContainer(navLinksVariables().linksWithHeadings.paddings.horizontal)
+            : extendItemContainer(vars.itemSpacing.horizontal)),
     };
 
     const verticalContainer = style("verticalContainer", {

--- a/library/src/scripts/navigation/NavLinksPlaceholder.tsx
+++ b/library/src/scripts/navigation/NavLinksPlaceholder.tsx
@@ -35,7 +35,7 @@ export function NavLinksPlaceholder(props: IProps) {
                     return (
                         <React.Fragment key={i}>
                             <SingleNavLinksPlaceholder itemCount={4} />
-                            {(i + 1) % 2 === 0 ? evenSeparator : oddSeparator}
+                            {i !== sectionsCount - 1 && ((i + 1) % 2 === 0 ? evenSeparator : oddSeparator)}
                         </React.Fragment>
                     );
                 })}

--- a/library/src/scripts/navigation/NavLinksPlaceholder.tsx
+++ b/library/src/scripts/navigation/NavLinksPlaceholder.tsx
@@ -13,9 +13,13 @@ import ScreenReaderContent from "@library/layout/ScreenReaderContent";
 import Container from "@library/layout/components/Container";
 import random from "lodash/random";
 
-interface IProps {}
+interface IProps {
+    sectionsCount?: number;
+    className?: string;
+}
 
 export function NavLinksPlaceholder(props: IProps) {
+    const { sectionsCount = 6 } = props;
     const classes = navLinksClasses();
 
     const evenSeparator = <hr className={classNames(classes.separator)} aria-hidden={true} role="presentation" />;
@@ -24,21 +28,17 @@ export function NavLinksPlaceholder(props: IProps) {
     );
 
     return (
-        <Container fullGutter narrow>
+        <Container fullGutter narrow className={props.className}>
             <h2>NavLinks Placeholder</h2>
             <nav className={classNames(classes.linksWithHeadings)}>
-                <SingleNavLinksPlaceholder itemCount={4} />
-                {oddSeparator}
-                <SingleNavLinksPlaceholder itemCount={5} />
-                {evenSeparator}
-                <SingleNavLinksPlaceholder itemCount={3} />
-                {oddSeparator}
-                <SingleNavLinksPlaceholder itemCount={4} />
-                {evenSeparator}
-                <SingleNavLinksPlaceholder itemCount={2} />
-                {oddSeparator}
-                <SingleNavLinksPlaceholder itemCount={3} />
-                {evenSeparator}
+                {Array.from(Array(sectionsCount)).map((_, i) => {
+                    return (
+                        <React.Fragment key={i}>
+                            <SingleNavLinksPlaceholder itemCount={4} />
+                            {(i + 1) % 2 === 0 ? evenSeparator : oddSeparator}
+                        </React.Fragment>
+                    );
+                })}
             </nav>
         </Container>
     );
@@ -54,7 +54,7 @@ function SingleNavLinksPlaceholder(props: { itemCount: number }) {
                 width={random(30, 75, false) + "%"}
             ></LoadingRectange>
             <div className={classes.items}>
-                {Array.from(Array(props.itemCount)).map(i => {
+                {Array.from(Array(props.itemCount)).map((_, i) => {
                     return (
                         <React.Fragment key={i}>
                             <LoadingRectange height={12} className={classes.item} width={random(70, 98, false) + "%"} />

--- a/library/src/scripts/navigation/NavLinksPlaceholder.tsx
+++ b/library/src/scripts/navigation/NavLinksPlaceholder.tsx
@@ -19,7 +19,7 @@ interface IProps {
     showTitle?: boolean;
 }
 
-export function NavLinksPlaceholder(props: IProps) {
+export const NavLinksPlaceholder = React.memo(function NavLinksPlaceholder(props: IProps) {
     const { sectionsCount = 6 } = props;
     const classes = navLinksClasses();
 
@@ -51,7 +51,7 @@ export function NavLinksPlaceholder(props: IProps) {
             </nav>
         </Container>
     );
-}
+});
 
 function SingleNavLinksPlaceholder(props: { itemCount: number }) {
     const classes = navLinksClasses();

--- a/library/src/scripts/navigation/NavLinksPlaceholder.tsx
+++ b/library/src/scripts/navigation/NavLinksPlaceholder.tsx
@@ -3,19 +3,20 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
-import { navLinksClasses } from "@library/navigation/navLinksStyles";
+import Container from "@library/layout/components/Container";
 import Heading from "@library/layout/Heading";
 import { LoadingRectange } from "@library/loaders/LoadingRectangle";
+import { navLinksClasses } from "@library/navigation/navLinksStyles";
+import { visibility } from "@library/styles/styleHelpers";
 import classNames from "classnames";
-import { classes } from "typestyle";
-import ScreenReaderContent from "@library/layout/ScreenReaderContent";
-import Container from "@library/layout/components/Container";
 import random from "lodash/random";
+import React from "react";
 
 interface IProps {
     sectionsCount?: number;
     className?: string;
+    title: string;
+    showTitle?: boolean;
 }
 
 export function NavLinksPlaceholder(props: IProps) {
@@ -29,8 +30,16 @@ export function NavLinksPlaceholder(props: IProps) {
 
     return (
         <Container fullGutter narrow className={props.className}>
-            <h2>NavLinks Placeholder</h2>
             <nav className={classNames(classes.linksWithHeadings)}>
+                <Heading
+                    title={props.title}
+                    depth={2}
+                    className={classNames(
+                        classes.title,
+                        classes.topTitle,
+                        !props.showTitle && visibility().visuallyHidden,
+                    )}
+                />
                 {Array.from(Array(sectionsCount)).map((_, i) => {
                     return (
                         <React.Fragment key={i}>

--- a/library/src/scripts/navigation/NavLinksPlaceholder.tsx
+++ b/library/src/scripts/navigation/NavLinksPlaceholder.tsx
@@ -18,15 +18,27 @@ interface IProps {}
 export function NavLinksPlaceholder(props: IProps) {
     const classes = navLinksClasses();
 
+    const evenSeparator = <hr className={classNames(classes.separator)} aria-hidden={true} role="presentation" />;
+    const oddSeparator = (
+        <hr className={classNames(classes.separator, classes.separatorOdd)} aria-hidden={true} role="presentation" />
+    );
+
     return (
         <Container fullGutter narrow>
+            <h2>NavLinks Placeholder</h2>
             <nav className={classNames(classes.linksWithHeadings)}>
                 <SingleNavLinksPlaceholder itemCount={4} />
+                {oddSeparator}
                 <SingleNavLinksPlaceholder itemCount={5} />
+                {evenSeparator}
                 <SingleNavLinksPlaceholder itemCount={3} />
+                {oddSeparator}
                 <SingleNavLinksPlaceholder itemCount={4} />
+                {evenSeparator}
                 <SingleNavLinksPlaceholder itemCount={2} />
+                {oddSeparator}
                 <SingleNavLinksPlaceholder itemCount={3} />
+                {evenSeparator}
             </nav>
         </Container>
     );
@@ -39,7 +51,7 @@ function SingleNavLinksPlaceholder(props: { itemCount: number }) {
             <LoadingRectange
                 className={classes.title}
                 height={24}
-                width={random(50, 75, false) + "%"}
+                width={random(30, 75, false) + "%"}
             ></LoadingRectange>
             <div className={classes.items}>
                 {Array.from(Array(props.itemCount)).map(i => {

--- a/library/src/scripts/navigation/NavLinksPlaceholder.tsx
+++ b/library/src/scripts/navigation/NavLinksPlaceholder.tsx
@@ -1,0 +1,58 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { navLinksClasses } from "@library/navigation/navLinksStyles";
+import Heading from "@library/layout/Heading";
+import { LoadingRectange } from "@library/loaders/LoadingRectangle";
+import classNames from "classnames";
+import { classes } from "typestyle";
+import ScreenReaderContent from "@library/layout/ScreenReaderContent";
+import Container from "@library/layout/components/Container";
+import random from "lodash/random";
+
+interface IProps {}
+
+export function NavLinksPlaceholder(props: IProps) {
+    const classes = navLinksClasses();
+
+    return (
+        <Container fullGutter narrow>
+            <nav className={classNames(classes.linksWithHeadings)}>
+                <SingleNavLinksPlaceholder itemCount={4} />
+                <SingleNavLinksPlaceholder itemCount={5} />
+                <SingleNavLinksPlaceholder itemCount={3} />
+                <SingleNavLinksPlaceholder itemCount={4} />
+                <SingleNavLinksPlaceholder itemCount={2} />
+                <SingleNavLinksPlaceholder itemCount={3} />
+            </nav>
+        </Container>
+    );
+}
+
+function SingleNavLinksPlaceholder(props: { itemCount: number }) {
+    const classes = navLinksClasses();
+    return (
+        <div className={classes.root}>
+            <LoadingRectange
+                className={classes.title}
+                height={24}
+                width={random(50, 75, false) + "%"}
+            ></LoadingRectange>
+            <div className={classes.items}>
+                {Array.from(Array(props.itemCount)).map(i => {
+                    return (
+                        <React.Fragment key={i}>
+                            <LoadingRectange height={12} className={classes.item} width={random(70, 98, false) + "%"} />
+                        </React.Fragment>
+                    );
+                })}
+                <div className={classes.viewAllItem}>
+                    <LoadingRectange width={"70px"} height={12} className={classes.viewAll} />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/library/src/scripts/navigation/NavLinksWithHeadings.tsx
+++ b/library/src/scripts/navigation/NavLinksWithHeadings.tsx
@@ -14,9 +14,11 @@ import { navLinksClasses } from "@library/navigation/navLinksStyles";
 import { ILinkListData } from "@library/@types/api/core";
 import NavLinks from "@library/navigation/NavLinks";
 import Container from "@library/layout/components/Container";
+import { visibility } from "@library/styles/styleHelpers";
 
 interface IProps {
     title: string; // For accessibility, title of group
+    showTitle?: boolean;
     depth?: 1 | 2 | 3 | 4 | 5 | 6;
     classNames?: string;
     data: ILinkListData;
@@ -66,9 +68,15 @@ export default class NavLinksWithHeadings extends Component<IProps> {
                     <nav
                         className={classNames("navLinksWithHeadings", this.props.classNames, classes.linksWithHeadings)}
                     >
-                        <ScreenReaderContent>
-                            <Heading title={this.props.title} depth={this.props.depth} />
-                        </ScreenReaderContent>
+                        <Heading
+                            title={this.props.title}
+                            depth={this.props.depth}
+                            className={classNames(
+                                classes.title,
+                                classes.topTitle,
+                                !this.props.showTitle && visibility().visuallyHidden,
+                            )}
+                        />
                         {groupedContent}
                         {ungroupedContent}
                     </nav>

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -178,6 +178,11 @@ export const navLinksClasses = useThemeCache(() => {
         },
     });
 
+    const topTitle = style("topTitle", {
+        ...paddings({ horizontal: vars.item.padding.horizontal / 2 }),
+        width: "100%",
+    });
+
     const linkColors = setAllLinkColors({
         default: globalVars.mainColors.fg,
     });
@@ -257,6 +262,7 @@ export const navLinksClasses = useThemeCache(() => {
         items,
         item,
         title,
+        topTitle,
         link,
         viewAllItem,
         viewAll,

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -224,14 +224,14 @@ export const navLinksClasses = useThemeCache(() => {
         "linksWithHeadings",
         {
             ...paddings(vars.linksWithHeadings.paddings),
-            ...extendItemContainer(vars.item.padding.horizontal),
+            ...extendItemContainer(vars.item.padding.horizontal + vars.linksWithHeadings.paddings.horizontal),
             display: "flex",
             flexWrap: "wrap",
             alignItems: "stretch",
             justifyContent: "space-between",
         },
         mediaQueries.oneColumn({
-            ...extendItemContainer(vars.item.paddingMobile.horizontal),
+            ...extendItemContainer(vars.item.paddingMobile.horizontal + vars.linksWithHeadings.paddings.horizontal),
         }),
     );
 

--- a/library/src/scripts/navigation/navLinksWithHeadings.story.tsx
+++ b/library/src/scripts/navigation/navLinksWithHeadings.story.tsx
@@ -31,5 +31,5 @@ StandardNavLinksStory.story = {
 };
 
 export function Placeholder() {
-    return <NavLinksPlaceholder />;
+    return <NavLinksPlaceholder title="Navigation Placeholder" showTitle />;
 }

--- a/library/src/scripts/navigation/navLinksWithHeadings.story.tsx
+++ b/library/src/scripts/navigation/navLinksWithHeadings.story.tsx
@@ -8,6 +8,7 @@ import NavLinksWithHeadingsComponent from "@library/navigation/NavLinksWithHeadi
 import { navLinksWithHeadingsData } from "@library/navigation/navLinksWithHeadings.storyData";
 import { t } from "@library/utility/appUtils";
 import React from "react";
+import { NavLinksPlaceholder } from "@library/navigation/NavLinksPlaceholder";
 
 export default {
     title: "NavLinksWithHeadings",
@@ -25,7 +26,10 @@ export function StandardNavLinksStory() {
         />
     );
 }
-
 StandardNavLinksStory.story = {
     name: "Standard",
 };
+
+export function Placeholder() {
+    return <NavLinksPlaceholder />;
+}


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1575

- Adds a placeholder for Nav Links.
- Adds a story for this placeholder.
- Fixes the width of the NavLinksWithHeading & associated home widget style to be the same width as the tiles grid.