### PR TITLE
Fix click outside Flyout with Safari/Iphone by adding touchstart event

### DIFF
--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -38,9 +38,9 @@
         $(document).delegate(".Flyout, .Dropdown", "click", function (e) {
             e.stopPropagation();
         });
-        $(document).on("click", function (e) {
+        $(document).on("click touchstart", function (e) {
             closeAllFlyouts();
-        })
+        });
     });
 
     /**


### PR DESCRIPTION
Latest version of Safari on iPhone seems to have an issue handling [click events](https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html), resulting in a bug where the flyouts don’t close once the user clicks outside.

**Reproduce the Error:**
1. Open community on an iPhone with latest version of Safari (or use Browserstack iPhone 8+).
1. Click on the Hamburger menu.
1. Click on any icon on the Mebox.
1. Try click outside the flyout to close it. 

**Fix:** :  Add ```touchstart``` event to handle the ```closeAllFlyouts()```

