### PR TITLE
Fix double encoding in DiscussionsModule titles

### DIFF
--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -16,8 +16,12 @@ if (!function_exists('WriteModuleDiscussion')):
    </span>
 
             <div class="Title"><?php
-                echo anchor(htmlspecialchars($discussion->Name), discussionUrl($discussion).($discussion->CountCommentWatch > 0 ? '#Item_'.$discussion->CountCommentWatch : ''), 'DiscussionLink');
-                ?></div>
+                echo anchor(
+                    Gdn::formatService()->renderHTML($discussion->Name, \Vanilla\Formatting\Formats\TextFormat::FORMAT_KEY),
+                    discussionUrl($discussion).($discussion->CountCommentWatch > 0 ? '#Item_'.$discussion->CountCommentWatch : ''),
+                    'DiscussionLink'
+                );
+            ?></div>
             <div class="Meta DiscussionsModuleMeta">
                 <?php
                 $last = new stdClass();

--- a/applications/vanilla/views/modules/helper_functions.php
+++ b/applications/vanilla/views/modules/helper_functions.php
@@ -2,6 +2,9 @@
 
 if (!function_exists('WriteModuleDiscussion')):
     function writeModuleDiscussion($discussion, $px = 'Bookmark', $showPhotos = false) {
+        /** @var Vanilla\Formatting\Html\HtmlSanitizer */
+        $htmlSanitizer = Gdn::getContainer()->get(Vanilla\Formatting\Html\HtmlSanitizer::class);
+
         ?>
         <li id="<?php echo "{$px}_{$discussion->DiscussionID}"; ?>" class="<?php echo cssClass($discussion); ?>">
             <?php if ($showPhotos) :
@@ -17,7 +20,7 @@ if (!function_exists('WriteModuleDiscussion')):
 
             <div class="Title"><?php
                 echo anchor(
-                    Gdn::formatService()->renderHTML($discussion->Name, \Vanilla\Formatting\Formats\TextFormat::FORMAT_KEY),
+                    $htmlSanitizer->filter($discussion->Name), // Should already be encoded, but filter as an additional measure.
                     discussionUrl($discussion).($discussion->CountCommentWatch > 0 ? '#Item_'.$discussion->CountCommentWatch : ''),
                     'DiscussionLink'
                 );


### PR DESCRIPTION
#8980 altered the way discussion titles are rendered in some modules. In the case of `DiscussionModule`, it ran titles through `htmlspecialchars`. Since those titles were already encoded, they are ultimately rendered as double-encoded on the site. This leads to seeing things like &amp;gt; instead of > or &amp;amp instead of & in discussion titles displayed by the module.

Title rendering has fallen back to displaying these titles using the practical replacement of the original `Gdn_Format::text`. No unnecessary HTML encoding is performed.

Closes vanilla/support#1727