### PR TITLE
Fix HTML encoding in robots.txt

### DIFF
--- a/applications/dashboard/views/robots/index.twig
+++ b/applications/dashboard/views/robots/index.twig
@@ -2,5 +2,5 @@
 Sitemap: {{ url(sitemap, true) }}
 {% endfor %}
 {% for rule in rules %}
-{{ rule }}
+{{ rule|raw }}
 {% endfor %}


### PR DESCRIPTION
The rules in robots.txt are being encoded as if they're HTML. They should be treated as plain text. This update removes the automatic HTML encoding applied to them via the Twig template.

### Testing
1. Add some robots rules to Vanilla's `Robots.Rules` config that include some HTML special characters (e.g. &).
1. Open /robots.txt on the site.
1. Observe the special characters are not encoded (e.g. & is not &amp;amp;).

Closes vanilla/support#1627