### PR TITLE
Add events to userinfo view

### DIFF
--- a/applications/dashboard/views/modules/userinfo.php
+++ b/applications/dashboard/views/modules/userinfo.php
@@ -6,6 +6,7 @@ if (Gdn::config('Garden.Profile.ShowAbout')) {
     ?>
     <div class="About P">
         <h2 class="H"><?php echo t('About'); ?></h2>
+        <?php  $this->fireEvent('BeforeAboutList');  ?>
         <dl class="About">
             <?php
             if ($this->User->Banned) {
@@ -74,6 +75,7 @@ if (Gdn::config('Garden.Profile.ShowAbout')) {
             $this->fireEvent('OnBasicInfo');
             ?>
         </dl>
+        <?php  $this->fireEvent('AfterAboutList');  ?>
     </div>
 <?php
 }


### PR DESCRIPTION
Clients with custom themes always want to change the profile page and more than often this view has to be overridden because of the lack of flexibility. Adding those events should suppress that need in the future.

Reference: https://github.com/vanillaforums/telkomsel/pull/13#discussion_r401522988