### PR TITLE
Fix normalization of current theme when Garden.CurrentTheme isn't set

### DIFF
--- a/library/Vanilla/Theme/ThemeService.php
+++ b/library/Vanilla/Theme/ThemeService.php
@@ -545,8 +545,11 @@ class ThemeService {
         $theme->setSupportedSections($supportedSections);
 
         // Fix current theme.
-        $currentThemeID = $this->config->get(ThemeServiceHelper::CONFIG_CURRENT_THEME, ThemeServiceHelper::CONFIG_MOBILE_THEME);
-        $theme->setCurrent($currentThemeID == $theme->getThemeID());
+        $currentThemeID =
+            $this->config->get(ThemeServiceHelper::CONFIG_CURRENT_THEME)
+            ?: $this->config->get(ThemeServiceHelper::CONFIG_DESKTOP_THEME);
+        $isCurrent = $currentThemeID == $theme->getThemeID();
+        $theme->setCurrent($isCurrent);
 
         $this->overlayAddonVariables($theme);
         return $theme;


### PR DESCRIPTION
Related https://github.com/vanilla/support/issues/2021
Related https://github.com/vanilla/support/issues/2060
Fixes https://github.com/vanilla/support/issues/2047
Related https://github.com/vanilla/support/issues/2063