### PR TITLE
Fix some docblocks

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -657,7 +657,7 @@ class Gdn_Request implements RequestInterface {
     /**
      * Alias for requestAddress()
      *
-     * @return type
+     * @return string
      */
     public function ipAddress() {
         return $this->_Environment['ADDRESS'];

--- a/library/core/functions.framework.php
+++ b/library/core/functions.framework.php
@@ -1841,10 +1841,9 @@ if (!function_exists('t')) {
      *
      * @param string $code The code related to the language-specific definition.
      *   Codes that begin with an '@' symbol are treated as literals and not translated.
-     * @param string $default The default value to be displayed if the translation code is not found.
+     * @param string|false $default The default value to be displayed if the translation code is not found.
      * @return string The translated string or $code if there is no value in $default.
      * @see Gdn::translate()
-     * @deprecated
      */
     function t($code, $default = false) {
         return Gdn::translate($code, $default);

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1262,7 +1262,7 @@ if (!function_exists('plural')) {
      * @param $number
      * @param $singular
      * @param $plural
-     * @param bool $formattedNumber
+     * @param string|false $formattedNumber
      * @return string
      */
     function plural($number, $singular, $plural, $formattedNumber = false) {


### PR DESCRIPTION
- When calling functions my IDE gives warnings that sometimes come from wrong types in docblocks.
- The `t()` function really shouldn’t be deprecated as there isn’t a good alternative right now.