### PR TITLE
Fix permission check in post method

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -575,12 +575,7 @@ class DiscussionsApiController extends AbstractApiController {
             $categoryID = $discussionData['CategoryID'];
         }
 
-        $category = CategoryModel::categories($categoryID);
-        if ($category) {
-            $permissionCategoryID = $category['PermissionCategoryID'];
-        } else {
-            $permissionCategoryID = -1;
-        }
+        $permissionCategoryID = self::getPermissionID($categoryID);
 
         $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $permissionCategoryID);
         $this->fieldPermission($body, 'pinned', 'Vanilla.Discussions.Announce', $permissionCategoryID);
@@ -592,6 +587,21 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $this->discussionByID($id);
         $result = $this->normalizeOutput($result);
         return $out->validate($result);
+    }
+
+    /**
+     * Get the category permission ID.
+     *
+     * @param int $categoryID The category ID.
+     * @return int Returns the associated permission ID.
+     */
+    public static function getPermissionID(int $categoryID): int {
+        $category = CategoryModel::categories($categoryID);
+        if ($category) {
+            return $category['PermissionCategoryID'];
+        } else {
+            return -1;
+        }
     }
 
     /**
@@ -609,10 +619,11 @@ class DiscussionsApiController extends AbstractApiController {
 
         $body = $in->validate($body);
         $categoryID = $body['categoryID'];
+        $categoryPermissionID = self::getPermissionID($categoryID);
         $this->discussionModel->categoryPermission('Vanilla.Discussions.Add', $categoryID);
-        $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $categoryID);
-        $this->fieldPermission($body, 'pinned', 'Vanilla.Discussions.Announce', $categoryID);
-        $this->fieldPermission($body, 'sink', 'Vanilla.Discussions.Sink', $categoryID);
+        $this->fieldPermission($body, 'closed', 'Vanilla.Discussions.Close', $categoryPermissionID);
+        $this->fieldPermission($body, 'pinned', 'Vanilla.Discussions.Announce', $categoryPermissionID);
+        $this->fieldPermission($body, 'sink', 'Vanilla.Discussions.Sink', $categoryPermissionID);
 
         $discussionData = ApiUtils::convertInputKeys($body);
         $id = $this->discussionModel->save($discussionData);


### PR DESCRIPTION
This will close vanilla/support#1837.

The post method of the discussionApiController currently uses the `categoryID` to check permissions, which creates a problem for creating discussions in certain nested categories. This PR fixes the problem by using the associated `CategoryPermissionID` from the `Gdn_Category` table. 

### TO TEST
Make a category with custom permissions that allows a moderator to post discussions. Then add a subcategory that doesn't have custom permissions. Try to post a discussion to the subcategory through postman as a moderator. Alternately, you can comment out lines 309-311 in Permissions.php and post as an administrator.