### PR TITLE
Backport: Allow plugins to add selects in getWhere function of the DiscussionModel.

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -860,14 +860,8 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
         }
 
         // Add select of addition fields to the SQL object.
-        if (!empty($selects)) {
-            if (!is_array($selects)) {
-                $selects = [$selects];
-            }
-
-            foreach ($selects as $select) {
-                $sql->select($select);
-            }
+        foreach ($selects as $select) {
+            $sql->select($select);
         }
 
         $outerQuery = $sql->getSelect();

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -782,8 +782,10 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
             $orderBy = [$orderFields => $orderDirection];
         }
 
+        $selects = [];
         $this->EventArguments['OrderBy'] = &$orderBy;
         $this->EventArguments['Wheres'] = &$where;
+        $this->EventArguments['Selects'] = &$selects;
         $this->fireEvent('BeforeGet');
 
         // Verify permissions (restricting by category if necessary)
@@ -855,6 +857,17 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
                 ->select('w.DateLastViewed, w.Dismissed, w.Bookmarked')
                 ->select('w.CountComments', '', 'CountCommentWatch')
                 ->select('w.Participated');
+        }
+
+        // Add select of addition fields to the SQL object.
+        if (!empty($selects)) {
+            if (!is_array($selects)) {
+                $selects = [$selects];
+            }
+
+            foreach ($selects as $select) {
+                $sql->select($select);
+            }
         }
 
         $outerQuery = $sql->getSelect();


### PR DESCRIPTION
Backport: https://github.com/vanilla/vanilla/pull/10187

A change was made in https://github.com/vanilla/vanilla/pull/10094 to optimize the getWhere function of the discussion model.

A custom plugin created a little while ago was hooking into the `beforeGet` event fired in this same function to add a "select" to the SQL object. This new change is now breaking the query into two parts and the select is now being added to the wrong query. The query then fails when the plugin is turned on.

https://github.com/vanillaforums/mse/issues/166

### The solution

Instead of firing an additional event, a new argument is passed to it allowing plugins to specify columns to add to the query.
