### PR TITLE
Fix compatibility styles applying to Keystone based themes

### DIFF
--- a/library/src/scripts/theming/ThemeProvider.tsx
+++ b/library/src/scripts/theming/ThemeProvider.tsx
@@ -75,7 +75,7 @@ export const ThemeProvider: React.FC<IProps> = (props: IProps) => {
         }
     }, [assets, disabled, setTopOffset, variablesOnly, getAssets, themeKey, cacheID]);
 
-    if (props.disabled) {
+    if (props.disabled || props.variablesOnly) {
         return <>{props.children}</>;
     }
 


### PR DESCRIPTION
The new compatibility styles are only supposed to apply to Foundation based themes and it was always applied.

Closes: https://github.com/vanilla/vanilla/issues/10328