### PR TITLE
Add read-only cache mode to CategoryCollection

### DIFF
--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -202,7 +202,6 @@ class CategoryCollection {
         if (!empty($category)) {
             // This category came from the database, so must be calculated.
             $this->calculateStatic($category);
-            $adt = val("AllowedDiscussionTypes", $category);
 
             $this->cacheStore(
                 $this->cacheKey(self::$CACHE_CATEGORY, $category['CategoryID']),


### PR DESCRIPTION
Any time a category collection is created, it will save its calculated entries to the site cache. If a category collection is created by an addon and configured with custom calculation routines, it can cause bad data to be cached for all other category collections.

This update allows creating a category collection that will only read from the cache, not write to it. Custom category calculations are still allowed without polluting the site's cache.