### PR TITLE
Keep text field lengths the same on alters

### DIFF
--- a/applications/dashboard/settings/class.hooks.php
+++ b/applications/dashboard/settings/class.hooks.php
@@ -939,4 +939,15 @@ class DashboardHooks extends Gdn_Plugin {
 
         $args['Path'] = $localPath;
     }
+
+    /**
+     * Keep text fields their lengths when altering tables.
+     *
+     * @param \Gdn_DatabaseStructure $structure
+     */
+    public function gdn_mySQLStructure_beforeSet(\Gdn_DatabaseStructure $structure): void {
+        if (!\Vanilla\FeatureFlagHelper::featureEnabled(\Vanilla\Utility\SqlUtils::FEATURE_ALTER_TEXT_FIELD_LENGTHS)) {
+            \Vanilla\Utility\SqlUtils::keepTextFieldLengths($structure);
+        }
+    }
 }

--- a/library/Vanilla/Utility/SqlUtils.php
+++ b/library/Vanilla/Utility/SqlUtils.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace Vanilla\Utility;
+
+use Gdn_DatabaseStructure;
+
+/**
+ * Utilities that act on the `Gdn_SQLDriver` and `Gdn_Structure` classes.
+ */
+final class SqlUtils {
+    public const FEATURE_ALTER_TEXT_FIELD_LENGTHS = 'alterTextFieldLengths';
+
+    /**
+     * @param Gdn_DatabaseStructure $structure
+     */
+    public static function keepTextFieldLengths(Gdn_DatabaseStructure $structure): void {
+        $textTypes = ['tinytext' => 1, 'text' => 2, 'mediumtext' => 3, 'longtext' => 4];
+
+        if (!$structure->tableExists()) {
+            return;
+        }
+
+        $old = $structure->existingColumns();
+
+        foreach ($old as $name => $oldDef) {
+            $oldType = strtolower($oldDef->Type ?? '');
+            if (!isset($textTypes[$oldType])) {
+                continue;
+            }
+
+            if (null !== $newDef = $structure->columns($name)) {
+                $newType = strtolower($newDef->Type ?? '');
+                if ($textTypes[$oldType] !== ($textTypes[$newType] ?? 0)) {
+                    $newDef->Type = $oldType;
+                }
+            }
+        }
+    }
+}

--- a/library/Vanilla/Utility/SqlUtils.php
+++ b/library/Vanilla/Utility/SqlUtils.php
@@ -16,6 +16,18 @@ final class SqlUtils {
     public const FEATURE_ALTER_TEXT_FIELD_LENGTHS = 'alterTextFieldLengths';
 
     /**
+     * Protect against alters of text field lengths.
+     *
+     * This method is meant to be run just before a call to `Gdn_DatabaseStructure::set()`. It ensures that existing
+     * text fields don't get altered. Why? Well for two reasons:
+     *
+     * 1. Sometimes a site needs a different size text field (usually larger).
+     * 2. It doesn't really hurt anything to have a different size text field on a site.
+     * 3. Altering tables is expensive, especially on the types of tables that have text fields. Best to avoid that.
+     *
+     * You can call this method directly, but it's also something that can be bound to the `"gdn_mySQLStructure_beforeSet"`
+     * event to act site-wide. Neat.
+     *
      * @param Gdn_DatabaseStructure $structure
      */
     public static function keepTextFieldLengths(Gdn_DatabaseStructure $structure): void {

--- a/library/Vanilla/Utility/SqlUtils.php
+++ b/library/Vanilla/Utility/SqlUtils.php
@@ -34,10 +34,7 @@ final class SqlUtils {
             }
 
             if (null !== $newDef = $structure->columns($name)) {
-                $newType = strtolower($newDef->Type ?? '');
-                if ($textTypes[$oldType] !== ($textTypes[$newType] ?? 0)) {
-                    $newDef->Type = $oldType;
-                }
+                $newDef->Type = $oldType;
             }
         }
     }

--- a/tests/Library/Vanilla/Utility/SqlUtilsTest.php
+++ b/tests/Library/Vanilla/Utility/SqlUtilsTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Vanilla\Utility;
+
+use Garden\EventManager;
+use PHPUnit\Framework\TestCase;
+use Vanilla\Utility\SqlUtils;
+use VanillaTests\BootstrapTrait;
+use VanillaTests\SetupTraitsTrait;
+
+/**
+ * Testa for the `SqlUtils` helpers.
+ */
+class SqlUtilsTest extends TestCase {
+    use SetupTraitsTrait, BootstrapTrait;
+    /**
+     * @var \Gdn_MySQLStructure
+     */
+    private $structure;
+
+    /**
+     * @var \Gdn_MySQLDriver
+     */
+    private $sql;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->setupTestTraits();
+        $this->initializeDatabase();
+
+        $this->container()->call(function (
+            \Gdn_MySQLStructure $structure,
+            \Gdn_MySQLDriver $sql
+        ) {
+            $this->structure = $structure;
+            $this->sql = $sql;
+        });
+    }
+
+    /**
+     * Larger text fields should be kept when altering a table.
+     */
+    public function testKeepTextFields(): void {
+        $this->doKeepTextFieldsTest(__FUNCTION__, function () {
+            SqlUtils::keepTextFieldLengths($this->structure);
+        });
+    }
+
+    /**
+     * The `SqlUtils::keepTextFields()` helper should work as an event handler.
+     */
+    public function testKeepTextFieldsEvent(): void {
+        $this->doKeepTextFieldsTest(__FUNCTION__, function () {
+            $this->container()->call(function (EventManager $events) {
+                $events->bind(\Gdn_MySQLStructure::class.'_beforeSet', [SqlUtils::class, 'keepTextFieldLengths']);
+            });
+        });
+    }
+
+    /**
+     * Run the actual test for `SqlUtils::keepTextFields()`.
+     *
+     * @param string $tableName
+     * @param callable $keep
+     */
+    protected function doKeepTextFieldsTest(string $tableName, callable $keep): void {
+        $this->structure->table($tableName);
+
+        // Create a basic table first.
+        $this->structure->table($tableName)
+            ->primaryKey('id')
+            ->column('Body', 'mediumtext')
+            ->set();
+
+        // Now do an alter and make sure it works.
+        $this->structure->table($tableName)
+            ->column('body', 'text');
+
+        $keep();
+
+        $this->structure->set();
+
+        // Now see if the table was altered.
+        $columns = $this->structure->table($tableName)->existingColumns();
+        $this->assertSame('mediumtext', $columns['body']->Type);
+    }
+}


### PR DESCRIPTION
This feature will ensure that text fields are not altered when the database alters if the old field is already a text field.

Sometimes a text field changes in size for whatever reason or sometimes a particular site requires a larger field. We want to be able to support those scenarios without being spammed on database alters.

This feature does not come without some risk: we are hiding inconsistency in our system and we are changing some important, low-level code. However, that risk is mitigated with tests and best practices. We should use this feature rarely and carefully.

Closes https://github.com/vanilla/internal/issues/2730