### PR TITLE
Remove Gdn_SQLDriver::noReset()

### DIFF
--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -505,7 +505,6 @@ class Gdn_Model extends Gdn_Pluggable {
         $resetData = false;
         if ($options === true || val('reset', $options)) {
             deprecated('Gdn_Model->delete() with reset true');
-            $resetData = true;
         } elseif (is_numeric($options)) {
             deprecated('The $limit parameter is deprecated in Gdn_Model->delete(). Use the limit option.');
             $limit = $options;
@@ -514,11 +513,8 @@ class Gdn_Model extends Gdn_Pluggable {
             $limit = $options['limit'];
         }
 
-        if ($resetData) {
-            $result = $this->SQL->delete($this->Name, $where, $limit);
-        } else {
-            $result = $this->SQL->noReset()->delete($this->Name, $where, $limit);
-        }
+        $result = $this->SQL->delete($this->Name, $where, $limit);
+
         return $result;
     }
 

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -74,14 +74,6 @@ abstract class Gdn_SQLDriver {
      */
     protected $_NamedParameters = [];
 
-    /**
-     * @var int Whether or not to reset the properties when a query is executed.
-     *   0 = The object will reset after query execution.
-     *   1 = The object will not reset after the <b>NEXT</b> query execution.
-     *   2 = The object will not reset after <b>ALL</b> query executions.
-     */
-    protected $_NoReset = false;
-
     /** @var int The offset from which data should be returned. FALSE by default. */
     protected $_Offset;
 
@@ -1389,9 +1381,10 @@ abstract class Gdn_SQLDriver {
      * @param boolean $Reset Whether or not to reset this object when the next query executes.
      * @param boolean $oneTime Whether or not this will apply for only the next query or for all subsequent queries.
      * @return Gdn_SQLDriver $this
+     * @deprecated
      */
     public function noReset($noReset = true, $oneTime = true) {
-        $_NoReset = $noReset ? ($oneTime ? 1 : 2) : 0;
+        deprecated(__FUNCTION__);
         return $this;
     }
 
@@ -1775,14 +1768,6 @@ abstract class Gdn_SQLDriver {
      * @return Gdn_SQLDriver $this
      */
     public function reset() {
-        // Check the _NoReset flag.
-        switch ($this->_NoReset) {
-            case 1:
-                $this->_NoReset = 0;
-                return;
-            case 2:
-                return;
-        }
         $this->_Selects = [];
         $this->_Froms = [];
         $this->_Joins = [];


### PR DESCRIPTION
See #5428
Looking back at the oldest commit, `Gdn_SQLDriver::noReset()` never worked because it never actually set the class property:

https://github.com/vanilla/vanilla/blob/474d00d3dadb287ae0b3ca4da2177745c32c4c3e/library/database/class.sqldriver.php#L1207

As this hasn't been needed for 11 years now, I propose to remove this non-functionality and deprecate its usage.