### PR TITLE
Theming UI - Fix secondary button outline color when using "solid" preset

### DIFF
--- a/library/src/scripts/forms/buttonStyles.ts
+++ b/library/src/scripts/forms/buttonStyles.ts
@@ -123,7 +123,14 @@ export const buttonVariables = useThemeCache((forcedVars?: IThemeVariables) => {
     const standardPreset = makeThemeVars("standard", {
         preset: {
             ...standardPresetInit2.preset,
-            borderState: standardPresetInit2.preset.bgState,
+            border:
+                standardPresetInit.preset.style === ButtonPreset.OUTLINE
+                    ? standardPresetInit2.preset.border
+                    : standardPresetInit2.preset.bg,
+            borderState:
+                standardPresetInit.preset.style === ButtonPreset.OUTLINE
+                    ? standardPresetInit2.preset.fgState
+                    : standardPresetInit2.preset.bgState,
         },
     });
 


### PR DESCRIPTION
Fix border color for secondary button ouline color, when selecting the "solid" preset.

Closes: https://github.com/vanilla/internal/issues/2308