### PR TITLE
Add resource event dispatching for user notifications

### DIFF
--- a/applications/dashboard/Events/NotificationEvent.php
+++ b/applications/dashboard/Events/NotificationEvent.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Dashboard\Events;
+
+use Garden\Events\ResourceEvent;
+
+/**
+ * Represent a user notification event.
+ */
+class NotificationEvent extends ResourceEvent {
+}

--- a/applications/dashboard/controllers/api/NotificationsApiController.php
+++ b/applications/dashboard/controllers/api/NotificationsApiController.php
@@ -134,15 +134,7 @@ class NotificationsApiController extends AbstractApiController {
      * @return array
      */
     private function normalizeOutput(array $row): array {
-        $row["notificationID"] = $row["ActivityID"];
-        $row["photoUrl"] = $row["Photo"];
-        $row["read"] = $row["Notified"] === ActivityModel::SENT_OK;
-
-        $body = formatString($row["Headline"], $row);
-        // Replace anchors with bold text until notifications can be spun off from activities.
-        $row["body"] = preg_replace("#<a [^>]+>(.+)</a>#Ui", "<strong>$1</strong>", $body);
-
-        $row = ApiUtils::convertOutputKeys($row);
+        $row = $this->activityModel->normalizeNotificationRow($row);
         return $row;
     }
 
@@ -185,38 +177,7 @@ class NotificationsApiController extends AbstractApiController {
         static $schema;
 
         if ($schema === null) {
-            $schema = $this->schema([
-                "notificationID" => [
-                    "description" => "A unique ID to identify the notification.",
-                    "type" => "integer",
-                ],
-                "body" => [
-                    "description" => "The notification text. This contains some HTML, but only <b> tags.",
-                    "type" => "string",
-                ],
-                "photoUrl" => [
-                    "allowNull" => true,
-                    "description" => "An avatar or thumbnail associated with the notification.",
-                    "type" => "string",
-                ],
-                "url" => [
-                    "description" => "The target of the notification.",
-                    "type" => "string",
-                ],
-                "dateInserted" => [
-                    "description" => "When the notification was first made.",
-                    "type" => "datetime",
-                ],
-                "dateUpdated" => [
-                    // phpcs:ignore
-                    "description" => "When the notification was last updated.\n\nNotifications on the same record will group together into a single notification, updating just the dateUpdated property.",
-                    "type" => "datetime",
-                ],
-                "read" => [
-                    "description" => "Whether or not the notification has been seen.",
-                    "type" => "boolean",
-                ],
-            ], "NotificationSchema");
+            $schema = $this->schema($this->activityModel->notificationSchema(), "NotificationSchema");
         }
 
         return $schema;

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -8,30 +8,24 @@
  * @since 2.0
  */
 
-use Garden\Events\EventFromRowInterface;
 use Garden\Events\ResourceEvent;
 use Garden\Schema\Schema;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
-use Vanilla\Contracts\Formatting\FormatFieldInterface;
 use Vanilla\Dashboard\Models\ActivityEmail;
 use Vanilla\Formatting\Formats\TextFormat;
 use Vanilla\Formatting\Formats;
-use Vanilla\Formatting\FormatFieldTrait;
 use Vanilla\Formatting\FormatService;
 use Vanilla\Dashboard\Events\NotificationEvent;
 use Vanilla\Models\UserFragmentSchema;
-use Vanilla\SchemaFactory;
 use Vanilla\Utility\CamelCaseScheme;
 
 /**
  * Activity data management.
  */
-class ActivityModel extends Gdn_Model implements FormatFieldInterface {
+class ActivityModel extends Gdn_Model {
 
     use \Vanilla\FloodControlTrait;
-
-    use FormatFieldTrait;
 
     /** Maximum length of activity story excerpts. */
     private const DEFAULT_EXCERPT_LENGTH = 160;

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -73,6 +73,8 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
     /** Timeout for SSO */
     const SSO_TIMEOUT = 1200;
 
+    private const USERAUTHENTICATION_CACHE_EXPIRY = 60;
+
     /** @var EventManager */
     private $eventManager;
 
@@ -1533,11 +1535,45 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
      * @param string $provider
      * @return array
      */
-    private function getUserAuthentications(array $userIDs, string $provider): array {
-        return $this->SQL->getWhere(
-            'UserAuthentication',
-            ['UserID' => $userIDs, 'ProviderKey' => $provider]
-        )->resultArray();
+    private function getAuthentications(array $userIDs, string $provider): array {
+        $result = [];
+
+        // Check the cache...
+        $cacheKeys = [];
+        foreach ($userIDs as $currentID) {
+            $cacheKeys[] = $this->authenticationCacheKey($provider, $currentID);
+        }
+        $cachedRows = Gdn::cache()->get($cacheKeys);
+
+        if (is_array($cachedRows)) {
+            $result = $result + array_values($cachedRows);
+            $userIDs = array_diff($userIDs, array_column($result, "UserID"));
+        }
+
+        // ...and query the DB for what's left.
+        if (!empty($userIDs)) {
+            $rows = $this->SQL->getWhere(
+                "UserAuthentication",
+                ["UserID" => $userIDs, "ProviderKey" => $provider]
+            )->resultArray();
+
+            foreach ($rows as $userAuthentication) {
+                $userID = $userAuthentication["UserID"] ?? null;
+                if ($userID === null) {
+                    continue;
+                }
+                $cacheKey = $this->authenticationCacheKey($provider, $userID);
+                Gdn::cache()->store(
+                    $cacheKey,
+                    $userAuthentication,
+                    [Gdn_Cache::FEATURE_EXPIRY => self::USERAUTHENTICATION_CACHE_EXPIRY]
+                );
+            }
+
+            $result = $result + $rows;
+        }
+
+        return $result;
     }
 
     /**
@@ -5588,6 +5624,18 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
     }
 
     /**
+     * Generate a cache key for a user authentication row for a specific provider.
+     *
+     * @param string $provider
+     * @param int $userID
+     * @return string
+     */
+    private function authenticationCacheKey(string $provider, int $userID): string {
+        $result = "userAuthentication.{$provider}.{$userID}";
+        return $result;
+    }
+
+    /**
      * Given an array of user IDs
      *
      * @param array $userIDs
@@ -5601,7 +5649,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
             return $result;
         }
 
-        $connections = $this->getUserAuthentications($userIDs, $defaultProvider["AuthenticationKey"]);
+        $connections = $this->getAuthentications($userIDs, $defaultProvider["AuthenticationKey"]);
         $mapping = array_column($connections, "ForeignUserKey", "UserID");
         foreach ($mapping as $userID => $ssoID) {
             $result[$userID] = $ssoID;

--- a/tests/Models/ActivityModelTest.php
+++ b/tests/Models/ActivityModelTest.php
@@ -55,6 +55,24 @@ class ActivityModelTest extends TestCase {
     }
 
     /**
+     * Verify a notification event is not dispatched when no notifications are pending.
+     *
+     * @return void
+     */
+    public function testNotificationEventNotDispatched(): void {
+        $this->model->save([
+            "ActivityUserID" => 1,
+            "Body" => "Hello world.",
+            "Format" => "markdown",
+            "HeadlineFormat" => __FUNCTION__,
+            "Notified" => ActivityModel::SENT_SKIPPED,
+            "NotifyUserID" => 2
+        ]);
+
+        $this->assertNull($this->lastEvent);
+    }
+
+    /**
      * Verify notification event dispatched when adding a new notification.
      *
      * @return void
@@ -68,7 +86,10 @@ class ActivityModelTest extends TestCase {
             "Notified" => ActivityModel::SENT_PENDING,
             "NotifyUserID" => 2
         ]);
+
         $this->assertInstanceOf(NotificationEvent::class, $this->lastEvent);
-        $this->assertEquals(NotificationEvent::ACTION_INSERT, $this->lastEvent->getAction());
+        $this->assertEquals("notification", $this->lastEvent->getType());
+        $this->assertNull($this->lastEvent->getSender());
+        $this->assertArrayHasKey("notification", $this->lastEvent->getPayload());
     }
 }

--- a/tests/Models/ActivityModelTest.php
+++ b/tests/Models/ActivityModelTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Models;
+
+use ActivityModel;
+use Garden\EventManager;
+use PHPUnit\Framework\TestCase;
+use Vanilla\Dashboard\Events\NotificationEvent;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Some basic tests for the `ActivityModel`.
+ */
+class ActivityModelTest extends TestCase {
+
+    use SiteTestTrait;
+
+    /** @var NotificationEvent */
+    private $lastEvent;
+
+    /** @var ActivityModel */
+    private $model;
+
+    /**
+     * A test listener that increments the counter.
+     *
+     * @param NotificationEvent $e
+     * @return NotificationEvent
+     */
+    public function handleNotificationEvent(NotificationEvent $e): NotificationEvent {
+        $this->lastEvent = $e;
+        return $e;
+    }
+
+    /**
+     * Get a new model for each test.
+     */
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->model = $this->container()->get(ActivityModel::class);
+
+        // Make event testing a little easier.
+        $this->container()->setInstance(self::class, $this);
+        $this->lastEvent = null;
+
+        /** @var EventManager */
+        $eventManager = $this->container()->get(EventManager::class);
+        $eventManager->unbindClass(self::class);
+        $eventManager->addListenerMethod(self::class, "handleNotificationEvent");
+    }
+
+    /**
+     * Verify notification event dispatched when adding a new notification.
+     *
+     * @return void
+     */
+    public function testNotificationEventDispatched(): void {
+        $this->model->save([
+            "ActivityUserID" => 1,
+            "Body" => "Hello world.",
+            "Format" => "markdown",
+            "HeadlineFormat" => __FUNCTION__,
+            "Notified" => ActivityModel::SENT_PENDING,
+            "NotifyUserID" => 2
+        ]);
+        $this->assertInstanceOf(NotificationEvent::class, $this->lastEvent);
+        $this->assertEquals(NotificationEvent::ACTION_INSERT, $this->lastEvent->getAction());
+    }
+}


### PR DESCRIPTION
This update adds dispatching of a new `NotificationEvent` object when there are user notifications on a site.

1. `NotificationEvent` has been added to represent a user notification event.
1. The notifications API controller has had its schema and normalize methods extracted and moved to `ActivityModel`. There should be no functional changes in the notifications API controller.
1. The random calls to `Gdn::userModel` within `ActivityModel` are now replaced with a more apparent dependency, set as a class property in the class constructor. No functional changes should be caused by this adjustment.
1. If a notification is scheduled to be sent to a user, a `NotificationEvent` should be dispatched.
1. If a queue of user notifications is being processed, the default SSO IDs and user rows are cached in advance. This data is used in the notification event payload.
1. Caching has been added to `UserModel::getAuthentications`. User authentication records retrieved via this method are cached for sixty seconds.
1. A test case for `ActivityModel` has been added. Currently, only notification events are tested.