### PR TITLE
Fix Gdn_SQLDriver::noReset()

### DIFF
--- a/library/core/class.model.php
+++ b/library/core/class.model.php
@@ -502,16 +502,16 @@ class Gdn_Model extends Gdn_Pluggable {
             $where = [$this->PrimaryKey => $where];
         }
 
-        $resetData = false;
+        $resetData = true;
         if ($options === true || val('reset', $options)) {
             deprecated('Gdn_Model->delete() with reset true');
-            $resetData = true;
         } elseif (is_numeric($options)) {
             deprecated('The $limit parameter is deprecated in Gdn_Model->delete(). Use the limit option.');
             $limit = $options;
         } else {
-            $options += ['rest' => true, 'limit' => null];
+            $options += ['reset' => true, 'limit' => null];
             $limit = $options['limit'];
+            $resetData = $options['reset'];
         }
 
         if ($resetData) {

--- a/library/database/class.sqldriver.php
+++ b/library/database/class.sqldriver.php
@@ -1431,7 +1431,7 @@ abstract class Gdn_SQLDriver {
      * @return $this
      */
     public function noReset($noReset = true, $oneTime = true) {
-        $_NoReset = $noReset ? ($oneTime ? 1 : 2) : 0;
+        $this->_NoReset = $noReset ? ($oneTime ? 1 : 2) : 0;
         return $this;
     }
 
@@ -2123,7 +2123,7 @@ abstract class Gdn_SQLDriver {
         }
 
         $sql = $this->getTruncate($table);
-        $result = $this->query($sql, 'truncate');
+        $result = $this->query($sql, 'delete');
         return $result;
     }
 

--- a/tests/Library/Core/ModelTest.php
+++ b/tests/Library/Core/ModelTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Library\Core;
+
+use PHPUnit\Framework\TestCase;
+use VanillaTests\BootstrapTrait;
+use VanillaTests\SetupTraitsTrait;
+
+/**
+ * Tests for the `Gdn_Model` class.
+ */
+class ModelTest extends TestCase {
+    use BootstrapTrait, SetupTraitsTrait;
+
+    /**
+     * @var \Gdn_Model
+     */
+    private $model;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->initializeDatabase();
+        $this->setupTestTraits();
+
+        $this->container()->call(function (
+            \Gdn_DatabaseStructure $st,
+            \Gdn_SQLDriver $sql
+        ) {
+            $st->table('model')
+                ->primaryKey('modelID')
+                ->column('name', 'varchar(50)')
+                ->set();
+
+            $sql->truncate('model');
+        });
+
+        $this->model = new \Gdn_Model('model');
+    }
+
+    /**
+     * Test `Gdn_Model::delete()` with an option of `reset = false`.
+     */
+    public function testDeleteNoReset(): void {
+        $id = $this->model->insert(['name' => 'toDelete']);
+        $this->assertNotFalse($id);
+
+        $r = $this->model->delete(['modelID' => $id], ['reset' => false]);
+        $this->assertSame(1, $this->model->SQL->whereCount());
+        $this->model->SQL->reset();
+        $this->assertFalse($this->model->getID($id));
+    }
+}


### PR DESCRIPTION
There seems to be a bug in `Gdn_SQLDriver::noReset()`. This is one of those things that is definitely a fix, but could also lead to a regression. The only place I saw a usage in our entire code base is in `Gdn_Model` There was actually a typo above that was making that code path be hit in tests too which I fixed.

Finally, some tests were throwing exceptions because of an error in `Gdn_SQLDriver::truncate()` where they pass a non-existent option of ‘truncate’ to `Gdn_Database::query()`.

*Note: I made this fix on a different PR and it initially caused a flurry of failures which I addressed. This shows the code is getting hit a reasonable amount in our tests.*