### PR TITLE
Fix previous link page error

### DIFF
--- a/applications/dashboard/modules/class.pagermodule.php
+++ b/applications/dashboard/modules/class.pagermodule.php
@@ -386,7 +386,7 @@ class PagerModule extends Gdn_Module {
             return sprintf(
                 $this->Wrapper,
                 attribute(['class' => concatSep(' ', $this->CssClass, static::PREV_NEXT_CLASS)]),
-                $this->previousLink($pageCount + 1, $attributes)
+                $this->previousLink($pageCount + 1)
             );
         }
 
@@ -672,11 +672,12 @@ class PagerModule extends Gdn_Module {
     }
 
     /**
-     * @param $currentPage
-     * @param array $options
+     * Generate the previous page link.
+     *
+     * @param int $currentPage
      * @return string
      */
-    private function previousLink($currentPage, $options): string {
+    private function previousLink($currentPage): string {
         return anchor(t('Previous'), $this->pageUrl($currentPage - 1), 'Previous', ['rel' => 'prev', 'tabindex' => '0']);
     }
 }


### PR DESCRIPTION
There was a change introduced in [this PR](https://github.com/vanilla/vanilla/pull/10694) that was later partially rolled back [here](https://github.com/vanilla/vanilla/pull/10694). It left behind an extra parameter that wasn’t always passed, which lead to a page crash because the method wasn’t being properly called.

Closes https://github.com/vanilla/support/issues/2189.