### PR TITLE
Add the HtmlUtils::formatTags() method

### DIFF
--- a/library/Vanilla/Utility/HtmlUtils.php
+++ b/library/Vanilla/Utility/HtmlUtils.php
@@ -72,7 +72,7 @@ final class HtmlUtils {
      *
      * Examples
      *
-     * ```
+     * ```php
      * StringUtils::formatTags('test');
      * // returns 'test'
      *
@@ -91,6 +91,7 @@ final class HtmlUtils {
      * // You can replace a string value using a self-closing tag with a string argument.
      * StringUtils::formatTags('Hello <0 />', 'world');
      * // returns 'Hello world'
+     * ```
      *
      * @param string $format The string to format.
      * @param mixed $args Arguments that will replace the tags in the string.

--- a/library/Vanilla/Utility/HtmlUtils.php
+++ b/library/Vanilla/Utility/HtmlUtils.php
@@ -28,7 +28,7 @@ final class HtmlUtils {
             }
 
             if (is_array($val) && strpos($name, 'data-') === 0) {
-                $val = json_encode($val);
+                $val = json_encode($val, JSON_UNESCAPED_UNICODE);
             }
 
             if ($val === true) {

--- a/library/Vanilla/Utility/HtmlUtils.php
+++ b/library/Vanilla/Utility/HtmlUtils.php
@@ -8,21 +8,117 @@
 namespace Vanilla\Utility;
 
 /**
- * Utilities related to HMTL formatting.
+ * Utilities related to HTML formatting.
+ *
+ * DO NOT ADD PROPERTIES OR NON-STATIC METHODS TO THIS CLASS.
  */
-class HtmlUtils {
+final class HtmlUtils {
+    /**
+     * Takes an array of attributes and formats them in attribute="value" format.
+     *
+     * @param array $attributes The attribute array to format.
+     * @return string Returns a string in ` attribute="value" attribute="value"` format.
+     */
+    public static function attributes(array $attributes): string {
+        $result = '';
+
+        foreach ($attributes as $name => $val) {
+            if (is_numeric($name) || in_array($val, [false, null], true)) {
+                continue;
+            }
+
+            if (is_array($val) && strpos($name, 'data-') === 0) {
+                $val = json_encode($val);
+            }
+
+            if ($val === true) {
+                $result .= ' '.$name;
+            } else {
+                $result .= ' '.$name.'="'.htmlspecialchars($val, ENT_COMPAT, 'UTF-8').'"';
+            }
+        }
+        return $result;
+    }
 
     /**
-     * Join some group of CSS classnames.
+     * Join some group of CSS class names.
      *
-     * @param mixed[] $args Multiple CSS classnames to join together. Items may be string or null.
+     * @param mixed[] $args Multiple CSS class names to join together. Items may be string or null.
      *
      * @return string The CSS classes joined together.
      */
     public static function classNames(...$args): string {
         $args = array_filter($args, function ($item) {
-            return is_string($item);
+            return is_string($item) && $item !== '';
         });
         return implode(' ', $args);
+    }
+
+    /**
+     * Similar to `sprintf()`, but uses numbered HTML tags for replacement instead of `%s`.
+     *
+     * Can accept source strings with interpolated translation components in a form such as:
+     * - "Published on <0/> by <1 />."
+     * - "For more information, please see our <0>public documentation</0>."
+     *
+     * About the placeholders:
+     * - Self closing placeholders will be replace with the result from the argument that has a corresponding index.
+     *   Eg. "<0/>" will be replaced by the first argument.
+     *   "<3 />" will be replaced by the fourth argument.
+     * - Placeholders content will have their translated content passed as an argument to their callback prop.
+     *
+     * Limitations
+     * - These tag's CANNOT be nested currently.
+     *
+     * Examples
+     *
+     * ```
+     * StringUtils::formatTags('test');
+     * // returns 'test'
+     *
+     * StringUtils::formatTags('Hello <0/>');
+     * // error, no argument provided
+     *
+     * StringUtils::formatTags('This is <0>important</0>', 'strong');
+     * // returns 'This is <strong>important</strong>'
+     *
+     * StringUtils::formatTags('Hello <0/> world!', ['img', 'src' => '//example.com/foo.png']);
+     * // returns 'Hello <img src="//example.com/foo.png" /> world!'
+     *
+     * StringUtils::formatTags('Visit <0>our site</0> for help.', ['a', 'href' => 'http://site.com']);
+     * // returns 'Visit <a href="http://site.com">our site</a> for help.'
+     *
+     * // You can replace a string value using a self-closing tag with a string argument.
+     * StringUtils::formatTags('Hello <0 />', 'world');
+     * // returns 'Hello world'
+     *
+     * @param string $format The string to format.
+     * @param mixed $args Arguments that will replace the tags in the string.
+     * @return string Returns the formatted string.
+     */
+    public static function formatTags(string $format, ...$args): string {
+        $r = preg_replace_callback('`<(/)?([\d]+)(\s*/?)>`', function ($m) use ($args, $format) {
+            $index = $m[2];
+
+            if (!isset($args[$index])) {
+                trigger_error("Invalid tag: ".$m[0], E_USER_NOTICE);
+                return '';
+            } else {
+                $arg = (array)$args[$index];
+            }
+
+            if (!empty($m[1])) {
+                // This is a closing tag.
+                return "</{$arg[0]}>";
+            } elseif (!empty($m[3]) && is_string($args[$index])) {
+                // This is a self-closing tag with a string literal.
+                return $args[$index];
+            } else {
+                // This is an opening tag or a self-closing tag.
+                return '<'.$arg[0].self::attributes($arg).$m[3].'>';
+            }
+        }, $format);
+
+        return $r;
     }
 }

--- a/library/core/functions.general.php
+++ b/library/core/functions.general.php
@@ -288,40 +288,6 @@ if (!function_exists('arrayValueI')) {
     }
 }
 
