### PR TITLE
[Backport 2020.011] Fix theme service caching not accounting for normalized variables

### DIFF
--- a/library/Vanilla/Theme/ThemeService.php
+++ b/library/Vanilla/Theme/ThemeService.php
@@ -142,7 +142,7 @@ class ThemeService {
         $cacheKey = $this->cache->cacheKey($themeKey, $query);
         $result = $this->cache->get($cacheKey);
         if ($result instanceof Theme) {
-            return $result;
+            return $this->normalizeTheme($result);
         }
 
         $provider = $this->getThemeProvider($themeKey);


### PR DESCRIPTION
Backport https://github.com/vanilla/vanilla/pull/10754