### PR TITLE
Fix JSON asset rendering and fetching the wrong asset for theme JS

### DIFF
--- a/library/Vanilla/Theme/Asset/JsonThemeAsset.php
+++ b/library/Vanilla/Theme/Asset/JsonThemeAsset.php
@@ -40,7 +40,7 @@ class JsonThemeAsset extends ThemeAsset {
                 "error" => "Error decoding JSON",
                 "message" => json_last_error_msg(),
             ];
-            $this->jsonString = json_encode($this->data);
+            $this->jsonString = json_encode($this->data, JSON_FORCE_OBJECT);
         } else {
             $this->jsonString = $data;
             $this->data = $decoded;
@@ -76,6 +76,18 @@ class JsonThemeAsset extends ThemeAsset {
      */
     public function getValue(): array {
         return $this->data;
+    }
+
+    /**
+     * Overridden so objects don't get coerced into arrays.
+     *
+     * @inheritdoc
+     */
+    public function jsonSerialize() {
+        return [
+            'type' => $this->getDefaultType(),
+            'data' => json_decode($this->jsonString),
+        ];
     }
 
     /**

--- a/library/Vanilla/Theme/Asset/JsonThemeAsset.php
+++ b/library/Vanilla/Theme/Asset/JsonThemeAsset.php
@@ -84,10 +84,16 @@ class JsonThemeAsset extends ThemeAsset {
      * @inheritdoc
      */
     public function jsonSerialize() {
-        return [
+        $result = [
+            'url' => $this->getUrl(),
             'type' => $this->getDefaultType(),
-            'data' => json_decode($this->jsonString),
         ];
+
+        if ($this->includeValueInJson) {
+            $result['data'] = json_decode($this->jsonString);
+        }
+
+        return $result;
     }
 
     /**

--- a/library/Vanilla/Theme/Asset/NeonThemeAsset.php
+++ b/library/Vanilla/Theme/Asset/NeonThemeAsset.php
@@ -29,7 +29,7 @@ class NeonThemeAsset extends JsonThemeAsset {
         $this->neonString = $data;
         try {
             $this->data = Neon::decode($data);
-            $this->jsonString = json_encode($this->data);
+            $this->jsonString = json_encode($this->data, JSON_FORCE_OBJECT);
         } catch (\Exception $e) {
             // It's a bad asset.
             // Replace the asset with some json containing the error message.

--- a/library/Vanilla/Theme/Theme.php
+++ b/library/Vanilla/Theme/Theme.php
@@ -284,7 +284,7 @@ class Theme implements \JsonSerializable {
         $variablesAsset = $this->getAssets()[ThemeAssetFactory::ASSET_VARIABLES] ?? null;
         if ($variablesAsset instanceof JsonThemeAsset) {
             $merged = array_replace_recursive($variablesAsset->getValue(), $variables);
-            $newAsset = new JsonThemeAsset(json_encode($merged, JSON_UNESCAPED_UNICODE), $variablesAsset->getUrl());
+            $newAsset = new JsonThemeAsset(json_encode($merged, JSON_UNESCAPED_UNICODE | JSON_FORCE_OBJECT), $variablesAsset->getUrl());
             $this->assets[ThemeAssetFactory::ASSET_VARIABLES] = $newAsset;
         }
     }

--- a/library/Vanilla/Theme/ThemePreloadProvider.php
+++ b/library/Vanilla/Theme/ThemePreloadProvider.php
@@ -113,7 +113,7 @@ class ThemePreloadProvider implements ReduxActionProviderInterface {
             return null;
         }
 
-        $script = $theme->getAssets()[ThemeAssetFactory::ASSET_SCRIPTS] ?? null;
+        $script = $theme->getAsset(ThemeAssetFactory::ASSET_JAVASCRIPT);
         if (!($script instanceof JavascriptThemeAsset) || !$script->__toString()) {
             return null;
         }


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1967

- Fix JSON asset rendering all objects as arrays. This was a bug even before the refactor.
- Fix javascript asset not getting loaded (I was loading the wrong asset name.)