### PR TITLE
Add link rel elements to simple pager

### DIFF
--- a/library/src/scripts/navigation/SimplePager.tsx
+++ b/library/src/scripts/navigation/SimplePager.tsx
@@ -4,7 +4,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import React, { useEffect } from "react";
 import { simplePagerClasses } from "@library/navigation/simplePagerStyles";
 import { ILinkPages } from "@library/navigation/SimplePagerModel";
 import LinkAsButton from "@library/routing/LinkAsButton";
@@ -28,14 +28,20 @@ export default class SimplePager extends React.Component<IProps> {
         return (
             <div className={classNames("simplePager", classes.root)}>
                 {prev && (
-                    <LinkAsButton className={classNames(classes.button, { isSingle })} to={this.makeUrl(prev)}>
-                        {t("Previous")}
-                    </LinkAsButton>
+                    <>
+                        <LinkAsButton className={classNames(classes.button, { isSingle })} to={this.makeUrl(prev)}>
+                            {t("Previous")}
+                        </LinkAsButton>
+                        <LinkMeta rel={"prev"} url={this.makeUrl(prev)} />
+                    </>
                 )}
                 {next && (
-                    <LinkAsButton className={classNames(classes.button, { isSingle })} to={this.makeUrl(next)}>
-                        {t("Next")}
-                    </LinkAsButton>
+                    <>
+                        <LinkAsButton className={classNames(classes.button, { isSingle })} to={this.makeUrl(next)}>
+                            {t("Next")}
+                        </LinkAsButton>
+                        <LinkMeta rel={"next"} url={this.makeUrl(next)} />
+                    </>
                 )}
             </div>
         );
@@ -45,4 +51,29 @@ export default class SimplePager extends React.Component<IProps> {
         const { url } = this.props;
         return url.replace(":page:", page.toString());
     }
+}
+
+interface ILinkMeta {
+    url: string;
+    rel: "next" | "prev";
+}
+
+function LinkMeta(props: ILinkMeta) {
+    const { url, rel } = props;
+
+    useEffect(() => {
+        let existingRel = document.querySelector(`link[rel=${rel}]`);
+
+        const newRel = document.createElement("link");
+        newRel.setAttribute("rel", rel);
+        newRel.setAttribute("href", url);
+
+        if (existingRel) {
+            existingRel.parentNode?.replaceChild(existingRel, newRel);
+        } else {
+            document.head.appendChild(newRel);
+        }
+    }, [url, rel]);
+
+    return <></>;
 }


### PR DESCRIPTION
Relates to https://github.com/vanilla/internal/issues/2534

Using `<SimplePager />` will now automatically set `<link rel="prev|"next" />` elements in the head when used.
