### PR TITLE
Fix rich post format getting lost

### DIFF
--- a/applications/vanilla/settings/structure.php
+++ b/applications/vanilla/settings/structure.php
@@ -35,16 +35,27 @@ $LastDiscussionIDExists = $Construct->columnExists('LastDiscussionID');
 $CountAllDiscussionsExists = $Construct->columnExists('CountAllDiscussions');
 $CountAllCommentsExists = $Construct->columnExists('CountAllComments');
 
+$config = Gdn::config();
 // Rename the remnants of the Hero Image plugin.
 if ($HeroImageExists) {
-    Gdn::config()->remove('EnabledPlugins.heroimage');
+    $config->remove('EnabledPlugins.heroimage');
     $Construct->table('Category');
     $Construct->renameColumn('HeroImage', 'BannerImage');
 }
 
 if ($configBannerImage = Gdn::config('Garden.HeroImage')) {
-    Gdn::config()->set('Garden.BannerImage', $configBannerImage);
-    Gdn::config()->remove('Garden.HeroImage');
+    $config->set('Garden.BannerImage', $configBannerImage);
+    $config->remove('Garden.HeroImage');
+}
+
+// Fix the casening of the Rich post format.
+// For a short period, lowercase rich format values were being saved into the config.
+if ($config->get('Garden.InputFormatter') === 'rich') {
+    $config->set('Garden.InputFormatter', 'Rich');
+}
+
+if ($config->get('Garden.MobileInputFormatter') === 'rich') {
+    $config->set('Garden.MobileInputFormatter', 'Rich');
 }
 
 $Construct->primaryKey('CategoryID')

--- a/applications/vanilla/tests/VanillaStructureTest.php
+++ b/applications/vanilla/tests/VanillaStructureTest.php
@@ -13,14 +13,14 @@ use VanillaTests\SiteTestTrait;
 /**
  * Test the migration of the hero image plugin.
  */
-class HeroImageMigrateTest extends TestCase {
+class VanillaStructureTest extends TestCase {
 
     use SiteTestTrait;
 
     /**
      * Test that the old
      */
-    public function testMigration() {
+    public function testHeroImageMigration() {
         $structure = \Gdn::structure();
         $config = \Gdn::config();
 
@@ -51,7 +51,7 @@ class HeroImageMigrateTest extends TestCase {
         include_once PATH_LIBRARY.'/SmartyPlugins/function.hero_image_link.php';
         include_once PATH_LIBRARY.'/SmartyPlugins/function.banner_image_url.php';
 
-        $uploadBase = 'http://vanilla.test/heroimagemigratetest/uploads/';
+        $uploadBase = 'http://vanilla.test/vanillastructuretest/uploads/';
 
         // Test that we can still fetch our information using the old functions after the migrations.
         $this->assertEquals("category.png", @\HeroImagePlugin::getHeroImageSlug($categoryID));
@@ -65,5 +65,20 @@ class HeroImageMigrateTest extends TestCase {
         \Gdn::controller($ctrl);
 
         $this->assertEquals("${uploadBase}category.png", @\smarty_function_hero_image_link([], $smarty));
+    }
+
+    /**
+     * Test that we properly fix input formatters that were improperly named.
+     */
+    public function testInputFormatRename() {
+        $config = \Gdn::config();
+        $config->set('Garden.InputFormatter', 'rich');
+        $config->set('Garden.MobileInputFormatter', 'rich');
+
+        // Run the structure.
+        include PATH_APPLICATIONS.'/vanilla/settings/structure.php';
+
+        $this->assertSame('Rich', $config->get('Garden.InputFormatter'));
+        $this->assertSame('Rich', $config->get('Garden.MobileInputFormatter'));
     }
 }

--- a/plugins/rich-editor/RichEditorPlugin.php
+++ b/plugins/rich-editor/RichEditorPlugin.php
@@ -85,7 +85,7 @@ class RichEditorPlugin extends Gdn_Plugin {
      * @return string[] Additional post formats.
      */
     public function getPostFormats_handler(array $postFormats): array {
-        $postFormats[] = RichFormat::FORMAT_KEY;
+        $postFormats[] = 'Rich'; // The config values have always been uppercase. (including in default configs).
         return $postFormats;
     }
 


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla/issues/10536

- At some point we changed the rich format that gets applied from the branding page to `'rich`
- Config defaults (local and on infra) are 'Rich'.
- Value was historically 'Rich'

The casening was done in most places to some lowercase constant, and a lot of checks are case-insensitive, however getting the config values to be lowercase would be a lot riskier. As a result I'm reverting the config values to the old value for rich, and added something in structure to ensure it gets fixed for existing sites that may have set themselves to the lowercase value in the interim.

## Notes

This affected a couple of our own sites which raised it to my attention. Notably in the last few days, our demo, staff, and success sites all lost their formatter as someone configured something on the posting page.