### PR TITLE
Fix changing theme not affecting dashboard navigation

### DIFF
--- a/applications/dashboard/controllers/api/DashboardApiController.php
+++ b/applications/dashboard/controllers/api/DashboardApiController.php
@@ -8,31 +8,88 @@
 namespace Vanilla\Dashboard\Api;
 
 use DashboardNavModule;
+use Garden\EventManager;
+use Garden\Schema\Schema;
+use Garden\Web\Data;
+use Garden\Web\RequestInterface;
+use Vanilla\Exception\PermissionException;
 use Vanilla\Web\Controller;
 
 /**
  * Contains information useful for building the dashboard.
  */
 class DashboardApiController extends Controller {
+
+    /** @var \Gdn_Locale */
+    private $locale;
+
+    /** @var EventManager */
+    private $eventManager;
+
+    /**
+     * Constructor.
+     *
+     * @param \Gdn_Locale $locale
+     * @param EventManager $eventManager
+     */
+    public function __construct(\Gdn_Locale $locale, EventManager $eventManager) {
+        $this->locale = $locale;
+        $this->eventManager = $eventManager;
+    }
+
+
+    /**
+     * Get the HTML for the legacy dashboard menu.
+     *
+     * @param RequestInterface $request The request.
+     * @param array $query Query parameters.
+     *
+     * @return array
+     */
+    public function get_menuLegacy(RequestInterface $request, array $query = []) {
+        $this->checkDashboardPermission();
+        $this->locale->set($query['locale']);
+
+        $in = Schema::parse([
+            "activeUrl:s",
+            "section:s?" => [
+                "enum" => ["moderation", "settings"],
+            ],
+            "locale:s",
+        ]);
+
+        $params = $in->validate($query);
+        $section = ucfirst($query['section'] ?? 'settings');
+
+        $activeUrl = $params['activeUrl'];
+        if (filter_var($activeUrl, FILTER_VALIDATE_URL)) {
+            $activeUrlPath = parse_url($activeUrl, PHP_URL_PATH);
+            $toReplace = $request->getAssetRoot();
+            $activeUrlPath = str_replace($toReplace, '', $activeUrlPath);
+        } else {
+            $activeUrlPath = $activeUrl;
+        }
+
+        $dashboardNavModule = new DashboardNavModule();
+        $dashboardNavModule->setCurrentSections([$section]);
+        $dashboardNavModule->setHighlightRoute($activeUrlPath);
+
+        // Getting menus will call any necessary events.
+        $dashboardNavModule->getMenus();
+
+        $result = $dashboardNavModule->toString();
+        return [
+            'html' => $result,
+        ];
+    }
+
     /**
      * Get the menus in the dashboard.
      *
      * @return array Returns the menus.
      */
     public function index_menus() {
-        // This is the array of permissions from the module.
-        // We just want to make sure the user has at least one of the permissions although if they don't then the menus would be empty.
-        $this->permission([
-            'Garden.Settings.Manage',
-            'Garden.Community.Manage',
-            'Garden.Moderation.Manage',
-            'Garden.Settings.View',
-            'Moderation.ModerationQueue.Manage',
-            'Garden.Users.Add',
-            'Garden.Users.Edit',
-            'Garden.Users.Delete',
-            'Garden.Users.Approve',
-        ]);
+        $this->checkDashboardPermission();
 
         $in = $this->schema([], 'in')->setDescription('List the dashboard menus.');
         $out = $this->schema([
@@ -72,5 +129,25 @@ class DashboardApiController extends Controller {
         $result = $out->validate($result);
 
         return $result;
+    }
+
+    /**
+     * This is the array of permissions from the module.
+     * We just want to make sure the user has at least one of the permissions although if they don't then the menus would be empty.
+     *
+     * @throws PermissionException If the user doesn't have enough permission.
+     */
+    private function checkDashboardPermission() {
+        $this->permission([
+            'Garden.Settings.Manage',
+            'Garden.Community.Manage',
+            'Garden.Moderation.Manage',
+            'Garden.Settings.View',
+            'Moderation.ModerationQueue.Manage',
+            'Garden.Users.Add',
+            'Garden.Users.Edit',
+            'Garden.Users.Delete',
+            'Garden.Users.Approve',
+        ]);
     }
 }

--- a/applications/dashboard/openapi/dashboard.yml
+++ b/applications/dashboard/openapi/dashboard.yml
@@ -107,3 +107,45 @@ paths:
                   - groups
                 type: array
           description: Success
+  /dashboard/menu-legacy:
+    get:
+      x-hidden: true
+      summary: Get an HTML dashboard menu.
+      description: |
+        This endpoint is for internal use only. It is subject to change at any time. It generates the dashboard panel HTML.
+      tags:
+      - Dashboard
+      parameters:
+        - in: query
+          name: locale
+          description: The locale to get the HTML in.
+          example: en
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: activeUrl
+          description: The currently active page URL. Used to set the active item.
+          example: https://mysite.com/forum/settings/brandin
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: section
+          description: Section of the dashboard to load for.
+          schema:
+            type: string
+            enum:
+              - settings
+              - moderation
+      responses:
+        '200':
+          content:
+            'application/json':
+              schema:
+                type: object
+                properties:
+                  html:
+                    type: string
+                    description: HTML contents of the panel.
+          description: Success

--- a/applications/dashboard/src/scripts/reloadDashboardNav.tsx
+++ b/applications/dashboard/src/scripts/reloadDashboardNav.tsx
@@ -1,0 +1,39 @@
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import apiv2 from "@vanilla/library/src/scripts/apiv2";
+import { getCurrentLocale } from "@vanilla/i18n";
+import { logError, logWarning } from "@vanilla/utils";
+import { triggerContentLoaded } from "@vanilla/library/src/scripts/utility/appUtils";
+
+/**
+ * Reload the dashboard navigation.
+ */
+export async function reloadDashboardNav() {
+    try {
+        const panel = document.querySelector(".js-panel-nav");
+        if (!(panel instanceof HTMLElement)) {
+            logWarning("Could not find dashboard navigation to replace.");
+            return;
+        }
+        const response = await apiv2.get("/dashboard/menu-legacy", {
+            params: {
+                locale: getCurrentLocale(),
+                activeUrl: window.location.href,
+            },
+        });
+
+        const html = response.data?.html ?? null;
+        if (!html) {
+            logError("No valid panel HTML to insert.");
+            return;
+        }
+
+        panel.innerHTML = html;
+        triggerContentLoaded();
+    } catch (error) {
+        logError(error);
+    }
+}

--- a/library/src/scripts/bootstrap.ts
+++ b/library/src/scripts/bootstrap.ts
@@ -5,7 +5,7 @@
  * @license GPL-2.0-only
  */
 
-import { onContent, getMeta, _executeReady } from "@library/utility/appUtils";
+import { onContent, getMeta, _executeReady, triggerContentLoaded } from "@library/utility/appUtils";
 import { logDebug, logError, debug } from "@vanilla/utils";
 import { translationDebug } from "@vanilla/i18n";
 import apiv2 from "@library/apiv2";
@@ -58,8 +58,7 @@ _executeReady()
             mountInputs();
         });
 
-        const contentEvent = new CustomEvent("X-DOMContentReady", { bubbles: true, cancelable: false });
-        document.dispatchEvent(contentEvent);
+        triggerContentLoaded();
     })
     .catch(error => {
         logError(error);

--- a/library/src/scripts/theming/ThemeActions.ts
+++ b/library/src/scripts/theming/ThemeActions.ts
@@ -11,6 +11,7 @@ import { IThemeInfo } from "@library/theming/CurrentThemeInfo";
 import { resetThemeCache } from "@library/styles/styleUtils";
 import { reinit, forceRenderStyles } from "typestyle";
 import { setMeta } from "@library/utility/appUtils";
+import { reloadDashboardNav } from "@dashboard/reloadDashboardNav";
 
 const createAction = actionCreatorFactory("@@themes");
 
@@ -110,6 +111,8 @@ export default class ThemeActions extends ReduxActions {
             const response = await this.api.put(`/themes/current`, body);
             setMeta("ui.themeKey", themeID);
             setMeta("ui.mobileThemeKey", themeID);
+            setMeta("ui.desktopThemeKey", themeID);
+            reloadDashboardNav();
             return response.data;
         })(body);
         return this.dispatch(thunk);

--- a/library/src/scripts/utility/appUtils.tsx
+++ b/library/src/scripts/utility/appUtils.tsx
@@ -249,6 +249,11 @@ export function removeOnContent(callback: (event: CustomEvent) => void) {
     document.removeEventListener("X-DOMContentReady", callback);
 }
 
+export function triggerContentLoaded() {
+    const contentEvent = new CustomEvent("X-DOMContentReady", { bubbles: true, cancelable: false });
+    document.dispatchEvent(contentEvent);
+}
+
 /**
  * Make a URL to a user's profile.
  */

--- a/tests/APIv2/DashboardTest.php
+++ b/tests/APIv2/DashboardTest.php
@@ -7,10 +7,16 @@
 
 namespace VanillaTests\APIv2;
 
+use Garden\EventManager;
+
 /**
  * Tests for the /api/v2/dashboard endpoints.
  */
 class DashboardTest extends AbstractAPIv2Test {
+
+    private $calledInit = false;
+
+    private $calledLegacyInit = false;
 
     /**
      * A basic smoke test of the dashboard menus.
@@ -19,5 +25,47 @@ class DashboardTest extends AbstractAPIv2Test {
         $r = $this->api()->get('/dashboard/menus');
         $data = $r->getBody();
         $this->assertSame(3, count($data));
+    }
+
+    /**
+     * Handler for the modern init.
+     */
+    public function dashboardNavModule_init_handler() {
+        $this->calledInit = true;
+    }
+
+    /**
+     * Handler for the legacy init.
+     *
+     * @param mixed $sender
+     */
+    public function base_getAppSettingsMenuItems_handler($sender) {
+        $this->calledLegacyInit = true;
+        $adapter = $sender->EventArguments['SideMenu'];
+        $this->assertInstanceOf(\NestedCollectionAdapter::class, $adapter);
+    }
+
+    /**
+     * A basic smoke test of the dashboard menu html handler.
+     */
+    public function testHtmlMenuSmoke() {
+        /** @var EventManager $eventManager */
+        $eventManager = self::container()->get(EventManager::class);
+        $eventManager->bindClass($this);
+
+        $noActive = $this->api()->get('/dashboard/menu-legacy', [
+            'activeUrl' => 'https://test.com',
+            'locale' => 'en',
+        ])->getBody();
+
+        $this->assertNotNull($noActive['html']);
+        $this->assertTrue($this->calledInit);
+        $this->assertTrue($this->calledLegacyInit);
+
+        $actualActive = $this->api()->get('/dashboard/menu-legacy', [
+            'activeUrl' => \Gdn::request()->getSimpleUrl('/dashboard/settings/branding'),
+            'locale' => 'en',
+        ])->getBody();
+        $this->assertEquals($actualActive, $noActive);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vanilla/support/issues/2084

- Adds an endpoint to return dashboard nav HTML.

  Here's the API documentation (even though I have the x-hidden flag to hide it).

  ![image](https://user-images.githubusercontent.com/1770056/84712583-f44cf380-af36-11ea-8909-9feee45787ed.png)

- Adds tests for that endpoint.
- Adds frontend method for reloading the dashboard navigation.
- Have frontend call this method after changing themes.
