### PR TITLE
Fix theme service caching not accounting for normalized variables

### DIFF
--- a/library/Vanilla/Theme/ThemeService.php
+++ b/library/Vanilla/Theme/ThemeService.php
@@ -142,7 +142,7 @@ class ThemeService {
         $cacheKey = $this->cache->cacheKey($themeKey, $query);
         $result = $this->cache->get($cacheKey);
         if ($result instanceof Theme) {
-            return $result;
+            return $this->normalizeTheme($result);
         }
 
         $provider = $this->getThemeProvider($themeKey);


### PR DESCRIPTION
These changes are needed for the K KB launch.

Normalization can merge in extra variables that aren't considered in our theme cache, so we still have to do this no matter what.

Things this accounts for:

- ThemeFeatures.
- Current theme
- overlayed addon variables