### PR TITLE
Add convenience method for replacing shared instances in the container

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -604,9 +604,11 @@ register_shutdown_function(function () use ($dic) {
     $dic->get(\Garden\EventManager::class)->fire('SchedulerDispatch');
 });
 
-// Construct the logger earlier so that its dependencies are satisfied.
-$log = $dic->get(\Vanilla\Logging\LogDecorator::class);
-// Replace the logger interface with the decorator.
-$dic->rule(\Vanilla\Logging\LogDecorator::class)
-    ->addAlias(\Psr\Log\LoggerInterface::class);
+// Add the log decorator.
+ContainerUtils::replace(
+    $dic,
+    \Psr\Log\LoggerInterface::class,
+    \Vanilla\Logging\LogDecorator::class,
+    true
+);
 Logger::setLogger(null);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -608,7 +608,6 @@ register_shutdown_function(function () use ($dic) {
 ContainerUtils::replace(
     $dic,
     \Psr\Log\LoggerInterface::class,
-    \Vanilla\Logging\LogDecorator::class,
-    true
+    \Vanilla\Logging\LogDecorator::class
 );
 Logger::setLogger(null);

--- a/library/Vanilla/Utility/ContainerUtils.php
+++ b/library/Vanilla/Utility/ContainerUtils.php
@@ -88,8 +88,7 @@ class ContainerUtils {
      */
     public static function replace(Container $container, string $target, string $replacement): void {
         if ($container->hasInstance($target)) {
-            $new = $container->get($replacement);
-            $container->setInstance($target, $new);
+            $container->setInstance($target, null);
         }
 
         $container->rule($replacement)

--- a/library/Vanilla/Utility/ContainerUtils.php
+++ b/library/Vanilla/Utility/ContainerUtils.php
@@ -75,7 +75,7 @@ class ContainerUtils {
 
     /**
      * Replace one type of object in the container with another type of object. Existing shared instances will be
-     * overwritten. Optionally, an alias may be created from the original type to the new type.
+     * overwritten. An alias will be created from the original type to the new type.
      *
      * Sometimes an object has limitations or shortcomings that could be resolved by something like a decorator, where
      * a drop-in replacement wraps existing functionality in enhancements or customizations. This method could configure
@@ -85,21 +85,14 @@ class ContainerUtils {
      * @param Container $container Container to configure.
      * @param string $target Container rule to target for replacement. Shared instances will be overwritten.
      * @param string $replacement Container rule used to determine what will be replace the target in the container.
-     * @param bool $addAlias Should an alias from the target rule be made to the replacement?
      */
-    public static function replace(
-        Container $container,
-        string $target,
-        string $replacement,
-        bool $addAlias = false
-    ): void {
+    public static function replace(Container $container, string $target, string $replacement): void {
         if ($container->hasInstance($target)) {
             $new = $container->get($replacement);
             $container->setInstance($target, $new);
         }
-        if ($addAlias) {
-            $container->rule($replacement)
-                ->addAlias($target);
-        }
+
+        $container->rule($replacement)
+            ->addAlias($target);
     }
 }

--- a/library/Vanilla/Utility/ContainerUtils.php
+++ b/library/Vanilla/Utility/ContainerUtils.php
@@ -79,6 +79,7 @@ class ContainerUtils {
      * @param Container $container
      * @param string $target
      * @param string $replacement
+     * @param bool $addAlias
      */
     public static function replace(
         Container $container,

--- a/library/Vanilla/Utility/ContainerUtils.php
+++ b/library/Vanilla/Utility/ContainerUtils.php
@@ -74,12 +74,18 @@ class ContainerUtils {
     }
 
     /**
-     * Replace container instance of a class, if present, and optionally add it as an alias for its replacement.
+     * Replace one type of object in the container with another type of object. Existing shared instances will be
+     * overwritten. Optionally, an alias may be created from the original type to the new type.
      *
-     * @param Container $container
-     * @param string $target
-     * @param string $replacement
-     * @param bool $addAlias
+     * Sometimes an object has limitations or shortcomings that could be resolved by something like a decorator, where
+     * a drop-in replacement wraps existing functionality in enhancements or customizations. This method could configure
+     * a container to use the decorator, replacing stored instances and ensuring new requests to the container would
+     * receive the decorator instead of the original class.
+     *
+     * @param Container $container Container to configure.
+     * @param string $target Container rule to target for replacement. Shared instances will be overwritten.
+     * @param string $replacement Container rule used to determine what will be replace the target in the container.
+     * @param bool $addAlias Should an alias from the target rule be made to the replacement?
      */
     public static function replace(
         Container $container,

--- a/library/Vanilla/Utility/ContainerUtils.php
+++ b/library/Vanilla/Utility/ContainerUtils.php
@@ -83,15 +83,15 @@ class ContainerUtils {
      * receive the decorator instead of the original class.
      *
      * @param Container $container Container to configure.
-     * @param string $target Container rule to target for replacement. Shared instances will be overwritten.
-     * @param string $replacement Container rule used to determine what will be replace the target in the container.
+     * @param string $old Container rule to target for replacement. Shared instances will be overwritten.
+     * @param string $new Container rule used to determine what will be replace the target in the container.
      */
-    public static function replace(Container $container, string $target, string $replacement): void {
-        if ($container->hasInstance($target)) {
-            $container->setInstance($target, null);
+    public static function replace(Container $container, string $old, string $new): void {
+        if ($container->hasInstance($old)) {
+            $container->setInstance($old, null);
         }
 
-        $container->rule($replacement)
-            ->addAlias($target);
+        $container->rule($new)
+            ->addAlias($old);
     }
 }

--- a/library/Vanilla/Utility/ContainerUtils.php
+++ b/library/Vanilla/Utility/ContainerUtils.php
@@ -8,12 +8,12 @@
 namespace Vanilla\Utility;
 
 use Garden\Container\Callback;
-use Garden\Container\Reference;
+use Garden\Container\Container;
 use Garden\Container\ReferenceInterface;
 use Psr\Container\ContainerInterface;
 use Vanilla\Contracts\ConfigurationInterface;
-use Vanilla\AddonManager;
 use Vanilla\Theme\ThemeService;
+use Vanilla\Web\Asset\DeploymentCacheBuster;
 
 /**
  * Utility functions for container configuration.
@@ -67,9 +67,32 @@ class ContainerUtils {
     public static function cacheBuster(): ReferenceInterface {
         return new Callback(
             function (ContainerInterface $dic) {
-                $cacheBuster = $dic->get(\Vanilla\Web\Asset\DeploymentCacheBuster::class);
+                $cacheBuster = $dic->get(DeploymentCacheBuster::class);
                 return $cacheBuster->value();
             }
         );
+    }
+
+    /**
+     * Replace container instance of a class, if present, and optionally add it as an alias for its replacement.
+     *
+     * @param Container $container
+     * @param string $target
+     * @param string $replacement
+     */
+    public static function replace(
+        Container $container,
+        string $target,
+        string $replacement,
+        bool $addAlias = false
+    ): void {
+        if ($container->hasInstance($target)) {
+            $new = $container->get($replacement);
+            $container->setInstance($target, $new);
+        }
+        if ($addAlias) {
+            $container->rule($replacement)
+                ->addAlias($target);
+        }
     }
 }

--- a/tests/Library/Vanilla/Utility/ContainerUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/ContainerUtilsTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Utility;
+
+use Garden\Container\Container;
+use PHPUnit\Framework\TestCase;
+use Vanilla\Utility\ContainerUtils;
+use VanillaTests\Fixtures\Aliases\ExtendsNewClass;
+use VanillaTests\Fixtures\Aliases\NewClass;
+
+class ContainerUtilsTest extends TestCase {
+
+    /** @var Container */
+    private $container;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->container = new Container();
+    }
+
+    /**
+     * Verify replacing instance, including an alias.
+     */
+    public function testReplaceAlias(): void {
+        $this->container->rule(NewClass::class)->setShared(true);
+
+        $original = $this->container->get(NewClass::class);
+        $this->assertInstanceOf(NewClass::class, $original);
+
+        ContainerUtils::replace(
+            $this->container,
+            NewClass::class,
+            ExtendsNewClass::class,
+            true
+        );
+
+        // Verify replacement.
+        $replacement = $this->container->get(NewClass::class);
+        $this->assertInstanceOf(ExtendsNewClass::class, $replacement);
+
+        // Verify alias.
+        $this->container->setInstance(NewClass::class, null);
+        $aliased = $this->container->get(NewClass::class);
+        $this->assertInstanceOf(ExtendsNewClass::class, $aliased);
+    }
+
+    /**
+     * Verify replacing instance, without an alias.
+     */
+    public function testReplaceWithoutAlias(): void {
+        $this->container->rule(NewClass::class)->setShared(true);
+
+        $original = $this->container->get(NewClass::class);
+        $this->assertInstanceOf(NewClass::class, $original);
+
+        ContainerUtils::replace(
+            $this->container,
+            NewClass::class,
+            ExtendsNewClass::class,
+            false
+        );
+
+        // Verify replacement.
+        $replacement = $this->container->get(NewClass::class);
+        $this->assertInstanceOf(ExtendsNewClass::class, $replacement);
+
+        // Verify no alias set.
+        $this->container->setInstance(NewClass::class, null);
+        $aliased = $this->container->get(NewClass::class);
+        $this->assertSame(NewClass::class, get_class($aliased));
+    }
+}

--- a/tests/Library/Vanilla/Utility/ContainerUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/ContainerUtilsTest.php
@@ -31,7 +31,7 @@ class ContainerUtilsTest extends TestCase {
     /**
      * Verify replacing instance, including an alias.
      */
-    public function testReplaceAlias(): void {
+    public function testReplace(): void {
         $this->container->rule(NewClass::class)->setShared(true);
 
         $original = $this->container->get(NewClass::class);
@@ -40,8 +40,7 @@ class ContainerUtilsTest extends TestCase {
         ContainerUtils::replace(
             $this->container,
             NewClass::class,
-            ExtendsNewClass::class,
-            true
+            ExtendsNewClass::class
         );
 
         // Verify replacement.
@@ -52,31 +51,5 @@ class ContainerUtilsTest extends TestCase {
         $this->container->setInstance(NewClass::class, null);
         $aliased = $this->container->get(NewClass::class);
         $this->assertInstanceOf(ExtendsNewClass::class, $aliased);
-    }
-
-    /**
-     * Verify replacing instance, without an alias.
-     */
-    public function testReplaceWithoutAlias(): void {
-        $this->container->rule(NewClass::class)->setShared(true);
-
-        $original = $this->container->get(NewClass::class);
-        $this->assertInstanceOf(NewClass::class, $original);
-
-        ContainerUtils::replace(
-            $this->container,
-            NewClass::class,
-            ExtendsNewClass::class,
-            false
-        );
-
-        // Verify replacement.
-        $replacement = $this->container->get(NewClass::class);
-        $this->assertInstanceOf(ExtendsNewClass::class, $replacement);
-
-        // Verify no alias set.
-        $this->container->setInstance(NewClass::class, null);
-        $aliased = $this->container->get(NewClass::class);
-        $this->assertSame(NewClass::class, get_class($aliased));
     }
 }

--- a/tests/Library/Vanilla/Utility/ContainerUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/ContainerUtilsTest.php
@@ -12,6 +12,9 @@ use Vanilla\Utility\ContainerUtils;
 use VanillaTests\Fixtures\Aliases\ExtendsNewClass;
 use VanillaTests\Fixtures\Aliases\NewClass;
 
+/**
+ * Tests for the container utilities class.
+ */
 class ContainerUtilsTest extends TestCase {
 
     /** @var Container */


### PR DESCRIPTION
This update adds a `replace` method to `ContainerUtils` that performs the following:

1. Replaces a shared instance of a class, if available.
1. Optionally adds an alias from the original class to the replacement class.

The method is used to replace the introduction of the log decorator in the bootstrap.

The `ContainerUtils` class has been cleaned up a little to satisfy my IDE.