### PR TITLE
Fix Gdn_Form notice: add "additionalpermissions" as reserved attribute

### DIFF
--- a/library/core/class.form.php
+++ b/library/core/class.form.php
@@ -3381,7 +3381,8 @@ PASSWORDMETER;
             'fields',
             'inlineerrors',
             'wrap',
-            'categorydata'
+            'categorydata',
+            'additionalpermissions'
         ];
         $return = '';
 


### PR DESCRIPTION
`Gdn_Form` options that are not actually attributes have to be added to `$reservedAttributes`.