### PR TITLE
Check if last category id is zero

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -343,7 +343,7 @@ if (!function_exists('WriteTableRow')):
                                 $row['LastUrl'],
                                 'CommentDate MItem');
 
-                            if (isset($row['LastCategoryID']) && $row['LastCategoryID'] !== 0) {
+                            if (!empty($row['LastCategoryID'])) {
                                 $lastCategory = CategoryModel::categories($row['LastCategoryID']);
 
                                 echo ' <span>',

--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -343,7 +343,7 @@ if (!function_exists('WriteTableRow')):
                                 $row['LastUrl'],
                                 'CommentDate MItem');
 
-                            if (isset($row['LastCategoryID'])) {
+                            if (isset($row['LastCategoryID']) && $row['LastCategoryID'] !== 0) {
                                 $lastCategory = CategoryModel::categories($row['LastCategoryID']);
 
                                 echo ' <span>',


### PR DESCRIPTION
I ran into an issue where my `LastCategoryID` is 0 and it crashes the page. I added an extra check. @igraziatto, I saw you touched [this line](https://github.com/vanilla/vanilla/compare/fix%2Flast-category-id-zero?expand=1#diff-c1b172827df39c8108768ab4a4ebce5fL350) recently, so it might be related to that? 

I'm not sure if it's just my DB that has bad data, or this is a bug. If it's my DB, ignore this PR, but I would like to know how to fix it. Thanks!

