### PR TITLE
Revert "A config overide for relative/absolute path in setCacheDir"

### DIFF
--- a/library/Vanilla/AddonManager.php
+++ b/library/Vanilla/AddonManager.php
@@ -1210,7 +1210,7 @@ class AddonManager {
      * @return AddonManager Returns `$this` for fluent calls.
      */
     public function setCacheDir($cacheDir) {
-        if ($cacheDir !== null && strpos($cacheDir, PATH_ROOT) !== 0 && Gdn::config('Cache.DirRelative', true)) {
+        if ($cacheDir !== null && strpos($cacheDir, PATH_ROOT) !== 0) {
             $cacheDir = PATH_ROOT.$cacheDir;
         }
         $this->cacheDir = $cacheDir;


### PR DESCRIPTION
This reverts commit 04ad592d91b9a638b593f082b76506c3206bea5b.

Sorry, we strive not to use static references in the Vanilla and Garden namespaces. Moreover, that reference is bugged.