### PR TITLE
Fix deleting discussion timeouts

### DIFF
--- a/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
+++ b/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
@@ -43,7 +43,7 @@ class UpdateDiscussionCount implements LocalJobInterface {
         $schema = Schema::parse([
             "categoryID" => ["type" => "integer"],
             "discussion:a|n?"
-            ]);
+        ]);
         return $schema;
     }
 

--- a/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
+++ b/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
@@ -22,7 +22,7 @@ class UpdateDiscussionCount implements LocalJobInterface {
     /** @var int */
     private $categoryID;
 
-    /** @var array|bool */
+    /** @var array|null */
     private $discussion;
 
     /**
@@ -48,12 +48,9 @@ class UpdateDiscussionCount implements LocalJobInterface {
     }
 
     /**
-     * Update category discussion count.
+     * Update category discussion and comment count.
      */
     public function run(): JobExecutionStatus {
-        if (!$this->categoryID) {
-            return JobExecutionStatus::abandoned();
-        }
         $this->categoryModel->updateDiscussionCount($this->categoryID, $this->discussion);
         return JobExecutionStatus::complete();
     }
@@ -66,7 +63,7 @@ class UpdateDiscussionCount implements LocalJobInterface {
     public function setMessage(array $message) {
         $message = $this->messageSchema()->validate($message);
         $this->categoryID = $message["categoryID"];
-        $this->discussion = $message["discussion"] ?: null;
+        $this->discussion = $message["discussion"];
     }
 
     /**

--- a/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
+++ b/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
@@ -52,7 +52,7 @@ class UpdateDiscussionCount implements LocalJobInterface {
      * Update category discussion count.
      */
     public function run(): JobExecutionStatus {
-        $isValidDiscussion = is_array($this->discussion) || is_bool($this->discussion);
+        $isValidDiscussion = (is_array($this->discussion) || is_bool($this->discussion));
         $isValidCategory = is_int($this->categoryID);
         if (!$isValidDiscussion || !$isValidCategory) {
             return JobExecutionStatus::abandoned();

--- a/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
+++ b/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
@@ -43,8 +43,7 @@ class UpdateDiscussionCount implements LocalJobInterface {
         $schema = Schema::parse([
             "categoryID" => ["type" => "integer"],
             "discussion:a|b"
-            ]
-        );
+            ]);
         return $schema;
     }
 

--- a/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
+++ b/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
@@ -42,9 +42,8 @@ class UpdateDiscussionCount implements LocalJobInterface {
     private function messageSchema(): Schema {
         $schema = Schema::parse([
             "categoryID" => ["type" => "integer"],
-            "discussion:a|b"
-            ]
-        );
+            "discussion:a|n?"
+            ]);
         return $schema;
     }
 

--- a/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
+++ b/applications/vanilla/library/Jobs/UpdateDiscussionCount.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Library\Jobs;
+
+use Garden\Schema\Schema;
+use Vanilla\Scheduler\Job\JobExecutionStatus;
+use Vanilla\Scheduler\Job\JobPriority;
+use Vanilla\Scheduler\Job\LocalJobInterface;
+
+/**
+ * Update category discussion count.
+ */
+class UpdateDiscussionCount implements LocalJobInterface {
+
+    /** @var \DiscussionModel */
+    private $discussionModel;
+
+    /** @var int */
+    private $categoryID;
+
+    /**
+     * Initial job setup.
+     *
+     * @param \DiscussionModel $discussionModel
+     */
+    public function __construct(\DiscussionModel $discussionModel) {
+        $this->discussionModel = $discussionModel;
+    }
+
+    /**
+     * Validate the message against the schema.
+     *
+     * @return Schema
+     */
+    private function messageSchema(): Schema {
+        $schema = Schema::parse(["categoryID" => ["type" => "integer"]]);
+        return $schema;
+    }
+
+    /**
+     * Update category discussion count.
+     */
+    public function run(): JobExecutionStatus {
+        if (!is_int($this->categoryID)) {
+            return JobExecutionStatus::abandoned();
+        }
+        $this->discussionModel->updateDiscussionCount($this->categoryID);
+        return JobExecutionStatus::complete();
+    }
+
+    /**
+     * Set job Message
+     *
+     * @param array $message
+     */
+    public function setMessage(array $message) {
+        $message = $this->messageSchema()->validate($message);
+        $this->categoryID = $message["categoryID"];
+    }
+
+    /**
+     * Set job priority
+     *
+     * @param JobPriority $priority
+     * @return void
+     */
+    public function setPriority(JobPriority $priority) {
+    }
+
+    /**
+     * Set job execution delay
+     *
+     * @param int $seconds
+     * @return void
+     */
+    public function setDelay(int $seconds) {
+    }
+}

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3568,7 +3568,7 @@ SQL;
      * @param array|false $discussion Discussion to update category "last discussion" field.
      */
     public function updateDiscussionCount(int $categoryID, $discussion = null) {
-        $discussionID = $discussion['DiscussionID'] ?: null;
+        $discussionID = $discussion['DiscussionID'] ?? null;
         $this->SQL
             ->select('d.DiscussionID', 'count', 'CountDiscussions')
             ->select('d.CountComments', 'sum', 'CountComments')
@@ -3588,7 +3588,7 @@ SQL;
             $cacheAmendment = array_merge($cacheAmendment, [
                 'LastDiscussionID' => $discussionID,
                 'LastCommentID' => null,
-                'LastDateInserted' => val('DateInserted', $discussion)
+                'LastDateInserted' => $discussion['DateInserted'] ?? null
             ]);
         }
 

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3567,7 +3567,7 @@ SQL;
      * @param int $categoryID Unique ID of category we are updating.
      * @param array|null $discussion Discussion to update category "last discussion" field.
      */
-    public function updateDiscussionCount(int $categoryID, $discussion = null) {
+    public function updateDiscussionCount(int $categoryID, ?array $discussion = null) {
         $discussionID = $discussion['DiscussionID'] ?? null;
         $this->SQL
             ->select('d.DiscussionID', 'count', 'CountDiscussions')

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -3565,7 +3565,7 @@ SQL;
      * Update category discussion and comment count.
      *
      * @param int $categoryID Unique ID of category we are updating.
-     * @param array|false $discussion Discussion to update category "last discussion" field.
+     * @param array|null $discussion Discussion to update category "last discussion" field.
      */
     public function updateDiscussionCount(int $categoryID, $discussion = null) {
         $discussionID = $discussion['DiscussionID'] ?? null;

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3066,7 +3066,9 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
         $this->SQL->delete('Discussion', ['DiscussionID' => $discussionID]);
 
         $this->SQL->delete('UserDiscussion', ['DiscussionID' => $discussionID]);
-        $this->updateDiscussionCount($categoryID);
+        /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */
+        $scheduler = Gdn::getContainer()->get(Vanilla\Scheduler\SchedulerInterface::class);
+        $scheduler->addJob(Vanilla\Library\Jobs\UpdateDiscussionCount::class, ['categoryID' => $categoryID]);
 
         // Update the last post info for the category and its parents.
         CategoryModel::instance()->refreshAggregateRecentPost($categoryID, true);

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2642,7 +2642,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
     /**
      * Scheduled category discussion count update.
      *
-     * @param $categoryID
+     * @param int $categoryID Unique ID of category we are updating.
      * @param array|false $discussion The discussion to update the count for or **false** for all of them.
      */
     public function scheduledUpdateCount($categoryID, $discussion = false) {

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2634,6 +2634,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
 
         } elseif (is_numeric($categoryID)) {
             /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */
+            $discussion = $discussion ?: null;
             $scheduler = Gdn::getContainer()->get(Vanilla\Scheduler\SchedulerInterface::class);
             $scheduler->addJob(Vanilla\Library\Jobs\UpdateDiscussionCount::class, ['categoryID' => $categoryID, 'discussion' => $discussion]);
         }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2640,42 +2640,6 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
     }
 
     /**
-     * Scheduled category discussion count update.
-     *
-     * @param int $categoryID Unique ID of category we are updating.
-     * @param array|false $discussion The discussion to update the count for or **false** for all of them.
-     */
-    public function scheduledUpdateCount($categoryID, $discussion = false) {
-        $discussionID = $discussion['DiscussionID'] ?: false;
-        $this->SQL
-                ->select('d.DiscussionID', 'count', 'CountDiscussions')
-                ->select('d.CountComments', 'sum', 'CountComments')
-                ->from('Discussion d')
-                ->where('d.CategoryID', $categoryID);
-
-            $data = $this->SQL->get()->firstRow();
-            $countDiscussions = (int)getValue('CountDiscussions', $data, 0);
-            $countComments = (int)getValue('CountComments', $data, 0);
-
-            $cacheAmendment = [
-                'CountDiscussions' => $countDiscussions,
-                'CountComments' => $countComments
-            ];
-
-            if ($discussionID) {
-                $cacheAmendment = array_merge($cacheAmendment, [
-                    'LastDiscussionID' => $discussionID,
-                    'LastCommentID' => null,
-                    'LastDateInserted' => val('DateInserted', $discussion)
-                ]);
-            }
-
-            $categoryModel = new CategoryModel();
-            $categoryModel->setField($categoryID, $cacheAmendment);
-            $categoryModel->setRecentPost($categoryID);
-    }
-
-    /**
      * @param int|array|stdClass $discussion The discussion ID or discussion.
      * @throws Exception
      * @deprecated

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2646,7 +2646,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
      * @param array|false $discussion The discussion to update the count for or **false** for all of them.
      */
     public function scheduledUpdateCount($categoryID, $discussion = false) {
-        $discussionID = val('DiscussionID', $discussion, false);
+        $discussionID = $discussion['DiscussionID'] ?: false;
         $this->SQL
                 ->select('d.DiscussionID', 'count', 'CountDiscussions')
                 ->select('d.CountComments', 'sum', 'CountComments')

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2634,7 +2634,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface {
 
         } elseif (is_numeric($categoryID)) {
             /** @var Vanilla\Scheduler\SchedulerInterface $scheduler */
-            $discussion = $discussion ?: null;
+            $discussion = (array)$discussion ?: null;
             $scheduler = Gdn::getContainer()->get(Vanilla\Scheduler\SchedulerInterface::class);
             $scheduler->addJob(Vanilla\Library\Jobs\UpdateDiscussionCount::class, ['categoryID' => $categoryID, 'discussion' => $discussion]);
         }


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1709
closes https://github.com/vanilla/support/issues/1814
closes https://github.com/vanilla/support/issues/1804

### Details

When a category has hundreds of thousands of discussions, deleting a discussion is causing timeouts.

running select count(DiscussionID) on a table with 150+ records will take >30 seconds to complete.
Everytime we delete a discussion, w'ere calling https://github.com/vanilla/vanilla/blob/9d44b56e402ddc159012ece449ab307cd3bc71e9/applications/vanilla/models/class.discussionmodel.php#L2638
that updates the discussion count on a category.
updateDiscussionCount is taking more than 30 seconds(timeout) to complete.


I've created a job to update the count.

### To Test

On a category with >150K discussions, delete a discussion