### PR TITLE
Backport: Fix firing PSR-14 user events for users with empty password fields

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -940,10 +940,7 @@ class UsersApiController extends AbstractApiController {
      */
     public function userSchema($type = '') {
         if ($this->userSchema === null) {
-            $schema = Schema::parse(['userID', 'name', 'email', 'photoUrl', 'points', 'emailConfirmed',
-                'showEmail', 'bypassSpam', 'banned', 'dateInserted', 'dateLastActive', 'dateUpdated', 'roles?']);
-            $schema = $schema->add($this->fullSchema());
-            $this->userSchema = $this->schema($schema, 'User');
+            $this->userSchema = $this->schema($this->userModel->readSchema(), 'User');
         }
         return $this->schema($this->userSchema, $type);
     }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2527,7 +2527,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
      */
     private function eventFromRow(array $row, string $action): UserEvent {
         $user = $this->normalizeRow($row, false);
-        $user = $this->schema()->validate($user);
+        $user = $this->userSchema()->validate($user);
         $result = new UserEvent(
             $action,
             ["user" => $user]
@@ -2609,6 +2609,23 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
         ]);
         return $result;
     }
+
+
+    /**
+     * Get the user schema without the password.
+     *
+     * @param string $type The type of schema.
+     * @return Schema Returns a schema object.
+     */
+    public function userSchema() {
+            $schema = Schema::parse(['userID', 'name', 'hashMethod', 'email', 'photo', 'photoUrl', 'points',
+                'emailConfirmed', 'showEmail', 'bypassSpam', 'banned', 'dateInserted',
+                'dateLastActive', 'dateUpdated']);
+            $schema = $schema->add($schema);
+
+            return $schema;
+    }
+
 
     /**
      * Create an admin user account.

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2614,7 +2614,6 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
     /**
      * Get the user schema without the password.
      *
-     * @param string $type The type of schema.
      * @return Schema Returns a schema object.
      */
     public function userSchema() {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2527,7 +2527,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
      */
     private function eventFromRow(array $row, string $action): UserEvent {
         $user = $this->normalizeRow($row, false);
-        $user = $this->userSchema()->validate($user);
+        $user = $this->readSchema()->validate($user);
         $result = new UserEvent(
             $action,
             ["user" => $user]
@@ -2610,21 +2610,31 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
         return $result;
     }
 
-
     /**
-     * Get the user schema without the password.
+     * A schema representing fields relevant to reading and displaying user info (e.g. no password).
      *
-     * @return Schema Returns a schema object.
+     * @return Schema
      */
-    public function userSchema() {
-            $schema = Schema::parse(['userID', 'name', 'hashMethod', 'email', 'photo', 'photoUrl', 'points',
-                'emailConfirmed', 'showEmail', 'bypassSpam', 'banned', 'dateInserted',
-                'dateLastActive', 'dateUpdated']);
-            $schema = $schema->add($schema);
+    public function readSchema() {
+            $result = Schema::parse([
+                "banned",
+                "bypassSpam",
+                "email",
+                "emailConfirmed",
+                "dateInserted",
+                "dateLastActive",
+                "dateUpdated",
+                "name",
+                "photoUrl",
+                "points",
+                "roles?",
+                "showEmail",
+                "userID",
+            ]);
+            $result->add($this->schema());
 
-            return $schema;
+            return $result;
     }
-
 
     /**
      * Create an admin user account.


### PR DESCRIPTION
Backport: vanilla#10244

This PR will close vanilla/support#1582

Moving the user Schema from the API controller to the usermodel caused a problem when updating the User table when the Password field is empty. This PR will fix that by adding a subset of the full schema to the UserModel.

