### PR TITLE
Fix embedded discussions link translation 

### DIFF
--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -525,49 +525,7 @@ class PostController extends VanillaController {
                 $this->Form->addHidden('vanilla_url', $vanilla_url);
                 $this->Form->addHidden('vanilla_category_id', $vanilla_category_id);
 
-                $PageInfo = fetchPageInfo($vanilla_url);
-
-                if (!($Title = $this->Form->getFormValue('Name'))) {
-                    $Title = val('Title', $PageInfo, '');
-                    if ($Title == '') {
-                        $Title = t('Undefined discussion subject.');
-                        if (!empty($PageInfo['Exception']) && $PageInfo['Exception'] === "Couldn't connect to host.") {
-                            $Title .= ' '.t('Page timed out.');
-                        }
-
-                    }
-                }
-
-                $Description = val('Description', $PageInfo, '');
-                $Images = val('Images', $PageInfo, []);
-                $LinkText = t('EmbeddedDiscussionLinkText', t('Read the full story here'));
-
-                if (!$Description && count($Images) == 0) {
-                    $Body = formatString(
-                        '<p><a href="{Url}">{LinkText}</a></p>',
-                        ['Url' => $vanilla_url, 'LinkText' => $LinkText]
-                    );
-                } else {
-                    $Body = formatString('
-                <div class="EmbeddedContent">{Image}<strong>{Title}</strong>
-                   <p>{Excerpt}</p>
-                   <p><a href="{Url}">{LinkText}</a></p>
-                   <div class="ClearFix"></div>
-                </div>', [
-                        'Title' => $Title,
-                        'Excerpt' => $Description,
-                        'Image' => (count($Images) > 0 ? img(val(0, $Images), ['class' => 'LeftAlign']) : ''),
-                        'Url' => $vanilla_url,
-                        'LinkText' => $LinkText
-                    ]);
-                }
-
-                if ($Body == '') {
-                    $Body = $vanilla_url;
-                }
-                if ($Body == '') {
-                    $Body = t('Undefined discussion body.');
-                }
+                $PageInfo = $this->DiscussionModel->fetchPageInfo($vanilla_url);
 
                 // Validate the CategoryID for inserting.
                 $Category = CategoryModel::categories($vanilla_category_id);
@@ -610,9 +568,9 @@ class PostController extends VanillaController {
                     'CategoryID' => $vanilla_category_id,
                     'ForeignID' => $vanilla_identifier,
                     'Type' => $vanilla_type,
-                    'Name' => $Title,
-                    'Body' => $Body,
-                    'Format' => 'Html',
+                    'Name' => $PageInfo['Name'],
+                    'Body' => $PageInfo['Body'],
+                    'Format' => $PageInfo['Format'],
                     'Attributes' => dbencode($Attributes)
                 ];
                 $this->EventArguments['Discussion'] =& $EmbeddedDiscussionData;

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -540,7 +540,7 @@ class PostController extends VanillaController {
 
                 $Description = val('Description', $PageInfo, '');
                 $Images = val('Images', $PageInfo, []);
-                $LinkText = t('EmbededDiscussionLinkText', 'Read the full story here');
+                $LinkText = t('EmbededDiscussionLinkText', t('Read the full story here'));
 
                 if (!$Description && count($Images) == 0) {
                     $Body = formatString(

--- a/applications/vanilla/controllers/class.postcontroller.php
+++ b/applications/vanilla/controllers/class.postcontroller.php
@@ -540,7 +540,7 @@ class PostController extends VanillaController {
 
                 $Description = val('Description', $PageInfo, '');
                 $Images = val('Images', $PageInfo, []);
-                $LinkText = t('EmbededDiscussionLinkText', t('Read the full story here'));
+                $LinkText = t('EmbeddedDiscussionLinkText', t('Read the full story here'));
 
                 if (!$Description && count($Images) == 0) {
                     $Body = formatString(


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/2164

**Steps to test:**
1. Make sure you have embedded comments setup on your local (or Wordpress)
2. If a discussion is already created with the embedded comments local, delete it. (this test requires the discussion to be created).
3. Change your local language to spanish.
4. Make a comment in the embedded comments.
5. Go to your local and open the discussion it created, notice the link to the post says "Read the full story here"
6. Delete the discussion.
7. Checkout this branch and repeat from step **4.**. Observe now that the link matches the language set.