### PR TITLE
Obscure known sensitive fields in the LogDecorator 

### DIFF
--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -787,7 +787,6 @@ class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
                 'code' => $code,
                 'client_id' => val('AssociationKey', $provider),
                 'redirect_uri' => url('/entry/'. $this->getProviderKey(), true),
-                'client_secret' => val('AssociationSecret', $provider),
                 'grant_type' => 'authorization_code',
                 'scope' => val('AcceptedScope', $provider)
             ];

--- a/library/core/class.oauth2.php
+++ b/library/core/class.oauth2.php
@@ -787,6 +787,7 @@ class Gdn_OAuth2 extends SSOAddon implements \Vanilla\InjectableInterface {
                 'code' => $code,
                 'client_id' => val('AssociationKey', $provider),
                 'redirect_uri' => url('/entry/'. $this->getProviderKey(), true),
+                'client_secret' => val('AssociationSecret', $provider),
                 'grant_type' => 'authorization_code',
                 'scope' => val('AcceptedScope', $provider)
             ];

--- a/tests/Library/Vanilla/Logging/LogDecoratorTest.php
+++ b/tests/Library/Vanilla/Logging/LogDecoratorTest.php
@@ -70,4 +70,12 @@ class LogDecoratorTest extends TestCase {
             'userid' => 123,
         ]);
     }
+
+    /**
+     * Test basic context cleaning.
+     */
+    public function testObscureContext(): void {
+        $this->log->info('foo', ['a' => ['ClientSecret' => 'a', 'Password' => 'b']]);
+        $this->assertLog(['a' => ['ClientSecret' => '***', 'Password' => '***']]);
+    }
 }


### PR DESCRIPTION
Even though viewing our logs are generally something that is admin access only, we should be better about sending sensitive information to the log. This PR removes one such sensitive secret and also adds some global protection against sending sensitive information.

Closes https://github.com/vanilla/support/issues/2191.