### PR TITLE
Fix - add x.com to Twitter domains ( Embed )

### DIFF
--- a/library/Vanilla/EmbeddedContent/Factories/TwitterEmbedFactory.php
+++ b/library/Vanilla/EmbeddedContent/Factories/TwitterEmbedFactory.php
@@ -16,7 +16,7 @@ use Vanilla\EmbeddedContent\Embeds\TwitterEmbed;
  */
 class TwitterEmbedFactory extends AbstractEmbedFactory
 {
-    const DOMAINS = ["twitter.com"];
+    const DOMAINS = ["twitter.com", "x.com"];
 
     /** @var HttpClient */
     private $httpClient;


### PR DESCRIPTION
Since the Twitter domain changed, x.com embedded was not working, so with this fix, x.com is supported in the links.