### PR TITLE
Optimize field expression in Gdn_SQLDriver::_whereIn()

### DIFF
--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -2127,7 +2127,7 @@ abstract class Gdn_SQLDriver {
             return $this;
         }
 
-        $fieldExpr = $this->_parseExpr($field);
+        $fieldExpr = $this->escapeFieldReference($field);
 
         // Build up the in clause.
         $in = [];

--- a/tests/Library/Database/MySQLDriverTest.php
+++ b/tests/Library/Database/MySQLDriverTest.php
@@ -206,4 +206,18 @@ EOT;
         $r = $this->sql->delete('testDelete', ['name' => $id]);
         $this->assertEquals(2, $r);
     }
+
+    /**
+     * Test a basic where in clause.
+     */
+    public function testWhereInField() {
+        $actual = $this->sql->select()->from('foo')->where('bar', [1, 2, 'three'])->getSelect();
+        $expected = <<<EOT
+select *
+from `GDN_foo` `foo`
+where `bar` in ('1', '2', 'three')
+EOT;
+
+        $this->assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
The SQL driver’s field expression passes through an unnecessarily long code path to arrive at a basic escape. This PR removes the overhead.