### PR TITLE
Fix crash of product chooser when theme UI is disabled

### DIFF
--- a/applications/dashboard/src/scripts/entries/admin.tsx
+++ b/applications/dashboard/src/scripts/entries/admin.tsx
@@ -16,9 +16,8 @@ import "@library/theming/reset";
 import { ScrollOffsetContext, SCROLL_OFFSET_DEFAULTS } from "@vanilla/library/src/scripts/layout/ScrollOffsetContext";
 import { registerReducer } from "@vanilla/library/src/scripts/redux/reducerRegistry";
 import { roleReducer } from "@dashboard/roles/roleReducer";
-import { BannerContextProviderNoHistory } from "@library/banner/BannerContext";
+import { themeSettingsReducer } from "@library/theming/themeSettingsReducer";
 import { bodyCSS } from "@vanilla/library/src/scripts/layout/bodyStyles";
-import { compatibilityStyles } from "@dashboard/compatibilityStyles";
 import { applyCompatibilityIcons } from "@dashboard/compatibilityStyles/compatibilityIcons";
 
 addComponent("imageUploadGroup", DashboardImageUploadGroup, { overwrite: true });
@@ -26,6 +25,7 @@ addComponent("imageUploadGroup", DashboardImageUploadGroup, { overwrite: true })
 disableComponentTheming();
 onContent(() => initAllUserContent());
 registerReducer("roles", roleReducer);
+registerReducer("themeSettings", themeSettingsReducer);
 
 applySharedPortalContext(props => {
     const [navHeight, setNavHeight] = useState(0);

--- a/library/src/scripts/theming/ThemeChooserInput.tsx
+++ b/library/src/scripts/theming/ThemeChooserInput.tsx
@@ -47,7 +47,9 @@ export function ThemeChooserInput(props: IProps) {
 
     const defaultOption: IComboBoxOption = {
         value: "",
-        label: ((<Translate source="Default <0/>" c0={`(${defaultTheme.name})`} />) as unknown) as string,
+        label: defaultTheme
+            ? (((<Translate source="Default <0/>" c0={`(${defaultTheme.name})`} />) as unknown) as string)
+            : t("Loading"),
     };
 
     const dbThemeGroupOptions: IComboBoxOption[] = themes.map(function(theme, index) {
@@ -65,7 +67,7 @@ export function ThemeChooserInput(props: IProps) {
     });
 
     let themeGroupOptions: IComboBoxOption[] = [...dbThemeGroupOptions, ...templateThemeGroupOptions];
-    themeGroupOptions = themeGroupOptions.filter(option => option.value !== defaultTheme.themeID);
+    themeGroupOptions = themeGroupOptions.filter(option => option.value !== defaultTheme?.themeID);
     themeGroupOptions.push(defaultOption);
 
     const selectedTheme =


### PR DESCRIPTION
Issue https://github.com/vanilla/support/issues/1786

This is a core reducer but was only being registered in the themeapi plugin. As a result when it was disabled the theme chooser input would crash. I've removed the registration from the themeapi here https://github.com/vanilla/internal/pull/2453

I also added a couple of null checks.
