### PR TITLE
Correct Gdn_Dirtycache documentation

### DIFF
--- a/library/core/class.dirtycache.php
+++ b/library/core/class.dirtycache.php
@@ -12,7 +12,7 @@
 /**
  * Cache Layer: Dirty.
  *
- * This is a cache implementation that caches nothing and always reports cache misses.
+ * This is a cache implementation that caches values in memory only for the time of the request.
  */
 class Gdn_Dirtycache extends Gdn_Cache {
 


### PR DESCRIPTION
Dirtycache caches values since 2013 despite its class description. See #6199 for more detail.

Since at least the UserModel relies on this behaviour (for the DB not to be flooded with queries), it should be documented.