### PR TITLE
Fix the Panopto embed Content Security policy.

### DIFF
--- a/library/Vanilla/Web/ContentSecurityPolicy/EmbedWhitelistContentSecurityPolicyProvider.php
+++ b/library/Vanilla/Web/ContentSecurityPolicy/EmbedWhitelistContentSecurityPolicyProvider.php
@@ -13,7 +13,7 @@ use Vanilla\EmbeddedContent\Embeds\PanoptoEmbed;
  */
 class EmbedWhitelistContentSecurityPolicyProvider implements ContentSecurityPolicyProviderInterface {
     const EMBED_WHITELIST = [
-        PanoptoEmbed::JS_SCRIPT,
+        'https://developers.panopto.com',
         'https://embed-cdn.gettyimages.com',
         'https://s.imgur.com',
         'https://platform.instagram.com',


### PR DESCRIPTION
The script path defined in the PanoptoEmbed class was added to the EMBED_WHITELIST array in the EmbedWhitelistContentSecurityPolicyProvider class.

However, Content Security policy only works with domains.

The script path was replaced with the domain.



