### PR TITLE
[Backport] Fix validating content length on Reported Posts

### DIFF
--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2124,13 +2124,13 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface, EventFr
             $this->Validation->applyRule('Body', 'MeAction');
             $maxCommentLength = Gdn::config('Vanilla.Comment.MaxLength');
             $minCommentLength = Gdn::config('Vanilla.Comment.MinLength');
-
+            $isReport = $formPostValues['Attributes']['Report'] ?? false;
             if (is_numeric($maxCommentLength) && $maxCommentLength > 0) {
                 $this->Validation->setSchemaProperty('Body', 'maxPlainTextLength', $maxCommentLength);
                 $this->Validation->applyRule('Body', 'plainTextLength');
             }
 
-            if ($minCommentLength && is_numeric($minCommentLength)) {
+            if ($minCommentLength && is_numeric($minCommentLength) && !$isReport) {
                 $this->Validation->setSchemaProperty('Body', 'MinTextLength', $minCommentLength);
                 $this->Validation->applyRule('Body', 'MinTextLength');
             } else {

--- a/applications/vanilla/models/class.discussionmodel.php
+++ b/applications/vanilla/models/class.discussionmodel.php
@@ -2124,18 +2124,18 @@ class DiscussionModel extends Gdn_Model implements FormatFieldInterface, EventFr
             $this->Validation->applyRule('Body', 'MeAction');
             $maxCommentLength = Gdn::config('Vanilla.Comment.MaxLength');
             $minCommentLength = Gdn::config('Vanilla.Comment.MinLength');
-            $isReport = $formPostValues['Attributes']['Report'] ?? false;
+            $ignoreMinLength = $settings['ignoreMinLength'] ?? false;
             if (is_numeric($maxCommentLength) && $maxCommentLength > 0) {
                 $this->Validation->setSchemaProperty('Body', 'maxPlainTextLength', $maxCommentLength);
                 $this->Validation->applyRule('Body', 'plainTextLength');
             }
 
-            if ($minCommentLength && is_numeric($minCommentLength) && !$isReport) {
+            if ($minCommentLength && is_numeric($minCommentLength) && !$ignoreMinLength) {
                 $this->Validation->setSchemaProperty('Body', 'MinTextLength', $minCommentLength);
                 $this->Validation->applyRule('Body', 'MinTextLength');
             } else {
                 // Add min length if body is required.
-                if (Gdn::config('Vanilla.DiscussionBody.Required', true)) {
+                if (Gdn::config('Vanilla.DiscussionBody.Required', true) && !$ignoreMinLength) {
                     $this->Validation->setSchemaProperty('Body', 'MinTextLength', 1);
                     $this->Validation->applyRule('Body', 'MinTextLength');
                 }


### PR DESCRIPTION
This PR will backport https://github.com/vanilla/vanilla/pull/10804 to release/2020.012

When using the Report feature we quote the post and create a new post with the quote. This means that the post now consists of an embedded quote which does not get counted in the size of the post. In other words, the full post becomes : "Quote" when you convert to plain text. It's count is therefore, 7 with the quotation marks. If a forum is configured to have a minimum content length of, say, 10 it will say that this content is 3 characters too short. 

Since Reports are always quoted, this PR will bypass that plain text conversion when validating its minimum length.

### Testing
 1. Turn on reporting.
 2. Make sure the minimum post length is more that 7 in "Posting" in the Dashboard.
 3. Report a post (make sure your Report comment is bigger than the minimum post length).
 4. Observe the error.
 5. Checkout this branch and `fix/quoting-text-when-reporting` in internal repo.
 6. Report another post (**NOTE** once a post is reported it can be reported again but it does not create a new post so it wouldn't fail on the second time.)
 7. See it work.
 8. Make other posts **above** and **below** the minimum to make sure regular functionality is still working.
 9. Approve this PR and retire to the pub.