### PR TITLE
Fix OpenAPI’s schema merging

### DIFF
--- a/applications/vanilla/openapi/discussions.yml
+++ b/applications/vanilla/openapi/discussions.yml
@@ -72,25 +72,7 @@ paths:
           type: integer
         x-filter:
           field: d.InsertUserID
-      - description: >
-          Expand associated records using one or more valid field names. A
-          value of "all" will expand all expandable fields.
-        in: query
-        name: expand
-        schema:
-          items:
-            enum:
-            - all
-            - category
-            - insertUser
-            - lastUser
-            - lastPost
-            - lastPost.body
-            - lastPost.insertUser
-            - reactions
-            type: string
-          type: array
-        style: form
+      - $ref: '#/components/parameters/DiscussionExpand'
       - description: The group the discussion is in.
         in: query
         name: groupID
@@ -139,24 +121,7 @@ paths:
           default: 30
           maximum: 100
           minimum: 1
-      - description: >
-          Expand associated records using one or more valid field names. A
-          value of "all" will expand all expandable fields.
-        in: query
-        name: expand
-        schema:
-          items:
-            enum:
-            - insertUser
-            - lastUser
-            - lastPost
-            - lastPost.body
-            - lastPost.insertUser
-            - reactions
-            - all
-            type: string
-          type: array
-        style: form
+      - $ref: '#/components/parameters/DiscussionExpand'
       responses:
         '200':
           content:
@@ -241,13 +206,7 @@ paths:
           default: 30
           maximum: 100
           minimum: 1
-      - description: |
-          Expand associated records.
-        in: query
-        name: expand
-        schema:
-          default: false
-          type: boolean
+      - $ref: '#/components/parameters/DiscussionExpand'
       responses:
         '200':
           content:
@@ -270,19 +229,7 @@ paths:
         required: true
         schema:
           type: integer
-      - description: >
-          Expand associated records using one or more valid field names. A
-          value of "all" will expand all expandable fields.
-        in: query
-        name: expand
-        schema:
-          items:
-            enum:
-            - reactions
-            - all
-            type: string
-          type: array
-        style: form
+      - $ref: '#/components/parameters/DiscussionExpand'
       responses:
         '204':
           description: Success
@@ -298,19 +245,7 @@ paths:
         required: true
         schema:
           type: integer
-      - description: >
-          Expand associated records using one or more valid field names. A
-          value of "all" will expand all expandable fields.
-        in: query
-        name: expand
-        schema:
-          items:
-            enum:
-            - reactions
-            - all
-            type: string
-          type: array
-        style: form
+      - $ref: '#/components/parameters/DiscussionExpand'
       responses:
         '200':
           content:
@@ -392,19 +327,7 @@ paths:
         required: true
         schema:
           type: integer
-      - description: >
-          Expand associated records using one or more valid field names. A
-          value of "all" will expand all expandable fields.
-        in: query
-        name: expand
-        schema:
-          items:
-            enum:
-            - reactions
-            - all
-            type: string
-          type: array
-        style: form
+      - $ref: '#/components/parameters/DiscussionExpand'
       responses:
         '200':
           content:
@@ -478,19 +401,7 @@ paths:
         required: true
         schema:
           type: integer
-      - description: >
-          Expand associated records using one or more valid field names. A
-          value of "all" will expand all expandable fields.
-        in: query
-        name: expand
-        schema:
-          items:
-            enum:
-            - reactions
-            - all
-            type: string
-          type: array
-        style: form
+      - $ref: '#/components/parameters/DiscussionExpand'
       responses:
         '200':
           content:
@@ -694,19 +605,7 @@ paths:
         required: true
         schema:
           type: integer
-      - description: >
-          Expand associated records using one or more valid field names. A
-          value of "all" will expand all expandable fields.
-        in: query
-        name: expand
-        schema:
-          items:
-            enum:
-            - reactions
-            - all
-            type: string
-          type: array
-        style: form
+      - $ref: '#/components/parameters/DiscussionExpand'
       responses:
         '204':
           description: Success
@@ -774,6 +673,25 @@ components:
       schema:
         format: date-filter
         type: string
+    DiscussionExpand:
+      name: expand
+      description: >
+        Expand associated records using one or more valid field names. A value of "all" will expand all expandable fields.
+      in: query
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+          - all
+          - category
+          - insertUser
+          - lastUser
+          - lastPost
+          - lastPost.body
+          - lastPost.insertUser
+          - reactions
+      style: form
   schemas:
     CategoryFragment:
       properties:

