### PR TITLE
Add expand reactions option to bookmarked discussions

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -88,7 +88,7 @@ class DiscussionsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
-            'expand?' => ApiUtils::getExpandDefinition(['insertUser', 'lastUser', 'lastPost', 'lastPost.body', 'lastPost.insertUser'])
+            'expand?' => ApiUtils::getExpandDefinition(['insertUser', 'lastUser', 'lastPost', 'lastPost.body', 'lastPost.insertUser', 'reactions'])
         ], 'in')->setDescription('Get a list of the current user\'s bookmarked discussions.');
         $out = $this->schema([':a' => $this->discussionSchema()], 'out');
 
@@ -112,6 +112,8 @@ class DiscussionsApiController extends AbstractApiController {
         $this->expandLastCommentBody($rows, $query['expand']);
 
         $result = $out->validate($rows);
+
+        $result = $this->getEventManager()->fireFilter('discussionsApiController_getOutput', $result, $this, $in, $query, $rows);
 
         $paging = ApiUtils::morePagerInfo($result, '/api/v2/discussions/bookmarked', $query, $in);
 
@@ -533,7 +535,7 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $out->validate($rows, true);
 
         // Allow addons to modify the result.
-        $result = $this->getEventManager()->fireFilter('discussionsApiController_indexOutput', $result, $this, $in, $query, $rows);
+        $result = $this->getEventManager()->fireFilter('discussionsApiController_getOutput', $result, $this, $in, $query, $rows);
 
         $whereCount = count($where);
         $isWhereOptimized = (isset($where['d.CategoryID']) && ($whereCount === 1 || ($whereCount === 2 && isset($where['Announce']))));

--- a/applications/vanilla/openapi/discussions.yml
+++ b/applications/vanilla/openapi/discussions.yml
@@ -152,6 +152,7 @@ paths:
             - lastPost
             - lastPost.body
             - lastPost.insertUser
+            - reactions
             - all
             type: string
           type: array


### PR DESCRIPTION
This PR addresses vanilla/support#1240 and works in conjunction with vanilla/internal#2507

It adds the option to expand reactions to the `discussions/bookmarked` endpoint. It also changes the event name in the `fireEvent` call in the `discussionApiController`'s index method.

### TO TEST
1. Make sure you have some discussions that are both bookmarked and have reactions. 
1. Check out both this branch and the `fix/refactor-reaction-api-hooks` branch from the internal repo.
1. Make these calls:
  `api/v2/discussions?expand=reactions`
  `api/v2/discussion/{some discussionID}?expand=reactions`
  `api/v2/discussions/bookmarked?expand=reactions`
1. Verify that reactions are expanded on all of these calls