### PR TITLE
Foundation - Removed padding from user photo

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/forumLayoutStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/forumLayoutStyles.ts
@@ -155,10 +155,6 @@ export const forumLayoutCSS = () => {
                 all: globalVars.gutter.half,
             }),
             $nest: {
-                "& .PhotoWrapLarge img": {
-                    left: globalVars.gutter.half,
-                    right: globalVars.gutter.half,
-                },
                 "& > *": {
                     ...paddings({
                         horizontal: globalVars.gutter.half,

--- a/applications/dashboard/src/scripts/compatibilityStyles/index.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/index.ts
@@ -328,6 +328,10 @@ export const compatibilityStyles = useThemeCache(() => {
         marginTop: unit(vars.gutter.size),
     });
 
+    cssOut(`.Panel > .PhotoWrapLarge`, {
+        padding: 0,
+    });
+
     cssOut(".Panel li a", {
         minHeight: 0,
     });


### PR DESCRIPTION
Removed padding from user photo, it was getting cut off by its parent container.

Closes :https://github.com/vanilla/vanilla/issues/10250

