### PR TITLE
Fix SSO provider can be default when disabled

### DIFF
--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -440,6 +440,7 @@ class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
         } else {
 
             $form->setFormValue('AuthenticationKey', $this->getProviderKey());
+            $form->setFormValue('AuthenticationSchemeAlias', $this->getAuthenticationScheme());
 
             $sender->Form->validateRule('AssociationKey', 'ValidateRequired', 'You must provide a unique AccountID.');
             $sender->Form->validateRule('AssociationSecret', 'ValidateRequired', 'You must provide a Secret');

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -27,13 +27,16 @@ use Vanilla\Permissions;
  * any of its methods of constants.
  *
  */
-class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
+class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
 
     /** @var string token provided by authenticator  */
     protected $accessToken;
 
     /** @var array response to token request by authenticator  */
     protected $accessTokenResponse;
+
+    /** @var string AuthenticationSchemeAlias value */
+    protected $authenticationScheme = '';
 
     /** @var string key for GDN_UserAuthenticationProvider table  */
     protected $providerKey = null;
@@ -58,6 +61,18 @@ class Gdn_OAuth2 extends Gdn_Plugin implements \Vanilla\InjectableInterface {
 
     /** @var  @var string optional set the settings view */
     protected $settingsView;
+
+    /**
+     * Gets the $authenticaitonScheme variable
+     *
+     * @return string
+     */
+    protected function getAuthenticationScheme(): string {
+        if (!$this->authenticationScheme) {
+            return '';
+        }
+        return $this->authenticationScheme;
+    }
 
     /**
      * @var SsoUtils

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -63,24 +63,6 @@ class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
     protected $settingsView;
 
     /**
-     * Gets the $authenticaitonSchemeAlias variable
-     *
-     * @return string
-     */
-    protected function getAuthenticationSchemeAlias(): string {
-        return $this->authenticationSchemeAlias ?: $this->providerKey;
-    }
-
-    /**
-     * Sets the $authenticationSchemeAlias variable
-     *
-     * @param string $alias The AuthenticationSchemeAlias name.
-     */
-    protected function setAuthenticationSchemeAlias(string $alias): void {
-        $this->authenticationSchemeAlias = $alias;
-    }
-
-    /**
      * @var SsoUtils
      */
     private $ssoUtils;
@@ -108,6 +90,24 @@ class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
             // We passed in a connection
             $this->accessToken = $accessToken;
         }
+    }
+
+    /**
+     * Gets the $authenticaitonSchemeAlias variable
+     *
+     * @return string
+     */
+    protected function getAuthenticationSchemeAlias(): string {
+        return $this->authenticationSchemeAlias ?: $this->providerKey;
+    }
+
+    /**
+     * Sets the $authenticationSchemeAlias variable
+     *
+     * @param string $alias The AuthenticationSchemeAlias name.
+     */
+    protected function setAuthenticationSchemeAlias(string $alias): void {
+        $this->authenticationSchemeAlias = $alias;
     }
 
     /**
@@ -440,7 +440,7 @@ class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
         } else {
 
             $form->setFormValue('AuthenticationKey', $this->getProviderKey());
-            $form->setFormValue('AuthenticationSchemeAlias', $this->getAuthenticationScheme());
+            $form->setFormValue('AuthenticationSchemeAlias', $this->getAuthenticationSchemeAlias());
 
             $sender->Form->validateRule('AssociationKey', 'ValidateRequired', 'You must provide a unique AccountID.');
             $sender->Form->validateRule('AssociationSecret', 'ValidateRequired', 'You must provide a Secret');

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -36,7 +36,7 @@ class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
     protected $accessTokenResponse;
 
     /** @var string AuthenticationSchemeAlias value */
-    protected $authenticationScheme = '';
+    protected $authenticationSchemeAlias = '';
 
     /** @var string key for GDN_UserAuthenticationProvider table  */
     protected $providerKey = null;
@@ -63,15 +63,21 @@ class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
     protected $settingsView;
 
     /**
-     * Gets the $authenticaitonScheme variable
+     * Gets the $authenticaitonSchemeAlias variable
      *
      * @return string
      */
