### PR TITLE
Add a Roles as translatable field to OAuth2 feature.

### DIFF
--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -791,12 +791,12 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
     public function translateProfileResults($rawProfile = []) {
         $provider = $this->provider();
         $translatedKeys = [
-            $provider['ProfileKeyEmail'] ?? 'email' => 'Email',
-            $provider['ProfileKeyPhoto'] ?? 'picture' => 'Photo',
-            $provider['ProfileKeyName'] ?? 'displayname' => 'Name',
-            $provider['ProfileKeyFullName'] ?? 'name' => 'FullName',
-            $provider['ProfileKeyUniqueID'] ?? 'user_id' => 'UniqueID',
-            $provider['ProfileKeyRoles'] ?? 'roles' => 'Roles'
+            ($provider['ProfileKeyEmail'] ?? 'email') => 'Email',
+            ($provider['ProfileKeyPhoto'] ?? 'picture') => 'Photo',
+            ($provider['ProfileKeyName'] ?? 'displayname') => 'Name',
+            ($provider['ProfileKeyFullName'] ?? 'name') => 'FullName',
+            ($provider['ProfileKeyUniqueID'] ?? 'user_id') => 'UniqueID',
+            ($provider['ProfileKeyRoles'] ?? 'roles') => 'Roles'
         ];
 
         $profile = self::translateArrayMulti($rawProfile, $translatedKeys, true);

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -137,7 +137,8 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
                 'ProfileKeyPhoto' => 'picture',
                 'ProfileKeyName' => 'nickname',
                 'ProfileKeyFullName' => 'name',
-                'ProfileKeyUniqueID' => 'sub'
+                'ProfileKeyUniqueID' => 'sub',
+                'ProfileKeyRoles' => 'roles'
             ];
 
             $model->save($provider);
@@ -377,6 +378,7 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
             'ProfileKeyName' => ['LabelCode' => 'Display Name', 'Description' => 'The Key in the JSON array to designate Display Name.'],
             'ProfileKeyFullName' => ['LabelCode' => 'Full Name', 'Description' => 'The Key in the JSON array to designate Full Name.'],
             'ProfileKeyUniqueID' => ['LabelCode' => 'User ID', 'Description' => 'The Key in the JSON array to designate UserID.'],
+            'ProfileKeyRoles' => ['LabelCode' => 'Roles', 'Description' => 'The Key in the JSON array to designate Roles.'],
             'Prompt' => ['LabelCode' => 'Prompt', 'Description' => 'Prompt Parameter to append to Authorize Url', 'Control' => 'DropDown', 'Items' => $promptOptions]
         ];
         return $formFields;
@@ -788,13 +790,13 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
      */
     public function translateProfileResults($rawProfile = []) {
         $provider = $this->provider();
-        $email = val('ProfileKeyEmail', $provider, 'email');
         $translatedKeys = [
-            val('ProfileKeyEmail', $provider, 'email') => 'Email',
-            val('ProfileKeyPhoto', $provider, 'picture') => 'Photo',
-            val('ProfileKeyName', $provider, 'displayname') => 'Name',
-            val('ProfileKeyFullName', $provider, 'name') => 'FullName',
-            val('ProfileKeyUniqueID', $provider, 'user_id') => 'UniqueID'
+            $provider['ProfileKeyEmail'] ?? 'email' => 'Email',
+            $provider['ProfileKeyPhoto'] ?? 'picture' => 'Photo',
+            $provider['ProfileKeyName'] ?? 'displayname' => 'Name',
+            $provider['ProfileKeyFullName'] ?? 'name' => 'FullName',
+            $provider['ProfileKeyUniqueID'] ?? 'user_id' => 'UniqueID',
+            $provider['ProfileKeyRoles'] ?? 'roles' => 'Roles'
         ];
 
         $profile = self::translateArrayMulti($rawProfile, $translatedKeys, true);


### PR DESCRIPTION
The OAuth2 SSO method allows for admins to translate the keys of the profile response for authenticating a user so that it matches what our script expects. More and more organizations pass Roles over SSO. This PR will add Roles to the translation array and gives an interface for the admins to modify the name of the key.

### Testing.
(Backwards compatibility)
 - With an existing OAuth2 configuration:
    - Checkout this branch.
    - Connect over SSO.
 - With an existing OAuth2 configuration:
   - Check out this branch.
   - Modify the Roles field in the Dashboard Settings.
   - Connect over SSO
 - With an existing OAuth2 configuration:
   - Check out this branch.
   - Modify the Roles field in the Dashboard Settings to match roles being passed. e.g. put 'position' in the Roles field. (if you are unable to pass roles over SSO you can fudge it by inserting a role into the rawProfile array before it gets translated [see here](https://github.com/vanilla/vanilla/blob/d510e30533a4be57a8bae9c7815d7c65fef02604/library/core/class.oauth2.php#L840) e.g. `$rawProfile['position'] = 'Moderator';`. )
   - Connect over SSO.
   - Verify that the user is given the role of Moderator.
 - Repeat the above tests with a fresh configuration of the OAuth2

Closes #10265