### PR TITLE
Remove caching of dependencies in SchemaFactory

### DIFF
--- a/library/Vanilla/SchemaFactory.php
+++ b/library/Vanilla/SchemaFactory.php
@@ -16,12 +16,6 @@ use Psr\Container\ContainerInterface;
  */
 final class SchemaFactory {
 
-    /** @var ContainerInterface */
-    private static $container;
-
-    /** @var EventManager */
-    private static $eventManager;
-
     /**
      * Get an instance of a schema object by its class name.
      *
@@ -31,7 +25,7 @@ final class SchemaFactory {
      */
     public static function get(string $schema, ?string $id = null): Schema {
         /** @var Schema */
-        $schema = self::getContainer()->get($schema);
+        $schema = Gdn::getContainer()->get($schema);
         if ($id) {
             $schema->setID($id);
         }
@@ -43,26 +37,20 @@ final class SchemaFactory {
      * Get the configured container.
      *
      * @return ContainerInterface
+     * @deprecated
      */
     public static function getContainer(): ContainerInterface {
-        if (!isset(self::$container)) {
-            self::$container = Gdn::getContainer();
-        }
-        return self::$container;
+        return Gdn::getContainer();
     }
 
     /**
      * Get the configured event manager instance.
      *
      * @return EventManager
+     * @deprecated
      */
     public static function getEventManager(): EventManager {
-        if (!isset(self::$eventManager)) {
-            /** @var EventManager */
-            $eventManager = self::getContainer()->get(EventManager::class);
-            self::setEventManager($eventManager);
-        }
-        return self::$eventManager;
+        return Gdn::getContainer()->get(EventManager::class);
     }
 
     /**
@@ -101,7 +89,7 @@ final class SchemaFactory {
 
         if ($id) {
             // Fire an event for schema modification.
-            self::getEventManager()->fire("{$id}Schema_init", $result);
+            Gdn::getContainer()->get(EventManager::class)->fire("{$id}Schema_init", $result);
         }
 
         return $result;
@@ -112,9 +100,10 @@ final class SchemaFactory {
      *
      * @param ContainerInterface $container
      * @return void
+     * @deprecated
      */
     public static function setContainer(?ContainerInterface $container): void {
-        self::$container = $container;
+        return;  // noop
     }
 
     /**
@@ -122,8 +111,9 @@ final class SchemaFactory {
      *
      * @param EventManager $eventManager
      * @return void
+     * @deprecated
      */
     public static function setEventManager(?EventManager $eventManager): void {
-        self::$eventManager = $eventManager;
+        return; // noop
     }
 }

--- a/tests/Library/Vanilla/SchemaFactoryTest.php
+++ b/tests/Library/Vanilla/SchemaFactoryTest.php
@@ -21,6 +21,17 @@ class SchemaFactoryTest extends TestCase {
 
     use BootstrapTrait;
 
+    /** @var EventManager */
+    private $eventManager;
+
+    /**
+     * This method is called before each test.
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->eventManager = $this->container()->get(EventManager::class);
+    }
+
     /**
      * Provide type prameters to verify the associated events are properly dispatched.
      *
@@ -53,14 +64,6 @@ class SchemaFactoryTest extends TestCase {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function setUp(): void {
-        SchemaFactory::setContainer($this->container());
-        SchemaFactory::setEventManager($this->container()->get(EventManager::class));
-    }
-
-    /**
      * Verify the expected events are dispatched when the schema is retrieved from the container.
      *
      * @param string $class
@@ -70,12 +73,8 @@ class SchemaFactoryTest extends TestCase {
      * @dataProvider provideGetEvents
      */
     public function testGetEventDispatched(string $class, string $id, string $event): void {
-        // Start with a clean slate.
-        $eventManager = new EventManager($this->container());
-        SchemaFactory::setEventManager($eventManager);
-
         $dispatched = false;
-        $eventManager->bind($event, function () use (&$dispatched) {
+        $this->eventManager->bind($event, function () use (&$dispatched) {
             $dispatched = true;
         });
 
@@ -92,12 +91,8 @@ class SchemaFactoryTest extends TestCase {
      * @dataProvider provideParseEvents
      */
     public function testParseEventDispatched(string $id, string $event): void {
-        // Start with a clean slate.
-        $eventManager = new EventManager($this->container());
-        SchemaFactory::setEventManager($eventManager);
-
         $dispatched = false;
-        $eventManager->bind($event, function () use (&$dispatched) {
+        $this->eventManager->bind($event, function () use (&$dispatched) {
             $dispatched = true;
         });
 
@@ -111,11 +106,8 @@ class SchemaFactoryTest extends TestCase {
      * @return void
      */
     public function testPrepareEventDispatched(): void {
-        $eventManager = new EventManager($this->container());
-        SchemaFactory::setEventManager($eventManager);
-
         $dispatched = false;
-        $eventManager->bind("fooSchema_init", function () use (&$dispatched) {
+        $this->eventManager->bind("fooSchema_init", function () use (&$dispatched) {
             $dispatched = true;
         });
 
@@ -128,61 +120,5 @@ class SchemaFactoryTest extends TestCase {
         $schema->setID("bar");
         SchemaFactory::prepare($schema, "foo");
         $this->assertTrue($dispatched, "Overwriting an existing schema ID.");
-    }
-
-    /**
-     * Verify the container will automatically be retrieved when not explicitly set.
-     *
-     * @return void
-     */
-    public function testGetContainerDefault(): void {
-        // Unset the existing container.
-        SchemaFactory::setContainer(null);
-        $this->assertSame(
-            $this->container(),
-            SchemaFactory::getContainer()
-        );
-    }
-
-    /**
-     * Verify the event manager will automatically be retrieved when not explicitly set.
-     *
-     * @return void
-     */
-    public function testGetEventManagerDefault(): void {
-        // Unset the existing event manager.
-        SchemaFactory::setEventManager(null);
-        $this->assertSame(
-            $this->container()->get(EventManager::class),
-            SchemaFactory::getEventManager()
-        );
-    }
-
-    /**
-     * Test configuring the container dependency.
-     *
-     * @return void
-     */
-    public function testSetContainer(): void {
-        $container = new Container();
-        SchemaFactory::setContainer($container);
-        $this->assertSame(
-            $container,
-            SchemaFactory::getContainer()
-        );
-    }
-
-    /**
-     * Test configuring the event manager dependency.
-     *
-     * @return void
-     */
-    public function testSetEventManager(): void {
-        $eventManager = new EventManager($this->container());
-        SchemaFactory::setEventManager($eventManager);
-        $this->assertSame(
-            $eventManager,
-            SchemaFactory::getEventManager()
-        );
     }
 }


### PR DESCRIPTION
Static caching of the container and event manager can make testing difficult for any components that make use of `SchemaFactory`. The initial usage creates the instances, which are then stored. Future usage will reference a potentially out-of-date container or event manager.

The caching here is probably unnecessary, so it's being dropped. Tests won't have to worry about `SchemaFactory`'s container doppelgänger anymore.