### PR TITLE
Added pocket location after banner

### DIFF
--- a/applications/dashboard/models/BannerImageModel.php
+++ b/applications/dashboard/models/BannerImageModel.php
@@ -71,6 +71,16 @@ class BannerImageModel {
         } else {
             $html = "<div data-react='community-content-banner' data-props='$propsJson'><div style=\"minHeight='500px'\"></div></div>";
         }
+
+        if (Gdn::themeFeatures()->useDataDrivenTheme()) {
+            /** @var \Garden\EventManager $eventManager */
+            $eventManager = Gdn::getContainer()->get(\Garden\EventManager::class);
+            $afterBanner = $eventManager->fire('AfterBanner', $this);
+            if (!empty($afterBanner)) {
+                $html .= implode("", $afterBanner);
+            }
+        }
+
         return new \Twig\Markup($html, 'utf-8');
     }
 

--- a/applications/dashboard/models/BannerImageModel.php
+++ b/applications/dashboard/models/BannerImageModel.php
@@ -72,13 +72,11 @@ class BannerImageModel {
             $html = "<div data-react='community-content-banner' data-props='$propsJson'><div style=\"minHeight='500px'\"></div></div>";
         }
 
-        if (Gdn::themeFeatures()->useDataDrivenTheme()) {
-            /** @var \Garden\EventManager $eventManager */
-            $eventManager = Gdn::getContainer()->get(\Garden\EventManager::class);
-            $afterBanner = $eventManager->fire('AfterBanner', $this);
-            if (!empty($afterBanner)) {
-                $html .= implode("", $afterBanner);
-            }
+        /** @var \Garden\EventManager $eventManager */
+        $eventManager = Gdn::getContainer()->get(\Garden\EventManager::class);
+        $afterBanner = $eventManager->fire('AfterBanner', $this);
+        if (!empty($afterBanner)) {
+            $html .= implode("", $afterBanner);
         }
 
         return new \Twig\Markup($html, 'utf-8');

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -52,6 +52,10 @@ class PocketsPlugin extends Gdn_Plugin {
             $colspan = c('Plugins.Pockets.Colspan', ($useAdminChecks) ? 6 : 5);
             $this->Locations['BetweenDiscussions']['Wrap'] = ['<tr><td colspan="'.$colspan.'">', '</td></tr>'];
         }
+
+        if (Gdn::themeFeatures()->useDataDrivenTheme()) {
+            $this->Locations['AfterBanner'] = ['Name' => 'After Banner'];
+        }
     }
 
     /**
@@ -133,6 +137,20 @@ class PocketsPlugin extends Gdn_Plugin {
             return;
         }
         $this->processPockets($sender, 'BetweenComments');
+    }
+
+    /**
+     * Hook into after banner pocket location
+     *
+     * @param Gdn_Controller $sender
+     * @param array $args
+     * @return string
+     */
+    public function AfterBanner_handler($sender, $args = []) {
+        ob_start();
+        $this->processPockets($sender, "AfterBanner");
+        $output = ob_get_clean();
+        return $output;
     }
 
     /**
@@ -332,6 +350,10 @@ class PocketsPlugin extends Gdn_Plugin {
 
             // Convert the form data into a format digestable by the database.
             $repeat = $form->getFormValue('RepeatType');
+            if ($form->getFormValue("Location") === "AfterBanner") {
+                $repeat = Pocket::REPEAT_ONCE;
+            }
+
             switch ($repeat) {
                 case Pocket::REPEAT_EVERY:
                     $pocketModel->Validation->applyRule('EveryFrequency', 'Integer');
@@ -355,6 +377,7 @@ class PocketsPlugin extends Gdn_Plugin {
                 default:
                     break;
             }
+
             $form->setFormValue('Repeat', $repeat);
             $form->setFormValue('Sort', 0);
             $form->setFormValue('Format', 'Raw');
@@ -547,7 +570,7 @@ class PocketsPlugin extends Gdn_Plugin {
         if (Gdn::controller()->deliveryMethod() != DELIVERY_METHOD_XHTML) {
             return;
         }
-        if (Gdn::controller()->data('_NoMessages') && $location != 'Head') {
+        if (Gdn::controller()->data('_NoMessages') && $location != 'Head' && $location !== 'AfterBanner') {
             return;
         }
 
@@ -867,14 +890,15 @@ class PocketsPlugin extends Gdn_Plugin {
 
         $pocketData = $pocket->Data;
         $categoryID = $pocketData['CategoryID'] ?? null;
+
+        if (empty($categoryID)) {
+            return $existingCanRender;
+        }
+
         if (!is_numeric($categoryID)) {
             return false;
         } else {
             $categoryID = (int) $categoryID;
-        }
-
-        if (empty($categoryID)) {
-            return $existingCanRender;
         }
 
         $controller = \Gdn::controller();

--- a/plugins/pockets/PocketsPlugin.php
+++ b/plugins/pockets/PocketsPlugin.php
@@ -146,7 +146,7 @@ class PocketsPlugin extends Gdn_Plugin {
      * @param array $args
      * @return string
      */
-    public function AfterBanner_handler($sender, $args = []) {
+    public function afterBanner_handler($sender, $args = []) {
         ob_start();
         $this->processPockets($sender, "AfterBanner");
         $output = ob_get_clean();

--- a/plugins/pockets/js/pockets.js
+++ b/plugins/pockets/js/pockets.js
@@ -40,6 +40,7 @@ var revealRepeatOptions = function() {
 var toggleRepeat = function() {
     var selected = $("select[name$=Location] option:selected").text();
     switch (selected) {
+        case 'AfterBanner':
         case 'Custom':
             $('.js-repeat').hide();
             break;

--- a/plugins/pockets/src/scripts/conditions/PocketCategoryInput.tsx
+++ b/plugins/pockets/src/scripts/conditions/PocketCategoryInput.tsx
@@ -43,7 +43,7 @@ export function PocketCategoryInput(props) {
                         value={category}
                     />
                 </div>
-                <input name={props.fieldName} type={"hidden"} value={hasCategory ?? undefined} />
+                <input name={props.fieldName} type={"hidden"} value={hasCategory ?? ""} />
                 <div className={classNames("checkbox", classes.checkBoxAfterInput)}>
                     <DashboardRadioGroup>
                         <DashboardCheckBox


### PR DESCRIPTION
This PR adds a pocket location under the banner, only for data driven themes.

Note I also found a bug with the category filter not being cleared properly on save.

Closes: https://github.com/vanilla/vanilla/issues/10417