### PR TITLE
Fix the signatures of the PATCH /api/v2/notifications/* endpoints

### DIFF
--- a/applications/dashboard/controllers/api/NotificationsApiController.php
+++ b/applications/dashboard/controllers/api/NotificationsApiController.php
@@ -237,12 +237,11 @@ class NotificationsApiController extends AbstractApiController {
         $this->permission("Garden.SignIn.Allow");
 
         $this->idParamSchema();
-        $in = $this->schema(Schema::parse([
+        $in = $this->schema([
             "read?" => [
-                "description" => "Mark the notification read/unread.",
                 "enum" => [true]
             ]
-        ])->add($this->notificationSchema()), "in")->setDescription("Update a notification.");
+        ], "in")->setDescription("Update a notification.");
         $out = $this->schema($this->notificationSchema(), "out");
 
         $body = $in->validate($body);
@@ -273,12 +272,11 @@ class NotificationsApiController extends AbstractApiController {
     public function patch_index(array $body): Data {
         $this->permission("Garden.SignIn.Allow");
 
-        $in = $this->schema(Schema::parse([
+        $in = $this->schema([
             "read?" => [
-                "description" => "Mark the notification read/unread.",
                 "enum" => [true]
             ]
-        ])->add($this->notificationSchema()), "in")->setDescription("Update all notifications.");
+        ], "in")->setDescription("Update all notifications.");
         $out = $this->schema([], "out");
 
         $body = $in->validate($body);

--- a/applications/dashboard/openapi/notifications.yml
+++ b/applications/dashboard/openapi/notifications.yml
@@ -27,14 +27,18 @@ paths:
       - Notifications
       summary: List notifications for the current user.
     patch:
-      responses:
-        '204':
-          description: Success
+      summary: Mark all notifications read.
       tags:
       - Notifications
       requestBody:
-        $ref: '#/components/requestBodies/NotificationSchema'
-      summary: Update all notifications.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationPatchSchema'
+        required: true
+      responses:
+        '204':
+          description: Success
   '/notifications/{id}':
     get:
       parameters:
@@ -56,12 +60,21 @@ paths:
       - Notifications
       summary: Get a single notification.
     patch:
+      summary: Mark a notification read.
+      tags:
+        - Notifications
       parameters:
       - in: path
         name: id
         required: true
         schema:
           type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationPatchSchema'
+        required: true
       responses:
         '200':
           content:
@@ -69,15 +82,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/NotificationSchema'
           description: Success
-      tags:
-      - Notifications
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NotificationSchema'
-        required: true
-      summary: Update a notification.
 components:
   requestBodies:
     NotificationSchema:
@@ -127,3 +131,11 @@ components:
       - dateUpdated
       - read
       type: object
+    NotificationPatchSchema:
+      description: Fields for patching a notification.
+      type: object
+      properties:
+        read:
+          type: boolean
+          enum:
+            - true

--- a/tests/APIv2/NotificationsApiTest.php
+++ b/tests/APIv2/NotificationsApiTest.php
@@ -88,7 +88,36 @@ class NotificationsApiTest extends AbstractAPIv2Test {
      * Test PATCH /notifications.
      */
     public function testPatchIndex() {
-        $this->assertTrue(true);
+        $ids = [];
+        for ($i = 0; $i < 3; $i++) {
+            $ids[] = $this->addNotification();
+            $ids[] = $this->addNotification();
+        }
+
+        $notifications = array_column(
+            $this->api()->get("/notifications")->getBody(),
+            null,
+            'notificationID'
+        );
+
+        // Make sure the notifications were added and are not read.
+        foreach ($ids as $id) {
+            $this->assertArrayHasKey($id, $notifications);
+            $this->assertFalse($notifications[$id]['read']);
+        }
+
+        // Flag ALL notifications as read.
+        $r = $this->api()->patch("/notifications", ["read" => true]);
+
+        $patched = array_column(
+            $this->api()->get("/notifications")->getBody(),
+            null,
+            'notificationID'
+        );
+
+        foreach ($patched as $notification) {
+            $this->assertTrue($notification['read']);
+        }
     }
 
     /**
@@ -108,6 +137,7 @@ class NotificationsApiTest extends AbstractAPIv2Test {
         // Flag the notification as read.
         $patchResponse = $this->api()->patch("/notifications/{$id}", ["read" => true]);
         $this->assertEquals($patchResponse->getStatusCode(), 200);
+        $this->assertTrue($patchResponse['read']);
 
         // Get the updated notification.
         $updatedGetResponse = $this->api()->get("/notifications/{$id}");


### PR DESCRIPTION
These endpoints functionally can only mark notifications read, but were taking entire notifications as input parameters. This PR removes the rest of the notification input parameters, but does not otherwise modify functionality.