### PR TITLE
Fix structure for MySQL 8

### DIFF
--- a/library/database/class.mysqldriver.php
+++ b/library/database/class.mysqldriver.php
@@ -167,6 +167,9 @@ class Gdn_MySQLDriver extends Gdn_SQLDriver {
                 }
             }
 
+            // Remove "unsigned" suffix on MySQL > 5.7
+            $type = str_replace(' unsigned', '', $type);
+
             $object = new stdClass();
             $object->Name = $field->Field;
             $object->PrimaryKey = ($field->Key == 'PRI' ? true : false);


### PR DESCRIPTION
MySQL > 5.7 seems to report the INT type of standard length differently when using `SHOW COLUMNS`:

`int unsigned` instead of `int(11) unsigned`

This causes the structure to fail as Gdn_MySQLDriver::fetchTableSchema just trims everything after the first parenthesis.