-    protected function getAuthenticationScheme(): string {
-        if (!$this->authenticationScheme) {
-            return '';
-        }
-        return $this->authenticationScheme;
+    protected function getAuthenticationSchemeAlias(): string {
+        return $this->authenticationSchemeAlias ?: $this->providerKey;
+    }
+
+    /**
+     * Sets the $authenticationSchemeAlias variable
+     *
+     * @param string $alias The AuthenticationSchemeAlias name.
+     */
+    protected function setAuthenticationSchemeAlias(string $alias): void {
+        $this->authenticationSchemeAlias = $alias;
     }
 
     /**

--- a/library/core/class.ssoaddon.php
+++ b/library/core/class.ssoaddon.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author Richard Flynn <richard.flynn@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+/**
+ * Sub-class of plugins for SSO authentication.
+ */
+abstract class SSOAddon extends Gdn_Plugin {
+
+    /**
+     * Gets the AuthenticationScheme to match the db's 'AuthenticationSchemeAlias' column.
+     *
+     * @return string
+     */
+    abstract protected function getAuthenticationScheme(): string;
+
+    /**
+     * Sets the value of 'IsDefault' to 0 when the plugin is disabled.
+     */
+    public function onDisable() {
+        /** @var Gdn_AuthenticationProviderModel $authenticationProvider */
+        $authenticationProvider = Gdn::getContainer()->get(Gdn_AuthenticationProviderModel::class);
+        $authenticationProvider->update(['IsDefault' => 0], ['AuthenticationSchemeAlias' => $this->getAuthenticationScheme()]);
+    }
+}

--- a/library/core/class.ssoaddon.php
+++ b/library/core/class.ssoaddon.php
@@ -15,7 +15,7 @@ abstract class SSOAddon extends Gdn_Plugin {
      *
      * @return string
      */
-    abstract protected function getAuthenticationScheme(): string;
+    abstract protected function getAuthenticationSchemeAlias(): string;
 
     /**
      * Sets the value of 'IsDefault' to 0 when the plugin is disabled.
@@ -23,6 +23,6 @@ abstract class SSOAddon extends Gdn_Plugin {
     public function onDisable() {
         /** @var Gdn_AuthenticationProviderModel $authenticationProvider */
         $authenticationProvider = Gdn::getContainer()->get(Gdn_AuthenticationProviderModel::class);
-        $authenticationProvider->update(['IsDefault' => 0], ['AuthenticationSchemeAlias' => $this->getAuthenticationScheme()]);
+        $authenticationProvider->update(['IsDefault' => 0], ['AuthenticationSchemeAlias' => $this->getAuthenticationSchemeAlias()]);
     }
 }

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -10,12 +10,14 @@ use Vanilla\Web\CurlWrapper;
 /**
  * Class FacebookPlugin
  */
