### PR TITLE
Fix API call to ensure returned array is not nested

### DIFF
--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -260,7 +260,7 @@ class DiscussionsApiController extends AbstractApiController {
         $result = $out->validate($row);
 
         // Allow addons to modify the result.
-        $result = $this->getEventManager()->fireFilter('discussionsApiController_getOutput', $result, $this, $in, $query, $row);
+        $result = $this->getEventManager()->fireFilter('discussionsApiController_getOutput', $result, $this, $in, $query, $row, true);
         return $result;
     }
 


### PR DESCRIPTION
This addresses vanilla/support#1970 and depends on vanilla/internal#___.

The refactored API function is returning results that are structured differently than they were before. This adds a parameter to make sure backward compatibility is maintained.