### PR TITLE
Fix filtering on site messages

### DIFF
--- a/applications/dashboard/modules/class.messagemodule.php
+++ b/applications/dashboard/modules/class.messagemodule.php
@@ -25,6 +25,13 @@ class MessageModule extends Gdn_Module {
     public function __construct($sender = '', $message = false) {
         parent::__construct($sender);
 
+        // Filter message markup, if present.
+        if (is_string($message['Content'] ?? null)) {
+            /** @var Vanilla\Formatting\Html\HtmlSanitizer */
+            $htmlSanitizer = Gdn::getContainer()->get(Vanilla\Formatting\Html\HtmlSanitizer::class);
+            $message['Content'] = $htmlSanitizer->filter($message['Content']);
+        }
+
         $this->_ApplicationFolder = 'dashboard';
         $this->_Message = $message;
     }


### PR DESCRIPTION
Site messages are managed by site administrators and community managers. In their current form, they allow direct HTML entry. This lack of filtering/processing can cause undesired effects, including broken markup in the page.

This update adds some standard HTML processing to the message prior to rendering using `HtmLawed` via Vanilla's `HtmlSanitizer`.

Closes #10296