### PR TITLE
Fix theme API filtering

### DIFF
--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -165,7 +165,7 @@ class Addon implements Contracts\AddonInterface {
                     }
                 }
             }
-            
+
             return $info;
         }
 
@@ -427,7 +427,7 @@ class Addon implements Contracts\AddonInterface {
      * @param array $info The new info array to set.
      * @return Addon Returns `$this` for fluent calls.
      */
-    private function setInfo($info) {
+    private function setInfo(array $info) {
         $this->info = $info;
         return $this;
     }
@@ -689,13 +689,9 @@ class Addon implements Contracts\AddonInterface {
     }
 
     /**
-     * Get a single value from the info array.
-     *
-     * @param string $key The key in the info array.
-     * @param mixed $default The default value to return if there is no item.
-     * @return mixed Returns the info value or {@link $default}.
+     * @inheritdoc
      */
-    public function getInfoValue($key, $default = null) {
+    public function getInfoValue(string $key, $default = null) {
         return isset($this->info[$key]) ? $this->info[$key] : $default;
     }
 
@@ -1150,11 +1146,9 @@ class Addon implements Contracts\AddonInterface {
     }
 
     /**
-     * Get the info.
-     *
-     * @return array Returns the info.
+     * @inheritdoc
      */
-    public function getInfo() {
+    public function getInfo(): array {
         return $this->info;
     }
 

--- a/library/Vanilla/Contracts/AddonInterface.php
+++ b/library/Vanilla/Contracts/AddonInterface.php
@@ -24,4 +24,20 @@ interface AddonInterface {
      * @return string The addon key.
      */
     public function getKey(): string;
+
+    /**
+     * Get information about the addon.
+     *
+     * @return array
+     */
+    public function getInfo(): array;
+
+    /**
+     * Get a single value from the info array.
+     *
+     * @param string $key The key in the info array.
+     * @param mixed $default The default value to return if there is no item.
+     * @return mixed Returns the info value or {@link $default}.
+     */
+    public function getInfoValue(string $key, $default = null);
 }

--- a/library/Vanilla/Models/ThemeModelHelper.php
+++ b/library/Vanilla/Models/ThemeModelHelper.php
@@ -62,7 +62,7 @@ class ThemeModelHelper {
             return true;
         }
 
-        $isAdmin = ($this->session->User->Admin ?? 0) !== 0;
+        $isAdmin = ($this->session->User->Admin ?? 0) === 2;
         if ($isAdmin) {
             // All theme visible for system admins.
             return true;

--- a/library/Vanilla/Models/ThemeModelHelper.php
+++ b/library/Vanilla/Models/ThemeModelHelper.php
@@ -69,7 +69,7 @@ class ThemeModelHelper {
         }
 
         $themeKey = $theme->getKey();
-        $alwaysVisibleThemes = array_map('trim', explode(',', $confVisible));
+        $alwaysVisibleThemes = array_map('trim', explode(",", $confVisible));
 
         if (in_array($themeKey, $alwaysVisibleThemes, true)) {
             return true;
@@ -89,10 +89,10 @@ class ThemeModelHelper {
             $sites[] = $site;
         }
 
-        if ($hidden === true) {
-            return false;
-        } elseif ($hidden === true) {
+        if ($hidden === false) {
             return true;
+        } elseif ($hidden === true) {
+            return false;
         } else {
             $hidden = false;
             foreach ($sites as $addonSite) {

--- a/library/Vanilla/Models/ThemeModelHelper.php
+++ b/library/Vanilla/Models/ThemeModelHelper.php
@@ -62,7 +62,8 @@ class ThemeModelHelper {
             return true;
         }
 
-        if ($this->session->getPermissions()->isAdmin()) {
+        $isAdmin = ($this->session->User->Admin ?? 0) !== 0;
+        if ($isAdmin) {
             // All theme visible for system admins.
             return true;
         }

--- a/library/Vanilla/Models/ThemeModelHelper.php
+++ b/library/Vanilla/Models/ThemeModelHelper.php
@@ -6,8 +6,10 @@
 
 namespace Vanilla\Models;
 
+use Vanilla\Contracts\AddonInterface;
 use Vanilla\Contracts\AddonProviderInterface;
 use Gdn_Session as SessionInterface;
+use Vanilla\Addon;
 use Vanilla\Contracts\ConfigurationInterface;
 use Vanilla\Theme\ThemeProviderInterface;
 
@@ -39,6 +41,69 @@ class ThemeModelHelper {
         $this->session = $session;
         $this->addonManager = $addonManager;
         $this->config  = $config;
+    }
+
+    /**
+     * Filter themes based on their addon.json.
+     *
+     * @param AddonInterface $theme A themes data from it's addon.json.
+     * @param string $siteName The vanilla domain of the site.
+     *
+     * @return bool
+     */
+    public function isThemeVisible(AddonInterface $theme, ?string $siteName = null): bool {
+        if ($siteName === null && defined('CLIENT_NAME')) {
+            $siteName = CLIENT_NAME;
+        }
+        $confVisible = $this->config->get('Garden.Themes.Visible', '');
+
+        if ($confVisible === 'all') {
+            // Config setup to show all themes.
+            return true;
+        }
+
+        $isAdmin = ($this->session->User->Admin ?? 0) !== 0;
+        if ($isAdmin) {
+            // All theme visible for system admins.
+            return true;
+        }
+
+        $themeKey = $theme->getKey();
+        $alwaysVisibleThemes = array_map('trim', explode(',', $confVisible));
+
+        if (in_array($themeKey, $alwaysVisibleThemes, true)) {
+            return true;
+        }
+
+        $currentTheme = $this->config->get('Garden.CurrentTheme', $this->config->get('Garden.Theme'));
+        if ($currentTheme === $themeKey) {
+            // Always visible.
+            return true;
+        }
+
+        // Check if theme visibility is set through the JSON.
+        $hidden = $theme->getInfoValue('hidden', null);
+        $sites = $theme->getInfoValue('sites', []);
+        $site = $theme->getInfoValue('site', null);
+        if ($site !== null) {
+            $sites[] = $site;
+        }
+
+        if ($hidden === true) {
+            return false;
+        } elseif ($hidden === true) {
+            return true;
+        } else {
+            $hidden = false;
+            foreach ($sites as $addonSite) {
+                if ($addonSite === $siteName || fnmatch($addonSite, $siteName)) {
+                    $hidden = true;
+                    break;
+                }
+            }
+
+            return $hidden;
+        }
     }
 
     /**
@@ -84,5 +149,14 @@ class ThemeModelHelper {
                 'PreviewThemeName' => ''
             ]
         );
+    }
+
+    /**
+     * Get the current theme key from the config.
+     *
+     * @return string
+     */
+    public function getConfigThemeKey(): string {
+        return $this->config->get('Garden.CurrentTheme', $this->config->get('Garden.Theme'));
     }
 }

--- a/library/Vanilla/Models/ThemeModelHelper.php
+++ b/library/Vanilla/Models/ThemeModelHelper.php
@@ -62,8 +62,7 @@ class ThemeModelHelper {
             return true;
         }
 
-        $isAdmin = ($this->session->User->Admin ?? 0) !== 0;
-        if ($isAdmin) {
+        if ($this->session->getPermissions()->isAdmin()) {
             // All theme visible for system admins.
             return true;
         }

--- a/library/src/scripts/theming/addThemeStyles.ts
+++ b/library/src/scripts/theming/addThemeStyles.ts
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import { unit, paddings, margins, flexHelper } from "@library/styles/styleHelpers";
+import { unit, paddings, flexHelper } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { themeCardVariables } from "./themePreviewCardStyles";
@@ -13,9 +13,6 @@ export const addthemeVariables = useThemeCache(() => {
     const makeThemeVars = variableFactory("currentThemeInfo");
     const globalVars = globalVariables();
 
-    const colors = makeThemeVars("colors", {
-        fg: globalVars.messageColors.warning.fg,
-    });
     const addTheme = makeThemeVars("addTheme", {
         width: percent(100),
         height: percent(100),
@@ -29,7 +26,6 @@ export const addthemeVariables = useThemeCache(() => {
 
 export const addThemeClasses = useThemeCache(() => {
     const vars = addthemeVariables();
-    const globalVars = globalVariables();
 
     const style = styleFactory("addTheme");
 
@@ -50,7 +46,7 @@ export const addThemeClasses = useThemeCache(() => {
 
     const button = style("button", {
         padding: 0,
-        minHeight: 100,
+        minHeight: 200,
         minWidth: themeCardVariables().container.minWidth,
         maxWidth: themeCardVariables().container.maxWidth,
         $nest: {

--- a/tests/APIv2/ThemesTest.php
+++ b/tests/APIv2/ThemesTest.php
@@ -176,6 +176,7 @@ class ThemesTest extends AbstractAPIv2Test {
      *
      */
     public function testIndex() {
+        $this->api()->setUserID(\UserModel::GUEST_USER_ID);
         $response = $this->api()->get("themes");
         $body = $response->getBody();
         $this->assertEquals(3, count($body), 'The 2 unhidden files, and the current are returned');

--- a/tests/MinimalContainerTestCase.php
+++ b/tests/MinimalContainerTestCase.php
@@ -154,6 +154,24 @@ class MinimalContainerTestCase extends TestCase {
     }
 
     /**
+     * Set information about the current user in the session.
+     * @param array $info The user information to set.
+     */
+    public function setUserInfo(array $info) {
+        $session = new \Gdn_Session();
+
+        foreach ($info as $key => $value) {
+            if ($key === 'UserID') {
+                $session->UserID = $value;
+            }
+
+            $session->User = new \stdClass();
+            $session->User->{$key} = $value;
+        }
+        self::container()->setInstance(\Gdn_Session::class, $session);
+    }
+
+    /**
      * Set some configuration key for the tests.
      *
      * @param string $key The config key.

--- a/tests/MinimalContainerTestCase.php
+++ b/tests/MinimalContainerTestCase.php
@@ -165,6 +165,10 @@ class MinimalContainerTestCase extends TestCase {
                 $session->UserID = $value;
             }
 
+            if ($key === 'Admin' && $value > 0) {
+                $session->getPermissions()->setAdmin(true);
+            }
+
             $session->User = new \stdClass();
             $session->User->{$key} = $value;
         }

--- a/tests/Models/ThemeModelHelperTest.php
+++ b/tests/Models/ThemeModelHelperTest.php
@@ -50,6 +50,16 @@ class ThemeModelHelperTest extends MinimalContainerTestCase {
     }
 
     /**
+     * With no other factors test the theme hidden value.
+     */
+    public function testThemeHidden() {
+        $this->assertFalse($this->getHelper()->isThemeVisible(new MockAddon('theme-no-hidden-field')));
+        $this->assertFalse($this->getHelper()->isThemeVisible(new MockAddon('theme-hidden-true', ['hidden' => true])));
+        $this->assertTrue($this->getHelper()->isThemeVisible(new MockAddon('theme-hidden-false', ['hidden' => false])));
+    }
+
+
+    /**
      * Test the configuration based visibilies.
      */
     public function testVisibilityConfig() {

--- a/tests/Models/ThemeModelHelperTest.php
+++ b/tests/Models/ThemeModelHelperTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Models;
+
+use Vanilla\Models\ThemeModelHelper;
+use VanillaTests\Fixtures\MockAddon;
+use VanillaTests\MinimalContainerTestCase;
+
+/**
+ * Tests for the theme helper model.
+ */
+class ThemeModelHelperTest extends MinimalContainerTestCase {
+
+    /**
+     * Utility for getting the helper.
+     */
+    private function getHelper(): ThemeModelHelper {
+        return self::container()->get(ThemeModelHelper::class);
+    }
+
+    /**
+     * Test the config theme key fetching.
+     */
+    public function testConfigThemeKey() {
+        $this->setConfigs([
+            'Garden.Theme' => 'oldKey'
+        ]);
+        $this->assertEquals('oldKey', $this->getHelper()->getConfigThemeKey());
+
+        $this->setConfigs([
+            'Garden.Theme' => 'oldKey',
+            'Garden.CurrentTheme' => 'newKey',
+        ]);
+        $this->assertEquals('newKey', $this->getHelper()->getConfigThemeKey());
+    }
+
+    /**
+     * Test current theme always visible.
+     */
+    public function testVisiblityCurrentTheme() {
+        $this->setConfigs([
+            'Garden.CurrentTheme' => 'theme-active'
+        ]);
+        $this->assertTrue($this->getHelper()->isThemeVisible(new MockAddon('theme-active', ['hidden' => true])));
+    }
+
+    /**
+     * Test the configuration based visibilies.
+     */
+    public function testVisibilityConfig() {
+        $this->setConfigs([]);
+        $this->assertFalse($this->getHelper()->isThemeVisible(new MockAddon('theme-hidden', ['hidden' => true])));
+
+        $this->setConfigs([
+            'Garden.Themes.Visible' => 'all',
+        ]);
+        $this->assertTrue($this->getHelper()->isThemeVisible(new MockAddon('theme-hidden', ['hidden' => true])));
+        $this->setConfigs([
+            'Garden.Themes.Visible' => 'some-theme, theme-hidden',
+        ]);
+        $this->assertTrue($this->getHelper()->isThemeVisible(new MockAddon('theme-hidden', ['hidden' => true])));
+    }
+
+    /**
+     * Test the configuration based visibilies.
+     */
+    public function testSites() {
+        $this->setConfigs([]);
+        $this->assertFalse($this->getHelper()->isThemeVisible(
+            new MockAddon(
+                'theme-hidden',
+                ['sites' => ['adam.vanillawip.com']]
+            ),
+            'todd.vanillawip.com'
+        ));
+
+        $this->assertTrue($this->getHelper()->isThemeVisible(
+            new MockAddon(
+                'theme-hidden',
+                ['sites' => ['adam.vanillawip.com']]
+            ),
+            'adam.vanillawip.com'
+        ));
+
+        $this->assertTrue($this->getHelper()->isThemeVisible(
+            new MockAddon(
+                'theme-hidden',
+                ['site' => 'adam.vanillawip.com']
+            ),
+            'adam.vanillawip.com'
+        ));
+
+        // Globs
+        $this->assertTrue($this->getHelper()->isThemeVisible(
+            new MockAddon(
+                'theme-hidden',
+                ['sites' => ['adam-*.vanillawip.com']]
+            ),
+            'adam-hub.vanillawip.com'
+        ));
+    }
+
+    /**
+     * Test that sysadmins always see all themes.
+     */
+    public function testThemeVisibleSysAdmin() {
+        $this->setUserInfo([ 'Admin' => 2 ]);
+        $this->setConfigs([]);
+        $this->assertTrue($this->getHelper()->isThemeVisible(new MockAddon('theme-hidden', ['hidden' => true])));
+    }
+}

--- a/tests/fixtures/src/MockAddon.php
+++ b/tests/fixtures/src/MockAddon.php
@@ -17,13 +17,18 @@ class MockAddon implements Contracts\AddonInterface {
     /** @var string */
     private $key;
 
+    /** @var array */
+    private $info;
+
     /**
      * Constructor for MockAddon
      *
      * @param string $key
+     * @param array $info
      */
-    public function __construct(string $key) {
+    public function __construct(string $key, array $info = []) {
         $this->key = $key;
+        $this->info = $info;
     }
 
     /**
@@ -38,5 +43,19 @@ class MockAddon implements Contracts\AddonInterface {
      */
     public function getKey(): string {
         return $this->key;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getInfo(): array {
+        return $this->info;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getInfoValue(string $key, $default = null) {
+        return isset($this->info[$key]) ? $this->info[$key] : $default;
     }
 }


### PR DESCRIPTION
Relating to https://github.com/vanilla/knowledge/issues/1681

We had some issues with hidden themes appearing in results, so I've done some refactoring to the method and added some tests for it.

- Update AddonInterface and MockAddon with additional info methods.
- Move `FsThemeProvider::filterTheme` to `ThemeHelperModel::isThemeVisible`.
- The method now takes an addon instead of an array.
- Add unit tests for this method.
- Update `MinimalContainerTestCase` to allow setting session information.
- Fix the minHeight on the add theme item (visible when it is by itself).
- SysAdmin users can see all themes now, similar to our behaviour on the addons page. **_Because of this I had to set the user to a guest for the theme index test_**

_Note:_ I moved a "public" method on the `FsThemeProvider` but it had no other usages.
