### PR TITLE
[Backport 2020.010] Fix simple pager meta link crash

### DIFF
--- a/library/src/scripts/navigation/SimplePager.tsx
+++ b/library/src/scripts/navigation/SimplePager.tsx
@@ -69,7 +69,7 @@ function LinkMeta(props: ILinkMeta) {
         newRel.setAttribute("href", url);
 
         if (existingRel) {
-            existingRel.parentNode?.replaceChild(existingRel, newRel);
+            existingRel.parentNode?.replaceChild(newRel, existingRel);
         } else {
             document.head.appendChild(newRel);
         }


### PR DESCRIPTION
Backport #10669 

I've only backported the bug fix part. I did not backport the testing library updates.