### PR TITLE
Add functions for comparing ranked permissions

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -734,7 +734,7 @@ class UsersApiController extends AbstractApiController {
      * @return array
      */
     public function put_ban($id, array $body) {
-        $this->permission('Garden.Users.Edit');
+        $this->permission(['Garden.Moderation.Manage', 'Garden.Users.Edit', 'Moderation.Users.Ban']);
 
         $this->idParamSchema('in');
         $in = $this
@@ -754,8 +754,11 @@ class UsersApiController extends AbstractApiController {
             throw new \Garden\Web\Exception\ForbiddenException(t('You are not allowed to ban a user with the same permission level as you.'));
         }
 
-        $banned = intval($body['banned']);
-        $this->userModel->setField($id, 'Banned', $banned);
+        if ($body['banned']) {
+            $this->userModel->ban($id);
+        } else {
+            $this->userModel->unBan($id);
+        }
 
         $result = $this->userByID($id);
         return $out->validate($result);

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -755,9 +755,9 @@ class UsersApiController extends AbstractApiController {
         }
 
         if ($body['banned']) {
-            $this->userModel->ban($id);
+            $this->userModel->ban($id, []);
         } else {
-            $this->userModel->unBan($id);
+            $this->userModel->unBan($id, []);
         }
 
         $result = $this->userByID($id);

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -411,6 +411,9 @@ class UserController extends DashboardController {
             throw forbiddenException("@You may not ban a super admin.");
         }
 
+        // Check to make sure the session user has a higher permission level than the user to be banned.
+        Gdn::session()->hasHigherPermissionLevel('Garden.Moderation.Manage', $userID);
+
         // Is the user banned for other reasons?
         $this->setData('OtherReasons', BanModel::isBanned(val('Banned', $user, 0), ~BanModel::BAN_MANUAL));
 

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -412,7 +412,9 @@ class UserController extends DashboardController {
         }
 
         // Check to make sure the session user has a higher permission level than the user to be banned.
-        Gdn::session()->hasHigherPermissionLevel('Garden.Moderation.Manage', $userID);
+        if (!Gdn::session()->hasHigherPermissionLevel('Garden.Moderation.Manage', $userID)) {
+            throw permissionException();
+        }
 
         // Is the user banned for other reasons?
         $this->setData('OtherReasons', BanModel::isBanned(val('Banned', $user, 0), ~BanModel::BAN_MANUAL));

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -15,7 +15,6 @@ use Vanilla\Contracts\ConfigurationInterface;
 use Vanilla\Contracts\Models\UserProviderInterface;
 use Vanilla\Exception\Database\NoResultsException;
 use Vanilla\Models\UserFragmentSchema;
-use Vanilla\Permissions;
 use Vanilla\SchemaFactory;
 use Vanilla\Utility\CamelCaseScheme;
 
@@ -5512,43 +5511,5 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
     public function setEmailUnique(bool $emailUnique) {
         $this->emailUnique = $emailUnique;
         return $this;
-    }
-
-    /**
-     * Checks the session user's permission level against the permissions level of the user they want
-     * to perform some action on.
-     *
-     * @param int|string|null $userA User A's userID
-     * @param int|string|null $userB User B's userID
-     * @return int
-     */
-    public function hasHigherPermissionLevel(string $userA, $userB) {
-        $rankedPermissions = Permissions::RANKED_PERMISSIONS;
-
-        $permissionsUserA = self::getPermissions($userA);
-        $permissionsUserA = $permissionsUserA->getPermissions();
-
-        $permissionsUserB = self::getPermissions($userB);
-        $permissionsUserB = $permissionsUserB->getPermissions();
-
-        $levelUserA = 0;
-        $levelUserB = 0;
-
-
-        for ($i = 0; $i < sizeof($rankedPermissions); $i++) {
-            if (in_array($rankedPermissions[$i], $permissionsUserA)) {
-                $levelUserA = $rankedPermissions[$i];
-                break;
-            }
-        }
-
-        for ($i = 0; $i < sizeof($rankedPermissions); $i++) {
-            if (in_array($rankedPermissions[$i], $permissionsUserB)) {
-                $levelUserB = $rankedPermissions[$i];
-                break;
-            }
-        }
-
-        return $levelUserA <=> $levelUserB;
     }
 }

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -15,6 +15,7 @@ use Vanilla\Contracts\ConfigurationInterface;
 use Vanilla\Contracts\Models\UserProviderInterface;
 use Vanilla\Exception\Database\NoResultsException;
 use Vanilla\Models\UserFragmentSchema;
+use Vanilla\Permissions;
 use Vanilla\SchemaFactory;
 use Vanilla\Utility\CamelCaseScheme;
 
@@ -5511,5 +5512,43 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
     public function setEmailUnique(bool $emailUnique) {
         $this->emailUnique = $emailUnique;
         return $this;
+    }
+
+    /**
+     * Checks the session user's permission level against the permissions level of the user they want
+     * to perform some action on.
+     *
+     * @param int|string|null $userA User A's userID
+     * @param int|string|null $userB User B's userID
+     * @return int
+     */
+    public function hasHigherPermissionLevel(string $userA, $userB) {
+        $rankedPermissions = Permissions::RANKED_PERMISSIONS;
+
+        $permissionsUserA = self::getPermissions($userA);
+        $permissionsUserA = $permissionsUserA->getPermissions();
+
+        $permissionsUserB = self::getPermissions($userB);
+        $permissionsUserB = $permissionsUserB->getPermissions();
+
+        $levelUserA = 0;
+        $levelUserB = 0;
+
+
+        for ($i = 0; $i < sizeof($rankedPermissions); $i++) {
+            if (in_array($rankedPermissions[$i], $permissionsUserA)) {
+                $levelUserA = $rankedPermissions[$i];
+                break;
+            }
+        }
+
+        for ($i = 0; $i < sizeof($rankedPermissions); $i++) {
+            if (in_array($rankedPermissions[$i], $permissionsUserB)) {
+                $levelUserB = $rankedPermissions[$i];
+                break;
+            }
+        }
+
+        return $levelUserA <=> $levelUserB;
     }
 }

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -119,8 +119,8 @@ class Gdn_Session {
      * @param string $permission
      * @param int|string $userID
      * @return bool
-     * @throws ContainerException
-     * @throws NotFoundException
+     * @throws ContainerException Throws exception if there's a problem getting the container.
+     * @throws NotFoundException Throws exception if there's a problem getting the container.
      */
     public function checkUserRankedPermission(string $permission, $userID) {
         $rankedPermissions = self::RANKED_PERMISSIONS;

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -10,6 +10,8 @@
  * @since 2.0
  */
 
+use Garden\Container\ContainerException;
+use Garden\Container\NotFoundException;
 use Vanilla\Permissions;
 
 /**
@@ -89,8 +91,8 @@ class Gdn_Session {
      * @param string $sessionPermission
      * @param int|string $userID
      * @return bool
-     * @throws \Garden\Container\ContainerException
-     * @throws \Garden\Container\NotFoundException
+     * @throws NotFoundException Throws exception if there's a problem getting the container.
+     * @throws ContainerException Throws exception if there's a problem getting the container.
      */
     public function hasHigherPermissionLevel(string $sessionPermission, $userID) {
 
@@ -103,7 +105,7 @@ class Gdn_Session {
         // Throw a permission error if the session user doesn't outrank the user to be banned. Otherwise, return true.
 
         if ($this->checkUserRankedPermission($sessionPermission, $userID) || !$this->checkRankedPermission($sessionPermission)) {
-            throw permissionException();
+            return false;
         } else {
             return true;
         }
@@ -117,8 +119,8 @@ class Gdn_Session {
      * @param string $permission
      * @param int|string $userID
      * @return bool
-     * @throws \Garden\Container\ContainerException
-     * @throws \Garden\Container\NotFoundException
+     * @throws ContainerException
+     * @throws NotFoundException
      */
     public function checkUserRankedPermission(string $permission, $userID) {
         $rankedPermissions = self::RANKED_PERMISSIONS;

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -82,7 +82,17 @@ class Gdn_Session {
         $this->permissions->merge($newPermissions);
     }
 
-    public function hasHigherPermissionLevel($sessionPermission, $userID) {
+    /**
+     * Checks the session user's permission level against the permissions level of the user they want
+     * to perform some action on.
+     *
+     * @param string $sessionPermission
+     * @param int|string $userID
+     * @return bool
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
+     */
+    public function hasHigherPermissionLevel(string $sessionPermission, $userID) {
 
         // If the current user is an admin, they can do whatever they want.
         if ($this->permissions->has('Garden.Settings.Manage')) {
@@ -99,7 +109,18 @@ class Gdn_Session {
         }
     }
 
-    public function checkUserRankedPermission($permission, $userID) {
+    /**
+     * Checks a user's permission level against a ranked list of permissions and implicitly assigns
+     * the user any permissions below their level even in if the permission isn't explicitly assigned.
+     * Based on checkRakedPermission().
+     *
+     * @param string $permission
+     * @param int|string $userID
+     * @return bool
+     * @throws \Garden\Container\ContainerException
+     * @throws \Garden\Container\NotFoundException
+     */
+    public function checkUserRankedPermission(string $permission, $userID) {
         $rankedPermissions = self::RANKED_PERMISSIONS;
 
         $userModel = Gdn::getContainer()->get(UserModel::class);

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -10,8 +10,6 @@
  * @since 2.0
  */
 
-use Garden\Container\ContainerException;
-use Garden\Container\NotFoundException;
 use Vanilla\Permissions;
 
 /**
@@ -76,109 +74,20 @@ class Gdn_Session {
     }
 
     /**
-     * Checks the session user's permission level against the permissions level of the user they want
-     * to perform some action on.
-     *
-     * @param string $sessionPermission
-     * @param int|string $userID
-     * @return bool
-     * @throws NotFoundException Throws exception if there's a problem getting the container.
-     * @throws ContainerException Throws exception if there's a problem getting the container.
-     */
-    public function hasHigherPermissionLevel(string $sessionPermission, $userID) {
-
-        // If the current user is an admin, they can do whatever they want.
-        if ($this->permissions->has('Garden.Settings.Manage')) {
-            return true;
-        }
-
-        // Otherwise, check the current user's permissions against the user they want to ban/warn/etc.
-        // Return false if the session user doesn't outrank the user to be banned. Otherwise, return true.
-        $userModel = Gdn::getContainer()->get(UserModel::class);
-        if ($userModel->hasHigherPermissionLevel($this->UserID, $userID) <= 0 || !$this->permissions->checkRankedPermission($sessionPermission)) {
-            return false;
-        } else {
-            return true;
-        }
-    }
-
-    /**
-     * Checks a user's permission level against a ranked list of permissions and implicitly assigns
-     * the user any permissions below their level even in if the permission isn't explicitly assigned.
-     * Based on checkRakedPermission().
-     *
-     * @param string $permission
-     * @param int|string $userID
-     * @return bool
-     * @throws ContainerException Throws exception if there's a problem getting the container.
-     * @throws NotFoundException Throws exception if there's a problem getting the container.
-     */
-//    public function checkUserRankedPermission(string $permission, $userID) {
-//        $rankedPermissions = self::RANKED_PERMISSIONS;
-//
-//        $userModel = Gdn::getContainer()->get(UserModel::class);
-//        $userPermissions = $userModel->getPermissions($userID);
-//        $userPermissions = $userPermissions->getPermissions();
-//        // Get the highest permission in the user's permission array.
-//
-//        if ($userPermissions[$permission] === true) {
-//            return true;
-//        } elseif ($userPermissions[$permission] === false) {
-//            return false;
-//        } elseif (in_array($permission, $rankedPermissions)) {
-//            // Ordered rank of some permissions, highest to lowest
-//            $currentPermissionRank = array_search($permission, $rankedPermissions);
-
-            /**
-             * If the current permission is in our ranked list, iterate through the list, starting from the highest
-             * ranked permission down to our target permission, and determine if any are applicable to the current
-             * user.  This is done so that a user with a permission like Garden.Settings.Manage can still validate
-             * permissions against a Garden.Moderation.Manage permission check, without explicitly having it
-             * assigned to their role.
-             */
-//            for ($i = 0; $i <= $currentPermissionRank; $i++) {
-//                if (in_array($rankedPermissions[$i], $userPermissions)) {
-//                    return true;
-//                }
-//            }
-//            return false;
-//        }
-//    }
-
-    /**
      * Check the given permission, but also return true if the user has a higher permission.
      *
      * @param bool|string $permission The permission to check.  Bool to force true/false.
-     * @return boolean True on valid authorization, false on failure to authorize
+     * @return boolean True on valid authorization, false on failure to authorize.
+     * @deprecated Use `Permissions::hasRanked()` instead.
      */
     public function checkRankedPermission($permission) {
-        $rankedPermissions = Permissions::RANKED_PERMISSIONS;
-
         if ($permission === true) {
             return true;
         } elseif ($permission === false) {
             return false;
-        } elseif (in_array($permission, $rankedPermissions)) {
-            // Ordered rank of some permissions, highest to lowest
-            $currentPermissionRank = array_search($permission, $rankedPermissions);
-
-            /**
-             * If the current permission is in our ranked list, iterate through the list, starting from the highest
-             * ranked permission down to our target permission, and determine if any are applicable to the current
-             * user.  This is done so that a user with a permission like Garden.Settings.Manage can still validate
-             * permissions against a Garden.Moderation.Manage permission check, without explicitly having it
-             * assigned to their role.
-             */
-            for ($i = 0; $i <= $currentPermissionRank; $i++) {
-                if ($this->permissions->has($rankedPermissions[$i])) {
-                    return true;
-                }
-            }
-            return false;
+        } else {
+            return $this->permissions->hasRanked($permission);
         }
-
-        // Check to see if the user has at least the given permission.
-        return $this->permissions->has($permission);
     }
 
     /**

--- a/tests/APIv2/AbstractResourceTest.php
+++ b/tests/APIv2/AbstractResourceTest.php
@@ -349,7 +349,7 @@ abstract class AbstractResourceTest extends AbstractAPIv2Test {
      */
     public function testIndex() {
         $indexUrl = $this->indexUrl();
-        $originalIndex = $this->api()->get($indexUrl);
+        $originalIndex = $this->api()->get($indexUrl, ['limit' => 100]);
         $this->assertEquals(200, $originalIndex->getStatusCode());
 
         $originalRows = $originalIndex->getBody();

--- a/tests/SiteTestTrait.php
+++ b/tests/SiteTestTrait.php
@@ -43,6 +43,21 @@ trait SiteTestTrait {
     private $sessionBak;
 
     /**
+     * @var int
+     */
+    protected $memberID;
+
+    /**
+     * @var int
+     */
+    protected $adminID;
+
+    /**
+     * @var int
+     */
+    protected $moderatorID;
+
+    /**
      * Get the names of addons to install.
      *
      * @return string[] Returns an array of addon names.
@@ -225,5 +240,49 @@ TEMPLATE;
         $fn->bindTo($session, \Gdn_Session::class);
         $fn($this->sessionBak['permissions']);
         $this->sessionBak = null;
+    }
+
+    /**
+     * Create a few test users and set them on the class.
+     *
+     * @param ?string $sx The suffix to use for the usernames and email addresses.
+     */
+    protected function createUserFixtures(?string $sx = null): void {
+        // Create some users to help.
+        if ($sx === null) {
+            $sx = (string)(time() . mt_rand(1000, 9999));
+        }
+
+        $this->adminID = $this->createTestUser('Administrator', $sx);
+        $this->moderatorID = $this->createTestUser('Moderator', $sx);
+        $this->memberID = $this->createTestUser('Member', $sx);
+    }
+
+    /**
+     * Create a test user with a given role.
+     *
+     * @param string $role
+     * @param string $sx
+     * @return int
+     */
+    protected function createTestUser(string $role, string $sx): int {
+        static $roleIDs;
+        if (!isset($roleIDs)) {
+            $roleIDs = array_column(
+                static::container()->get(\Gdn_SQLDriver::class)->getWhere('Role', [])->resultArray(),
+                'RoleID',
+                'Name'
+            );
+        }
+
+        $row = $this->api()->post('/users', [
+            'name' => "$role$sx",
+            'email' => "$role.$sx@example.com",
+            'password' => 'test',
+            'roleID' => [
+                $roleIDs[$role],
+            ],
+        ]);
+        return $row['userID'];
     }
 }


### PR DESCRIPTION
Partially addresses vanilla/support#1571

This PR adds functions that allow comparison between the current user's permissions and the permissions of a user the current user wants to perform some kind of administrative action on (ban, mark as a troll, etc.). These functions can be called by other classes to make sure a user isn't able to take an action against another user with the same or higher permissions.

The PR also implements this check in the ban method of the `usercontroller.php`

### TO TEST
1. Make sure the moderator role can warn users (enable `Garden.Moderation.Manage` for that role).
1. Make sure you have at least to moderator users.
1. As one moderator, try to ban the other. Verify that it works.
1. Check out this branch and repeat step 4, but verify that it doesn't work.