### PR TITLE
Fix permission query when join JunctionTable data

### DIFF
--- a/applications/dashboard/models/class.permissionmodel.php
+++ b/applications/dashboard/models/class.permissionmodel.php
@@ -425,6 +425,7 @@ class PermissionModel extends Gdn_Model {
             if ($foreignKey && $foreignID) {
                 $this->SQL
                     ->join("$junctionTable j", "j.$junctionColumn = p.JunctionID")
+                    ->where("p.JunctionTable", $junctionTable)
                     ->where("j.$foreignKey", $foreignID);
             }
         } else {


### PR DESCRIPTION
We need to only join when `JunctionTable` filtered, if not we can attach wrong data and get wrong permissions.

Relates to: https://github.com/vanilla/knowledge/issues/1538