### PR TITLE
Fix default navigation items missing

### DIFF
--- a/addons/themes/theme-foundation/assets/variables.json5
+++ b/addons/themes/theme-foundation/assets/variables.json5
@@ -120,21 +120,21 @@
         /// See https://success.vanillaforums.com/kb/articles/142-navigation-links#customizing-navigation-links
         ///
         navItems: {
-            default: [
-                // {
-                //     to: "/discussions",
-                //     children: "Discussions",
-                // },
-                // {
-                //     to: "/categories",
-                //     children: "Categories",
-                // },
-                // {
-                //     children: "Help",
-                //     permission: "kb.view",
-                //     to: "/kb",
-                // },
-            ],
+            // default: [
+            // {
+            //     to: "/discussions",
+            //     children: "Discussions",
+            // },
+            // {
+            //     to: "/categories",
+            //     children: "Categories",
+            // },
+            // {
+            //     children: "Help",
+            //     permission: "kb.view",
+            //     to: "/kb",
+            // },
+            // ],
             /// Some other languages
             // en: [],
             // fr: [],


### PR DESCRIPTION
The empty array should have been commented in the default variables.