### PR TITLE
2020.007 backports

### DIFF
--- a/applications/dashboard/src/scripts/entries/forum.tsx
+++ b/applications/dashboard/src/scripts/entries/forum.tsx
@@ -42,12 +42,7 @@ Router.addRoutes([
 
 applySharedPortalContext(props => {
     return (
-        <AppContext
-            variablesOnly={
-                !getMeta("themeFeatures.DataDrivenTheme", false) && !getMeta("themeFeatures.SharedMasterView", false)
-            }
-            errorComponent={ErrorPage}
-        >
+        <AppContext variablesOnly errorComponent={ErrorPage}>
             {props.children}
         </AppContext>
     );

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -12,7 +12,7 @@
  * @param {jQuery} $
  */
 (function(window, $) {
-    var USE_NEW_FLYOUTS = gdn.getMeta("useNewFlyouts", false);
+    var USE_NEW_FLYOUTS = window.gdn.meta.themeFeatures.NewFlyouts || false;
     var OPEN_CLASS = "Open";
 
     /**

--- a/library/Vanilla/Theme/ThemeProviderCleanupInterface.php
+++ b/library/Vanilla/Theme/ThemeProviderCleanupInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Theme;
+
+/**
+ * Interface that indicates a theme provider requires additional cleanup when switched to another theme provider.
+ */
+interface ThemeProviderCleanupInterface {
+    /**
+     * Method to be called if active theme provider is changed to another theme.
+     */
+    public function afterCurrentProviderChange(): void;
+}

--- a/library/Vanilla/Theme/ThemeProviderInterface.php
+++ b/library/Vanilla/Theme/ThemeProviderInterface.php
@@ -4,9 +4,9 @@
  * @license GPL-2.0-only
  */
 
- namespace Vanilla\Theme;
+namespace Vanilla\Theme;
 
- use Garden\Web\Exception\NotFoundException;
+use Garden\Web\Exception\NotFoundException;
 
  /**
   * Interface for providing variables on a theme.
@@ -106,7 +106,7 @@ interface ThemeProviderInterface {
     /**
      * Get master (parent) theme key.
      *
-     * @param strig|int $themeKey Theme key or id
+     * @param string|int $themeKey Theme key or id
      * @throws NotFoundException Throws an exception when theme is not found.
      * @return string
      */
@@ -115,7 +115,7 @@ interface ThemeProviderInterface {
     /**
      * Get theme name.
      *
-     * @param strig|int $themeKey Theme key or id
+     * @param string|int $themeKey Theme key or id
      * @return string
      */
     public function getName($themeKey): string;

--- a/tests/Library/Vanilla/Web/Asset/WebpackAssetProviderTest.php
+++ b/tests/Library/Vanilla/Web/Asset/WebpackAssetProviderTest.php
@@ -51,14 +51,12 @@ class WebpackAssetProviderTest extends MinimalContainerTestCase {
             $session,
             $config
         );
-        $themeModel = new ThemeModel(
+        $themeModel = self::container()->getArgs(ThemeModel::class, [
             $config,
             $session,
             $addonManager,
             $themeHelper,
-            self::container()->get(ThemeSectionModel::class),
-            self::container()->get(SiteSectionModel::class)
-        );
+        ]);
         $request = new Request();
         $fsThemeProvider = new FsThemeProvider(
             $addonManager,

--- a/tests/Models/ThemeModelTest.php
+++ b/tests/Models/ThemeModelTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Models;
+
+use Vanilla\Models\ThemeModel;
+use VanillaTests\SharedBootstrapTestCase;
+
+/**
+ * Core tests for the theme model.
+ */
+class ThemeModelTest extends SharedBootstrapTestCase {
+
+    /**
+     * @return ThemeModel
+     */
+    private function getThemeModel(): ThemeModel {
+        return self::container()->get(ThemeModel::class);
+    }
+
+    /**
+     * Test getting a theme when no provider is registered.
+     */
+    public function testNoProviderRegisteredWarning() {
+        // No provider should be registered.
+        $this->expectWarning();
+        $theme = $this->getThemeModel()->getThemeWithAssets(1);
+        $this->assertSame(ThemeModel::FALLBACK_THEME_KEY, $theme['themeID']);
+    }
+
+    /**
+     * Test getting a theme when no provider is registered.
+     */
+    public function testNoProviderRegisteredReturn() {
+        // No provider should be registered.
+        $theme = @$this->getThemeModel()->getThemeWithAssets(1);
+        $this->assertSame(ThemeModel::FALLBACK_THEME_KEY, $theme['themeID']);
+    }
+}


### PR DESCRIPTION
This PR backports to the following 2 changes to 2020.007

- [Fix theme model crashing site when theme provider can't be found](https://github.com/vanilla/vanilla/pull/10462)
- [Fix flyout and modal bugs in foundation](https://github.com/vanilla/vanilla/pull/10460)