### PR TITLE
Fix 'Mark Read' displaying in dropdown when All Viewed plugin is disabled

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -73,7 +73,10 @@ if (!function_exists('getOptions')):
         $tk = urlencode(Gdn::session()->transientKey());
         $followed = val('Followed', $category);
 
-        $dropdown->addLink(t('Mark Read'), "/category/markread?categoryid={$categoryID}&tkey={$tk}", 'mark-read');
+        if (c('EnabledPlugins.AllViewed')) {
+            // We should probably also check whether there are any unread discussions in the category as well.
+            $dropdown->addLink(t('Mark Read'), "/category/markread?categoryid={$categoryID}&tkey={$tk}", 'mark-read');
+        }
 
         if (c('Vanilla.EnableCategoryFollowing') && val('DisplayAs', $category) == 'Discussions') {
             $dropdown->addLink(


### PR DESCRIPTION
Closes vanilla/support#1796

This fixes a problem where the 'Mark Read' option displays in the category dropdown even when the 'All Viewed' plugin is disabled by adding a check to see if the plugin is enabled or not.

### TO TEST
Before checking out branch:
1. Disable the "All Viewed" plugin.
1. Confirm that the cog wheel dropdown for a category displays the "Mark Read" option.
After checking out branch:
1. Confirm that the "Mark Read" option is now gone from the category cog wheel dropdown.