### PR TITLE
Add various theme fixes

### DIFF
--- a/applications/dashboard/models/BannerImageModel.php
+++ b/applications/dashboard/models/BannerImageModel.php
@@ -56,6 +56,8 @@ class BannerImageModel {
         $propsJson = htmlspecialchars(json_encode($props, JSON_UNESCAPED_UNICODE), ENT_QUOTES);
         if (inSection(c("Theme.Banner.VisibleSections"))) {
             $html = "<div data-react='community-banner' data-props='$propsJson'><div style=\"minHeight='500px'\"></div></div>";
+        } else {
+            $html = "<div data-react='community-content-banner' data-props='$propsJson'><div style=\"minHeight='500px'\"></div></div>";
         }
         return new \Twig\Markup($html, 'utf-8');
     }

--- a/applications/dashboard/src/scripts/entries/forum.tsx
+++ b/applications/dashboard/src/scripts/entries/forum.tsx
@@ -25,7 +25,7 @@ import { applyCompatibilityIcons } from "@dashboard/compatibilityStyles/compatib
 import { fullBackgroundCompat } from "@vanilla/library/src/scripts/layout/Backgrounds";
 import { applySharedPortalContext } from "@vanilla/react-utils";
 import { ErrorPage } from "@vanilla/library/src/scripts/errorPages/ErrorComponent";
-import CommunityBanner from "@vanilla/library/src/scripts/banner/CommunityBanner";
+import { CommunityBanner, CommunityContentBanner } from "@vanilla/library/src/scripts/banner/CommunityBanner";
 
 onReady(initAllUserContent);
 onContent(convertAllUserContent);
@@ -58,6 +58,7 @@ addComponent("App", () => <Router disableDynamicRouting />);
 
 addComponent("title-bar-hamburger", TitleBarHamburger);
 addComponent("community-banner", CommunityBanner);
