### PR TITLE
Fix static calls and lint on the AliasProviderTrait

### DIFF
--- a/library/Vanilla/AliasProviderTrait.php
+++ b/library/Vanilla/AliasProviderTrait.php
@@ -36,7 +36,7 @@ trait AliasProviderTrait {
      *
      * @return array A mapping of Class Name => AliasName[]
      */
-    protected abstract static function provideAliases(): array;
+    abstract protected static function provideAliases(): array;
 
     /**
      * Get the map of class => alias[]
@@ -45,7 +45,7 @@ trait AliasProviderTrait {
      */
     private static function getClassToAliases(): array {
         if (self::$classToAliases === null) {
-            self::$classToAliases = self::provideAliases();
+            self::$classToAliases = static::provideAliases();
         }
 
         return self::$classToAliases;
@@ -59,7 +59,7 @@ trait AliasProviderTrait {
     private static function getAliasesToClasses(): array {
         if (self::$aliasesToClasses === null) {
             self::$aliasesToClasses = [];
-            foreach (self::getClassToAliases() as $className => $aliases) {
+            foreach (static::getClassToAliases() as $className => $aliases) {
                 foreach ($aliases as $alias) {
                     self::$aliasesToClasses[$alias] = $className;
                 }


### PR DESCRIPTION
My IDE was reporting issues with the `AliasProviderTrait`, specifically the use of `self` on an abstract method. While I don’t think this is a bug for a trait per se, it is a best practice to call methods with `static::` instead of `self::`.