### PR TITLE
Pockets by subcommunity

### DIFF
--- a/library/src/scripts/utility/componentRegistry.tsx
+++ b/library/src/scripts/utility/componentRegistry.tsx
@@ -32,7 +32,7 @@ export function isComponentThemingEnabled() {
     return useTheme;
 }
 
-interface IRegisteredComponent {
+export interface IRegisteredComponent {
     Component: React.ComponentType<any>;
     mountOptions?: IComponentMountOptions;
 }

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -795,7 +795,6 @@ class PocketsPlugin extends Gdn_Plugin {
             "pocket-multi-role-input",
             [
                 "tag" => "li",
-                "value" => $Form->getvalue("RoleIDs") ?? []
             ]
         );
     }

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -577,10 +577,7 @@ class PocketsPlugin extends Gdn_Plugin {
 
         $locationOptions = val($location, $this->Locations, []);
 
-        if ($this->ShowPocketLocations &&
-            arrasettingsController_additionalPocketFiltersy_key_exists($location, $this->Locations) &&
-            checkPermission('Plugins.Pockets.Manage') && $sender->MasterView != 'admin'
-        ) {
+        if ($this->ShowPocketLocations && arrasettingsController_AdditionalPocketFiltersy_key_exists($location, $this->Locations) && checkPermission('Plugins.Pockets.Manage') && $sender->MasterView != 'admin') {
             $locationName = val("Name", $this->Locations, $location);
             echo
                 valr('Wrap.0', $locationOptions, ''),

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -578,7 +578,7 @@ class PocketsPlugin extends Gdn_Plugin {
         $locationOptions = val($location, $this->Locations, []);
 
         if ($this->ShowPocketLocations &&
-            arrasettingsController_AdditionalPocketFiltersy_key_exists($location, $this->Locations) &&
+            array_key_exists($location, $this->Locations) &&
             checkPermission('Plugins.Pockets.Manage') && $sender->MasterView != 'admin') {
             $locationName = val("Name", $this->Locations, $location);
             echo

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -577,7 +577,9 @@ class PocketsPlugin extends Gdn_Plugin {
 
         $locationOptions = val($location, $this->Locations, []);
 
-        if ($this->ShowPocketLocations && arrasettingsController_AdditionalPocketFiltersy_key_exists($location, $this->Locations) && checkPermission('Plugins.Pockets.Manage') && $sender->MasterView != 'admin') {
+        if ($this->ShowPocketLocations &&
+            arrasettingsController_AdditionalPocketFiltersy_key_exists($location, $this->Locations) &&
+            checkPermission('Plugins.Pockets.Manage') && $sender->MasterView != 'admin') {
             $locationName = val("Name", $this->Locations, $location);
             echo
                 valr('Wrap.0', $locationOptions, ''),

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -578,7 +578,7 @@ class PocketsPlugin extends Gdn_Plugin {
         $locationOptions = val($location, $this->Locations, []);
 
         if ($this->ShowPocketLocations &&
-            arrasettingsController_AdditionalPocketFiltersy_key_exists($location, $this->Locations) &&
+            arrasettingsController_additionalPocketFiltersy_key_exists($location, $this->Locations) &&
             checkPermission('Plugins.Pockets.Manage') && $sender->MasterView != 'admin'
         ) {
             $locationName = val("Name", $this->Locations, $location);
@@ -789,7 +789,7 @@ class PocketsPlugin extends Gdn_Plugin {
      *
      * @param array $args
      */
-    function settingsController_additionalPocketFilterInputs_handler ($args) {
+    public function settingsController_additionalPocketFilterInputs_handler ($args) {
         $Form = $args['form'];
         echo $Form->react(
             "RoleIDs",

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -789,7 +789,7 @@ class PocketsPlugin extends Gdn_Plugin {
      *
      * @param array $args
      */
-    public function settingsController_additionalPocketFilterInputs_handler($args) {
+    function settingsController_additionalPocketFilterInputs_handler ($args) {
         $Form = $args['form'];
         echo $Form->react(
             "RoleIDs",

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -789,7 +789,7 @@ class PocketsPlugin extends Gdn_Plugin {
      *
      * @param array $args
      */
-    public function settingsController_additionalPocketFilterInputs_handler ($args) {
+    public function settingsController_additionalPocketFilterInputs_handler($args) {
         $Form = $args['form'];
         echo $Form->react(
             "RoleIDs",

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -796,6 +796,7 @@ class PocketsPlugin extends Gdn_Plugin {
             "pocket-multi-role-input",
             [
                 "tag" => "li",
+                "value" => $Form->getvalue("RoleIDs") ?? []
             ]
         );
     }

--- a/plugins/pockets/addon.json
+++ b/plugins/pockets/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Pockets",
     "description": "Administrators may add raw HTML to various places on the site. This plugin is very powerful, but can easily break your site if you make a mistake.",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "registerPermissions": {
         "Plugins.Pockets.Manage": "Garden.Settings.Manage",
         "0": "Garden.NoAds.Allow"

--- a/plugins/pockets/src/scripts/conditions/PocketMultiRoleInput.tsx
+++ b/plugins/pockets/src/scripts/conditions/PocketMultiRoleInput.tsx
@@ -3,7 +3,7 @@
  * @license GPL-2.0-only
  */
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useState } from "react";
 import { MultiRoleInput } from "@dashboard/roles/MultiRoleInput";
 import { DashboardFormGroup } from "@dashboard/forms/DashboardFormGroup";
 import { t } from "@vanilla/i18n/src";


### PR DESCRIPTION
This PR adds a new section to the edit pocket page, allowing the user to only display the pocket in chosen subcommunities.

A few things to note:
- The subcommunity picker and the roles picker have been moved up because they have a dropdown that made the page jump at the bottom

Closes: https://github.com/vanilla/vanilla/issues/10586

Requires: https://github.com/vanilla/multisite/pull/370

Replaced: https://github.com/vanilla/vanilla/pull/10629