### PR TITLE
Fix banner search strip positioning and home widget background

### DIFF
--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -112,21 +112,59 @@ export default function Banner(props: IProps) {
                 - Spacer elements for all the main content, but no actual content.
                 - Overflow hidden can't be applied to the main content, because it has a search box that can't be cut off.
             */}
-            <div className={classes.overflowRightImageContainer}>
+            <div className={classes.bannerContainer}>
+                <div className={classes.overflowRightImageContainer}>
+                    <div
+                        className={classNames(classes.middleContainer, {
+                            [classesTitleBar.bannerPadding]: varsTitleBar.fullBleed.enabled,
+                        })}
+                    >
+                        <div className={classNames(classes.outerBackground(props.backgroundImage || undefined))}>
+                            {!props.backgroundImage &&
+                                !vars.outerBackground.image &&
+                                !vars.outerBackground.unsetBackground && (
+                                    <DefaultBannerBg isContentBanner={isContentBanner} />
+                                )}
+                        </div>
+                        {vars.backgrounds.useOverlay && <div className={classes.backgroundOverlay} />}
+                        <Container fullGutter className={classes.fullHeight}>
+                            <div className={classes.imagePositioner}>
+                                {/*For SEO & accessibility*/}
+                                {options.hideTitle && (
+                                    <Heading className={visibility().visuallyHidden} depth={1}>
+                                        {title}
+                                    </Heading>
+                                )}
+                                <ConditionalWrap
+                                    className={classes.contentContainer(!rightImageSrc)}
+                                    condition={
+                                        showMiddleSearch ||
+                                        !options.hideTitle ||
+                                        !options.hideDescription ||
+                                        !!logoImageSrc
+                                    }
+                                ></ConditionalWrap>
+                                {rightImageSrc && (
+                                    <div className={classes.imageElementContainer}>
+                                        {/*We rely on the title for screen readers as we don't yet have alt text hooked up to image*/}
+                                        <img className={classes.rightImage} src={rightImageSrc} aria-hidden={true} />
+                                    </div>
+                                )}
+                            </div>
+                        </Container>
+                        {showBottomSearch && <div className={classes.searchStrip} style={{ background: "none" }}></div>}
+                    </div>
+                </div>
+                {/* Main Content Area
+                - Note that background is up in the previous grouping.
+                - Overflow hidden CAN NEVER BE APPLIED HERE.
+            */}
                 <div
                     className={classNames(classes.middleContainer, {
                         [classesTitleBar.bannerPadding]: varsTitleBar.fullBleed.enabled,
                     })}
                 >
