### PR TITLE
Add a model with full record caching

### DIFF
--- a/library/Vanilla/FeatureFlagHelper.php
+++ b/library/Vanilla/FeatureFlagHelper.php
@@ -60,4 +60,11 @@ class FeatureFlagHelper {
             throw new $exceptionClass(...$exceptionArguments);
         }
     }
+
+    /**
+     * Clear the cache on the feature flag helper.
+     */
+    public static function clearCache() {
+        self::$sCache = [];
+    }
 }

--- a/library/Vanilla/Models/FullRecordCacheModel.php
+++ b/library/Vanilla/Models/FullRecordCacheModel.php
@@ -20,11 +20,12 @@ class FullRecordCacheModel extends PipelineModel {
      * Model constructor.
      *
      * @param string $table Database table associated with this resource.
+     * @param \Gdn_Cache $cache The cache instance.
      * @param array|null $defaultCacheOptions Default options to apply for storing cache values.
      */
-    public function __construct(string $table, ?array $defaultCacheOptions = []) {
+    public function __construct(string $table, \Gdn_Cache $cache, ?array $defaultCacheOptions = []) {
         parent::__construct($table);
-        $this->modelCache = ModelCache::fromModel($this, $defaultCacheOptions);
+        $this->modelCache = new ModelCache($this->getTable(), $cache, $defaultCacheOptions);
         $this->addPipelineProcessor($this->modelCache->createInvalidationProcessor());
     }
 

--- a/library/Vanilla/Models/FullRecordCacheModel.php
+++ b/library/Vanilla/Models/FullRecordCacheModel.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license Proprietary
+ */
+
+namespace Vanilla\Models;
+
+/**
+ * A model that caches all queries that come through, and invalidates the cache on every change.
+ *
+ * Ideal for DB tables that are infrequently updated and have smaller record sets.
+ */
+class FullRecordCacheModel extends PipelineModel {
+
+    /** @var ModelCache $cache */
+    private $modelCache;
+
+    /**
+     * Model constructor.
+     *
+     * @param string $table Database table associated with this resource.
+     * @param array|null $defaultCacheOptions Default options to apply for storing cache values.
+     */
+    public function __construct(string $table, ?array $defaultCacheOptions = []) {
+        parent::__construct($table);
+        $this->modelCache = ModelCache::fromModel($this, $defaultCacheOptions);
+        $this->addPipelineProcessor($this->modelCache->createInvalidationProcessor());
+    }
+
+    /**
+     * Get resource rows from the cache or a database table.
+     *
+     * @param array $where Conditions for the select query.
+     * @param array $options Options for the select query.
+     *    - orderFields (string, array): Fields to sort the result by.
+     *    - orderDirection (string): Sort direction for the order fields.
+     *    - limit (int): Limit on the total results returned.
+     *    - offset (int): Row offset before capturing the result.
+     * @param array|null $cacheOptions Options for the cache storage.
+     * @return array Rows matching the conditions and within the parameters specified in the options.
+     */
+    public function get(array $where = [], array $options = [], ?array $cacheOptions = []): array {
+        return $this->modelCache->getCachedOrHydrate(
+            [
+                'where' => $where,
+                'options' => $options,
+            ],
+            function () use ($where, $options) {
+                return parent::get($where, $options);
+            }
+        );
+    }
+
+    /**
+     * Get all records.
+     */
+    public function getAll() {
+        return $this->get();
+    }
+
+    /**
+     * @return ModelCache
+     */
+    public function getModelCache(): ModelCache {
+        return $this->modelCache;
+    }
+}

--- a/library/Vanilla/Models/FullRecordCacheModel.php
+++ b/library/Vanilla/Models/FullRecordCacheModel.php
@@ -45,6 +45,7 @@ class FullRecordCacheModel extends PipelineModel {
             [
                 'where' => $where,
                 'options' => $options,
+                'function' => __FUNCTION__, // For uniqueness.
             ],
             function () use ($where, $options) {
                 return parent::get($where, $options);

--- a/library/Vanilla/Models/FullRecordCacheModel.php
+++ b/library/Vanilla/Models/FullRecordCacheModel.php
@@ -21,9 +21,9 @@ class FullRecordCacheModel extends PipelineModel {
      *
      * @param string $table Database table associated with this resource.
      * @param \Gdn_Cache $cache The cache instance.
-     * @param array|null $defaultCacheOptions Default options to apply for storing cache values.
+     * @param array $defaultCacheOptions Default options to apply for storing cache values.
      */
-    public function __construct(string $table, \Gdn_Cache $cache, ?array $defaultCacheOptions = []) {
+    public function __construct(string $table, \Gdn_Cache $cache, array $defaultCacheOptions = []) {
         parent::__construct($table);
         $this->modelCache = new ModelCache($this->getTable(), $cache, $defaultCacheOptions);
         $this->addPipelineProcessor($this->modelCache->createInvalidationProcessor());
@@ -38,10 +38,11 @@ class FullRecordCacheModel extends PipelineModel {
      *    - orderDirection (string): Sort direction for the order fields.
      *    - limit (int): Limit on the total results returned.
      *    - offset (int): Row offset before capturing the result.
-     * @param array|null $cacheOptions Options for the cache storage.
+     *    - cacheOptions (array): Feature options from `Gdn_Cache::FEATURE_*`.
      * @return array Rows matching the conditions and within the parameters specified in the options.
      */
-    public function get(array $where = [], array $options = [], ?array $cacheOptions = []): array {
+    public function get(array $where = [], array $options = []): array {
+        $cacheOptions = $options['cacheOptions'] ?? [];
         return $this->modelCache->getCachedOrHydrate(
             [
                 'where' => $where,
@@ -50,7 +51,8 @@ class FullRecordCacheModel extends PipelineModel {
             ],
             function () use ($where, $options) {
                 return parent::get($where, $options);
-            }
+            },
+            $cacheOptions
         );
     }
 
@@ -59,12 +61,5 @@ class FullRecordCacheModel extends PipelineModel {
      */
     public function getAll() {
         return $this->get();
-    }
-
-    /**
-     * @return ModelCache
-     */
-    public function getModelCache(): ModelCache {
-        return $this->modelCache;
     }
 }

--- a/library/Vanilla/Models/FullRecordCacheModel.php
+++ b/library/Vanilla/Models/FullRecordCacheModel.php
@@ -14,7 +14,7 @@ namespace Vanilla\Models;
 class FullRecordCacheModel extends PipelineModel {
 
     /** @var ModelCache $cache */
-    private $modelCache;
+    protected $modelCache;
 
     /**
      * Model constructor.

--- a/library/Vanilla/Models/ModelCache.php
+++ b/library/Vanilla/Models/ModelCache.php
@@ -49,10 +49,10 @@ class ModelCache implements InjectableInterface {
      *
      * @param string $cacheNameSpace Namespace to use in the cache.
      * @param \Gdn_Cache $cache The cache instance.
-     * @param array|null $defaultCacheOptions Default options to apply for storing cache values.
+     * @param array $defaultCacheOptions Default options to apply for storing cache values.
      */
-    public function __construct(string $cacheNameSpace, \Gdn_Cache $cache, ?array $defaultCacheOptions = []) {
-        $this->cache = $cache;
+    public function __construct(string $cacheNameSpace, \Gdn_Cache $cache, array $defaultCacheOptions = []) {
+        $this->setCache($cache);
         $this->cacheNameSpace = $cacheNameSpace;
         $this->defaultCacheOptions = array_merge(self::GLOBAL_DEFAULT_OPTIONS, $defaultCacheOptions ?? []);
         $this->isFeatureDisabled = FeatureFlagHelper::featureEnabled(self::DISABLE_FEATURE_FLAG);
@@ -77,11 +77,11 @@ class ModelCache implements InjectableInterface {
      *
      * @param array $keyArgs The arguments to build the cache key.
      * @param callable $hydrate A callable to hydrate the cache.
-     * @param array|null $cacheOptions Options for the cache storage.
+     * @param array $cacheOptions Options for the cache storage.
      *
      * @return mixed
      */
-    public function getCachedOrHydrate(array $keyArgs, callable $hydrate, ?array $cacheOptions = []) {
+    public function getCachedOrHydrate(array $keyArgs, callable $hydrate, array $cacheOptions = []) {
         if ($this->isFeatureDisabled) {
             return $hydrate();
         }

--- a/library/Vanilla/Models/ModelCache.php
+++ b/library/Vanilla/Models/ModelCache.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models;
+
+use Vanilla\InjectableInterface;
+
+/**
+ * Cache for records out of various models.
+ *
+ * Particularly good support for PipelineModel.
+ */
+class ModelCache implements InjectableInterface {
+
+    /** @var int When we hit this size of incrementing key, we reset from 0. */
+    const MAX_INCREMENTING_KEY = 1000000;
+
+    /** @var string */
+    const INCREMENTING_KEY_NAMESPACE = 'vanillaIncrementingKey';
+
+    const GLOBAL_DEFAULT_OPTIONS = [
+        \Gdn_Cache::FEATURE_EXPIRY => 600,
+    ];
+
+    /** @var string */
+    private $namespace;
+
+    /** @var number */
+    private $defaultCacheOptions;
+
+    /** @var int */
+    private $incrementingKey;
+
+    /** @var \Gdn_Cache */
+    private $cache;
+
+    /**
+     * Create a cache from a model.
+     *
+     * @param Model $model The model to create from.
+     * @param array|null $defaultCacheOptions Default options to apply for storing cache values.
+     *
+     * @return ModelCache
+     */
+    public static function fromModel(Model $model, ?array $defaultCacheOptions = []): ModelCache {
+        $cache = \Gdn::getContainer()->getArgs(ModelCache::class, [$model->getTable(), $defaultCacheOptions]);
+        return $cache;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param string $namespace
+     * @param array|null $defaultCacheOptions Default options to apply for storing cache values.
+     */
+    public function __construct(string $namespace, ?array $defaultCacheOptions = []) {
+        $this->namespace = $namespace;
+        $this->defaultCacheOptions = array_merge(self::GLOBAL_DEFAULT_OPTIONS, $defaultCacheOptions ?? []);
+    }
+
+    /**
+     * Dependency Injection.
+     *
+     * @param \Gdn_Cache $cache
+     */
+    public function setDependencies(\Gdn_Cache $cache) {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Create a cache key for some parameters.
+     *
+     * @param array $keyArgs Some arguments to generate the cache key from.
+     *
+     * @return string
+     */
+    public function createCacheKey(array $keyArgs): string {
+        $key = $this->namespace . '-' . $this->getIncrementingKey() . '-' . md5(json_encode($keyArgs));
+        return $key;
+    }
+
+    /**
+     * Try to get a cached record.
+     *
+     * If the record can't be found, we hydrate it with the $hydrate callable and return it.
+     *
+     * @param array $keyArgs The arguments to build the cache key.
+     * @param callable $hydrate A callable to hydrate the cache.
+     * @param array|null $cacheOptions Options for the cache storage.
+     *
+     * @return mixed
+     */
+    public function getCachedOrHydrate(array $keyArgs, callable $hydrate, ?array $cacheOptions = []) {
+        $key = $this->createCacheKey($keyArgs);
+        $result = $this->cache->get($key);
+
+        if ($result === \Gdn_Cache::CACHEOP_FAILURE) {
+            $result = $hydrate();
+            $options = array_merge($this->defaultCacheOptions, $cacheOptions);
+            $this->cache->store($key, serialize($result), $options);
+        } else {
+            $result = unserialize($result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Invalidate all cached results for this cache.
+     */
+    public function invalidateAll() {
+        $this->rolloverIncrementingKey();
+    }
+
+    /**
+     * Create a pipeline processor for invalidating the entire cache on every record.
+     *
+     * @return ModelCacheInvalidationProcessor
+     */
+    public function createInvalidationProcessor(): ModelCacheInvalidationProcessor {
+        return new ModelCacheInvalidationProcessor($this);
+    }
+
+    /**
+     * @param \Gdn_Cache $cache
+     */
+    public function setCache(\Gdn_Cache $cache): void {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Get an incrementing key that can be rolled over everytime the whole cache is invalidated.
+     *
+     * @return int
+     */
+    private function getIncrementingKey(): int {
+        if ($this->incrementingKey === null) {
+            $incrementKeyCacheKey = self::INCREMENTING_KEY_NAMESPACE . '-' . $this->namespace;
+            $result = $this->cache->get($incrementKeyCacheKey);
+
+            if ($result === \Gdn_Cache::CACHEOP_FAILURE) {
+                $result = 0;
+            }
+            $this->incrementingKey = $result;
+
+            $this->cache->store($incrementKeyCacheKey, $this->incrementingKey);
+        }
+
+        return $this->incrementingKey;
+    }
+
+    /**
+     * Update the incrementing key.
+     */
+    private function rolloverIncrementingKey(): void {
+        $key = $this->getIncrementingKey();
+
+        $newKey = $key + 1;
+        if ($newKey > self::MAX_INCREMENTING_KEY) {
+            // Restart from 0.
+            $newKey = 0;
+        }
+
+        $incrementKeyCacheKey = self::INCREMENTING_KEY_NAMESPACE . '-' . $this->namespace;
+        $this->incrementingKey = $newKey;
+        $this->cache->store($incrementKeyCacheKey, $newKey);
+    }
+}

--- a/library/Vanilla/Models/ModelCache.php
+++ b/library/Vanilla/Models/ModelCache.php
@@ -27,7 +27,7 @@ class ModelCache implements InjectableInterface {
         \Gdn_Cache::FEATURE_EXPIRY => 600,
     ];
 
-    const DISABLE_FEATURE_FLAG = "Feature.DisableNewModelCaching.Enabled";
+    const DISABLE_FEATURE_FLAG = "DisableNewModelCaching";
 
     /** @var string */
     private $namespace;
@@ -66,7 +66,7 @@ class ModelCache implements InjectableInterface {
     public function __construct(string $namespace, ?array $defaultCacheOptions = []) {
         $this->namespace = $namespace;
         $this->defaultCacheOptions = array_merge(self::GLOBAL_DEFAULT_OPTIONS, $defaultCacheOptions ?? []);
-        $this->isFeatureDisabled = \Gdn::config(self::DISABLE_FEATURE_FLAG);
+        $this->isFeatureDisabled = FeatureFlagHelper::featureEnabled(self::DISABLE_FEATURE_FLAG);
     }
 
     /**
@@ -86,7 +86,7 @@ class ModelCache implements InjectableInterface {
      * @return string
      */
     public function createCacheKey(array $keyArgs): string {
-        $key = $this->namespace . '-' . $this->getIncrementingKey() . '-' . md5(json_encode($keyArgs));
+        $key = $this->namespace . '-' . $this->getIncrementingKey() . '-' . sha1(json_encode($keyArgs));
         return $key;
     }
 

--- a/library/Vanilla/Models/ModelCacheInvalidationProcessor.php
+++ b/library/Vanilla/Models/ModelCacheInvalidationProcessor.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models;
+
+use Vanilla\Database\Operation;
+use Vanilla\Database\Operation\Processor;
+
+/**
+ * Processor for doing some invalidation of cache.
+ */
+class ModelCacheInvalidationProcessor implements Processor {
+
+    /** @var ModelCache */
+    private $cache;
+
+    /**
+     * @param ModelCache $cache
+     */
+    public function __construct(ModelCache $cache) {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Clear the cache on certain operations.
+     *
+     * @param Operation $databaseOperation
+     * @param callable $stack
+     * @return mixed|void
+     */
+    public function handle(Operation $databaseOperation, callable $stack) {
+        $result = $stack($databaseOperation);
+
+        if (in_array($databaseOperation->getType(), [Operation::TYPE_INSERT, Operation::TYPE_DELETE, Operation::TYPE_UPDATE])) {
+            $this->cache->invalidateAll();
+        }
+
+        return $result;
+    }
+}

--- a/library/Vanilla/Models/PipelineModel.php
+++ b/library/Vanilla/Models/PipelineModel.php
@@ -119,4 +119,28 @@ class PipelineModel extends Model implements InjectableInterface {
         });
         return $result;
     }
+
+    /**
+     * Delete resource rows.
+     *
+     * @param array $where Conditions to restrict the deletion.
+     * @param array $options Options for the delete query.
+     *    - limit (int): Limit on the results to be deleted.
+     * @throws Exception If an error is encountered while performing the query.
+     * @return bool True.
+     */
+    public function delete(array $where, array $options = []): bool {
+        $databaseOperation = new Operation();
+        $databaseOperation->setType(Operation::TYPE_DELETE);
+        $databaseOperation->setCaller($this);
+        $databaseOperation->setWhere($where);
+        $databaseOperation->setOptions($options);
+        $result = $this->pipeline->process($databaseOperation, function (Operation $databaseOperation) {
+            return parent::delete(
+                $databaseOperation->getWhere(),
+                $databaseOperation->getOptions()
+            );
+        });
+        return $result;
+    }
 }

--- a/tests/Library/Vanilla/Models/ModelCacheTest.php
+++ b/tests/Library/Vanilla/Models/ModelCacheTest.php
@@ -59,10 +59,7 @@ class ModelCacheTest extends TestCase {
         });
 
         $this->model = $this->container()->getArgs(PipelineModel::class, ['model']);
-        $this->modelCache = ModelCache::fromModel($this->model);
-
-        // Apply a specific cache.
-        $this->modelCache->setCache(new \Gdn_Dirtycache());
+        $this->modelCache = new ModelCache($this->model->getTable(), new \Gdn_Dirtycache());
     }
 
     /**
@@ -129,8 +126,7 @@ class ModelCacheTest extends TestCase {
      */
     public function testFullRecordCacheModelInvalidation() {
         /** @var FullRecordCacheModel $model */
-        $model = $this->container()->getArgs(FullRecordCacheModel::class, ['model']);
-        $model->getModelCache()->setCache(new \Gdn_Dirtycache());
+        $model = $this->container()->getArgs(FullRecordCacheModel::class, ['model', new \Gdn_Dirtycache()]);
         $this->model = $model;
 
         $fooID = $this->insertOne('foo');
@@ -170,12 +166,11 @@ class ModelCacheTest extends TestCase {
         $this->runWithConfig([
             'Feature.'.ModelCache::DISABLE_FEATURE_FLAG.'.Enabled' => true,
         ], function () {
-            $this->modelCache = ModelCache::fromModel($this->model);
             $mockCache = $this->createMock(\Gdn_Dirtycache::class);
             $mockCache
                 ->expects($this->never())
                 ->method($this->anything());
-            $this->modelCache->setCache($mockCache);
+            $this->modelCache = new ModelCache($this->model->getTable(), $mockCache);
             $this->testAutoInvalidation();
         });
         FeatureFlagHelper::clearCache();

--- a/tests/Library/Vanilla/Models/ModelCacheTest.php
+++ b/tests/Library/Vanilla/Models/ModelCacheTest.php
@@ -162,6 +162,23 @@ class ModelCacheTest extends TestCase {
     }
 
     /**
+     * We have a feature flag to disable the new caching if it causes issues.
+     */
+    public function testCacheDisabled() {
+        $this->runWithConfig([
+            ModelCache::DISABLE_FEATURE_FLAG => true,
+        ], function () {
+            $this->modelCache = ModelCache::fromModel($this->model);
+            $mockCache = $this->createMock(\Gdn_Dirtycache::class);
+            $mockCache
+                ->expects($this->never())
+                ->method($this->anything());
+            $this->modelCache->setCache($mockCache);
+            $this->testAutoInvalidation();
+        });
+    }
+
+    /**
      * Insert a basic test row.
      *
      * @param string $name

--- a/tests/Library/Vanilla/Models/ModelCacheTest.php
+++ b/tests/Library/Vanilla/Models/ModelCacheTest.php
@@ -158,14 +158,7 @@ class ModelCacheTest extends TestCase {
         $this->assertSame(['bar'], array_column($result, 'name'));
 
         $result = $this->model->selectSingle(['modelID' => $fooID]);
-        $this->assertSame('foo update', $result);
-    }
-
-    /**
-     * Use the model to assert a bunch of cache tests.
-     */
-    public function assertInvalidation() {
-
+        $this->assertSame('foo update', $result['name']);
     }
 
     /**

--- a/tests/Library/Vanilla/Models/ModelCacheTest.php
+++ b/tests/Library/Vanilla/Models/ModelCacheTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Models;
+
+use PHPUnit\Framework\TestCase;
+use Vanilla\Models\Model;
+use Vanilla\Models\ModelCache;
+use Vanilla\Models\PipelineModel;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Tests for the `Model` class.
+ */
+class ModelCacheTest extends TestCase {
+    use SiteTestTrait;
+
+    /**
+     * @var PipelineModel
+     */
+    private $model;
+
+    /**
+     * @var ModelCache
+     */
+    private $modelCache;
+
+    /**
+     * Install the site and set up a test table.
+     */
+    public static function setupBeforeClass(): void {
+        static::setupBeforeClassSiteTestTrait();
+
+        static::container()->call(function (
+            \Gdn_DatabaseStructure $st
+        ) {
+            $st->table('model')
+                ->primaryKey('modelID')
+                ->column('name', 'varchar(50)')
+                ->set()
+            ;
+        });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        $this->container()->call(function (
+            \Gdn_SQLDriver $sql
+        ) {
+            $sql->truncate('model');
+        });
+
+        $this->model = $this->container()->getArgs(PipelineModel::class, ['model']);
+        $this->modelCache = ModelCache::fromModel($this->model);
+
+        // Apply a specific cache.
+        $this->modelCache->setCache(new \Gdn_Dirtycache());
+    }
+
+    /**
+     * Test that we can get and invalidate from the cache.
+     */
+    public function testGetInvalidate() {
+        $this->insertOne('foo');
+        $this->insertOne('bar');
+
+        $hydrator = function () {
+            return $this->model->get();
+        };
+
+        $initialResult = $this->modelCache->getCachedOrHydrate([], $hydrator);
+
+        // Insert another. We have no automatic cache invalidation enabled.
+        $this->insertOne('bar2');
+
+        $secondResult = $this->modelCache->getCachedOrHydrate([], $hydrator);
+
+        $this->assertSame($initialResult, $secondResult);
+        $this->assertSame(['foo', 'bar'], array_column($secondResult, 'name'));
+
+        // Invalidate and see they are different.
+        $this->modelCache->invalidateAll();
+
+        $finalResult = $this->modelCache->getCachedOrHydrate([], $hydrator);
+        $this->assertSame(['foo', 'bar', 'bar2'], array_column($finalResult, 'name'));
+    }
+
+    /**
+     * Test that we can get and invalidate from the cache.
+     */
+    public function testAutoInvalidation() {
+        $fooID = $this->insertOne('foo');
+        $this->insertOne('bar');
+        $this->model->addPipelinePostProcessor($this->modelCache->createInvalidationProcessor());
+
+        $hydrator = function () {
+            return $this->model->get();
+        };
+
+        $result = $this->modelCache->getCachedOrHydrate([], $hydrator);
+        $this->assertSame(['foo', 'bar'], array_column($result, 'name'));
+
+        // Insert another. This should invalidate the cache.
+        $bar2ID = $this->insertOne('bar2');
+        $result = $this->modelCache->getCachedOrHydrate([], $hydrator);
+        $this->assertSame(['foo', 'bar', 'bar2'], array_column($result, 'name'));
+
+        // Delete an item.
+        $this->model->delete(['modelID' => $bar2ID]);
+        $result = $this->modelCache->getCachedOrHydrate([], $hydrator);
+        $this->assertSame(['foo', 'bar'], array_column($result, 'name'));
+
+        // Update an item.
+        $this->model->update(['name' => 'foo update'], ['modelID' => $fooID]);
+        $result = $this->modelCache->getCachedOrHydrate([], $hydrator);
+        $this->assertSame(['foo update', 'bar'], array_column($result, 'name'));
+    }
+
+    /**
+     * Insert a basic test row.
+     *
+     * @param string $name
+     * @return int
+     */
+    private function insertOne(string $name = 'foo'): int {
+        $id = $this->model->insert(['name' => $name]);
+        return $id;
+    }
+}

--- a/tests/Library/Vanilla/Models/ModelCacheTest.php
+++ b/tests/Library/Vanilla/Models/ModelCacheTest.php
@@ -8,6 +8,7 @@
 namespace VanillaTests\Library\Vanilla\Models;
 
 use PHPUnit\Framework\TestCase;
+use Vanilla\FeatureFlagHelper;
 use Vanilla\Models\FullRecordCacheModel;
 use Vanilla\Models\Model;
 use Vanilla\Models\ModelCache;
@@ -165,8 +166,9 @@ class ModelCacheTest extends TestCase {
      * We have a feature flag to disable the new caching if it causes issues.
      */
     public function testCacheDisabled() {
+        FeatureFlagHelper::clearCache();
         $this->runWithConfig([
-            ModelCache::DISABLE_FEATURE_FLAG => true,
+            'Feature.'.ModelCache::DISABLE_FEATURE_FLAG.'.Enabled' => true,
         ], function () {
             $this->modelCache = ModelCache::fromModel($this->model);
             $mockCache = $this->createMock(\Gdn_Dirtycache::class);
@@ -176,6 +178,7 @@ class ModelCacheTest extends TestCase {
             $this->modelCache->setCache($mockCache);
             $this->testAutoInvalidation();
         });
+        FeatureFlagHelper::clearCache();
     }
 
     /**


### PR DESCRIPTION
Related https://github.com/vanilla/internal/issues/2691

Implement a core model and some utilities that implement full record caching.

To help lower the risk (because this will likely need to be backported for performance considerations), I've added a feature flag to disable it.

`Feature.DisableNewModelCaching.Enabled = true`

## Pieces

- A pipeline processor for invalidating.
- Nice utility methods
  - `getCachedOrHydrate(array $cacheArgs, callable $hydrator)` -> Get a cached value or hydrate it.
  - `invalidateAll()` -> Invalidate the whole cache for the model.
- A extra convienience model base class anything that passes through the pipeline.

## Invalidation

- Items could be manually invalidated with the invalidate method.
- Invalidation happens by rolling over an incrementing ID thats used in every cache key.
- Pipeline invalidation occurs on any insert, delete, or update.

## Other notes

- The `PipelineProcessor` did not run the pipeline for delete operations. Now it does.

## Example usages

Initial PRs
- https://github.com/vanilla/multisite/pull/384
- https://github.com/vanilla/knowledge/pull/1868