### PR TITLE
Add prefix support to the Cookie class

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -112,6 +112,7 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
 
     ->rule(Garden\Web\Cookie::class)
     ->setShared(true)
+    ->addCall('setPrefix', [ContainerUtils::config('Garden.Cookie.Name', 'Vanilla')])
     ->addAlias('Cookie')
 
     // PluginManager

--- a/library/Garden/Web/Cookie.php
+++ b/library/Garden/Web/Cookie.php
@@ -49,6 +49,11 @@ class Cookie {
     private $flushAll = false;
 
     /**
+     * @var string
+     */
+    private $prefix = '';
+
+    /**
      * Construct a {@link Cookie} objects.
      *
      * @param array $cookies The initial cookies array or **null** to use the **$_COOKIE** super global.
@@ -92,7 +97,7 @@ class Cookie {
      * @return null
      */
     public function get($name, $default = null) {
-        return isset($this->cookies[$name]) ? $this->cookies[$name] : $default;
+        return $this->cookies[$this->cookieName($name)] ?? $default;
     }
 
     /**
@@ -140,6 +145,8 @@ class Cookie {
      * @return $this
      */
     public function setCookie($name, $value, $expire = 0, $path = null, $domain = null, $secure = false, $httpOnly = false) {
+        $name = $this->cookieName($name);
+
         if ($value === null) {
             $this->delete($name);
         } else {
@@ -165,6 +172,8 @@ class Cookie {
      * @return $this
      */
     public function delete($name) {
+        $name = $this->cookieName($name);
+
         unset($this->cookies[$name]);
         return $this;
     }
@@ -311,5 +320,39 @@ class Cookie {
     public function setFlushAll($flushAll) {
         $this->flushAll = $flushAll;
         return $this;
+    }
+
+    /**
+     * Get the cookie prefix.
+     *
+     * @return string
+     */
+    public function getPrefix(): string {
+        return $this->prefix;
+    }
+
+    /**
+     * Set the cookie prefix.
+     *
+     * @param string $prefix
+     * @return $this
+     */
+    public function setPrefix(string $prefix) {
+        $this->prefix = $prefix;
+        return $this;
+    }
+
+    /**
+     * Calculate the full cookie named based on the prefix.
+     *
+     * @param string $name
+     * @return string
+     */
+    protected function cookieName(string $name): string {
+        if (substr($name, 0, 1) === '/') {
+            return substr($name, 1);
+        } else {
+            return $this->getPrefix().$name;
+        }
     }
 }

--- a/library/core/helpers/class.ssoutils.php
+++ b/library/core/helpers/class.ssoutils.php
@@ -8,6 +8,7 @@
 use Firebase\JWT\JWT;
 use Garden\Web\Cookie;
 use Vanilla\Logger;
+use Vanilla\Events\EventAction;
 
 /**
  * Class SsoUtils
@@ -42,6 +43,11 @@ class SsoUtils {
 
     /**
      * SsoUtils constructor.
+     *
+     * @param \Gdn_Configuration $config
+     * @param Cookie $cookie
+     * @param \Gdn_Session $session
+     * @param \Psr\Log\LoggerInterface $logger
      */
     public function __construct(Gdn_Configuration $config, Cookie $cookie, Gdn_Session $session, ?\Psr\Log\LoggerInterface $logger = null) {
         $this->cookie = $cookie;
@@ -93,7 +99,7 @@ class SsoUtils {
      * action should use a different context name.
      *
      * @param string $context Context defining where the verification happens.
-     * @param $stateToken
+     * @param string $stateToken
      * @throws Gdn_UserException If the state token is invalid/expired.
      */
     public function verifyStateToken($context, $stateToken) {
@@ -108,7 +114,8 @@ class SsoUtils {
             // Stash the token in case we post back!
             $this->session->stash("{$context}StateToken", $storedStateTokenData);
             $isStateTokenValid = true;
-        } catch (Exception $e){}
+        } catch (Exception $e) {
+        }
 
         if (!$storedStateTokenData) {
             $storedStateTokenData = $this->session->stash("{$context}StateToken", '', false);
@@ -123,9 +130,9 @@ class SsoUtils {
     /**
      * Consume a state token and return its data.
      *
-     * @throws Exception
-     * @param $stateToken
+     * @param string $stateToken
      * @return array The state token data.
+     * @throws Exception Throws an exception when the token is invalid.
      */
     protected function consumeStateToken($stateToken) {
         $stateTokenData = null;
@@ -133,7 +140,8 @@ class SsoUtils {
         if ($jwt) {
             try {
                 $stateTokenData = (array)JWT::decode($jwt, $this->cookieSalt, [self::JWT_ALGORITHM]);
-            } catch (Exception $e) {}
+            } catch (Exception $e) {
+            }
         }
 
         if (!$stateTokenData || empty($stateTokenData['stateToken'])) {
@@ -159,7 +167,7 @@ class SsoUtils {
     protected function isStateTokenValid($stateTokenData, $stateToken, $source = '') {
         $loggingContext = [
             'source' => $source,
-            'event' => 'state_token_errors',
+            'event' => EventAction::eventName('stateToken', EventAction::FAILURE),
             'timestamp' => time(),
         ];
         // Validate expected data.
@@ -188,7 +196,10 @@ class SsoUtils {
 
         // Check the token.
         if ($stateToken !== $stateTokenData['stateToken']) {
-            $this->logger->error('StateTokens do not match.', ['StoredStateToken' => $stateTokenData['stateToken'], 'RecievedStateToken' => $stateToken] + $loggingContext);
+            $this->logger->error(
+                'StateTokens do not match.',
+                ['storedStateToken' => $stateTokenData['stateToken'], 'receivedStateToken' => $stateToken] + $loggingContext
+            );
             return false;
         }
 

--- a/library/core/helpers/class.ssoutils.php
+++ b/library/core/helpers/class.ssoutils.php
@@ -45,7 +45,7 @@ class SsoUtils {
      */
     public function __construct(Gdn_Configuration $config, Cookie $cookie, Gdn_Session $session, ?\Psr\Log\LoggerInterface $logger = null) {
         $this->cookie = $cookie;
-        $this->cookieName = $config->get('Garden.Cookie.Name', 'Vanilla').'-ssostatetoken';
+        $this->cookieName = '-ssostatetoken';
         $this->cookieSalt = $config->get('Garden.Cookie.Salt');
         $this->session = $session;
         if ($logger === null) {
@@ -62,7 +62,7 @@ class SsoUtils {
      * Get a state token to verify on a subsequent request.
      *
      * @param bool $forceNew Force a new token to be generated.
-     * @return A state token.
+     * @return string A state token.
      */
     public function getStateToken($forceNew = false) {
         if ($this->stateToken === null || $forceNew) {

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -251,6 +251,11 @@ class Bootstrap {
             ->addAlias(Gdn::AliasLocale)
             ->addAlias(LocaleInterface::class)
 
+            ->rule(\Garden\Web\Cookie::class)
+            ->setShared(true)
+            ->addCall('setPrefix', [ContainerUtils::config('Garden.Cookie.Name', 'Vanilla')])
+            ->addAlias('Cookie')
+
             ->rule('Identity')
             ->setClass('Gdn_CookieIdentity')
             ->setShared(true)

--- a/tests/Library/Core/SsoUtilsTest.php
+++ b/tests/Library/Core/SsoUtilsTest.php
@@ -9,6 +9,7 @@ namespace VanillaTests\Library\Core;
 
 use Garden\Web\Cookie;
 use PHPUnit\Framework\TestCase;
+use VanillaTests\Bootstrap;
 use VanillaTests\SiteTestTrait;
 
 /**
@@ -43,11 +44,45 @@ class SsoUtilsTest extends TestCase {
     }
 
     /**
+     * @inheritDoc
+     */
+//    public function tearDown(): void {
+//        parent::tearDown();
+//        Bootstrap::cleanup($this->container());
+//    }
+
+    /**
      * Test creating and then verifying a state token.
      */
     public function testStateToken(): void {
         $token = $this->ssoUtils->getStateToken(true);
         $this->ssoUtils->verifyStateToken('test', $token);
         $this->assertTrue(true);
+    }
+
+    /**
+     * An empty state token should not verify.
+     */
+    public function testEmptyStateToken(): void {
+        $this->expectExceptionCode(403);
+        $this->ssoUtils->verifyStateToken('test', '');
+    }
+
+    /**
+     * An invalid state token should not verify.
+     */
+    public function testInvalidStateToken(): void {
+        $this->expectExceptionCode(400);
+        $this->ssoUtils->verifyStateToken('test', 'foo');
+    }
+
+    /**
+     * Test a valid token that hasn't been saved.
+     */
+    public function testDifferentToken(): void {
+        $token1 = $this->ssoUtils->getStateToken(true);
+        $token2 = $this->ssoUtils->getStateToken(true);
+        $this->expectExceptionCode(400);
+        $this->ssoUtils->verifyStateToken('test', $token1);
     }
 }

--- a/tests/Library/Core/SsoUtilsTest.php
+++ b/tests/Library/Core/SsoUtilsTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use Garden\Web\Cookie;
+use PHPUnit\Framework\TestCase;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Tests for the `SsoUtils` class.
+ */
+class SsoUtilsTest extends TestCase {
+    use SiteTestTrait;
+
+    /**
+     * @var Cookie
+     */
+    private $cookie;
+
+    /**
+     * @var \SsoUtils
+     */
+    private $ssoUtils;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->setupSiteTestTrait();
+        $this->container()->call(function (
+            \SsoUtils $ssoUtils,
+            Cookie $cookie
+        ) {
+            $this->ssoUtils = $ssoUtils;
+            $this->cookie = $cookie;
+        });
+    }
+
+    /**
+     * Test creating and then verifying a state token.
+     */
+    public function testStateToken(): void {
+        $token = $this->ssoUtils->getStateToken(true);
+        $this->ssoUtils->verifyStateToken('test', $token);
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Library/Core/SsoUtilsTest.php
+++ b/tests/Library/Core/SsoUtilsTest.php
@@ -44,14 +44,6 @@ class SsoUtilsTest extends TestCase {
     }
 
     /**
-     * @inheritDoc
-     */
-//    public function tearDown(): void {
-//        parent::tearDown();
-//        Bootstrap::cleanup($this->container());
-//    }
-
-    /**
      * Test creating and then verifying a state token.
      */
     public function testStateToken(): void {

--- a/tests/Library/Garden/Web/CookieTest.php
+++ b/tests/Library/Garden/Web/CookieTest.php
@@ -63,6 +63,15 @@ class CookieTest extends SharedBootstrapTestCase {
     }
 
     /**
+     * Test the cookie prefix accessors.
+     */
+    public function testGetSetPrefix() {
+        $cookie = new Cookie();
+        $cookie->setPrefix('px');
+        $this->assertSame('px', $cookie->getPrefix());
+    }
+
+    /**
      * Test deleting a cookie.
      */
     public function testDelete() {
@@ -263,5 +272,31 @@ class CookieTest extends SharedBootstrapTestCase {
 
         $r = $cookie->makeDeleteCookieCalls();
         $this->assertArrayHasKey('foo', $r);
+    }
+
+    /**
+     * The cookie prefix should be prepended to cookie names.
+     */
+    public function testCookiePrefix() {
+        $cookie = new Cookie();
+        $cookie->setPrefix('_');
+
+        $cookie->set('a', 'b');
+        $this->assertSame('b', $cookie->get('a'));
+        $this->assertSame('b', $cookie->get('/_a'));
+
+        $cookie->delete('a');
+        $this->assertSame('foo', $cookie->get('a', 'foo'));
+    }
+
+    /**
+     * I should be able to specify an absolute cookie name by prefixing with a "/".
+     */
+    public function testCookiePrefixRoot() {
+        $cookie = new Cookie();
+        $cookie->setPrefix('f');
+
+        $cookie->set('/foo', 'bar');
+        $this->assertSame('bar', $cookie->get('oo'));
     }
 }


### PR DESCRIPTION
Since Vanilla prefixes all of its cookies it would be nice to be able to inject that prefix to the cookie utility class.