### PR TITLE
Show an message in empty nav categories instead of hiding them

### DIFF
--- a/library/src/scripts/navigation/NavLinks.tsx
+++ b/library/src/scripts/navigation/NavLinks.tsx
@@ -20,51 +20,64 @@ interface IProps {
     title: string;
     items: INavigationItem[];
     url?: string;
+    recordID?: number;
+    recordType?: string;
     depth?: 1 | 2 | 3 | 4 | 5 | 6;
     accessibleViewAllMessage?: string;
+    NoItemsComponent?: INavLinkNoItemComponent;
 }
+
+export interface INavLinkNoItemComponentProps {
+    className?: string;
+    recordID?: number;
+    recordType?: string;
+}
+export type INavLinkNoItemComponent = React.ComponentType<INavLinkNoItemComponentProps>;
 
 /**
  * Component for displaying lists in "tiles"
  */
-export default class NavLinks extends Component<IProps> {
-    public render() {
-        if (this.props.items.length !== 0) {
-            const viewAll = t("View All");
-            const classes = navLinksClasses();
-            const contents = this.props.items.map((item, i) => {
-                return (
-                    <li className={classNames(classes.item)} key={i}>
-                        <SmartLink to={item.url} className={classNames(classes.link)} title={item.name}>
-                            {item.name}
+export default function NavLinks(props: IProps) {
+    const { items, NoItemsComponent } = props;
+
+    const viewAll = t("View All");
+    const classes = navLinksClasses();
+    const contents =
+        items.length > 0
+            ? items.map((item, i) => {
+                  return (
+                      <li className={classes.item} key={i}>
+                          <SmartLink to={item.url} className={classes.link} title={item.name}>
+                              {item.name}
+                          </SmartLink>
+                      </li>
+                  );
+              })
+            : NoItemsComponent && (
+                  <li className={classes.item}>
+                      <NoItemsComponent
+                          className={classes.link}
+                          recordID={props.recordID}
+                          recordType={props.recordType}
+                      />
+                  </li>
+              );
+    return (
+        <article className={classNames("navLinks", props.classNames, classes.root)}>
+            <Heading title={props.title} className={classNames("navLinks-title", classes.title)} depth={props.depth} />
+            <ul className={classNames(classes.items)}>
+                {contents}
+                {props.url && props.accessibleViewAllMessage && (
+                    <li className={classNames(classes.viewAllItem)}>
+                        <SmartLink to={props.url} className={classNames(classes.viewAll)}>
+                            <span aria-hidden={true}>{viewAll}</span>
+                            <ScreenReaderContent>
+                                <Translate source={props.accessibleViewAllMessage} c0={props.title} />
+                            </ScreenReaderContent>
                         </SmartLink>
                     </li>
-                );
-            });
-            return (
-                <article className={classNames("navLinks", this.props.classNames, classes.root)}>
-                    <Heading
-                        title={this.props.title}
-                        className={classNames("navLinks-title", classes.title)}
-                        depth={this.props.depth}
-                    />
-                    <ul className={classNames(classes.items)}>
-                        {contents}
-                        {this.props.url && this.props.accessibleViewAllMessage && (
-                            <li className={classNames(classes.viewAllItem)}>
-                                <SmartLink to={this.props.url} className={classNames(classes.viewAll)}>
-                                    <span aria-hidden={true}>{viewAll}</span>
-                                    <ScreenReaderContent>
-                                        <Translate source={this.props.accessibleViewAllMessage} c0={this.props.title} />
-                                    </ScreenReaderContent>
-                                </SmartLink>
-                            </li>
-                        )}
-                    </ul>
-                </article>
-            );
-        } else {
-            return null;
-        }
-    }
+                )}
+            </ul>
+        </article>
+    );
 }

--- a/library/src/scripts/navigation/NavLinksWithHeadings.tsx
+++ b/library/src/scripts/navigation/NavLinksWithHeadings.tsx
@@ -12,7 +12,7 @@ import classNames from "classnames";
 import ScreenReaderContent from "@library/layout/ScreenReaderContent";
 import { navLinksClasses } from "@library/navigation/navLinksStyles";
 import { ILinkListData } from "@library/@types/api/core";
-import NavLinks from "@library/navigation/NavLinks";
+import NavLinks, { INavLinkNoItemComponent } from "@library/navigation/NavLinks";
 import Container from "@library/layout/components/Container";
 import { visibility } from "@library/styles/styleHelpers";
 

--- a/library/src/scripts/navigation/NavLinksWithHeadings.tsx
+++ b/library/src/scripts/navigation/NavLinksWithHeadings.tsx
@@ -25,6 +25,7 @@ interface IProps {
     accessibleViewAllMessage?: string;
     ungroupedViewAllUrl?: string;
     ungroupedTitle?: string;
+    NoItemsComponent?: INavLinkNoItemComponent;
 }
 
 /**
@@ -38,19 +39,23 @@ export default class NavLinksWithHeadings extends Component<IProps> {
         const classes = navLinksClasses();
         const ungroupedTitle = this.props.ungroupedTitle || t("Overview");
 
-        if (ungrouped.length !== 0 || grouped.length !== 0) {
-            const ungroupedContent = (
-                <NavLinks
-                    title={ungroupedTitle}
-                    items={ungrouped}
-                    accessibleViewAllMessage={this.props.accessibleViewAllMessage}
-                    url={this.props.ungroupedViewAllUrl}
-                />
-            );
+        if (ungrouped.length > 0 || grouped.length > 0) {
+            const ungroupedContent =
+                ungrouped.length > 0 ? (
+                    <NavLinks
+                        title={ungroupedTitle}
+                        items={ungrouped}
+                        accessibleViewAllMessage={this.props.accessibleViewAllMessage}
+                        url={this.props.ungroupedViewAllUrl}
+                    />
+                ) : null;
             const groupedContent = grouped.map((group, i) => {
                 return (
                     <React.Fragment key={i}>
                         <NavLinks
+                            recordID={group.category.recordID}
+                            recordType={group.category.recordType}
+                            NoItemsComponent={this.props.NoItemsComponent}
                             items={group.items}
                             title={group.category.name}
                             url={group.category.url}

--- a/library/src/scripts/navigation/SiteNavNode.tsx
+++ b/library/src/scripts/navigation/SiteNavNode.tsx
@@ -112,7 +112,7 @@ export default class SiteNavNode extends React.Component<IProps> {
                 role="treeitem"
                 aria-expanded={this.isOpen}
             >
-                {collapsible ? (
+                {collapsible && this.props.children.length > 0 ? (
                     <div
                         className={classNames("siteNavNode-buttonOffset", classes.buttonOffset, {
                             hasNoOffset: this.props.depth === 1,

--- a/library/src/scripts/navigation/navLinksStyles.ts
+++ b/library/src/scripts/navigation/navLinksStyles.ts
@@ -217,6 +217,8 @@ export const navLinksClasses = useThemeCache(() => {
         default: globalVars.mainColors.primary,
     });
 
+    const noItemLink = style("noItemLink", { ...clickableItemStates(), marginTop: globalVars.gutter.quarter });
+
     const viewAll = style("viewAll", {
         display: "block",
         ...fonts({
@@ -284,6 +286,7 @@ export const navLinksClasses = useThemeCache(() => {
         root,
         items,
         item,
+        noItemLink,
         title,
         topTitle,
         link,


### PR DESCRIPTION
Working towards https://github.com/vanilla/knowledge/issues/1685

The nav categories component now has the ability to show a message on empty nav categories instead of hiding them.

Additionally they will never be hidden now. The view all link will always be displayed even if the index is empty.