### PR TITLE
Tweak the EntryController target cleaning

### DIFF
--- a/applications/dashboard/controllers/class.entrycontroller.php
+++ b/applications/dashboard/controllers/class.entrycontroller.php
@@ -2121,10 +2121,7 @@ class EntryController extends Gdn_Controller {
     /**
      * Set where to go after signin.
      *
-     * @access public
-     * @since 2.0.0
-     *
-     * @param string $target Where we're requested to go to.
+     * @param string|false $target Where we're requested to go to.
      * @return string URL to actually go to (validated & safe).
      */
     public function target($target = false) {
@@ -2134,21 +2131,16 @@ class EntryController extends Gdn_Controller {
                 $target = $this->Request->get('Target', $this->Request->get('target', '/'));
             }
         }
+        $target = url($target, true);
 
-        // Make sure that the target is a valid url.
-        if (!preg_match('`(^https?://)`', $target)) {
-            $target = '/' . ltrim($target, '/');
-
-            // Never redirect back to signin.
-            if (preg_match('`^/entry/signin`i', $target)) {
-                $target = '/';
-            }
+        // Never redirect back to sign in/out pages.
+        if (($this->Request->getHost() === parse_url($target, PHP_URL_HOST) &&
+            preg_match('`/entry/(?:signin|signout|autosignedout)($|\?)`i', $target)) ||
+            !isTrustedDomain($target)
+        ) {
+            $target = url('/', true);
         }
 
-        if (!isTrustedDomain(url($target, true))) {
-            $target = url(Gdn::router()->getDestination('DefaultController'));
-        }
-
-        return url($target, true);
+        return $target;
     }
 }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -380,6 +380,9 @@ class Bootstrap {
             ->addCall('setDispatchEventName', ['SchedulerDispatch'])
             ->addCall('setDispatchedEventName', ['SchedulerDispatched'])
             ->setShared(true)
+
+            ->rule(\Gdn_Form::class)
+            ->addAlias('Form')
             ;
     }
 

--- a/tests/Controllers/EntryControllerTest.php
+++ b/tests/Controllers/EntryControllerTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2020 Vanilla Forums Inc.
+ * @license GPL-2.0-only
+ */
+
+namespace VanillaTests\Controllers;
+
+use PHPUnit\Framework\TestCase;
+use VanillaTests\BootstrapTrait;
+use VanillaTests\SetupTraitsTrait;
+
+/**
+ * Tests for the `EntryController` class.
+ *
+ * These tests aren't exhaustive. If more tests are added then we may need to tweak this class to use the `SiteTestTrait`.
+ */
+class EntryControllerTest extends TestCase {
+    use BootstrapTrait, SetupTraitsTrait;
+
+    /**
+     * @var \EntryController
+     */
+    private $controller;
+
+    /**
+     * @inheritDoc
+     */
+    public function setUp(): void {
+        parent::setUp();
+        $this->setupTestTraits();
+
+        $this->controller = $this->container()->get(\EntryController::class);
+        $this->controller->getImports();
+        $this->controller->Request = $this->container()->get(\Gdn_Request::class);
+        $this->controller->initialize();
+    }
+
+    /**
+     * Target URLs should be checked for safety and UX.
+     *
+     * @param string|false $url
+     * @param string $expected
+     * @dataProvider provideTargets
+     */
+    public function testTarget($url, string $expected): void {
+        $expected = url($expected, true);
+
+        $actual = $this->controller->target($url);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * The querystring and form should control the target.
+     */
+    public function testTargetFallback(): void {
+        $target = url('/foo', true);
+        $this->controller->Request->setQuery(['target' => $target]);
+
+        $this->assertSame($target, $this->controller->target());
+
+        $target2 = url('/bar', true);
+        $this->controller->Form->setFormValue('Target', $target2);
+        $this->assertSame($target2, $this->controller->target());
+    }
+
+    /**
+     * Provide some sign out target tests.
+     *
+     * @return array
+     */
+    public function provideTargets(): array {
+        $r = [
+            ['/foo', '/foo'],
+            ['entry/signin', '/'],
+            ['entry/signout?foo=bar', '/'],
+            ['/entry/autosignedout', '/'],
+            ['/entry/autosignedout234', '/entry/autosignedout234'],
+            ['https://danger.test/hack', '/'],
+            [false, '/'],
+        ];
+
+        return array_column($r, null, 0);
+    }
+}


### PR DESCRIPTION
This makes a few tweaks to the target cleaning functionality of the `EntryController`.

- Add /entry/autosignedout to the list of URLs that won’t redirect. This is mainly a UX fix.
- Make unsafe domains redirect to ‘/‘ instead of the default route. This should dispatch to the default route.
- Make URLs process on the same domain rather than just checking targets without a domain. This ostensibly fixes a regression, but could also cause a regression where code depends on the behavior. I think this is an acceptable risk.

Closes https://github.com/vanilla/support/issues/2231