### PR TITLE
Add host to links in discussion list API header

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -538,9 +538,9 @@ class DiscussionsApiController extends AbstractApiController {
         $whereCount = count($where);
         $isWhereOptimized = (isset($where['d.CategoryID']) && ($whereCount === 1 || ($whereCount === 2 && isset($where['Announce']))));
         if ($whereCount === 0 || $isWhereOptimized) {
-            $paging = ApiUtils::numberedPagerInfo($this->discussionModel->getCount($where), '/api/v2/discussions', $query, $in);
+            $paging = ApiUtils::numberedPagerInfo($this->discussionModel->getCount($where), $_ENV['HTTP_HOST'] . '/api/v2/discussions', $query, $in);
         } else {
-            $paging = ApiUtils::morePagerInfo($rows, '/api/v2/discussions', $query, $in);
+            $paging = ApiUtils::morePagerInfo($rows, $_ENV['HTTP_HOST'] . '/api/v2/discussions', $query, $in);
         }
 
         return new Data($result, ['paging' => $paging]);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -538,9 +538,9 @@ class DiscussionsApiController extends AbstractApiController {
         $whereCount = count($where);
         $isWhereOptimized = (isset($where['d.CategoryID']) && ($whereCount === 1 || ($whereCount === 2 && isset($where['Announce']))));
         if ($whereCount === 0 || $isWhereOptimized) {
-            $paging = ApiUtils::numberedPagerInfo($this->discussionModel->getCount($where), $_ENV['HTTP_HOST'] . '/api/v2/discussions', $query, $in);
+            $paging = ApiUtils::numberedPagerInfo($this->discussionModel->getCount($where), '/api/v2/discussions', $query, $in);
         } else {
-            $paging = ApiUtils::morePagerInfo($rows, $_ENV['HTTP_HOST'] . '/api/v2/discussions', $query, $in);
+            $paging = ApiUtils::morePagerInfo($rows, '/api/v2/discussions', $query, $in);
         }
 
         return new Data($result, ['paging' => $paging]);

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -157,7 +157,7 @@ class ApiUtils {
         if (!empty($argsStr)) {
             $url .= (strpos($url, '?') === false ? '?' : '&').$argsStr;
         }
-        $url = \Gdn::request()->url($url, true);
+        $url = \Gdn::request()->getSimpleUrl($url);
         return $url;
     }
 

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -157,6 +157,7 @@ class ApiUtils {
         if (!empty($argsStr)) {
             $url .= (strpos($url, '?') === false ? '?' : '&').$argsStr;
         }
+        $url = \Gdn::request()->url($url, true);
         return $url;
     }
 

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -141,12 +141,11 @@ abstract class AbstractAPIv2Test extends TestCase {
         $this->assertTrue(preg_match('/<([^;]*?'.preg_quote($resourcePath, '/').'[^>]+)>; rel="next"/', $link, $matches) === 1);
 
         // Ensure we are getting full url
-        $m = strpos($matches[1], 'http');
-        $this->assertTrue($m >= 0);
-        
-        $baseUrl = $this->api()->getBaseUrl();
-        $matches[1] = ltrim($matches[1], $baseUrl);
-        $result = $this->api()->get($resourcePath . $matches[1]);
+        $parsedMatch = parse_url($matches[1]);
+        $this->assertTrue($parsedMatch['scheme'] === 'http' || $parsedMatch['scheme'] === 'https');
+
+        $result = $this->api()->get($resourcePath . '?' . $parsedMatch['query']);
+
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertEquals(1, count($result->getBody()));
     }

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -140,7 +140,13 @@ abstract class AbstractAPIv2Test extends TestCase {
         $this->assertTrue(preg_match('/<([^;]*?'.preg_quote($resourcePath, '/').'[^>]+)>; rel="first"/', $link) === 1);
         $this->assertTrue(preg_match('/<([^;]*?'.preg_quote($resourcePath, '/').'[^>]+)>; rel="next"/', $link, $matches) === 1);
 
-        $result = $this->api()->get(str_replace('/api/v2', '', $matches[1]));
+        // Ensure we are getting full url
+        $m = strpos($matches[1], 'http');
+        $this->assertTrue($m >= 0);
+        
+        $baseUrl = $this->api()->getBaseUrl();
+        $matches[1] = ltrim($matches[1], $baseUrl);
+        $result = $this->api()->get($resourcePath . $matches[1]);
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertEquals(1, count($result->getBody()));
     }


### PR DESCRIPTION
Closes vanilla/vanilla#9004

This PR fixes a problem where, when making this API call: `https://dev.vanilla.localhost/api/v2/discussions/`
the "Link" headers containing links to next and previous pages were relative rather than absolute.

### TO TEST
Check out the branch and make this call: `https://dev.vanilla.localhost/api/v2/discussions/`
Verify that the links in the "Link" header are absolute.