### PR TITLE
Implement responsive breakpoint utils and components for theming system

### DIFF
--- a/build/scripts/configs/makeBaseConfig.ts
+++ b/build/scripts/configs/makeBaseConfig.ts
@@ -57,7 +57,7 @@ ${chalk.green(aliases)}`;
                             "p-debounce",
                             "@vanilla/.*",
                             "react-redux",
-                            "react-spring",
+                            "react-spring/.*",
                         ];
                         const exclusionRegex = new RegExp(`node_modules/(${modulesRequiringTranspilation.join("|")})/`);
 

--- a/library/src/scripts/banner/banner.story.tsx
+++ b/library/src/scripts/banner/banner.story.tsx
@@ -650,8 +650,10 @@ export const bannerImageOnly = storyWithConfig(
                     position: "50% 100%",
                     color: color("#54367c"),
                     image: "https://us.v-cdn.net/5022541/uploads/091/7G8KTIZCJU5S.jpeg",
-                    mobile: {
-                        image: "https://us.v-cdn.net/5022541/uploads/470/U68ZI0LRPRBQ.png",
+                    breakpoints: {
+                        mobile: {
+                            image: "https://us.v-cdn.net/5022541/uploads/470/U68ZI0LRPRBQ.png",
+                        },
                     },
                 },
             },

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -38,10 +38,12 @@ import { styleFactory, useThemeCache, variableFactory } from "@library/styles/st
 import { widgetVariables } from "@library/styles/widgetStyleVars";
 import { IThemeVariables } from "@library/theming/themeReducer";
 import { BackgroundColorProperty, FontWeightProperty, PaddingProperty, TextShadowProperty } from "csstype";
-import { calc, important, percent, px, quote, rgba, translateX, translateY, ColorHelper } from "csx";
+import { calc, important, percent, px, quote, rgba, translateX, translateY, ColorHelper, color } from "csx";
 import { media } from "typestyle";
 import { NestedCSSProperties, TLength } from "typestyle/lib/types";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
+import { breakpointVariables } from "@library/styles/styleHelpersBreakpoints";
+import { t } from "@vanilla/i18n";
 
 export enum BannerAlignment {
     LEFT = "left",
@@ -185,15 +187,26 @@ export const bannerVariables = useThemeCache((forcedVars?: IThemeVariables, altN
         },
     });
 
-    const outerBackground = makeThemeVars("outerBackground", {
+    const outerBackgroundInit = makeThemeVars("outerBackground", {
         ...EMPTY_BACKGROUND,
         color: colors.primary.lighten("12%"),
         repeat: "no-repeat",
         position: "50% 50%",
         size: "cover",
-        mobile: {
-            image: undefined as undefined | string,
-        },
+    });
+
+    const outerBackground = makeThemeVars("outerBackground", {
+        ...outerBackgroundInit,
+        ...breakpointVariables({
+            tablet: {
+                breakpointUILabel: t("Tablet"),
+                ...EMPTY_BACKGROUND,
+            },
+            mobile: {
+                breakpointUILabel: t("Mobile"),
+                ...EMPTY_BACKGROUND,
+            },
+        }),
     });
 
     const innerBackground = makeThemeVars("innerBackground", {
@@ -507,6 +520,8 @@ export const bannerClasses = useThemeCache(
 
         const outerBackground = useThemeCache((url?: string) => {
             const finalUrl = url ?? vars.outerBackground.image ?? undefined;
+            const finalTabletUrl = url ?? vars.outerBackground.breakpoints.tablet.image;
+            const finalMobileUrl = url ?? vars.outerBackground.breakpoints.mobile.image;
             const finalVars = {
                 ...vars.outerBackground,
                 image: finalUrl,
@@ -524,9 +539,10 @@ export const bannerClasses = useThemeCache(
                     display: "block",
                     ...backgroundHelper(finalVars),
                 },
-                mediaQueries.oneColumnDown({
-                    image: vars.outerBackground.mobile.image,
-                } as NestedCSSProperties),
+                finalTabletUrl &&
+                    mediaQueries.twoColumnsDown(backgroundHelper({ ...vars.outerBackground, image: finalTabletUrl })),
+                finalMobileUrl &&
+                    mediaQueries.oneColumnDown(backgroundHelper({ ...vars.outerBackground, image: finalMobileUrl })),
             );
         });
 

--- a/library/src/scripts/banner/contentBannerStyles.tsx
+++ b/library/src/scripts/banner/contentBannerStyles.tsx
@@ -8,6 +8,8 @@ import { bannerVariables, bannerClasses, BannerAlignment } from "@library/banner
 import clamp from "lodash/clamp";
 import { IThemeVariables } from "@library/theming/themeReducer";
 import { EMPTY_SPACING } from "@library/styles/styleHelpers";
+import merge from "lodash/merge";
+import clone from "lodash/clone";
 
 export const CONTENT_BANNER_MAX_HEIGHT = 180;
 export const CONTENT_BANNER_MIN_HEIGHT = 80;
@@ -44,41 +46,39 @@ export const contentBannerVariables = useThemeCache((forcedVars?: IThemeVariable
         },
     });
 
-    const normalBannerVars = bannerVariables();
+    const normalBannerVars = bannerVariables(forcedVars, "contentBanner");
 
-    return bannerVariables(
-        {
-            contentBanner: {
-                options: {
-                    ...options,
-                    hideDescription: true,
-                    hideTitle: true,
-                    hideSearch: true,
-                },
-                dimensions: {
-                    minHeight: minHeight,
-                    mobile: {
-                        minHeight: minHeightMobile,
-                    },
-                },
-                logo: {
-                    height: minHeight - normalBannerVars.logo.padding.all * 2,
-                    width: "auto",
-                    mobile: {
-                        height: minHeightMobile - normalBannerVars.logo.padding.all * 2,
-                    },
-                },
-                spacing: {
-                    padding: {
-                        top: 0,
-                        bottom: 0,
-                    },
-                },
-                contentContainer,
+    const forced = merge(clone(forcedVars), {
+        contentBanner: {
+            options: {
+                ...options,
+                hideDescription: true,
+                hideTitle: true,
+                hideSearch: true,
             },
+            dimensions: {
+                minHeight: minHeight,
+                mobile: {
+                    minHeight: minHeightMobile,
+                },
+            },
+            logo: {
+                height: minHeight - normalBannerVars.logo.padding.all * 2,
+                width: "auto",
+                mobile: {
+                    height: minHeightMobile - normalBannerVars.logo.padding.all * 2,
+                },
+            },
+            spacing: {
+                padding: {
+                    top: 0,
+                    bottom: 0,
+                },
+            },
+            contentContainer,
         },
-        "contentBanner",
-    );
+    });
+    return bannerVariables(forced, "contentBanner");
 });
 
 export const contentBannerClasses = useThemeCache(() => {

--- a/library/src/scripts/forms/FormToggle.styles.ts
+++ b/library/src/scripts/forms/FormToggle.styles.ts
@@ -59,8 +59,8 @@ export const formToggleClasses = useThemeCache((forcedVars?: IThemeVariables) =>
         height: vars.well.height,
         width: vars.well.width,
         ...borders(vars.well.border),
-        background: colorOut(vars.well.color),
-        ...defaultTransition("background", "border"),
+        backgroundColor: colorOut(vars.well.color),
+        transition: "0.3s linear background, 0.3s linear border",
     });
 
     const slider = style("slider", {
@@ -72,8 +72,8 @@ export const formToggleClasses = useThemeCache((forcedVars?: IThemeVariables) =>
         top: vars.sizing.gutter,
         bottom: vars.sizing.gutter,
         left: vars.sizing.gutter,
-        background: colorOut(vars.slider.color),
-        transition: "0.2 ease border, 0.5s ease left, 0.5s ease right",
+        backgroundColor: colorOut(vars.slider.color),
+        transition: "0.3s linear border, 0.2s linear left",
     });
 
     const root = style({
@@ -83,18 +83,15 @@ export const formToggleClasses = useThemeCache((forcedVars?: IThemeVariables) =>
         width: vars.well.width,
         $nest: {
             [`&.isEnabled .${slider}`]: {
-                left: "initial",
-                right: vars.sizing.gutter,
+                left: vars.well.width / 2 + vars.sizing.gutter,
                 ...borders({ ...vars.slider.border, color: vars.slider.color }),
             },
             [`&.isEnabled .${well}`]: {
-                background: colorOut(vars.well.colorActive),
+                backgroundColor: colorOut(vars.well.colorActive),
                 ...borders({ ...vars.slider.border, color: vars.well.colorActive }),
             },
             [`&.isIndeterminate .${slider}`]: {
-                left: 0,
-                right: 0,
-                margin: "0 auto",
+                left: vars.slider.width / 2 + vars.sizing.gutter,
             },
             [`&.isFocused .${well}, &:hover .${well}`]: {
                 ...borders({ ...vars.slider.border, color: vars.well.colorActive }),
@@ -104,7 +101,7 @@ export const formToggleClasses = useThemeCache((forcedVars?: IThemeVariables) =>
             },
             [`&.isEnabled.isFocused .${well}, &.isEnabled:hover .${well}`]: {
                 ...borders({ ...vars.well.border, color: vars.well.colorActiveState }),
-                background: colorOut(vars.well.colorActiveState),
+                backgroundColor: colorOut(vars.well.colorActiveState),
             },
             [`&.isEnabled.isFocused .${slider}, &.isEnabled:hover .${slider}`]: {
                 ...borders({ ...vars.slider.border, color: vars.slider.color }),

--- a/library/src/scripts/forms/FormToggle.tsx
+++ b/library/src/scripts/forms/FormToggle.tsx
@@ -53,6 +53,7 @@ export function FormToggle(props: IProps) {
                     type="checkbox"
                     aria-labelledby={labelID}
                     id={id}
+                    checked={enabled}
                     onChange={e => {
                         onChange(e.target.checked);
                     }}

--- a/library/src/scripts/forms/themeEditor/ThemeBuilderBreakpoints.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderBreakpoints.tsx
@@ -1,0 +1,104 @@
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import React from "react";
+import { useThemeVariableField } from "@library/forms/themeEditor/ThemeBuilderContext";
+import { ThemeBuilderBlock, useThemeBlock } from "@library/forms/themeEditor/ThemeBuilderBlock";
+import { t } from "@vanilla/i18n";
+import { ThemeToggle } from "@library/forms/themeEditor/ThemeToggle";
+import { logWarning } from "@vanilla/utils";
+import { Spring, animated, config as springConfig } from "react-spring/renderprops";
+import { style } from "typestyle";
+import { ThemeBuilderUpload } from "@library/forms/themeEditor/ThemeBuilderUpload";
+
+interface IProps {
+    baseKey: string;
+    responsiveKey: string;
+    enabledView: BreakpointViewType | BreakpointCallback;
+}
+
+export function ThemeBuilderBreakpoints(props: IProps) {
+    const { baseKey, responsiveKey, enabledView } = props;
+    const {
+        rawValue: rawBreakpoints = {},
+        generatedValue: breakpoints = {},
+        setValue: setBreakpoints,
+    } = useThemeVariableField(baseKey + ".breakpoints");
+    const { rawValue: isEnabled } = useThemeVariableField(baseKey + ".breakpointUIEnabled");
+
+    // We have 1 key here by default. "breakpointUIEnabled".
+    // If we have more, than means some breakpoints have been configured.
+    const isForceEnabled = rawBreakpoints && Object.keys(rawBreakpoints).length > 1 ? true : undefined;
+    const isExpanded = isEnabled || isForceEnabled;
+    const callback = typeof enabledView === "function" ? enabledView : breakpointCallbackForType(enabledView);
+
+    return (
+        <>
+            <ThemeBuilderBlock
+                label={t("Responsive Breakpoints")}
+                info={t("You can configure some values differently for different screensizes.")}
+            >
+                <ThemeToggle
+                    forcedValue={isForceEnabled}
+                    afterChange={value => {
+                        if (!value) {
+                            // We were turned off, so clear all of the breakpoint values.
+                            setBreakpoints(undefined);
+                        }
+                    }}
+                    variableKey={baseKey + ".breakpointUIEnabled"}
+                />
+            </ThemeBuilderBlock>
+            <Spring
+                config={{ ...springConfig.stiff, clamp: true }}
+                from={{ height: 0 }}
+                to={{ height: isExpanded ? "auto" : 0 }}
+            >
+                {({ height }) => {
+                    return (
+                        <animated.div style={{ height }} className={style({ overflow: "hidden" })}>
+                            {breakpoints &&
+                                Object.entries(breakpoints).map(([breakpointKey, value]) => {
+                                    const variableKey = `${baseKey}.breakpoints.${breakpointKey}.${responsiveKey}`;
+                                    if (typeof value === "object" && value && value["breakpointUILabel"]) {
+                                        return (
+                                            <React.Fragment key={variableKey}>
+                                                {callback({ variableKey, label: value["breakpointUILabel"] })}
+                                            </React.Fragment>
+                                        );
+                                    } else {
+                                        logWarning("variableKey is not a well formed breakpoint");
+                                        return <React.Fragment key={variableKey} />;
+                                    }
+                                })}
+                        </animated.div>
+                    );
+                }}
+            </Spring>
+        </>
+    );
+}
+
+export enum BreakpointViewType {
+    IMAGE = "image",
+}
+
+type BreakpointCallback = (params: { variableKey: string; label: string }) => React.ReactNode;
+
+function breakpointCallbackForType(type: BreakpointViewType): BreakpointCallback {
+    switch (type) {
+        case BreakpointViewType.IMAGE:
+        default:
+            return breakpointImageCallback;
+    }
+}
+
+function breakpointImageCallback({ variableKey, label }) {
+    return (
+        <ThemeBuilderBlock label={label}>
+            <ThemeBuilderUpload variableKey={variableKey} />
+        </ThemeBuilderBlock>
+    );
+}

--- a/library/src/scripts/forms/themeEditor/ThemeBuilderContext.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderContext.tsx
@@ -14,7 +14,9 @@ import unset from "lodash/unset";
 import { bannerVariables } from "@library/banner/bannerStyles";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { contentBannerVariables } from "@library/banner/contentBannerStyles";
-import { userContentVariables } from "@library/content/userContentStyles";
+import { userContentVariables, userContentClasses } from "@library/content/userContentStyles";
+import { escapeHTML } from "@vanilla/dom-utils";
+import UserContent from "@library/content/UserContent";
 
 ///
 /// Types
@@ -64,7 +66,7 @@ export function useThemeVariableField<T>(variableKey: string) {
         initialValue: get(context.initialThemeVariables, variableKey, undefined) as T | null | undefined,
         generatedValue: get(context.generatedThemeVariables, variableKey, undefined) as T | null | undefined,
         error: get(context.variableErrors, variableKey, undefined) as string | null | undefined,
-        setValue: (value: T | null) => {
+        setValue: (value: T | null | undefined) => {
             context.setVariableValue(variableKey, value);
         },
         setError: (value: T | null) => {
@@ -112,20 +114,23 @@ export function ThemeBuilderContextProvider(props: IProps) {
         const newErrors = calculateNewErrors(variableKey, null);
         const hasErrors = getErrorCount(newErrors) > 0;
         let cloned = cloneDeep(rawValueRef.current);
+
         rawValueRef.current = cloned;
+
         if (value === "" || value === undefined) {
             // Null does not clear this. Null is a valid value.
             unset(cloned, variableKey);
         } else {
             cloned = set(cloned, variableKey, value);
         }
+
         onChange(cloned, hasErrors);
     };
 
     return (
         <context.Provider
             value={{
-                rawThemeVariables,
+                rawThemeVariables: rawValueRef.current,
                 defaultThemeVariables,
                 generatedThemeVariables,
                 initialThemeVariables,

--- a/library/src/scripts/forms/themeEditor/ThemeEditor.story.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeEditor.story.tsx
@@ -17,6 +17,7 @@ import { action } from "@storybook/addon-actions";
 import { t } from "@vanilla/i18n";
 import React, { useState } from "react";
 import { ThemeToggle } from "@library/forms/themeEditor/ThemeToggle";
+import { ThemeBuilderBreakpoints, BreakpointViewType } from "@library/forms/themeEditor/ThemeBuilderBreakpoints";
 
 export default {
     title: "Forms",
@@ -67,6 +68,11 @@ export function ThemeEditor() {
                     <ThemeBuilderBlock label={t("Number Radius")}>
                         <ThemeInputNumber variableKey="global.border.radius" max={10} step={2} min={2} />
                     </ThemeBuilderBlock>
+                    <ThemeBuilderBreakpoints
+                        baseKey="contentBanner.outerBackground"
+                        responsiveKey="image"
+                        enabledView={BreakpointViewType.IMAGE}
+                    ></ThemeBuilderBreakpoints>
                 </ThemeBuilderSection>
             </ThemeBuilderContextProvider>
         </div>

--- a/library/src/scripts/forms/themeEditor/ThemeToggle.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeToggle.tsx
@@ -10,12 +10,27 @@ import { useThemeBlock } from "@library/forms/themeEditor/ThemeBuilderBlock";
 
 interface IProps {
     variableKey: string;
+    forcedValue?: boolean;
+    afterChange?: (value: boolean) => void;
 }
 
 export function ThemeToggle(props: IProps) {
-    const { variableKey } = props;
+    const { variableKey, forcedValue, afterChange } = props;
     const { generatedValue, setValue } = useThemeVariableField(variableKey);
     const { inputID, labelID } = useThemeBlock();
 
-    return <FormToggle id={inputID} labelID={labelID} slim enabled={!!generatedValue} onChange={setValue} />;
+    const value = forcedValue ?? !!generatedValue;
+
+    return (
+        <FormToggle
+            id={inputID}
+            labelID={labelID}
+            slim
+            enabled={value}
+            onChange={newValue => {
+                setValue(newValue);
+                afterChange?.(newValue);
+            }}
+        />
+    );
 }

--- a/library/src/scripts/styles/styleHelpersBreakpoints.ts
+++ b/library/src/scripts/styles/styleHelpersBreakpoints.ts
@@ -1,0 +1,12 @@
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+type IBreakpointVar = {
+    breakpointUILabel: string;
+} & Record<string, any>;
+
+export function breakpointVariables(breakpoints: Record<string, IBreakpointVar>) {
+    return { breakpoints, breakpointUIEnabled: false };
+}


### PR DESCRIPTION
Blocking https://github.com/vanilla/internal/pull/2371

- Implements a utility method for defining responsive breakpoints.
- Implements a theme UI component for handling responsive breakpoints.
  - Target something using responsive variables.
  - Has a toggle to enable.
  - When disabled it clears existing responsive images.
- Adds responsive breakpoint to story.
- Tweak the transition of the form toggle to be more fluid.
