### PR TITLE
Refactor State Names

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/forumMetaStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/forumMetaStyles.ts
@@ -84,8 +84,8 @@ export const forumMetaCSS = () => {
                         color: colorOut(globalVars.links.colors.focus),
                         textDecoration: "underline",
                     },
-                    accessibleFocus: {
-                        color: colorOut(globalVars.links.colors.accessibleFocus),
+                    keyboardFocus: {
+                        color: colorOut(globalVars.links.colors.keyboardFocus),
                         textDecoration: "underline",
                     },
                     active: {

--- a/applications/dashboard/src/scripts/compatibilityStyles/index.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/index.ts
@@ -39,6 +39,7 @@ import { messagesCSS } from "@dashboard/compatibilityStyles/messagesStyles";
 import { signaturesCSS } from "./signaturesSyles";
 import { searchResultsVariables } from "@vanilla/library/src/scripts/features/search/searchResultsStyles";
 import { forumTagCSS } from "@dashboard/compatibilityStyles/forumTagStyles";
+import { emptyObject } from "expect/build/utils";
 
 // To use compatibility styles, set '$staticVariables : true;' in custom.scss
 // $Configuration['Feature']['DeferredLegacyScripts']['Enabled'] = true;
@@ -424,20 +425,29 @@ export const nestedWorkaround = (selector: string, nestedObject: {}) => {
     let rawStyles = `\n`;
     Object.keys(nestedObject).forEach(key => {
         const finalSelector = `${selector}${key.replace(/^&+/, "")}`;
+        let newStyleDeclaration = "";
         if (selector !== "") {
             const targetStyles = nestedObject[key];
-            const keys = Object.keys(targetStyles);
-            if (keys.length > 0) {
-                rawStyles += `${finalSelector} { `;
-                keys.forEach(property => {
+            const styleProps = targetStyles ? Object.keys(targetStyles) : [];
+
+            let emptyStyles = true;
+
+            if (styleProps.length > 0) {
+                newStyleDeclaration += `${finalSelector} { `;
+                styleProps.forEach(property => {
                     const style = targetStyles[property];
-                    if (style) {
-                        rawStyles += `\n    ${camelCaseToDash(property)}: ${
+                    if (style !== undefined && style !== "") {
+                        newStyleDeclaration += `\n    ${camelCaseToDash(property)}: ${
                             style instanceof ColorHelper ? colorOut(style) : style
                         };`;
+                        emptyStyles = false;
                     }
                 });
-                rawStyles += `\n}\n\n`;
+                newStyleDeclaration += `\n}\n\n`;
+            }
+
+            if (!emptyStyles) {
+                rawStyles += newStyleDeclaration;
             }
         }
     });

--- a/applications/dashboard/src/scripts/compatibilityStyles/searchPageStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/searchPageStyles.ts
@@ -60,8 +60,8 @@ export const searchPageCSS = () => {
                 hover: {
                     color: colorOut(globalVars.links.colors.hover),
                 },
-                accessibleFocus: {
-                    color: colorOut(globalVars.links.colors.accessibleFocus),
+                keyboardFocus: {
+                    color: colorOut(globalVars.links.colors.keyboardFocus),
                 },
                 focus: {
                     color: colorOut(globalVars.links.colors.focus),

--- a/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
@@ -5,7 +5,7 @@
  * @license GPL-2.0-only
  */
 
-import { colorOut, setAllLinkStateStyles } from "@library/styles/styleHelpers";
+import { colorOut, clickableItemStates } from "@library/styles/styleHelpers";
 import { cssOut, nestedWorkaround, trimTrailingCommas } from "@dashboard/compatibilityStyles/index";
 import { globalVariables } from "@library/styles/globalStyleVars";
 
@@ -13,22 +13,22 @@ export const textLinkCSS = () => {
     const globalVars = globalVariables();
 
     // Various links
-    mixinTextLink(".Navigation-linkContainer a");
-    mixinTextLink(".Panel .PanelInThisDiscussion a");
-    mixinTextLink(".Panel .Leaderboard a");
-    mixinTextLink(".Panel .InThisConversation a");
-    mixinTextLink(".FieldInfo a");
+    mixinClickInput(".Navigation-linkContainer a");
+    mixinClickInput(".Panel .PanelInThisDiscussion a");
+    mixinClickInput(".Panel .Leaderboard a");
+    mixinClickInput(".Panel .InThisConversation a");
+    mixinClickInput(".FieldInfo a");
 
-    mixinTextLink("div.Popup .Body a");
-    mixinTextLink(".selectBox-toggle");
-    mixinTextLink(".followButton");
-    mixinTextLink(".SelectWrapper::after");
-    mixinTextLink(".Back a");
-    mixinTextLink(".OptionsLink-Clipboard");
-    mixinTextLink("a.OptionsLink");
-    mixinTextLink("a.MoreWrap, .MoreWrap a, .MorePager a, .more.More, .MoreWrap a.more.More");
-    mixinTextLink(`body.Section-BestOf .Tile .Message a`);
-    mixinTextLink(
+    mixinClickInput("div.Popup .Body a");
+    mixinClickInput(".selectBox-toggle");
+    mixinClickInput(".followButton");
+    mixinClickInput(".SelectWrapper::after");
+    mixinClickInput(".Back a");
+    mixinClickInput(".OptionsLink-Clipboard");
+    mixinClickInput("a.OptionsLink");
+    mixinClickInput("a.MoreWrap, .MoreWrap a, .MorePager a, .more.More, .MoreWrap a.more.More");
+    mixinClickInput(`body.Section-BestOf .Tile .Message a`);
+    mixinClickInput(
         `
         .DataList .IdeationTag,
         .DataList .tag-tracker,
@@ -41,11 +41,11 @@ export const textLinkCSS = () => {
         .DataTableWrap .MItem.RoleTracker
         `,
     );
-    mixinTextLink(`
+    mixinClickInput(`
         .Container .userContent a,
         .Container .UserContent a
     `);
-    mixinTextLink(".BreadcrumbsBox .Breadcrumbs a", {
+    mixinClickInput(".BreadcrumbsBox .Breadcrumbs a", {
         default: globalVars.links.colors.default,
     });
 
@@ -64,17 +64,17 @@ export const textLinkCSS = () => {
 };
 
 // Mixins replacement
-export const mixinTextLink = (selector: string, overwrite?: {}) => {
+export const mixinClickInput = (selector: string, overwrite?: {}) => {
     selector = trimTrailingCommas(selector);
     const selectors = selector.split(",");
-    const linkColors = setAllLinkStateStyles(overwrite);
+    const linkColors = clickableItemStates(overwrite);
     if (!selectors) {
         if (linkColors.color !== undefined) {
             cssOut(selector, {
                 color: colorOut(linkColors.color),
             });
         }
-        nestedWorkaround(trimTrailingCommas(selector), linkColors.nested);
+        nestedWorkaround(trimTrailingCommas(selector), linkColors.$nest);
     } else {
         selectors.map(s => {
             if (linkColors.color !== undefined) {
@@ -82,12 +82,12 @@ export const mixinTextLink = (selector: string, overwrite?: {}) => {
                     color: colorOut(linkColors.color),
                 });
             }
-            nestedWorkaround(trimTrailingCommas(s), linkColors.nested);
+            nestedWorkaround(trimTrailingCommas(s), linkColors.$nest);
         });
     }
 };
 
 export const mixinTextLinkNoDefaultLinkAppearance = selector => {
     const globalVars = globalVariables();
-    mixinTextLink(selector, { default: globalVars.mainColors.fg, textDecoration: "none" });
+    mixinClickInput(selector, { default: globalVars.mainColors.fg, textDecoration: "none" });
 };

--- a/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
@@ -69,15 +69,19 @@ export const mixinTextLink = (selector: string, overwrite?: {}) => {
     const selectors = selector.split(",");
     const linkColors = setAllLinkStateStyles(overwrite);
     if (!selectors) {
-        cssOut(selector, {
-            color: colorOut(linkColors.color),
-        });
-        nestedWorkaround(trimTrailingCommas(selector), linkColors.nested);
-    } else {
-        selectors.map(s => {
+        if (linkColors.color !== undefined) {
             cssOut(selector, {
                 color: colorOut(linkColors.color),
             });
+        }
+        nestedWorkaround(trimTrailingCommas(selector), linkColors.nested);
+    } else {
+        selectors.map(s => {
+            if (linkColors.color !== undefined) {
+                cssOut(selector, {
+                    color: colorOut(linkColors.color),
+                });
+            }
             nestedWorkaround(trimTrailingCommas(s), linkColors.nested);
         });
     }

--- a/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
@@ -5,9 +5,8 @@
  * @license GPL-2.0-only
  */
 
-import { colorOut, ILinkColorOverwritesWithOptions, setAllLinkColors } from "@library/styles/styleHelpers";
+import { colorOut, setAllLinkStateStyles } from "@library/styles/styleHelpers";
 import { cssOut, nestedWorkaround, trimTrailingCommas } from "@dashboard/compatibilityStyles/index";
-import { throwError } from "rxjs";
 import { globalVariables } from "@library/styles/globalStyleVars";
 
 export const textLinkCSS = () => {
@@ -68,7 +67,7 @@ export const textLinkCSS = () => {
 export const mixinTextLink = (selector: string, overwrite?: {}) => {
     selector = trimTrailingCommas(selector);
     const selectors = selector.split(",");
-    const linkColors = setAllLinkColors(overwrite);
+    const linkColors = setAllLinkStateStyles(overwrite);
     if (!selectors) {
         cssOut(selector, {
             color: colorOut(linkColors.color),

--- a/library/src/scripts/content/userContentStyles.ts
+++ b/library/src/scripts/content/userContentStyles.ts
@@ -10,7 +10,7 @@ import {
     fonts,
     margins,
     paddings,
-    setAllLinkColors,
+    setAllLinkStateStyles,
     unit,
     singleBorder,
 } from "@library/styles/styleHelpers";
@@ -241,7 +241,7 @@ export const userContentClasses = useThemeCache(() => {
         },
     };
 
-    const linkColors = setAllLinkColors();
+    const linkColors = setAllLinkStateStyles();
     const linkStyle = {
         "& a": {
             color: colorOut(linkColors.color),
@@ -255,7 +255,7 @@ export const userContentClasses = useThemeCache(() => {
             textDecoration: "underline",
         },
         "& a.focus-visible": {
-            color: colorOut(globalVars.links.colors.accessibleFocus),
+            color: colorOut(globalVars.links.colors.keyboardFocus),
             textDecoration: "underline",
         },
         "& a:active": {

--- a/library/src/scripts/content/userContentStyles.ts
+++ b/library/src/scripts/content/userContentStyles.ts
@@ -10,7 +10,7 @@ import {
     fonts,
     margins,
     paddings,
-    setAllLinkStateStyles,
+    clickableItemStates,
     unit,
     singleBorder,
 } from "@library/styles/styleHelpers";
@@ -241,7 +241,7 @@ export const userContentClasses = useThemeCache(() => {
         },
     };
 
-    const linkColors = setAllLinkStateStyles();
+    const linkColors = clickableItemStates();
     const linkStyle = {
         "& a": {
             color: colorOut(linkColors.color),

--- a/library/src/scripts/flyouts/dropDownStyles.ts
+++ b/library/src/scripts/flyouts/dropDownStyles.ts
@@ -494,7 +494,7 @@ export const actionMixin = (classBasedStates?: IStateSelectors): NestedCSSProper
                         ? colorOut(globalVars.states.active.contrast, true)
                         : undefined,
                 },
-                accessibleFocus: {
+                keyboardFocus: {
                     borderColor: colorOut(globalVars.states.focus.highlight, true),
                     color: globalVars.states.hover.contrast
                         ? colorOut(globalVars.states.focus.contrast, true)

--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -152,20 +152,6 @@ export const buttonVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         },
     });
 
-    // const primaryPresetInit1 = makeThemeVars("primary", {
-    //     preset: {
-    //         ...standardPresetInit.preset,
-    //         bg:
-    //             primaryPresetInit.preset.style === ButtonPreset.OUTLINE
-    //                 ? globalVars.mainColors.bg
-    //                 : primaryPresetInit.preset.border,
-    //         fg:
-    //             primaryPresetInit.preset.style === ButtonPreset.OUTLINE
-    //                 ? globalVars.mainColors.fg
-    //                 : offsetLightness(globalVars.mainColors.fg, 0.1),
-    //     },
-    // });
-
     const primaryPresetInit2 = makeThemeVars("primary", {
         preset: {
             ...primaryPresetInit.preset,

--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -386,10 +386,10 @@ export const buttonUtilityClasses = useThemeCache(() => {
             hover: {
                 color: colorOut(globalVars.mainColors.primary),
             },
-            focusNotKeyboard: {
+            clickFocus: {
                 outline: 0,
             },
-            accessibleFocus: {
+            keyboardFocus: {
                 outline: "initial",
             },
         }),

--- a/library/src/scripts/headers/titleBarStyles.ts
+++ b/library/src/scripts/headers/titleBarStyles.ts
@@ -716,7 +716,7 @@ export const titleBarClasses = useThemeCache(() => {
                                     },
                                 },
                             },
-                            accessibleFocus: {
+                            keyboardFocus: {
                                 outline: 0,
                                 color: colorOut(vars.colors.fg),
                                 $nest: {

--- a/library/src/scripts/headers/vanillaHeaderStyles.ts
+++ b/library/src/scripts/headers/vanillaHeaderStyles.ts
@@ -355,7 +355,7 @@ export const titleBarClasses = useThemeCache(() => {
                             },
                         },
                     },
-                    accessibleFocus: {
+                    keyboardFocus: {
                         outline: 0,
                         $nest: {
                             "& .meBox-buttonContent": {

--- a/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
@@ -16,10 +16,10 @@ import {
     EMPTY_SPACING,
     fonts,
     IBackground,
-    linkStyleFallbacks,
     paddings,
-    setAllLinkStateStyles,
+    clickableItemStates,
     unit,
+    linkStyleFallbacks,
 } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { percent } from "csx";
@@ -144,12 +144,12 @@ export const homeWidgetItemClasses = useThemeCache((optionOverrides?: IHomeWidge
         }
     })();
 
-    const linkStyles = setAllLinkStateStyles();
+    const buttonStateStyles = clickableItemStates();
 
     const name = style("name", {
         color: colorOut(vars.options.fg),
         ...fonts(vars.name.font),
-        ...linkStyleFallbacks,
+        // ...linkStyleFallbacks,
         marginBottom: unit(globalVars.gutter.half),
     });
 
@@ -162,9 +162,10 @@ export const homeWidgetItemClasses = useThemeCache((optionOverrides?: IHomeWidge
             overflow: "hidden",
             minWidth: unit(vars.sizing.minWidth),
             $nest: {
-                [`&:active .${name}`]: linkStyles.nested["&&:active"],
-                [`&:focus .${name}`]: linkStyles.nested["&&:focus"],
-                [`&:hover .${name}`]: linkStyles.nested["&&:hover"],
+                [`&:hover .${name}`]: buttonStateStyles.$nest["&&:hover"],
+                [`&:focus .${name}`]: buttonStateStyles.$nest["&&:focus"],
+                [`&:focus-visible .${name}`]: buttonStateStyles.$nest["&&:focus-visible"],
+                [`&:active .${name}`]: buttonStateStyles.$nest["&&:active"],
             },
         },
         borderStyling,

--- a/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetItem.styles.ts
@@ -18,7 +18,7 @@ import {
     IBackground,
     linkStyleFallbacks,
     paddings,
-    setAllLinkColors,
+    setAllLinkStateStyles,
     unit,
 } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
@@ -144,7 +144,7 @@ export const homeWidgetItemClasses = useThemeCache((optionOverrides?: IHomeWidge
         }
     })();
 
-    const linkStyles = setAllLinkColors();
+    const linkStyles = setAllLinkStateStyles();
 
     const name = style("name", {
         color: colorOut(vars.options.fg),

--- a/library/src/scripts/messages/messageStyles.ts
+++ b/library/src/scripts/messages/messageStyles.ts
@@ -219,7 +219,7 @@ export const messagesClasses = useThemeCache(() => {
                     allStates: {
                         color: colorOut(vars.colors.states.fg),
                     },
-                    focusNotKeyboard: {
+                    clickFocus: {
                         outline: 0,
                     },
                 }),

--- a/library/src/scripts/navigation/breadcrumbsStyles.ts
+++ b/library/src/scripts/navigation/breadcrumbsStyles.ts
@@ -12,7 +12,7 @@ import {
     colorOut,
     margins,
     paddings,
-    setAllLinkStateStyles,
+    clickableItemStates,
     singleLineEllipsis,
     unit,
     userSelect,
@@ -32,7 +32,7 @@ export const breadcrumbsClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const vars = breadcrumbsVariables();
     const style = styleFactory("breadcrumbs");
-    const linkColors = setAllLinkStateStyles();
+    const linkColors = clickableItemStates();
     const link = style("link", {
         ...singleLineEllipsis(),
         display: "inline-flex",
@@ -40,7 +40,7 @@ export const breadcrumbsClasses = useThemeCache(() => {
         lineHeight: globalVars.lineHeights.condensed,
         textTransform: "uppercase",
         color: colorOut(linkColors.color),
-        $nest: linkColors.nested,
+        $nest: linkColors.$nest,
     });
 
     const root = style({

--- a/library/src/scripts/navigation/breadcrumbsStyles.ts
+++ b/library/src/scripts/navigation/breadcrumbsStyles.ts
@@ -12,7 +12,7 @@ import {
     colorOut,
     margins,
     paddings,
-    setAllLinkColors,
+    setAllLinkStateStyles,
     singleLineEllipsis,
     unit,
     userSelect,
@@ -32,7 +32,7 @@ export const breadcrumbsClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const vars = breadcrumbsVariables();
     const style = styleFactory("breadcrumbs");
-    const linkColors = setAllLinkColors();
+    const linkColors = setAllLinkStateStyles();
     const link = style("link", {
         ...singleLineEllipsis(),
         display: "inline-flex",

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -9,7 +9,7 @@ import {
     colorOut,
     margins,
     paddings,
-    setAllLinkColors,
+    setAllLinkStateStyles,
     unit,
     fonts,
     extendItemContainer,
@@ -75,7 +75,7 @@ export const navLinksVariables = useThemeCache(() => {
         fontSize: 16,
     });
 
-    const viewAllLinkColors = setAllLinkColors();
+    const viewAllLinkColors = setAllLinkStateStyles();
     const viewAll = makeThemeVars("viewAll", {
         color: viewAllLinkColors.color,
         fontWeight: globalVars.fonts.weights.semiBold,
@@ -192,7 +192,7 @@ export const navLinksClasses = useThemeCache(() => {
         },
     });
 
-    const linkColors = setAllLinkColors({
+    const linkColors = setAllLinkStateStyles({
         default: globalVars.mainColors.fg,
     });
 
@@ -214,7 +214,7 @@ export const navLinksClasses = useThemeCache(() => {
         ...paddings(vars.viewAll.paddings),
     });
 
-    const viewAllLinkColors = setAllLinkColors({
+    const viewAllLinkColors = setAllLinkStateStyles({
         default: globalVars.mainColors.primary,
     });
 

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -9,7 +9,7 @@ import {
     colorOut,
     margins,
     paddings,
-    setAllLinkStateStyles,
+    clickableItemStates,
     unit,
     fonts,
     extendItemContainer,
@@ -75,7 +75,7 @@ export const navLinksVariables = useThemeCache(() => {
         fontSize: 16,
     });
 
-    const viewAllLinkColors = setAllLinkStateStyles();
+    const viewAllLinkColors = clickableItemStates();
     const viewAll = makeThemeVars("viewAll", {
         color: viewAllLinkColors.color,
         fontWeight: globalVars.fonts.weights.semiBold,
@@ -192,7 +192,7 @@ export const navLinksClasses = useThemeCache(() => {
         },
     });
 
-    const linkColors = setAllLinkStateStyles({
+    const linkColors = clickableItemStates({
         default: globalVars.mainColors.fg,
     });
 
@@ -204,7 +204,7 @@ export const navLinksClasses = useThemeCache(() => {
             // @ts-ignore
             color: linkColors.color,
         }),
-        $nest: linkColors.nested as NestedCSSProperties,
+        $nest: linkColors.$nest as NestedCSSProperties,
     } as NestedCSSProperties);
 
     const viewAllItem = style("viewAllItem", {
@@ -214,7 +214,7 @@ export const navLinksClasses = useThemeCache(() => {
         ...paddings(vars.viewAll.paddings),
     });
 
-    const viewAllLinkColors = setAllLinkStateStyles({
+    const viewAllLinkColors = clickableItemStates({
         default: globalVars.mainColors.primary,
     });
 

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -86,7 +86,7 @@ export const navLinksVariables = useThemeCache(() => {
         paddings: {
             top: globalVars.gutter.size,
         },
-        $nest: viewAllLinkColors.nested,
+        $nest: viewAllLinkColors.$nest,
     });
 
     const spacing = makeThemeVars("spacing", {
@@ -226,7 +226,7 @@ export const navLinksClasses = useThemeCache(() => {
             // @ts-ignore
             color: vars.viewAll.color,
         }),
-        $nest: viewAllLinkColors.nested,
+        $nest: viewAllLinkColors.$nest,
     });
 
     const linksWithHeadings = style(

--- a/library/src/scripts/navigation/siteNavStyles.ts
+++ b/library/src/scripts/navigation/siteNavStyles.ts
@@ -145,8 +145,8 @@ export const siteNavNodeClasses = useThemeCache(() => {
                 focus: {
                     color: colorOut(globalVars.links.colors.focus),
                 },
-                accessibleFocus: {
-                    color: colorOut(globalVars.links.colors.accessibleFocus),
+                keyboardFocus: {
+                    color: colorOut(globalVars.links.colors.keyboardFocus),
                 },
                 active: {
                     color: colorOut(globalVars.links.colors.active),

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -140,7 +140,7 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
             default: linkDerivedColors.default,
             hover: linkDerivedColors.state,
             focus: linkDerivedColors.state,
-            accessibleFocus: linkDerivedColors.state,
+            keyboardFocus: linkDerivedColors.state,
             active: linkDerivedColors.state,
             visited: undefined,
         },

--- a/library/src/scripts/styles/styleHelpersButtons.ts
+++ b/library/src/scripts/styles/styleHelpersButtons.ts
@@ -13,8 +13,8 @@ export interface IActionStates {
     allStates?: object; // Applies to all
     hover?: object;
     focus?: object;
-    focusNotKeyboard?: object; // Focused, not through keyboard?: object;
-    accessibleFocus?: object; // Optionally different state for keyboard accessed element. Will default to "focus" state if not set.
+    clickFocus?: object; // Focused, not through keyboard?: object;
+    keyboardFocus?: object; // Optionally different state for keyboard accessed element. Will default to "focus" state if not set.
     active?: object;
 }
 
@@ -23,8 +23,8 @@ export interface IStateSelectors {
     allStates?: string; // Applies to all
     hover?: string;
     focus?: string;
-    focusNotKeyboard?: string; // Focused, not through keyboard?: object;
-    accessibleFocus?: string; // Optionally different state for keyboard accessed element. Will default to "focus" state if not set.
+    clickFocus?: string; // Focused, not through keyboard?: object;
+    keyboardFocus?: string; // Optionally different state for keyboard accessed element. Will default to "focus" state if not set.
     active?: string;
 }
 
@@ -33,8 +33,8 @@ export interface IButtonStates {
     noState?: object; // Applies to stateless link
     hover?: object;
     focus?: object;
-    focusNotKeyboard?: object; // Focused, not through keyboard
-    accessibleFocus?: object; // Optionally different state for keyboard accessed element. Will default to "focus" state if not set.
+    clickFocus?: object; // Focused, not through keyboard
+    keyboardFocus?: object; // Optionally different state for keyboard accessed element. Will default to "focus" state if not set.
     active?: object;
 }
 
@@ -64,8 +64,8 @@ export const allButtonStates = (styles: IButtonStates, nested?: object, isLink?:
             "&": noState,
             "&:hover:not(:disabled)": { ...allStates, ...styles.hover },
             "&:focus": { ...allStates, ...styles.focus },
-            "&:focus:not(.focus-visible)": { ...allStates, ...styles.focusNotKeyboard },
-            "&&.focus-visible": { ...allStates, ...styles.accessibleFocus },
+            "&:focus:not(.focus-visible)": { ...allStates, ...styles.clickFocus },
+            "&&.focus-visible": { ...allStates, ...styles.keyboardFocus },
             "&:active:not(:disabled)": { ...allStates, ...styles.active },
             ...disabledStyles,
             ...nested,
@@ -90,8 +90,8 @@ export const buttonStates = (styles: IActionStates, nest?: object, classBasedSta
     const allStates = styles.allStates !== undefined ? styles.allStates : {};
     const hover = styles.hover !== undefined ? styles.hover : {};
     const focus = styles.focus !== undefined ? styles.focus : {};
-    const focusNotKeyboard = styles.focusNotKeyboard !== undefined ? styles.focusNotKeyboard : {};
-    const accessibleFocus = styles.accessibleFocus !== undefined ? styles.accessibleFocus : {};
+    const clickFocus = styles.clickFocus !== undefined ? styles.clickFocus : {};
+    const keyboardFocus = styles.keyboardFocus !== undefined ? styles.keyboardFocus : {};
     const active = styles.active !== undefined ? styles.active : {};
     const noState = styles.noState !== undefined ? styles.noState : {};
 
@@ -103,13 +103,13 @@ export const buttonStates = (styles: IActionStates, nest?: object, classBasedSta
         [appendExtraSelector("&", classBasedStates.allStates)]: { ...allStates, ...noState },
         [appendExtraSelector("&:hover", classBasedStates.hover)]: { ...allStates, ...hover },
         [appendExtraSelector("&:focus", classBasedStates.focus)]: { ...allStates, ...focus },
-        [appendExtraSelector("&:focus:not(.focus-visible)", classBasedStates.focusNotKeyboard)]: {
+        [appendExtraSelector("&:focus:not(.focus-visible)", classBasedStates.clickFocus)]: {
             ...allStates,
-            ...focusNotKeyboard,
+            ...clickFocus,
         },
-        [appendExtraSelector("&.focus-visible", classBasedStates.accessibleFocus)]: {
+        [appendExtraSelector("&.focus-visible", classBasedStates.keyboardFocus)]: {
             ...allStates,
-            ...accessibleFocus,
+            ...keyboardFocus,
         },
         [appendExtraSelector("&&:active", classBasedStates.active)]: { ...allStates, ...active },
         ...nest,

--- a/library/src/scripts/styles/styleHelpersLinks.ts
+++ b/library/src/scripts/styles/styleHelpersLinks.ts
@@ -8,7 +8,6 @@ import { ColorHelper } from "csx";
 import { colorOut, ColorValues } from "@library/styles/styleHelpersColors";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { IButtonStates } from "@library/styles/styleHelpersButtons";
-import { IBorderStyles } from "@library/styles/styleHelpersBorders";
 
 export interface ILinkStates {
     allStates?: object; // Applies to all
@@ -69,7 +68,7 @@ export const EMPTY_LINK_COLOR_OVERWRITES_WITH_OPTIONS = {
     skipDefault: undefined as undefined | boolean,
 };
 
-export const setAllLinkStateStyles = (overwriteColors?: ILinkColorOverwritesWithOptions) => {
+export const clickableItemStates = (overwriteColors?: ILinkColorOverwritesWithOptions) => {
     const vars = globalVariables();
     // We want to default to the standard styles and only overwrite what we want/need
     const linkColors = vars.links.colors;
@@ -116,7 +115,7 @@ export const setAllLinkStateStyles = (overwriteColors?: ILinkColorOverwritesWith
 
     const final = {
         color: styles.default.color as ColorValues,
-        nested: {
+        $nest: {
             "&&:hover": styles.hover,
             "&&:focus": {
                 ...(styles.focus ?? {}),

--- a/library/src/scripts/styles/styleHelpersLinks.ts
+++ b/library/src/scripts/styles/styleHelpersLinks.ts
@@ -8,13 +8,14 @@ import { ColorHelper } from "csx";
 import { colorOut, ColorValues } from "@library/styles/styleHelpersColors";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { IButtonStates } from "@library/styles/styleHelpersButtons";
+import { IBorderStyles } from "@library/styles/styleHelpersBorders";
 
 export interface ILinkStates {
     allStates?: object; // Applies to all
     noState?: object;
     hover?: object;
     focus?: object;
-    accessibleFocus?: object;
+    keyboardFocus?: object;
     active?: object;
     visited?: object;
 }
@@ -41,7 +42,8 @@ export interface ILinkColorOverwrites {
     default?: ColorValues;
     hover?: ColorValues;
     focus?: ColorValues;
-    accessibleFocus?: ColorValues;
+    clickFocus?: ColorValues;
+    keyboardFocus?: ColorValues;
     active?: ColorValues;
     visited?: ColorValues;
     allStates?: ColorValues;
@@ -51,7 +53,8 @@ export const EMPTY_LINK_COLOR_OVERWRITES = {
     default: undefined as undefined | ColorValues,
     hover: undefined as undefined | ColorValues,
     focus: undefined as undefined | ColorValues,
-    accessibleFocus: undefined as undefined | ColorValues,
+    clickFocus: undefined as undefined | ColorValues,
+    keyboardFocus: undefined as undefined | ColorValues,
     active: undefined as undefined | ColorValues,
     visited: undefined as undefined | ColorValues,
     allStates: undefined as undefined | ColorValues,
@@ -66,22 +69,21 @@ export const EMPTY_LINK_COLOR_OVERWRITES_WITH_OPTIONS = {
     skipDefault: undefined as undefined | boolean,
 };
 
-export const setAllLinkColors = (overwriteValues?: ILinkColorOverwritesWithOptions) => {
+export const setAllLinkStateStyles = (overwriteColors?: ILinkColorOverwritesWithOptions) => {
     const vars = globalVariables();
     // We want to default to the standard styles and only overwrite what we want/need
     const linkColors = vars.links.colors;
-    const overwrites = overwriteValues ? overwriteValues : {};
+
+    const overwrites = overwriteColors ? overwriteColors : {};
+
     const mergedColors = {
         default: !overwrites.skipDefault
             ? linkStyleFallbacks(overwrites.default, overwrites.allStates, linkColors.default)
             : undefined,
         hover: linkStyleFallbacks(overwrites.hover, overwrites.allStates, linkColors.hover),
         focus: linkStyleFallbacks(overwrites.focus, overwrites.allStates, linkColors.focus),
-        accessibleFocus: linkStyleFallbacks(
-            overwrites.accessibleFocus,
-            overwrites.allStates,
-            linkColors.accessibleFocus,
-        ),
+        clickFocus: linkStyleFallbacks(overwrites.clickFocus, overwrites.allStates, linkColors.focus),
+        keyboardFocus: linkStyleFallbacks(overwrites.keyboardFocus, overwrites.allStates, linkColors.keyboardFocus),
         active: linkStyleFallbacks(overwrites.active, overwrites.allStates, linkColors.active),
         visited: linkStyleFallbacks(overwrites.visited, overwrites.allStates, linkColors.visited),
     };
@@ -97,8 +99,11 @@ export const setAllLinkColors = (overwriteValues?: ILinkColorOverwritesWithOptio
         focus: {
             color: colorOut(mergedColors.focus),
         },
-        accessibleFocus: {
-            color: colorOut(mergedColors.accessibleFocus),
+        clickFocus: {
+            color: colorOut(mergedColors.focus),
+        },
+        keyboardFocus: {
+            color: colorOut(mergedColors.keyboardFocus),
         },
         active: {
             color: colorOut(mergedColors.active),
@@ -113,8 +118,14 @@ export const setAllLinkColors = (overwriteValues?: ILinkColorOverwritesWithOptio
         color: styles.default.color as ColorValues,
         nested: {
             "&&:hover": styles.hover,
-            "&&:focus": styles.focus,
-            "&&.focus-visible": styles.accessibleFocus,
+            "&&:focus": {
+                ...(styles.focus ?? {}),
+                ...(styles.clickFocus ?? {}),
+            },
+            "&&.focus-visible": {
+                ...(styles.focus ?? {}),
+                ...(styles.keyboardFocus ?? {}),
+            },
             "&&:active": styles.active,
             "&:visited": styles.visited ?? undefined,
         },

--- a/library/src/scripts/styles/tagStyles.ts
+++ b/library/src/scripts/styles/tagStyles.ts
@@ -5,7 +5,7 @@ import { EMPTY_SPACING } from "@library/styles/styleHelpersSpacing";
 import { EMPTY_FONTS, IFont } from "@library/styles/styleHelpersTypography";
 import {
     ILinkColorOverwritesWithOptions,
-    setAllLinkStateStyles,
+    clickableItemStates,
     EMPTY_LINK_COLOR_OVERWRITES_WITH_OPTIONS,
 } from "@library/styles/styleHelpersLinks";
 import merge from "lodash/merge";
@@ -23,14 +23,14 @@ export const tagVariables = useThemeCache(() => {
         textDecoration: important("none"),
     };
 
-    const linkColors = setAllLinkStateStyles(colorOverwrite);
+    const linkColors = clickableItemStates(colorOverwrite);
 
     const allStates = {
-        color: linkColors.nested["&&:hover"].color,
-        ...borders({ color: linkColors.nested["&&:hover"].color } as IBorderStyles, {}),
+        color: linkColors.$nest["&&:hover"].color,
+        ...borders({ color: linkColors.$nest["&&:hover"].color } as IBorderStyles, {}),
     };
 
-    const nested = merge(linkColors.nested, {
+    const nested = merge(linkColors.$nest, {
         "&&:hover": {
             ...allStyles,
             ...allStates,

--- a/library/src/scripts/styles/tagStyles.ts
+++ b/library/src/scripts/styles/tagStyles.ts
@@ -5,7 +5,7 @@ import { EMPTY_SPACING } from "@library/styles/styleHelpersSpacing";
 import { EMPTY_FONTS, IFont } from "@library/styles/styleHelpersTypography";
 import {
     ILinkColorOverwritesWithOptions,
-    setAllLinkColors,
+    setAllLinkStateStyles,
     EMPTY_LINK_COLOR_OVERWRITES_WITH_OPTIONS,
 } from "@library/styles/styleHelpersLinks";
 import merge from "lodash/merge";
@@ -23,7 +23,7 @@ export const tagVariables = useThemeCache(() => {
         textDecoration: important("none"),
     };
 
-    const linkColors = setAllLinkColors(colorOverwrite);
+    const linkColors = setAllLinkStateStyles(colorOverwrite);
 
     const allStates = {
         color: linkColors.nested["&&:hover"].color,

--- a/plugins/rich-editor/src/scripts/flyouts/pieces/insertEmojiClasses.ts
+++ b/plugins/rich-editor/src/scripts/flyouts/pieces/insertEmojiClasses.ts
@@ -43,7 +43,7 @@ export const insertEmojiClasses = useThemeCache(() => {
                     active: {
                         opacity: 1,
                     },
-                    accessibleFocus: {
+                    keyboardFocus: {
                         backgroundColor: colorOut(globalVars.states.hover.highlight),
                     },
                 },


### PR DESCRIPTION
Refactored some unclear (or just plain bad) names to clarify the focus styles.

Extra checks to make sure we don't pass empty or undefined styles to CSS.

Companion PR: https://github.com/vanilla/knowledge/pull/1698

Working towards: https://github.com/vanilla/vanilla/issues/10218