### PR TITLE
Revert tag cloud tag

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/forumTagStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/forumTagStyles.ts
@@ -46,6 +46,7 @@ export const forumTagCSS = () => {
         textDecoration: important("none"),
     });
 
+    mixinTag(`.TagCloud a`);
     mixinTag(`.Tag`);
     mixinTag(`.DataTableWrap a.Tag`);
     mixinTag(`.Container .MessageList .ItemComment .MItem.RoleTracker a.Tag`);

--- a/applications/vanilla/modules/class.tagmodule.php
+++ b/applications/vanilla/modules/class.tagmodule.php
@@ -243,7 +243,7 @@ endforeach; ?>
                             echo anchor(
                                 htmlspecialchars(tagFullName($tag)).' '.wrap(number_format($tag['CountDiscussions']), 'span', ['class' => 'Count']),
                                 tagUrl($tag, '', '/'),
-                                ['class' => 'Tag_'.str_replace(' ', '_', $tag['Name'])." Tag"]
+                                ['class' => 'Tag_'.str_replace(' ', '_', $tag['Name'])]
                             );
                             ?></li>
                     <?php


### PR DESCRIPTION
Looks like adding the `.Tag` class on the tag cloud caused some compatibility issues with some legacy themes. Updated legacy styles to not rely on that class.


Closes: https://github.com/vanilla/support/issues/1722