### PR TITLE
Remove the fuzzy category watch from the discussion model

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3880,6 +3880,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface, EventFr
      *
      * @param object $discussion
      * @deprecated
+     * @codeCoverageIgnore
      */
     protected function markCategoryReadFuzzy($discussion): void {
         /**

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -3867,7 +3867,21 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface, EventFr
         // If there is a discrepancy between $countWatch and $discussion->CountCommentWatch,
         // update CountCommentWatch with the correct value.
         $discussion->CountCommentWatch = $countWatch;
+        if (\Vanilla\FeatureFlagHelper::featureEnabled('markCategoryReadFuzzy')) {
+            $this->markCategoryReadFuzzy($discussion);
+        }
+    }
 
+    /**
+     * Mark categories that this discussion was in as read.
+     *
+     * This method was extracted from `DiscussionModel::setWatch()`. It's not something I want running and I'm not sure
+     * if it even works. It will be put behind a feature flag for now.
+     *
+     * @param object $discussion
+     * @deprecated
+     */
+    protected function markCategoryReadFuzzy($discussion): void {
         /**
          * Fuzzy way of trying to automatically mark a category read again
          * if the user reads all the comments on the first few pages.


### PR DESCRIPTION
The discussion model has some logic to read a select set of discussions in order to try and mark the category read. I’m not super sure this has ever really worked, but is troubling from a scalability point of view.

This PR puts that logic behind a feature flag so that we can try a deploy with it turned off, but flip it back on if there really is some real functionality required.