### PR TITLE
Fix theme model crashing site when theme provider can't be found

### DIFF
--- a/library/Vanilla/Theme/ThemeProviderCleanupInterface.php
+++ b/library/Vanilla/Theme/ThemeProviderCleanupInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Theme;
+
+/**
+ * Interface that indicates a theme provider requires additional cleanup when switched to another theme provider.
+ */
+interface ThemeProviderCleanupInterface {
+    /**
+     * Method to be called if active theme provider is changed to another theme.
+     */
+    public function afterCurrentProviderChange(): void;
+}

--- a/library/Vanilla/Theme/ThemeProviderInterface.php
+++ b/library/Vanilla/Theme/ThemeProviderInterface.php
@@ -4,9 +4,9 @@
  * @license GPL-2.0-only
  */
 
- namespace Vanilla\Theme;
+namespace Vanilla\Theme;
 
- use Garden\Web\Exception\NotFoundException;
+use Garden\Web\Exception\NotFoundException;
 
  /**
   * Interface for providing variables on a theme.
@@ -106,7 +106,7 @@ interface ThemeProviderInterface {
     /**
      * Get master (parent) theme key.
      *
-     * @param strig|int $themeKey Theme key or id
+     * @param string|int $themeKey Theme key or id
      * @throws NotFoundException Throws an exception when theme is not found.
      * @return string
      */
@@ -115,7 +115,7 @@ interface ThemeProviderInterface {
     /**
      * Get theme name.
      *
-     * @param strig|int $themeKey Theme key or id
+     * @param string|int $themeKey Theme key or id
      * @return string
      */
     public function getName($themeKey): string;

--- a/tests/Library/Vanilla/Web/Asset/WebpackAssetProviderTest.php
+++ b/tests/Library/Vanilla/Web/Asset/WebpackAssetProviderTest.php
@@ -51,14 +51,12 @@ class WebpackAssetProviderTest extends MinimalContainerTestCase {
             $session,
             $config
         );
-        $themeModel = new ThemeModel(
+        $themeModel = self::container()->getArgs(ThemeModel::class, [
             $config,
             $session,
             $addonManager,
             $themeHelper,
-            self::container()->get(ThemeSectionModel::class),
-            self::container()->get(SiteSectionModel::class)
-        );
+        ]);
         $request = new Request();
         $fsThemeProvider = new FsThemeProvider(
             $addonManager,

--- a/tests/Models/ThemeModelTest.php
+++ b/tests/Models/ThemeModelTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Models;
+
+use Vanilla\Models\ThemeModel;
+use VanillaTests\SharedBootstrapTestCase;
+
+/**
+ * Core tests for the theme model.
+ */
+class ThemeModelTest extends SharedBootstrapTestCase {
+
+    /**
+     * @return ThemeModel
+     */
+    private function getThemeModel(): ThemeModel {
+        return self::container()->get(ThemeModel::class);
+    }
+
+    /**
+     * Test getting a theme when no provider is registered.
+     */
+    public function testNoProviderRegisteredWarning() {
+        // No provider should be registered.
+        $this->expectWarning();
+        $theme = $this->getThemeModel()->getThemeWithAssets(1);
+        $this->assertSame(ThemeModel::FALLBACK_THEME_KEY, $theme['themeID']);
+    }
+
+    /**
+     * Test getting a theme when no provider is registered.
+     */
+    public function testNoProviderRegisteredReturn() {
+        // No provider should be registered.
+        $theme = @$this->getThemeModel()->getThemeWithAssets(1);
+        $this->assertSame(ThemeModel::FALLBACK_THEME_KEY, $theme['themeID']);
+    }
+}


### PR DESCRIPTION
Regarding https://github.com/vanilla/support/issues/1749

I've updated the theme model to be more robust in case something prevents a provider from registering.

- No longer tries to directly fetch the `DbThemeProvider` through it's provider list. Instead it checks if the provider has switch and if the provider implements `ThemeProviderCleanupInterface` it will use that to cleanup. DbProvider implementation here https://github.com/vanilla/internal/pull/2421
- No longer throws an exception if a provider can't be found. Instead a known fallback provider (FsThemeProvider) will be used in the event of a misconfiguration, some plugin getting disabled, or a bug in container registration.
- Adds a couple tests.