### PR TITLE
Normalize unicode in URL paths before scraping

### DIFF
--- a/library/Vanilla/EmbeddedContent/EmbedService.php
+++ b/library/Vanilla/EmbeddedContent/EmbedService.php
@@ -8,6 +8,7 @@ namespace Vanilla\EmbeddedContent;
 
 use Garden\Container;
 use Garden\Schema\ValidationException;
+use League\Uri\Http;
 use Vanilla\EmbeddedContent\Embeds\CodePenEmbed;
 use Vanilla\EmbeddedContent\Embeds\ErrorEmbed;
 use Vanilla\EmbeddedContent\Embeds\FileEmbed;
@@ -39,6 +40,7 @@ use Vanilla\EmbeddedContent\Factories\InstagramEmbedFactory;
 use Vanilla\EmbeddedContent\Embeds\InstagramEmbed;
 use Vanilla\EmbeddedContent\Factories\GettyImagesEmbedFactory;
 use Vanilla\EmbeddedContent\Embeds\GettyImagesEmbed;
+use Vanilla\Utility\UrlUtils;
 use Vanilla\Web\RequestValidator;
 
 /**
@@ -245,6 +247,9 @@ class EmbedService implements EmbedCreatorInterface {
         // @see https://github.com/vanilla/dev-inter-ops/issues/23
         // We've had some situations where the site gets in an infinite loop requesting itself.
         $this->requestValidator->blockRequestType('GET', __METHOD__ . ' may not be called during a GET request.');
+
+        // Normalize the encoding on the URL.
+        $url = (string)UrlUtils::normalizeEncoding(Http::createFromString($url));
 
         // Check the cache first.
         if (!$force) {

--- a/library/Vanilla/Utility/UrlUtils.php
+++ b/library/Vanilla/Utility/UrlUtils.php
@@ -80,4 +80,22 @@ class UrlUtils {
         $r = implode('/', $parts);
         return $r;
     }
+
+    /**
+     * Make sure that a URL has appropriately encoded characters.
+     *
+     * Many browser can handle unicode characters in their URLs. However, such characters are not actually valid characters
+     * and will fail validation in many cases. This method takes improperly encoded characters and encodes them.
+     *
+     * @param UriInterface $url The URL to process.
+     * @return UriInterface Returns a URL string with characters appropriately encoded.
+     */
+    public static function normalizeEncoding(UriInterface $url): UriInterface {
+        $path = $url->getPath();
+        $str = preg_replace_callback('`[^%a-zA-Z0-9./_-]+`', function ($s): string {
+            return rawurlencode($s[0]);
+        }, $path);
+        $result = $url->withPath($str);
+        return $result;
+    }
 }

--- a/tests/Library/Vanilla/Utility/UrlUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/UrlUtilsTest.php
@@ -138,4 +138,35 @@ class UrlUtilsTest extends TestCase {
         $this->assertSame($encoded, UrlUtils::encodePath($decoded));
         $this->assertSame($decoded, UrlUtils::decodePath($encoded));
     }
+
+    /**
+     * Fix URLs with a mix of encoded and non-encoded UTF-8 in their paths.
+     *
+     * @param string $url
+     * @param string $expected
+     * @dataProvider provideFixUrlTests
+     */
+    public function testNormalizeEncoding(string $url, string $expected): void {
+        $fixed = UrlUtils::normalizeEncoding($url);
+        $this->assertSame($expected, $fixed);
+    }
+
+    /**
+     * Provide URL fix tests.
+     *
+     * @return array
+     */
+    public function provideFixUrlTests(): array {
+        $r = [
+            ['https://de.wikipedia.org/wiki/Prüfsumme', 'https://de.wikipedia.org/wiki/Pr%C3%BCfsumme'],
+            ['https://de.wikipedia.org/wiki/Prüfsümme', 'https://de.wikipedia.org/wiki/Pr%C3%BCfs%C3%BCmme'],
+            ['https://de.wikipedia.org/wiki/Pr%C3%BCfsumme', 'https://de.wikipedia.org/wiki/Pr%C3%BCfsumme'],
+            ['https://de.wikipedia.org/wiki/Pr%C3%BCfsümme', 'https://de.wikipedia.org/wiki/Pr%C3%BCfs%C3%BCmme'],
+            ['https://example.com', 'https://example.com'],
+            ['https://example.com/foo.html', 'https://example.com/foo.html'],
+            ['https://example.com/foo.html?q=a', 'https://example.com/foo.html?q=a'],
+            ['https://example.com/foo.html?q=ü', 'https://example.com/foo.html?q=%C3%BC'],
+        ];
+        return array_column($r, null, 0);
+    }
 }

--- a/tests/Library/Vanilla/Utility/UrlUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/UrlUtilsTest.php
@@ -147,7 +147,7 @@ class UrlUtilsTest extends TestCase {
      * @dataProvider provideFixUrlTests
      */
     public function testNormalizeEncoding(string $url, string $expected): void {
-        $fixed = UrlUtils::normalizeEncoding($url);
+        $fixed = (string)UrlUtils::normalizeEncoding(Http::createFromString($url));
         $this->assertSame($expected, $fixed);
     }
 


### PR DESCRIPTION
Currently, our schema rejects non-ascii URLs which results in scrape errors for unicode characters. This PR normalizes and encodes all URLs before scraping to address this. It also will hopefully use fewer cache keys for the scrapes.

Fixes https://github.com/vanilla/support/issues/860.