### PR TITLE
Backport: Add SVG pointer events fix to Vanilla Stats page override 

### DIFF
--- a/plugins/VanillaStats/class.vanillastats.plugin.php
+++ b/plugins/VanillaStats/class.vanillastats.plugin.php
@@ -115,6 +115,8 @@ class VanillaStatsPlugin extends Gdn_Plugin {
         $sender->permission($sender->RequiredAdminPermissions, '', false);
         $sender->setHighlightRoute('dashboard/settings');
 
+        $sender->CssClass .= " dashboard";
+
         if (!Gdn_Statistics::checkIsEnabled() && Gdn_Statistics::checkIsLocalhost()) {
             $sender->render('dashboardlocalhost', '', 'plugins/VanillaStats');
         } else {


### PR DESCRIPTION
Backporting #10810 to `release/2020.012`.

> #10700 fixed pointer events with SVGs in the dashboard, but Vanilla Stats overrides some dashboard pages and was not getting this fix because of it. This update applies the same fix to the Vanilla Stats page override.