### PR TITLE
Various Designer Feedback Fixes

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/searchPageStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/searchPageStyles.ts
@@ -16,10 +16,12 @@ import { metaContainerStyles, metaItemStyle } from "@vanilla/library/src/scripts
 import { important } from "csx";
 import { lineHeightAdjustment } from "@library/styles/textUtils";
 import { suggestedTextStyleHelper } from "@library/features/search/suggestedTextStyles";
+import { formElementsVariables } from "@library/forms/formElementStyles";
 
 export const searchPageCSS = () => {
     const globalVars = globalVariables();
     const layoutVars = forumLayoutVariables();
+    const formElementVars = formElementsVariables();
 
     cssOut(`.DataList.DataList-Search .Item.Item-Search .Img.PhotoWrap`, {
         top: unit(layoutVars.cell.paddings.vertical),
@@ -231,5 +233,18 @@ export const searchPageCSS = () => {
 
     cssOut(`.Item-Search .Summary`, {
         marginTop: unit(searchResultsVars.excerpt.margin),
+    });
+
+    const buttonWidth = 46;
+
+    cssOut(`body.Section-SearchResults .AdvancedSearch .InputAndButton .Handle.Handle `, {
+        right: unit(buttonWidth),
+    });
+    cssOut(`body.Section-SearchResults .AdvancedSearch .InputAndButton .bwrap.bwrap`, {
+        minWidth: unit(buttonWidth),
+    });
+
+    cssOut(`body.Section-SearchResults .AdvancedSearch .KeywordsWrap.InputAndButton .InputBox.InputBox`, {
+        paddingRight: unit(buttonWidth * 2 - 10),
     });
 };

--- a/library/src/scripts/forms/select/tokensStyles.ts
+++ b/library/src/scripts/forms/select/tokensStyles.ts
@@ -5,18 +5,10 @@
  */
 
 import { globalVariables } from "@library/styles/globalStyleVars";
-import {
-    borders,
-    colorOut,
-    debugHelper,
-    ISimpleBorderStyle,
-    paddings,
-    unit,
-    userSelect,
-} from "@library/styles/styleHelpers";
+import { borders, colorOut, paddings, unit, userSelect } from "@library/styles/styleHelpers";
 import { componentThemeVariables, styleFactory, useThemeCache } from "@library/styles/styleUtils";
 import { formElementsVariables } from "@library/forms/formElementStyles";
-import { percent, px } from "csx";
+import { important, percent, px } from "csx";
 
 export const tokensVariables = useThemeCache(() => {
     const globalVars = globalVariables();
@@ -75,6 +67,11 @@ export const tokensClasses = useThemeCache(() => {
                     },
                     ".tokens__input": {
                         flexGrow: 1,
+                        display: important("inline-flex"),
+                        alignItems: "center",
+                        justifyContent: "stretch",
+                        margin: unit((formElVars.sizing.height - vars.token.minHeight) / 2 - formElVars.border.width),
+                        minHeight: unit(vars.token.minHeight),
                     },
                     input: {
                         width: percent(100),


### PR DESCRIPTION
- Fixed size of title on KB search page to be bigger than the panel's title
- Fixed the styles of the token input, the spacing was ugly and strange when the inner input text wrapped to a new line. It looks a lot more consistent now
- Improvements to forum's advanced search input. The arrow was positioned properly and the padding was adjusted as to not have text going under the arrow.

Companion PR: https://github.com/vanilla/knowledge/pull/1796