### PR TITLE
Fix the user avatar for banned users.

### DIFF
--- a/library/core/functions.render.php
+++ b/library/core/functions.render.php
@@ -1535,7 +1535,7 @@ if (!function_exists('userPhotoUrl')) {
         $fullUser = Gdn::userModel()->getID(val('UserID', $user), DATASET_TYPE_ARRAY);
         $photo = val('Photo', $user);
         if ($fullUser && $fullUser['Banned']) {
-            $photo = 'https://images.v-cdn.net/banned_100.png';
+            $photo = c('Garden.BannedPhotoSmall', c('Garden.BannedPhoto', 'https://images.v-cdn.net/banned_100.png'));
         }
 
         if ($photo) {


### PR DESCRIPTION
This PR closes vanilla/support#1409

When a user is banned his/her avatar is replaced by a "Banned" avatar. Vanilla allows admins to add upload a different photo and configure it in the config file as `Garden.BannedPhoto`. However, in the dashboard we show a different avatar for banned users which is not configurable (`https://images.v-cdn.net/banned_100.png`). 

This PR will create a new config value `Garden.BannedPhotoSmall` which will allow admins the ability to set that to a custom photo. This is backwards compatible because if nothing is set it will get the default photo `https://images.v-cdn.net/banned_100.png`.