### PR TITLE
Add HeroBanner to mixed layout

### DIFF
--- a/addons/themes/keystone/views/default.master.tpl
+++ b/addons/themes/keystone/views/default.master.tpl
@@ -179,6 +179,7 @@
                 </div>
             {/if}
             <div class="Frame-body">
+                
                 <!---------- Hero Banner ---------->
                 {if $ThemeOptions.Options.hasHeroBanner && inSection(["CategoryList", "DiscussionList", "CategoryDiscussionList"])}
                     <div class="Herobanner">

--- a/addons/themes/keystone/views/default.master.tpl
+++ b/addons/themes/keystone/views/default.master.tpl
@@ -179,9 +179,8 @@
                 </div>
             {/if}
             <div class="Frame-body">
-
                 <!---------- Hero Banner ---------->
-                {if $ThemeOptions.Options.hasHeroBanner && inSection(["CategoryList", "DiscussionList"])}
+                {if $ThemeOptions.Options.hasHeroBanner && inSection(["CategoryList", "DiscussionList", "CategoryDiscussionList"])}
                     <div class="Herobanner">
                         {if {banner_image_url}}
                             <div class="Herobanner-bgImage" style="background-image:url('{banner_image_url}')"></div>


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1221

**Steps to test:**
- Enable Keystone
- Enable Integrate Banner Image
- Change layout to "Mixed"
- Look at the categories page