### PR TITLE
Add unread conversations to GET /me

### DIFF
--- a/applications/dashboard/controllers/api/UsersApiController.php
+++ b/applications/dashboard/controllers/api/UsersApiController.php
@@ -388,6 +388,10 @@ class UsersApiController extends AbstractApiController {
                 "description" => "Total number of unread notifications for the current user.",
                 "type" => "integer",
             ],
+            "countUnreadConversations" => [
+                "description" => "Total number of unread conversations for the current user.",
+                "type" => "integer",
+            ],
             "permissions" => [
                 "description" => "Global permissions available to the current user.",
                 "items" => [
@@ -409,6 +413,7 @@ class UsersApiController extends AbstractApiController {
         // Expand permissions for the current user.
         $user["permissions"] = $this->globalPermissions();
         $user["countUnreadNotifications"] = $this->activityModel->getUserTotalUnread($this->getSession()->UserID);
+        $user["countUnreadConversations"] = $user['countUnreadConversations'] ?? 0;
 
         $result = $out->validate($user);
         return $result;

--- a/applications/dashboard/openapi/users.yml
+++ b/applications/dashboard/openapi/users.yml
@@ -189,6 +189,12 @@ paths:
                         type: array
                         items:
                           type: string
+                      countUnreadNotifications:
+                        description: Total number of unread notifications for the current user.
+                        type: integer
+                      countUnreadConversations:
+                        description: Total number of unread conversations for the current user.
+                        type: integer
                     required:
                       - isAdmin
                       - permissions

--- a/applications/vanilla/library/Menu/UserCounterProvider.php
+++ b/applications/vanilla/library/Menu/UserCounterProvider.php
@@ -36,7 +36,6 @@ class UserCounterProvider implements CounterProviderInterface {
             $counters[] = new Counter("Bookmarks", $user->CountBookmarks ?? 0);
             $counters[] = new Counter("Discussions", $user->CountDiscussions ?? 0);
             $counters[] = new Counter("UnreadDiscussions", $user->CountUnreadDiscussions ?? 0);
-            $counters[] = new Counter("UnreadConversations", $user->CountUnreadConversations ?? 0);
             $counters[] = new Counter("Drafts", $user->CountDrafts ?? 0);
         }
         return $counters;

--- a/applications/vanilla/library/Menu/UserCounterProvider.php
+++ b/applications/vanilla/library/Menu/UserCounterProvider.php
@@ -36,6 +36,7 @@ class UserCounterProvider implements CounterProviderInterface {
             $counters[] = new Counter("Bookmarks", $user->CountBookmarks ?? 0);
             $counters[] = new Counter("Discussions", $user->CountDiscussions ?? 0);
             $counters[] = new Counter("UnreadDiscussions", $user->CountUnreadDiscussions ?? 0);
+            $counters[] = new Counter("UnreadConversations", $user->CountUnreadConversations ?? 0);
             $counters[] = new Counter("Drafts", $user->CountDrafts ?? 0);
         }
         return $counters;

--- a/library/src/scripts/@types/api/users.ts
+++ b/library/src/scripts/@types/api/users.ts
@@ -16,6 +16,7 @@ export interface IUserFragmentAndRoles extends IUserFragment, IUserRoles {}
 export interface IMe extends IUserFragment {
     permissions: string[];
     countUnreadNotifications: number;
+    countUnreadConversations: number;
     isAdmin: boolean;
 }
 

--- a/library/src/scripts/headers/mebox/pieces/MessagesCount.tsx
+++ b/library/src/scripts/headers/mebox/pieces/MessagesCount.tsx
@@ -8,6 +8,7 @@ import { MeBoxIcon } from "@library/headers/mebox/pieces/MeBoxIcon";
 import { MessagesIcon } from "@library/icons/titleBar";
 import { t } from "@library/utility/appUtils";
 import React from "react";
+import { useUsersState } from "@library/features/users/userModel";
 
 interface IProps {
     open?: boolean;
@@ -19,9 +20,11 @@ interface IProps {
  */
 export default function MessagesCount(props: IProps) {
     const { open, compact } = props;
+    const currentUser = useUsersState().currentUser;
+    const count = currentUser.data?.countUnreadConversations ? currentUser.data.countUnreadConversations : 0;
 
     return (
-        <MeBoxIcon count={0} countLabel={t("Messages") + ": "} compact={compact}>
+        <MeBoxIcon count={count} countLabel={t("Messages") + ": "} compact={compact}>
             <MessagesIcon filled={!!open} />
         </MeBoxIcon>
     );

--- a/library/src/scripts/headers/titeBar.story.tsx
+++ b/library/src/scripts/headers/titeBar.story.tsx
@@ -35,6 +35,7 @@ const makeMockGuestUser: IMe = {
     photoUrl: "",
     dateLastActive: "",
     countUnreadNotifications: 1,
+    countUnreadConversations: 1,
 };
 
 story.add(

--- a/library/src/scripts/headers/titleBarRegisterUser.story.tsx
+++ b/library/src/scripts/headers/titleBarRegisterUser.story.tsx
@@ -35,6 +35,7 @@ const makeMockRegisterUser: IMe = {
     photoUrl: "",
     dateLastActive: "",
     countUnreadNotifications: 1,
+    countUnreadConversations: 1,
 };
 
 story.add(

--- a/library/src/scripts/headers/titleBarStyles.story.tsx
+++ b/library/src/scripts/headers/titleBarStyles.story.tsx
@@ -41,6 +41,7 @@ const makeMockRegisterUser: IMe = {
     photoUrl: "",
     dateLastActive: "",
     countUnreadNotifications: 1,
+    countUnreadConversations: 1,
 };
 
 const initialState = testStoreState({

--- a/tests/APIv2/UsersTest.php
+++ b/tests/APIv2/UsersTest.php
@@ -228,6 +228,7 @@ class UsersTest extends AbstractResourceTest {
             "dateLastActive" => null,
             "isAdmin" => false,
             "countUnreadNotifications" => 0,
+            "countUnreadConversations" => 0,
             "permissions" => [
                 "activity.view",
                 "discussions.view",
@@ -271,6 +272,7 @@ class UsersTest extends AbstractResourceTest {
             "dateLastActive" => $dateLastActive,
             "isAdmin" => true,
             "countUnreadNotifications" => 0,
+            "countUnreadConversations" => 0,
             "permissions" => [
                 "activity.delete",
                 "activity.view",


### PR DESCRIPTION
Adds the users unread conversations count to the /me endpoint.  Applies it in the front for the message count.

closes https://github.com/vanilla/support/issues/2168
