### PR TITLE
Rate limit confirmation email deliveries

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -4560,6 +4560,9 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
 
         $email->setEmailTemplate($emailTemplate);
 
+        // Apply rate limiting
+        self::rateLimit($user);
+
         try {
             $email->send();
         } catch (Exception $e) {


### PR DESCRIPTION
Closes vanilla/support#939.

This PR adds rate limiting for confirmation email deliveries.

### TO TEST
1. Check out this branch
1. Have outgoing email set up 
1. Sign in as a user with a role of unconfirmed and an email address you can access
1. Set the `LOGIN_RATE` constant to 100 in `class.usermodel.php`
1. Click on the link to send an email confirmation multiple times
1. Confirm that only one email was sent