### PR TITLE
Move allow file upload outside custom permissions toggle

### DIFF
--- a/applications/vanilla/views/vanillasettings/editcategory.twig
+++ b/applications/vanilla/views/vanillasettings/editcategory.twig
@@ -97,9 +97,11 @@ dashboardHeading({
             {{ form.toggle('CustomPermissions', 'This category has custom permissions.') }}
         </li>
     {% endif %}
+    {% if _PermissionFields is defined %}
+        {{ form.simple(_PermissionFields, []) }}
+    {% endif %}
 </ul>
 <div class="CategoryPermissions">
-
     {% if DiscussionTypes|length > 1 %}
         <div class="P DiscussionTypes form-group">
             <div class="label-wrap">
@@ -112,11 +114,6 @@ dashboardHeading({
             </div>
         </div>
     {% endif %}
-
-    {% if _PermissionFields is defined %}
-    {{ form.simple(_PermissionFields, []) }}
-    {% endif %}
-
     <div class="padded">{{ t('Check all permissions that apply for each role') }}</div>
     {{ form.checkBoxGridGroups(PermissionData, 'Permission') }}
 </div>


### PR DESCRIPTION
 https://github.com/vanilla/support/issues/1592

### Details

Advanced Editor's "Allow File Upload" is only visible when Custom Category Permissions is toggled. This is confusing users, Allow File Upload checkbox could be enabled when "Custom Category Permissions" is disabled.
![Screen Shot 2020-06-26 at 10 18 05 AM](https://user-images.githubusercontent.com/31856281/85867046-5824b700-b796-11ea-9d03-f167cee5ed7c.png)

This PR moves the checkbox outside of Custom Permissions.
