### PR TITLE
Add an InstallModel smoke test

### DIFF
--- a/tests/Library/Vanilla/Models/InstallModelTest.php
+++ b/tests/Library/Vanilla/Models/InstallModelTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Models;
+
+use PHPUnit\Framework\TestCase;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Add some basic tests for the `InstallModel` class.
+ */
+class InstallModelTest extends TestCase {
+    use SiteTestTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function setupBeforeClass(): void {
+        // Do nothing to override the trait.
+    }
+
+    /**
+     * Smoke test a site installation.
+     */
+    public function testInstall(): void {
+        $this->assertEmpty(self::$siteInfo);
+        $this->setupBeforeClassSiteTestTrait();
+        $this->assertNotEmpty(self::$siteInfo);
+    }
+}


### PR DESCRIPTION
Although the install model runs to support a lot of tests, it gets missed on code coverage.