### PR TITLE
Clear user cache on insertInternal

### DIFF
--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -1070,6 +1070,9 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
         $userID = $this->SQL->insert($this->Name, $fields);
 
         if ($userID) {
+            //force clear cache for that UserID
+            $this->clearCache($userID, ['user']);
+
             $user = $this->getID($userID);
             $userEvent = $this->eventFromRow(
                 (array)$user,

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -5316,6 +5316,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
      * Delete cached data for user.
      *
      * @param int|null $userID The user to clear the cache for.
+     * @param ?string $cacheTypesToClear
      * @return bool Returns **true** if the cache was cleared or **false** otherwise.
      */
     public function clearCache($userID, $cacheTypesToClear = null) {

--- a/applications/dashboard/models/class.usermodel.php
+++ b/applications/dashboard/models/class.usermodel.php
@@ -75,6 +75,15 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
 
     private const USERAUTHENTICATION_CACHE_EXPIRY = 60;
 
+    /** @var string cache type flag for user data */
+    const CACHE_TYPE_USER = 'user';
+
+    /** @var string cache type flag for roles data */
+    const CACHE_TYPE_ROLES = 'roles';
+
+    /** @var string cache type flag for permissions data */
+    const CACHE_TYPE_PERMISSIONS = 'permissions';
+
     /** @var EventManager */
     private $eventManager;
 
@@ -1071,7 +1080,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
 
         if ($userID) {
             //force clear cache for that UserID
-            $this->clearCache($userID, ['user']);
+            $this->clearCache($userID, [self::CACHE_TYPE_USER]);
 
             $user = $this->getID($userID);
             $userEvent = $this->eventFromRow(
@@ -2579,7 +2588,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
                     $this->sendEmailConfirmationEmail($user, true);
                 }
 
-                $this->clearCache($userID, ['user']);
+                $this->clearCache($userID, [self::CACHE_TYPE_USER]);
                 $this->EventArguments['UserID'] = $userID;
                 $this->fireEvent('AfterSave');
             } else {
@@ -2832,7 +2841,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
             }
         }
 
-        $this->clearCache($UserID, ['roles', 'permissions']);
+        $this->clearCache($UserID, [self::CACHE_TYPE_ROLES, self::CACHE_TYPE_PERMISSIONS]);
 
         if ($RecordEvent) {
             $User = $this->getID($UserID);
@@ -4356,7 +4365,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
 
         // Save the values back to the db
         $saveResult = $this->SQL->put('User', [$column => $values], ['UserID' => $userID]);
-        $this->clearCache($userID, ['user']);
+        $this->clearCache($userID, [self::CACHE_TYPE_USER]);
 
         return $saveResult;
     }
@@ -5183,7 +5192,7 @@ class UserModel extends Gdn_Model implements UserProviderInterface, EventFromRow
             ->put();
 
         if (in_array($property, ['Permissions'])) {
-            $this->clearCache($rowID, ['permissions']);
+            $this->clearCache($rowID, [self::CACHE_TYPE_PERMISSIONS]);
         } else {
             $this->updateUserCache($rowID, $property, $value);
         }


### PR DESCRIPTION
Closes https://github.com/vanilla/vanilla-patches/issues/702

**Steps to reproduce:**
1. Register with an email and username (basic registration method) and wait for the confirmation email to appear.
1. Take the supplied link in the register confirmation  email (for example: https://open.vanillaforums.com/entry/emailconfirm/72565/ZKID6I2f6FwDeyshAXUCEkJybbkRAzYU) and increment the value "72565" (or whatever number appears in the confirmation link) by 1 (thus: "72566").
1. Open the changed link in a browser.
1. Logout.
1. Register with a different email and different username directly after opening the link. The error message will now pop up and say "value is not a valid object" preventing the user from registering.