### PR TITLE
Add error message when uploading avatar of disallowed file type

### DIFF
--- a/applications/dashboard/controllers/class.profilecontroller.php
+++ b/applications/dashboard/controllers/class.profilecontroller.php
@@ -364,7 +364,7 @@ class ProfileController extends Gdn_Controller {
      */
     public function edit($userReference = '', $username = '', $userID = '') {
         $this->permission(['Garden.SignIn.Allow', 'Garden.Profiles.Edit'], true);
-        
+
         $this->getUserInfo($userReference, $username, $userID, true);
         $userID = valr('User.UserID', $this);
         $settings = [];
@@ -907,7 +907,11 @@ class ProfileController extends Gdn_Controller {
 
                 $this->setRedirectTo(userUrl($this->User));
             }
-            $this->informMessage(t("Your settings have been saved."));
+            if ($upload->Exception) {
+                $this->Form->addError($upload->Exception);
+            } else {
+                $this->informMessage(t("Your settings have been saved."));
+            }
         }
 
         if (val('SideMenuModule', val('Panel', val('Assets', $this)))) {


### PR DESCRIPTION
Closes vanilla/support#2103.

Right now, if you try to upload an avatar that a disallowed file type (e.g., `.exe` or `.svg`), the file is never uploaded, but the user doesn't receive and error message. This PR adds an error message in that case.

### TO TEST
1. Go to `profile/picture` and try to add a disallowed file type.
1. Note that although the image doesn't get uploaded, you get a little inform message in the bottom lefthand corner that reads: "Your settings have been saved"
1. Check out this branch and try to upload the file again.
1. Verify that you get a proper error message.