### PR TITLE
Fix custom theme font loading on infrastructure

### DIFF
--- a/library/src/scripts/theming/loadThemeFonts.ts
+++ b/library/src/scripts/theming/loadThemeFonts.ts
@@ -39,9 +39,8 @@ export function loadThemeFonts() {
             custom: {
                 families: fonts.map(font => font.name),
                 urls: fonts.map(font => {
-                    const url = new URL(siteUrl(assetUrl(font.url)));
-                    url.searchParams.append("v", getMeta("context.cacheBuster"));
-                    return url.href;
+                    const fontUrl = assetUrl(`${font.url}?v=${getMeta("context.cacheBuster")}`);
+                    return fontUrl;
                 }),
             },
         };


### PR DESCRIPTION
Using both siteUrl and assetUrl breaks the assetUrl handling on infra's node sites. I've adjusted the handling to just use `assetUrl`.