### PR TITLE
Fixed layout calculations, pagination info and search result icons

### DIFF
--- a/applications/dashboard/src/scripts/compatibilityStyles/forumLayoutStyles.ts
+++ b/applications/dashboard/src/scripts/compatibilityStyles/forumLayoutStyles.ts
@@ -20,7 +20,6 @@ export const forumLayoutVariables = useThemeCache(() => {
 
     // Important variables that will be used to calculate other variables
     const foundationalWidths = makeThemeVars("foundationalWidths", {
-        fullGutter: globalVars.constants.fullGutter,
         panelWidth: 220, // main calculated based on panel width
         breakPoints: {
             // Other break points are calculated
@@ -131,16 +130,13 @@ export const forumLayoutVariables = useThemeCache(() => {
     };
 
     const gutter = makeThemeVars("gutter", {
-        full: foundationalWidths.fullGutter, // 48
-        size: foundationalWidths.fullGutter / 2, // 24
-        halfSize: foundationalWidths.fullGutter / 4, // 12
-        quarterSize: foundationalWidths.fullGutter / 8, // 6
+        ...globalVars.gutter,
         mainGutterOffset: 60 - globalVars.gutter.size,
     });
 
     const panel = makeThemeVars("panel", {
         width: foundationalWidths.panelWidth,
-        paddedWidth: foundationalWidths.panelWidth + gutter.full,
+        paddedWidth: foundationalWidths.panelWidth + gutter.bothSides,
     });
 
     const main = makeThemeVars("main", {

--- a/library/src/scripts/AppContext.tsx
+++ b/library/src/scripts/AppContext.tsx
@@ -20,8 +20,9 @@ import { LocaleProvider, ContentTranslationProvider } from "@vanilla/i18n";
 import { SearchContextProvider } from "@library/contexts/SearchContext";
 import { TitleBarDeviceProvider } from "@library/layout/TitleBarContext";
 import { ErrorPage } from "@library/errorPages/ErrorComponent";
-import { BannerContextProvider, BannerContextProviderNoHistory } from "@library/banner/BannerContext";
+import { BannerContextProviderNoHistory } from "@library/banner/BannerContext";
 import { SearchFormContextProvider } from "@library/search/SearchFormContext";
+import { TwoColumnLayoutDeviceProvider } from "@library/layout/TwoColumnLayoutDeviceContext";
 
 interface IProps {
     children: React.ReactNode;
@@ -59,7 +60,11 @@ export function AppContext(props: IProps) {
                                         <SearchFormContextProvider>
                                             <TitleBarDeviceProvider>
                                                 <BannerContextProviderNoHistory>
-                                                    <DeviceProvider>{props.children}</DeviceProvider>
+                                                    <DeviceProvider>
+                                                        <TwoColumnLayoutDeviceProvider>
+                                                            {props.children}
+                                                        </TwoColumnLayoutDeviceProvider>
+                                                    </DeviceProvider>
                                                 </BannerContextProviderNoHistory>
                                             </TitleBarDeviceProvider>
                                         </SearchFormContextProvider>

--- a/library/src/scripts/banner/banner.story.tsx
+++ b/library/src/scripts/banner/banner.story.tsx
@@ -382,7 +382,7 @@ export const LogoAndRightImage = storyWithConfig(
 (ImageAsElement as any).story = {
     parameters: {
         chromatic: {
-            viewports: [1400, globalVariables().content.width, layoutVariables().panelLayoutBreakPoints.oneColumn, 400],
+            viewports: [1400, globalVariables().contentWidthPadding, layoutVariables().panelLayoutBreakPoints.oneColumn, 400],
         },
     },
 };

--- a/library/src/scripts/banner/banner.story.tsx
+++ b/library/src/scripts/banner/banner.story.tsx
@@ -382,7 +382,12 @@ export const LogoAndRightImage = storyWithConfig(
 (ImageAsElement as any).story = {
     parameters: {
         chromatic: {
-            viewports: [1400, globalVariables().contentWidthPadding, layoutVariables().panelLayoutBreakPoints.oneColumn, 400],
+            viewports: [
+                1400,
+                globalVariables().contentWidthPadding,
+                layoutVariables().panelLayoutBreakPoints.oneColumn,
+                400,
+            ],
         },
     },
 };
@@ -400,8 +405,8 @@ export const ImageAsElementWide = storyWithConfig(
                         color: color("#efefef"),
                     },
                 },
-                content: {
-                    width: 1350,
+                middleColumn: {
+                    width: 800,
                 },
             },
             banner: {

--- a/library/src/scripts/banner/bannerStyles.ts
+++ b/library/src/scripts/banner/bannerStyles.ts
@@ -758,7 +758,7 @@ export const bannerClasses = useThemeCache(
             {
                 alignSelf: "stretch",
                 maxWidth: makeImageMinWidth(
-                    globalVars.content.width,
+                    globalVars.contentWidthPadding,
                     containerVariables().spacing.paddingFull.horizontal * 2,
                 ),
                 flexGrow: 1,
@@ -766,7 +766,7 @@ export const bannerClasses = useThemeCache(
                 overflow: "hidden",
             },
             media(
-                { maxWidth: globalVars.content.width },
+                { maxWidth: globalVars.contentWidthPadding },
                 {
                     minWidth: makeImageMinWidth("100vw", containerVariables().spacing.paddingFull.horizontal),
                 },

--- a/library/src/scripts/features/search/searchResultsStyles.ts
+++ b/library/src/scripts/features/search/searchResultsStyles.ts
@@ -191,31 +191,21 @@ export const searchResultClasses = useThemeCache(() => {
     const mediaWidth = vars.mediaElement.width + vars.spacing.padding.left;
     const iconWidth = vars.icon.size + vars.spacing.padding.left;
 
-    const main = style(
-        "main",
-        {
-            display: "block",
-            width: percent(100),
-            $nest: {
-                "&.hasMedia": {
-                    width: calc(`100% - ${unit(mediaWidth)}`),
-                },
-                "&.hasIcon": {
-                    width: calc(`100% - ${unit(iconWidth)}`),
-                },
-                "&.hasMedia.hasIcon": {
-                    width: calc(`100% - ${unit(mediaWidth + iconWidth)}`),
-                },
+    const main = style("main", {
+        display: "block",
+        width: percent(100),
+        $nest: {
+            "&.hasMedia": {
+                width: calc(`100% - ${unit(mediaWidth)}`),
+            },
+            "&.hasIcon": {
+                width: calc(`100% - ${unit(iconWidth)}`),
+            },
+            "&.hasMedia.hasIcon": {
+                width: calc(`100% - ${unit(mediaWidth + iconWidth)}`),
             },
         },
-        mediaQueries.compact({
-            $nest: {
-                "&.hasMedia": {
-                    width: percent(100),
-                },
-            },
-        }),
-    );
+    });
 
     const mediaElement = style(
         "mediaElement",

--- a/library/src/scripts/forms/dateRangeStyles.ts
+++ b/library/src/scripts/forms/dateRangeStyles.ts
@@ -16,7 +16,7 @@ export const dateRangeClasses = useThemeCache(() => {
     const style = styleFactory("dateRange");
     const mediaQueries = layoutVariables().mediaQueries();
 
-    const mobileGutterSize = globalVars.halfPadding + containerVariables().spacing.mobile.padding.horizontal;
+    const mobileGutterSize = globalVars.gutter.size + containerVariables().spacing.mobile.padding.horizontal;
 
     const input = style("input", {
         width: unit(136),

--- a/library/src/scripts/forms/dateRangeStyles.ts
+++ b/library/src/scripts/forms/dateRangeStyles.ts
@@ -16,8 +16,7 @@ export const dateRangeClasses = useThemeCache(() => {
     const style = styleFactory("dateRange");
     const mediaQueries = layoutVariables().mediaQueries();
 
-    const mobileGutterSize =
-        panelWidgetVariables().spacing.padding + containerVariables().spacing.mobile.padding.horizontal;
+    const mobileGutterSize = globalVars.halfPadding + containerVariables().spacing.mobile.padding.horizontal;
 
     const input = style("input", {
         width: unit(136),

--- a/library/src/scripts/forms/formElementStyles.ts
+++ b/library/src/scripts/forms/formElementStyles.ts
@@ -57,7 +57,7 @@ export const formElementsVariables = useThemeCache((forcedVars?: IThemeVariables
     const errorSpacing = makeThemeVars("errorSpacing", {
         horizontalPadding: varsLayouts.gutter.size,
         verticalPadding: varsLayouts.gutter.size,
-        verticalMargin: varsLayouts.gutter.halfSize,
+        verticalMargin: varsLayouts.gutter.half,
     });
 
     const placeholder = makeThemeVars("placeholder", {

--- a/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
+++ b/library/src/scripts/homeWidget/HomeWidgetContainer.styles.ts
@@ -58,7 +58,7 @@ export const homeWidgetContainerVariables = useThemeCache((optionOverrides?: IHo
                 ...EMPTY_BACKGROUND,
             },
             borderType: BorderType.NONE as BorderType | "navLinks",
-            maxWidth: globalVars.content.width,
+            maxWidth: globalVars.contentWidth,
             viewAll: {
                 to: undefined as string | undefined,
                 position: "bottom" as "top" | "bottom",

--- a/library/src/scripts/layout/PanelLayout.tsx
+++ b/library/src/scripts/layout/PanelLayout.tsx
@@ -105,14 +105,6 @@ export default function PanelLayout(props: IPanelLayoutProps) {
     const shouldRenderRightPanel: boolean =
         isFullWidth || ((!isTwoColumnLayout ? isTablet : !isMobile) && !shouldRenderLeftPanel);
 
-    // console.log("");
-    // console.log("device: ", device);
-    // console.log("isMobile: ", isMobile);
-    // console.log("isTablet: ", isTablet);
-    // console.log("isFullWidth: ", isFullWidth);
-    // console.log("shouldRenderLeftPanel: ", shouldRenderLeftPanel);
-    // console.log("shouldRenderRightPanel: ", shouldRenderRightPanel);
-
     // Determine the classes we want to display.
     const panelClasses = classNames(
         classes.root,

--- a/library/src/scripts/layout/TwoColumnLayout.tsx
+++ b/library/src/scripts/layout/TwoColumnLayout.tsx
@@ -4,10 +4,9 @@
  */
 import React from "react";
 import PanelLayout, { IPanelLayoutProps } from "@library/layout/PanelLayout";
-import { twoColumnLayoutClasses } from "@library/layout/twoColumnLayoutStyles";
 
 interface IProps extends Omit<IPanelLayoutProps, "leftTop" | "leftBottom" | "renderLeftPanelBackground"> {}
 
 export default function TwoColumnLayout(props: IProps) {
-    return <PanelLayout {...props} classes={twoColumnLayoutClasses()} />;
+    return <PanelLayout {...props} isTwoColumnLayout={true} />;
 }

--- a/library/src/scripts/layout/TwoColumnLayoutDeviceContext.tsx
+++ b/library/src/scripts/layout/TwoColumnLayoutDeviceContext.tsx
@@ -1,0 +1,94 @@
+/*
+ * @author Stéphane LaFlèche <stephane.l@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+import { Optionalize } from "@library/@types/utils";
+import throttle from "lodash/throttle";
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { twoColumnLayoutVariables } from "@library/layout/twoColumnLayoutStyles";
+
+export enum TwoColumnDevices {
+    XS = "xs",
+    MOBILE = "mobile",
+    NO_BLEED = "no_bleed", // Not enough space for back link which goes outside the margin.
+    DESKTOP = "desktop",
+}
+
+export interface ITwoColumnLayoutDeviceProps {
+    device: TwoColumnDevices;
+}
+
+const TwoColumnLayoutDeviceContext = React.createContext<TwoColumnDevices>(TwoColumnDevices.DESKTOP);
+export default TwoColumnLayoutDeviceContext;
+
+export function useTwoColumnLayoutDevice() {
+    const device = useContext(TwoColumnLayoutDeviceContext);
+    return device;
+}
+
+interface IProps {
+    children: React.ReactNode;
+}
+
+export function TwoColumnLayoutDeviceProvider(props: IProps) {
+    const calculateDevice = useCallback(() => {
+        const width = document.body.clientWidth;
+        const breakpoints = twoColumnLayoutVariables().panelLayoutBreakPoints;
+        if (width <= breakpoints.xs) {
+            return TwoColumnDevices.XS;
+        } else if (width <= breakpoints.oneColumn && width < breakpoints.noBleed) {
+            return TwoColumnDevices.MOBILE;
+        } else if (width <= breakpoints.noBleed) {
+            return TwoColumnDevices.NO_BLEED;
+        } else {
+            return TwoColumnDevices.DESKTOP;
+        }
+    }, []);
+    const [device, setDevice] = useState<TwoColumnDevices>(calculateDevice());
+
+    useEffect(() => {
+        const throttledUpdate = throttle(
+            () => {
+                setDevice(calculateDevice);
+            },
+            100,
+            {
+                leading: true,
+                trailing: true,
+            },
+        );
+        window.addEventListener("resize", throttledUpdate);
+        return () => {
+            window.removeEventListener("resize", throttledUpdate);
+        };
+    }, [calculateDevice, setDevice]);
+
+    return (
+        <TwoColumnLayoutDeviceContext.Provider value={device}>{props.children}</TwoColumnLayoutDeviceContext.Provider>
+    );
+}
+
+/**
+ * HOC to inject DeviceContext as props.
+ *
+ * @param WrappedComponent - The component to wrap
+ */
+export function withTwoColumnDevice<T extends ITwoColumnLayoutDeviceProps = ITwoColumnLayoutDeviceProps>(
+    WrappedComponent: React.ComponentType<T>,
+) {
+    const displayName = WrappedComponent.displayName || WrappedComponent.name || "Component";
+    const ComponentWithDevice = (props: Optionalize<T, ITwoColumnLayoutDeviceProps>) => {
+        return (
+            <TwoColumnLayoutDeviceContext.Consumer>
+                {context => {
+                    // https://github.com/Microsoft/TypeScript/issues/28938
+                    return <WrappedComponent device={context} {...(props as T)} />;
+                }}
+            </TwoColumnLayoutDeviceContext.Consumer>
+        );
+    };
+    ComponentWithDevice.displayName = `withTwoColumnDevice(${displayName})`;
+    return ComponentWithDevice;
+}

--- a/library/src/scripts/layout/components/containerStyles.ts
+++ b/library/src/scripts/layout/components/containerStyles.ts
@@ -10,22 +10,19 @@ import { percent, color } from "csx";
 import { paddings, unit } from "@library/styles/styleHelpers";
 import { globalVariables } from "@library/styles/globalStyleVars";
 import { NestedCSSProperties } from "typestyle/lib/types";
-import { panelWidgetVariables } from "@library/layout/panelWidgetStyles";
 
 export const containerVariables = useThemeCache(() => {
     const vars = layoutVariables();
     const globalVars = globalVariables();
     const makeThemeVars = variableFactory("containerVariables");
 
-    const smallPadding = panelWidgetVariables().spacing.padding;
-
     let spacingInit = makeThemeVars("spacing", {
         padding: {
-            horizontal: vars.gutter.size,
+            horizontal: globalVars.outerGutter.size,
         },
         mobile: {
             padding: {
-                horizontal: smallPadding,
+                horizontal: globalVars.gutter.half,
             },
         },
     });
@@ -33,10 +30,10 @@ export const containerVariables = useThemeCache(() => {
     const spacing = makeThemeVars("spacing", {
         ...spacingInit,
         paddingFull: {
-            horizontal: vars.gutter.size + smallPadding,
+            horizontal: vars.gutter.size,
         },
         paddingFullMobile: {
-            horizontal: smallPadding * 2,
+            horizontal: globalVars.gutter.size,
         },
     });
 
@@ -65,7 +62,7 @@ export const containerMainStyles = (): NestedCSSProperties => {
         position: "relative",
         boxSizing: "border-box",
         width: percent(100),
-        maxWidth: globalVars.content.width,
+        maxWidth: globalVars.contentWidthPadding,
         marginLeft: "auto",
         marginRight: "auto",
         ...paddings(vars.spacing.padding),

--- a/library/src/scripts/layout/panelLayoutStyles.ts
+++ b/library/src/scripts/layout/panelLayoutStyles.ts
@@ -35,7 +35,7 @@ export const layoutVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         },
     });
 
-    const gutter =  {
+    const gutter = {
         ...globalVars.gutter,
     };
 
@@ -52,9 +52,7 @@ export const layoutVariables = useThemeCache((forcedVars?: IThemeVariables) => {
     const contentSizes = makeThemeVars("content", {
         full: contentWidth,
         narrow:
-            foundationalWidths.narrowContentWidth < contentWidth
-                ? foundationalWidths.narrowContentWidth
-                : contentWidth,
+            foundationalWidths.narrowContentWidth < contentWidth ? foundationalWidths.narrowContentWidth : contentWidth,
     });
 
     const panelLayoutBreakPoints = makeThemeVars("panelLayoutBreakPoints", {
@@ -293,7 +291,9 @@ export const panelLayoutClasses = useThemeCache(() => {
         padding: 0,
     });
 
-    const offset = panelBackgroundVariables().config.render ? (layoutVariables().panelLayoutSpacing.withPanelBackground.gutter - globalVars.gutter.half) : 0;
+    const offset = panelBackgroundVariables().config.render
+        ? layoutVariables().panelLayoutSpacing.withPanelBackground.gutter - globalVars.gutter.half
+        : 0;
 
     const leftColumn = style("leftColumn", {
         position: "relative",

--- a/library/src/scripts/layout/panelLayoutStyles.ts
+++ b/library/src/scripts/layout/panelLayoutStyles.ts
@@ -11,10 +11,8 @@ import { globalVariables } from "@library/styles/globalStyleVars";
 import { margins, paddings, sticky, unit } from "@library/styles/styleHelpers";
 import { important } from "csx/lib/strings";
 import { panelListClasses } from "@library/layout/panelListStyles";
-import { titleBarVariables } from "@library/headers/titleBarStyles";
 import { panelAreaClasses } from "@library/layout/panelAreaStyles";
 import { NestedCSSProperties } from "typestyle/lib/types";
-import { panelWidgetVariables } from "@library/layout/panelWidgetStyles";
 import { panelBackgroundVariables } from "@library/layout/panelBackgroundStyles";
 import { IThemeVariables } from "@library/theming/themeReducer";
 
@@ -28,9 +26,6 @@ export const layoutVariables = useThemeCache((forcedVars?: IThemeVariables) => {
 
     // Important variables that will be used to calculate other variables
     const foundationalWidths = makeThemeVars("foundationalWidths", {
-        fullGutter: globalVars.constants.fullGutter,
-        panelWidth: globalVars.panel.width,
-        middleColumnWidth: 700,
         minimalMiddleColumnWidth: 550, // Will break if middle column width is smaller than this value.
         narrowContentWidth: 900, // For home page widgets, narrower than full width
         breakPoints: {
@@ -40,37 +35,30 @@ export const layoutVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         },
     });
 
-    const gutter = makeThemeVars("gutter", {
-        full: foundationalWidths.fullGutter, // 48
-        size: foundationalWidths.fullGutter / 2, // 24
-        halfSize: foundationalWidths.fullGutter / 4, // 12
-        quarterSize: foundationalWidths.fullGutter / 8, // 6
-    });
-
-    const fullPadding = panelWidgetVariables().spacing.padding * 2;
+    const gutter =  {
+        ...globalVars.gutter,
+    };
 
     const panel = makeThemeVars("panel", {
-        width: foundationalWidths.panelWidth,
-        paddedWidth: foundationalWidths.panelWidth + fullPadding,
+        ...globalVars.panel,
     });
 
     const middleColumn = makeThemeVars("middleColumn", {
-        width: foundationalWidths.middleColumnWidth,
-        paddedWidth: foundationalWidths.middleColumnWidth + fullPadding,
+        ...globalVars.middleColumn,
     });
 
-    const globalContentWidth = middleColumn.paddedWidth + panel.paddedWidth * 2 + fullPadding;
+    const contentWidth = globalVars.contentWidth;
 
     const contentSizes = makeThemeVars("content", {
-        full: globalContentWidth,
+        full: contentWidth,
         narrow:
-            foundationalWidths.narrowContentWidth < globalContentWidth
+            foundationalWidths.narrowContentWidth < contentWidth
                 ? foundationalWidths.narrowContentWidth
-                : globalContentWidth,
+                : contentWidth,
     });
 
     const panelLayoutBreakPoints = makeThemeVars("panelLayoutBreakPoints", {
-        noBleed: globalContentWidth,
+        noBleed: contentWidth,
         twoColumn: foundationalWidths.breakPoints.twoColumns,
         oneColumn: foundationalWidths.minimalMiddleColumnWidth + panel.paddedWidth,
         xs: foundationalWidths.breakPoints.xs,
@@ -82,7 +70,7 @@ export const layoutVariables = useThemeCache((forcedVars?: IThemeVariables) => {
             bottom: 0,
         },
         padding: {
-            top: gutter.halfSize * 1.5,
+            top: gutter.size * 1.5,
         },
         extraPadding: {
             top: 32,
@@ -201,7 +189,7 @@ export const layoutVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         panel,
         middleColumn,
         contentSizes,
-        globalContentWidth,
+        contentWidth,
         mediaQueries,
         panelLayoutSpacing,
         panelLayoutBreakPoints,
@@ -305,9 +293,7 @@ export const panelLayoutClasses = useThemeCache(() => {
         padding: 0,
     });
 
-    const offset = panelBackgroundVariables().config.render
-        ? layoutVariables().panelLayoutSpacing.withPanelBackground.gutter - panelWidgetVariables().spacing.padding * 2
-        : 0;
+    const offset = panelBackgroundVariables().config.render ? (layoutVariables().panelLayoutSpacing.withPanelBackground.gutter - globalVars.gutter.half) : 0;
 
     const leftColumn = style("leftColumn", {
         position: "relative",

--- a/library/src/scripts/layout/panelWidgetStyles.ts
+++ b/library/src/scripts/layout/panelWidgetStyles.ts
@@ -11,10 +11,11 @@ import { paddings } from "@library/styles/styleHelpers";
 import { layoutVariables } from "@library/layout/panelLayoutStyles";
 
 export const panelWidgetVariables = useThemeCache(() => {
+    const globalVars = globalVariables();
     const makeThemeVars = variableFactory("panelWidget");
 
     const spacing = makeThemeVars("spacing", {
-        padding: 8,
+        padding: globalVars.halfPadding,
     });
 
     return { spacing };

--- a/library/src/scripts/layout/panelWidgetStyles.ts
+++ b/library/src/scripts/layout/panelWidgetStyles.ts
@@ -15,7 +15,7 @@ export const panelWidgetVariables = useThemeCache(() => {
     const makeThemeVars = variableFactory("panelWidget");
 
     const spacing = makeThemeVars("spacing", {
-        padding: globalVars.halfPadding,
+        padding: globalVars.gutter.size,
     });
 
     return { spacing };

--- a/library/src/scripts/layout/twoColumnLayoutStyles.ts
+++ b/library/src/scripts/layout/twoColumnLayoutStyles.ts
@@ -12,40 +12,39 @@ import { unit } from "@library/styles/styleHelpers";
 import { NestedCSSProperties } from "typestyle/lib/types";
 import { IThemeVariables } from "@library/theming/themeReducer";
 import { IPanelLayoutClasses, layoutVariables, panelLayoutClasses } from "@library/layout/panelLayoutStyles";
-import { panelWidgetVariables } from "@library/layout/panelWidgetStyles";
 
 export const twoColumnLayoutVariables = useThemeCache((forcedVars?: IThemeVariables) => {
     const globalVars = globalVariables(forcedVars);
     const panelLayoutVars = layoutVariables();
     const makeThemeVars = variableFactory("twoColumnLayout", forcedVars);
-    const fullPadding = panelWidgetVariables().spacing.padding * 2;
 
-    const { gutter, globalContentWidth } = panelLayoutVars;
-    const { fullGutter } = panelLayoutVars.foundationalWidths;
+    const { gutter, contentWidth } = panelLayoutVars;
 
     // Important variables that will be used to calculate other variables
     const foundationalWidths = makeThemeVars("foundationalWidths", {
-        fullGutter,
-        minimalMiddleColumnWidth: 600,
-        panelWidth: 343,
+        minimalMiddleColumnWidth: 500,
         breakPoints: {
             xs: panelLayoutVars.foundationalWidths.breakPoints.xs,
         }, // Other break point are calculated
     });
 
-    const panel = makeThemeVars("panel", {
-        width: foundationalWidths.panelWidth,
-        paddedWidth: foundationalWidths.panelWidth + fullPadding * 2,
+    const panelInit = makeThemeVars("panel", {
+        width: 343,
     });
 
-    const mainColumnPaddedWidth = globalContentWidth - gutter.size - panel.paddedWidth;
-    const mainColumnWidth = mainColumnPaddedWidth - fullPadding * 2;
+    const panel = makeThemeVars("panel", {
+        width: panelInit.width,
+        paddedWidth: panelInit.width + gutter.bothSides,
+    });
+
+    const mainColumnPaddedWidth = contentWidth - panel.paddedWidth;
+    const mainColumnWidth = mainColumnPaddedWidth - gutter.bothSides;
 
     const panelLayoutSpacing = makeThemeVars("panelLayoutSpacing", panelLayoutVars.panelLayoutSpacing);
 
     const panelLayoutBreakPoints = makeThemeVars("panelLayoutBreakPoints", {
-        noBleed: globalContentWidth,
-        oneColumn: foundationalWidths.minimalMiddleColumnWidth + panel.paddedWidth,
+        noBleed: contentWidth,
+        oneColumn: foundationalWidths.minimalMiddleColumnWidth + panel.paddedWidth + globalVars.outerGutter.bothSides,
         xs: foundationalWidths.breakPoints.xs,
     });
 
@@ -72,8 +71,8 @@ export const twoColumnLayoutVariables = useThemeCache((forcedVars?: IThemeVariab
         const oneColumn = (styles: NestedCSSProperties, useMinWidth: boolean = true) => {
             return media(
                 {
-                    maxWidth: px(panelLayoutBreakPoints.oneColumn),
-                    minWidth: useMinWidth ? px(panelLayoutBreakPoints.xs + 1) : undefined,
+                    maxWidth: px(panelLayoutBreakPoints.noBleed),
+                    minWidth: useMinWidth ? px(panelLayoutBreakPoints.oneColumn + 1) : undefined,
                 },
                 styles,
             );

--- a/library/src/scripts/result/Result.tsx
+++ b/library/src/scripts/result/Result.tsx
@@ -66,9 +66,9 @@ export default function Result(props: IResult) {
     return (
         <li className={classNames(classesSearchResults.item, className)}>
             <article className={classNames(classesSearchResults.result)}>
-                <div className={classNames(classes.root, { hasIcon: !!icon })}>
+                <div className={classNames(classes.root)}>
                     {icon && <div className={classes.iconWrap}>{icon}</div>}
-                    <div className={classNames(classes.main, { hasMedia: !!media })}>
+                    <div className={classNames(classes.main, { hasMedia: !!media, hasIcon: !!icon })}>
                         <SmartLink to={url} tabIndex={0} className={classes.link}>
                             <HeadingTag className={classes.title}>{name}</HeadingTag>
                         </SmartLink>

--- a/library/src/scripts/search/SearchPage.tsx
+++ b/library/src/scripts/search/SearchPage.tsx
@@ -10,7 +10,6 @@ import SearchOption from "@library/features/search/SearchOption";
 import { ButtonTypes } from "@library/forms/buttonTypes";
 import TitleBar from "@library/headers/TitleBar";
 import Container from "@library/layout/components/Container";
-import { Devices, useDevice } from "@library/layout/DeviceContext";
 import Drawer from "@library/layout/drawer/Drawer";
 import { PageHeading } from "@library/layout/PageHeading";
 import { pageTitleClasses } from "@library/layout/pageTitleStyles";
@@ -34,6 +33,9 @@ import qs from "qs";
 import * as React from "react";
 import { useCallback, useEffect } from "react";
 import { useLocation } from "react-router";
+import ConditionalWrap from "@library/layout/ConditionalWrap";
+import { TwoColumnDevices, useTwoColumnLayoutDevice } from "@library/layout/TwoColumnLayoutDeviceContext";
+import { twoColumnLayoutVariables } from "@library/layout/twoColumnLayoutStyles";
 
 interface IProps {
     placeholder?: string;
@@ -49,8 +51,11 @@ function SearchPage(props: IProps) {
         getCurrentDomain,
         getDefaultFormValues,
     } = useSearchForm<{}>();
-    const device = useDevice();
+
+    const device = useTwoColumnLayoutDevice();
+    const Devices = TwoColumnDevices;
     const isMobile = device === Devices.MOBILE || device === Devices.XS;
+
     const classes = pageTitleClasses();
     useInitialQueryParamSync();
 
@@ -142,7 +147,7 @@ function SearchPage(props: IProps) {
                         </>
                     }
                     middleBottom={<SearchPageResults />}
-                    rightTop={!isMobile && <PanelWidget>{currentFilter}</PanelWidget>}
+                    rightTop={!isMobile && <PanelWidget>here{currentFilter}</PanelWidget>}
                 />
             </Container>
         </DocumentTitle>

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -46,7 +46,9 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
 
     const constants = makeThemeVars("constants", {
         stateColorEmphasis: 0.15,
-        fullGutter: 48,
+        outerGutter: 24, // Will be split in 2 in CSS. Will switch to innerGutter on smaller screens
+        innerGutter: 16, // will be split in 2 in CSS
+        //[outerGutter][innerGutter][panel][innerGutter][content][innerGutter][panel][innerGutter][outerGutter]
         states: {
             hover: {
                 stateEmphasis: 0.08,
@@ -190,12 +192,19 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         dropDowns: border,
     });
 
-    const gutterSize = 16;
-    const gutter = makeThemeVars("gutter", {
-        size: gutterSize,
-        half: gutterSize / 2,
-        quarter: gutterSize / 4,
-    });
+    const gutter = {
+        bothSides: constants.innerGutter * 2,
+        size: constants.innerGutter,
+        half: constants.innerGutter / 2,
+        quarter: constants.innerGutter / 4,
+        full: constants.innerGutter * 2,
+    };
+
+    const outerGutter = {
+        bothSides: constants.outerGutter * 2,
+        size: constants.outerGutter,
+        half: constants.outerGutter / 2,
+    };
 
     const lineHeights = makeThemeVars("lineHeight", {
         base: 1.5,
@@ -206,9 +215,13 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
     });
 
     const panelWidth = 216;
-    const panel = makeThemeVars("panelWidth", {
+    const panelInit = makeThemeVars("panelWidth", {
         width: panelWidth,
-        paddedWidth: panelWidth + gutter.size * 2,
+    });
+
+    const panel = makeThemeVars("panelWidth", {
+        width: panelInit.width,
+        paddedWidth: panelInit.width + gutter.size * 2,
     });
 
     const middleColumnWidth = 672;
@@ -221,9 +234,8 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         paddedWidth: middleColumnInit.width + gutter.size * 2,
     });
 
-    const content = makeThemeVars("content", {
-        width: middleColumn.paddedWidth + panel.paddedWidth * 2 + gutter.size * 4,
-    });
+    const contentWidth = middleColumn.paddedWidth + panel.paddedWidth * 2;
+    const contentWidthPadding = contentWidth + constants.outerGutter;
 
     const fontsInit0 = makeThemeVars("fonts", {
         size: {
@@ -477,11 +489,14 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
         border,
         meta,
         gutter,
+        outerGutter,
         panel,
-        content,
+        middleColumn,
         fonts,
         spacer,
         lineHeights,
+        contentWidth,
+        contentWidthPadding,
         icon,
         buttonIcon,
         animation,

--- a/library/src/scripts/styles/globalStyleVars.ts
+++ b/library/src/scripts/styles/globalStyleVars.ts
@@ -221,7 +221,7 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
 
     const panel = makeThemeVars("panelWidth", {
         width: panelInit.width,
-        paddedWidth: panelInit.width + gutter.size * 2,
+        paddedWidth: panelInit.width + gutter.bothSides,
     });
 
     const middleColumnWidth = 672;
@@ -231,7 +231,7 @@ export const globalVariables = useThemeCache((forcedVars?: IThemeVariables) => {
 
     const middleColumn = makeThemeVars("middleColumn", {
         width: middleColumnInit.width,
-        paddedWidth: middleColumnInit.width + gutter.size * 2,
+        paddedWidth: middleColumnInit.width + gutter.bothSides,
     });
 
     const contentWidth = middleColumn.paddedWidth + panel.paddedWidth * 2;


### PR DESCRIPTION
Fixed several small miscalculations for the panel variables. The widths set in the config should be matching exactly in the DOM now. I made an effort to make the variables easier to understand for the layout. Feedback is welcome.

To fix the responsive bugs with the search page, i had to make a new context for the two panel layout. Not ideal, but not trivial to do differently.

Fixed search result icon placement on smaller devices.

Fixed the counts for the pagination info, they were off by 1.