### PR TITLE
Banner and TitleBar Style polish

### DIFF
--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -658,7 +658,7 @@ export const bannerClasses = useThemeCache(
             height: unit(formElementVars.sizing.height),
             width: unit(formElementVars.sizing.height),
             flexBasis: unit(formElementVars.sizing.height),
-            transform: translateX(px(formElementVars.sizing.height - globalVars.icon.sizes.default / 2 - 13)),
+            transform: translateX(px((formElementVars.sizing.height - globalVars.icon.sizes.default) / 2 + 3)), // The "3" is to offset the pencil that visually doesn't look aligned without a cheat.
             $nest: {
                 ".searchBar-actionButton:after": {
                     content: quote(""),

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -238,8 +238,8 @@ export const bannerVariables = useThemeCache((forcedVars?: IThemeVariables, altN
         },
         margins: {
             ...EMPTY_SPACING,
-            top: 14,
-            bottom: 12,
+            top: 18,
+            bottom: 8,
         },
         text: "How can we help you?",
     });
@@ -658,7 +658,7 @@ export const bannerClasses = useThemeCache(
             height: unit(formElementVars.sizing.height),
             width: unit(formElementVars.sizing.height),
             flexBasis: unit(formElementVars.sizing.height),
-            transform: translateX(px((formElementVars.sizing.height - globalVars.icon.sizes.default) / 2 + 3)), // The "3" is to offset the pencil that visually doesn't look aligned without a cheat.
+            transform: translateX(px((formElementVars.sizing.height - globalVars.icon.sizes.default) / 2 - 1)), // The "3" is to offset the pencil that visually doesn't look aligned without a cheat.
             $nest: {
                 ".searchBar-actionButton:after": {
                     content: quote(""),

--- a/library/src/scripts/headers/TitleBar.tsx
+++ b/library/src/scripts/headers/TitleBar.tsx
@@ -125,7 +125,11 @@ export default function TitleBar(_props: IProps) {
                 <div className={classNames(classes.bar, { isHome: showSubNav })}>
                     {isCompact &&
                         (props.useMobileBackButton ? (
-                            <BackLink className={classes.leftFlexBasis} linkClassName={classes.button} />
+                            <BackLink
+                                hideIfNoHistory={true}
+                                className={classes.leftFlexBasis}
+                                linkClassName={classes.button}
+                            />
                         ) : (
                             <FlexSpacer className="pageHeading-leftSpacer" />
                         ))}
@@ -421,7 +425,7 @@ function MobileMeBox() {
     if (isGuest) {
         return (
             <SmartLink
-                className={classNames(classes.centeredButtonClass, classes.button)}
+                className={classNames(classes.centeredButton, classes.button, classes.signInIconOffset)}
                 to={`/entry/signin?target=${window.location.pathname}`}
             >
                 <SignInIcon className={"titleBar-signInIcon"} />

--- a/library/src/scripts/headers/mebox/pieces/CompactMeBox.tsx
+++ b/library/src/scripts/headers/mebox/pieces/CompactMeBox.tsx
@@ -58,7 +58,7 @@ export default class CompactMeBox extends React.Component<IProps, IState> {
             <div className={classNames("compactMeBox", this.props.className, classes.root)}>
                 <Button
                     title={t("My Account")}
-                    className={classNames(classes.openButton, titleBarVars.centeredButtonClass, titleBarVars.button)}
+                    className={classNames(classes.openButton, titleBarVars.centeredButton, titleBarVars.button)}
                     onClick={this.open}
                     buttonRef={this.buttonRef}
                     baseClass={ButtonTypes.CUSTOM}

--- a/library/src/scripts/headers/mebox/pieces/CompactSearch.tsx
+++ b/library/src/scripts/headers/mebox/pieces/CompactSearch.tsx
@@ -104,7 +104,7 @@ export function CompactSearch(props: ICompactSearchProps) {
             {!props.open && (
                 <Button
                     onClick={props.onSearchButtonClick}
-                    className={classNames(classesTitleBar.centeredButtonClass, props.buttonClass)}
+                    className={classNames(classesTitleBar.centeredButton, props.buttonClass)}
                     title={t("Search")}
                     aria-expanded={false}
                     aria-haspopup="true"

--- a/library/src/scripts/headers/mebox/pieces/compactMeBoxStyles.ts
+++ b/library/src/scripts/headers/mebox/pieces/compactMeBoxStyles.ts
@@ -4,11 +4,13 @@
  * @license GPL-2.0-only
  */
 
-import { absolutePosition, flexHelper, unit, sticky, colorOut } from "@library/styles/styleHelpers";
+import { absolutePosition, flexHelper, unit, sticky, colorOut, negativeUnit } from "@library/styles/styleHelpers";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import { calc, percent, viewHeight } from "csx";
 import { buttonResetMixin } from "@library/forms/buttonStyles";
+import { userPhotoVariables } from "@library/headers/mebox/pieces/userPhotoStyles";
+import { titleBarVariables } from "@library/headers/titleBarStyles";
 
 export const compactMeBoxVariables = useThemeCache(() => {
     const themeVars = variableFactory("compactMeBox");
@@ -33,6 +35,7 @@ export const compactMeBoxClasses = useThemeCache(() => {
 
     const root = style({
         display: "block",
+        marginRight: negativeUnit((titleBarVariables().sizing.mobile.width - userPhotoVariables().sizing.small) / 2),
     });
 
     const openButton = style("openButton", {

--- a/library/src/scripts/headers/titleBarStyles.ts
+++ b/library/src/scripts/headers/titleBarStyles.ts
@@ -502,7 +502,7 @@ export const titleBarClasses = useThemeCache(() => {
             paddingTop: px(vars.sizing.height / 2),
         },
         mediaQueries.compact({
-            paddingTop: px(vars.sizing.mobile.height / 2),
+            paddingTop: px(vars.sizing.mobile.height / 2 + 20),
         }),
     );
 

--- a/library/src/scripts/headers/titleBarStyles.ts
+++ b/library/src/scripts/headers/titleBarStyles.ts
@@ -22,6 +22,7 @@ import {
     userSelect,
     EMPTY_FONTS,
     isLightColor,
+    negativeUnit,
 } from "@library/styles/styleHelpers";
 import { styleFactory, useThemeCache, variableFactory } from "@library/styles/styleUtils";
 import {
@@ -784,7 +785,7 @@ export const titleBarClasses = useThemeCache(() => {
         transform: `translateX(6px)`,
     });
 
-    const centeredButtonClass = style("centeredButtonClass", {
+    const centeredButton = style("centeredButton", {
         ...flex.middle(),
     });
 
@@ -940,6 +941,7 @@ export const titleBarClasses = useThemeCache(() => {
 
     const hamburger = style("hamburger", {
         marginRight: unit(12),
+        marginLeft: negativeUnit(globalVars.buttonIcon.offset),
         $nest: {
             "&&": {
                 ...allButtonStates({
@@ -965,6 +967,10 @@ export const titleBarClasses = useThemeCache(() => {
     const overlay = style("overlay", {
         ...absolutePosition.fullSizeOfParent(),
         background: vars.overlay.background,
+    });
+
+    const signInIconOffset = style("signInIconOffset", {
+        marginRight: negativeUnit(globalVars.buttonIcon.offset + 3),
     });
 
     return {
@@ -1000,7 +1006,7 @@ export const titleBarClasses = useThemeCache(() => {
         leftFlexBasis,
         signIn,
         register,
-        centeredButtonClass,
+        centeredButton,
         compactSearchResults,
         clearButtonClass,
         guestButton,
@@ -1012,6 +1018,7 @@ export const titleBarClasses = useThemeCache(() => {
         logoAnimationWrap,
         overlay,
         swoop,
+        signInIconOffset,
     };
 });
 

--- a/library/src/scripts/headers/titleBarStyles.ts
+++ b/library/src/scripts/headers/titleBarStyles.ts
@@ -268,6 +268,8 @@ export const titleBarVariables = useThemeCache((forcedVars?: IThemeVariables) =>
         }, // add "url" if you want to set in theme. Use full path eg. "/addons/themes/myTheme/design/myLogo.png"
         mobile: {
             url: undefined,
+            maxWidth: undefined,
+            heightOffset: sizing.height / 3,
         }, // add "url" if you want to set in theme. Use full path eg. "/addons/themes/myTheme/design/myLogo.png"
         offsetVertical: {
             amount: 0,
@@ -1016,13 +1018,12 @@ export const titleBarClasses = useThemeCache(() => {
 export const titleBarLogoClasses = useThemeCache(() => {
     const vars = titleBarVariables();
     const style = styleFactory("titleBarLogo");
-    const logoHeight = px(vars.sizing.height - vars.logo.heightOffset);
 
     const logoFrame = style("logoFrame", { display: "inline-flex", alignSelf: "center" });
 
     const logo = style("logo", {
         display: "block",
-        maxHeight: logoHeight,
+        maxHeight: px(vars.sizing.height - vars.logo.heightOffset),
         maxWidth: unit(vars.logo.maxWidth),
         width: "auto",
         $nest: {
@@ -1033,7 +1034,10 @@ export const titleBarLogoClasses = useThemeCache(() => {
     });
 
     const mobileLogo = style("mobileLogo", {
+        display: "flex",
         justifyContent: vars.mobileLogo.justifyContent,
+        maxHeight: px(vars.sizing.mobile.height - (vars.logo.mobile.heightOffset ?? vars.logo.heightOffset)),
+        maxWidth: unit(vars.logo.mobile.maxWidth ?? vars.logo.maxWidth),
     });
 
     const isCenter = style("isCenter", {

--- a/library/src/scripts/headers/vanillaHeaderStyles.ts
+++ b/library/src/scripts/headers/vanillaHeaderStyles.ts
@@ -390,7 +390,7 @@ export const titleBarClasses = useThemeCache(() => {
         }),
     );
 
-    const centeredButtonClass = style("centeredButtonClass", {
+    const centeredButton = style("centeredButton", {
         ...flex.middle(),
     });
 
@@ -585,7 +585,7 @@ export const titleBarClasses = useThemeCache(() => {
         leftFlexBasis,
         signIn,
         register,
-        centeredButtonClass,
+        centeredButton,
         compactSearchResults,
         clearButtonClass,
         guestButton,

--- a/library/src/scripts/icons/iconClasses.ts
+++ b/library/src/scripts/icons/iconClasses.ts
@@ -35,8 +35,8 @@ export const iconVariables = useThemeCache(() => {
         width: 80,
         height: 32.3,
         mobile: {
-            width: 60,
-            height: 24.22,
+            width: undefined,
+            height: undefined,
         },
     });
 
@@ -196,8 +196,8 @@ export const iconClasses = useThemeCache(() => {
     });
 
     const vanillaLogoMobile = style("vanillaLogoMobile", {
-        width: unit(vars.vanillaLogo.mobile.width),
-        height: unit(vars.vanillaLogo.mobile.height),
+        width: unit(vars.vanillaLogo.mobile.width ?? vars.vanillaLogo.width),
+        height: unit(vars.vanillaLogo.mobile.height ?? vars.vanillaLogo.height),
     });
 
     const compact = style("compact", {

--- a/library/src/scripts/icons/iconClasses.ts
+++ b/library/src/scripts/icons/iconClasses.ts
@@ -34,6 +34,10 @@ export const iconVariables = useThemeCache(() => {
     const vanillaLogo = themeVars("vanillaLogo", {
         width: 80,
         height: 32.3,
+        mobile: {
+            width: 60,
+            height: 24.22,
+        },
     });
 
     const compact = themeVars("compact", {
@@ -191,6 +195,11 @@ export const iconClasses = useThemeCache(() => {
         height: unit(vars.vanillaLogo.height),
     });
 
+    const vanillaLogoMobile = style("vanillaLogoMobile", {
+        width: unit(vars.vanillaLogo.mobile.width),
+        height: unit(vars.vanillaLogo.mobile.height),
+    });
+
     const compact = style("compact", {
         width: unit(vars.compact.width),
         height: unit(vars.compact.height),
@@ -329,6 +338,7 @@ export const iconClasses = useThemeCache(() => {
         fileType,
         attachmentError,
         vanillaLogo,
+        vanillaLogoMobile,
         compact,
         settings,
         search,

--- a/library/src/scripts/icons/icons.story.tsx
+++ b/library/src/scripts/icons/icons.story.tsx
@@ -296,7 +296,7 @@ story.add("Icons", () => {
                     </div>
                 </StoryTileAndTextCompact>
                 <StoryTileAndTextCompact text={`VanillaLogo`}>
-                    {<titleBarIcons.VanillaLogo className={classes.smallerLogo} />}
+                    {<titleBarIcons.VanillaLogo className={classes.smallerLogo} isMobile={true} />}
                 </StoryTileAndTextCompact>
             </StoryTiles>
             <StoryHeading>Revisions</StoryHeading>

--- a/library/src/scripts/icons/titleBar.tsx
+++ b/library/src/scripts/icons/titleBar.tsx
@@ -67,14 +67,18 @@ export function DownloadIcon(props: { className?: string }) {
     );
 }
 
-export function VanillaLogo(props: { className?: string; fill?: string }) {
+export function VanillaLogo(props: { className?: string; fill?: string; isMobile?: boolean }) {
+    const { className, isMobile } = props;
     const title = `Vanilla`;
     const classes = iconClasses();
     const fill = props.fill ? props.fill : "currentColor";
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
-            className={classNames(props.className, classes.vanillaLogo)}
+            className={classNames(props.className, {
+                [classes.vanillaLogo]: !isMobile,
+                [classes.vanillaLogoMobile]: isMobile,
+            })}
             viewBox="0 0 296.866 119.883"
             role="img"
             aria-label={title}

--- a/library/src/scripts/routing/links/BackLink.tsx
+++ b/library/src/scripts/routing/links/BackLink.tsx
@@ -40,6 +40,9 @@ interface IProps {
 
     /** Whether or not to display the label visibly. */
     visibleLabel?: boolean;
+
+    /** Check history and hide if there's no where to go **/
+    hideIfNoHistory?: boolean;
 }
 
 /**
@@ -59,6 +62,10 @@ export default function BackLink(props: IProps) {
     const classes = backLinkClasses();
     const className = classNames(classes.link, { hasVisibleLabel: !!props.visibleLabel }, props.linkClassName);
     const title = props.title || t("Back");
+
+    if (!canGoBack && props.hideIfNoHistory && !props.fallbackUrl) {
+        return null;
+    }
 
     let content = (
         <>

--- a/library/src/scripts/theming/ThemeLogo.tsx
+++ b/library/src/scripts/theming/ThemeLogo.tsx
@@ -21,13 +21,14 @@ class ThemeLogo extends React.Component<IProps> {
         const themeDesktopUrl = titleBarVariables().logo.desktop.url;
         const themeMobileUrl = titleBarVariables().logo.mobile.url;
 
-        const themeUrl = this.props.type === LogoType.DESKTOP ? themeDesktopUrl : themeMobileUrl;
+        const isDesktop = this.props.type === LogoType.DESKTOP;
+        const themeUrl = isDesktop ? themeDesktopUrl : themeMobileUrl;
         const finalUrl = themeUrl ?? this.props.logoUrl;
 
         if (finalUrl) {
             content = <img className={this.props.className} src={finalUrl} />;
         } else {
-            content = <VanillaLogo className={this.props.className} />;
+            content = <VanillaLogo className={this.props.className} isMobile={!isDesktop} />;
         }
 
         return content;


### PR DESCRIPTION
Fixes various issues with titleBar/banner

- I was unable to reproduce the border radius issue
- Cheated position of icons (both signed in and out) to have the edge of the icon line up with the margins, not the edge of the button.
- Works with or without the back link. I added a param to hide it when there's no where to go (like when you land on the home page for the first time)
- Mobile logo is smaller and can be adjusted.


Closes: https://github.com/vanilla/vanilla/issues/10295

Needs approval from @ElisaAlmeida 