### PR TITLE
Fire page view event in the community

### DIFF
--- a/applications/dashboard/src/scripts/entries/forum.tsx
+++ b/applications/dashboard/src/scripts/entries/forum.tsx
@@ -22,10 +22,12 @@ import { TitleBarHamburger } from "@library/headers/TitleBarHamburger";
 import { authReducer } from "@dashboard/auth/authReducer";
 import { compatibilityStyles } from "@dashboard/compatibilityStyles";
 import { applyCompatibilityIcons } from "@dashboard/compatibilityStyles/compatibilityIcons";
-import { fullBackgroundCompat } from "@vanilla/library/src/scripts/layout/Backgrounds";
-import { applySharedPortalContext } from "@vanilla/react-utils";
+import { createBrowserHistory, History } from "history";
+import { applySharedPortalContext, mountPortal } from "@vanilla/react-utils";
 import { ErrorPage } from "@vanilla/library/src/scripts/errorPages/ErrorComponent";
 import { CommunityBanner, CommunityContentBanner } from "@vanilla/library/src/scripts/banner/CommunityBanner";
+import { initPageViewTracking } from "@vanilla/library/src/scripts/pageViews/pageViewTracking";
+import { enableLegacyAnalyticsTick } from "@vanilla/library/src/scripts/analytics/AnalyticsData";
 
 onReady(initAllUserContent);
 onContent(convertAllUserContent);
@@ -50,6 +52,14 @@ applySharedPortalContext(props => {
 
 // Routing
 addComponent("App", () => <Router disableDynamicRouting />);
+
+// The community is still very tied into the global.js and legacyAnalyticsTick.json.
+enableLegacyAnalyticsTick(true);
+
+// Configure page view tracking
+onReady(() => {
+    initPageViewTracking(createBrowserHistory());
+});
 
 addComponent("title-bar-hamburger", TitleBarHamburger);
 addComponent("community-banner", CommunityBanner);

--- a/library/src/scripts/analytics/AnalyticsData.tsx
+++ b/library/src/scripts/analytics/AnalyticsData.tsx
@@ -10,6 +10,16 @@ interface IProps {
     uniqueKey: string | number; // A new analytics event is only fired when this changes.
 }
 
+let legacyAnalyticsTickEnabled = false;
+
+export function enableLegacyAnalyticsTick(newValue: boolean) {
+    legacyAnalyticsTickEnabled = newValue;
+}
+
+export function isLegacyAnalyticsTickEnabled() {
+    return legacyAnalyticsTickEnabled;
+}
+
 /**
  * A component to trigger an analytics event. The unique key must change between renders for a new event to fire.
  */

--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -15,6 +15,7 @@ import { History } from "history";
 import { _mountComponents } from "@library/utility/componentRegistry";
 import { blotCSS } from "@rich-editor/quill/components/blotStyles";
 import { bootstrapLocales } from "@library/locales/localeBootstrap";
+import { isLegacyAnalyticsTickEnabled } from "@library/analytics/AnalyticsData";
 
 if (!getMeta("featureFlags.useFocusVisible.Enabled", true)) {
     document.body.classList.add("hasNativeFocus");
@@ -34,6 +35,10 @@ window.gdn.apiv2 = apiv2;
 
 // Record the page view.
 onPageView((params: { history: History }) => {
+    if (isLegacyAnalyticsTickEnabled()) {
+        // Don't use the new tick if we're still using the old one.
+        return;
+    }
     // Low priority so put a slight delay so other network requests run first.
     setTimeout(() => {
         void apiv2.post("/tick").then(() => {


### PR DESCRIPTION
As I was writing some documentation for https://github.com/vanilla/internal/issues/2415 on configuring analytics events, I noticed our new pageView event isn't firing on the community.

I configured it to run there, but had to add a method for disabling our standard APIv2-based analytics tick.

This is because we currently have our old tick very tangled up in `global.js` which runs in the community and I don't have time at the moment to untangle it.

## Expected result

**Community & Dashboard**

1. Page loads
2. Legacy analytics tick from `global.js` runs.
3. handlers registered with `window.onPageView()` will run.
  - The handler for `/api/v2/tick` will not run.
  - Customer registered handlers will run.

**KB**
1. Page loads
2. handlers registered with `window.onPageView()` will run.
  - The handler for `/api/v2/tick` will run.
  - The handler for KeenIO analytics events will run.
  - Registered custom events will run.
