### PR TITLE
Check if forcedFormat is set when Force.InputFormatter is true

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2244,6 +2244,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
 
             // If the post is new and it validates, make sure the user isn't spamming
             if (!$insert || !$this->checkUserSpamming(Gdn::session()->UserID, $this->floodGate)) {
+                $forcedFormat = $formPostValues['forcedFormat'] ?? false;
                 // Get all fields on the form that relate to the schema
                 $fields = $this->Validation->schemaValidationFields();
 
@@ -2308,7 +2309,6 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
                 } else {
                     // Inserting.
                     if (!val('Format', $fields) || c('Garden.ForceInputFormatter')) {
-                        $forcedFormat = $fields['forcedFormat'] ?? false;
                         $fields['Format'] = ($forcedFormat && $fields['Format'])
                             ? $fields['Format']
                             : c('Garden.InputFormatter', '');

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -8,6 +8,7 @@
  * @since 2.0
  */
 
+use Garden\EventManager;
 use Garden\Schema\Schema;
 use Vanilla\Attributes;
 use Vanilla\Community\Events\DiscussionEvent;
@@ -2307,7 +2308,10 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
                 } else {
                     // Inserting.
                     if (!val('Format', $fields) || c('Garden.ForceInputFormatter')) {
-                        $fields['Format'] = c('Garden.InputFormatter', '');
+                        /** @var EventManager $eventManager */
+                        $eventManager = Gdn::getContainer()->get(EventManager::class);
+                        $format = $eventManager->fireFilter('discussionModel_inputFormatter', $fields);
+                        $fields['Format'] = $format ?? c('Garden.InputFormatter', '');
                     }
 
                     // Check for approval

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -8,7 +8,6 @@
  * @since 2.0
  */
 
-use Garden\EventManager;
 use Garden\Schema\Schema;
 use Vanilla\Attributes;
 use Vanilla\Community\Events\DiscussionEvent;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2308,10 +2308,10 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
                 } else {
                     // Inserting.
                     if (!val('Format', $fields) || c('Garden.ForceInputFormatter')) {
-                        /** @var EventManager $eventManager */
-                        $eventManager = Gdn::getContainer()->get(EventManager::class);
-                        $format = $eventManager->fireFilter('discussionModel_inputFormatter', $fields);
-                        $fields['Format'] = $format ?? c('Garden.InputFormatter', '');
+                        $forcedFormat = $fields['forcedFormat'] ?? false;
+                        $fields['Format'] = ($forcedFormat && $fields['Format'])
+                            ? $fields['Format']
+                            : c('Garden.InputFormatter', '');
                     }
 
                     // Check for approval

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2309,7 +2309,6 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
                     // Inserting.
                     $format = $fields['Format'] ?? null;
                     if (!$format || c('Garden.ForceInputFormatter')) {
-
                         $fields['Format'] = ($forcedFormat && $format)
                             ? $format
                             : c('Garden.InputFormatter', '');

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2308,9 +2308,11 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
 
                 } else {
                     // Inserting.
-                    if (!val('Format', $fields) || c('Garden.ForceInputFormatter')) {
-                        $fields['Format'] = ($forcedFormat && $fields['Format'])
-                            ? $fields['Format']
+                    $format = $fields['Format'] ?? null;
+                    if (!$format || c('Garden.ForceInputFormatter')) {
+
+                        $fields['Format'] = ($forcedFormat && $format)
+                            ? $format
                             : c('Garden.InputFormatter', '');
                     }
 


### PR DESCRIPTION
Allows addons to adjust the format if the `force.inputformatter` is true

required for https://github.com/vanilla/internal/pull/2422

relates to https://github.com/vanilla/support/issues/999