### PR TITLE
Add primary key lookup support in various API v2 endpoints

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -474,14 +474,7 @@ class UsersApiController extends AbstractApiController {
                     'processor' => [DateFilterSchema::class, 'dateFilterField'],
                 ],
             ]),
-            'userID:a?' => [
-                'description' => 'One or more user IDs to lookup.',
-                'items' => ['type' => 'integer'],
-                'style' => 'form',
-                'x-filter' => [
-                    'field' => 'u.UserID',
-                ],
-            ],
+            'userID?' => \Vanilla\Schema\RangeExpression::createSchema([':int'])->setField('x-filter', ['field' => 'u.UserID']),
             'page:i?' => [
                 'description' => 'Page number. See [Pagination](https://docs.vanillaforums.com/apiv2/#pagination).',
                 'default' => 1,
@@ -493,7 +486,7 @@ class UsersApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100,
             ]
-        ], ['UserIndex', 'in'])->setDescription('List users.');
+        ], ['UserIndex', 'in']);
         $out = $this->schema([':a' => $this->userSchema()], 'out');
 
         $query = $in->validate($query);

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3031,7 +3031,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
     public function searchCount($filter = '') {
         if (is_array($filter)) {
             $where = $filter;
-            $keywords = $where['Keywords'] ?: '';
+            $keywords = $where['Keywords'] ?? '';
             unset($where['Keywords'], $where['Optimize']);
         } else {
             $keywords = $filter;

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -3031,7 +3031,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
     public function searchCount($filter = '') {
         if (is_array($filter)) {
             $where = $filter;
-            $keywords = $where['Keywords'];
+            $keywords = $where['Keywords'] ?: '';
             unset($where['Keywords'], $where['Optimize']);
         } else {
             $keywords = $filter;
@@ -3059,7 +3059,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
         if (filter_var($keywords, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4|FILTER_FLAG_IPV6) !== false) {
             $fields = ['LastIPAddress'];
             $this->addIpFilters($keywords, $fields);
-        } else if ($roleID) {
+        } elseif ($roleID) {
             $this->SQL->join('UserRole ur2', "u.UserID = ur2.UserID and ur2.RoleID = $roleID");
         } else {
             // Search on the user table.

--- a/applications/dashboard/openapi/schemas.yml
+++ b/applications/dashboard/openapi/schemas.yml
@@ -63,4 +63,10 @@ components:
               type: string
           required:
             - ssoID
+    RangeExpression:
+      description: Specify a range or CSV of values.
+      type: string
+      format: range-expression
+      externalDocs:
+        url: https://success.vanillaforums.com/kb/articles/308-range-expressions
 

--- a/applications/dashboard/openapi/users.yml
+++ b/applications/dashboard/openapi/users.yml
@@ -39,7 +39,7 @@ paths:
           format: date-filter
           type: string
       - name: userID
-        description: One or more user IDs to lookup.
+        description: Filter by a range or CSV of user IDs.
         in: query
         schema:
           $ref: '#/components/schemas/RangeExpression'

--- a/applications/dashboard/openapi/users.yml
+++ b/applications/dashboard/openapi/users.yml
@@ -38,17 +38,11 @@ paths:
         schema:
           format: date-filter
           type: string
-      - description: |
-          One or more user IDs to lookup.
+      - name: userID
+        description: One or more user IDs to lookup.
         in: query
-        name: userID
         schema:
-          items:
-            type: integer
-          type: array
-        style: form
-        x-filter:
-          field: u.UserID
+          $ref: '#/components/schemas/RangeExpression'
       - $ref: '#/components/parameters/Page'
       - description: |
           Desired number of items per page.

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -290,6 +290,7 @@ class CommentsApiController extends AbstractApiController {
         $this->permission();
 
         $in = $this->schema([
+            'commentID?' => \Vanilla\Schema\RangeExpression::createSchema([':int'])->setField('x-filter', ['field' => 'CommentID']),
             'dateInserted?' => new DateFilterSchema([
                 'description' => 'When the comment was created.',
                 'x-filter' => [
@@ -308,7 +309,7 @@ class CommentsApiController extends AbstractApiController {
                 'description' => 'The discussion ID.',
                 'x-filter' => [
                     'field' => 'DiscussionID',
-                    'processor' => function($name, $value) {
+                    'processor' => function ($name, $value) {
                         $discussion = $this->discussionByID($value);
                         $this->discussionModel->categoryPermission('Vanilla.Discussions.View', $discussion['CategoryID']);
                         return [$name => $value];
@@ -334,7 +335,7 @@ class CommentsApiController extends AbstractApiController {
                 ],
             ],
             'expand?' => ApiUtils::getExpandDefinition(['insertUser'])
-        ], ['CommentIndex', 'in'])->requireOneOf(['discussionID', 'insertUserID'])->setDescription('List comments.');
+        ], ['CommentIndex', 'in'])->requireOneOf(['commentID', 'discussionID', 'insertUserID'])->setDescription('List comments.');
         $out = $this->schema([':a' => $this->commentSchema()], 'out');
 
         $query = $in->validate($query);

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -418,6 +418,7 @@ class DiscussionsApiController extends AbstractApiController {
         $this->permission();
 
         $in = $this->schema([
+            'discussionID?' => \Vanilla\Schema\RangeExpression::createSchema([':int'])->setField('x-filter', ['field' => 'd.discussionID']),
             'categoryID:i?' => [
                 'description' => 'Filter by a category.',
                 'x-filter' => [
@@ -455,10 +456,9 @@ class DiscussionsApiController extends AbstractApiController {
                 'default' => false,
                 'description' => 'Only fetch discussions from followed categories. Pinned discussions are mixed in.'
             ],
-            'pinned:b?' => 'Whether or not to include pinned discussions. If true, only return pinned discussions. Cannot be used with the pinOrder parameter.',
+            'pinned:b?',
             'pinOrder:s?' => [
                 'default' => 'first',
-                'description' => 'If including pinned posts, in what order should they be integrated? When "first", discussions pinned to a specific category will only be affected if the discussion\'s category is passed as the categoryID parameter. Cannot be used with the pinned parameter.',
                 'enum' => ['first', 'mixed'],
             ],
             'page:i?' => [

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -482,9 +482,9 @@ class CategoryModel extends Gdn_Model {
     /**
      * Get a list of IDs of categories visible to the current user.
      *
-     * @see CategoryModel::categoryWatch
-     * @param array $options Options compatible with CategoryModel::getVisibleCategories
+     * @param array $options Options compatible with `CategoryModel::getVisibleCategories()`.
      * @return array|bool An array of filtered category IDs or true if no categories were filtered.
+     * @see CategoryModel::categoryWatch
      */
     public function getVisibleCategoryIDs(array $options = []) {
         $categoryModel = self::instance();

--- a/applications/vanilla/openapi/categories.yml
+++ b/applications/vanilla/openapi/categories.yml
@@ -365,14 +365,11 @@ paths:
         in: query
         name: expand
         schema:
-          oneOf:
-            - type: array
-            - type: boolean
           items:
             enum:
-            - breadcrumbs
-            - parent
-            - all
+              - breadcrumbs
+              - parent
+              - all
             type: string
       responses:
         '200':

--- a/applications/vanilla/openapi/categories.yml
+++ b/applications/vanilla/openapi/categories.yml
@@ -4,28 +4,29 @@ paths:
   /categories:
     get:
       parameters:
-      - description: |
-          Parent category ID.
+      - name: categoryID
+        description: Filter by a range or CSV of category IDs.
+        in: query
+        schema:
+          $ref: '#/components/schemas/RangeExpression'
+      - description: Parent category ID.
         in: query
         name: parentCategoryID
         schema:
           type: integer
-      - description: |
-          Parent category URL code.
+      - description: Parent category URL code.
         in: query
         name: parentCategoryCode
         schema:
           type: string
-      - description: |
-          Only list categories followed by the current user.
+      - description: Only list categories followed by the current user.
         in: query
         name: followed
         required: true
         schema:
           default: false
           type: boolean
-      - description: |+
-
+      - description: The maximum tree depth to return when getting a tree structure.
         in: query
         name: maxDepth
         schema:
@@ -42,17 +43,7 @@ paths:
           default: false
           type: boolean
         allowEmptyValue: true
-      - description: >
-          Page number. Works with flat and followed categories. See <a
-          rel="nofollow"
-          href="https://docs.vanillaforums.com/apiv2/#pagination">Pagination</a>
-        in: query
-        name: page
-        schema:
-          type: integer
-          default: 1
-          maximum: 100
-          minimum: 1
+      - $ref: '#/components/parameters/Page'
       - description: |
           Desired number of items per page.
         in: query

--- a/applications/vanilla/openapi/comments.yml
+++ b/applications/vanilla/openapi/comments.yml
@@ -4,10 +4,14 @@ paths:
   /comments:
     get:
       parameters:
+      - name: commentID
+        in: query
+        description: Filter by a range or CSV of comment IDs.
+        schema:
+          $ref: '#/components/schemas/RangeExpression'
       - $ref: '#/components/parameters/DateInserted'
       - $ref: '#/components/parameters/DateUpdated'
-      - description: |
-          The discussion ID.
+      - description: The discussion ID.
         in: query
         name: discussionID
         schema:

--- a/applications/vanilla/openapi/discussions.yml
+++ b/applications/vanilla/openapi/discussions.yml
@@ -4,13 +4,16 @@ paths:
   /discussions:
     get:
       parameters:
+      - name: discussionID
+        description: Filter by a range or CSV of discussion IDs.
+        in: query
+        schema:
+          $ref: '#/components/schemas/RangeExpression'
       - description: Filter by a category.
         in: query
         name: categoryID
         schema:
           type: integer
-        x-filter:
-          field: d.CategoryID
       - $ref: '#/components/parameters/DateInserted'
       - $ref: '#/components/parameters/DateUpdated'
       - $ref: '#/components/parameters/DateLastComment'

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -12,6 +12,9 @@ use Garden\Web\Data;
 use Vanilla\Utility\CamelCaseScheme;
 use Vanilla\Utility\CapitalCaseScheme;
 
+/**
+ * Utility methods useful for greating API endpoints.
+ */
 class ApiUtils {
 
     /**
@@ -164,10 +167,10 @@ class ApiUtils {
     /**
      * Convert query parameters to filters. Useful to fill a where clause ;)
      *
-     * @throws \Exception If something goes wrong. Example, the field processor is not callable.
      * @param Schema $schema
      * @param array $query
      * @return array
+     * @throws \Exception If something goes wrong. Example, the field processor is not callable.
      */
     public static function queryToFilters(Schema $schema, array $query) {
         $filters = [];
@@ -195,5 +198,23 @@ class ApiUtils {
         }
 
         return $filters;
+    }
+
+    /**
+     * Parse a `Link` header into a list of page links.
+     *
+     * @param string $link The link header to parse.
+     * @return array|null Returns an array in the form `[rel => url]` or **null** if the header is malformed.
+     */
+    public static function parsePageHeader(string $link): ?array {
+        if (preg_match_all('`<([^>]+)>;\s*rel="([^"]+)"`', $link, $m, PREG_SET_ORDER)) {
+            $result = [];
+            foreach ($m as $r) {
+                $result[$r[2]] = $r[1];
+            }
+            return $result;
+        } else {
+            return null;
+        }
     }
 }

--- a/library/Vanilla/Schema/RangeExpression.php
+++ b/library/Vanilla/Schema/RangeExpression.php
@@ -227,24 +227,7 @@ EOT;
      * @return $this
      */
     private function addValue(string $op, $value): self {
-        if (!in_array($op, self::OPERATORS)) {
-            switch ($op) {
-                case '[':
-                    $op = '>=';
-                    break;
-                case ']':
-                    $op = '<=';
-                    break;
-                case '(':
-                    $op = '>';
-                    break;
-                case ')':
-                    $op = '<';
-                    break;
-                default:
-                    throw new \InvalidArgumentException("Invalid operator: $op", 400);
-            }
-        }
+        $op = $this->translateOp($op);
 
         $this->values[$op] = $value;
         return $this;
@@ -294,6 +277,16 @@ EOT;
     }
 
     /**
+     * Get the filter value for a single operator.
+     *
+     * @param string $op The operator to inspect.
+     * @return mixed|null Returns the filter value or **null** if there isn't one.
+     */
+    public function getValue(string $op) {
+        return $this->values[$this->translateOp($op)] ?? null;
+    }
+
+    /**
      * Create a range expression and set its original expression.
      *
      * @param string $expr
@@ -338,5 +331,91 @@ EOT;
             return '';
             // @codeCoverageIgnoreStop
         }
+    }
+
+    /**
+     * Create a new range with a different value.
+     *
+     * @param string $op The operator to add.
+     * @param mixed $value The value at the operator.
+     * @return RangeExpression
+     */
+    public function withValue(string $op, $value): RangeExpression {
+        $range = clone $this;
+        $range->originalString = null;
+        $range->addValue($op, $value);
+        return $range;
+    }
+
+    /**
+     * Add a value to the range, merging with the existing filter.
+     *
+     * This method is similar to an AND operation.
+     *
+     * Example:
+     *
+     * ```php
+     * $range = new Range('>', 5);
+     * $range2 = $range->withFilteredValue('>', 6);
+     * echo $range2->getValue('>'); // outputs 6
+     * ```
+     *
+     * @param string $op The operator to add.
+     * @param mixed $value The new filter value.
+     * @return RangeExpression
+     */
+    public function withFilteredValue(string $op, $value): RangeExpression {
+        $op = $this->translateOp($op);
+        $range = clone $this;
+        $range->originalString = null;
+
+        if (!isset($range->values[$op])) {
+            $range->addValue($op, $value);
+        } else {
+            // If we have a similar op then we need to pick the "stricter" one.
+            switch ($op) {
+                case '>':
+                case '>=':
+                    $value = max($value, $range->getValue($op));
+                    break;
+                case '<':
+                case '<=':
+                    $value = min($value, $range->getValue($op));
+                    break;
+                case '=':
+                    $value = array_intersect((array)$value, (array)$range->getValue($op));
+                    break;
+            }
+            $range->addValue($op, $value);
+        }
+        return $range;
+    }
+
+    /**
+     * Translate an operator into its canonical form.
+     *
+     * @param string $op
+     * @return string
+     */
+    private function translateOp(string $op): string {
+        if (!in_array($op, self::OPERATORS)) {
+            switch ($op) {
+                case '[':
+                    $op = '>=';
+                    break;
+                case ']':
+                    $op = '<=';
+                    break;
+                case '(':
+                    $op = '>';
+                    break;
+                case ')':
+                    $op = '<';
+                    break;
+                default:
+                    throw new \InvalidArgumentException("Invalid operator: $op", 400);
+            }
+        }
+        return $op;
     }
 }

--- a/library/Vanilla/Schema/RangeExpression.php
+++ b/library/Vanilla/Schema/RangeExpression.php
@@ -62,11 +62,11 @@ EOT;
 
     private const REGEX_RANGE = <<<EOT
 `
-^([[(])?        # Left bracket
-([^.,]+)?       # From
-(?:\.\.\.?|,)   # Separator
-([^.,\]\)]+)?   # To
-([)\]])?        # Right bracket
+^([[(])?\s*         # Left bracket
+([^.,\s]+)?           # From
+\s*(?:\.\.\.?|,)\s* # Separator
+([^.,\]\)\s]+)?       # To
+\s*([)\]])?            # Right bracket
 `
 mx
 EOT;
@@ -146,18 +146,18 @@ EOT;
             // This is a range expression (ex. '1..10', '(1,5]', '2020-05-01..2020-05-14)')
             [$_, $left, $from, $to, $right] = $m + array_fill(0, 5, '');
 
-            if (empty($from) && empty($to)) {
+            if ($from === '' && $to === '') {
                 throw self::createValidationException('At least one value in the range is required.');
             }
 
             $args = [];
-            if (!empty($from)) {
+            if ($from !== '') {
                 $from = self::validateValue($from, $valueSchema, $validation, 'from');
                 $args[] = $left ?: '>=';
                 $args[] = $from;
             }
 
-            if (!empty($to)) {
+            if ($to !== '') {
                 $to = self::validateValue($to, $valueSchema, $validation, 'to');
                 $args[] = $right ?: '<=';
                 $args[] = $to;

--- a/library/Vanilla/Schema/RangeExpression.php
+++ b/library/Vanilla/Schema/RangeExpression.php
@@ -384,6 +384,11 @@ EOT;
                     break;
                 case '=':
                     $value = array_intersect((array)$value, (array)$range->getValue($op));
+                    if (count($value) === 1) {
+                        $value = array_pop($value);
+                    } else {
+                        $value = array_values($value);
+                    }
                     break;
             }
             $range->addValue($op, $value);

--- a/library/Vanilla/Utility/SchemaUtils.php
+++ b/library/Vanilla/Utility/SchemaUtils.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Utility;
+
+use Garden\Schema\Invalid;
+use Garden\Schema\ValidationField;
+
+/**
+ * Utility functions useful for schemas.
+ */
+final class SchemaUtils {
+    /**
+     * Return a validation function that will require only N keys be specified in an array.
+     *
+     * @param array $properties
+     * @param int $count
+     * @return callable
+     */
+    public static function onlyOneOf(array $properties, int $count = 1): callable {
+        return function ($value, ValidationField $field) use ($properties, $count) {
+            if (!ArrayUtils::isArray($value)) {
+                return $value;
+            }
+            $has = [];
+            foreach ($properties as $property) {
+                if (isset($value[$property])) {
+                    $has[] = $property;
+                }
+            }
+            if (count($has) > $count) {
+                if ($count === 1) {
+                    $message = 'Only one of {properties} are allowed.';
+                } else {
+                    $message = 'Only {count} of {properties} are allowed.';
+                }
+
+                $field->addError('onlyOneOf', [
+                    'messageCode' => $message,
+                    'properties' => $properties,
+                    'count' => $count
+                ]);
+                return Invalid::value();
+            }
+            return $value;
+        };
+    }
+}

--- a/tests/APIv2/CategoriesTest.php
+++ b/tests/APIv2/CategoriesTest.php
@@ -15,6 +15,7 @@ use Vanilla\Navigation\BreadcrumbModel;
  * Test the /api/v2/categories endpoints.
  */
 class CategoriesTest extends AbstractResourceTest {
+    use TestPrimaryKeyRangeFilterTrait;
 
     /** This category should never exist. */
     const BAD_CATEGORY_ID = 999;
@@ -65,8 +66,10 @@ class CategoriesTest extends AbstractResourceTest {
             switch ($key) {
                 case 'urlcode':
                     $value = md5($value);
+                    break;
                 case 'displayAs':
                     $value = $value === 'flat' ? 'categories' : 'flat';
+                    break;
             }
             $row[$key] = $value;
         }
@@ -358,5 +361,13 @@ class CategoriesTest extends AbstractResourceTest {
         $index = $this->api()->get($this->baseUrl, ['parentCategoryID' => self::PARENT_CATEGORY_ID])->getBody();
         $categories = array_column($index, null, 'categoryID');
         $this->assertFalse($categories[$row['categoryID']]['followed']);
+    }
+
+    /**
+     * Make sure `GET /categories` doesn't allow invalid querystring parameters.
+     */
+    public function testOnlyOneOfIndexQuery(): void {
+        $this->expectExceptionMessage('Only one of categoryID, parentCategoryID, parentCategoryCode, followed are allowed.');
+        $r = $this->api()->get($this->baseUrl, ['categoryID' => 123, 'followed' => true]);
     }
 }

--- a/tests/APIv2/CommentsTest.php
+++ b/tests/APIv2/CommentsTest.php
@@ -13,7 +13,7 @@ use DiscussionModel;
  * Test the /api/v2/discussions endpoints.
  */
 class CommentsTest extends AbstractResourceTest {
-    use AssertLoggingTrait;
+    use AssertLoggingTrait, TestPrimaryKeyRangeFilterTrait;
 
     /**
      * {@inheritdoc}

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -15,7 +15,7 @@ use Garden\Web\Exception\ForbiddenException;
  * Test the /api/v2/discussions endpoints.
  */
 class DiscussionsTest extends AbstractResourceTest {
-    use TestPutFieldTrait, AssertLoggingTrait;
+    use TestPutFieldTrait, AssertLoggingTrait, TestPrimaryKeyRangeFilterTrait;
 
     /** @var array */
     private static $categoryIDs = [];

--- a/tests/APIv2/TestPrimaryKeyRangeFilterTrait.php
+++ b/tests/APIv2/TestPrimaryKeyRangeFilterTrait.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\APIv2;
+
+use Garden\Http\HttpResponse;
+use PHPUnit\Framework\TestCase;
+use Vanilla\ApiUtils;
+
+/**
+ * Adds some tests for `AbstractResourceTest` subclasses that have support for primary key range filters.
+ */
+trait TestPrimaryKeyRangeFilterTrait {
+    /**
+     * Test a basic integration of the PK range.
+     */
+    public function testIndexRange(): void {
+        [$_, $rows] = $this->testIndex();
+
+        TestCase::assertGreaterThanOrEqual(4, count($rows), "The testIndex() method doesn't provide enough rows to test.");
+
+        [$minID, $maxID] = $this->minMaxIDs($rows);
+
+        /** @var HttpResponse $r */
+        $r = $this->api()->get(
+            $this->baseUrl,
+            [
+                $this->pk => "($minID,$maxID)",
+                'limit' => count($rows) - 3,
+            ]
+        );
+        $newRows = $r->getBody();
+
+        [$newMinID, $newMaxID] = $this->minMaxIDs($newRows);
+        TestCase::assertGreaterThan($minID, $newMinID, "The min ID range was not respected.");
+        TestCase::assertLessThan($maxID, $newMaxID, "The max ID range was not respected.");
+
+        TestCase::assertTrue($r->hasHeader("Link"), "No paging information was found.");
+        $paging = ApiUtils::parsePageHeader($r->getHeader('Link'));
+        TestCase::assertIsArray($paging, "The link header should parse to an array of page links.");
+        TestCase::assertArrayHasKey('next', $paging);
+        TestCase::assertIsString(filter_var($paging['next'], FILTER_VALIDATE_URL), "The next page is not a valid URL.");
+    }
+
+    /**
+     * Calculate the min and max IDs of a dataset.
+     *
+     * @param array $rows
+     * @return array
+     */
+    private function minMaxIDs(array $rows): array {
+        $minID = null;
+        $maxID = null;
+        foreach ($rows as $row) {
+            $minID = min($minID ?: PHP_INT_MAX, $row[$this->pk]);
+            $maxID = max($maxID ?: PHP_INT_MIN, $row[$this->pk]);
+        }
+        return array($minID, $maxID);
+    }
+}

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -18,7 +18,7 @@ use VanillaTests\Fixtures\TestUploader;
  * Test the /api/v2/users endpoints.
  */
 class UsersTest extends AbstractResourceTest {
-    use TestPutFieldTrait, AssertLoggingTrait;
+    use TestPutFieldTrait, AssertLoggingTrait, TestPrimaryKeyRangeFilterTrait;
 
     /** @var int A value to ensure new records are unique. */
     protected static $recordCounter = 1;

--- a/tests/Library/Database/MySQLDriverTest.php
+++ b/tests/Library/Database/MySQLDriverTest.php
@@ -266,6 +266,7 @@ EOT;
             'basic' => [new RangeExpression('>', 1), 'where `b` > :b'],
             'two values' => [new RangeExpression('>=', 1, '<=', 2), 'where `b` >= :b and `b` <= :b0'],
             'in clause' => [new RangeExpression('=', [1, 2]), "where `b` in ('1', '2')"],
+            'empty equals' => [new RangeExpression('=', []), "where 1 = 0"]
         ];
         return $r;
     }

--- a/tests/Library/Vanilla/ApiUtilsTest.php
+++ b/tests/Library/Vanilla/ApiUtilsTest.php
@@ -42,7 +42,7 @@ class ApiUtilsTest extends SharedBootstrapTestCase {
             'parameter:s' => [
                 'x-filter' => [
                     'field' => 'FilterFieldName',
-                    'processor' => function($fieldName, $value) {
+                    'processor' => function ($fieldName, $value) {
                         return [$fieldName.'Processed' => $value.'Processed'];
                     }
                 ],
@@ -89,5 +89,36 @@ class ApiUtilsTest extends SharedBootstrapTestCase {
         ]);
 
         ApiUtils::queryToFilters($schema, ['parameter' => 'test']);
+    }
+
+    /**
+     * Do a basic test of the page header parsing functionality.
+     */
+    public function testParsePageHeader() {
+        $link = <<<EOT
+<http://vanilla.test/categoriestest/api/v2/categories?page=1&limit=1>; rel="first",
+<http://vanilla.test/categoriestest/api/v2/categories?page=2&limit=1>; rel="next",
+<http://vanilla.test/categoriestest/api/v2/categories?page=2&limit=1>; rel="last"
+EOT;
+
+        $expected = array (
+            'first' => 'http://vanilla.test/categoriestest/api/v2/categories?page=1&limit=1',
+            'next' => 'http://vanilla.test/categoriestest/api/v2/categories?page=2&limit=1',
+            'last' => 'http://vanilla.test/categoriestest/api/v2/categories?page=2&limit=1',
+        );
+
+        $actual = ApiUtils::parsePageHeader($link);
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * A garbled link header should just return null.
+     */
+    public function testParsePageHeaderNull() {
+        $link = 'garbled';
+        $actual = ApiUtils::parsePageHeader($link);
+
+        $this->assertNull($actual);
     }
 }

--- a/tests/Library/Vanilla/OpenAPIBuilderTest.php
+++ b/tests/Library/Vanilla/OpenAPIBuilderTest.php
@@ -62,6 +62,6 @@ class OpenAPIBuilderTest extends TestCase {
         chdir(PATH_ROOT);
         exec("npx swagger-cli@2.3.4 validate $path", $output, $result);
         chdir($dir);
-        $this->assertSame(0, $result);
+        $this->assertSame(0, $result, $path);
     }
 }

--- a/tests/Library/Vanilla/RangeExpressionTest.php
+++ b/tests/Library/Vanilla/RangeExpressionTest.php
@@ -268,4 +268,63 @@ class RangeExpressionTest extends TestCase {
         $actual = RangeExpression::parse('( ,1)');
         $this->assertArrayNotHasKey('>', $actual->getValues());
     }
+
+    /**
+     * The value wither should return a new instance with the new value set.
+     */
+    public function testWithValue(): void {
+        $r1 = RangeExpression::parse('[1,2]');
+        $r2 = $r1->withValue('<=', 3);
+        $this->assertNotSame($r1, $r2);
+        $this->assertSame('1..3', (string)$r2);
+    }
+
+    /**
+     * Adding a filtered value should add it alongside other values.
+     */
+    public function testWithFilteredValueDifferent(): void {
+        $r1 = new RangeExpression('=', 1);
+        $r2 = $r1->withFilteredValue('>', 5);
+        $this->assertNotSame($r1, $r2);
+        $this->assertSame(1, $r2->getValue('='));
+        $this->assertSame(5, $r2->getValue('>'));
+    }
+
+    /**
+     * Test `RangeExpression::withFilteredValue()`.
+     *
+     * @param string $op
+     * @param mixed $value
+     * @param mixed $expected
+     * @dataProvider provideFilterValueMergeTests
+     */
+    public function testWithFilteredValueMerge(string $op, $value, $expected): void {
+        $r1 = new RangeExpression($op, 5);
+        $r2 = $r1->withFilteredValue($op, $value);
+        $this->assertSame(1, count($r2->getValues()), "The new value isn't supposed to add an operator");
+        $this->assertSame($expected, $r2->getValue($op));
+    }
+
+    /**
+     * Provide filter merge test data.
+     *
+     * @return array
+     */
+    public function provideFilterValueMergeTests(): array {
+        $r = [
+            'no change >' => ['>', 4, 5],
+            'no change >=' => ['>=', 4, 5],
+            'no change <' => ['<', 6, 5],
+            'no change <=' => ['<=', 6, 5],
+
+            'change >' => ['>', 6, 6],
+            'change >=' => ['>=', 6, 6],
+            'change <' => ['<', 4, 4],
+            'change <=' => ['<=', 4, 4],
+
+            'intersect' => ['=', [4, 5, 6], 5],
+            'empty' => ['=', [4, 6], []],
+        ];
+        return $r;
+    }
 }

--- a/tests/Library/Vanilla/RangeExpressionTest.php
+++ b/tests/Library/Vanilla/RangeExpressionTest.php
@@ -239,4 +239,33 @@ class RangeExpressionTest extends TestCase {
         $actual = RangeExpression::parse('..a')->__toString();
         $this->assertSame('<=a', $actual);
     }
+
+    /**
+     * Zeros can be an edge case because they are empty.
+     */
+    public function testZeroRange(): void {
+        $actual = RangeExpression::parse('[0,0]');
+        $this->assertSame('0', $actual->getValues()['>=']);
+        $this->assertSame('0', $actual->getValues()['<=']);
+    }
+
+    /**
+     * Whitespace should be trimmed.
+     */
+    public function testWhitespace(): void {
+        $actual = RangeExpression::parse('( 0 , 1 )');
+        $this->assertSame('0', $actual->getValues()['>']);
+        $this->assertSame('1', $actual->getValues()['<']);
+    }
+
+    /**
+     * Just whitespace shouldn't be evaluated to a range.
+     */
+    public function testJustWhitespace(): void {
+        $actual = RangeExpression::parse('(0, )');
+        $this->assertArrayNotHasKey('<', $actual->getValues());
+
+        $actual = RangeExpression::parse('( ,1)');
+        $this->assertArrayNotHasKey('>', $actual->getValues());
+    }
 }

--- a/tests/Library/Vanilla/Utility/SchemaUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/SchemaUtilsTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Utility;
+
+use Garden\Schema\Invalid;
+use Garden\Schema\Validation;
+use Garden\Schema\ValidationField;
+use PHPUnit\Framework\TestCase;
+use Vanilla\Utility\SchemaUtils;
+
+/**
+ * Tests for the `SchemaUtils` class.
+ */
+class SchemaUtilsTest extends TestCase {
+    /**
+     * Test some only one of error cases.
+     *
+     * @param array $properties
+     * @param int $count
+     * @dataProvider provideOnlyOneOfErrors
+     */
+    public function testOnlyOneOfErrors(array $properties, int $count = 1) {
+        $field = new ValidationField(new Validation(), [], '');
+        $fn = SchemaUtils::onlyOneOf($properties, $count);
+
+        $value = $fn(new \ArrayObject(['a' => 1, 'b' => 1, 'c' => 1]), $field);
+        $this->assertSame(Invalid::value(), $value);
+        $this->assertFalse($field->isValid());
+        $this->assertStringContainsString(implode(', ', $properties), $field->getValidation()->getMessage());
+    }
+
+    /**
+     * Provide some only one of errors.
+     *
+     * @return array
+     */
+    public function provideOnlyOneOfErrors(): array {
+        $r = [
+            'a, b' => [['a', 'b']],
+            'a, b, c' => [['a', 'b', 'c'], 2],
+        ];
+        return $r;
+    }
+
+    /**
+     * Test some only one of happy paths.
+     *
+     * @param array $properties
+     * @param int $count
+     * @dataProvider provideOnlyOneOfHappy
+     */
+    public function testOnlyOneOfHappy(array $properties, int $count = 1) {
+        $field = new ValidationField(new Validation(), [], '');
+        $fn = SchemaUtils::onlyOneOf($properties, $count);
+
+        $value = $fn(['a' => 1, 'b' => 1], $field);
+        $this->assertSame(['a' => 1, 'b' => 1], $value);
+        $this->assertTrue($field->isValid());
+    }
+
+    /**
+     * Provide some only one of errors.
+     *
+     * @return array
+     */
+    public function provideOnlyOneOfHappy(): array {
+        $r = [
+            'a, c' => [['a', 'c']],
+            'a, b, c' => [['a', 'b', 'c'], 2],
+        ];
+        return $r;
+    }
+
+    /**
+     * The only one of validator should only validate arrayish values.
+     */
+    public function testOnlyOneOfNotArray(): void {
+        $field = new ValidationField(new Validation(), [], '');
+        $fn = SchemaUtils::onlyOneOf(['a', 'b']);
+
+        $value = $fn('foo', $field);
+        $this->assertSame('foo', $value);
+    }
+}


### PR DESCRIPTION
Added the ability so specify a range or CSV of values in various endpoints:

- `GET /api/v2/discussions?discussionID=<range>`
- `GET /api/v2/users?userID=<range>`
- `GET /api/v2/comments?commentID=<range>`
- `GET /api/v2/categories?categoryID=<range>`

This functionality all has some basic test coverage.

This PR also comes with some yack shaving:

- The `RangeExpression` has some bug fixes and enhancements. Everything here has test coverage.
- I added the `ApiUtils::parsePageHeader()` utility function to cut down on regex errors. This was in service of the main tests, but it has its own smoke tests too.
- I added the `SchemaUtils::onlyOneOf()` utility higher order function to hopefully prevent a support request when someone passes incompatible parameters to the `GET /categories` endpoint. This has test coverage.
- Our open API docs had some bugs that have trickled in. I fixed them. You can run the `OpenAPIBuilderTest` to verify our merged schema.

This is a fairly large PR, but I did add a good number of tests so I'm hoping it's not the worst to review.