### PR TITLE
Fix kb dashboard dependency on kb

### DIFF
--- a/library/src/scripts/search/SearchPageRoute.tsx
+++ b/library/src/scripts/search/SearchPageRoute.tsx
@@ -3,8 +3,10 @@
  * @license GPL-2.0-only
  */
 
+import React from "react";
 import RouteHandler from "@library/routing/RouteHandler";
 import { NEW_SEARCH_PAGE_ENABLED } from "@library/search/searchConstants";
+import Loader from "@library/loaders/Loader";
 
 export function makeSearchUrl(): string {
     return NEW_SEARCH_PAGE_ENABLED ? "/search" : "/kb/search";
@@ -14,4 +16,5 @@ export const SearchPageRoute = new RouteHandler(
     () => import(/* webpackChunkName: "pages/search" */ "@vanilla/library/src/scripts/search/SearchPage"),
     makeSearchUrl(),
     makeSearchUrl,
+    (<Loader />),
 );


### PR DESCRIPTION
Fixes issue in the prod build where the dashboard won't load.

I'm not 100% sure why not implicitly specifying the loader for this page caused the issue, but this resolves it.