### PR TITLE
Backport: Fix analytics tick endpoint path reference

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -822,8 +822,7 @@ jQuery(document).ready(function($) {
     }
 
     gdn.stats = function() {
-        // Call directly back to the deployment and invoke the stats handler
-        var StatsURL = gdn.getMeta('context')["dynamicPathFolder"] + gdn.url('/settings/analyticstick.json');
+        var StatsURL = gdn.url('settings/analyticstick.json');
         var SendData = {
             'TransientKey': gdn.definition('TransientKey'),
             'Path': gdn.definition('Path'),


### PR DESCRIPTION
Backporting #10300 to `release/2020.006`.

> Vanilla may specify a path for its cookies. If specified, those cookies will only be sent on requests within that path. Some path-altering behavior was introduced in vanilla/vanilla#9809 that allowed the path to Vanilla's analytics endpoint to be overridden. If its path was not the same as Vanilla's cookie path (and it very likely would not be), vital cookies would not be sent to the analytics endpoint.
>
> The path changes for the analytics endpoint path are reverted here to reflect their state [prior to December 2019](https://github.com/vanilla/vanilla/commit/2c506946424fbc35d7ac23a4954f90b464b97238).