### PR TITLE
[Backport 2020.010] Fix NEON asset rendering

### DIFF
--- a/library/Vanilla/Theme/NeonAsset.php
+++ b/library/Vanilla/Theme/NeonAsset.php
@@ -22,8 +22,6 @@ class NeonAsset extends JsonAsset {
      * @param string $data
      */
     public function __construct($data) {
-        $this->data = Neon::decode($data);
-
-        $result = true;
+        $this->data = json_decode(json_encode(Neon::decode($data), JSON_FORCE_OBJECT));
     }
 }


### PR DESCRIPTION
Backport of the fix for vanilla/support#1967

Initial implementation was here https://github.com/vanilla/vanilla/pull/10655 but the assets are quite different so I just made the change differently.