### PR TITLE
add sub-case for redirecting to parent category

### DIFF
--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -84,12 +84,18 @@ class CategoryController extends VanillaController {
             'Followed' => $result
         ]);
 
+        $parentCategory = false;
+        if ($category['ParentCategoryID'] != -1) {
+            $parentCategory = $categoryModel::categories($category['ParentCategoryID'])['UrlCode'];
+        }
+
         switch ($this->deliveryType()) {
             case DELIVERY_TYPE_DATA:
                 $this->render('Blank', 'Utility', 'Dashboard');
                 return;
             case DELIVERY_TYPE_ALL:
-                redirectTo('/categories');
+                // If this is a subcategories, redirect to parent category. Otherwise, redirect to categories page.
+                $parentCategory ? redirectTo('/categories/'.$parentCategory) : redirectTo('/categories');
         }
 
         // Return the appropriate bookmark.

--- a/applications/vanilla/controllers/class.categorycontroller.php
+++ b/applications/vanilla/controllers/class.categorycontroller.php
@@ -85,7 +85,7 @@ class CategoryController extends VanillaController {
         ]);
 
         $parentCategory = false;
-        if ($category['ParentCategoryID'] != -1) {
+        if ($category['ParentCategoryID'] > 0) {
             $parentCategory = $categoryModel::categories($category['ParentCategoryID'])['UrlCode'];
         }
 


### PR DESCRIPTION
Closes vanilla/support#1776.

This PR fixes a problem where a user who follows a sub-category is redirected back to the main categories page, rather than the parent category page (i.e., the page they are on). This PR checks whether the followed category has a parent category and, if so, redirects to the parent category page.

### TO TEST
1. Make a nested category.
1. Click the inner category's cogwheel and choose 'Follow'
1. Note that you are redirected to the main categories page.
1. Check out this branch, repeat steps 1 and 2, and note that you stay on the parent category page.