### PR TITLE
Clear the theme cache on deploys

### DIFF
--- a/applications/dashboard/settings/structure.php
+++ b/applications/dashboard/settings/structure.php
@@ -8,6 +8,7 @@
  * @since 2.0
  */
 
+use Vanilla\Theme\ThemeCache;
 use Vanilla\Theme\ThemeServiceHelper;
 
 if (!defined('APPLICATION')) {
@@ -1052,3 +1053,9 @@ if (Gdn::config()->get("Robots.Rules") === false && $sitemapsRobotsRules = Gdn::
  */
 $themeHelper = Gdn::getContainer()->get(ThemeServiceHelper::class);
 $themeHelper->saveCurrentThemeToVisible();
+
+
+// Clear out the theme cache in case any file based themes were updated.
+/** @var ThemeCache $themeCache */
+$themeCache = Gdn::getContainer()->get(ThemeCache::class);
+$themeCache->clear();


### PR DESCRIPTION
File based themes can be updated on deploys so we need to clear out the theme cache when updating the site after the deploy.

Our cache TTL is pretty low, but this way there is no significant delay.