### PR TITLE
Adjust forum breadcrumb generation and add generic record class

### DIFF
--- a/applications/vanilla/library/Navigation/ForumBreadcrumbProvider.php
+++ b/applications/vanilla/library/Navigation/ForumBreadcrumbProvider.php
@@ -39,7 +39,13 @@ class ForumBreadcrumbProvider implements BreadcrumbProviderInterface {
             new Breadcrumb(self::t('Community'), \Gdn::request()->url('/')),
         ];
         foreach ($ancestors as $ancestor) {
-            $crumbs[] = new Breadcrumb($ancestor['Name'], categoryUrl($ancestor));
+            if ($ancestor['CategoryID'] === -1) {
+                // If we actually get the root category, we don't want to see the "synthetic" root.
+                // We actually just want the categories page.
+                $crumbs[] = new Breadcrumb(t('Categories'), url('/categories'));
+            } else {
+                $crumbs[] = new Breadcrumb($ancestor['Name'], categoryUrl($ancestor));
+            }
         }
         return $crumbs;
     }

--- a/library/Vanilla/Models/GenericRecord.php
+++ b/library/Vanilla/Models/GenericRecord.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models;
+
+use Vanilla\Contracts\RecordInterface;
+
+/**
+ * Generic record for a given type.
+ */
+class GenericRecord implements RecordInterface {
+
+    /** @var string */
+    private $recordType;
+
+    /** @var int */
+    private $recordID;
+
+    /**
+     * Constructor.
+     *
+     * @param string $recordType
+     * @param int $recordID
+     */
+    public function __construct(string $recordType, int $recordID) {
+        $this->recordType = $recordType;
+        $this->recordID = $recordID;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRecordType(): string {
+        return $this->recordType;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRecordID(): int {
+        return $this->recordID;
+    }
+}

--- a/library/Vanilla/Theme/ThemeFeatures.php
+++ b/library/Vanilla/Theme/ThemeFeatures.php
@@ -29,6 +29,7 @@ class ThemeFeatures implements \JsonSerializable {
         'ProfileHeader' => false,
         'DataDrivenTheme' => false,
         'DisableKludgedVars' => false,
+        'NewEventsPage' => false,
     ];
 
     /**
@@ -76,6 +77,7 @@ class ThemeFeatures implements \JsonSerializable {
             $themeValues['ProfileHeader'] = true;
             $themeValues['SharedMasterView'] = true;
             $themeValues['NewFlyouts'] = true;
+            $themeValues['NewEventsPage'] = true;
         }
 
         return array_merge(self::FEATURE_DEFAULTS, $configValues, $themeValues, $this->forcedFeatures);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
             "@knowledge/*": ["./plugins/knowledge/src/scripts/*"],
             "@webhooks/*": ["./plugins/webhooks/src/scripts/*"],
             "@themingapi/*": ["./plugins/themingapi/src/scripts/*"],
-            "@subcommunities/*": ["./plugins/subcommunities/src/scripts/*"]
+            "@subcommunities/*": ["./plugins/subcommunities/src/scripts/*"],
+            "@groups/*": ["./applications/groups/src/scripts/*"]
         },
         "typeRoots": ["@types", "./node_modules/@types"]
     },


### PR DESCRIPTION
Blocking https://github.com/vanilla/internal/pull/2519

## Generic Record

- A `GenericRecord` can be used when you don't know the exact type of your record and want to lookup breadcrumbs or something similar from what's registered on the model.

## Breadcrumb root

- Add some logic to make sure the "fake" synthetic root of the community is never returned.

The community has category named root as the `-1` record. Normally it does not get returned, however there's a special case of generating crumbs when viewing the root category. We actually want this to go to `/categories`.