### PR TITLE
[Backport 2020.010] Fix forced loading of the theme preview page when another theme is enabled

### DIFF
--- a/library/Vanilla/Models/ThemePreloadProvider.php
+++ b/library/Vanilla/Models/ThemePreloadProvider.php
@@ -141,7 +141,7 @@ class ThemePreloadProvider implements ReduxActionProviderInterface {
             if (!empty($this->revisionID)) {
                 // when theme-settings/{id}/revisions preview
                 $args['revisionID'] = $this->revisionID;
-            } elseif (!empty($revisionID = $this->siteMeta->getActiveThemeRevisionID())) {
+            } elseif (!$this->forcedThemeKey && !empty($revisionID = $this->siteMeta->getActiveThemeRevisionID())) {
                 $args['revisionID'] = $revisionID;
             }
 


### PR DESCRIPTION
Backport #10667
