### PR TITLE
Fix urls splitting on parentheses in BBCode

### DIFF
--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -848,9 +848,9 @@ class Gdn_Format {
         // Strip  Right-To-Left override.
         $mixed = str_replace("\xE2\x80\xAE", '', $mixed);
         if (unicodeRegexSupport()) {
-            $regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:(?:https?|ftp):)?//[@\p{L}\p{N}\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`iu";
+            $regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:(?:https?|ftp):)?//[\(\)@\p{L}\p{N}\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`iu";
         } else {
-            $regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:(?:https?|ftp):)?//[@a-z0-9\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`i";
+            $regex = "`(?:(</?)([!a-z]+))|(/?\s*>)|((?:(?:https?|ftp):)?//[\(\)@a-z0-9\x21\x23-\x27\x2a-\x2e\x3a\x3b\/\x3f-\x7a\x7e\x3d]+)`i";
         }
 
         $mixed = FormatUtil::replaceButProtectCodeBlocks(


### PR DESCRIPTION
Closes vanilla/support#664

While using the Advanced Editor's BBCode option, you cannot post a url that includes parentheses. This PR allows a url with parentheses as long as it occurs after the `//` in an address.

### TO TEST
#### Before checking out branch
1. Enable Advanced Editor and select the BBCode posting option.
1. Post this urs in a discussion: https://www.example.com/this(has)parenteses/will-it-work?yes=no
1. Verify that the link ends right before the first parenthiesis

#### After checking out branch
1. Repeat steps 1-2 above.
1. Verify that the whole url is a link