### PR TITLE
Fix comment cogwheel dropdown menu unresponsive after edit

### DIFF
--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -351,7 +351,7 @@ jQuery(document).ready(function($) {
         $(btn).closest('.CommentForm, .EditCommentForm').remove();
         $container.removeClass('Editing');
         $container.find(".ToggleFlyout.OptionsMenu").removeClass("Open");
-        $container.find('.Flyout.MenuItems').css('display',"").attr("aria-hidden", "true");
+        $container.find(".Flyout.MenuItems").css('display',"").attr("aria-hidden", "true");
         return false;
     });
 

--- a/applications/vanilla/js/discussion.js
+++ b/applications/vanilla/js/discussion.js
@@ -350,6 +350,8 @@ jQuery(document).ready(function($) {
         $(btn).closest('.Comment').find('div.Message').show();
         $(btn).closest('.CommentForm, .EditCommentForm').remove();
         $container.removeClass('Editing');
+        $container.find(".ToggleFlyout.OptionsMenu").removeClass("Open");
+        $container.find('.Flyout.MenuItems').css('display',"").attr("aria-hidden", "true");
         return false;
     });
 


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1684

### Details

When editing a comment, cancelling then editing again, the cogwheel is not unresponsive.
### Reason
when canceling, this is set to display:none
![Screen Shot 2020-04-22 at 4 40 30 PM](https://user-images.githubusercontent.com/31856281/80031694-0d49a300-84b8-11ea-8d13-51e1d52f14df.png)

### To Test

- Edit a comment
- Cancel
- Edit again
