### PR TITLE
Attempt to debug the failed revert when the theme's font is in our de…

### DIFF
--- a/library/src/scripts/forms/themeEditor/ThemeBuilderRevert.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderRevert.tsx
@@ -14,16 +14,19 @@ import isEqual from "lodash/isEqual";
 
 interface IProps extends Omit<React.ComponentProps<typeof Button>, "children" | "onClick"> {
     variableKey: string;
+    fallbackValue?: any;
 }
 
 export function ThemeBuilderRevert(_props: IProps) {
-    const { variableKey, ...props } = _props;
+    const { variableKey, fallbackValue, ...props } = _props;
     const classes = themeBuilderClasses();
     const { initialValue, rawValue, setValue } = useThemeVariableField(variableKey);
 
     if (isEqual(initialValue, rawValue)) {
         return null;
     }
+
+    console.log("fallbackValue: ", fallbackValue);
 
     return (
         <Button
@@ -32,7 +35,7 @@ export function ThemeBuilderRevert(_props: IProps) {
             baseClass={ButtonTypes.ICON_COMPACT}
             title={t("Reset")}
             onClick={() => {
-                setValue(initialValue);
+                setValue(initialValue ?? fallbackValue);
             }}
         >
             <ResetIcon />

--- a/library/src/scripts/forms/themeEditor/ThemeDropDown.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeDropDown.tsx
@@ -8,7 +8,7 @@ import SelectOne, { IMenuPlacement, MenuPlacement } from "@library/forms/select/
 import { useThemeBlock } from "@library/forms/themeEditor/ThemeBuilderBlock";
 import { useThemeVariableField } from "@library/forms/themeEditor/ThemeBuilderContext";
 import { t } from "@vanilla/i18n";
-import React from "react";
+import React, { useState } from "react";
 import { themeDropDownClasses } from "@library/forms/themeEditor/ThemeDropDown.styles";
 import { ThemeBuilderRevert } from "@library/forms/themeEditor/ThemeBuilderRevert";
 
@@ -25,6 +25,7 @@ export function ThemeDropDown(_props: IProps) {
     const { generatedValue, initialValue, rawValue, setValue } = useThemeVariableField(variableKey);
 
     const onChange = (option: IComboBoxOption | undefined) => {
+        setPrevValue(rawValue);
         const newValue = option ? option.value.toString() : undefined;
         setValue(newValue);
         afterChange?.(newValue);
@@ -45,6 +46,10 @@ export function ThemeDropDown(_props: IProps) {
         value: generatedValue,
     };
 
+    console.log("defaultOption.value: ", defaultOption.value);
+
+    const [prevValue, setPrevValue] = useState(defaultOption.value);
+
     return (
         <>
             <div className={themeDropDownClasses().root}>
@@ -63,7 +68,7 @@ export function ThemeDropDown(_props: IProps) {
                     onChange={onChange}
                 />
             </div>
-            <ThemeBuilderRevert variableKey={variableKey} />
+            <ThemeBuilderRevert variableKey={variableKey} fallbackValue={prevValue} />
         </>
     );
 }


### PR DESCRIPTION
WIP : Haven't solved the issue yet.

For: https://github.com/vanilla/knowledge/issues/1695

It seems to work fine when the theme you're editing starts with a custom font. I suspect it's because it's fetching the last value from the variables stored. When you start with the default, that's value isn't necessarily explicitly set and it bugs out. 