-if (!function_exists('attribute')) {
-    /**
-     * Takes an attribute (or array of attributes) and formats them in attribute="value" format.
-     *
-     * @param string|array $name The attribute array or the name of the attribute.
-     * @param mixed $valueOrExclude The value of the attribute or a prefix of attribute names to exclude.
-     * @return string Returns a string in attribute="value" format.
-     */
-    function attribute($name, $valueOrExclude = '') {
-        $return = '';
-        if (!is_array($name)) {
-            $name = [$name => $valueOrExclude];
-            $exclude = '';
-        } else {
-            $exclude = $valueOrExclude;
-        }
-
-        foreach ($name as $attribute => $val) {
-            if ((empty($val) && !in_array($val, [0, '0'], true)) || ($exclude && stringBeginsWith($attribute, $exclude))) {
-                continue;
-            }
-
-            if (is_array($val) && strpos($attribute, 'data-') === 0) {
-                $val = json_encode($val);
-            }
-
-            if ($val != '' && $attribute != 'Standard') {
-                $return .= ' '.$attribute.'="'.htmlspecialchars($val, ENT_COMPAT, 'UTF-8').'"';
-            }
-        }
-        return $return;
-    }
-}
-
 if (!function_exists('calculateNumberOfPages')) {
     /**
      * Calculate the total number of pages based on the total items and items per page.

--- a/library/deprecated/functions.deprecated.php
+++ b/library/deprecated/functions.deprecated.php
@@ -951,3 +951,38 @@ if (!function_exists('\Gdn::config()->touch')) {
         Gdn::config()->touch($name, $default);
     }
 }
+
+if (!function_exists('attribute')) {
+    /**
+     * Takes an attribute (or array of attributes) and formats them in attribute="value" format.
+     *
+     * @param string|array $name The attribute array or the name of the attribute.
+     * @param mixed $valueOrExclude The value of the attribute or a prefix of attribute names to exclude.
+     * @return string Returns a string in attribute="value" format.
+     * @deprecated Use HtmlUtils::attributes() instead.
+     */
+    function attribute($name, $valueOrExclude = '') {
+        $return = '';
+        if (!is_array($name)) {
+            $name = [$name => $valueOrExclude];
+            $exclude = '';
+        } else {
+            $exclude = $valueOrExclude;
+        }
+
+        foreach ($name as $attribute => $val) {
+            if ((empty($val) && !in_array($val, [0, '0'], true)) || ($exclude && stringBeginsWith($attribute, $exclude))) {
+                continue;
+            }
+
+            if (is_array($val) && strpos($attribute, 'data-') === 0) {
+                $val = json_encode($val);
+            }
+
+            if ($val != '' && $attribute != 'Standard') {
+                $return .= ' '.$attribute.'="'.htmlspecialchars($val, ENT_COMPAT, 'UTF-8').'"';
+            }
+        }
+        return $return;
+    }
+}

