### PR TITLE
Relax URL checks in BBCode

### DIFF
--- a/library/core/class.bbcode.php
+++ b/library/core/class.bbcode.php
@@ -156,7 +156,7 @@ class BBCode extends Gdn_Pluggable {
                 }
             } elseif (is_numeric($url)) {
                 $url = "/discussion/comment/$url#Comment_{$url}";
-            } elseif (!$bbcode->isValidURL($url)) {
+            } elseif (!$this->isValidURL($bbcode, $url)) {
                 $url = '';
             }
 
@@ -212,22 +212,21 @@ class BBCode extends Gdn_Pluggable {
      * @param string $content Value between the open and close tags, if any.
      * @return bool|string Formatted value.
      */
-    function doURL($bbcode, $action, $name, $default, $params, $content) {
+    public function doURL($bbcode, $action, $name, $default, $params, $content) {
         if ($action == Nbbc::BBCODE_CHECK) {
             return true;
         }
 
         $url = is_string($default) ? $default : $bbcode->unHtmlEncode(strip_tags($content));
 
-        if ($bbcode->isValidURL($url)) {
+        if ($this->isValidURL($bbcode, $url)) {
             if ($bbcode->getDebug()) {
                 print "ISVALIDURL<br />";
             }
 
             if ($bbcode->getUrlTargetable() !== false && isset($params['target'])) {
                 $target = " target=\"".htmlspecialchars($params['target'])."\"";
-            }
-            else {
+            } else {
                 $target = "";
             }
 
@@ -539,5 +538,18 @@ class BBCode extends Gdn_Pluggable {
     public function removeAttachment() {
         // We dont need this since we show attachments.
         return '<!-- phpBB Attachments -->';
+    }
+
+    /**
+     * @param $bbcode
+     * @param string $url
+     * @return mixed
+     */
+    protected function isValidURL($bbcode, string $url) {
+        $parsed = parse_url($url);
+        if ($parsed !== false && in_array($parsed['scheme'], ['http', 'https', 'ftp'], true)) {
+            return true;
+        }
+        return $bbcode->isValidURL($url);
     }
 }

--- a/library/core/class.bbcode.php
+++ b/library/core/class.bbcode.php
@@ -541,11 +541,13 @@ class BBCode extends Gdn_Pluggable {
     }
 
     /**
-     * @param $bbcode
-     * @param string $url
-     * @return mixed
+     * Check to see if a URL is valid.
+     *
+     * @param Nbbc $bbcode The BBCode class to check the URL with.
+     * @param string $url The URL being checked.
+     * @return bool
      */
-    protected function isValidURL($bbcode, string $url) {
+    protected function isValidURL($bbcode, string $url): bool {
         $parsed = parse_url($url);
         if ($parsed !== false && in_array($parsed['scheme'], ['http', 'https', 'ftp'], true)) {
             return true;

--- a/tests/Library/Vanilla/Formatting/Formats/BBCodeFormatTest.php
+++ b/tests/Library/Vanilla/Formatting/Formats/BBCodeFormatTest.php
@@ -29,4 +29,14 @@ class BBCodeFormatTest extends AbstractFormatTestCase {
     protected function prepareFixtures(): array {
         return (new FormatFixtureFactory('bbcode'))->getAllFixtures();
     }
+
+    /**
+     * Umlauts should be allowed in URLs.
+     */
+    public function testUmlautLinks(): void {
+        $bbcode = '[url=https://de.wikipedia.org/wiki/Prüfsumme]a[/url]';
+        $actual = $this->prepareFormatter()->renderHTML($bbcode);
+        $expected = '<a href="https://de.wikipedia.org/wiki/Prüfsumme" rel="nofollow">a</a>';
+        $this->assertHtmlStringEqualsHtmlString($expected, $actual);
+    }
 }


### PR DESCRIPTION
This change will allow any URL where `parse_url()` succeeds with an appropriate scheme. Closes vanilla/support#859.