### PR TITLE
Use the container for dba/counts model instantiation

### DIFF
--- a/applications/dashboard/models/class.dbamodel.php
+++ b/applications/dashboard/models/class.dbamodel.php
@@ -44,8 +44,12 @@ class DBAModel extends Gdn_Model {
      * @return Gdn_Model
      */
     public function createModel($table) {
+        $container = Gdn::getContainer();
         $modelName = $table.'Model';
-        if (class_exists($modelName)) {
+
+        if ($container->hasRule($modelName)) {
+            return $container->get($modelName);
+        } elseif (class_exists($modelName)) {
             return new $modelName();
         } else {
             return new Gdn_Model($table);


### PR DESCRIPTION
Currently the `counts` method can't be used if you want to use autowired dependencies in your models contructor, because it is called using `new`.

This checks if a class is available through the container first.