### PR TITLE
Refresh page after deleting route

### DIFF
--- a/applications/dashboard/controllers/class.routescontroller.php
+++ b/applications/dashboard/controllers/class.routescontroller.php
@@ -131,6 +131,8 @@ class RoutesController extends DashboardController {
             redirectTo('dashboard/routes');
         }
 
+        $this->jsonTarget('', '', 'Refresh');
+
         $this->render();
     }
 


### PR DESCRIPTION
Similar to #7728

After deleting a route, the page did not refresh, which could confuse users.