### PR TITLE
Fix structure of breadcrumb so that it follows the BreadcrumbList schema.

### DIFF
--- a/library/core/class.theme.php
+++ b/library/core/class.theme.php
@@ -95,6 +95,7 @@ class Gdn_Theme {
         $dataCount = 0;
         $homeLinkFound = false;
         $position = 1;
+        $displayStructuredData = false;
 
         foreach ($data as $row) {
             $dataCount++;
@@ -109,6 +110,7 @@ class Gdn_Theme {
             if ($count > 0) {
                 $result .= '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">';
                 $result .= '<meta itemprop="position" content="'.$position++.'" />';
+                $displayStructuredData = true;
             }
 
             $row['Url'] = $row['Url'] ? url($row['Url']) : '#';
@@ -123,7 +125,8 @@ class Gdn_Theme {
             $count++;
         }
 
-        $result = '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">'.$result.'</span>';
+        // Display as BreadcrumbList if there is structured data.
+        $result = '<span class="Breadcrumbs" '.(($displayStructuredData) ? 'itemscope itemtype="http://schema.org/BreadcrumbList"' : '').'>'.$result.'</span>';
         return $result;
     }
 

--- a/library/core/class.theme.php
+++ b/library/core/class.theme.php
@@ -58,7 +58,10 @@ class Gdn_Theme {
      * @return string
      */
     public static function breadcrumbs($data, $homeLink = true, $options = []) {
-        $format = '<a href="{Url,html}" itemprop="item"><span itemprop="name">{Name,html}</span></a>';
+        // Format breadcrumb that is part of breadcrumb structured data.
+        $format = '<a itemprop="item" href="{Url,html}"><span itemprop="name">{Name,html}</span></a>';
+        // Format the home link which is not part of breadcrumb structured data.
+        $baseFormat = '<a href="{Url,html}"><span>{Name,html}</span></a>';
 
         $result = '';
 
@@ -114,15 +117,10 @@ class Gdn_Theme {
                 $cssClass .= ' Last';
             }
 
-            $label = '<span class="'.$cssClass.'">'.formatString($format, $row).'</span> ';
+            $label = '<span class="'.$cssClass.'">'.(($count === 0) ? formatString($baseFormat, $row) : formatString($format, $row).'</span>').'</span>';
             $result = concatSep('<span class="Crumb">'.t('Breadcrumbs Crumb', '›').'</span> ', $result, $label);
 
             $count++;
-        }
-
-        // Close the stack.
-        for ($count--; $count > 0; $count--) {
-            $result .= '</span>';
         }
 
         $result = '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">'.$result.'</span>';

--- a/tests/Library/Core/BreadcrumbStructureTest.php
+++ b/tests/Library/Core/BreadcrumbStructureTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @author Patrick Kelly <patrick.k@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use VanillaTests\SharedBootstrapTestCase;
+
+class BreadcrumbStructureTest extends SharedBootstrapTestCase {
+    /**
+     * Provide a test for {@link \Gdn_Theme::breadcrumbs()}
+     *
+     * @param array $data Typical data that would make up a breadcrumb.
+     * @param bool $homeLink Whether to include the link to the homepage.
+     * @param array $options Two options that could be passed to a breadcrumb.
+     * @param string $expected HTML that would make up breadcrumbs with valid data structure.
+     * @dataProvider provideBreadcrumbConfigsArray
+     */
+    public function testBreadcrumb(array $data, bool $homeLink, array $options, string $expected) {
+        $breadCrumb = \Gdn_Theme::breadcrumbs($data, $homeLink, $options);
+        $this->assertEquals($expected, $breadCrumb);
+    }
+
+    /**
+     * Provide data for {@link \Gdn_Theme::breadcrumbs()}
+     *
+     * @return array Breadcrumb arguments and expected outcomes.
+     */
+    public function provideBreadcrumbConfigsArray() {
+        $r = [
+                [
+                   [
+                       ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories']
+                   ],
+                    true,
+                    [],
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories"><span itemprop="name">Categories</span></a></span></span></span>'
+                ],
+                [
+                    [
+                        ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories/one']
+                    ],
+                    true,
+                    [],
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
+                ],
+                [
+                    [
+                        ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories/one'],
+                        ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories/two']
+                    ],
+                    true,
+                    [],
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel "><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="2" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/two"><span itemprop="name">Categories</span></a></span></span></span>'
+                ],
+                [
+                    [
+                        ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories/one'],
+                        ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories/two']
+                    ],
+                    false,
+                    [],
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel "><a href="http://vanilla.test/categories/one"><span>Categories</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/two"><span itemprop="name">Categories</span></a></span></span></span>'
+                ],
+                [
+                    [
+                        ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories/one']
+                    ],
+                    false,
+                    [],
+                    '<span class="Breadcrumbs" ><span class="CrumbLabel  Last"><a href="http://vanilla.test/categories/one"><span>Categories</span></a></span></span>'
+                ],
+                [
+                    [
+                        ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories/one']
+                    ],
+                    true,
+                    ['HomeUrl' => 'http://vanilla.test/en'],
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/en"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
+                ],
+                [
+                    [
+                        ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories/one'],
+                        ['Name' => 'Categories', 'Url' => 'http://vanilla.test/categories/two']
+                    ],
+                    true,
+                    ['HideLast' => true],
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
+                ]
+            ];
+        return $r;
+    }
+}
+

--- a/tests/Library/Core/BreadcrumbStructureTest.php
+++ b/tests/Library/Core/BreadcrumbStructureTest.php
@@ -9,6 +9,13 @@ namespace VanillaTests\Library\Core;
 
 use VanillaTests\SharedBootstrapTestCase;
 
+/**
+ * Provide tests to ensure the validity of breadcrumbs. This class will ensure
+ * that all the breadcrumbs created by the core theme hooks contain valid data structure.
+ *
+ * Class BreadcrumbStructureTest
+ * @package VanillaTests\Library\Core
+ */
 class BreadcrumbStructureTest extends SharedBootstrapTestCase {
     /**
      * Provide a test for {@link \Gdn_Theme::breadcrumbs()}
@@ -37,7 +44,11 @@ class BreadcrumbStructureTest extends SharedBootstrapTestCase {
                    ],
                     true,
                     [],
-                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories"><span itemprop="name">Categories</span></a></span></span></span>'
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">'.
+                    '<span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span>'.
+                    '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">'.
+                    '<meta itemprop="position" content="1" /><span class="Crumb">›</span> '.
+                    '<span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories"><span itemprop="name">Categories</span></a></span></span></span>'
                 ],
                 [
                     [
@@ -45,7 +56,10 @@ class BreadcrumbStructureTest extends SharedBootstrapTestCase {
                     ],
                     true,
                     [],
-                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">'.
+                    '<span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span>'.
+                    '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> '.
+                    '<span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
                 ],
                 [
                     [
@@ -54,7 +68,12 @@ class BreadcrumbStructureTest extends SharedBootstrapTestCase {
                     ],
                     true,
                     [],
-                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel "><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="2" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/two"><span itemprop="name">Categories</span></a></span></span></span>'
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">'.
+                    '<span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span>'.
+                    '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> '.
+                    '<span class="CrumbLabel "><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span>'.
+                    '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="2" /><span class="Crumb">›</span> '.
+                    '<span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/two"><span itemprop="name">Categories</span></a></span></span></span>'
                 ],
                 [
                     [
@@ -63,7 +82,10 @@ class BreadcrumbStructureTest extends SharedBootstrapTestCase {
                     ],
                     false,
                     [],
-                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel "><a href="http://vanilla.test/categories/one"><span>Categories</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/two"><span itemprop="name">Categories</span></a></span></span></span>'
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">'.
+                    '<span class="CrumbLabel "><a href="http://vanilla.test/categories/one"><span>Categories</span></a></span>'.
+                    '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> '.
+                    '<span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/two"><span itemprop="name">Categories</span></a></span></span></span>'
                 ],
                 [
                     [
@@ -79,7 +101,9 @@ class BreadcrumbStructureTest extends SharedBootstrapTestCase {
                     ],
                     true,
                     ['HomeUrl' => 'http://vanilla.test/en'],
-                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/en"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/en"><span>Home</span></a></span>'.
+                    '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> '.
+                    '<span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
                 ],
                 [
                     [
@@ -88,7 +112,9 @@ class BreadcrumbStructureTest extends SharedBootstrapTestCase {
                     ],
                     true,
                     ['HideLast' => true],
-                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span><span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> <span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span>'.
+                    '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> '.
+                    '<span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
                 ]
             ];
         return $r;

--- a/tests/Library/Core/BreadcrumbStructureTest.php
+++ b/tests/Library/Core/BreadcrumbStructureTest.php
@@ -101,7 +101,8 @@ class BreadcrumbStructureTest extends SharedBootstrapTestCase {
                     ],
                     true,
                     ['HomeUrl' => 'http://vanilla.test/en'],
-                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/en"><span>Home</span></a></span>'.
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb">'.
+                    '<a href="http://vanilla.test/en"><span>Home</span></a></span>'.
                     '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> '.
                     '<span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
                 ],
@@ -112,7 +113,8 @@ class BreadcrumbStructureTest extends SharedBootstrapTestCase {
                     ],
                     true,
                     ['HideLast' => true],
-                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb"><a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span>'.
+                    '<span class="Breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList"><span class="CrumbLabel HomeCrumb">'.
+                    '<a href="http://vanilla.test/sharedbootstrap/"><span>Home</span></a></span>'.
                     '<span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><meta itemprop="position" content="1" /><span class="Crumb">›</span> '.
                     '<span class="CrumbLabel  Last"><a itemprop="item" href="http://vanilla.test/categories/one"><span itemprop="name">Categories</span></a></span></span></span>'
                 ]
@@ -120,4 +122,3 @@ class BreadcrumbStructureTest extends SharedBootstrapTestCase {
         return $r;
     }
 }
-


### PR DESCRIPTION
This PR will close vanilla/support#1658 

What's at issue here is that we are trying to follow http://schema.org/BreadcrumbList structured data but are receiving errors. The cause was twofold:

 1. We are not declaring the first item in the breadrumb (the link to home) but we are adding an `item` tag to it.
 2. We are using spans to structure the list but each list item, instead of being siblings are nested inside one another. 

This causes it to throw errors in googles validator: https://search.google.com/structured-data/testing-tool/u/0/

### Testing 
 - Add an entry in your `/etc/hosts` so that you are using a legit TLD (**not** `.localhost`, **this will throw errors non-descript errors in google's validator**, I found out the hard way). **OR** you can manually change the base URL in the breadcrumbs from `dev.vanilla.localhost` to `dev.vanilla.com` before you paste it into the validator.
 - Load a page of your local host.
 - Copy the page source to https://search.google.com/structured-data/testing-tool/u/0/
 - See errors.
 - Checkout this branch.
 - See that it does not return errors.