### PR TITLE
Add support for addons hooking in before user signin

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -567,6 +567,7 @@ class EntryController extends Gdn_Controller {
             }
 
             // Sign the user in.
+            Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $userID]);
             Gdn::session()->start($userID, true, (bool)$this->Form->getFormValue('RememberMe', c('Garden.SSO.RememberMe', true)));
             Gdn::userModel()->fireEvent('AfterSignIn');
 
@@ -659,6 +660,7 @@ class EntryController extends Gdn_Controller {
                             ]);
 
                             // Sign the user in.
+                            Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $userID]);
                             Gdn::session()->start($userID, true, (bool)$this->Form->getFormValue('RememberMe', c('Garden.SSO.RememberMe', true)));
                             Gdn::userModel()->fireEvent('AfterSignIn');
                             $this->_setRedirect(Gdn::request()->get('display') === 'popup');
@@ -787,6 +789,7 @@ class EntryController extends Gdn_Controller {
                     $this->Form->setFormValue('UserSelect', false);
 
                     // Sign in as the new user.
+                    Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $userID]);
                     Gdn::session()->start($userID, true, (bool)$this->Form->getFormValue('RememberMe', c('Garden.SSO.RememberMe', true)));
                     Gdn::userModel()->fireEvent('AfterSignIn');
 
@@ -908,6 +911,7 @@ class EntryController extends Gdn_Controller {
                 }
 
                 // Sign the user in.
+                Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $userID]);
                 Gdn::session()->start($this->Form->getFormValue('UserID'), true, (bool)$this->Form->getFormValue('RememberMe', c('Garden.SSO.RememberMe', true)));
                 Gdn::userModel()->fireEvent('AfterSignIn');
 
@@ -1106,6 +1110,7 @@ class EntryController extends Gdn_Controller {
                                 Gdn::userModel()->setField(val('UserID', $user), ['Password' => $pw, 'HashMethod' => 'Vanilla']);
                             }
 
+                            Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $user->UserID]);
                             Gdn::session()->start(val('UserID', $user), true, (bool)$this->Form->getFormValue('RememberMe'));
                             Gdn::userModel()->fireEvent('AfterSignIn');
                             if (!Gdn::session()->checkPermission('Garden.SignIn.Allow')) {

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1107,6 +1107,12 @@ class EntryController extends Gdn_Controller {
                             }
 
                             Gdn::session()->start(val('UserID', $user), true, (bool)$this->Form->getFormValue('RememberMe'));
+                            // If user is banned, check for expired warnings.
+                            if (!Gdn::session()->checkPermission('Garden.SignIn.Allow')) {
+//                                (new Garden\EventManager)->fire('CheckExpiredBan', ['UserID' => $user->UserID]);
+                                $this->fireEvent('CheckExpiredBan', ['UserID' => $user->UserID]);
+                                Gdn::session()->getPermissions();
+                            }
                             if (!Gdn::session()->checkPermission('Garden.SignIn.Allow')) {
                                 $this->Form->addError('ErrorPermission');
                                 Gdn::session()->end();

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1110,7 +1110,7 @@ class EntryController extends Gdn_Controller {
                                 Gdn::userModel()->setField(val('UserID', $user), ['Password' => $pw, 'HashMethod' => 'Vanilla']);
                             }
 
-                            Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $user->UserID]);
+                            Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $user->UserID ?? false]);
                             Gdn::session()->start(val('UserID', $user), true, (bool)$this->Form->getFormValue('RememberMe'));
                             if (!Gdn::session()->checkPermission('Garden.SignIn.Allow')) {
                                 $this->Form->addError('ErrorPermission');

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1112,7 +1112,6 @@ class EntryController extends Gdn_Controller {
 
                             Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $user->UserID]);
                             Gdn::session()->start(val('UserID', $user), true, (bool)$this->Form->getFormValue('RememberMe'));
-                            Gdn::userModel()->fireEvent('AfterSignIn');
                             if (!Gdn::session()->checkPermission('Garden.SignIn.Allow')) {
                                 $this->Form->addError('ErrorPermission');
                                 Gdn::session()->end();
@@ -1126,6 +1125,8 @@ class EntryController extends Gdn_Controller {
                                 if ($hourOffset != Gdn::session()->User->HourOffset) {
                                     Gdn::userModel()->setProperty(Gdn::session()->UserID, 'HourOffset', $hourOffset);
                                 }
+
+                                Gdn::userModel()->fireEvent('AfterSignIn');
 
                                 $this->_setRedirect();
                             }

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -911,7 +911,7 @@ class EntryController extends Gdn_Controller {
                 }
 
                 // Sign the user in.
-                Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $userID]);
+                Gdn::userModel()->fireEvent('BeforeSignIn', ['UserID' => $this->Form->getFormValue('UserID')]);
                 Gdn::session()->start($this->Form->getFormValue('UserID'), true, (bool)$this->Form->getFormValue('RememberMe', c('Garden.SSO.RememberMe', true)));
                 Gdn::userModel()->fireEvent('AfterSignIn');
 

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -1107,12 +1107,7 @@ class EntryController extends Gdn_Controller {
                             }
 
                             Gdn::session()->start(val('UserID', $user), true, (bool)$this->Form->getFormValue('RememberMe'));
-                            // If user is banned, check for expired warnings.
-                            if (!Gdn::session()->checkPermission('Garden.SignIn.Allow')) {
-//                                (new Garden\EventManager)->fire('CheckExpiredBan', ['UserID' => $user->UserID]);
-                                $this->fireEvent('CheckExpiredBan', ['UserID' => $user->UserID]);
-                                Gdn::session()->getPermissions();
-                            }
+                            Gdn::userModel()->fireEvent('AfterSignIn');
                             if (!Gdn::session()->checkPermission('Garden.SignIn.Allow')) {
                                 $this->Form->addError('ErrorPermission');
                                 Gdn::session()->end();
@@ -1126,8 +1121,6 @@ class EntryController extends Gdn_Controller {
                                 if ($hourOffset != Gdn::session()->User->HourOffset) {
                                     Gdn::userModel()->setProperty(Gdn::session()->UserID, 'HourOffset', $hourOffset);
                                 }
-
-                                Gdn::userModel()->fireEvent('AfterSignIn');
 
                                 $this->_setRedirect();
                             }


### PR DESCRIPTION
Along with vanilla/internal#2331, this closes vanilla/support#1606

This PR, in conjunction with vanilla/internal#2331, fixes a problem where temporary bans triggered by amassing more than 5 active warning points would never expire because the session would end before there was a check for expired warnings. This fixes that by adding a beforeSignIn event to complement the afterSignIn event calls in the entry controller.

### TO TEST
1. Give a user 5 or more active warning points and verify that the user is banned.
1. Alter the times in the GDN_UserAlert table to make the ban expire.
1. Try to sign in as the banned user and verify that the ban has been lifted