### PR TITLE
Extend SearchRecordTypeInterface with getIndexWeight() method.

### DIFF
--- a/library/Vanilla/Contracts/Search/SearchRecordTypeInterface.php
+++ b/library/Vanilla/Contracts/Search/SearchRecordTypeInterface.php
@@ -41,6 +41,13 @@ interface SearchRecordTypeInterface {
     public function getIndexName(): string;
 
     /**
+     * Get sphinx index weight
+     *
+     * @return integer
+     */
+    public function getIndexWeight(): int;
+
+    /**
      * Get search record linked data model type
      *
      * @return mixed

--- a/library/Vanilla/Contracts/Search/SearchRecordTypeTrait.php
+++ b/library/Vanilla/Contracts/Search/SearchRecordTypeTrait.php
@@ -94,6 +94,15 @@ trait SearchRecordTypeTrait {
     public function getIndexName(): string {
         return $this->templateExists() ? self::SPHINX_INDEX : '';
     }
+    /**
+     * @inheritdoc
+     */
+    public function getIndexWeight(): int {
+        $oClass = new ReflectionClass(__CLASS__);
+        $constants = $oClass->getConstants();
+        $weight = $constants['SPHINX_INDEX_WEIGHT'] ?? 1;
+        return $weight;
+    }
 
     /**
      * Check if sphinx index template is enabled on infrastructure.


### PR DESCRIPTION
Default index weight in SearchRecordTypeTrait to 1.

Relates to: https://github.com/vanilla/knowledge/issues/1658
