### PR TITLE
Fix view profile restrictions

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1071,12 +1071,6 @@ if (!function_exists('hasViewProfile')) {
 
         $result = checkPermission('Garden.Profiles.View');
 
-        $result = $result && (
-                c('Garden.Profile.Titles') ||
-                c('Garden.Profile.Locations', false) ||
-                c('Garden.Registration.Method') != 'Connect'
-            );
-
         return $result;
     }
 }


### PR DESCRIPTION
Closes vanilla/support#1523.

This fixes a problem where users who have the `Garden.Profiles.View` permission cannot view their own profiles. This PR removes some additional permission checks in the `hasViewProfile()` function that aren't necessary. (It appears they were copied over from the `hasEditProfile()` function). 

### TO TEST
1. Make sure that neither `Garden.Profile.Titles` nor `Garden.Profile.Locations` are enabled AND that `Garden.Registration.Method` is not set to `'Connect'`.
1. Sign in as a member-level user and verify that you the "View Profile" option is absent from the MeBox dropdown menu.
1. Checkout this branch and verify that the "View Profile" option is there.