### PR TITLE
Fix HTML legacy search results

### DIFF
--- a/library/Vanilla/Formatting/Formats/HtmlFormat.php
+++ b/library/Vanilla/Formatting/Formats/HtmlFormat.php
@@ -187,7 +187,7 @@ class HtmlFormat extends BaseFormat implements InjectableInterface {
     public function parseImages(string $content): array {
         $rendered = $this->renderHtml($content);
         $document = new HtmlDocument($rendered);
-        return $this->imageHtmlProcessor->getImageURLs($document);
+        return $this->imageHtmlProcessor->getImages($document);
     }
 
     /**


### PR DESCRIPTION
HtmlFormat::parseImages outputs the wrong data stucture causing the schema validation on search results to fail.

    Validation of result failed.
    APP Log:  Caught Garden\Schema\ValidationException: images[0] is not a valid object.
