### PR TITLE
Fix search page mounting

### DIFF
--- a/applications/dashboard/src/scripts/entries/forum.tsx
+++ b/applications/dashboard/src/scripts/entries/forum.tsx
@@ -17,7 +17,7 @@ import RecoverPasswordPage from "@dashboard/pages/RecoverPasswordPage";
 import NotificationsModel from "@library/features/notifications/NotificationsModel";
 import { Router } from "@library/Router";
 import { AppContext } from "@library/AppContext";
-import { addComponent } from "@library/utility/componentRegistry";
+import { addComponent, addPageComponent } from "@library/utility/componentRegistry";
 import { TitleBarHamburger } from "@library/headers/TitleBarHamburger";
 import { authReducer } from "@dashboard/auth/authReducer";
 import { compatibilityStyles } from "@dashboard/compatibilityStyles";
@@ -57,7 +57,7 @@ applySharedPortalContext(props => {
 });
 
 // Routing
-addComponent("App", () => <Router disableDynamicRouting />);
+addPageComponent(() => <Router disableDynamicRouting />);
 
 // The community is still very tied into the global.js and legacyAnalyticsTick.json.
 enableLegacyAnalyticsTick(true);

--- a/library/src/scripts/routing/RouteHandler.tsx
+++ b/library/src/scripts/routing/RouteHandler.tsx
@@ -32,7 +32,7 @@ export default class RouteHandler<GeneratorProps> {
         componentPromise: LoadFunction,
         public path: string | string[],
         url: (data: GeneratorProps) => string,
-        loadingComponent: React.ReactNode = Loader,
+        loadingComponent: React.ComponentType = Loader,
         key?: string,
     ) {
         this.loadable = Loadable({

--- a/library/src/scripts/search/SearchPage.tsx
+++ b/library/src/scripts/search/SearchPage.tsx
@@ -31,7 +31,7 @@ import { useLastValue } from "@vanilla/react-utils";
 import classNames from "classnames";
 import debounce from "lodash/debounce";
 import qs from "qs";
-import * as React from "react";
+import React from "react";
 import { useCallback, useEffect } from "react";
 import { useLocation } from "react-router";
 

--- a/library/src/scripts/search/SearchPageRoute.tsx
+++ b/library/src/scripts/search/SearchPageRoute.tsx
@@ -3,7 +3,6 @@
  * @license GPL-2.0-only
  */
 
-import React from "react";
 import RouteHandler from "@library/routing/RouteHandler";
 import { NEW_SEARCH_PAGE_ENABLED } from "@library/search/searchConstants";
 import Loader from "@library/loaders/Loader";
@@ -16,5 +15,5 @@ export const SearchPageRoute = new RouteHandler(
     () => import(/* webpackChunkName: "pages/search" */ "@vanilla/library/src/scripts/search/SearchPage"),
     makeSearchUrl(),
     makeSearchUrl,
-    (<Loader />),
+    Loader,
 );


### PR DESCRIPTION
The loader component type of `RouteHandler` was incorrect and as a result caused the search page to load incorrectly.

I've fixed the type and the incorrect usage.