### PR TITLE
Add check indicator to active item in `SelectOne` dropdown

### DIFF
--- a/library/src/scripts/features/search/SearchOption.tsx
+++ b/library/src/scripts/features/search/SearchOption.tsx
@@ -69,6 +69,6 @@ export default function SearchOption(props: IProps) {
             </li>
         );
     } else {
-        return <SelectOption {...props} />;
+        return <SelectOption {...props} value={props.data.value} />;
     }
 }

--- a/library/src/scripts/features/search/searchBarStyles.ts
+++ b/library/src/scripts/features/search/searchBarStyles.ts
@@ -16,6 +16,7 @@ import {
     importantUnit,
     getVerticalPaddingForTextInput,
     fonts,
+    flexHelper,
 } from "@library/styles/styleHelpers";
 import { calc, important, percent, px, rgba, translateX } from "csx";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
@@ -214,6 +215,10 @@ export const searchBarClasses = useThemeCache((overwrites = {}) => {
             },
             "& .suggestedTextInput-noOptions": {
                 padding: px(12),
+            },
+            "& .suggestedTextInput-head": {
+                ...flexHelper().middleLeft(),
+                justifyContent: "space-between",
             },
             "& .suggestedTextInput-option": {
                 ...buttonResetMixin(),

--- a/library/src/scripts/forms/select/SelectOne.tsx
+++ b/library/src/scripts/forms/select/SelectOne.tsx
@@ -23,6 +23,7 @@ export interface ISelectOneProps extends IMenuPlacement {
     inputID?: string;
     labelID?: string;
     disabled?: boolean;
+    defaultValue?: IComboBoxOption;
     className?: string;
     placeholder?: string;
     options: IComboBoxOption[] | undefined;
@@ -90,6 +91,7 @@ export default function SelectOne(props: ISelectOneProps) {
                     options={options}
                     inputId={inputID}
                     onChange={props.onChange}
+                    defaultValue={props.defaultValue}
                     onInputChange={props.onInputChange}
                     isClearable={props.isClearable}
                     isDisabled={disabled}

--- a/library/src/scripts/forms/select/overwrites.tsx
+++ b/library/src/scripts/forms/select/overwrites.tsx
@@ -4,11 +4,11 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
+import React, { useDebugValue, useState } from "react";
 import ButtonLoader from "@library/loaders/ButtonLoader";
 import { tokensClasses } from "@library/forms/select/tokensStyles";
 import { t } from "@library/utility/appUtils";
-import { ButtonTypes } from "@library/forms/buttonStyles";
+import { ButtonTypes, buttonClasses } from "@library/forms/buttonStyles";
 import { dropDownClasses } from "@library/flyouts/dropDownStyles";
 import { MultiValueRemoveProps } from "react-select/lib/components/MultiValue";
 import { MenuListComponentProps, MenuProps } from "react-select/lib/components/Menu";
@@ -18,7 +18,9 @@ import classNames from "classnames";
 import { OptionProps } from "react-select/lib/components/Option";
 import { components } from "react-select";
 import { searchBarClasses } from "@library/features/search/searchBarStyles";
-import { CloseCompactIcon, CloseTinyIcon } from "@library/icons/common";
+import { CloseCompactIcon, CloseTinyIcon, CheckIcon, CheckCompactIcon } from "@library/icons/common";
+import { IComboBoxOption } from "@library/features/search/SearchBar";
+import { selectOneClasses } from "@library/forms/select/selectOneStyles";
 
 /**
  * Overwrite for the controlContainer component in React Select
@@ -135,8 +137,9 @@ export function NullComponent() {
  * Overwrite for the menuOption component in React Select
  * @param props
  */
-export function SelectOption(props: OptionProps<any>) {
-    const { isSelected, isFocused } = props;
+export function SelectOption(props: OptionProps<any> & IComboBoxOption) {
+    const { isSelected, isFocused, selectProps, value } = props;
+    const placeholder = {};
 
     return (
         <li className="suggestedTextInput-item">
@@ -150,6 +153,9 @@ export function SelectOption(props: OptionProps<any>) {
             >
                 <span className="suggestedTextInput-head">
                     <span className="suggestedTextInput-title">{props.children}</span>
+                    {(isSelected || value === selectProps.value?.value) && (
+                        <CheckCompactIcon className={selectOneClasses().checkIcon} />
+                    )}
                 </span>
             </button>
         </li>

--- a/library/src/scripts/forms/select/overwrites.tsx
+++ b/library/src/scripts/forms/select/overwrites.tsx
@@ -41,7 +41,7 @@ export function OptionLoader(props: OptionProps<any>) {
         children: <ButtonLoader />,
     };
 
-    return <SelectOption {...props} />;
+    return <SelectOption {...props} value="" />;
 }
 
 /**

--- a/library/src/scripts/forms/select/selectOneStyles.tsx
+++ b/library/src/scripts/forms/select/selectOneStyles.tsx
@@ -61,5 +61,9 @@ export const selectOneClasses = useThemeCache(() => {
         },
     });
 
-    return { inputWrap };
+    const checkIcon = style("checkIcon", {
+        color: colorOut(globalVars.mainColors.primary),
+    });
+
+    return { inputWrap, checkIcon };
 });

--- a/library/src/scripts/forms/themeEditor/ThemeDropDown.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeDropDown.tsx
@@ -58,6 +58,7 @@ export function ThemeDropDown(_props: IProps) {
                     options={options}
                     value={selectedOption}
                     placeholder={defaultOption.label}
+                    defaultValue={defaultOption}
                     disabled={disabled ?? options.length === 1}
                     menuPlacement={MenuPlacement.AUTO}
                     isClearable={false}


### PR DESCRIPTION
Closes part of https://github.com/vanilla/internal/issues/2299

> There seems to have been a glitch when you selected different values for the banner alignment that seemed like a bug. You had to select the same item again to get it to take effect.

The issue was that we had no good indicator on which is item is currently selected from the dropdown. This could be confusing, so I've added our compact check as the current indicator of the selected value.

![image](https://user-images.githubusercontent.com/1770056/77097002-7f752680-69e6-11ea-99e4-ae617db47a7c.png)

This is consistent with some of the newer mockups we've had recently anyways.

![image](https://user-images.githubusercontent.com/1770056/77097060-9451ba00-69e6-11ea-847b-1d2780cb3699.png)
