### PR TITLE
Fix confirmCommentDelete redirect to point to current discussion

### DIFF
--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -280,7 +280,7 @@ class ModerationController extends VanillaController {
             unset($checkedComments[$discussionID]);
             Gdn::userModel()->saveAttribute($session->UserID, 'CheckedComments', $checkedComments);
             ModerationController::informCheckedComments($this);
-            $this->setRedirectTo('discussion/'.$discussionID);
+            $this->setRedirectTo(discussionUrl($discussion));
         }
 
         $this->render();

--- a/applications/vanilla/controllers/class.moderationcontroller.php
+++ b/applications/vanilla/controllers/class.moderationcontroller.php
@@ -280,7 +280,7 @@ class ModerationController extends VanillaController {
             unset($checkedComments[$discussionID]);
             Gdn::userModel()->saveAttribute($session->UserID, 'CheckedComments', $checkedComments);
             ModerationController::informCheckedComments($this);
-            $this->setRedirectTo('discussions');
+            $this->setRedirectTo('discussion/'.$discussionID);
         }
 
         $this->render();


### PR DESCRIPTION
Closes vanilla/support#1298.

Currently, when you delete one or more comments of a discussion via the checkbox (rather than the cogwheel), you are redirected to the main discussions page, which is undesirable if you're not done working on that discussion. This PR sets the redirect to the current discussion.

I have done functional tests within subcommunities and on a hub-node setup.

### TO TEST
1. Go to any discussion with comments and delete a comment via the checkbox.
1. Note that you get redirected to the main discussion page.
1. Repeat step 1 and verify that you get redirected to the current discussion.