### PR TITLE
Added function to fetch image attributes from user content

### DIFF
--- a/library/Vanilla/Contracts/Formatting/FormatInterface.php
+++ b/library/Vanilla/Contracts/Formatting/FormatInterface.php
@@ -98,13 +98,13 @@ interface FormatInterface {
     public function parseImageUrls(string $content): array;
 
     /**
-     * Parse image attributes out of the post contents.
+     * Parse image data from post content.
      *
      * @param string $content
      *
      * @return string[]
      */
-    public function parseImageAttributes(string $content): array;
+    public function parseImages(string $content): array;
 
     /**
      * Parse out a list of usernames mentioned in the post contents.

--- a/library/Vanilla/Contracts/Formatting/FormatInterface.php
+++ b/library/Vanilla/Contracts/Formatting/FormatInterface.php
@@ -98,6 +98,15 @@ interface FormatInterface {
     public function parseImageUrls(string $content): array;
 
     /**
+     * Parse image attributes out of the post contents.
+     *
+     * @param string $content
+     *
+     * @return string[]
+     */
+    public function parseImageAttributes(string $content): array;
+
+    /**
      * Parse out a list of usernames mentioned in the post contents.
      *
      * @param string $content The raw content to parse.

--- a/library/Vanilla/Contracts/Formatting/FormatInterface.php
+++ b/library/Vanilla/Contracts/Formatting/FormatInterface.php
@@ -102,7 +102,7 @@ interface FormatInterface {
      *
      * @param string $content
      *
-     * @return string[]
+     * @return array
      */
     public function parseImages(string $content): array;
 

--- a/library/Vanilla/EmbeddedContent/AbstractEmbed.php
+++ b/library/Vanilla/EmbeddedContent/AbstractEmbed.php
@@ -85,6 +85,15 @@ abstract class AbstractEmbed implements \JsonSerializable {
     }
 
     /**
+     * Get the alt text for the embed.
+     *
+     * @return string
+     */
+    public function getAlt(): string {
+        return $this->data['name'];
+    }
+
+    /**
      * Render the HTML form of the embed.
      *
      * This default implementation assumes javascript rendering the browser.

--- a/library/Vanilla/Formatting/FormatService.php
+++ b/library/Vanilla/Formatting/FormatService.php
@@ -142,7 +142,7 @@ class FormatService {
      * @param string $content
      * @param string|null $format The format of the content.
      *
-     * @return string[]
+     * @return array
      */
     public function parseImages(string $content, ?string $format): array {
         return $this

--- a/library/Vanilla/Formatting/FormatService.php
+++ b/library/Vanilla/Formatting/FormatService.php
@@ -137,6 +137,20 @@ class FormatService {
     }
 
     /**
+     * Parse image attributes out of the post contents.
+     *
+     * @param string $content
+     * @param string|null $format The format of the content.
+     *
+     * @return string[]
+     */
+    public function parseImageAttributes(string $content, ?string $format): array {
+        return $this
+            ->getFormatter($format)
+            ->parseImageAttributes($content);
+    }
+
+    /**
      * Parse out a list of headings from the post contents.
      *
      * @param string $content The raw content to parse.

--- a/library/Vanilla/Formatting/FormatService.php
+++ b/library/Vanilla/Formatting/FormatService.php
@@ -144,10 +144,10 @@ class FormatService {
      *
      * @return string[]
      */
-    public function parseImageAttributes(string $content, ?string $format): array {
+    public function parseImages(string $content, ?string $format): array {
         return $this
             ->getFormatter($format)
-            ->parseImageAttributes($content);
+            ->parseImages($content);
     }
 
     /**

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -166,6 +166,13 @@ class HtmlFormat extends BaseFormat {
     }
 
     /**
+     * @inheritdoc
+     */
+    public function parseImageAttributes(string $content): array {
+        return [];
+    }
+
+    /**
      * Apply HTML processors.
      *
      * @param string $content

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -169,7 +169,7 @@ class HtmlFormat extends BaseFormat {
      * @inheritdoc
      */
     public function parseImages(string $content): array {
-        return ["ImageUrls" => parseImageUrls($content), "ImageAttrs" => []];
+        return [];
     }
 
     /**

--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -168,8 +168,8 @@ class HtmlFormat extends BaseFormat {
     /**
      * @inheritdoc
      */
-    public function parseImageAttributes(string $content): array {
-        return [];
+    public function parseImages(string $content): array {
+        return ["ImageUrls" => parseImageUrls($content), "ImageAttrs" => []];
     }
 
     /**

--- a/library/Vanilla/Formatting/Formats/NotFoundFormat.php
+++ b/library/Vanilla/Formatting/Formats/NotFoundFormat.php
@@ -102,6 +102,13 @@ class NotFoundFormat implements FormatInterface {
     /**
      * @inheritdoc
      */
+    public function parseImageAttributes(string $content): array {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function parseMentions(string $content): array {
         return [];
     }

--- a/library/Vanilla/Formatting/Formats/NotFoundFormat.php
+++ b/library/Vanilla/Formatting/Formats/NotFoundFormat.php
@@ -102,7 +102,7 @@ class NotFoundFormat implements FormatInterface {
     /**
      * @inheritdoc
      */
-    public function parseImageAttributes(string $content): array {
+    public function parseImages(string $content): array {
         return [];
     }
 

--- a/library/Vanilla/Formatting/Formats/RichFormat.php
+++ b/library/Vanilla/Formatting/Formats/RichFormat.php
@@ -182,6 +182,25 @@ class RichFormat extends BaseFormat {
     /**
      * @inheritdoc
      */
+    public function parseImageAttributes(string $content): array {
+        $attributes = [];
+        try {
+            $embeds = $this->parseEmbedsOfType($content, ImageEmbed::class);
+            /** @var ImageEmbed $imageEmbed */
+            foreach ($embeds as $imageEmbed) {
+                $attributes[] = [
+                    "alt" => $imageEmbed->getAlt()
+                ];
+            }
+        } catch (\Throwable $e) {
+            $this->logBadInput($e);
+        }
+        return $attributes;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function parseAttachments(string $content): array {
         $attachments = [];
 

--- a/library/Vanilla/Formatting/Formats/RichFormat.php
+++ b/library/Vanilla/Formatting/Formats/RichFormat.php
@@ -182,12 +182,15 @@ class RichFormat extends BaseFormat {
     /**
      * @inheritdoc
      */
-    public function parseImageAttributes(string $content): array {
+    public function parseImages(string $content): array {
         $attributes = [];
+        $urls = [];
         try {
             $embeds = $this->parseEmbedsOfType($content, ImageEmbed::class);
+
             /** @var ImageEmbed $imageEmbed */
             foreach ($embeds as $imageEmbed) {
+                $urls[] = $imageEmbed->getUrl();
                 $attributes[] = [
                     "alt" => $imageEmbed->getAlt()
                 ];
@@ -195,7 +198,10 @@ class RichFormat extends BaseFormat {
         } catch (\Throwable $e) {
             $this->logBadInput($e);
         }
-        return $attributes;
+        return [
+            "ImageUrls" => $urls,
+            "ImageAttrs" => $attributes,
+        ];
     }
 
     /**

--- a/library/Vanilla/Formatting/Formats/RichFormat.php
+++ b/library/Vanilla/Formatting/Formats/RichFormat.php
@@ -183,25 +183,21 @@ class RichFormat extends BaseFormat {
      * @inheritdoc
      */
     public function parseImages(string $content): array {
-        $attributes = [];
-        $urls = [];
+        $props = [];
         try {
             $embeds = $this->parseEmbedsOfType($content, ImageEmbed::class);
 
             /** @var ImageEmbed $imageEmbed */
             foreach ($embeds as $imageEmbed) {
-                $urls[] = $imageEmbed->getUrl();
-                $attributes[] = [
+                $props[] = [
+                    "url" => $imageEmbed->getUrl(),
                     "alt" => $imageEmbed->getAlt()
                 ];
             }
         } catch (\Throwable $e) {
             $this->logBadInput($e);
         }
-        return [
-            "ImageUrls" => $urls,
-            "ImageAttrs" => $attributes,
-        ];
+        return $props;
     }
 
     /**

--- a/library/Vanilla/Formatting/Formats/TextFormat.php
+++ b/library/Vanilla/Formatting/Formats/TextFormat.php
@@ -74,7 +74,7 @@ class TextFormat extends BaseFormat {
     /**
      * @inheritdoc
      */
-    public function parseImageAttributes(string $content): array {
+    public function parseImages(string $content): array {
         return [];
     }
 

--- a/library/Vanilla/Formatting/Formats/TextFormat.php
+++ b/library/Vanilla/Formatting/Formats/TextFormat.php
@@ -74,6 +74,13 @@ class TextFormat extends BaseFormat {
     /**
      * @inheritdoc
      */
+    public function parseImageAttributes(string $content): array {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function parseHeadings(string $content): array {
         return [];
     }


### PR DESCRIPTION
This PR adds a new function to the formats interface to fetch image attributes. I chose not to touch the existing `parseImageUrls` as it is used in multiple places and I also don't want to make drastic changes to the code here. I'm just trying to fetch the alt tag for search results. 