### PR TITLE
Fix drafts CategoryDropdown when Subcomunities is enabled

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -111,11 +111,11 @@ class PostController extends VanillaController {
      *
      * @param int $categoryID Unique ID of the category to add the discussion to.
      */
-    public function discussion($categoryUrlCode = '') {
+    public function discussion($categoryID = '') {
         // Override CategoryID if categories are disabled
         $useCategories = $this->ShowCategorySelector = (bool)c('Vanilla.Categories.Use');
         if (!$useCategories) {
-            $categoryUrlCode = '';
+            $categoryID = '';
         }
 
         // Setup head
@@ -136,8 +136,8 @@ class PostController extends VanillaController {
         if (isset($this->Discussion)) {
             $this->CategoryID = $this->Discussion->CategoryID;
             $category = CategoryModel::categories($this->CategoryID);
-        } elseif ($categoryUrlCode != '') {
-            $category = CategoryModel::categories($categoryUrlCode);
+        } elseif ($categoryID != '') {
+            $category = CategoryModel::categories($categoryID);
 
             if ($category) {
                 $this->CategoryID = val('CategoryID', $category);

--- a/applications/vanilla/views/post/discussion.php
+++ b/applications/vanilla/views/post/discussion.php
@@ -28,6 +28,10 @@ if (!$CancelUrl) {
         if ($discussionType) {
             $options['DiscussionType'] = $discussionType;
         }
+        if (property_exists($this, 'Draft') && is_object($this->Draft)) {
+            $options['DraftID'] = $this->Draft->DraftID;
+        }
+
         echo '<div class="P">';
         echo '<div class="Category">';
         echo $this->Form->label('Category', 'CategoryID'), ' ';


### PR DESCRIPTION
Closes: https://github.com/vanilla/support/issues/1775

Relevant info: 
> The issue happens because drafts are not aware of subcommunities, when you access /drafts it returns all drafts made by that user, independent of which subcommunity you are.
When enabled, Subcommunities hook into the categoryDropdown and change the structure to fit the current subcommunity. It also shift the draft category ID to the subcommunity category, since this category is usually type "nested" it doesn't select that option in the categoryDropdown (because those options are disabled).
> 
> Since Drafts are supposed to be a shared content the Subcommunities is not supposed to intervene on the categoryDropdown when editing a draft.

**Reference:** https://github.com/vanilla/support/issues/1775#issuecomment-620731068

**Steps to reproduce:**
- Make sure you have subcommunities enabled and setup
- Make a discussion draft, make sure to select a category
- Navigate to `/drafts` and open your draft, you will note the categoryDropdown does not have the category selected.
- Checkout this branch and repeat the last step above.

**Notes:**
I took the liberty os changing the parameter name in `PostController->discussion()` from `$CategoryUrlCode` to `$categoryID` since it was misleading.

**Related PRs:**
https://github.com/vanilla/multisite/pull/364