### PR TITLE
Fix user count displaying 0 users when no search keyword is supplied

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2952,12 +2952,13 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
 
         // Check to see if the search exactly matches a role name.
         $roleID = false;
-        if (strtolower($keywords) == 'banned') {
-            $this->SQL->where('u.Banned >', 0);
-        } else {
-            $roleID = $this->SQL->getWhere('Role', ['Name' => $keywords])->value('RoleID');
+        if ($keywords !== "") {
+            if (strtolower($keywords) == 'banned') {
+                $this->SQL->where('u.Banned >', 0);
+            } else {
+                $roleID = $this->SQL->getWhere('Role', ['Name' => $keywords])->value('RoleID');
+            }
         }
-
         if (isset($where)) {
             $this->SQL->where($where, null, false);
         }


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1692

### Details

Searching for users in the dashboard moderation displays 0 users when no keyword is supplied if you have a role with no name and no users assigned to that role.

### Cause
https://github.com/vanilla/vanilla/blob/d510e30533a4be57a8bae9c7815d7c65fef02604/applications/dashboard/models/class.usermodel.php#L2958

we try to get a role based on the keyword provided, if there is nothing provided then the keyword would be an empty string, when we do
$roleID = $this->SQL->getWhere('Role', ['Name' => $keywords])->value('RoleID');
}
this would return any role that has no name.

### To Replicate/Test

- Create a Role with no name
- Go to the dashboard moderation page
- Notice your user count displays 0 (if the new role with no name has no users already assigned to it)

![Screen Shot 2020-04-09 at 10 59 04 AM](https://user-images.githubusercontent.com/31856281/78909206-27639a00-7a51-11ea-89ae-cdce9e1078e4.png)
![Screen Shot 2020-04-09 at 10 59 53 AM](https://user-images.githubusercontent.com/31856281/78909268-43673b80-7a51-11ea-8fbc-304d9b4a4b04.png)



