### PR TITLE
Fix backwards compatibility with old browsers

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/clickableItemHelpers.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/clickableItemHelpers.ts
@@ -14,7 +14,6 @@ import { cssOut, nestedWorkaround, trimTrailingCommas } from "@dashboard/compati
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { NestedCSSProperties } from "typestyle/lib/types";
 import merge from "lodash/merge";
-import { emptyObject } from "expect/build/utils";
 import { NestedCSSSelectors } from "typestyle/src/types";
 
 export const EMPTY_STATE_COLORS = {
@@ -45,7 +44,7 @@ export const clickStyleFallback = (
     defaultOverwrite: undefined | NestedCSSProperties,
 ) => {
     const mergedStyles = merge(specificOverwrite || {}, defaultOverwrite || {});
-    return emptyObject(mergedStyles) ? undefined : mergedStyles;
+    return Object.keys(mergedStyles).length === 0 ? undefined : mergedStyles;
 };
 
 export const mixinClickInput = (selector: string, overwriteColors?: {}, overwriteSpecial?: {}) => {

--- a/library/Vanilla/Web/Asset/InlinePolyfillContent.js.twig
+++ b/library/Vanilla/Web/Asset/InlinePolyfillContent.js.twig
@@ -4,8 +4,10 @@ var supportsAllFeatures =
     window.fetch &&
     window.Symbol &&
     window.CustomEvent &&
+    Array.prototype.includes &&
     Element.prototype.remove &&
     Element.prototype.closest &&
+    Element.prototype.attachShadow &&
     window.NodeList &&
     NodeList.prototype.forEach
 ;
@@ -22,7 +24,8 @@ if (!supportsAllFeatures) {
     // Which means we HAVE to set the element, even if it should be defaulted.
     #}
     script.async = false;
-    head.appendChild(script);
+    // document.write has to be used instead of append child for edge & old safari compatibility.
+    document.write(script.outerHTML);
 } else {
     {{ debugModeLiteral }} && console.log("Modern browser detected. No polyfills necessary");
 }

--- a/library/Vanilla/Web/ContentSecurityPolicy/ContentSecurityPolicyModel.php
+++ b/library/Vanilla/Web/ContentSecurityPolicy/ContentSecurityPolicyModel.php
@@ -54,7 +54,13 @@ class ContentSecurityPolicyModel {
      * @return Policy[]
      */
     public function getPolicies(): array {
-        $policies[] = new Policy(Policy::SCRIPT_SRC, '\'nonce-'.$this->getNonce().'\'');
+        $nonce = $this->getNonce();
+        // Note:
+        // In modern browsers that support `nonce-` unsafe-inline is ignored.
+        // Older browsers need unsafe inline applied.
+        // @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src
+        // "Specifying nonce makes a modern browser ignore 'unsafe-inline' which could still be set for older browsers without nonce support."
+        $policies[] = new Policy(Policy::SCRIPT_SRC, "'nonce-$nonce' 'unsafe-inline'");
         foreach ($this->providers as $provider) {
             $policies = array_merge($policies, $provider->getPolicies());
         }

--- a/library/src/scripts/styles/styleHelpersSpacing.ts
+++ b/library/src/scripts/styles/styleHelpersSpacing.ts
@@ -7,7 +7,6 @@
 import { NestedCSSProperties } from "typestyle/lib/types";
 import { unit } from "@library/styles/styleHelpers";
 import { calc } from "csx";
-import { emptyObject } from "expect/build/utils";
 
 export interface ISpacing {
     top?: string | number;


### PR DESCRIPTION
Closes https://github.com/vanilla/knowledge/issues/1600
Closes https://github.com/vanilla/vanilla/issues/9988

Comments inline should be clear enough I think.

I've tested in browserstack with safari 9 and edge 17/18. IE was already working beforehand.