### PR TITLE
Encode banner title strings before outputting them

### DIFF
--- a/library/core/class.theme.php
+++ b/library/core/class.theme.php
@@ -434,7 +434,7 @@ class Gdn_Theme {
         if ($logo) {
             return img(Gdn_Upload::url($logo), ['alt' => $title]);
         } else {
-            return $title;
+            return htmlEsc($title);
         }
     }
 


### PR DESCRIPTION
Closes vanilla/vanilla-patches#682.

Currently, the banner title string is being encoded in the `Gdn_Theme::logo()` method, but not the `Gdn_Theme::mobileLogo()` method, which returns even when the site loaded on a desktop. Because we want to prevent html from being output from that field, this encodes the `$title` variable before returning it.

### TO TEST
1. Go to `https://dev.vanilla.localhost/dashboard/settings/branding`
1. Enter `aaaa"><script>alert(1337)</script>` in the "Banner Title" field.
1. Navigate to the homepage and verify that an alert is triggered.
1. Checkout this branch and reload the page.
1. Verify that the alert is not triggered.