### PR TITLE
Fix ProfileExtender clearing fields when editing profiles

### DIFF
--- a/plugins/ProfileExtender/class.profileextender.plugin.php
+++ b/plugins/ProfileExtender/class.profileextender.plugin.php
@@ -366,7 +366,7 @@ class ProfileExtenderPlugin extends Gdn_Plugin {
         $this->ProfileFields = $this->getProfileFields($stripBuiltinFields);
         $this->ProfileFields = $eventManager->fireFilter("modifyProfileFields", $this->ProfileFields);
         // Get user-specific data
-        $this->UserFields = $this->getUserProfileValues([$Sender->Form->getValue('UserID')]);
+        $this->UserFields = $this->getUserFields($Sender->Form->getValue('UserID'));
 
         $this->fireEvent('beforeGetProfileFields');
         // Fill in user data on form


### PR DESCRIPTION
A wrong method call causes all fields showing up as empty wehen editing profiles causing users to delete all their extended info.