### PR TITLE
Fix robots.txt being served from subcommunities.

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -87,7 +87,7 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->setClass(\Vanilla\Site\ApplicationProvider::class)
     ->addCall('add', [new Reference(
         \Vanilla\Site\Application::class,
-        ['garden', ['api', 'entry', 'sso', 'utility']]
+        ['garden', ['api', 'entry', 'sso', 'utility', 'robots.txt']]
     )])
     ->setShared(true)
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -87,7 +87,7 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->setClass(\Vanilla\Site\ApplicationProvider::class)
     ->addCall('add', [new Reference(
         \Vanilla\Site\Application::class,
-        ['garden', ['api', 'entry', 'sso', 'utility', 'robots.txt']]
+        ['garden', ['api', 'entry', 'sso', 'utility', 'robots.txt', 'robots']]
     )])
     ->setShared(true)
 


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1711

What is at issue here is that robots.txt is being served in the root of every subcommunity but never in the root of a domian. If someone has subcommunities turned on and they do want to apply specific rules for specific subcommunities they cannot. This PR will fix that.

### Testing
- Turn on subcommunities.
- In a browser, type the root domain /robots or /robots.txt
- See that you are redirected to the default subdomain.
- Check out this branch.
- Repeat.
- See that you get a robots.txt in the root domain.