### PR TITLE
Deprecate fixnl2br(), discussionLink(), and condense() render functions

### DIFF
--- a/applications/dashboard/models/class.searchmodel.php
+++ b/applications/dashboard/models/class.searchmodel.php
@@ -219,7 +219,7 @@ class SearchModel extends Gdn_Model {
      * @return string
      * @deprecated
      */
-    private function condense($html) {
+    private static function condense($html) {
         $html = preg_replace('`(?:<br\s*/?>\s*)+`', "<br />", $html);
         $html = preg_replace('`/>\s*<br />\s*<img`', "/> <img", $html);
         return $html;

--- a/applications/dashboard/models/class.searchmodel.php
+++ b/applications/dashboard/models/class.searchmodel.php
@@ -177,7 +177,7 @@ class SearchModel extends Gdn_Model {
 
         foreach ($result as $key => $value) {
             if (isset($value['Summary'])) {
-                $value['Summary'] = condense(Gdn_Format::to($value['Summary'], $value['Format']));
+                $value['Summary'] = self::condense(Gdn_Format::to($value['Summary'], $value['Format']));
                 // We just converted it to HTML. Make sure everything downstream knows it.
                 // Taking this HTML and feeding it into the Rich Format for example, would be invalid.
                 $value['Format'] = 'Html';
@@ -210,5 +210,18 @@ class SearchModel extends Gdn_Model {
             $this->_SearchMode = $value;
         }
         return $this->_SearchMode;
+    }
+
+    /**
+     * Reduce whitespace in some HTML.
+     *
+     * @param string $html
+     * @return string
+     * @deprecated
+     */
+    private function condense($html) {
+        $html = preg_replace('`(?:<br\s*/?>\s*)+`', "<br />", $html);
+        $html = preg_replace('`/>\s*<br />\s*<img`', "/> <img", $html);
+        return $html;
     }
 }

--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -491,20 +491,6 @@ if (!function_exists('categoryUrl')) {
     }
 }
 
-if (!function_exists('condense')) {
-    /**
-     *
-     *
-     * @param string $html
-     * @return mixed
-     */
-    function condense($html) {
-        $html = preg_replace('`(?:<br\s*/?>\s*)+`', "<br />", $html);
-        $html = preg_replace('`/>\s*<br />\s*<img`', "/> <img", $html);
-        return $html;
-    }
-}
-
 if (!function_exists('countString')) {
     /**
      *
@@ -906,24 +892,6 @@ if (!function_exists('filtersDropDown')) {
         }
 
         return $output;
-    }
-}
-
-if (!function_exists('fixnl2br')) {
-    /**
-     * Removes the break above and below tags that have a natural margin.
-     *
-     * @param string $text The text to fix.
-     * @return string
-     * @since 2.1
-     *
-     * @deprecated 3.2 - Use \Vanilla\Formatting\Html\HtmlFormat::cleanupLineBreaks
-     */
-    function fixnl2br($text) {
-        deprecated(__FUNCTION__, '\Vanilla\Formatting\Formats\HtmlFormat::cleanupLineBreaks');
-        /** @var Formats\HtmlFormat $htmlFormat */
-        $htmlFormat = Gdn::getContainer()->get(Formats\HtmlFormat::class);
-        return $htmlFormat->cleanupLineBreaks((string) $text);
     }
 }
 
@@ -1661,32 +1629,6 @@ if (!function_exists('wrapIf')) {
         } else {
             return wrap($string, $tag, $attributes);
         }
-    }
-}
-
-if (!function_exists('discussionLink')) {
-    /**
-     * Build URL for discussion.
-     *
-     * @deprecated discussionUrl()
-     * @param $discussion
-     * @param bool $extended
-     * @return string
-     */
-    function discussionLink($discussion, $extended = true) {
-        deprecated('discussionLink', 'discussionUrl');
-
-        $discussionID = val('DiscussionID', $discussion);
-        $discussionName = val('Name', $discussion);
-        $parts = [
-            'discussion',
-            $discussionID,
-            Gdn_Format::url($discussionName)
-        ];
-        if ($extended) {
-            $parts[] = ($discussion->CountCommentWatch > 0) ? '#Item_'.$discussion->CountCommentWatch : '';
-        }
-        return url(implode('/', $parts), true);
     }
 }
 

--- a/library/deprecated/functions.deprecated.php
+++ b/library/deprecated/functions.deprecated.php
@@ -222,6 +222,20 @@ if (!function_exists('compareHashDigest')) {
     }
 }
 
+if (!function_exists('condense')) {
+    /**
+     *
+     *
+     * @param string $html
+     * @return mixed
+     */
+    function condense($html) {
+        $html = preg_replace('`(?:<br\s*/?>\s*)+`', "<br />", $html);
+        $html = preg_replace('`/>\s*<br />\s*<img`', "/> <img", $html);
+        return $html;
+    }
+}
+
 if (!function_exists('ConsolidateArrayValuesByKey')) {
     /**
      * Return the values from a single column in the input array.
@@ -284,6 +298,50 @@ if (!function_exists('cTo')) {
             $current =& $current[$key];
         }
         $current[$lastKey] = $value;
+    }
+}
+
+if (!function_exists('discussionLink')) {
+    /**
+     * Build URL for discussion.
+     *
+     * @deprecated discussionUrl()
+     * @param $discussion
+     * @param bool $extended
+     * @return string
+     */
+    function discussionLink($discussion, $extended = true) {
+        deprecated('discussionLink', 'discussionUrl');
+
+        $discussionID = val('DiscussionID', $discussion);
+        $discussionName = val('Name', $discussion);
+        $parts = [
+            'discussion',
+            $discussionID,
+            Gdn_Format::url($discussionName)
+        ];
+        if ($extended) {
+            $parts[] = ($discussion->CountCommentWatch > 0) ? '#Item_'.$discussion->CountCommentWatch : '';
+        }
+        return url(implode('/', $parts), true);
+    }
+}
+
+if (!function_exists('fixnl2br')) {
+    /**
+     * Removes the break above and below tags that have a natural margin.
+     *
+     * @param string $text The text to fix.
+     * @return string
+     * @since 2.1
+     *
+     * @deprecated 3.2 - Use \Vanilla\Formatting\Html\HtmlFormat::cleanupLineBreaks
+     */
+    function fixnl2br($text) {
+        deprecated(__FUNCTION__, '\Vanilla\Formatting\Formats\HtmlFormat::cleanupLineBreaks');
+        /** @var Formats\HtmlFormat $htmlFormat */
+        $htmlFormat = Gdn::getContainer()->get(Formats\HtmlFormat::class);
+        return $htmlFormat->cleanupLineBreaks((string) $text);
     }
 }
 


### PR DESCRIPTION
The condense() function is likely to be buggy. The discussionLink() and fixnl2br() functions were already deprecated, but never moved.

I’ve checked and cleaned up usages of these functions.