### PR TITLE
Specify HTTP protocol version to use in ProxyRequest class.

### DIFF
--- a/library/core/class.proxyrequest.php
+++ b/library/core/class.proxyrequest.php
@@ -428,6 +428,7 @@ class ProxyRequest {
         curl_setopt($handler, CURLOPT_CONNECTTIMEOUT, $connectTimeout);
         curl_setopt($handler, CURLOPT_HEADERFUNCTION, [$this, 'CurlHeader']);
         curl_setopt($handler, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+        curl_setopt($handler, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 
         if ($transferMode == 'binary') {
             curl_setopt($handler, CURLOPT_BINARYTRANSFER, true);


### PR DESCRIPTION
This is a temporary fix until our code completely supports the HTTP/2 protocol. Before updating the our base data server image to focal, the protocol used was HTTP/1.1.

> According to curl's documentation, the curl tool enables HTTP/2 by default for HTTPS connections since 7.47.0.
> 
> Headers are lower cased on HTTP/2, while they aren't on HTTP/1.1. This is causing problems, especially in cases like this one, where we are using the response "Content-Type" header to determine how we handle the response.
> 
> The temporary solution we found is to ensure the CURLOPT_HTTP_VERSION is specified and set to CURL_HTTP_VERSION_1_1 when making curl calls on infrastructure.

More information on the above here: https://github.com/vanillaops/roadmap/issues/331