### PR TITLE
Fix some URL formatting issues

### DIFF
--- a/library/core/class.vanillahtmlformatter.php
+++ b/library/core/class.vanillahtmlformatter.php
@@ -189,7 +189,7 @@ class VanillaHtmlFormatter {
             'valid_xhtml' => 0
         ];
 
-        if ($options['allowedExtendedContent'] ?? null) {
+        if ($options['allowedExtendedContent'] ?? false) {
             $elements = $config['elements'] ?? null;
             $config['elements'] = str_replace('-iframe', '', $elements);
         }
@@ -203,7 +203,9 @@ class VanillaHtmlFormatter {
         }
 
         // Turn embedded videos into simple links (legacy workaround)
-        $html = $this->legacyEmbedReplacer->unembedContent($html);
+        if (!($options['allowedExtendedContent'] ?? false)) {
+            $html = $this->legacyEmbedReplacer->unembedContent($html);
+        }
 
         // We check the flag within Gdn_Format to see
         // if htmLawed should place rel="nofollow" links

--- a/library/src/scripts/utility/appUtils.tsx
+++ b/library/src/scripts/utility/appUtils.tsx
@@ -139,7 +139,12 @@ export function siteUrl(path: string): string {
     // The context paths that come down are expect to have no / at the end of them.
     // Normally a domain like so: https://someforum.com
     // When we don't have that we want to fallback to "" so that our path with a / can get passed.
-    const urlBase = window.location.origin + getMeta("context.host", "");
+    let urlBase = window.location.origin;
+
+    const host = getMeta("context.host", "");
+    if (!path.startsWith(host)) {
+        urlBase += host;
+    }
     return urlBase + path;
 }
 


### PR DESCRIPTION
- Fix URLs in the frontend ocasionally getting the base path added twice. (this could occur easily if you used `assetUrl` or `themeUrl` on something, then used `siteUrl()` to get a fully qualified URL).
- Fix embeds getting un-embedded in the trusted content formatter. Youtube embeds were the one I noticed, but iframe embeds would get transformed into our ugly old embeds instead of staying as iframes.