### PR TITLE
Make the data test use the proper PHPUnit method

### DIFF
--- a/tests/Library/Garden/Web/DataTest.php
+++ b/tests/Library/Garden/Web/DataTest.php
@@ -262,9 +262,8 @@ class DataTest extends TestCase {
      */
     public function testRenderNoHeaders() {
         $expected = json_encode($this->data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR);
-
-        $actual = $this->getRenderedData();
-        $this->assertSame($expected, $actual);
+        $this->expectOutputString($expected);
+        $this->data->render();
     }
 
     /**
@@ -273,8 +272,8 @@ class DataTest extends TestCase {
     public function testRenderOneHeader() {
         $this->data->setHeader('xxx', 'xxx');
         $expected = json_encode($this->data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR);
-        $actual = $this->getRenderedData();
-        $this->assertSame($expected, $actual);
+        $this->expectOutputString($expected);
+        $this->data->render();
     }
 
     /**
@@ -442,17 +441,5 @@ class DataTest extends TestCase {
     public function testIntStatusConstructor() {
         $data = new Data([], 200);
         $this->assertSame(200, $data->getStatus());
-    }
-
-    /**
-     * Get the rendered data from the data class.
-     *
-     * @return false|string
-     */
-    private function getRenderedData() {
-        ob_start();
-        $this->data->render();
-        $actual = ob_get_clean();
-        return $actual;
     }
 }


### PR DESCRIPTION
When I fixed the data test earlier, I had forgotten that there is actually a proper PHPUnit way to test echo’d output. Have a look.