### PR TITLE
Fix username not visible in conversation email when using a subject

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -76,7 +76,7 @@ class ActivityModel extends Gdn_Model {
 
     /** @var FormatService */
     private $formatService;
-    
+
     /**
      * Defines the related database table name.
      *
@@ -1136,7 +1136,7 @@ class ActivityModel extends Gdn_Model {
         $emailSubject = $options["EmailSubject"] ?? null;
         $headline = $this->formatService->renderPlainText($activity["Headline"], Formats\HtmlFormat::FORMAT_KEY);
         if ($emailSubject) {
-            $emailSubject = $emailSubject.' '.$headline;
+            $emailSubject = $headline.' in '.$emailSubject;
         }
         $result = $emailSubject ?: $headline;
         return $result;

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -76,6 +76,7 @@ class ActivityModel extends Gdn_Model {
 
     /** @var FormatService */
     private $formatService;
+    
     /**
      * Defines the related database table name.
      *


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/921

### To Test 

- Enable conversations with subject $Configuration['Conversations']['Subjects']['Visible'] = true;
- Send a message to a user with a subject
- email received should have the sender's name added to the subject
- test again with $Configuration['Conversations']['Subjects']['Visible'] = false, you should still see the username.

