### PR TITLE
Change the no bookmarks translation code

### DIFF
--- a/applications/vanilla/views/discussions/popin.php
+++ b/applications/vanilla/views/discussions/popin.php
@@ -36,6 +36,6 @@
             ?>
         </li>
     <?php else: ?>
-        <li class="Item Empty Center"><?php echo t('Bookmark a discussion using its star icon.', 'You do not have any bookmarks.'); ?></li>
+        <li class="Item Empty Center"><?php echo t('You do not have any bookmarks.', 'You do not have any bookmarks.'); ?></li>
     <?php endif; ?>
 </ul>


### PR DESCRIPTION
This was actually a fairly tedious support issue to track down because both the old and new translation key were in different resources.