### PR TITLE
Make header shadow dom mounting work in edge

### DIFF
--- a/packages/vanilla-dom-utils/src/shadowDom.tsx
+++ b/packages/vanilla-dom-utils/src/shadowDom.tsx
@@ -20,7 +20,7 @@ export function prepareShadowRoot(
 ): HTMLElement {
     let html = element.innerHTML;
     // This is likely a noscript tag.
-    if (browserEscapesNoScript() || html.startsWith("&lt;")) {
+    if (browserEscapesNoScript() || html.trim().includes("&lt;")) {
         html = unescapeHTML(html);
     }
     // Safari escapes the contents of the noscript.


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/2036

I tried to fix this in `2020.010` but it looks like my solution wasn't robust enough. I believe ops changed our HTML/whitespace compressions recently and as a result the header HTML now always starts with 8 spaces and a newline, breaking the existing fragile check.