### PR TITLE
Add categories module to side panel on nested category page

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -588,6 +588,7 @@ class CategoriesController extends VanillaController {
         $this->addModule('NewDiscussionModule');
         $this->addModule('DiscussionFilterModule');
         $this->addModule('BookmarkedModule');
+        $this->addModule('CategoriesModule');
         $this->addModule($CategoryFollowToggleModule);
         $this->addModule('TagModule');
 


### PR DESCRIPTION
Closes vanilla/support#1910.

This PR fixes an issue where the Categories aren't displayed in the side panel when viewing a nested category.

### TO TEST
1. Set a category's display mode to "Nested".
1. View the category and note that the "Categories" section is missing from the side panel.
1. Check out this branch, view the page, and verify that the "Categories" section is there.