### PR TITLE
Fix Dispatcher::reflectArgs()

### DIFF
--- a/library/Garden/Web/Dispatcher.php
+++ b/library/Garden/Web/Dispatcher.php
@@ -469,7 +469,13 @@ class Dispatcher {
             $lname = strtolower($param->getName());
 
             if ($param->getClass() !== null) {
-                if ($container->has($param->getClass()->getName())) {
+                $className = $param->getClass()->getName();
+
+                if (isset($largs[$lname]) && is_a($largs[$lname], $className)) {
+                    $value = $largs[$lname];
+                } elseif (isset($largs[$index]) && is_a($largs[$index], $className)) {
+                    $value = $largs[$index];
+                } elseif ($container->has($className)) {
                     $value = $container->get($param->getClass()->getName());
                 } else {
                     $value = null;

--- a/tests/Library/Garden/Web/DispatcherTest.php
+++ b/tests/Library/Garden/Web/DispatcherTest.php
@@ -14,6 +14,7 @@ use Garden\Web\Exception\ClientException;
 use Garden\Web\RequestInterface;
 use Garden\Web\ResourceRoute;
 use VanillaTests\Fixtures\Locale;
+use VanillaTests\Fixtures\Tuple;
 use VanillaTests\SharedBootstrapTestCase;
 use VanillaTests\Fixtures\Request;
 use VanillaTests\Fixtures\ExactRoute;
@@ -23,6 +24,15 @@ use VanillaTests\Fixtures\ExactRoute;
  */
 class DispatcherTest extends SharedBootstrapTestCase {
     private static $locale;
+
+    /**
+     * @var Tuple
+     */
+    private static $sender;
+    /**
+     * @var Tuple
+     */
+    private static $sender2;
 
     /**
      * Test Dispatcher::callMiddlewares().
@@ -163,6 +173,7 @@ class DispatcherTest extends SharedBootstrapTestCase {
     public function testReflectArgsHappy(\ReflectionMethod $func, array $args, array $expected): void {
         $container = new ArrayContainer();
         $container[get_class(self::$locale)] = self::$locale;
+        $container[Tuple::class] = self::$sender2;
 
         $actual = Dispatcher::reflectArgs($func, $args, $container, true);
         $this->assertSame($expected, $actual);
@@ -176,8 +187,13 @@ class DispatcherTest extends SharedBootstrapTestCase {
     public function provideHappyReflectArgsTests(): array {
         $f1 = new \ReflectionMethod($this, 'dummy1');
         $f2 = new \ReflectionMethod($this, 'dummy2');
+        $f3 = new \ReflectionMethod($this, 'sender1');
+        $f4 = new \ReflectionMethod($this, 'sender2');
+
         $basic = ['foo' => 123, 'bar' => 'foo'];
         self::$locale = new Locale();
+        self::$sender = new Tuple(1, 1);
+        self::$sender2 = new Tuple(2, 2);
 
         $r = [
             'named' => [$f1, ['bar' => 'foo', 'FOO' => 123], $basic],
@@ -186,6 +202,11 @@ class DispatcherTest extends SharedBootstrapTestCase {
             'default' => [$f1, [123], ['foo' => 123, 'bar' => 'baz']],
             'container' => [$f2, [], ['obj' => self::$locale, 'foo' => 123]],
             'container overrides args' => [$f2, ['obj' => 123], ['obj' => self::$locale, 'foo' => 123]],
+            'sender order' => [$f3, [self::$sender, 'a'], ['sender' => self::$sender, 'foo' => 'a', 'bar' => 123]],
+            'sender order hint' => [$f4, [self::$sender, 'a'], ['sender' => self::$sender, 'foo' => 'a', 'bar' => 123]],
+            'sender key' => [$f3, ['sender' => self::$sender, 'foo' => 'a'], ['sender' => self::$sender, 'foo' => 'a', 'bar' => 123]],
+            'sender key hint' => [$f4, ['sender' => self::$sender, 'foo' => 'a'], ['sender' => self::$sender, 'foo' => 'a', 'bar' => 123]],
+            'bad sender' => [$f4, ['sender' => 123, 'foo' => 'a'], ['sender' => self::$sender2, 'foo' => 'a', 'bar' => 123]],
         ];
 
         return $r;
@@ -243,6 +264,28 @@ class DispatcherTest extends SharedBootstrapTestCase {
      * @param int $foo
      */
     protected function dummy2(Locale $obj, int $foo = 123): void {
+        // Do nothing.
+    }
+
+    /**
+     * A dummy method for testing argument reflection.
+     *
+     * @param Tuple $sender
+     * @param mixed $foo
+     * @param int $bar
+     */
+    protected function sender1($sender, $foo, $bar = 123): void {
+        // Do nothing.
+    }
+
+    /**
+     * A dummy method for testing argument reflection.
+     *
+     * @param Tuple $sender
+     * @param mixed $foo
+     * @param int $bar
+     */
+    protected function sender2(Tuple $sender, $foo, $bar = 123): void {
         // Do nothing.
     }
 }


### PR DESCRIPTION
I had forgotten about our event handler controller args where the dispatcher itself supplies object arguments. This PR allows arguments to supply objects, but protects against bad arguments.

Closes #10446.