### PR TITLE
Change the Target to the full path to website.

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -2146,6 +2146,6 @@ class EntryController extends Gdn_Controller {
             $target = url(Gdn::router()->getDestination('DefaultController'));
         }
 
-        return $target;
+        return url($target, true);
     }
 }


### PR DESCRIPTION
This PR will close: vanilla/support#1718.

When we pass the target to the login link it is always a relative path. Forums with subcommunities and sitehub enabled are redirecting back to the hub but not the right subcommunity. In our smarty link function we pass the full URL as the target. 

https://github.com/vanilla/vanilla/blob/master/library/core/class.theme.php#L206

This PR would pass it in the default Sign In link.