### PR TITLE
Add an optional title for number count

### DIFF
--- a/library/src/scripts/content/NumberFormatted.tsx
+++ b/library/src/scripts/content/NumberFormatted.tsx
@@ -12,6 +12,7 @@ import { numberFormattedClasses } from "@library/content/NumberFormatted.styles"
 interface IProps {
     value: number;
     className?: string;
+    title?: string;
 }
 
 /**
@@ -28,7 +29,7 @@ export default class NumberFormatted extends React.Component<IProps> {
 
         const Tag = fullValue === compactValue ? `span` : `abbr`;
         return (
-            <Tag title={fullValue} className={classNames("number", className, classes.root)}>
+            <Tag title={this.props.title || fullValue} className={classNames("number", className, classes.root)}>
                 {compactValue}
             </Tag>
         );


### PR DESCRIPTION
This PR is related to the issue [#2587](https://github.com/vanilla/internal/issues/2587) and the PR [#2602](https://github.com/vanilla/internal/pull/2602). Todd commented that the number 2 tooltip on top of the number is not useful (see screenshot below): 

<img width="770" alt="Screen Shot 2020-06-01 at 11 16 15 AM" src="https://user-images.githubusercontent.com/52762119/83423682-536c1d80-a3f9-11ea-847f-b4556168fb0b.png">

I've add an optional title so that we could have 

<img width="815" alt="Screen Shot 2020-06-01 at 11 04 08 AM" src="https://user-images.githubusercontent.com/52762119/83423721-65e65700-a3f9-11ea-9dc2-fd326ad4b501.png">

by writing ` +<NumberFormatted value={extraCount} title={"View all attendees"} />`

