### PR TITLE
Fix kludged flyouts being unnecessarily re-kludged

### DIFF
--- a/applications/vanilla/js/autosave.js
+++ b/applications/vanilla/js/autosave.js
@@ -19,7 +19,9 @@ jQuery(document).ready(function($) {
             ];
             if (!defaultValues.includes(currentVal)) {
                 lastVal = currentVal;
-                $(options.button).click();
+                window.requestAnimationFrame(function () {
+                    $(options.button).click();
+                });
             }
         };
 

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -41,12 +41,12 @@
      * Workarounds for limitations of flyout's HTML structure.
      */
     function kludgeFlyoutHTML() {
-        var $handles = $(".ToggleFlyout, .editor-dropdown, .ButtonGroup");
+        var $handles = $(".ToggleFlyout:not([data-is-kludged]), .editor-dropdown:not([data-is-kludged]), .ButtonGroup:not([data-is-kludged])");
 
-        $handles.each(function() {
+        $handles.each(function () {
             $handles
                 .find(".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)")
-                .each(function() {
+                .each(function () {
                     $(this)
                         .attr("tabindex", "0")
                         .attr("role", "button")
@@ -55,15 +55,17 @@
                     $(this).accessibleFlyoutHandle(false);
                 });
 
-            $handles.find(".Flyout, .Dropdown").each(function() {
+            $handles.find(".Flyout, .Dropdown").each(function () {
                 $(this).accessibleFlyout(false);
 
                 $(this)
                     .find("a")
-                    .each(function() {
+                    .each(function () {
                         $(this).attr("tabindex", "0");
                     });
             });
+
+            $(this).attr("data-is-kludged", "true");
         });
 
         if (USE_NEW_FLYOUTS) {

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -23,6 +23,21 @@
     });
 
     /**
+     * Improve keyboard actions on button-style elements for added accessibility.
+     */
+    $(document).delegate("[role=button]", "keydown", function(event) {
+        var $button = $(this);
+        var ENTER_KEY = 13;
+        var SPACE_KEY = 32;
+        var isActiveElement = document.activeElement === $button[0];
+        var isSpaceOrEnter = event.keyCode === ENTER_KEY || event.keyCode === SPACE_KEY;
+        if (isActiveElement && isSpaceOrEnter) {
+            event.preventDefault();
+            $button.click();
+        }
+    });
+
+    /**
      * Document ready handler. Runs only the first time the page is loaded.
      */
     $(function() {
@@ -69,7 +84,7 @@
         });
 
         if (USE_NEW_FLYOUTS) {
-            var $contents = $(".Flyout, .ButtonGroup .Dropdown");
+            var $contents = $(".Flyout:not([data-is-kludged]), .ButtonGroup .Dropdown:not([data-is-kludged])");
             var wrap = document.createElement("span");
             wrap.classList.add("mobileFlyoutOverlay");
 
@@ -82,21 +97,10 @@
                 // Some flyouts had conflicting inline display: none directly in the view.
                 // We don't change that on open/close with the new style anymore so let's clean it up here.
                 $item.removeAttr("style");
+
+                $(this).attr("data-is-kludged", "true");
             });
         }
-
-        // Button accessibility
-        $(document).delegate("[role=button]", "keydown", function(event) {
-            var $button = $(this);
-            var ENTER_KEY = 13;
-            var SPACE_KEY = 32;
-            var isActiveElement = document.activeElement === $button[0];
-            var isSpaceOrEnter = event.keyCode === ENTER_KEY || event.keyCode === SPACE_KEY;
-            if (isActiveElement && isSpaceOrEnter) {
-                event.preventDefault();
-                $button.click();
-            }
-        });
     }
 
     var BODY_CLASS = "flyoutIsOpen";

--- a/js/flyouts.js
+++ b/js/flyouts.js
@@ -43,10 +43,10 @@
     function kludgeFlyoutHTML() {
         var $handles = $(".ToggleFlyout:not([data-is-kludged]), .editor-dropdown:not([data-is-kludged]), .ButtonGroup:not([data-is-kludged])");
 
-        $handles.each(function () {
+        $handles.each(function() {
             $handles
                 .find(".FlyoutButton, .Button-Options, .Handle, .editor-action:not(.editor-action-separator)")
-                .each(function () {
+                .each(function() {
                     $(this)
                         .attr("tabindex", "0")
                         .attr("role", "button")
@@ -55,12 +55,12 @@
                     $(this).accessibleFlyoutHandle(false);
                 });
 
-            $handles.find(".Flyout, .Dropdown").each(function () {
+            $handles.find(".Flyout, .Dropdown").each(function() {
                 $(this).accessibleFlyout(false);
 
                 $(this)
                     .find("a")
-                    .each(function () {
+                    .each(function() {
                         $(this).attr("tabindex", "0");
                     });
             });


### PR DESCRIPTION
Making some improvements to saving drafts and kludging flyouts.

1. Saving drafts will be de-prioritized a bit in the browser by way of [`window.requestAnimationFrame`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame).
1. All flyouts in a page are currently being kludged whenever new content is loaded. This means the same content can be re-kludged several times, per page view (e.g. when drafts are automatically saved and the notification is displayed). They're now tagged as being kludged and the selector should dodge them in subsequent kludging.

Closes vanilla/support#1484 (best effort for now)