### PR TITLE
Foundation - Switch discussions titles color

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/textLinkStyles.ts
@@ -46,7 +46,6 @@ export const textLinkCSS = () => {
         default: globalVars.links.colors.default,
     });
     mixinClickInput(".DataList .Item .Title a");
-    mixinClickInput(`.DataTable.DiscussionsTable a.Title`);
 
     // Links that have FG color by default but regular state colors.
     mixinTextLinkNoDefaultLinkAppearance(".ItemContent a");
@@ -62,6 +61,7 @@ export const textLinkCSS = () => {
     mixinTextLinkNoDefaultLinkAppearance(`.DataList#search-results .Breadcrumbs a`);
     mixinTextLinkNoDefaultLinkAppearance(`.Container a.UserLink`);
     mixinTextLinkNoDefaultLinkAppearance(`.DataTable a.CommentDate`);
+    mixinTextLinkNoDefaultLinkAppearance(`.DataTable.DiscussionsTable a.Title`);
 };
 
 export const mixinTextLinkNoDefaultLinkAppearance = selector => {


### PR DESCRIPTION
As per https://github.com/vanilla/internal/issues/2349 we're changing the color of discussion titles on the discussions page to black.

Closes: https://github.com/vanilla/internal/issues/2349