### PR TITLE
Fix js files not loading at profile/edit endpoint

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -365,9 +365,13 @@ class ProfileController extends Gdn_Controller {
     public function edit($userReference = '', $username = '', $userID = '') {
         $this->permission(['Garden.SignIn.Allow', 'Garden.Profiles.Edit'], true);
 
+        $this->Head->addScript('js/library/jquery.js');
+
         $this->getUserInfo($userReference, $username, $userID, true);
         $userID = valr('User.UserID', $this);
         $settings = [];
+
+        $this->buildProfile();
 
         // Set up form
         $user = Gdn::userModel()->getID($userID, DATASET_TYPE_ARRAY);

--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -364,9 +364,7 @@ class ProfileController extends Gdn_Controller {
      */
     public function edit($userReference = '', $username = '', $userID = '') {
         $this->permission(['Garden.SignIn.Allow', 'Garden.Profiles.Edit'], true);
-
-        $this->Head->addScript('js/library/jquery.js');
-
+        
         $this->getUserInfo($userReference, $username, $userID, true);
         $userID = valr('User.UserID', $this);
         $settings = [];


### PR DESCRIPTION
Closes vanilla/support#1824.

This PR fixes a problem that results in users being able to upload a photo from the `profile/edit` endpoint if that page includes with a `userphotomodule`. This fix loads the necessary js files that allow the button to function.

### TO TEST
1. Load a version of vanilla that includes the userphotomodule at the `profile/edit`.
1. Go to that endpoint and try to upload a photo.
1. Note that the "Upload New Picture" button doesn't work.
1. Checkout this branch and try again, this time noting that it does work.