### PR TITLE
Fix bug regarding border radius of search bar in banner

### DIFF
--- a/library/src/scripts/features/search/searchBarStyles.ts
+++ b/library/src/scripts/features/search/searchBarStyles.ts
@@ -126,10 +126,6 @@ export const searchBarClasses = useThemeCache((overwrites = {}) => {
         {
             cursor: "pointer",
             $nest: {
-                ".inputText.inputText": {
-                    borderTopLeftRadius: importantUnit(buttonBorderRadius),
-                    borderBottomLeftRadius: importantUnit(buttonBorderRadius),
-                },
                 "& .searchBar__placeholder": {
                     color: colorOut(formElementVars.placeholder.color),
                     margin: "auto",


### PR DESCRIPTION
Note that the border radis for the butons, do not impact the input text.

The Banner has as sparate border radius for the search, that's what's fixed here.


Closes: https://github.com/vanilla/knowledge/issues/1753ut