### PR TITLE
Add checkmark link prop for DropdownItemLink

### DIFF
--- a/library/src/scripts/flyouts/StoryExampleDropDown.tsx
+++ b/library/src/scripts/flyouts/StoryExampleDropDown.tsx
@@ -64,6 +64,9 @@ export function StoryExampleDropDown(props: IProps) {
             <DropDownItemLink name={t("Link 1")} to={"#"} />
             <DropDownItemLink name={t("Link 2")} to={"#"} />
             <DropDownItemLink name={t("Link 3")} to={"#"} />
+            <DropDownItemLink to="#" isChecked={true}>
+                Link with checkmark
+            </DropDownItemLink>
             <DropDownSection title={"Section Title"}>
                 <MeBoxDropDownItemList
                     emptyMessage={t("You do not have any notifications yet.")}

--- a/library/src/scripts/flyouts/dropDownStyles.ts
+++ b/library/src/scripts/flyouts/dropDownStyles.ts
@@ -407,6 +407,9 @@ export const dropDownClasses = useThemeCache(() => {
 
     const check = style("check", {
         color: colorOut(globalVars.mainColors.primary),
+
+        /// Check to fix icon alignment.
+        transform: `translateX(4px)`,
     });
 
     const flyoutOffset = vars.item.padding.horizontal + globalVars.border.width;

--- a/library/src/scripts/flyouts/items/DropDownItemLink.tsx
+++ b/library/src/scripts/flyouts/items/DropDownItemLink.tsx
@@ -11,7 +11,7 @@ import SmartLink from "@library/routing/links/SmartLink";
 import classNames from "classnames";
 import { LocationDescriptor } from "history";
 import React from "react";
-import { CheckIcon, DropDownMenuIcon } from "@library/icons/common";
+import { CheckIcon, DropDownMenuIcon, CheckCompactIcon } from "@library/icons/common";
 
 export interface IDropDownItemLink {
     to: LocationDescriptor;
@@ -19,7 +19,7 @@ export interface IDropDownItemLink {
     children?: React.ReactNode;
     className?: string;
     lang?: string;
-    isCurrent?: boolean;
+    isChecked?: boolean;
     isActive?: boolean;
 }
 
@@ -40,6 +40,7 @@ export default class DropDownItemLink extends React.Component<IDropDownItemLink>
                     className={classNames(classes.action, this.props.isActive && classes.actionActive)}
                 >
                     {linkContents}
+                    {this.props.isChecked && <CheckCompactIcon className={classes.check} aria-hidden={true} />}
                 </SmartLink>
             </DropDownItem>
         );


### PR DESCRIPTION
- isCurrent was unused.
- Check style is similar to the dropdown toggle.
- Added a cheat to our `dropdown-check` class to align it to the right (so it aligns correctly to the edge).