### PR TITLE
Generate fewer folders in upload directory

### DIFF
--- a/library/Vanilla/FileUtils.php
+++ b/library/Vanilla/FileUtils.php
@@ -60,7 +60,7 @@ class FileUtils
                 $name = randomString(12);
             }
             if ($chunk) {
-                $subdir = randomString(12) . "/";
+                $subdir = sprintf('%03d', mt_rand(0, 999)).'/';
             }
             $path = "{$targetDirectory}/{$subdir}{$name}.{$extension}";
         } while (file_exists($path));


### PR DESCRIPTION
#11090 has not been fixed

> https://github.com/vanilla/vanilla/blob/7e68d0fdb633b12b94132307146f4c95b759cb89/library/Vanilla/FileUtils.php#L60
> 
> This will create up to 36^12 (4.738.381.338.321.616.896) different folders. 
> This does not help reduce file system load in any way, it is probably even worse than just dumping every upload in a single folder.
> 
> The old implementation creating folders from 0 to 999 is restored with this fix.
> See:
> https://github.com/vanilla/vanilla/commit/3108657b66721a18ac36550d391b3188cbe73f78#diff-db1553fc5ca69f1a7449390029c1ba07a3eb80beac707e6b13c06098ff424405L281