### PR TITLE
Move content heading styles to compat styles

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/discussionStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/discussionStyles.ts
@@ -24,6 +24,20 @@ export const discussionCSS = () => {
         },
     );
 
+    cssOut(
+        `
+        .userContent.userContent h1,
+        .userContent.userContent h2,
+        .userContent.userContent h3,
+        .userContent.userContent h4,
+        .userContent.userContent h5,
+        .userContent.userContent h6
+    `,
+        {
+            color: colorOut(globalVars.mainColors.fg),
+        },
+    );
+
     // Polls
 
     cssOut(

--- a/plugins/rich-editor/src/scripts/quill/components/blotStyles.ts
+++ b/plugins/rich-editor/src/scripts/quill/components/blotStyles.ts
@@ -11,7 +11,6 @@ import { emojiCSS } from "@rich-editor/quill/components/emojiStyles";
 import { spoilerCSS } from "@rich-editor/quill/components/spoilerStyles";
 import { codeBlockCSS } from "@rich-editor/quill/components/codeBlockStyles";
 import { loadedCSS } from "@rich-editor/quill/components/loadedStyles";
-import { userContentCSS } from "@library/content/userContentStyles";
 
 export const blotCSS = () => {
     accessibilityCSS();
@@ -20,6 +19,5 @@ export const blotCSS = () => {
     emojiCSS();
     spoilerCSS();
     codeBlockCSS();
-    userContentCSS();
     loadedCSS();
 };


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/1547

These styles were only supposed to be applied in foundation, but they manage to sneak into the normal styles