### PR TITLE
Fix theme current crash

### DIFF
--- a/library/Vanilla/AliasLoader.php
+++ b/library/Vanilla/AliasLoader.php
@@ -27,6 +27,7 @@ class AliasLoader {
             \Vanilla\Web\Asset\LegacyAssetModel::class => ['AssetModel'],
             \Vanilla\Dashboard\Models\BannerImageModel::class => ['HeroImagePlugin'],
             \Vanilla\Dashboard\Events\UserEvent::class => ["Vanilla\Community\Events\UserEvent"],
+            \Vanilla\Theme\ThemeService::class => ["Vanilla\Models\ThemeModel"],
         ];
     }
 }

--- a/library/Vanilla/Theme/Theme.php
+++ b/library/Vanilla/Theme/Theme.php
@@ -423,6 +423,13 @@ class Theme implements \JsonSerializable {
     }
 
     /**
+     * @param bool $current
+     */
+    public function setCurrent(bool $current): void {
+        $this->current = $current;
+    }
+
+    /**
      * @return ThemeAsset[]
      */
     public function getAssets(): array {
@@ -470,4 +477,6 @@ class Theme implements \JsonSerializable {
     public function setIsCacheHit(bool $isCacheHit): void {
         $this->isCacheHit = $isCacheHit;
     }
+
+
 }

--- a/library/Vanilla/Theme/ThemeService.php
+++ b/library/Vanilla/Theme/ThemeService.php
@@ -544,6 +544,10 @@ class ThemeService {
         }
         $theme->setSupportedSections($supportedSections);
 
+        // Fix current theme.
+        $currentThemeID = $this->config->get(ThemeServiceHelper::CONFIG_CURRENT_THEME, ThemeServiceHelper::CONFIG_MOBILE_THEME);
+        $theme->setCurrent($currentThemeID == $theme->getThemeID());
+
         $this->overlayAddonVariables($theme);
         return $theme;
     }


### PR DESCRIPTION
Fixes https://github.com/vanilla/knowledge/issues/1840

We had an edge case where a theme could be cached, but the value of whether it was current or not was changed by something that didn't trigger a cache clear (like manually editing a theme).

This would cause the manage themes page to get the incorrect "current" theme. In order to mitigate this, our "normalize" method now set the proper current theme for every theme that passes through.