### PR TITLE
Fix quoted text showing white on white.

### DIFF
--- a/library/src/scripts/embeddedContent/embedStyles.ts
+++ b/library/src/scripts/embeddedContent/embedStyles.ts
@@ -17,7 +17,7 @@ export const embedContainerVariables = useThemeCache(() => {
 
     const colors = makeThemeVars("colors", {
         bg: globalVars.mainColors.bg,
-        fg: globalVars.mainColors.fg
+        fg: globalVars.mainColors.fg,
     });
 
     const border = makeThemeVars("border", {

--- a/library/src/scripts/embeddedContent/embedStyles.ts
+++ b/library/src/scripts/embeddedContent/embedStyles.ts
@@ -17,6 +17,7 @@ export const embedContainerVariables = useThemeCache(() => {
 
     const colors = makeThemeVars("colors", {
         bg: globalVars.mainColors.bg,
+        fg: globalVars.mainColors.fg
     });
 
     const border = makeThemeVars("border", {
@@ -80,7 +81,7 @@ export const embedContainerClasses = useThemeCache(() => {
             display: "block",
             position: "relative",
             textDecoration: "none",
-            color: "inherit",
+            color: colorOut(vars.colors.fg),
             margin: "auto",
             padding: withPadding ? vars.spacing.padding : 0,
             ...(inEditor ? userSelect() : {}),


### PR DESCRIPTION
This PR will close vanilla/support#1321

Recent changes to our EmbedStyles added a white background colour explicitly but did not specify the font colour. This meant, in certain themes it was rendered white on white. This PR will add the the foreground colour to the font.

### Testing
 - Find a theme which has white text as default (or set it in custom CSS).
 - Do `yarn build` in the root of vanilla.
 - Warn a user's post.
 - Go to the user's profile page.
 - See that the body text is invisible.
 - Pull this branch.
 - Repeat the above steps. 
 - See that the body text is visible.