### PR TITLE
Cleanup Gdn_Request and its test

### DIFF
--- a/library/core/class.request.php
+++ b/library/core/class.request.php
@@ -149,8 +149,9 @@ class Gdn_Request implements RequestInterface {
      * Gets/Sets the domain from the current url. e.g. "http://localhost" in
      * "http://localhost/this/that/garden/index.php?/controller/action/"
      *
-     * @param $domain optional value to set
+     * @param string|null $domain Optional value to set
      * @return string | null
+     * @deprecated Use Gdn_Request::getHost() and Gdn_Request::setHost() instead.
      */
     public function domain($domain = null) {
         return $this->_parsedRequestElement('Domain', $domain);
@@ -218,6 +219,8 @@ class Gdn_Request implements RequestInterface {
     /**
      * Convenience method for accessing unparsed environment data via request(ELEMENT) method calls.
      *
+     * @param string $method
+     * @param array $args
      * @return string
      */
     public function __call($method, $args) {
@@ -235,7 +238,7 @@ class Gdn_Request implements RequestInterface {
      *
      * Mostly used in conjunction with fromImport()
      *
-     * @param $export Data group to export
+     * @param string $export Data group to export.
      * @return mixed
      */
     public function export($export) {
@@ -257,7 +260,7 @@ class Gdn_Request implements RequestInterface {
      * As with the case above (OutputFormat), this value depends heavily on there being a filename
      * at the end of the URI. In the example above, filename() would return 'cashflow2009.pdf'.
      *
-     * @param $filename Optional Filename to set.
+     * @param string|null $filename Optional Filename to set.
      * @return string
      */
     public function filename($filename = null) {
@@ -532,6 +535,8 @@ class Gdn_Request implements RequestInterface {
     /**
      * Get an item from the query string array.
      *
+     * @param string $key
+     * @param mixed $default
      * @return string
      */
     public function getQueryItem($key, $default = null) {
@@ -632,8 +637,9 @@ class Gdn_Request implements RequestInterface {
      * Gets/Sets the host from the current url. e.g. "foo.com" in
      * "http://foo.com/this/that/garden/index.php?/controller/action/"
      *
-     * @param $hostname optional value to set.
-     * @return string | null
+     * @param string|null $hostname Optional value to set.
+     * @return string|null
+     * @deprecated Use Gdn_Request::getHost() and Gdn_Request::setHost() instead.
      */
     public function host($hostname = null) {
         return $this->_environmentElement('HOST', $hostname);
@@ -641,8 +647,9 @@ class Gdn_Request implements RequestInterface {
 
     /**
      * Return the host and port together if the port isn't standard.
+     *
      * @return string
-     * @since 2.1
+     * @deprecated Use Gdn_Request::getHostAndPort() instead.
      */
     public function hostAndPort() {
         $host = $this->host();
@@ -658,6 +665,7 @@ class Gdn_Request implements RequestInterface {
      * Alias for requestAddress()
      *
      * @return string
+     * @deprecated Use Gdn_Request::getIP() instead.
      */
     public function ipAddress() {
         return $this->_Environment['ADDRESS'];
@@ -710,9 +718,10 @@ class Gdn_Request implements RequestInterface {
     /**
      * Gets/sets the port of the request.
      *
-     * @param int $Port
+     * @param int $port
      * @return int
      * @since 2.1
+     * @deprecated Use Gdn_Request::getPort() instead.
      */
     public function port($port = null) {
         return $this->_environmentElement('PORT', $port);
@@ -722,8 +731,9 @@ class Gdn_Request implements RequestInterface {
      * Gets/Sets the scheme from the current url. e.g. "http" in
      * "http://foo.com/this/that/garden/index.php?/controller/action/"
      *
-     * @param $scheme optional value to set.
+     * @param string $scheme Optional value to set.
      * @return string | null
+     * @deprecated Use Gdn_Request::getScheme() instead.
      */
     public function scheme($scheme = null) {
         return $this->_environmentElement('SCHEME', $scheme);
@@ -735,8 +745,6 @@ class Gdn_Request implements RequestInterface {
      * The purpose of this method is to consolidate all the various environment information into one
      * array under a set of common names, thereby removing the tedium of figuring out which superglobal
      * and key combination contain the requested information each time it is needed.
-     *
-     * @return void
      */
     protected function _loadEnvironment() {
         $this->_environmentElement('ConfigWebRoot', Gdn::config('Garden.WebRoot'));
@@ -903,8 +911,8 @@ class Gdn_Request implements RequestInterface {
      *    http://www.forum.com/vanilla/index.php?/discussion/345897/attachment/234/download/cashflow2009.pdf
      * then this method will return the filetype (in this case 'pdf').
      *
-     * @param $outputFormat Optional OutputFormat to set.
-     * @return string | null
+     * @param string|null $outputFormat Optional OutputFormat to set.
+     * @return string|null
      */
     public function outputFormat($outputFormat = null) {
         $outputFormat = (!is_null($outputFormat)) ? strtolower($outputFormat) : $outputFormat;
@@ -917,8 +925,6 @@ class Gdn_Request implements RequestInterface {
      * This method analyzes the Request environment and produces the ParsedRequest array which
      * contains the Path and OutputFormat keys. These are used by the Dispatcher to decide which
      * controller and method to invoke.
-     *
-     * @return void
      */
     protected function _parseRequest() {
         $this->_Parsing = true;
@@ -933,7 +939,9 @@ class Gdn_Request implements RequestInterface {
         if ($path !== false) {
             $this->path(trim($path, '/'));
         } else {
-            $expression = '/^(?:\/?'.str_replace('/', '\/', $this->_environmentElement('Folder')).')?(?:'.$this->_environmentElement('Script').')?\/?(.*?)\/?(?:[#?].*)?$/i';
+            $expression = '/^(?:\/?'.
+                str_replace('/', '\/', $this->_environmentElement('Folder')).
+                ')?(?:'.$this->_environmentElement('Script').')?\/?(.*?)\/?(?:[#?].*)?$/i';
             if (preg_match($expression, $this->_environmentElement('URI'), $match)) {
                 $this->path($match[1]);
             } else {
@@ -1027,6 +1035,7 @@ class Gdn_Request implements RequestInterface {
      *  - true: Url encode the returned path.
      *  - null: Return the path.
      * @return string | null
+     * @deprecated Use Gdn_Request::getPath() and Gdn_Request::setPath() instead.
      */
     public function path($path = null) {
         if (is_string($path)) {
@@ -1044,6 +1053,13 @@ class Gdn_Request implements RequestInterface {
         return $result;
     }
 
+    /**
+     * Get/set the request's path and query string.
+     *
+     * @param string|null $pathAndQuery Set a new path and query.
+     * @return string|null
+     * @deprecated Use Gdn_Request::setUrl() instead.
+     */
     public function pathAndQuery($pathAndQuery = null) {
         // Set the path and query if it is supplied.
         if ($pathAndQuery) {
@@ -1107,6 +1123,9 @@ class Gdn_Request implements RequestInterface {
         }
     }
 
+    /**
+     * Reset properties to default values.
+     */
     public function reset() {
         $this->_Environment = [];
         $this->_RequestArguments = [];
@@ -1176,7 +1195,7 @@ class Gdn_Request implements RequestInterface {
          * @param array $files
          * @return array
          */
-        $normalizeArray = function(array $files) use (&$getUpload) {
+        $normalizeArray = function (array $files) use (&$getUpload) {
             $result = [];
             foreach ($files['tmp_name'] as $key => $val) {
                 // Consolidate the attributes and push them down the tree.
@@ -1201,7 +1220,7 @@ class Gdn_Request implements RequestInterface {
          * @param array $value
          * @return array|UploadedFile
          */
-        $getUpload = function(array $value) use (&$normalizeArray) {
+        $getUpload = function (array $value) use (&$normalizeArray) {
             if (is_array($value['tmp_name'])) {
                 // We need to go deeper.
                 $result = $normalizeArray($value);
@@ -1274,9 +1293,11 @@ class Gdn_Request implements RequestInterface {
     /**
      * Decode the environment's post depending on content type.
      *
-     * @param array $post Usually the {@link $_POST} super-global.
-     * @param array $server Usually the {@link $_SERVER} super-global.
-     * @param string $inputFile Usually **php://input** for the raw input stream.
+     * @param array $post Usually the `$_POST` super-global.
+     * @param array $server Usually the `$_SERVER` super-global.
+     * @param string $inputFile Usually `php://input` for the raw input stream.
+     * @param array|null $files Usually the `$_FILES` super-global.
+     * @return mixed Returns the decoded post.
      */
     private function decodePost($post, $server, $inputFile = 'php://input', $files = null) {
         $contentType = !isset($server['CONTENT_TYPE']) ? 'application/x-www-form-urlencoded' : $server['CONTENT_TYPE'];
@@ -1304,7 +1325,7 @@ class Gdn_Request implements RequestInterface {
     /**
      * Set the POST body for the request.
      *
-     * @param $body
+     * @param mixed $body
      * @return self
      */
     public function setBody($body) {
@@ -1446,6 +1467,12 @@ class Gdn_Request implements RequestInterface {
         return $this;
     }
 
+    /**
+     * Set all of the request arguments of a type.
+     *
+     * @param string $paramsType One of the `INPUT_*` constants.
+     * @param array $paramsData The data to set.
+     */
     public function setRequestArguments($paramsType, $paramsData) {
         $this->_RequestArguments[$paramsType] = $paramsData;
     }
@@ -1516,6 +1543,13 @@ class Gdn_Request implements RequestInterface {
         return $this;
     }
 
+    /**
+     * Set a value on one of the core input arrays.
+     *
+     * @param string $paramType One of the `INPUT_*` constants.
+     * @param string $paramName The name of the parameter key.
+     * @param mixed $paramValue The new value.
+     */
     public function setValueOn($paramType, $paramName, $paramValue) {
         if (!isset($this->_RequestArguments[$paramType])) {
             $this->_RequestArguments[$paramType] = [];
@@ -1528,7 +1562,6 @@ class Gdn_Request implements RequestInterface {
      * Detach a dataset from the request
      *
      * @param int $paramsType type of data to remove. One of the self::INPUT_* constants
-     * @return void
      */
     public function _unsetRequestArguments($paramsType) {
         unset($this->_RequestArguments[$paramsType]);
@@ -1591,11 +1624,12 @@ class Gdn_Request implements RequestInterface {
                 $path = str_replace('https:', 'http:', $path);
                 $scheme = 'http';
             }
-        } else if ($withDomain && $withDomain !== '/') {
+        } elseif ($withDomain && $withDomain !== '/') {
             $scheme = $this->scheme();
         }
 
-        if (substr($path, 0, 2) == '//' || in_array(strpos($path, '://'), [4, 5])) { // Accounts for http:// and https:// - some querystring params may have "://", and this would cause things to break.
+        if (substr($path, 0, 2) == '//' || in_array(strpos($path, '://'), [4, 5])) {
+            // Accounts for http:// and https:// - some querystring params may have "://", and this would cause things to break.
             return $path;
         }
 
@@ -1664,10 +1698,11 @@ class Gdn_Request implements RequestInterface {
     }
 
     /**
-     * Get the url.
-     * (Simply concatenate host to uri provided)
+     * Get the URL.
      *
-     * @param strinп $uri
+     * This method simply concatenate host to URI provided.
+     *
+     * @param string $uri
      * @return string
      */
     public function getSimpleUrl(string $uri = ''): string {
@@ -1684,7 +1719,7 @@ class Gdn_Request implements RequestInterface {
      * @param string $url2 The second url to compare.
      * @return int Returns 0 if the urls are equal or 1, -1 if they are not.
      */
-    function urlCompare($url1, $url2) {
+    public function urlCompare($url1, $url2) {
         $parts1 = parse_url($this->url($url1));
         $parts2 = parse_url($this->url($url2));
 
@@ -1750,6 +1785,7 @@ class Gdn_Request implements RequestInterface {
      *
      * @param string? $webRoot The new web root to set.
      * @return string
+     * @deprecated Use Gdn_Request::getRoot() and Gdn_Request::setRoot() instead.
      */
     public function webRoot($webRoot = null) {
         if ($webRoot !== null || !$this->_HaveParsedRequest) {
@@ -1775,14 +1811,14 @@ class Gdn_Request implements RequestInterface {
      * specific PHP superglobal and including them here causes their data to be imported into the request
      * object.
      *
-     * @param self ::INPUT_*
+     * @param string $args One or more `INPUT_*` constants.
      * @flow chain
      * @return Gdn_Request
      */
-    public function withArgs() {
-        $argAliasList = func_get_args();
-        if (count($argAliasList)) {
-            foreach ($argAliasList as $argAlias) {
+    public function withArgs(...$args) {
+        $args = func_get_args();
+        if (count($args)) {
+            foreach ($args as $argAlias) {
                 $this->_setRequestArguments(strtolower($argAlias));
             }
         }
@@ -1797,7 +1833,7 @@ class Gdn_Request implements RequestInterface {
      * itself) to be attached in front of the other request superglobals and transparently override
      * their values when they are requested via val(). This method sets that data.
      *
-     * @param $customArgs key/value array of custom request argument data.
+     * @param array $customArgs Key/value array of custom request argument data.
      * @flow chain
      * @return Gdn_Request
      */
@@ -1809,9 +1845,9 @@ class Gdn_Request implements RequestInterface {
     /**
      * Chainable URI Setter, source is a controller + method + args list
      *
-     * @param $controller Gdn_Controller Object or string controller name.
-     * @param $method Optional name of the method to call. Omit or null for default (Index).
-     * @param $args Optional argument list to forward to the method. Omit for none.
+     * @param Gdn_Controller|string $controller Object or string controller name.
+     * @param string|null $method Optional name of the method to call. Omit or null for default (Index).
+     * @param array $args Optional argument list to forward to the method. Omit for none.
      * @flow chain
      * @return Gdn_Request
      */
@@ -1829,16 +1865,34 @@ class Gdn_Request implements RequestInterface {
         return $this;
     }
 
+    /**
+     * Set the delivery type.
+     *
+     * @param string $deliveryType
+     * @return $this
+     */
     public function withDeliveryType($deliveryType) {
         $this->setValueOn(self::INPUT_GET, 'DeliveryType', $deliveryType);
         return $this;
     }
 
+    /**
+     * Set the delivery method.
+     *
+     * @param string $deliveryMethod
+     * @return $this
+     */
     public function withDeliveryMethod($deliveryMethod) {
         $this->setValueOn(self::INPUT_GET, 'DeliveryMethod', $deliveryMethod);
         return $this;
     }
 
+    /**
+     * Set the URL from a route.
+     *
+     * @param string $route
+     * @return $this
+     */
     public function withRoute($route) {
         $parsedURI = Gdn::router()->getDestination($route);
         if ($parsedURI) {

--- a/tests/Library/Core/RequestTest.php
+++ b/tests/Library/Core/RequestTest.php
@@ -14,6 +14,9 @@ use Gdn_Request;
  */
 class RequestTest extends SharedBootstrapTestCase {
 
+    /**
+     * Provide some test URLs and how they should expand.
+     */
     public function provideUrls() {
         return [
             [
@@ -52,6 +55,9 @@ class RequestTest extends SharedBootstrapTestCase {
         ];
     }
 
+    /**
+     * The body should be the same as the POST.
+     */
     public function testBodyEquivalence() {
         $req = new Gdn_Request();
 
@@ -98,6 +104,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertNotInstanceOf(\Vanilla\UploadedFile::class, $request->post('Foo'), 'POST value overwritten by file.');
     }
 
+    /**
+     * Test `Gdn_Request::getUrl()`.
+     */
     public function testGetUrl() {
         $request = new Gdn_Request();
         $request->setScheme('http');
@@ -111,6 +120,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame('http://localhost:8080/root-dir/path/to/resource.json?foo=bar', $request->getUrl());
     }
 
+    /**
+     * Test request header accessors.
+     */
     public function testGetHeaders() {
         $server = [
             'CONTENT_TYPE' => 'application/json',
@@ -129,6 +141,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertEquals($expectedHeaders, $request->getHeaders());
     }
 
+    /**
+     * Test request header accessors.
+     */
     public function testGetHeader() {
         $server = [
             'CONTENT_TYPE' => 'application/json',
@@ -148,6 +163,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertEquals('no-cache', $request->getHeader('cache-control'));
     }
 
+    /**
+     * Test request header accessors.
+     */
     public function testGetHeaderLine() {
         $server = [
             'CONTENT_LENGTH' => '',
@@ -163,6 +181,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertEquals('application/json,application/xml', $request->getHeaderLine('Accept'));
     }
 
+    /**
+     * Test request header accessors.
+     */
     public function testHasHeader() {
         $server = [
             'CONTENT_TYPE' => 'application/json',
@@ -184,6 +205,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertFalse($request->hasHeader('Auth'));
     }
 
+    /**
+     * Test compatibility between `Gdn_Request::getHost()` and `Gdn_Request::host()`.
+     */
     public function testHostEquivalence() {
         $req = new Gdn_Request();
 
@@ -194,6 +218,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame($req->getHost(), $req->host());
     }
 
+    /**
+     * Test compatibility between `Gdn_Request::getHostAndPort()` and `Gdn_Request::hostAndPort()`.
+     */
     public function testHostAndPortEquivalence() {
         $req = new Gdn_Request();
 
@@ -206,6 +233,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame($req->getHostAndPort(), $req->hostAndPort());
     }
 
+    /**
+     * Test compatibility between `Gdn_Request::getIP()` and `Gdn_Request::ipAddress()`.
+     */
     public function testIPEquivalence() {
         $req = new Gdn_Request();
 
@@ -213,6 +243,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame($req->getIP(), $req->ipAddress());
     }
 
+    /**
+     * Test `Gdn_Request::mergeQuery()`.
+     */
     public function testMergeQuery() {
         $request = new Gdn_Request();
         $request->setQuery([
@@ -290,6 +323,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame('/foo', $req->getPath());
     }
 
+    /**
+     * Test compatibility between `Gdn_Request::getPort()` and `Gdn_Request::port()`.
+     */
     public function testPortEquivalence() {
         $req = new Gdn_Request();
 
@@ -348,6 +384,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertInstanceOf(\Vanilla\UploadedFile::class, $formFiles['Details']['Avatar'][1]);
     }
 
+    /**
+     * Test `Gdn_Request::getQuery()`.
+     */
     public function testQueryEquivalence() {
         $req = new Gdn_Request();
 
@@ -356,9 +395,11 @@ class RequestTest extends SharedBootstrapTestCase {
 
         $req->setRequestArguments(Gdn_Request::INPUT_GET, ['foo' => 'bar']);
         $this->assertSame($req->getQuery(), $req->getRequestArguments(Gdn_Request::INPUT_GET));
-
     }
 
+    /**
+     * Test `Gdn_Request::getQueryItem()`.
+     */
     public function testQueryItemEquivalence() {
         $req = new Gdn_Request();
 
@@ -369,6 +410,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame($req->getQueryItem('foo'), $req->getValueFrom(Gdn_Request::INPUT_GET, 'foo'));
     }
 
+    /**
+     * Test `Gdn_Request::setFullPath()`.
+     */
     public function testSetFullPath() {
         $request = new Gdn_Request();
         $request->setRoot('root-dir');
@@ -379,6 +423,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame('.json', $request->getExt());
     }
 
+    /**
+     * Test `Gdn_Request::setPathExt()`.
+     */
     public function testSetPathExt() {
         $request = new Gdn_Request();
         $request->setPathExt('path/to/resource.json');
@@ -387,6 +434,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame('.json', $request->getExt());
     }
 
+    /**
+     * Test `Gdn_Request::setQueryItem()`.
+     */
     public function testSetQueryItem() {
         $request = new Gdn_Request();
         $request->setQuery([
@@ -400,6 +450,8 @@ class RequestTest extends SharedBootstrapTestCase {
     }
 
     /**
+     * Test `Gdn_Request::setUrl()`.
+     *
      * @param string $url
      * @param array $expected
      * @dataProvider provideUrls
@@ -416,6 +468,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame($expected['query'], $request->getQuery());
     }
 
+    /**
+     * Test compatibility of `Gdn_Request::getRoot()` and `Gdn_Request::webRoot()`.
+     */
     public function testRootEquivalence() {
         $req = new Gdn_Request();
 
@@ -439,6 +494,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame('', $req->getRoot());
     }
 
+    /**
+     * Test compatibility between `Gdn_Request::getScheme()` and `Gdn_Request::scheme()`.
+     */
     public function testSchemeEquivalence() {
         $req = new Gdn_Request();
 
@@ -449,6 +507,9 @@ class RequestTest extends SharedBootstrapTestCase {
         $this->assertSame($req->getScheme(), $req->scheme());
     }
 
+    /**
+     * Test compatibility between `Gdn_Request::getUrl()` and `Gdn_Request::url('', true)`.
+     */
     public function testUrlEquivalence() {
         // Simulate that rewrite is ON
         $_SERVER['X_REWRITE'] = 1;


### PR DESCRIPTION
This is a bit of campground cleanup with the following:

1. Added doc blocks to `Gdn_Request` and `RequestTest`.
2. Fix some line length and other lint issues.
3. Soft deprecate some of our older `Gdn_Request` methods where new ones already exist.