### PR TITLE
Fix regression in url event firing

### DIFF
--- a/library/core/class.upload.php
+++ b/library/core/class.upload.php
@@ -371,7 +371,7 @@ class Gdn_Upload extends Gdn_Pluggable {
             $sender->Returns = [];
             $sender->EventArguments = [];
             $sender->EventArguments['Urls'] =& $this->uploadWebPaths;
-            $this->eventManager->fire('Gdn_Upload_GetUrls', $sender);
+            $this->eventManager->fire('Gdn_Upload_GetUrls', $sender, $sender->EventArguments);
         }
         return $this->uploadWebPaths;
     }


### PR DESCRIPTION
Regression from https://github.com/vanilla/vanilla/pull/10520
Example handler https://github.com/vanilla/vanillainfrastructure/blob/master/plugins/s3files/src/S3FilesPlugin.php#L208-L226

Fix the way we are passing the arguments to more consistent with existing events.