### PR TITLE
Various banner title changes

### DIFF
--- a/applications/dashboard/models/BannerImageModel.php
+++ b/applications/dashboard/models/BannerImageModel.php
@@ -41,16 +41,18 @@ class BannerImageModel {
     public function renderBanner(array $props = []): \Twig\Markup {
         $controller = \Gdn::controller();
         $defaultProps = [
-            'title' => $controller->data(
-                'Category.Name',
-                $this->siteMeta->getSiteTitle()
-            ),
             'description' => $controller->data(
                 'Category.Description',
                 $controller->description()
             ),
             'backgroundImage' => self::getCurrentBannerImageLink(),
         ];
+        $title = $controller->data('Category.Name');
+
+        if ($title) {
+              $defaultProps['title'] = $title;
+        }
+
         $props = array_merge($defaultProps, $props);
         $html = "";
         $propsJson = htmlspecialchars(json_encode($props, JSON_UNESCAPED_UNICODE), ENT_QUOTES);

--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -15,7 +15,7 @@ import { useBannerContainerDivRef } from "@library/banner/BannerContext";
 import { bannerClasses, bannerVariables } from "@library/banner/bannerStyles";
 import { assetUrl, t } from "@library/utility/appUtils";
 import classNames from "classnames";
-import React, { useDebugValue } from "react";
+import React from "react";
 import { titleBarClasses, titleBarVariables } from "@library/headers/titleBarStyles";
 import { DefaultBannerBg } from "@library/banner/DefaultBannerBg";
 import ConditionalWrap from "@library/layout/ConditionalWrap";
@@ -43,13 +43,15 @@ export default function Banner(props: IProps) {
     const device = useDevice();
     const bannerContextRef = useBannerContainerDivRef();
 
-    const { action, className, title, isContentBanner } = props;
+    const { action, className, isContentBanner } = props;
 
     const varsTitleBar = titleBarVariables();
     const classesTitleBar = titleBarClasses();
     const classes = isContentBanner ? contentBannerClasses() : bannerClasses();
     const vars = isContentBanner ? contentBannerVariables() : bannerVariables();
     const { options } = vars;
+
+    const { title = vars.title.text } = props;
 
     useComponentDebug({ vars });
 
@@ -181,7 +183,7 @@ export default function Banner(props: IProps) {
                                 {!!logoImageSrc && (
                                     <div className={classes.logoSpacer}>
                                         <div className={classes.logoContainer}>
-                                            {/*We rely on the title for screen readers as we don't yet have alt text hooked up to image*/}
+                                            {/*We rely on the       for screen readers as we don't yet have alt text hooked up to image*/}
                                             <img className={classes.logo} src={logoImageSrc} aria-hidden={true} />
                                         </div>
                                     </div>

--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -183,7 +183,7 @@ export default function Banner(props: IProps) {
                                 {!!logoImageSrc && (
                                     <div className={classes.logoSpacer}>
                                         <div className={classes.logoContainer}>
-                                            {/*We rely on the       for screen readers as we don't yet have alt text hooked up to image*/}
+                                            {/*We rely on the title for screen readers as we don't yet have alt text hooked up to image*/}
                                             <img className={classes.logo} src={logoImageSrc} aria-hidden={true} />
                                         </div>
                                     </div>

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -43,6 +43,7 @@ import { NestedCSSProperties, TLength } from "typestyle/lib/types";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { breakpointVariables } from "@library/styles/styleHelpersBreakpoints";
 import { t } from "@vanilla/i18n";
+import { getMeta } from "@library/utility/appUtils";
 
 export enum BannerAlignment {
     LEFT = "left",
@@ -254,7 +255,7 @@ export const bannerVariables = useThemeCache((forcedVars?: IThemeVariables, altN
             top: 18,
             bottom: 8,
         },
-        text: "How can we help you?",
+        text: getMeta("ui.siteName", t("How can we help you?")),
     });
 
     const description = makeThemeVars("description", {

--- a/library/src/scripts/forms/themeEditor/ThemeBuilderContext.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderContext.tsx
@@ -65,8 +65,8 @@ export function useThemeVariableField<T>(variableKey: string) {
         initialValue: get(context.initialThemeVariables, variableKey, undefined) as T | null | undefined,
         generatedValue: get(context.generatedThemeVariables, variableKey, undefined) as T | null | undefined,
         error: get(context.variableErrors, variableKey, undefined) as string | null | undefined,
-        setValue: (value: T | null | undefined, allowNull = false) => {
-            context.setVariableValue(variableKey, value, allowNull);
+        setValue: (value: T | null | undefined, allowEmpty = false) => {
+            context.setVariableValue(variableKey, value, allowEmpty);
         },
         setError: (value: T | null) => {
             context.setVariableError(variableKey, value);
@@ -109,13 +109,13 @@ export function ThemeBuilderContextProvider(props: IProps) {
         onChange(rawValueRef.current, hasErrors);
     };
 
-    const setVariableValue = (variableKey: string, value: any, allowNull: boolean = false) => {
+    const setVariableValue = (variableKey: string, value: any, allowEmpty: boolean = false) => {
         const newErrors = calculateNewErrors(variableKey, null);
         const hasErrors = getErrorCount(newErrors) > 0;
         let cloned = cloneDeep(rawValueRef.current);
         rawValueRef.current = cloned;
 
-        if ((value === "" || value === undefined) && !allowNull) {
+        if ((value === "" || value === undefined) && !allowEmpty) {
             // Null does not clear this. Null is a valid value.
             unset(cloned, variableKey);
         } else {

--- a/library/src/scripts/forms/themeEditor/ThemeBuilderContext.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderContext.tsx
@@ -26,7 +26,7 @@ interface IThemeBuilderContext {
     initialThemeVariables: IThemeVariables;
     generatedThemeVariables: IThemeVariables;
     variableErrors: IThemeVariables;
-    setVariableValue: (variableKey: string, value: any, allowNull: boolean) => void;
+    setVariableValue: (variableKey: string, value: any, allowNull?: boolean) => void;
     setVariableError: (variableKey: string, value: any) => void;
 }
 

--- a/library/src/scripts/forms/themeEditor/ThemeBuilderContext.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeBuilderContext.tsx
@@ -15,6 +15,7 @@ import { bannerVariables } from "@library/banner/bannerStyles";
 import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { contentBannerVariables } from "@library/banner/contentBannerStyles";
 import { userContentVariables, userContentClasses } from "@library/content/userContentStyles";
+import { all } from "q";
 
 ///
 /// Types
@@ -25,7 +26,7 @@ interface IThemeBuilderContext {
     initialThemeVariables: IThemeVariables;
     generatedThemeVariables: IThemeVariables;
     variableErrors: IThemeVariables;
-    setVariableValue: (variableKey: string, value: any) => void;
+    setVariableValue: (variableKey: string, value: any, allowNull: boolean) => void;
     setVariableError: (variableKey: string, value: any) => void;
 }
 
@@ -64,8 +65,8 @@ export function useThemeVariableField<T>(variableKey: string) {
         initialValue: get(context.initialThemeVariables, variableKey, undefined) as T | null | undefined,
         generatedValue: get(context.generatedThemeVariables, variableKey, undefined) as T | null | undefined,
         error: get(context.variableErrors, variableKey, undefined) as string | null | undefined,
-        setValue: (value: T | null | undefined) => {
-            context.setVariableValue(variableKey, value);
+        setValue: (value: T | null | undefined, allowNull = false) => {
+            context.setVariableValue(variableKey, value, allowNull);
         },
         setError: (value: T | null) => {
             context.setVariableError(variableKey, value);
@@ -108,13 +109,13 @@ export function ThemeBuilderContextProvider(props: IProps) {
         onChange(rawValueRef.current, hasErrors);
     };
 
-    const setVariableValue = (variableKey: string, value: any) => {
+    const setVariableValue = (variableKey: string, value: any, allowNull: boolean = false) => {
         const newErrors = calculateNewErrors(variableKey, null);
         const hasErrors = getErrorCount(newErrors) > 0;
         let cloned = cloneDeep(rawValueRef.current);
         rawValueRef.current = cloned;
 
-        if (value === "" || value === undefined) {
+        if ((value === "" || value === undefined) && !allowNull) {
             // Null does not clear this. Null is a valid value.
             unset(cloned, variableKey);
         } else {

--- a/library/src/scripts/forms/themeEditor/ThemeInputText.tsx
+++ b/library/src/scripts/forms/themeEditor/ThemeInputText.tsx
@@ -18,6 +18,7 @@ interface IProps {
     validation?: (newValue: string) => boolean;
     errorMessage?: string;
     forceError?: boolean;
+    allowEmpty?: true;
 }
 
 export function ThemeInputText(props: IProps) {
@@ -28,6 +29,7 @@ export function ThemeInputText(props: IProps) {
         },
         errorMessage,
         forceError,
+        allowEmpty,
     } = props;
     const classes = themeInputTextClasses();
 
@@ -48,7 +50,11 @@ export function ThemeInputText(props: IProps) {
     const _debounceInput = useCallback(
         debounce(
             (newValue: string) => {
-                setValue(newValue);
+                if (allowEmpty) {
+                    setValue(newValue, true);
+                } else {
+                    setValue(newValue);
+                }
             },
             debounceTime,
             { trailing: true, leading: true },


### PR DESCRIPTION
- Modifies the bannerStyles.title.text to take the siteTitle and fallback to default text.
- Modifies bannerModel to only pass title prop if there is a category title.
- Modifies banner to use bannerStyles.title.text if no title prop is passed.
- Add allowEmpty on ThemeBuilderContext to allow for empty strings to be saved passed from ThemeInputText

required for https://github.com/vanilla/internal/pull/2436
related issue https://github.com/vanilla/knowledge/issues/1752