### PR TITLE
Fix events created in root category failing validation

### DIFF
--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -855,7 +855,8 @@ class CategoryModel extends Gdn_Model {
      */
     public function getRootCategoryForDisplay() {
         $category = self::categories(-1);
-        $category['Name'] = Gdn::config('Garden.Title');
+        $name =  Gdn::config('Garden.Title');
+        $category['Name'] = !empty($name) ? $name : 'Vanilla';
         $category['Url'] = Gdn::request()->getSimpleUrl('/categories');
         $category['UrlCode'] = '';
         return $category;


### PR DESCRIPTION
When expanding a the root category we were assigning the name of the category to the value in config for `$Configuration['Garden']['Title'] `.  If that was empty it would return an empty string which would fail validation on the expand param in the \events endpoint.  This fallback to the value set in our config-defaults which is `Vanilla`, if the config value is empty.

closes https://github.com/vanilla/vanilla/issues/10751
