### PR TITLE
Fix check for image in BBCode parser

### DIFF
--- a/library/core/class.bbcode.php
+++ b/library/core/class.bbcode.php
@@ -54,7 +54,8 @@ class BBCode extends Gdn_Pluggable {
             $src = htmlspecialchars(Gdn_Upload::url(val('Path', $media)));
             $name = htmlspecialchars(val('Name', $media));
 
-            if (val('ImageWidth', $media)) {
+            // Test to see if this is an image
+            if (exif_imagetype($src)) {
                 return "<div class=\"Attachment Image\"><img src=\"{$src}\" alt=\"{$name}\" /></div>";
             } else {
                 return anchor($name, $src, 'Attachment File');


### PR DESCRIPTION
Currently the logic tests the Media ImageWidth value to see if it has any value other then 0 or NULL to conclude if it is an image. This logic would have to assume that the Media ImageWidth column is 100% correct. But there are cases where ImageWidth value could be NULL for an image (IE. After an import form another forum) So instead of the images being shown properly inline only a link to the image is shown. 

The changes made above tests the file before displaying it to make sure its a file this guarantees that images are displayed properly and non images are displayed as a link

