### PR TITLE
Tweak link color state generation

### DIFF
--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -147,7 +147,8 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
     Object.keys(links.colors).forEach(state => {
         if (state !== "default" && state !== "visited") {
             if (!links[state]) {
-                links.colors[state] = generatedMainColors.stateSecondary ?? offsetLightness(links.colors.default, 0.2);
+                links.colors[state] =
+                    generatedMainColors.stateSecondary ?? offsetLightness(links.colors.default, 0.008);
             }
         }
     });


### PR DESCRIPTION
As noted in the demo the offset here, stacked on top of the offset we already had for the secondary could result in some colors that were way to dark for a hover variation.

I've toned it down for a much lighter touch.