### PR TITLE
Do not display mobile theme options when a theme responsive.

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -295,8 +295,8 @@ class DashboardHooks extends Gdn_Plugin {
         }
 
         if ($mobileTheme) {
-            $isDistinctMobileTheme = $mobileTheme !== $desktopTheme;
-            $hasMobileThemeOptions = $isDistinctMobileTheme && count($mobileTheme->getInfoValue('options', [])) > 0;
+            $isDistinctMobileTheme = $mobileTheme !== $desktopTheme && $mobileTheme->getInfoValue('isMobile');
+            $hasMobileThemeOptions = $isDistinctMobileTheme && (count($mobileTheme->getInfoValue('options', [])) > 0);
         }
 
         $sort = -1; // Ensure these nav items come before any plugin nav items.

--- a/applications/dashboard/views/settings/mobilethemes.php
+++ b/applications/dashboard/views/settings/mobilethemes.php
@@ -94,7 +94,7 @@ helpAsset(t('About Theme Preview'), t('Not getting what you expect when you prev
         echo '</div>';
         echo '<div class="media-description Description"><p class="description">'.$this->data('EnabledTheme.Description', '').'</p>';
 
-        if ($this->data('EnabledTheme.Options')) {
+        if ($this->data('EnabledTheme.Options') && $this->data('EnabledTheme.isMobile')) {
             $OptionsDescription = sprintf(t('This theme has additional options.', 'This theme has additional options on the %s page.'),
                 anchor(t('Theme Options'), '/dashboard/settings/themeoptions'));
 


### PR DESCRIPTION
This PR will close this issue: https://github.com/vanilla/support/issues/1583 

What is at issue here is that there are desktop themes with options and mobile themes with options and there are desktop themes with options are that are also responsive. If you have chosen a responsive theme as your mobile theme you should not be presented with the options. 

This PR makes the distinction between a mobile theme and a responsive desktop theme and only allows users to change the mobile options on mobile themes.

### To test
 - Choose a desktop theme with options (hint: keystone).
 - See that there is a link in the Theme description to modify the Theme Options.
 - See that you have a link in the left-hand menu for Mobile Theme Options
 - Click on it and see that there are many checkmarks on theoretical display options.
 - Checkout this branch and see that this page is not available.