### PR TITLE
Update site test trait to allow overrides

### DIFF
--- a/tests/SiteTestTrait.php
+++ b/tests/SiteTestTrait.php
@@ -103,7 +103,7 @@ trait SiteTestTrait {
         static::bootstrapBeforeClass();
 
         $dic = self::$container;
-        self::configureContainerBeforeStartup($dic);
+        static::configureContainerBeforeStartup($dic);
 
         /* @var TestInstallModel $installer */
         $installer = $dic->get(TestInstallModel::class);


### PR DESCRIPTION
I just recently added this method so that it could be overridden, but I accidently used `self` instead of `static`.