### PR TITLE
Fix swagger try-it not appearing in the dashboard

### DIFF
--- a/library/src/scripts/content/userContentStyles.ts
+++ b/library/src/scripts/content/userContentStyles.ts
@@ -361,17 +361,17 @@ export const userContentClasses = useThemeCache(() => {
     };
 
     const tables: NestedCSSSelectors = {
-        "& table": {
+        "& > table": {
             width: "100% !important",
         },
-        "& td": {
+        "& > table td": {
             ...borders(),
             ...paddings({
                 vertical: 6,
                 horizontal: 12,
             }),
         },
-        "& tr td": {
+        "& > table tr td": {
             fontWeight: globalVars.fonts.weights.bold,
         },
     };

--- a/library/src/scripts/features/swagger/swaggerStyles.scss
+++ b/library/src/scripts/features/swagger/swaggerStyles.scss
@@ -110,3 +110,7 @@
         flex-direction: column;
     }
 }
+
+.tryIt .swagger-ui .try-out {
+    display: block;
+}

--- a/library/src/scripts/features/swagger/useSwaggerUI.ts
+++ b/library/src/scripts/features/swagger/useSwaggerUI.ts
@@ -24,11 +24,17 @@ function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
     return value !== null && value !== undefined;
 }
 
-export function useSwaggerUI(_options: { url?: string; spec?: object; [key: string]: any }) {
-    const { url, spec } = _options;
+export function useSwaggerUI(_options: { url?: string; spec?: object; [key: string]: any; tryIt?: boolean }) {
+    const { url, spec, tryIt = false } = _options;
     const [headings, setHeadings] = useState<ISwaggerHeading[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const swaggerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+        if (tryIt && swaggerRef.current && !swaggerRef.current.classList.contains("tryIt")) {
+            swaggerRef.current.classList.add("tryIt");
+        }
+    }, [tryIt]);
 
     useEffect(() => {
         importSwagger().then(SwaggerUIConstructor => {

--- a/plugins/swagger-ui/src/scripts/entries/admin.tsx
+++ b/plugins/swagger-ui/src/scripts/entries/admin.tsx
@@ -22,6 +22,7 @@ function SwaggerUI() {
             return request;
         },
         url: siteUrl("/api/v2/open-api/v3" + window.location.search),
+        tryIt: true,
     });
 
     return <div ref={swaggerRef}></div>;


### PR DESCRIPTION
Our recent changes caused it to be hidden away with some CSS. In reality we only wanted this working sometimes, so I added a param for it and now have enabled it for the dashboard.

I also tweaked some table styles that were conflicting with it's UI a little.