### PR TITLE
[Backport 2020.011] Add ability for addons to have a new addon display name

### DIFF
--- a/applications/dashboard/views/settings/helper_functions.php
+++ b/applications/dashboard/views/settings/helper_functions.php
@@ -118,7 +118,7 @@ function writeAddonMedia($addonName, $addonInfo, $isEnabled, $addonType, $filter
     $capitalCaseSheme = new \Vanilla\Utility\CapitalCaseScheme();
     $addonInfo = $capitalCaseSheme->convertArrayKeys($addonInfo, ['RegisterPermissions']);
 
-    $screenName = Gdn_Format::display(val('Name', $addonInfo, $addonName));
+    $screenName = $info['DisplayName'] ?? $info['displayName'] ?? $info['Name'] ?? $info['name'] ?? $addonName;
     $description = Gdn_Format::html(t(val('Name', $addonInfo, $addonName).' Description', val('Description', $addonInfo, '')));
     $id = Gdn_Format::url($addonName).'-addon';
     $documentationUrl = val('DocumentationUrl', $addonInfo, '');

--- a/library/Vanilla/Addon.php
+++ b/library/Vanilla/Addon.php
@@ -1101,7 +1101,11 @@ class Addon {
      * @return string Returns the name of the addon or its key if it has no name.
      */
     public function getName() {
-        return $this->getInfoValue('name', $this->getRawKey());
+        $displayName = $this->getInfoValue('displayName');
+        $name = $this->getInfoValue('name');
+        $rawKey = $this->getRawKey();
+
+        return $displayName ?? $name ?? $rawKey;
     }
 
     /**

--- a/tests/Library/Vanilla/AddonTest.php
+++ b/tests/Library/Vanilla/AddonTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla;
+
+use Vanilla\Addon;
+use VanillaTests\Fixtures\MockAddon;
+use VanillaTests\MinimalContainerTestCase;
+
+/**
+ * Tests for the addon class.
+ */
+class AddonTest extends MinimalContainerTestCase {
+
+    /**
+     * Test that the name of an addon is correct.
+     *
+     * @param Addon $addon
+     * @param string $expectedName
+     *
+     * @dataProvider provideAddonNames
+     */
+    public function testAddonName(Addon $addon, string $expectedName) {
+        $this->assertEquals($expectedName, $addon->getName());
+    }
+
+    /**
+     * @return array
+     */
+    public function provideAddonNames(): array {
+        return [
+            [
+                new MockAddon('addon1', [ 'name' => 'Addon 1' ]),
+                'Addon 1',
+            ],
+            [
+                new MockAddon('addon2', [
+                    'name' => 'Addon 2',
+                    'displayName' => 'Addon 2 Display Name',
+                ]),
+                'Addon 2 Display Name',
+            ],
+            [
+                new MockAddon('addon3'),
+                'addon3',
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Backport https://github.com/vanilla/vanilla/pull/10684
Issue https://github.com/vanilla/support/issues/2012