### PR TITLE
Fix conversation message MaxLength config

### DIFF
--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -118,7 +118,7 @@ class MessagesApiController extends AbstractApiController {
                 'messageID:i' => 'The ID of the message.',
                 'conversationID:i' => 'The ID of the conversation.',
                 'body:s' => [
-                    'maxLength' => $this->config->get('MaxLength', 2000),
+                    'maxLength' => $this->config->get('Conversations.Message.MaxLength', 2000),
                     'description' => 'The body of the message.',
                 ],
                 'insertUserID:i' => 'The user that created the message.',

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -117,10 +117,7 @@ class MessagesApiController extends AbstractApiController {
             $schema = $this->schema([
                 'messageID:i' => 'The ID of the message.',
                 'conversationID:i' => 'The ID of the conversation.',
-                'body:s' => [
-                    'maxLength' => $this->config->get('Conversations.Message.MaxLength', 2000),
-                    'description' => 'The body of the message.',
-                ],
+                'body:s' => 'The body of the message.',
                 'insertUserID:i' => 'The user that created the message.',
                 'insertUser?' => $this->getUserFragmentSchema(),
                 'dateInserted:dt' => 'When the message was created.',
@@ -358,7 +355,10 @@ class MessagesApiController extends AbstractApiController {
             $postSchema = $this->schema(
                 Schema::parse([
                     'conversationID',
-                    'body',
+                    'body:s' => [
+                        'maxLength' => $this->config->get('Conversations.Message.MaxLength', 2000),
+                        'description' => 'The body of the message.',
+                    ],
                     'format' => new \Vanilla\Models\FormatSchema(),
                 ])->add($this->fullSchema()),
                 'MessagePost'

--- a/applications/conversations/controllers/api/MessagesApiController.php
+++ b/applications/conversations/controllers/api/MessagesApiController.php
@@ -357,7 +357,6 @@ class MessagesApiController extends AbstractApiController {
                     'conversationID',
                     'body:s' => [
                         'maxLength' => $this->config->get('Conversations.Message.MaxLength', 2000),
-                        'description' => 'The body of the message.',
                     ],
                     'format' => new \Vanilla\Models\FormatSchema(),
                 ])->add($this->fullSchema()),


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1579#event-3232022436
### Details

Conversation message max length is configurable. You can do that by setting 
$Configuration['Conversations']['Message']['MaxLength']. 
Setting this config is not taking effect because of 
https://github.com/vanilla/vanilla/blob/1f988352b1888568f8160c5cc7a96c38f5cae860/applications/conversations/controllers/api/MessagesApiController.php#L121

We are looking for MaxLength config instead of Conversations.Message.MaxLength.

