### PR TITLE
Extend CurrentUserFieldProcessor to respect operation MODE_IMPORT

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -890,6 +890,7 @@ $Construct
     ->column("reactionValue", "int", false)
     ->column("insertUserID", "int", false, ["index"])
     ->column("dateInserted", "datetime")
+    ->column('foreignID', 'varchar(32)', true, 'index')
     ->set($Explicit, $Drop);
 
 $Construct

--- a/library/Vanilla/Database/Operation/CurrentUserFieldProcessor.php
+++ b/library/Vanilla/Database/Operation/CurrentUserFieldProcessor.php
@@ -74,7 +74,9 @@ class CurrentUserFieldProcessor implements Processor {
             $fieldExists = $databaseOperation->getCaller()->getWriteSchema()->getField("properties.{$field}");
             if ($fieldExists) {
                 $set = $databaseOperation->getSet();
-                $set[$field] = $this->session->UserID;
+                if (empty($set[$field] ?? null) || $databaseOperation->getMode() === Operation::MODE_DEFAULT) {
+                    $set[$field] = $this->session->UserID;
+                };
                 $databaseOperation->setSet($set);
             }
         }

--- a/tests/Library/Vanilla/Database/CurrentUserFieldProcessorTest.php
+++ b/tests/Library/Vanilla/Database/CurrentUserFieldProcessorTest.php
@@ -53,4 +53,77 @@ class CurrentUserFieldProcessorTest extends TestCase {
             [Operation::TYPE_UPDATE, ["UpdateUserID" => self::CURRENT_USER_ID]],
         ];
     }
+
+    /**
+     * Verify processor adds/resets fields to current user when operations in default mode.
+     *
+     * @param string $type
+     * @param array $expectedSet
+     * @dataProvider provideUserFields
+     */
+    public function testUserFieldsModeDefault(string $type, array $expectedSet) {
+        $model = new BasicPipelineModel("Example");
+        $session = new Gdn_Session();
+        $session->UserID = self::CURRENT_USER_ID;
+        $processor = new CurrentUserFieldProcessor($session);
+        $model->addPipelineProcessor($processor);
+
+        $operation = new Operation();
+        $operation->setType($type);
+        $operation->setCaller($model);
+        $operation->setSet($expectedSet);
+        $model->doOperation($operation);
+        $set = $operation->getSet();
+
+        foreach ($set as $setField => $setValue) {
+            if (!array_key_exists($setField, $expectedSet)) {
+                // Throw a failure exception.
+                $this->fail("Unexpected field: {$setField}");
+            }
+            $this->assertEquals(self::CURRENT_USER_ID, $setValue);
+        }
+    }
+
+    /**
+     * Verify processor set user fields when operations in import mode.
+     *
+     * @param string $type
+     * @param array $expectedSet
+     * @dataProvider provideUserFields
+     */
+    public function testUserFieldsModeImport(string $type, array $expectedSet) {
+        $model = new BasicPipelineModel("Example");
+        $session = new Gdn_Session();
+        $session->UserID = self::CURRENT_USER_ID;
+        $processor = new CurrentUserFieldProcessor($session);
+        $model->addPipelineProcessor($processor);
+
+        $operation = new Operation();
+        $operation->setType($type);
+        $operation->setCaller($model);
+        $operation->setMode(Operation::MODE_IMPORT);
+        $operation->setSet($expectedSet);
+        $model->doOperation($operation);
+        $set = $operation->getSet();
+
+        foreach ($set as $setField => $setValue) {
+            if (!array_key_exists($setField, $expectedSet)) {
+                // Throw a failure exception.
+                $this->fail("Unexpected field: {$setField}");
+            }
+            $this->assertEquals($expectedSet[$setField], $setValue);
+        }
+    }
+
+    /**
+     * Generate type and "sets" pairs for testing if the current user fields should be set (or not).
+     *
+     * @return array
+     */
+    public function provideUserFields() {
+        return [
+            [Operation::TYPE_INSERT, ["InsertUserID" => 200]],
+            [Operation::TYPE_UPDATE, ["UpdateUserID" => 200]],
+        ];
+    }
 }


### PR DESCRIPTION
Add new `foreignID` field to reaction model db table.

Adjust `CurrentUserFieldProcessor` to allow user fields to be set when operations in `MODE_IMPORT`

Extend **CurrentUserFieldProcessorTest** to test operations in `MODE_DEFAULT` and `MODE_IMPORT`

Relates to: https://github.com/vanilla/knowledge/issues/1675
