### PR TITLE
Fix file upload inputs not being cleared after upload

### DIFF
--- a/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
+++ b/applications/dashboard/src/scripts/forms/DashboardImageUpload.tsx
@@ -50,6 +50,7 @@ export function DashboardImageUpload(props: IProps) {
         <div className={rootClass}>
             <label className="file-upload">
                 <input
+                    key={`${isLoading}`}
                     type="file"
                     id={inputID}
                     className={classes}

--- a/library/src/scripts/forms/themeEditor/ThemeBuilderUpload.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderUpload.tsx
@@ -48,6 +48,7 @@ export function ThemeBuilderUpload(props: IProps) {
                     role="button"
                 >
                     <input
+                        key={`${isLoading}`}
                         className={classNames(visibility().visuallyHidden)}
                         aria-labelledby={labelID}
                         type="file"

--- a/plugins/rich-editor/src/scripts/editor/pieces/EditorUploadButton.tsx
+++ b/plugins/rich-editor/src/scripts/editor/pieces/EditorUploadButton.tsx
@@ -22,7 +22,10 @@ interface IProps extends IWithEditorProps {
     legacyMode: boolean;
 }
 
-export class EditorUploadButton extends React.Component<IProps, {}> {
+export class EditorUploadButton extends React.Component<IProps, { uploadCount: number }> {
+    public state = {
+        uploadCount: 0,
+    };
     private inputRef: React.RefObject<HTMLInputElement> = React.createRef();
 
     public render() {
@@ -42,6 +45,7 @@ export class EditorUploadButton extends React.Component<IProps, {}> {
             >
                 <IconForButtonWrap icon={this.icon} />
                 <input
+                    key={this.state.uploadCount}
                     ref={this.inputRef}
                     onChange={this.onInputChange}
                     className={classNames("richEditor-upload", classesRichEditor.upload)}
@@ -106,6 +110,8 @@ export class EditorUploadButton extends React.Component<IProps, {}> {
         const maxUploads = getMeta("upload.maxUploads", 20);
 
         if (files && embedInsertion) {
+            // Increment the upload count to reset the input.
+            this.setState({ uploadCount: this.state.uploadCount + 1 });
             const filesArray = Array.from(files);
             if (filesArray.length >= maxUploads) {
                 const error = new Error(`Can't upload more than ${maxUploads} files at once.`);


### PR DESCRIPTION
Closes part of https://github.com/vanilla/internal/issues/2299
Older issue of the same thing (that was never resolved but closed anyways) https://github.com/vanilla/vanilla/issues/7864

- HTML input elements with a file type don't fire a change event when if you try to give the same file they already have.
- The only way to clear the existing file is to re-create the input from scratch.
- I've done this just be added a key prop that changes on upload to our 3 image upload components.