### PR TITLE
Save current theme into the allowed theme keys on structure

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -1,6 +1,4 @@
-<?php if (!defined('APPLICATION')) {
-    exit();
-      }
+<?php
 /**
  * Dashboard database structure.
  *
@@ -10,6 +8,11 @@
  * @since 2.0
  */
 
+use Vanilla\Models\ThemeModelHelper;
+
+if (!defined('APPLICATION')) {
+    exit();
+}
 if (!isset($Drop)) {
     $Drop = false;
 }
@@ -1023,3 +1026,12 @@ if (Gdn::config()->get("Robots.Rules") === false && $sitemapsRobotsRules = Gdn::
     Gdn::config()->set("Robots.Rules", $sitemapsRobotsRules);
     Gdn::config()->remove("Sitemap.Robots.Rules");
 }
+
+
+// Save current theme value into the visible themes. This way existing sites will continue to see them even if they get hidden.
+
+/**
+ * @var ThemeModelHelper $themeHelper
+ */
+$themeHelper = Gdn::getContainer()->get(ThemeModelHelper::class);
+$themeHelper->saveCurrentThemeToVisible();

--- a/library/Vanilla/Contracts/ConfigurationInterface.php
+++ b/library/Vanilla/Contracts/ConfigurationInterface.php
@@ -19,4 +19,14 @@ interface ConfigurationInterface {
      * @return mixed The configuration value.
      */
     public function get($key, $defaultValue = false);
+
+    /**
+     * Save a value to the configuration.
+     *
+     * @param string $name A config key. Dot notation supported.
+     * @param string $value The value to save.
+     * @param array|false $options Some options on how to save it. Pass false to do an "in-memory" save.
+     * @return bool|int
+     */
+    public function saveToConfig($name, $value = '', $options = []);
 }

