### PR TITLE
Add random_bytes fallback to betterRandomString

### DIFF
--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -1515,6 +1515,11 @@ if (!function_exists('betterRandomString')) {
             $randomChars = unpack('C*', mcrypt_create_iv($length));
             $cryptoStrong = true;
             // @codeCoverageIgnoreEnd
+        } elseif (function_exists("random_bytes")) {
+            // @codeCoverageIgnoreStart
+            $randomChars = unpack("C*", random_bytes($length));
+            $cryptoStrong = true;
+            // @codeCoverageIgnoreEnd
         } else {
             // @codeCoverageIgnoreStart
             for ($i = 0; $i < $length; $i++) {


### PR DESCRIPTION
`betterRandomString` has a series of fallback strategies for attempting to generate cryptographically-secure values. The [`random_bytes`](https://www.php.net/random_bytes) function has been added as one of them.