### PR TITLE
Fixed independent search style inconsistencies

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/inputStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/inputStyles.ts
@@ -19,7 +19,7 @@ import {
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { calc, important, percent, translateY } from "csx";
 import { cssOut, nestedWorkaround, trimTrailingCommas } from "@dashboard/compatibilityStyles/index";
-import { inputClasses, inputVariables } from "@library/forms/inputStyles";
+import { inputVariables, inputMixin } from "@library/forms/inputStyles";
 import { formElementsVariables } from "@library/forms/formElementStyles";
 
 export const inputCSS = () => {
@@ -105,9 +105,8 @@ export const inputCSS = () => {
     mixinInputStyles(".Container ul.token-input-list", ".Container ul.token-input-list.token-input-focused");
     mixinInputStyles(".input:-internal-autofill-selected", false, true);
     mixinInputStyles(".AdvancedSearch .InputBox", false, false);
-    cssOut(".InputBox.InputBox.InputBox", inputClasses().inputMixin);
+    cssOut(".InputBox.InputBox.InputBox", inputMixin());
     cssOut(`.richEditor-frame.InputBox.InputBox.InputBox `, { padding: 0 });
-    // cssOut(".token-input-list", inputClasses().inputMixin);
     cssOut("select", {
         $nest: {
             "&:hover, &:focus, &.focus-visible, &:active": {

--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -91,6 +91,8 @@ export default function Banner(props: IProps) {
                                     }
                                     contentClass={classes.content}
                                     valueContainerClasses={classes.valueContainer}
+                                    iconContainerClasses={classes.iconContainer}
+                                    resultsAsModalClasses={classes.resultsAsModal}
                                 />
                             </div>
                         )}

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -34,7 +34,8 @@ import { IButtonType } from "@library/forms/styleHelperButtonInterface";
 import { media } from "typestyle";
 import { containerVariables } from "@library/layout/components/containerStyles";
 import { ButtonPresets } from "@library/forms/buttonStyles";
-import { searchBarClasses } from "@library/features/search/searchBarStyles";
+import { searchBarClasses, searchBarVariables } from "@library/features/search/searchBarStyles";
+import { inputMixin } from "@library/forms/inputStyles";
 
 export enum BannerAlignment {
     LEFT = "left",
@@ -363,6 +364,7 @@ export const bannerVariables = useThemeCache(() => {
         title,
         description,
         paragraph,
+        state,
         searchBar,
         buttonShadow,
         searchButton,
@@ -588,10 +590,10 @@ export const bannerClasses = useThemeCache(() => {
     }
 
     const content = style("content", {
+        ...inputMixin({ sizing: vars.searchBar.sizing }),
         boxSizing: "border-box",
         zIndex: 1,
         boxShadow: vars.searchBar.shadow.show ? vars.searchBar.shadow.style : undefined,
-
         borderTopLeftRadius: unit(leftRadius),
         borderBottomLeftRadius: unit(leftRadius),
         borderTopRightRadius: unit(rightRadius),

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -408,6 +408,7 @@ export const bannerClasses = useThemeCache(() => {
                     vars.searchBar.font.size,
                     vars.searchBar.border.width * 2,
                 ),
+                boxSizing: "border-box",
                 paddingLeft: unit(searchBarVariables().searchIcon.gap),
                 backgroundColor: colorOut(vars.searchBar.colors.bg),
                 ...borders({

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -22,6 +22,7 @@ import {
     fonts,
     IFont,
     modifyColorBasedOnLightness,
+    textInputSizingFromFixedHeight,
     unit,
 } from "@library/styles/styleHelpers";
 import { NestedCSSProperties, TLength } from "typestyle/lib/types";
@@ -241,10 +242,11 @@ export const bannerVariables = useThemeCache(() => {
         },
         sizing: {
             maxWidth: 705,
+            height: 40,
         },
         font: {
             color: colors.fg,
-            size: formElVars.giantInput.fontSize,
+            size: globalVars.fonts.size.large,
         },
         margin: {
             ...EMPTY_SPACING,
@@ -318,6 +320,9 @@ export const bannerVariables = useThemeCache(() => {
         name: "searchButton",
         preset: presets.button.preset,
         spinnerColor: colors.primaryContrast,
+        sizing: {
+            minHeight: searchBar.sizing.height,
+        },
         colors: {
             bg: searchButtonBg,
             fg: colors.primaryContrast,
@@ -326,7 +331,7 @@ export const bannerVariables = useThemeCache(() => {
         fonts: {
             color: colors.primaryContrast,
             size: globalVars.fonts.size.large,
-            weight: globalVars.fonts.weights.semiBold,
+            weight: globalVars.fonts.weights.bold,
         },
         state: buttonStateStyles,
     } as IButtonType);
@@ -386,11 +391,24 @@ export const bannerClasses = useThemeCache(() => {
     const presets = presetsBanner();
 
     const isCentered = vars.options.alignment === "center";
-    const searchButton = style("searchButton", generateButtonStyleProperties(vars.searchButton), { left: -1 });
+    const searchButton = style("searchButton", {
+        $nest: {
+            "&.searchBar-submitButton": {
+                ...generateButtonStyleProperties(vars.searchButton),
+                left: -1,
+            },
+        },
+    });
 
     const valueContainer = style("valueContainer", {
         $nest: {
-            "&&": {
+            "&&.inputText": {
+                ...textInputSizingFromFixedHeight(
+                    vars.searchBar.sizing.height,
+                    vars.searchBar.font.size,
+                    vars.searchBar.border.width * 2,
+                ),
+                paddingLeft: unit(searchBarVariables().searchIcon.gap),
                 backgroundColor: colorOut(vars.searchBar.colors.bg),
                 ...borders({
                     color: vars.searchBar.border.color,
@@ -400,8 +418,6 @@ export const bannerClasses = useThemeCache(() => {
                         ...borders(vars.searchBar.border),
                     },
                 },
-            },
-            ".inputText": {
                 borderColor: colorOut(vars.searchBar.border.color),
             },
             ".searchBar__control": {
@@ -590,7 +606,6 @@ export const bannerClasses = useThemeCache(() => {
     }
 
     const content = style("content", {
-        ...inputMixin({ sizing: vars.searchBar.sizing }),
         boxSizing: "border-box",
         zIndex: 1,
         boxShadow: vars.searchBar.shadow.show ? vars.searchBar.shadow.style : undefined,
@@ -598,7 +613,7 @@ export const bannerClasses = useThemeCache(() => {
         borderBottomLeftRadius: unit(leftRadius),
         borderTopRightRadius: unit(rightRadius),
         borderBottomRightRadius: unit(rightRadius),
-
+        height: unit(vars.searchBar.sizing.height),
         $nest: {
             "&.hasFocus .searchBar-valueContainer": {
                 boxShadow: `0 0 0 1px ${colorOut(vars.colors.primary)} inset`,
@@ -699,6 +714,25 @@ export const bannerClasses = useThemeCache(() => {
         },
     });
 
+    const iconContainer = style("iconContainer", {
+        $nest: {
+            "&&": {
+                height: unit(vars.searchBar.sizing.height),
+                outline: 0,
+                border: 0,
+                background: "transparent",
+            },
+        },
+    });
+
+    const resultsAsModal = style("resultsAsModalClasses", {
+        $nest: {
+            "&&": {
+                top: unit(vars.searchBar.sizing.height),
+            },
+        },
+    });
+
     return {
         root,
         outerBackground,
@@ -718,6 +752,8 @@ export const bannerClasses = useThemeCache(() => {
         descriptionWrap,
         content,
         valueContainer,
+        iconContainer,
+        resultsAsModal,
         backgroundOverlay,
         imageElementContainer,
         imageElement,

--- a/library/src/scripts/features/search/IndependentSearch.tsx
+++ b/library/src/scripts/features/search/IndependentSearch.tsx
@@ -30,6 +30,8 @@ interface IProps extends IWithSearchProps, RouteComponentProps<{}> {
     hideSearchButton?: boolean;
     isLarge?: boolean;
     buttonBaseClass?: ButtonTypes;
+    iconContainerClasses?: string;
+    resultsAsModalClasses?: string;
 }
 
 interface IState {
@@ -75,17 +77,18 @@ export function IndependentSearch(props: IProps) {
                 resultsRef={resultsRef}
                 buttonClassName={props.buttonClass}
                 buttonBaseClass={props.buttonBaseClass}
-                isLarge={props.isLarge}
                 buttonLoaderClassName={props.buttonLoaderClassName}
                 hideSearchButton={props.hideSearchButton}
                 contentClass={props.contentClass}
                 valueContainerClasses={props.valueContainerClasses}
+                iconContainerClasses={props.iconContainerClasses}
             />
             <div
                 ref={resultsRef}
                 className={classNames("search-results", {
                     [classesSearchBar.results]: !!query,
                     [classesSearchBar.resultsAsModal]: !!query,
+                    [props.resultsAsModalClasses ?? ""]: !!query,
                 })}
             />
         </div>

--- a/library/src/scripts/features/search/IndependentSearch.tsx
+++ b/library/src/scripts/features/search/IndependentSearch.tsx
@@ -75,7 +75,7 @@ export function IndependentSearch(props: IProps) {
                 resultsRef={resultsRef}
                 buttonClassName={props.buttonClass}
                 buttonBaseClass={props.buttonBaseClass}
-                isBigInput={props.isLarge}
+                isLarge={props.isLarge}
                 buttonLoaderClassName={props.buttonLoaderClassName}
                 hideSearchButton={props.hideSearchButton}
                 contentClass={props.contentClass}

--- a/library/src/scripts/features/search/SearchBar.tsx
+++ b/library/src/scripts/features/search/SearchBar.tsx
@@ -40,7 +40,7 @@ interface IProps extends IOptionalComponentID, RouteComponentProps<any> {
     loadOptions?: (inputValue: string) => Promise<any>;
     value: string;
     onChange: (value: string) => void;
-    isBigInput?: boolean;
+    isLarge?: boolean;
     noHeading: boolean;
     title: string;
     titleAsComponent?: React.ReactNode;
@@ -78,7 +78,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
 
     public static defaultProps: Partial<IProps> = {
         disabled: false,
-        isBigInput: false,
+        isLarge: false,
         noHeading: false,
         isLoading: false,
         optionComponent: selectOverrides.SelectOption,
@@ -277,7 +277,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                                 {
                                     ["focus-visible"]: props.isFocused,
                                     [classes.compoundValueContainer]: !this.props.hideSearchButton,
-                                    isLarge: this.props.isBigInput,
+                                    isLarge: this.props.isLarge,
                                     noSearchButton: !!this.props.hideSearchButton,
                                 },
                             )}
@@ -299,7 +299,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                                     "searchBar-submitButton",
                                     this.props.buttonClassName ?? classes.actionButton,
                                     {
-                                        isLarge: this.props.isBigInput,
+                                        isLarge: this.props.isLarge,
                                     },
                                 )}
                                 tabIndex={this.props.hideSearchButton ? -1 : 0}
@@ -317,7 +317,7 @@ export default class SearchBar extends React.Component<IProps, IState> {
                         <div
                             onClick={this.focus}
                             className={classNames("searchBar-iconContainer", classes.iconContainer, {
-                                [classes.iconContainerBigInput]: this.props.isBigInput,
+                                [classes.iconContainerBigInput]: this.props.isLarge,
                             })}
                         >
                             <SearchIcon className={classNames("searchBar-icon", classes.icon)} />

--- a/library/src/scripts/features/search/SearchBar.tsx
+++ b/library/src/scripts/features/search/SearchBar.tsx
@@ -14,10 +14,9 @@ import { LinkContext } from "@library/routing/links/LinkContextProvider";
 import { MenuProps } from "react-select/lib/components/Menu";
 import ConditionalWrap from "@library/layout/ConditionalWrap";
 import { t } from "@library/utility/appUtils";
-import { ButtonTypes, buttonVariables } from "@library/forms/buttonStyles";
+import { ButtonTypes } from "@library/forms/buttonStyles";
 import Button from "@library/forms/Button";
-import { dropDownClasses } from "@library/flyouts/dropDownStyles";
-import { InputActionMeta, ActionMeta } from "react-select/lib/types";
+import { ActionMeta, InputActionMeta } from "react-select/lib/types";
 import { RouteComponentProps } from "react-router";
 import Translate from "@library/content/Translate";
 import classNames from "classnames";
@@ -40,7 +39,6 @@ interface IProps extends IOptionalComponentID, RouteComponentProps<any> {
     loadOptions?: (inputValue: string) => Promise<any>;
     value: string;
     onChange: (value: string) => void;
-    isLarge?: boolean;
     noHeading: boolean;
     title: string;
     titleAsComponent?: React.ReactNode;
@@ -62,6 +60,8 @@ interface IProps extends IOptionalComponentID, RouteComponentProps<any> {
     contentClass?: string;
     buttonBaseClass?: ButtonTypes;
     valueContainerClasses?: string;
+    iconContainerClasses?: string;
+    resultsAsModalClasses?: string;
 }
 
 interface IState {
@@ -78,7 +78,6 @@ export default class SearchBar extends React.Component<IProps, IState> {
 
     public static defaultProps: Partial<IProps> = {
         disabled: false,
-        isLarge: false,
         noHeading: false,
         isLoading: false,
         optionComponent: selectOverrides.SelectOption,
@@ -105,7 +104,6 @@ export default class SearchBar extends React.Component<IProps, IState> {
     }
 
     public render() {
-        const { className, disabled, isLoading } = this.props;
         return (
             <AsyncCreatable
                 id={this.id}
@@ -120,11 +118,11 @@ export default class SearchBar extends React.Component<IProps, IState> {
                 blurInputOnSelect={false}
                 allowCreateWhileLoading={true}
                 controlShouldRenderValue={false}
-                isDisabled={disabled}
+                isDisabled={this.props.disabled}
                 loadOptions={this.props.loadOptions!}
                 menuIsOpen={this.isMenuVisible}
                 classNamePrefix={this.prefix}
-                className={classNames(this.prefix, className)}
+                className={classNames(this.prefix, this.props.className)}
                 placeholder={this.props.placeholder}
                 aria-label={t("Search")}
                 escapeClearsValue={true}
@@ -140,6 +138,8 @@ export default class SearchBar extends React.Component<IProps, IState> {
                 onMenuClose={this.props.onCloseSuggestions}
                 onFocus={this.onFocus}
                 onBlur={this.onBlur}
+                iconContainerClasses={this.props.iconContainerClasses}
+                resultsAsModalClasses={this.props.resultsAsModalClasses}
             />
         );
     }
@@ -277,7 +277,6 @@ export default class SearchBar extends React.Component<IProps, IState> {
                                 {
                                     ["focus-visible"]: props.isFocused,
                                     [classes.compoundValueContainer]: !this.props.hideSearchButton,
-                                    isLarge: this.props.isLarge,
                                     noSearchButton: !!this.props.hideSearchButton,
                                 },
                             )}
@@ -298,9 +297,6 @@ export default class SearchBar extends React.Component<IProps, IState> {
                                 className={classNames(
                                     "searchBar-submitButton",
                                     this.props.buttonClassName ?? classes.actionButton,
-                                    {
-                                        isLarge: this.props.isLarge,
-                                    },
                                 )}
                                 tabIndex={this.props.hideSearchButton ? -1 : 0}
                             >
@@ -314,14 +310,15 @@ export default class SearchBar extends React.Component<IProps, IState> {
                                 )}
                             </Button>
                         </ConditionalWrap>
-                        <div
+                        <Button
+                            baseClass={ButtonTypes.CUSTOM}
                             onClick={this.focus}
-                            className={classNames("searchBar-iconContainer", classes.iconContainer, {
-                                [classes.iconContainerBigInput]: this.props.isLarge,
-                            })}
+                            className={classNames(classes.iconContainer, props.selectProps.iconContainerClasses)}
+                            aria-hidden={true}
+                            tabIndex={-1}
                         >
                             <SearchIcon className={classNames("searchBar-icon", classes.icon)} />
-                        </div>
+                        </Button>
                     </div>
                 </form>
             </div>

--- a/library/src/scripts/features/search/searchBarStyles.ts
+++ b/library/src/scripts/features/search/searchBarStyles.ts
@@ -14,9 +14,8 @@ import {
     unit,
     paddings,
     importantUnit,
-    IBorderRadiusValue,
     getVerticalPaddingForTextInput,
-    textInputSizingFromFixedHeight,
+    fonts,
 } from "@library/styles/styleHelpers";
 import { calc, important, percent, px, rgba, translateX } from "csx";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
@@ -147,7 +146,6 @@ export const searchBarClasses = useThemeCache((overwrites = {}) => {
                 "& .searchBar__control": {
                     border: 0,
                     backgroundColor: "transparent",
-                    height: percent(100),
                     width: percent(100),
                     maxWidth: calc(`100% - ${unit(vars.sizing.height)}`),
                     $nest: {
@@ -186,6 +184,8 @@ export const searchBarClasses = useThemeCache((overwrites = {}) => {
                     width: percent(100),
                 },
                 "& .searchBar__input input": {
+                    height: "auto",
+                    minHeight: 0,
                     width: important(`100%`),
                     lineHeight: unit(globalVars.lineHeights.base * globalVars.fonts.size.medium),
                 },
@@ -222,6 +222,9 @@ export const searchBarClasses = useThemeCache((overwrites = {}) => {
                     vertical: 9,
                     horizontal: 12,
                 }),
+                ...fonts({
+                    size: globalVars.fonts.size.medium,
+                }),
                 textAlign: "left",
                 display: "block",
                 color: "inherit",
@@ -237,6 +240,9 @@ export const searchBarClasses = useThemeCache((overwrites = {}) => {
                 padding: 0,
             },
             "& .suggestedTextInput-item": {
+                ...fonts({
+                    size: globalVars.fonts.size.medium,
+                }),
                 listStyle: "none",
                 $nest: {
                     "& + .suggestedTextInput-item": {
@@ -255,6 +261,7 @@ export const searchBarClasses = useThemeCache((overwrites = {}) => {
         ...borders({
             radius: vars.results.borderRadius,
         }),
+        boxSizing: "border-box",
         ...shadow.dropDown(),
         zIndex: 1,
     });

--- a/library/src/scripts/features/search/searchBarStyles.ts
+++ b/library/src/scripts/features/search/searchBarStyles.ts
@@ -368,6 +368,7 @@ export const searchBarClasses = useThemeCache((overwrites = {}) => {
     });
 
     const iconContainer = style("iconContainer", {
+        ...buttonResetMixin(),
         position: "absolute",
         top: 0,
         bottom: 0,

--- a/library/src/scripts/features/search/searchBarStyles.ts
+++ b/library/src/scripts/features/search/searchBarStyles.ts
@@ -372,6 +372,7 @@ export const searchBarClasses = useThemeCache((overwrites = {}) => {
         width: unit(vars.searchIcon.gap),
         zIndex: 1,
         cursor: "text",
+        outline: 0,
         $nest: {
             [`.${icon}`]: {
                 width: unit(vars.searchIcon.width),

--- a/library/src/scripts/forms/themeEditor/colorPickerStyles.ts
+++ b/library/src/scripts/forms/themeEditor/colorPickerStyles.ts
@@ -37,7 +37,7 @@ export const colorPickerClasses = useThemeCache(() => {
 
     const textInput = style("textInput", {
         position: "relative",
-        ...textInputSizingFromFixedHeight(vars.sizing.height, builderVariables.input.fonts.size, 2, vars.sizing.height),
+        ...textInputSizingFromFixedHeight(vars.sizing.height, builderVariables.input.fonts.size, 2),
         width: unit(inputWidth),
         color: colorOut(builderVariables.defaultFont.color),
         flexBasis: unit(inputWidth),

--- a/library/src/scripts/forms/themeEditor/inputNumberStyles.ts
+++ b/library/src/scripts/forms/themeEditor/inputNumberStyles.ts
@@ -76,7 +76,6 @@ export const inputNumberClasses = useThemeCache(() => {
             vars.sizing.height,
             vars.label.fonts.size,
             builderVariables.border.width * 2, // 2
-            vars.sizing.height,
         ),
         height: unit(vars.sizing.height),
         width: unit(vars.input.width - vars.spinner.width),

--- a/library/src/scripts/headers/titleBarNavStyles.ts
+++ b/library/src/scripts/headers/titleBarNavStyles.ts
@@ -163,10 +163,9 @@ const titleBarNavClasses = useThemeCache(() => {
         fontSize: unit(vars.navLinks.fontSize),
         fontWeight: globalVars.fonts.weights.normal,
         position: "relative",
-        display: "flex",
+        display: "inline-flex",
         alignItems: "center",
-        minHeight: unit(vars.item.size),
-        lineHeight: unit(vars.item.size),
+        alignSelf: "center",
         height: 0, // IE11 Fix.
     });
 

--- a/library/src/scripts/styles/styleHelpersTypography.ts
+++ b/library/src/scripts/styles/styleHelpersTypography.ts
@@ -72,19 +72,14 @@ export const getHorizontalPaddingForTextInput = (height: number, fontSize: numbe
     return getVerticalPaddingForTextInput(height, fontSize, fullBorderWidth) * 2;
 };
 
-export const textInputSizingFromFixedHeight = (
-    height: number,
-    fontSize: number,
-    fullBorderWidth: number,
-    minHeight = formElementsVariables().sizing.height,
-) => {
+export const textInputSizingFromFixedHeight = (height: number, fontSize: number, fullBorderWidth: number) => {
     const paddingVertical = getVerticalPaddingForTextInput(height, fontSize, fullBorderWidth);
     const paddingHorizontal = getHorizontalPaddingForTextInput(height, fontSize, fullBorderWidth);
     return {
         fontSize: unit(fontSize),
         width: percent(100),
         lineHeight: 1.5,
-        minHeight: unit(minHeight),
+        minHeight: unit(height),
         ...paddings({
             vertical: unit(paddingVertical),
             horizontal: unit(paddingHorizontal),


### PR DESCRIPTION
Fixes height, alignment issues (placeholder mostly) and font sizes inconsistencies with independent search. 

FYI, if you see the placeholder misaligned again, it's missing a "box-sizing: 'content-box'" style.

Companion PR: https://github.com/vanilla/knowledge/pull/1647