### PR TITLE
Add form toggle component and info to theme block

### DIFF
--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -121,7 +121,9 @@ export default function Banner(props: IProps) {
                     <div className={classNames(classes.outerBackground(props.backgroundImage || undefined))}>
                         {!props.backgroundImage &&
                             !vars.outerBackground.image &&
-                            !vars.outerBackground.unsetBackground && <DefaultBannerBg />}
+                            !vars.outerBackground.unsetBackground && (
+                                <DefaultBannerBg isContentBanner={isContentBanner} />
+                            )}
                     </div>
                     {vars.backgrounds.useOverlay && <div className={classes.backgroundOverlay} />}
                     <Container fullGutter className={classes.fullHeight}>

--- a/library/src/scripts/banner/DefaultBannerBg.tsx
+++ b/library/src/scripts/banner/DefaultBannerBg.tsx
@@ -5,10 +5,16 @@
 import React from "react";
 import { bannerClasses, bannerVariables } from "@library/banner/bannerStyles";
 import { colorOut } from "@library/styles/styleHelpers";
+import { contentBannerClasses, contentBannerVariables } from "@library/banner/contentBannerStyles";
 
-export function DefaultBannerBg() {
-    const classes = bannerClasses();
-    const vars = bannerVariables();
+interface IProps {
+    isContentBanner?: boolean;
+}
+
+export function DefaultBannerBg(props: IProps) {
+    const { isContentBanner } = props;
+    const classes = isContentBanner ? contentBannerClasses() : bannerClasses();
+    const vars = isContentBanner ? contentBannerVariables() : bannerVariables();
 
     return (
         <svg

--- a/library/src/scripts/embeddedContent/FormElements.story.tsx
+++ b/library/src/scripts/embeddedContent/FormElements.story.tsx
@@ -26,15 +26,13 @@ import "@library/forms/datePicker.scss";
 import RadioButtonGroup from "@library/forms/RadioButtonGroup";
 import CheckboxGroup from "@library/forms/CheckboxGroup";
 import { StorySmallContent } from "@library/storybook/StorySmallContent";
+import { FormToggle } from "@library/forms/FormToggle";
+import { flexHelper } from "@library/styles/styleHelpers";
 
-const story = storiesOf("Form Elements", module);
+const story = storiesOf("Forms/User Facing", module);
 
-story.add("Inputs", () => {
+story.add("Elements", () => {
     let activeTab = "Tab A";
-
-    const doNothing = () => {
-        return;
-    };
 
     /**
      * Simple form setter.
@@ -68,6 +66,20 @@ story.add("Inputs", () => {
                 <Checkbox label="Option C" />
                 <Checkbox label="Option D" />
             </CheckboxGroup>
+            <StoryHeading>Toggles</StoryHeading>
+            <div style={flexHelper().middle()}>
+                <StoryToggle accessibleLabel="Enabled" enabled={true} />
+                <StoryToggle accessibleLabel="Disabled" enabled={false} />
+                <StoryToggle accessibleLabel="Indeterminate" indeterminate enabled={true} />
+                <StoryToggle accessibleLabel="Indeterminate" indeterminate enabled={false} />
+            </div>
+            <StoryHeading>Toggles (Slim)</StoryHeading>
+            <div style={flexHelper().middle()}>
+                <StoryToggle accessibleLabel="Enabled" enabled={true} slim />
+                <StoryToggle accessibleLabel="Disabled" enabled={false} slim />
+                <StoryToggle accessibleLabel="Indeterminate" indeterminate enabled={true} slim />
+                <StoryToggle accessibleLabel="Indeterminate" indeterminate enabled={false} slim />
+            </div>
             <StoryHeading>Radio Buttons - In a Group</StoryHeading>
             <RadioButtonGroup label={"Gaggle of radio buttons"}>
                 <RadioButton label={"Option A"} name={radioButtonGroup1} defaultChecked />
@@ -133,3 +145,15 @@ story.add("Inputs", () => {
         </StoryContent>
     );
 });
+
+const doNothing = () => {
+    return;
+};
+
+function StoryToggle(props: Omit<React.ComponentProps<typeof FormToggle>, "onChange">) {
+    return (
+        <InputBlock label={props.accessibleLabel}>
+            <FormToggle {...props} onChange={doNothing} />
+        </InputBlock>
+    );
+}

--- a/library/src/scripts/errorPages/ErrorBoundary.tsx
+++ b/library/src/scripts/errorPages/ErrorBoundary.tsx
@@ -40,9 +40,12 @@ export class ErrorBoundary extends React.Component<IProps, IState> {
             return (
                 <Message
                     onCancel={() => {
+                        this.setState({ error: null });
+                    }}
+                    onConfirm={() => {
                         window.location.reload();
                     }}
-                    cancelText={t("Reload")}
+                    confirmText={t("Reload")}
                     isFixed
                     icon={<ErrorIcon />}
                     stringContents={error.message}

--- a/library/src/scripts/errorPages/ErrorBoundary.tsx
+++ b/library/src/scripts/errorPages/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { logError } from "@vanilla/utils";
+import Message from "@library/messages/Message";
+import { ErrorIcon } from "@library/icons/common";
+
+interface IProps {
+    children: React.ReactNode;
+    errorComponent?: React.ComponentType<any>;
+}
+
+interface IState {
+    error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<IProps, IState> {
+    public state: IState = {
+        error: null,
+    };
+
+    componentDidCatch(error: Error, errorInfo: any) {
+        // You can also log the error to an error reporting service
+        logError(error, errorInfo);
+        this.setState({ error });
+    }
+
+    render() {
+        const { error } = this.state;
+        if (error) {
+            // You can render any custom fallback UI
+            return (
+                <Message
+                    onCancel={() => {
+                        this.setState({ error: null });
+                    }}
+                    isFixed
+                    icon={<ErrorIcon />}
+                    stringContents={error.message}
+                />
+            );
+        }
+
+        return this.props.children;
+    }
+}

--- a/library/src/scripts/errorPages/ErrorBoundary.tsx
+++ b/library/src/scripts/errorPages/ErrorBoundary.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { logError } from "@vanilla/utils";
 import Message from "@library/messages/Message";
 import { ErrorIcon } from "@library/icons/common";
+import { t } from "@vanilla/i18n";
 
 interface IProps {
     children: React.ReactNode;
@@ -22,10 +23,14 @@ export class ErrorBoundary extends React.Component<IProps, IState> {
         error: null,
     };
 
+    static getDerivedStateFromError(error: Error) {
+        // Update state so the next render will show the fallback UI.
+        return { error };
+    }
+
     componentDidCatch(error: Error, errorInfo: any) {
         // You can also log the error to an error reporting service
         logError(error, errorInfo);
-        this.setState({ error });
     }
 
     render() {
@@ -35,8 +40,9 @@ export class ErrorBoundary extends React.Component<IProps, IState> {
             return (
                 <Message
                     onCancel={() => {
-                        this.setState({ error: null });
+                        window.location.reload();
                     }}
+                    cancelText={t("Reload")}
                     isFixed
                     icon={<ErrorIcon />}
                     stringContents={error.message}

--- a/library/src/scripts/forms/FormToggle.styles.ts
+++ b/library/src/scripts/forms/FormToggle.styles.ts
@@ -1,0 +1,116 @@
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { useThemeCache, variableFactory, styleFactory } from "@library/styles/styleUtils";
+import { globalVariables } from "@library/styles/globalStyleVars";
+import { inputVariables } from "@library/forms/inputStyles";
+import { borders, colorOut, defaultTransition, timedTransition } from "@library/styles/styleHelpers";
+import { IThemeVariables } from "@library/theming/themeReducer";
+
+export const formToggleVariables = useThemeCache((forcedVars?: IThemeVariables) => {
+    const globalVars = globalVariables(forcedVars);
+    const inputVars = inputVariables(forcedVars);
+    const makeVars = variableFactory("formToggle", forcedVars);
+
+    const options = makeVars("options", {
+        slim: false,
+    });
+
+    const sizing = makeVars("sizing", {
+        height: options.slim ? 30 : inputVars.sizing.height,
+        gutter: 3,
+    });
+
+    const well = makeVars("well", {
+        height: sizing.height,
+        width: sizing.height * 2,
+        border: {
+            ...inputVars.border,
+            radius: sizing.height,
+        },
+        color: globalVars.mainColors.bg,
+        colorActive: globalVars.mainColors.primary,
+        colorActiveState: globalVars.mainColors.secondary,
+    });
+
+    const slider = makeVars("sizing", {
+        height: sizing.height - sizing.gutter * 2,
+        width: sizing.height - sizing.gutter * 2,
+        border: {
+            ...inputVars.border,
+            radius: sizing.height,
+        },
+        color: globalVars.mainColors.bg,
+    });
+
+    return { options, sizing, well, slider };
+});
+
+export const formToggleClasses = useThemeCache((forcedVars?: IThemeVariables) => {
+    const vars = formToggleVariables(forcedVars);
+    const style = styleFactory("formToggle");
+
+    const well = style("well", {
+        cursor: "pointer",
+        display: "block",
+        position: "relative",
+        height: vars.well.height,
+        width: vars.well.width,
+        ...borders(vars.well.border),
+        background: colorOut(vars.well.color),
+        ...defaultTransition("background", "border"),
+    });
+
+    const slider = style("slider", {
+        cursor: "pointer",
+        height: vars.slider.height,
+        width: vars.slider.width,
+        ...borders(vars.slider.border),
+        position: "absolute",
+        top: vars.sizing.gutter,
+        bottom: vars.sizing.gutter,
+        left: vars.sizing.gutter,
+        background: colorOut(vars.slider.color),
+        transition: "0.2 ease border, 0.5s ease left, 0.5s ease right",
+    });
+
+    const root = style({
+        display: "block",
+        position: "relative",
+        height: vars.well.height,
+        width: vars.well.width,
+        $nest: {
+            [`&.isEnabled .${slider}`]: {
+                left: "initial",
+                right: vars.sizing.gutter,
+                ...borders({ ...vars.slider.border, color: vars.slider.color }),
+            },
+            [`&.isEnabled .${well}`]: {
+                background: colorOut(vars.well.colorActive),
+                ...borders({ ...vars.slider.border, color: vars.well.colorActive }),
+            },
+            [`&.isIndeterminate .${slider}`]: {
+                left: 0,
+                right: 0,
+                margin: "0 auto",
+            },
+            [`&.isFocused .${well}, &:hover .${well}`]: {
+                ...borders({ ...vars.slider.border, color: vars.well.colorActive }),
+            },
+            [`&.isFocused .${slider}, &:hover .${slider}`]: {
+                ...borders({ ...vars.slider.border, color: vars.well.colorActive }),
+            },
+            [`&.isEnabled.isFocused .${well}, &.isEnabled:hover .${well}`]: {
+                ...borders({ ...vars.well.border, color: vars.well.colorActiveState }),
+                background: colorOut(vars.well.colorActiveState),
+            },
+            [`&.isEnabled.isFocused .${slider}, &.isEnabled:hover .${slider}`]: {
+                ...borders({ ...vars.slider.border, color: vars.slider.color }),
+            },
+        },
+    });
+
+    return { root, well, slider };
+});

--- a/library/src/scripts/forms/FormToggle.tsx
+++ b/library/src/scripts/forms/FormToggle.tsx
@@ -1,0 +1,65 @@
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React, { useState } from "react";
+import { srOnly } from "@library/styles/styleHelpers";
+import ScreenReaderContent from "@library/layout/ScreenReaderContent";
+import { useUniqueID } from "@library/utility/idUtils";
+import { formToggleClasses } from "@library/forms/FormToggle.styles";
+import classNames from "classnames";
+
+interface IProps {
+    enabled: boolean;
+    onChange: (enabled: boolean) => void;
+    className?: string;
+    indeterminate?: boolean;
+    id?: string;
+    labelID?: string;
+    accessibleLabel?: string;
+    slim?: boolean;
+}
+
+export function FormToggle(props: IProps) {
+    const { enabled, onChange, className, indeterminate, accessibleLabel, slim, ...IDs } = props;
+    const [isFocused, setIsFocused] = useState(false);
+
+    if (IDs.labelID == null && accessibleLabel == null) {
+        throw new Error("Either a labelID or accessibleLabel must be passed to <FormToggle />");
+    }
+
+    const ownLabelID = useUniqueID("formToggleLabel");
+    const ownID = useUniqueID("formToggle");
+    const id = IDs.id ?? ownID;
+    const labelID = IDs.labelID ?? ownLabelID;
+    const classes = formToggleClasses(slim ? { formToggle: { options: { slim } } } : undefined);
+
+    return (
+        <label
+            className={classNames(
+                props.className,
+                classes.root,
+                enabled && "isEnabled",
+                indeterminate && "isIndeterminate",
+                isFocused && "isFocused",
+            )}
+        >
+            <ScreenReaderContent>
+                {accessibleLabel && <span id={labelID}>{accessibleLabel}</span>}
+                <input
+                    onFocus={() => setIsFocused(true)}
+                    onBlur={() => setIsFocused(false)}
+                    type="checkbox"
+                    aria-labelledby={labelID}
+                    id={id}
+                    onChange={e => {
+                        onChange(e.target.checked);
+                    }}
+                />
+            </ScreenReaderContent>
+            <div className={classes.well}></div>
+            <div className={classes.slider}></div>
+        </label>
+    );
+}

--- a/library/src/scripts/forms/checkRadioStyles.ts
+++ b/library/src/scripts/forms/checkRadioStyles.ts
@@ -29,9 +29,8 @@ export const checkRadioVariables = useThemeCache(() => {
     const themeVars = variableFactory("checkRadio");
 
     const border = themeVars("border", {
-        width: formElementVars.border.width,
+        ...formElementVars.border,
         radius: 2,
-        color: globalVars.mixBgAndFg(0.5),
     });
 
     const main = themeVars("check", {
@@ -97,7 +96,6 @@ export const checkRadioClasses = useThemeCache(() => {
     const globalVars = globalVariables();
     const vars = checkRadioVariables();
     const style = styleFactory("checkRadio");
-    const flexes = flexHelper();
 
     const isDashboard = style("isDashboard", {});
 

--- a/library/src/scripts/forms/formElementStyles.ts
+++ b/library/src/scripts/forms/formElementStyles.ts
@@ -32,7 +32,7 @@ export const formElementsVariables = useThemeCache((forcedVars?: IThemeVariables
     const border = makeThemeVars("border", {
         width: vars.borderType.formElements.default.width ?? vars.border.width,
         color: vars.borderType.formElements.default.color ?? vars.border.color,
-        style: vars.borderType.formElements.default.radius ?? vars.border.style,
+        style: vars.borderType.formElements.default.style ?? vars.border.style,
         radius: vars.borderType.formElements.default.radius ?? vars.border.radius,
     });
 

--- a/library/src/scripts/forms/inputStyles.ts
+++ b/library/src/scripts/forms/inputStyles.ts
@@ -48,8 +48,7 @@ export const inputVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         color: colors.fg,
     });
 
-    const border: IBordersWithRadius = makeThemeVars("borders", {
-        ...EMPTY_BORDER,
+    const border = makeThemeVars("borders", {
         ...globalVars.borderType.formElements.default,
     });
 

--- a/library/src/scripts/forms/inputStyles.ts
+++ b/library/src/scripts/forms/inputStyles.ts
@@ -3,32 +3,30 @@
  * @license GPL-2.0-only
  */
 
+import { cssOut } from "@dashboard/compatibilityStyles";
+import { formElementsVariables } from "@library/forms/formElementStyles";
 import { globalVariables } from "@library/styles/globalStyleVars";
-import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import {
     borders,
     colorOut,
     EMPTY_BORDER,
+    EMPTY_FONTS,
     fonts,
-    IBorderRadiusValue,
     IBordersWithRadius,
     placeholderStyles,
     textInputSizingFromFixedHeight,
     unit,
-    EMPTY_FONTS,
-    paddings,
 } from "@library/styles/styleHelpers";
-import { cssRule } from "typestyle";
-import { formElementsVariables } from "@library/forms/formElementStyles";
-import { NestedCSSProperties } from "typestyle/lib/types";
+import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
+import { IThemeVariables } from "@library/theming/themeReducer";
 import { percent } from "csx";
 import merge from "lodash/merge";
-import { cssOut } from "@dashboard/compatibilityStyles";
+import { NestedCSSProperties } from "typestyle/lib/types";
 
-export const inputVariables = useThemeCache(() => {
-    const globalVars = globalVariables();
-    const formElementVars = formElementsVariables();
-    const makeThemeVars = variableFactory("input");
+export const inputVariables = useThemeCache((forcedVars?: IThemeVariables) => {
+    const globalVars = globalVariables(forcedVars);
+    const formElementVars = formElementsVariables(forcedVars);
+    const makeThemeVars = variableFactory("input", forcedVars);
 
     const colors = makeThemeVars("colors", {
         placeholder: globalVars.mixBgAndFg(0.5),

--- a/library/src/scripts/forms/themeEditor/ThemeBuilder.styles.ts
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilder.styles.ts
@@ -7,11 +7,22 @@
 import { styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { color, percent } from "csx";
 import { fonts } from "@library/styles/styleHelpersTypography";
-import { colorOut, margins, negativeUnit, paddings, unit, sticky, flexHelper } from "@library/styles/styleHelpers";
+import {
+    colorOut,
+    margins,
+    negativeUnit,
+    paddings,
+    unit,
+    sticky,
+    flexHelper,
+    importantUnit,
+} from "@library/styles/styleHelpers";
 import { TextTransformProperty } from "csstype";
 import { globalVariables } from "@library/styles/globalStyleVars";
+import { inputVariables } from "@library/forms/inputStyles";
 
 export const themeBuilderVariables = () => {
+    const inputVars = inputVariables();
     // Intentionally not overwritable with theming system.
     const fontFamily = ["Open Sans"];
 
@@ -72,9 +83,7 @@ export const themeBuilderVariables = () => {
         },
     };
     const border = {
-        color: color("#bfcbd8"),
-        width: 1,
-        style: "solid",
+        ...inputVars.border,
         radius: 3,
     };
     const wrap = {
@@ -193,6 +202,10 @@ export const themeBuilderClasses = useThemeCache(() => {
         position: "relative",
     });
 
+    const checkBox = style("checkBox", {
+        marginRight: importantUnit(0),
+    });
+
     const checkBoxWrap = style("checkBoxWrap", {
         display: "flex",
         flexWrap: "wrap",
@@ -285,6 +298,7 @@ export const themeBuilderClasses = useThemeCache(() => {
 
     const tooltip = style("tooltip", {
         ...flexHelper().middle(),
+        marginLeft: globalVars.gutter.half,
         $nest: {
             "&:hover": {
                 color: colorOut(globalVars.mainColors.primary),
@@ -309,6 +323,7 @@ export const themeBuilderClasses = useThemeCache(() => {
         label,
         undoWrap,
         inputWrap,
+        checkBox,
         checkBoxWrap,
         title,
         section,

--- a/library/src/scripts/forms/themeEditor/ThemeBuilderBlock.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderBlock.tsx
@@ -9,12 +9,14 @@ import { useUniqueID } from "@library/utility/idUtils";
 import { useThrowError } from "@vanilla/react-utils";
 import classNames from "classnames";
 import React, { useContext } from "react";
+import { ThemeInfoTooltip } from "@library/forms/themeEditor/ThemeInfoTooltip";
 
 interface IProps {
     label: string;
     undo?: boolean;
     children: React.ReactNode;
     inputWrapClass?: string;
+    info?: React.ReactNode;
 }
 
 interface IThemeBlockContext {
@@ -46,6 +48,7 @@ export function ThemeBuilderBlock(props: IProps) {
         <div className={classes.block}>
             <label htmlFor={labelID} className={classes.label}>
                 {props.label}
+                {props.info && <ThemeInfoTooltip label={props.info} />}
             </label>
             <span className={classNames(classes.inputWrap, props.inputWrapClass)}>
                 <ThemeBlockContext.Provider value={{ inputID, labelID }}>{props.children}</ThemeBlockContext.Provider>

--- a/library/src/scripts/forms/themeEditor/ThemeBuilderCheckBox.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderCheckBox.tsx
@@ -26,6 +26,7 @@ export function ThemeBuilderCheckBox(props: IProps) {
             <span className={classes.label}></span>
             <span className={classes.checkBoxWrap}>
                 <CheckBox
+                    className={classes.checkBox}
                     label={label}
                     isHorizontal
                     checked={!!generatedValue}

--- a/library/src/scripts/forms/themeEditor/ThemeBuilderUpload.styles.ts
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderUpload.styles.ts
@@ -14,6 +14,7 @@ import {
     colorOut,
     absolutePosition,
     importantColorOut,
+    importantUnit,
 } from "@library/styles/styleHelpers";
 import { inputMixin } from "@library/forms/inputStyles";
 
@@ -54,7 +55,7 @@ export const themeBuilderUploadClasses = useThemeCache(() => {
         color: colorOut(globalVars.elementaryColors.white),
     });
     const optionButton = style("optionButton", {
-        height: themeBuilderVars.input.height - 2,
+        height: importantUnit(themeBuilderVars.input.height - 2),
         color: colorOut(globalVars.elementaryColors.white),
         $nest: {
             "&:hover, &:active, &:focus": {

--- a/library/src/scripts/forms/themeEditor/ThemeDropDown.styles.ts
+++ b/library/src/scripts/forms/themeEditor/ThemeDropDown.styles.ts
@@ -47,7 +47,7 @@ export const themeDropDownClasses = useThemeCache(() => {
                 ...flexHelper().middleLeft(),
                 justifyContent: "space-between",
             },
-            "& .suggestedTextInput-valueContainer": {
+            "& .suggestedTextInput-valueContainer.suggestedTextInput-valueContainer": {
                 minHeight: unit(builderVariables.input.height),
                 paddingTop: 0,
                 paddingBottom: 0,

--- a/library/src/scripts/forms/themeEditor/ThemeEditor.story.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeEditor.story.tsx
@@ -1,0 +1,74 @@
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { BannerAlignment } from "@library/banner/bannerStyles";
+import { ThemeBuilderBlock } from "@library/forms/themeEditor/ThemeBuilderBlock";
+import { ThemeBuilderCheckBox } from "@library/forms/themeEditor/ThemeBuilderCheckBox";
+import { ThemeBuilderContextProvider } from "@library/forms/themeEditor/ThemeBuilderContext";
+import { ThemeBuilderSection } from "@library/forms/themeEditor/ThemeBuilderSection";
+import { ThemeBuilderTitle } from "@library/forms/themeEditor/ThemeBuilderTitle";
+import { ThemeBuilderUpload } from "@library/forms/themeEditor/ThemeBuilderUpload";
+import { ThemeColorPicker } from "@library/forms/themeEditor/ThemeColorPicker";
+import { ThemeDropDown } from "@library/forms/themeEditor/ThemeDropDown";
+import { ThemeInputNumber } from "@library/forms/themeEditor/ThemeInputNumber";
+import { action } from "@storybook/addon-actions";
+import { t } from "@vanilla/i18n";
+import React, { useState } from "react";
+import { ThemeToggle } from "@library/forms/themeEditor/ThemeToggle";
+
+export default {
+    title: "Forms",
+};
+
+export function ThemeEditor() {
+    const [vars, setVars] = useState({});
+    return (
+        <div style={{ maxWidth: 400, margin: "0 auto" }}>
+            <ThemeBuilderContextProvider
+                rawThemeVariables={vars}
+                onChange={vars => {
+                    action("Variable Change");
+                    setVars(vars);
+                }}
+            >
+                <ThemeBuilderTitle title="Title Component" />
+                <ThemeBuilderBlock label={t("Option Chooser")}>
+                    <ThemeDropDown
+                        variableKey="banner.options.alignment"
+                        options={[
+                            {
+                                label: "Option 1",
+                                value: BannerAlignment.LEFT,
+                            },
+                            {
+                                label: "Option 2",
+                                value: BannerAlignment.CENTER,
+                            },
+                        ]}
+                    />
+                </ThemeBuilderBlock>
+                <ThemeBuilderBlock label={t("Toggle")} info={"This is a Toggle component."}>
+                    <ThemeToggle variableKey="banner.backgrounds.useOverlay" />
+                </ThemeBuilderBlock>
+                <ThemeBuilderSection label="Section">
+                    <ThemeBuilderBlock label={t("Image Upload")}>
+                        <ThemeBuilderUpload variableKey="banner.outerBackground.image" />
+                    </ThemeBuilderBlock>
+                    <ThemeBuilderCheckBox
+                        label={t("Checkbox")}
+                        variableKey="banner.backgrounds.useOverlay"
+                        info={"Test tooltip"}
+                    />
+                    <ThemeBuilderBlock label={t("Color")}>
+                        <ThemeColorPicker variableKey="banner.colors.primary" />
+                    </ThemeBuilderBlock>
+                    <ThemeBuilderBlock label={t("Number Radius")}>
+                        <ThemeInputNumber variableKey="global.border.radius" max={10} step={2} min={2} />
+                    </ThemeBuilderBlock>
+                </ThemeBuilderSection>
+            </ThemeBuilderContextProvider>
+        </div>
+    );
+}

--- a/library/src/scripts/forms/themeEditor/ThemeToggle.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeToggle.tsx
@@ -1,0 +1,21 @@
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { FormToggle } from "@library/forms/FormToggle";
+import { useThemeVariableField } from "@library/forms/themeEditor/ThemeBuilderContext";
+import { useThemeBlock } from "@library/forms/themeEditor/ThemeBuilderBlock";
+
+interface IProps {
+    variableKey: string;
+}
+
+export function ThemeToggle(props: IProps) {
+    const { variableKey } = props;
+    const { generatedValue, setValue } = useThemeVariableField(variableKey);
+    const { inputID, labelID } = useThemeBlock();
+
+    return <FormToggle id={inputID} labelID={labelID} slim enabled={!!generatedValue} onChange={setValue} />;
+}

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -174,7 +174,7 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
 
     const borderType = makeThemeVars("borderType", {
         formElements: {
-            default: border,
+            default: { ...border, color: mixBgAndFg(0.35).saturate(0.1) },
             buttons: border,
         },
         modals: border,

--- a/library/src/scripts/styles/styleHelpersAnimation.ts
+++ b/library/src/scripts/styles/styleHelpersAnimation.ts
@@ -6,14 +6,17 @@
 
 import { globalVariables } from "@library/styles/globalStyleVars";
 
-export const defaultTransition = (...properties) => {
+export const defaultTransition = (...properties: string[]) => {
+    const vars = globalVariables();
+    return timedTransition(vars.animation.defaultTiming, ...properties);
+};
+
+export const timedTransition = (timing: string, ...properties: string[]) => {
     const vars = globalVariables();
     properties = properties.length === 0 ? ["all"] : properties;
     return {
         transition: `${properties.map((prop, index) => {
-            return `${prop} ${vars.animation.defaultTiming} ${vars.animation.defaultEasing}${
-                index === properties.length ? ", " : ""
-            }`;
+            return `${prop} ${timing} ${vars.animation.defaultEasing}${index === properties.length ? ", " : ""}`;
         })}`,
     };
 };


### PR DESCRIPTION
- Add a form toggle component ([see the story](https://www.chromaticqa.com/component?appId=5d5eba16c782b600204ba187&name=Forms%2FUser%20Facing&mode=interactive&buildNumber=2936&specName=Elements&viewport=1200&browser=chrome)).
- Add a theme toggle component ([see the story](https://www.chromaticqa.com/component?appId=5d5eba16c782b600204ba187&name=Forms&mode=interactive&buildNumber=2936&specName=Theme%20Editor&viewport=1200&browser=chrome)).
- Update `<ThemeBuilderBlock />` to allow an info tooltip.
- Make form border colors consistent (we had different ones in use for the checkboxes, other user inputs, and the theme inputs).
