### PR TITLE
Add a test trait to make testing roles and user more easy

### DIFF
--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -13,6 +13,13 @@
  */
 class RoleModel extends Gdn_Model {
 
+    const DEFAULT_GUEST_ID = 2;
+    const DEFAULT_UNCONFIRMED_ID = 3;
+    const DEFAULT_APPLICANT_ID = 4;
+    const DEFAULT_MEMBER_ID = 8;
+    const DEFAULT_ADMIN_ID = 16;
+    const DEFAULT_MOD_ID = 32;
+
     /** Slug for Guest role type. */
     const TYPE_GUEST = 'guest';
 

--- a/applications/dashboard/models/class.rolemodel.php
+++ b/applications/dashboard/models/class.rolemodel.php
@@ -13,12 +13,12 @@
  */
 class RoleModel extends Gdn_Model {
 
-    const DEFAULT_GUEST_ID = 2;
-    const DEFAULT_UNCONFIRMED_ID = 3;
-    const DEFAULT_APPLICANT_ID = 4;
-    const DEFAULT_MEMBER_ID = 8;
-    const DEFAULT_ADMIN_ID = 16;
-    const DEFAULT_MOD_ID = 32;
+    const GUEST_ID = 2;
+    const UNCONFIRMED_ID = 3;
+    const APPLICANT_ID = 4;
+    const MEMBER_ID = 8;
+    const ADMIN_ID = 16;
+    const MOD_ID = 32;
 
     /** Slug for Guest role type. */
     const TYPE_GUEST = 'guest';

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -62,6 +62,24 @@ abstract class AbstractAPIv2Test extends TestCase {
 
         $this->logger = new TestLogger();
         \Logger::addLogger($this->logger);
+        $this->setUpTestTraits();
+    }
+
+    /**
+     * Setup test traits.
+     *
+     * Any trait that defines a method `setUpNameOfTrait` will be called.
+     */
+    public function setUpTestTraits() {
+        $uses = array_flip(class_uses(static::class));
+        foreach ($uses as $traitName) {
+            $shortName = (new \ReflectionClass($traitName))->getShortName();
+            $methodName = 'setUp'.$shortName;
+
+            if (method_exists($this, $methodName)) {
+                call_user_func([$this, $methodName]);
+            }
+        }
     }
 
     /**

--- a/tests/InternalClient.php
+++ b/tests/InternalClient.php
@@ -14,6 +14,8 @@ use Garden\Web\Exception\HttpException;
 
 class InternalClient extends HttpClient {
 
+    const DEFAULT_USER_ID = 2;
+
     /**
      * @var Container The container used to construct request objects.
      */
@@ -22,7 +24,7 @@ class InternalClient extends HttpClient {
     /**
      * @var int
      */
-    private $userID;
+    private $userID = self::DEFAULT_USER_ID;
 
     /**
      * @var string

--- a/tests/UsersAndRolesApiTestTrait.php
+++ b/tests/UsersAndRolesApiTestTrait.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace VanillaTests;
+
+use VanillaTests\InternalClient;
+
+/**
+ * @method InternalClient api()
+ */
+trait UsersAndRolesApiTestTrait {
+
+    /** @var int|null */
+    protected $lastUserID = null;
+
+    /** @var int|null */
+    protected $lastRoleID = null;
+
+    /**
+     * Clear local info between tests.
+     */
+    public function setUpUsersAndRolesApiTestTrait(): void {
+        $this->api()->setUserID(InternalClient::DEFAULT_USER_ID);
+        $this->lastUserID = null;
+        $this->lastRoleID = null;
+    }
+
+    /**
+     * Create an user through the API.
+     *
+     * @param array $overrides
+     *
+     * @return array
+     */
+    protected function createUser(array $overrides = []): array {
+        $salt = '-' . round(microtime(true) * 1000) . rand(1, 1000);
+
+        $body = $overrides + [
+            'bypassSpam' => false,
+            'email' => "test-$salt@test.com",
+            'emailConfirmed' => true,
+            'name' => "user-$salt",
+            'password' => 'testpassword',
+            'photo' => null,
+            'roleID' => [
+                \RoleModel::DEFAULT_MEMBER_ID,
+            ]
+        ];
+
+        $result = $this->api()->post('/users', $body)->getBody();
+        $this->lastUserID = $result['userID'];
+        return $result;
+    }
+
+    /**
+     * Create an user through the API.
+     *
+     * @param array $updates
+     *
+     * @return array
+     */
+    protected function updateUser(array $updates): array {
+        $userID = $updates['userID'] ?? $this->lastUserID;
+
+        if ($userID === null) {
+            throw new \Exception('There was no userID to update');
+        }
+
+        $result = $this->api()->patch("/users/$userID", $updates)->getBody();
+        $this->lastUserID = $result['userID'];
+        return $result;
+    }
+
+
+    /**
+     * Create a role.
+     *
+     * @param array $overrides
+     * @return array
+     */
+    public function createRole(array $overrides = []): array {
+        $salt = '-' . round(microtime(true) * 1000) . rand(1, 1000);
+
+        $body = $overrides + [
+            "canSession" => true,
+            "deletable" => true,
+            "description" => "A custom role.",
+            "name" => "role$salt",
+            "permissions" => [
+                [
+                    "id" => 0,
+                    "permissions" => [],
+                    "type" => "global"
+                ]
+            ],
+            "personalInfo" => true,
+            "type" => "member",
+        ];
+
+        $result = $this->api()->post('/roles', $body)->getBody();
+        $this->lastRoleID = $result['roleID'];
+        return $result;
+    }
+}

--- a/tests/UsersAndRolesApiTestTrait.php
+++ b/tests/UsersAndRolesApiTestTrait.php
@@ -47,7 +47,7 @@ trait UsersAndRolesApiTestTrait {
             'password' => 'testpassword',
             'photo' => null,
             'roleID' => [
-                \RoleModel::DEFAULT_MEMBER_ID,
+                \RoleModel::MEMBER_ID,
             ]
         ];
 


### PR DESCRIPTION
The trait structure and setup is inspired by the laravel setup test.

- Make an easy way to apply traits to our API testcase that each hook into the setup. This is done by making a method of a particular name. They cannot specify just `setUp` because then it is impossible to use multiple of these traits together.
- Create a user/role test trait.
  - Create users.
  - Create roles.