### PR TITLE
Fix SphinxTrait compatibility with Sphinx v3 API

### DIFF
--- a/library/Garden/SphinxTrait.php
+++ b/library/Garden/SphinxTrait.php
@@ -52,8 +52,13 @@ trait SphinxTrait {
         $client->setServer($sphinxHost, $sphinxPort);
 
         // Set some defaults
-        $client->setMatchMode(SPH_MATCH_EXTENDED2);
-        $client->setSortMode(SPH_SORT_TIME_SEGMENTS, 'DateInserted');
+        if (method_exists($client, "setMatchMode")) {
+            $client->setMatchMode(SPH_MATCH_EXTENDED2);
+            $client->setSortMode(SPH_SORT_TIME_SEGMENTS, 'DateInserted');
+        } else {
+            // SPH_SORT_TIME_SEGMENTS is not a valid sort mode in Sphinx 3.2.1.
+            $client->setSortMode(SPH_SORT_RELEVANCE);
+        }
         $client->setMaxQueryTime(5000);
 
         return $client;


### PR DESCRIPTION
In order to address fatal errors when using the bundled PHP API class bundled with Sphinx v3.2.1, changes need to be made to `SphinxTrait`. The changes are backwards-compatible with v2, so either should be functional.

### Overview
1. `setMatchMode` has been removed from the Sphinx API as of v3.1.1. It was already deprecated in newer versions of v2, so seeing it go here should be no surprise. Its presence is used to determine which version of the API we'll be working with. The default search behavior in v3  matches the "extended" behavior, so there's not much to do here aside from removing it.
1. `SPH_SORT_TIME_SEGMENTS` is not a valid sort mode in Sphinx v3.2.1. It's documented as a valid sort mode, but attempting to use it throws a fatal unknown/unsupported error from the search service. Its usage is being replaced here for v3 with the "relevance" sort mode. This will likely have an impact on search results, but it should be limited to no longer giving newer posts higher ranking over more relevant posts.