-class FacebookPlugin extends Gdn_Plugin {
+class FacebookPlugin extends SSOAddon {
 
     const API_VERSION = '2.7';
 
     /** Authentication table key. */
     const PROVIDER_KEY = 'Facebook';
+
+    private const AUTHENTICATION_SCHEME = 'facebook';
 
     /** @var string  */
     protected $_AccessToken = null;
@@ -25,6 +27,15 @@ class FacebookPlugin extends Gdn_Plugin {
 
     /** @var SsoUtils */
     private $ssoUtils;
+
+    /**
+     * Get the AuthenticationSchemeAlias value.
+     *
+     * @return string The AuthenticationSchemeAlias.
+     */
+    protected function getAuthenticationScheme(): string {
+        return self::AUTHENTICATION_SCHEME;
+    }
 
     /**
      * Constructor.
@@ -472,7 +483,7 @@ class FacebookPlugin extends Gdn_Plugin {
         curl_setopt($c, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($c, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS);
         curl_setopt($c, CURLOPT_URL, $url);
-        
+
         $contents = CurlWrapper::curlExec($c, false);
         $info = curl_getinfo($c);
         if (strpos(val('content_type', $info, ''), '/javascript') !== false) {
@@ -666,7 +677,12 @@ class FacebookPlugin extends Gdn_Plugin {
         // Save the facebook provider type.
         Gdn::sql()->replace(
             'UserAuthenticationProvider',
-            ['AuthenticationSchemeAlias' => 'facebook', 'URL' => '...', 'AssociationSecret' => '...', 'AssociationHashMethod' => '...'],
+            [
+                'AuthenticationSchemeAlias' => self::AUTHENTICATION_SCHEME,
+                'URL' => '...',
+                'AssociationSecret' => '...',
+                'AssociationHashMethod' => '...'
+            ],
             ['AuthenticationKey' => self::PROVIDER_KEY],
             true
         );

--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -29,15 +29,6 @@ class FacebookPlugin extends SSOAddon {
     private $ssoUtils;
 
     /**
-     * Get the AuthenticationSchemeAlias value.
-     *
-     * @return string The AuthenticationSchemeAlias.
-     */
-    protected function getAuthenticationScheme(): string {
-        return self::AUTHENTICATION_SCHEME;
-    }
-
-    /**
      * Constructor.
      *
      * @param SsoUtils $ssoUtils
@@ -45,6 +36,15 @@ class FacebookPlugin extends SSOAddon {
     public function __construct(SsoUtils $ssoUtils) {
         parent::__construct();
         $this->ssoUtils = $ssoUtils;
+    }
+
+    /**
+     * Get the AuthenticationSchemeAlias value.
+     *
+     * @return string The AuthenticationSchemeAlias.
+     */
+    protected function getAuthenticationSchemeAlias(): string {
+        return self::AUTHENTICATION_SCHEME;
     }
 
     /**

--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -34,7 +34,7 @@ class TwitterPlugin extends SSOAddon {
      *
      * @return string The AuthenticationSchemeAlias.
      */
-    protected function getAuthenticationScheme(): string {
+    protected function getAuthenticationSchemeAlias(): string {
         return self::AUTHENTICATION_SCHEME;
     }
 

--- a/plugins/Twitter/class.twitter.plugin.php
+++ b/plugins/Twitter/class.twitter.plugin.php
@@ -12,10 +12,13 @@ use Vanilla\Web\CurlWrapper;
 /**
  * Class TwitterPlugin
  */
-class TwitterPlugin extends Gdn_Plugin {
+class TwitterPlugin extends SSOAddon {
 
     /** Authentication provider key. */
     const PROVIDER_KEY = 'Twitter';
+
+    /** AuthenticationSchemeAlias */
+    private const AUTHENTICATION_SCHEME = 'twitter';
 
     /** @var string Twitter's URL. */
     public static $BaseApiUrl = 'https://api.twitter.com/1.1/';
@@ -25,6 +28,15 @@ class TwitterPlugin extends Gdn_Plugin {
 
     /** @var string */
     protected $_RedirectUri = null;
+
+    /**
+     * Get the AuthenticationSchemeAlias value.
+     *
+     * @return string The AuthenticationSchemeAlias.
+     */
+    protected function getAuthenticationScheme(): string {
+        return self::AUTHENTICATION_SCHEME;
+    }
 
     /**
      * Gets/sets the current oauth access token.
@@ -894,7 +906,7 @@ class TwitterPlugin extends Gdn_Plugin {
         // Save the twitter provider type.
         Gdn::sql()->replace(
             'UserAuthenticationProvider',
-            ['AuthenticationSchemeAlias' => 'twitter', 'URL' => '...', 'AssociationSecret' => '...', 'AssociationHashMethod' => '...'],
+            ['AuthenticationSchemeAlias' => self::AUTHENTICATION_SCHEME, 'URL' => '...', 'AssociationSecret' => '...', 'AssociationHashMethod' => '...'],
             ['AuthenticationKey' => self::PROVIDER_KEY],
             true
         );

--- a/plugins/googlesignin/class.googlesignin.plugin.php
+++ b/plugins/googlesignin/class.googlesignin.plugin.php
@@ -22,7 +22,6 @@ class GoogleSignInPlugin extends Gdn_OAuth2 {
     public function __construct() {
         $this->setProviderKey('googlesignin');
         $this->settingsView = 'plugins/settings/googlesignin';
-        $this->authenticationScheme = 'googlesignin';
     }
 
     /**

--- a/plugins/googlesignin/class.googlesignin.plugin.php
+++ b/plugins/googlesignin/class.googlesignin.plugin.php
@@ -22,6 +22,7 @@ class GoogleSignInPlugin extends Gdn_OAuth2 {
     public function __construct() {
         $this->setProviderKey('googlesignin');
         $this->settingsView = 'plugins/settings/googlesignin';
+        $this->authenticationScheme = 'googlesignin';
     }
 
     /**

--- a/plugins/oauth2/class.oauth2.plugin.php
+++ b/plugins/oauth2/class.oauth2.plugin.php
@@ -17,6 +17,6 @@ class OAuth2Plugin extends Gdn_OAuth2 {
     public function __construct() {
         $this->setProviderKey('oauth2');
         $this->settingsView = 'plugins/settings/oauth2';
-        $this->authenticationScheme = 'oauth2';
+        $this->setAuthenticationSchemeAlias('oauth2');
     }
 }

--- a/plugins/oauth2/class.oauth2.plugin.php
+++ b/plugins/oauth2/class.oauth2.plugin.php
@@ -17,5 +17,6 @@ class OAuth2Plugin extends Gdn_OAuth2 {
     public function __construct() {
         $this->setProviderKey('oauth2');
         $this->settingsView = 'plugins/settings/oauth2';
+        $this->authenticationScheme = 'oauth2';
     }
 }


### PR DESCRIPTION
vanilla/addons#796 depends on this PR.
vanilla/internal#2399 depends on this PR.

Partially addresses vanilla/support#1618
Partially addresses vanilla/internal#2342.
Closes #10331

This PR fixes a problem where an SSO provider could be the default authentication provider even when disabled. This PR creates a class, SSOAddon, that extends Gdn_Plugin and includes a method that sets the `Gdn_UserAuthenticationProvider`'s 'IsDefault' value to 0 for any provider matching the 'AuthenticationSchemeAlias'.

It also adds an authenticationSheme variable to the Gdn_oauth2 class, which can be set in the Oauth2Plugin constructor.

### TO TEST
I have done functional tests with every SSO plugin I know about, but this probably should be tested with one or two client custom oauth plugins as well.

1. Enable an authentication provider that extends the SSOAddon class.
1. Set the provider's 'IsDefault' value in the `Gdn_UserAuthenticationProvider` table to 1.
1. Disable the addon and verify that the 'IsDefault' value is still 1.
1. Check out this branch.
1. Repeat steps 1-3, except this time verify that the 'IsDefault' value changes to 0.