### PR TITLE
Add date filters and search relevance

### DIFF
--- a/library/Vanilla/Search/GlobalSearchType.php
+++ b/library/Vanilla/Search/GlobalSearchType.php
@@ -108,8 +108,6 @@ class GlobalSearchType extends AbstractSearchType {
             }
 
             // Sorts
-            // title is used in sphinx instead of name.
-//            $sort = str_replace('name', 'title', $sort);
             $sortField = ltrim($sort, '-');
 
             if ($sortField === SearchQuery::SORT_RELEVANCE) {

--- a/library/Vanilla/Search/SearchQuery.php
+++ b/library/Vanilla/Search/SearchQuery.php
@@ -16,6 +16,8 @@ abstract class SearchQuery {
     const FILTER_OP_OR = 'or';
     const FILTER_OP_AND = 'and';
 
+    const SORT_RELEVANCE = 'relevance';
+
     /** @var Schema */
     private $querySchema;
 


### PR DESCRIPTION
This PR implements a few new features in our search service (currently only implementation to target is sphinx. MySQL will need to be implemented by @alex-mtl).

- Implements filtering by date.
- Implements 2 new recently added explicit sort filters. Relevance was always the default before, but now sorting can be specifically done by dateInserted (which is a global sort).

Tests for sphinx implementation are here https://github.com/vanilla/internal/pull/2738