### PR TITLE
Add some PHP 8 compatibility functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
         "fig/event-dispatcher-util": "^1.1",
         "symfony/polyfill-php73": "^1.13",
         "symfony/polyfill-php74": "^1.13",
+        "symfony/polyfill-php80": "^1.15",
         "metasyntactical/composer-plugin-license-check": "^0.5.0",
         "colinodell/json5": "^2.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "fig/event-dispatcher-util": "^1.1",
         "symfony/polyfill-php73": "^1.13",
         "symfony/polyfill-php74": "^1.13",
-        "symfony/polyfill-php80": "^1.15",
+        "symfony/polyfill-php80": "^1.16",
         "metasyntactical/composer-plugin-license-check": "^0.5.0",
         "colinodell/json5": "^2.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a2cdfe6b7ace677830237d03235f215",
+    "content-hash": "ad9c3c414e58bfb89a836987642048f0",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -1170,16 +1170,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.15.0",
+            "version": "v1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "8854dc880784d2ae32908b75824754339b5c0555"
+                "reference": "c4bdcb0490a6c0e12c51e9d771fda5867e908fd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/8854dc880784d2ae32908b75824754339b5c0555",
-                "reference": "8854dc880784d2ae32908b75824754339b5c0555",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/c4bdcb0490a6c0e12c51e9d771fda5867e908fd2",
+                "reference": "c4bdcb0490a6c0e12c51e9d771fda5867e908fd2",
                 "shasum": ""
             },
             "require": {
@@ -1188,7 +1188,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.15-dev"
+                    "dev-master": "1.16-dev"
                 }
             },
             "autoload": {
@@ -1242,7 +1242,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-03-03T16:59:03+00:00"
+            "time": "2020-05-08T16:50:20+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "baa5cd12646efdf877aaf2633842dae7",
+    "content-hash": "5a2cdfe6b7ace677830237d03235f215",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -1167,6 +1167,82 @@
                 "shim"
             ],
             "time": "2019-11-27T14:18:11+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "8854dc880784d2ae32908b75824754339b5c0555"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/8854dc880784d2ae32908b75824754339b5c0555",
+                "reference": "8854dc880784d2ae32908b75824754339b5c0555",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-03T16:59:03+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/library/core/functions.compatibility.php
+++ b/library/core/functions.compatibility.php
@@ -344,6 +344,36 @@ function setvalr($key, &$collection, $value = null) {
     }
 }
 
+if (!function_exists('str_ends_with')) {
+    /**
+     * A polyfill for PHP 8's `str_ends_with()` function.
+     *
+     * @param string $haystack
+     * @param string $needle
+     * @return bool
+     * @see https://php.watch/versions/8.0/str_starts_with-str_ends_with
+     * @codeCoverageIgnore
+     */
+    function str_ends_with(string $haystack, string $needle): bool {
+        return $needle === '' || $needle === \substr($haystack, -\strlen($needle));
+    }
+}
+
+if (!function_exists('str_starts_with')) {
+    /**
+     * A polyfill for PHP 8's `str_ends_with()` function.
+     *
+     * @param string $haystack
+     * @param string $needle
+     * @return bool
+     * @see https://php.watch/versions/8.0/str_starts_with-str_ends_with
+     * @codeCoverageIgnore
+     */
+    function str_starts_with(string $haystack, string $needle): bool {
+        return \strncmp($haystack, $needle, \strlen($needle)) === 0;
+    }
+}
+
 if (!function_exists('svalr')) {
     /**
      * Set a key to a value in a collection.

--- a/library/core/functions.compatibility.php
+++ b/library/core/functions.compatibility.php
@@ -344,36 +344,6 @@ function setvalr($key, &$collection, $value = null) {
     }
 }
 
-if (!function_exists('str_ends_with')) {
-    /**
-     * A polyfill for PHP 8's `str_ends_with()` function.
-     *
-     * @param string $haystack
-     * @param string $needle
-     * @return bool
-     * @see https://php.watch/versions/8.0/str_starts_with-str_ends_with
-     * @codeCoverageIgnore
-     */
-    function str_ends_with(string $haystack, string $needle): bool {
-        return $needle === '' || $needle === \substr($haystack, -\strlen($needle));
-    }
-}
-
-if (!function_exists('str_starts_with')) {
-    /**
-     * A polyfill for PHP 8's `str_ends_with()` function.
-     *
-     * @param string $haystack
-     * @param string $needle
-     * @return bool
-     * @see https://php.watch/versions/8.0/str_starts_with-str_ends_with
-     * @codeCoverageIgnore
-     */
-    function str_starts_with(string $haystack, string $needle): bool {
-        return \strncmp($haystack, $needle, \strlen($needle)) === 0;
-    }
-}
-
 if (!function_exists('svalr')) {
     /**
      * Set a key to a value in a collection.


### PR DESCRIPTION
PHP 8 has a few nice string functions that would be good to start using where needed rather than calling our own weird versions. The functions are:

- `str_starts_with()`
- `str_ends_with()`
- `str_contains()`