### PR TITLE
Add a global autoloader for testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
         "voku/simple_html_dom": "4.1.7",
         "mikey179/vfsstream": "~1.6",
         "phing/phing": "2.*",
-        "roave/security-advisories": "dev-master"
+        "roave/security-advisories": "dev-master",
+        "nette/robot-loader": "^3.2"
     },
     "provide": {
         "ext-gd": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c1d7dcbdaca4655da6b67674332adcc",
+    "content-hash": "dd65871abce34ef83aaee73d63f4643d",
     "packages": [
         {
             "name": "chrisjean/php-ico",
@@ -2116,6 +2116,210 @@
             "time": "2019-12-15T19:12:40+00:00"
         },
         {
+            "name": "nette/finder",
+            "version": "v2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/finder.git",
+                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/finder/zipball/4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
+                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^2.4 || ^3.0",
+                "php": ">=7.1"
+            },
+            "conflict": {
+                "nette/nette": "<2.2"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🔍 Nette Finder: find files and directories with an intuitive API.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "filesystem",
+                "glob",
+                "iterator",
+                "nette"
+            ],
+            "time": "2020-01-03T20:35:40+00:00"
+        },
+        {
+            "name": "nette/robot-loader",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/robot-loader.git",
+                "reference": "726c462e73e739e965ec654a667407074cfe83c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/robot-loader/zipball/726c462e73e739e965ec654a667407074cfe83c0",
+                "reference": "726c462e73e739e965ec654a667407074cfe83c0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "nette/finder": "^2.5 || ^3.0",
+                "nette/utils": "^3.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🍀 Nette RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "autoload",
+                "class",
+                "interface",
+                "nette",
+                "trait"
+            ],
+            "time": "2020-02-28T13:10:07+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "2c17d16d8887579ae1c0898ff94a3668997fd3eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/2c17d16d8887579ae1c0898ff94a3668997fd3eb",
+                "reference": "2c17d16d8887579ae1c0898ff94a3668997fd3eb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "~2.0",
+                "phpstan/phpstan": "^0.12",
+                "tracy/tracy": "^2.3"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize() and toAscii()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
+                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠 Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "time": "2020-02-09T14:10:55+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.3.0",
             "source": {
@@ -4080,6 +4284,7 @@
     "platform": {
         "php": ">=7.2.0",
         "ext-pdo": "*",
+        "ext-intl": "*",
         "ext-json": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",

--- a/tests/APIv2/AbstractApiControllerTest.php
+++ b/tests/APIv2/AbstractApiControllerTest.php
@@ -24,7 +24,6 @@ class AbstractApiControllerTest extends TestCase {
      */
     public static function setUpBeforeClass(): void {
         parent::setUpBeforeClass();
-        require_once __DIR__.'/../../applications/dashboard/controllers/api/AbstractApiController.php';
     }
 
     /**

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -547,4 +547,28 @@ class Bootstrap {
 
         return PATH_ROOT."/conf/{$host}{$path}.php";
     }
+
+    /**
+     * Register an autoloader that loads all classes.
+     */
+    public static function registerAutoloader(): void {
+        $loader = new RobotLoader();
+        $loader->addDirectory(PATH_APPLICATIONS, PATH_PLUGINS);
+
+        $excluded = [
+            'Mustache',
+            'sitehub',
+            'lithecompiler',
+            'lithestyleguide',
+            'Warnings',
+        ];
+        foreach ($excluded as $subdir) {
+            $loader->excludeDirectory(PATH_PLUGINS.'/'.$subdir);
+        }
+
+        // And set caching to the 'temp' directory
+        $loader->setTempDirectory(PATH_ROOT.'/tests/cache/autoloader');
+        $loader->register();
+    }
 }
+

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -11,6 +11,7 @@ use Garden\Container\Container;
 use Garden\Container\Reference;
 use Garden\Web\RequestInterface;
 use Gdn;
+use Nette\Loaders\RobotLoader;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use Psr\Log\LoggerAwareInterface;

--- a/tests/Library/Vanilla/Web/APIExpandMiddlewareTest.php
+++ b/tests/Library/Vanilla/Web/APIExpandMiddlewareTest.php
@@ -33,9 +33,6 @@ class APIExpandMiddlewareTest extends TestCase {
     public static function setUpBeforeClass(): void {
         parent::setUpBeforeClass();
         self::bootstrapSetUpBeforeClass();
-
-        require_once __DIR__ . "/../../../../applications/dashboard/models/class.sessionmodel.php";
-        require_once __DIR__ . "/../../../../applications/dashboard/models/class.usermodel.php";
     }
 
     /**

--- a/tests/definitions.php
+++ b/tests/definitions.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+// Define some constants to help with testing.
+define('APPLICATION', 'Vanilla Tests');
+define('PATH_ROOT', realpath(__DIR__.'/..'));
+define('PATH_UPLOADS', PATH_ROOT . '/tests/cache/uploads');
+
+define("PATH_FIXTURES", PATH_ROOT . DIRECTORY_SEPARATOR . "tests" . DIRECTORY_SEPARATOR . "fixtures");

--- a/tests/phpunit.php
+++ b/tests/phpunit.php
@@ -6,12 +6,14 @@
 
 use VanillaTests\NullContainer;
 
+require_once __DIR__.'/definitions.php';
+
 // Use consistent timezone for all tests.
 date_default_timezone_set("UTC");
 
 ini_set("default_charset", "UTF-8");
-
 error_reporting(E_ALL);
+
 // Alias classes for some limited PHPUnit v5 compatibility with v6.
 $classCompatibility = [
     'PHPUnit\\Framework\\TestCase' => 'PHPUnit_Framework_TestCase', // See https://github.com/php-fig/log/pull/52
@@ -21,13 +23,6 @@ foreach ($classCompatibility as $class => $legacyClass) {
         class_alias($class, $legacyClass);
     }
 }
-
-// Define some constants to help with testing.
-define('APPLICATION', 'Vanilla Tests');
-define('PATH_ROOT', realpath(__DIR__.'/..'));
-define('PATH_UPLOADS', PATH_ROOT . '/tests/cache/uploads');
-
-define("PATH_FIXTURES", PATH_ROOT . DIRECTORY_SEPARATOR . "tests" . DIRECTORY_SEPARATOR . "fixtures");
 
 // Copy the cgi-bin files.
 $dir = PATH_ROOT.'/cgi-bin';
@@ -47,13 +42,17 @@ foreach ($files as $file) {
 // ===========================================================================
 require PATH_ROOT.'/environment.php';
 
+// Allow any addon class to be auto-loaded.
+\VanillaTests\Bootstrap::registerAutoloader();
+
+
 // Allow a test before.
 $bootstrapTestFile = PATH_CONF . '/bootstrap.tests.php';
 if (file_exists($bootstrapTestFile)) {
     require_once $bootstrapTestFile;
 }
 
-// This effectively disable the auto instanciation of a new container when calling Gdn::getContainer();
+// This effectively disable the auto instantiation of a new container when calling Gdn::getContainer();
 Gdn::setContainer(new NullContainer());
 
 // Clear the test cache.


### PR DESCRIPTION
This PR makes all applications and plugin classes available during testing. This should aid addon tests that can be run without enabling the addon and reduce the need for extraneous `require` statements.

You will see in Bootstrap::registerAutoloader() there are some hard-coded addons being excluded. These addons have duplicate class definitions which is no-bueno. Until we can fix those addons they’ll need to be tested without global autoloading.