### PR TITLE
Exclude NBBC from autoloader tests

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -570,6 +570,7 @@ class Bootstrap {
             'sitehub',
             'lithecompiler',
             'lithestyleguide',
+            'NBBC',
             'Warnings',
         ];
         foreach ($excluded as $subdir) {


### PR DESCRIPTION
This fixes a conflict where the autoloader tests were failing because the tests registered duplicate classes. Excluding this older plugin from the tests will fix the problem.