### PR TITLE
fix category following filter

### DIFF
--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -145,7 +145,9 @@ class DiscussionsController extends VanillaController {
             $followed = false;
         }
         $this->setData('EnableFollowingFilter', $this->enableFollowingFilter);
-        $this->setData('Followed', $followed);
+        if ($this->enableFollowingFilter === true) {
+            $this->setData('Followed', $followed);
+        }
 
         // Set criteria & get discussions data
         $this->setData('Category', false, true);

--- a/applications/vanilla/controllers/class.discussionscontroller.php
+++ b/applications/vanilla/controllers/class.discussionscontroller.php
@@ -145,7 +145,7 @@ class DiscussionsController extends VanillaController {
             $followed = false;
         }
         $this->setData('EnableFollowingFilter', $this->enableFollowingFilter);
-        if ($this->enableFollowingFilter === true) {
+        if ($this->enableFollowingFilter) {
             $this->setData('Followed', $followed);
         }
 


### PR DESCRIPTION
closes https://github.com/vanilla/support/issues/1046

**Details**

Category following filter is getting applied to pages other than /discussions.

**To Test**

- Follow a category
- In recent discussions, filter by followed categories
- Goto /discussions/unanswered, the filter should not be applied to this page

Categories are getting filtered on the discussions/unanswered page because of https://github.com/vanilla/vanilla/blob/7edd743c181f2d80c828f78ccd6724c13b37e122/applications/vanilla/controllers/class.discussionscontroller.php#L165
we are returning followed categories. 


The filtering has been removed from Qna here https://github.com/vanilla/vanilla/pull/7220
