### PR TITLE
Adjust headers separators for tiles and navLinks

### DIFF
--- a/library/src/scripts/features/tiles/Tiles.tsx
+++ b/library/src/scripts/features/tiles/Tiles.tsx
@@ -9,6 +9,7 @@ import Paragraph from "@library/layout/Paragraph";
 import classNames from "classnames";
 import Tile from "@library/features/tiles/Tile";
 import { tilesClasses, tilesVariables } from "@library/features/tiles/tilesStyles";
+import Container from "@library/layout/components/Container";
 
 interface ITile {
     icon: string;
@@ -46,28 +47,32 @@ export default function Tiles(props: IProps) {
 
     if (items.length === 0) {
         return (
-            <div className={classNames(className, "isEmpty", classes.root)}>
-                <Paragraph>{props.emptyMessage}</Paragraph>
-            </div>
+            <Container fullGutter>
+                <div className={classNames(className, "isEmpty", classes.root)}>
+                    <Paragraph>{props.emptyMessage}</Paragraph>
+                </div>
+            </Container>
         );
     } else {
         return (
-            <div className={classNames(className, classes.root)}>
-                <ul className={classNames(classes.items)}>
-                    {items.map((tile, i) => (
-                        <li key={i} className={classNames(classes.item)}>
-                            <Tile
-                                icon={tile.icon}
-                                fallbackIcon={props.fallbackIcon}
-                                title={tile.name}
-                                description={tile.description}
-                                url={tile.url}
-                                columns={columns}
-                            />
-                        </li>
-                    ))}
-                </ul>
-            </div>
+            <Container fullGutter>
+                <div className={classNames(className, classes.root)}>
+                    <ul className={classNames(classes.items)}>
+                        {items.map((tile, i) => (
+                            <li key={i} className={classNames(classes.item)}>
+                                <Tile
+                                    icon={tile.icon}
+                                    fallbackIcon={props.fallbackIcon}
+                                    title={tile.name}
+                                    description={tile.description}
+                                    url={tile.url}
+                                    columns={columns}
+                                />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </Container>
         );
     }
 }

--- a/library/src/scripts/features/tiles/Tiles.tsx
+++ b/library/src/scripts/features/tiles/Tiles.tsx
@@ -10,10 +10,8 @@ import classNames from "classnames";
 import Tile from "@library/features/tiles/Tile";
 import { tilesClasses, tilesVariables } from "@library/features/tiles/tilesStyles";
 import Container from "@library/layout/components/Container";
-import { Title } from "@themingapi/theme/ThemeEditorPage";
 import Heading from "@library/layout/Heading";
 import { visibility } from "@library/styles/styleHelpers";
-import { navLinksClasses } from "@library/navigation/navLinksStyles";
 
 interface ITile {
     icon: string;

--- a/library/src/scripts/features/tiles/Tiles.tsx
+++ b/library/src/scripts/features/tiles/Tiles.tsx
@@ -10,6 +10,10 @@ import classNames from "classnames";
 import Tile from "@library/features/tiles/Tile";
 import { tilesClasses, tilesVariables } from "@library/features/tiles/tilesStyles";
 import Container from "@library/layout/components/Container";
+import { Title } from "@themingapi/theme/ThemeEditorPage";
+import Heading from "@library/layout/Heading";
+import { visibility } from "@library/styles/styleHelpers";
+import { navLinksClasses } from "@library/navigation/navLinksStyles";
 
 interface ITile {
     icon: string;
@@ -45,18 +49,20 @@ export default function Tiles(props: IProps) {
     const { columns } = options;
     const classes = tilesClasses(optionOverrides);
 
-    if (items.length === 0) {
-        return (
-            <Container fullGutter>
+    return (
+        <Container fullGutter>
+            {items.length === 0 ? (
                 <div className={classNames(className, "isEmpty", classes.root)}>
                     <Paragraph>{props.emptyMessage}</Paragraph>
                 </div>
-            </Container>
-        );
-    } else {
-        return (
-            <Container fullGutter>
+            ) : (
                 <div className={classNames(className, classes.root)}>
+                    <Heading
+                        depth={props.titleLevel}
+                        className={classNames(classes.title, props.hiddenTitle && visibility().visuallyHidden)}
+                    >
+                        {props.title}
+                    </Heading>
                     <ul className={classNames(classes.items)}>
                         {items.map((tile, i) => (
                             <li key={i} className={classNames(classes.item)}>
@@ -72,7 +78,7 @@ export default function Tiles(props: IProps) {
                         ))}
                     </ul>
                 </div>
-            </Container>
-        );
-    }
+            )}
+        </Container>
+    );
 }

--- a/library/src/scripts/features/tiles/tiles.story.tsx
+++ b/library/src/scripts/features/tiles/tiles.story.tsx
@@ -21,48 +21,43 @@ export default {
     },
 };
 
+const tileItems = [
+    {
+        name: "Development",
+        description: "Processes and guidance for developers.",
+        url: "https://staff.vanillaforums.com/kb/dev",
+        icon: "https://us.v-cdn.net/5022541/uploads/341/G35SLM2LBY4G.png",
+    },
+    {
+        name: "Success",
+        description: "Information for CSMs about troubleshooting & working with Vanilla.",
+        url: "https://staff.vanillaforums.com/kb/success",
+        icon: "https://us.v-cdn.net/5022541/uploads/466/WCXDHD4UMW3K.png",
+    },
+    {
+        name: "Internal Testing",
+        description: "Knowledge for us in internal tests. Don't put anything important here.",
+        url: "https://staff.vanillaforums.com/kb/testing",
+        icon: "https://us.v-cdn.net/5022541/uploads/048/66SQHHGSZT2R.png",
+    },
+    {
+        name: "Information Security",
+        description: "Internal company security practices.",
+        url: "https://staff.vanillaforums.com/kb/infosec",
+        icon: "https://us.v-cdn.net/5022541/uploads/346/B6QMAFIQAXLI.png",
+    },
+    {
+        name: "Information Security",
+        description: "Internal company security practices.",
+        url: "https://staff.vanillaforums.com/kb/infosec",
+        icon: "https://us.v-cdn.net/5022541/uploads/346/B6QMAFIQAXLI.png",
+    },
+];
+
 function TilesStory(props: { title: string }) {
     return (
         <>
-            <StoryContent>
-                <StoryHeading>{props.title}</StoryHeading>
-            </StoryContent>
-            <Tiles
-                items={[
-                    {
-                        name: "Development",
-                        description: "Processes and guidance for developers.",
-                        url: "https://staff.vanillaforums.com/kb/dev",
-                        icon: "https://us.v-cdn.net/5022541/uploads/341/G35SLM2LBY4G.png",
-                    },
-                    {
-                        name: "Success",
-                        description: "Information for CSMs about troubleshooting & working with Vanilla.",
-                        url: "https://staff.vanillaforums.com/kb/success",
-                        icon: "https://us.v-cdn.net/5022541/uploads/466/WCXDHD4UMW3K.png",
-                    },
-                    {
-                        name: "Internal Testing",
-                        description: "Knowledge for us in internal tests. Don't put anything important here.",
-                        url: "https://staff.vanillaforums.com/kb/testing",
-                        icon: "https://us.v-cdn.net/5022541/uploads/048/66SQHHGSZT2R.png",
-                    },
-                    {
-                        name: "Information Security",
-                        description: "Internal company security practices.",
-                        url: "https://staff.vanillaforums.com/kb/infosec",
-                        icon: "https://us.v-cdn.net/5022541/uploads/346/B6QMAFIQAXLI.png",
-                    },
-                    {
-                        name: "Information Security",
-                        description: "Internal company security practices.",
-                        url: "https://staff.vanillaforums.com/kb/infosec",
-                        icon: "https://us.v-cdn.net/5022541/uploads/346/B6QMAFIQAXLI.png",
-                    },
-                ]}
-                title={"Our Games"}
-                emptyMessage={"No subcommunities found"}
-            />
+            <Tiles items={tileItems} title={props.title} emptyMessage={"No Items found"} />
         </>
     );
 }
@@ -167,3 +162,11 @@ export const Tiles4Variation1 = storyWithConfig(
         return <TilesStory title="As Tiles - Variation 1" />;
     },
 );
+
+export function NoItems() {
+    return <Tiles items={[]} title="No Items Story" emptyMessage={"No Items found"} />;
+}
+
+export function HiddenTitle() {
+    return <Tiles items={tileItems} title="Hidden Title" hiddenTitle emptyMessage={"No Items found"} />;
+}

--- a/library/src/scripts/features/tiles/tilesStyles.ts
+++ b/library/src/scripts/features/tiles/tilesStyles.ts
@@ -151,5 +151,13 @@ export const tilesClasses = useThemeCache((optionOverrides?: ITilesOptions) => {
         }),
     );
 
-    return { root, items, item };
+    const title = style("title", {
+        marginTop: globalVars.gutter.size,
+        marginBottom: 0,
+        fontSize: globalVars.fonts.size.title,
+        fontWeight: globalVars.fonts.weights.bold,
+        lineHeight: globalVars.lineHeights.condensed,
+    });
+
+    return { root, items, item, title };
 });

--- a/library/src/scripts/navigation/NavLinksWithHeadings.tsx
+++ b/library/src/scripts/navigation/NavLinksWithHeadings.tsx
@@ -68,13 +68,14 @@ export default class NavLinksWithHeadings extends Component<IProps> {
                     <nav
                         className={classNames("navLinksWithHeadings", this.props.classNames, classes.linksWithHeadings)}
                     >
+                        {this.props.showTitle && <hr className={classes.separator}></hr>}
                         <Heading
                             title={this.props.title}
                             depth={this.props.depth}
                             className={classNames(
                                 classes.title,
-                                classes.topTitle,
                                 !this.props.showTitle && visibility().visuallyHidden,
+                                this.props.showTitle && classes.topTitle,
                             )}
                         />
                         {groupedContent}

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -256,6 +256,21 @@ export const navLinksClasses = useThemeCache(() => {
         mediaQueries.oneColumn(margins({ horizontal: vars.item.paddingMobile.horizontal })),
     );
 
+    const separatorIndependant = style(
+        "separatorIndependant",
+        {
+            display: "block",
+            ...extendItemContainer(vars.item.padding.horizontal),
+
+            // Has to be a border and not a BG, because sometimes chrome rounds it's height to 0.99px and it disappears.
+            borderBottom: singleBorder({ color: vars.separator.bg, width: vars.separator.height }),
+        },
+        mediaQueries.oneColumn(margins({ horizontal: vars.item.paddingMobile.horizontal })),
+        mediaQueries.oneColumn({
+            ...extendItemContainer(vars.item.paddingMobile.horizontal),
+        }),
+    );
+
     const separatorOdd = style(
         "separatorOdd",
         {
@@ -278,5 +293,6 @@ export const navLinksClasses = useThemeCache(() => {
         linksWithHeadings,
         separator,
         separatorOdd,
+        separatorIndependant,
     };
 });

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -179,8 +179,17 @@ export const navLinksClasses = useThemeCache(() => {
     });
 
     const topTitle = style("topTitle", {
-        ...paddings({ horizontal: vars.item.padding.horizontal / 2 }),
-        width: "100%",
+        $nest: {
+            "&&": {
+                ...margins({
+                    vertical: vars.item.padding.vertical,
+                    top: vars.item.padding.top,
+                    bottom: 0,
+                }),
+                ...paddings({ horizontal: vars.item.padding.horizontal / 2 }),
+                width: "100%",
+            },
+        },
     });
 
     const linkColors = setAllLinkColors({


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1575

- Update `Tiles` to display its existing title props (not sure why these weren't being used before.)
  - I updated the story to use this title.
- Adjust spacing of separator and top title of the navLinks