### PR TITLE
Add the "Selects" argument to the BeforeGetID event fired in the discussion model.

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1898,17 +1898,27 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
      */
     public function getID($discussionID, $dataSetType = DATASET_TYPE_OBJECT, $options = []) {
         $session = Gdn::session();
+
+        $selects = [];
+        $this->EventArguments['Selects'] = &$selects;
         $this->fireEvent('BeforeGetID');
 
         $this->options($options);
 
-        $discussion = $this->SQL
+        $this->SQL
             ->select('d.*')
             ->select('w.DateLastViewed, w.Dismissed, w.Bookmarked')
             ->select('w.CountComments', '', 'CountCommentWatch')
             ->select('w.Participated')
             ->select('d.DateLastComment', '', 'LastDate')
-            ->select('d.LastCommentUserID', '', 'LastUserID')
+            ->select('d.LastCommentUserID', '', 'LastUserID');
+
+        // Add select of additional fields to the SQL object.
+        foreach ($selects as $select) {
+            $this->SQL->select($select);
+        }
+
+        $discussion = $this->SQL
             ->from('Discussion d')
             ->join('UserDiscussion w', 'd.DiscussionID = w.DiscussionID and w.UserID = '.$session->UserID, 'left')
             ->where('d.DiscussionID', $discussionID)


### PR DESCRIPTION
This change has been made following the PRs below.

https://github.com/vanilla/vanilla/pull/10187
https://github.com/vanillaforums/mse/pull/167

This change will allow plugins to hook into the `beforeGetID` event fired in the DiscussionModel and add fields to the query that are expected in the result. The "Selects" array is now passed as event argument, in which additional columns can be added to.

Before this change, it was only possible to add fields by grabbing the SQL object from the plugin and call the select method on it, which is not a good practice in general.

This same logic was added to the `getWhere` function of the discussion model a few days ago. (can be found in the first linked PR above)