### PR TITLE
Add the role ID parameter to the GET /users endpoint

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -22,6 +22,7 @@ use Vanilla\Utility\DelimitedScheme;
 use Vanilla\Menu\CounterModel;
 use Vanilla\Utility\InstanceValidatorSchema;
 use Vanilla\Menu\Counter;
+use Vanilla\Utility\SchemaUtils;
 
 /**
  * API Controller for the `/users` resource.
@@ -474,6 +475,9 @@ class UsersApiController extends AbstractApiController {
                     'processor' => [DateFilterSchema::class, 'dateFilterField'],
                 ],
             ]),
+            'roleID:i?' => [
+                'x-filter' => ['field' => 'roleID']
+            ],
             'userID?' => \Vanilla\Schema\RangeExpression::createSchema([':int'])->setField('x-filter', ['field' => 'u.UserID']),
             'page:i?' => [
                 'description' => 'Page number. See [Pagination](https://docs.vanillaforums.com/apiv2/#pagination).',
@@ -489,7 +493,8 @@ class UsersApiController extends AbstractApiController {
             'sort:s?' => [
                 'enum' => ApiUtils::sortEnum('dateInserted', 'dateLastActive', 'name', 'userID')
             ]
-        ], ['UserIndex', 'in']);
+        ], ['UserIndex', 'in'])
+            ->addValidator("", SchemaUtils::onlyOneOf(["dateInserted", "dateUpdated", "roleID", "userID"]));
         $out = $this->schema([':a' => $this->userSchema()], 'out');
 
         $query = $in->validate($query);

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -2898,7 +2898,8 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
             $where = $filter;
             $keywords = val('Keywords', $filter, '');
             $optimize = val('Optimize', $filter);
-            unset($where['Keywords'], $where['Optimize']);
+            $roleID = $filter["roleID"] ?? null;
+            unset($where['Keywords'], $where['Optimize'], $where["roleID"]);
         } else {
             $keywords = $filter;
         }
@@ -2914,7 +2915,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
         } elseif (preg_match('/^\d+$/', $keywords)) {
             $numericQuery = $keywords;
             $keywords = '';
-        } elseif (!empty($keywords)) {
+        } elseif (!empty($roleID) && !empty($keywords)) {
             // Check to see if the search exactly matches a role name.
             $roleID = $this->SQL->getWhere('Role', ['Name' => $keywords])->value('RoleID');
         }
@@ -3029,18 +3030,20 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
      * @return int
      */
     public function searchCount($filter = '') {
+        $roleID = false;
+
         if (is_array($filter)) {
             $where = $filter;
             $keywords = $where['Keywords'] ?? '';
-            unset($where['Keywords'], $where['Optimize']);
+            $roleID = $where["roleID"] ?? false;
+            unset($where['Keywords'], $where['Optimize'], $where["roleID"]);
         } else {
             $keywords = $filter;
         }
         $keywords = trim($keywords);
 
         // Check to see if the search exactly matches a role name.
-        $roleID = false;
-        if ($keywords !== "") {
+        if (empty($roleID) && $keywords !== "") {
             if (strtolower($keywords) == 'banned') {
                 $this->SQL->where('u.Banned >', 0);
             } else {

--- a/applications/dashboard/openapi/users.yml
+++ b/applications/dashboard/openapi/users.yml
@@ -38,6 +38,11 @@ paths:
         schema:
           format: date-filter
           type: string
+      - name: roleID
+        description: Filter by the role ID of a user.
+        in: query
+        schema:
+          type: integer
       - name: userID
         description: Filter by a range or CSV of user IDs.
         in: query

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -685,4 +685,17 @@ class UsersTest extends AbstractResourceTest {
         ksort($registeredUser);
         $this->assertEquals($registration, $registeredUser);
     }
+
+    /**
+     * Test the users role filter.
+     */
+    public function testRoleFilter(): void {
+        $roleID = $this->getRoles()['Moderator'];
+
+        $users = $this->api()->get('/users', ['roleID' => $roleID])->getBody();
+        $this->assertNotEmpty($users);
+        foreach ($users as $user) {
+            $this->assertTrue(in_array($roleID, array_column($user['roles'], 'roleID')), 'The user does not satisfy the roleID filter.');
+        }
+    }
 }

--- a/tests/SiteTestTrait.php
+++ b/tests/SiteTestTrait.php
@@ -58,6 +58,11 @@ trait SiteTestTrait {
     protected $moderatorID;
 
     /**
+     * @var array
+     */
+    protected $roles;
+
+    /**
      * Get the names of addons to install.
      *
      * @return string[] Returns an array of addon names.
@@ -280,7 +285,8 @@ TEMPLATE;
      * @return int
      */
     protected function createUserFixture(string $role, string $sx): int {
-        static $roleIDs;
+        $roleIDs = $this->getRoles();
+
         if (!isset($roleIDs)) {
             $roleIDs = array_column(
                 static::container()->get(\Gdn_SQLDriver::class)->getWhere('Role', [])->resultArray(),
@@ -298,5 +304,22 @@ TEMPLATE;
             ],
         ]);
         return $row['userID'];
+    }
+
+    /**
+     * Return all of the roles, keyed by name.
+     *
+     * @return array
+     */
+    protected function getRoles(): array {
+        if ($this->roles === null) {
+            $roles = array_column(
+                static::container()->get(\Gdn_SQLDriver::class)->getWhere('Role', [])->resultArray(),
+                'RoleID',
+                'Name'
+            );
+            $this->roles = $roles;
+        }
+        return $this->roles;
     }
 }


### PR DESCRIPTION
This PR adds a `roleID` parameter to the `GET /api/v2/users` endpoint. Closes https://github.com/vanilla/support/issues/2151.