### PR TITLE
Fixed colors for current tab

### DIFF
--- a/library/src/scripts/sectioning/TabStyles.ts
+++ b/library/src/scripts/sectioning/TabStyles.ts
@@ -169,7 +169,8 @@ export const tabClasses = useThemeCache(() => {
     });
 
     const isActive = style("isActive", {
-        backgroundColor: colorOut(globalVars.elementaryColors.white),
+        color: colorOut(vars.colors.bg),
+        backgroundColor: colorOut(vars.colors.fg),
     });
 
     return {


### PR DESCRIPTION
The current tab was while on whilte in the theme editor. This fixes the colors.