### PR TITLE
Fix Twitch clip URL parsing

### DIFF
--- a/library/Vanilla/EmbeddedContent/Factories/TwitchEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/TwitchEmbedFactory.php
@@ -110,20 +110,22 @@ class TwitchEmbedFactory extends AbstractEmbedFactory {
      * @param string $url
      * @return string|null
      */
-    private function idFromUrl(string $url): ?string {
+    public function idFromUrl(string $url): ?string {
         $host = parse_url($url, PHP_URL_HOST);
         $path = parse_url($url, PHP_URL_PATH);
 
-        if ($host === false || $host === null || $path === false || $path === null) {
+        if (!is_string($host) || !is_string($path)) {
             return null;
         }
 
-        if ($host === "clips.twitch.tv" || preg_match("`/(?<channel>[^/]+)/clip/(?<clipID>[^/]+)`", $path, $clipsMatch)) {
+        if ($host === "clips.twitch.tv" && preg_match("`^/(?<clipID>[^/]+)`", $path, $clipsMatch)) {
             return "clip:{$clipsMatch['clipID']}";
-        } elseif (preg_match("`/(?<type>videos|collections)/(?<id>[^/]+)`", $path, $videosMatch)) {
+        } elseif (preg_match("`^/(?<channel>[^/]+)/clip/(?<clipID>[^/]+)`", $path, $clipsMatch)) {
+            return "clip:{$clipsMatch['clipID']}";
+        } elseif (preg_match("`^/(?<type>videos|collections)/(?<id>[^/]+)`", $path, $videosMatch)) {
             $type = $videosMatch["type"] === "videos" ? "video" : "collection";
             return "{$type}:{$videosMatch['id']}";
-        } elseif (preg_match("`/(?<channel>[^/]+)`", $path, $channelMatch)) {
+        } elseif (preg_match("`^/(?<channel>[^/]+)`", $path, $channelMatch)) {
             return "channel:{$channelMatch['channel']}";
         }
 

--- a/tests/Library/Vanilla/EmbeddedContent/Factories/TwitchEmbedFactoryTest.php
+++ b/tests/Library/Vanilla/EmbeddedContent/Factories/TwitchEmbedFactoryTest.php
@@ -114,4 +114,47 @@ class TwitchEmbedFactoryTest extends MinimalContainerTestCase {
         $dataEmbed = new TwitchEmbed($embedData);
         $this->assertInstanceOf(TwitchEmbed::class, $dataEmbed);
     }
+
+    /**
+     * Verify generating Twitch video embed type and ID from a URL.
+     *
+     * @param string $url
+     * @param string|null $expectedID
+     * @dataProvider provideIDTestUrls
+     */
+    public function testIDFromUrl(string $url, ?string $expectedID): void {
+        $embed = $this->factory->createEmbedForUrl($url);
+        $data = $embed->jsonSerialize();
+        $this->assertSame($data["twitchID"], $expectedID);
+    }
+
+    /**
+     * Provide data for testing extracting an embed type and ID from a URL.
+     *
+     * @return array
+     */
+    public function provideIDTestUrls(): array {
+        return [
+            "Clip, short-form" => [
+                "https://clips.twitch.tv/KnottyOddFishShazBotstix",
+                "clip:KnottyOddFishShazBotstix",
+            ],
+            "Clip, long-form" => [
+                "https://www.twitch.tv/jerma985/clip/KnottyOddFishShazBotstix",
+                "clip:KnottyOddFishShazBotstix",
+            ],
+            "Channel" => [
+                "https://www.twitch.tv/jerma985",
+                "channel:jerma985",
+            ],
+            "Video" => [
+                "https://www.twitch.tv/videos/346728148",
+                "video:346728148",
+            ],
+            "Collection" => [
+                "https://www.twitch.tv/collections/myIbIFkZphQSbQ",
+                "collection:myIbIFkZphQSbQ",
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Twitch "clip" URL detection was broken for the clips.twitch.tv domain, due to an incorrect condition. It has been resolved here. Additionally, tests have been added for the ID-extraction routine.