### PR TITLE
Allow color parsing to work with integer alpha values

### DIFF
--- a/library/src/scripts/styles/styleUtils.ts
+++ b/library/src/scripts/styles/styleUtils.ts
@@ -196,9 +196,9 @@ function stripUndefinedKeys(obj: any) {
 }
 
 const rgbRegex = /^rgb\((\d{1,3}%?),\s*(\d{1,3}%?),\s*(\d{1,3}%?)\)$/;
-const rgbaRegex = /^rgba\((\d{1,3}%?),\s*(\d{1,3}%?),\s*(\d{1,3}%?),\s*(\d*(?:\.\d+))\)$/;
+const rgbaRegex = /^rgba\((\d{1,3}%?),\s*(\d{1,3}%?),\s*(\d{1,3}%?),\s*(\d*(?:\.\d+)?)\)$/;
 const hslRegex = /^hsl\((\d+),\s*([\d.]+)%,\s*([\d.]+)%\)$/;
-const hslaRegex = /^hsla\((\d+),\s*([\d.]+)%,\s*([\d.]+)%,\s*(\d*(?:\.\d+))\)/;
+const hslaRegex = /^hsla\((\d+),\s*([\d.]+)%,\s*([\d.]+)%,\s*(\d*(?:\.\d+)?)\)/;
 const hexRegex = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
 
 /**


### PR DESCRIPTION
We've had some warning popping up in the console here. https://success.vanillaforums.com/kb

Previously our `rgba()` and `hsla()` regexes did not allow integer values for the alpha, like `0` and `1`.

Now they do.