### PR TITLE
Make sure we call renderPlainText() with a string

### DIFF
--- a/applications/vanilla/views/categories/helper_functions.php
+++ b/applications/vanilla/views/categories/helper_functions.php
@@ -28,7 +28,7 @@ if (!function_exists('CategoryPhoto')):
 
         if ($photoUrl) {
             $result = anchor(
-                '<img src="'.$photoUrl.'" class="CategoryPhoto" alt="'.Gdn::formatService()->renderPlainText(val('Name', $row), \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY).'" />',
+                '<img src="'.$photoUrl.'" class="CategoryPhoto" alt="'.Gdn::formatService()->renderPlainText(val('Name', $row, ''), \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY).'" />',
                 categoryUrl($row, '', '//'),
                 'Item-Icon PhotoWrap PhotoWrap-Category');
         } else {
@@ -292,7 +292,7 @@ if (!function_exists('WriteTableRow')):
                     }
 
                     echo "<{$h} aria-level='".$level."' class='".$headingClass."'>";
-                    $safeName = Gdn::formatService()->renderPlainText($row['Name'], \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY);
+                    $safeName = Gdn::formatService()->renderPlainText($row['Name'] ?? '', \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY);
                     echo $row['DisplayAs'] === 'Heading' ? $safeName : anchor($safeName, $row['Url']);
                     Gdn::controller()->EventArguments['Category'] = $row;
                     Gdn::controller()->fireEvent('AfterCategoryTitle');
@@ -355,7 +355,7 @@ if (!function_exists('WriteTableRow')):
                                 $lastCategory = CategoryModel::categories($row['LastCategoryID']);
 
                                 echo ' <span>',
-                                sprintf('in %s', anchor(Gdn::formatService()->renderPlainText($lastCategory['Name'], \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY), categoryUrl($lastCategory, '', '//'))),
+                                sprintf('in %s', anchor(Gdn::formatService()->renderPlainText($lastCategory['Name'] ?? '', \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY), categoryUrl($lastCategory, '', '//'))),
                                 '</span>';
 
                             }
@@ -413,7 +413,7 @@ if (!function_exists('writeCategoryTable')):
             $displayAs = val('DisplayAs', $category);
             $urlCode = $category['UrlCode'];
             $class = val('CssClass', $category);
-            $name = Gdn::formatService()->renderPlainText($category['Name'], \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY);
+            $name = Gdn::formatService()->renderPlainText($category['Name'] ?? '', \Vanilla\Formatting\Formats\HtmlFormat::FORMAT_KEY);
 
             if ($displayAs === 'Heading') :
                 if ($inTable) {


### PR DESCRIPTION
The `FormatService::renderPlainText()` method requires a string and will crash the page if null is passed to it. This change does some casting and default checking.

Note that we encountered the null when it came to the line with `$lastCategory` being null.
