### PR TITLE
Remove dead code from setField() in DiscussionModel and UserModel

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -5037,10 +5037,6 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
             $this->updateUserCache($rowID, $property, $value);
         }
 
-        if (!is_array($property)) {
-            $property = [$property => $value];
-        }
-
         $this->EventArguments['UserID'] = $rowID;
         $this->EventArguments['Fields'] = $property;
         $this->fireEvent('AfterSetField');

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2064,7 +2064,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
         }
 
         $this->EventArguments['DiscussionID'] = $rowID;
-		$this->EventArguments['SetField'] = $property;
+        $this->EventArguments['SetField'] = $property;
 
         parent::setField($rowID, $property);
         $this->fireEvent('AfterSetField');

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2064,13 +2064,9 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
         }
 
         $this->EventArguments['DiscussionID'] = $rowID;
-        if (!is_array($property)) {
-            $this->EventArguments['SetField'] = [$property => $value];
-        } else {
-            $this->EventArguments['SetField'] = $property;
-        }
+		$this->EventArguments['SetField'] = $property;
 
-        parent::setField($rowID, $property, $value);
+        parent::setField($rowID, $property);
         $this->fireEvent('AfterSetField');
     }
 


### PR DESCRIPTION
There are some duplicate tests around the `Gdn_Model->setField()` method. This is the code from the Gdn_Model:

```
   public function setField($rowID, $property, $value = false) {
       if (!is_array($property)) {
           $property = [$property => $value];
       }
```

`$property` is obviously expected to be an array.

In `DiscussionModel->setField()` that same test is made twice before the `parent::setField()` call is made. The second check for `$property` being an array wall always be false so that this check doesn't make sense. In the end `parent::setField($rowID, [$property => $value], $value)` is called which is obviously wrong, but at least has no bad consequences because the single `$value` parameter is simply ignored by the parent method.

In `UserModel->setField()` there is also a duplicate test for `$property` being an array. I have removed all that superfluous code.