### PR TITLE
Fix location data missing when exporting profiles

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -582,14 +582,14 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
                 continue;
             }
             // Add this field to the output
-                $columnNames[] = val('Label', $fieldData, $slug);
+            $columnNames[] = val('Label', $fieldData, $slug);
 
-                // Add this field to the query.
-                $quoted = Gdn::sql()->quote("Profile.$slug");
-                    Gdn::sql()
-                        ->join('UserMeta a' . $i, "u.UserID = a$i.UserID and a$i.Name = $quoted", 'left')
-                        ->select('a' . $i . '.Value', '', $slug);
-                    $i++;
+            // Add this field to the query.
+            $quoted = Gdn::sql()->quote("Profile.$slug");
+            Gdn::sql()
+                ->join('UserMeta a' . $i, "u.UserID = a$i.UserID and a$i.Name = $quoted", 'left')
+                ->select('a' . $i . '.Value', '', $slug);
+            $i++;
         }
 
         // Get our user data.

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -574,10 +574,11 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
                 ->leftJoin('Rank ra', 'ra.RankID = u.RankID');
         }
 
+        $lowerCaseColumnNames =  array_map('strtolower', $columnNames);
         $i = 0;
         foreach ($fields as $slug => $fieldData) {
-            // Don't overwrite Location data (it's always stored in the user table, never the userMeta table).
-            if (strtolower($slug) === 'location') {
+            // Don't overwrite data if there's already a column with the same name.
+            if (in_array(strtolower($slug), $lowerCaseColumnNames)) {
                 continue;
             }
             // Add this field to the output

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -577,7 +577,9 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         $i = 0;
         foreach ($fields as $slug => $fieldData) {
             // Add this field to the output
-            if (!strtolower($slug) === 'location') {
+            if (strtolower($slug) === 'location') {
+                continue;
+            }
                 $columnNames[] = val('Label', $fieldData, $slug);
 
                 // Add this field to the query.
@@ -586,7 +588,6 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
                         ->join('UserMeta a' . $i, "u.UserID = a$i.UserID and a$i.Name = $quoted", 'left')
                         ->select('a' . $i . '.Value', '', $slug);
                     $i++;
-            }
         }
 
         // Get our user data.

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -581,10 +581,12 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
 
             // Add this field to the query.
             $quoted = Gdn::sql()->quote("Profile.$slug");
-            Gdn::sql()
-                ->join('UserMeta a'.$i, "u.UserID = a$i.UserID and a$i.Name = $quoted", 'left')
-                ->select('a'.$i.'.Value', '', $slug);
-            $i++;
+            if (strcasecmp($slug, 'location')) {
+                Gdn::sql()
+                    ->join('UserMeta a' . $i, "u.UserID = a$i.UserID and a$i.Name = $quoted", 'left')
+                    ->select('a' . $i . '.Value', '', $slug);
+                $i++;
+            }
         }
 
         // Get our user data.

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -576,10 +576,11 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
 
         $i = 0;
         foreach ($fields as $slug => $fieldData) {
-            // Add this field to the output
+            // Don't overwrite Location data (it's always stored in the user table, never the userMeta table).
             if (strtolower($slug) === 'location') {
                 continue;
             }
+            // Add this field to the output
                 $columnNames[] = val('Label', $fieldData, $slug);
 
                 // Add this field to the query.

--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -577,15 +577,15 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         $i = 0;
         foreach ($fields as $slug => $fieldData) {
             // Add this field to the output
-            $columnNames[] = val('Label', $fieldData, $slug);
+            if (!strtolower($slug) === 'location') {
+                $columnNames[] = val('Label', $fieldData, $slug);
 
-            // Add this field to the query.
-            $quoted = Gdn::sql()->quote("Profile.$slug");
-            if (strcasecmp($slug, 'location')) {
-                Gdn::sql()
-                    ->join('UserMeta a' . $i, "u.UserID = a$i.UserID and a$i.Name = $quoted", 'left')
-                    ->select('a' . $i . '.Value', '', $slug);
-                $i++;
+                // Add this field to the query.
+                $quoted = Gdn::sql()->quote("Profile.$slug");
+                    Gdn::sql()
+                        ->join('UserMeta a' . $i, "u.UserID = a$i.UserID and a$i.Name = $quoted", 'left')
+                        ->select('a' . $i . '.Value', '', $slug);
+                    $i++;
             }
         }
 


### PR DESCRIPTION
Closes vanilla/support#2015.

Currently, if you have a profile extender field named "location," the location data that is stored in the `Gdn_User` table is overwritten by the query for location data in the `Gdn_UserMeta` table. The problem is that the location data is never stored in the `Gdn_UserMeta` table in the first place, so the location field will always be empty. This PR fixes the problem by skipping the `Gdn_UserMeta` query if the field is named "location".

### TO TEST
1. Enable Profile extender and add a "Location" field.
1. Create or edit a user to give their profile a location.
1. Go to the `utility/exportprofiles` endpoint and press enter.
1. Look at the .csv file and note that there is no location data for that user.
1. Check out this branch and repeat step 3.
1. Look at the .csv file and verify that the first location field is populated for that user.