### PR TITLE
Remove phpunit.xml.dist from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,5 +98,4 @@ yarn-error.log
 lerna-debug.log
 git-diff.txt
 phpcs-diff.json
-phpunit.xml.dist
 .phpunit.result.cache


### PR DESCRIPTION
In #9505 this addition was [flagged](https://github.com/vanilla/vanilla/pull/9505#pullrequestreview-309312316) as incorrect, but it made it in anyway.