### PR TITLE
Fix theme options not working in the theme service

### DIFF
--- a/library/Vanilla/Theme/Theme.php
+++ b/library/Vanilla/Theme/Theme.php
@@ -121,8 +121,8 @@ class Theme implements \JsonSerializable {
         // Trim off the active theme option key.
         foreach ($addonAssets as $addonAssetKey => $addonAsset) {
             preg_match($optionAssetRegex, $addonAssetKey, $matches);
-            if (isset($matches[0])) {
-                $addonAssets[$matches[0]] = $addonAsset;
+            if (isset($matches[1])) {
+                $addonAssets[$matches[1]] = $addonAsset;
             }
         }
 

--- a/tests/Library/Vanilla/Theme/ThemeServiceCurrentTest.php
+++ b/tests/Library/Vanilla/Theme/ThemeServiceCurrentTest.php
@@ -7,17 +7,14 @@
 
 namespace VanillaTests\Library\Vanilla\Theme;
 
-use Vanilla\AddonManager;
+use Vanilla\Addon;
 use Vanilla\Theme\Asset\CssThemeAsset;
 use Vanilla\Theme\Asset\JsonThemeAsset;
+use Vanilla\Theme\Theme;
 use Vanilla\Theme\ThemeAssetFactory;
-use Vanilla\Theme\ThemeService;
 use Vanilla\Theme\ThemeServiceHelper;
 use Vanilla\Theme\ThemeFeatures;
 use VanillaTests\Fixtures\MockAddon;
-use VanillaTests\Fixtures\MockAddonManager;
-use VanillaTests\Fixtures\Theme\MockThemeProvider;
-use VanillaTests\MinimalContainerTestCase;
 
 /**
  * Tests for getting the current theme from the theme model.
@@ -97,6 +94,33 @@ class ThemeServiceCurrentTest extends MockThemeTestCase {
         /** @var ThemeFeatures $features */
         $features = self::container()->get(ThemeFeatures::class);
         $this->assertEquals(false, $features->useSharedMasterView());
+    }
+
+    /**
+     * Test theme options working.
+     *
+     * @param string $optionName
+     *
+     * @dataProvider provideOptions
+     */
+    public function testThemeOptionVariables(string $optionName) {
+        $this->setConfig('Garden.ThemeOptions.Styles.Value', $optionName);
+        $addon = new Addon('/tests/fixtures/addons/themes/theme-options');
+        $theme = Theme::fromAddon($addon);
+
+        /** @var JsonThemeAsset $variables */
+        $variables = $theme->getAsset('variables');
+        $this->assertTrue($variables->get($optionName, false));
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideOptions(): array {
+        return [
+            ['option1'],
+            ['option2'],
+        ];
     }
 
     /**

--- a/tests/fixtures/addons/themes/theme-options/addon.json
+++ b/tests/fixtures/addons/themes/theme-options/addon.json
@@ -1,0 +1,15 @@
+{
+    "key": "theme-options",
+    "name": "Theme with options.",
+    "type": "theme",
+    "assets": {
+        "option1_variables": {
+            "type": "json",
+            "file": "option1_variables.json"
+        },
+        "option2_variables": {
+            "type": "json",
+            "file": "option2_variables.json"
+        }
+    }
+}

--- a/tests/fixtures/addons/themes/theme-options/assets/option1_variables.json
+++ b/tests/fixtures/addons/themes/theme-options/assets/option1_variables.json
@@ -1,0 +1,3 @@
+{
+    "option1": true
+}

--- a/tests/fixtures/addons/themes/theme-options/assets/option2_variables.json
+++ b/tests/fixtures/addons/themes/theme-options/assets/option2_variables.json
@@ -1,0 +1,3 @@
+{
+    "option2": true
+}


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/2077

I was using the wrong index on the theme options regex. I fixed the index and added some tests.