--- a/library/Vanilla/Models/ThemeModelHelper.php
+++ b/library/Vanilla/Models/ThemeModelHelper.php
@@ -17,6 +17,20 @@ use Vanilla\Theme\ThemeProviderInterface;
  * Theme helper functions.
  */
 class ThemeModelHelper {
+
+    // Config holding all forced visiblity themes.
+    const CONFIG_THEMES_VISIBLE = 'Garden.Themes.Visible';
+    const ALL_VISIBLE = 'all';
+
+    // Old desktop config key.
+    const CONFIG_DESKTOP_THEME = 'Garden.Theme';
+
+    // Old Mobile config key.
+    const CONFIG_MOBILE_THEME = 'Garden.MobileTheme';
+
+    // New theme API config.
+    const CONFIG_CURRENT_THEME = 'Garden.CurrentTheme';
+
     /** @var SessionInterface $session */
     private $session;
 
@@ -55,9 +69,9 @@ class ThemeModelHelper {
         if ($siteName === null && defined('CLIENT_NAME')) {
             $siteName = CLIENT_NAME;
         }
-        $confVisible = $this->config->get('Garden.Themes.Visible', '');
+        $confVisible = $this->config->get(self::CONFIG_THEMES_VISIBLE);
 
-        if ($confVisible === 'all') {
+        if ($confVisible === self::ALL_VISIBLE) {
             // Config setup to show all themes.
             return true;
         }
@@ -157,5 +171,38 @@ class ThemeModelHelper {
      */
     public function getConfigThemeKey(): string {
         return $this->config->get('Garden.CurrentTheme', $this->config->get('Garden.Theme'));
+    }
+
+    /**
+     * Take the current themes in the config and save theme as visible.
+     *
+     * This way if themes are hidden in the future, a customer won't lose access to the theme.
+     */
+    public function saveCurrentThemeToVisible() {
+        $currentVisible = $this->config->get(self::CONFIG_THEMES_VISIBLE, '');
+        if ($currentVisible === self::ALL_VISIBLE) {
+            // Don't modify because all are visible.
+            return;
+        }
+
+        $themes = array_filter(array_map('trim', explode(",", $currentVisible)));
+        $desktopTheme = $this->config->get(self::CONFIG_DESKTOP_THEME);
+        $mobileTheme = $this->config->get(self::CONFIG_MOBILE_THEME);
+        $currentTheme = $this->config->get(self::CONFIG_CURRENT_THEME);
+
+        if ($desktopTheme && !in_array($desktopTheme, $themes, true)) {
+            $themes[] = $desktopTheme;
+        }
+
+        if ($mobileTheme && !in_array($mobileTheme, $themes, true)) {
+            $themes[] = $mobileTheme;
+        }
+
+        if ($currentTheme && !in_array($currentTheme, $themes, true)) {
+            $themes[] = $currentTheme;
+        }
+
+        $resultConfig = implode($themes, ",");
+        $this->config->saveToConfig(self::CONFIG_THEMES_VISIBLE, $resultConfig);
     }
 }

--- a/library/core/class.configuration.php
+++ b/library/core/class.configuration.php
@@ -889,12 +889,7 @@ class Gdn_Configuration extends Gdn_Pluggable implements \Vanilla\Contracts\Conf
     }
 
     /**
-     *
-     *
-     * @param $name
-     * @param string $value
-     * @param array $options
-     * @return bool|int
+     * @inheritdoc
      */
     public function saveToConfig($name, $value = '', $options = []) {
         $save = $options === false ? false : val('Save', $options, true);

--- a/tests/MinimalContainerTestCase.php
+++ b/tests/MinimalContainerTestCase.php
@@ -182,9 +182,7 @@ class MinimalContainerTestCase extends TestCase {
      * @param mixed $value The value to set.
      */
     public static function setConfig(string $key, $value) {
-        /** @var MockConfig $config */
-        $config = self::container()->get(ConfigurationInterface::class);
-        $config->set($key, $value);
+        self::getConfig()->set($key, $value);
     }
 
     /**
@@ -193,9 +191,14 @@ class MinimalContainerTestCase extends TestCase {
      * @param array $configs An array of $configKey => $value
      */
     public static function setConfigs(array $configs) {
-        /** @var MockConfig $config */
-        $config = self::container()->get(MockConfig::class);
-        $config->loadData($configs);
+        self::getConfig()->loadData($configs);
+    }
+
+    /**
+     * Get the config object.
+     */
+    public static function getConfig(): ConfigurationInterface {
+        return self::container()->get(ConfigurationInterface::class);
     }
 
     /**

--- a/tests/Models/ThemeModelHelperTest.php
+++ b/tests/Models/ThemeModelHelperTest.php
@@ -7,6 +7,7 @@
 
 namespace VanillaTests\Models;
 
+use Vanilla\Contracts\ConfigurationInterface;
 use Vanilla\Models\ThemeModelHelper;
 use VanillaTests\Fixtures\MockAddon;
 use VanillaTests\MinimalContainerTestCase;
@@ -122,5 +123,34 @@ class ThemeModelHelperTest extends MinimalContainerTestCase {
         $this->setUserInfo([ 'Admin' => 2 ]);
         $this->setConfigs([]);
         $this->assertTrue($this->getHelper()->isThemeVisible(new MockAddon('theme-hidden', ['hidden' => true])));
+    }
+
+    /**
+     * Test saving the current themes into the visible themes.
+     */
+    public function testSaveCurrentThemeToVisible() {
+        $this->setConfigs([
+            ThemeModelHelper::CONFIG_THEMES_VISIBLE => ThemeModelHelper::ALL_VISIBLE,
+            ThemeModelHelper::CONFIG_DESKTOP_THEME => 'test-active',
+        ]);
+        $this->getHelper()->saveCurrentThemeToVisible();
+        $this->assertEquals(ThemeModelHelper::ALL_VISIBLE, self::getConfig()->get(ThemeModelHelper::CONFIG_THEMES_VISIBLE));
+
+        $this->setConfigs([
+            ThemeModelHelper::CONFIG_THEMES_VISIBLE => '',
+            ThemeModelHelper::CONFIG_DESKTOP_THEME => 'test-active',
+            ThemeModelHelper::CONFIG_MOBILE_THEME => 'test-active',
+        ]);
+        $this->getHelper()->saveCurrentThemeToVisible();
+        $this->assertEquals('test-active', self::getConfig()->get(ThemeModelHelper::CONFIG_THEMES_VISIBLE));
+
+        $this->setConfigs([
+            ThemeModelHelper::CONFIG_THEMES_VISIBLE => '',
+            ThemeModelHelper::CONFIG_DESKTOP_THEME => 'test-desktop',
+            ThemeModelHelper::CONFIG_MOBILE_THEME => 'test-mobile',
+            ThemeModelHelper::CONFIG_CURRENT_THEME => 'test-current',
+        ]);
+        $this->getHelper()->saveCurrentThemeToVisible();
+        $this->assertEquals('test-desktop,test-mobile,test-current', self::getConfig()->get(ThemeModelHelper::CONFIG_THEMES_VISIBLE));
     }
 }

--- a/tests/fixtures/src/MockConfig.php
+++ b/tests/fixtures/src/MockConfig.php
@@ -55,6 +55,13 @@ class MockConfig implements Contracts\ConfigurationInterface {
     }
 
     /**
+     * @inheritdoc
+     */
+    public function saveToConfig($name, $value = '', $options = []) {
+        $this->set($name, $value);
+    }
+
+    /**
      * Flatten and set the data into configuration.
      *
      * @param array $data


### PR DESCRIPTION
Address part of https://github.com/vanilla/knowledge/issues/1681
Targeting https://github.com/vanilla/vanilla/pull/10275 until that is merged.

> If someone has a hidden theme enabled and then disables it it should still be allowed to show. Maybe add a config key for visible themes that will always display.

It turns out we already have that config!

- Save current themes into forced visible themes config on structure.
- Add some tests.
- Expand config interface to allow saving.
- Use some constants for config values in the `ThemeHelper`.