### PR TITLE
Fix height for search

### DIFF
--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -712,6 +712,9 @@ export const bannerClasses = useThemeCache(() => {
         backgroundColor: colorOut(vars.outerBackground.color),
         $nest: {
             [`& .${searchBarClasses().independentRoot}`]: rootConditionalStyles,
+            "& .searchBar": {
+                height: unit(vars.searchBar.sizing.height),
+            },
         },
     });
 


### PR DESCRIPTION
I noticed in storybook, some of the searches had the wrong height. This explicitly setting the height.