### PR TITLE
Add crawl support (REBASED)

### DIFF
--- a/applications/dashboard/controllers/api/ResourcesApiController.php
+++ b/applications/dashboard/controllers/api/ResourcesApiController.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Dashboard\Controllers\API;
+
+use Garden\Schema\Schema;
+use Garden\Web\Data;
+use Vanilla\Contracts\Models\CrawlableInterface;
+use Vanilla\Models\ModelFactory;
+use Vanilla\Web\Controller;
+
+/**
+ * Gives meta information about the resource models in the system.
+ */
+class ResourcesApiController extends Controller {
+    /**
+     * The `GET /resources` endpoint.
+     *
+     * @param \Gdn_Request $request
+     * @param array $query
+     * @return Data
+     */
+    public function index(\Gdn_Request $request, array $query = []): Data {
+        $this->permission('Garden.Settings.Manage');
+
+        $in = Schema::parse([
+            'crawlable:b?'
+        ]);
+        $query = $in->validate($query);
+
+        if (isset($query['crawlable'])) {
+            $models = $this->factory->getAllByInterface(CrawlableInterface::class, $query['crawlable']);
+        } else {
+            $models = $this->factory->getAll();
+        }
+
+        $r = [];
+        foreach ($models as $recordType => $model) {
+            $r[] = [
+                'recordType' => $recordType,
+                'url' => $request->getSimpleUrl("/api/v2/resources/$recordType"),
+                'crawlable' => ($model instanceof CrawlableInterface),
+            ];
+        }
+        return new Data($r);
+    }
+
+    /**
+     * @var ModelFactory
+     */
+    private $factory;
+
+    /**
+     * ResourcesApiController constructor.
+     *
+     * @param ModelFactory $factory
+     */
+    public function __construct(ModelFactory $factory) {
+        $this->factory = $factory;
+    }
+
+    /**
+     * The `GET /resources/:recordType` endpoint.
+     *
+     * @param \Gdn_Request $request
+     * @param string $recordType
+     * @return Data
+     */
+    public function get(\Gdn_Request $request, string $recordType): Data {
+        $this->permission('Garden.Settings.Manage');
+
+        $model = $this->factory->get($recordType);
+        $recordType = $this->factory->getRecordType(get_class($model));
+
+        $r = [
+            'recordType' => $recordType,
+        ];
+        if ($model instanceof CrawlableInterface) {
+            $r['crawl'] = $model->getCrawlInfo();
+            $r['crawl']['url'] = $request->getSimpleUrl($r['crawl']['url']);
+        }
+
+        return new Data($r);
+    }
+}

--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -485,6 +485,9 @@ class UsersApiController extends AbstractApiController {
                 'default' => 30,
                 'minimum' => 1,
                 'maximum' => 100,
+            ],
+            'sort:s?' => [
+                'enum' => ApiUtils::sortEnum('dateInserted', 'dateLastActive', 'name', 'userID')
             ]
         ], ['UserIndex', 'in']);
         $out = $this->schema([':a' => $this->userSchema()], 'out');
