### PR TITLE
Prevent double encoding of email subject

### DIFF
--- a/library/core/class.email.php
+++ b/library/core/class.email.php
@@ -448,7 +448,7 @@ class Gdn_Email extends Gdn_Pluggable implements LoggerAwareInterface {
      * @return Gdn_Email
      */
     public function subject($subject) {
-        $this->PhpMailer->Subject = mb_encode_mimeheader($subject, $this->PhpMailer->CharSet);
+        $this->PhpMailer->Subject = $subject;
         return $this;
     }
 


### PR DESCRIPTION
This recently came up here:
https://open.vanillaforums.com/discussion/38637/encoding-used-in-automatic-email-messages

...and was also discussed on PHPMailers issues:
https://github.com/PHPMailer/PHPMailer/issues/133#issuecomment-799172596

The change was originally introduced here:
https://github.com/vanilla/vanilla/pull/4107

However encoding the subject before passing it to PHPMailer should **not** be required. It is likely that this fixed a bug with the older PHPMailer version that Vanilla used back then (5.1 vs 6.1.6 via composer now):

https://github.com/vanilla/vanilla/blob/3951bdc0750c35af994b07084ee3d9cb50024eaf/library/vendors/phpmailer/class.phpmailer.php

