### PR TITLE
Add string utils methods

### DIFF
--- a/library/Vanilla/Utility/StringUtils.php
+++ b/library/Vanilla/Utility/StringUtils.php
@@ -9,7 +9,7 @@ namespace Vanilla\Utility;
 /**
  * A collection of string utilities.
  */
-class StringUtils {
+final class StringUtils {
     /**
      * Encode a value as JSON or throw an exception on error.
      *
@@ -47,5 +47,41 @@ class StringUtils {
             throw new \Exception("JSON encoding error: {$errorMessage}", 500);
         }
         return $encoded;
+    }
+
+    /**
+     * Remove a substring from the beginning of the string.
+     *
+     * @param string $str The string to search.
+     * @param string $trim The substring to trim off the search string.
+     * @param bool $caseInsensitive Whether or not to do a case insensitive comparison.
+     * @return string Returns the trimmed string.
+     */
+    public static function substringLeftTrim(string $str, string $trim, bool $caseInsensitive = false): string {
+        if (strlen($str) < strlen($trim)) {
+            return $str;
+        } elseif (substr_compare($str, $trim, 0, strlen($trim), $caseInsensitive) === 0) {
+            return substr($str, strlen($trim));
+        } else {
+            return $str;
+        }
+    }
+
+    /**
+     * Remove a substring from the end of the string.
+     *
+     * @param string $str The string to search.
+     * @param string $trim The substring to trim off the search string.
+     * @param bool $caseInsensitive Whether or not to do a case insensitive comparison.
+     * @return string Returns the trimmed string.
+     */
+    public static function substringRightTrim(string $str, string $trim, bool $caseInsensitive = false): string {
+        if (strlen($str) < strlen($trim)) {
+            return $str;
+        } elseif (substr_compare($str, $trim, -strlen($trim), null, $caseInsensitive) === 0) {
+            return substr($str, 0, -strlen($trim));
+        } else {
+            return $str;
+        }
     }
 }

--- a/tests/Library/Vanilla/Utility/StringUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/StringUtilsTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Utility;
+
+use PHPUnit\Framework\TestCase;
+use Vanilla\Utility\StringUtils;
+use VanillaTests\Fixtures\Tuple;
+
+/**
+ * Tests for the `StringUtils` class.
+ */
+class StringUtilsTest extends TestCase {
+    /**
+     * Test a basic happy path for `jsonEncodeChecked()`.
+     */
+    public function testJsonEncodeHappy(): void {
+        $str = StringUtils::jsonEncodeChecked(123);
+        $this->assertSame('123', $str);
+    }
+
+    /**
+     * Test `jsonEncodeChecked()` exceptions.
+     *
+     * @param mixed $in
+     * @param string $message
+     * @dataProvider provideJsonEncodeExceptions
+     */
+    public function testJsonEncodeExceptions($in, $message): void {
+        $this->expectExceptionMessage($message);
+        $str = StringUtils::jsonEncodeChecked($in);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideJsonEncodeExceptions(): array {
+        $rec = new \stdClass();
+        $rec->r = $rec;
+
+        $r = [
+            [$rec, 'recursive references'],
+            [substr('🐶🐶', -1), 'Malformed UTF-8'],
+            [NAN, 'NAN or INF'],
+        ];
+
+        return array_column($r, null, 1);
+    }
+
+
+    /**
+     * Test `StringUtils::substringLeftTrim()`.
+     *
+     * @param string $str
+     * @param bool $caseInsensitive
+     * @param string $expected
+     * @dataProvider provideLeftTrimTests
+     */
+    public function testSubstringLeftTrim(string $str, bool $caseInsensitive, string $expected): void {
+        $actual = StringUtils::substringLeftTrim($str, 'foo', $caseInsensitive);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Provide trim tests.
+     *
+     * @return array
+     */
+    public function provideLeftTrimTests(): array {
+        $r = [
+            'happy' => ['foobar', false, 'bar'],
+            'shorter' => ['f', false, 'f'],
+            'not' => ['bazbar', false, 'bazbar'],
+            'case insensitive' => ['FOObar', true, 'bar'],
+        ];
+
+        return $r;
+    }
+
+    /**
+     * Test `StringUtils::substringRightTrim()`.
+     *
+     * @param string $str
+     * @param bool $caseInsensitive
+     * @param string $expected
+     * @dataProvider provideRightTrimTests
+     */
+    public function testSubstringRightTrim(string $str, bool $caseInsensitive, string $expected): void {
+        $actual = StringUtils::substringRightTrim($str, 'foo', $caseInsensitive);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Provide trim tests.
+     *
+     * @return array
+     */
+    public function provideRightTrimTests(): array {
+        $r = [
+            'happy' => ['barfoo', false, 'bar'],
+            'shorter' => ['f', false, 'f'],
+            'not' => ['bazbar', false, 'bazbar'],
+            'case insensitive' => ['barFOO', true, 'bar'],
+        ];
+
+        return $r;
+    }
+}


### PR DESCRIPTION
These methods are meant to deprecate our problematic `stringBeginsWith()` and `stringEndsWith()`.