### PR TITLE
Add CategoryCollection::getDescendantIDs

### DIFF
--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -462,6 +462,36 @@ class CategoryCollection {
     }
 
     /**
+     * Get the id's of a category's descendants.
+     * @todo implement caching
+     * @param int $parentID
+     * @param array $options
+     * @return array
+     */
+    public function getDescendantIDs($parentID = -1, $options = []) {
+        $ids = [];
+        $parentID = $parentID ?: -1;
+        $defaultOptions = [
+            'maxDepth' => 3,
+            'permission' => 'PermsDiscussionsView'
+        ];
+        $options = array_change_key_case($options) ?: [];
+        $options = $options + $defaultOptions ;
+
+        for ($i = 0; $i < $options['maxDepth']; $i++) {
+            $childCategory = $this->getChildrenByParents([$parentID], $options['permission']);
+            $childCategory = reset($childCategory);
+            if (empty($childCategory)) {
+                break;
+            }
+            $ids[] = $childCategory['CategoryID'] ?? null ;
+            $parentID = $childCategory['CategoryID'] ?? null;
+        }
+
+        return $ids;
+    }
+
+    /**
      * Get all of the children of a parent category.
      *
      * @param int[] $parentIDs The IDs of the parent categories.

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -249,7 +249,8 @@ class CategoryCollection {
      */
     private function cacheKey($type, $id) {
         switch ($type) {
-            case self::$CACHE_CATEGORY;
+            case self::$CACHE_CATEGORY:
+            case self::$CACHE_CATEGORY_DESCENDANTS:
                 $r = $this->getCacheInc().$type.$id;
                 return $r;
             case self::$CACHE_CATEGORY_SLUG;
@@ -478,7 +479,7 @@ class CategoryCollection {
      * @return array
      */
     public function getDescendantIDs(int $parentID = -1, array $options = []): array {
-        $ids = $this->cache->get($this->cacheKey(self::$CACHE_CATEGORY_DESCENDANTS, $parentID)) ?? [];
+        $cachedIDs = $this->cache->get($this->cacheKey(self::$CACHE_CATEGORY_DESCENDANTS, $parentID)) ?? [];
         $parentIDs = [$parentID];
         $defaultOptions = [
             'maxDepth' => 3,
@@ -486,7 +487,8 @@ class CategoryCollection {
         ];
         $options = $options + $defaultOptions;
 
-        if (!$ids) {
+        $ids = [];
+        if (!$cachedIDs) {
             for ($i = 0; $i < $options['maxDepth']; $i++) {
                 $childCategories = $this->getChildrenByParents($parentIDs, $options['permission']);
                 if (empty($childCategories)) {
@@ -503,6 +505,8 @@ class CategoryCollection {
                     $parentIDs = $childCategoriesIDs;
                 }
             }
+        } else {
+            $ids = $cachedIDs;
         }
 
         $this->cacheStore(

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -20,7 +20,7 @@ class CategoryCollection {
      * @var string The cache key prefix that stores category IDs by slug (URL code).
      */
     private static $CACHE_CATEGORY_SLUG = '/catslug/';
-
+    
     /**
      * @var int The absolute select limit of the categories.
      */
@@ -463,7 +463,7 @@ class CategoryCollection {
 
     /**
      * Get the id's of a category's descendants.
-     * @todo implement caching
+     *
      * @param int $parentID
      * @param array $options
      * @return array

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -20,7 +20,7 @@ class CategoryCollection {
      * @var string The cache key prefix that stores category IDs by slug (URL code).
      */
     private static $CACHE_CATEGORY_SLUG = '/catslug/';
-    
+
     /**
      * @var int The absolute select limit of the categories.
      */
@@ -464,13 +464,13 @@ class CategoryCollection {
     /**
      * Get the id's of a category's descendants.
      *
-     * @param int $parentID
+     * @param int $parentIDs
      * @param array $options
      * @return array
      */
-    public function getDescendantIDs($parentID = -1, $options = []) {
+    public function getDescendantIDs($parentIDs = -1, $options = []) {
         $ids = [];
-        $parentID = $parentID ?: -1;
+        $parentIDs = [$parentIDs] ?: [-1];
         $defaultOptions = [
             'maxDepth' => 3,
             'permission' => 'PermsDiscussionsView'
@@ -479,15 +479,21 @@ class CategoryCollection {
         $options = $options + $defaultOptions ;
 
         for ($i = 0; $i < $options['maxDepth']; $i++) {
-            $childCategory = $this->getChildrenByParents([$parentID], $options['permission']);
-            $childCategory = reset($childCategory);
-            if (empty($childCategory)) {
+            $childCategories = $this->getChildrenByParents($parentIDs, $options['permission']);
+            if (empty($childCategories)) {
                 break;
             }
-            $ids[] = $childCategory['CategoryID'] ?? null ;
-            $parentID = $childCategory['CategoryID'] ?? null;
+            if (count($childCategories) === 1 ) {
+                $childCategories = reset($childCategories);
+                $childCategoryID = [$childCategories['CategoryID']]?? [];
+                $ids = array_merge($ids, $childCategoryID);
+                $parentIDs = $childCategoryID;
+            } else {
+                $childCategoriesIDs = array_column($childCategories, 'CategoryID');
+                $ids = array_merge($ids, $childCategoriesIDs) ;
+                $parentIDs = $childCategoriesIDs;
+            }
         }
-
         return $ids;
     }
 

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -464,18 +464,17 @@ class CategoryCollection {
     /**
      * Get the id's of a category's descendants.
      *
-     * @param int $parentIDs
+     * @param int $parentID
      * @param array $options
      * @return array
      */
     public function getDescendantIDs(int $parentID = -1, array $options = []) {
         $ids = [];
-        $parentIDs = [$parentIDs] ?: [-1];
+        $parentIDs = [$parentID];
         $defaultOptions = [
             'maxDepth' => 3,
             'permission' => 'PermsDiscussionsView'
         ];
-        $options = array_change_key_case($options) ?: [];
         $options = $options + $defaultOptions ;
 
         for ($i = 0; $i < $options['maxDepth']; $i++) {
@@ -483,7 +482,7 @@ class CategoryCollection {
             if (empty($childCategories)) {
                 break;
             }
-            if (count($childCategories) === 1 ) {
+            if (count($childCategories) === 1) {
                 $childCategories = reset($childCategories);
                 $childCategoryID = [$childCategories['CategoryID']]?? [];
                 $ids = array_merge($ids, $childCategoryID);

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -468,7 +468,7 @@ class CategoryCollection {
      * @param array $options
      * @return array
      */
-    public function getDescendantIDs($parentIDs = -1, $options = []) {
+    public function getDescendantIDs(int $parentID = -1, array $options = []) {
         $ids = [];
         $parentIDs = [$parentIDs] ?: [-1];
         $defaultOptions = [

--- a/applications/vanilla/library/class.categorycollection.php
+++ b/applications/vanilla/library/class.categorycollection.php
@@ -474,10 +474,11 @@ class CategoryCollection {
      *
      * @param int $parentID
      * @param array $options
+     *
      * @return array
      */
-    public function getDescendantIDs(int $parentID = -1, array $options = []) {
-        $ids =  $this->cache->get($this->cacheKey(self::$CACHE_CATEGORY_DESCENDANTS, $parentID));
+    public function getDescendantIDs(int $parentID = -1, array $options = []): array {
+        $ids = $this->cache->get($this->cacheKey(self::$CACHE_CATEGORY_DESCENDANTS, $parentID)) ?? [];
         $parentIDs = [$parentID];
         $defaultOptions = [
             'maxDepth' => 3,

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -846,7 +846,7 @@ class CategoryModel extends Gdn_Model {
         reset($rows);
         $single = is_string(key($rows));
 
-        $populate = function(array &$row, string $field) {
+        $populate = function (array &$row, string $field) {
             $categoryID = $row['CategoryID'] ?? $row['ParentRecordID'] ?? false;
             if ($categoryID) {
                 $category = self::categories($categoryID);

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -835,8 +835,9 @@ class CategoryModel extends Gdn_Model {
      * Add multi-dimensional category data to an array.
      *
      * @param array $rows Results we need to associate category data with.
+     * @param string $field
      */
-    public function expandCategories(array &$rows) {
+    public function expandCategories(array &$rows, string $field = 'Category') {
         if (count($rows) === 0) {
             // Nothing to do here.
             return;
@@ -845,22 +846,22 @@ class CategoryModel extends Gdn_Model {
         reset($rows);
         $single = is_string(key($rows));
 
-        $populate = function(array &$row) {
+        $populate = function(array &$row, string $field) {
             $categoryID = $row['CategoryID'] ?? $row['ParentRecordID'] ?? false;
             if ($categoryID) {
                 $category = self::categories($categoryID);
                 if ($category) {
-                    setValue('Category', $row, $category);
+                    setValue($field, $row, $category);
                 }
             }
         };
 
         // Inject those categories.
         if ($single) {
-            $populate($rows);
+            $populate($rows, $field);
         } else {
             foreach ($rows as &$row) {
-                $populate($row);
+                $populate($row, $field);
             }
         }
     }

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -846,8 +846,9 @@ class CategoryModel extends Gdn_Model {
         $single = is_string(key($rows));
 
         $populate = function(array &$row) {
-            if (array_key_exists('CategoryID', $row)) {
-                $category = self::categories($row['CategoryID']);
+            $categoryID = $row['CategoryID'] ?? $row['ParentRecordID'] ?? false;
+            if ($categoryID) {
+                $category = self::categories($categoryID);
                 if ($category) {
                     setValue('Category', $row, $category);
                 }
@@ -1038,6 +1039,20 @@ class CategoryModel extends Gdn_Model {
         $result = $this->collection->getTree($categoryID, $options);
         return $result;
     }
+
+
+    /**
+     * Get the ID's of a descendant.
+     *
+     * @param int $categoryID
+     * @param array $options
+     * @return array
+     */
+    public function getCategoryDescendantIDs(int $categoryID, array $options = []): array {
+        $result = $this->collection->getDescendantIDs($categoryID, $options);
+        return $result;
+    }
+
 
     /**
      * @param int|string $id The parent category ID or slug.


### PR DESCRIPTION
Required for https://github.com/vanilla/internal/pull/2612

- Add `getDescendantIDs` method to categoryCollection class.
- Modifies `expandCategories` to look for `ParentRecordID` if `CategoryID` not available. 