### PR TITLE
Fix category homepage displaying the root category

### DIFF
--- a/applications/vanilla/controllers/class.categoriescontroller.php
+++ b/applications/vanilla/controllers/class.categoriescontroller.php
@@ -11,6 +11,7 @@
 use Vanilla\Contracts\Site\SiteSectionInterface;
 use Vanilla\Formatting\Formats\HtmlFormat;
 use Vanilla\Formatting\Html\HtmlSanitizer;
+use Vanilla\Site\DefaultSiteSection;
 use Vanilla\Site\SiteSectionModel;
 
 /**
@@ -268,7 +269,9 @@ class CategoriesController extends VanillaController {
         if (!$categoryIdentifier) {
             /** @var SiteSectionInterface $siteSection */
             $siteSection = Gdn::getContainer()->get(SiteSectionModel::class)->getCurrentSiteSection();
-            $categoryIdentifier = $siteSection->getAttributes()['categoryID'] ?? '';
+            if (!($siteSection instanceof DefaultSiteSection)) {
+                $categoryIdentifier = $siteSection->getAttributes()['categoryID'] ?? '';
+            }
         }
 
         // Figure out which category layout to choose (Defined on "Homepage" settings page).


### PR DESCRIPTION
Fixes an issue where the root category would be visible because our default site section now has a categoryID.