### PR TITLE
Extend database Operation with mode: force, default.

### DIFF
--- a/library/Vanilla/Database/Operation.php
+++ b/library/Vanilla/Database/Operation.php
@@ -25,6 +25,10 @@ class Operation {
     /** Type identifier for update operations. */
     const TYPE_UPDATE = 'UPDATE';
 
+    const MODE_FORCE = 'force';
+
+    const MODE_DEFAULT = 'default';
+
     /** @var PipelineModel Reference to the object performing this operation. */
     private $caller;
 
@@ -39,6 +43,8 @@ class Operation {
 
     /** @var array Conditions to specify the scope of the operation. */
     private $where = [];
+
+    private $mode = self::MODE_FORCE;
 
     /**
      * Get the reference to the object performing this operation.
@@ -101,6 +107,24 @@ class Operation {
      */
     public function setOptions(array $options) {
         $this->options = $options;
+    }
+
+    /**
+     * Set the mode for the operation.
+     *
+     * @param string $mode
+     */
+    public function setMode(string $mode) {
+        $this->mode = $mode;
+    }
+
+    /**
+     * Get the mode for the operation.
+     *
+     * @return string
+     */
+    public function getMode(): string {
+        return $this->mode;
     }
 
     /**

--- a/library/Vanilla/Database/Operation.php
+++ b/library/Vanilla/Database/Operation.php
@@ -25,9 +25,9 @@ class Operation {
     /** Type identifier for update operations. */
     const TYPE_UPDATE = 'UPDATE';
 
-    const MODE_FORCE = 'force';
-
     const MODE_DEFAULT = 'default';
+
+    const MODE_IMPORT = 'import';
 
     /** @var PipelineModel Reference to the object performing this operation. */
     private $caller;
@@ -44,7 +44,7 @@ class Operation {
     /** @var array Conditions to specify the scope of the operation. */
     private $where = [];
 
-    private $mode = self::MODE_FORCE;
+    private $mode = self::MODE_DEFAULT;
 
     /**
      * Get the reference to the object performing this operation.

--- a/library/Vanilla/Database/Operation/CurrentDateFieldProcessor.php
+++ b/library/Vanilla/Database/Operation/CurrentDateFieldProcessor.php
@@ -61,7 +61,13 @@ class CurrentDateFieldProcessor implements Processor {
             $fieldExists = $databaseOperation->getCaller()->getWriteSchema()->getField("properties.{$field}");
             if ($fieldExists) {
                 $set = $databaseOperation->getSet();
-                $set[$field] = date("Y-m-d H:i:s");
+                if (empty($set[$field] ?? null) || $databaseOperation->getMode() === Operation::MODE_FORCE) {
+                    $set[$field] = date("Y-m-d H:i:s");
+                } else {
+                    if ($set[$field] instanceof \DateTimeImmutable) {
+                        $set[$field] = $set[$field]->format("Y-m-d H:i:s");
+                    }
+                }
                 $databaseOperation->setSet($set);
             }
         }

--- a/library/Vanilla/Database/Operation/CurrentDateFieldProcessor.php
+++ b/library/Vanilla/Database/Operation/CurrentDateFieldProcessor.php
@@ -61,7 +61,7 @@ class CurrentDateFieldProcessor implements Processor {
             $fieldExists = $databaseOperation->getCaller()->getWriteSchema()->getField("properties.{$field}");
             if ($fieldExists) {
                 $set = $databaseOperation->getSet();
-                if (empty($set[$field] ?? null) || $databaseOperation->getMode() === Operation::MODE_FORCE) {
+                if (empty($set[$field] ?? null) || $databaseOperation->getMode() === Operation::MODE_DEFAULT) {
                     $set[$field] = date("Y-m-d H:i:s");
                 } else {
                     if ($set[$field] instanceof \DateTimeImmutable) {

--- a/library/Vanilla/Models/PipelineModel.php
+++ b/library/Vanilla/Models/PipelineModel.php
@@ -94,7 +94,7 @@ class PipelineModel extends Model implements InjectableInterface {
      * @return mixed ID of the inserted row.
      * @throws Exception If an error is encountered while performing the query.
      */
-    public function insert(array $set, string $mode = Operation::MODE_FORCE) {
+    public function insert(array $set, string $mode = Operation::MODE_DEFAULT) {
         $databaseOperation = new Operation();
         $databaseOperation->setType(Operation::TYPE_INSERT);
         $databaseOperation->setCaller($this);
@@ -115,7 +115,7 @@ class PipelineModel extends Model implements InjectableInterface {
      * @throws Exception If an error is encountered while performing the query.
      * @return bool True.
      */
-    public function update(array $set, array $where, string $mode = Operation::MODE_FORCE): bool {
+    public function update(array $set, array $where, string $mode = Operation::MODE_DEFAULT): bool {
         $databaseOperation = new Operation();
         $databaseOperation->setType(Operation::TYPE_UPDATE);
         $databaseOperation->setCaller($this);

--- a/library/Vanilla/Models/PipelineModel.php
+++ b/library/Vanilla/Models/PipelineModel.php
@@ -90,14 +90,16 @@ class PipelineModel extends Model implements InjectableInterface {
      * Add a resource row.
      *
      * @param array $set Field values to set.
+     * @param string $mode Operation mode (force || default).
      * @return mixed ID of the inserted row.
      * @throws Exception If an error is encountered while performing the query.
      */
-    public function insert(array $set) {
+    public function insert(array $set, string $mode = Operation::MODE_FORCE) {
         $databaseOperation = new Operation();
         $databaseOperation->setType(Operation::TYPE_INSERT);
         $databaseOperation->setCaller($this);
         $databaseOperation->setSet($set);
+        $databaseOperation->setMode($mode);
         $result = $this->pipeline->process($databaseOperation, function (Operation $databaseOperation) {
             return parent::insert($databaseOperation->getSet());
         });
@@ -109,15 +111,17 @@ class PipelineModel extends Model implements InjectableInterface {
      *
      * @param array $set Field values to set.
      * @param array $where Conditions to restrict the update.
+     * @param string $mode Operation mode (force || default).
      * @throws Exception If an error is encountered while performing the query.
      * @return bool True.
      */
-    public function update(array $set, array $where): bool {
+    public function update(array $set, array $where, string $mode = Operation::MODE_FORCE): bool {
         $databaseOperation = new Operation();
         $databaseOperation->setType(Operation::TYPE_UPDATE);
         $databaseOperation->setCaller($this);
         $databaseOperation->setSet($set);
         $databaseOperation->setWhere($where);
+        $databaseOperation->setMode($mode);
         $result = $this->pipeline->process($databaseOperation, function (Operation $databaseOperation) {
             return parent::update(
                 $databaseOperation->getSet(),

--- a/tests/Library/Vanilla/Database/CurrentDateFieldProcessorTest.php
+++ b/tests/Library/Vanilla/Database/CurrentDateFieldProcessorTest.php
@@ -69,4 +69,95 @@ class CurrentDateFieldProcessorTest extends TestCase {
             [Operation::TYPE_UPDATE, ["DateUpdated"]],
         ];
     }
+
+    /**
+     * Verify processor adds fields to insert operations default mode.
+     *
+     * @param string $type
+     * @param array $dateFields
+     * @dataProvider provideOperationsDate
+     */
+    public function testOperationModeDefault(string $type, $dateFields) {
+        $model = new BasicPipelineModel("Example");
+        $processor = new CurrentDateFieldProcessor();
+        $model->addPipelineProcessor($processor);
+
+        $operation = new Operation();
+        $operation->setType($type);
+        $operation->setCaller($model);
+        $operation->setSet($dateFields);
+        $model->doOperation($operation);
+
+        $set = $operation->getSet();
+
+        foreach ($set as $setField => $setValue) {
+            if (!array_key_exists($setField, $dateFields)) {
+                // Throw a failure exception.
+                $this->fail("Unexpected field: {$setField}");
+            }
+
+            // Attempt to parse into a DateTime object to validate the value.
+            $dateTime = DateTime::createFromFormat("Y-m-d H:i:s", $setValue);
+            if ($dateTime instanceof DateTime) {
+                // Verify what went in is what comes back out.
+                $this->assertTrue($dateTime->format("Y-m-d H:i:s") === $setValue);
+                $this->assertNotEquals($dateFields[$setField], $setValue);
+            } else {
+                $this->fail("Invalid date: {$setValue}");
+            }
+        }
+    }
+    /**
+     * Verify processor adds fields to insert operations import mode.
+     *
+     * @param string $type
+     * @param array $dateFields
+     * @dataProvider provideOperationsDate
+     */
+    public function testOperationModeImport(string $type, $dateFields) {
+        $model = new BasicPipelineModel("Example");
+        $processor = new CurrentDateFieldProcessor();
+        $model->addPipelineProcessor($processor);
+
+        $operation = new Operation();
+        $operation->setType($type);
+        $operation->setCaller($model);
+        $operation->setMode(Operation::MODE_IMPORT);
+        $operation->setSet($dateFields);
+        $model->doOperation($operation);
+
+        $set = $operation->getSet();
+
+        foreach ($set as $setField => $setValue) {
+            if (!array_key_exists($setField, $dateFields)) {
+                // Throw a failure exception.
+                $this->fail("Unexpected field: {$setField}");
+            }
+
+            // Attempt to parse into a DateTime object to validate the value.
+            $dateTime = DateTime::createFromFormat("Y-m-d H:i:s", $setValue);
+            if ($dateTime instanceof DateTime) {
+                // Verify what went in is what comes back out.
+                $this->assertTrue($dateTime->format("Y-m-d H:i:s") === $setValue);
+                $this->assertEquals($dateFields[$setField], $setValue);
+            } else {
+                $this->fail("Invalid date: {$setValue}");
+            }
+        }
+    }
+
+    /**
+     * Generate type and "sets" pairs for testing if the current date fields should be set (or not).
+     *
+     * @return array
+     */
+    public function provideOperationsDate() {
+        $timestamp = (new DateTime())
+        ->modify('-1 hour')
+        ->format("Y-m-d H:i:s");
+        return [
+            [Operation::TYPE_INSERT, ["DateInserted" => $timestamp]],
+            [Operation::TYPE_UPDATE, ["DateUpdated" => $timestamp]],
+        ];
+    }
 }

--- a/tests/Library/Vanilla/Database/CurrentDateFieldProcessorTest.php
+++ b/tests/Library/Vanilla/Database/CurrentDateFieldProcessorTest.php
@@ -71,7 +71,7 @@ class CurrentDateFieldProcessorTest extends TestCase {
     }
 
     /**
-     * Verify processor adds fields to insert operations default mode.
+     * Verify processor reset fields to current timestamp when operations default mode.
      *
      * @param string $type
      * @param array $dateFields
@@ -108,7 +108,7 @@ class CurrentDateFieldProcessorTest extends TestCase {
         }
     }
     /**
-     * Verify processor adds fields to insert operations import mode.
+     * Verify processor allow date fields to insert with no transformation when operations import mode.
      *
      * @param string $type
      * @param array $dateFields


### PR DESCRIPTION
Adjust CurrentDateFieldProcessor to reflect operation mode accordingly.

Relates to: https://github.com/vanilla/knowledge/issues/1671
