### PR TITLE
Remove theme-boilerplate private flag

### DIFF
--- a/addons/themes/theme-boilerplate/package.json
+++ b/addons/themes/theme-boilerplate/package.json
@@ -1,8 +1,7 @@
 {
-    "name": "@vanilla/theme-boilerplate",
+    "name": "@vanillaforums/theme-boilerplate",
     "version": "3.0.1",
     "description": "A boilerplate for Vanillaforums themes",
-    "private": true,
     "bin": {
         "boilerplate-install": "./setup/boilerplateInstall.js"
     },


### PR DESCRIPTION
This is a blocker for publishing theme-boilerplate to maintaining themes who have it as a dependency.

This is a blocker for: https://github.com/vanilla/support/issues/1863