@@ -494,7 +497,7 @@ class UsersApiController extends AbstractApiController {
 
         [$offset, $limit] = offsetLimit("p{$query['page']}", $query['limit']);
 
-        $rows = $this->userModel->search($where, '', '', $limit, $offset)->resultArray();
+        $rows = $this->userModel->search($where, $query['sort'] ?? '', '', $limit, $offset)->resultArray();
         foreach ($rows as &$row) {
             $this->userModel->setCalculatedFields($row);
             $row = $this->normalizeOutput($row);

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -23,7 +23,7 @@ use Vanilla\Utility\CamelCaseScheme;
 /**
  * Handles user data.
  */
-class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRowInterface {
+class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRowInterface, \Vanilla\Contracts\Models\CrawlableInterface {
 
     /** @var int */
     const GUEST_USER_ID = 0;
@@ -2885,7 +2885,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
      * Search users.
      *
      * @param array|string $filter
-     * @param string $orderFields
+     * @param string|array $orderFields
      * @param string $orderDirection
      * @param bool $limit
      * @param bool $offset
@@ -5670,5 +5670,17 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
             $result = $this->getGeneratedFragment(self::GENERATED_FRAGMENT_KEY_GUEST);
         }
         return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCrawlInfo(): array {
+        $r = \Vanilla\Models\LegacyModelUtils::getCrawlInfoFromPrimaryKey(
+            $this,
+            '/api/v2/users?sort=-userID',
+            'userID'
+        );
+        return $r;
     }
 }

--- a/applications/dashboard/openapi/resources.yml
+++ b/applications/dashboard/openapi/resources.yml
@@ -24,13 +24,13 @@ paths:
               example:
                 - recordType: user
                   url: "https://example.com/api/v2/resources/user"
-                  hasCrawl: true
+                  crawlable: true
                 - recordType: discussion
                   url: "https://example.com/api/v2/resources/discussion"
-                  hasCrawl: true
+                  crawlable: true
                 - recordType: comment
                   url: "https://example.com/api/v2/resources/comment"
-                  hasCrawl: true
+                  crawlable: true
         '403':
           $ref: '#/components/responses/PermissionError'
   /resources/{recordType}:
@@ -79,13 +79,13 @@ components:
           type: string
           description: The URL of the resource meta information.
           format: uri
-        hasCrawl:
+        crawlable:
           type: boolean
           description: Whether or not the resource has crawl information.
       required:
         - recordType
         - url
-        - hasCrawl
+        - crawlable
     Resource:
       type: object
       properties:

--- a/applications/dashboard/openapi/resources.yml
+++ b/applications/dashboard/openapi/resources.yml
@@ -1,0 +1,122 @@
+openapi: 3.0.2
+info:
+paths:
+  /resources:
+    get:
+      summary: List the resources available on the site.
+      tags:
+        - Resources
+      parameters:
+        - name: crawlable
+          in: query
+          schema:
+            type: boolean
+            description: Filter by resources that have crawling information.
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResourceFragment'
+              example:
+                - recordType: user
+                  url: "https://example.com/api/v2/resources/user"
+                  hasCrawl: true
+                - recordType: discussion
+                  url: "https://example.com/api/v2/resources/discussion"
+                  hasCrawl: true
+                - recordType: comment
+                  url: "https://example.com/api/v2/resources/comment"
+                  hasCrawl: true
+        '403':
+          $ref: '#/components/responses/PermissionError'
+  /resources/{recordType}:
+    get:
+      summary: Get the details of a resource.
+      tags:
+        - Resources
+      parameters:
+        - name: recordType
+          description: The record type slug of the resource.
+          in: path
+          required: true
+          schema:
+            type: string
+            example: discussion
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resource'
+        '403':
+          $ref: '#/components/responses/PermissionError'
+components:
+  schemas:
+    ResourceFragment:
+      description: Meta information about a resource.
+      type: object
+      properties:
+        recordType:
+          type: string
+          description: The record the resource represents. Also the unique ID of the resource.
+        url:
+          type: string
+          description: The URL of the resource meta information.
+          format: uri
+        hasCrawl:
+          type: boolean
+          description: Whether or not the resource has crawl information.
+      required:
+        - recordType
+        - url
+        - hasCrawl
+    Resource:
+      type: object
+      properties:
+        recordType:
+          type: string
+          description: The record the resource represents. Also the unique ID of the resource.
+        crawl:
+          type: object
+          properties:
+            url:
+              type: string
+              description: The URL template used to crawl the resource.
+              format: uri
+            min:
+              type: number
+              format: int32
+              description: The minimum parameter value for crawling the resource.
+            max:
+              type: integer
+              format: int32
+              description: The maximum parameter value for crawling the resource.
+            count:
+              type: number
+              format: int32
+              description: The approximate number of rows the resource has.
+            parameter:
+              type: string
+              description: The name of the parameter you need to pass to the crawl URL.
+          required:
+            - url
+            - min
+            - max
+            - count
+            - parameter
+      required:
+        - recordType
+      example:
+        recordType: discussion
+        crawl:
+          url: https://example.com/api/v2/discussions?expand=crawl?order=-discussionID
+          min: 1,
+          max: 500000,
+          count: 499560,
+          parameter: discussionID
+

--- a/applications/dashboard/openapi/resources.yml
+++ b/applications/dashboard/openapi/resources.yml
@@ -46,6 +46,17 @@ paths:
           schema:
             type: string
             example: discussion
+        - name: expand
+          description: Expand fields on the result.
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - all
+                - crawl
+          style: form
       responses:
         '200':
           description: Success
@@ -89,13 +100,19 @@ components:
               description: The URL template used to crawl the resource.
               format: uri
             min:
-              type: number
-              format: int32
               description: The minimum parameter value for crawling the resource.
+              oneOf:
+                - type: number
+                  format: int32
+                - type: string
+                  format: date-time
             max:
-              type: integer
-              format: int32
               description: The maximum parameter value for crawling the resource.
+              oneOf:
+                - type: number
+                  format: int32
+                - type: string
+                  format: date-time
             count:
               type: number
               format: int32

--- a/applications/dashboard/openapi/responses.yml
+++ b/applications/dashboard/openapi/responses.yml
@@ -1,0 +1,19 @@
+openapi: 3.0.2
+info:
+paths:
+components:
+  responses:
+    PermissionError:
+      description: You don't have adequate permissions to access this resource.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                description: A message that tells you the permissions you need.
+              status:
+                type: number
+                description: The HTTP status code for the error.
+                format: int32

--- a/applications/dashboard/openapi/users.yml
+++ b/applications/dashboard/openapi/users.yml
@@ -53,6 +53,20 @@ paths:
           default: 30
           maximum: 100
           minimum: 1
+      - name: sort
+        in: query
+        description: Sort the results.
+        schema:
+          type: string
+          enum:
+            - dateInserted
+            - dateLastActive
+            - name
+            - userID
+            - -dateInserted
+            - -dateLastActive
+            - -name
+            - -userID
       - description: >
           Expand associated records using one or more valid field names. A
           value of "all" will expand all expandable fields.

--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -81,6 +81,9 @@ class DashboardHooks extends Gdn_Plugin {
             ->addCall('addProvider', [new Reference(LogCounterProvider::class)])
             ->addCall('addProvider', [new Reference(RoleCounterProvider::class)])
         ;
+
+        $mf = \Vanilla\Models\ModelFactory::fromContainer($dic);
+        $mf->addModel('user', UserModel::class, 'u');
     }
 
     /**

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -647,6 +647,7 @@ class CategoriesApiController extends AbstractApiController {
      * @param array $where
      * @param int|null $limit
      * @param int|null $offset
+     * @param string $order
      * @return array
      */
     private function getCategoriesWhere(array $where, $limit, $offset, $order = ''): array {

--- a/applications/vanilla/controllers/api/CategoriesApiController.php
+++ b/applications/vanilla/controllers/api/CategoriesApiController.php
@@ -335,7 +335,7 @@ class CategoriesApiController extends AbstractApiController {
             $where = [
                 'categoryID' => $range,
             ];
-            [$categories, $totalCountCallBack] = $this->getCategoriesWhere($where, $limit, $offset);
+            [$categories, $totalCountCallBack] = $this->getCategoriesWhere($where, $limit, $offset, 'categoryID');
         } elseif ($query['followed'] ?? false) {
             $where = ['Followed' => true];
             [$categories, $totalCountCallBack] = $this->getCategoriesWhere($where, $limit, $offset);
@@ -649,9 +649,9 @@ class CategoriesApiController extends AbstractApiController {
      * @param int|null $offset
      * @return array
      */
-    private function getCategoriesWhere(array $where, $limit, $offset): array {
+    private function getCategoriesWhere(array $where, $limit, $offset, $order = ''): array {
         $categories = $this->categoryModel
-            ->getWhere($where, '', 'asc', $limit, $offset)
+            ->getWhere($where, $order, '', $limit, $offset)
             ->resultArray();
 
         // Index by ID for category calculation functions.

--- a/applications/vanilla/controllers/api/CommentsApiController.php
+++ b/applications/vanilla/controllers/api/CommentsApiController.php
@@ -328,6 +328,10 @@ class CommentsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
+            'sort:s?' => [
+                'enum' => ApiUtils::sortEnum('dateInserted', 'commentID'),
+                'default' => 'dateInserted',
+            ],
             'insertUserID:i?' => [
                 'description' => 'Filter by author.',
                 'x-filter' => [
@@ -346,7 +350,8 @@ class CommentsApiController extends AbstractApiController {
 
         list($offset, $limit) = offsetLimit("p{$query['page']}", $query['limit']);
 
-        $rows = $this->commentModel->lookup($where, true, $limit, $offset, 'asc', 'DateInserted')->resultArray();
+        [$orderField, $orderDirection] = \Vanilla\Models\LegacyModelUtils::orderFieldDirection($query['sort']);
+        $rows = $this->commentModel->lookup($where, true, $limit, $offset, $orderDirection, $orderField)->resultArray();
         $hasMore = $this->commentModel->LastCommentCount >= $limit;
 
         // Expand associated rows.

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -508,12 +508,12 @@ class DiscussionsApiController extends AbstractApiController {
         $pinned = array_key_exists('pinned', $query) ? $query['pinned'] : null;
         if ($pinned === true) {
             $announceWhere = array_merge($where, ['d.Announce >' => '0']);
-            $rows = $this->discussionModel->getAnnouncements($announceWhere, $offset, $limit, (array)($query['sort'] ?? []))->resultArray();
+            $rows = $this->discussionModel->getAnnouncements($announceWhere, $offset, $limit, $query['sort'] ?? '')->resultArray();
         } else {
             $pinOrder = array_key_exists('pinOrder', $query) ? $query['pinOrder'] : null;
             [$orderField, $orderDirection] = \Vanilla\Models\LegacyModelUtils::orderFieldDirection($query['sort'] ?? '');
             if ($pinOrder == 'first') {
-                $announcements = $this->discussionModel->getAnnouncements($where, $offset, $limit, (array)($query['sort'] ?? []))->resultArray();
+                $announcements = $this->discussionModel->getAnnouncements($where, $offset, $limit, $query['sort'] ?? '')->resultArray();
                 $discussions = $this->discussionModel->getWhere($where, $orderField, $orderDirection, $limit, $offset, false)->resultArray();
                 $rows = array_merge($announcements, $discussions);
             } else {

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -505,7 +505,7 @@ class DiscussionsApiController extends AbstractApiController {
             $query['pinOrder'] = 'mixed';
         }
 
-        $pinned = array_key_exists('pinned', $query) ? $query['pinned'] : null;
+        $pinned = $query['pinned'] ?? null;
         if ($pinned === true) {
             $announceWhere = array_merge($where, ['d.Announce >' => '0']);
             $rows = $this->discussionModel->getAnnouncements($announceWhere, $offset, $limit, $query['sort'] ?? '')->resultArray();

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -473,6 +473,9 @@ class DiscussionsApiController extends AbstractApiController {
                 'minimum' => 1,
                 'maximum' => 100
             ],
+            'sort:s?' => [
+                'enum' => ApiUtils::sortEnum('dateLastComment', 'dateInserted', 'discussionID'),
+            ],
             'insertUserID:i?' => [
                 'description' => 'Filter by author.',
                 'x-filter' => [
@@ -505,16 +508,17 @@ class DiscussionsApiController extends AbstractApiController {
         $pinned = array_key_exists('pinned', $query) ? $query['pinned'] : null;
         if ($pinned === true) {
             $announceWhere = array_merge($where, ['d.Announce >' => '0']);
-            $rows = $this->discussionModel->getAnnouncements($announceWhere, $offset, $limit)->resultArray();
+            $rows = $this->discussionModel->getAnnouncements($announceWhere, $offset, $limit, $query['sort'] ?? null)->resultArray();
         } else {
             $pinOrder = array_key_exists('pinOrder', $query) ? $query['pinOrder'] : null;
+            [$orderField, $orderDirection] = \Vanilla\Models\LegacyModelUtils::orderFieldDirection($query['sort'] ?? '');
             if ($pinOrder == 'first') {
-                $announcements = $this->discussionModel->getAnnouncements($where, $offset, $limit)->resultArray();
-                $discussions = $this->discussionModel->getWhereRecent($where, $limit, $offset, false)->resultArray();
+                $announcements = $this->discussionModel->getAnnouncements($where, $offset, $limit, $query['sort'] ?? null)->resultArray();
+                $discussions = $this->discussionModel->getWhere($where, $orderField, $orderDirection, $limit, $offset, false)->resultArray();
                 $rows = array_merge($announcements, $discussions);
             } else {
                 $where['Announce'] = 'all';
-                $rows = $this->discussionModel->getWhereRecent($where, $limit, $offset, false)->resultArray();
+                $rows = $this->discussionModel->getWhere($where, $orderField, $orderDirection, $limit, $offset, false)->resultArray();
             }
         }
 

--- a/applications/vanilla/controllers/api/DiscussionsApiController.php
+++ b/applications/vanilla/controllers/api/DiscussionsApiController.php
@@ -508,12 +508,12 @@ class DiscussionsApiController extends AbstractApiController {
         $pinned = array_key_exists('pinned', $query) ? $query['pinned'] : null;
         if ($pinned === true) {
             $announceWhere = array_merge($where, ['d.Announce >' => '0']);
-            $rows = $this->discussionModel->getAnnouncements($announceWhere, $offset, $limit, $query['sort'] ?? null)->resultArray();
+            $rows = $this->discussionModel->getAnnouncements($announceWhere, $offset, $limit, (array)($query['sort'] ?? []))->resultArray();
         } else {
             $pinOrder = array_key_exists('pinOrder', $query) ? $query['pinOrder'] : null;
             [$orderField, $orderDirection] = \Vanilla\Models\LegacyModelUtils::orderFieldDirection($query['sort'] ?? '');
             if ($pinOrder == 'first') {
-                $announcements = $this->discussionModel->getAnnouncements($where, $offset, $limit, $query['sort'] ?? null)->resultArray();
+                $announcements = $this->discussionModel->getAnnouncements($where, $offset, $limit, (array)($query['sort'] ?? []))->resultArray();
                 $discussions = $this->discussionModel->getWhere($where, $orderField, $orderDirection, $limit, $offset, false)->resultArray();
                 $rows = array_merge($announcements, $discussions);
             } else {

--- a/applications/vanilla/models/class.categorymodel.php
+++ b/applications/vanilla/models/class.categorymodel.php
@@ -17,7 +17,7 @@ use Vanilla\SchemaFactory;
 /**
  * Manages discussion categories' data.
  */
-class CategoryModel extends Gdn_Model {
+class CategoryModel extends Gdn_Model implements \Vanilla\Contracts\Models\CrawlableInterface {
 
     /** Cache key. */
     const CACHE_KEY = 'Categories';
@@ -3811,5 +3811,18 @@ SQL;
                 return strcasecmp($a['Name'], $b['Name']);
             }
         });
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCrawlInfo(): array {
+        $r = \Vanilla\Models\LegacyModelUtils::getCrawlInfoFromPrimaryKey(
+            $this,
+            '/api/v2/categories',
+            'categoryID'
+        );
+        $r['min'] = max($r['min'], 1); // kludge around root category
+        return $r;
     }
 }

--- a/applications/vanilla/models/class.commentmodel.php
+++ b/applications/vanilla/models/class.commentmodel.php
@@ -24,7 +24,7 @@ use Vanilla\Utility\CamelCaseScheme;
 /**
  * Manages discussion comments data.
  */
-class CommentModel extends Gdn_Model implements FormatFieldInterface, EventFromRowInterface {
+class CommentModel extends Gdn_Model implements FormatFieldInterface, EventFromRowInterface, \Vanilla\Contracts\Models\CrawlableInterface {
 
     use \Vanilla\FloodControlTrait;
 
@@ -1763,5 +1763,17 @@ class CommentModel extends Gdn_Model implements FormatFieldInterface, EventFromR
         }
 
         return parent::editContentTimeout($comment, $timeLeft);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCrawlInfo(): array {
+        $r = \Vanilla\Models\LegacyModelUtils::getCrawlInfoFromPrimaryKey(
+            $this,
+            '/api/v2/comments?sort=-commentID',
+            'commentID'
+        );
+        return $r;
     }
 }

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -1303,15 +1303,14 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface, EventFr
      * @param array $wheres SQL conditions.
      * @param int $offset The number of records to skip.
      * @param int $limit The number of records to limit the query to.
-     * @param string[] $orderBy An array of column names for sorting.
-     * @return object SQL result.
+     * @param string|string[]|null $orderBy An array of column names for sorting.
+     * @return Gdn_DataSet SQL result.
      */
-    public function getAnnouncements($wheres = '', $offset = 0, $limit = false, array $orderBy = null) {
-
+    public function getAnnouncements($wheres = '', $offset = 0, $limit = false, $orderBy = null) {
         $wheres = $this->combineWheres($this->getWheres(), $wheres);
         $session = Gdn::session();
         if ($limit === false) {
-            c('Vanilla.Discussions.PerPage', 30);
+            $limit = c('Vanilla.Discussions.PerPage', 30);
         }
         $userID = $session->UserID > 0 ? $session->UserID : 0;
         $categoryID = val('d.CategoryID', $wheres, 0);
@@ -1393,13 +1392,7 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface, EventFr
         $this->SQL->limit($limit, $offset);
 
         $orderBy = $orderBy ?? $this->getOrderBy();
-        foreach ($orderBy as $field => $direction) {
-            if (is_numeric($field)) {
-                $this->SQL->orderBy($this->addFieldPrefix($direction));
-            } else {
-                $this->SQL->orderBy($this->addFieldPrefix($field), $direction);
-            }
-        }
+        $this->SQL->orderByPrefix('d.', $orderBy);
         $this->EventArguments['Wheres'] = &$wheres;
         $this->fireEvent('beforeGetAnnouncements');
 

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -27,7 +27,7 @@ use Vanilla\Utility\ModelUtils;
 /**
  * Manages discussions data.
  */
-class DiscussionModel extends Gdn_Model implements FormatFieldInterface, EventFromRowInterface {
+class DiscussionModel extends Gdn_Model implements FormatFieldInterface, EventFromRowInterface, \Vanilla\Contracts\Models\CrawlableInterface {
 
     use StaticInitializer;
 
@@ -3913,5 +3913,17 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface, EventFr
         $categoryModel = new CategoryModel();
         $categoryModel->saveUserTree($categoryID, ['DateMarkedRead' => Gdn_Format::toDateTime()]);
         unset($categoryModel);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCrawlInfo(): array {
+        $r = \Vanilla\Models\LegacyModelUtils::getCrawlInfoFromPrimaryKey(
+            $this,
+            '/api/v2/discussions?pinOrder=mixed&sort=-discussionID',
+            'discussionID'
+        );
+        return $r;
     }
 }

--- a/applications/vanilla/openapi/comments.yml
+++ b/applications/vanilla/openapi/comments.yml
@@ -26,6 +26,16 @@ paths:
           default: '30'
           maximum: 100
           minimum: 1
+      - name: sort
+        description: Sort the results.
+        in: query
+        schema:
+            type: string
+            enum:
+              - dateInserted
+              - commentID
+              - -dateInserted
+              - -commentID
       - description: |
           Filter by author.
         in: query

--- a/applications/vanilla/openapi/discussions.yml
+++ b/applications/vanilla/openapi/discussions.yml
@@ -17,8 +17,7 @@ paths:
       - $ref: '#/components/parameters/DateInserted'
       - $ref: '#/components/parameters/DateUpdated'
       - $ref: '#/components/parameters/DateLastComment'
-      - description: |
-          Filter by discussion type.
+      - description: Filter by discussion type.
         in: query
         name: type
         schema:
@@ -58,8 +57,7 @@ paths:
           - first
           - mixed
       - $ref: '#/components/parameters/Page'
-      - description: |
-          Desired number of items per page.
+      - description: Desired number of items per page.
         in: query
         name: limit
         schema:
@@ -67,6 +65,18 @@ paths:
           default: 30
           maximum: 100
           minimum: 1
+      - name: sort
+        description: Sort the results.
+        in: query
+        schema:
+          type: string
+          enum:
+            - dateLastComment
+            - dateInserted
+            - discussionID
+            - -dateLastComment
+            - -dateInserted
+            - -discussionID
       - description: |
           Filter by author.
         in: query

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -15,7 +15,7 @@ use Vanilla\Theme\ThemeSectionModel;
 /**
  * Vanilla's event handlers.
  */
-class VanillaHooks implements Gdn_IPlugin {
+class VanillaHooks extends Gdn_Plugin {
 
     /**
      * Handle the container init event to register things with the container.

--- a/applications/vanilla/settings/class.hooks.php
+++ b/applications/vanilla/settings/class.hooks.php
@@ -32,6 +32,11 @@ class VanillaHooks implements Gdn_IPlugin {
 
         $dic->rule(ThemeSectionModel::class)
             ->addCall('registerLegacySection', [t('Forum')]);
+
+        $mf = \Vanilla\Models\ModelFactory::fromContainer($dic);
+        $mf->addModel('category', CategoryModel::class, 'cat');
+        $mf->addModel('discussion', DiscussionModel::class, 'd');
+        $mf->addModel('comment', CommentModel::class, 'c');
     }
 
     /**

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -217,4 +217,18 @@ class ApiUtils {
             return null;
         }
     }
+
+    /**
+     * Takes an array of fields for a sort and adds their descending counterparts.
+     *
+     * @param string $fields
+     * @return array
+     */
+    public static function sortEnum(string ...$fields): array {
+        $desc = $fields;
+        foreach ($desc as &$field) {
+            $field = '-'.$field;
+        }
+        return array_merge($fields, $desc);
+    }
 }

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -221,12 +221,16 @@ class ApiUtils {
     /**
      * Takes an array of fields for a sort and adds their descending counterparts.
      *
-     * @param string $fields
+     * @param string $fields The default sort fields.
      * @return array
+     * @throws \InvalidArgumentException Throws an exception if you pass a field that begins with a dash.
      */
     public static function sortEnum(string ...$fields): array {
         $desc = $fields;
         foreach ($desc as &$field) {
+            if ($field[0] === '-') {
+                throw new \InvalidArgumentException("Default sort fields cannot begin with '-': $field", 400);
+            }
             $field = '-'.$field;
         }
         return array_merge($fields, $desc);

--- a/library/Vanilla/Contracts/Models/CrawlableInterface.php
+++ b/library/Vanilla/Contracts/Models/CrawlableInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Contracts\Models;
+
+/**
+ * Models implement this interface to signify they are crawlable.
+ */
+interface CrawlableInterface {
+    /**
+     * Gets the crawl information
+     *
+     * - url: The URL template to crawl.
+     * - min: The minimum value to crawl. Usually the primary key.
+     * - max: The maximum value to crawl. Usually the primary key.
+     * - count: An approximate count of the crawl rows.
+     * - parameter: The discussion to pass to the crawl URL.
+     *
+     * @return array
+     */
+    public function getCrawlInfo(): array;
+}

--- a/library/Vanilla/Models/AddonModel.php
+++ b/library/Vanilla/Models/AddonModel.php
@@ -222,8 +222,10 @@ class AddonModel implements LoggerAwareInterface {
      *
      * @param string $pluginClass The name of the plugin class.
      */
-    private function callBootstrapEvents($pluginClass) {
+    public function callBootstrapEvents($pluginClass) {
         $instance = $this->container->get($pluginClass);
+        // Kludge: Force the plugin class as shared. This should be done in the EventManager eventually.
+        $this->container->setInstance($pluginClass, $instance);
 
         $this->events->fireClass($instance, 'container_init', $this->container);
     }

--- a/library/Vanilla/Models/InstallModel.php
+++ b/library/Vanilla/Models/InstallModel.php
@@ -7,6 +7,7 @@
 
 namespace Vanilla\Models;
 
+use Garden\Container\Container;
 use Garden\Schema\Schema;
 use Garden\Schema\Validation;
 use Garden\Schema\ValidationException;
@@ -26,7 +27,7 @@ class InstallModel {
     /** @var AddonModel  */
     protected $addonModel;
 
-    /** @var ContainerInterface  */
+    /** @var Container  */
     protected $container;
 
     /** @var \Gdn_Session  */
@@ -37,12 +38,12 @@ class InstallModel {
      *
      * @param \Gdn_Configuration $config The configuration dependency used to load/save configuration information.
      * @param AddonModel $addonModel The addon model dependency used to enable installation addons.
-     * @param ContainerInterface $container The container used to create additional dependencies once they are enabled.
+     * @param Container $container The container used to create additional dependencies once they are enabled.
      */
     public function __construct(
         \Gdn_Configuration $config,
         AddonModel $addonModel,
-        ContainerInterface $container,
+        Container $container,
         \Gdn_Session $session
     ) {
         $this->config = $config;
@@ -121,6 +122,9 @@ class InstallModel {
             $this->session->start($adminUserID, false);
             $this->config->set('Garden.Installed', $oldConfigValue);
         }
+
+        // Kludge: If we are testing the dashboard hooks will not have had an opportunity to configure the container.
+        $this->addonModel->callBootstrapEvents(\DashboardHooks::class);
 
         // Run through the addons.
         $data += ['addons' => static::$DEFAULT_ADDONS];

--- a/library/Vanilla/Models/LegacyModelUtils.php
+++ b/library/Vanilla/Models/LegacyModelUtils.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models;
+
+/**
+ * Utility functions that operate on models.
+ */
+final class LegacyModelUtils {
+    /**
+     * Get the crawl information for a model.
+     *
+     * @param \Gdn_Model $model
+     * @param string $url
+     * @param string $parameter
+     * @return array
+     */
+    public static function getCrawlInfoFromPrimaryKey(\Gdn_Model $model, string $url, string $parameter): array {
+        $count = $model->getTotalRowCount();
+        $range = $model->SQL
+            ->select($model->PrimaryKey, 'min', 'min')
+            ->select($model->PrimaryKey, 'max', 'max')
+            ->get($model->Name)->firstRow(DATASET_TYPE_ARRAY) ?: ['min' => null, 'max' => null];
+
+        $r = [
+                'url' => $url,
+                'parameter' => $parameter,
+                'count' => $count,
+            ] + $range;
+        return $r;
+    }
+
+    /**
+     * Converts a field using the new `field, -field` order syntax to a field and direction.
+     *
+     * @param string $field
+     * @return array Returns an array in the form `[$field, $direction]`.
+     */
+    public static function orderFieldDirection(string $field): array {
+        if (empty($field)) {
+            return ['', ''];
+        } elseif ($field[0] === '-') {
+            return [substr($field, 1), 'desc'];
+        } else {
+            return [$field, 'asc'];
+        }
+    }
+}

--- a/library/Vanilla/Models/ModelFactory.php
+++ b/library/Vanilla/Models/ModelFactory.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Models;
+
+use Garden\Container\Container;
+use Garden\Container\NotFoundException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Vanilla\AddonManager;
+
+/**
+ * Class ModelFactory
+ * @package Vanilla\Models
+ */
+class ModelFactory implements ContainerInterface {
+    private const KEY_INDEX = '@models.index';
+
+    /**
+     * @var Container
+     */
+    private $container;
+
+    /**
+     * ModelFactory constructor.
+     *
+     * @param Container $container
+     */
+    public function __construct(
+        Container $container
+    ) {
+        $this->container = $container;
+    }
+
+    /**
+     * Grab the factory instance from the container.
+     *
+     * This is a useful method to get helpful IDE support.
+     *
+     * @param ContainerInterface $container
+     * @return ModelFactory
+     */
+    public static function fromContainer(ContainerInterface $container): self {
+        return $container->get(static::class);
+    }
+
+    /**
+     * Get the model associated with a record type.
+     *
+     * @param string $recordType The record type or alias to lookup.
+     * @return \Gdn_Model|Model
+     */
+    public function get($recordType) {
+        $r = $this->container->get(self::key($recordType));
+        return $r;
+    }
+
+    /**
+     * Register a model for lookup.
+     *
+     * @param string $recordType
+     * @param string $className
+     * @param string $alias
+     * @return self
+     */
+    public function addModel(string $recordType, string $className, string $alias = ''): self {
+        $this
+            ->container
+            ->rule($className)
+            ->addAlias(self::key($recordType));
+
+
+        if ($alias !== '') {
+            $this->container->addAlias(self::key($alias));
+        }
+
+        $allModels = $this->getRecordTypes();
+        $allModels[$className] = $recordType;
+        return $this;
+    }
+
+    /**
+     * Get the record type for a reference with the proper casing.
+     *
+     * @param string $ref On of the following: The record type (case insensitive), an alias, or the model class name.
+     * @return string Returns the name of the record type.
+     * @throws NotFoundExceptionInterface Throws an exception when the ref isn't found.
+     */
+    public function getRecordType(string $ref): string {
+        $r = $this->getRecordTypes()[$ref];
+        if ($r !== null) {
+            return $r;
+        }
+
+        $key = self::key($ref);
+        if ($this->container->has($key)) {
+            $className = $this->container->rule($key)->getAliasOf();
+
+            $r = $this->getRecordTypes()[$className] ?? null;
+            if ($r !== null) {
+                return $r;
+            }
+        }
+        throw new NotFoundException("Record type not found for: $ref", 404);
+    }
+
+    /**
+     * Add a record type alias.
+     *
+     * @param string $recordType
+     * @param string $alias
+     * @return $this
+     */
+    public function addAlias(string $recordType, string $alias): self {
+        $key = self::key($recordType);
+
+        if ($this->container->hasRule($key)) {
+            $this->container->rule($key);
+
+            $this->container->rule($this->container->getAliasOf())->addAlias(self::key($alias));
+            return $this;
+        } else {
+            throw new NotFoundException("Record type was not found: $recordType", 404);
+        }
+    }
+
+    /**
+     * Canonicalize a key that is being registered.
+     *
+     * @param string $key
+     * @return string
+     */
+    private static function key(string $key): string {
+        return '@models.'.strtolower($key);
+    }
+
+    /**
+     * Check whether or not the record type is recognized.
+     *
+     * @param string $recordType
+     * @return bool
+     */
+    public function has($recordType) {
+        return $this->container->has(self::key($recordType));
+    }
+
+    /**
+     * Get the index of registered models.
+     *
+     * @return \ArrayObject
+     */
+    private function getRecordTypes(): \ArrayObject {
+        if ($this->container->has(self::KEY_INDEX)) {
+            return $this->container->get(self::KEY_INDEX);
+        } else {
+            $r = new \ArrayObject();
+            $this->container->setInstance(self::KEY_INDEX, $r);
+            return $r;
+        }
+    }
+
+    /**
+     * Get all of the models that have been registered.
+     *
+     * @return array
+     */
+    public function getAll(): array {
+        $index = $this->getRecordTypes();
+
+        $result = [];
+        foreach ($index as $className => $recordType) {
+            $result[$recordType] = $this->container->get(self::key($recordType));
+        }
+        return $result;
+    }
+
+    /**
+     * Get all of the modes that implement an interface or don't implement it.
+     *
+     * @param string $interface The name of the interface. Start with a "-" for negation.
+     * @param bool $include Whether to include (true) or exclude (false) models that implement the interface.
+     * @return array
+     */
+    public function getAllByInterface(string $interface, bool $include = true): array {
+        $index = $this->getRecordTypes();
+
+        $result = [];
+        foreach ($index as $className => $recordType) {
+            $key = self::key($recordType);
+            $className = $this->container->rule($key)->getAliasOf();
+            if (is_a($className, $interface, true) === $include) {
+                $result[$recordType] = $this->container->get(self::key($recordType));
+            }
+        }
+        return $result;
+    }
+}

--- a/library/Vanilla/Models/ModelFactory.php
+++ b/library/Vanilla/Models/ModelFactory.php
@@ -91,7 +91,7 @@ class ModelFactory implements ContainerInterface {
      * @throws NotFoundExceptionInterface Throws an exception when the ref isn't found.
      */
     public function getRecordType(string $ref): string {
-        $r = $this->getRecordTypes()[$ref];
+        $r = $this->getRecordTypes()[$ref] ?? null;
         if ($r !== null) {
             return $r;
         }

--- a/library/Vanilla/Utility/ArrayUtils.php
+++ b/library/Vanilla/Utility/ArrayUtils.php
@@ -303,4 +303,45 @@ final class ArrayUtils {
 
         return $arr;
     }
+
+    /**
+     * Return a function that can be used to sort a dataset by one or more keys.
+     *
+     * Consider a dataset that looks something like this:
+     *
+     * ```
+     * $data = [
+     *     ['score' => 0, 'date' => '2010-05-02', ...],
+     *     ...
+     * ]
+     * ```
+     *
+     * I can sort this dataset by score (descending), then date with the following code:
+     *
+     * ```
+     * usort($data, ArrayUtils::datasetSortCallback('-score', 'date'));
+     * ```
+     *
+     * @param string $keys The keys to sort by.
+     * @return callable Returns a function that can be passed to `usort`.
+     */
+    public static function sortCallback(string ...$keys): callable {
+        $sortKeys = [];
+        foreach ($keys as $key) {
+            if ($key[0] === '-') {
+                $sortKeys[substr($key, 0, 1)] = -1;
+            } else {
+                $sortKeys[$key] = 1;
+            }
+        }
+
+        return function ($a, $b) use ($sortKeys): int {
+            foreach ($sortKeys as $key => $desc) {
+                $s = $a <=> $b;
+                if ($s !== 0) {
+                    return $desc * $s;
+                }
+            }
+        };
+    }
 }

--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -1022,4 +1022,19 @@ class Gdn_Model extends Gdn_Pluggable {
         $keyReleased = Gdn::cache()->remove($lockKey);
         return $keyReleased;
     }
+
+    /**
+     * Get the approximate total row count of the model's table.
+     *
+     * @return int
+     */
+    public function getTotalRowCount(): int {
+        $data = $this->Database->query(
+            'show table status like '.$this->Database->connection()->quote($this->Database->DatabasePrefix.$this->Name),
+            [],
+            ['ReturnType' => 'DataSet']
+        );
+
+        return $data->value('Rows', 0);
+    }
 }

--- a/library/database/class.database.php
+++ b/library/database/class.database.php
@@ -214,7 +214,10 @@ class Gdn_Database {
                         throw new Exception(errorMessage('Timeout while connecting to the database', $this->ClassName, 'Connection', $ex->getMessage()), 504);
                     }
 
-                    throw new Exception(errorMessage('An error occurred while attempting to connect to the database', $this->ClassName, 'Connection', $ex->getMessage()), 500);
+                    throw new Exception(
+                        "An error occurred while attempting to connect to the database. dsn: $dsn, error: ".$dsn.$ex->getMessage(),
+                        500
+                    );
                 }
             }
         } while (true);

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -662,7 +662,8 @@ abstract class Gdn_SQLDriver {
             $this->limit($limit, $offset);
         }
 
-        $result = $this->query($this->getSelect());
+        $sql = $this->getSelect();
+        $result = $this->query($sql);
         return $result;
     }
 

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1428,9 +1428,9 @@ abstract class Gdn_SQLDriver {
         } elseif ($value !== null) {
             $this->_Options[$key] = $value;
             return $this;
-        } elseif (isset($this->_Options[$key]))
+        } elseif (isset($this->_Options[$key])) {
             return $this->_Options[$key];
-        else {
+        } else {
             return null;
         }
     }
@@ -1438,20 +1438,57 @@ abstract class Gdn_SQLDriver {
     /**
      * Adds to the $this->_OrderBys collection.
      *
-     * @param string $fields A string of fields to be ordered.
+     * This method supports many different formats for legacy reasons.
+     *
+     * The current best practice is:
+     *
+     * ```
+     * $sql->orderBy(['column1', '-column2', ...]); // prefix with "-" for descending
+     * $sql->orderBy('column1')
+     *     ->orderBy('-column2')
+     * ```
+     *
+     * Legacy versions include:
+     *
+     * ```
+     * $sql->orderBy('column', 'asc|desc');
+     * $sql->orderBy('column1 desc, column2', '');
+     * $sql->orderByy(['column1' => 'desc', 'column2' => 'asc']);
+     * ```
+     *
+     * @param string|array|null $fields A string of fields to be ordered.
      * @param string $direction The direction of the sort.
      * @return Gdn_SQLDriver $this
      */
     public function orderBy($fields, $direction = 'asc') {
+        $r = $this->orderByPrefix('', $fields, $direction);
+        return $r;
+    }
+
+    /**
+     * Order by a field or fields, adding a prefix to each fields.
+     *
+     * @param string $px
+     * @param string|array|null $fields
+     * @param string $direction
+     * @return $this
+     * @see Gdn_SQLDriver::orderBy()
+     */
+    public function orderByPrefix(string $px, $fields, $direction = 'asc') {
         if (!$fields) {
             return $this;
         }
 
-        $fields = explode(',', "$fields $direction");
+        if (!is_array($fields)) {
+            $fields = explode(',', "$fields $direction");
+        }
 
-        foreach ($fields as $parts) {
-            if (preg_match('`^(-)?([^\s]+?)(?:\s+?(asc|desc))?$`i', trim($parts), $m)) {
-                $field = $m[2];
+        foreach ($fields as $key => $parts) {
+            if (!is_numeric($key) && in_array($parts, ['asc', 'desc'], true)) {
+                // This is in the form: column => direction
+                $this->_OrderBys[] = $this->escapeFieldReference($key).' '.$parts;
+            } elseif (preg_match('`^(-)?([^\s]+?)(?:\s+?(asc|desc))?$`i', trim($parts), $m)) {
+                $field = $px.$m[2];
                 if (!empty($m[1])) {
                     $direction = 'desc';
                 } else {

--- a/tests/APIv0/AltTest.php
+++ b/tests/APIv0/AltTest.php
@@ -36,6 +36,8 @@ class AltTest extends SharedBootstrapTestCase {
 
     /**
      * Test an ALT install with a valid update token.
+     *
+     * @large
      */
     public function testAltInstallWithUpdateToken() {
         $this->doAltInstallWithUpdateToken(true, 'xkcd', 'xkcd');
@@ -43,6 +45,8 @@ class AltTest extends SharedBootstrapTestCase {
 
     /**
      * Test an ALT install with no update token.
+     *
+     * @large
      */
     public function testAltInstallWithNoUpdateToken() {
         $this->expectException(\Exception::class);

--- a/tests/APIv2/AbstractAPIv2Test.php
+++ b/tests/APIv2/AbstractAPIv2Test.php
@@ -144,7 +144,7 @@ abstract class AbstractAPIv2Test extends TestCase {
         $pagingTestUrl = $resourceUrl.(strpos($resourceUrl, '?') === false ? '?' : '&').'limit=1';
         $resourcePath = parse_url($resourceUrl, PHP_URL_PATH);
 
-        $result = $this->api()->get($pagingTestUrl);
+        $result = $this->api()->get($pagingTestUrl, ['pinOrder' => 'mixed']);
         $link = $result->getHeader('Link');
         $this->assertNotEmpty($link);
         $this->assertTrue(preg_match('/<([^;]*?'.preg_quote($resourcePath, '/').'[^>]+)>; rel="first"/', $link) === 1);

--- a/tests/APIv2/CommentsTest.php
+++ b/tests/APIv2/CommentsTest.php
@@ -13,7 +13,7 @@ use DiscussionModel;
  * Test the /api/v2/discussions endpoints.
  */
 class CommentsTest extends AbstractResourceTest {
-    use AssertLoggingTrait, TestPrimaryKeyRangeFilterTrait;
+    use AssertLoggingTrait, TestPrimaryKeyRangeFilterTrait, TestSortingTrait;
 
     /**
      * {@inheritdoc}
@@ -22,6 +22,7 @@ class CommentsTest extends AbstractResourceTest {
         $this->baseUrl = '/comments';
         $this->resourceName = 'comment';
         $this->record += ['discussionID' => 1];
+        $this->sortFields = ['dateInserted', 'commentID'];
 
         parent::__construct($name, $data, $dataName);
     }

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -15,7 +15,7 @@ use Garden\Web\Exception\ForbiddenException;
  * Test the /api/v2/discussions endpoints.
  */
 class DiscussionsTest extends AbstractResourceTest {
-    use TestPutFieldTrait, AssertLoggingTrait, TestPrimaryKeyRangeFilterTrait;
+    use TestPutFieldTrait, AssertLoggingTrait, TestPrimaryKeyRangeFilterTrait, TestSortingTrait;
 
     /** @var array */
     private static $categoryIDs = [];
@@ -28,6 +28,7 @@ class DiscussionsTest extends AbstractResourceTest {
         $this->resourceName = 'discussion';
 
         $this->patchFields = ['body', 'categoryID', 'closed', 'format', 'name', 'pinLocation', 'pinned', 'sink'];
+        $this->sortFields = ['dateLastComment', 'dateInserted', 'discussionID'];
 
         parent::__construct($name, $data, $dataName);
     }

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -101,7 +101,8 @@ class DiscussionsTest extends AbstractResourceTest {
     public function setUp(): void {
         parent::setUp();
         DiscussionModel::categoryPermissions(false, true);
-        $this->model = $this->container()->get(DiscussionModel::class);
+        $this->setupTestDiscussionModelTrait();
+        $this->setupTraits();
     }
 
     /**
@@ -299,7 +300,7 @@ class DiscussionsTest extends AbstractResourceTest {
      * Announcements should obey the sort.
      */
     public function testAnnouncementSort(): void {
-        $this->insertRecords(3, ['Announce' => 1]);
+        $this->insertDiscussions(3, ['Announce' => 1]);
 
         $fields = ['discussionID', '-discussionID'];
 
@@ -314,8 +315,8 @@ class DiscussionsTest extends AbstractResourceTest {
      * A mix of announcements and discussions should sort properly.
      */
     public function testAnnouncementMixed(): void {
-        $rows = $this->insertRecords(2, ['Announce' => 1]);
-        $rows = array_merge($rows, $this->insertRecords(2));
+        $rows = $this->insertDiscussions(2, ['Announce' => 1]);
+        $rows = array_merge($rows, $this->insertDiscussions(2));
         $ids = array_column($rows, 'DiscussionID');
 
         $fields = ['discussionID', '-discussionID'];

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -102,7 +102,6 @@ class DiscussionsTest extends AbstractResourceTest {
         parent::setUp();
         DiscussionModel::categoryPermissions(false, true);
         $this->setupTestDiscussionModelTrait();
-        $this->setupTraits();
     }
 
     /**

--- a/tests/APIv2/DiscussionsTest.php
+++ b/tests/APIv2/DiscussionsTest.php
@@ -314,13 +314,14 @@ class DiscussionsTest extends AbstractResourceTest {
      * A mix of announcements and discussions should sort properly.
      */
     public function testAnnouncementMixed(): void {
-        $this->insertRecords(2, ['Announce' => 1]);
-        $this->insertRecords(2);
+        $rows = $this->insertRecords(2, ['Announce' => 1]);
+        $rows = array_merge($rows, $this->insertRecords(2));
+        $ids = array_column($rows, 'DiscussionID');
 
         $fields = ['discussionID', '-discussionID'];
 
         foreach ($fields as $field) {
-            $rows = $this->api()->get($this->baseUrl, ['pinOrder' => 'first', 'sort' => $field])->getBody();
+            $rows = $this->api()->get($this->baseUrl, ['discussionID' => $ids, 'pinOrder' => 'first', 'sort' => $field])->getBody();
             $this->assertNotEmpty($rows);
             $this->assertSorted($rows, '-pinned', $field);
         }

--- a/tests/APIv2/ResourcesTest.php
+++ b/tests/APIv2/ResourcesTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\APIv2;
+
+use Vanilla\Utility\ArrayUtils;
+use Vanilla\Utility\StringUtils;
+
+/**
+ * Tests for the `/resources` endpoints.
+ */
+class ResourcesTest extends AbstractAPIv2Test {
+    /**
+     * @inheritDoc
+     */
+    public static function getAddons(): array {
+        return ['dashboard', 'vanilla'];
+    }
+
+    /**
+     * The index should return the resource for the main tables.
+     */
+    public function testIndex(): void {
+        $r = $this->api()->get('/resources')->getBody();
+        $expected = [
+            [
+                'recordType' => 'user',
+                'url' => 'http://vanilla.test/resourcestest/api/v2/resources/user',
+                'crawlable' => true,
+            ],
+            [
+                'recordType' => 'category',
+                'url' => 'http://vanilla.test/resourcestest/api/v2/resources/category',
+                'crawlable' => true,
+            ],
+            [
+                'recordType' => 'discussion',
+                'url' => 'http://vanilla.test/resourcestest/api/v2/resources/discussion',
+                'crawlable' => true,
+            ],
+            [
+                'recordType' => 'comment',
+                'url' => 'http://vanilla.test/resourcestest/api/v2/resources/comment',
+                'crawlable' => true,
+            ],
+        ];
+
+        usort($expected, ArrayUtils::sortCallback('recordType'));
+        usort($r, ArrayUtils::sortCallback('recordType'));
+
+        $this->assertSame($expected, $r);
+    }
+
+    /**
+     * A basic smoke test of the individual resource endpoints.
+     */
+    public function testResourceCrawlInspection(): void {
+        $resources = $this->api()->get('/resources', ['crawlable' => true])->getBody();
+        foreach ($resources as $row) {
+            ['url' => $url] = $row;
+            StringUtils::substringLeftTrim($url, $this->api()->getBaseUrl());
+            $r = $this->api()->get($url, ['expand' => 'crawl'])->getBody();
+            $this->assertIsInt($r['crawl']['count']);
+        }
+    }
+}

--- a/tests/APIv2/ResourcesTest.php
+++ b/tests/APIv2/ResourcesTest.php
@@ -62,9 +62,26 @@ class ResourcesTest extends AbstractAPIv2Test {
         $resources = $this->api()->get('/resources', ['crawlable' => true])->getBody();
         foreach ($resources as $row) {
             ['url' => $url] = $row;
-            StringUtils::substringLeftTrim($url, $this->api()->getBaseUrl());
             $r = $this->api()->get($url, ['expand' => 'crawl'])->getBody();
             $this->assertIsInt($r['crawl']['count']);
+        }
+    }
+
+    /**
+     * A basic smoke test of the individual resource endpoints.
+     */
+    public function testResourceCrawlInspectionAndCrawl(): void {
+        $resources = $this->api()->get('/resources', ['crawlable' => true])->getBody();
+        foreach ($resources as $row) {
+            ['url' => $url] = $row;
+            $r = $this->api()->get($url, ['expand' => 'crawl'])->getBody();
+            ['url' => $crawlUrl, 'parameter' => $param, 'min' => $min, 'max' => $max] = $r['crawl'];
+
+            $min = $min ?? 0;
+            $max = $max ?? 100;
+
+            $crawl = $this->api()->get($crawlUrl, [$param => "$min..$max"]);
+            $this->assertSame(200, $crawl->getStatusCode());
         }
     }
 }

--- a/tests/APIv2/TestSortingTrait.php
+++ b/tests/APIv2/TestSortingTrait.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\APIv2;
+
+use PHPUnit\Framework\TestCase;
+use Vanilla\Utility\ArrayUtils;
+
+/**
+ * Allows an `AbstractResourceTest` to test API sorting.
+ */
+trait TestSortingTrait {
+    /**
+     * @var array The fields that are allowed for sorting.
+     */
+    protected $sortFields = [];
+
+    /**
+     * Test the sorting of a single field.
+     *
+     * @param string $field
+     * @dataProvider provideSortFields
+     */
+    public function testIndexSort(string $field): void {
+        $rows = $this->generateIndexRows();
+
+        $fields = [$field, '-'.$field];
+
+        foreach ($fields as $field) {
+            /* @var AbstractResourceTest $this */
+            $actual = $this->api()->get($this->indexUrl(), ['sort' => $field, 'pinOrder' => 'mixed'])->getBody();
+            $expected = $actual;
+            usort($expected, ArrayUtils::sortCallback($field));
+
+            $actual = array_values(array_unique(array_column($actual, trim($field, '-'))));
+            $expected = array_values(array_unique(array_column($expected, trim($field, '-'))));
+
+            $this->assertSame($expected, $actual, "Sort test failed for $field");
+        }
+    }
+
+    /**
+     * Get the sort fields as a data provider.
+     *
+     * @return string[]
+     */
+    public function provideSortFields(): array {
+        $r = [];
+        foreach ($this->sortFields as $field) {
+            $r[$field] = [$field];
+        }
+        return $r;
+    }
+}

--- a/tests/APIv2/TestSortingTrait.php
+++ b/tests/APIv2/TestSortingTrait.php
@@ -36,7 +36,6 @@ trait TestSortingTrait {
             static::assertSorted($actual, $field);
         }
     }
-            usort($expected, ArrayUtils::sortCallback($field));
 
     /**
      * Assert that a dataset is properly sorted.

--- a/tests/APIv2/TestSortingTrait.php
+++ b/tests/APIv2/TestSortingTrait.php
@@ -33,14 +33,30 @@ trait TestSortingTrait {
         foreach ($fields as $field) {
             /* @var AbstractResourceTest $this */
             $actual = $this->api()->get($this->indexUrl(), ['sort' => $field, 'pinOrder' => 'mixed'])->getBody();
-            $expected = $actual;
+            static::assertSorted($actual, $field);
+        }
+    }
             usort($expected, ArrayUtils::sortCallback($field));
 
-            $actual = array_values(array_unique(array_column($actual, trim($field, '-'))));
-            $expected = array_values(array_unique(array_column($expected, trim($field, '-'))));
+    /**
+     * Assert that a dataset is properly sorted.
+     *
+     * @param array $arr The actual array to assert.
+     * @param string $fields The fields the dataset should be sorted by.
+     */
+    public static function assertSorted(array $arr, string ...$fields): void {
+        $sorted = $arr;
+        usort($sorted, ArrayUtils::sortCallback(...$fields));
 
-            $this->assertSame($expected, $actual, "Sort test failed for $field");
+        $actual = $expected = [];
+        for ($i = 0; $i < count($arr); $i++) {
+            foreach ($fields as $field) {
+                $j = trim($field, '-');
+                $actual[$i][$j] = $arr[$i][$j];
+                $expected[$i][$j] = $sorted[$i][$j];
+            }
         }
+        TestCase::assertSame($expected, $actual, "The two arrays are not sorted the same: ".implode(', ', $fields));
     }
 
     /**

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -18,7 +18,7 @@ use VanillaTests\Fixtures\TestUploader;
  * Test the /api/v2/users endpoints.
  */
 class UsersTest extends AbstractResourceTest {
-    use TestPutFieldTrait, AssertLoggingTrait, TestPrimaryKeyRangeFilterTrait;
+    use TestPutFieldTrait, AssertLoggingTrait, TestPrimaryKeyRangeFilterTrait, TestSortingTrait;
 
     /** @var int A value to ensure new records are unique. */
     protected static $recordCounter = 1;
@@ -49,6 +49,7 @@ class UsersTest extends AbstractResourceTest {
             'name' => null,
             'email' => null
         ];
+        $this->sortFields = ['dateInserted', 'dateLastActive', 'name', 'userID'];
 
         parent::__construct($name, $data, $dataName);
     }

--- a/tests/BootstrapTrait.php
+++ b/tests/BootstrapTrait.php
@@ -142,4 +142,20 @@ trait BootstrapTrait {
         $logger = static::container()->get(TestLogger::class);
         return $logger;
     }
+
+    /**
+     * Configure the container for connecting to the database.
+     */
+    protected static function initializeDatabase() {
+        /** @var TestInstallModel $model */
+        $model = static::container()->get(TestInstallModel::class);
+        static::container()
+            ->rule(\Gdn_Database::class)
+            ->setConstructorArgs([
+                'Host' => $model->getDbHost(),
+                'Dbname' => $model->getDbName(),
+                'User' => $model->getDbUser(),
+                'Password' => $model->getDbPassword(),
+            ]);
+    }
 }

--- a/tests/BootstrapTrait.php
+++ b/tests/BootstrapTrait.php
@@ -149,13 +149,15 @@ trait BootstrapTrait {
     protected static function initializeDatabase() {
         /** @var TestInstallModel $model */
         $model = static::container()->get(TestInstallModel::class);
-        static::container()
-            ->rule(\Gdn_Database::class)
-            ->setConstructorArgs([
-                'Host' => $model->getDbHost(),
-                'Dbname' => $model->getDbName(),
-                'User' => $model->getDbUser(),
-                'Password' => $model->getDbPassword(),
-            ]);
+
+        /** @var \Gdn_Database $database */
+        $database = static::container()->get(\Gdn_Database::class);
+
+        $database->init([
+            'Host' => $model->getDbHost(),
+            'Dbname' => $model->getDbName(),
+            'User' => $model->getDbUser(),
+            'Password' => $model->getDbPassword(),
+        ]);
     }
 }

--- a/tests/Library/Database/MySQLDriverTest.php
+++ b/tests/Library/Database/MySQLDriverTest.php
@@ -275,7 +275,7 @@ EOT;
      * Test the various legacy order Bys.
      *
      * @param string $expected
-     * @param mixed ...$params
+     * @param mixed $params
      * @dataProvider provideOrderBys
      */
     public function testLegacyOrderBys($expected, ...$params): void {

--- a/tests/Library/Database/MySQLDriverTest.php
+++ b/tests/Library/Database/MySQLDriverTest.php
@@ -270,4 +270,46 @@ EOT;
         ];
         return $r;
     }
+
+    /**
+     * Test the various legacy order Bys.
+     *
+     * @param string $expected
+     * @param mixed ...$params
+     * @dataProvider provideOrderBys
+     */
+    public function testLegacyOrderBys($expected, ...$params): void {
+        $actual = $this->sql->from('t')->orderBy(...$params)->getSelect();
+
+        if (!empty($expected)) {
+            $expected = "\norder by $expected";
+        }
+
+        $sql = <<<EOT
+select *
+from `GDN_t` `t`$expected
+EOT;
+        $this->assertSame($sql, $actual);
+    }
+
+    /**
+     * Provide order by tests.
+     *
+     * @return array
+     */
+    public function provideOrderBys(): array {
+        $r = [
+            'column' => ['`a` asc', 'a'],
+            '-column' => ['`a` desc', '-a'],
+            'csv' => ['`a` asc, `b` desc', ['a', '-b']],
+
+            'column dir' => ['`a` desc', 'a', 'desc'],
+            'a, b' => ['`a` asc, `b` desc', 'a, b', 'desc'],
+            'a => desc' => ['`a` desc', ['a' => 'desc']],
+
+            "''" => ['', ''],
+            '[]' => ['', []],
+        ];
+        return $r;
+    }
 }

--- a/tests/Library/Vanilla/ApiUtilsTest.php
+++ b/tests/Library/Vanilla/ApiUtilsTest.php
@@ -121,4 +121,21 @@ EOT;
 
         $this->assertNull($actual);
     }
+
+    /**
+     * Test a basic call of `ApiUtils::sortEnum()`.
+     */
+    public function testSortEnum(): void {
+        $r = ApiUtils::sortEnum('a', 'b');
+        $this->assertSame(['a', 'b', '-a', '-b'], $r);
+    }
+
+    /**
+     * You should be able to pass `"-$field"` to `ApiUtils::sortEnum()`.
+     */
+    public function testSortEnumException(): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('-a');
+        $r = ApiUtils::sortEnum('-a');
+    }
 }

--- a/tests/Library/Vanilla/Models/LegacyModelUtilsTest.php
+++ b/tests/Library/Vanilla/Models/LegacyModelUtilsTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Models;
+
+use PHPUnit\Framework\TestCase;
+use Vanilla\Models\LegacyModelUtils;
+use VanillaTests\BootstrapTrait;
+use VanillaTests\SiteTestTrait;
+
+/**
+ * Tests for the `LegacyModelUtils` class.
+ */
+class LegacyModelUtilsTest extends TestCase {
+    use BootstrapTrait;
+
+    /**
+     * @var \Gdn_Model
+     */
+    private $model;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->setupBoostrapTrait();
+
+        $this->initializeDatabase();
+        $this->model = $this->container()->getArgs(\Gdn_Model::class, ['legacyModelUtilsTest']);
+
+        // Create a basic table for the test.
+        $this->model->Database->structure()->table($this->model->Name)
+            ->primaryKey($this->model->Name.'ID')
+            ->column('name', 'varchar(20)')
+            ->set();
+
+        $this->model->delete([]);
+
+        for ($i = 1; $i <= 10; $i++) {
+            $this->model->insert(['name' => "row $i"]);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function tearDown(): void {
+        parent::tearDown();
+        $this->model->Database->structure()->table($this->model->Name)->drop();
+    }
+
+    /**
+     * Test a happy path for `LegacyModelUtils::getCrawlInfoFromPrimaryKey()`.
+     */
+    public function testGetCrawlInfoFromPrimaryKey(): void {
+        $crawl = LegacyModelUtils::getCrawlInfoFromPrimaryKey($this->model, 'https://example.com/api', 'foo');
+
+        $this->assertSame('https://example.com/api', $crawl['url']);
+        $this->assertSame('foo', $crawl['parameter']);
+
+        $this->assertIsInt($crawl['count']);
+        $this->assertIsInt($crawl['min']);
+        $this->assertIsInt($crawl['max']);
+    }
+
+    /**
+     * Test the basic functionality of `LegacyModelUtils::orderFieldDirection()`.
+     */
+    public function testOrderFieldDirection(): void {
+        [$field, $dir] = LegacyModelUtils::orderFieldDirection('a');
+        $this->assertSame('a', $field);
+        $this->assertSame('asc', $dir);
+
+        [$field, $dir] = LegacyModelUtils::orderFieldDirection('-b');
+        $this->assertSame('b', $field);
+        $this->assertSame('desc', $dir);
+
+        [$field, $dir] = LegacyModelUtils::orderFieldDirection('');
+        $this->assertSame('', $field);
+        $this->assertSame('', $dir);
+    }
+}

--- a/tests/Library/Vanilla/Models/ModelFactoryTest.php
+++ b/tests/Library/Vanilla/Models/ModelFactoryTest.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Models;
+
+use Garden\Container\NotFoundException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Vanilla\Models\Model;
+use Vanilla\Models\ModelFactory;
+use VanillaTests\BootstrapTrait;
+
+/**
+ * Tests for the `ModelFactory` class.
+ */
+class ModelFactoryTest extends TestCase {
+    use BootstrapTrait;
+
+    const RECORD_TYPE = 'test';
+    const ALIAS = 't';
+
+    /**
+     * @var ModelFactory
+     */
+    private $factory;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->setupBoostrapTrait();
+        $this->initializeDatabase();
+
+        $this->factory = ModelFactory::fromContainer($this->container());
+        $this->factory->addModel(self::RECORD_TYPE, TestModel::class, self::ALIAS);
+    }
+
+    /**
+     * The factory should have its models' record types and aliases.
+     */
+    public function testHas(): void {
+        $this->assertTrue($this->factory->has(self::RECORD_TYPE));
+        $this->assertTrue($this->factory->has(self::ALIAS));
+    }
+
+    /**
+     * You should be able to add multiple aliases to record types.
+     */
+    public function testAddAlias(): void {
+        $this->factory->addAlias(self::RECORD_TYPE, 'tt');
+        $this->assertTrue($this->factory->has('tt'));
+    }
+
+    /**
+     * You should be able to create a model from its record type.
+     */
+    public function testModelCreation(): void {
+        $model = $this->factory->get(self::RECORD_TYPE);
+        $this->assertInstanceOf(TestModel::class, $model);
+    }
+
+    /**
+     * You should be able to create a model from its alias.
+     */
+    public function testModelCreationAlias(): void {
+        $model = $this->factory->get(self::ALIAS);
+        $this->assertInstanceOf(TestModel::class, $model);
+    }
+
+    /**
+     * Record types and aliases should be case insensitive.
+     */
+    public function testModelCreationCaseInsensitive(): void {
+        $recordType = strtoupper(self::RECORD_TYPE);
+        $this->assertNotSame($recordType, self::RECORD_TYPE);
+        $model = $this->factory->get($recordType);
+        $this->assertInstanceOf(TestModel::class, $model);
+
+        $alias = strtoupper(self::ALIAS);
+        $this->assertNotSame($alias, self::ALIAS);
+        $model = $this->factory->get($alias);
+        $this->assertInstanceOf(TestModel::class, $model);
+    }
+
+    /**
+     * The `getRecordType()` method should work with a variety of references.
+     *
+     * @param string $ref
+     * @dataProvider provideValidRefs
+     */
+    public function testGetRecordType(string $ref): void {
+        $this->assertSame(self::RECORD_TYPE, $this->factory->getRecordType($ref));
+    }
+
+    /**
+     * Provide some valid references.
+     *
+     * @return array
+     */
+    public function provideValidRefs(): array {
+        $r = [
+            [self::ALIAS],
+            [self::RECORD_TYPE],
+            [strtoupper(self::RECORD_TYPE)],
+            [TestModel::class],
+        ];
+
+        return array_column($r, null, 0);
+    }
+
+    /**
+     * An invalid record type ref should be an exception.
+     */
+    public function testInvalidRecordTypeRef(): void {
+        $this->expectException(NotFoundException::class);
+        $this->factory->getRecordType('foo');
+    }
+
+    /**
+     * Adding an alias to an invalid record type should be an exception.
+     */
+    public function testInvalidAlias(): void {
+        $this->expectException(NotFoundException::class);
+        $this->factory->addAlias('foo', 'bar');
+    }
+
+    /**
+     * Smoke test `getAll()`.
+     */
+    public function testGetAll(): void {
+        $r = $this->factory->getAll();
+        $this->assertArrayHasKey(self::RECORD_TYPE, $r);
+        $this->assertInstanceOf(TestModel::class, $r[self::RECORD_TYPE]);
+    }
+
+    /**
+     * Smoke test `getAllByInterface()`.
+     */
+    public function testGetAllByInterface(): void {
+        $r = $this->factory->getAllByInterface(LoggerInterface::class);
+        $this->assertEmpty($r);
+
+        $r2 = $this->factory->getAllByInterface(Model::class);
+        $this->assertArrayHasKey(self::RECORD_TYPE, $r2);
+        $this->assertInstanceOf(TestModel::class, $r2[self::RECORD_TYPE]);
+    }
+}

--- a/tests/Library/Vanilla/Models/TestModel.php
+++ b/tests/Library/Vanilla/Models/TestModel.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Models;
+
+use Vanilla\Models\Model;
+
+/**
+ * A basic model for testing the factory or whatever.
+ */
+class TestModel extends Model {
+    /**
+     * TestModel constructor.
+     */
+    public function __construct() {
+        parent::__construct('testModel');
+    }
+}

--- a/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/ArrayUtilsTest.php
@@ -342,4 +342,37 @@ class ArrayUtilsTest extends TestCase {
         ];
         return $r;
     }
+
+    /**
+     * Test `ArrayUtils::sortCallback()`.
+     *
+     * @param array $fields
+     * @param int $expected
+     * @dataProvider provideSortCallbackTests
+     */
+    public function testSortCallback(array $fields, int $expected) {
+        $a = ['a' => 1, 'b' => 'B', 'c' => 1];
+        $b = ['a' => 1, 'b' => 'a', 'c' => 2];
+
+        $fn = ArrayUtils::sortCallback(...$fields);
+
+        $actual = $fn($a, $b);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function provideSortCallbackTests(): array {
+        $r = [
+            'same' => [['a'], 0],
+            'case insensitive' => [['b'], 1],
+            'multi' => [['a', 'b'], 1],
+            'multi bail' => [['c', 'b'], -1],
+            'desc' => [['-c'], 1],
+        ];
+        return $r;
+    }
 }

--- a/tests/Models/DiscussionModelTest.php
+++ b/tests/Models/DiscussionModelTest.php
@@ -57,7 +57,7 @@ class DiscussionModelTest extends TestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->model = $this->container()->get(\DiscussionModel::class);
+        $this->setupTestDiscussionModelTrait();
         $this->now = new \DateTimeImmutable();
         $this->session = Gdn::session();
         $this->backupSession();
@@ -83,24 +83,24 @@ class DiscussionModelTest extends TestCase {
      * An empty archive date should be null.
      */
     public function testArchiveDateEmpty() {
-        $this->model->setArchiveDate('');
-        $this->assertNull($this->model->getArchiveDate());
+        $this->discussionModel->setArchiveDate('');
+        $this->assertNull($this->discussionModel->getArchiveDate());
     }
 
     /**
      * A date expression is valid.
      */
     public function testDayInPast() {
-        $this->model->setArchiveDate('-3 days');
-        $this->assertLessThan($this->now, $this->model->getArchiveDate());
+        $this->discussionModel->setArchiveDate('-3 days');
+        $this->assertLessThan($this->now, $this->discussionModel->getArchiveDate());
     }
 
     /**
      * A future date expression gets flipped to the past.
      */
     public function testDayFlippedToPast() {
-        $this->model->setArchiveDate('3 days');
-        $this->assertLessThan($this->now, $this->model->getArchiveDate());
+        $this->discussionModel->setArchiveDate('3 days');
+        $this->assertLessThan($this->now, $this->discussionModel->getArchiveDate());
     }
 
     /**
@@ -109,7 +109,7 @@ class DiscussionModelTest extends TestCase {
     public function testInvalidArchiveDate() {
         $this->expectException(\Exception::class);
 
-        $this->model->setArchiveDate('dnsfids');
+        $this->discussionModel->setArchiveDate('dnsfids');
     }
 
     /**
@@ -121,8 +121,8 @@ class DiscussionModelTest extends TestCase {
      * @dataProvider provideIsArchivedTests
      */
     public function testIsArchived(string $archiveDate, ?string $dateLastComment, bool $expected) {
-        $this->model->setArchiveDate($archiveDate);
-        $actual = $this->model->isArchived($dateLastComment);
+        $this->discussionModel->setArchiveDate($archiveDate);
+        $actual = $this->discussionModel->isArchived($dateLastComment);
         $this->assertSame($expected, $actual);
     }
 
@@ -130,10 +130,10 @@ class DiscussionModelTest extends TestCase {
      * An invalid date should return a warning.
      */
     public function testIsArchivedInvalidDate() {
-        $this->model->setArchiveDate('2019-10-26');
+        $this->discussionModel->setArchiveDate('2019-10-26');
 
         $this->runWithExpectedError(function () {
-            $actual = $this->model->isArchived('fldjsjs');
+            $actual = $this->discussionModel->isArchived('fldjsjs');
             $this->assertFalse($actual);
         }, self::assertErrorNumber(E_USER_WARNING));
     }
@@ -321,11 +321,11 @@ class DiscussionModelTest extends TestCase {
         ?string $testMaxDateInserted,
         $expected
     ) {
-        $this->model->DateLastViewed = $testDiscussionArray['DateLastViewed'];
-        $this->model->CountCommentWatch = $testDiscussionArray['CountCommentWatch'];
-        $this->model->DateInserted = $testDiscussionArray['DateInserted'];
-        $this->model->DateLastComment = $testDiscussionArray['DateLastComment'];
-        $actual = $this->model->calculateWatch($this->model, $testLimit, $testOffset, $testTotalComments, $testMaxDateInserted);
+        $this->discussionModel->DateLastViewed = $testDiscussionArray['DateLastViewed'];
+        $this->discussionModel->CountCommentWatch = $testDiscussionArray['CountCommentWatch'];
+        $this->discussionModel->DateInserted = $testDiscussionArray['DateInserted'];
+        $this->discussionModel->DateLastComment = $testDiscussionArray['DateLastComment'];
+        $actual = $this->discussionModel->calculateWatch($this->discussionModel, $testLimit, $testOffset, $testTotalComments, $testMaxDateInserted);
         $this->assertSame($expected, $actual);
     }
 
@@ -449,7 +449,7 @@ class DiscussionModelTest extends TestCase {
         ?string $userLastReadDate,
         $expected
     ) {
-        $actual = $this->model->calculateCommentReadData(
+        $actual = $this->discussionModel->calculateCommentReadData(
             $discussionCommentCount,
             $discussionLastCommentDate,
             $userReadComments,
@@ -567,12 +567,12 @@ class DiscussionModelTest extends TestCase {
      * @return void
      */
     public function testDeleteEventDispatched(): void {
-        $discussionID = $this->model->save([
+        $discussionID = $this->discussionModel->save([
             "Name" => __FUNCTION__,
             "Body" => "Hello world.",
             "Format" => "markdown",
         ]);
-        $this->model->deleteID($discussionID);
+        $this->discussionModel->deleteID($discussionID);
 
         $this->assertInstanceOf(DiscussionEvent::class, $this->lastEvent);
         $this->assertEquals(DiscussionEvent::ACTION_DELETE, $this->lastEvent->getAction());
@@ -584,7 +584,7 @@ class DiscussionModelTest extends TestCase {
      * @return void
      */
     public function testSaveInsertEventDispatched(): void {
-        $this->model->save([
+        $this->discussionModel->save([
             "Name" => __FUNCTION__,
             "Body" => "Hello world.",
             "Format" => "markdown",
@@ -599,12 +599,12 @@ class DiscussionModelTest extends TestCase {
      * @return void
      */
     public function testSaveUpdateEventDispatched(): void {
-        $discussionID = $this->model->save([
+        $discussionID = $this->discussionModel->save([
             "Name" => __FUNCTION__,
             "Body" => "Hello world.",
             "Format" => "markdown",
         ]);
-        $this->model->save([
+        $this->discussionModel->save([
             "DiscussionID" => $discussionID,
             "Body" => "Hello again, world.",
         ]);
@@ -633,9 +633,9 @@ class DiscussionModelTest extends TestCase {
         ];
 
         // Confirm the initial state, so changes are easy to detect.
-        $discussionID = $this->model->save($discussion);
-        $this->assertNotEmpty($discussionID, $this->model->Validation->resultsText());
-        $discussion = $this->model->getID($discussionID);
+        $discussionID = $this->discussionModel->save($discussion);
+        $this->assertNotEmpty($discussionID, $this->discussionModel->Validation->resultsText());
+        $discussion = $this->discussionModel->getID($discussionID);
         $this->assertIsObject($discussion);
         $this->assertNull(
             $discussion->CountCommentWatch,
@@ -643,8 +643,8 @@ class DiscussionModelTest extends TestCase {
         );
 
         // Create a comment watch status.
-        $this->model->setWatch($discussion, 10, 0, $discussion->CountComments);
-        $discussionFirstVisit = $this->model->getID($discussionID);
+        $this->discussionModel->setWatch($discussion, 10, 0, $discussion->CountComments);
+        $discussionFirstVisit = $this->discussionModel->getID($discussionID);
         $this->assertSame(
             $discussionFirstVisit->CountComments,
             $discussionFirstVisit->CountCommentWatch,
@@ -653,9 +653,9 @@ class DiscussionModelTest extends TestCase {
 
         // Update an existing comment watch status.
         $updatedCountComments = $countComments + 1;
-        $this->model->setField($discussionID, "CountComments", $updatedCountComments);
-        $this->model->setWatch($discussionFirstVisit, 10, 0, $updatedCountComments);
-        $discussionSecondVisit = $this->model->getID($discussionID);
+        $this->discussionModel->setField($discussionID, "CountComments", $updatedCountComments);
+        $this->discussionModel->setWatch($discussionFirstVisit, 10, 0, $updatedCountComments);
+        $discussionSecondVisit = $this->discussionModel->getID($discussionID);
         $this->assertSame(
             $discussionSecondVisit->CountComments,
             $discussionSecondVisit->CountCommentWatch,
@@ -705,7 +705,7 @@ class DiscussionModelTest extends TestCase {
             "CountCommentWatch" => $discussionMarkedRead ? 5 : null,
         ];
 
-        $this->model->calculate($discussion);
+        $this->discussionModel->calculate($discussion);
 
         $this->assertSame($expected, $discussion->DateLastViewed);
 
@@ -764,5 +764,16 @@ class DiscussionModelTest extends TestCase {
             ],
         ];
         return $result;
+    }
+
+    /**
+     * Announcements should properly sort.
+     */
+    public function testAnnouncementSorting() {
+        $row = ['Name' => 'ax1', 'Announce' => 1];
+        $this->insertDiscussions(10, $row);
+
+        $rows = $this->discussionModel->getAnnouncements($row, 0, false, '-DiscussionID')->resultArray();
+        TestSortingTrait::assertSorted($rows, '-DiscussionID');
     }
 }

--- a/tests/Models/DiscussionModelTest.php
+++ b/tests/Models/DiscussionModelTest.php
@@ -13,6 +13,7 @@ use Garden\EventManager;
 use Gdn;
 use PHPUnit\Framework\TestCase;
 use Vanilla\Community\Events\DiscussionEvent;
+use VanillaTests\APIv2\TestSortingTrait;
 use VanillaTests\ExpectErrorTrait;
 use VanillaTests\SiteTestTrait;
 
@@ -20,15 +21,10 @@ use VanillaTests\SiteTestTrait;
  * Some basic tests for the `DiscussionModel`.
  */
 class DiscussionModelTest extends TestCase {
-    use SiteTestTrait, ExpectErrorTrait;
+    use SiteTestTrait, ExpectErrorTrait, TestDiscussionModelTrait;
 
     /** @var DiscussionEvent */
     private $lastEvent;
-
-    /**
-     * @var \DiscussionModel
-     */
-    private $model;
 
     /**
      * @var \DateTimeImmutable
@@ -403,7 +399,7 @@ class DiscussionModelTest extends TestCase {
             ],
             'User Has Read Page One, but not Page Two' => [
                 [
-                    'DateLastViewed' =>  '2020-01-18 19:20:02',
+                    'DateLastViewed' => '2020-01-18 19:20:02',
                     'CountCommentWatch' => 30,
                     'DateInserted' => '2020-01-17 19:20:02',
                     'DateLastComment' => '2020-01-19 19:20:02',

--- a/tests/Models/TestDiscussionModelTrait.php
+++ b/tests/Models/TestDiscussionModelTrait.php
@@ -7,6 +7,8 @@
 
 namespace VanillaTests\Models;
 
+use DiscussionModel;
+
 /**
  * Useful methods for testing a discussion model.
  */
@@ -14,7 +16,14 @@ trait TestDiscussionModelTrait {
     /**
      * @var \DiscussionModel
      */
-    private $model;
+    private $discussionModel;
+
+    /**
+     * Instantiate a fresh model for each
+     */
+    protected function setupTestDiscussionModelTrait() {
+        $this->discussionModel = $this->container()->get(DiscussionModel::class);
+    }
 
     /**
      * Create a test record.
@@ -23,7 +32,7 @@ trait TestDiscussionModelTrait {
      *
      * @return array
      */
-    public function createRecord(array $override): array {
+    public function newDiscussion(array $override): array {
         static $i = 1;
 
         $r = $override + [
@@ -43,11 +52,11 @@ trait TestDiscussionModelTrait {
      * @param array $overrides An array of row overrides.
      * @return array
      */
-    private function insertRecords(int $count, array $overrides = []): array {
+    private function insertDiscussions(int $count, array $overrides = []): array {
         for ($i = 0; $i < $count; $i++) {
-            $ids[] = $this->model->save($this->createRecord($overrides));
+            $ids[] = $this->discussionModel->save($this->newDiscussion($overrides));
         }
-        $rows = $this->model->getWhere(['DiscussionID' => $ids, 'Announce' => 'All'])->resultArray();
+        $rows = $this->discussionModel->getWhere(['DiscussionID' => $ids, 'Announce' => 'All'])->resultArray();
         return $rows;
     }
 }

--- a/tests/Models/TestDiscussionModelTrait.php
+++ b/tests/Models/TestDiscussionModelTrait.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Models;
+
+/**
+ * Useful methods for testing a discussion model.
+ */
+trait TestDiscussionModelTrait {
+    /**
+     * @var \DiscussionModel
+     */
+    private $model;
+
+    /**
+     * Create a test record.
+     *
+     * @param array $override
+     *
+     * @return array
+     */
+    public function createRecord(array $override): array {
+        static $i = 1;
+
+        $r = $override + [
+                'Name' => "How do I test $i?",
+                'CategoryID' => 1,
+                'Body' => "Foo $i.",
+                'Format' => 'Text',
+            ];
+
+        return $r;
+    }
+
+    /**
+     * Insert test records and return them.
+     *
+     * @param int $count
+     * @param array $overrides An array of row overrides.
+     * @return array
+     */
+    private function insertRecords(int $count, array $overrides = []): array {
+        for ($i = 0; $i < $count; $i++) {
+            $ids[] = $this->model->save($this->createRecord($overrides));
+        }
+        $rows = $this->model->getWhere(['DiscussionID' => $ids, 'Announce' => 'All'])->resultArray();
+        return $rows;
+    }
+}


### PR DESCRIPTION
The PR does quite a bit so let me try and break it down.

1. I added the `ModelFactory` class to create models from record types.
2. I added a `CrawlableInterface` that models can implement to say they support crawling.
3. I use the factory to create new `/resources` endpoint that can be used to inspect record types in the system.
4. I also needed to implement sorting on many of our basic API index endpoints because crawling needs reliable primary key sorting.

The sorting in particular proved to be fairly tedious to implement because we have a lot of inconsistent legacy code around sorting in the models and `GDN_SQLDriver`. To clean this up I did the following.

1. I added support and tests for our various legacy and new sorting to `GDN_SQLDriver::orderBy()`.
2. I added `GDN_SQLDriver::orderByPrefixed()` for those few models that have a join and have a need to prefix sort fields.
3. I added some test utilities to make asserting sorting easier.
4. I added some specific tests to the various sorting methods in the `DiscussionModel`.
5. I added some more specific tests to to the `DiscussionsApiController`.

It was my goal to get all of my changed code as close to 100% covered as possible.