### PR TITLE
Verify if user information is defined.

### DIFF
--- a/library/src/scripts/headers/mebox/pieces/MeBoxDropDownItem.tsx
+++ b/library/src/scripts/headers/mebox/pieces/MeBoxDropDownItem.tsx
@@ -62,12 +62,16 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
             const authorCount = this.props.authors.length;
             if ("authors" in this.props && authorCount > 0) {
                 authors = this.props.authors!.map((user, index) => {
-                    return (
-                        <React.Fragment key={`meBoxAuthor-${index}`}>
-                            <strong>{user.name}</strong>
-                            {`${index < authorCount - 1 ? `, ` : ""}`}
-                        </React.Fragment>
-                    );
+                    if (user) {
+                        return (
+                            <React.Fragment key={`meBoxAuthor-${index}`}>
+                                <strong>{user.name}</strong>
+                                {`${index < authorCount - 1 ? `, ` : ""}`}
+                            </React.Fragment>
+                        );
+                    } else {
+                        return <></>;
+                    }
                 });
             }
         }

--- a/library/src/scripts/headers/mebox/pieces/MeBoxDropDownItem.tsx
+++ b/library/src/scripts/headers/mebox/pieces/MeBoxDropDownItem.tsx
@@ -62,7 +62,7 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
             const { authors } = this.props;
             const authorCount = this.props.authors.length;
             if (authors && authorCount > 0) {
-                authorList = this.props.authors!.map((user, index) => {
+                authorList = authors.map((user, index) => {
                     if (user) {
                         return (
                             <React.Fragment key={`meBoxAuthor-${index}`}>

--- a/library/src/scripts/headers/mebox/pieces/MeBoxDropDownItem.tsx
+++ b/library/src/scripts/headers/mebox/pieces/MeBoxDropDownItem.tsx
@@ -55,13 +55,14 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
         const classesMeBoxMessage = meBoxMessageClasses();
         const classesMetas = metasClasses();
 
-        let authors: JSX.Element[];
+        let authorList: JSX.Element[];
 
         if (this.props.type === MeBoxItemType.MESSAGE) {
             // Message
+            const { authors } = this.props;
             const authorCount = this.props.authors.length;
-            if ("authors" in this.props && authorCount > 0) {
-                authors = this.props.authors!.map((user, index) => {
+            if (authors && authorCount > 0) {
+                authorList = this.props.authors!.map((user, index) => {
                     if (user) {
                         return (
                             <React.Fragment key={`meBoxAuthor-${index}`}>
@@ -70,7 +71,7 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
                             </React.Fragment>
                         );
                     } else {
-                        return <></>;
+                        return <React.Fragment key={`meBoxAuthor-${index}`} />;
                     }
                 });
             }
@@ -87,9 +88,9 @@ export default class MeBoxDropDownItem extends React.Component<IProps> {
                         )}
                     </div>
                     <div className={classNames("meBoxMessage-contents", classesMeBoxMessage.contents)}>
-                        {!!authors! && (
+                        {!!authorList! && (
                             <div className={classNames("meBoxMessage-message", classesMeBoxMessage.message)}>
-                                {authors!}
+                                {authorList!}
                             </div>
                         )}
                         {/* Current notifications API returns HTML-formatted messages. Should be updated to return something aside from raw HTML. */}


### PR DESCRIPTION
This fixes https://github.com/vanilla/support/issues/2166.  Not all the user information is sent back from `/conversations`, so trying access the authors prop info would throw an error.

closes https://github.com/vanilla/support/issues/2166
closes https://github.com/vanilla/support/issues/1758