### PR TITLE
Add option to delete moderation notes

### DIFF
--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -509,9 +509,6 @@ class UserController extends DashboardController {
     public function delete($userID = '', $method = '') {
         $this->permission('Garden.Users.Delete');
         $session = Gdn::session();
-
-        $formValues = $this->Form->formValues();
-
         if ($session->User->UserID == $userID) {
             trigger_error(errorMessage("You cannot delete the user you are logged in as.", $this->ClassName, 'FetchViewLocation'), E_USER_ERROR);
         }
@@ -553,7 +550,10 @@ class UserController extends DashboardController {
             }
 
             if ($this->Form->authenticatedPostBack(true) && $method != '') {
-                $userModel->deleteID($userID, ['DeleteMethod' => $method, 'DeleteModerationInfo' => $formValues['DeleteNotes']]);
+                $userModel->deleteID(
+                    $userID,
+                    ['DeleteMethod' => $method, 'DeleteModerationInfo' => $this->Form->getFormValue('DeleteModerationInfo')]
+                );
                 $this->View = 'deletecomplete';
             }
 

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -509,6 +509,9 @@ class UserController extends DashboardController {
     public function delete($userID = '', $method = '') {
         $this->permission('Garden.Users.Delete');
         $session = Gdn::session();
+
+        $formValues = $this->Form->formValues();
+
         if ($session->User->UserID == $userID) {
             trigger_error(errorMessage("You cannot delete the user you are logged in as.", $this->ClassName, 'FetchViewLocation'), E_USER_ERROR);
         }
@@ -550,7 +553,7 @@ class UserController extends DashboardController {
             }
 
             if ($this->Form->authenticatedPostBack(true) && $method != '') {
-                $userModel->deleteID($userID, ['DeleteMethod' => $method]);
+                $userModel->deleteID($userID, ['DeleteMethod' => $method, 'DeleteNotes' => $formValues['DeleteNotes']]);
                 $this->View = 'deletecomplete';
             }
 

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -553,7 +553,7 @@ class UserController extends DashboardController {
             }
 
             if ($this->Form->authenticatedPostBack(true) && $method != '') {
-                $userModel->deleteID($userID, ['DeleteMethod' => $method, 'DeleteModInfo' => $formValues['DeleteNotes']]);
+                $userModel->deleteID($userID, ['DeleteMethod' => $method, 'DeleteModerationInfo' => $formValues['DeleteNotes']]);
                 $this->View = 'deletecomplete';
             }
 

--- a/applications/dashboard/controllers/class.usercontroller.php
+++ b/applications/dashboard/controllers/class.usercontroller.php
@@ -553,7 +553,7 @@ class UserController extends DashboardController {
             }
 
             if ($this->Form->authenticatedPostBack(true) && $method != '') {
-                $userModel->deleteID($userID, ['DeleteMethod' => $method, 'DeleteNotes' => $formValues['DeleteNotes']]);
+                $userModel->deleteID($userID, ['DeleteMethod' => $method, 'DeleteModInfo' => $formValues['DeleteNotes']]);
                 $this->View = 'deletecomplete';
             }
 

--- a/applications/dashboard/views/user/delete.php
+++ b/applications/dashboard/views/user/delete.php
@@ -18,9 +18,4 @@ if ($this->data("CanDelete")) {
     <div class="label-wrap-wide"><?php echo t('UserDeleteMessage', "Delete the user and completely remove all of the user's content. This may cause discussions to be disjointed. Best option for removing spam."); ?></div>
     <div class="input-wrap-right"><?php echo anchor(t('UserDelete', 'Delete User Content'), 'user/delete/'.$this->User->UserID.'/delete', 'btn btn-secondary js-modal', ['data-css-class' => 'modal-sm']); ?></div>
 </div>
-<div class="form-group">
-    <div class="input-wrap-right">
-        <?php echo $this->Form->checkBox('DeleteNotes', 'Delete Moderation Notes', ['value' => '1']); ?>
-    </div>
-</div>
 <?php } ?>

--- a/applications/dashboard/views/user/delete.php
+++ b/applications/dashboard/views/user/delete.php
@@ -18,5 +18,9 @@ if ($this->data("CanDelete")) {
     <div class="label-wrap-wide"><?php echo t('UserDeleteMessage', "Delete the user and completely remove all of the user's content. This may cause discussions to be disjointed. Best option for removing spam."); ?></div>
     <div class="input-wrap-right"><?php echo anchor(t('UserDelete', 'Delete User Content'), 'user/delete/'.$this->User->UserID.'/delete', 'btn btn-secondary js-modal', ['data-css-class' => 'modal-sm']); ?></div>
 </div>
-
+<div class="form-group">
+    <div class="input-wrap-right">
+        <?php echo $this->Form->checkBox('DeleteNotes', 'Delete Moderation Notes', ['value' => '1']); ?>
+    </div>
+</div>
 <?php } ?>

--- a/applications/dashboard/views/user/deleteconfirm.php
+++ b/applications/dashboard/views/user/deleteconfirm.php
@@ -16,7 +16,7 @@ echo $this->Form->errors();
         echo t("All of the user content will be replaced with a message stating the user has been deleted.");
     else
         echo t("The user content will be completely deleted."),
-        $this->Form->checkBox('DeleteModInfo', t('Delete moderation information'), ['value' => '1']);
+        $this->Form->checkBox('DeleteModerationInfo', t('Delete moderation information'), ['value' => '1']);
     ?>
 </div>
 <?php

--- a/applications/dashboard/views/user/deleteconfirm.php
+++ b/applications/dashboard/views/user/deleteconfirm.php
@@ -16,6 +16,7 @@ echo $this->Form->errors();
         echo t("All of the user content will be replaced with a message stating the user has been deleted.");
     else
         echo t("The user content will be completely deleted.");
+        echo $this->Form->checkBox('DeleteNotes', 'Delete Moderation Notes', ['value' => '1']);
     ?>
 </div>
 <?php

--- a/applications/dashboard/views/user/deleteconfirm.php
+++ b/applications/dashboard/views/user/deleteconfirm.php
@@ -15,8 +15,8 @@ echo $this->Form->errors();
     else if ($this->Method == 'wipe')
         echo t("All of the user content will be replaced with a message stating the user has been deleted.");
     else
-        echo t("The user content will be completely deleted.");
-        echo $this->Form->checkBox('DeleteNotes', 'Delete Moderation Notes', ['value' => '1']);
+        echo t("The user content will be completely deleted."),
+        $this->Form->checkBox('DeleteNotes', t('Delete moderation notes as well'), ['value' => '1']);
     ?>
 </div>
 <?php

--- a/applications/dashboard/views/user/deleteconfirm.php
+++ b/applications/dashboard/views/user/deleteconfirm.php
@@ -16,7 +16,7 @@ echo $this->Form->errors();
         echo t("All of the user content will be replaced with a message stating the user has been deleted.");
     else
         echo t("The user content will be completely deleted."),
-        $this->Form->checkBox('DeleteNotes', t('Delete moderation notes as well'), ['value' => '1']);
+        $this->Form->checkBox('DeleteModInfo', t('Delete moderation information'), ['value' => '1']);
     ?>
 </div>
 <?php


### PR DESCRIPTION
Along with vanilla/internal#2485, this closes vanilla/support#1455.

This PR adds a checkbox option when deleting a user's content to choose whether to delete any moderation notes pertaining to the user's posts.

### TO TEST
1. Create 2 users and add a moderation note for each one.
1. Check out both this branch and the `add/delete-notes-check` branch from vanilla/internal.
1. From `dashboard/user`, select the first user to delete using the trash can icon.
1. Choose 'Delete User Content'.
1. Leave the 'Delete moderation information' box unchecked and click 'Delete User Forever'.
1. Verify that the user is deleted, but the moderation note is still present (in the `Gdn_UserNote` table).
1. Repeat steps 2-4 with the second user.
1. This time, check the checkbox.
1. Verify that the moderation note is deleted.