-                    <div className={classNames(classes.outerBackground(props.backgroundImage || undefined))}>
-                        {!props.backgroundImage &&
-                            !vars.outerBackground.image &&
-                            !vars.outerBackground.unsetBackground && (
-                                <DefaultBannerBg isContentBanner={isContentBanner} />
-                            )}
-                    </div>
-                    {vars.backgrounds.useOverlay && <div className={classes.backgroundOverlay} />}
-                    <Container fullGutter className={classes.fullHeight}>
+                    <Container fullGutter>
                         <div className={classes.imagePositioner}>
                             {/*For SEO & accessibility*/}
                             {options.hideTitle && (
@@ -139,70 +177,39 @@ export default function Banner(props: IProps) {
                                 condition={
                                     showMiddleSearch || !options.hideTitle || !options.hideDescription || !!logoImageSrc
                                 }
-                            ></ConditionalWrap>
-                            {rightImageSrc && (
-                                <div className={classes.imageElementContainer}>
-                                    {/*We rely on the title for screen readers as we don't yet have alt text hooked up to image*/}
-                                    <img className={classes.rightImage} src={rightImageSrc} aria-hidden={true} />
-                                </div>
-                            )}
+                            >
+                                {!!logoImageSrc && (
+                                    <div className={classes.logoSpacer}>
+                                        <div className={classes.logoContainer}>
+                                            {/*We rely on the title for screen readers as we don't yet have alt text hooked up to image*/}
+                                            <img className={classes.logo} src={logoImageSrc} aria-hidden={true} />
+                                        </div>
+                                    </div>
+                                )}
+                                {!options.hideTitle && (
+                                    <div className={classes.titleWrap}>
+                                        <FlexSpacer className={classes.titleFlexSpacer} />
+                                        {title && (
+                                            <Heading className={classes.title} depth={1} isLarge>
+                                                {title}
+                                            </Heading>
+                                        )}
+                                        <div className={classNames(classes.text, classes.titleFlexSpacer)}>
+                                            {action}
+                                        </div>
+                                    </div>
+                                )}
+                                {!options.hideDescription && description && (
+                                    <div className={classes.descriptionWrap}>
+                                        <p className={classNames(classes.description, classes.text)}>{description}</p>
+                                    </div>
+                                )}
+                                {showMiddleSearch && searchComponent}
+                            </ConditionalWrap>
+                            {rightImageSrc && <div className={classes.imageElementContainer} />}
                         </div>
                     </Container>
-                    {showBottomSearch && <div className={classes.searchStrip} style={{ background: "none" }}></div>}
                 </div>
-            </div>
-            {/* Main Content Area
-                - Note that background is up in the previous grouping.
-                - Overflow hidden CAN NEVER BE APPLIED HERE.
-            */}
-            <div
-                className={classNames(classes.middleContainer, {
-                    [classesTitleBar.bannerPadding]: varsTitleBar.fullBleed.enabled,
-                })}
-            >
-                <Container fullGutter>
-                    <div className={classes.imagePositioner}>
-                        {/*For SEO & accessibility*/}
-                        {options.hideTitle && (
-                            <Heading className={visibility().visuallyHidden} depth={1}>
-                                {title}
-                            </Heading>
-                        )}
-                        <ConditionalWrap
-                            className={classes.contentContainer(!rightImageSrc)}
-                            condition={
-                                showMiddleSearch || !options.hideTitle || !options.hideDescription || !!logoImageSrc
-                            }
-                        >
-                            {!!logoImageSrc && (
-                                <div className={classes.logoSpacer}>
-                                    <div className={classes.logoContainer}>
-                                        {/*We rely on the title for screen readers as we don't yet have alt text hooked up to image*/}
-                                        <img className={classes.logo} src={logoImageSrc} aria-hidden={true} />
-                                    </div>
-                                </div>
-                            )}
-                            {!options.hideTitle && (
-                                <div className={classes.titleWrap}>
-                                    <FlexSpacer className={classes.titleFlexSpacer} />
-                                    {title && (
-                                        <Heading className={classes.title} depth={1} isLarge>
-                                            {title}
-                                        </Heading>
-                                    )}
-                                    <div className={classNames(classes.text, classes.titleFlexSpacer)}>{action}</div>
-                                </div>
-                            )}
-                            {!options.hideDescription && description && (
-                                <div className={classes.descriptionWrap}>
-                                    <p className={classNames(classes.description, classes.text)}>{description}</p>
-                                </div>
-                            )}
-                            {showMiddleSearch && searchComponent}
-                        </ConditionalWrap>
-                        {rightImageSrc && <div className={classes.imageElementContainer} />}
-                    </div>
-                </Container>
             </div>
             {showBottomSearch && (
                 <div className={classes.searchStrip}>

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -862,6 +862,10 @@ export const bannerClasses = useThemeCache(
                 : {},
         );
 
+        const bannerContainer = style("bannerContainer", {
+            position: "relative",
+        });
+
         // Use this for cutting of the right image with overflow hidden.
         const overflowRightImageContainer = style("overflowRightImageContainer", {
             ...absolutePosition.fullSizeOfParent(),
@@ -926,6 +930,7 @@ export const bannerClasses = useThemeCache(
 
         return {
             root,
+            bannerContainer,
             overflowRightImageContainer,
             fullHeight,
             outerBackground,

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -84,7 +84,7 @@ export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHo
         {
             ...options,
             innerBackground: {
-                color: options.borderType !== BorderType.NONE ? globalVars.mainColors.bg : undefined,
+                color: options.borderType !== BorderType.NONE ? globalVars.body.backgroundImage.color : undefined,
             },
         },
         optionOverrides,


### PR DESCRIPTION
Issue https://github.com/vanilla/knowledge/issues/1700

**NOTE: I highly recommend [viewing with whitespace changes hidden](https://github.com/vanilla/vanilla/pull/10410/files?diff=split&w=1)**

## Search Strip

The search strip was being positioned on top of the background image, even if there was no offset being applied. This was due to a bug after our previous round of overflow fixes. Basically a `position: relative` container was missing.

## Home Widget BG

Update the home widget inner container default color to match the body background instead of the main colors bg. The body BG defaults to the main color BG, but it the home widget is meant to blend with the body BG even if explicitly set.
