### PR TITLE
Fix file uploads for images with spaces

### DIFF
--- a/library/Vanilla/FileUtils.php
+++ b/library/Vanilla/FileUtils.php
@@ -52,7 +52,7 @@ class FileUtils {
                 $name = randomString(12);
             }
             if ($chunk) {
-                $subdir = sprintf('%03d', mt_rand(0, 999)).'/';
+                $subdir = randomString(12);
             }
             $path = "${targetDirectory}/{$subdir}${name}.${extension}";
         } while (file_exists($path));

--- a/library/Vanilla/FileUtils.php
+++ b/library/Vanilla/FileUtils.php
@@ -52,7 +52,7 @@ class FileUtils {
                 $name = randomString(12);
             }
             if ($chunk) {
-                $subdir = randomString(12);
+                $subdir = randomString(12).'/';
             }
             $path = "${targetDirectory}/{$subdir}${name}.${extension}";
         } while (file_exists($path));

--- a/library/Vanilla/UploadedFile.php
+++ b/library/Vanilla/UploadedFile.php
@@ -165,6 +165,7 @@ class UploadedFile {
         $keys = parse_url($url); // parse the url
         $path = explode("/", $keys['path'] ?? randomString(12)); // splitting the path
         $last = end($path) ?: null; // get the value of the last element
+        $last = urldecode($last);
         return $last;
     }
 
@@ -195,6 +196,7 @@ class UploadedFile {
         $ext = strtolower(pathinfo($this->getClientFilename(), PATHINFO_EXTENSION));
         $baseName = basename($this->getClientFilename(), ".${ext}");
         $baseName = sprintf($nameFormat, $baseName);
+        $baseName = \Gdn_Format::url($baseName);
         $uploadPath = FileUtils::generateUniqueUploadPath($ext, true, $baseName, $persistDirectory);
         return $uploadPath;
     }

--- a/tests/Library/Vanilla/UploadedFileTest.php
+++ b/tests/Library/Vanilla/UploadedFileTest.php
@@ -73,6 +73,33 @@ class UploadedFileTest extends SharedBootstrapTestCase {
     }
 
     /**
+     * Test that we can safely persist files with spaces in their name.
+     *
+     * @param string $name
+     *
+     * @dataProvider provideImagesWithSpaces
+     */
+    public function testPersistFileWithSpaces(string $name) {
+        // Perform some tests related to saving uploads.
+        $file = UploadedFile::fromRemoteResourceUrl($name);
+
+        // Save the upload.
+        $file->persistUpload();
+        $this->assertFileExists(PATH_UPLOADS.'/'.$file->getPersistedPath(), 'Final upload file is persisted');
+        $this->assertStringContainsString('image-with-spaces.jpg', $file->getPersistedPath());
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideImagesWithSpaces(): array {
+        return [
+            'no url encoding' => ['https://us.v-cdn.net/6032207/uploads/770/Image with spaces.jpg'],
+            'with url encoding' => ['https://us.v-cdn.net/6032207/uploads/770/Image%20with%20spaces.jpg'],
+        ];
+    }
+
+    /**
      * Test that custom paths can be persisted.
      */
     public function testCustomPersistedPath() {

--- a/tests/Library/Vanilla/UploadedFileTest.php
+++ b/tests/Library/Vanilla/UploadedFileTest.php
@@ -112,7 +112,7 @@ class UploadedFileTest extends SharedBootstrapTestCase {
         // Save the upload.
         $file->persistUpload(false, 'subdir', 'prefix-%s');
         $this->assertFileExists(PATH_UPLOADS.'/'.$file->getPersistedPath(), 'Final upload file is persisted');
-        $this->assertStringMatchesFormat('subdir/%d/prefix-logo.svg', $file->getPersistedPath());
+        $this->assertStringMatchesFormat('subdir/%s/prefix-logo.svg', $file->getPersistedPath());
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/vanilla/vanilla/issues/10593
Related https://github.com/vanilla/support/issues/1880

The bug was was introduced in https://github.com/vanilla/vanilla/pull/10520 when I started trying to preserve original file names in the URL. (previously we always used random IDs).

I swapped to slugifying the file names because it's URL safe and easier than handling URL encoding them (because then the file names on disk and in the URL are different). There's still no chance of collision because we use unique hashes for the file directory.