### PR TITLE
Apply HTML outline IDs into headings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,8 @@
         "ext-pdo": "*",
         "ext-json": "*",
         "ext-fileinfo": "*",
+        "ext-dom": "*",
+        "ext-libxml": "*",
         "container-interop/container-interop": "^1.1",
         "chrisjean/php-ico": "~1.0",
         "firebase/php-jwt": "~5.0",

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -17,10 +17,14 @@ use Garden\StaticCacheTranslationTrait;
 use Vanilla\Formatting\BaseFormat;
 use Vanilla\Formatting\Exception\FormattingException;
 use Vanilla\Contracts\Formatting\Heading;
+use Vanilla\Formatting\Html\HtmlDocument;
 use Vanilla\Formatting\Html\HtmlEnhancer;
 use Vanilla\Formatting\Html\HtmlPlainTextConverter;
 use Vanilla\Formatting\Html\HtmlSanitizer;
 use Vanilla\Formatting\Html\LegacySpoilerTrait;
+use Vanilla\Formatting\Html\Processor\HeadingHtmlProcessor;
+use Vanilla\Formatting\Html\Processor\ImageHtmlProcessor;
+use Vanilla\Formatting\Html\Processor\UserContentCssProcessor;
 
 /**
  * Format definition for HTML based formats.
@@ -68,6 +72,7 @@ class HtmlFormat extends BaseFormat {
         $this->shouldCleanupLineBreaks = $shouldCleanupLineBreaks;
         $this->allowExtendedContent = $allowExtendedContent;
     }
+
     /**
      * @inheritdoc
      */
@@ -84,8 +89,7 @@ class HtmlFormat extends BaseFormat {
             $result = $this->htmlEnhancer->enhance($result);
         }
 
-        $result = self::cleanupEmbeds($result);
-
+        $result = $this->processsDocument($result);
         return $result;
     }
 
@@ -111,6 +115,7 @@ class HtmlFormat extends BaseFormat {
 
         // No Embeds
         $result = $this->htmlEnhancer->enhance($result, true, false);
+        $result = $this->processsDocument($result);
         return $result;
     }
 
