### PR TITLE
Add SplitMerge translation strings to locale

### DIFF
--- a/plugins/SplitMerge/locale/en.php
+++ b/plugins/SplitMerge/locale/en.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @author Richard Flynn <richard.flynn@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+// phpcs:ignoreFile
+
+$Definition['Create New Discussion'] = 'Create New Discussion';
+$Definition['Leave a redirect link from the old discussions.'] = 'Leave a redirect link from the old discussions.';
+$Definition['New Discussion Topic'] = 'New Discussion Topic';
+$Definition['Split %s to new discussion'] = 'You have chosen to split %s into a new discussion.';

--- a/plugins/SplitMerge/locale/en.php
+++ b/plugins/SplitMerge/locale/en.php
@@ -6,7 +6,4 @@
  */
 // phpcs:ignoreFile
 
-$Definition['Create New Discussion'] = 'Create New Discussion';
-$Definition['Leave a redirect link from the old discussions.'] = 'Leave a redirect link from the old discussions.';
-$Definition['New Discussion Topic'] = 'New Discussion Topic';
 $Definition['Split %s to new discussion'] = 'You have chosen to split %s into a new discussion.';

--- a/plugins/SplitMerge/views/mergediscussions.php
+++ b/plugins/SplitMerge/views/mergediscussions.php
@@ -18,7 +18,7 @@ if (count($Discussions) < 2) {
     echo '</li></ul>';
 
     echo '<div class="P">'.
-        $this->Form->checkBox('RedirectLink', 'Leave a redirect links from the old discussions.').
+        $this->Form->checkBox('RedirectLink', 'Leave a redirect link from the old discussions.').
         '</div>';
 
     echo '<div class="Buttons">'.


### PR DESCRIPTION
Closes vanilla/support#1630

This PR adds a locale directory and en.php file to the splitmerge plugin. It also fixes a typo in the `mergediscussions` view.