### PR TITLE
Fix color generation of mebox count items

### DIFF
--- a/library/src/scripts/content/Count.tsx
+++ b/library/src/scripts/content/Count.tsx
@@ -14,8 +14,6 @@ export interface IProps {
     count?: number;
     label: string; // For accessibility, should be in the style of: "Notifications: "
     max?: number;
-    countBg?: ColorValues;
-    countFg?: ColorValues;
 }
 
 /**
@@ -29,12 +27,12 @@ export default class Count extends React.Component<IProps> {
         const classes = countClasses();
 
         return (
-            <div className={classNames("count", this.props.className, classes.root(this.props.countBg))}>
+            <div className={classNames(this.props.className, classes.root)}>
                 <span className="sr-only" aria-live="polite">
                     {hasCount ? this.props.label + ` ${this.props.count}` : ""}
                 </span>
                 {hasCount && (
-                    <div className={classNames("count-text", classes.text(this.props.countFg))} aria-hidden={true}>
+                    <div className={classes.text} aria-hidden={true}>
                         {visibleCount}
                     </div>
                 )}

--- a/library/src/scripts/content/countStyles.ts
+++ b/library/src/scripts/content/countStyles.ts
@@ -4,7 +4,7 @@
  * @license GPL-2.0-only
  */
 
-import { absolutePosition, colorOut, ColorValues, unit } from "@library/styles/styleHelpers";
+import { absolutePosition, colorOut, ColorValues, unit, isLightColor } from "@library/styles/styleHelpers";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 
@@ -35,30 +35,28 @@ export const countClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const vars = countVariables();
     const style = styleFactory("count");
+    const fg = isLightColor(vars.notifications.bg)
+        ? globalVars.elementaryColors.almostBlack
+        : globalVars.elementaryColors.white;
 
-    const root = (countBg?: ColorValues) => {
-        return style({
-            ...absolutePosition.topRight(4),
-            display: "block",
-            backgroundColor: countBg ? colorOut(countBg) : colorOut(vars.notifications.bg),
-            height: unit(vars.sizing.height),
-            lineHeight: unit(vars.sizing.height),
-            minWidth: unit(vars.sizing.height),
-            fontSize: unit(vars.font.size),
-            fontWeight: globalVars.fonts.weights.semiBold,
-            borderRadius: unit(vars.sizing.height / 2),
-            whiteSpace: "nowrap",
-            padding: `0 3px`,
-        });
-    };
-
-    const text = (countFg?: ColorValues) => {
-        return style("text", {
-            display: "block",
-            textAlign: "center",
-            color: countFg ? colorOut(countFg) : "inherit",
-        });
-    };
+    const root = style({
+        ...absolutePosition.topRight(4),
+        display: "block",
+        backgroundColor: colorOut(vars.notifications.bg),
+        height: unit(vars.sizing.height),
+        lineHeight: unit(vars.sizing.height),
+        minWidth: unit(vars.sizing.height),
+        fontSize: unit(vars.font.size),
+        fontWeight: globalVars.fonts.weights.semiBold,
+        borderRadius: unit(vars.sizing.height / 2),
+        whiteSpace: "nowrap",
+        padding: `0 3px`,
+    });
+    const text = style("text", {
+        display: "block",
+        textAlign: "center",
+        color: colorOut(fg),
+    });
 
     return { root, text };
 });


### PR DESCRIPTION
Fixes the color generation of count items in the mebox.

Related https://github.com/vanilla/knowledge/issues/1700

- Removed unused method parameters and props from `<Count />`
- Foreground color will always be white/black based on contrast with the count background color.