### PR TITLE
Refactor HTML processors to be instance based

### DIFF
--- a/library/Vanilla/Formatting/BaseFormat.php
+++ b/library/Vanilla/Formatting/BaseFormat.php
@@ -8,13 +8,64 @@
 namespace Vanilla\Formatting;
 
 use Vanilla\Contracts\Formatting\FormatInterface;
+use Vanilla\Formatting\Html\HtmlDocument;
+use Vanilla\Formatting\Html\Processor\HtmlProcessor;
 
 /**
  * Base format with simple simple implementations.
  */
 abstract class BaseFormat implements FormatInterface {
+
     /** @var int */
     const EXCERPT_MAX_LENGTH = 325;
+
+    /** @var HtmlProcessor[] */
+    protected $staticProcessors = [];
+
+    /** @var HtmlProcessor[] */
+    protected $dynamicProcessors = [];
+
+    /**
+     * Apply an HTML processor to the stack of processors.
+     *
+     * @param HtmlProcessor $processor
+     *
+     * @return $this For chaining.
+     */
+    public function addHtmlProcessor(HtmlProcessor $processor): BaseFormat {
+        if ($processor->getProcessorType() === HtmlProcessor::TYPE_DYNAMIC) {
+            $this->dynamicProcessors[] = $processor;
+        } else {
+            $this->staticProcessors[] = $processor;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Apply the registered HTML processors.
+     *
+     * @param string $html The HTML to apply processors to.
+     * @param string|null $processorType The type of HTML processors to apply. See HtmlProcessor::TYPE constants.
+     * @return string The processed HTML.
+     */
+    public function applyHtmlProcessors(string $html, ?string $processorType = null): string {
+        $document = new HtmlDocument($html);
+
+        if ($processorType === HtmlProcessor::TYPE_STATIC || $processorType === null) {
+            foreach ($this->staticProcessors as $processor) {
+                $document = $processor->processDocument($document);
+            }
+        }
+
+        if ($processorType === HtmlProcessor::TYPE_DYNAMIC || $processorType === null) {
+            foreach ($this->dynamicProcessors as $processor) {
+                $document = $processor->processDocument($document);
+            }
+        }
+
+        return $document->getInnerHtml();
+    }
 
     /**
      * Implement rendering of excerpts based on the plain-text version of format.

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -7,31 +7,24 @@
 
 namespace Vanilla\Formatting\Formats;
 
-use DOMDocument;
-use DOMElement;
-use DOMNode;
-use DOMNodeList;
-use DOMXPath;
 use Exception;
 use Garden\StaticCacheTranslationTrait;
 use Vanilla\Formatting\BaseFormat;
 use Vanilla\Formatting\Exception\FormattingException;
-use Vanilla\Contracts\Formatting\Heading;
 use Vanilla\Formatting\Html\HtmlDocument;
 use Vanilla\Formatting\Html\HtmlEnhancer;
 use Vanilla\Formatting\Html\HtmlPlainTextConverter;
 use Vanilla\Formatting\Html\HtmlSanitizer;
-use Vanilla\Formatting\Html\LegacySpoilerTrait;
 use Vanilla\Formatting\Html\Processor\AttachmentHtmlProcessor;
 use Vanilla\Formatting\Html\Processor\HeadingHtmlProcessor;
 use Vanilla\Formatting\Html\Processor\ImageHtmlProcessor;
-use Vanilla\Formatting\Html\Processor\ZendeskWysiwygProcessor;
 use Vanilla\Formatting\Html\Processor\UserContentCssProcessor;
+use Vanilla\InjectableInterface;
 
 /**
  * Format definition for HTML based formats.
  */
-class HtmlFormat extends BaseFormat {
+class HtmlFormat extends BaseFormat implements InjectableInterface {
 
     use StaticCacheTranslationTrait;
 
@@ -49,10 +42,17 @@ class HtmlFormat extends BaseFormat {
     /** @var HtmlPlainTextConverter */
     private $plainTextConverter;
 
+    /** @var HeadingHtmlProcessor */
+    private $headingHtmlProcessor;
+
+    /** @var AttachmentHtmlProcessor */
+    private $attachmentHtmlProcessor;
+
+    /** @var ImageHtmlProcessor */
+    private $imageHtmlProcessor;
+
     /** @var bool allowExtendedContent */
     private $allowExtendedContent;
-
-    protected $processors = [UserContentCssProcessor::class, HeadingHtmlProcessor::class];
 
     /**
      * Constructor for dependency injection.
@@ -78,6 +78,28 @@ class HtmlFormat extends BaseFormat {
     }
 
     /**
+     * Dependency injection.
+     *
+     * @param AttachmentHtmlProcessor $attachmentHtmlProcessor
+     * @param HeadingHtmlProcessor $headingHtmlProcessor
+     * @param ImageHtmlProcessor $imageHtmlProcessor
+     * @param UserContentCssProcessor $userContentCssProcessor
+
+     */
+    public function setDependencies(
+        AttachmentHtmlProcessor $attachmentHtmlProcessor,
+        HeadingHtmlProcessor $headingHtmlProcessor,
+        ImageHtmlProcessor $imageHtmlProcessor,
+        UserContentCssProcessor $userContentCssProcessor
+    ) {
+        $this->attachmentHtmlProcessor = $attachmentHtmlProcessor;
+        $this->headingHtmlProcessor = $headingHtmlProcessor;
+        $this->imageHtmlProcessor = $imageHtmlProcessor;
+        $this->addHtmlProcessor($headingHtmlProcessor);
+        $this->addHtmlProcessor($userContentCssProcessor);
+    }
+
+    /**
      * @inheritdoc
      */
     public function renderHtml(string $content, bool $enhance = true): string {
@@ -93,7 +115,7 @@ class HtmlFormat extends BaseFormat {
             $result = $this->htmlEnhancer->enhance($result);
         }
 
-        $result = $this->processDocument($result);
+        $result = $this->applyHtmlProcessors($result);
         return $result;
     }
 
@@ -119,7 +141,7 @@ class HtmlFormat extends BaseFormat {
 
         // No Embeds
         $result = $this->htmlEnhancer->enhance($result, true, false);
-        $result = $this->processDocument($result);
+        $result = $this->applyHtmlProcessors($result);
         return $result;
     }
 
@@ -141,8 +163,7 @@ class HtmlFormat extends BaseFormat {
      */
     public function parseAttachments(string $content): array {
         $document = new HtmlDocument($content);
-        $processor = new AttachmentHtmlProcessor($document);
-        return $processor->getAttachments();
+        return $this->attachmentHtmlProcessor->getAttachments($document);
     }
 
     /**
@@ -151,8 +172,7 @@ class HtmlFormat extends BaseFormat {
     public function parseHeadings(string $content): array {
         $rendered = $this->renderHtml($content);
         $document = new HtmlDocument($rendered);
-        $headingProcessor = new HeadingHtmlProcessor($document);
-        return $headingProcessor->getHeadings();
+        return $this->headingHtmlProcessor->getHeadings($document);
     }
 
     /**
@@ -161,21 +181,7 @@ class HtmlFormat extends BaseFormat {
     public function parseImageUrls(string $content): array {
         $rendered = $this->renderHtml($content);
         $document = new HtmlDocument($rendered);
-        $processor = new ImageHtmlProcessor($document);
-        return $processor->getImageURLs();
-    }
-
-    /**
-     * Apply HTML processors.
-     *
-     * @param string $content
-     * @return string
-     */
-    private function processDocument(string $content) {
-        // Normalization
-        $document = new HtmlDocument($content);
-        $document = $document->applyProcessors($this->processors);
-        return $document->getInnerHtml();
+        return $this->imageHtmlProcessor->getImageURLs($document);
     }
 
     /**

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -8,7 +8,6 @@
 namespace Vanilla\Formatting\Formats;
 
 use Exception;
-use Garden\StaticCacheTranslationTrait;
 use Vanilla\Formatting\BaseFormat;
 use Vanilla\Formatting\Exception\FormattingException;
 use Vanilla\Formatting\Html\HtmlDocument;
@@ -25,8 +24,6 @@ use Vanilla\InjectableInterface;
  * Format definition for HTML based formats.
  */
 class HtmlFormat extends BaseFormat implements InjectableInterface {
-
-    use StaticCacheTranslationTrait;
 
     const FORMAT_KEY = "html";
 

--- a/library/Vanilla/Formatting/Formats/RichFormat.php
+++ b/library/Vanilla/Formatting/Formats/RichFormat.php
@@ -66,7 +66,9 @@ class RichFormat extends BaseFormat {
             $content = $this->filterer->filter($content);
             $operations = Quill\Parser::jsonToOperations($content);
             $blotGroups = $this->parser->parse($operations);
-            return $this->renderer->render($blotGroups);
+            $html = $this->renderer->render($blotGroups);
+            $html = $this->applyHtmlProcessors($html);
+            return $html;
         } catch (\Throwable $e) {
             $this->logBadInput($e);
             if ($throw) {

--- a/library/Vanilla/Formatting/Formats/TextExFormat.php
+++ b/library/Vanilla/Formatting/Formats/TextExFormat.php
@@ -9,6 +9,7 @@ namespace Vanilla\Formatting\Formats;
 
 use Vanilla\Formatting\FormatConfig;
 use Vanilla\Formatting\Html\HtmlEnhancer;
+use Vanilla\Formatting\Html\Processor\UserContentCssProcessor;
 
 /**
  * Class for rendering content of the markdown format.
@@ -25,12 +26,17 @@ class TextExFormat extends TextFormat {
      *
      * @param FormatConfig $formatConfig
      * @param HtmlEnhancer $htmlEnhancer
+     * @param UserContentCssProcessor $userContentCssProcessor
      */
-    public function __construct(FormatConfig $formatConfig, HtmlEnhancer $htmlEnhancer) {
+    public function __construct(
+        FormatConfig $formatConfig,
+        HtmlEnhancer $htmlEnhancer,
+        UserContentCssProcessor $userContentCssProcessor
+    ) {
         parent::__construct($formatConfig);
         $this->htmlEnhancer = $htmlEnhancer;
+        $this->addHtmlProcessor($userContentCssProcessor);
     }
-
 
     /**
      * @inheritdoc
@@ -38,6 +44,7 @@ class TextExFormat extends TextFormat {
     public function renderHTML(string $content): string {
         $result = parent::renderHTML($content);
         $result = $this->htmlEnhancer->enhance($result);
+        $result = $this->applyHtmlProcessors($result);
         return $result;
     }
 

--- a/library/Vanilla/Formatting/Formats/TextExFormat.php
+++ b/library/Vanilla/Formatting/Formats/TextExFormat.php
@@ -44,7 +44,6 @@ class TextExFormat extends TextFormat {
     public function renderHTML(string $content): string {
         $result = parent::renderHTML($content);
         $result = $this->htmlEnhancer->enhance($result);
-        $result = $this->applyHtmlProcessors($result);
         return $result;
     }
 

--- a/library/Vanilla/Formatting/Formats/TextFormat.php
+++ b/library/Vanilla/Formatting/Formats/TextFormat.php
@@ -27,7 +27,6 @@ class TextFormat extends BaseFormat {
         $this->formatConfig = $formatConfig;
     }
 
-
     /**
      * @inheritdoc
      */

--- a/library/Vanilla/Formatting/Formats/TextFormat.php
+++ b/library/Vanilla/Formatting/Formats/TextFormat.php
@@ -39,6 +39,8 @@ class TextFormat extends BaseFormat {
             $result = nl2br(trim($result));
         }
 
+        $result = $this->applyHtmlProcessors($result);
+
         return $result;
     }
 

--- a/library/Vanilla/Formatting/Formats/WysiwygFormat.php
+++ b/library/Vanilla/Formatting/Formats/WysiwygFormat.php
@@ -30,10 +30,11 @@ class WysiwygFormat extends HtmlFormat {
     public function __construct(
         HtmlSanitizer $htmlSanitizer,
         HtmlEnhancer $htmlEnhancer,
-        HtmlPlainTextConverter $plainTextConverter
+        HtmlPlainTextConverter $plainTextConverter,
+        ZendeskWysiwygProcessor $zendeskWysiwygProcessor
     ) {
         parent::__construct($htmlSanitizer, $htmlEnhancer, $plainTextConverter, false);
-        $this->processors[] = ZendeskWysiwygProcessor::class;
+        $this->addHtmlProcessor($zendeskWysiwygProcessor);
     }
 
     /**

--- a/library/Vanilla/Formatting/Html/HtmlDocument.php
+++ b/library/Vanilla/Formatting/Html/HtmlDocument.php
@@ -31,13 +31,6 @@ class HtmlDocument {
     }
 
     /**
-     * Pre-encode certain characters that dom document has difficulty with.
-     */
-    private function preEncodeCharacters() {
-
-    }
-
-    /**
      * Query the DOM with some xpath.
      *
      * @param string $xpathQuery

--- a/library/Vanilla/Formatting/Html/HtmlDocument.php
+++ b/library/Vanilla/Formatting/Html/HtmlDocument.php
@@ -23,11 +23,18 @@ class HtmlDocument {
      * @param string $innerHtml HTML to construct the DOM with.
      */
     public function __construct(string $innerHtml) {
-        $this->dom = new \DOMDocument();
+        $this->dom = new \DOMDocument('1.0', 'UTF-8');
 
         // DomDocument will automatically add html, head and body wrapper if we don't.
         // We add our own to ensure consistency.
         @$this->dom->loadHTML($this->getDocumentPrefix() . $innerHtml . $this->getDocumentSuffix(), LIBXML_NOBLANKS);
+    }
+
+    /**
+     * Pre-encode certain characters that dom document has difficulty with.
+     */
+    private function preEncodeCharacters() {
+
     }
 
     /**

--- a/library/Vanilla/Formatting/Html/HtmlDocument.php
+++ b/library/Vanilla/Formatting/Html/HtmlDocument.php
@@ -31,29 +31,16 @@ class HtmlDocument {
     }
 
     /**
-     * Apply an array of processors in order.
+     * Query the DOM with some xpath.
      *
-     * @param string[] $processors An array of classes implemented HtmlProcessor.
-     * @return HtmlDocument
+     * @param string $xpathQuery
+     * @see https://devhints.io/xpath For a cheatsheet.
+     *
+     * @return \DOMNodeList
      */
-    public function applyProcessors(array $processors): HtmlDocument {
-        $document = $this;
-        foreach ($processors as $processor) {
-            if (!is_subclass_of($processor, HtmlProcessor::class, true)) {
-                trigger_error("$processor does not extends HtmlProcessor", E_USER_WARNING);
-                continue;
-            }
-
-            $actualProcessor = $processor;
-            if ($actualProcessor instanceof HtmlProcessor) {
-                $actualProcessor->setDocument($document);
-            } else {
-                // Construct it.
-                $actualProcessor = new $actualProcessor($document);
-            }
-            $document = $actualProcessor->processDocument();
-        }
-        return $document;
+    public function queryXPath(string $xpathQuery) {
+        $xpath = new \DOMXPath($this->getDom());
+        return $xpath->query($xpathQuery) ?: new \DOMNodeList();
     }
 
     /**

--- a/library/Vanilla/Formatting/Html/Processor/AttachmentHtmlProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/AttachmentHtmlProcessor.php
@@ -12,26 +12,26 @@ use Vanilla\Formatting\Attachment;
 use Vanilla\Formatting\Html\HtmlDocument;
 
 /**
- * Processor of HMTL headings.
+ * Processor of HMTL attachments.
  */
 class AttachmentHtmlProcessor extends HtmlProcessor {
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
-    public function processDocument(): HtmlDocument {
-        return $this->document;
+    public function processDocument(HtmlDocument $document): HtmlDocument {
+        return $document;
     }
 
     /**
-     * Get all the headings in the document.
+     * Get all the attachments in the document.
      *
-     * @param bool $applyToDom Whether or not to apply the heading ids into the dom.
+     * @param HtmlDocument $document The document to parse.
      *
-     * @return Heading[]
+     * @return Attachment[]
      */
-    public function getAttachments(bool $applyToDom = false): array {
-        $domLinks = $this->queryXPath('.//a[@download]');
+    public function getAttachments(HtmlDocument $document): array {
+        $domLinks = $document->queryXPath('.//a[@download]');
 
         /** @var Attachment[] $attachemnts */
         $attachemnts = [];

--- a/library/Vanilla/Formatting/Html/Processor/HeadingHtmlProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/HeadingHtmlProcessor.php
@@ -16,22 +16,23 @@ use Vanilla\Formatting\Html\HtmlDocument;
 class HeadingHtmlProcessor extends HtmlProcessor {
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
-    public function processDocument(): HtmlDocument {
-        $this->getHeadings(true);
-        return $this->document;
+    public function processDocument(HtmlDocument $document): HtmlDocument {
+        $this->getHeadings($document, true);
+        return $document;
     }
 
     /**
      * Get all the headings in the document.
      *
+     * @param HtmlDocument $document The document to parse.
      * @param bool $applyToDom Whether or not to apply the heading ids into the dom.
      *
      * @return Heading[]
      */
-    public function getHeadings(bool $applyToDom = false): array {
-        $domHeadings = $this->queryXPath('.//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]');
+    public function getHeadings(HtmlDocument $document, bool $applyToDom = false): array {
+        $domHeadings = $document->queryXPath('.//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]');
 
         /** @var Heading[] $headings */
         $headings = [];

--- a/library/Vanilla/Formatting/Html/Processor/HtmlProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/HtmlProcessor.php
@@ -14,118 +14,31 @@ use Vanilla\Formatting\Html\HtmlDocument;
  */
 abstract class HtmlProcessor {
 
-    /** @var HtmlDocument */
-    protected $document;
+    /**
+     * Dynamic processors should be re-applied on every render.
+     */
+    const TYPE_DYNAMIC = "dynamic";
 
     /**
-     * Constructor.
+     * Results from dynamic processors can be cached indefinitely.
+     */
+    const TYPE_STATIC = "static";
+
+    /**
+     * Get the processor type.
      *
-     * @param HtmlDocument $document
+     * @return string One of TYPE_DYNAMIC or TYPE_STATIC.
      */
-    public function __construct(HtmlDocument $document) {
-        $this->document = $document;
-    }
-
-    /**
-     * @param HtmlDocument $document
-     */
-    public function setDocument(HtmlDocument $document) {
-        $this->document = $document;
+    public function getProcessorType(): string {
+        return self::TYPE_STATIC;
     }
 
     /**
      * Process the HTML document in some way.
      *
-     * @return HtmlDocument
+     * @param HtmlDocument $document The document to process.
+     *
+     * @return HtmlDocument The modified document.
      */
-    abstract public function processDocument(): HtmlDocument;
-
-    ///
-    /// Some Utilities
-    ///
-
-    /**
-     * Get Attribute from dom node
-     *
-     * @param string $attr The attribute you want
-     * @param \DOMElement $domNode The dom node
-     *
-     * @return array
-     */
-    protected function getAttrData(string $attr, \DOMElement $domNode) {
-        // Empty array to hold all classes to return
-        //Loop through each tag in the dom and add it's attribute data to the array
-        $attrData = [];
-        if (empty($domNode->getAttribute($attr)) === false) {
-            $attrData = explode(" ", $domNode->getAttribute($attr));
-        } else {
-            array_push($attrData, "");
-        }
-        //Return the array of attribute data
-        return array_unique($attrData);
-    }
-
-    /**
-     * Get dom node classes
-     *
-     * @param \DOMElement $domElement the dom element
-     * @return array array
-     */
-    protected function getClasses($domElement) {
-        return self::getAttrData('class', $domElement);
-    }
-
-    /**
-     * Check if class exists in class array
-     *
-     * @param array of strings $classes
-     * @param string $target
-     * @return string array
-     */
-    protected function hasClass($classes, $target) {
-        foreach ($classes as $c) {
-            if ($c === $target) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Set attribute on dom node
-     *
-     * @param \DOMElement $domNode
-     * @param string $key
-     * @param string $value
-     */
-    protected function setAttribute(\DOMElement $domNode, $key, $value) {
-        $domNode->setAttribute($key, $value);
-    }
-
-    /**
-     * Append class to dom node.
-     *
-     * @param \DOMElement $domNode
-     * @param string $class
-     */
-    protected function appendClass(\DOMElement &$domNode, $class) {
-        if (empty($domNode->getAttribute("class"))) {
-            $domNode->setAttribute("class", $class);
-        } else {
-            $domNode->setAttribute("class", $domNode->getAttribute("class") . " " . $class);
-        }
-    }
-
-    /**
-     * Query the DOM with some xpath.
-     *
-     * @param string $xpathQuery
-     * @see https://devhints.io/xpath For a cheatsheet.
-     *
-     * @return \DOMNodeList
-     */
-    protected function queryXPath(string $xpathQuery) {
-        $xpath = new \DOMXPath($this->document->getDom());
-        return $xpath->query($xpathQuery) ?: new \DOMNodeList();
-    }
+    abstract public function processDocument(HtmlDocument $document): HtmlDocument;
 }

--- a/library/Vanilla/Formatting/Html/Processor/ImageHtmlProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/ImageHtmlProcessor.php
@@ -18,17 +18,21 @@ class ImageHtmlProcessor extends HtmlProcessor {
     const EMBED_IMAGE_XPATH = './/img[not(contains(@class, "emoji"))]';
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
-    public function processDocument(): HtmlDocument {
-        return $this->document;
+    public function processDocument(HtmlDocument $document): HtmlDocument {
+        return $document;
     }
 
     /**
+     * Parse all images URLs from the document.
+     *
+     * @param HtmlDocument $document The document to parse.
+     *
      * @return string[]
      */
-    public function getImageURLs(): array {
-        $domImages = $this->queryXPath(self::EMBED_IMAGE_XPATH);
+    public function getImageURLs(HtmlDocument $document): array {
+        $domImages = $document->queryXPath(self::EMBED_IMAGE_XPATH);
 
         /** @var string[] $headings */
         $imageUrls = [];

--- a/library/Vanilla/Formatting/Html/Processor/UserContentCssProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/UserContentCssProcessor.php
@@ -8,6 +8,7 @@
 namespace Vanilla\Formatting\Html\Processor;
 
 use Vanilla\Formatting\Html\HtmlDocument;
+use Vanilla\Utility\HtmlUtils;
 
 /**
  * Process user content to ensure certain CSS classes are applied.
@@ -15,21 +16,23 @@ use Vanilla\Formatting\Html\HtmlDocument;
 class UserContentCssProcessor extends HtmlProcessor {
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
-    public function processDocument(): HtmlDocument {
-        $this->cleanupBlockquotes();
-        $this->cleanupImages();
-        $this->cleanupCodeBlocks();
-        $this->cleanupInlineCodeBlocks();
-        return $this->document;
+    public function processDocument(HtmlDocument $document): HtmlDocument {
+        $this->cleanupBlockquotes($document);
+        $this->cleanupImages($document);
+        $this->cleanupCodeBlocks($document);
+        $this->cleanupInlineCodeBlocks($document);
+        return $document;
     }
 
     /**
      * Format HTML of code blocks imported from other formats.
+     *
+     * @param HtmlDocument $document The document to parse.
      */
-    private function cleanupCodeBlocks() {
-        $blockCodeBlocks = $this->queryXPath('.//*[self::pre]');
+    private function cleanupCodeBlocks(HtmlDocument $document) {
+        $blockCodeBlocks = $document->queryXPath('.//*[self::pre]');
         foreach ($blockCodeBlocks as $codeBlock) {
             if (!($codeBlock instanceof \DOMElement)) {
                 continue;
@@ -47,61 +50,56 @@ class UserContentCssProcessor extends HtmlProcessor {
                 }
             }
 
-            $classes = $this->getClasses($codeBlock);
-            if (!$this->hasClass($classes, "code")) {
-                $this->appendClass($codeBlock, "code");
-            }
-
-            if (!$this->hasClass($classes, "codeBlock")) {
-                $this->appendClass($codeBlock, "codeBlock");
-            }
-
-            $this->setAttribute($codeBlock, "spellcheck", "false");
+            HtmlUtils::appendClass($codeBlock, "code");
+            HtmlUtils::appendClass($codeBlock, "codeBlock");
+            $codeBlock->setAttribute('spellcheck', 'false');
         }
     }
 
     /**
      * Format HTML of inline code blocks imported from other formats.
+     *
+     * @param HtmlDocument $document The document to parse.
      */
-    private function cleanupInlineCodeBlocks() {
-        $inlineCodeBlocks = $this->queryXPath('.//*[self::code]');
-        foreach ($inlineCodeBlocks as $c) {
-            $this->appendClass($c, "code");
-            $this->appendClass($c, "codeInline");
-            $this->setAttribute($c, "spellcheck", "false");
+    private function cleanupInlineCodeBlocks(HtmlDocument $document) {
+        $inlineCodeBlocks = $document->queryXPath('.//*[self::code]');
+        foreach ($inlineCodeBlocks as $codeBlock) {
+            HtmlUtils::appendClass($codeBlock, "code");
+            HtmlUtils::appendClass($codeBlock, "codeInline");
+            $codeBlock->setAttribute('spellcheck', 'false');
         }
     }
 
     /**
      * Format HTML of images imported from other formats.
+     *
+     * @param HtmlDocument $document The document to parse.
      */
-    private function cleanupImages() {
-        $images = $this->queryXPath(ImageHtmlProcessor::EMBED_IMAGE_XPATH);
+    private function cleanupImages(HtmlDocument $document) {
+        $images = $document->queryXPath(ImageHtmlProcessor::EMBED_IMAGE_XPATH);
         foreach ($images as $image) {
-            $this->appendClass($image, "embedImage-img");
-            $this->appendClass($image, "importedEmbed-img");
+            HtmlUtils::appendClass($image, 'embedImage-img');
+            HtmlUtils::appendClass($image, 'importedEmbed-img');
         }
     }
 
     /**
      * Format HTML of blockquotes imported from other formats.
+     *
+     * @param HtmlDocument $document The document to parse.
      */
-    private function cleanupBlockquotes() {
-        $blockQuotes = $this->queryXPath('.//*[self::blockquote]');
-        foreach ($blockQuotes as $b) {
-            self::appendClass($b, "blockquote");
-            $children = $b->childNodes;
+    private function cleanupBlockquotes(HtmlDocument $document) {
+        $blockQuotes = $document->queryXPath('.//*[self::blockquote]');
+        foreach ($blockQuotes as $blockQuote) {
+            HtmlUtils::appendClass($blockQuote, 'blockquote');
+            $children = $blockQuote->childNodes;
             foreach ($children as $child) {
-                if (property_exists($child, "tagName")) {
-                    if ($child->tagName === "div") {
-                        self::setAttribute($child, "class", "blockquote-content");
-                        $grandChildren = $child->childNodes;
-                        foreach ($grandChildren as $grandChild) {
-                            if (property_exists($grandChild, "tagName")) {
-                                if ($grandChild->tagName === "p") {
-                                    self::appendClass($grandChild, "blockquote-line");
-                                }
-                            }
+                if (property_exists($child, "tagName") && $child->tagName === "div") {
+                    HtmlUtils::appendClass($child, "blockquote-content");
+                    $grandChildren = $child->childNodes;
+                    foreach ($grandChildren as $grandChild) {
+                        if (property_exists($grandChild, "tagName") && $grandChild->tagName === "p") {
+                            HtmlUtils::appendClass($grandChild, "blockquote-line");
                         }
                     }
                 }

--- a/library/Vanilla/Formatting/Html/Processor/ZendeskWysiwygProcessor.php
+++ b/library/Vanilla/Formatting/Html/Processor/ZendeskWysiwygProcessor.php
@@ -19,23 +19,27 @@ class ZendeskWysiwygProcessor extends HtmlProcessor {
     const ZENDESK_NODE_XPATH = '//*[@data-editor]|//*[@data-block]|//*[@data-offset-key]';
 
     /**
-     * @inheritDoc
+     * @inheritdoc
      */
-    public function processDocument(): HtmlDocument {
-        if ($this->hasZendeskContent()) {
+    public function processDocument(HtmlDocument $document): HtmlDocument {
+        if ($this->hasZendeskContent($document)) {
             // Only process if we actually have zendesk content.
-            $this->stripNonBreakingSpaces();
-            $this->unwrapNestedDivs();
-            $this->stripUselessAttributes();
+            $this->stripNonBreakingSpaces($document);
+            $this->unwrapNestedDivs($document);
+            $this->stripUselessAttributes($document);
         }
-        return $this->document;
+        return $document;
     }
 
     /**
      * A quick check to see if we should even try and process the document.
+     *
+     * @param HtmlDocument $document The document to parse.
+     *
+     * @return bool
      */
-    private function hasZendeskContent(): bool {
-        $html = $this->document->getInnerHtml();
+    private function hasZendeskContent(HtmlDocument $document): bool {
+        $html = $document->getInnerHtml();
         foreach (self::ZENDESK_ATTRIBUTES as $attribute) {
             if (strpos($html, $attribute) !== false) {
                 return true;
@@ -47,9 +51,11 @@ class ZendeskWysiwygProcessor extends HtmlProcessor {
 
     /**
      * Some imported formats may have useless non-breaking spaces.
+     *
+     * @param HtmlDocument $document The document to parse.
      */
-    private function stripNonBreakingSpaces() {
-        $editorNodes = $this->queryXPath(self::ZENDESK_NODE_XPATH);
+    private function stripNonBreakingSpaces(HtmlDocument $document) {
+        $editorNodes = $document->queryXPath(self::ZENDESK_NODE_XPATH);
 
         /** @var \DOMNode $editorNode */
         foreach ($editorNodes as $editorNode) {
@@ -63,9 +69,11 @@ class ZendeskWysiwygProcessor extends HtmlProcessor {
 
     /**
      * Unwrap useless nested divs.
+     *
+     * @param HtmlDocument $document The document to parse.
      */
-    private function unwrapNestedDivs() {
-        $nestedDivs = $this->queryXPath('//div[@data-block]');
+    private function unwrapNestedDivs(HtmlDocument $document) {
+        $nestedDivs = $document->queryXPath('//div[@data-block]');
 
         /** @var \DOMNode $nestedDiv */
         foreach ($nestedDivs as $nestedDiv) {
@@ -82,9 +90,11 @@ class ZendeskWysiwygProcessor extends HtmlProcessor {
 
     /**
      * Strip off some attributes that serve no value to vanilla.
+     *
+     * @param HtmlDocument $document The document to parse.
      */
-    private function stripUselessAttributes() {
-        $nodes = $this->queryXPath(self::ZENDESK_NODE_XPATH);
+    private function stripUselessAttributes(HtmlDocument $document) {
+        $nodes = $document->queryXPath(self::ZENDESK_NODE_XPATH);
 
         /** @var \DOMElement $node */
         foreach ($nodes as $node) {

--- a/library/Vanilla/Utility/HtmlUtils.php
+++ b/library/Vanilla/Utility/HtmlUtils.php
@@ -41,6 +41,46 @@ final class HtmlUtils {
     }
 
     /**
+     * Get all unique classes from dom node.
+     *
+     * @param \DOMElement $domNode The dom node.
+     *
+     * @return array
+     */
+    public static function getClasses(\DOMElement $domNode): array {
+        $result = [];
+        if ($classes = $domNode->getAttribute('class')) {
+            $result = explode(" ", $classes);
+        }
+        return array_unique($result);
+    }
+
+    /**
+     * Check if class exists in class array
+     *
+     * @param \DOMElement $domElement The domNode to check.
+     * @param string $className The class name to look for.
+     * @return bool
+     */
+    public static function hasClass(\DOMElement $domElement, string $className): bool {
+        $classes = self::getClasses($domElement);
+        return in_array($className, $classes);
+    }
+
+    /**
+     * Append class to dom node.
+     *
+     * @param \DOMElement $domNode
+     * @param string $className
+     */
+    public static function appendClass(\DOMElement $domNode, string $className) {
+        $classes = self::getClasses($domNode);
+        $classes[] = $className;
+        $classes = array_unique($classes);
+        $domNode->setAttribute('class', implode(" ", $classes));
+    }
+
+    /**
      * Join some group of CSS class names.
      *
      * @param mixed[] $args Multiple CSS class names to join together. Items may be string or null.

--- a/tests/Library/Vanilla/Formatting/Formats/MarkdownFormatTest.php
+++ b/tests/Library/Vanilla/Formatting/Formats/MarkdownFormatTest.php
@@ -41,7 +41,7 @@ class MarkdownFormatTest extends AbstractFormatTestCase {
 > [/spoiler]
 EOT;
         $expected = <<<EOT
-<blockquote class="UserQuote blockquote"><div class="blockquote-content">
+<blockquote class="UserQuote blockquote"><div class="QuoteText blockquote-content">
   <p class="blockquote-line">[spoiler]</p>
   
   <p class="blockquote-line">[/spoiler]</p>

--- a/tests/Library/Vanilla/Formatting/HtmlNormalizeTrait.php
+++ b/tests/Library/Vanilla/Formatting/HtmlNormalizeTrait.php
@@ -56,6 +56,7 @@ trait HtmlNormalizeTrait {
         }
         $html = preg_replace("/\>\</", ">\n<", $html);
         $html = preg_replace("/ \</", "<", $html);
+        $html = preg_replace("/\&nbsp\;/", html_entity_decode("&nbsp;"), $html);
         return $html;
     }
 

--- a/tests/Library/Vanilla/Utility/HtmlUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/HtmlUtilsTest.php
@@ -8,12 +8,14 @@
 namespace VanillaTests\Library\Vanilla\Utility;
 
 use PHPUnit\Framework\TestCase;
+use Vanilla\Formatting\Html\HtmlDocument;
 use Vanilla\Utility\HtmlUtils;
 
 /**
  * Tests for the `HtmlUtils` class.
  */
 final class HtmlUtilsTest extends TestCase {
+
     /**
      * Tests for `HtmlUtils::classNames()`
      *
@@ -38,6 +40,95 @@ final class HtmlUtilsTest extends TestCase {
             [['foo', '', 'bar'], 'foo bar'],
         ];
         return $r;
+    }
+
+    /**
+     * Test get classes.
+     *
+     * @param \DOMElement $element
+     * @param array $expected
+     *
+     * @dataProvider provideGetClasses
+     */
+    public function testGetClasses(\DOMElement $element, array $expected) {
+        $this->assertEquals($expected, HtmlUtils::getClasses($element));
+    }
+
+    /**
+     * @return HtmlDocument
+     */
+    private function getTestHtmlDoc(): HtmlDocument {
+        $html = '<div id="1" class="class1 class2 class1"></div><div id="2" class="class1"></div>';
+        return new HtmlDocument($html);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideGetClasses(): array {
+        $doc = $this->getTestHtmlDoc();
+        return [
+            [ $doc->queryXPath('//*[@id="1"]')->item(0), ['class1', 'class2'] ],
+            [ $doc->queryXPath('//*[@id="2"]')->item(0), ['class1'] ]
+        ];
+    }
+
+    /**
+     * Test hasClass.
+     *
+     * @param \DOMElement $element
+     * @param string $class
+     * @param bool $expected
+     *
+     * @dataProvider provideHasClass
+     */
+    public function testHasClass(\DOMElement $element, string $class, bool $expected) {
+        $this->assertEquals($expected, HtmlUtils::hasClass($element, $class));
+    }
+
+    /**
+     * @return array
+     */
+    public function provideHasClass(): array {
+        $doc = $this->getTestHtmlDoc();
+        return [
+            [ $doc->queryXPath('//*[@id="1"]')->item(0), 'class1', true ],
+            [ $doc->queryXPath('//*[@id="1"]')->item(0), 'class2', true ],
+            [ $doc->queryXPath('//*[@id="1"]')->item(0), 'class3', false ],
+            [ $doc->queryXPath('//*[@id="1"]')->item(0), 'class', false ],
+        ];
+    }
+
+    /**
+     * Test appendClass.
+     *
+     * @param \DOMElement $element
+     * @param string $class
+     * @param array $expected
+     *
+     * @dataProvider provideAppendClass
+     */
+    public function testAppendClass(\DOMElement $element, string $class, array $expected) {
+        HtmlUtils::appendClass($element, $class);
+        $this->assertEquals($expected, HtmlUtils::getClasses($element));
+    }
+
+    /**
+     * @return array
+     */
+    public function provideAppendClass(): array {
+        return [
+            'add existing class' => [
+                $this->getTestHtmlDoc()->queryXPath('//*[@id="1"]')->item(0),
+                'class1',
+                ['class1', 'class2'],
+            ],
+            'add new class' => [
+                $this->getTestHtmlDoc()->queryXPath('//*[@id="1"]')->item(0),
+                'class3',
+                ['class1', 'class2', 'class3'],
+            ],
+        ];
     }
 
     /**

--- a/tests/fixtures/formats/bbcode/block-formatting/output.html
+++ b/tests/fixtures/formats/bbcode/block-formatting/output.html
@@ -12,7 +12,7 @@
 [h1]No heading support in bbcode[/h1]
 <br>
 <blockquote class="Quote UserQuote blockquote">
-    <div class="blockquote-content">Quote Hello world<br />
+    <div class="QuoteText blockquote-content">Quote Hello world<br />
         <br />
         <br />
         Line 4<br />

--- a/tests/fixtures/formats/html/paragraph-formats/output.html
+++ b/tests/fixtures/formats/html/paragraph-formats/output.html
@@ -20,7 +20,7 @@
 <img alt="" class="embedImage-img importedEmbed-img" src=https://us.v-cdn.net/5022541/uploads/editor/bo/dqpgwnvkn6tx.png>
 <blockquote class="UserQuote blockquote">
     <br>
-    <div class="blockquote-content">
+    <div class="QuoteText blockquote-content">
         <p class="blockquote-line">Block Quote line 1</p>
         <p class="blockquote-line">Block Quote line 2</p>
     </div>

--- a/tests/fixtures/formats/markdown/paragraph-formatting/output.html
+++ b/tests/fixtures/formats/markdown/paragraph-formatting/output.html
@@ -5,7 +5,7 @@
 <h2 data-id=h2>h2</h2>
 
 <blockquote class="UserQuote blockquote">
-    <div class="blockquote-content">
+    <div class="QuoteText blockquote-content">
         <p class="blockquote-line">Quote</p>
     </div>
 </blockquote>

--- a/tests/fixtures/formats/rich/all-blocks/output.html
+++ b/tests/fixtures/formats/rich/all-blocks/output.html
@@ -11,14 +11,14 @@ class MyThemeNameThemeHooks extends Gdn_Plugin {
      * @param  Controller $sender The sending controller object.
      */
     public function base_render_beforebase_render_beforebase_render_beforebase_render_beforebase_render_before($sender) {
-        // Bail out if we&#039;re in the dashboard
-        if (inSection(&#039;Dashboard&#039;)) {
+        // Bail out if we're in the dashboard
+        if (inSection('Dashboard')) {
             return;
         }
 
         // Fetch the currently enabled locale (en by default)
         $locale = Gdn::locale()-&gt;current();
-        $sender-&gt;setData(&#039;locale&#039;, $locale);
+        $sender-&gt;setData('locale', $locale);
     }
 }
 </pre>

--- a/tests/fixtures/formats/rich/mentions/output.html
+++ b/tests/fixtures/formats/rich/mentions/output.html
@@ -10,5 +10,5 @@
     <a class="atMention" data-userid="543" data-username="@thisIsARealMention" href="http://vanilla.test/minimal-container-test/profile/%40thisIsARealMention">@@thisIsARealMention</a>
     <a class="atMention" data-userid="542" data-username="@duplicateMention" href="http://vanilla.test/minimal-container-test/profile/%40duplicateMention">@@duplicateMention</a>
     <a class="atMention" data-userid="542" data-username="@duplicateMention" href="http://vanilla.test/minimal-container-test/profile/%40duplicateMention">@@duplicateMention</a>
-    <a class="atMention" data-userid="1" data-username="@@@@@!@#$%^&amp;*()&quot;&quot;" href="http://vanilla.test/minimal-container-test/profile/%40%40%40%40%40%21%40%23%24%25%5E%26%2A%28%29%22%22">@@@@@@!@#$%^&amp;*()&quot;&quot;</a>
+    <a class="atMention" data-userid="1" data-username="@@@@@!@#$%^&amp;*()&quot;&quot;" href="http://vanilla.test/minimal-container-test/profile/%40%40%40%40%40%21%40%23%24%25%5E%26%2A%28%29%22%22">@@@@@@!@#$%^&amp;*()""</a>
 </p>

--- a/tests/fixtures/formats/wysiwyg/paragraph-formats/output.html
+++ b/tests/fixtures/formats/wysiwyg/paragraph-formats/output.html
@@ -5,7 +5,7 @@
 <code class="CodeInline code codeInline" spellcheck=false>    &lt;script&gt;alert("xss");&lt;/script&gt;</code>
 <div class=Spoiler>Spoiler</div> [spoiler]Legacy Spoiler's Don't Apply[/spoiler]
 <blockquote class="UserQuote blockquote">
-    <div class=blockquote-content>
+    <div class="QuoteText blockquote-content">
         <p class=blockquote-line>Quote
             <br> Quote line 2</p>
     </div>


### PR DESCRIPTION
Working towards https://github.com/vanilla/vanilla/issues/10464

- Makes `HtmlProcessor` be used as an instance. This allows dependencies to be injected into it.
- Make processors work on all formats.
- Refactor some utility methods off of `HtmlProcessor` to `HtmlDocument` and `HtmlUtils`.
  - Add tests for these methods.
  - While writing tests for these, I fixed a bug that was causing the `QuoteText` classname to be stripped from our HTML fixtures. I've had to add this class into our expected HTML fixtures now that the bug is fixed.

## How to register a custom processor

```php
$dic->rule(BaseFormat::class)
    ->setInherit(true)
    ->addCall('addHtmlProcessor', [new Reference(MyCustomProcessor::class)])
```

These could also be registered to specific formats by changing what the rule applies to.

## Not Implemented Here

There are a few pieces of https://github.com/vanilla/vanilla/issues/10464 that I didn't implement here as I felt the PR was starting to grow in size.

- Plaintext processors (although this happens to work html based processors).
- The processors gained the ability to be marked as static or dynamic, but the format service can't differentiate between "dynamic" and "static" processing yet. 