### PR TITLE
Improve user feedback upon login if there's a user match but the password is missing

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -870,6 +870,14 @@ class EntryController extends Gdn_Controller {
                             } catch (Gdn_UserException $ex) {
                                 $this->Form->addError($ex);
                             }
+                        } else {
+                            // If we have a user match & there is no password.
+                            $this->Form->addError(
+                                t(
+                                    'You are trying to connect with a username that is already assigned to a user. '.
+                                    'If this is you, please enter the password you used when you created this account on this forum.'
+                                )
+                            );
                         }
                     }
                 }

--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -872,12 +872,7 @@ class EntryController extends Gdn_Controller {
                             }
                         } else {
                             // If we have a user match & there is no password.
-                            $this->Form->addError(
-                                t(
-                                    'You are trying to connect with a username that is already assigned to a user. '.
-                                    'If this is you, please enter the password you used when you created this account on this forum.'
-                                )
-                            );
+                            $this->Form->addError(t('UserMatchNeedsPassword'));
                         }
                     }
                 }

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,1 +1,0 @@
-Deny from all

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,0 +1,1 @@
+Deny from all


### PR DESCRIPTION
Original issue: https://github.com/vanillaforums/sonicwall/issues/50

**Description**: Depending on the login scenario the messaging sent to the user is confusing & may not be applicable. We need supplemental messages that would better explain the situation and guide the user. The new message goes as follow: "_You are trying to connect with a username that is already assigned to a user. If this is you, please enter the password you used when you created this account on this forum._" and is shown when the user tries to login with an existing user & no password is provided.

**QA Steps**:
- Have OAuth2 login enabled on the platform.
- Try to authentify with a user that would suggest an existing user handle. Ex.: If there is a user using the user handle "info" try an OAuth2 login with an email which starts with "info", like "info@somethingwebsite.com".
- Once the OAuth2 authentification is successful, the platform will suggest to login with the matching existing "info" user, thus displaying the newly added message.