### PR TITLE
Theme TitleBar improvements

### DIFF
--- a/library/Vanilla/Theme/KludgedVariablesProviderInterface.php
+++ b/library/Vanilla/Theme/KludgedVariablesProviderInterface.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Theme;
+
+interface KludgedVariablesProviderInterface extends VariablesProviderInterface {
+}

--- a/library/Vanilla/Theme/KludgedVariablesProviderInterface.php
+++ b/library/Vanilla/Theme/KludgedVariablesProviderInterface.php
@@ -7,5 +7,8 @@
 
 namespace Vanilla\Theme;
 
+/**
+ * A variable provider than can be ignored by the ThemeFeature 'DisableKludgedVars'.
+ */
 interface KludgedVariablesProviderInterface extends VariablesProviderInterface {
 }

--- a/library/Vanilla/Theme/VariablesProviderInterface.php
+++ b/library/Vanilla/Theme/VariablesProviderInterface.php
@@ -4,7 +4,7 @@
  * @license GPL-2.0-only
  */
 
- namespace Vanilla\Theme;
+namespace Vanilla\Theme;
 
  /**
   * Interface for providing variables on a theme.

--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -97,28 +97,30 @@ export default function TitleBar(_props: IProps) {
     }, [isPreviewFirstRender]);
 
     const headerContent = (
-        <HashOffsetReporter className={classes.bgContainer}>
-            <animated.div
-                {...bgProps}
-                className={classNames(classes.bg1, { [classes.swoop]: vars.swoop.amount > 0 })}
-            ></animated.div>
-            {!isPreviewFirstRender && (
+        <HashOffsetReporter className={classes.container}>
+            <div className={classes.bgContainer}>
                 <animated.div
-                    {...bg2Props}
-                    className={classNames(classes.bg2, { [classes.swoop]: vars.swoop.amount > 0 })}
-                >
-                    {/* Cannot be a background image there will be flickering. */}
-                    {vars.colors.bgImage && (
-                        <img
-                            src={vars.colors.bgImage}
-                            className={classes.bgImage}
-                            alt={"titleBarImage"}
-                            aria-hidden={true}
-                        />
-                    )}
-                    {vars.overlay && <div className={classes.overlay}></div>}
-                </animated.div>
-            )}
+                    {...bgProps}
+                    className={classNames(classes.bg1, { [classes.swoop]: vars.swoop.amount > 0 })}
+                ></animated.div>
+                {!isPreviewFirstRender && (
+                    <animated.div
+                        {...bg2Props}
+                        className={classNames(classes.bg2, { [classes.swoop]: vars.swoop.amount > 0 })}
+                    >
+                        {/* Cannot be a background image there will be flickering. */}
+                        {vars.colors.bgImage && (
+                            <img
+                                src={vars.colors.bgImage}
+                                className={classes.bgImage}
+                                alt={"titleBarImage"}
+                                aria-hidden={true}
+                            />
+                        )}
+                        {vars.overlay && <div className={classes.overlay}></div>}
+                    </animated.div>
+                )}
+            </div>
             <Container fullGutter>
                 <div className={classNames(classes.bar, { isHome: showSubNav })}>
                     {isCompact &&

--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -131,25 +131,38 @@ export default function TitleBar(_props: IProps) {
                         ))}
                     {!isCompact && (isDesktopLogoCentered ? !isSearchOpen : true) && (
                         <animated.div className={classNames(classes.logoAnimationWrap)} {...logoProps}>
-                            <HeaderLogo
-                                className={classNames(
-                                    "titleBar-logoContainer",
-                                    classes.logoContainer,
-                                    isDesktopLogoCentered && classes.logoCenterer,
-                                )}
-                                logoClassName="titleBar-logo"
-                                logoType={LogoType.DESKTOP}
-                            />
+                            <span
+                                className={classNames(isDesktopLogoCentered && classes.logoCenterer)}
+                                ref={!isCompact && isDesktopLogoCentered ? collisionSourceRef : undefined}
+                            >
+                                <HeaderLogo
+                                    className={classNames("titleBar-logoContainer", classes.logoContainer)}
+                                    logoClassName="titleBar-logo"
+                                    logoType={LogoType.DESKTOP}
+                                />
+                            </span>
                         </animated.div>
                     )}
