### PR TITLE
Set the default character set to UTF-8

### DIFF
--- a/environment.php
+++ b/environment.php
@@ -70,6 +70,7 @@ date_default_timezone_set('UTC');
 if (function_exists('mb_internal_encoding')) {
     mb_internal_encoding('UTF-8');
 }
+ini_set("default_charset", "UTF-8");
 
 // Include the core autoloader.
 if (!include_once PATH_ROOT.'/vendor/autoload.php') {

--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -9,6 +9,8 @@ use VanillaTests\NullContainer;
 // Use consistent timezone for all tests.
 date_default_timezone_set("UTC");
 
+ini_set("default_charset", "UTF-8");
+
 error_reporting(E_ALL);
 // Alias classes for some limited PHPUnit v5 compatibility with v6.
 $classCompatibility = [


### PR DESCRIPTION
This ensures that calls to functions like `htmlspecialchars()` will default to UTF-8.

Closes #10388.