### PR TITLE
Translate Whoops error message

### DIFF
--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -270,7 +270,7 @@ function gdn_ExceptionHandler($Exception) {
 
         if ($DeliveryType != DELIVERY_TYPE_ALL) {
             if (!$Debug) {
-                die('<b class="Bonk">' . t("Whoops! There was an error.") . '</b>');
+                die('<b class="Bonk">'.t("Whoops! There was an error.").'</b>');
             }
 
             // This is an ajax request, so dump an error that is more eye-friendly in the debugger

--- a/library/core/functions.error.php
+++ b/library/core/functions.error.php
@@ -270,7 +270,7 @@ function gdn_ExceptionHandler($Exception) {
 
         if ($DeliveryType != DELIVERY_TYPE_ALL) {
             if (!$Debug) {
-                die('<b class="Bonk">Whoops! There was an error.</b>');
+                die('<b class="Bonk">' . t("Whoops! There was an error.") . '</b>');
             }
 
             // This is an ajax request, so dump an error that is more eye-friendly in the debugger


### PR DESCRIPTION
Closes vanilla/support#1896.

This PR puts the "Whoops! There was an error." string through the translate function.