### PR TITLE
Fix Visits recording

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1591,7 +1591,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
      *
      * @param int $iD The ID of the user.
      * @param string|false $datasetType Whether to return an array or object.
-     * @param array $options Additional options to affect fetching. Currently unused.
+     * @param array $options Additional options to affect fetching. "skipCache" will always fetch from the db.
      * @return array|object|false Returns the user or **false** if the user wasn't found.
      */
     public function getID($iD, $datasetType = false, $options = []) {
@@ -1603,7 +1603,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface {
         // Check page cache, then memcached
         $user = $this->getUserFromCache($iD, 'userid');
         // If not, query DB
-        if ($user === Gdn_Cache::CACHEOP_FAILURE) {
+        if ($user === Gdn_Cache::CACHEOP_FAILURE || $options['skipCache'] === true) {
             $user = parent::getID($iD, DATASET_TYPE_ARRAY);
 
             // We want to cache a non-existent user no-matter what.

--- a/library/core/class.session.php
+++ b/library/core/class.session.php
@@ -265,15 +265,17 @@ class Gdn_Session {
      * @return bool
      */
     public function isNewVisit() {
-        if ($this->User) {
+        //avoid getting user from cache so we can get an accurate DateLastActive
+        $user = Gdn::userModel()->getID($this->UserID, false, ['skipCache' => true]);
+        if ($user) {
             $cookie = $this->getCookie('-Vv', false);
-            $userVisitExpiry = Gdn_Format::toTimeStamp($this->User->DateLastActive) + self::VISIT_LENGTH;
+            $userVisitExpiry = Gdn_Format::toTimeStamp($user->DateLastActive) + self::VISIT_LENGTH;
 
             if ($cookie) {
                 $result = false; // User has cookie, not a new visit.
-            } elseif ($userVisitExpiry > time())
+            } elseif ($userVisitExpiry > time()) {
                 $result = false; // User was last active less than 20 minutes ago, not a new visit.
-            else {
+            } else {
                 $result = true; // No cookie and not active in the last 20 minutes? New visit.
             }
         } else {


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1535
Relevant: https://github.com/vanilla/support/issues/1535#issuecomment-631628920

**Steps to test:**
1. Login with a user on your local and logoff.
2. On the DB verify that the "DateLastActive", it should be now. Make a note of the current "CountVisits".
3. Change this user "DateLastActive" to any time more than 20 minutes ago from the time you logged off.
4. Open an incognito tab and login again.
5. Verify that the CountVisits has not increased. You can even put a breakpoint in https://github.com/vanilla/vanilla/blob/d363af7b520c95b1a043275332175b1bb5b3ad28/library/core/class.session.php#L270 and see that the `DateLastActive` is set to now, and not the tie you've manually set.
6. Checkout this branch, close the incognito tab.
7. Repeat steps, the `CountVisits` should increase.