+addComponent("community-content-banner", CommunityContentBanner);
 
 if (getMeta("themeFeatures.DataDrivenTheme", false)) {
     compatibilityStyles();

--- a/library/Vanilla/Models/CurrentUserPreloadProvider.php
+++ b/library/Vanilla/Models/CurrentUserPreloadProvider.php
@@ -19,13 +19,18 @@ class CurrentUserPreloadProvider implements ReduxActionProviderInterface {
     /** @var \UsersApiController */
     private $usersApi;
 
+    /** @var \SessionController */
+    private $session;
+
     /**
      * DI.
      *
      * @param \UsersApiController $usersApi
+     * @param \Gdn_Session $session
      */
-    public function __construct(\UsersApiController $usersApi) {
+    public function __construct(\UsersApiController $usersApi, \Gdn_Session $session) {
         $this->usersApi = $usersApi;
+        $this->session = $session;
     }
 
 
@@ -34,9 +39,10 @@ class CurrentUserPreloadProvider implements ReduxActionProviderInterface {
      */
     public function createActions(): array {
         $user = $this->usersApi->get_me([]);
-
+        $permissions = $this->usersApi->get_permissions($this->session->UserID);
         return [
-            new ReduxAction(\UsersApiController::ME_ACTION_CONSTANT, Data::box($user), [])
+            new ReduxAction(\UsersApiController::ME_ACTION_CONSTANT, Data::box($user), []),
+            new ReduxAction(\UsersApiController::PERMISSIONS_ACTION_CONSTANT, Data::box($permissions), [])
         ];
     }
 }

--- a/library/Vanilla/Models/FsThemeProvider.php
+++ b/library/Vanilla/Models/FsThemeProvider.php
@@ -305,7 +305,14 @@ class FsThemeProvider implements ThemeProviderInterface {
         if ($filename) {
             $fullFilename = $theme->path("/assets/{$filename}");
             if (!file_exists($fullFilename) || !is_readable($fullFilename)) {
-                trigger_error("Theme asset file does not exist or is not readable: {$fullFilename}", E_USER_WARNING);
+                if (!$asset['isDefault']) {
+                    $message = "Theme asset file does not exist or is not readable: {$fullFilename}";
+                    if (debug()) {
+                        throw new ServerException($message);
+                    } else {
+                        trigger_error($message, E_USER_WARNING);
+                    }
+                }
             } else {
                 return file_get_contents($fullFilename);
             }
@@ -373,6 +380,7 @@ class FsThemeProvider implements ThemeProviderInterface {
     private function getDefaultAssets(): array {
         return [
             "variables" => [
+                'isDefault' => true,
                 "type" => "json",
                 "file" => "variables.json",
                 "placeholder" => '{}',

--- a/library/Vanilla/Models/SiteMeta.php
+++ b/library/Vanilla/Models/SiteMeta.php
@@ -165,7 +165,7 @@ class SiteMeta implements \JsonSerializable {
         $currentThemeAddon = $themeModel->getCurrentThemeAddon();
 
         $this->activeThemeKey = $currentTheme['themeID'];
-        $this->activeThemeViewPath = $currentThemeAddon->path('/views');
+        $this->activeThemeViewPath = $currentThemeAddon->path('/views/');
         $this->mobileThemeKey = $config->get('Garden.MobileTheme', 'Garden.Theme');
         $this->themePreview =  $themeModel->getPreviewTheme();
 

--- a/library/Vanilla/Models/SiteMeta.php
+++ b/library/Vanilla/Models/SiteMeta.php
@@ -61,6 +61,9 @@ class SiteMeta implements \JsonSerializable {
     private $mobileThemeKey;
 
     /** @var string */
+    private $desktopThemeKey;
+
+    /** @var string */
     private $activeThemeViewPath;
 
     /** @var ThemeFeatures */
@@ -167,6 +170,7 @@ class SiteMeta implements \JsonSerializable {
         $this->activeThemeKey = $currentTheme['themeID'];
         $this->activeThemeViewPath = $currentThemeAddon->path('/views/');
         $this->mobileThemeKey = $config->get('Garden.MobileTheme', 'Garden.Theme');
+        $this->desktopThemeKey = $config->get('Garden.Theme', ThemeModel::FALLBACK_THEME_KEY);
         $this->themePreview =  $themeModel->getPreviewTheme();
 
         if ($favIcon = $config->get("Garden.FavIcon")) {
@@ -214,6 +218,7 @@ class SiteMeta implements \JsonSerializable {
                 'localeKey' => $this->localeKey,
                 'themeKey' => $this->activeThemeKey,
                 'mobileThemeKey' => $this->mobileThemeKey,
+                'desktopThemeKey' => $this->desktopThemeKey,
                 'logo' => $this->logo,
                 'favIcon' => $this->favIcon,
                 'shareImage' => $this->shareImage,

--- a/library/Vanilla/Theme/ThemeFeatures.php
+++ b/library/Vanilla/Theme/ThemeFeatures.php
@@ -7,16 +7,15 @@
 
 namespace Vanilla\Theme;
 
-use Vanilla\Addon;
+use Vanilla\Contracts\AddonInterface;
 use Vanilla\Contracts\ConfigurationInterface;
-use Vanilla\Models\ThemeModel;
 
 /**
  * Class to hold information about a theme and it's configuration options.
  */
 class ThemeFeatures implements \JsonSerializable {
 
-    /** @var Addon */
+    /** @var AddonInterface */
     private $theme;
 
     /** @var ConfigurationInterface */
@@ -36,9 +35,9 @@ class ThemeFeatures implements \JsonSerializable {
      * Constuctor.
      *
      * @param ConfigurationInterface $config
-     * @param Addon $theme
+     * @param AddonInterface $theme
      */
-    public function __construct(ConfigurationInterface $config, Addon $theme) {
+    public function __construct(ConfigurationInterface $config, AddonInterface $theme) {
         $this->config = $config;
         $this->theme = $theme;
     }

--- a/library/Vanilla/Theme/ThemeFeatures.php
+++ b/library/Vanilla/Theme/ThemeFeatures.php
@@ -22,6 +22,8 @@ class ThemeFeatures implements \JsonSerializable {
     /** @var ConfigurationInterface */
     private $config;
 
+    private $forcedFeatures = [];
+
     const FEATURE_DEFAULTS = [
         'NewFlyouts' => false,
         'SharedMasterView' => false,
@@ -39,6 +41,15 @@ class ThemeFeatures implements \JsonSerializable {
     public function __construct(ConfigurationInterface $config, Addon $theme) {
         $this->config = $config;
         $this->theme = $theme;
+    }
+
+    /**
+     * Force some theme features to be active.
+     *
+     * @param array $forcedFeatures An array of Feature => boolean.
+     */
+    public function forceThemeValues(array $forcedFeatures) {
+        $this->forcedFeatures = $forcedFeatures;
     }
 
     /**
@@ -68,7 +79,7 @@ class ThemeFeatures implements \JsonSerializable {
             $themeValues['NewFlyouts'] = true;
         }
 
-        return array_merge(self::FEATURE_DEFAULTS, $configValues, $themeValues);
+        return array_merge(self::FEATURE_DEFAULTS, $configValues, $themeValues, $this->forcedFeatures);
     }
 
     /**

--- a/library/Vanilla/Theme/ThemeFeatures.php
+++ b/library/Vanilla/Theme/ThemeFeatures.php
@@ -48,7 +48,7 @@ class ThemeFeatures implements \JsonSerializable {
      *
      * @param array $forcedFeatures An array of Feature => boolean.
      */
-    public function forceThemeValues(array $forcedFeatures) {
+    public function forceFeatures(array $forcedFeatures) {
         $this->forcedFeatures = $forcedFeatures;
     }
 

--- a/library/Vanilla/Web/TwigEnhancer.php
+++ b/library/Vanilla/Web/TwigEnhancer.php
@@ -261,6 +261,15 @@ class TwigEnhancer {
     }
 
     /**
+     * Make an asset URL.
+     *
+     * @param string $url
+     */
+    public function assetUrl(string $url) {
+        return asset($url, true, true);
+    }
+
+    /**
      * Render out breadcrumbs from the controller.
      *
      * @param array $options
@@ -311,6 +320,7 @@ class TwigEnhancer {
             'inSection' => [\Gdn_Theme::class, 'inSection'],
 
             // Routing.
+            'assetUrl' => [$this, 'assetUrl'],
             'url' => [$this->request, 'url'],
         ];
     }

--- a/library/Vanilla/Web/TwigEnhancer.php
+++ b/library/Vanilla/Web/TwigEnhancer.php
@@ -10,6 +10,7 @@ namespace Vanilla\Web;
 use Garden\EventManager;
 use \Gdn_Request;
 use Gdn;
+use PocketsPlugin;
 use Twig\Loader\FilesystemLoader;
 use Twig\TwigFunction;
 use Vanilla\Contracts\AddonProviderInterface;
@@ -199,6 +200,23 @@ class TwigEnhancer {
     }
 
     /**
+     * Render a pocket if it exists.
+     *
+     * @param string $pocketName The name of the pocket.
+     * @param array $pocketArgs Arguments to pass to PocketsPlugin::pocketString().
+     *
+     * @return \Twig\Markup
+     */
+    public function renderPocket(string $pocketName, array $pocketArgs = []): \Twig\Markup {
+        if (!class_exists(PocketsPlugin::class)) {
+            return new \Twig\Markup('', 'utf-8');
+        }
+
+        $result = PocketsPlugin::pocketString($pocketName, $pocketArgs);
+        return new \Twig\Markup($result, 'utf-8');
+    }
+
+    /**
      * Get a config key. The result will then be cached for the instance of the twig enhancer.
      *
      * @param string $key Config key.
@@ -282,6 +300,7 @@ class TwigEnhancer {
             'renderControllerAsset' => [$this, 'renderControllerAsset'],
             'renderModule' => [$this, 'renderModule'],
             'renderBreadcrumbs' => [$this, 'renderBreadcrumbs'],
+            'renderPocket' => [$this, 'renderPocket'],
             'renderBanner' => $this->bannerImageModel ? [$this->bannerImageModel, 'renderBanner'] : [$this, 'renderNoop'],
             'fireEchoEvent' => [$this, 'fireEchoEvent'],
             'firePluggableEchoEvent' => [$this, 'firePluggableEchoEvent'],

--- a/library/Vanilla/Web/TwigRenderTrait.php
+++ b/library/Vanilla/Web/TwigRenderTrait.php
@@ -31,7 +31,7 @@ trait TwigRenderTrait {
 
         $isDebug = \Gdn::config('Debug') === true;
         $envArgs = [
-            'cache' => $enhancer->getCompileCacheDirectory() ?? false, // Null not allowed. Only false or string.
+            'cache' => $isDebug ? false : $enhancer->getCompileCacheDirectory() ?? false, // Null not allowed. Only false or string.
             'debug' => $isDebug,
             // Automatically controlled by the debug value.
             // This causes twig to check the FS timestamp before going to cache.

--- a/library/src/scripts/banner/CommunityBanner.tsx
+++ b/library/src/scripts/banner/CommunityBanner.tsx
@@ -17,12 +17,23 @@ interface IProps {
 }
 
 /**
- * A component representing a single crumb in a breadcrumb component.
+ * Main banner for the community.
  */
-export default function CommunityBanner(props: IProps) {
+export function CommunityBanner(props: IProps) {
     return (
         <MemoryRouter>
             <Banner {...props} />
+        </MemoryRouter>
+    );
+}
+
+/**
+ * Content banner for the community.
+ */
+export function CommunityContentBanner(props: IProps) {
+    return (
+        <MemoryRouter>
+            <Banner {...props} isContentBanner />
         </MemoryRouter>
     );
 }

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -41,6 +41,7 @@ import { BackgroundColorProperty, FontWeightProperty, PaddingProperty, TextShado
 import { calc, important, percent, px, quote, rgba, translateX, translateY, ColorHelper } from "csx";
 import { media } from "typestyle";
 import { NestedCSSProperties, TLength } from "typestyle/lib/types";
+import { titleBarVariables } from "@library/headers/titleBarStyles";
 
 export enum BannerAlignment {
     LEFT = "left",
@@ -818,20 +819,30 @@ export const bannerClasses = useThemeCache(
                   }
                 : {};
 
+        const titleBarVars = titleBarVariables();
+
         // NOTE FOR FUTURE
         // Do no apply overflow hidden here.
         // It will cut off the search box in the banner.
-        const root = style({
-            position: "relative",
-            maxWidth: percent(100),
-            backgroundColor: colorOut(vars.outerBackground.color),
-            $nest: {
-                [`& .${searchBarClasses().independentRoot}`]: rootConditionalStyles,
-                "& .searchBar": {
-                    height: unit(vars.searchBar.sizing.height),
+        const root = style(
+            {
+                position: "relative",
+                maxWidth: percent(100),
+                backgroundColor: colorOut(vars.outerBackground.color),
+                $nest: {
+                    [`& .${searchBarClasses().independentRoot}`]: rootConditionalStyles,
+                    "& .searchBar": {
+                        height: unit(vars.searchBar.sizing.height),
+                    },
                 },
             },
-        });
+            titleBarVars.swoop.amount > 0
+                ? {
+                      marginTop: -titleBarVars.swoop.swoopOffset,
+                      paddingTop: titleBarVars.swoop.swoopOffset,
+                  }
+                : {},
+        );
 
         // Use this for cutting of the right image with overflow hidden.
         const overflowRightImageContainer = style("overflowRightImageContainer", {

--- a/library/src/scripts/banner/contentBannerStyles.tsx
+++ b/library/src/scripts/banner/contentBannerStyles.tsx
@@ -7,6 +7,7 @@ import { useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { bannerVariables, bannerClasses, BannerAlignment } from "@library/banner/bannerStyles";
 import clamp from "lodash/clamp";
 import { IThemeVariables } from "@library/theming/themeReducer";
+import { EMPTY_SPACING } from "@library/styles/styleHelpers";
 
 export const CONTENT_BANNER_MAX_HEIGHT = 180;
 export const CONTENT_BANNER_MIN_HEIGHT = 80;
@@ -28,6 +29,19 @@ export const contentBannerVariables = useThemeCache((forcedVars?: IThemeVariable
         enabled: false,
         alignment: BannerAlignment.CENTER,
         mobileAlignment: BannerAlignment.LEFT,
+    });
+
+    const contentContainer = makeVars("contentContainer", {
+        padding: {
+            ...EMPTY_SPACING,
+        },
+        mobile: {
+            padding: {
+                ...EMPTY_SPACING,
+                top: 0,
+                bottom: 0,
+            },
+        },
     });
 
     const normalBannerVars = bannerVariables();
@@ -60,14 +74,7 @@ export const contentBannerVariables = useThemeCache((forcedVars?: IThemeVariable
                         bottom: 0,
                     },
                 },
-                contentContainer: {
-                    mobile: {
-                        padding: {
-                            top: 0,
-                            bottom: 0,
-                        },
-                    },
-                },
+                contentContainer,
             },
         },
         "contentBanner",

--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -84,6 +84,7 @@ export const buttonVariables = useThemeCache((forcedVars?: IThemeVariables) => {
     const globalVars = globalVariables(forcedVars);
     const makeThemeVars = variableFactory("button", forcedVars);
     const vars = buttonGlobalVariables(forcedVars);
+    const buttonGlobals = buttonGlobalVariables();
 
     const standardPresetInit = makeThemeVars("standard", {
         preset: {
@@ -130,11 +131,12 @@ export const buttonVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         },
         borders: {
             color: standardPreset.preset.border,
-            radius: globalVars.border.radius,
+            radius: buttonGlobals.border.radius,
         },
         state: {
             borders: {
                 ...globalVars.borderType.formElements.buttons,
+                radius: buttonGlobals.border.radius,
                 color: standardPreset.preset.borderState,
             },
             colors: {
@@ -185,7 +187,7 @@ export const buttonVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         },
         borders: {
             color: primaryPreset.preset.border,
-            radius: globalVars.border.radius,
+            radius: buttonGlobals.border.radius,
         },
         state: {
             colors: {
@@ -193,6 +195,7 @@ export const buttonVariables = useThemeCache((forcedVars?: IThemeVariables) => {
                 fg: primaryPreset.preset.fgState,
             },
             borders: {
+                radius: buttonGlobals.border.radius,
                 color: primaryPreset.preset.borderState,
             },
         },

--- a/library/src/scripts/forms/styleHelperButtonGenerator.ts
+++ b/library/src/scripts/forms/styleHelperButtonGenerator.ts
@@ -73,6 +73,7 @@ export const generateButtonStyleProperties = (buttonTypeVars: IButtonType, setZI
 
     let defaultBorder = borders({
         ...EMPTY_BORDER,
+        ...buttonGlobals.border,
         ...buttonTypeVars.borders,
     });
 
@@ -80,25 +81,37 @@ export const generateButtonStyleProperties = (buttonTypeVars: IButtonType, setZI
 
     const hoverBorder =
         buttonTypeVars.hover && buttonTypeVars.hover.borders
-            ? merge(cloneDeep(defaultBorder), borders({ ...EMPTY_BORDER, ...buttonTypeVars.hover.borders }))
+            ? merge(
+                  cloneDeep(defaultBorder),
+                  borders({ ...EMPTY_BORDER, ...buttonTypeVars.hover.borders }, buttonGlobals.border),
+              )
             : {};
 
     const activeBorder =
         buttonTypeVars.active && buttonTypeVars.active.borders
-            ? merge(cloneDeep(defaultBorder), borders({ ...EMPTY_BORDER, ...buttonTypeVars.active.borders }))
+            ? merge(
+                  cloneDeep(defaultBorder),
+                  borders({ ...EMPTY_BORDER, ...buttonTypeVars.active.borders }, buttonGlobals.border),
+              )
             : {};
 
     const focusBorder =
         buttonTypeVars.focus && buttonTypeVars.focus.borders
             ? merge(
                   cloneDeep(defaultBorder),
-                  borders({ ...EMPTY_BORDER, ...(buttonTypeVars.focus && buttonTypeVars.focus.borders) }),
+                  borders(
+                      { ...EMPTY_BORDER, ...(buttonTypeVars.focus && buttonTypeVars.focus.borders) },
+                      buttonGlobals.border,
+                  ),
               )
             : defaultBorder;
 
     const focusAccessibleBorder =
         buttonTypeVars.focusAccessible && buttonTypeVars.focusAccessible.borders
-            ? merge(cloneDeep(defaultBorder), borders({ ...EMPTY_BORDER, ...buttonTypeVars.focusAccessible.borders }))
+            ? merge(
+                  cloneDeep(defaultBorder),
+                  borders({ ...EMPTY_BORDER, ...buttonTypeVars.focusAccessible.borders }, buttonGlobals.border),
+              )
             : {};
 
     const fontVars = { ...EMPTY_FONTS, ...buttonGlobals.font, ...buttonTypeVars.fonts };

--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -127,7 +127,7 @@ export default function TitleBar(_props: IProps) {
                         ) : (
                             <FlexSpacer className="pageHeading-leftSpacer" />
                         ))}
-                    {!isCompact && (
+                    {!isCompact && (isDesktopLogoCentered ? !isSearchOpen : true) && (
                         <animated.div className={classNames(classes.logoAnimationWrap)} {...logoProps}>
                             <HeaderLogo
                                 className={classNames(

--- a/library/src/scripts/headers/titleBarNavStyles.ts
+++ b/library/src/scripts/headers/titleBarNavStyles.ts
@@ -4,7 +4,7 @@
  * @license GPL-2.0-only
  */
 
-import { percent, px, calc, quote } from "csx";
+import { percent, px, calc, quote, rgba } from "csx";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import {
     absolutePosition,
@@ -14,6 +14,7 @@ import {
     paddings,
     unit,
     userSelect,
+    isLightColor,
 } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { globalVariables } from "@library/styles/globalStyleVars";
@@ -39,10 +40,11 @@ export const titleBarNavigationVariables = useThemeCache(() => {
     });
 
     const linkActive = makeThemeVars("linkActive", {
-        offset: 2,
+        offset: 0,
         height: 3,
         bg: titleBarVars.colors.fg,
         bottomSpace: 1,
+        maxWidth: 40,
     });
 
     const navLinks = makeThemeVars("navLinks", {
@@ -130,16 +132,16 @@ const titleBarNavClasses = useThemeCache(() => {
         paddingRight: unit(vars.navLinks.padding.right),
         $nest: {
             "&.focus-visible": {
-                color: colorOut(titleBarVars.colors.fg),
-                backgroundColor: colorOut(titleBarVars.buttonContents.state.bg),
+                color: colorOut(titleBarVars.colors.state.fg),
+                backgroundColor: colorOut(titleBarVars.colors.state.bg),
             },
             "&:focus": {
-                color: colorOut(titleBarVars.colors.fg),
-                backgroundColor: colorOut(titleBarVars.buttonContents.state.bg),
+                color: colorOut(titleBarVars.colors.state.fg),
+                backgroundColor: colorOut(titleBarVars.colors.state.bg),
             },
             "&:hover": {
-                color: colorOut(titleBarVars.colors.fg),
-                backgroundColor: colorOut(titleBarVars.buttonContents.state.bg),
+                color: colorOut(titleBarVars.colors.state.fg),
+                backgroundColor: colorOut(titleBarVars.colors.state.bg),
             },
         },
     });
@@ -150,12 +152,14 @@ const titleBarNavClasses = useThemeCache(() => {
                 ...absolutePosition.topLeft(
                     `calc(50% - ${unit(vars.linkActive.height + vars.linkActive.bottomSpace)})`,
                 ),
+                maxWidth: unit(vars.linkActive.maxWidth),
                 content: quote(""),
                 height: unit(vars.linkActive.height),
+                left: percent(50),
                 marginLeft: unit(negative(vars.linkActive.offset)),
                 width: calc(`100% + ${unit(vars.linkActive.offset * 2)}`),
                 backgroundColor: colorOut(vars.linkActive.bg),
-                transform: `translateY(${unit(titleBarVars.sizing.height / 2)})`,
+                transform: `translate(-50%, ${unit(titleBarVars.sizing.height / 2)})`,
             },
         },
     });

--- a/library/src/scripts/headers/titleBarStyles.ts
+++ b/library/src/scripts/headers/titleBarStyles.ts
@@ -20,6 +20,8 @@ import {
     sticky,
     unit,
     userSelect,
+    EMPTY_FONTS,
+    isLightColor,
 } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import {
@@ -75,10 +77,18 @@ export const titleBarVariables = useThemeCache((forcedVars?: IThemeVariables) =>
         background: undefined as BackgroundProperty<TLength> | Array<BackgroundProperty<TLength>> | undefined,
     });
 
-    const colors = makeThemeVars("colors", {
+    const colorsInit = makeThemeVars("colors", {
         fg: globalVars.mainColors.primaryContrast,
         bg: globalVars.mainColors.primary,
         bgImage: null as string | null,
+    });
+
+    const colors = makeThemeVars("colors", {
+        ...colorsInit,
+        state: {
+            bg: isLightColor(colorsInit.bg) ? rgba(0, 0, 0, 0.1) : rgba(255, 255, 255, 0.1),
+            fg: colorsInit.fg,
+        },
     });
 
     const border = makeThemeVars("border", {
@@ -94,8 +104,13 @@ export const titleBarVariables = useThemeCache((forcedVars?: IThemeVariables) =>
             ? border.width
             : 0;
 
-    const swoop = makeThemeVars("swoop", {
+    const swoopInit = makeThemeVars("swoop", {
         amount: 0,
+    });
+
+    const swoop = makeThemeVars("swoop", {
+        ...swoopInit,
+        swoopOffset: (16 * swoopInit.amount) / 50,
     });
 
     const fullBleed = makeThemeVars("fullBleed", {
@@ -124,7 +139,7 @@ export const titleBarVariables = useThemeCache((forcedVars?: IThemeVariables) =>
             width: buttonSize,
         },
         state: {
-            bg: globalVars.mainColors.statePrimary,
+            bg: colors.state.bg,
         },
     });
 
@@ -139,6 +154,7 @@ export const titleBarVariables = useThemeCache((forcedVars?: IThemeVariables) =>
             fg: colors.fg,
         },
         fonts: {
+            ...EMPTY_FONTS,
             color: colors.fg,
         },
         sizing: {
@@ -402,9 +418,16 @@ export const titleBarClasses = useThemeCache(() => {
                 backgroundColor: colorOut(vars.compactSearch.bg),
             },
         },
-        ...mediaQueries.compact({
-            height: px(vars.sizing.mobile.height),
-        }).$nest,
+        ...(vars.swoop.amount
+            ? {
+                  $nest: {
+                      "& + *": {
+                          // Offset the next element to account for the swoop. (next element should go under the swoop slightly).
+                          marginTop: -vars.swoop.swoopOffset,
+                      },
+                  },
+              }
+            : {}),
     });
 
     const swoopStyles = {
@@ -428,7 +451,7 @@ export const titleBarClasses = useThemeCache(() => {
     const bg1 = style("bg1", {
         willChange: "opacity",
         ...absolutePosition.fullSizeOfParent(),
-        backgroundColor: colorOut(vars.colors.bg),
+        // backgroundColor: colorOut(vars.colors.bg),
         ...shadowAsBorder,
         overflow: "hidden",
         $nest: {
@@ -528,7 +551,7 @@ export const titleBarClasses = useThemeCache(() => {
             alignSelf: "center",
             color: colorOut(vars.colors.fg),
             marginRight: unit(vars.logo.offsetRight),
-            justifyContent: vars.mobileLogo.justifyContent,
+            justifyContent: vars.logo.justifyContent,
             ...logoOffsetDesktop,
             $nest: {
                 "&&": {
@@ -692,23 +715,7 @@ export const titleBarClasses = useThemeCache(() => {
                 "&&": {
                     ...allButtonStates(
                         {
-                            active: {
-                                color: colorOut(vars.colors.fg),
-                                $nest: {
-                                    "& .meBox-buttonContent": {
-                                        backgroundColor: colorOut(vars.buttonContents.state.bg),
-                                    },
-                                },
-                            },
-                            hover: {
-                                color: colorOut(vars.colors.fg),
-                                $nest: {
-                                    "& .meBox-buttonContent": {
-                                        backgroundColor: colorOut(vars.buttonContents.state.bg),
-                                    },
-                                },
-                            },
-                            focus: {
+                            allStates: {
                                 color: colorOut(vars.colors.fg),
                                 $nest: {
                                     "& .meBox-buttonContent": {

--- a/library/src/scripts/layout/PanelLayout.tsx
+++ b/library/src/scripts/layout/PanelLayout.tsx
@@ -14,6 +14,7 @@ import classNames from "classnames";
 import React, { useMemo, useRef } from "react";
 import { style } from "typestyle";
 import { panelBackgroundVariables } from "@library/layout/panelBackgroundStyles";
+import { useBannerContext } from "@library/banner/BannerContext";
 
 interface IProps {
     className?: string;
@@ -69,6 +70,7 @@ export default function PanelLayout(props: IProps) {
 
     // Measure the panel itself.
     const { offsetClass, topOffset } = useScrollOffset();
+    const { bannerRect } = useBannerContext();
     const device = useDevice();
     const panelRef = useRef<HTMLDivElement | null>(null);
     const sidePanelMeasure = useMeasure(panelRef);
@@ -77,7 +79,7 @@ export default function PanelLayout(props: IProps) {
         return measuredPanelTop + window.scrollY; // Every time this changes, adjust for the scroll height.
     }, [measuredPanelTop]);
 
-    const overflowOffset = sidePanelDistanceFromTop - topOffset;
+    const overflowOffset = sidePanelDistanceFromTop - topOffset - (bannerRect?.height ?? 0);
 
     const panelOffsetClass = useMemo(() => style({ top: overflowOffset, $debugName: "stickyOffset" }), [
         overflowOffset,

--- a/library/src/scripts/navigation/breadcrumbsStyles.ts
+++ b/library/src/scripts/navigation/breadcrumbsStyles.ts
@@ -16,16 +16,28 @@ import {
     singleLineEllipsis,
     unit,
     userSelect,
+    EMPTY_FONTS,
+    fonts,
 } from "@library/styles/styleHelpers";
 
 export const breadcrumbsVariables = useThemeCache(() => {
+    const globalVars = globalVariables();
     const makeVariables = variableFactory("breadcrumbs");
 
     const sizing = makeVariables("sizing", {
         minHeight: 16,
     });
 
-    return { sizing };
+    const link = makeVariables("link", {
+        textTransform: "uppercase",
+        font: {
+            ...EMPTY_FONTS,
+            size: globalVars.fonts.size.small,
+            lineHeight: globalVars.lineHeights.condensed,
+        },
+    });
+
+    return { sizing, link };
 });
 
 export const breadcrumbsClasses = useThemeCache(() => {
@@ -36,9 +48,8 @@ export const breadcrumbsClasses = useThemeCache(() => {
     const link = style("link", {
         ...singleLineEllipsis(),
         display: "inline-flex",
-        fontSize: unit(globalVars.fonts.size.small),
-        lineHeight: globalVars.lineHeights.condensed,
-        textTransform: "uppercase",
+        ...fonts(vars.link.font),
+        textTransform: vars.link.textTransform as any,
         color: colorOut(linkColors.color),
         $nest: linkColors.$nest,
     });

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -238,6 +238,7 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
             bold: 700,
         },
         forceGoogleFont: false,
+        customFontUrl: undefined as undefined | string,
         families: {
             body: ["Open Sans"],
             monospace: [],

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -218,7 +218,7 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         width: middleColumn.paddedWidth + panel.paddedWidth * 2 + gutter.size * 4,
     });
 
-    const fonts = makeThemeVars("fonts", {
+    const fontsInit = makeThemeVars("fonts", {
         size: {
             large: 16,
             medium: 14,
@@ -243,12 +243,18 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
             body: ["Open Sans"],
             monospace: [],
         },
+    });
+
+    const isOpenSans = fontsInit.families.body[0] === "Open Sans";
+
+    const fonts = makeThemeVars("fonts", {
+        ...fontsInit,
         alignment: {
             headings: {
-                capitalLetterRatio: 0.73, // Calibrated for Open Sans
-                verticalOffset: 1, // Calibrated for Open Sans
-                horizontal: -0.03, // Calibrated for Open Sans
-                verticalOffsetForAdjacentElements: "-.13em", // Calibrated for Open Sans
+                capitalLetterRatio: isOpenSans ? 0.73 : 0.75, // Calibrated for Open Sans
+                verticalOffset: 1,
+                horizontal: isOpenSans ? -0.03 : 0, // Calibrated for Open Sans
+                verticalOffsetForAdjacentElements: isOpenSans ? "-.13em" : "0em", // Calibrated for Open Sans
             },
         },
     });

--- a/library/src/scripts/theming/ThemeActions.ts
+++ b/library/src/scripts/theming/ThemeActions.ts
@@ -94,7 +94,6 @@ export default class ThemeActions extends ReduxActions {
             const response = await this.api.put(`/themes/current`, body);
             setMeta("ui.themeKey", themeID);
             setMeta("ui.mobileThemeKey", themeID);
-            setMeta("ui.desktopThemeKey", themeID);
             return response.data;
         })(body);
         return this.dispatch(thunk);

--- a/library/src/scripts/theming/ThemeActions.ts
+++ b/library/src/scripts/theming/ThemeActions.ts
@@ -94,6 +94,7 @@ export default class ThemeActions extends ReduxActions {
             const response = await this.api.put(`/themes/current`, body);
             setMeta("ui.themeKey", themeID);
             setMeta("ui.mobileThemeKey", themeID);
+            setMeta("ui.desktopThemeKey", themeID);
             return response.data;
         })(body);
         return this.dispatch(thunk);

--- a/library/src/scripts/theming/ThemePreviewTitle.tsx
+++ b/library/src/scripts/theming/ThemePreviewTitle.tsx
@@ -40,6 +40,6 @@ export function ThemePreviewTitle(props: IProps) {
             </h3>
         </ToolTip>
     ) : (
-        <h3 className={classes.title}>name</h3>
+        <h3 className={classes.title}>{name}</h3>
     );
 }

--- a/tests/Library/Vanilla/Theme/ThemeFeaturesTest.php
+++ b/tests/Library/Vanilla/Theme/ThemeFeaturesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Theme;
+
+use Vanilla\Theme\ThemeFeatures;
+use VanillaTests\Fixtures\MockAddon;
+use VanillaTests\MinimalContainerTestCase;
+
+/**
+ * Tests for theme features.
+ */
+class ThemeFeaturesTest extends MinimalContainerTestCase {
+
+    /**
+     * Test that data driven theme forces most other features on.
+     */
+    public function testDataDriven() {
+        $addon = new MockAddon('test', ['Features' => ['DataDrivenTheme' => true]]);
+        $features = new ThemeFeatures($this->getConfig(), $addon);
+        $this->assertTrue($features->useDataDrivenTheme());
+        $this->assertTrue($features->useSharedMasterView());
+        $this->assertTrue($features->useNewFlyouts());
+        $this->assertTrue($features->useProfileHeader());
+        $this->assertTrue($features->disableKludgedVars());
+    }
+
+    /**
+     * Test that data driven theme forces most other features on.
+     */
+    public function testSpecificItems() {
+        $addon = new MockAddon('test', ['Features' => ['SharedMasterView' => true, 'NewFlyouts' => true]]);
+        $features = new ThemeFeatures($this->getConfig(), $addon);
+        $this->assertFalse($features->useDataDrivenTheme());
+        $this->assertTrue($features->useSharedMasterView());
+        $this->assertTrue($features->useNewFlyouts());
+        $this->assertFalse($features->useProfileHeader());
+        $this->assertFalse($features->disableKludgedVars());
+    }
+
+    /**
+     * Test that data driven theme forces most other features on.
+     */
+    public function testForcedItems() {
+        $addon = new MockAddon('test', ['Features' => []]);
+        $features = new ThemeFeatures($this->getConfig(), $addon);
+        $features->forceFeatures(['SharedMasterView' => true]);
+
+        $this->assertFalse($features->useDataDrivenTheme());
+        $this->assertTrue($features->useSharedMasterView());
+        $this->assertFalse($features->useNewFlyouts());
+        $this->assertFalse($features->useProfileHeader());
+        $this->assertFalse($features->disableKludgedVars());
+    }
+}

--- a/tests/Library/Vanilla/Theme/ThemeFeaturesTest.php
+++ b/tests/Library/Vanilla/Theme/ThemeFeaturesTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @author Adam Charron <adam.c@vanillaforums.com>
  * @copyright 2009-2020 Vanilla Forums Inc.

--- a/tests/Library/Vanilla/Theme/TwigAssetTest.php
+++ b/tests/Library/Vanilla/Theme/TwigAssetTest.php
@@ -5,7 +5,7 @@
  * @license GPL-2.0-only
  */
 
-namespace VanillaTests\Library\Vanilla;
+namespace VanillaTests\Library\Theme;
 
 use Vanilla\Theme\TwigAsset;
 use VanillaTests\MinimalContainerTestCase;


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/10286
Closes https://github.com/vanilla/internal/issues/2333
Working towards https://github.com/vanilla/knowledge/issues/1682
Theme to test with https://github.com/vanillaforums/king/pull/230

Numerous features and fixes were implemented to service this issue.

## TitleBar

- Fix centered logo not hiding on search open
- Adjust titlebar nav to use transparent overlays 
- Add an offset for the item immediately following a "swooped" titlebar.
- Fix flickering of titlebar nav items with permissions (Items would "pop in" as permissions loaded). The fix was to preload the permissions the same way we preload the user info. 

## New Variables

- Add additional breadcrumb variables 
- Add simpler custom font loading (Just set `global.font.customFontUrl`)
- Add additional content banner variables.

## Banner

- Add the content banner to community when enabled.
- Fix panel layout offset to account for the content banner.

## Twig/Theme Utils

- Fix theme view path for custom master views (was broken due to a missing slash).
- Fix exceptions for default theme assets (default theme assets would point to a file that doesn't actually exist and trigger a warning. This was causes and exception in debug mode).
- Allow values for `ThemeFeatures` to be set from the container.

## Other Fixes

- Fix button border radius on hover. (it was going back to the global).
- Add a `renderPocket` method for twig templates. If pockets is not enabled or the pocket does not exist and empty string is returned (behaves the same as the smarty pocket function).
- Add assetURL function to twig. Forces fully qualified URLs and cache busters.
