### PR TITLE
Fixed sticky panel calculation

### DIFF
--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -42,7 +42,7 @@ interface IProps {
 export default function Banner(props: IProps) {
     const device = useDevice();
     const bannerContextRef = useBannerContainerDivRef();
-    const { overlayTitleBar, setOverlayTitleBar } = useBannerContext();
+    const { setOverlayTitleBar } = useBannerContext();
 
     const { action, className, isContentBanner } = props;
 

--- a/library/src/scripts/banner/Banner.tsx
+++ b/library/src/scripts/banner/Banner.tsx
@@ -4,6 +4,7 @@
  * @license GPL-2.0-only
  */
 
+import React, { useEffect } from "react";
 import IndependentSearch from "@library/features/search/IndependentSearch";
 import { ButtonPreset } from "@library/forms/buttonStyles";
 import { ButtonTypes } from "@library/forms/buttonTypes";
@@ -11,11 +12,10 @@ import Container from "@library/layout/components/Container";
 import { Devices, useDevice } from "@library/layout/DeviceContext";
 import FlexSpacer from "@library/layout/FlexSpacer";
 import Heading from "@library/layout/Heading";
-import { useBannerContainerDivRef } from "@library/banner/BannerContext";
+import { useBannerContainerDivRef, useBannerContext } from "@library/banner/BannerContext";
 import { bannerClasses, bannerVariables } from "@library/banner/bannerStyles";
 import { assetUrl, t } from "@library/utility/appUtils";
 import classNames from "classnames";
-import React from "react";
 import { titleBarClasses, titleBarVariables } from "@library/headers/titleBarStyles";
 import { DefaultBannerBg } from "@library/banner/DefaultBannerBg";
 import ConditionalWrap from "@library/layout/ConditionalWrap";
@@ -42,6 +42,7 @@ interface IProps {
 export default function Banner(props: IProps) {
     const device = useDevice();
     const bannerContextRef = useBannerContainerDivRef();
+    const { overlayTitleBar, setOverlayTitleBar } = useBannerContext();
 
     const { action, className, isContentBanner } = props;
 
@@ -54,6 +55,10 @@ export default function Banner(props: IProps) {
     const { title = vars.title.text } = props;
 
     useComponentDebug({ vars });
+
+    useEffect(() => {
+        setOverlayTitleBar(!!options.overlayTitleBar);
+    }, [options.overlayTitleBar]);
 
     if (!options.enabled) {
         return null;
@@ -102,7 +107,7 @@ export default function Banner(props: IProps) {
 
     return (
         <div
-            ref={options.overlayTitleBar ? bannerContextRef : undefined}
+            ref={bannerContextRef}
             className={classNames(className, classes.root, {
                 [classesTitleBar.negativeSpacer]: varsTitleBar.fullBleed.enabled && options.overlayTitleBar,
             })}
@@ -145,7 +150,7 @@ export default function Banner(props: IProps) {
                                         !options.hideDescription ||
                                         !!logoImageSrc
                                     }
-                                ></ConditionalWrap>
+                                />
                                 {rightImageSrc && (
                                     <div className={classes.imageElementContainer}>
                                         {/*We rely on the title for screen readers as we don't yet have alt text hooked up to image*/}
@@ -154,7 +159,7 @@ export default function Banner(props: IProps) {
                                 )}
                             </div>
                         </Container>
-                        {showBottomSearch && <div className={classes.searchStrip} style={{ background: "none" }}></div>}
+                        {showBottomSearch && <div className={classes.searchStrip} style={{ background: "none" }} />}
                     </div>
                 </div>
                 {/* Main Content Area

--- a/library/src/scripts/banner/BannerContext.tsx
+++ b/library/src/scripts/banner/BannerContext.tsx
@@ -4,7 +4,6 @@
  */
 
 import React, { useContext, useState, useEffect, useRef, useDebugValue } from "react";
-import { useHistory } from "react-router";
 import { useMeasure } from "@vanilla/react-utils";
 import { usePageChangeListener } from "@library/pageViews/pageViewTracking";
 
@@ -13,6 +12,8 @@ interface IContextValue {
     setBannerExists: (exists: boolean) => void;
     bannerRect: DOMRect | null;
     setBannerRect: (rect: DOMRect | null) => void;
+    overlayTitleBar: boolean;
+    setOverlayTitleBar: (exists: boolean) => void;
 }
 
 const context = React.createContext<IContextValue>({
@@ -20,6 +21,8 @@ const context = React.createContext<IContextValue>({
     setBannerExists: () => {},
     bannerRect: null,
     setBannerRect: () => {},
+    overlayTitleBar: false,
+    setOverlayTitleBar: () => {},
 });
 
 export function useBannerContext() {
@@ -49,10 +52,12 @@ export function useBannerContainerDivRef() {
 
 export function BannerContextProvider(props: { children: React.ReactNode }) {
     const [bannerExists, setBannerExists] = useState(false);
+    const [overlayTitleBar, setOverlayTitleBar] = useState(false);
     const [bannerRect, setBannerRect] = useState<DOMRect | null>(null);
     usePageChangeListener(() => {
         setBannerExists(false);
         setBannerRect(null);
+        setOverlayTitleBar(false);
     });
     return (
         <context.Provider
@@ -61,6 +66,8 @@ export function BannerContextProvider(props: { children: React.ReactNode }) {
                 setBannerExists,
                 bannerRect,
                 setBannerRect,
+                overlayTitleBar,
+                setOverlayTitleBar,
             }}
         >
             {props.children}
@@ -71,6 +78,7 @@ export function BannerContextProvider(props: { children: React.ReactNode }) {
 export function BannerContextProviderNoHistory(props: { children: React.ReactNode }) {
     const [bannerExists, setBannerExists] = useState(false);
     const [bannerRect, setBannerRect] = useState<DOMRect | null>(null);
+    const [overlayTitleBar, setOverlayTitleBar] = useState(false);
     return (
         <context.Provider
             value={{
@@ -78,6 +86,8 @@ export function BannerContextProviderNoHistory(props: { children: React.ReactNod
                 setBannerExists,
                 bannerRect,
                 setBannerRect,
+                overlayTitleBar,
+                setOverlayTitleBar,
             }}
         >
             {props.children}

--- a/tests/fixtures/formats/html/attachments/output-attachments.json
+++ b/tests/fixtures/formats/html/attachments/output-attachments.json
@@ -5,7 +5,7 @@
         "mediaID": -1,
         "size": 0,
         "type": "unknown",
-        "url": "http:\/\/test.com"
+        "url": "http://test.com"
     },
     {
         "name": "Attachment 2",
@@ -13,6 +13,6 @@
         "mediaID": -1,
         "size": 0,
         "type": "unknown",
-        "url": "http:\/\/test.com"
+        "url": "http://test.com"
     }
 ]

--- a/tests/fixtures/formats/html/attachments/output-attachments.json
+++ b/tests/fixtures/formats/html/attachments/output-attachments.json
@@ -5,7 +5,7 @@
         "mediaID": -1,
         "size": 0,
         "type": "unknown",
-        "url": "http://test.com"
+        "url": "http:\/\/test.com"
     },
     {
         "name": "Attachment 2",
@@ -13,6 +13,6 @@
         "mediaID": -1,
         "size": 0,
         "type": "unknown",
-        "url": "http://test.com"
+        "url": "http:\/\/test.com"
     }
 ]


### PR DESCRIPTION
The ref for the banner was undefined when `options.overlayTitleBar` was false, causing the calculation of the banner height to be 0.


Closes: https://github.com/vanilla/knowledge/issues/1808