### PR TITLE
Fix modal scrolling on iOS

### DIFF
--- a/library/src/scripts/flyouts/DropDown.tsx
+++ b/library/src/scripts/flyouts/DropDown.tsx
@@ -136,7 +136,13 @@ export default function DropDown(props: IDropDownProps) {
                                 {mobileTitle ?? title}
                             </FrameHeaderMinimal>
                         )}
-                        <ContentTag className={classNames("dropDownItems", classes.items)}>{props.children}</ContentTag>
+                        {openAsModal ? (
+                            props.children
+                        ) : (
+                            <ContentTag className={classNames("dropDownItems", classes.items)}>
+                                {props.children}
+                            </ContentTag>
+                        )}
                     </DropDownContents>
                 );
             }}

--- a/library/src/scripts/flyouts/DropDown.tsx
+++ b/library/src/scripts/flyouts/DropDown.tsx
@@ -136,7 +136,7 @@ export default function DropDown(props: IDropDownProps) {
                                 {mobileTitle ?? title}
                             </FrameHeaderMinimal>
                         )}
-                        {openAsModal ? (
+                        {openAsModal && props.flyoutType === FlyoutType.FRAME ? (
                             props.children
                         ) : (
                             <ContentTag className={classNames("dropDownItems", classes.items)}>

--- a/library/src/scripts/flyouts/DropDownContents.tsx
+++ b/library/src/scripts/flyouts/DropDownContents.tsx
@@ -45,6 +45,9 @@ export default class DropDownContents extends React.Component<IProps> {
               })
             : undefined;
         const asModalClasses = this.props.openAsModal ? classNames("dropDown-asModal", classes.asModal) : undefined;
+        if (this.props.openAsModal) {
+            return this.props.children;
+        }
 
         return (
             <div

--- a/library/src/scripts/modal/modalStyles.ts
+++ b/library/src/scripts/modal/modalStyles.ts
@@ -35,7 +35,7 @@ export const modalVariables = useThemeCache(() => {
         large: 720,
         medium: 516,
         small: 375,
-        height: viewHeight(96),
+        height: percent(96), // VH units cause issues on iOS.
         zIndex: 1050, // Sorry it's so high. Our dashboard uses some bootstrap which specifies 1040 for the old modals.
         // When nesting our modals on top we need to be higher.
     });


### PR DESCRIPTION
Closes https://github.com/vanilla/knowledge/issues/1727

- Modals were overflowing the screen on iOS due to the max height getting set in vh units. VH units extend beyond the UI chrome on iOS. Percentages are more consistent and work because we are a fixed position container.
- Fix scrolling being broken in dropdowns converted to modals. The main issue here was extra containers being added around by the dropdown between the modal root and the scrollable frame. I fixed this by removing them. These extra wrappers didn't add any significant styles that weren't already provided by the modals.

The `VH` unit fix could only be reproduced on an actual iOS device. I did testing with my personal one. The scrolling could be reproduced with a big subcommunity list and desktop chrome in responsive mode. It was most apparent with the subcommunity chooser on mobile with a lot of languages.