### PR TITLE
Pass resource specific permissions to the frontend

### DIFF
--- a/applications/dashboard/controllers/api/RolesApiController.php
+++ b/applications/dashboard/controllers/api/RolesApiController.php
@@ -8,6 +8,7 @@ use Garden\Schema\Schema;
 use Garden\Web\Exception\NotFoundException;
 use Garden\Web\Exception\ServerException;
 use Vanilla\ApiUtils;
+use Vanilla\Models\PermissionFragmentSchema;
 use Vanilla\PermissionsTranslationTrait;
 use Vanilla\Utility\CamelCaseScheme;
 use Vanilla\Utility\DelimitedScheme;
@@ -231,13 +232,7 @@ class RolesApiController extends AbstractApiController {
         static $permissionsFragment;
 
         if ($permissionsFragment === null) {
-            $permissionsFragment = $this->schema([
-                'id:i?',
-                'type:s' => [
-                    'enum' => ['global', 'category'],
-                ],
-                'permissions:o',
-            ], 'PermissionFragment');
+            $permissionsFragment = new PermissionFragmentSchema();
         }
 
         return $permissionsFragment;

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -13,6 +13,7 @@ use Garden\Web\Exception\ServerException;
 use Vanilla\ApiUtils;
 use Vanilla\DateFilterSchema;
 use Vanilla\ImageResizer;
+use Vanilla\Models\PermissionFragmentSchema;
 use Vanilla\UploadedFile;
 use Vanilla\UploadedFileSchema;
 use Vanilla\PermissionsTranslationTrait;
@@ -30,6 +31,8 @@ class UsersApiController extends AbstractApiController {
     use PermissionsTranslationTrait;
 
     const ME_ACTION_CONSTANT = "@@users/GET_ME_DONE";
+    const PERMISSIONS_ACTION_CONSTANT = "@@users/GET_PERMISSIONS_DONE";
+
 
     /** @var ActivityModel */
     private $activityModel;
@@ -281,10 +284,10 @@ class UsersApiController extends AbstractApiController {
         ], 'out');
 
         $query = $in->validate($query);
-        list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
+        [$offset, $limit] = offsetLimit("p{$query['page']}", $query['limit']);
 
         if ($query['order'] == 'mention') {
-            list($sortField, $sortDirection) = $this->userModel->getMentionsSort();
+            [$sortField, $sortDirection] = $this->userModel->getMentionsSort();
         } else {
             $sortField = $query['order'];
             switch ($sortField) {
@@ -310,6 +313,53 @@ class UsersApiController extends AbstractApiController {
         $paging = ApiUtils::morePagerInfo($result, '/api/v2/users/names', $query, $in);
 
         return new Data($result, ['paging' => $paging]);
+    }
+
+    /**
+     * Get a user's permissions.
+     *
+     * @param int $id The user's ID.
+     *
+     * @return Data
+     */
+    public function get_permissions(int $id): Data {
+        $requestedUserID = $id;
+        $this->permission();
+
+        if (is_object($this->getSession()->User)) {
+            $sessionUser = (array)$this->getSession()->User;
+            $sessionUser = $this->normalizeOutput($sessionUser);
+        } else {
+            $sessionUser = $this->getGuestFragment();
+        }
+
+        // If it's not our own user, then we need to check for a stronger permissions.
+
+        if ($sessionUser['userID'] !== $requestedUserID) {
+            $this->permission([
+                'Garden.Users.Add',
+                'Garden.Users.Edit',
+                'Garden.Users.Delete'
+            ]);
+        }
+
+        $requestedUser = $this->userByID($requestedUserID);
+        $requestedUser = $this->normalizeOutput($requestedUser);
+
+        // Build the permissions
+        // This endpoint is heavily used (every page request), so we rely on caching in the model.
+        $permissions = $this->userModel->getPermissions($requestedUserID);
+
+        $out = $this->schema([
+            'permissions:a' => new PermissionFragmentSchema(),
+            "isAdmin:b",
+        ]);
+        $result = ([
+            'isAdmin' => $requestedUser['isAdmin'],
+            'permissions' => $permissions->asPermissionFragments(),
+        ]);
+
+        return Data::box($result);
     }
 
     /**
@@ -447,7 +497,7 @@ class UsersApiController extends AbstractApiController {
         $query = $in->validate($query);
         $where = ApiUtils::queryToFilters($in, $query);
 
-        list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
+        [$offset, $limit] = offsetLimit("p{$query['page']}", $query['limit']);
 
         $rows = $this->userModel->search($where, '', '', $limit, $offset)->resultArray();
         foreach ($rows as &$row) {

--- a/library/Vanilla/Models/PermissionFragmentSchema.php
+++ b/library/Vanilla/Models/PermissionFragmentSchema.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models;
+
+use Garden\Schema\Schema;
+
+/**
+ * Fragment representing some group of permissions.
+ */
+class PermissionFragmentSchema extends Schema {
+
+    const TYPE_GLOBAL = "global";
+
+    /**
+     * Override to add schema.
+     */
+    public function __construct() {
+        parent::__construct($this->parseInternal([
+            'type:s' => [
+                'enum' => ['global', 'category', 'knowledgeBase'],
+            ],
+            'id:i?', // The record ID of the permission (if it has a record type.)
+            'permissions:o', // The permissions for the type + id combination.
+        ]));
+    }
+}

--- a/library/Vanilla/PermissionsTranslationTrait.php
+++ b/library/Vanilla/PermissionsTranslationTrait.php
@@ -18,6 +18,50 @@ trait PermissionsTranslationTrait {
     /** @var NameScheme */
     private $nameScheme;
 
+    /**
+     * TECH DEBT HERE
+     * Currently our permission caches and main permission object do not keep the junction table that a permission maps to.
+     *
+     * TEMPORARY ASSUMPTION
+     * This _assumes_ that each permission name only has 1 junction table to map to. This may not hold true in the future.
+     * If that ever becomes the case, this mapping will need to be removed, and the junction tables stored in Permission object & cache.
+     *
+     * @var array [ JunctionTable => [permission.name, permission.otherName] ]
+     */
+    private $junctionTableMappings = [
+        'knowledgeBase' => ['kb.view', 'articles.add'],
+        'category' => [
+            "comments.add",
+            "comments.delete",
+            "comments.edit",
+            "discussions.add",
+            "discussions.manage",
+            "discussions.moderate",
+            "discussions.view",
+            "discussions.edit",
+            "discussions.announce",
+            "discussions.sink",
+            "discussions.close",
+            "discussions.delete"
+        ],
+    ];
+
+    /**
+     * Get the "assumed" junction table name
+     *
+     * @param string $permissionName
+     * @return string|null
+     */
+    private function getJunctionTableForPermission(string $permissionName): ?string {
+        foreach ($this->junctionTableMappings as $table => $permissions) {
+            if (in_array($permissionName, $permissions)) {
+                return $table;
+            }
+        }
+
+        return null;
+    }
+
     /** @var array Groups of permissions that can be consolidated into one. */
     private $consolidatedPermissions = [
         'discussions.moderate' => ['discussions.announce', 'discussions.close', 'discussions.sink'],

--- a/library/Vanilla/Web/UserSmartIDResolver.php
+++ b/library/Vanilla/Web/UserSmartIDResolver.php
@@ -53,11 +53,7 @@ class UserSmartIDResolver {
         }
 
         if ($column === 'me' && empty($value)) {
-            if ($this->session->isValid()) {
-                return $this->session->UserID;
-            } else {
-                throw new ForbiddenException('You must sign in.');
-            }
+            return $this->session->UserID; // Could be 0 for a guest.
         } elseif (in_array($column, ['name', 'email'])) {
             // These are basic field lookups on the user table.
             return $sender->fetchValue('User', $pk, [$column => $value]);

--- a/library/src/scripts/__tests__/TestReduxProvider.tsx
+++ b/library/src/scripts/__tests__/TestReduxProvider.tsx
@@ -1,0 +1,17 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { DeepPartial } from "redux";
+import { ICoreStoreState } from "@library/redux/reducerRegistry";
+import { testStoreState } from "@library/__tests__/testStoreState";
+import { Provider } from "react-redux";
+import getStore from "@library/redux/getStore";
+
+export function TestReduxProvider(props: { state: DeepPartial<ICoreStoreState>; children?: React.ReactNode }) {
+    const initialState = testStoreState(props.state);
+
+    return <Provider store={getStore(initialState, true)}>{props.children}</Provider>;
+}

--- a/library/src/scripts/features/users/Permission.test.tsx
+++ b/library/src/scripts/features/users/Permission.test.tsx
@@ -4,14 +4,12 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
-import { Permission } from "@library/features/users/Permission";
-import { mount, shallow } from "enzyme";
-import UserActions from "@library/features/users/UserActions";
-import { ILoadable, LoadStatus } from "@library/@types/api/core";
-import { IMe } from "@library/@types/api/users";
-import sinon from "sinon";
+import { LoadStatus } from "@library/@types/api/core";
+import Permission, { PermissionMode } from "@library/features/users/Permission";
+import { TestReduxProvider } from "@library/__tests__/TestReduxProvider";
 import { assert } from "chai";
+import { mount, shallow } from "enzyme";
+import React from "react";
 
 // tslint:disable:jsx-use-translation-function
 
@@ -20,132 +18,192 @@ const noop = () => {
 };
 
 describe("<Permission />", () => {
-    let user: ILoadable<IMe>;
-    let actions: UserActions;
-
-    const makeMockUser = (withPermissions: string[] = [], isAdmin: boolean = false): IMe => {
-        return {
-            name: "test",
-            userID: 0,
-            permissions: withPermissions,
-            isAdmin,
-            photoUrl: "",
-            dateLastActive: "",
-            countUnreadNotifications: 1,
-        };
-    };
-
     describe("with no data loaded yet", () => {
-        beforeEach(() => {
-            user = {
-                status: LoadStatus.PENDING,
-            };
-        });
-
         it("returns nothing if the data isn't loaded yet.", () => {
             const result = shallow(
-                <Permission permission="test" currentUser={user} requestData={noop}>
-                    Test
-                </Permission>,
+                <TestReduxProvider
+                    state={{
+                        users: {
+                            permissions: {
+                                status: LoadStatus.PENDING,
+                            },
+                        },
+                    }}
+                >
+                    <Permission permission="test">Test</Permission>
+                </TestReduxProvider>,
             );
 
-            assert(result.isEmptyRender(), "Something was rendered");
+            assert(!result.contains("test"), "Something was rendered");
         });
 
         it("loads the fallback if nothing is rendered yet.", () => {
             const fallback = <div>{`fallback`}</div>;
-            const result = shallow(
-                <Permission permission="test" currentUser={user} requestData={noop} fallback={fallback}>
-                    Test
-                </Permission>,
+            const result = mount(
+                <TestReduxProvider
+                    state={{
+                        users: {
+                            permissions: {
+                                status: LoadStatus.PENDING,
+                            },
+                        },
+                    }}
+                >
+                    <Permission permission="test" fallback={fallback}>
+                        Test
+                    </Permission>
+                </TestReduxProvider>,
             );
 
-            assert(result.equals(fallback), "The fallback was not equivalent to the reuslt");
-        });
-
-        it("dispatches an action to get the data", () => {
-            const spy = sinon.spy();
-            assert(!spy.called, "The spy was called before the component even mounted.");
-            mount(
-                <Permission permission="test" currentUser={user} requestData={spy}>
-                    Test
-                </Permission>,
-            );
-
-            assert(spy.called, "The spy was not called by the component.");
+            assert(result.contains("fallback"), "The fallback was not equivalent to the reuslt");
         });
     });
 
     describe("with data", () => {
-        beforeEach(() => {
-            user = {
-                status: LoadStatus.SUCCESS,
-                data: makeMockUser(["perm1", "perm2", "perm3"]),
-            };
-            actions = new UserActions(sinon.fake(), sinon.fake() as any);
-        });
+        function Wrapper(props: any) {
+            return (
+                <TestReduxProvider
+                    state={{
+                        users: {
+                            permissions: {
+                                status: LoadStatus.SUCCESS,
+                                data: {
+                                    isAdmin: props.isAdmin ?? false,
+                                    permissions: [
+                                        {
+                                            type: "global",
+                                            id: null,
+                                            permissions: {
+                                                perm1: true,
+                                                perm2: true,
+                                                perm3: true,
+                                                "someResource.globalOnly": true,
+                                                "someResource.view": true,
+                                            },
+                                        },
+                                        {
+                                            type: "someResource",
+                                            id: 5,
+                                            permissions: {
+                                                "someResource.view": true,
+                                                "someResource.add": true,
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    }}
+                >
+                    {props.children}
+                </TestReduxProvider>
+            );
+        }
 
         it("renders children if the user has one of the given permissions", () => {
             const successComponent = <div>{`Success`}</div>;
-            let result = shallow(
-                <Permission permission="perm1" currentUser={user} requestData={noop}>
-                    {successComponent}
-                </Permission>,
+            let result = mount(
+                <Wrapper>
+                    <Permission permission="perm1">{successComponent}</Permission>
+                </Wrapper>,
+            );
+
+            assert(result.contains("Success"), "the success component did not render with 1 good permission passed");
+
+            result = mount(
+                <Wrapper>
+                    <Permission permission={["perm1", "asdfa"]}>{successComponent}</Permission>
+                </Wrapper>,
             );
 
             assert(
-                result.contains(successComponent),
-                "the success component did not render with 1 good permission passed",
-            );
-
-            result = shallow(
-                <Permission permission={["perm1", "asdfa"]} currentUser={user} requestData={noop}>
-                    {successComponent}
-                </Permission>,
-            );
-
-            assert(
-                result.contains(successComponent),
+                result.contains("Success"),
                 "the success component did not render with 1 good and 1 bad permission passed",
             );
         });
 
         it("renders children if the user does not have one of the given permissions", () => {
             const successComponent = <div>{`Success`}</div>;
-            let result = shallow(
-                <Permission permission="asd" currentUser={user} requestData={noop}>
-                    {successComponent}
-                </Permission>,
+            let result = mount(
+                <Wrapper>
+                    <Permission permission="asd">{successComponent}</Permission>
+                </Wrapper>,
             );
 
-            assert(!result.contains(successComponent), "the success component rendered with 1 bad permission passed");
+            assert(!result.contains("Success"), "the success component rendered with 1 bad permission passed");
 
-            result = shallow(
-                <Permission permission={["fds", "asdfa"]} currentUser={user} requestData={noop}>
-                    {successComponent}
-                </Permission>,
+            result = mount(
+                <Wrapper>
+                    <Permission permission={["fds", "asdfa"]}>{successComponent}</Permission>
+                </Wrapper>,
             );
 
-            assert(
-                !result.contains(successComponent),
-                "the success component did not render with 2 bad permissions passed",
+            assert(!result.contains("Success"), "the success component did not render with 2 bad permissions passed");
+        });
+
+        it("checks resource specific permission", () => {
+            const successComponent = <div>{`Success`}</div>;
+            let result = mount(
+                <Wrapper>
+                    <Permission resourceID={5} resourceType={"someResource"} permission="someResource.view">
+                        {successComponent}
+                    </Permission>
+                </Wrapper>,
             );
+
+            assert(result.contains("Success"), "the resource permission is checked");
+
+            result = mount(
+                <Wrapper>
+                    <Permission resourceID={5} resourceType={"someResource"} permission="someResource.globalOnly">
+                        {successComponent}
+                    </Permission>
+                </Wrapper>,
+            );
+
+            assert(!result.contains("Success"), "globalOnly permission should not appear when checking a resource");
+
+            result = mount(
+                <Wrapper>
+                    <Permission resourceID={5} resourceType={"someResource"} permission="someResource.add">
+                        {successComponent}
+                    </Permission>
+                </Wrapper>,
+            );
+
+            assert(result.contains("Success"), "A resource only permission must work");
+
+            result = mount(
+                <Wrapper>
+                    <Permission mode={PermissionMode.GLOBAL_OR_RESOURCE} permission="someResource.add">
+                        {successComponent}
+                    </Permission>
+                </Wrapper>,
+            );
+
+            assert(result.contains("Success"), "Resource permission must work in global or resource mode");
+
+            result = mount(
+                <Wrapper>
+                    <Permission mode={PermissionMode.GLOBAL} permission="someResource.add">
+                        {successComponent}
+                    </Permission>
+                </Wrapper>,
+            );
+
+            assert(!result.contains("Success"), "Resource permission must be ignored in in global mode");
         });
 
         it("renders children if the user has 'isAdmin' set", () => {
             const successComponent = <div>{`Success`}</div>;
-            user = {
-                status: LoadStatus.SUCCESS,
-                data: makeMockUser([], true),
-            };
             const result = shallow(
-                <Permission permission="asd" currentUser={user} requestData={noop}>
-                    {successComponent}
-                </Permission>,
+                <Wrapper isAdmin={true}>
+                    <Permission permission="asd">{successComponent}</Permission>
+                </Wrapper>,
             );
 
             assert(
-                result.contains(successComponent),
+                result.contains("Success"),
                 "the success component did not render with 1 bad permission passed and an isAdmin flag set to true",
             );
         });

--- a/library/src/scripts/features/users/Permission.test.tsx
+++ b/library/src/scripts/features/users/Permission.test.tsx
@@ -13,10 +13,6 @@ import React from "react";
 
 // tslint:disable:jsx-use-translation-function
 
-const noop = () => {
-    return;
-};
-
 describe("<Permission />", () => {
     describe("with no data loaded yet", () => {
         it("returns nothing if the data isn't loaded yet.", () => {
@@ -100,7 +96,7 @@ describe("<Permission />", () => {
             );
         }
 
-        it("renders children if the user has one of the given permissions", () => {
+        it.only("renders children if the user has one of the given permissions", () => {
             const successComponent = <div>{`Success`}</div>;
             let result = mount(
                 <Wrapper>

--- a/library/src/scripts/features/users/Permission.test.tsx
+++ b/library/src/scripts/features/users/Permission.test.tsx
@@ -96,7 +96,7 @@ describe("<Permission />", () => {
             );
         }
 
-        it.only("renders children if the user has one of the given permissions", () => {
+        it("renders children if the user has one of the given permissions", () => {
             const successComponent = <div>{`Success`}</div>;
             let result = mount(
                 <Wrapper>

--- a/library/src/scripts/features/users/Permission.tsx
+++ b/library/src/scripts/features/users/Permission.tsx
@@ -7,6 +7,7 @@
 import { LoadStatus } from "@library/@types/api/core";
 import getStore from "@library/redux/getStore";
 import React from "react";
+import { usePermissions } from "@library/features/users/userModel";
 
 export enum PermissionMode {
     GLOBAL = "global",
@@ -29,6 +30,8 @@ interface IProps {
  * Conditionally renders either it's children or a fallback based on if the user has a permission.
  */
 export default function Permission(props: IProps) {
+    usePermissions();
+
     if (!props.permission) {
         return <>{props.children}</>;
     }

--- a/library/src/scripts/features/users/Permission.tsx
+++ b/library/src/scripts/features/users/Permission.tsx
@@ -4,21 +4,23 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
-import { logError } from "@vanilla/utils";
-import { LoadStatus, ILoadable } from "@library/@types/api/core";
-import { IInjectableUserState, mapUsersStoreState } from "@library/features/users/userModel";
-import apiv2 from "@library/apiv2";
-import UserActions from "@library/features/users/UserActions";
-import { connect } from "react-redux";
-import { IMe } from "@library/@types/api/users";
+import { LoadStatus } from "@library/@types/api/core";
 import getStore from "@library/redux/getStore";
+import React from "react";
 
-interface IProps extends IInjectableUserState {
+export enum PermissionMode {
+    GLOBAL = "global",
+    RESOURCE = "resource",
+    GLOBAL_OR_RESOURCE = "globalOrResource",
+}
+
+interface IProps {
     permission?: string | string[];
+    mode?: PermissionMode;
+    resourceType?: string;
+    resourceID?: number;
     children: React.ReactNode;
     fallback?: React.ReactNode;
-    requestData: () => void;
 }
 
 /**
@@ -26,32 +28,25 @@ interface IProps extends IInjectableUserState {
  *
  * Conditionally renders either it's children or a fallback based on if the user has a permission.
  */
-export class Permission extends React.Component<IProps> {
-    public render(): React.ReactNode {
-        if (!this.props.permission) {
-            return this.props.children;
-        }
-
-        return hasPermission(this.props.permission, this.props.currentUser)
-            ? this.props.children
-            : this.props.fallback || null;
+export default function Permission(props: IProps) {
+    if (!props.permission) {
+        return <>{props.children}</>;
     }
 
-    /**
-     * Trigger fetching of data if it hasn't already occurred.
-     */
-    public componentDidMount() {
-        if (this.props.currentUser.status === LoadStatus.PENDING) {
-            void this.props.requestData();
-        }
-    }
+    const result = hasPermission(props.permission, {
+        mode: props.mode ?? (props.resourceID != null ? PermissionMode.RESOURCE : PermissionMode.GLOBAL_OR_RESOURCE),
+        resourceType: props.resourceType,
+        resourceID: props.resourceID,
+    })
+        ? props.children
+        : props.fallback ?? null;
+    return <>{result}</>;
+}
 
-    /**
-     * @inheritdoc
-     */
-    public componentDidCatch(error, info) {
-        logError(error, info);
-    }
+interface IPermissionOptions {
+    mode: PermissionMode;
+    resourceType?: string;
+    resourceID?: number | null;
 }
 
 /**
@@ -61,38 +56,53 @@ export class Permission extends React.Component<IProps> {
  * - Always true if the user has the admin flag set.
  * - Only 1 one of the provided permissions needs to match.
  */
-export function hasPermission(permission: string | string[], currentUser?: ILoadable<IMe>) {
-    if (!currentUser) {
-        currentUser = getStore().getState().users.current;
+export function hasPermission(permission: string | string[], options?: IPermissionOptions) {
+    const { permissions } = getStore().getState().users;
+
+    let permissionsToCheck = permission;
+    if (!Array.isArray(permissionsToCheck)) {
+        permissionsToCheck = [permissionsToCheck];
     }
-    let lookupPermissions = permission;
-    if (!Array.isArray(lookupPermissions)) {
-        lookupPermissions = [lookupPermissions];
+
+    if (!permissions.data || permissions.status !== LoadStatus.SUCCESS) {
+        return false;
     }
 
-    return (
-        currentUser.status === LoadStatus.SUCCESS &&
-        !!currentUser.data &&
-        (currentUser.data.isAdmin || arrayContainsOneOf(lookupPermissions, currentUser.data.permissions))
-    );
-}
-/**
- * Check if an a haystack contains 1 of the passed needles.
- *
- * @param needles The strings to check for.
- * @param haystack The place to look for them.
- */
-function arrayContainsOneOf(needles: string[], haystack: string[]) {
-    return needles.some(val => haystack.indexOf(val) >= 0);
-}
+    if (permissions.data.isAdmin) {
+        return true;
+    }
 
-function mapDispatchToProps(dispatch) {
-    const actions = new UserActions(dispatch, apiv2);
-    return {
-        requestData: actions.getMe,
-    };
+    if (!options) {
+        options = {
+            mode: PermissionMode.GLOBAL_OR_RESOURCE,
+        };
+    }
+
+    if (!options.resourceType) {
+        options.resourceType = "global";
+        options.resourceID = null;
+    }
+
+    const permissionGroups = permissions.data.permissions.filter(permission => {
+        const matchesGlobal = permission.type === "global";
+        const matchesResource = permission.type === options?.resourceType && permission.id === options?.resourceID;
+        switch (options!.mode) {
+            case PermissionMode.GLOBAL:
+                return matchesGlobal;
+            case PermissionMode.GLOBAL_OR_RESOURCE:
+                return true; // All allowed to be checked.
+            case PermissionMode.RESOURCE:
+                return matchesResource;
+        }
+    });
+
+    let hasMatch = false;
+    permissionGroups.forEach(permissionGroupToCheck => {
+        for (const [permissionKey, permissionValue] of Object.entries(permissionGroupToCheck.permissions)) {
+            if (permissionsToCheck.includes(permissionKey) && permissionValue) {
+                hasMatch = true;
+            }
+        }
+    });
+    return hasMatch;
 }
-
-const withRedux = connect(mapUsersStoreState, mapDispatchToProps);
-
-export default withRedux(Permission);

--- a/library/src/scripts/features/users/UserActions.ts
+++ b/library/src/scripts/features/users/UserActions.ts
@@ -8,7 +8,7 @@ import { IApiError, LoadStatus } from "@library/@types/api/core";
 import { IMe, IMeCounts } from "@library/@types/api/users";
 import ReduxActions, { bindThunkAction, useReduxActions } from "@library/redux/ReduxActions";
 import { actionCreatorFactory } from "typescript-fsa";
-import { IPermission } from "@library/features/users/userModel";
+import { IPermission, IPermissions } from "@library/features/users/userModel";
 import { ICoreStoreState } from "@library/redux/reducerRegistry";
 import { useSelector } from "react-redux";
 
@@ -39,7 +39,7 @@ export default class UserActions extends ReduxActions {
         return this.dispatch(apiThunk);
     };
 
-    public static getPermissionsACs = createAction.async<{}, IPermission[], IApiError>("GET_PERMISSIONS");
+    public static getPermissionsACs = createAction.async<{}, IPermissions, IApiError>("GET_PERMISSIONS");
     /**
      * Request the currently signed in user data if it's not loaded.
      */

--- a/library/src/scripts/features/users/userModel.ts
+++ b/library/src/scripts/features/users/userModel.ts
@@ -26,7 +26,7 @@ export interface IPermission {
     permissions: Record<string, boolean>;
 }
 
-interface IPermissions {
+export interface IPermissions {
     isAdmin?: boolean;
     permissions: IPermission[];
 }

--- a/library/src/scripts/features/users/userModel.ts
+++ b/library/src/scripts/features/users/userModel.ts
@@ -149,7 +149,7 @@ export function usePermissions() {
     const { status } = permissions;
 
     useEffect(() => {
-        if (![LoadStatus.PENDING, LoadStatus.LOADING].includes(status)) {
+        if ([LoadStatus.PENDING, LoadStatus.LOADING].includes(status)) {
             void getPermissions();
         }
     }, [status, getPermissions]);

--- a/library/src/scripts/features/users/userModel.ts
+++ b/library/src/scripts/features/users/userModel.ts
@@ -6,7 +6,7 @@
 import { ILoadable, LoadStatus } from "@library/@types/api/core";
 import { IMe, IMeCounts, IUser, IUserFragment } from "@library/@types/api/users";
 import UserSuggestionModel, { IUserSuggestionState } from "@library/features/users/suggestion/UserSuggestionModel";
-import UserActions from "@library/features/users/UserActions";
+import UserActions, { useUserActions } from "@library/features/users/UserActions";
 import produce from "immer";
 import { reducerWithInitialState } from "typescript-fsa-reducers";
 import { ICoreStoreState } from "@library/redux/reducerRegistry";
@@ -14,13 +14,26 @@ import NotificationsActions from "@library/features/notifications/NotificationsA
 import { IThemeState } from "@library/theming/themeReducer";
 import { ILocaleState } from "@library/locales/localeReducer";
 import { useSelector } from "react-redux";
+import { useEffect } from "react";
 
 export interface IInjectableUserState {
     currentUser: ILoadable<IMe>;
 }
 
+export interface IPermission {
+    type: string;
+    id: number | null;
+    permissions: Record<string, boolean>;
+}
+
+interface IPermissions {
+    isAdmin?: boolean;
+    permissions: IPermission[];
+}
+
 interface IUsersState {
     current: ILoadable<IMe>;
+    permissions: ILoadable<IPermissions>;
     countInformation: {
         counts: IMeCounts;
         lastRequested: number | null; // A timestamp of the last time we received this count data.
@@ -36,6 +49,9 @@ const suggestionReducer = new UserSuggestionModel().reducer;
 
 export const INITIAL_USERS_STATE: IUsersState = {
     current: {
+        status: LoadStatus.PENDING,
+    },
+    permissions: {
         status: LoadStatus.PENDING,
     },
     countInformation: {
@@ -78,6 +94,20 @@ export const usersReducer = produce(
             state.current.error = payload.error;
             return state;
         })
+        .case(UserActions.getPermissionsACs.started, state => {
+            state.permissions.status = LoadStatus.LOADING;
+            return state;
+        })
+        .case(UserActions.getPermissionsACs.done, (state, payload) => {
+            state.permissions.data = payload.result;
+            state.permissions.status = LoadStatus.SUCCESS;
+            return state;
+        })
+        .case(UserActions.getPermissionsACs.failed, (state, payload) => {
+            state.permissions.status = LoadStatus.ERROR;
+            state.permissions.error = payload.error;
+            return state;
+        })
         .case(UserActions.getCountsACs.started, state => {
             state.countInformation.lastRequested = new Date().getTime();
             return state;
@@ -111,4 +141,18 @@ export function mapUsersStoreState(state: ICoreStoreState): IInjectableUserState
 
 export function useUsersState(): IInjectableUserState {
     return useSelector(mapUsersStoreState);
+}
+
+export function usePermissions() {
+    const permissions = useSelector((state: ICoreStoreState) => state.users.permissions);
+    const { getPermissions } = useUserActions();
+    const { status } = permissions;
+
+    useEffect(() => {
+        if (![LoadStatus.PENDING, LoadStatus.LOADING].includes(status)) {
+            void getPermissions();
+        }
+    }, [status, getPermissions]);
+
+    return permissions;
 }

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -341,7 +341,6 @@ class UsersTest extends AbstractResourceTest {
             'permissions' => [
                 [
                     'type' => PermissionFragmentSchema::TYPE_GLOBAL,
-                    'id' => null,
                     'permissions' => [
                         'community.manage' => true,
                     ],

--- a/tests/Library/Vanilla/Web/SmartIDMiddlewareTest.php
+++ b/tests/Library/Vanilla/Web/SmartIDMiddlewareTest.php
@@ -253,14 +253,13 @@ class SmartIDMiddlewareTest extends TestCase {
     }
 
     /**
-     * The `$me` smart ID without a session should be an exception.
+     * The `$me` smart ID without a session should give the guest ID.
      */
-    public function testInvalidMe() {
-        $this->expectException(ForbiddenException::class);
-
+    public function testGuestMe() {
         $this->session->UserID = 0;
 
         $request = new Request('/users/$me');
         $r = $this->callMiddleware($request);
+        $this->assertEquals($r->getPath(), '/users/0');
     }
 }


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1619

**Create a user endpoint to return all permissions for a particular user**

- Extract a PermissionFragmentSchema from the roles controller.
- Permission fragments for global and each resource are returned.
- Method added to `Permission` object to generate permission fragments.
- This can be used for the current user with the `$me` smartID.

**Update frontend**

The frontend has been updated to use the data from this endpoint now instead of the `/users/me` endpoint.

- Add reducer & action for new endpoint.
- Update `<Permission />` component to use this new data.
- Uddate `<Permission />` to be able to check per-resource, global, or combinations of them for permissions.