@@ -139,38 +144,9 @@ class HtmlFormat extends BaseFormat {
      */
     public function parseHeadings(string $content): array {
         $rendered = $this->renderHtml($content);
-        $dom = new DOMDocument();
-        @$dom->loadHTML($rendered);
-
-        $xpath = new DOMXPath($dom);
-        $domHeadings = $xpath->query('.//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]');
-
-        /** @var Heading[] $headings */
-        $headings = [];
-
-        // Mapping of $key => $usageCount.
-        $slugKeyCache = [];
-
-        /** @var DOMNode $domHeading */
-        foreach ($domHeadings as $domHeading) {
-            $level = (int) str_replace('h', '', $domHeading->tagName);
-
-            $text = $domHeading->textContent;
-            $slug = slugify($text);
-            $count = $slugKeyCache[$slug] ?? 0;
-            $slugKeyCache[$slug] = $count + 1;
-            if ($count > 0) {
-                $slug .= '-' . $count;
-            }
-
-            $headings[] = new Heading(
-                $domHeading->textContent,
-                $level,
-                $slug
-            );
-        }
-
-        return $headings;
+        $document = new HtmlDocument($rendered);
+        $headingProcessor = new HeadingHtmlProcessor($document);
+        return $headingProcessor->getHeadings();
     }
 
     /**
@@ -178,30 +154,23 @@ class HtmlFormat extends BaseFormat {
      */
     public function parseImageUrls(string $content): array {
         $rendered = $this->renderHtml($content);
-        $dom = new \DOMDocument();
-        @$dom->loadHTML($rendered);
-
-        $xpath = new \DOMXPath($dom);
-        $domImages = $xpath->query('//img');
-
-        /** @var string[] $headings */
-        $imageUrls = [];
-
-        /** @var \DOMNode $domImages */
-        foreach ($domImages as $domImage) {
-            $domImageClass = $domImage->getAttribute('class');
-            $src = $domImage->getAttribute('src');
-            if ($domImageClass === 'emoji') {
-                continue;
-            }
-            if ($src) {
-                $imageUrls[] = $src;
-            }
-        }
-
-        return $imageUrls;
+        $document = new HtmlDocument($rendered);
+        $processor = new ImageHtmlProcessor($document);
+        return $processor->getImageURLs();
     }
 
+    /**
+     * Apply HTML processors.
+     *
+     * @param string $content
+     * @return string
+     */
+    private function processsDocument(string $content) {
+        // Normalization
+        $document = new HtmlDocument($content);
+        $document = $document->applyProcessors([UserContentCssProcessor::class, HeadingHtmlProcessor::class]);
+        return $document->getInnerHtml();
+    }
 
     /**
      * @inheritdoc
@@ -212,211 +181,6 @@ class HtmlFormat extends BaseFormat {
         return getMentions($content);
     }
 
-
-    /**
-     * Get Attribute from dom node
-     *
-     * @param string $attr The attribute you want
-     * @param DOMElement $domNode The dom node
-     *
-     * @return string array
-     */
-    public function getAttrData(string $attr, DOMElement $domNode) {
-        // Empty array to hold all classes to return
-        //Loop through each tag in the dom and add it's attribute data to the array
-        $attrData = [];
-        if (empty($domNode->getAttribute($attr)) === false) {
-            $attrData = explode(" ", $domNode->getAttribute($attr));
-        } else {
-            array_push($attrData, "");
-        }
-        //Return the array of attribute data
-        return array_unique($attrData);
-    }
-
-    /**
-     * Get dom node classes
-     *
-     * @param DOMElement $domElement the dom element
-     * @return string array
-     */
-    public function getClasses($domElement) {
-        return self::getAttrData('class', $domElement);
-    }
-
-    /**
-     * Check if class exists in class array
-     *
-     * @param array of strings $classes
-     * @param string $target
-     * @return string array
-     */
-    public function hasClass($classes, $target) {
-        foreach ($classes as $c) {
-            if ($c === $target) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Set attribute on dom node
-     *
-     * @param DOMNode $domNode
-     * @param string $key
-     * @param string $value
-     * @return string array
-     */
-    public function setAttribute($domNode, $key, $value) {
-        $domNode->setAttribute($key, $value);
-    }
-
-    /**
-     * Append class to dom node.
-     *
-     * @param DOMNode $domNode
-     * @param string $class
-     * @return string array
-     */
-    public function appendClass(&$domNode, $class) {
-        if (empty($domNode->getAttribute("class"))) {
-            $domNode->setAttribute("class", $class);
-        } else {
-            $domNode->setAttribute("class", $domNode->getAttribute("class") . " " . $class);
-        }
-    }
-
-    /**
-     * Format HTML of code blocks imported from other formats.
-     *
-     * @param array $blockCodeBlocks
-     * @return string array
-     */
-    public function cleanupCodeBlocks(&$blockCodeBlocks) {
-        foreach ($blockCodeBlocks as $c) {
-            $child = $c->firstChild;
-
-            if (!is_null($child)) {
-                if (property_exists($child, "tagName") && $child->tagName === "code") {
-                    $children = $child->childNodes;
-                    $c->removeChild($child);
-                    foreach ($children as $child) {
-                        $c->appendChild($child);
-                    }
-                }
-            }
-
-            $classes = self::getClasses($c);
-            if (!self::hasClass($classes, "code")) {
-                self::appendClass($c, "code");
-            }
-
-            if (!self::hasClass($classes, "codeBlock")) {
-                self::appendClass($c, "codeBlock");
-            }
-
-            self::setAttribute($c, "spellcheck", "false");
-        }
-    }
-
-    /**
-     * Format HTML of inline code blocks imported from other formats.
-     *
-     * @param array $inlineCodeBlocks
-     * @return string array
-     */
-    public function cleanupInlineCodeBlocks(&$inlineCodeBlocks) {
-        foreach ($inlineCodeBlocks as $c) {
-            self::appendClass($c, "code");
-            self::appendClass($c, "codeInline");
-            self::setAttribute($c, "spellcheck", "false");
-        }
-    }
-
-    /**
-     * Format HTML of images imported from other formats.
-     *
-     * @param array $images
-     * @return string array
-     */
-    public function cleanupImages(&$images) {
-        foreach ($images as $i) {
-            $classes = self::getClasses($i);
-            if (!self::hasClass($classes, "emoji")) {
-                self::appendClass($i, "embedImage-img");
-                self::appendClass($i, "importedEmbed-img");
-            }
-        }
-    }
-
-    /**
-     * Format HTML of blockquotes imported from other formats.
-     *
-     * @param DOMNodeList $blockquotes
-     * @return string array
-     */
-    public function cleanupBlockquotes(DOMNodeList &$blockquotes) {
-        foreach ($blockquotes as $b) {
-            self::appendClass($b, "blockquote");
-            $children = $b->childNodes;
-            foreach ($children as $child) {
-                if (property_exists($child, "tagName")) {
-                    if ($child->tagName === "div") {
-                        self::setAttribute($child, "class", "blockquote-content");
-                        $grandChildren = $child->childNodes;
-                        foreach ($grandChildren as $grandChild) {
-                            if (property_exists($grandChild, "tagName")) {
-                                if ($grandChild->tagName === "p") {
-                                    self::appendClass($grandChild, "blockquote-line");
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Fixes html output for embeds that were imported from another platform
-     *
-     * @param string $html An HTML string to process.
-     *
-     * @return string
-     * @internal Marked public for internal backwards compatibility only.
-     */
-    public function cleanupEmbeds(string $html): string {
-
-        $contentPrefix = <<<HTML
-<html><head><meta content="text/html; charset=utf-8" http-equiv="Content-Type"></head>
-<body>
-HTML;
-        $contentSuffix = "</body></html>";
-        $dom = new DOMDocument();
-        @$dom->loadHTML($contentPrefix . $html . $contentSuffix, LIBXML_NOBLANKS);
-        $xpath = new DOMXPath($dom);
-
-        $blockCodeBlocks = $xpath->query('.//*[self::pre]');
-        self::cleanupCodeBlocks($blockCodeBlocks);
-        $images = $xpath->query('.//*[self::img]');
-        self::cleanupImages($images);
-        $blockQuotes = $xpath->query('.//*[self::blockquote]');
-        self::cleanupBlockquotes($blockQuotes, $dom);
-        $inlineCodeBlocks = $xpath->query('.//*[self::code]');
-        self::cleanupInlineCodeBlocks($inlineCodeBlocks);
-
-        $content = $dom->getElementsByTagName('body');
-        $htmlBodyString = @$dom->saveXML($content[0], LIBXML_NOEMPTYTAG);
-
-        // The DOM Document added starting body and ending tags. We need to remove them.
-        $htmlBodyString = preg_replace('/^<body>/', '', $htmlBodyString);
-        $htmlBodyString = preg_replace('/<\/body>$/', '', $htmlBodyString);
-        // saveXML adds closing <br> tags, which breaks formatting.
-        $htmlBodyString = preg_replace('/<\/br>/', '', $htmlBodyString);
-
-        return $htmlBodyString;
-    }
 
     const BLOCK_WITH_OWN_WHITESPACE =
         "(?:table|dl|ul|ol|pre|blockquote|address|p|h[1-6]|" .

--- a/library/Vanilla/Formatting/Html/HtmlDocument.php
+++ b/library/Vanilla/Formatting/Html/HtmlDocument.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting\Html;
+
+use Vanilla\Formatting\Html\Processor\HtmlProcessor;
+
+/**
+ * Class for parsing and modifying HTML.
+ */
+class HtmlDocument {
+
+    /** @var \DOMDocument */
+    private $dom;
+
+    /**
+     * Constructor.
+     *
+     * @param string $innerHtml HTML to construct the DOM with.
+     */
+    public function __construct(string $innerHtml) {
+        $this->dom = new \DOMDocument();
+
+        // DomDocument will automatically add html, head and body wrapper if we don't.
+        // We add our own to ensure consistency.
+        @$this->dom->loadHTML($this->getDocumentPrefix() . $innerHtml . $this->getDocumentSuffix(), LIBXML_NOBLANKS);
+    }
+
+    /**
+     * Apply an array of processors in order.
+     *
+     * @param string[] $processors An array of classes implemented HtmlProcessor.
+     * @return HtmlDocument
+     */
+    public function applyProcessors(array $processors): HtmlDocument {
+        $document = $this;
+        foreach ($processors as $processor) {
+            if (!is_subclass_of($processor, HtmlProcessor::class, true)) {
+                trigger_error("$processor does not extends HtmlProcessor", E_USER_WARNING);
+                continue;
+            }
+
+            $actualProcessor = $processor;
+            if ($actualProcessor instanceof HtmlProcessor) {
+                $actualProcessor->setDocument($document);
+            } else {
+                // Construct it.
+                $actualProcessor = new $actualProcessor($document);
+            }
+            $document = $actualProcessor->processDocument();
+        }
+        return $document;
+    }
+
+    /**
+     * Get the document.
+     *
+     * @return \DOMDocument
+     */
+    public function getDom(): \DOMDocument {
+        return $this->dom;
+    }
+
+    /**
+     * Return the inner HTML content of the document.
+     * We grab everything inside the document body.
+     *
+     * @return string
+     */
+    public function getInnerHtml(): string {
+        $content = $this->dom->getElementsByTagName('body');
+        $result = @$this->dom->saveXML($content[0], LIBXML_NOEMPTYTAG);
+
+        // The DOM Document added starting body and ending tags. We need to remove them.
+        $result = preg_replace('/^<body>/', '', $result);
+        $result = preg_replace('/<\/body>$/', '', $result);
+        // saveXML adds closing <br> tags, which breaks formatting.
+        $result = preg_replace('/<\/br>/', '', $result);
+        return $result;
+    }
+
+    /**
+     * Get the opening tag of the document.
+     *
+     * @return string
+     */
+    private function getDocumentPrefix() {
+        return <<<HTML
+    <html><head><meta content="text/html; charset=utf-8" http-equiv="Content-Type"></head>
+    <body>
+HTML;
+    }
+
+    /**
+     * Get the closing tag of the document.
+     * @return string
+     */
+    private function getDocumentSuffix() {
+        return "</body></html>";
+    }
+}

--- a/library/Vanilla/Formatting/Html/Processor/HeadingHtmlProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/HeadingHtmlProcessor.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting\Html\Processor;
+
+use Vanilla\Contracts\Formatting\Heading;
+use Vanilla\Formatting\Html\HtmlDocument;
+
+/**
+ * Processor of HMTL headings.
+ */
+class HeadingHtmlProcessor extends HtmlProcessor {
+
+    /**
+     * @inheritDoc
+     */
+    public function processDocument(): HtmlDocument {
+        return $this->document;
+    }
+
+    /**
+     * @return Heading[]
+     */
+    public function getHeadings(): array {
+        $domHeadings = $this->queryXPath('.//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]');
+
+        /** @var Heading[] $headings */
+        $headings = [];
+
+        // Mapping of $key => $usageCount.
+        $slugKeyCache = [];
+
+        /** @var \DOMElement $domHeading */
+        foreach ($domHeadings as $domHeading) {
+            $level = (int) str_replace('h', '', $domHeading->tagName);
+
+            $text = $domHeading->textContent;
+            $slug = slugify($text);
+            $count = $slugKeyCache[$slug] ?? 0;
+            $slugKeyCache[$slug] = $count + 1;
+            if ($count > 0) {
+                $slug .= '-' . $count;
+            }
+
+            $headings[] = new Heading(
+                $domHeading->textContent,
+                $level,
+                $slug
+            );
+        }
+
+        return $headings;
+    }
+}

--- a/library/Vanilla/Formatting/Html/Processor/HeadingHtmlProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/HeadingHtmlProcessor.php
@@ -19,13 +19,18 @@ class HeadingHtmlProcessor extends HtmlProcessor {
      * @inheritDoc
      */
     public function processDocument(): HtmlDocument {
+        $this->getHeadings(true);
         return $this->document;
     }
 
     /**
+     * Get all the headings in the document.
+     *
+     * @param bool $applyToDom Whether or not to apply the heading ids into the dom.
+     *
      * @return Heading[]
      */
-    public function getHeadings(): array {
+    public function getHeadings(bool $applyToDom = false): array {
         $domHeadings = $this->queryXPath('.//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]');
 
         /** @var Heading[] $headings */
@@ -39,11 +44,20 @@ class HeadingHtmlProcessor extends HtmlProcessor {
             $level = (int) str_replace('h', '', $domHeading->tagName);
 
             $text = $domHeading->textContent;
+            if ($text === "") {
+                // Ignore empty slugs.
+                continue;
+            }
             $slug = slugify($text);
+
             $count = $slugKeyCache[$slug] ?? 0;
             $slugKeyCache[$slug] = $count + 1;
             if ($count > 0) {
                 $slug .= '-' . $count;
+            }
+
+            if ($applyToDom) {
+                $domHeading->setAttribute('data-id', $slug);
             }
 
             $headings[] = new Heading(

--- a/library/Vanilla/Formatting/Html/Processor/HtmlProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/HtmlProcessor.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting\Html\Processor;
+
+use Vanilla\Formatting\Html\HtmlDocument;
+
+/**
+ * Processor an HtmlDocument.
+ */
+abstract class HtmlProcessor {
+
+    /** @var HtmlDocument */
+    protected $document;
+
+    /**
+     * Constructor.
+     *
+     * @param HtmlDocument $document
+     */
+    public function __construct(HtmlDocument $document) {
+        $this->document = $document;
+    }
+
+    /**
+     * @param HtmlDocument $document
+     */
+    public function setDocument(HtmlDocument $document) {
+        $this->document = $document;
+    }
+
+    /**
+     * Process the HTML document in some way.
+     *
+     * @return HtmlDocument
+     */
+    abstract public function processDocument(): HtmlDocument;
+
+    ///
+    /// Some Utilities
+    ///
+
+    /**
+     * Get Attribute from dom node
+     *
+     * @param string $attr The attribute you want
+     * @param \DOMElement $domNode The dom node
+     *
+     * @return array
+     */
+    protected function getAttrData(string $attr, \DOMElement $domNode) {
+        // Empty array to hold all classes to return
+        //Loop through each tag in the dom and add it's attribute data to the array
+        $attrData = [];
+        if (empty($domNode->getAttribute($attr)) === false) {
+            $attrData = explode(" ", $domNode->getAttribute($attr));
+        } else {
+            array_push($attrData, "");
+        }
+        //Return the array of attribute data
+        return array_unique($attrData);
+    }
+
+    /**
+     * Get dom node classes
+     *
+     * @param \DOMElement $domElement the dom element
+     * @return array array
+     */
+    protected function getClasses($domElement) {
+        return self::getAttrData('class', $domElement);
+    }
+
+    /**
+     * Check if class exists in class array
+     *
+     * @param array of strings $classes
+     * @param string $target
+     * @return string array
+     */
+    protected function hasClass($classes, $target) {
+        foreach ($classes as $c) {
+            if ($c === $target) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Set attribute on dom node
+     *
+     * @param \DOMElement $domNode
+     * @param string $key
+     * @param string $value
+     */
+    protected function setAttribute(\DOMElement $domNode, $key, $value) {
+        $domNode->setAttribute($key, $value);
+    }
+
+    /**
+     * Append class to dom node.
+     *
+     * @param \DOMElement $domNode
+     * @param string $class
+     */
+    protected function appendClass(\DOMElement &$domNode, $class) {
+        if (empty($domNode->getAttribute("class"))) {
+            $domNode->setAttribute("class", $class);
+        } else {
+            $domNode->setAttribute("class", $domNode->getAttribute("class") . " " . $class);
+        }
+    }
+
+    /**
+     * Query the DOM with some xpath.
+     *
+     * @param string $xpathQuery
+     * @see https://devhints.io/xpath For a cheatsheet.
+     *
+     * @return \DOMNodeList
+     */
+    protected function queryXPath(string $xpathQuery) {
+        $xpath = new \DOMXPath($this->document->getDom());
+        return $xpath->query($xpathQuery) ?: new \DOMNodeList();
+    }
+}

--- a/library/Vanilla/Formatting/Html/Processor/ImageHtmlProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/ImageHtmlProcessor.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting\Html\Processor;
+
+use Vanilla\Contracts\Formatting\Heading;
+use Vanilla\Formatting\Html\HtmlDocument;
+
+/**
+ * Processor of HMTL headings.
+ */
+class ImageHtmlProcessor extends HtmlProcessor {
+
+    const EMBED_IMAGE_XPATH = './/img[not(contains(@class, "emoji"))]';
+
+    /**
+     * @inheritDoc
+     */
+    public function processDocument(): HtmlDocument {
+        return $this->document;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getImageURLs(): array {
+        $domImages = $this->queryXPath(self::EMBED_IMAGE_XPATH);
+
+        /** @var string[] $headings */
+        $imageUrls = [];
+
+        /** @var \DOMElement $domImage */
+        foreach ($domImages as $domImage) {
+            $src = $domImage->getAttribute('src');
+            if ($src) {
+                $imageUrls[] = $src;
+            }
+        }
+
+        return $imageUrls;
+    }
+}

--- a/library/Vanilla/Formatting/Html/Processor/UserContentCssProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/UserContentCssProcessor.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Formatting\Html\Processor;
+
+use Vanilla\Formatting\Html\HtmlDocument;
+
+/**
+ * Process user content to ensure certain CSS classes are applied.
+ */
+class UserContentCssProcessor extends HtmlProcessor {
+
+    /**
+     * @inheritDoc
+     */
+    public function processDocument(): HtmlDocument {
+        $this->cleanupBlockquotes();
+        $this->cleanupImages();
+        $this->cleanupCodeBlocks();
+        $this->cleanupInlineCodeBlocks();
+        return $this->document;
+    }
+
+    /**
+     * Format HTML of code blocks imported from other formats.
+     */
+    private function cleanupCodeBlocks() {
+        $blockCodeBlocks = $this->queryXPath('.//*[self::pre]');
+        foreach ($blockCodeBlocks as $codeBlock) {
+            if (!($codeBlock instanceof \DOMElement)) {
+                continue;
+            }
+
+            $child = $codeBlock->firstChild;
+
+            if ($child instanceof \DOMElement) {
+                if ($child->tagName === "code") {
+                    $children = $child->childNodes;
+                    $codeBlock->removeChild($child);
+                    foreach ($children as $child) {
+                        $codeBlock->appendChild($child);
+                    }
+                }
+            }
+
+            $classes = $this->getClasses($codeBlock);
+            if (!$this->hasClass($classes, "code")) {
+                $this->appendClass($codeBlock, "code");
+            }
+
+            if (!$this->hasClass($classes, "codeBlock")) {
+                $this->appendClass($codeBlock, "codeBlock");
+            }
+
+            $this->setAttribute($codeBlock, "spellcheck", "false");
+        }
+    }
+
+    /**
+     * Format HTML of inline code blocks imported from other formats.
+     */
+    private function cleanupInlineCodeBlocks() {
+        $inlineCodeBlocks = $this->queryXPath('.//*[self::code]');
+        foreach ($inlineCodeBlocks as $c) {
+            $this->appendClass($c, "code");
+            $this->appendClass($c, "codeInline");
+            $this->setAttribute($c, "spellcheck", "false");
+        }
+    }
+
+    /**
+     * Format HTML of images imported from other formats.
+     */
+    private function cleanupImages() {
+        $images = $this->queryXPath(ImageHtmlProcessor::EMBED_IMAGE_XPATH);
+        foreach ($images as $image) {
+            $this->appendClass($image, "embedImage-img");
+            $this->appendClass($image, "importedEmbed-img");
+        }
+    }
+
+    /**
+     * Format HTML of blockquotes imported from other formats.
+     */
+    private function cleanupBlockquotes() {
+        $blockQuotes = $this->queryXPath('.//*[self::blockquote]');
+        foreach ($blockQuotes as $b) {
+            self::appendClass($b, "blockquote");
+            $children = $b->childNodes;
+            foreach ($children as $child) {
+                if (property_exists($child, "tagName")) {
+                    if ($child->tagName === "div") {
+                        self::setAttribute($child, "class", "blockquote-content");
+                        $grandChildren = $child->childNodes;
+                        foreach ($grandChildren as $grandChild) {
+                            if (property_exists($grandChild, "tagName")) {
+                                if ($grandChild->tagName === "p") {
+                                    self::appendClass($grandChild, "blockquote-line");
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/fixtures/formats/html/paragraph-formats/input.html
+++ b/tests/fixtures/formats/html/paragraph-formats/input.html
@@ -1,5 +1,6 @@
 <h1>h1</h1>
 <h2>h2</h2>
+<h2></h2>
 <h2>Title with same key</h2>
 <h2>Title with same key</h2>
 <h3>Title with same key</h3>

--- a/tests/fixtures/formats/html/paragraph-formats/output.html
+++ b/tests/fixtures/formats/html/paragraph-formats/output.html
@@ -1,8 +1,9 @@
-<h1>h1</h1>
-<h2>h2</h2>
-<h2>Title with same key</h2>
-<h2>Title with same key</h2>
-<h3>Title with same key</h3>
+<h1 data-id="h1">h1</h1>
+<h2 data-id="h2">h2</h2>
+<h2></h2>
+<h2 data-id="title-with-same-key">Title with same key</h2>
+<h2 data-id="title-with-same-key-1">Title with same key</h2>
+<h3 data-id="title-with-same-key-2">Title with same key</h3>
 <div class=Quote>quote</div>
 <br>
 <code class="CodeInline code codeInline" spellcheck=false>    &lt;script&gt;alert("xss");&lt;/script&gt;</code>

--- a/tests/fixtures/formats/html/paragraph-formats/output.txt
+++ b/tests/fixtures/formats/html/paragraph-formats/output.txt
@@ -2,6 +2,8 @@ h1
 
 h2
 
+
+
 Title with same key
 
 Title with same key

--- a/tests/fixtures/formats/html/xss/output.html
+++ b/tests/fixtures/formats/html/xss/output.html
@@ -1,2 +1,2 @@
 alert("xss");<br><div></div>
-<h2>Heading in Script</h2>
+<h2 data-id="heading-in-script">Heading in Script</h2>

--- a/tests/fixtures/formats/markdown/paragraph-formatting/output.html
+++ b/tests/fixtures/formats/markdown/paragraph-formatting/output.html
@@ -1,8 +1,8 @@
 <p>Normal</p>
 
-<h1>h1</h1>
+<h1 data-id=h1>h1</h1>
 
-<h2>h2</h2>
+<h2 data-id=h2>h2</h2>
 
 <blockquote class="UserQuote blockquote">
     <div class="blockquote-content">

--- a/tests/fixtures/formats/wysiwyg/paragraph-formats/output.html
+++ b/tests/fixtures/formats/wysiwyg/paragraph-formats/output.html
@@ -1,6 +1,6 @@
-<h1>heading 1</h1>
-<h2>heading 2</h2>
-<h2>heading 2</h2>
+<h1 data-id=heading-1>heading 1</h1>
+<h2 data-id=heading-2>heading 2</h2>
+<h2 data-id=heading-2-1>heading 2</h2>
 <div class=Quote>quote</div>
 <code class="CodeInline code codeInline" spellcheck=false>    &lt;script&gt;alert("xss");&lt;/script&gt;</code>
 <div class=Spoiler>Spoiler</div> [spoiler]Legacy Spoiler's Don't Apply[/spoiler]


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1723 and https://github.com/vanilla/support/issues/1510

## Refactoring HTML processing

I'm moved out HTML processing out of `HtmlFormat` and into a few new classes.

- `HtmlDocument`
- `HtmlProcessor` -> `HeadingHtmlProcess`, `ImageHtmlProcessor`, `UserContentCssProcessor`

## Changes to heading processing.

Previously our heading processing only extracted IDs from HTML. Now it applies them to the HTML as well.

- I've also updated the heading extraction to stop generating IDs for empty headings.
