### PR TITLE
Fix regional locale variants displaying incorrectly

### DIFF
--- a/applications/dashboard/controllers/api/LocalesApiController.php
+++ b/applications/dashboard/controllers/api/LocalesApiController.php
@@ -71,9 +71,12 @@ class LocalesApiController extends Controller {
         $hasEnLocale = false;
         $result = [];
         foreach ($locales as $localeID => $locale) {
+            $localKey = (strlen($locale['Locale']) === 5) ?
+                substr($locale['Locale'], 0, 5) :
+                substr($locale['Locale'], 0, 2);
             $localeItem = [
                 'localeID' => $localeID,
-                'localeKey' => substr($locale['Locale'], 0, 2),
+                'localeKey' => $localKey,
                 'regionalKey' => $locale['Locale'],
             ];
 
@@ -111,7 +114,8 @@ class LocalesApiController extends Controller {
             $displayNames = [];
             foreach ($locales as $locale) {
                 $displayName = \Locale::getDisplayLanguage($row["localeKey"], $locale);
-
+                $displayNameRegion = \Locale::getDisplayRegion($row["localeKey"], $locale);
+                $displayName = (empty($displayNameRegion)) ? $displayName : $displayName . " ($displayNameRegion)";
                 // Standardize capitalization
                 $displayName = mb_convert_case($displayName, MB_CASE_TITLE);
 

--- a/applications/dashboard/controllers/api/LocalesApiController.php
+++ b/applications/dashboard/controllers/api/LocalesApiController.php
@@ -71,12 +71,9 @@ class LocalesApiController extends Controller {
         $hasEnLocale = false;
         $result = [];
         foreach ($locales as $localeID => $locale) {
-            $localKey = (strlen($locale['Locale']) === 5) ?
-                substr($locale['Locale'], 0, 5) :
-                substr($locale['Locale'], 0, 2);
             $localeItem = [
                 'localeID' => $localeID,
-                'localeKey' => $localKey,
+                'localeKey' => $locale['Locale'],
                 'regionalKey' => $locale['Locale'],
             ];
 


### PR DESCRIPTION
Fixes regional locale variants being displayed as `unknown`.  We were originally not trimming to the locale key to the first 2 characters which exclude the variant (ie. pt_BR would be just pt).  This has been changed and the region has been appended to display name if there is one.

closes https://github.com/vanilla/multisite/issues/354