### PR TITLE
Restore dev environment after Phing build

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -26,6 +26,14 @@
             <arg line="--working-dir=${project.dir} install --no-dev --optimize-autoloader" />
         </composer>
     </target>
+    
+    <!-- Restore developer localhost after the build. -->
+    <target name="cleanup">
+        <composer composer="/usr/local/bin/composer" command="install">
+            <arg value="--working-dir=${project.dir}" />
+            <arg value="--quiet" />
+        </composer>
+    </target>
 
     <!-- Build the package. -->
     <target name="dist" depends="build">
@@ -60,5 +68,7 @@
 
         <!-- Archive everything in the package contents directory. -->
         <exec command="zip -X -r vanilla.zip ./package" dir="." />
+        
+        <phingcall target="cleanup" />
     </target>
 </project>


### PR DESCRIPTION
This change restores the dev requirements in your Composer install after Phing runs. Previously, you had to manually run `composer install` again after running Phing. 

Thought I'd contribute back this improvement from developing with Phing on a different project. It always drove me crazy the Phing build here destroyed your local dev install (by using `--no-dev` on it) and then just drops the mic and walks away. This puts you back where you started when the process is over.

I chose to use a slightly nicer (imo) syntax for the Composer steps here. I have a bunch of other minor niceties I could add to the config here if you'd like but thought I'd constrain the first change to the one extremely annoying item since I don't even know if it's still used.