### PR TITLE
Backport: Don’t install the log decorator too early

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -143,10 +143,10 @@ $dic->setInstance(Garden\Container\Container::class, $dic)
     ->rule(\Vanilla\Logging\LogDecorator::class)
     ->setShared(true)
     ->setConstructorArgs(['logger' => new Reference(\Vanilla\Logger::class)])
-    ->addAlias(\Psr\Log\LoggerInterface::class)
 
     ->rule(\Vanilla\Logger::class)
     ->setShared(true)
+    ->addAlias(\Psr\Log\LoggerInterface::class)
 
     ->rule(\Psr\Log\LoggerAwareInterface::class)
     ->addCall('setLogger')
@@ -500,7 +500,11 @@ $dic->call(function (
     $addonManager->startAddonsByKey([$currentTheme], Addon::TYPE_THEME);
 
     // Construct the logger earlier so that its dependencies are satisfied.
-    $log = $dic->get(\Psr\Log\LoggerInterface::class);
+    $log = $dic->get(\Vanilla\Logging\LogDecorator::class);
+    // Replace the logger interface with the decorator.
+    $dic->rule(\Vanilla\Logging\LogDecorator::class)
+        ->addAlias(\Psr\Log\LoggerInterface::class);
+    Logger::setLogger(null);
 
     // Load the configurations for enabled addons.
     foreach ($addonManager->getEnabled() as $addon) {
@@ -557,7 +561,7 @@ $dic->call(function (
 
 // Send out cookie headers.
 register_shutdown_function(function () use ($dic) {
-    $dic->call(function(Garden\Web\Cookie $cookie) {
+    $dic->call(function (Garden\Web\Cookie $cookie) {
         $cookie->flush();
     });
 });

--- a/library/Vanilla/Logging/LogDecorator.php
+++ b/library/Vanilla/Logging/LogDecorator.php
@@ -46,12 +46,12 @@ class LogDecorator implements LoggerInterface {
     /**
      * LogDecorator constructor.
      *
-     * @param \Gdn_Session $session
-     * @param \Gdn_Request $request
-     * @param \UserModel $userModel
      * @param LoggerInterface $logger
+     * @param \Gdn_Request $request
+     * @param \Gdn_Session $session
+     * @param \UserModel $userModel
      */
-    public function __construct(\Gdn_Session $session, \Gdn_Request $request, \UserModel $userModel, LoggerInterface $logger) {
+    public function __construct(LoggerInterface $logger, \Gdn_Request $request, \Gdn_Session $session, \UserModel $userModel) {
         $this->session = $session;
         $this->request = $request;
         $this->logger = $logger;
@@ -72,11 +72,11 @@ class LogDecorator implements LoggerInterface {
     public function log($level, $message, array $context = array()) {
         $context += $this->staticContextDefaults + [
             Logger::FIELD_USERID => $this->session->UserID,
-            'ip' => $this->request->ipAddress(),
+            'ip' => $this->request->getIP(),
             'timestamp' => time(),
             'method' => $this->request->requestMethod(),
             'domain' => rtrim($this->request->url('/', true), '/'),
-            'path' => $this->request->path(),
+            'path' => $this->request->getPath(),
             'requestID' => $this->request->getAttribute('requestID', null),
         ];
 

--- a/library/core/class.logger.php
+++ b/library/core/class.logger.php
@@ -15,7 +15,7 @@ use Psr\Log\LoggerInterface;
  *
  * If nothing sets logger then Logger will be set to BaseLogger which is a dry loop.
  *
- * @see BaseLogger
+ * @deprecated Inject a PSR logger into your class instead.
  */
 class Logger {
     public const FIELD_EVENT = \Vanilla\Logger::FIELD_EVENT;
@@ -93,9 +93,10 @@ class Logger {
      * @param LoggerInterface $logger Specify a new value to set the logger to.
      */
     public static function setLogger($logger = null) {
+        self::$realLogger = null;
+
         if ($logger === null) {
             self::$instance = null;
-            self::$realLogger = null;
         } elseif ($logger instanceof \Vanilla\Logger) {
             self::$instance = $logger;
         } else {


### PR DESCRIPTION
Backporting #10688 to `release/2020.011`.