### PR TITLE
Fix legacy themes mobile flyouts

### DIFF
--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -29,16 +29,10 @@
         $(document).delegate(".Hijack, .js-hijack", "click", handleHijackClick);
         $(document).delegate(".ButtonGroup > .Handle", "click", handleButtonHandleClick);
         $(document).delegate(".ToggleFlyout", "click", handleToggleFlyoutClick);
-        $(document).delegate(".ToggleFlyout a, .Dropdown a", "mouseup", handleToggleFlyoutMouseUp);
+        $(document).delegate(".ToggleFlyout a", "mouseup", handleToggleFlyoutMouseUp);
+        $(document).delegate(document, "click", closeAllFlyouts);
         $(document).delegate(".mobileFlyoutOverlay", "click", function (e) {
-            e.preventDefault();
             e.stopPropagation();
-            closeAllFlyouts();
-        });
-        $(document).delegate(".Flyout, .Dropdown", "click", function (e) {
-            e.stopPropagation();
-        });
-        $(document).on("click", function (e) {
             closeAllFlyouts();
         });
     });


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/2061

The code introduced here https://github.com/vanilla/vanilla/pull/8475 make a few improvements on the flyouts but also broke it on lithemobile.

**Steps to reproduce:**
This is a bit tedious to test but essentially you need to test the flyouts on a bunch of different themes. I've tested with:
- keystone (desktop and mobile)
- theme-foundation (desktop and mobile)
- deflector (desktop)
- bootstrap3 (desktop)
- lithemobile (mobile)

**Tests to perform:**
- The "New Discussion" dropdown:
  - Open the flyout, close clicking outside, close clicking the arrow, choose one of the options (test desktop and mobile)
- The "Flag" flyout:
  - Open the flyout, close clicking outside, choose the "warn" option. Close the popup (test desktop and mobile).
- The mebox:
  - Open the flyout, close clicking outside (test desktop and mobile).
- Advanced Editor flyouts:
  - Emojis, Upload and Images buttons also have flyouts. Same tests: open the flyout, close clicking outside, (est desktop and mobile.