### PR TITLE
ConversationModel: Fix count() warning and max recipients bug

### DIFF
--- a/applications/conversations/models/class.conversationmodel.php
+++ b/applications/conversations/models/class.conversationmodel.php
@@ -896,11 +896,11 @@ class ConversationModel extends ConversationsModel {
             if (!$countRecipients) {
                 // Count current recipients
                 $conversationModel = new ConversationModel();
-                $countRecipients = $conversationModel->getRecipients($conversationID);
+                $countRecipients = count($conversationModel->getRecipients($conversationID));
             }
 
             // Add 1 because sender counts as a recipient.
-            $canAddRecipients = count($countRecipients) < ($maxRecipients + 1);
+            $canAddRecipients = $countRecipients < ($maxRecipients + 1);
         }
 
         return $canAddRecipients;


### PR DESCRIPTION
When supplied with an argument for `$countRecipients` > 0, `ConversationModel::addUserAllowed()` will apply `count()` to that number which throws a warning and always returns 1 which is also a bug (this means conversation user limits are currently only enforced [on the module](https://github.com/vanilla/vanilla/blob/818e6a6dc387dd47a0a9fa78c6899aebf6ba7ecb/applications/conversations/modules/class.addpeoplemodule.php#L36), [not on the controller](https://github.com/vanilla/vanilla/blob/d02782849c733ed79ccc64651db74c272ad1ab5e/applications/conversations/controllers/class.messagescontroller.php#L87)).

    PHP Warning:  count(): Parameter must be an array or an object that implements Countable