### PR TITLE
docs: fix small typo error

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Vanilla releases are built using [Phing](https://www.phing.info/) to create a pr
 ./bin/release
 ```
 
-The following dependenies are all required for building a release.
+The following dependencies are all required for building a release.
 
 -   `node`
 -   `yarn`


### PR DESCRIPTION
I only fixed a small typo error

Please make sure these points are completed:

* [x] Title is formatted in present imperative (ex: "Fix X by doing Y").
* [ ] Title makes sense as a release note, not a literal technical description.
* [ ] An issue was filed, and this links to it.
* [ ] Any related PRs are cross-referenced via link.
* [ ] Your description tells the story of why _this_ is the right change.
* [ ] You list QA steps or testing criteria if appropriate.
