### PR TITLE
Fix RangeExpression parameters not being passed in link headers

### DIFF
--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -150,7 +150,7 @@ class ApiUtils {
         $args = [];
         foreach ($query as $key => $value) {
             if ($key !== 'page' && (!isset($properties[$key]['default']) || $value != $properties[$key]['default'])) {
-                $args[$key] = $value;
+                $args[$key] = (string)$value;
             }
         }
         $argsStr = http_build_query($args);

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -97,7 +97,7 @@ class ApiUtils {
         $count = is_array($rows) ? count($rows) : $rows;
 
         return [
-            'page' => $query['page'] ?? 1,
+            'page' => $query['page'] ?: 1,
             'more' => $count === true || $count >= $query['limit'],
             'urlFormat' => static::pagerUrlFormat($url, $query, $schema),
         ];

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -150,7 +150,12 @@ class ApiUtils {
         $args = [];
         foreach ($query as $key => $value) {
             if ($key !== 'page' && (!isset($properties[$key]['default']) || $value != $properties[$key]['default'])) {
-                $args[$key] = (string)$value;
+                if (is_object($value) && method_exists($value, "__toString")) {
+                    // If we can stringify, do it.
+                    $args[$key] = (string)$value;
+                } else {
+                    $args[$key] = $value;
+                }
             }
         }
         $argsStr = http_build_query($args);

--- a/library/Vanilla/ApiUtils.php
+++ b/library/Vanilla/ApiUtils.php
@@ -97,7 +97,7 @@ class ApiUtils {
         $count = is_array($rows) ? count($rows) : $rows;
 
         return [
-            'page' => $query['page'] ?: 1,
+            'page' => $query['page'] ?? 1,
             'more' => $count === true || $count >= $query['limit'],
             'urlFormat' => static::pagerUrlFormat($url, $query, $schema),
         ];


### PR DESCRIPTION
When an object is used internally in an API endpoint, such as `RangeExpression`, pagination headers are not properly including these values. This is due to `http_build_query` not stingifying objects.

`ApiUtils::pagerUrlFormat` has been updated to cast values to strings before attempting to build the query.