### PR TITLE
Foundation - Tag styles

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/discussionStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/discussionStyles.ts
@@ -83,4 +83,12 @@ export const discussionCSS = () => {
             left: 2,
         },
     );
+
+    cssOut(`.Container .DataTable span.MItem`, {
+        display: "inline-block",
+    });
+
+    cssOut(`.Container .DataTable span.MItem a`, {
+        display: "inline",
+    });
 };

--- a/applications/dashboard/src/scripts/compatibilityStyles/fontStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/fontStyles.ts
@@ -125,8 +125,8 @@ export const fontCSS = () => {
 
     cssOut(
         `
-        .Panel .Box a:not(.Button),
-        .Panel .BoxFilter a:not(.Button),
+        .Panel .Box a:not(.Button):not(.Tag),
+        .Panel .BoxFilter a:not(.Button):not(.Tag),
         body.Section-EditProfile .Box .PanelCategories li.Depth3 a,
         body.Section-EditProfile .Box .PanelCategories li.Depth4 a,
         body.Section-EditProfile .Box .PanelCategories li.Depth5 a,

--- a/applications/dashboard/src/scripts/compatibilityStyles/forumMetaStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/forumMetaStyles.ts
@@ -54,15 +54,20 @@ export const forumMetaCSS = () => {
     );
 
     const linkSelectors = `
-        .MessageList .ItemDiscussion .MItem.RoleTracker a,
-        .MessageList .ItemComment .MItem.RoleTracker a,
+        .MessageList .ItemDiscussion .MItem.RoleTracker a:not(.Tag),
+        .MessageList .ItemComment .MItem.RoleTracker a:not(.Tag),
         .MainContent.Content .MessageList.Discussion .Item.ItemComment .MItem.RoleTracker a,
-        .MainContent.Content .MItem.RoleTracker a,
+        .MainContent.Content .MItem.RoleTracker a:not(.Tag),
         .MessageList .ItemComment .Username,
         .MessageList .ItemDiscussion .Username,
-        .AuthorInfo .MItem.RoleTracker,
+        .AuthorInfo .MItem.RoleTracker a:not(.Tag),
         .MItem > a,
         `;
+
+    cssOut(`.MessageList .ItemComment span.MItem.RoleTracker`, {
+        padding: 0,
+        margin: 0,
+    });
 
     // Links
     cssOut(linkSelectors, {
@@ -103,10 +108,10 @@ export const forumMetaCSS = () => {
 
     cssOut(
         `
-        .MessageList .ItemDiscussion .MItem.RoleTracker a,
-        .MessageList .ItemComment .MItem.RoleTracker a,
-        .MainContent.Content .MessageList.Discussion .Item.ItemComment .MItem.RoleTracker a,
-        .MainContent.Content .MItem.RoleTracker a,
+        .MessageList .ItemDiscussion .MItem.RoleTracker a:not(.Tag),
+        .MessageList .ItemComment .MItem.RoleTracker a:not(.Tag),
+        .MainContent.Content .MessageList.Discussion .Item.ItemComment .MItem.RoleTracker a:not(.Tag),
+        .MainContent.Content .MItem.RoleTracker a:not(.Tag),
     `,
         {
             ...paddings({
@@ -173,7 +178,7 @@ export const forumMetaCSS = () => {
         `
     .AuthorWrap a.Username,
     .AuthorInfo .MItem,
-    .DiscussionMeta .MItem
+    .DiscussionMeta .MItem,
     `,
         {
             ...paddings({
@@ -212,7 +217,6 @@ export const forumMetaCSS = () => {
 
     cssOut(
         `
-    .Content .Meta-Discussion > .Tag,
     .Content  .idea-counter-module
     `,
         {

--- a/applications/dashboard/src/scripts/compatibilityStyles/forumMetaStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/forumMetaStyles.ts
@@ -56,12 +56,12 @@ export const forumMetaCSS = () => {
     const linkSelectors = `
         .MessageList .ItemDiscussion .MItem.RoleTracker a:not(.Tag),
         .MessageList .ItemComment .MItem.RoleTracker a:not(.Tag),
-        .MainContent.Content .MessageList.Discussion .Item.ItemComment .MItem.RoleTracker a,
+        .MainContent.Content .MessageList.Discussion .Item.ItemComment .MItem.RoleTracker a:not(.Tag),
         .MainContent.Content .MItem.RoleTracker a:not(.Tag),
         .MessageList .ItemComment .Username,
         .MessageList .ItemDiscussion .Username,
         .AuthorInfo .MItem.RoleTracker a:not(.Tag),
-        .MItem > a,
+        .MItem > a:not(.Tag),
         `;
 
     cssOut(`.MessageList .ItemComment span.MItem.RoleTracker`, {
@@ -136,9 +136,15 @@ export const forumMetaCSS = () => {
         },
     );
 
-    cssOut(`.Content .MessageList .RoleTracker > .Tag, .Tag`, {
-        color: colorOut(globalVars.mainColors.fg),
-    });
+    cssOut(
+        `
+        .Content .MessageList .RoleTracker > .Tag,
+        .Tag
+        `,
+        {
+            color: colorOut(globalVars.mainColors.fg),
+        },
+    );
 
     cssOut(
         `

--- a/applications/dashboard/src/scripts/compatibilityStyles/forumTagStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/forumTagStyles.ts
@@ -43,7 +43,14 @@ export const forumTagCSS = () => {
 
     mixinTag(`.Tag`);
     mixinTag(`.DataTableWrap a.Tag`);
-    mixinTag(`.Container .MessageList .ItemComment .MItem.RoleTracker a`);
+    mixinTag(`.Container .MessageList .ItemComment .MItem.RoleTracker .Tag`);
+    mixinTag(
+        `
+        .MessageList .ItemComment .MItem.RoleTracker a.Tag,
+        .MessageList .ItemDiscussion .MItem.RoleTracker a.Tag,
+        .MessageList .ItemComment .MItem.RoleTracker,
+        `,
+    );
 };
 
 function mixinTag(selector: string, overwrite?: {}) {
@@ -59,10 +66,10 @@ function mixinTag(selector: string, overwrite?: {}) {
 
     selectors.map(s => {
         cssOut(selector, {
+            color: colorOut(vars.font.color),
             maxWidth: percent(100),
             display: "inline-block",
             whiteSpace: "normal",
-            color: colorOut(vars.colors.fg),
             textDecoration: important("none"),
             textOverflow: "ellipsis",
             ...userSelect(),

--- a/applications/dashboard/src/scripts/compatibilityStyles/forumTagStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/forumTagStyles.ts
@@ -1,0 +1,77 @@
+/**
+ * Compatibility styles, using the color variables.
+ *
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import {
+    borders,
+    paddings,
+    fonts,
+    colorOut,
+    defaultTransition,
+    margins,
+    userSelect,
+    negative,
+} from "@library/styles/styleHelpers";
+import { cssOut, nestedWorkaround, trimTrailingCommas } from "@dashboard/compatibilityStyles/index";
+import { tagVariables } from "@library/styles/tagStyles";
+import { globalVariables } from "@library/styles/globalStyleVars";
+import { important, percent } from "csx";
+
+export const forumTagCSS = () => {
+    const vars = tagVariables();
+
+    cssOut(`.TagCloud`, {
+        ...margins({
+            vertical: negative(vars.margin.vertical),
+            horizontal: negative(vars.margin.horizontal),
+        }),
+        padding: 0,
+    });
+
+    cssOut(".Panel.Panel li.TagCloud-Item", {
+        margin: 0,
+        padding: 0,
+        maxWidth: percent(100),
+    });
+
+    cssOut(`.AuthorInfo .MItem.RoleTracker a`, {
+        textDecoration: important("none"),
+    });
+
+    mixinTag(`.Tag`);
+    mixinTag(`.DataTableWrap a.Tag`);
+    mixinTag(`.Container .MessageList .ItemComment .MItem.RoleTracker a`);
+};
+
+function mixinTag(selector: string, overwrite?: {}) {
+    selector = trimTrailingCommas(selector);
+    const selectors = selector.split(",") || [];
+
+    if (selectors.length === 0) {
+        selectors.push(selector);
+    }
+
+    const vars = tagVariables();
+    const globalVars = globalVariables();
+
+    selectors.map(s => {
+        cssOut(selector, {
+            maxWidth: percent(100),
+            display: "inline-block",
+            whiteSpace: "normal",
+            color: colorOut(vars.colors.fg),
+            textDecoration: important("none"),
+            textOverflow: "ellipsis",
+            ...userSelect(),
+            ...paddings(vars.padding),
+            ...borders(vars.border),
+            ...fonts(vars.font),
+            ...defaultTransition("border"),
+            ...margins(vars.margin),
+        });
+        nestedWorkaround(trimTrailingCommas(s), vars.nested);
+    });
+}

--- a/applications/dashboard/src/scripts/compatibilityStyles/index.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/index.ts
@@ -38,6 +38,7 @@ import { photoGridCSS } from "@dashboard/compatibilityStyles/photoGridStyles";
 import { messagesCSS } from "@dashboard/compatibilityStyles/messagesStyles";
 import { signaturesCSS } from "./signaturesSyles";
 import { searchResultsVariables } from "@vanilla/library/src/scripts/features/search/searchResultsStyles";
+import { forumTagCSS } from "@dashboard/compatibilityStyles/forumTagStyles";
 
 // To use compatibility styles, set '$staticVariables : true;' in custom.scss
 // $Configuration['Feature']['DeferredLegacyScripts']['Enabled'] = true;
@@ -360,6 +361,7 @@ export const compatibilityStyles = useThemeCache(() => {
     buttonCSS();
     flyoutCSS();
     textLinkCSS();
+    forumTagCSS();
     forumMetaCSS();
     inputCSS();
     socialConnectCSS();

--- a/applications/dashboard/src/scripts/compatibilityStyles/tableStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/tableStyles.ts
@@ -52,6 +52,4 @@ export const tableCSS = () => {
             },
         },
     });
-
-    cssOut(".Container .DataTable .DiscussionName .Meta.Meta-Discussion");
 };

--- a/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
@@ -50,7 +50,6 @@ export const textLinkCSS = () => {
     mixinTextLinkNoDefaultLinkAppearance(".DataList .Item h3 a");
     mixinTextLinkNoDefaultLinkAppearance(".DataList .Item a.Title");
     mixinTextLinkNoDefaultLinkAppearance(".DataList .Item .Title a");
-    mixinTextLinkNoDefaultLinkAppearance("a.Tag");
     mixinTextLinkNoDefaultLinkAppearance(".MenuItems a");
     mixinTextLinkNoDefaultLinkAppearance(".DataTable h2 a");
     mixinTextLinkNoDefaultLinkAppearance(".DataTable h3 a");

--- a/applications/vanilla/modules/class.tagmodule.php
+++ b/applications/vanilla/modules/class.tagmodule.php
@@ -108,7 +108,7 @@ class TagModule extends Gdn_Module {
         $this->EventArguments['ParentType'] = $this->ParentType;
         $this->EventArguments['tagData'] = &$tagData;
         $this->fireEvent('getData');
-        
+
         if (is_array($tagData)) {
             $this->_TagData = new Gdn_DataSet($tagData, DATASET_TYPE_ARRAY);
             return;
@@ -239,7 +239,7 @@ endforeach; ?>
 ?>
                     <?php if ($tag['Name'] != '') :
 ?>
-                        <li><?php
+                        <li class="TagCloud-Item"><?php
                             echo anchor(
                                 htmlspecialchars(tagFullName($tag)).' '.wrap(number_format($tag['CountDiscussions']), 'span', ['class' => 'Count']),
                                 tagUrl($tag, '', '/'),

--- a/applications/vanilla/modules/class.tagmodule.php
+++ b/applications/vanilla/modules/class.tagmodule.php
@@ -243,7 +243,7 @@ endforeach; ?>
                             echo anchor(
                                 htmlspecialchars(tagFullName($tag)).' '.wrap(number_format($tag['CountDiscussions']), 'span', ['class' => 'Count']),
                                 tagUrl($tag, '', '/'),
-                                ['class' => 'Tag_'.str_replace(' ', '_', $tag['Name'])]
+                                ['class' => 'Tag_'.str_replace(' ', '_', $tag['Name'])." Tag"]
                             );
                             ?></li>
                     <?php

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -475,9 +475,9 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
 });
 
 export interface IGlobalBorderStyles extends IBorderRadiusOutput {
-    color: ColorValues;
-    width: BorderWidthProperty<TLength> | number;
-    style: BorderStyleProperty;
+    color?: ColorValues;
+    width?: BorderWidthProperty<TLength> | number;
+    style?: BorderStyleProperty;
     radius?: radiusValue;
 }
 

--- a/library/src/scripts/styles/styleHelpersLinks.ts
+++ b/library/src/scripts/styles/styleHelpersLinks.ts
@@ -47,9 +47,24 @@ export interface ILinkColorOverwrites {
     allStates?: ColorValues;
 }
 
+export const EMPTY_LINK_COLOR_OVERWRITES = {
+    default: undefined as undefined | ColorValues,
+    hover: undefined as undefined | ColorValues,
+    focus: undefined as undefined | ColorValues,
+    accessibleFocus: undefined as undefined | ColorValues,
+    active: undefined as undefined | ColorValues,
+    visited: undefined as undefined | ColorValues,
+    allStates: undefined as undefined | ColorValues,
+};
+
 export interface ILinkColorOverwritesWithOptions extends ILinkColorOverwrites {
     skipDefault?: boolean;
 }
+
+export const EMPTY_LINK_COLOR_OVERWRITES_WITH_OPTIONS = {
+    ...EMPTY_LINK_COLOR_OVERWRITES,
+    skipDefault: undefined as undefined | boolean,
+};
 
 export const setAllLinkColors = (overwriteValues?: ILinkColorOverwritesWithOptions) => {
     const vars = globalVariables();

--- a/library/src/scripts/styles/tagStyles.ts
+++ b/library/src/scripts/styles/tagStyles.ts
@@ -1,0 +1,102 @@
+import { useThemeCache, variableFactory } from "@library/styles/styleUtils";
+import { globalVariables } from "@library/styles/globalStyleVars";
+import { borders, EMPTY_BORDER, IBorderStyles } from "@library/styles/styleHelpersBorders";
+import { EMPTY_SPACING } from "@library/styles/styleHelpersSpacing";
+import { EMPTY_FONTS, IFont } from "@library/styles/styleHelpersTypography";
+import {
+    ILinkColorOverwritesWithOptions,
+    setAllLinkColors,
+    EMPTY_LINK_COLOR_OVERWRITES_WITH_OPTIONS,
+} from "@library/styles/styleHelpersLinks";
+import merge from "lodash/merge";
+import { important } from "csx";
+
+export const tagVariables = useThemeCache(() => {
+    const makeThemeVars = variableFactory("forumFonts");
+    const globalVars = globalVariables();
+
+    const colorOverwrite = makeThemeVars("colorOverwrite", {
+        ...(EMPTY_LINK_COLOR_OVERWRITES_WITH_OPTIONS as ILinkColorOverwritesWithOptions),
+    } as ILinkColorOverwritesWithOptions);
+
+    const allStyles = {
+        textDecoration: important("none"),
+    };
+
+    const linkColors = setAllLinkColors(colorOverwrite);
+
+    const allStates = {
+        color: linkColors.nested["&&:hover"].color,
+        ...borders({ color: linkColors.nested["&&:hover"].color } as IBorderStyles, {}),
+    };
+
+    const nested = merge(linkColors.nested, {
+        "&&:hover": {
+            ...allStyles,
+            ...allStates,
+        },
+        "&&:focus": {
+            ...allStyles,
+            ...allStates,
+        },
+        "&&.focus-visible": {
+            ...allStyles,
+            ...allStates,
+        },
+        "&&:active": {
+            ...allStyles,
+            ...allStates,
+        },
+        "&:visited": undefined,
+    });
+
+    const colors = makeThemeVars("color", {
+        fg: linkColors.color,
+    });
+
+    const font = makeThemeVars("font", {
+        ...EMPTY_FONTS,
+        fg: colors.fg,
+        lineHeight: globalVars.lineHeights.meta,
+        size: globalVars.fonts.size.small,
+    } as IFont);
+
+    const padding = makeThemeVars("padding", {
+        ...EMPTY_SPACING,
+        vertical: 2,
+        horizontal: 9,
+    });
+
+    const margin = makeThemeVars("margin", {
+        ...EMPTY_SPACING,
+        vertical: 2,
+        horizontal: globalVars.meta.spacing.default,
+    });
+
+    const border = makeThemeVars("border", {
+        ...EMPTY_BORDER,
+        fg: colors.fg,
+        width: 1, // these are really small, I don't think it makes sense to default to anything else.
+    } as IBorderStyles);
+
+    // If border radius not overwritten, calculate it to be round.
+    if (!border.radius) {
+        border.radius =
+            ((((font.lineHeight || 1.45) as number) * ((font.size as number) ?? 12)) as number) / 2 +
+            padding.vertical +
+            (!!border.width && border.width > 0 ? (border.width as number) : 0);
+    }
+
+    const output = {
+        colors,
+        font,
+        padding,
+        border,
+        nested,
+        margin,
+    };
+
+    return output;
+});
+
+// For now we only have compatibility styles in //forumTagStyles.ts

--- a/packages/vanilla-theme-core/scss/components/_lists.scss
+++ b/packages/vanilla-theme-core/scss/components/_lists.scss
@@ -503,7 +503,9 @@
                 padding: 0 $utility-baseUnitHalf;
 
                 a {
-                    color: inherit;
+                    @if ($staticVariables) {
+                        color: inherit;
+                    }
                     margin: 0;
 
                     &:hover,


### PR DESCRIPTION
Fixed styles for tags to match mockups: https://app.zeplin.io/project/5e271637b9bef8985fd77a08/screen/5e73dd7eb601dab3510c6736

Note that the color and border are a tad different from the mockups, because I used the same ones we have as defaults instead of making new colors.

Closes: https://github.com/vanilla/vanilla/issues/10220