### PR TITLE
Fix a bug preventing descriptions from appearing in foundation category list

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -169,7 +169,7 @@ if (!function_exists('writeListItem')):
                 Gdn::controller()->EventArguments['Category'] = &$category;
                 Gdn::controller()->fireEvent('BeforeCategoryItem');
                 $headingClass = "CategoryNameHeading";
-                if (empty($row['Description'])) {
+                if (empty($category['Description'])) {
                     $headingClass .= " isEmptyDescription";
                 }
                 ?>


### PR DESCRIPTION
Fixed https://github.com/vanilla/vanilla/issues/10499

`$row` was actually the incorrect variable. Looks like it was a copy/paste mistake. +10 points to adding some static checking into our PHP process.