### PR TITLE
Fix permission check on GET categories endpoint

### DIFF
--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -5,6 +5,7 @@
  */
 
 use Garden\Schema\Schema;
+use Garden\Web\Exception\ForbiddenException;
 use Vanilla\Dashboard\Models\BannerImageModel;
 use Vanilla\Forum\Navigation\ForumCategoryRecordType;
 use Vanilla\Navigation\BreadcrumbModel;
@@ -164,7 +165,9 @@ class CategoriesApiController extends AbstractApiController {
      * @return array
      */
     public function get(int $id) {
-        $this->permission('Garden.Settings.Manage');
+        if (!$this->categoryModel::checkPermission($id, 'Vanilla.Discussions.View')) {
+            throw new ForbiddenException('Category');
+        }
 
         $in = $this->idParamSchema()->setDescription('Get a category.');
         $out = $this->schema($this->schemaWithParent(), 'out');


### PR DESCRIPTION
I'm not sure why this was manage before, but we do have category permissions. We have category-specific permissions.

Here's the check on the normal category controller.

https://github.com/vanilla/vanilla/blob/3c15c05b199331e5677c828b6f8d745052b86688/applications/vanilla/controllers/class.categoriescontroller.php#L321

This category model method checks the PermissionCategoryID of the given category, then goes to the session to check the permission on it.