### PR TITLE
User status clear: Align frontend permission with backend permission

### DIFF
--- a/applications/dashboard/views/profile/before-page-box.php
+++ b/applications/dashboard/views/profile/before-page-box.php
@@ -27,7 +27,7 @@ echo '<div class="DismissMessage InfoMessage">', t('This is a system account and
 
 if ($this->User->About != '') {
 echo '<div id="Status" itemprop="description">'.wrap(Gdn_Format::display($this->User->About));
-    if ($this->User->About != '' && ($Session->UserID == $this->User->UserID || $Session->checkPermission('Garden.Users.Edit')))
+    if ($this->User->About != '' && ($Session->UserID == $this->User->UserID || $Session->checkPermission('Garden.Moderation.Manage')))
     echo ' - '.anchor(t('clear'), '/profile/clear/'.$this->User->UserID, 'Hijack');
 
     echo '</div>';


### PR DESCRIPTION
The frontend permission for clearing a users status does not match the backend permission:
https://github.com/vanilla/vanilla/blob/7cc3ce7c31e181d934514b78c6f8406f7b5c5e3a/applications/dashboard/controllers/class.profilecontroller.php#L207

Since moderators are usually allowed to moderate activities, they should be able to clear a users status too.