### PR TITLE
Fix permission check in categories that inherit permissions

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -576,7 +576,11 @@ class DiscussionsApiController extends AbstractApiController {
         }
 
         $category = CategoryModel::categories($categoryID);
-        $permissionCategoryID = $category->PermissionCategoryID;
+        if ($category) {
+            $permissionCategoryID = $category['PermissionCategoryID'];
+        } else {
+            $permissionCategoryID = -1;
+        }
 
         $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $permissionCategoryID);
         $this->fieldPermission($body, 'pinned', 'Vanilla.Discussions.Announce', $permissionCategoryID);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -567,6 +567,8 @@ class DiscussionsApiController extends AbstractApiController {
         $discussionData = ApiUtils::convertInputKeys($body);
         $discussionData['DiscussionID'] = $id;
         $categoryID = $row['CategoryID'];
+        $category = $this->categoryModel->getID($categoryID);
+        $permissionCategoryID = $category->PermissionCategoryID;
         if ($row['InsertUserID'] !== $this->getSession()->UserID) {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.Edit', $categoryID);
         }
@@ -575,9 +577,9 @@ class DiscussionsApiController extends AbstractApiController {
             $categoryID = $discussionData['CategoryID'];
         }
 
-        $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $categoryID);
-        $this->fieldPermission($body, 'pinned', 'Vanilla.Discussions.Announce', $categoryID);
-        $this->fieldPermission($body, 'sink', 'Vanilla.Discussions.Sink', $categoryID);
+        $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $permissionCategoryID);
+        $this->fieldPermission($body, 'pinned', 'Vanilla.Discussions.Announce', $permissionCategoryID);
+        $this->fieldPermission($body, 'sink', 'Vanilla.Discussions.Sink', $permissionCategoryID);
 
         $this->discussionModel->save($discussionData);
         $this->validateModel($this->discussionModel);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -567,8 +567,6 @@ class DiscussionsApiController extends AbstractApiController {
         $discussionData = ApiUtils::convertInputKeys($body);
         $discussionData['DiscussionID'] = $id;
         $categoryID = $row['CategoryID'];
-        $category = $this->categoryModel->getID($categoryID);
-        $permissionCategoryID = $category->PermissionCategoryID;
         if ($row['InsertUserID'] !== $this->getSession()->UserID) {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.Edit', $categoryID);
         }
@@ -576,6 +574,9 @@ class DiscussionsApiController extends AbstractApiController {
             $this->discussionModel->categoryPermission('Vanilla.Discussions.Add', $discussionData['CategoryID']);
             $categoryID = $discussionData['CategoryID'];
         }
+
+        $category = CategoryModel::categories($categoryID);
+        $permissionCategoryID = $category->PermissionCategoryID;
 
         $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $permissionCategoryID);
         $this->fieldPermission($body, 'pinned', 'Vanilla.Discussions.Announce', $permissionCategoryID);


### PR DESCRIPTION
Closes vanilla/support#962

This PR fixes a problem in the DiscussionsAPIController class where the categoryID is being used in the patch() method's fieldPermission calls. This creates a permission error when trying to patch a discussion in a nested category that inherits custom permissions from its parent by replacing the categoryID with the PermissionsCategoryID.

### TO TEST
Make a category with custom permissions that allows a moderator to sink the discussion. Then add a subcategory that doesn't have custom permissions. Add a discussion to that subcategory and try to sink that discussion through postman as a moderator.