### PR TITLE
[backport] Fix JSON output of empty arrays in /api/v2/themes/:id/assets/:assetID

### DIFF
--- a/library/Vanilla/Theme/Asset/JsonThemeAsset.php
+++ b/library/Vanilla/Theme/Asset/JsonThemeAsset.php
@@ -140,7 +140,7 @@ class JsonThemeAsset extends ThemeAsset {
         ];
 
         if ($this->includeValueInJson) {
-            $result['data'] = $this->preservedOutputDecode($this->jsonString);
+            $result['data'] = json_decode($this->jsonString);
         }
 
         return $result;

--- a/tests/Library/Vanilla/Theme/JsonThemeAssetTest.php
+++ b/tests/Library/Vanilla/Theme/JsonThemeAssetTest.php
@@ -51,10 +51,9 @@ JSON;
             'empty object' => [
                 '{}'
             ],
-            // Unfortunately can't be fixed at the moment.
-            // 'nested empty array' => [
-            //    '{"key":[]}'
-            // ],
+             'nested empty array' => [
+                '{"key":[]}'
+             ],
             'nested empty object' => [
                 '{"key":{}}'
             ],


### PR DESCRIPTION
Backport: https://github.com/vanilla/vanilla-cloud/pull/222