### PR TITLE
Fix applicants email notification

### DIFF
--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -806,7 +806,7 @@ class ActivityModel extends Gdn_Model {
     public function add($activityUserID, $activityType, $story = null, $regardingUserID = null, $commentActivityID = null, $route = null, $sendEmail = '') {
         // Get the ActivityTypeID & see if this is a notification.
         $activityTypeRow = self::getActivityType($activityType);
-        $notify = $activityTypeRow['Notify'] ? (bool)$activityTypeRow['Notify'] : false;
+        $notify = val('Notify', $activityTypeRow, false);
 
         if ($activityTypeRow === false) {
             trigger_error(

--- a/applications/dashboard/models/class.activitymodel.php
+++ b/applications/dashboard/models/class.activitymodel.php
@@ -806,7 +806,7 @@ class ActivityModel extends Gdn_Model {
     public function add($activityUserID, $activityType, $story = null, $regardingUserID = null, $commentActivityID = null, $route = null, $sendEmail = '') {
         // Get the ActivityTypeID & see if this is a notification.
         $activityTypeRow = self::getActivityType($activityType);
-        $notify = val('Notify', $activityTypeRow, false);
+        $notify = $activityTypeRow['Notify'] ? (bool)$activityTypeRow['Notify'] : false;
 
         if ($activityTypeRow === false) {
             trigger_error(

--- a/library/core/class.format.php
+++ b/library/core/class.format.php
@@ -155,7 +155,8 @@ class Gdn_Format {
             }
         } else {
             $activityRouteLink = url($activity->Route);
-            $route = anchor(t($activity->RouteCode), $activity->Route);
+            $routeCode = is_string($activity->RouteCode) ? $activity->RouteCode : $activity->ActivityName;
+            $route = anchor(t($routeCode, $activity->Name), $activity->Route);
         }
 
         // Translate the gender suffix.


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/1872

**Steps to reproduce:**
1. Make sure your local is setup to send emails
2. On the Dashboard > Registration > Method set to **Approval**
3. Take an admin user, go to edit profile mark the "Notify me when anyone applies for membership."  preference. Save the form.
4. Open an anonymous tab and register for your local.
5. Notice you do not get an email notification saying "{username} applied for membership." 
6. Checkout this branch and repeat step 4., this time you should get an email.