### PR TITLE
Fix Sign Out url in TitleBar

### DIFF
--- a/library/Vanilla/Models/SiteMeta.php
+++ b/library/Vanilla/Models/SiteMeta.php
@@ -163,6 +163,9 @@ class SiteMeta implements \JsonSerializable {
 
         $this->session = $session;
 
+        //Sign Out URL
+        $this->signOutUrl = $session->isValid() ? signOutUrl() : null;
+
         // Theming
         $currentTheme = $themeModel->getCurrentTheme();
         $currentThemeAddon = $themeModel->getCurrentThemeAddon();
@@ -230,6 +233,7 @@ class SiteMeta implements \JsonSerializable {
                 'maxUploads' => $this->maxUploads,
                 'allowedExtensions' => $this->allowedExtensions,
             ],
+            'signOutUrl' => $this->signOutUrl,
             'featureFlags' => $this->featureFlags,
             'themeFeatures' => $this->themeFeatures->allFeatures(),
             'siteSection' => $this->currentSiteSection,

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
@@ -5,6 +5,7 @@
  */
 
 import apiv2 from "@library/apiv2";
+import gdn from "@library/gdn";
 import Permission from "@library/features/users/Permission";
 import UserActions from "@library/features/users/UserActions";
 import { dropDownClasses } from "@library/flyouts/dropDownStyles";
@@ -24,6 +25,7 @@ import { connect } from "react-redux";
  */
 function UserDropDownContents(props: IProps) {
     const { userInfo } = props;
+    const signOutUrl = gdn.meta.signOutUrl ?? `/entry/signout?target=${window.location.href}`;
     const siteSection = getSiteSection();
     if (!userInfo) {
         return null;
@@ -84,7 +86,7 @@ function UserDropDownContents(props: IProps) {
             <Permission permission={["site.manage", "settings.view"]}>
                 <DropDownItemLink to={"/dashboard/settings"} name={t("Dashboard")} />
             </Permission>
-            <DropDownItemLink to={`/entry/signout?target=${window.location.href}`} name={t("Sign Out")} />
+            <DropDownItemLink to={signOutUrl} name={t("Sign Out")} />
         </div>
     );
 }

--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContext.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContext.tsx
@@ -21,12 +21,14 @@ import { t } from "@library/utility/appUtils";
 import classNames from "classnames";
 import React from "react";
 import { connect } from "react-redux";
+import gdn from "@library/gdn";
 
 /**
  * Implements User Drop down for header
  */
 function UserDropDownContents(props: IProps) {
     const { userInfo } = props;
+    const signOutUrl = gdn.meta.signOutUrl ?? `/entry/signout?target=${window.location.href}`;
     if (!userInfo) {
         return null;
     }
@@ -82,7 +84,7 @@ function UserDropDownContents(props: IProps) {
             <Permission permission={["site.manage", "settings.view"]}>
                 <DropDownItemLink to={"/dashboard/settings"} name={t("Dashboard")} />
             </Permission>
-            <DropDownItemLink to={`/entry/signout?target=${window.location.href}`} name={t("Sign Out")} />
+            <DropDownItemLink to={signOutUrl} name={t("Sign Out")} />
         </div>
     );
 }


### PR DESCRIPTION
Closes: https://github.com/vanilla/vanilla/issues/10387

**Steps to reproduce:**
- Make sure you have SSO setup, I'm using jsConnect but any here will do https://github.com/vanilla/stub-sso-providers
- Make sure you have the Foundation theme or Keystone with the config `$Configuration['Feature']['DataDrivenTitleBar']['Enabled'] = true;` set to `true`.
- Log-in through SSO and click "Sign Out" in the mebox.
- Navigate back to the community and click "Sign In", your session should continue automatically because the cookie wasn't killed.
- Checkout this branch and reproduce the Sign-in/Sign-out steps to see the cookie was killed this time.