### PR TITLE
Fix  VANILLA_BUILD_DISABLE_AUTO_BUILD check

### DIFF
--- a/library/setup/ComposerHelper.php
+++ b/library/setup/ComposerHelper.php
@@ -93,9 +93,9 @@ class ComposerHelper {
      */
     public static function postUpdate() {
         $vanillaRoot = realpath(__DIR__ . "/../../");
-        $skipBuild = getenv(self::DISABLE_AUTO_BUILD) ? true : false;
+        $skipBuild = getenv(self::DISABLE_AUTO_BUILD) === 'true';
         if ($skipBuild) {
-            printf("\nSkipping automatic JS build because " . self::DISABLE_AUTO_BUILD . " env variable is set.\n");
+            printf("\nSkipping automatic JS build because " . self::DISABLE_AUTO_BUILD . " env variable is set to \"true\".\n");
             return;
         }
 


### PR DESCRIPTION
`getenv()` returns a string. 

Setting `VANILLA_BUILD_DISABLE_AUTO_BUILD` to `false` (or anything) returned true.
This PR fixes that by ensuring that the value must be equals to `"true"`