--- a/library/Vanilla/OpenAPIBuilder.php
+++ b/library/Vanilla/OpenAPIBuilder.php
@@ -85,7 +85,7 @@ class OpenAPIBuilder {
             return $r;
         };
 
-        $schema1 = ArrayUtils::arrayMergeRecursive($schema1, $schema2, $merge);
+        $schema1 = ArrayUtils::mergeRecursive($schema1, $schema2, $merge);
         return $schema1;
     }
 

--- a/library/Vanilla/OpenAPIBuilder.php
+++ b/library/Vanilla/OpenAPIBuilder.php
@@ -60,11 +60,12 @@ class OpenAPIBuilder {
      * @return array
      */
     public static function mergeSchemas(array $schema1, array $schema2): array {
-        // This method is on the conservative side. It has a whitelist of known numeric keys and their behavior.
-        // Everything else uses plain old `array_replace_recursive()`.
+        // This callback is on the conservative side. It has a whitelist of known numeric keys and their behavior.
+        // Everything else uses plain old `array_merge()`.
         $merge = function (array $arr1, array $arr2, string $key) {
             switch ($key) {
                 case 'required':
+                    // Don't sort required because it's often in a logical order already.
                     $r = array_values(array_unique(array_merge($arr1, $arr2)));
                     break;
                 case 'enum':

--- a/library/Vanilla/OpenAPIBuilder.php
+++ b/library/Vanilla/OpenAPIBuilder.php
@@ -9,6 +9,7 @@ namespace Vanilla;
 
 use Garden\Web\RequestInterface;
 use Symfony\Component\Yaml\Yaml;
+use Vanilla\Utility\ArrayUtils;
 
 /**
  * A class for building a full OpenAPI 3.0 spec by combining all of the add-on OpenAPI files.
@@ -46,6 +47,39 @@ class OpenAPIBuilder {
         $this->addonManager = $addonManager;
         $this->cachePath = $cachePath ?: PATH_CACHE.'/openapi.php';
         $this->request = $request;
+    }
+
+    /**
+     * Merge two Opan API schemas.
+     *
+     * Although this class uses this method to always merge top-level schemas, it should support any schema fragment so
+     * long as both schemas are at the same level.
+     *
+     * @param array $schema1
+     * @param array $schema2
+     * @return array
+     */
+    public static function mergeSchemas(array $schema1, array $schema2): array {
+        // This method is on the conservative side. It has a whitelist of known numeric keys and their behavior.
+        // Everything else uses plain old `array_replace_recursive()`.
+        $merge = function (array $arr1, array $arr2, string $key) {
+            switch ($key) {
+                case 'required':
+                    $r = array_values(array_unique(array_merge($arr1, $arr2)));
+                    break;
+                case 'enum':
+                case 'tags':
+                    $r = array_unique(array_merge($arr1, $arr2));
+                    sort($r);
+                    break;
+                default:
+                    $r = array_merge($arr1, $arr2);
+            }
+            return $r;
+        };
+
+        $schema1 = ArrayUtils::arrayMergeRecursive($schema1, $schema2, $merge);
+        return $schema1;
     }
 
     /**
@@ -196,7 +230,7 @@ class OpenAPIBuilder {
                 $this->cleanData($data);
                 $this->annotateData($data, $addon);
                 $results[] = $data;
-                $result = array_replace_recursive($result, $data);
+                $result = self::mergeSchemas($result, $data);
             }
         }
 

--- a/library/Vanilla/OpenAPIBuilder.php
+++ b/library/Vanilla/OpenAPIBuilder.php
@@ -72,6 +72,12 @@ class OpenAPIBuilder {
                     $r = array_unique(array_merge($arr1, $arr2));
                     sort($r);
                     break;
+                case 'parameters':
+                    // Parameters work a lot like associative arrays, but have to be made that way.
+                    $arr1 = array_column($arr1, null, 'name');
+                    $arr2 = array_column($arr2, null, 'name');
+                    $r = array_values(self::mergeSchemas($arr1, $arr2));
+                    break;
                 default:
                     $r = array_merge($arr1, $arr2);
             }

--- a/library/Vanilla/Utility/ArrayUtils.php
+++ b/library/Vanilla/Utility/ArrayUtils.php
@@ -254,18 +254,27 @@ final class ArrayUtils {
     }
 
     /**
-     * @param array $arr1
-     * @param array $arr2
-     * @param callable|null $numeric
+     * Recursively merge two arrays with special handling for numeric arrays.
+     *
+     * This method is very similar to `array_merge_recursive()` however it allows you to customize the handling of
+     * numeric array merging. This is handy when you do have some nested numeric arrays because you rerely want the
+     * behavior of `array_merge_recursive()` when dealing with JSON style model data.
+     *
+     * @param array $arr1 The first array.
+     * @param array $arr2 The second array. This array will overwrite the first array when keys match.
+     * @param callable|null $numeric The merge function to use when numeric arrays are encountered.
+     * If you don't supply a callback then the arrays will be uniquely merged. If you want to supply a callback you can
+     * look at the default definition at the top of the method.
      * @return array
      */
     public static function arrayMergeRecursive(array $arr1, array $arr2, callable $numeric = null): array {
         if ($numeric === null) {
-            $numeric = function (array $arr1, array $arr2, $key): array {
+            $numeric = function (array $arr1, array $arr2, string $key): array {
                 return array_values(array_unique(array_merge($arr1, $arr2)));
             };
         }
 
+        // Do a full replace to simplify some of the walking logic.
         // For the purposes of this method, replace is the same as merge, but presumably faster.
         $arr = array_replace_recursive($arr1, $arr2);
 
@@ -287,9 +296,6 @@ final class ArrayUtils {
                             $clean($value, $arr1[$key] ?? null, $arr2[$key] ?? null);
                         }
                     }
-                } elseif (is_array($value)) {
-                    // Here we recurse to child arrays.
-//                    $clean($value, $arr1[$key] ?? null, $arr2[$key] ?? null);
                 }
             }
         };

--- a/library/Vanilla/Utility/ArrayUtils.php
+++ b/library/Vanilla/Utility/ArrayUtils.php
@@ -267,7 +267,7 @@ final class ArrayUtils {
      * look at the default definition at the top of the method.
      * @return array
      */
-    public static function arrayMergeRecursive(array $arr1, array $arr2, callable $numeric = null): array {
+    public static function mergeRecursive(array $arr1, array $arr2, callable $numeric = null): array {
         if ($numeric === null) {
             $numeric = function (array $arr1, array $arr2, string $key): array {
                 return array_values(array_unique(array_merge($arr1, $arr2)));

--- a/tests/Library/Vanilla/OpenAPIBuilderTest.php
+++ b/tests/Library/Vanilla/OpenAPIBuilderTest.php
@@ -89,9 +89,9 @@ class OpenAPIBuilderTest extends TestCase {
                 ['enum' => ['a', 'c']], ['enum' => ['a', 'b']], ['enum' => ['a', 'b', 'c']]
             ],
             'parameters' => [
-                ['parameters' => [['name' => 'a']]],
-                ['parameters' => [['name' => 'b']]],
-                ['parameters' => [['name' => 'a'], ['name' => 'b']]],
+                ['parameters' => [['name' => 'a', 'e' => [1]]]],
+                ['parameters' => [['name' => 'b'], ['name' => 'a', 'e' => [2]]]],
+                ['parameters' => [['name' => 'a', 'e' => [1, 2]], ['name' => 'b']]],
             ]
         ];
         return $r;

--- a/tests/Library/Vanilla/OpenAPIBuilderTest.php
+++ b/tests/Library/Vanilla/OpenAPIBuilderTest.php
@@ -92,7 +92,10 @@ class OpenAPIBuilderTest extends TestCase {
                 ['parameters' => [['name' => 'a', 'e' => [1]]]],
                 ['parameters' => [['name' => 'b'], ['name' => 'a', 'e' => [2]]]],
                 ['parameters' => [['name' => 'a', 'e' => [1, 2]], ['name' => 'b']]],
-            ]
+            ],
+            'required' => [
+                ['required' => ['a', 'c']], ['required' => ['a', 'b']], ['required' => ['a', 'c', 'b']]
+            ],
         ];
         return $r;
     }

--- a/tests/Library/Vanilla/OpenAPIBuilderTest.php
+++ b/tests/Library/Vanilla/OpenAPIBuilderTest.php
@@ -64,4 +64,36 @@ class OpenAPIBuilderTest extends TestCase {
         chdir($dir);
         $this->assertSame(0, $result);
     }
+
+    /**
+     * Test specific OpenAPI schema merging bugs.
+     *
+     * @param array $schema1
+     * @param array $schema2
+     * @param array $expected
+     * @dataProvider provideSchemaMergeScenarios
+     */
+    public function testSchemaMergeBugs(array $schema1, array $schema2, array $expected) {
+        $actual = OpenAPIBuilder::mergeSchemas($schema1, $schema2);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function provideSchemaMergeScenarios(): array {
+        $r = [
+            'enum' => [
+                ['enum' => ['a', 'c']], ['enum' => ['a', 'b']], ['enum' => ['a', 'b', 'c']]
+            ],
+            'parameters' => [
+                ['parameters' => [['name' => 'a']]],
+                ['parameters' => [['name' => 'b']]],
+                ['parameters' => [['name' => 'a'], ['name' => 'b']]],
+            ]
+        ];
+        return $r;
+    }
 }

--- a/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
@@ -305,6 +305,11 @@ class ArrayUtilsTest extends TestCase {
         $this->assertSame($expected, $actual);
     }
 
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
     public function provideArrayMergeRecursiveTests(): array {
         $r = [
             'overwrite' => [

--- a/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
@@ -334,9 +334,6 @@ class ArrayUtilsTest extends TestCase {
             'mismatch' => [
                 ['a' => ['a']], ['a' => 'a'], ['a' => 'a']
             ],
-            'root numeric' => [
-                ['a', 'b'], ['a', 'c'], ['a', 'b', 'c']
-            ],
         ];
         return $r;
     }

--- a/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
@@ -298,7 +298,7 @@ class ArrayUtilsTest extends TestCase {
         $tree($arr2);
         $tree($expected);
 
-        $actual = ArrayUtils::arrayMergeRecursive($arr1, $arr2);
+        $actual = ArrayUtils::mergeRecursive($arr1, $arr2);
 
         ksort($actual);
         ksort($expected);

--- a/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
@@ -280,4 +280,64 @@ class ArrayUtilsTest extends TestCase {
         $this->expectExceptionMessage('expects argument 1 to be an array or array-like object');
         ArrayUtils::keys("foo");
     }
+
+    /**
+     * Test `ArrayUtils::ArrayMergeRecursiveFancy()`.
+     *
+     * @param array $arr1
+     * @param array $arr2
+     * @param array $expected
+     * @dataProvider provideArrayMergeRecursiveTests
+     */
+    public function testArrayMergeRecursiveFancy(array $arr1, array $arr2, array $expected): void {
+        $tree = function (array &$arr) {
+            $arr['child'] = $arr;
+            unset($arr['child']['child']);
+        };
+        $tree($arr1);
+        $tree($arr2);
+        $tree($expected);
+
+        $actual = ArrayUtils::arrayMergeRecursive($arr1, $arr2);
+
+        ksort($actual);
+        ksort($expected);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function provideArrayMergeRecursiveTests(): array {
+        $r = [
+            'overwrite' => [
+                ['a' => 'a'], ['a' => 'b'], ['a' => 'b']
+            ],
+            'just 1' => [
+                ['a' => 'a'], [], ['a' => 'a']
+            ],
+            'just 2' => [
+                [], ['a' => 'a'], ['a' => 'a']
+            ],
+            'numeric' => [
+                ['a' => ['a', 'b']], ['a' => ['a', 'c']], ['a' => ['a', 'b', 'c']]
+            ],
+            'just recurse 1' => [
+                ['a' => ['b' => 'c']], [], ['a' => ['b' => 'c']]
+            ],
+            'just recurse 2' => [
+                [], ['a' => ['b' => 'c']], ['a' => ['b' => 'c']]
+            ],
+            'empty numeric' => [
+                ['a' => []], ['a' => ['a']], ['a' => ['a']]
+            ],
+            'numeric empty' => [
+                ['a' => ['a']], ['a' => []], ['a' => ['a']]
+            ],
+            'mismatch' => [
+                ['a' => ['a']], ['a' => 'a'], ['a' => 'a']
+            ],
+            'root numeric' => [
+                ['a', 'b'], ['a', 'c'], ['a', 'b', 'c']
+            ],
+        ];
+        return $r;
+    }
 }


### PR DESCRIPTION
This PR fixes a long standing issue with the way we build our schemas when two schemas have overlapping enums. Before it would choose one. Now it will merge the two and remove duplicates.

This PR introduces the following changes:

- Added the `ArrayUtils::arrayMergeRecursive()` utility function as a generic way to solve this problem. It has full test coverage, but I'm guessing there are edge cases it doesn't cover.
- Refactored the `OpenAPIBuilder` a tiny bit to make use of the above utility function. In particular `OpenAPIBuilder::mergeSchemas()` handles the specific schema merging. It has tests for the specific bugs in question.
- Refactored the `discussions.yml` OpenAPI spec to consolidate the various expand parameters as this was the cause of the original bug report, addressed in [this PR](https://github.com/vanilla/addons/pull/813). Once this PR is merged, the other one will hopefully pass.

Also note that this change does go through a fair amount of integration testing as there is a test to merge all of our OpenAPI docs and validate them.