### PR TITLE
Edit translation string t() args with shorter codes

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -568,8 +568,8 @@ class SettingsController extends DashboardController {
                 'LabelCode' => t('Defer Javascript Loading'),
                 'Control' => 'toggle',
                 'Default' => true,
-                'Description' => t('Defer Javascript Loading description' .
-                    anchor(t('More information'), 'https://success.vanillaforums.com/kb/articles/140-defer-javascript-loading-feature')),
+                'Description' => t('Defer Javascript Loading description') .
+                    anchor(t('More information'), 'https://success.vanillaforums.com/kb/articles/140-defer-javascript-loading-feature'),
                 'Options' => [
                     'UseRealBoolean' => true
                 ]

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -568,7 +568,7 @@ class SettingsController extends DashboardController {
                 'LabelCode' => t('Defer Javascript Loading'),
                 'Control' => 'toggle',
                 'Default' => true,
-                'Description' => t('Defer Javascript Loading description') .
+                'Description' => t('This setting loads the page before executing Javascript') .
                     anchor(t('More information'), 'https://success.vanillaforums.com/kb/articles/140-defer-javascript-loading-feature'),
                 'Options' => [
                     'UseRealBoolean' => true

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -568,8 +568,7 @@ class SettingsController extends DashboardController {
                 'LabelCode' => t('Defer Javascript Loading'),
                 'Control' => 'toggle',
                 'Default' => true,
-                'Description' => t('This setting loads the page before executing Javascript which can improve your SEO.<br>
-                    <strong>**Warning: Enabling this feature may cause Javascript errors on your site.**</strong> ' .
+                'Description' => t('Defer Javascript Loading description' .
                     anchor(t('More information'), 'https://success.vanillaforums.com/kb/articles/140-defer-javascript-loading-feature')),
                 'Options' => [
                     'UseRealBoolean' => true

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -568,7 +568,7 @@ class SettingsController extends DashboardController {
                 'LabelCode' => t('Defer Javascript Loading'),
                 'Control' => 'toggle',
                 'Default' => true,
-                'Description' => t('This setting loads the page before executing Javascript') .
+                'Description' => t('This setting loads the page before executing Javascript.') .
                     anchor(t('More information'), 'https://success.vanillaforums.com/kb/articles/140-defer-javascript-loading-feature'),
                 'Options' => [
                     'UseRealBoolean' => true

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -568,7 +568,7 @@ class SettingsController extends DashboardController {
                 'LabelCode' => t('Defer Javascript Loading'),
                 'Control' => 'toggle',
                 'Default' => true,
-                'Description' => t('This setting loads the page before executing Javascript.') .
+                'Description' => t('This setting loads the page before executing Javascript.') . " " .
                     anchor(t('More information'), 'https://success.vanillaforums.com/kb/articles/140-defer-javascript-loading-feature'),
                 'Options' => [
                     'UseRealBoolean' => true

--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -158,16 +158,22 @@ $Definition['ConnectName'] = 'Username';
 //$Definition['EmbededDiscussionFormat'] = '<div class="EmbeddedContent">{Image}<strong>{Title}</strong>
 //<p>{Excerpt}</p>
 //<p><a href="{Url}">Read the full story here</a></p><div class="ClearFix"></div></div>';
+$Definition['Alert users if they click external link.'] = 'Alert users if they click a link in a post that will lead them away from the forum. 
+    Users will not be warned when following links that match a Trusted Domain';
 $Definition['Check out the new community forum I\'ve just set up.'] = 'Hi Pal!
 
 Check out the new community forum I\'ve just set up. It\'s a great place for us to chat with each other online.';
+$Definition['If you want to embed your forum, enable embedding.'] = 'If you want to embed your forum or use Vanilla\'s comments in your blog 
+    then you need to enable embedding. If you aren\'t using embedding then we recommend leaving this setting off.';
+$Definition['Invitation email failed to send.'] =
+    'Although the invitation was created successfully, the email failed to send. The server reported the following error: %s';
 $Definition['Large images will be scaled down.'] = 'Large images will be scaled down to a max width of %spx and a max height of %spx.';
 $Definition['Locales allow you to support other languages on your site.'] =
     'Locales allow you to support other languages on your site. Enable and disable locales you want to make available here.';
 $Definition['Test Email Message'] = '<p>This is a test email message.</p>'.
     '<p>You can configure the appearance of your forum\'s emails by navigating to the Email page in the dashboard.</p>';
+$Definition['This setting loads the page before executing Javascript'] = 'This setting loads the page before executing 
+    Javascript which can improve your SEO.<br><strong>**Warning: Enabling this feature may cause Javascript errors on your site.**</strong> ';
 $Definition['oauth2Instructions'] = '<p>Configure your forum to connect with an OAuth2 application by putting your unique Client ID, Client Secret, and required endpoints. You will probably need to provide your SSO application with an allowed callback URL, in part, to validate requests. The callback url for this forum is <code>%s</code></p>';
-$Definition['External link alert details'] = 'Alert users if they click a link in a post that will lead them away from the forum. 
-    Users will not be warned when following links that match a Trusted Domain';
 
 // TODO: PROVIDE TRANSLATIONS FOR ALL CONFIGURATION SETTINGS THAT ARE EDITABLE ON ADMIN FORMS (ie. Vanilla.Comments.MaxLength, etc).

--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -172,7 +172,7 @@ $Definition['Locales allow you to support other languages on your site.'] =
     'Locales allow you to support other languages on your site. Enable and disable locales you want to make available here.';
 $Definition['Test Email Message'] = '<p>This is a test email message.</p>'.
     '<p>You can configure the appearance of your forum\'s emails by navigating to the Email page in the dashboard.</p>';
-$Definition['This setting loads the page before executing Javascript'] = 'This setting loads the page before executing 
+$Definition['This setting loads the page before executing Javascript.'] = 'This setting loads the page before executing 
     Javascript which can improve your SEO.<br><strong>**Warning: Enabling this feature may cause Javascript errors on your site.**</strong> ';
 $Definition['oauth2Instructions'] = '<p>Configure your forum to connect with an OAuth2 application by putting your unique Client ID, Client Secret, and required endpoints. You will probably need to provide your SSO application with an allowed callback URL, in part, to validate requests. The callback url for this forum is <code>%s</code></p>';
 

--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -167,6 +167,7 @@ $Definition['Locales allow you to support other languages on your site.'] =
 $Definition['Test Email Message'] = '<p>This is a test email message.</p>'.
     '<p>You can configure the appearance of your forum\'s emails by navigating to the Email page in the dashboard.</p>';
 $Definition['oauth2Instructions'] = '<p>Configure your forum to connect with an OAuth2 application by putting your unique Client ID, Client Secret, and required endpoints. You will probably need to provide your SSO application with an allowed callback URL, in part, to validate requests. The callback url for this forum is <code>%s</code></p>';
-
+$Definition['External link alert details'] = 'Alert users if they click a link in a post that will lead them away from the forum. 
+    Users will not be warned when following links that match a Trusted Domain';
 
 // TODO: PROVIDE TRANSLATIONS FOR ALL CONFIGURATION SETTINGS THAT ARE EDITABLE ON ADMIN FORMS (ie. Vanilla.Comments.MaxLength, etc).

--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -1,4 +1,5 @@
 <?php if (!defined('APPLICATION')) exit();
+// phpcs:ignoreFile
 /**
  * Default user-facing text strings.
  *
@@ -158,13 +159,13 @@ $Definition['ConnectName'] = 'Username';
 //$Definition['EmbededDiscussionFormat'] = '<div class="EmbeddedContent">{Image}<strong>{Title}</strong>
 //<p>{Excerpt}</p>
 //<p><a href="{Url}">Read the full story here</a></p><div class="ClearFix"></div></div>';
-$Definition['Alert users if they click external link.'] = 'Alert users if they click a link in a post that will lead them away from the forum. 
-    Users will not be warned when following links that match a Trusted Domain';
+$Definition['Alert users if they click external link.'] =
+    'Alert users if they click a link in a post that will lead them away from the forum. Users will not be warned when following links that match a Trusted Domain';
 $Definition['Check out the new community forum I\'ve just set up.'] = 'Hi Pal!
 
 Check out the new community forum I\'ve just set up. It\'s a great place for us to chat with each other online.';
-$Definition['If you want to embed your forum, enable embedding.'] = 'If you want to embed your forum or use Vanilla\'s comments in your blog 
-    then you need to enable embedding. If you aren\'t using embedding then we recommend leaving this setting off.';
+$Definition['If you want to embed your forum, enable embedding.'] =
+    'If you want to embed your forum or use Vanilla\'s comments in your blog then you need to enable embedding. If you aren\'t using embedding then we recommend leaving this setting off.';
 $Definition['Invitation email failed to send.'] =
     'Although the invitation was created successfully, the email failed to send. The server reported the following error: %s';
 $Definition['Large images will be scaled down.'] = 'Large images will be scaled down to a max width of %spx and a max height of %spx.';
@@ -172,8 +173,8 @@ $Definition['Locales allow you to support other languages on your site.'] =
     'Locales allow you to support other languages on your site. Enable and disable locales you want to make available here.';
 $Definition['Test Email Message'] = '<p>This is a test email message.</p>'.
     '<p>You can configure the appearance of your forum\'s emails by navigating to the Email page in the dashboard.</p>';
-$Definition['This setting loads the page before executing Javascript.'] = 'This setting loads the page before executing 
-    Javascript which can improve your SEO.<br><strong>**Warning: Enabling this feature may cause Javascript errors on your site.**</strong> ';
+$Definition['This setting loads the page before executing Javascript.'] =
+    'This setting loads the page before executing Javascript which can improve your SEO.<br><strong>**Warning: Enabling this feature may cause Javascript errors on your site.**</strong> ';
 $Definition['oauth2Instructions'] = '<p>Configure your forum to connect with an OAuth2 application by putting your unique Client ID, Client Secret, and required endpoints. You will probably need to provide your SSO application with an allowed callback URL, in part, to validate requests. The callback url for this forum is <code>%s</code></p>';
 
 // TODO: PROVIDE TRANSLATIONS FOR ALL CONFIGURATION SETTINGS THAT ARE EDITABLE ON ADMIN FORMS (ie. Vanilla.Comments.MaxLength, etc).

--- a/applications/dashboard/locale/en.php
+++ b/applications/dashboard/locale/en.php
@@ -166,7 +166,7 @@ $Definition['Check out the new community forum I\'ve just set up.'] = 'Hi Pal!
 Check out the new community forum I\'ve just set up. It\'s a great place for us to chat with each other online.';
 $Definition['If you want to embed your forum, enable embedding.'] =
     'If you want to embed your forum or use Vanilla\'s comments in your blog then you need to enable embedding. If you aren\'t using embedding then we recommend leaving this setting off.';
-$Definition['Invitation email failed to send.'] =
+$Definition['Invitation email failed to send: %s'] =
     'Although the invitation was created successfully, the email failed to send. The server reported the following error: %s';
 $Definition['Large images will be scaled down.'] = 'Large images will be scaled down to a max width of %spx and a max height of %spx.';
 $Definition['Locales allow you to support other languages on your site.'] =

--- a/applications/dashboard/models/class.invitationmodel.php
+++ b/applications/dashboard/models/class.invitationmodel.php
@@ -160,7 +160,7 @@ class InvitationModel extends Gdn_Model {
                 try {
                     $this->send($invitationID);
                 } catch (Exception $ex) {
-                    $this->Validation->addValidationResult('Email', sprintf(t('Invitation email failed to send.'), strip_tags($ex->getMessage())));
+                    $this->Validation->addValidationResult('Email', sprintf('Invitation email failed to send.', strip_tags($ex->getMessage())));
                     return false;
                 }
             }

--- a/applications/dashboard/models/class.invitationmodel.php
+++ b/applications/dashboard/models/class.invitationmodel.php
@@ -160,7 +160,7 @@ class InvitationModel extends Gdn_Model {
                 try {
                     $this->send($invitationID);
                 } catch (Exception $ex) {
-                    $this->Validation->addValidationResult('Email', sprintf(t('Although the invitation was created successfully, the email failed to send. The server reported the following error: %s'), strip_tags($ex->getMessage())));
+                    $this->Validation->addValidationResult('Email', sprintf(t('Invitation email error description'), strip_tags($ex->getMessage())));
                     return false;
                 }
             }

--- a/applications/dashboard/models/class.invitationmodel.php
+++ b/applications/dashboard/models/class.invitationmodel.php
@@ -160,7 +160,7 @@ class InvitationModel extends Gdn_Model {
                 try {
                     $this->send($invitationID);
                 } catch (Exception $ex) {
-                    $this->Validation->addValidationResult('Email', sprintf('Invitation email failed to send.', strip_tags($ex->getMessage())));
+                    $this->Validation->addValidationResult('Email', sprintf('Invitation email failed to send: %s', strip_tags($ex->getMessage())));
                     return false;
                 }
             }

--- a/applications/dashboard/models/class.invitationmodel.php
+++ b/applications/dashboard/models/class.invitationmodel.php
@@ -160,7 +160,7 @@ class InvitationModel extends Gdn_Model {
                 try {
                     $this->send($invitationID);
                 } catch (Exception $ex) {
-                    $this->Validation->addValidationResult('Email', sprintf(t('Invitation email error description'), strip_tags($ex->getMessage())));
+                    $this->Validation->addValidationResult('Email', sprintf(t('Invitation email failed to send.'), strip_tags($ex->getMessage())));
                     return false;
                 }
             }

--- a/applications/dashboard/views/embed/forum.php
+++ b/applications/dashboard/views/embed/forum.php
@@ -9,7 +9,7 @@ echo heading(t('Embedding'));
 <div class="row form-group">
     <div class="label-wrap-wide">
         <div class="label"><?php echo t('Embed My Forum'); ?></div>
-        <div class="label-description"><?php echo t('Enable embedding description'); ?></div>
+        <div class="label-description"><?php echo t('If you want to embed your forum, enable embedding.'); ?></div>
     </div>
     <div class="input-wrap-right">
     <span id="plaintext-toggle">

--- a/applications/dashboard/views/embed/forum.php
+++ b/applications/dashboard/views/embed/forum.php
@@ -9,7 +9,7 @@ echo heading(t('Embedding'));
 <div class="row form-group">
     <div class="label-wrap-wide">
         <div class="label"><?php echo t('Embed My Forum'); ?></div>
-        <div class="label-description"><?php echo t('If you want to embed your forum or use Vanilla\'s comments in your blog then you need to enable embedding. If you aren\'t using embedding then we recommend leaving this setting off.'); ?></div>
+        <div class="label-description"><?php echo t('Enable embedding description'); ?></div>
     </div>
     <div class="input-wrap-right">
     <span id="plaintext-toggle">

--- a/applications/dashboard/views/settings/security.php
+++ b/applications/dashboard/views/settings/security.php
@@ -12,7 +12,7 @@ echo $form->errors();
         <li class="form-group">
             <?php
             $leavingLabel = 'Warn users if a link in a post will cause them to leave the forum';
-            $leavingDesc = '@'.t('External link alert details';
+            $leavingDesc = '@'.t('External link alert details');
             echo $form->toggle('Garden.Format.WarnLeaving', $leavingLabel, [], $leavingDesc);
             ?>
         </li>

--- a/applications/dashboard/views/settings/security.php
+++ b/applications/dashboard/views/settings/security.php
@@ -12,8 +12,7 @@ echo $form->errors();
         <li class="form-group">
             <?php
             $leavingLabel = 'Warn users if a link in a post will cause them to leave the forum';
-            $leavingDesc = 'Alert users if they click a link in a post that will lead them away from the forum. ';
-            $leavingDesc .= 'Users will not be warned when following links that match a Trusted Domain.';
+            $leavingDesc = '@'.t('External link alert details';
             echo $form->toggle('Garden.Format.WarnLeaving', $leavingLabel, [], $leavingDesc);
             ?>
         </li>

--- a/applications/dashboard/views/settings/security.php
+++ b/applications/dashboard/views/settings/security.php
@@ -12,7 +12,7 @@ echo $form->errors();
         <li class="form-group">
             <?php
             $leavingLabel = 'Warn users if a link in a post will cause them to leave the forum';
-            $leavingDesc = '@'.t('External link alert details');
+            $leavingDesc = '@'.t('Alert users if they click external link.');
             echo $form->toggle('Garden.Format.WarnLeaving', $leavingLabel, [], $leavingDesc);
             ?>
         </li>

--- a/applications/vanilla/locale/en.php
+++ b/applications/vanilla/locale/en.php
@@ -8,6 +8,8 @@
  * @since 2.0
  */
 
+$Definition['Allow links to be transformed'] = 'Allow links to be transformed into embedded representations in discussions and comments. 
+    For example, a YouTube link will transform into an embedded video.';
 $Definition['EmbeddedDiscussionFormat'] = '<div class="EmbeddedContent">{Image}<strong>{Title}</strong>
 <p>{Excerpt}</p>
 <p><a href="{Url}">Read the full story here</a></p><div class="ClearFix"></div></div>';

--- a/applications/vanilla/locale/en.php
+++ b/applications/vanilla/locale/en.php
@@ -1,4 +1,5 @@
 <?php if (!defined('APPLICATION')) exit();
+// phpcs:ignoreFile
 /**
  * Vanilla's default locale.
  *
@@ -8,8 +9,8 @@
  * @since 2.0
  */
 
-$Definition['Allow links to be transformed'] = 'Allow links to be transformed into embedded representations in discussions and comments. 
-    For example, a YouTube link will transform into an embedded video.';
+$Definition['Allow links to be transformed'] =
+    'Allow links to be transformed into embedded representations in discussions and comments. For example, a YouTube link will transform into an embedded video.';
 $Definition['EmbeddedDiscussionFormat'] = '<div class="EmbeddedContent">{Image}<strong>{Title}</strong>
 <p>{Excerpt}</p>
 <p><a href="{Url}">Read the full story here</a></p><div class="ClearFix"></div></div>';

--- a/applications/vanilla/views/vanillasettings/posting.php
+++ b/applications/vanilla/views/vanillasettings/posting.php
@@ -25,7 +25,7 @@ echo $form->errors();
     <div class="form-group">
         <?php
         $embedsLabel = 'Enable link embeds in discussions and comments';
-        $embedsDesc = '@'.t('Embedding description');
+        $embedsDesc = '@'.t('Allow links to be transformed');
         echo $form->toggle('Garden.Format.DisableUrlEmbeds', $embedsLabel, [], $embedsDesc, true);
         ?>
     </div>

--- a/applications/vanilla/views/vanillasettings/posting.php
+++ b/applications/vanilla/views/vanillasettings/posting.php
@@ -25,8 +25,7 @@ echo $form->errors();
     <div class="form-group">
         <?php
         $embedsLabel = 'Enable link embeds in discussions and comments';
-        $embedsDesc = 'Allow links to be tranformed into embedded representations in discussions and comments. ';
-        $embedsDesc .= 'For example, a YouTube link will transform into an embedded video.';
+        $embedsDesc = '@'.t('Embedding description');
         echo $form->toggle('Garden.Format.DisableUrlEmbeds', $embedsLabel, [], $embedsDesc, true);
         ?>
     </div>


### PR DESCRIPTION
Some translation string codes are shortened by vanilla/locales#266. This PR changes the args of the relevant t() function calls to match the shortened codes.

Addresses vanilla/locales#264