### PR TITLE
Add some addition permission utilities

### DIFF
--- a/library/Vanilla/Exception/PermissionException.php
+++ b/library/Vanilla/Exception/PermissionException.php
@@ -31,7 +31,7 @@ class PermissionException extends ForbiddenException {
             $description = sprintft(\Gdn::translate('You need one of %s permissions to do that.'), implode(', ', $permissions));
         }
         $context['description'] = $description;
-        $message = \Gdn::translate('No Permission');
+        $message = \Gdn::translate('Permission Problem');
 
         parent::__construct($message, $context);
     }

--- a/library/Vanilla/Exception/PermissionException.php
+++ b/library/Vanilla/Exception/PermissionException.php
@@ -26,11 +26,13 @@ class PermissionException extends ForbiddenException {
         $context['permissions'] = $permissions;
 
         if (count($permissions) === 1) {
-            $msg = sprintft('You need the %s permission to do that.', $permissions[0]);
+            $description = sprintft(\Gdn::translate('You need the %s permission to do that.'), $permissions[0]);
         } else {
-            $msg = sprintft('You need one of %s permissions to do that.', implode(', ', $permissions));
+            $description = sprintft(\Gdn::translate('You need one of %s permissions to do that.'), implode(', ', $permissions));
         }
+        $context['description'] = $description;
+        $message = \Gdn::translate('No Permission');
 
-        parent::__construct($msg, $context);
+        parent::__construct($message, $context);
     }
 }

--- a/library/src/scripts/errorPages/CoreErrorMessages.tsx
+++ b/library/src/scripts/errorPages/CoreErrorMessages.tsx
@@ -94,7 +94,7 @@ export function messageFromErrorCode(errorCode?: string | number) {
     switch (errorCode) {
         case 403:
         case DefaultError.PERMISSION:
-            return t("No Permission");
+            return t("Permission Problem");
         case 404:
         case DefaultError.GENERIC:
         default:

--- a/tests/Library/Vanilla/PermissionsTest.php
+++ b/tests/Library/Vanilla/PermissionsTest.php
@@ -107,12 +107,15 @@ class PermissionsTest extends SharedBootstrapTestCase {
 
         $this->assertTrue($permissions->has('Vanilla.Discussions.View'));
         $this->assertFalse($permissions->has('Garden.Settings.Manage'));
+        $this->assertTrue($permissions->has('Vanilla.Discussions.Add'));
 
         $this->assertTrue($permissions->has('Vanilla.Discussions.Add', 10));
+        $this->assertTrue($permissions->has('Vanilla.Discussions.Add', 10, Permissions::CHECK_MODE_RESOURCE_ONLY));
         $this->assertFalse($permissions->has('Vanilla.Discussions.Add', 100));
 
         $this->assertTrue($permissions->has('Vanilla.Discussions.Add', null));
         $this->assertTrue($permissions->has('Vanilla.Discussions.View', null));
+        $this->assertFalse($permissions->has('Vanilla.Discussions.Add', null, Permissions::CHECK_MODE_GLOBAL_ONLY));
         $this->assertFalse($permissions->has('Vanilla.Discussions.Edit'));
     }
 


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1642 and https://github.com/vanilla/knowledge/issues/1619

- Add some permission checking utilities to the core permission model. There are 3 modes.
  - **Check Resource Only** (was possible by passing a resource id before, but not explicit).
  - **Check Global only** (was not possible to check before).
  - **Check global or any resource** (previous default).
- These 3 modes are not an optional third param to the various `has*` methods.
- Add couple test assertions to existing permission object tests.
- Update the `PermissionException` class.
  - Now has a short title.
  - Description is the exception message.
  - Translates it's title and message.
  - This means incorrect permission errors in the dashboard now look like this.
    ![image](https://user-images.githubusercontent.com/1770056/76122310-bea57f80-5fc3-11ea-82b4-733527b31e5d.png)
