### PR TITLE
Added optional fallbackLogo option to set on smarty function.

### DIFF
--- a/library/SmartyPlugins/function.logo.php
+++ b/library/SmartyPlugins/function.logo.php
@@ -32,6 +32,9 @@ function smarty_function_logo($params, &$smarty) {
     if (isset($params['width'])) {
         $options['width']  = $params['width'];
     }
+    if (isset($params['fallbackLogo'])) {
+        $options['fallbackLogo']  = $params['fallbackLogo'];
+    }
 
     $result = Gdn_Theme::logo($options);
 	return $result;

--- a/library/SmartyPlugins/function.mobile_logo.php
+++ b/library/SmartyPlugins/function.mobile_logo.php
@@ -14,6 +14,10 @@
  * @return string The url.
  */
 function smarty_function_mobile_logo($params, &$smarty) {
-    $result = Gdn_Theme::mobileLogo('Title');
+    $options = [];
+    if (isset($params['fallbackLogo'])) {
+        $options['fallbackLogo']  = $params['fallbackLogo'];
+    }
+    $result = Gdn_Theme::mobileLogo($params);
 	return $result;
 }

--- a/library/core/class.theme.php
+++ b/library/core/class.theme.php
@@ -385,6 +385,10 @@ class Gdn_Theme {
         $logo = c('Garden.Logo');
         $title = c('Garden.Title', 'Title');
 
+        if (!$logo && isset($properties['fallbackLogo']) && isUrl($properties['fallbackLogo'])) {
+            $logo = $properties['fallbackLogo'];
+        }
+
         if ($logo) {
             $properties += ['alt' => $title];
 
@@ -413,11 +417,16 @@ class Gdn_Theme {
      * Returns the mobile banner logo. If there is no mobile logo defined then this will just return
      * the regular logo or the mobile title.
      *
+     * @param array $properties
      * @return string
      */
-    public static function mobileLogo() {
+    public static function mobileLogo($properties = []) {
         $logo = c('Garden.MobileLogo', c('Garden.Logo'));
         $title = c('Garden.MobileTitle', c('Garden.Title', 'Title'));
+
+        if (!$logo && isset($properties['fallbackLogo']) && isUrl($properties['fallbackLogo'])) {
+            $logo = $properties['fallbackLogo'];
+        }
 
         if ($logo) {
             return img(Gdn_Upload::url($logo), ['alt' => $title]);

--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -20,7 +20,6 @@ import { SignInIcon } from "@library/icons/common";
 import Container from "@library/layout/components/Container";
 import ConditionalWrap from "@library/layout/ConditionalWrap";
 import FlexSpacer from "@library/layout/FlexSpacer";
-import { PanelWidgetHorizontalPadding } from "@library/layout/PanelLayout";
 import { HashOffsetReporter, useScrollOffset } from "@library/layout/ScrollOffsetContext";
 import { TitleBarDevices, useTitleBarDevice } from "@library/layout/TitleBarContext";
 import BackLink from "@library/routing/links/BackLink";

--- a/library/src/scripts/headers/titleBarStyles.ts
+++ b/library/src/scripts/headers/titleBarStyles.ts
@@ -210,8 +210,8 @@ export const titleBarVariables = useThemeCache(() => {
         maxWidth: 200,
         heightOffset: sizing.height / 3,
         tablet: {},
-        desktop: {}, // add "url" if you want to set in theme
-        mobile: {}, // add "url" if you want to set in theme
+        desktop: {}, // add "url" if you want to set in theme. Use full path eg. "/addons/themes/myTheme/design/myLogo.png"
+        mobile: {}, // add "url" if you want to set in theme. Use full path eg. "/addons/themes/myTheme/design/myLogo.png"
     });
 
     const mobileLogo = makeThemeVars("mobileLogo", {


### PR DESCRIPTION
Working on the Success community, I wanted to set a default logo so it was more portable with the theme. I created a new prop for the smarty helpers "logo" and "mobile_logo" to accept a "fallbackLogo" param. This will only apply if no logo was found in the config. Makes logos more portable/version controlled, but still editable by client.

Example usage:

`{logo fallbackLogo={"/themes/success/design/images/logo.png"|asset_url:true:true} }`

May be of interest for @irina-vanillaforums @alexbrohman @hhovhannes 