### PR TITLE
Fix oauth can still be default provider when disabled

### DIFF
--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1454,7 +1454,6 @@ class SettingsController extends DashboardController {
         }
 
         $addon = Gdn::addonManager()->lookupAddon($pluginName);
-        $this->fireEvent('BeforeDisablePlugin', ['PluginName' => $pluginName]);
 
         try {
             Gdn::pluginManager()->disablePlugin($pluginName);

--- a/applications/dashboard/controllers/class.settingscontroller.php
+++ b/applications/dashboard/controllers/class.settingscontroller.php
@@ -1454,6 +1454,7 @@ class SettingsController extends DashboardController {
         }
 
         $addon = Gdn::addonManager()->lookupAddon($pluginName);
+        $this->fireEvent('BeforeDisablePlugin', ['PluginName' => $pluginName]);
 
         try {
             Gdn::pluginManager()->disablePlugin($pluginName);

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -27,13 +27,16 @@ use Vanilla\Permissions;
  * any of its methods of constants.
  *
  */
-class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
+class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
 
     /** @var string token provided by authenticator  */
     protected $accessToken;
 
     /** @var array response to token request by authenticator  */
     protected $accessTokenResponse;
+
+    /** @var string AuthenticationSchemeAlias value */
+    protected $authenticationScheme = '';
 
     /** @var string key for GDN_UserAuthenticationProvider table  */
     protected $providerKey = null;
@@ -58,6 +61,18 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
 
     /** @var  @var string optional set the settings view */
     protected $settingsView;
+
+    /**
+     * Gets the $authenticaitonScheme variable
+     *
+     * @return string
+     */
+    protected function getAuthenticationScheme(): string {
+        if (!$this->authenticationScheme) {
+            return '';
+        }
+        return $this->authenticationScheme;
+    }
 
     /**
      * @var SsoUtils
@@ -472,15 +487,6 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
         $sender->setData('redirectUrls', $redirectUrls);
 
         $sender->render('settings', '', $view);
-    }
-
-    /**
-     * Set the 'IsDefault' field to zero when disabling to prevent conflicts.\
-     */
-    public function onDisable() {
-        /** @var Gdn_AuthenticationProviderModel $authenticationProvider */
-        $authenticationProvider = Gdn::getContainer()->get(Gdn_AuthenticationProviderModel::class);
-        $authenticationProvider->update(['IsDefault' => 0], ['AuthenticationKey' => $this->providerKey]);
     }
 
 

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -475,18 +475,12 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
     }
 
     /**
-     * Set the 'IsDefault' field to zero before disabling to prevent conflicts.
-     *
-     * @param Gdn_Controller $sender The Controller info.
-     * @param Gdn_Controller $args Event args.
+     * Set the 'IsDefault' field to zero when disabling to prevent conflicts.\
      */
-    public function settingsController_beforeDisablePlugin_handler($sender, $args) {
-        if (isset($args['PluginName'])) {
-            $authenticationProvider = new Gdn_AuthenticationProviderModel();
-            $providerData = Gdn_AuthenticationProviderModel::getProviderByKey($args['PluginName']);
-            $providerData['IsDefault'] = 0;
-            $authenticationProvider->save($providerData);
-        }
+    public function onDisable() {
+        /** @var Gdn_AuthenticationProviderModel $authenticationProvider */
+        $authenticationProvider = Gdn::getContainer()->get(Gdn_AuthenticationProviderModel::class);
+        $authenticationProvider->update(['IsDefault' => 0], ['AuthenticationKey' => $this->providerKey]);
     }
 
 

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -474,6 +474,21 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
         $sender->render('settings', '', $view);
     }
 
+    /**
+     * Set the 'IsDefault' field to zero before disabling to prevent conflicts.
+     *
+     * @param Gdn_Controller $sender The Controller info.
+     * @param Gdn_Controller $args Event args.
+     */
+    public function settingsController_beforeDisablePlugin_handler($sender, $args) {
+        if (isset($args['PluginName'])) {
+            $authenticationProvider = new Gdn_AuthenticationProviderModel();
+            $providerData = Gdn_AuthenticationProviderModel::getProviderByKey($args['PluginName']);
+            $providerData['IsDefault'] = 0;
+            $authenticationProvider->save($providerData);
+        }
+    }
+
 
 
     /** ------------------- Connection Related Methods --------------------- */

--- a/plugins/googlesignin/class.googlesignin.plugin.php
+++ b/plugins/googlesignin/class.googlesignin.plugin.php
@@ -22,6 +22,7 @@ class GoogleSignInPlugin extends Gdn_OAuth2 {
     public function __construct() {
         $this->setProviderKey('googlesignin');
         $this->settingsView = 'plugins/settings/googlesignin';
+        $this->authenticationScheme = 'googlesignin';
     }
 
     /**

--- a/plugins/oauth2/class.oauth2.plugin.php
+++ b/plugins/oauth2/class.oauth2.plugin.php
@@ -17,5 +17,6 @@ class OAuth2Plugin extends Gdn_OAuth2 {
     public function __construct() {
         $this->setProviderKey('oauth2');
         $this->settingsView = 'plugins/settings/oauth2';
+        $this->authenticationScheme = 'oauth2';
     }
 }


### PR DESCRIPTION
THIS IS NOW ALL FOLDED INTO vanilla/vanilla#10423.

Closes #10331

Depends on vanilla/vanilla#10423

Partially addresses vanilla/support#1618.

If Oauth2 is set as the default connection method, it remains so even if you disable it, which can cause conflicts and confusion. This PR makes sure the 'IsDefault' field is set to 0 whenever the plugin is disabled.

### TO TEST
After checking out this branch:
1. Turn on Oauth2 plugin and set it as the default connection method.
1. Disable the Oauth2 plugin.
1. Look at the 'IsDefault' field in the `GDN_UserAuthenticationProvider` table and verify that it is set to 0.