### PR TITLE
Add Panopto video embeds support.

### DIFF
--- a/library/Vanilla/EmbeddedContent/EmbedService.php
+++ b/library/Vanilla/EmbeddedContent/EmbedService.php
@@ -179,7 +179,7 @@ class EmbedService implements EmbedCreatorInterface {
             // YouTube
             ->registerFactory($dic->get(YouTubeEmbedFactory::class))
             ->registerEmbed(YouTubeEmbed::class, YouTubeEmbed::TYPE)
-            // Panopto Vanilla quote embed.
+            // Panopto
             ->registerFactory($dic->get(PanoptoEmbedFactory::class))
             ->registerEmbed(PanoptoEmbed::class, PanoptoEmbed::TYPE)
             // Scrape-able Embeds

--- a/library/Vanilla/EmbeddedContent/EmbedService.php
+++ b/library/Vanilla/EmbeddedContent/EmbedService.php
@@ -15,6 +15,8 @@ use Vanilla\EmbeddedContent\Embeds\GiphyEmbed;
 use Vanilla\EmbeddedContent\Embeds\ImageEmbed;
 use Vanilla\EmbeddedContent\Embeds\ImgurEmbed;
 use Vanilla\EmbeddedContent\Embeds\LinkEmbed;
+use Vanilla\EmbeddedContent\Factories\PanoptoEmbedFactory;
+use Vanilla\EmbeddedContent\Embeds\PanoptoEmbed;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbed;
 use Vanilla\EmbeddedContent\Embeds\QuoteEmbedFilter;
 use Vanilla\EmbeddedContent\Factories\CodePenEmbedFactory;
@@ -177,6 +179,9 @@ class EmbedService implements EmbedCreatorInterface {
             // YouTube
             ->registerFactory($dic->get(YouTubeEmbedFactory::class))
             ->registerEmbed(YouTubeEmbed::class, YouTubeEmbed::TYPE)
+            // Panopto Vanilla quote embed.
+            ->registerFactory($dic->get(PanoptoEmbedFactory::class))
+            ->registerEmbed(PanoptoEmbed::class, PanoptoEmbed::TYPE)
             // Scrape-able Embeds
             ->setFallbackFactory($dic->get(ScrapeEmbedFactory::class))
             ->registerEmbed(ImageEmbed::class, ImageEmbed::TYPE)

--- a/library/Vanilla/EmbeddedContent/Embeds/PanoptoEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/PanoptoEmbed.php
@@ -52,16 +52,6 @@ class PanoptoEmbed extends AbstractEmbed {
         return Schema::parse([
             "sessionId:s",
             "domain:s",
-            "height:i",
-            "width:i",
         ]);
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function normalizeData(array $data): array {
-        $data = EmbedUtils::ensureDimensions($data);
-        return $data;
     }
 }

--- a/library/Vanilla/EmbeddedContent/Embeds/PanoptoEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/PanoptoEmbed.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
 
 namespace Vanilla\EmbeddedContent\Embeds;
 

--- a/library/Vanilla/EmbeddedContent/Embeds/PanoptoEmbed.php
+++ b/library/Vanilla/EmbeddedContent/Embeds/PanoptoEmbed.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Vanilla\EmbeddedContent\Embeds;
+
+use Garden\Schema\Schema;
+use Vanilla\EmbeddedContent\AbstractEmbed;
+use Vanilla\EmbeddedContent\EmbedUtils;
+use Vanilla\Web\Asset\AssetPreloader;
+use Vanilla\Web\Asset\ExternalAsset;
+
+/**
+ * Embed data object for Panopto.
+ */
+class PanoptoEmbed extends AbstractEmbed {
+
+    /** @var string JS_SCRIPT */
+    const JS_SCRIPT = "https://developers.panopto.com/scripts/embedapi.min.js";
+
+    /** @var string TYPE */
+    const TYPE = 'panopto';
+
+    /**
+     * PanoptoEmbed constructor.
+     *
+     * @param array $data
+     */
+    public function __construct(array $data) {
+        parent::__construct($data);
+
+        EmbedUtils::getPreloadModel()->addScript(
+            new ExternalAsset(self::JS_SCRIPT),
+            AssetPreloader::REL_PRELOAD,
+            'panopto-embed-script-asset'
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getAllowedTypes(): array {
+        return [self::TYPE];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function schema(): Schema {
+        return Schema::parse([
+            "sessionId:s",
+            "domain:s",
+            "height:i",
+            "width:i",
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function normalizeData(array $data): array {
+        $data = EmbedUtils::ensureDimensions($data);
+        return $data;
+    }
+}

--- a/library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactory.php
@@ -15,12 +15,6 @@ use Vanilla\EmbeddedContent\Embeds\PanoptoEmbed;
  */
 class PanoptoEmbedFactory extends AbstractEmbedFactory {
 
-    /** @var int DEFAULT_HEIGHT */
-    private const DEFAULT_HEIGHT = 360;
-
-    /** @var int DEFAULT_WIDTH */
-    private const DEFAULT_WIDTH = 640;
-
     /** @var array DOMAINS */
     private const DOMAINS = [
         'hosted.panopto.com',
@@ -41,8 +35,6 @@ class PanoptoEmbedFactory extends AbstractEmbedFactory {
             'embedType' => PanoptoEmbed::TYPE,
             'domain' => $path,
             'url' => $url,
-            'height' => self::DEFAULT_HEIGHT,
-            'width' => self::DEFAULT_WIDTH,
             'sessionId' => $this->sessionIDFromUrl($url),
         ]);
     }

--- a/library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactory.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\EmbeddedContent\Factories;
+
+use Vanilla\EmbeddedContent\AbstractEmbed;
+use Vanilla\EmbeddedContent\AbstractEmbedFactory;
+use Vanilla\EmbeddedContent\Embeds\PanoptoEmbed;
+
+/**
+ * PanoptoEmbedFactory class.
+ */
+class PanoptoEmbedFactory extends AbstractEmbedFactory {
+
+    /** @var int DEFAULT_HEIGHT */
+    private const DEFAULT_HEIGHT = 360;
+
+    /** @var int DEFAULT_WIDTH */
+    private const DEFAULT_WIDTH = 640;
+
+    /** @var array DOMAINS */
+    private const DOMAINS = [
+        'hosted.panopto.com',
+        'ca.panopto.com',
+        'cloud.panopto.eu',
+        'ap.panopto.com',
+    ];
+
+    /**
+     * Use the page scraper to scrape page data.
+     *
+     * @inheritdoc
+     */
+    public function createEmbedForUrl(string $url): AbstractEmbed {
+        $path = parse_url($url, PHP_URL_HOST);
+
+        return new PanoptoEmbed([
+            'embedType' => PanoptoEmbed::TYPE,
+            'domain' => $path,
+            'url' => $url,
+            'height' => self::DEFAULT_HEIGHT,
+            'width' => self::DEFAULT_WIDTH,
+            'sessionId' => $this->sessionIDFromUrl($url),
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSupportedDomains(): array {
+        return self::DOMAINS;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getSupportedPathRegex(string $domain): string {
+        return "`^/?Panopto/Pages/(Viewer|Embed)\.aspx`";
+    }
+
+    /**
+     * Given a Panopto URL, return the session ID.
+     *
+     * @param string $url
+     * @return string|null
+     */
+    private function sessionIDFromUrl(string $url): ?string {
+        $parameters = [];
+        parse_str(
+            parse_url($url, PHP_URL_QUERY) ?? "",
+            $parameters
+        );
+        return $parameters['id'] ?? null;
+    }
+}

--- a/library/Vanilla/Web/ContentSecurityPolicy/EmbedWhitelistContentSecurityPolicyProvider.php
+++ b/library/Vanilla/Web/ContentSecurityPolicy/EmbedWhitelistContentSecurityPolicyProvider.php
@@ -13,13 +13,13 @@ use Vanilla\EmbeddedContent\Embeds\PanoptoEmbed;
  */
 class EmbedWhitelistContentSecurityPolicyProvider implements ContentSecurityPolicyProviderInterface {
     const EMBED_WHITELIST = [
+        PanoptoEmbed::JS_SCRIPT,
         'https://embed-cdn.gettyimages.com',
         'https://s.imgur.com',
         'https://platform.instagram.com',
         'https://platform.twitter.com',
         'https://cdn.syndication.twimg.com',
         'https://www.instagram.com/embed.js',
-        PanoptoEmbed::JS_SCRIPT,
     ];
 
     /**

--- a/library/Vanilla/Web/ContentSecurityPolicy/EmbedWhitelistContentSecurityPolicyProvider.php
+++ b/library/Vanilla/Web/ContentSecurityPolicy/EmbedWhitelistContentSecurityPolicyProvider.php
@@ -6,6 +6,8 @@
 
 namespace Vanilla\Web\ContentSecurityPolicy;
 
+use Vanilla\EmbeddedContent\Embeds\PanoptoEmbed;
+
 /**
  * Embeds domains whitelist content security policy provider
  */
@@ -17,6 +19,7 @@ class EmbedWhitelistContentSecurityPolicyProvider implements ContentSecurityPoli
         'https://platform.twitter.com',
         'https://cdn.syndication.twimg.com',
         'https://www.instagram.com/embed.js',
+        PanoptoEmbed::JS_SCRIPT,
     ];
 
     /**

--- a/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
+++ b/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
@@ -24,7 +24,11 @@ const EMBED_LOADED_CLASS: string = "isLoaded";
  */
 export function PanoptoEmbed(props: IProps): JSX.Element {
     const throwError = useThrowError();
-    const playerId = 'player-' + Math.random().toString(36).substr(2, 9);
+    const playerId =
+        "player-" +
+        Math.random()
+            .toString(36)
+            .substr(2, 9);
 
     useLayoutEffect(() => {
         void convertPanoptoEmbeds().catch(throwError);
@@ -42,8 +46,7 @@ export function PanoptoEmbed(props: IProps): JSX.Element {
                         data-playerid={playerId}
                         data-sessionid={props.sessionId}
                         data-url={props.url}
-                    >
-                    </div>
+                    ></div>
                 </EmbedContent>
             </EmbedContainer>
         </>
@@ -98,8 +101,8 @@ async function renderPanoptoEmbed(element: HTMLElement) {
     element.classList.add(EMBED_LOADED_CLASS);
 
     // Add embedVideo-iframe class for proper dimensions.
-    let iframe: HTMLElement|undefined = element.getElementsByTagName('iframe')[0];
+    let iframe: HTMLElement | undefined = element.getElementsByTagName("iframe")[0];
     if (iframe != undefined) {
-        iframe.classList.add("embedVideo-iframe")
+        iframe.classList.add("embedVideo-iframe");
     }
 }

--- a/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
+++ b/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
@@ -1,0 +1,79 @@
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { ensureScript } from "@vanilla/dom-utils";
+import { EmbedContent } from "@library/embeddedContent/EmbedContent";
+import { IBaseEmbedProps } from "@library/embeddedContent/embedService";
+import React, { useLayoutEffect } from "react";
+import { useThrowError } from "@vanilla/react-utils";
+import { EmbedContainer } from "@library/embeddedContent/EmbedContainer";
+
+
+interface IProps extends IBaseEmbedProps {
+    sessionId: string,
+    domain: string,
+    width: number,
+    height: number
+}
+
+const PANOPTO_SCRIPT = "https://developers.panopto.com/scripts/embedapi.min.js";
+
+/**
+ * A class for rendering Twitter embeds.
+ */
+export function PanoptoEmbed(props: IProps): JSX.Element {
+    const throwError = useThrowError();
+
+    useLayoutEffect(() => {
+        void convertPanoptoEmbeds().catch(throwError);
+    });
+
+    return (
+        <>
+            <EmbedContainer>
+                <EmbedContent type={props.embedType}>
+                    <div
+                        className="panopto-media"
+                        data-sessionid={props.sessionId}
+                        data-domain={props.domain}
+                        data-url={props.url}
+                        data-height={props.height}
+                        data-width={props.width}
+                    >
+                        <div id={"player-" + props.sessionId}>
+                        </div>
+                    </div>
+                </EmbedContent>
+            </EmbedContainer>
+        </>
+    )
+}
+
+async function convertPanoptoEmbeds() {
+    const panoptoEmbeds = Array.from(document.querySelectorAll(".panopto-media"));
+
+    if (panoptoEmbeds.length > 0) {
+        await ensureScript(PANOPTO_SCRIPT);
+        panoptoEmbeds.map(contentElement => {
+            renderPanoptoEmbed(contentElement as HTMLElement);
+        });
+    }
+}
+
+async function renderPanoptoEmbed(element: HTMLElement) {
+    const sessionId = element.getAttribute("data-sessionid");
+    const height = element.getAttribute("data-height");
+    const width = element.getAttribute("data-width");
+    const domain = element.getAttribute("data-domain");
+
+    let embedApi = new window.EmbedApi("player-" + sessionId, {
+        width: width,
+        height: height,
+        serverName: domain,
+        sessionId: sessionId
+    });
+
+    embedApi.loadVideo();
+}

--- a/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
+++ b/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
@@ -17,11 +17,9 @@ interface IProps extends IBaseEmbedProps {
     height: number;
 }
 
-/** @constant {string} */
-const PANOPTO_SCRIPT = "https://developers.panopto.com/scripts/embedapi.min.js";
+const PANOPTO_SCRIPT: string = "https://developers.panopto.com/scripts/embedapi.min.js";
 
-/** @constant {string} */
-const EMBED_LOADED_CLASS = "isLoaded";
+const EMBED_LOADED_CLASS: string = "isLoaded";
 
 /**
  * A class for rendering Twitter embeds.

--- a/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
+++ b/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
@@ -17,7 +17,11 @@ interface IProps extends IBaseEmbedProps {
     height: number;
 }
 
+/** @constant {string} */
 const PANOPTO_SCRIPT = "https://developers.panopto.com/scripts/embedapi.min.js";
+
+/** @constant {string} */
+const EMBED_LOADED_CLASS = "isLoaded";
 
 /**
  * A class for rendering Twitter embeds.
@@ -34,7 +38,7 @@ export function PanoptoEmbed(props: IProps): JSX.Element {
             <EmbedContainer>
                 <EmbedContent type={props.embedType}>
                     <div
-                        className="panopto-media"
+                        className="panoptoVideo"
                         data-sessionid={props.sessionId}
                         data-domain={props.domain}
                         data-url={props.url}
@@ -53,12 +57,15 @@ export function PanoptoEmbed(props: IProps): JSX.Element {
  * Convert all of the Panopto embeds in the page.
  */
 async function convertPanoptoEmbeds() {
-    const panoptoEmbeds = Array.from(document.querySelectorAll(".panopto-media"));
+    const panoptoEmbeds = Array.from(document.querySelectorAll(".panoptoVideo"));
 
     if (panoptoEmbeds.length > 0) {
         await ensureScript(PANOPTO_SCRIPT);
         panoptoEmbeds.map(contentElement => {
-            renderPanoptoEmbed(contentElement as HTMLElement);
+            // Only render the embed if its not loaded yet.
+            if (!contentElement.classList.contains(EMBED_LOADED_CLASS)) {
+                renderPanoptoEmbed(contentElement as HTMLElement);
+            }
         });
     }
 }
@@ -88,4 +95,5 @@ async function renderPanoptoEmbed(element: HTMLElement) {
     });
 
     embedApi.loadVideo();
+    element.classList.add(EMBED_LOADED_CLASS);
 }

--- a/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
+++ b/library/src/scripts/embeddedContent/PanoptoEmbed.tsx
@@ -10,12 +10,11 @@ import React, { useLayoutEffect } from "react";
 import { useThrowError } from "@vanilla/react-utils";
 import { EmbedContainer } from "@library/embeddedContent/EmbedContainer";
 
-
 interface IProps extends IBaseEmbedProps {
-    sessionId: string,
-    domain: string,
-    width: number,
-    height: number
+    sessionId: string;
+    domain: string;
+    width: number;
+    height: number;
 }
 
 const PANOPTO_SCRIPT = "https://developers.panopto.com/scripts/embedapi.min.js";
@@ -42,15 +41,17 @@ export function PanoptoEmbed(props: IProps): JSX.Element {
                         data-height={props.height}
                         data-width={props.width}
                     >
-                        <div id={"player-" + props.sessionId}>
-                        </div>
+                        <div id={"player-" + props.sessionId}></div>
                     </div>
                 </EmbedContent>
             </EmbedContainer>
         </>
-    )
+    );
 }
 
+/**
+ * Convert all of the Panopto embeds in the page.
+ */
 async function convertPanoptoEmbeds() {
     const panoptoEmbeds = Array.from(document.querySelectorAll(".panopto-media"));
 
@@ -62,17 +63,28 @@ async function convertPanoptoEmbeds() {
     }
 }
 
+/**
+ * Render a single Panopto embed.
+ */
 async function renderPanoptoEmbed(element: HTMLElement) {
     const sessionId = element.getAttribute("data-sessionid");
+    if (sessionId == null) {
+        throw new Error("Attempted to embed a Panopto video but the sessionId could not be found.");
+    }
+
+    const domain = element.getAttribute("data-domain");
+    if (domain == null) {
+        throw new Error("Attempted to embed a Panopto video but the domain could not be found.");
+    }
+
     const height = element.getAttribute("data-height");
     const width = element.getAttribute("data-width");
-    const domain = element.getAttribute("data-domain");
 
     let embedApi = new window.EmbedApi("player-" + sessionId, {
         width: width,
         height: height,
         serverName: domain,
-        sessionId: sessionId
+        sessionId: sessionId,
     });
 
     embedApi.loadVideo();

--- a/library/src/scripts/embeddedContent/embedService.tsx
+++ b/library/src/scripts/embeddedContent/embedService.tsx
@@ -16,6 +16,7 @@ import { QuoteEmbed } from "@library/embeddedContent/QuoteEmbed";
 import { SoundCloudEmbed } from "@library/embeddedContent/SoundCloudEmbed";
 import { convertTwitterEmbeds, TwitterEmbed } from "@library/embeddedContent/TwitterEmbed";
 import { VideoEmbed } from "@library/embeddedContent/VideoEmbed";
+import { PanoptoEmbed } from "@library/embeddedContent/PanoptoEmbed";
 import { onContent, t } from "@library/utility/appUtils";
 import { logWarning } from "@vanilla/utils";
 import React, { useContext } from "react";
@@ -162,6 +163,7 @@ registerEmbed("twitter", TwitterEmbed);
 registerEmbed("vimeo", VideoEmbed);
 registerEmbed("wistia", VideoEmbed);
 registerEmbed("youtube", VideoEmbed);
+registerEmbed("panopto", PanoptoEmbed);
 registerEmbed("image", ImageEmbed);
 
 // This is specifically required because of some legacy formats that don't render

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactoryTest.php
@@ -68,8 +68,6 @@ class PanoptoEmbedFactoryTest extends MinimalContainerTestCase {
             'embedType' => PanoptoEmbed::TYPE,
             'domain' => parse_url($urlToTest, PHP_URL_HOST),
             'url' => $urlToTest,
-            'height' => 360,
-            'width' => 640,
             'sessionId' => $parameters['id'] ?? null,
         ];
 

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactoryTest.php
@@ -45,6 +45,9 @@ class PanoptoEmbedFactoryTest extends MinimalContainerTestCase {
     public function supportedUrlsProvider(): array {
         return [
             ['https://howtovideos.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=a5f152d0-0718-45de-bab0-a937015c2f35'],
+            ['https://demo.ca.panopto.com/Panopto/Pages/Viewer.aspx?id=7604d3f5-c51d-4053-8c59-ab4400e0bbe6'],
+            ['https://demo.cloud.panopto.eu/Panopto/Pages/Viewer.aspx?id=2eb0bf71-e051-4386-8aa3-0c7cf8a28135'],
+            ['https://demo.ap.panopto.com/Panopto/Pages/Viewer.aspx?id=25329997-baa2-42cf-89c4-ab4400e080e3'],
         ];
     }
 

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactoryTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @author Patrick Desjardins <patrick.d@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\EmbeddedContent\Factories;
+
+use Vanilla\EmbeddedContent\Embeds\PanoptoEmbed;
+use Vanilla\EmbeddedContent\Factories\PanoptoEmbedFactory;
+use VanillaTests\MinimalContainerTestCase;
+
+/**
+ * Tests for the Panopto embed factory.
+ */
+class PanoptoEmbedFactoryTest extends MinimalContainerTestCase {
+
+    /** @var PanoptoEmbedFactory */
+    private $factory;
+
+    /**
+     * Set the factory.
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->factory = new PanoptoEmbedFactory();
+    }
+
+    /**
+     * Test that all domain types are supported.
+     *
+     * @param string $urlToTest
+     * @dataProvider supportedUrlsProvider
+     */
+    public function testSupportedUrls(string $urlToTest) {
+        $this->assertTrue($this->factory->canHandleUrl($urlToTest));
+    }
+
+    /**
+     * Return an array of supported urls.
+     *
+     * @return array
+     */
+    public function supportedUrlsProvider(): array {
+        return [
+            ['https://howtovideos.hosted.panopto.com/Panopto/Pages/Viewer.aspx?id=a5f152d0-0718-45de-bab0-a937015c2f35'],
+        ];
+    }
+
+    /**
+     * Test the Panopto Embed instantiation.
+     */
+    public function testCreateEmbedForUrl() {
+        $urlsToTest = $this->supportedUrlsProvider();
+
+        foreach ($urlsToTest as $urlToTest) {
+            $urlToTest = $urlToTest[0];
+
+            $parameters = [];
+            parse_str(
+                parse_url($urlToTest, PHP_URL_QUERY) ?? "",
+                $parameters
+            );
+
+            $data = [
+                'embedType' => PanoptoEmbed::TYPE,
+                'domain' => parse_url($urlToTest, PHP_URL_HOST),
+                'url' => $urlToTest,
+                'height' => 360,
+                'width' => 640,
+                'sessionId' => $parameters['id'] ?? null,
+            ];
+
+            $panoptoEmbed = $this->factory->createEmbedForUrl($urlToTest);
+            $embedData = $panoptoEmbed->jsonSerialize();
+
+            $this->assertEquals($data, $embedData, 'Data can be used to render embed.');
+
+            $embed = new PanoptoEmbed($embedData);
+            $this->assertInstanceOf(PanoptoEmbed::class, $embed);
+        }
+    }
+}

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/PanoptoEmbedFactoryTest.php
@@ -53,35 +53,32 @@ class PanoptoEmbedFactoryTest extends MinimalContainerTestCase {
 
     /**
      * Test the Panopto Embed instantiation.
+     *
+     * @param string $urlToTest
+     * @dataProvider supportedUrlsProvider
      */
-    public function testCreateEmbedForUrl() {
-        $urlsToTest = $this->supportedUrlsProvider();
+    public function testCreateEmbedForUrl(string $urlToTest) {
+        $parameters = [];
+        parse_str(
+            parse_url($urlToTest, PHP_URL_QUERY) ?? "",
+            $parameters
+        );
 
-        foreach ($urlsToTest as $urlToTest) {
-            $urlToTest = $urlToTest[0];
+        $data = [
+            'embedType' => PanoptoEmbed::TYPE,
+            'domain' => parse_url($urlToTest, PHP_URL_HOST),
+            'url' => $urlToTest,
+            'height' => 360,
+            'width' => 640,
+            'sessionId' => $parameters['id'] ?? null,
+        ];
 
-            $parameters = [];
-            parse_str(
-                parse_url($urlToTest, PHP_URL_QUERY) ?? "",
-                $parameters
-            );
+        $panoptoEmbed = $this->factory->createEmbedForUrl($urlToTest);
+        $embedData = $panoptoEmbed->jsonSerialize();
 
-            $data = [
-                'embedType' => PanoptoEmbed::TYPE,
-                'domain' => parse_url($urlToTest, PHP_URL_HOST),
-                'url' => $urlToTest,
-                'height' => 360,
-                'width' => 640,
-                'sessionId' => $parameters['id'] ?? null,
-            ];
+        $this->assertEquals($data, $embedData, 'Data can be used to render embed.');
 
-            $panoptoEmbed = $this->factory->createEmbedForUrl($urlToTest);
-            $embedData = $panoptoEmbed->jsonSerialize();
-
-            $this->assertEquals($data, $embedData, 'Data can be used to render embed.');
-
-            $embed = new PanoptoEmbed($embedData);
-            $this->assertInstanceOf(PanoptoEmbed::class, $embed);
-        }
+        $embed = new PanoptoEmbed($embedData);
+        $this->assertInstanceOf(PanoptoEmbed::class, $embed);
     }
 }


### PR DESCRIPTION
Estimate request: https://github.com/vanillaforums/estimates/issues/932
Issue: https://github.com/vanillaforums/panopto/issues/2

Add embed support for Panopto videos. You can find videos to test with [right here](https://howtovideos.hosted.panopto.com/Panopto/Pages/Folders/DepartmentHome.aspx?folderID=4b9de7ae-0080-4158-8496-a9ba01692c2e)

You can find the documentation I referred to in [a comment](https://github.com/vanillaforums/panopto/issues/2#issuecomment-599748154) I left in the github issue living in the customer's repo.

I looked at existing code we had for the react part, but it might not be the most efficient way to do it, I am open to any recommendations.