### PR TITLE
Fix deleting user attachments when deleting user content

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -4066,6 +4066,9 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
         // Remove comments in moderation queue
         $this->getDelete('Log', ['RecordUserID' => $userID, 'Operation' => 'Pending'], $content);
 
+        // Remove media.
+        $this->getDelete('Media', ['InsertUserID' => $userID], $content);
+
         // Clear out information on the user.
         $this->setField($userID, [
             'About' => null,


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/2053

### Details

When deleting user with "Delete user content option" user's media does not get deleted.
<img width="234" alt="Screen Shot 2020-06-16 at 6 56 22 PM" src="https://user-images.githubusercontent.com/31856281/84836241-58d58480-b003-11ea-85e8-dfb1a76e0d5e.png">


**To Test**

- Delete a user
- Check if the user's media files got deleted in GDN_Media  