### PR TITLE
Allow plugins to hook into the UserFragmentSchema.

### DIFF
--- a/library/Vanilla/Models/UserFragmentSchema.php
+++ b/library/Vanilla/Models/UserFragmentSchema.php
@@ -9,6 +9,7 @@ namespace Vanilla\Models;
 
 use Garden\Schema\Schema;
 use Vanilla\ApiUtils;
+use Vanilla\SchemaFactory;
 
 /**
  * Schema to validate shape of some media upload metadata.
@@ -37,7 +38,7 @@ class UserFragmentSchema extends Schema {
      */
     public static function instance(): UserFragmentSchema {
         if (self::$cache === null) {
-            self::$cache = new UserFragmentSchema();
+            self::$cache = SchemaFactory::get(self::class, 'UserFragment');
         }
 
         return self::$cache;


### PR DESCRIPTION
This PR will close vanilla/support#1198

The original issue arose at the release of release/2019.018 when an event that one of your customers was hooking into to alter the UserFragmentSchema stopped working.

This PR returns that functionality by instantiating the SchemaFactory.

### Testing

To test you will need to 
 1. Create profile extender fields.
 2. Populate those fields for a user.
 3. Turn on an addon that adds user meta values to the UserFragment.
 4. Make this API call: https://dev.vanilla.localhost/api/v2/users/{userID}?expand=true;
 5. Checkout this branch and repeat. 
 6. Compare.