### PR TITLE
Honour ProfileExtender text fiels options on registration page

### DIFF
--- a/plugins/ProfileExtender/views/registrationfields.php
+++ b/plugins/ProfileExtender/views/registrationfields.php
@@ -12,6 +12,10 @@ if (is_array($Sender->RegistrationFields)) {
             $Options = array_combine($values, $labels);
         }
 
+        if ($Field['FormType'] == 'TextBox' && !empty($Field['Options'])) {
+            $Options = $Field['Options'];
+        }
+
         if ($Field['FormType'] == 'CheckBox') {
             echo wrap($Sender->Form->{$Field['FormType']}($Name, $Field['Label']), 'li');
         } else {


### PR DESCRIPTION
Related to https://github.com/vanilla/support/issues/952

Options were honoured properly in the profile view but not the registration view.

This caused an issue where `MaxLength` option would be respected on the profile page but not at registration.

This fix replicate exactly what is in the other view to minimize unforeseen problems. The logic seems very odd to me...