### PR TITLE
Encode empty PHP arrays as “{}” in the JsonFieldProcessor

### DIFF
--- a/library/Vanilla/Database/Operation/JsonFieldProcessor.php
+++ b/library/Vanilla/Database/Operation/JsonFieldProcessor.php
@@ -61,7 +61,7 @@ class JsonFieldProcessor implements Processor {
         $set = $operation->getSet();
         foreach ($this->getFields() as $field) {
             if (array_key_exists($field, $set)) {
-                $packed = json_encode($set[$field]);
+                $packed = json_encode($set[$field], JSON_FORCE_OBJECT);
                 if ($packed === false) {
                     throw new \Exception("Unable to encode field as JSON.");
                 }


### PR DESCRIPTION
Given that our attributes are almost always key value stores I think it’s more prudent to encode empty arrays as “{}” instead of “{}”.