### PR TITLE
Fix addon model check to force as visible

### DIFF
--- a/addons/themes/theme-foundation/addon.json
+++ b/addons/themes/theme-foundation/addon.json
@@ -3,7 +3,7 @@
     "name": "Foundation",
     "description": "A responsive, asset-compatible Vanilla Forums theme.",
     "version": "1.0.0",
-    "hidden": true,
+    "hidden": false,
     "authors": [
         {
             "name": "Stéphane LaFlèche",

--- a/library/Vanilla/Models/AddonModel.php
+++ b/library/Vanilla/Models/AddonModel.php
@@ -449,7 +449,7 @@ class AddonModel implements LoggerAwareInterface {
             'enabled' => null,
             'type' => null,
             'addonID' => null,
-            'hidden' => $this->config->get('Garden.Themes.Visible') ? null : false,
+            'hidden' => $this->config->get('Garden.Themes.Visible') === 'all' ? null : false,
             'deprecated' => null,
             'themeType' => 'desktop'
         ];


### PR DESCRIPTION
The check introduced here looks to see if themes are visible or not. https://github.com/vanilla/vanilla/commit/538011cd388f3c3eec6cb1f8e3d2926f1d4062a8

However, this config can also be a CSV, with 'all' as the value that shows everything.

The line here was recently introduced and is both combined broke our tests on circleCI.
https://github.com/vanilla/vanilla/blob/d618eef0945177ed2e3ae7df8d6f593fca37dd85/applications/dashboard/settings/structure.php#L1037

https://app.circleci.com/pipelines/github/vanilla/vanilla/5817/workflows/7e5b37a8-d097-49e6-b7bb-ae69247148c9/jobs/47311

## Changes

- Fix that check to look for 'all'.
- Mark foundation as visible.