### PR TITLE
Fixes dashboard issues with Dropdown Styles 

### DIFF
--- a/applications/dashboard/src/scripts/forms/dashboardStyles.ts
+++ b/applications/dashboard/src/scripts/forms/dashboardStyles.ts
@@ -21,8 +21,6 @@ export const dashboardClasses = useThemeCache(() => {
         marginBottom: globalVars.gutter.size,
     });
 
-    cssOut(`.form-group .suggestedTextInput-option`, suggestedTextStyleHelper().option);
-
     return {
         formList,
         helpAsset,

--- a/applications/dashboard/src/scripts/tables/DashboardTable.tsx
+++ b/applications/dashboard/src/scripts/tables/DashboardTable.tsx
@@ -5,6 +5,7 @@
 
 import React from "react";
 import { DashboardTableHeadItem } from "@dashboard/tables/DashboardTableHeadItem";
+import { dashboardClasses } from "@dashboard/forms/dashboardStyles";
 
 interface IProps {
     head: React.ReactNode;
@@ -12,6 +13,7 @@ interface IProps {
 }
 
 export function DashboardTable(props: IProps) {
+    dashboardClasses();
     return (
         <div className="table-wrap">
             <table className="table-data">

--- a/applications/dashboard/src/scripts/tables/DashboardTable.tsx
+++ b/applications/dashboard/src/scripts/tables/DashboardTable.tsx
@@ -5,7 +5,6 @@
 
 import React from "react";
 import { DashboardTableHeadItem } from "@dashboard/tables/DashboardTableHeadItem";
-import { dashboardClasses } from "@dashboard/forms/dashboardStyles";
 
 interface IProps {
     head: React.ReactNode;

--- a/applications/dashboard/src/scripts/tables/DashboardTable.tsx
+++ b/applications/dashboard/src/scripts/tables/DashboardTable.tsx
@@ -13,7 +13,6 @@ interface IProps {
 }
 
 export function DashboardTable(props: IProps) {
-    dashboardClasses();
     return (
         <div className="table-wrap">
             <table className="table-data">

--- a/applications/vanilla/src/scripts/entries/admin.ts
+++ b/applications/vanilla/src/scripts/entries/admin.ts
@@ -4,6 +4,9 @@
  */
 
 import { onReady, onContent } from "@library/utility/appUtils";
+import { suggestedTextStyleHelper } from "@library/features/search/suggestedTextStyles";
+import { cssOut } from "@dashboard/compatibilityStyles";
+cssOut(`.suggestedTextInput-option`, suggestedTextStyleHelper().option);
 
 onReady(handleImageUploadInputDisplay);
 onContent(handleImageUploadInputDisplay);

--- a/library/src/scripts/forms/select/selectOneStyles.tsx
+++ b/library/src/scripts/forms/select/selectOneStyles.tsx
@@ -14,7 +14,7 @@ export const selectOneVariables = useThemeCache(() => {
 
     const padding = vars("padding", {
         right: 30,
-        left: inputMixin().paddingRight,
+        left: inputMixin().paddingRight as string,
     });
 
     return { padding };

--- a/library/src/scripts/forms/select/selectOneStyles.tsx
+++ b/library/src/scripts/forms/select/selectOneStyles.tsx
@@ -7,12 +7,14 @@ import { useThemeCache, styleFactory, variableFactory } from "@library/styles/st
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { borders, colorOut, unit } from "@library/styles/styleHelpers";
 import { calc, percent } from "csx";
+import { inputMixin } from "@library/forms/inputStyles";
 
 export const selectOneVariables = useThemeCache(() => {
     const vars = variableFactory("selectOne");
 
     const padding = vars("padding", {
         right: 30,
+        left: inputMixin().paddingRight,
     });
 
     return { padding };
@@ -33,6 +35,7 @@ export const selectOneClasses = useThemeCache(() => {
             },
             "& .inputBlock-inputText": {
                 paddingRight: unit(vars.padding.right),
+                paddingLeft: unit(vars.padding.left),
                 position: "relative",
             },
             "& .SelectOne__indicators": {

--- a/library/src/scripts/forms/themeEditor/ThemeBuilder.styles.ts
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilder.styles.ts
@@ -99,6 +99,7 @@ export const themeBuilderVariables = () => {
         fonts: {
             ...defaultFont,
             size: 13,
+            lineHeight: 1.5,
         },
     };
 

--- a/library/src/scripts/forms/themeEditor/ThemeBuilder.styles.ts
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilder.styles.ts
@@ -98,7 +98,7 @@ export const themeBuilderVariables = () => {
         width: panel.width - 2 * panel.padding - undo.width - label.width,
         fonts: {
             ...defaultFont,
-            size: 13,
+            size: 14,
             lineHeight: 1.5,
         },
     };


### PR DESCRIPTION
I've made a more generic fix for the dropdown styles, so this should fix both the styles in the dashboard and in the theme editor pages.

@charrondev I don't see any font size consistencies in the dashboard anymore, do you have an example?