### PR TITLE
Fix sending messages to users with comma in username

### DIFF
--- a/applications/conversations/controllers/class.messagescontroller.php
+++ b/applications/conversations/controllers/class.messagescontroller.php
@@ -71,17 +71,7 @@ class MessagesController extends ConversationsController {
 
         // Sending a new conversation.
         if ($this->Form->authenticatedPostBack()) {
-            $recipientUserIDs = [];
-            $to = explode(',', $this->Form->getFormValue('To', ''));
-            $userModel = new UserModel();
-            foreach ($to as $name) {
-                if (trim($name) != '') {
-                    $user = $userModel->getByUsername(trim($name));
-                    if (is_object($user)) {
-                        $recipientUserIDs[] = $user->UserID;
-                    }
-                }
-            }
+            $recipientUserIDs = explode(',', $this->Form->getFormValue('To', ''));
 
             // Enforce MaxRecipients
             if (!$this->ConversationModel->addUserAllowed(0, count($recipientUserIDs))) {

--- a/applications/conversations/js/conversations.js
+++ b/applications/conversations/js/conversations.js
@@ -109,7 +109,7 @@ jQuery(document).ready(function($) {
 
            $author.tokenInput(gdn.url('/user/tagsearch'), {
                hintText: gdn.definition("TagHint", "Start to type..."),
-               tokenValue: 'name',
+               tokenValue: 'id',
                tokenLimit: maxRecipients,
                searchingText: '', // search text gives flickery ux, don't like
                searchDelay: 300,


### PR DESCRIPTION

### Details

Sending messages to users with comma in their username is failing because of https://github.com/vanilla/vanilla/blob/ec766e44dd12ee0fcbcbc6ee1d0b7de9978e2690/applications/conversations/controllers/class.messagescontroller.php#L75

### To Test
Send a messages to users with comma in their username.