### PR TITLE
Fix type error in LegacyEmbedReplacer.php

### DIFF
--- a/library/Vanilla/EmbeddedContent/LegacyEmbedReplacer.php
+++ b/library/Vanilla/EmbeddedContent/LegacyEmbedReplacer.php
@@ -121,7 +121,7 @@ EOT;
                     $seconds = $matches["seconds"] ?? false;
                     $fullUrl = $videoId . "?autoplay=1";
                     if (!empty($minutes) || !empty($seconds)) {
-                        $time = $minutes * 60 + $seconds;
+                        $time = (int)$minutes * 60 + (int)$seconds;
                         $fullUrl .= "&start=" . $time;
                     }
 


### PR DESCRIPTION
PHP8 is stricter about math operations on strings that can't be parsed to numbers.