### PR TITLE
Fix encoding on file names.

### DIFF
--- a/library/Vanilla/UploadedFile.php
+++ b/library/Vanilla/UploadedFile.php
@@ -196,7 +196,7 @@ class UploadedFile {
         $ext = strtolower(pathinfo($this->getClientFilename(), PATHINFO_EXTENSION));
         $baseName = basename($this->getClientFilename(), ".${ext}");
         $baseName = sprintf($nameFormat, $baseName);
-        $baseName = \Gdn_Format::url($baseName);
+        $baseName = \Gdn_Format::url(urlencode($baseName));
         $uploadPath = FileUtils::generateUniqueUploadPath($ext, true, $baseName, $persistDirectory);
         return $uploadPath;
     }

--- a/tests/Library/Vanilla/UploadedFileTest.php
+++ b/tests/Library/Vanilla/UploadedFileTest.php
@@ -102,7 +102,6 @@ class UploadedFileTest extends SharedBootstrapTestCase {
 
         // Save the upload.
         $file->persistUpload();
-        $f = $file->getPersistedPath();
         $this->assertFileExists(PATH_UPLOADS.'/'.$file->getPersistedPath(), 'Final upload file is persisted');
         $this->assertStringContainsString('my-25e5-259c-2596-25e7-2589-2587.png', $file->getPersistedPath());
     }

--- a/tests/Library/Vanilla/UploadedFileTest.php
+++ b/tests/Library/Vanilla/UploadedFileTest.php
@@ -90,12 +90,39 @@ class UploadedFileTest extends SharedBootstrapTestCase {
     }
 
     /**
+     * Test that we can safely persist files with url_encoded characters in their name.
+     *
+     * @param string $name
+     *
+     * @dataProvider provideImagesEncodedChars
+     */
+    public function testPersistFileEncodedChars(string $name) {
+        // Perform some tests related to saving uploads.
+        $file = UploadedFile::fromRemoteResourceUrl($name);
+
+        // Save the upload.
+        $file->persistUpload();
+        $f = $file->getPersistedPath();
+        $this->assertFileExists(PATH_UPLOADS.'/'.$file->getPersistedPath(), 'Final upload file is persisted');
+        $this->assertStringContainsString('my-25e5-259c-2596-25e7-2589-2587.png', $file->getPersistedPath());
+    }
+
+    /**
      * @return string[][]
      */
     public function provideImagesWithSpaces(): array {
         return [
             'no url encoding' => ['https://us.v-cdn.net/6032207/uploads/770/Image with spaces.jpg'],
             'with url encoding' => ['https://us.v-cdn.net/6032207/uploads/770/Image%20with%20spaces.jpg'],
+        ];
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideImagesEncodedChars(): array {
+        return [
+            'with url encoding chinese chars' => ['https://us.v-cdn.net/5022541/uploads/320EG16UF3D6/my-%25E5%259C%2596%25E7%2589%2587.png'],
         ];
     }
 


### PR DESCRIPTION
This PR will close vanilla/support#1962

In Rich editor we use actual names of files for images embedded on sites which is great for SEO, etc. Unfortunately when image that have "foreign" characters in their names they are saved URL encoded. But when you fetch them the URLs are decoded, so that they are not found.

This PR will double encode the saved URL so that when we fetch the image from storage we have the correct address.

### Testing
 1. Turn on Rich editor.
 2. Re-name an image on your local computer to 'pic-我的照片.jpg'
 3. Upload it in a post.
 4. See that it is not found.
 5. Check out this branch.
 6. Upload the same image.
 7. Make sure English named images still work.
 8. Test on other editors.
 9. Approve PR.