### PR TITLE
Sort APIv2 comments by dateInserted rather than commentID

### DIFF
--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -345,7 +345,7 @@ class CommentsApiController extends AbstractApiController {
 
         list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
 
-        $rows = $this->commentModel->lookup($where, true, $limit, $offset, 'asc')->resultArray();
+        $rows = $this->commentModel->lookup($where, true, $limit, $offset, 'asc', 'DateInserted')->resultArray();
         $hasMore = $this->commentModel->LastCommentCount >= $limit;
 
         // Expand associated rows.

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -504,12 +504,15 @@ class CommentModel extends Gdn_Model implements FormatFieldInterface {
             }
         }
 
+        $this->orderBy('c.'.$sort);
+        $orderBy = $this->orderBy();
+
         $query = $this->SQL
             ->select('c.*')
             ->select('d.CategoryID')
             ->from('Comment c')
             ->join('Discussion d', 'c.DiscussionID = d.DiscussionID')
-            ->orderBy('c.'.$sort, $order);
+            ->orderBy($orderBy[0][0], $order);
         if (!empty($where)) {
             $query->where($where);
         }

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -481,10 +481,11 @@ class CommentModel extends Gdn_Model implements FormatFieldInterface {
      * @param bool $permissionFilter Filter results by the current user's permissions.
      * @param int|null $limit Max number to get.
      * @param int $offset Number to skip.
+     * @param string $sort The column to sort by.
      * @param string $order Order comments ascending (asc) or descending (desc) by ID.
      * @return Gdn_DataSet SQL results.
      */
-    public function lookup(array $where = [], $permissionFilter = true, $limit = null, $offset = 0, $order = 'desc') {
+    public function lookup(array $where = [], $permissionFilter = true, $limit = null, $offset = 0, $order = 'desc', $sort = 'CommentID') {
         if ($limit === null) {
             $limit = $this->getDefaultLimit();
         }
@@ -508,7 +509,7 @@ class CommentModel extends Gdn_Model implements FormatFieldInterface {
             ->select('d.CategoryID')
             ->from('Comment c')
             ->join('Discussion d', 'c.DiscussionID = d.DiscussionID')
-            ->orderBy('c.CommentID', $order);
+            ->orderBy('c.'.$sort, $order);
         if (!empty($where)) {
             $query->where($where);
         }

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -481,11 +481,11 @@ class CommentModel extends Gdn_Model implements FormatFieldInterface {
      * @param bool $permissionFilter Filter results by the current user's permissions.
      * @param int|null $limit Max number to get.
      * @param int $offset Number to skip.
-     * @param string $sort The column to sort by.
      * @param string $order Order comments ascending (asc) or descending (desc) by ID.
+     * @param string $sort The column to sort by.
      * @return Gdn_DataSet SQL results.
      */
-    public function lookup(array $where = [], $permissionFilter = true, $limit = null, $offset = 0, $order = 'desc', $sort = 'CommentID') {
+    public function lookup(array $where = [], $permissionFilter = true, $limit = null, $offset = 0, $order = 'desc', string $sort = 'CommentID') {
         if ($limit === null) {
             $limit = $this->getDefaultLimit();
         }


### PR DESCRIPTION
Closes #9673 

The API sorts comments by commentID, but we want it to sort them by dateInserted instead. This PR does that by adding a $sort param in the `commentmodel.php` lookup function that can takes the name of the column to sort by. The `CommentsApiController` index function then specifies that comments should be sorted according to the DateInserted column.

### TO TEST
1. Check out this branch. 
1. Find a discussion with multiple comments and change the dates of that discussion's comments in the `GDN_Comment table` so that the date order doesn't match the commentID order.
1. Make the api call to get the comments (`https://dev.vanilla.localhost/api/V2/comments?discussionID={discussionID}`).
1. Verify that the comments are ordered by date rather than commentID.