### PR TITLE
Fix format is required error with rank format restriction

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -455,8 +455,9 @@ class PostController extends VanillaController {
         // Verify we can add to the category content
         $this->categoryPermission($this->CategoryID, 'Vanilla.Discussions.Add');
 
-        if (c('Garden.ForceInputFormatter')) {
-            $this->Form->removeFormValue('Format');
+        if (Gdn::config('Garden.ForceInputFormatter')) {
+            $format = Gdn::config('Garden.InputFormatter', '');
+            $this->Form->setFormValue('Format', $format);
         }
 
         $this->setData('_CancelUrl', discussionUrl($this->data('Discussion')));
@@ -987,8 +988,9 @@ class PostController extends VanillaController {
         // Normalize the edit data.
         $this->applyFormatCompatibility($this->Comment, 'Body', 'Format');
 
-        if (c('Garden.ForceInputFormatter')) {
-            $this->Form->removeFormValue('Format');
+        if (Gdn::config('Garden.ForceInputFormatter')) {
+            $format = Gdn::config('Garden.InputFormatter', '');
+            $this->Form->setFormValue('Format', $format);
         }
 
         $this->View = 'editcomment';


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1734

### Details

When a user has a rank that is restricted to a certain format, when the user edit a comment/discussion, the user gets "Format is required" erorr.

This is coming from here

https://github.com/vanilla/vanilla/blob/12770740af4634049ab9812dec0ef368b6cb5046/applications/vanilla/controllers/class.postcontroller.php#L990

w'ere setting ForceInutFormatter here
https://github.com/vanilla/internal/blob/master/plugins/Ranks/class.rankmodel.php#L278
then we check for that config, based on it, we remove the format.

### To Test

Create and assign a rank that restricts a format to a user.
Post a comment/discussion and edit/save.