### PR TITLE
LocalesApiController requires ext-intl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "require": {
         "php": ">=7.2.0",
         "ext-pdo": "*",
+        "ext-intl": "*",
         "ext-json": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",


### PR DESCRIPTION
This API has a clear dependency on the `intl` extension, and is used by various parts of the frontend.