### PR TITLE
Fix various theme issues

### DIFF
--- a/library/src/scripts/banner/BannerContext.tsx
+++ b/library/src/scripts/banner/BannerContext.tsx
@@ -6,6 +6,7 @@
 import React, { useContext, useState, useEffect, useRef, useDebugValue } from "react";
 import { useHistory } from "react-router";
 import { useMeasure } from "@vanilla/react-utils";
+import { usePageChangeListener } from "@library/pageViews/pageViewTracking";
 
 interface IContextValue {
     bannerExists: boolean;
@@ -49,15 +50,10 @@ export function useBannerContainerDivRef() {
 export function BannerContextProvider(props: { children: React.ReactNode }) {
     const [bannerExists, setBannerExists] = useState(false);
     const [bannerRect, setBannerRect] = useState<DOMRect | null>(null);
-    const history = useHistory();
-    useEffect(() => {
-        // Clear the banner information when navigating between pages.
-        return history.listen(() => {
-            setBannerExists(false);
-            setBannerRect(null);
-        });
-    }, [history]);
-
+    usePageChangeListener(() => {
+        setBannerExists(false);
+        setBannerRect(null);
+    });
     return (
         <context.Provider
             value={{

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -490,7 +490,7 @@ export const bannerClasses = useThemeCache(
                         },
                         ...borderRadii({
                             left: vars.border.radius,
-                            right: mirrorLeftRadius ? important(vars.border.radius) : important(0),
+                            right: mirrorLeftRadius ? importantUnit(vars.border.radius) : importantUnit(0),
                         }),
                         borderColor: colorOut(vars.searchBar.border.color),
                     },

--- a/library/src/scripts/result/ResultList.tsx
+++ b/library/src/scripts/result/ResultList.tsx
@@ -28,8 +28,7 @@ export default class ResultList extends React.Component<IProps> {
     public render() {
         const hasResults = this.props.results && this.props.results.length > 0;
         let content;
-        const classes = searchBarClasses();
-        const classesSearchResults = searchResultsClasses();
+        const classes = searchResultsClasses();
 
         if (hasResults) {
             const ResultComponent = this.props.result ? this.props.result : Result;
@@ -38,13 +37,13 @@ export default class ResultList extends React.Component<IProps> {
             });
         } else if (this.props.searchTerm === undefined || this.props.searchTerm === "") {
             content = (
-                <Paragraph className={classNames("searchResults-noResults", classesSearchResults.noResults)}>
+                <Paragraph className={classNames("searchResults-noResults", classes.noResults)}>
                     {this.props.emptyMessage ? this.props.emptyMessage : t("No results found.")}
                 </Paragraph>
             );
         } else {
             content = (
-                <Paragraph className={classNames("searchResults-noResults", "isEmpty", classesSearchResults.noResults)}>
+                <Paragraph className={classNames("searchResults-noResults", "isEmpty", classes.noResults)}>
                     <Translate source="No results for '<0/>'." c0={this.props.searchTerm} />
                 </Paragraph>
             );
@@ -52,17 +51,6 @@ export default class ResultList extends React.Component<IProps> {
 
         const Tag = hasResults ? `ul` : `div`;
 
-        return (
-            <Tag
-                className={classNames(
-                    "searchResults",
-                    classesSearchResults.root,
-                    this.props.className,
-                    classes.results,
-                )}
-            >
-                {content}
-            </Tag>
-        );
+        return <Tag className={classNames("searchResults", classes.root, this.props.className)}>{content}</Tag>;
     }
 }


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1700

## Banner

- Fix border radius of search not applying correctly on mobile. This was to do numerical radii not getting a unit attached. Eg. `border-top-right-radius: 40 !important`

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/1770056/78382821-6d2de780-75a5-11ea-92f2-ea9b03d9b3b9.png)|![image](https://user-images.githubusercontent.com/1770056/78382845-75862280-75a5-11ea-948b-27df5a6ad28f.png)|

## Remove search bar styles from result list

Our result list component actually has no coupling to the search bar. Some search bar styles were applying though and causing unwanted BG colors to apply. See the category issue in https://github.com/vanilla/knowledge/issues/1700

## Fix "On this Page" breaking with content banner

Our banner context provider was resetting on _any_ location change (including hash changes to affect scrolling). I've updated the hook to only change on page changes.

