### PR TITLE
Fix broken Facebook Social Connect button

### DIFF
--- a/plugins/Facebook/class.facebook.plugin.php
+++ b/plugins/Facebook/class.facebook.plugin.php
@@ -319,7 +319,7 @@ class FacebookPlugin extends SSOAddon {
         $this->EventArguments['User'] = $sender->User;
         $this->fireEvent('AfterConnection');
 
-        redirectTo(userUrl($sender->User, '', 'connections'));
+        redirectTo(self::profileConnecUrl());
     }
 
     /**
@@ -608,7 +608,7 @@ class FacebookPlugin extends SSOAddon {
      * @return string URL.
      */
     public static function profileConnecUrl() {
-        return url(userUrl(Gdn::session()->User, false, 'facebookconnect'), true);
+        return url('entry/connect/facebook', true);
     }
 
     /**


### PR DESCRIPTION
Closes vanilla/support#1527.

This PR fixes a problem where clicking on the facebook "connect" button at the `profiles/connections` endpoint causes an error because the redirect url is dynamic, which facebook doesn't allow. This changes the redirect url to `entry/connect/facebook`.

### TO TEST
You have to have the facebook social connect addon enabled and configured (meaning you have to add a domain in your `etc/hosts` file that facebook will accept).

1. Using an account that has an email address linked to a facebook account, go to the `profile/connections` endpoint and click on the "Connect" button associated with facebook.
1. Note that facebook sends back an error message.
1. Check out this branch and try again.
1. Note that you can connect successfully.