### PR TITLE
Remove unwanted separator from navlinks

### DIFF
--- a/library/src/scripts/navigation/NavLinksWithHeadings.tsx
+++ b/library/src/scripts/navigation/NavLinksWithHeadings.tsx
@@ -68,7 +68,6 @@ export default class NavLinksWithHeadings extends Component<IProps> {
                     <nav
                         className={classNames("navLinksWithHeadings", this.props.classNames, classes.linksWithHeadings)}
                     >
-                        {this.props.showTitle && <hr className={classes.separator}></hr>}
                         <Heading
                             title={this.props.title}
                             depth={this.props.depth}


### PR DESCRIPTION
See with https://github.com/vanilla/knowledge/pull/1607

We needed more control over when the separator is displayed in the universal content widget, so I  moved the separator to the widget itself.
