### PR TITLE
Theme Editor - Loosen valid url value check

### DIFF
--- a/library/src/scripts/forms/themeEditor/CustomFontUrl.tsx
+++ b/library/src/scripts/forms/themeEditor/CustomFontUrl.tsx
@@ -26,7 +26,7 @@ export function CustomFontUrl(props: IProps) {
                 if (props.forceError) {
                     return false;
                 } else {
-                    return newValue === "" || urlValidation(newValue);
+                    return !newValue || urlValidation(newValue);
                 }
             }}
             errorMessage={t("Invalid URL")}


### PR DESCRIPTION
I loosened the check for valid urls to allow empty fields to be valid. Prevents the user from seeing an error before having entered anything.