### PR TITLE
Conversations: Add "Cache-Control: no-store" to inbox

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -45,6 +45,14 @@ class MessagesController extends ConversationsController {
         if (checkPermission('Conversations.Conversations.Add')) {
             $this->addModule('NewConversationModule');
         }
+
+        /**
+         * The default Cache-Control header does not include no-store, which can cause issues (e.g. inaccurate unread
+         * status or new message counts) when users visit the conversation list via the browser's back button. The same
+         * check is performed here as in Gdn_Controller before the Cache-Control header is added, but this value
+         * includes the no-store specifier.
+         */
+        $this->setHeader('Cache-Control', 'private, no-cache, no-store, max-age=0, must-revalidate');
     }
 
     /**


### PR DESCRIPTION
This prevents opened conversations from still being shown as "new" when navigating back to the inbox list using the back button. (this issue mostly exists in mobile chrome which seems to cache more aggressively)

This is similar to how back button navigation is handled in category and discussion lists. See:
https://github.com/vanilla/vanilla/search?q=no-store&unscoped_q=no-store