### PR TITLE
fix Applicants count on UserDropDownContents

### DIFF
--- a/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
+++ b/library/src/scripts/headers/mebox/pieces/UserDropDownContents.tsx
@@ -68,7 +68,7 @@ function UserDropDownContents(props: IProps) {
                     <DropDownItemLinkWithCount
                         to={"/dashboard/user/applicants"}
                         name={t("Applicants")}
-                        count={getCountByName("Applications")}
+                        count={getCountByName("Applicants")}
                     />
                     <DropDownItemLinkWithCount
                         to={"/dashboard/log/spam"}


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/2055

**Steps to reproduce:**
- Have some applicants count
- Enable Foundation theme or Keystone with `$Configuration['Feature']['DataDrivenTitleBar']['Enabled'] = true;`
- Check that the Applicants count don't match
- Checkout this branch