### PR TITLE
Fix emoji flyout position on Wysiwyg

### DIFF
--- a/applications/dashboard/src/scripts/legacy/atwho.ts
+++ b/applications/dashboard/src/scripts/legacy/atwho.ts
@@ -218,7 +218,7 @@ export function initializeAtComplete(editorElement, iframe?: any) {
     /**
      * Pre-insert handler for atwho.
      *
-     * Note, in contenteditable mode (iframe for us), the value is surrounded by span tags.
+     * Note, in content editable mode (iframe for us), the value is surrounded by span tags.
      */
     function beforeInsertHandler(value: string, $li: JQuery<any>): string {
         // It's better to use the value provided, as it may have
@@ -309,7 +309,6 @@ export function initializeAtComplete(editorElement, iframe?: any) {
             cWindow: iframeWindow,
         })
         .atwho({
-            alias: "emoji",
             at: ":",
             tpl: emojiTemplate,
             insert_tpl: "${atwho-data-value}",


### PR DESCRIPTION
Closes https://github.com/vanilla/support/issues/2195

**Steps to test:**
- Make sure you have "wysiwyg" as your posting format
- Got to a discussion and on the comment form type some content and then type `:` and some emoji "name" (like "wink", or "smile")
- Notice that the emoji flyout open at the top of the page:
https://user-images.githubusercontent.com/19805402/85891270-c8deca00-b7bc-11ea-8072-7df1edf7d8da.png
- Checkout this branch 
- run `yarn build` and repeat

**Further testing:**
- Type `@` an start of the name of a user in your community to check the mention flyout position.