### PR TITLE
Fix null checking in dashboard hooks

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -286,9 +286,18 @@ class DashboardHooks extends Gdn_Plugin {
         $session = Gdn::session();
         $desktopTheme = $this->addonManager->lookupTheme($this->desktopThemeKey);
         $mobileTheme = $this->addonManager->lookupTheme($this->mobileThemeKey);
-        $isDistinctMobileTheme = $mobileTheme !== $desktopTheme;
-        $hasThemeOptions = count($desktopTheme->getInfoValue('options', [])) > 0;
-        $hasMobileThemeOptions = $isDistinctMobileTheme && count($mobileTheme->getInfoValue('options', [])) > 0;
+
+        $hasThemeOptions = false;
+        $isDistinctMobileTheme = false;
+        $hasMobileThemeOptions = false;
+        if ($desktopTheme) {
+            $hasThemeOptions = count($desktopTheme->getInfoValue('options', [])) > 0;
+        }
+
+        if ($mobileTheme) {
+            $isDistinctMobileTheme = $mobileTheme !== $desktopTheme;
+            $hasMobileThemeOptions = $isDistinctMobileTheme && count($mobileTheme->getInfoValue('options', [])) > 0;
+        }
 
         $sort = -1; // Ensure these nav items come before any plugin nav items.
 


### PR DESCRIPTION
Fixes this potential error which could be reproduced with an invalid theme config. (dashboard only).

![image](https://user-images.githubusercontent.com/1770056/78716185-85c33800-78ec-11ea-8566-9e4060b151f9.png)


