### PR TITLE
[Backport 2020.011] Add new mockSiteSectionGroup with only one section

### DIFF
--- a/tests/fixtures/src/MockSiteSectionProvider.php
+++ b/tests/fixtures/src/MockSiteSectionProvider.php
@@ -157,6 +157,19 @@ class MockSiteSectionProvider implements SiteSectionProviderInterface {
             );
         }
 
+        $siteSections[] = new MockSiteSection(
+            "single_siteSectionName_ru",
+            "ru",
+            '/single-ru',
+            "single-mockSiteSection-ru",
+            "mockSiteSectionGroup-3",
+            [
+                'Destination' => 'discussions',
+                'Type' => 'Internal'
+            ],
+            'keystone'
+        );
+
         /** @var MockSiteSectionProvider $provider */
         $provider = \Gdn::getContainer()->get(MockSiteSectionProvider::class);
         $provider->addSiteSections($siteSections);


### PR DESCRIPTION
back-port of https://github.com/vanilla/vanilla/pull/10696
