### PR TITLE
Add content type to the return of a theme

### DIFF
--- a/applications/dashboard/openapi/themes.yml
+++ b/applications/dashboard/openapi/themes.yml
@@ -8,6 +8,10 @@ x-aliases:
     url:
       type: string
       description: Absolute URL of the asset.
+    content-type:
+      description: The content-type of the asset.
+      type: string
+      example: application/json
   StringAssetOut: &StringAssetOut
     <<: *AssetOut
     data:

--- a/library/Vanilla/Theme/Asset/JsonThemeAsset.php
+++ b/library/Vanilla/Theme/Asset/JsonThemeAsset.php
@@ -87,6 +87,7 @@ class JsonThemeAsset extends ThemeAsset {
         $result = [
             'url' => $this->getUrl(),
             'type' => $this->getDefaultType(),
+            'content-type' => $this->getContentType(),
         ];
 
         if ($this->includeValueInJson) {

--- a/library/Vanilla/Theme/Asset/JsonThemeAsset.php
+++ b/library/Vanilla/Theme/Asset/JsonThemeAsset.php
@@ -42,10 +42,10 @@ class JsonThemeAsset extends ThemeAsset {
             ];
             $this->jsonString = json_encode($this->data, JSON_FORCE_OBJECT);
         } else {
-            $this->jsonString = $data;
             $this->data = $decoded;
+            $this->jsonString = json_encode($this->data, JSON_FORCE_OBJECT);
+            $this->ensureArray();
         }
-        $this->ensureArray();
     }
 
     /**
@@ -54,6 +54,7 @@ class JsonThemeAsset extends ThemeAsset {
     protected function ensureArray() {
         if (!is_array($this->data)) {
             $this->data = [ 'value' => $this->data ];
+            $this->error = new ClientException('JSON asset must be an object or array.');
         }
     }
 

--- a/library/Vanilla/Theme/Asset/ThemeAsset.php
+++ b/library/Vanilla/Theme/Asset/ThemeAsset.php
@@ -109,6 +109,7 @@ abstract class ThemeAsset implements \JsonSerializable {
         $result = [
             'url' => $this->getUrl(),
             'type' => $this->getDefaultType(),
+            'content-type' => $this->getContentType(),
         ];
 
         if ($this->includeValueInJson) {

--- a/tests/APIv2/ThemesTest.php
+++ b/tests/APIv2/ThemesTest.php
@@ -91,6 +91,7 @@ class ThemesTest extends AbstractAPIv2Test {
                 [
                     'type' => 'json',
                     'data' => json_decode(file_get_contents("$assetRoot/fonts.json"), true),
+                    'content-type' => 'application/json',
                 ],
             ],
             'variables' => [
@@ -99,6 +100,7 @@ class ThemesTest extends AbstractAPIv2Test {
                 [
                     'type' => 'json',
                     'data' => json_decode(file_get_contents("$assetRoot/variables.json"), true),
+                    'content-type' => 'application/json',
                 ],
             ],
             'scripts' => [
@@ -107,6 +109,7 @@ class ThemesTest extends AbstractAPIv2Test {
                 [
                     'type' => 'json',
                     'data' => json_decode(file_get_contents("$assetRoot/scripts.json"), true),
+                    'content-type' => 'application/json',
                 ],
             ],
             'header' => [
@@ -115,6 +118,7 @@ class ThemesTest extends AbstractAPIv2Test {
                 [
                     'type' => 'html',
                     'data' => file_get_contents("$assetRoot/header.html"),
+                    'content-type' => 'text/html',
                 ],
             ],
             'footer' => [
@@ -123,6 +127,7 @@ class ThemesTest extends AbstractAPIv2Test {
                 [
                     'type' => 'html',
                     'data' => file_get_contents("$assetRoot/footer.html"),
+                    'content-type' => 'text/html',
                 ],
             ],
             'javascript' => [
@@ -131,6 +136,7 @@ class ThemesTest extends AbstractAPIv2Test {
                 [
                     'type' => 'js',
                     'data' => file_get_contents("$assetRoot/javascript.js"),
+                    'content-type' => 'application/javascript',
                 ],
             ],
             'styles' => [
@@ -139,6 +145,7 @@ class ThemesTest extends AbstractAPIv2Test {
                 [
                     'type' => 'css',
                     'data' => file_get_contents("$assetRoot/styles.css"),
+                    'content-type' => 'text/css',
                 ],
             ],
         ];


### PR DESCRIPTION
As requested during the demo.

Requires https://github.com/vanilla/internal/pull/2590 as well to keep tests passing over there.