### PR TITLE
Optimize Categories Mixed Layout loading discussions

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -662,7 +662,7 @@ class CategoriesController extends VanillaController {
         $Discussions = [];
 
         foreach ($this->CategoryData->result() as $Category) {
-            if ($Category->CategoryID > 0) {
+            if ($Category->CategoryID > 0 && $Category->CountDiscussions > 0) {
                 $this->CategoryDiscussionData[$Category->CategoryID] = $DiscussionModel->get(0, $this->DiscussionsPerCategory, ['d.CategoryID' => $Category->CategoryID, 'Announce' => 'all']);
 
                 $Discussions = array_merge(

--- a/applications/vanilla/views/categories/discussions.php
+++ b/applications/vanilla/views/categories/discussions.php
@@ -25,7 +25,7 @@ $ViewLocation = $this->fetchViewLocation('discussions', 'discussions');
                     ?>
                 </h2>
 
-                <?php if ($this->DiscussionData->numRows() > 0) : ?>
+                <?php if (isset($this->DiscussionData) && $this->DiscussionData->numRows() > 0) : ?>
                     <ul class="DataList Discussions">
                         <?php include($this->fetchViewLocation('discussions', 'discussions')); ?>
                     </ul>


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1248

Relevant info: https://github.com/vanilla/support/issues/1248#issuecomment-595801464

**Steps to test:**
- Test it in chrome.
- Test it in a local with a bunch of data (categories and discussions). Enable the mixed layout and set the categories page as the homepage.
- Checkout `master` and measure the "DOMContentLoaded" on the dev tools, Network tab.
- Checkout this branch, refresh the page and match the difference.

(Although I know local testing doesn't mean much in this case, I monitored mine and it decreased from 1.6min to 8.17s).