-                    {!isCompact && <div ref={hBoundary1Ref} style={{ width: 1, height: 1 }}></div>}
+                    {!isCompact && !isDesktopLogoCentered && (
+                        <div ref={hBoundary1Ref} style={{ width: 1, height: 1 }}></div>
+                    )}
                     {!isSearchOpen && !isCompact && (
                         <TitleBarNav
                             isCentered={vars.navAlignment.alignment === "center"}
-                            containerRef={vars.navAlignment.alignment === "center" ? collisionSourceRef : undefined}
+                            containerRef={
+                                vars.navAlignment.alignment === "center" && !isDesktopLogoCentered
+                                    ? collisionSourceRef
+                                    : undefined
+                            }
                             className={classes.nav}
                             linkClassName={classes.topElement}
                             linkContentClassName="titleBar-navLinkContent"
+                            afterNode={
+                                !isCompact &&
+                                isDesktopLogoCentered && (
+                                    <div ref={hBoundary2Ref} style={{ width: 1, height: 20 }}></div>
+                                )
+                            }
                         />
                     )}
                     {isCompact && (
@@ -176,7 +189,9 @@ export default function TitleBar(_props: IProps) {
                             )}
                         </>
                     )}
-                    {!isCompact && <div ref={hBoundary2Ref} style={{ width: 1, height: 1 }}></div>}
+                    {!isCompact && !isDesktopLogoCentered && (
+                        <div ref={hBoundary2Ref} style={{ width: 1, height: 1 }}></div>
+                    )}
                     <ConditionalWrap className={classes.rightFlexBasis} condition={!!showMobileDropDown}>
                         {!isSearchOpen && (
                             <div className={classes.extraMeBoxIcons}>

--- a/library/src/scripts/headers/mebox/pieces/HeaderLogo.tsx
+++ b/library/src/scripts/headers/mebox/pieces/HeaderLogo.tsx
@@ -10,10 +10,10 @@ import { formatUrl, t } from "@library/utility/appUtils";
 import SmartLink from "@library/routing/links/SmartLink";
 import { titleBarLogoClasses, titleBarVariables } from "@library/headers/titleBarStyles";
 import classNames from "classnames";
+import { navigationVariables } from "@library/headers/navigationVariables";
 
 export interface IHeaderLogo {
     className?: string;
-    to: string;
     logoClassName?: string;
     logoType: LogoType;
     color?: string;
@@ -23,21 +23,18 @@ export interface IHeaderLogo {
  * Implements Logo component
  */
 export default class HeaderLogo extends React.Component<IHeaderLogo> {
-    public static defaultProps: Partial<IHeaderLogo> = {
-        to: "/",
-    };
-
     public render() {
         const { doubleLogoStrategy } = titleBarVariables().logo;
         const classes = titleBarLogoClasses();
         const logoClassName = classNames("headerLogo-logo", this.props.logoClassName, classes.logo);
+        const url = navigationVariables().logo.url;
 
         if (doubleLogoStrategy === "hidden") {
             return null;
         }
 
         return (
-            <SmartLink to={this.props.to} className={classNames("headerLogo", this.props.className)}>
+            <SmartLink to={url} className={classNames("headerLogo", this.props.className)}>
                 <span className={classNames("headerLogo-logoFrame", classes.logoFrame)}>
                     <ThemeLogo alt={t("Vanilla")} className={logoClassName} type={this.props.logoType} />
                 </span>

--- a/library/src/scripts/headers/mebox/pieces/TitleBarNav.tsx
+++ b/library/src/scripts/headers/mebox/pieces/TitleBarNav.tsx
@@ -22,6 +22,7 @@ export interface ITitleBarNavProps {
     excludeExtraNavItems?: boolean;
     containerRef?: React.RefObject<HTMLElement | null>;
     isCentered?: boolean;
+    afterNode?: React.ReactNode;
 }
 
 /**
@@ -98,6 +99,7 @@ export default class TitleBarNav extends React.Component<ITitleBarNavProps> {
                                 })}
                         </>
                     </ul>
+                    {this.props.afterNode}
                 </nav>
             </>
         );

--- a/library/src/scripts/headers/navigationVariables.ts
+++ b/library/src/scripts/headers/navigationVariables.ts
@@ -2,7 +2,7 @@
  * @copyright 2009-2019 Vanilla Forums Inc.
  * @license GPL-2.0-only
  */
-import { getMeta, t } from "@library/utility/appUtils";
+import { getMeta, t, assetUrl, formatUrl } from "@library/utility/appUtils";
 import { variableFactory, useThemeCache } from "@library/styles/styleUtils";
 import { getCurrentLocale } from "@vanilla/i18n";
 import { ITitleBarNav } from "./mebox/pieces/TitleBarNavItem";
@@ -34,6 +34,10 @@ export const navigationVariables = useThemeCache(() => {
         [getCurrentLocale()]: undefined,
     });
 
+    const logo = makeVars("logo", {
+        url: formatUrl("/"),
+    });
+
     const currentLocale = getCurrentLocale();
 
     const getNavItemsForLocale = (locale = currentLocale): ITitleBarNav[] => {
@@ -44,5 +48,5 @@ export const navigationVariables = useThemeCache(() => {
         }
     };
 
-    return { navItems, getNavItemsForLocale };
+    return { navItems, logo, getNavItemsForLocale };
 });

--- a/library/src/scripts/headers/titleBarNavStyles.ts
+++ b/library/src/scripts/headers/titleBarNavStyles.ts
@@ -146,6 +146,8 @@ const titleBarNavClasses = useThemeCache(() => {
         },
     });
 
+    const offsetWidth = vars.linkActive.offset * 2;
+
     const linkActive = style("linkActive", {
         $nest: {
             "&:after": {
@@ -157,7 +159,7 @@ const titleBarNavClasses = useThemeCache(() => {
                 height: unit(vars.linkActive.height),
                 left: percent(50),
                 marginLeft: unit(negative(vars.linkActive.offset)),
-                width: calc(`100% + ${unit(vars.linkActive.offset * 2)}`),
+                width: offsetWidth === 0 ? percent(100) : calc(`100% + ${unit(offsetWidth)}`),
                 backgroundColor: colorOut(vars.linkActive.bg),
                 transform: `translate(-50%, ${unit(titleBarVars.sizing.height / 2)})`,
             },

--- a/library/src/scripts/headers/titleBarStyles.ts
+++ b/library/src/scripts/headers/titleBarStyles.ts
@@ -435,7 +435,7 @@ export const titleBarClasses = useThemeCache(() => {
         left: 0,
         margin: `0 auto`,
         position: `absolute`,
-        height: calc(`100% - ${unit(vars.border.width + 1)}`),
+        height: calc(`80% - ${unit(vars.border.width + 1)}`),
         transform: translateX(`-10vw`),
         width: `120vw`,
         borderRadius: `0 0 100% 100%/0 0 ${percent(vars.swoop.amount)} ${percent(vars.swoop.amount)}`,
@@ -470,13 +470,22 @@ export const titleBarClasses = useThemeCache(() => {
         },
     });
 
-    const bgContainer = style("bgContainer", {
+    const container = style("container", {
         position: "relative",
         height: percent(100),
         width: percent(100),
         paddingTop: unit(vars.spacing.padding.top),
         paddingBottom: unit(vars.spacing.padding.bottom),
+    });
+
+    const bgContainer = style("bgContainer", {
+        ...absolutePosition.fullSizeOfParent(),
+        height: percent(100),
+        width: percent(100),
+        paddingTop: unit(vars.spacing.padding.top),
+        paddingBottom: unit(vars.spacing.padding.bottom),
         boxSizing: "content-box",
+        overflow: "hidden",
     });
 
     const bgImage = style("bgImage", {
@@ -956,22 +965,11 @@ export const titleBarClasses = useThemeCache(() => {
         background: vars.overlay.background,
     });
 
-    const curvedBackground = style("curvedBackground", {
-        content: quote(``),
-        background: `linear-gradient(-180deg,#fdfcfa,#f0e8de)`,
-        borderRadius: `0 0 100% 100%/0 0 60% 60%`,
-        boxShadow: `0 4px 0 #e2d5c7`,
-        height: calc(`100% - 5px`),
-        left: `-10vw`,
-        margin: `0 auto`,
-        position: "absolute",
-        width: `120vw`,
-    });
-
     return {
         root,
         bg1,
         bg2,
+        container,
         bgContainer,
         bgImage,
         negativeSpacer,

--- a/library/src/scripts/styles/styleHelpers.ts
+++ b/library/src/scripts/styles/styleHelpers.ts
@@ -47,7 +47,8 @@ export const ifExistsWithFallback = checkProp => {
 };
 
 export const unit = (val: string | number | undefined, unitFunction = px) => {
-    const valIsNumeric = val ? isNumeric(val.toString().trim()) : false;
+    const valIsNumeric = val || val === 0 ? isNumeric(val.toString().trim()) : false;
+
     if (typeof val === "string" && !valIsNumeric) {
         return val;
     } else if (val !== undefined && val !== null && valIsNumeric) {

--- a/library/src/scripts/styles/styleHelpersBorders.test.ts
+++ b/library/src/scripts/styles/styleHelpersBorders.test.ts
@@ -82,9 +82,9 @@ describe("styleHelperBorders", () => {
                     right: 29,
                 };
                 const expected: IBorderRadiusOutput = {
-                    borderBottomLeftRadius: 0,
+                    borderBottomLeftRadius: "0px",
                     borderBottomRightRadius: "29px",
-                    borderTopLeftRadius: 0,
+                    borderTopLeftRadius: "0px",
                     borderTopRightRadius: "29px",
                 };
 
@@ -99,8 +99,8 @@ describe("styleHelperBorders", () => {
                 const expected: IBorderRadiusOutput = {
                     borderBottomLeftRadius: "12px",
                     borderBottomRightRadius: "12px",
-                    borderTopLeftRadius: 0,
-                    borderTopRightRadius: 0,
+                    borderTopLeftRadius: "0px",
+                    borderTopRightRadius: "0px",
                 };
 
                 expect(standardizeBorderRadius(input)).deep.eq(expected);

--- a/packages/vanilla-react-utils/src/useCollisionDetector.tsx
+++ b/packages/vanilla-react-utils/src/useCollisionDetector.tsx
@@ -20,44 +20,44 @@ function doRectsOverlap(rect1: DOMRectReadOnly, rect2: DOMRectReadOnly) {
     let hasHorizontalOverlap = false;
 
     //  [      { ]       }
-    if (rect1.left < rect2.left && rect1.right > rect2.left) {
+    if (rect1.left <= rect2.left && rect1.right >= rect2.left) {
         hasHorizontalOverlap = true;
     }
 
     //  {    [  }   ]
-    if (rect2.left < rect1.left && rect2.right > rect1.left) {
+    if (rect2.left <= rect1.left && rect2.right >= rect1.left) {
         hasHorizontalOverlap = true;
     }
 
     //  [   {} ]
-    if (rect1.left < rect2.left && rect1.right > rect2.right) {
+    if (rect1.left <= rect2.left && rect1.right >= rect2.right) {
         hasHorizontalOverlap = true;
     }
 
     //  {  []   }
-    if (rect2.left < rect1.left && rect2.right > rect1.right) {
+    if (rect2.left <= rect1.left && rect2.right >= rect1.right) {
         hasHorizontalOverlap = true;
     }
 
     let hasVerticalOverlap = false;
 
     // Verical version of  [      { ]       }
-    if (rect1.top < rect2.top && rect1.bottom > rect2.top) {
+    if (rect1.top <= rect2.top && rect1.bottom >= rect2.top) {
         hasVerticalOverlap = true;
     }
 
     // Verical version of  {    [  }   ]
-    if (rect2.top < rect1.top && rect2.bottom > rect1.top) {
+    if (rect2.top <= rect1.top && rect2.bottom >= rect1.top) {
         hasVerticalOverlap = true;
     }
 
     // Verical version of  [   {} ]
-    if (rect1.top < rect2.top && rect1.bottom > rect2.bottom) {
+    if (rect1.top <= rect2.top && rect1.bottom >= rect2.bottom) {
         hasVerticalOverlap = true;
     }
 
     // Verical version of  {  []   }
-    if (rect2.top < rect1.top && rect2.bottom > rect1.bottom) {
+    if (rect2.top <= rect1.top && rect2.bottom >= rect1.bottom) {
         hasVerticalOverlap = true;
     }
 


### PR DESCRIPTION
## Fix swoop overflow

The swoop style header was creating some body overlay after recent changes. Since we can't put `overflow: hidden` back on the body (it was removed to fix this https://github.com/vanilla/vanilla/pull/10312), I've opted for an extra overflow container around the swooped backgrounds.

I also had to adjust the height here to compensate for the swoop.

## Allow custom logo URLs

Added a custom logo URL.

Closes https://github.com/vanilla/vanilla/issues/10107

## Fix collision detection for centered desktop logo.

Our desktop centered logo did not have collision detection with the nav. As a result you could have them overlaying each other at different breakpoints.

I've fixed it.

## Add `KludgedVariableProviderInterface`

Previously all variable providers were considered kludged and could be excluded by a theme feature.

Some themes may need a custom variable provider though, so I've added a different interface to differentiate between a kludged one (trying to replace themeUI) and a proper one (trying to provide some custom data source).

See the KB updates to mark it's own vars as kludged https://github.com/vanilla/knowledge/pull/1709