--- a/tests/Library/Vanilla/Utility/HtmlUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/HtmlUtilsTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Utility;
+
+use PHPUnit\Framework\TestCase;
+use Vanilla\Utility\HtmlUtils;
+
+/**
+ * Tests for the `HtmlUtils` class.
+ */
+final class HtmlUtilsTest extends TestCase {
+    /**
+     * Tests for `HtmlUtils::classNames()`
+     *
+     * @param array $args
+     * @param string $expected
+     * @dataProvider provideClassNameTests
+     */
+    public function testClassNames(array $args, string $expected): void {
+        $actual = HtmlUtils::classNames(...$args);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Provide tests for `testClassNames()`.
+     * @return array
+     */
+    public function provideClassNameTests(): array {
+        $r = [
+            [[''], ''],
+            [['foo', 'bar'], 'foo bar'],
+            [['foo', null, 'bar'], 'foo bar'],
+            [['foo', '', 'bar'], 'foo bar'],
+        ];
+        return $r;
+    }
+
+    /**
+     * Formatting tags when the argument isn't supplied is a notice.
+     */
+    public function testFormatTagsInvalidArgNotice(): void {
+        $actual = @HtmlUtils::formatTags('Hello <0/>');
+        $this->assertSame('Hello ', $actual);
+
+        $this->expectNotice();
+        $this->expectExceptionMessage('<0/>');
+        HtmlUtils::formatTags('Hello <0/>');
+    }
+
+    /**
+     * Test various format tag formats.
+     *
+     * @param string $format
+     * @param string $expected
+     * @dataProvider provideFormatTagFormats
+     */
+    public function testFormatTagsFormats(string $format, string $expected): void {
+        $args = [
+            'b',
+            ['img', 'src' => '//example.com/foo.png'],
+            ['a', 'href' => 'http://site.com'],
+            'world'
+        ];
+
+        $actual = HtmlUtils::formatTags($format, ...$args);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Provide various formats for `testFormatTagsFormats()`.
+     *
+     * @return array
+     */
+    public function provideFormatTagFormats(): array {
+        $r = [
+            ['test', 'test'],
+            ['Hello <1 /> world!', 'Hello <img src="//example.com/foo.png" /> world!'],
+            ['This is <0>important</0>', 'This is <b>important</b>'],
+            ['Visit <2>our site</2> for help.', 'Visit <a href="http://site.com">our site</a> for help.'],
+            ["<0>a</0>\n<0>b</0>", "<b>a</b>\n<b>b</b>"],
+            ['Hello <3/>', 'Hello world'],
+            ['<b>a</b>', '<b>a</b>'],
+        ];
+
+        return array_column($r, null, 0);
+    }
+
+    /**
+     * Tests for `HtmlUtils::attributes()`.
+     *
+     * @param array $attributes
+     * @param string $expected
+     * @dataProvider provideAttributesTests
+     */
+    public function testAttributes(array $attributes, string $expected): void {
+        $actual = HtmlUtils::attributes($attributes);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Provide tests for `testAttributes()`.
+     *
+     * @return array
+     */
+    public function provideAttributesTests(): array {
+        $r = [
+            'empty' => [[], ''],
+            'one' => [['a' => 'b'], ' a="b"'],
+            'two' => [['a' => 'b', 'c' => 'd'], ' a="b" c="d"'],
+            'bool true' => [['type' => 'checkbox', 'checked' => true], ' type="checkbox" checked'],
+            'bool false' => [['type' => 'checkbox', 'checked' => false], ' type="checkbox"'],
+            'json data' => [['data-foo' => ['a' => 'b']], ' data-foo="{&quot;a&quot;:&quot;b&quot;}"'],
+        ];
+        return $r;
+    }
+}

--- a/tests/Library/Vanilla/Utility/HtmlUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/HtmlUtilsTest.php
@@ -48,7 +48,7 @@ final class HtmlUtilsTest extends TestCase {
         $this->assertSame('Hello ', $actual);
 
         $this->expectNotice();
-        $this->expectExceptionMessage('<0/>');
+        $this->expectNoticeMessage('<0/>');
         HtmlUtils::formatTags('Hello <0/>');
     }
 
@@ -115,6 +115,7 @@ final class HtmlUtilsTest extends TestCase {
             'bool true' => [['type' => 'checkbox', 'checked' => true], ' type="checkbox" checked'],
             'bool false' => [['type' => 'checkbox', 'checked' => false], ' type="checkbox"'],
             'json data' => [['data-foo' => ['a' => 'b']], ' data-foo="{&quot;a&quot;:&quot;b&quot;}"'],
+            'unicode json' => [['data-foo' => ['a' => 'ぁ']], ' data-foo="{&quot;a&quot;:&quot;ぁ&quot;}"'],
         ];
         return $r;
     }


### PR DESCRIPTION
This method provides a PHP implementation similar to our [Translate component](https://github.com/vanilla/vanilla/blob/fc69c3cc00298ef0b7711b634fbcef72731fed86/library/src/scripts/content/Translate.tsx#L51) so that we can use the same translation strings on the client and server.