### PR TITLE
Set locale chooser assetTarget to Panel

### DIFF
--- a/plugins/Multilingual/modules/class.localechoosermodule.php
+++ b/plugins/Multilingual/modules/class.localechoosermodule.php
@@ -10,7 +10,7 @@ class LocaleChooserModule extends Gdn_Module {
     public $Links = '';
 
     public function assetTarget() {
-        return 'Foot';
+        return 'Panel';
     }
 
     /**


### PR DESCRIPTION
The Multilingual locale chooser module is not displayed at all in Vanilla 4.0.
When we change the assetTarget to Panel it is displayed properly and we can let users actually change language.
