### PR TITLE
Fix path of new message button to be new message and not inbox

### DIFF
--- a/library/src/scripts/headers/mebox/pieces/MessagesContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/MessagesContents.tsx
@@ -43,7 +43,7 @@ export class MessagesContents extends React.Component<IProps> {
                     <FrameHeaderWithAction title={title}>
                         <LinkAsButton
                             title={t("New Message")}
-                            to={"/messages/new"}
+                            to={"/messages/add"}
                             baseClass={ButtonTypes.ICON}
                             className={classNames(buttonUtils.pushRight)}
                         >

--- a/library/src/scripts/headers/mebox/pieces/MessagesContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/MessagesContents.tsx
@@ -43,7 +43,7 @@ export class MessagesContents extends React.Component<IProps> {
                     <FrameHeaderWithAction title={title}>
                         <LinkAsButton
                             title={t("New Message")}
-                            to={"/messages/inbox"}
+                            to={"/messages/new"}
                             baseClass={ButtonTypes.ICON}
                             className={classNames(buttonUtils.pushRight)}
                         >


### PR DESCRIPTION
Seems like we've had 2 links to the messages inbox instead of 1 to new message and 1 to inbox in the mebox messages menu.

@hhovhannes 