### PR TITLE
Fix json processor breaking delete operations

### DIFF
--- a/library/Vanilla/Database/Operation/JsonFieldProcessor.php
+++ b/library/Vanilla/Database/Operation/JsonFieldProcessor.php
@@ -49,6 +49,8 @@ class JsonFieldProcessor implements Processor {
         } elseif ($operation->getType() === Operation::TYPE_SELECT) {
             $result = $stack($operation);
             return $this->unpackFields($result);
+        } else {
+            return $stack($operation);
         }
     }
 

--- a/tests/Library/Vanilla/Models/ModelTest.php
+++ b/tests/Library/Vanilla/Models/ModelTest.php
@@ -21,7 +21,7 @@ class ModelTest extends TestCase {
     /**
      * @var Model
      */
-    private $model;
+    protected $model;
 
     /**
      * Install the site and set up a test table.

--- a/tests/Library/Vanilla/Models/PipelineModelTest.php
+++ b/tests/Library/Vanilla/Models/PipelineModelTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Models;
+
+use Vanilla\Database\Operation\JsonFieldProcessor;
+use Vanilla\Models\PipelineModel;
+
+/**
+ * Tests for the `Model` class.
+ */
+class PipelineModelTest extends ModelTest {
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        $this->container()->call(function (
+            \Gdn_SQLDriver $sql
+        ) {
+            $sql->truncate('model');
+        });
+
+        /** @var PipelineModel $model */
+        $model = $this->container()->getArgs(PipelineModel::class, ['model']);
+        $model->addPipelineProcessor(new JsonFieldProcessor(['attributes']));
+        $this->model = $model;
+    }
+}


### PR DESCRIPTION
Since https://github.com/vanilla/vanilla/pull/10764 we are now running pipelines on delete operations.

CI over here is failing because we have tests for a delete operation on a pipelinemodel using the JsonFieldProcessor. https://app.circleci.com/jobs/github/vanilla/knowledge/18628

- I've fixed the json processor.
- I've added some tests that reproduced the issue in core.
- I've reviewed all of our other processors. This is the only one with a condition where it would fail to return a value.