### PR TITLE
Make the Tabs  Component CSS more flexible

### DIFF
--- a/library/src/scripts/sectioning/TabStyles.ts
+++ b/library/src/scripts/sectioning/TabStyles.ts
@@ -18,12 +18,16 @@ import {
     extendItemContainer,
     flexHelper,
     modifyColorBasedOnLightness,
+    margins,
+    singleBorder,
 } from "@library/styles/styleHelpers";
 import { userSelect } from "@library/styles/styleHelpers";
 import { layoutVariables } from "@library/layout/panelLayoutStyles";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { formElementsVariables } from "@library/forms/formElementStyles";
-import { percent, viewHeight, calc } from "csx";
+import { percent, viewHeight, calc, quote } from "csx";
+import { TabsTypes } from "./tabsTypes";
+import { NestedCSSProperties } from "typestyle/lib/types";
 
 export const tabsVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -66,9 +70,9 @@ export const tabsVariables = useThemeCache(() => {
     };
 });
 
-export const tabClasses = useThemeCache(() => {
+export const tabStandardClasses = useThemeCache(() => {
     const vars = tabsVariables();
-    const style = styleFactory("tabs");
+    const style = styleFactory(TabsTypes.STANDARD);
     const mediaQueries = layoutVariables().mediaQueries();
     const formElementVariables = formElementsVariables();
     const globalVars = globalVariables();
@@ -156,7 +160,7 @@ export const tabClasses = useThemeCache(() => {
         }),
     );
 
-    const tabPanels = style("tab", {
+    const tabPanels = style("tabPanels", {
         flexGrow: 1,
         height: percent(100),
         flexDirection: "column",
@@ -182,4 +186,63 @@ export const tabClasses = useThemeCache(() => {
         panel,
         isActive,
     };
+});
+
+export const tabBrowseClasses = useThemeCache(() => {
+    const globalVars = globalVariables();
+    const style = styleFactory(TabsTypes.BROWSE);
+
+    const horizontalPadding = 18;
+    const verticalPadding = globalVars.gutter.size / 2;
+    const activeStyles = {
+        "&::before": {
+            content: quote(""),
+            display: "block",
+            position: "absolute",
+            bottom: 0,
+            ...margins({
+                vertical: 0,
+                horizontal: "auto",
+            }),
+            height: "2px",
+            backgroundColor: colorOut(globalVars.mainColors.primary),
+            width: calc(`${percent(100)} - ${horizontalPadding * 2}px`),
+        },
+    };
+
+    const root = style({});
+    const tabPanels = style("tabPanels", {});
+
+    const tabList = style("tabList", {
+        display: "flex",
+        borderBottom: singleBorder({ color: globalVars.separator.color, width: globalVars.separator.size }),
+    });
+
+    const tab = style("tab", {
+        fontSize: globalVars.fonts.size.small,
+        fontWeight: globalVars.fonts.weights.bold,
+        position: "relative",
+        textTransform: "uppercase",
+        ...paddings({
+            vertical: verticalPadding,
+            horizontal: horizontalPadding,
+        }),
+        ...margins({
+            bottom: "-1px",
+        }),
+        $nest: {
+            "&:active": activeStyles as NestedCSSProperties,
+        },
+    });
+
+    const panel = style("panel", {
+        ...paddings({
+            vertical: "24px",
+            horizontal: horizontalPadding,
+        }),
+    });
+
+    const isActive = style("isActive", activeStyles as NestedCSSProperties);
+
+    return { root, tab, tabPanels, tabList, panel, isActive };
 });

--- a/library/src/scripts/sectioning/TabStyles.ts
+++ b/library/src/scripts/sectioning/TabStyles.ts
@@ -26,7 +26,7 @@ import { layoutVariables } from "@library/layout/panelLayoutStyles";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { formElementsVariables } from "@library/forms/formElementStyles";
 import { percent, viewHeight, calc, quote } from "csx";
-import { TabsTypes } from "./tabsTypes";
+import { TabsTypes } from "@library/sectioning/TabsTypes";
 import { NestedCSSProperties } from "typestyle/lib/types";
 
 export const tabsVariables = useThemeCache(() => {

--- a/library/src/scripts/sectioning/Tabs.story.tsx
+++ b/library/src/scripts/sectioning/Tabs.story.tsx
@@ -10,6 +10,7 @@ import { Tabs } from "@library/sectioning/Tabs";
 import React from "react";
 import TextEditor from "@library/textEditor/TextEditor";
 import { StoryTextContent } from "@library/storybook/storyData";
+import { TabsTypes } from "@library/sectioning/TabsTypes";
 
 export default {
     title: "Tabs",
@@ -37,7 +38,7 @@ export function TabWithErrors() {
     return (
         <>
             <StoryContent>
-                <StoryHeading>Simple Tab List </StoryHeading>
+                <StoryHeading>Standard Tab Styles</StoryHeading>
             </StoryContent>
             <Tabs
                 data={[
@@ -71,6 +72,36 @@ export function TabWithErrors() {
                             </>
                         ),
                         contents: <StoryTextContent firstTitle={"Tab 4 (Disabled)"} />,
+                    },
+                ]}
+            />
+        </>
+    );
+}
+
+export function TabBrowse() {
+    return (
+        <>
+            <StoryContent>
+                <StoryHeading>Browse Tab Styles</StoryHeading>
+            </StoryContent>
+            <Tabs
+                tabType={TabsTypes.BROWSE}
+                data={[
+                    {
+                        label: "Tab 1",
+                        panelData: "",
+                        contents: <StoryTextContent firstTitle={"Hello Tab 1"} />,
+                    },
+                    {
+                        label: "Tab 2",
+                        panelData: "",
+                        contents: <StoryTextContent firstTitle={"Hello Tab 2"} />,
+                    },
+                    {
+                        label: "Tab 3",
+                        panelData: "",
+                        contents: <StoryTextContent firstTitle={"Hello Tab 3"} />,
                     },
                 ]}
             />

--- a/library/src/scripts/sectioning/Tabs.tsx
+++ b/library/src/scripts/sectioning/Tabs.tsx
@@ -6,7 +6,7 @@ import { IError } from "@library/errorPages/CoreErrorMessages";
 import { ToolTip, ToolTipIcon } from "@library/toolTip/ToolTip";
 import { ErrorIcon, WarningIcon } from "@library/icons/common";
 import { iconClasses } from "@library/icons/iconClasses";
-import { TabsTypes } from "./tabsTypes";
+import { TabsTypes } from "@library/sectioning/TabsTypes";
 
 interface IData {
     label: string;

--- a/library/src/scripts/sectioning/Tabs.tsx
+++ b/library/src/scripts/sectioning/Tabs.tsx
@@ -1,11 +1,12 @@
 import React, { ReactElement, useState } from "react";
 import { Tabs as ReachTabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
-import { tabClasses } from "@library/sectioning/TabStyles";
+import { tabStandardClasses, tabBrowseClasses } from "@library/sectioning/TabStyles";
 import classNames from "classnames";
 import { IError } from "@library/errorPages/CoreErrorMessages";
 import { ToolTip, ToolTipIcon } from "@library/toolTip/ToolTip";
 import { ErrorIcon, WarningIcon } from "@library/icons/common";
 import { iconClasses } from "@library/icons/iconClasses";
+import { TabsTypes } from "./tabsTypes";
 
 interface IData {
     label: string;
@@ -17,12 +18,13 @@ interface IData {
 }
 interface IProps {
     data: IData[];
-    classes?: any;
+    tabType?: TabsTypes;
 }
 
 export function Tabs(props: IProps) {
-    const { data, classes = tabClasses() } = props;
+    const { data, tabType } = props;
     const [activeTab, setActiveTab] = useState(0);
+    const classes = tabType && tabType === TabsTypes.BROWSE ? tabBrowseClasses() : tabStandardClasses();
 
     return (
         <ReachTabs

--- a/library/src/scripts/sectioning/Tabs.tsx
+++ b/library/src/scripts/sectioning/Tabs.tsx
@@ -17,11 +17,11 @@ interface IData {
 }
 interface IProps {
     data: IData[];
+    classes?: any;
 }
 
 export function Tabs(props: IProps) {
-    const { data } = props;
-    const classes = tabClasses();
+    const { data, classes = tabClasses() } = props;
     const [activeTab, setActiveTab] = useState(0);
 
     return (

--- a/library/src/scripts/sectioning/TabsTypes.ts
+++ b/library/src/scripts/sectioning/TabsTypes.ts
@@ -1,0 +1,9 @@
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+export enum TabsTypes {
+    STANDARD = "tab-standard",
+    BROWSE = "tab-browse",
+}


### PR DESCRIPTION
Recently I needed to use this component for a different feature and needed to change the styles to fulfill this mockup https://app.zeplin.io/project/5d0cf4c83418a6702b634982/screen/5e6bde2eae501b111c0602bc even though the functionality is the same.

**This PR is a dependency for:**
https://github.com/vanilla/internal/issues/2358